### PR TITLE
fix(codex-native): suppress old-model startup prompt

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -57,6 +57,7 @@ from omnigent.inner.codex_executor import (
     codex_router_session_id,
     codex_routing_hook_skip_reason,
     materialize_codex_provider_config,
+    read_codex_model_catalog,
     write_codex_hooks_file,
 )
 from omnigent.inner.databricks_executor import _databricks_gateway_host
@@ -110,6 +111,7 @@ _MIN_POLICY_HOOK_CODEX_VERSION = (0, 129, 0)
 # (including a version we could not parse) the flag is omitted and the
 # interactive trust prompt may appear instead.
 _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION = (0, 131, 0)
+_MODEL_MIGRATION_CATALOG_TIMEOUT_SECONDS = 3.0
 
 
 def _string_object_dict(value: object) -> _JsonObject | None:
@@ -383,6 +385,43 @@ def _sync_codex_developer_instructions(
         document["developer_instructions"] = active
     elif "developer_instructions" in document:
         del document["developer_instructions"]
+    config_path.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+
+def _codex_model_upgrade_target(catalog: object, model: str) -> str | None:
+    """Return Codex's replacement for *model*, when the catalog declares one."""
+    if not isinstance(catalog, dict):
+        return None
+    models = catalog.get("models")
+    if not isinstance(models, list):
+        return None
+    for entry in models:
+        if not isinstance(entry, dict) or entry.get("slug") != model:
+            continue
+        upgrade = entry.get("upgrade")
+        if not isinstance(upgrade, dict):
+            return None
+        target = upgrade.get("model") or upgrade.get("id")
+        if isinstance(target, str) and target and target != model:
+            return target
+        return None
+    return None
+
+
+def _acknowledge_codex_model_migration(codex_home: Path, model: str, target: str) -> None:
+    """Suppress one model-migration prompt in a private runner-owned config."""
+    config_path = codex_home / "config.toml"
+    existing = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    document = tomlkit.parse(existing) if existing else tomlkit.document()
+    notice = document.get("notice")
+    if notice is None:
+        notice = tomlkit.table()
+        document["notice"] = notice
+    migrations = notice.get("model_migrations")
+    if migrations is None:
+        migrations = tomlkit.table()
+        notice["model_migrations"] = migrations
+    migrations[model] = target
     config_path.write_text(tomlkit.dumps(document), encoding="utf-8")
 
 
@@ -920,6 +959,15 @@ class CodexNativeAppServer:
         self.router_hooks_registered = router_bridge_dir is not None and policy_hooks_supported
         routed_spawns = router_bridge_dir is not None
         config_source = _codex_home_config_source_from_env()
+        model_migration_target: str | None = None
+        if self.trust_project and self.pinned_model:
+            catalog = await asyncio.to_thread(
+                read_codex_model_catalog,
+                self.codex_path,
+                config_source,
+                timeout=_MODEL_MIGRATION_CATALOG_TIMEOUT_SECONDS,
+            )
+            model_migration_target = _codex_model_upgrade_target(catalog, self.pinned_model)
         # Off the loop: this copies/symlinks a home AND (on a Smart Routing
         # session) shells out to ``codex debug models`` with a 10s timeout. Run
         # inline it stalled every other session sharing this event loop for that
@@ -944,6 +992,12 @@ class CodexNativeAppServer:
         )
         if self.pinned_model:
             _pin_codex_config_model(self.codex_home, self.pinned_model)
+            if model_migration_target is not None:
+                _acknowledge_codex_model_migration(
+                    self.codex_home,
+                    self.pinned_model,
+                    model_migration_target,
+                )
         _sync_codex_developer_instructions(
             self.codex_home,
             self.developer_instructions,

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4002,9 +4002,9 @@ async def _auto_create_codex_terminal(
         ap_server_url=launch_config.policy_server_url,
         ap_auth_headers=policy_headers,
         bypass_sandbox=launch_config.bypass_sandbox,
-        # Codex 0.146 prompts for project trust before creating a thread.
-        # This TUI runs detached for the web UI, so trust the runner-selected
-        # workspace in the session-private config instead of blocking forever.
+        # Codex can show project-trust and legacy-model migration prompts before
+        # creating a thread. This TUI runs detached for the web UI, so persist
+        # the runner-owned acknowledgements in the private session config.
         trust_project=True,
         **routed_spawn_extras,
     )

--- a/tests/e2e_ui/chat/test_codex_old_model_startup.py
+++ b/tests/e2e_ui/chat/test_codex_old_model_startup.py
@@ -1,0 +1,47 @@
+"""E2E: an old Codex model must not block the first web message."""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import MockedCodexNativeSession
+from tests.e2e_ui.messages.test_message_render_parity import (
+    _ASSISTANT,
+    _WORKING,
+    _ensure_chat_view,
+    _send,
+)
+from tests.e2e_ui.messages.test_native_codex_render_parity import (
+    _open_terminal_view,
+    _wait_terminal_connected,
+)
+
+_OLD_MODEL = "gpt-5.4"
+_TIMEOUT_MS = 60_000
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize("mocked_native_codex_session", [_OLD_MODEL], indirect=True)
+def test_codex_old_model_does_not_block_first_web_message(
+    page: Page,
+    mocked_native_codex_session: MockedCodexNativeSession,
+) -> None:
+    """A pinned legacy model starts without the terminal migration prompt."""
+    session = mocked_native_codex_session
+    page.goto(f"{session.base_url}/c/{session.session_id}")
+
+    _open_terminal_view(page)
+    _wait_terminal_connected(page)
+    _ensure_chat_view(page)
+
+    prompt = "Process this first web message without waiting for terminal input."
+    _send(page, prompt)
+    expect(page.locator(_ASSISTANT, has_text="E2E_GOAL_BOOTSTRAP").first).to_be_visible(
+        timeout=_TIMEOUT_MS
+    )
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=_TIMEOUT_MS)
+
+    requests = session.sidecar.requests(min_count=1, timeout_ms=30_000)
+    assert requests[0]["body"]["model"] == _OLD_MODEL
+    assert prompt in str(requests[0]["body"]["input"])

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -2526,7 +2526,12 @@ def native_claude_plan_session(
                 respawned.wait(timeout=5)
 
 
-def _create_native_codex_session(base_url: str, runner_id: str) -> str:
+def _create_native_codex_session(
+    base_url: str,
+    runner_id: str,
+    *,
+    model: str | None = None,
+) -> str:
     """Register the ``codex-native`` wrapper agent and bind its session.
 
     Reuses the exact terminal-first spec ``omnigent codex`` ships
@@ -2543,10 +2548,12 @@ def _create_native_codex_session(base_url: str, runner_id: str) -> str:
     gateway auth from its own credentials, and pre-accepts the first-run
     trust/onboarding prompts — no CLI client required. ``model=None`` lets the
     configured provider's default model win (matching the seeded codex bundle
-    built via ``_build_native_bundle``).
+    built via ``_build_native_bundle``); tests can pin a specific catalog model
+    to exercise model-specific startup behavior.
 
     :param base_url: Spawned server base URL.
     :param runner_id: The token-bound runner id to bind.
+    :param model: Optional Codex model to pin in the wrapper spec.
     :returns: The new session/conversation id.
     """
     import json as _json
@@ -2561,7 +2568,7 @@ def _create_native_codex_session(base_url: str, runner_id: str) -> str:
     from omnigent.codex_native import _materialize_codex_agent_spec
 
     with tempfile.TemporaryDirectory() as _tmp:
-        spec_path = _materialize_codex_agent_spec(Path(_tmp), model=None)
+        spec_path = _materialize_codex_agent_spec(Path(_tmp), model=model)
         yaml_text = spec_path.read_text()
 
     buf = io.BytesIO()
@@ -2777,7 +2784,12 @@ class MockedCodexNativeSession:
     sidecar: CodexResponsesSidecar
 
 
-def _write_mock_codex_provider_config(config_home: Path, base_url: str) -> None:
+def _write_mock_codex_provider_config(
+    config_home: Path,
+    base_url: str,
+    *,
+    model: str = "mock-model",
+) -> None:
     """Write provider config that routes native Codex to the sidecar."""
     config_home.mkdir(parents=True, exist_ok=True)
     (config_home / "config.yaml").write_text(
@@ -2791,7 +2803,7 @@ providers:
       api_key: "sk-e2e-mock"
       wire_api: responses
       models:
-        default: mock-model
+        default: {model}
 """,
         encoding="utf-8",
     )
@@ -2821,22 +2833,25 @@ def mocked_native_codex_session(
     if not _codex_cli_supports_mocked_app_server(codex_path):
         pytest.skip("codex CLI >= 0.139.0 is required for mocked app-server e2e")
 
+    fixture_param = getattr(request, "param", None)
+    model = fixture_param if isinstance(fixture_param, str) else "mock-model"
+
     try:
         sidecar_bin = build_sidecar_bin()
     except RuntimeError:
         pytest.skip("cargo is required for Codex parity sidecar")
 
     server_tmp = tmp_path_factory.mktemp("e2e_ui_mocked_codex_server")
-    responses = getattr(
-        request,
-        "param",
-        [
+    responses = (
+        fixture_param
+        if isinstance(fixture_param, list)
+        else [
             [
                 ev_response_created("resp-goal-ui-bootstrap"),
                 ev_assistant_message("msg-goal-ui-bootstrap", "E2E_GOAL_BOOTSTRAP"),
                 ev_completed("resp-goal-ui-bootstrap"),
             ]
-        ],
+        ]
     )
     sidecar = start_codex_responses_sidecar(
         sidecar_bin,
@@ -2867,7 +2882,7 @@ def mocked_native_codex_session(
         encoding="utf-8",
     )
     codex_shim = _write_codex_unknown_version_shim(server_tmp, codex_path)
-    _write_mock_codex_provider_config(config_home, sidecar.base_url)
+    _write_mock_codex_provider_config(config_home, sidecar.base_url, model=model)
 
     port = _find_free_port()
     log_path = server_tmp / "server.log"
@@ -2979,7 +2994,7 @@ def mocked_native_codex_session(
                 f"{runner_log_path.read_text()[-3000:] if runner_log_path.exists() else ''}"
             )
 
-        session_id = _create_native_codex_session(base_url, runner_id)
+        session_id = _create_native_codex_session(base_url, runner_id, model=model)
         yield MockedCodexNativeSession(base_url=base_url, session_id=session_id, sidecar=sidecar)
     finally:
         if session_id is not None:

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -1685,6 +1685,38 @@ async def test_policy_hook_command_runs_python_isolated() -> None:
     assert argv[1:3] == ["-I", "-m"]
 
 
+def test_codex_model_upgrade_target_reads_catalog_migration() -> None:
+    """The runner records the exact old-to-new mapping Codex advertises."""
+    from omnigent.codex_native_app_server import _codex_model_upgrade_target
+
+    catalog = {
+        "models": [
+            {"slug": "gpt-5.4", "upgrade": {"model": "gpt-5.6-terra"}},
+            {"slug": "current", "upgrade": None},
+        ]
+    }
+
+    assert _codex_model_upgrade_target(catalog, "gpt-5.4") == "gpt-5.6-terra"
+    assert _codex_model_upgrade_target(catalog, "current") is None
+    assert _codex_model_upgrade_target(catalog, "missing") is None
+
+
+def test_acknowledge_codex_model_migration_updates_private_config(tmp_path: Path) -> None:
+    """Acknowledgement preserves user notices while suppressing one prompt."""
+    from omnigent.codex_native_app_server import _acknowledge_codex_model_migration
+
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    config_path = codex_home / "config.toml"
+    config_path.write_text("[notice]\nhide_rate_limit_model_nudge = true\n", encoding="utf-8")
+
+    _acknowledge_codex_model_migration(codex_home, "gpt-5.4", "gpt-5.6-terra")
+
+    config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert config["notice"]["hide_rate_limit_model_nudge"] is True
+    assert config["notice"]["model_migrations"] == {"gpt-5.4": "gpt-5.6-terra"}
+
+
 def test_routed_spawn_note_appends_then_restores_the_user_base(tmp_path: Path) -> None:
     """The codex routed-spawn note rides ``developer_instructions``, reversibly.
 


### PR DESCRIPTION
## Related issue

Follow-up to #5108.

## Summary

- Detect model upgrade metadata from the installed Codex catalog for runner-owned sessions.
- Record Codex's own old→replacement migration acknowledgement in the private session config before launching the detached TUI, preserving the explicitly selected model while skipping the terminal-only prompt.
- Add a real-Codex browser regression pinned to `gpt-5.4` that verifies the first web message reaches the selected model without terminal input.

**ELI5:** Codex asks terminal users whether they want to switch away from an old model. Web-launched sessions run that terminal in the background, so nobody can answer. Omnigent now records “keep my selected model” in the session-private config before starting the terminal.

```text
Web session selects gpt-5.4
          |
          v
Codex catalog: gpt-5.4 -> gpt-5.6-terra
          |
          v
Private config records acknowledgement
          |
          v
TUI starts directly; first web message reaches gpt-5.4
```

## Test Plan

- Reproduced on unmodified main (`3da0e9f4`): `test_codex_old_model_does_not_block_first_web_message` failed after Codex never created a thread and the runner reported a startup timeout.
- After the fix: the same test passed and asserted the Responses request still used `gpt-5.4`.
- `.venv/bin/pytest tests/test_codex_native_app_server.py tests/runner/test_app_sessions_native_terminals_runtime.py::test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir -q`
- `CODEX_PARITY_SIDECAR_BIN=<sidecar> .venv/bin/pytest tests/e2e_ui/chat/test_codex_old_model_startup.py::test_codex_old_model_does_not_block_first_web_message -q -s`
- `CODEX_PARITY_SIDECAR_BIN=<sidecar> .venv/bin/pytest tests/e2e_ui/chat/test_codex_goal_mode.py::test_codex_goal_mode_processes_first_message_with_untrusted_hooks -q`
- `.venv/bin/pre-commit run --all-files`

## Demo

N/A — native startup behavior; no web layout or visual UI changed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the new test fails on main with the same “Codex native thread never started” timeout caused by the migration prompt, then passes after the fix in 13 seconds. The passing request retained `model=gpt-5.4`, confirming the fix dismisses the prompt rather than silently switching the user's selection.

## Changelog

Codex subscription sessions using an older selected model no longer get stuck waiting for an embedded-terminal migration prompt.
