### PR TITLE
fix(electron): populate normalized recent servers

### DIFF
--- a/tests/e2e_ui/desktop/test_setup_connect.py
+++ b/tests/e2e_ui/desktop/test_setup_connect.py
@@ -148,12 +148,13 @@ def test_shared_url_module_defaults_scheme_in_browser(page: Page) -> None:
     """
     _open_setup_page(page)
 
-    # Remote host → https; the guide's /omnigent suffix is preserved.
+    # Remote host → https root; the main process then probes and appends the
+    # canonical /omnigent workspace mount when this is a Databricks workspace.
     assert (
         page.evaluate(
             "() => window.omnigentUrl.normalizeUrl('dbc-x.cloud.databricks.com/omnigent')"
         )
-        == "https://dbc-x.cloud.databricks.com/omnigent"
+        == "https://dbc-x.cloud.databricks.com/"
     )
     # Loopback stays http for local dev.
     assert (

--- a/web/electron/setup/index.html
+++ b/web/electron/setup/index.html
@@ -486,8 +486,8 @@
           });
       }
 
-      // Recently-connected servers (persisted by the main process on every
-      // successful non-ephemeral Connect). The URL keeps its one-click Connect
+      // Recently-connected servers (persisted by the main process after each
+      // successful non-ephemeral connection). The URL keeps its one-click Connect
       // behavior; the adjacent clipboard action copies without navigating.
       // An empty/unavailable list keeps the section hidden.
       const recentsSection = document.getElementById("recents");

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -1132,7 +1132,20 @@ function createWindow(targetUrl, opts = {}) {
         if (!win.isDestroyed()) setWindowServerManifest(win, manifest);
       });
     }
-    void win.loadURL(destination);
+    void win
+      .loadURL(destination)
+      .then(() => {
+        // A saved server can predate the recents list. Backfill it only after
+        // a successful cold load; explicit targets may be conversation URLs.
+        if (!ephemeral && !explicit && serverUrl) {
+          const settings = loadSettings();
+          rememberRecentServer(settings, serverUrl);
+          saveSettings(settings);
+        }
+      })
+      .catch(() => {
+        // Load failure falls back via did-fail-load → setup page w/ error.
+      });
   } else {
     // ?ephemeral=1 only changes the setup page's copy (the window's
     // WindowState is the source of truth for persistence behavior).

--- a/web/electron/src/url.js
+++ b/web/electron/src/url.js
@@ -46,10 +46,11 @@
   }
 
   /**
-   * Normalize a user-entered server URL into something navigable. Accepts a
-   * bare `host[:port][/path]` and defaults the scheme (https://, or http:// for
-   * loopback hosts), trims whitespace, and rejects anything that isn't an
-   * http(s) URL — fail loud rather than navigate to garbage.
+   * Normalize a user-entered server URL to its origin. Accepts a bare
+   * `host[:port][/path]`, defaults the scheme (https://, or http:// for loopback
+   * hosts), trims whitespace, and discards paths, queries, and fragments. A
+   * server connection always starts at the canonical root; workspace mounts
+   * are discovered separately by expandDatabricksWorkspaceUrl.
    *
    * @param {string} raw
    * @returns {string} A normalized absolute http(s) URL.
@@ -69,7 +70,7 @@
     if (url.protocol !== "http:" && url.protocol !== "https:") {
       throw new Error(`unsupported scheme '${url.protocol}' (use http/https)`);
     }
-    return url.toString();
+    return `${url.origin}/`;
   }
 
   /**

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -183,6 +183,22 @@ describe("OAuth popup COOP-strip wiring (src/main.js)", () => {
   });
 });
 
+describe("recent-server startup wiring (src/main.js)", () => {
+  it("backfills a saved server only after its cold load succeeds", () => {
+    assert.match(
+      liveCode,
+      /loadURL\(destination\)\s*\.then\(\(\)\s*=>\s*\{\s*if\s*\(!ephemeral\s*&&\s*!explicit\s*&&\s*serverUrl\)[\s\S]{0,200}rememberRecentServer\(settings,\s*serverUrl\)/,
+      [
+        "createWindow no longer backfills a successfully loaded saved server into",
+        "recent_servers. Existing installs can have server_url without recent_servers,",
+        "so the setup page would show no recents after leaving that server. Keep the",
+        "backfill in loadURL(destination).then, gated away from ephemeral windows and",
+        "explicit target URLs (which may include a conversation path).",
+      ].join(" "),
+    );
+  });
+});
+
 // Guard for the deep-link path join in createWindow. A basename-less SPA path
 // (/c/<id>) lives UNDER the server's workspace mount (/omnigent), so it
 // must be string-concatenated (resolveServerPath) — NOT resolved with

--- a/web/electron/test/url.test.js
+++ b/web/electron/test/url.test.js
@@ -1,7 +1,7 @@
 // Tests for the shared desktop URL helpers (src/url.js), run with
 // `node --test` (no extra deps). Covers the scheme-defaulting that lets a
-// pasted workspace URL (schemeless, /omnigent suffix from the internal user
-// guide) connect, the plain-http warning, and the workspace probe/expansion.
+// pasted workspace URL (including paths copied from the browser) connect, the
+// plain-http warning, and the workspace probe/expansion.
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
@@ -35,10 +35,10 @@ describe("defaultSchemeFor", () => {
 });
 
 describe("normalizeUrl", () => {
-  it("defaults a schemeless workspace /omnigent URL to https", () => {
+  it("defaults a schemeless workspace URL to https and removes its path", () => {
     assert.equal(
       normalizeUrl("dbc-a5d4177a-49dc.cloud.databricks.com/omnigent"),
-      "https://dbc-a5d4177a-49dc.cloud.databricks.com/omnigent",
+      "https://dbc-a5d4177a-49dc.cloud.databricks.com/",
     );
   });
 
@@ -61,8 +61,11 @@ describe("normalizeUrl", () => {
     assert.equal(normalizeUrl("http://example.databricks.com"), "http://example.databricks.com/");
   });
 
-  it("trims surrounding whitespace", () => {
-    assert.equal(normalizeUrl("  example.com/omnigent  "), "https://example.com/omnigent");
+  it("trims whitespace and removes paths, queries, and fragments", () => {
+    assert.equal(
+      normalizeUrl("  example.com/omnigent/c/123?view=chat#latest  "),
+      "https://example.com/",
+    );
   });
 
   it("rejects empty input", () => {
@@ -168,7 +171,7 @@ describe("databricksWorkspaceUiUrl", () => {
 });
 
 describe("expandDatabricksWorkspaceUrl", () => {
-  it("expands a bare https Databricks workspace root to the UI mount", async () => {
+  it("normalizes a pasted workspace path and expands to the canonical UI mount", async () => {
     const calls = [];
     await withFetch(
       async (url, opts) => {
@@ -176,8 +179,15 @@ describe("expandDatabricksWorkspaceUrl", () => {
         return fakeResponse("databricks");
       },
       async () => {
-        const out = await expandDatabricksWorkspaceUrl("https://ws.cloud.databricks.com/");
-        assert.equal(out, `https://ws.cloud.databricks.com${WORKSPACE_UI_PATH}`);
+        const normalized = normalizeUrl(
+          "https://ws.cloud.databricks.com/some/copied/path?o=123#fragment",
+        );
+        assert.equal(normalized, "https://ws.cloud.databricks.com/");
+        assert.equal(WORKSPACE_UI_PATH, "/omnigent");
+        assert.equal(
+          await expandDatabricksWorkspaceUrl(normalized),
+          "https://ws.cloud.databricks.com/omnigent",
+        );
       },
     );
     // Probed the root with a HEAD request.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Backfill a previously saved server into the recent-server list after its cold load succeeds, so existing installations do not show an empty landing-page picker.
- Normalize user-entered server URLs to their origin before navigation and persistence, removing paths, queries, and fragments while retaining Databricks workspace mount discovery.

ELI5: the desktop now remembers the server it successfully opened and stores the server address instead of whichever page was pasted.

```text
pasted URL -> origin normalization -> workspace discovery -> successful load -> recents
```

## Test Plan

- `node --test web/electron/test/url.test.js web/electron/test/main.test.js`
- `pre-commit run --files web/electron/src/url.js web/electron/test/url.test.js web/electron/src/main.js web/electron/setup/index.html web/electron/test/main.test.js`

## Demo

N/A — behavior-only change with no layout updates.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression tests cover cold-load backfilling and origin-only URL normalization.

## Changelog

Recent servers now appear reliably in the Electron connection screen, with pasted URLs normalized to the server origin.
