### PR TITLE
fix(web): keep the queued-message strip docked when the background task pill shows

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5351,6 +5351,11 @@ export function Composer({
           }
         }}
       />
+      {/* Background tasks that outlive the turn show as a pill, not the
+          "Working…" shimmer. Sits above the queued/sub-agent trays: those dock
+          onto the composer card with a negative margin, so nothing may come
+          between them and the card. Self-gates to null otherwise. */}
+      <BackgroundTaskPill />
       {/* Queued messages — peeks above the card like the sub-agent tray.
           Lists follow-ups held while the agent is busy; drains FIFO on idle.
           Scope to this conversation so a queue held elsewhere never leaks in. */}
@@ -5378,9 +5383,6 @@ export function Composer({
           Truthy (not just non-null) so an empty label never peeks a
           nameless tray. */}
       {subAgentLabel ? <SubagentComposerTray label={subAgentLabel} /> : null}
-      {/* Background tasks that outlive the turn show as a pill here, not the
-          "Working…" shimmer. Self-gates to null otherwise. */}
-      <BackgroundTaskPill />
       {/* Single rounded container — textarea + action row. No focus-within
           ring; drag-over still lifts an inset ring. dark:bg-card-solid so
           upper trays (queued / sub-agent) don't ghost through glass --card. */}


### PR DESCRIPTION
## Related issue

No tracked issue — a composer layout regression spotted while a queued message and a background task were showing at once.

## Summary

- When a queued ("Steer") message and a background-task pill are shown at the same time, the queued strip lifts well off the composer and reads as detached — floating ~20px too high.
- Root cause: `QueuedMessagesStrip` and `SubagentComposerTray` dock onto the composer card with a `-mb-4` negative margin that tucks their translucent bottom behind the *opaque* card (`dark:bg-card-solid`). `BackgroundTaskPill` was rendered *between* those trays and the card, so the tuck landed on the pill's transparent, non-full-width wrapper instead — and the pill's own height pushed the strip up.
- Fix: render `<BackgroundTaskPill />` **above** the queued/sub-agent trays. The trays dock onto the composer card again, and the pill floats above as its own chip.

## Test Plan

- `oxlint --deny-warnings` on `ChatPage.tsx` — clean.
- Reproduced the exact stacking (real Tailwind spacing values + dark tokens) in a headless Chrome render: with the pill between the trays and the card the strip detaches; with the pill on top the strip re-docks. Before/after in the Demo.
- No test asserts the pill's DOM position relative to the strip, so existing `ChatPage` unit tests and the `background_task` e2e_ui tests are unaffected.

To see it live: open a session, get a background task running (e.g. a background shell) so its turn settles into the background-tasks-only state, and queue a follow-up message. The "Steer" strip should sit docked on the composer with the pill floating above it — not lifted away.

## Demo

**Before:** queued "Steer" strip lifted ~20px off the composer, pill wedged in the exposed gap.
<img width="888" height="209" alt="Screenshot 2026-08-20 at 3 59 12 PM" src="https://github.com/user-attachments/assets/9f6f5faf-96de-4c4e-aa06-fc123763ba68" />

**After:** pill floats on top; the "Steer" strip docks flush onto the composer as designed.
<img width="905" height="246" alt="Screenshot 2026-08-20 at 3 57 00 PM" src="https://github.com/user-attachments/assets/022d89a9-5a1b-4092-afbb-838e6c11698e" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This is a JSX reorder of sibling composer trays — no logic change. Existing `ChatPage` unit tests and the `background_task` e2e_ui tests don't assert the pill's stacking position, so they stay green and confirm no regression in send-gating / pill visibility. The layout itself was validated by a headless render of the exact tray/pill/composer stacking (see Demo); the UI Snapshot pixel gate and a human confirming in-app (steps in Test Plan) are the definitive checks.

## Changelog

Kept the queued-message strip docked to the composer when a background task is running
