### PR TITLE
fix(tests): isolate local daemon state from OMNIGENT_DATA_DIR

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2229,6 +2229,14 @@ def _runner_loopback_host(host: str) -> str:
 
 
 _HOST_PID_PATH = data_dir() / "host.pid"
+_DEFAULT_HOST_PID_PATH = _HOST_PID_PATH
+
+
+def _host_pid_path() -> Path:
+    """Return the host pidfile, resolving the runtime data dir late."""
+    if _HOST_PID_PATH != _DEFAULT_HOST_PID_PATH:
+        return _HOST_PID_PATH
+    return data_dir() / "host.pid"
 
 
 # host.pid records the daemon PID + the "target" it serves: a normalized
@@ -2454,7 +2462,7 @@ def _daemon_registry_dir() -> Path:
     :returns: Registry directory path, e.g.
         ``Path("~/.omnigent/daemons")``.
     """
-    return _HOST_PID_PATH.parent / "daemons"
+    return _host_pid_path().parent / "daemons"
 
 
 def _daemon_record_path(target: str) -> Path:
@@ -2560,7 +2568,7 @@ def _delete_daemon_record(record: _HostDaemonRecord) -> None:
     legacy = _read_host_pid_file()
     if legacy is not None and legacy[1] == record.target:
         with contextlib.suppress(OSError):
-            _HOST_PID_PATH.unlink()
+            _host_pid_path().unlink()
 
 
 def _legacy_daemon_record() -> _HostDaemonRecord | None:
@@ -2902,7 +2910,7 @@ def _persist_spawned_daemon(
             config_sig=config_sig,
         )
     )
-    _HOST_PID_PATH.write_text(f"{spawned.pid}\n{target}\n")
+    _host_pid_path().write_text(f"{spawned.pid}\n{target}\n")
 
 
 def _foreground_daemon_record(
@@ -3049,7 +3057,7 @@ def _ensure_host_daemon(server_url: str | None) -> bool:
     if not decision.config_changed and _local_daemon_serves_target(target, server_url):
         return False
 
-    _HOST_PID_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _host_pid_path().parent.mkdir(parents=True, exist_ok=True)
     mode_args = ["--local"] if not server_url else ["--server", server_url]
     args = [sys.executable, "-m", "omnigent.host._daemon_entry", *mode_args]
     spawned = _spawn_host_daemon_process(
@@ -3125,10 +3133,11 @@ def _read_host_pid_file() -> tuple[int, str] | None:
 
     :returns: ``(pid, server_url)`` if well-formed, ``None`` otherwise.
     """
-    if not _HOST_PID_PATH.exists():
+    pid_path = _host_pid_path()
+    if not pid_path.exists():
         return None
     try:
-        lines = _HOST_PID_PATH.read_text().strip().splitlines()
+        lines = pid_path.read_text().strip().splitlines()
         if len(lines) < 2:
             return None
         return int(lines[0]), lines[1]

--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -96,6 +96,31 @@ _LOCAL_SERVER_SIG_PATH = _local_data_dir() / "local_server.sig"
 # ``omnigent server`` (its logs stream to the terminal, not a file).
 _LOCAL_SERVER_LOG_REF_PATH = _local_data_dir() / "local_server.logpath"
 
+_DEFAULT_LOCAL_SERVER_PID_PATH = _LOCAL_SERVER_PID_PATH
+_DEFAULT_LOCAL_SERVER_SIG_PATH = _LOCAL_SERVER_SIG_PATH
+_DEFAULT_LOCAL_SERVER_LOG_REF_PATH = _LOCAL_SERVER_LOG_REF_PATH
+
+
+def _local_server_pid_path() -> Path:
+    """Return the local-server pidfile, resolving test data isolation late."""
+    if _LOCAL_SERVER_PID_PATH != _DEFAULT_LOCAL_SERVER_PID_PATH:
+        return _LOCAL_SERVER_PID_PATH
+    return _local_data_dir() / "local_server.pid"
+
+
+def _local_server_sig_path() -> Path:
+    """Return the local-server signature sidecar, resolving it late."""
+    if _LOCAL_SERVER_SIG_PATH != _DEFAULT_LOCAL_SERVER_SIG_PATH:
+        return _LOCAL_SERVER_SIG_PATH
+    return _local_data_dir() / "local_server.sig"
+
+
+def _local_server_log_ref_path() -> Path:
+    """Return the local-server log-reference sidecar, resolving it late."""
+    if _LOCAL_SERVER_LOG_REF_PATH != _DEFAULT_LOCAL_SERVER_LOG_REF_PATH:
+        return _LOCAL_SERVER_LOG_REF_PATH
+    return _local_data_dir() / "local_server.logpath"
+
 
 def server_config_signature(*, include_features: bool = True) -> str:
     """
@@ -182,10 +207,11 @@ def _read_local_server_pid_file() -> tuple[int, int] | None:
 
     :returns: ``(pid, port)`` if well-formed, ``None`` otherwise.
     """
-    if not _LOCAL_SERVER_PID_PATH.exists():
+    pid_path = _local_server_pid_path()
+    if not pid_path.exists():
         return None
     try:
-        lines = _LOCAL_SERVER_PID_PATH.read_text().strip().splitlines()
+        lines = pid_path.read_text().strip().splitlines()
         if len(lines) < 2:
             return None
         return int(lines[0]), int(lines[1])
@@ -245,19 +271,22 @@ def _write_local_server_record(
         any stale log-ref sidecar is then removed so status never reports a
         log file that doesn't apply to the running server.
     """
-    _LOCAL_SERVER_PID_PATH.parent.mkdir(parents=True, exist_ok=True)
+    pid_path = _local_server_pid_path()
+    sig_path = _local_server_sig_path()
+    log_ref_path = _local_server_log_ref_path()
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
     # Write each file atomically (temp + os.replace) so a concurrent
     # connect/run reader never observes a half-written record — a torn read
     # would parse as malformed and trigger a needless respawn. Sig first:
     # both replaces are individually atomic, so once the pidfile (what reuse
     # keys on) appears, its sig is already fully in place.
-    _atomic_write(_LOCAL_SERVER_SIG_PATH, f"{sig}\n")
+    _atomic_write(sig_path, f"{sig}\n")
     if log_path is not None:
-        _atomic_write(_LOCAL_SERVER_LOG_REF_PATH, f"{log_path}\n")
+        _atomic_write(log_ref_path, f"{log_path}\n")
     else:
         with contextlib.suppress(OSError):
-            _LOCAL_SERVER_LOG_REF_PATH.unlink()
-    _atomic_write(_LOCAL_SERVER_PID_PATH, f"{pid}\n{port}\n")
+            log_ref_path.unlink()
+    _atomic_write(pid_path, f"{pid}\n{port}\n")
 
 
 def _read_local_server_log_path() -> Path | None:
@@ -269,7 +298,7 @@ def _read_local_server_log_path() -> Path | None:
         record, or no server) or unreadable.
     """
     try:
-        text = _LOCAL_SERVER_LOG_REF_PATH.read_text().strip()
+        text = _local_server_log_ref_path().read_text().strip()
     except OSError:
         return None
     return Path(text) if text else None
@@ -310,7 +339,7 @@ def _read_local_server_sig() -> str | None:
         ``None`` if the sidecar is absent (legacy server) or unreadable.
     """
     try:
-        sig = _LOCAL_SERVER_SIG_PATH.read_text().strip()
+        sig = _local_server_sig_path().read_text().strip()
     except OSError:
         return None
     return sig or None
@@ -360,6 +389,48 @@ def _terminate_pid(pid: int) -> None:
         time.sleep(_STOP_POLL_INTERVAL_S)
 
 
+def _server_belongs_to_local_data_dir(pid: int) -> bool:
+    """Return whether *pid* can be proven to be this data dir's server.
+
+    A pidfile alone is not ownership evidence: it can belong to a live daemon
+    from another checkout or to a recycled PID. Refuse to signal whenever the
+    command line is unavailable, does not describe an Omnigent server, or its
+    artifact directory lies outside the currently resolved data directory.
+    """
+    try:
+        cmdline = list(psutil.Process(pid).cmdline())
+    except (psutil.Error, OSError):
+        return False
+    if not cmdline:
+        return False
+    executable = Path(cmdline[0]).name
+    if executable not in {"omnigent", "omni"} and "omnigent.cli" not in cmdline:
+        return False
+    try:
+        server_index = cmdline.index("server")
+    except ValueError:
+        return False
+    if server_index == 0:
+        return False
+    artifact: str | None = None
+    for index, arg in enumerate(cmdline):
+        if arg == "--artifact-location" and index + 1 < len(cmdline):
+            artifact = cmdline[index + 1]
+            break
+        if arg.startswith("--artifact-location="):
+            artifact = arg.split("=", 1)[1]
+            break
+    if artifact is None:
+        return False
+    try:
+        artifact_parent = Path(artifact).expanduser().resolve().parent
+        data_dir = _local_data_dir().resolve()
+        artifact_parent.relative_to(data_dir)
+    except (OSError, ValueError):
+        return False
+    return True
+
+
 def stop_local_omnigent_server() -> None:
     """Stop the daemon-owned background local server and clear its files.
 
@@ -381,13 +452,16 @@ def stop_local_omnigent_server() -> None:
     existing = _read_local_server_pid_file()
     if existing is not None:
         pid, _port = existing
+        if not _server_belongs_to_local_data_dir(pid):
+            _logger.warning("Refusing to stop unverified local server pid=%s", pid)
+            return
         _terminate_pid(pid)
     with contextlib.suppress(OSError):
-        _LOCAL_SERVER_PID_PATH.unlink()
+        _local_server_pid_path().unlink()
     with contextlib.suppress(OSError):
-        _LOCAL_SERVER_SIG_PATH.unlink()
+        _local_server_sig_path().unlink()
     with contextlib.suppress(OSError):
-        _LOCAL_SERVER_LOG_REF_PATH.unlink()
+        _local_server_log_ref_path().unlink()
 
 
 @dataclass(frozen=True)
@@ -804,25 +878,16 @@ def stop_untracked_local_server(port: int = _DEFAULT_LOCAL_PORT) -> int | None:
     The pidfile can be lost while the server process lives (a torn/cleared
     record, a respawn that landed on a different port, a crash). Such a
     server then escapes :func:`stop_local_omnigent_server`, which only knows the
-    pidfile PID — so ``omnigent stop`` / ``server stop`` would leave it
-    running. This sweep covers that hole: if a live Omnigent server answers
-    ``/health`` on the canonical loopback *port*, find its PID and terminate
-    it. Call it AFTER :func:`stop_local_omnigent_server` so a normally-tracked
-    server is already gone and ``/health`` no longer answers (this is a
-    no-op). Best-effort: returns ``None`` when nothing untracked is found or
-    ``lsof`` is unavailable.
+    pidfile PID. It is deliberately left running: a listener and health
+    response prove neither process ownership nor PID lineage, so terminating
+    it could kill a user's foreground server. Best-effort: this always returns
+    ``None`` until a future record format supplies verifiable ownership.
 
     :param port: Canonical loopback port to sweep, e.g. ``6767``.
     :returns: The PID stopped, or ``None`` if there was nothing to stop.
     """
-    base_url = f"http://127.0.0.1:{port}"
-    if not _local_server_health_ok(base_url):
-        return None
-    pid = _pid_listening_on_port(port)
-    if pid is None or not _pid_alive(pid):
-        return None
-    _terminate_pid(pid)
-    return pid
+    del port
+    return None
 
 
 def register_local_server(port: int) -> None:
@@ -857,11 +922,11 @@ def clear_local_server_record() -> None:
     existing = _read_local_server_pid_file()
     if existing is not None and existing[0] == os.getpid():
         with contextlib.suppress(OSError):
-            _LOCAL_SERVER_PID_PATH.unlink()
+            _local_server_pid_path().unlink()
         with contextlib.suppress(OSError):
-            _LOCAL_SERVER_SIG_PATH.unlink()
+            _local_server_sig_path().unlink()
         with contextlib.suppress(OSError):
-            _LOCAL_SERVER_LOG_REF_PATH.unlink()
+            _local_server_log_ref_path().unlink()
 
 
 def _wait_for_local_omnigent_server(
@@ -950,9 +1015,9 @@ def _raise_local_server_failed(base_url: str, log_path: Path) -> None:
     # A failed spawn leaves a misleading pidfile; clear it (and the sig
     # sidecar) so the next invocation does not try to reuse a dead entry.
     with contextlib.suppress(OSError):
-        _LOCAL_SERVER_PID_PATH.unlink()
+        _local_server_pid_path().unlink()
     with contextlib.suppress(OSError):
-        _LOCAL_SERVER_SIG_PATH.unlink()
+        _local_server_sig_path().unlink()
     raise click.ClickException(
         f"Background local server failed to start ({base_url}).\n"
         f"  Server log: {log_path}\n"

--- a/tests/cli/test_server_lifecycle.py
+++ b/tests/cli/test_server_lifecycle.py
@@ -11,6 +11,7 @@ import pytest
 from click import ClickException
 from click.testing import CliRunner
 
+import omnigent.cli as cli_module
 from omnigent.cli import _HostDaemonRecord, _SessionPagesResult, cli
 from omnigent.host.local_server import LocalServerInfo, LocalServerStartup
 
@@ -33,6 +34,18 @@ def _record(
         log_path=None,
         started_at=0,
     )
+
+
+def test_host_daemon_paths_honor_data_dir_set_after_import(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Daemon registry writes stay inside pytest's late-bound data directory."""
+    isolated = tmp_path / "isolated"
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(isolated))
+
+    assert cli_module._host_pid_path() == isolated / "host.pid"
+    assert cli_module._daemon_registry_dir() == isolated / "daemons"
 
 
 # ── server status ──────────────────────────────────────────────────

--- a/tests/host/test_local_server.py
+++ b/tests/host/test_local_server.py
@@ -133,6 +133,7 @@ def test_ensure_local_omnigent_server_reuses_without_spawning(
     monkeypatch.setattr(
         local_server, "_LOCAL_SERVER_LOG_REF_PATH", tmp_path / "local_server.logpath"
     )
+    monkeypatch.setattr(local_server, "_server_belongs_to_local_data_dir", lambda pid: True)
 
     def _must_not_popen(*_args: object, **_kwargs: object) -> Any:
         raise AssertionError("spawned a new server despite a healthy one existing")
@@ -166,6 +167,7 @@ def test_ensure_local_omnigent_server_respawns_on_config_drift(
     monkeypatch.setattr(
         local_server, "_LOCAL_SERVER_LOG_REF_PATH", tmp_path / "local_server.logpath"
     )
+    monkeypatch.setattr(local_server, "_server_belongs_to_local_data_dir", lambda pid: True)
     monkeypatch.setattr(local_server, "_LOCAL_SERVER_PID_PATH", tmp_path / "local_server.pid")
     monkeypatch.setattr(local_server, "pick_local_port", lambda preferred=8000: 8766)
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
@@ -346,6 +348,7 @@ def test_stop_local_omnigent_server_waits_for_process_exit(
     until the process exits. This test verifies the poll loop runs and
     that both the pidfile and sig sidecar are cleaned up.
     """
+    monkeypatch.setattr(local_server, "_server_belongs_to_local_data_dir", lambda pid: True)
     pid_file = tmp_path / "local_server.pid"
     sig_file = tmp_path / "local_server.sig"
     pid_file.write_text("7777\n8000\n")
@@ -407,6 +410,7 @@ def test_stop_local_omnigent_server_escalates_to_sigkill(
     the port stays bound indefinitely. The test stubs ``time.monotonic``
     to simulate the grace period expiring, then verifies SIGKILL is sent.
     """
+    monkeypatch.setattr(local_server, "_server_belongs_to_local_data_dir", lambda pid: True)
     pid_file = tmp_path / "local_server.pid"
     sig_file = tmp_path / "local_server.sig"
     pid_file.write_text("8888\n8000\n")
@@ -482,6 +486,19 @@ def test_local_data_dir_honors_data_dir_not_config_home(
     # DATA_DIR is the data-isolation knob.
     monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
     assert local_server._local_data_dir() == tmp_path / "data"
+
+
+def test_local_server_paths_honor_data_dir_set_after_import(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Late test isolation must not read the user's import-time pidfile."""
+    isolated = tmp_path / "isolated"
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(isolated))
+
+    assert local_server._local_server_pid_path() == isolated / "local_server.pid"
+    assert local_server._local_server_sig_path() == isolated / "local_server.sig"
+    assert local_server._local_server_log_ref_path() == isolated / "local_server.logpath"
 
 
 def test_pick_local_port_returns_preferred_when_free() -> None:
@@ -795,32 +812,18 @@ def _fake_subprocess(stdout: str | None = None, raises: BaseException | None = N
     return _Sub
 
 
-def test_stop_untracked_local_server_kills_orphan_on_default_port(
+def test_stop_untracked_local_server_refuses_unowned_listener(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A live Omnigent server on :8000 with no pidfile entry is found and stopped.
+    """A listener without ownership evidence is never terminated."""
 
-    This is the reported bug: the pidfile was lost while the server lived, so
-    ``stop_local_omnigent_server`` (pidfile-scoped) couldn't see it. The sweep must
-    confirm it's our server via ``/health``, resolve its PID via lsof, and
-    terminate it — returning the PID so the off-switch can report it.
-    """
-
-    def _healthy(url: str, *, timeout: float, trust_env: bool) -> _FakeHealthResp:
-        assert trust_env is False
-        return _FakeHealthResp(200, {"status": "ok"})
-
-    monkeypatch.setattr("httpx.get", _healthy)
-    monkeypatch.setattr(local_server, "subprocess", _fake_subprocess(stdout="93359\n93360\n"))
-    monkeypatch.setattr(local_server, "_pid_alive", lambda pid: True)
     terminated: list[int] = []
     monkeypatch.setattr(local_server, "_terminate_pid", terminated.append)
 
     result = local_server.stop_untracked_local_server(port=8000)
 
-    # The first lsof PID is the listener; it must actually be terminated.
-    assert result == 93359
-    assert terminated == [93359]
+    assert result is None
+    assert terminated == []
 
 
 def test_stop_untracked_local_server_noop_when_nothing_listening(
@@ -1280,3 +1283,33 @@ def test_wait_fails_fast_without_stopping_a_child_that_already_died(
         )
 
     assert proc.terminated is False
+
+
+def test_stop_local_server_refuses_pid_from_another_data_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A test-local pidfile must never signal a server owned by another dir."""
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "isolated"))
+    pid_file = tmp_path / "isolated" / "local_server.pid"
+    pid_file.parent.mkdir()
+    pid_file.write_text("4242\n8123\n")
+    monkeypatch.setattr(local_server, "_pid_alive", lambda pid: pid == 4242)
+
+    class _Process:
+        def cmdline(self) -> list[str]:
+            return [
+                "omnigent",
+                "server",
+                "--artifact-location",
+                str(tmp_path / "live" / "artifacts"),
+            ]
+
+    monkeypatch.setattr(local_server.psutil, "Process", lambda pid: _Process())
+    terminated: list[int] = []
+    monkeypatch.setattr(local_server, "_terminate_pid", terminated.append)
+
+    local_server.stop_local_omnigent_server()
+
+    assert terminated == []
+    assert pid_file.exists()


### PR DESCRIPTION
## Related issue

Partial fix for #4757.

## Summary

- Resolve local-server pid, signature, log-reference, host pid, and daemon-registry paths at use time so `OMNIGENT_DATA_DIR` set by pytest after module import isolates test state from a developer's live `~/.omnigent` daemon.
- Preserve existing monkeypatch seams for lifecycle tests while removing the production import-time path snapshots.
- Make `stop_untracked_local_server()` fail closed: a listener on the canonical port is not terminated without ownership evidence.

**ELI5:** Tests now use their own daemon files instead of accidentally reading the files that belong to your real local server. And a server-stop command no longer kills an untracked process just because it happens to answer on the usual port.

```mermaid
flowchart LR
    A[pytest sets OMNIGENT_DATA_DIR] --> B[late-bound daemon paths]
    B --> C[test-only pidfile and registry]
    D[untracked listener] --> E{Ownership evidence?}
    E -->|No| F[Leave process alone]
```

## Test Plan

- `/Users/corey.zumar/omnigent-worktrees/omni-3218/.venv/bin/pytest tests/host/test_local_server.py tests/cli/test_server_lifecycle.py -q` — 55 passed.
- New late-binding regression tests fail unchanged on `main` and pass on this branch.
- `ruff check omnigent/host/local_server.py tests/host/test_local_server.py tests/cli/test_server_lifecycle.py` — passed.

## Demo

N/A — non-visual lifecycle safety change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This draft covers late-bound test data isolation and the untracked-listener kill path. It intentionally remains draft while tracked pidfile shutdown gains record-lineage verification, so the full ownership guarantee requested by #4757 is reviewed before merge.

## Changelog

Tests no longer share local daemon state with your active Omnigent server.
