### PR TITLE
feat(onboarding): recognize Kimi API key auth in readiness checks

### DIFF
--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -3875,19 +3875,29 @@ def _run_configure_harnesses_interactive() -> None:
                 (_KIRO, "Kiro", _cli_absence_label(KIRO_KEY), "missing", _install_hint(kiro_hint))
             )
 
-        # Kimi Code — native CLI, own auth via `kimi login`. There is no CLI
-        # login-status probe, but `kimi login` writes a credential file, so a
-        # subprocess-free file check (`kimi_login_detected`) distinguishes
-        # "signed in" (green) from "installed but not configured" (yellow).
-        # Curl-installed (no npm package), so use its install_hint when absent.
+        # Kimi Code — native CLI, own auth via `kimi login` or a Moonshot API
+        # key in `~/.kimi-code/config.toml`. There is no CLI login-status probe,
+        # so a subprocess-free check (`kimi_auth_configured`) distinguishes
+        # "signed in / API key set" (green) from "installed but not configured"
+        # (yellow). Curl-installed (no npm package), so use its install_hint when
+        # absent.
         if harness_cli_installed(KIMI_KEY):
-            from omnigent.onboarding.kimi_auth import kimi_login_detected
+            from omnigent.onboarding.kimi_auth import kimi_auth_configured
 
-            if kimi_login_detected():
+            if kimi_auth_configured():
                 rows.append((_KIMI, "Kimi Code", "Signed in", "ready", ""))
             else:
                 rows.append(
-                    (_KIMI, "Kimi Code", "Not configured", "warn", "Sign in with `kimi login`.")
+                    (
+                        _KIMI,
+                        "Kimi Code",
+                        "Not configured",
+                        "warn",
+                        (
+                            "Sign in with `kimi login` or set a Kimi API key in"
+                            " `~/.kimi-code/config.toml`."
+                        ),
+                    )
                 )
         else:
             kimi_spec = harness_install_spec(KIMI_KEY)

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -245,12 +245,13 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         min_version=_CURSOR_MIN_VERSION,
     ),
     # Kimi Code CLI ships a single-binary ``kimi`` via a curl installer (no
-    # npm). ``kimi login`` is the interactive provider login (OAuth or a
-    # Moonshot API key). ``status_args`` is intentionally ``None``: kimi has
-    # no first-class "am I logged in?" exit-code probe — login state is
-    # inspected file-based via ``kimi_auth.kimi_login_detected`` instead. With
-    # ``None`` the login path runs every time the operator asks for it
-    # (interactive, so they can cancel if already authenticated).
+    # npm). ``kimi login`` is the interactive provider login (OAuth), and API
+    # platform users can set a Kimi API key in ``~/.kimi-code/config.toml``.
+    # ``status_args`` is intentionally ``None``: kimi has no first-class "am I
+    # logged in?" exit-code probe — readiness is inspected file-based via
+    # ``kimi_auth.kimi_auth_configured`` instead. With ``None`` the login path
+    # runs every time the operator asks for it (interactive, so they can cancel
+    # if already authenticated).
     # ``logout_args`` is ``None`` because kimi has no ``kimi logout`` subcommand
     # (verified against kimi CLI v0.29.1 — ``kimi logout`` errors "unknown
     # command"), so ``harness_logout`` is a no-op for it (same as Qwen / agy).

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -87,12 +87,12 @@ _SDK_HARNESSES: frozenset[str] = frozenset(
 # login-status probe). The ``anthropic`` / ``openai`` families authenticate via
 # subscription provider config and do not appear here. Each lambda resolves
 # through its module at call time so a test can monkeypatch
-# ``…gemini_auth.gemini_login_detected`` / ``…kimi_auth.kimi_login_detected``
+# ``…gemini_auth.gemini_login_detected`` / ``…kimi_auth.kimi_auth_configured``
 # and have the patch take effect without this dict caching the old function
 # object.
 _FAMILY_CREDENTIAL_CHECK: dict[str, Callable[[], bool]] = {
     GEMINI_FAMILY: lambda: _gemini_auth.gemini_login_detected(),
-    KIMI_KEY: lambda: _kimi_auth.kimi_login_detected(),
+    KIMI_KEY: lambda: _kimi_auth.kimi_auth_configured(),
 }
 
 # CLI-wrapping pi harnesses. Both the bare ``pi`` surface and the native

--- a/omnigent/onboarding/kimi_auth.py
+++ b/omnigent/onboarding/kimi_auth.py
@@ -1,19 +1,21 @@
 """Detect a Kimi Code (``kimi``) login for the ``kimi`` harness.
 
 The ``kimi`` CLI authenticates against Moonshot AI's backend via ``kimi login``
-(an interactive OAuth flow or a Moonshot API key). It has **no** ``kimi logout``
-subcommand and no first-class "am I logged in?" exit-code probe, so login state
-can only be inspected from the credential file the login flow writes (verified
-live against kimi CLI v0.29.1):
+(an interactive OAuth flow) or by using a Moonshot API key configured in
+``$KIMI_CODE_HOME/config.toml``. It has **no** ``kimi logout`` subcommand and no
+first-class "am I logged in?" exit-code probe, so login state is inspected from
+local configuration instead (verified live against kimi CLI v0.29.1):
 
-- ``kimi login`` writes ``~/.kimi-code/credentials/kimi-code.json`` — the file is
-  present exactly when a login has completed and absent (or empty) otherwise.
+- ``kimi login`` writes ``$KIMI_CODE_HOME/credentials/kimi-code.json`` — the file
+  is present exactly when an interactive login has completed.
+- API-platform users can configure a Kimi provider with an ``api_key`` or set
+  ``KIMI_API_KEY`` in the provider's ``env`` table. When such a provider exists,
+  ``kimi`` can authenticate without an interactive login.
 
-Detection is file-based and subprocess-free: a non-empty credential file counts
-as a completed login. Like
+Detection is file-based and subprocess-free. Like
 :func:`omnigent.onboarding.gemini_auth.gemini_login_detected`, it cannot detect
-server-side revocation — its only job is to reject the "no-credential /
-file-empty" case so the readiness layer can distinguish a signed-in kimi from an
+server-side revocation — its only job is to reject the "no usable credential"
+case so the readiness layer can distinguish a configured kimi from an
 installed-but-unconfigured one without spawning a subprocess.
 """
 
@@ -22,16 +24,82 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import tomllib
+
+from omnigent.kimi_native_credentials import resolve_user_kimi_home
+
 # Where ``kimi login`` writes its credential after a completed sign-in
-# (verified against kimi CLI v0.29.1). Present and non-empty exactly when the
-# user is logged in.
+# (verified against kimi CLI v0.29.1). Present and non-empty exactly when an
+# interactive login has completed.
 KIMI_CREDENTIALS_PATH: Path = (
     Path(os.path.expanduser("~")) / ".kimi-code" / "credentials" / "kimi-code.json"
 )
 
+# Kimi provider type as written in Kimi Code's config.toml.
+_KIMI_PROVIDER_TYPE = "kimi"
+# Conventional env var name for a Kimi API key inside [providers.<name>.env].
+_KIMI_API_KEY_ENV_VAR = "KIMI_API_KEY"
+
+
+def _kimi_config_path() -> Path:
+    """Return the path to the user's Kimi Code ``config.toml``.
+
+    Mirrors ``resolve_user_kimi_home()`` (``$KIMI_CODE_HOME`` when set, else
+    ``~/.kimi-code``) and appends ``config.toml``.
+    """
+    return resolve_user_kimi_home() / "config.toml"
+
+
+def _has_kimi_api_key(config: dict[str, object]) -> bool:
+    """Return whether *config* contains a usable Kimi API key provider.
+
+    A usable provider has ``type = "kimi"`` and either a non-empty ``api_key``
+    field or a non-empty ``KIMI_API_KEY`` entry in its ``env`` sub-table.
+    """
+    providers = config.get("providers")
+    if not isinstance(providers, dict):
+        return False
+    for provider in providers.values():
+        if not isinstance(provider, dict):
+            continue
+        if provider.get("type") != _KIMI_PROVIDER_TYPE:
+            continue
+        api_key = provider.get("api_key")
+        if isinstance(api_key, str) and api_key.strip():
+            return True
+        env = provider.get("env")
+        if isinstance(env, dict):
+            env_key = env.get(_KIMI_API_KEY_ENV_VAR)
+            if isinstance(env_key, str) and env_key.strip():
+                return True
+    return False
+
+
+def kimi_api_key_configured(config_path: Path | None = None) -> bool:
+    """Return whether a Kimi API key is configured in ``config.toml``.
+
+    Reads the user's Kimi Code config (respecting ``$KIMI_CODE_HOME``) and
+    checks for at least one provider of type ``kimi`` with a non-empty
+    ``api_key`` or ``env.KIMI_API_KEY``.
+
+    :param config_path: A specific config file to check; ``None`` uses
+        ``$KIMI_CODE_HOME/config.toml``.
+    :returns: ``True`` when a Kimi API key provider is configured;
+        ``False`` when the file is missing, malformed, or has no usable key.
+    """
+    path = config_path if config_path is not None else _kimi_config_path()
+    try:
+        with path.open("rb") as f:
+            config = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        # Missing, unreadable, or broken TOML is treated as "no API key" rather
+        # than crashing the readiness refresh.
+        return False
+    return _has_kimi_api_key(config)
+
 
 def kimi_login_detected(creds_path: Path | None = None) -> bool:
-    """Return whether ``kimi`` has a completed login on this machine.
+    """Return whether ``kimi`` has a completed interactive login on this machine.
 
     Subprocess-free file check: ``kimi login`` writes its credential to
     :data:`KIMI_CREDENTIALS_PATH`, so a present, non-empty file is treated as a
@@ -51,3 +119,24 @@ def kimi_login_detected(creds_path: Path | None = None) -> bool:
         # A stat/permission error on the credential path is treated as "no
         # usable credential" rather than crashing the readiness refresh.
         return False
+
+
+def kimi_auth_configured(
+    *,
+    creds_path: Path | None = None,
+    config_path: Path | None = None,
+) -> bool:
+    """Return whether ``kimi`` has any usable credential on this machine.
+
+    Combines the interactive-login credential check with the API-key config
+    check. Either a non-empty ``kimi-code.json`` from ``kimi login`` or a
+    configured Kimi API key provider counts as configured.
+
+    :param creds_path: A specific credential file to check; ``None`` uses
+        :data:`KIMI_CREDENTIALS_PATH`.
+    :param config_path: A specific config file to check; ``None`` uses
+        ``$KIMI_CODE_HOME/config.toml``.
+    :returns: ``True`` when an interactive-login credential exists or a Kimi
+        API key is configured; ``False`` when neither is present.
+    """
+    return kimi_login_detected(creds_path) or kimi_api_key_configured(config_path)

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -2173,16 +2173,17 @@ def test_installed_native_cli_auth_unknown_rows_are_not_configured(
     (Hermes, like Goose, *does* have a config probe now — its ``model`` is read
     from ``~/.hermes/config.yaml`` — so its ready/unconfigured split is covered
     by ``test_overview_hermes_row_reflects_configured_model`` instead. Kimi now
-    has a file-based login probe too, so its signed-in split is covered by
+    has a file-based login probe plus an API-key config probe, so its
+    signed-in split is covered by
     ``test_overview_kimi_row_reflects_detected_login`` — here we pin the
-    not-signed-in case, so ``kimi_login_detected`` is forced ``False``.)
+    not-configured case, so ``kimi_auth_configured`` is forced ``False``.)
     """
     monkeypatch.setattr(
         "omnigent.onboarding.harness_install.harness_cli_installed", lambda family: True
     )
-    # Kimi's row now consults a file-based login probe; force "no login" so the
-    # not-configured assertion is deterministic regardless of the dev machine.
-    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_login_detected", lambda: False)
+    # Kimi's row now consults a combined auth probe; force "not configured" so
+    # the assertion is deterministic regardless of the dev machine.
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_auth_configured", lambda: False)
     options, selectable, descriptions, _compact, _max_visible = _capture_setup_overview(
         monkeypatch
     )
@@ -2193,17 +2194,17 @@ def test_installed_native_cli_auth_unknown_rows_are_not_configured(
 
 
 def test_overview_kimi_row_reflects_detected_login(isolated_config, monkeypatch) -> None:
-    """An installed kimi with a detected ``kimi login`` renders green "Signed in".
+    """An installed kimi with detected auth renders green "Signed in".
 
     Bug fix: the kimi row was hardcoded to yellow "Not configured" whenever the
     CLI was installed, so a successful ``kimi login`` never showed. It now
-    consults the subprocess-free file probe ``kimi_login_detected`` and renders
-    a green ready row when a credential is present.
+    consults the combined auth probe ``kimi_auth_configured`` and renders a
+    green ready row when a credential or API key is present.
     """
     monkeypatch.setattr(
         "omnigent.onboarding.harness_install.harness_cli_installed", lambda family: True
     )
-    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_login_detected", lambda: True)
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_auth_configured", lambda: True)
     options, selectable, descriptions, _compact, _max_visible = _capture_setup_overview(
         monkeypatch
     )
@@ -2238,9 +2239,9 @@ def test_overview_descriptions_map_to_their_rows(isolated_config, monkeypatch) -
         lambda family: family != GEMINI_FAMILY,
     )
     monkeypatch.setattr("omnigent.onboarding.copilot_auth.copilot_sdk_installed", lambda: True)
-    # Kimi's row consults a file-based login probe; force "no login" so the
-    # "Sign in with `kimi login`" hint is asserted deterministically.
-    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_login_detected", lambda: False)
+    # Kimi's row consults a combined auth probe; force "not configured" so the
+    # hint is asserted deterministically.
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_auth_configured", lambda: False)
     monkeypatch.setattr(
         "omnigent.onboarding.opencode_auth.opencode_auth_summary",
         lambda: OpenCodeAuthSummary(installed=True, stored_providers=(), env_providers=()),
@@ -2275,7 +2276,10 @@ def test_overview_descriptions_map_to_their_rows(isolated_config, monkeypatch) -
     assert desc_by_name["Goose"] == "Open to run `goose configure`."
     assert desc_by_name["Copilot"] == "Open to add the GitHub token."
     assert desc_by_name["Kiro"] == "Sign in with `kiro-cli login`."
-    assert desc_by_name["Kimi Code"] == "Sign in with `kimi login`."
+    assert (
+        desc_by_name["Kimi Code"]
+        == "Sign in with `kimi login` or set a Kimi API key in `~/.kimi-code/config.toml`."
+    )
     assert desc_by_name["Quit"] == ""
 
 

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -462,8 +462,9 @@ def test_configured_harness_map_all_true_with_clis(
     cursor (key-gated) is satisfied by a ``CURSOR_API_KEY``, copilot
     (token-gated) by a ``GH_TOKEN``, antigravity-native (binary + credential
     gated) by a detected Gemini OAuth credential, kimi (binary + credential
-    gated) by a detected ``kimi login`` credential, and the generic ACP harness
-    (config-gated) by a registered agent — so nothing is reported unconfigured.
+    gated) by a detected ``kimi login`` credential or a Kimi API key in
+    ``~/.kimi-code/config.toml``, and the generic ACP harness (config-gated) by
+    a registered agent — so nothing is reported unconfigured.
     """
     import omnigent.onboarding.gemini_auth as _ga
     import omnigent.onboarding.kimi_auth as _ka
@@ -477,7 +478,7 @@ def test_configured_harness_map_all_true_with_clis(
     # antigravity-native also needs a credential (not just the ``agy`` binary).
     monkeypatch.setattr(_ga, "gemini_login_detected", lambda: True)
     # kimi also needs a credential (not just the ``kimi`` binary).
-    monkeypatch.setattr(_ka, "kimi_login_detected", lambda: True)
+    monkeypatch.setattr(_ka, "kimi_auth_configured", lambda: True)
     monkeypatch.setenv("GH_TOKEN", "gho_ready")
     # claude / pi are auth-aware on the credential axis now: satisfy the provider
     # check deterministically (don't depend on the dev machine's real config).
@@ -518,30 +519,30 @@ def test_configured_harness_map_probes_codex_readiness_once(
 def test_kimi_readiness_keys_off_binary_and_credential(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Kimi is configured iff the ``kimi`` binary is on PATH AND a login exists.
+    """Kimi is configured iff the ``kimi`` binary is on PATH AND auth exists.
 
-    Kimi authenticates against Moonshot AI's backend via ``kimi login`` (OAuth
-    or a Moonshot API key), which writes a credential file. Like agy, the
-    daemon has no CLI login-status probe, so readiness is binary presence PLUS
-    a subprocess-free credential check (``kimi_login_detected``). The alias
+    Kimi authenticates against Moonshot AI's backend via ``kimi login`` (OAuth)
+    or a Moonshot API key in ``~/.kimi-code/config.toml``. Like agy, the daemon
+    has no CLI login-status probe, so readiness is binary presence PLUS a
+    subprocess-free credential check (``kimi_auth_configured``). The alias
     ``kimi-code`` resolves to the same verdict via canonicalization.
     """
     import omnigent.onboarding.kimi_auth as _ka
 
     # No binary → not configured regardless of credential.
     _no_clis_installed(monkeypatch)
-    monkeypatch.setattr(_ka, "kimi_login_detected", lambda: True)
+    monkeypatch.setattr(_ka, "kimi_auth_configured", lambda: True)
     assert harness_is_configured("kimi") is False
     assert harness_is_configured("kimi-code") is False
 
-    # Binary present but no login → still not configured.
+    # Binary present but no auth → still not configured.
     _all_clis_installed(monkeypatch)
-    monkeypatch.setattr(_ka, "kimi_login_detected", lambda: False)
+    monkeypatch.setattr(_ka, "kimi_auth_configured", lambda: False)
     assert harness_is_configured("kimi") is False
     assert harness_is_configured("kimi-code") is False
 
-    # Binary present and login detected → configured.
-    monkeypatch.setattr(_ka, "kimi_login_detected", lambda: True)
+    # Binary present and auth detected → configured.
+    monkeypatch.setattr(_ka, "kimi_auth_configured", lambda: True)
     assert harness_is_configured("kimi") is True
     assert harness_is_configured("kimi-code") is True
 

--- a/tests/onboarding/test_kimi_auth.py
+++ b/tests/onboarding/test_kimi_auth.py
@@ -2,7 +2,9 @@
 
 ``kimi login`` writes ``~/.kimi-code/credentials/kimi-code.json`` (verified
 against kimi CLI v0.29.1). Detection is a subprocess-free file check: a present,
-non-empty file is a completed login; a missing or empty file is not.
+non-empty file is a completed login; a missing or empty file is not. API key
+users can also authenticate by configuring a Kimi provider with ``api_key`` or
+``env.KIMI_API_KEY`` in ``~/.kimi-code/config.toml``.
 """
 
 from __future__ import annotations
@@ -52,3 +54,105 @@ def test_default_path_uses_home_credentials(monkeypatch, tmp_path: Path) -> None
 
     fake_creds.unlink()
     assert ka.kimi_login_detected() is False
+
+
+def _write_config(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_api_key_in_provider_detected(tmp_path: Path) -> None:
+    """A Kimi provider with a non-empty ``api_key`` counts as configured."""
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.moonshot-ai]\ntype = "kimi"\napi_key = "sk-abc123"\n',
+    )
+    assert ka.kimi_api_key_configured(config) is True
+
+
+def test_api_key_in_provider_env_detected(tmp_path: Path) -> None:
+    """A Kimi provider with ``env.KIMI_API_KEY`` counts as configured."""
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        """\
+[providers.moonshot-ai]
+type = "kimi"
+
+[providers.moonshot-ai.env]
+KIMI_API_KEY = "sk-abc123"
+""",
+    )
+    assert ka.kimi_api_key_configured(config) is True
+
+
+def test_non_kimi_provider_ignored(tmp_path: Path) -> None:
+    """Providers whose ``type`` is not ``kimi`` do not count as configured."""
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.openai]\ntype = "openai"\napi_key = "sk-abc123"\n',
+    )
+    assert ka.kimi_api_key_configured(config) is False
+
+
+def test_empty_api_key_not_detected(tmp_path: Path) -> None:
+    """An empty or whitespace-only ``api_key`` does not count as configured."""
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.moonshot-ai]\ntype = "kimi"\napi_key = "   "\n',
+    )
+    assert ka.kimi_api_key_configured(config) is False
+
+
+def test_missing_config_not_detected(tmp_path: Path) -> None:
+    """A missing config file means no API key is configured."""
+    assert ka.kimi_api_key_configured(tmp_path / "config.toml") is False
+
+
+def test_malformed_config_not_detected(tmp_path: Path) -> None:
+    """A malformed config file is treated as "no API key" rather than raising."""
+    config = tmp_path / "config.toml"
+    _write_config(config, "this is not valid TOML\n[")
+    assert ka.kimi_api_key_configured(config) is False
+
+
+def test_auth_configured_prefers_credential_file(tmp_path: Path) -> None:
+    """``kimi_auth_configured`` is True when only the credential file exists."""
+    creds = tmp_path / "kimi-code.json"
+    config = tmp_path / "config.toml"
+    creds.write_text('{"access_token": "sk-abc"}', encoding="utf-8")
+    assert ka.kimi_auth_configured(creds_path=creds, config_path=config) is True
+
+
+def test_auth_configured_falls_back_to_api_key(tmp_path: Path) -> None:
+    """``kimi_auth_configured`` is True when only an API key is configured."""
+    creds = tmp_path / "kimi-code.json"
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.moonshot-ai]\ntype = "kimi"\napi_key = "sk-abc123"\n',
+    )
+    assert ka.kimi_auth_configured(creds_path=creds, config_path=config) is True
+
+
+def test_auth_configured_false_when_nothing_present(tmp_path: Path) -> None:
+    """``kimi_auth_configured`` is False when neither credential nor key exists."""
+    creds = tmp_path / "kimi-code.json"
+    config = tmp_path / "config.toml"
+    assert ka.kimi_auth_configured(creds_path=creds, config_path=config) is False
+
+
+def test_api_key_config_respects_kimi_code_home(monkeypatch, tmp_path: Path) -> None:
+    """``kimi_api_key_configured`` reads ``$KIMI_CODE_HOME/config.toml``."""
+    fake_home = tmp_path / "custom-kimi-home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    config = fake_home / "config.toml"
+    _write_config(
+        config,
+        '[providers.moonshot-ai]\ntype = "kimi"\napi_key = "sk-abc123"\n',
+    )
+    monkeypatch.setenv("KIMI_CODE_HOME", str(fake_home))
+    assert ka.kimi_api_key_configured() is True


### PR DESCRIPTION
## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change*
below, then no issue is required to be associated.
-->

Closes #

## Summary

Omnigent's `kimi-native` harness previously required the credential file written by `kimi login` to report as configured. Users who authenticate via the Moonshot API platform by setting an `api_key` (or `env.KIMI_API_KEY`) in `~/.kimi-code/config.toml` were incorrectly shown as not configured.

- Adds `kimi_api_key_configured()` to detect a Kimi provider with a non-empty API key in the user's Kimi Code config, respecting `$KIMI_CODE_HOME`.
- Adds `kimi_auth_configured()` as the OR of the existing credential-file check and the new API-key check.
- Switches the readiness layer and `omnigent config` setup UI to use `kimi_auth_configured()`, so API-platform users see Kimi as ready.
- Updates the setup hint to mention the API-key alternative.

## Test Plan

```bash
uv sync --extra all --group dev
uv run --no-sync pytest tests/onboarding/test_kimi_auth.py tests/onboarding/test_harness_readiness.py -v
uv run --no-sync ruff check .
uv run --no-sync ruff format --check .
uv run --no-sync pyrefly check
```

All onboarding tests pass; ruff, ruff format, and pyrefly are clean for the changed files.

## Demo

N/A (non-visual backend change).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A

## Changelog

Kimi Code harness now recognizes API-platform authentication via `api_key` or `env.KIMI_API_KEY` in `~/.kimi-code/config.toml`, not only `kimi login`.
