### PR TITLE
feat(cli): set a per-workspace databricks profile at login to avoid an unclear picker

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10950,6 +10950,12 @@ def _run_databricks_browser_login(workspace_host: str, org_id: str | None = None
         the workspace rejects it).
     :raises click.ClickException: When the Databricks CLI binary is
         missing or the login exits non-zero.
+
+    The login writes to a ``.databrickscfg`` profile named after the
+    workspace's first DNS label (e.g. ``acme`` for
+    ``acme.cloud.databricks.com``), keeping distinct workspaces off the
+    shared ``DEFAULT`` profile. The OAuth grant itself stays host-keyed,
+    so :func:`_databricks_workspace_token` still resolves it by host.
     """
     databricks_bin = shutil.which("databricks")
     if databricks_bin is None:
@@ -10958,14 +10964,21 @@ def _run_databricks_browser_login(workspace_host: str, org_id: str | None = None
             "Install it first: https://docs.databricks.com/dev-tools/cli/install.html"
         )
     login_host = _host_with_org(workspace_host, org_id)
-    click.echo(f"Opening browser to log in to {login_host} ...")
+    # Pin the grant to a profile named for the workspace's first DNS label so
+    # distinct workspaces don't clobber each other under the CLI's ``DEFAULT``.
+    from urllib.parse import urlsplit
+
+    split = urlsplit(workspace_host.rstrip("/"))
+    host = split.hostname or split.netloc or split.path
+    profile = host.split(".")[0]
+    click.echo(f"Opening browser to log in to {login_host} (profile {profile}) ...")
     result = subprocess.run(
-        [databricks_bin, "auth", "login", "--host", login_host],
+        [databricks_bin, "auth", "login", "--host", login_host, "--profile", profile],
         check=False,
     )
     if result.returncode != 0:
         raise click.ClickException(
-            f"`databricks auth login --host {login_host}` failed "
+            f"`databricks auth login --host {login_host} --profile {profile}` failed "
             f"(exit {result.returncode}). If the workspace is unreachable from "
             "this machine (VPN / IP access lists), resolve that and retry."
         )

--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -28,6 +28,8 @@ cli_group = cli_mod.cli
 
 _APPS_URL = "https://myapp-1234.aws.databricksapps.com"
 _WORKSPACE = "https://example.databricks.com"
+# The login pins ``--profile`` to the workspace's first DNS label.
+_PROFILE = "example"
 _APPS_REDIRECT = f"{_WORKSPACE}/oidc/oauth2/v2.0/authorize?client_id=abc&response_type=code"
 _WORKSPACE_API_URL = f"{_WORKSPACE}/api/2.0/omnigent"
 
@@ -245,8 +247,11 @@ def test_login_runs_databricks_auth_login_when_no_cached_grant(
 ) -> None:
     """No cached host-keyed grant → ``databricks auth login --host <ws>`` runs.
 
-    The login is host-keyed (no ``--profile`` / profile name anywhere);
-    after it succeeds the token resolves and the record is stored.
+    The login pins ``--profile`` to the workspace's first DNS label so a
+    second workspace doesn't clobber the shared ``DEFAULT`` profile;
+    resolution stays host-matched (name-agnostic), so the profile name
+    isn't consulted anywhere. After login the token resolves and the
+    record is stored.
     """
     from omnigent.cli_auth import load_databricks_workspace_host
 
@@ -266,10 +271,9 @@ def test_login_runs_databricks_auth_login_when_no_cached_grant(
     result = CliRunner().invoke(cli_group, ["login", _APPS_URL])
 
     assert result.exit_code == 0, result.output
-    # Exactly one browser login, host-keyed, with no profile flag — a
-    # `--profile` here would recreate the named-profile coupling this
-    # flow exists to remove.
-    assert login_calls == [f"auth login --host {_WORKSPACE}"]
+    # Exactly one browser login, pinned to the per-workspace profile so
+    # ``DEFAULT`` is left alone; ``?o=`` stays only on ``--host``.
+    assert login_calls == [f"auth login --host {_WORKSPACE} --profile {_PROFILE}"]
     assert load_databricks_workspace_host(_APPS_URL) == _WORKSPACE
 
 
@@ -354,7 +358,7 @@ def test_login_stale_cached_grant_triggers_fresh_login_and_retry(
     assert result.exit_code == 0, result.output
     # Exactly one forced re-login — a second rejection must fail loud,
     # not loop the browser flow.
-    assert login_calls == [f"auth login --host {_WORKSPACE}"]
+    assert login_calls == [f"auth login --host {_WORKSPACE} --profile {_PROFILE}"]
     # The retry verify presented the freshly minted token, not the stale one.
     assert fake.requests[-1]["authorization"] == "Bearer tok-fresh"
     assert load_databricks_workspace_host(_APPS_URL) == _WORKSPACE
@@ -389,7 +393,7 @@ def test_foreign_subprocess_calls_stay_out_of_the_login_recorder(
     result = CliRunner().invoke(cli_group, ["login", _APPS_URL])
 
     assert result.exit_code == 0, result.output
-    assert login_calls == [f"auth login --host {_WORKSPACE}"]
+    assert login_calls == [f"auth login --host {_WORKSPACE} --profile {_PROFILE}"]
     # Delegated to the real runner rather than stubbed out from under it.
     assert probe.returncode == 0
     assert b"git version" in probe.stdout
@@ -477,8 +481,9 @@ def test_login_threads_org_id_through_workspace_login_and_verify(
     result = CliRunner().invoke(cli_group, ["login", _SELECTOR_URL])
 
     assert result.exit_code == 0, result.output
-    # The browser login carries the selector so the profile is workspace-scoped.
-    assert login_calls == [f"auth login --host {_WORKSPACE}/?o={_ORG_ID}"]
+    # The browser login carries the selector on --host so the grant is
+    # workspace-scoped; the profile name stays the bare first DNS label.
+    assert login_calls == [f"auth login --host {_WORKSPACE}/?o={_ORG_ID} --profile {_PROFILE}"]
     # The verify request routes to the workspace via ?o= (and used the token).
     assert fake.requests[-1]["params"] == {"o": _ORG_ID}
     assert fake.requests[-1]["authorization"] == "Bearer tok-fresh"


### PR DESCRIPTION
## Related issue

No linked issue — a small fix to local `~/.databrickscfg` handling during `omnigent login`.

Closes #

## Summary

- `omnigent login` to a Databricks-fronted server ran `databricks auth login --host <ws>` with no `--profile`, so the CLI wrote the shared `DEFAULT` profile in `~/.databrickscfg`. Logging in to a second workspace overwrote the first workspace's `DEFAULT` entry.
- This isn't only a nuisance for other databricks-CLI usage: omnigent's own token resolution (`_resolve_databricks_auth_for_host`) **prefers** a `~/.databrickscfg` profile whose `host` matches the workspace, matched **by host value, not by profile name**, and falls back to the host-keyed `databricks auth token` lookup that the code itself documents as unreliable across CLI versions. Clobbering `DEFAULT` therefore drops every workspace except the most-recent one onto that unreliable fallback — and leaves the user facing an unclear profile picker at login when a `DEFAULT` for a different workspace already exists.
- The fix is confined to the login side (the `databricks auth login` invocation); token resolution is unchanged.
- Fix: pass `--profile <first DNS label>` (e.g. `acme` for `acme.cloud.databricks.com`). Each workspace gets its own `.databrickscfg` section, `DEFAULT` is left alone, and resolution still matches by host — so no profile *name* coupling is introduced. The `?o=` selector stays only on `--host`.
- The OAuth grant remains host-keyed in the token cache, so behavior for a single-workspace user is unchanged.

## Test Plan

- `uv run pytest tests/cli/test_login_databricks.py tests/cli/test_backend.py` — updated the login-command guard tests to expect `--profile <first-label>` (login-side only; resolution assertions untouched), plus a new unit test asserting the subprocess argv carries `--profile` with `?o=` only on `--host`.
- `uv run ruff check` / `uv run ruff format --check` on the changed files — clean.
- Manual, against two live Databricks workspaces: fresh `omnigent login` for two workspaces each wrote its own first-label profile, both minted tokens, and pre-existing profiles (including `DEFAULT`) were left intact. Clearing the cached grants and re-running confirmed the fresh-login path writes the per-workspace profile.

## Demo

N/A (non-visual CLI change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified `omnigent login` against two Databricks workspaces: fresh logins each wrote their own first-label profile, both minted tokens, and existing `~/.databrickscfg` profiles (including `DEFAULT`) were untouched. The unit tests lock in the subprocess argv (`--host` carries `?o=`; `--profile` carries the bare first DNS label). The guard tests in `test_login_databricks.py` that previously asserted a profile-less login were updated to the new per-host profile, with their comments rewritten — resolution stays host-matched and name-agnostic, so the change does not reintroduce name coupling.

## Changelog

`omnigent login` to a Databricks workspace now writes a per-workspace `~/.databrickscfg` profile instead of overwriting the shared `DEFAULT`.
