### PR TITLE
fix(electron): return Databricks workspace roots to Omnigent

### DIFF
--- a/web/android/README.md
+++ b/web/android/README.md
@@ -86,9 +86,8 @@ WebView is committing a navigation can be dropped.
 
 Host matching is by domain (`*.databricks.com`, `*.azuredatabricks.net`) — no
 probe request. `*.databricksapps.com` is excluded: Apps serve their own app at
-the root and have no workspace mount. Note the desktop and iOS shells still
-expand to `/ml/omnigents` after a `server: databricks` probe; that divergence is
-intentional for now (see the comment in `web/electron/src/url.js`).
+the root and have no workspace mount. All three native shells redirect a bare
+workspace root to `/omnigent`.
 
 ## Managed configuration (org-preset servers)
 

--- a/web/android/app/src/main/java/ai/omnigent/android/WorkspaceChromeScript.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/WorkspaceChromeScript.kt
@@ -37,10 +37,9 @@ object WorkspaceChromeScript {
      * JS that installs [css] into the current document, at most once.
      *
      * The caller injects this on every finished main-frame load of the pinned
-     * origin, and must NOT gate it on the URL's path. The workspace serves the SPA
-     * on more than one mount (`/ml/omnigents` for the desktop shells, `/omnigent`
-     * in `omnigent/conversation_browser.py`) and an auth redirect can land on
-     * neither, so a path guard leaves the workspace switcher visible — from there a
+     * origin, and must NOT gate it on the URL's path. An auth redirect can land on
+     * a path other than the `/omnigent` mount, so a path guard leaves the workspace
+     * switcher visible — from there a
      * user navigates into another workspace app with no way back. Do not
      * reintroduce a path guard.
      */

--- a/web/android/app/src/test/java/ai/omnigent/android/OmnigentWebViewClientTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/OmnigentWebViewClientTest.kt
@@ -66,9 +66,8 @@ class OmnigentWebViewClientTest {
         val webView = RecordingWebView(ApplicationProvider.getApplicationContext())
         val client = client(shouldInjectBridgeAtPageReady = false)
 
-        // A post-login landing on the pinned server's root, and the `/omnigent`
-        // mount the CLI records — neither starts with `/ml/omnigents`. Both must
-        // still get the CSS or the workspace switcher stays visible.
+        // A post-login landing on the pinned server's root and a nested app route
+        // both need the CSS or the workspace switcher stays visible.
         client.onPageFinished(webView, "$PINNED_ORIGIN/")
         client.onPageFinished(webView, "$PINNED_ORIGIN/omnigent/c/abc")
 

--- a/web/electron/README.md
+++ b/web/electron/README.md
@@ -638,13 +638,13 @@ server in the desktop app — the way a browser deep link opens a page:
 
 ```
 omnigent://localhost:8000/c/conv_abc              → http://localhost:8000/c/conv_abc
-omnigent://my-workspace.cloud.databricks.com/c/x → https://…/ml/omnigents/c/x
+omnigent://my-workspace.cloud.databricks.com/c/x → https://…/omnigent/c/x
 ```
 
 The link names a server by **host** (with port if non-default) and carries no
 `http`/`https` — the shell infers the scheme with the same rule the setup page
 uses (`http` for loopback, `https` for a remote host), so a deep link and a
-pasted URL can never disagree. The Databricks workspace mount (`/ml/omnigents`)
+pasted URL can never disagree. The Databricks workspace mount (`/omnigent`)
 is **not** in the link; it is server-determined and discovered the same way a
 pasted workspace URL is. v1 accepts only `/c/<session_id>`; other paths are
 ignored.

--- a/web/electron/src/deepLink.js
+++ b/web/electron/src/deepLink.js
@@ -8,7 +8,7 @@
 // The link carries no http/https scheme — we infer it with the SAME rule the
 // setup page uses (defaultSchemeFor: http for loopback, https for remote),
 // so a deep link and a pasted URL can never disagree on scheme. The
-// workspace mount (`/ml/omnigents`) is deliberately NOT in the link: it is
+// workspace mount (`/omnigent`) is deliberately NOT in the link: it is
 // server-determined and discovered by expandDatabricksWorkspaceUrl, exactly
 // as for a pasted workspace URL.
 

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -45,6 +45,7 @@ const {
 } = require("./url");
 const { parseOmnigentDeepLink, chooseDeepLinkStrategy } = require("./deepLink");
 const { registerWorkspaceChromeHide } = require("./workspace-chrome");
+const { registerWorkspaceRootBounce } = require("./workspace-root-bounce");
 const { createBrowserViewRegistry } = require("./browserViewRegistry");
 const { createBrowserViewBoundsController } = require("./browserViewBounds");
 const { registerBrowserIpc } = require("./browserIpc");
@@ -581,7 +582,7 @@ function pinWindow(win, origin) {
 /**
  * Record (or clear) the full server URL a window is connected to. The pinned
  * `origin` drops any path, but the host/server CLI commands need the exact URL
- * the user connected with (e.g. a Databricks ``…/ml/omnigents`` mount), so the
+ * the user connected with (e.g. a Databricks ``…/omnigent`` mount), so the
  * window keeps both.
  *
  * @param {BrowserWindow} win
@@ -976,10 +977,10 @@ function hardenOauthPopup(child) {
 
 /**
  * Join a basename-less SPA path (e.g. ``/c/conv_abc``) onto a server URL that
- * may carry a workspace mount (e.g. ``https://host/ml/omnigents/``). The path
- * is an ABSOLUTE in-app route, but it lives UNDER the server's mount —
+ * may carry a workspace mount (e.g. ``https://host/omnigent/``). The path is
+ * an ABSOLUTE in-app route, but it lives UNDER the server's mount —
  * ``new URL("/c/x", serverUrl)`` would resolve against the ORIGIN and drop
- * ``/ml/omnigents`` — so we string-concatenate: strip the server URL's trailing
+ * ``/omnigent`` — so we string-concatenate: strip the server URL's trailing
  * slash, append the path. The SPA's react-router basename then matches
  * ``${mount}/c/:id``. Shared by createWindow (cold open) and loadServerUrl
  * (re-pointing an existing window) so the mount-aware join is in one place.
@@ -1119,6 +1120,7 @@ function createWindow(targetUrl, opts = {}) {
     // Per-conversation embedded-browser view registry for this window.
     browserRegistry: createBrowserRegistryForWindow(win),
   });
+  registerWorkspaceRootBounce(win.webContents, () => pinnedOrigin(win));
   if (destination) {
     // Learn the server's version alongside the load. Every window that opens
     // straight onto a server (normal app launch with a saved URL, a deep link,
@@ -2771,7 +2773,7 @@ function drainPendingDeepLinks() {
  * (expandDatabricksWorkspaceUrl) runs ONLY after the user consents to an
  * UNKNOWN server — so clicking (or the OS dispatching) a link to an
  * attacker-chosen host makes no HTTP request until the user has agreed. The
- * probe is safe post-consent because it can only append a path (`/ml/omnigents`)
+ * probe is safe post-consent because it can only append a path (`/omnigent`)
  * under the SAME origin — it never changes the origin the user approved.
  *
  * @param {string} raw The raw `omnigent://...` URL.
@@ -2786,7 +2788,7 @@ async function handleDeepLink(raw) {
   // same origin, so approving the origin is approving the server.
   const targetOrigin = parsed.origin;
   // A KNOWN server: reuse its recorded URL (already mount-bearing, e.g.
-  // `https://host/ml/omnigents`) so we SKIP the probe entirely. null for an
+  // `https://host/omnigent`) so we SKIP the probe entirely. null for an
   // unknown server — the mount is discovered AFTER consent (see consent-unknown).
   const known = findKnownServerUrl(targetOrigin);
 

--- a/web/electron/src/url.js
+++ b/web/electron/src/url.js
@@ -98,30 +98,46 @@
     return url.protocol === "http:" && !LOCAL_HOSTS.has(url.hostname);
   }
 
-  /**
-   * Path under a Databricks workspace where the Omnigent web UI is mounted. A
-   * bare workspace URL serves the workspace's own web app at the root, so a
-   * user who pastes just the workspace host (e.g.
-   * ``https://<ws>.azuredatabricks.net``) lands on a 404 unless this suffix is
-   * appended.
-   *
-   * NOTE: the Python CLI records the UI mount as ``/omnigent`` in
-   * ``omnigent/conversation_browser.py`` (WORKSPACE_UI_PATH), whereas the
-   * desktop deliberately keeps ``/ml/omnigents`` for now — that is the path the
-   * live workspace serves the embedded SPA on. The two are intentionally
-   * divergent pending reconciliation; do not "fix" this to ``/omnigent``
-   * without verifying what the workspace actually serves to the desktop shell.
-   */
-  const WORKSPACE_UI_PATH = "/ml/omnigents";
+  /** Path where the Omnigent SPA is mounted in a Databricks workspace. */
+  const WORKSPACE_UI_PATH = "/omnigent";
 
   /**
-   * Databricks Apps are served from ``*.databricksapps.com`` and answer with the
-   * same ``server: databricks`` header as a workspace, but they are NOT
-   * workspaces and have no ``/ml/omnigents`` mount. Skip expansion for these
-   * hosts so a user who points the shell at a Databricks App is left on the URL
-   * they entered.
+   * Domains that serve Databricks workspaces. Databricks Apps are deliberately
+   * absent: ``*.databricksapps.com`` serves the app itself at the root and must
+   * not be redirected to a workspace mount.
    */
+  const WORKSPACE_DOMAINS = ["databricks.com", "azuredatabricks.net"];
   const DATABRICKS_APPS_HOST_SUFFIX = "databricksapps.com";
+
+  /** True when a host is, or sits under, a Databricks workspace domain. */
+  function isDatabricksWorkspaceHost(host) {
+    const normalized = (host ?? "").toLowerCase();
+    return WORKSPACE_DOMAINS.some(
+      (domain) => normalized === domain || normalized.endsWith(`.${domain}`),
+    );
+  }
+
+  /**
+   * Return the workspace UI URL for a bare Databricks workspace root.
+   * Deliberate deep links are left untouched, while query and fragment survive
+   * because e.g. ``?o=<org>`` can select the workspace.
+   *
+   * @param {string | null | undefined} rawUrl
+   * @returns {string | null}
+   */
+  function databricksWorkspaceUiUrl(rawUrl) {
+    let url;
+    try {
+      url = new URL(rawUrl);
+    } catch {
+      return null;
+    }
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (!isDatabricksWorkspaceHost(url.hostname)) return null;
+    if (url.pathname !== "/" && url.pathname !== "") return null;
+    url.pathname = WORKSPACE_UI_PATH;
+    return url.toString();
+  }
 
   /**
    * Probe timeout for Databricks workspace detection. Deliberately short: a
@@ -138,7 +154,7 @@
    * hostnames, probe the URL and adopt the mount only when the host answers
    * like a Databricks workspace — a response carrying the ``server: databricks``
    * header. URLs that already carry a path, or aren't https, are returned
-   * untouched WITHOUT a probe, so a user who pastes the full ``…/ml/omnigents``
+   * untouched WITHOUT a probe, so a user who pastes the full ``…/omnigent``
    * URL (or connects to any non-workspace server) is never second-guessed.
    *
    * The CLI appends the API mount because it's an API client; the desktop shell
@@ -162,7 +178,7 @@
       return normalized;
     }
     // Databricks Apps share the workspace ``server: databricks`` header but have
-    // no ``/ml/omnigents`` mount, so never expand them.
+    // no workspace UI mount, so never expand them.
     const host = url.hostname.toLowerCase();
     if (host === DATABRICKS_APPS_HOST_SUFFIX || host.endsWith(`.${DATABRICKS_APPS_HOST_SUFFIX}`)) {
       return normalized;
@@ -285,6 +301,7 @@
     isPlainHttpRemote,
     WORKSPACE_UI_PATH,
     WORKSPACE_PROBE_TIMEOUT_MS,
+    databricksWorkspaceUiUrl,
     expandDatabricksWorkspaceUrl,
     WELL_KNOWN_MANIFEST_PATH,
     MANIFEST_FETCH_TIMEOUT_MS,

--- a/web/electron/src/workspace-root-bounce.js
+++ b/web/electron/src/workspace-root-bounce.js
@@ -1,0 +1,62 @@
+// Keep a workspace-hosted shell on Omnigent when Databricks navigation or an
+// auth hand-back lands the main frame on the bare workspace root. Kept free of
+// Electron imports so navigation behavior can be tested with a fake webContents.
+
+"use strict";
+
+const { databricksWorkspaceUiUrl } = require("./url");
+
+const MAX_ROOT_BOUNCES = 1;
+
+/** Return a URL's origin, or null when it is not an absolute URL. */
+function originOf(rawUrl) {
+  try {
+    return new URL(rawUrl).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Register the bare-root redirect for one shell window.
+ *
+ * One redirect is allowed until a non-root page on the pinned origin finishes.
+ * This prevents a workspace without the mount from looping forever if
+ * ``/omnigent`` redirects back to ``/``.
+ *
+ * @param {{
+ *   on: (event: string, listener: (...args: unknown[]) => void) => void,
+ *   getURL: () => string,
+ *   loadURL: (url: string) => Promise<unknown>
+ * }} webContents
+ * @param {() => string | null} pinnedOrigin
+ */
+function registerWorkspaceRootBounce(webContents, pinnedOrigin) {
+  let rootBounces = 0;
+
+  function bounceIfNeeded(rawUrl) {
+    const target = databricksWorkspaceUiUrl(rawUrl);
+    const pinned = pinnedOrigin();
+    if (!target || !pinned || originOf(rawUrl) !== pinned) return;
+    if (rootBounces >= MAX_ROOT_BOUNCES) return;
+    rootBounces++;
+    void webContents.loadURL(target).catch(() => {});
+  }
+
+  // Successful full navigations include server redirects and form-POST auth
+  // hand-backs, which can bypass will-navigate.
+  webContents.on("did-navigate", (_event, url) => bounceIfNeeded(url));
+
+  // pushState, replaceState, and history navigation do not load a document.
+  webContents.on("did-navigate-in-page", (_event, url, isMainFrame) => {
+    if (isMainFrame) bounceIfNeeded(url);
+  });
+
+  webContents.on("did-finish-load", () => {
+    const current = webContents.getURL();
+    if (originOf(current) !== pinnedOrigin()) return;
+    if (databricksWorkspaceUiUrl(current) === null) rootBounces = 0;
+  });
+}
+
+module.exports = { MAX_ROOT_BOUNCES, registerWorkspaceRootBounce };

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -42,6 +42,15 @@ describe("setup clipboard IPC wiring", () => {
   });
 });
 
+describe("workspace root bounce wiring (src/main.js)", () => {
+  it("registers the bounce against the window's current pinned origin", () => {
+    assert.match(
+      liveCode,
+      /registerWorkspaceRootBounce\(\s*win\.webContents,\s*\(\)\s*=>\s*pinnedOrigin\(win\)\s*\)/,
+    );
+  });
+});
+
 describe("workspace chrome injection wiring (src/main.js)", () => {
   it("invokes registerWorkspaceChromeHide(win.webContents) as live code", () => {
     assert.match(
@@ -175,7 +184,7 @@ describe("OAuth popup COOP-strip wiring (src/main.js)", () => {
 });
 
 // Guard for the deep-link path join in createWindow. A basename-less SPA path
-// (/c/<id>) lives UNDER the server's workspace mount (/ml/omnigents), so it
+// (/c/<id>) lives UNDER the server's workspace mount (/omnigent), so it
 // must be string-concatenated (resolveServerPath) — NOT resolved with
 // `new URL(path, serverUrl)`, which would anchor against the ORIGIN and drop
 // the mount, opening the wrong URL for every workspace deep link. This catches
@@ -187,7 +196,7 @@ describe("deep-link path join wiring (src/main.js)", () => {
       /resolveServerPath\(serverUrl, opts\.path\)/,
       [
         "createWindow no longer joins opts.path onto opts.serverUrl via",
-        "resolveServerPath. A deep link to a workspace server (origin + /ml/omnigents",
+        "resolveServerPath. A deep link to a workspace server (origin + /omnigent",
         "mount) would lose the mount and 404. Restore the mount-aware join (see",
         "resolveServerPath); do not replace it with `new URL(path, serverUrl)`.",
       ].join(" "),

--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -113,6 +113,7 @@ function loadMainHarness({
       expandDatabricksWorkspaceUrl: async (url) => url,
     },
     "./workspace-chrome": { registerWorkspaceChromeHide: () => {} },
+    "./workspace-root-bounce": { registerWorkspaceRootBounce: () => {} },
     "./omnigent_cli": {
       isExecutableFile: () => false,
       resolveCliPath: () => null,

--- a/web/electron/test/url.test.js
+++ b/web/electron/test/url.test.js
@@ -10,6 +10,7 @@ const {
   defaultSchemeFor,
   normalizeUrl,
   isPlainHttpRemote,
+  databricksWorkspaceUiUrl,
   expandDatabricksWorkspaceUrl,
   WORKSPACE_UI_PATH,
   fetchServerManifest,
@@ -129,6 +130,42 @@ async function withFetch(stub, fn) {
 function fakeResponse(serverHeader) {
   return { headers: { get: (name) => (name === "server" ? serverHeader : null) } };
 }
+
+describe("databricksWorkspaceUiUrl", () => {
+  it("maps AWS and Azure workspace roots to /omnigent", () => {
+    assert.equal(
+      databricksWorkspaceUiUrl("https://ws.cloud.databricks.com/"),
+      "https://ws.cloud.databricks.com/omnigent",
+    );
+    assert.equal(
+      databricksWorkspaceUiUrl("http://ws.azuredatabricks.net"),
+      "http://ws.azuredatabricks.net/omnigent",
+    );
+  });
+
+  it("preserves port, query, and fragment", () => {
+    assert.equal(
+      databricksWorkspaceUiUrl("https://ws.cloud.databricks.com:8443/?o=123#page"),
+      "https://ws.cloud.databricks.com:8443/omnigent?o=123#page",
+    );
+  });
+
+  it("matches domains only on a dot boundary", () => {
+    assert.equal(databricksWorkspaceUiUrl("https://databricks.com.example.org/"), null);
+    assert.equal(databricksWorkspaceUiUrl("https://notdatabricks.com/"), null);
+  });
+
+  it("does not map Databricks Apps or deliberate deep links", () => {
+    assert.equal(databricksWorkspaceUiUrl("https://my-app.aws.databricksapps.com/"), null);
+    assert.equal(databricksWorkspaceUiUrl("https://ws.cloud.databricks.com/somewhere"), null);
+  });
+
+  it("returns null for unsupported or invalid URLs", () => {
+    assert.equal(databricksWorkspaceUiUrl("ftp://ws.cloud.databricks.com/"), null);
+    assert.equal(databricksWorkspaceUiUrl("not a url"), null);
+    assert.equal(databricksWorkspaceUiUrl(null), null);
+  });
+});
 
 describe("expandDatabricksWorkspaceUrl", () => {
   it("expands a bare https Databricks workspace root to the UI mount", async () => {
@@ -385,7 +422,7 @@ describe("fetchServerManifest", () => {
   });
 
   it("requests the manifest at the origin root, ignoring any path", async () => {
-    // A workspace-mounted server (…/ml/omnigents) still serves the manifest at
+    // A workspace-mounted server (…/omnigent) still serves the manifest at
     // the ORIGIN root — well-known URIs are origin-scoped by RFC 8615.
     await withFetch(
       async (url) => {
@@ -393,7 +430,7 @@ describe("fetchServerManifest", () => {
         return fakeJsonResponse({ manifest_version: 1 });
       },
       async () => {
-        const m = await fetchServerManifest("https://ws.example.com/ml/omnigents");
+        const m = await fetchServerManifest("https://ws.example.com/omnigent");
         assert.equal(m.manifestVersion, 1);
       },
     );

--- a/web/electron/test/workspace-chrome.test.js
+++ b/web/electron/test/workspace-chrome.test.js
@@ -22,7 +22,7 @@ describe("applyWorkspaceChromeHideCss", () => {
   it("injects the chrome-hide CSS even when the URL is not under the workspace path", () => {
     const injected = [];
     const webContents = {
-      // A path variant the old guard would have skipped (not /ml/omnigents).
+      // A path variant the old guard would have skipped (not /omnigent).
       getURL: () => "https://dbc-x.cloud.databricks.com/dashboard",
       insertCSS: (css) => {
         injected.push(css);
@@ -37,7 +37,7 @@ describe("applyWorkspaceChromeHideCss", () => {
       [WORKSPACE_CHROME_HIDE_CSS],
       [
         "applyWorkspaceChromeHideCss must inject WORKSPACE_CHROME_HIDE_CSS for ANY loaded",
-        "URL, but it did not fire for a non-/ml/omnigents path. A URL/path guard has likely",
+        "URL, but it did not fire for a non-/omnigent path. A URL/path guard has likely",
         "been reintroduced. That is the original bug: gating injection by path left the",
         "Databricks workspace switcher visible on auth redirects and path variants. Injection",
         "must stay unconditional — the CSS only targets .omnigent-app (workspace-embedded",

--- a/web/electron/test/workspace-root-bounce.test.js
+++ b/web/electron/test/workspace-root-bounce.test.js
@@ -1,0 +1,68 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+
+const { registerWorkspaceRootBounce } = require("../src/workspace-root-bounce");
+
+class FakeWebContents extends EventEmitter {
+  constructor(url = "") {
+    super();
+    this.url = url;
+    this.loads = [];
+  }
+
+  getURL() {
+    return this.url;
+  }
+
+  async loadURL(url) {
+    this.loads.push(url);
+    this.url = url;
+  }
+}
+
+describe("registerWorkspaceRootBounce", () => {
+  it("redirects a completed workspace-root navigation to /omnigent", () => {
+    const webContents = new FakeWebContents();
+    registerWorkspaceRootBounce(webContents, () => "https://ws.cloud.databricks.com");
+
+    webContents.emit("did-navigate", {}, "https://ws.cloud.databricks.com/?o=123#page");
+
+    assert.deepEqual(webContents.loads, ["https://ws.cloud.databricks.com/omnigent?o=123#page"]);
+  });
+
+  it("redirects main-frame in-page navigation but ignores subframes", () => {
+    const webContents = new FakeWebContents();
+    registerWorkspaceRootBounce(webContents, () => "https://ws.azuredatabricks.net");
+
+    webContents.emit("did-navigate-in-page", {}, "https://ws.azuredatabricks.net/", false);
+    webContents.emit("did-navigate-in-page", {}, "https://ws.azuredatabricks.net/", true);
+
+    assert.deepEqual(webContents.loads, ["https://ws.azuredatabricks.net/omnigent"]);
+  });
+
+  it("does not redirect foreign origins or non-workspace hosts", () => {
+    const webContents = new FakeWebContents();
+    registerWorkspaceRootBounce(webContents, () => "https://ws.cloud.databricks.com");
+
+    webContents.emit("did-navigate", {}, "https://other.cloud.databricks.com/");
+    webContents.emit("did-navigate", {}, "https://example.com/");
+
+    assert.deepEqual(webContents.loads, []);
+  });
+
+  it("caps redirects until a pinned non-root page finishes", () => {
+    const origin = "https://ws.cloud.databricks.com";
+    const webContents = new FakeWebContents();
+    registerWorkspaceRootBounce(webContents, () => origin);
+
+    webContents.emit("did-navigate", {}, `${origin}/`);
+    webContents.emit("did-navigate", {}, `${origin}/`);
+    assert.deepEqual(webContents.loads, [`${origin}/omnigent`]);
+
+    webContents.url = `${origin}/omnigent`;
+    webContents.emit("did-finish-load");
+    webContents.emit("did-navigate", {}, `${origin}/`);
+    assert.deepEqual(webContents.loads, [`${origin}/omnigent`, `${origin}/omnigent`]);
+  });
+});

--- a/web/ios/Omnigent/WorkspaceChromeScript.swift
+++ b/web/ios/Omnigent/WorkspaceChromeScript.swift
@@ -30,10 +30,9 @@ enum WorkspaceChromeScript {
   /// JS that installs ``css`` into the current document, at most once.
   ///
   /// The caller injects this on every finished main-frame load of the pinned
-  /// origin, and must NOT gate it on the URL's path. The workspace serves the SPA
-  /// on more than one mount (`/ml/omnigents` for the desktop shells, `/omnigent`
-  /// in `omnigent/conversation_browser.py`) and an auth redirect can land on
-  /// neither, so a path guard leaves the workspace switcher visible — from there a
+  /// origin, and must NOT gate it on the URL's path. An auth redirect can land on
+  /// a path other than the `/omnigent` mount, so a path guard leaves the workspace
+  /// switcher visible — from there a
   /// user navigates into another workspace app with no way back. Do not
   /// reintroduce a path guard.
   static var source: String {

--- a/web/ios/Omnigent/WorkspaceURLExpander.swift
+++ b/web/ios/Omnigent/WorkspaceURLExpander.swift
@@ -2,8 +2,7 @@ import Foundation
 
 enum WorkspaceURLExpander {
   /// Path the Omnigent SPA is mounted at inside a Databricks workspace. Matches
-  /// Android's `WORKSPACE_UI_PATH` (`Origins.kt`). The Electron shell still uses
-  /// `/ml/omnigents`; see the note in `web/electron/src/url.js`.
+  /// Android and Electron's `WORKSPACE_UI_PATH`.
   static let workspaceUIPath = "/omnigent"
 
   /// Databricks domains that serve a workspace, and therefore mount the SPA at


### PR DESCRIPTION
## Related issue

Closes [OMNI-2406 — Show Omnigent UI after login on desktop app](https://linear.app/omnigent/issue/OMNI-2406)

## Summary

- Redirect pinned Databricks workspace roots back to `/omnigent` after full-page auth hand-backs or in-page history navigation.
- Match AWS and Azure workspace domains on dot boundaries, preserve URL metadata, exclude Databricks Apps, and cap redirects to avoid loops.
- Align Electron's workspace mount with the mobile shells and add focused behavior and wiring coverage.

**ELI5:** Electron now watches the main page address. If a Databricks workspace drops the user at its front door (`/`), the shell sends them back into Omnigent (`/omnigent`) once, without following foreign sites or looping forever.

```text
Pinned Databricks window
        │
        ├─ non-root / foreign origin ──► leave unchanged
        │
        └─ workspace root `/` ─────────► `/omnigent`
                                              │
                              redirects to `/` again?
                                      stop after one bounce
```

## Test Plan

- `node --test web/electron/test/url.test.js web/electron/test/workspace-root-bounce.test.js web/electron/test/main.test.js web/electron/test/update-main.test.js`
- `node --test web/electron/test/workspace-chrome.test.js`
- `web/node_modules/.bin/oxlint --deny-warnings --report-unused-disable-directives web/electron/src/deepLink.js web/electron/src/main.js web/electron/src/url.js web/electron/src/workspace-root-bounce.js web/electron/test/main.test.js web/electron/test/update-main.test.js web/electron/test/url.test.js web/electron/test/workspace-chrome.test.js web/electron/test/workspace-root-bounce.test.js`
- `web/android/bin/ktlint.sh web/android/app/src/main/java/ai/omnigent/android/WorkspaceChromeScript.kt web/android/app/src/test/java/ai/omnigent/android/OmnigentWebViewClientTest.kt`
- `web/ios/bin/swift-format.sh format lint --strict web/ios/Omnigent/WorkspaceURLExpander.swift web/ios/Omnigent/WorkspaceChromeScript.swift`
- Pre-commit hooks passed.

## Demo

N/A — this changes native navigation recovery without adding or changing visual UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests exercise full and in-page root navigation, domain/origin restrictions, URL preservation, wiring, and loop prevention.

## Changelog

The Electron app now returns you to Omnigent when a Databricks workspace navigation lands at the workspace root.




