### PR TITLE
fix(triage): assign an owner to every triaged issue, duplicates included

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -26,7 +26,8 @@ name: Issue Triage
 #   6. Optionally comments when a duplicate or related issue is found
 #      (disabled by default; never comments when nothing matches)
 #   7. Optionally closes validated high-confidence duplicates (disabled by default)
-#   8. Assigns P0/P1 issues to a maintainer via round-robin
+#   8. Assigns an owner to every triaged open issue via round-robin — including
+#      duplicates left open when closure is disabled
 
 on:
   issues:
@@ -725,10 +726,13 @@ jobs:
                 gh issue close "$ISSUE_NUMBER" --repo "$REPO" \
                   --duplicate-of "$duplicate_of"
               fi
-            else
-              echo "Duplicate closure disabled; leaving issue open."
+              # Closed as a duplicate; no owner needed.
+              exit 0
             fi
-            exit 0
+            # Closure disabled: the duplicate stays open, so fall through and
+            # route it to an owner like any other triaged open issue rather than
+            # leaving it permanently unassigned.
+            echo "Duplicate closure disabled; leaving issue open and assigning an owner."
           fi
 
           # If the issue was filed by a maintainer, assign it to them directly.
@@ -747,9 +751,10 @@ jobs:
           # Otherwise, assign an owner: the least-loaded area owner, with LLM
           # rank as a tiebreaker (load primary, rank secondary). Symmetric with
           # the PR reviewer path. Skipped if the maintainer-author was already
-          # assigned above. Every triaged issue gets an owner — the only issues
-          # left unassigned are needs_info ones (too vague to route until the
-          # reporter adds detail).
+          # assigned above. Every triaged open issue gets an owner — including
+          # duplicates left open when closure is disabled — the only issues left
+          # unassigned are needs_info ones (too vague to route until the reporter
+          # adds detail).
           needs_info=$(jq -r '.needs_info // false' /tmp/triage_result.json)
           if [ "$maintainer_assigned" = "false" ] && [ "$needs_info" != "true" ]; then
             # Open-issue load per candidate (fewest assigned open issues wins ties).

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -25,9 +25,10 @@ name: Issue Triage
 #   5. Flags incomplete issues — `needs-info` (replaces priority label)
 #   6. Optionally comments when a duplicate or related issue is found
 #      (disabled by default; never comments when nothing matches)
-#   7. Optionally closes validated high-confidence duplicates (disabled by default)
-#   8. Assigns an owner to every triaged open issue via round-robin — including
-#      duplicates left open when closure is disabled
+#   7. Assigns an owner to every triaged open issue via round-robin — duplicates
+#      included, so the owner persists if the issue is later reopened
+#   8. Optionally closes validated high-confidence duplicates (disabled by
+#      default), after the owner above is assigned
 
 on:
   issues:
@@ -715,46 +716,27 @@ jobs:
             exit 0
           fi
 
-          duplicate_decision=$(jq -r '.duplicate_decision' /tmp/triage_result.json)
-          if [ "$duplicate_decision" = "duplicate" ]; then
-            close_duplicate_issue=$(jq -r '.close_duplicate_issue' /tmp/triage_result.json)
-            if [ "$close_duplicate_issue" = "true" ]; then
-              duplicate_of=$(jq -r '.duplicate_of' /tmp/triage_result.json)
-              issue_state=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" \
-                --json state --jq '.state')
-              if [ "$issue_state" = "OPEN" ]; then
-                gh issue close "$ISSUE_NUMBER" --repo "$REPO" \
-                  --duplicate-of "$duplicate_of"
-              fi
-              # Closed as a duplicate; no owner needed.
-              exit 0
-            fi
-            # Closure disabled: the duplicate stays open, so fall through and
-            # route it to an owner like any other triaged open issue rather than
-            # leaving it permanently unassigned.
-            echo "Duplicate closure disabled; leaving issue open and assigning an owner."
-          fi
+          # Assign an owner to every triaged open issue, BEFORE the duplicate
+          # closure below. Duplicates get an owner too, and it persists if the
+          # issue is later reopened — triage only fires on `opened`, so a
+          # reopened issue would otherwise come back unassigned.
 
           # If the issue was filed by a maintainer, assign it to them directly.
           author=$(jq -r '.author.login // empty' /tmp/issue.json)
           maintainer_assigned=false
           if [ -n "$author" ] && grep -qxF "$author" .github/MAINTAINER; then
             echo "Issue filed by maintainer $author — assigning to author"
-            issue_state=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" \
-              --json state --jq '.state')
-            if [ "$issue_state" = "OPEN" ]; then
-              gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-assignee "$author"
-              maintainer_assigned=true
-            fi
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-assignee "$author"
+            maintainer_assigned=true
           fi
 
           # Otherwise, assign an owner: the least-loaded area owner, with LLM
           # rank as a tiebreaker (load primary, rank secondary). Symmetric with
           # the PR reviewer path. Skipped if the maintainer-author was already
-          # assigned above. Every triaged open issue gets an owner — including
-          # duplicates left open when closure is disabled — the only issues left
-          # unassigned are needs_info ones (too vague to route until the reporter
-          # adds detail).
+          # assigned above. Every triaged issue gets an owner — duplicates
+          # included, even ones about to be closed below — so the only issues
+          # left unassigned are needs_info ones (too vague to route until the
+          # reporter adds detail).
           needs_info=$(jq -r '.needs_info // false' /tmp/triage_result.json)
           if [ "$maintainer_assigned" = "false" ] && [ "$needs_info" != "true" ]; then
             # Open-issue load per candidate (fewest assigned open issues wins ties).
@@ -799,11 +781,26 @@ jobs:
 
             assignee=$(cat /tmp/assignee.txt)
             if [ -n "$assignee" ]; then
+              gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-assignee "$assignee"
+            fi
+          fi
+
+          # Finally, close the issue if it is a high-confidence duplicate and
+          # closure is enabled. The owner assigned above stays on the issue,
+          # ready if it is reopened.
+          duplicate_decision=$(jq -r '.duplicate_decision' /tmp/triage_result.json)
+          if [ "$duplicate_decision" = "duplicate" ]; then
+            close_duplicate_issue=$(jq -r '.close_duplicate_issue' /tmp/triage_result.json)
+            if [ "$close_duplicate_issue" = "true" ]; then
+              duplicate_of=$(jq -r '.duplicate_of' /tmp/triage_result.json)
               issue_state=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" \
                 --json state --jq '.state')
               if [ "$issue_state" = "OPEN" ]; then
-                gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-assignee "$assignee"
+                gh issue close "$ISSUE_NUMBER" --repo "$REPO" \
+                  --duplicate-of "$duplicate_of"
               fi
+            else
+              echo "Duplicate closure disabled; leaving issue open."
             fi
           fi
 


### PR DESCRIPTION
## Related issue

Relates to #4437 and #4484 (both were triaged, P1-high, and left unassigned by
this bug; already backfilled manually). No single closing issue — this fixes the
automation itself.

## Summary

- The issue-triage workflow short-circuited assignment for duplicates: the
  duplicate branch ran *before* the assignment step and `exit 0`ed. So any issue
  classified a duplicate — closed, or (with auto-closing disabled by default)
  left open — never got an owner, even P0/P1 ones.
- **Reordered** so assignment runs first, for *every* triaged open issue, and the
  optional duplicate closure runs afterward. Duplicates now get an owner too.
- Because the owner is assigned before the close and **persists across a
  close/reopen**, a reopened issue no longer comes back unassigned — triage only
  fires on `opened`, not `reopened`, so this avoids needing any reopen trigger.
- Dropped the now-redundant per-mutation `state == OPEN` re-checks on the
  assignment path (the issue is guaranteed open here by the guard above); the
  closure step keeps its guard against a concurrent human close.

Flow is now: **label → assign owner (all triaged open issues) → close if
duplicate + closure enabled**.

Known limitation (unchanged): an issue the classifier also marks `needs_info` is
still left unassigned by design (too vague to route).

## Test Plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/issue-triage.yml'))"` — YAML parses.
- `pre-commit run --files .github/workflows/issue-triage.yml` — passes.
- Traced the control flow: the top `state != OPEN` guard still exits early;
  dry-run still exits before any mutation; assignment (maintainer-author or
  least-loaded owner) now always runs for a triaged open issue; closure runs
  last and re-checks `OPEN` before calling `gh issue close`.
- Backfill sweep that surfaced this: only `#4437` and `#4484` were affected
  (open + `duplicate` + unassigned); both manually assigned to the owner already
  on their fix PRs (`dhruv0811`, `dbczumar`).

## Demo

N/A — CI workflow logic change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Manual verification completed
- [x] Not applicable

## Coverage notes

The triage assignment logic is an inline shell/Python block in the workflow YAML
with no dedicated test harness (unlike `auto-assign-reviewer.js`), so there's no
unit test to add here. Verified manually via YAML lint, pre-commit, and a
control-flow trace as described in the Test Plan. The next triaged duplicate will
exercise the new path in production.

This pull request and its description were written by Isaac.
