### PR TITLE
fix(tests): isolate Omnigent runtime data

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import os
+import shutil
 import sys
+import tempfile
 import time
 from collections.abc import Generator
 from pathlib import Path
@@ -14,6 +16,11 @@ try:
     import resource as _resource  # POSIX-only; absent on Windows.
 except ImportError:
     _resource = None  # type: ignore[assignment]
+
+# Establish test data isolation before importing any Omnigent modules. This
+# deliberately replaces ambient state; subprocesses inherit the safe override.
+_TEST_OMNIGENT_DATA_DIR = Path(tempfile.mkdtemp(prefix="omnigent-pytest-")).resolve()
+os.environ["OMNIGENT_DATA_DIR"] = str(_TEST_OMNIGENT_DATA_DIR)
 
 # Skip the synchronous api.litellm.ai/model_catalog HTTP fallback during
 # tests. Hardened CI runners can't reach the public internet, so every
@@ -54,9 +61,9 @@ os.environ.setdefault("OMNIGENT_AUTH_PROVIDER", "header")
 # monkeypatch.delenv-ing this var.
 os.environ.setdefault("OMNIGENT_LOCAL_SINGLE_USER", "1")
 
-from omnigent.db.utils import _engine_cache, _engine_lock, get_or_create_engine
-from omnigent.runtime.filesystem_registry import GitFilesystemRegistry
-from tests import _model_pools
+from omnigent.db.utils import _engine_cache, _engine_lock, get_or_create_engine  # noqa: E402
+from omnigent.runtime.filesystem_registry import GitFilesystemRegistry  # noqa: E402
+from tests import _model_pools  # noqa: E402
 
 pytest_plugins = ["tests._token_usage"]
 
@@ -122,6 +129,7 @@ def _run_test_environment_guardrails(config: pytest.Config) -> None:
 
 def pytest_unconfigure(config: pytest.Config) -> None:
     """Clean up per-session resources."""
+    shutil.rmtree(_TEST_OMNIGENT_DATA_DIR, ignore_errors=True)
 
 
 # Per-worker progress logger: fsync'd START/END lines so a

--- a/tests/e2e/omnigent/test_host_ctrl_c_stop_server.py
+++ b/tests/e2e/omnigent/test_host_ctrl_c_stop_server.py
@@ -80,6 +80,9 @@ def _connect_env(base_env: Mapping[str, str], home: Path) -> dict[str, str]:
     :returns: Environment dict for ``pexpect.spawn``.
     """
     env = dict(base_env)
+    # The suite-level pytest data directory would otherwise override this
+    # test's deliberately isolated HOME in the spawned CLI process.
+    env.pop("OMNIGENT_DATA_DIR", None)
     env["HOME"] = str(home)
     env["TERM"] = "xterm-256color"
     env["LINES"] = "40"

--- a/tests/e2e/omnigent/test_repl_session_lifecycle.py
+++ b/tests/e2e/omnigent/test_repl_session_lifecycle.py
@@ -178,6 +178,8 @@ def _repl_env(
     :returns: Environment dict for ``pexpect.spawn``.
     """
     env = dict(base_env)
+    # This process uses its per-test HOME for daemon state and logs.
+    env.pop("OMNIGENT_DATA_DIR", None)
     env["HOME"] = str(home)
     env["TERM"] = "xterm-256color"
     env["LINES"] = "40"

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -953,6 +953,7 @@ async def test_handle_launch_prints_exact_runner_log_path(
     tmp (no write to the developer's real ``~/.omnigent``).
     """
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / ".omnigent"))
     host = _make_host_process()
     workspace = tmp_path / "project"
     workspace.mkdir()
@@ -1222,6 +1223,7 @@ async def test_handle_launch_immediate_exit_reports_exit_code_and_log_tail(
     can surface the cause to the user verbatim.
     """
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / ".omnigent"))
     host = _make_host_process()
     workspace = tmp_path / "project"
     workspace.mkdir()
@@ -4063,6 +4065,7 @@ def test_run_host_process_announces_session_log_dir_on_start(
     advertised dir resolves under tmp.
     """
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / ".omnigent"))
     # A single CancelledError ends the connect loop cleanly (no fatal exit),
     # so run_host_process returns after printing the startup banner.
     _patch_connect(monkeypatch, _ConnectSpy([asyncio.CancelledError()]))

--- a/tests/host/test_local_server.py
+++ b/tests/host/test_local_server.py
@@ -650,7 +650,7 @@ def test_ensure_local_omnigent_server_spawn_records_and_returns_log_path(
     monkeypatch.setattr(local_server, "_LOCAL_SERVER_SIG_PATH", sig_file)
     monkeypatch.setattr(local_server, "_LOCAL_SERVER_LOG_REF_PATH", log_ref)
     # Point the persistent data dir at tmp so logs/server lands under tmp.
-    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / ".omnigent"))
 
     class _Proc:
         pid = 9001

--- a/tests/server/test_accounts.py
+++ b/tests/server/test_accounts.py
@@ -969,6 +969,7 @@ def _build_accounts_app(
         admin is created and ``/v1/info`` reports ``needs_setup``.
     """
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / ".omnigent"))
     # Accounts is the default provider now, but pin it explicitly
     # so this fixture doesn't depend on the global default.
     monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", "accounts")

--- a/tests/test_data_dir_isolation.py
+++ b/tests/test_data_dir_isolation.py
@@ -1,0 +1,20 @@
+"""Regression coverage for pytest runtime-data isolation."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from omnigent import cli
+from omnigent.host import local_server
+
+
+def test_pytest_uses_an_isolated_omnigent_data_dir() -> None:
+    """Daemon state used by tests must never resolve under the real home."""
+    test_data_dir = Path(os.environ["OMNIGENT_DATA_DIR"]).resolve()
+    real_data_dir = (Path.home() / ".omnigent").resolve()
+
+    assert test_data_dir != real_data_dir
+    assert local_server._LOCAL_SERVER_PID_PATH.resolve().is_relative_to(test_data_dir)
+    assert cli._HOST_PID_PATH.resolve().is_relative_to(test_data_dir)
+    assert cli._daemon_registry_dir().resolve().is_relative_to(test_data_dir)


### PR DESCRIPTION
## Related issue

Closes #4757

## Summary

- Create a unique temporary `OMNIGENT_DATA_DIR` before any Omnigent modules are imported by pytest.
- Let test subprocesses inherit the isolated runtime-data directory, keeping pidfiles and daemon records away from the developer's live `~/.omnigent` state.
- Add regression coverage for local-server, host-pid, and daemon-registry paths.

**ELI5:** Omnigent tests now get their own temporary `.omnigent` directory, so they cannot find or stop the server used by the developer running the tests.

```mermaid
flowchart LR
    A[pytest starts] --> B[create temporary data dir]
    B --> C[set OMNIGENT_DATA_DIR]
    C --> D[import Omnigent modules]
    D --> E[test-only pidfiles and daemon records]
```

## Test Plan

- `.venv/bin/pytest tests/test_data_dir_isolation.py tests/host/test_local_server.py tests/cli/test_server_lifecycle.py -q` — 54 passed.
- `uvx pre-commit run --files tests/conftest.py tests/test_data_dir_isolation.py tests/host/test_local_server.py` — passed.

## Demo

N/A — non-visual test isolation change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression test verifies that every daemon-state path bound during test import is contained by the temporary pytest data directory rather than the user's real home directory.
