### PR TITLE
feat(electron): allow opt-in production DevTools

### DIFF
--- a/web/electron/README.md
+++ b/web/electron/README.md
@@ -110,6 +110,26 @@ Open another view with **Server → New Window** (`Cmd/Ctrl+N`). It clones the
 focused window's current URL onto a new window against the same server, so two
 conversations can be watched at once.
 
+## Debugging a packaged macOS build
+
+Developer Tools are disabled by default in the production app. To opt in, quit
+Omnigent, set its macOS user default, and reopen it:
+
+```bash
+defaults write ai.omnigent.desktop DeveloperMode -bool true
+```
+
+The **Debug → Developer Tools** menu is then available in the packaged app. To
+turn production debugging off again, quit Omnigent and remove the override:
+
+```bash
+defaults delete ai.omnigent.desktop DeveloperMode
+```
+
+Development (`pnpm --dir web/electron dev`) builds keep Developer Tools enabled
+without this preference. The override is intentionally macOS-only and does not
+relax production update security checks.
+
 The native enhancements live on the web side in
 [`../src/lib/nativeBridge.ts`](../src/lib/nativeBridge.ts). It detects the
 Electron shell at runtime (the preload exposes `window.omnigentDesktop`

--- a/web/electron/src/developer_mode.js
+++ b/web/electron/src/developer_mode.js
@@ -1,0 +1,30 @@
+"use strict";
+
+/** macOS NSUserDefaults key in the ai.omnigent.desktop preference domain. */
+const DEVELOPER_MODE_KEY = "DeveloperMode";
+
+/**
+ * Whether shell developer affordances should be enabled.
+ *
+ * Development builds always enable them. Packaged builds require an explicit
+ * macOS user default so production debugging cannot be turned on accidentally.
+ *
+ * @param {{
+ *   isPackaged: boolean,
+ *   platform?: NodeJS.Platform,
+ *   getUserDefault?: (key: string, type: string) => unknown,
+ * }} options
+ * @returns {boolean}
+ */
+function isDeveloperModeEnabled({ isPackaged, platform = process.platform, getUserDefault }) {
+  if (!isPackaged) return true;
+  if (platform !== "darwin" || typeof getUserDefault !== "function") return false;
+
+  try {
+    return getUserDefault(DEVELOPER_MODE_KEY, "boolean") === true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { DEVELOPER_MODE_KEY, isDeveloperModeEnabled };

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -49,6 +49,7 @@ const { registerWorkspaceRootBounce } = require("./workspace-root-bounce");
 const { createBrowserViewRegistry } = require("./browserViewRegistry");
 const { createBrowserViewBoundsController } = require("./browserViewBounds");
 const { registerBrowserIpc } = require("./browserIpc");
+const { isDeveloperModeEnabled } = require("./developer_mode");
 const { registerSessionExpiryReload } = require("./session-expiry");
 const { decideWindowOpen, stripCrossOriginOpenerHeaders, WEB_SCHEMES } = require("./popupPolicy");
 const omnigentCli = require("./omnigent_cli");
@@ -90,6 +91,21 @@ const POPUP_PRELOAD = path.join(__dirname, "popup_preload.js");
 
 /** Absolute path to the app icon (PNG works for the macOS dock at runtime). */
 const ICON_PNG = path.join(__dirname, "..", "icons", "icon.png");
+
+/**
+ * Development builds always expose debugging. Packaged macOS builds require
+ * `defaults write ai.omnigent.desktop DeveloperMode -bool true` before launch.
+ */
+function developerModeEnabled() {
+  return isDeveloperModeEnabled({
+    isPackaged: app.isPackaged,
+    platform: process.platform,
+    getUserDefault:
+      typeof systemPreferences.getUserDefault === "function"
+        ? systemPreferences.getUserDefault.bind(systemPreferences)
+        : undefined,
+  });
+}
 
 /**
  * Quit-safety timeouts (see the before-quit handler near the end of this
@@ -1075,6 +1091,9 @@ function createWindow(targetUrl, opts = {}) {
       preload: path.join(__dirname, "preload.js"),
       contextIsolation: true,
       nodeIntegration: false,
+      // Packaged builds expose DevTools only after the macOS user explicitly
+      // opts in through the DeveloperMode user default.
+      devTools: developerModeEnabled(),
       // Electron passes HTML5 drag-drop through to the page by default (no
       // native handler intercepts it), so images drop onto the composer
       // textbox with no extra work.
@@ -1929,7 +1948,7 @@ function buildMenu() {
     ],
   });
   // Standard View roles (Reload/zoom/fullscreen). Developer Tools lives in
-  // the Debug menu (dev only), so this menu is identical in dev and release.
+  // the opt-in Debug menu, so this menu is identical in normal releases.
   template.push({
     label: "View",
     submenu: [
@@ -1945,14 +1964,11 @@ function buildMenu() {
   });
   template.push({ role: "windowMenu" });
 
-  // Debug menu (dev only, !app.isPackaged): consolidates every debug-only /
-  // non-production affordance behind a single top-level menu — the macOS
-  // notification-sound settings (sound playback uses `afplay`, so macOS-only)
-  // and the developer tools. Restart-to-update now lives in the production
-  // Server menu (it's a needed install path, not a debug affordance, once the
-  // UpdateBanner toast is dismissible). Hidden in the shipped .app. Placed
-  // last so it never displaces the standard menus users expect.
-  if (!app.isPackaged) {
+  // Consolidate non-production affordances behind one top-level menu. It is
+  // always present in development and can be explicitly enabled in a packaged
+  // macOS app through the DeveloperMode user default. Restart-to-update stays
+  // in the production Server menu because it is a normal install path.
+  if (developerModeEnabled()) {
     /** @type {Electron.MenuItemConstructorOptions[]} */
     const debugSubmenu = [];
 

--- a/web/electron/test/developer_mode.test.js
+++ b/web/electron/test/developer_mode.test.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { DEVELOPER_MODE_KEY, isDeveloperModeEnabled } = require("../src/developer_mode");
+
+describe("developer mode", () => {
+  it("is always enabled for development builds", () => {
+    assert.equal(
+      isDeveloperModeEnabled({
+        isPackaged: false,
+        platform: "linux",
+        getUserDefault: () => false,
+      }),
+      true,
+    );
+  });
+
+  it("reads the packaged macOS opt-in as a boolean user default", () => {
+    const calls = [];
+    const enabled = isDeveloperModeEnabled({
+      isPackaged: true,
+      platform: "darwin",
+      getUserDefault: (...args) => {
+        calls.push(args);
+        return true;
+      },
+    });
+
+    assert.equal(enabled, true);
+    assert.deepEqual(calls, [[DEVELOPER_MODE_KEY, "boolean"]]);
+  });
+
+  it("stays disabled when the packaged macOS preference is false", () => {
+    assert.equal(
+      isDeveloperModeEnabled({
+        isPackaged: true,
+        platform: "darwin",
+        getUserDefault: () => false,
+      }),
+      false,
+    );
+  });
+
+  it("stays disabled for packaged builds on other platforms", () => {
+    let reads = 0;
+    const enabled = isDeveloperModeEnabled({
+      isPackaged: true,
+      platform: "win32",
+      getUserDefault: () => {
+        reads += 1;
+        return true;
+      },
+    });
+
+    assert.equal(enabled, false);
+    assert.equal(reads, 0);
+  });
+
+  it("fails closed if macOS user defaults cannot be read", () => {
+    assert.equal(
+      isDeveloperModeEnabled({
+        isPackaged: true,
+        platform: "darwin",
+        getUserDefault: () => {
+          throw new Error("NSUserDefaults unavailable");
+        },
+      }),
+      false,
+    );
+  });
+});

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -42,6 +42,12 @@ describe("setup clipboard IPC wiring", () => {
   });
 });
 
+describe("production developer-mode wiring (src/main.js)", () => {
+  it("uses the same opt-in to enable the shell window's DevTools capability", () => {
+    assert.match(liveCode, /webPreferences:\s*\{[\s\S]{0,400}devTools:\s*developerModeEnabled\(\)/);
+  });
+});
+
 describe("workspace root bounce wiring (src/main.js)", () => {
   it("registers the bounce against the window's current pinned origin", () => {
     assert.match(

--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -12,6 +12,9 @@ function loadMainHarness({
   forceDevUpdateConfig = false,
   dialogResponses = [{ response: 1, checkboxChecked: false }],
   serverShutdown = () => Promise.resolve(),
+  isPackaged = false,
+  platform = process.platform,
+  developerMode = false,
 } = {}) {
   const userData = fs.mkdtempSync(path.join(os.tmpdir(), "omnigent-update-test-"));
   fs.writeFileSync(path.join(userData, "settings.json"), JSON.stringify(settings), "utf8");
@@ -61,7 +64,7 @@ function loadMainHarness({
 
   const electron = {
     app: {
-      isPackaged: false,
+      isPackaged,
       getPath: (name) => (name === "userData" ? userData : userData),
       setName: () => {},
       requestSingleInstanceLock: () => true,
@@ -103,7 +106,10 @@ function loadMainHarness({
     screen: {},
     session: { defaultSession: {} },
     shell: {},
-    systemPreferences: {},
+    systemPreferences: {
+      getUserDefault: (key, type) =>
+        key === "DeveloperMode" && type === "boolean" ? developerMode : false,
+    },
   };
 
   const localRequires = {
@@ -155,6 +161,7 @@ function loadMainHarness({
     module,
     process: {
       ...process,
+      platform,
       env: {
         ...process.env,
         // No OMNIGENT_FORCE_DEV_UPDATE_CONFIG injection: main.js now derives
@@ -215,6 +222,10 @@ function findMenuItem(menu, id) {
   return null;
 }
 
+function hasDebugMenu(menu) {
+  return menu.template.some((item) => item.label === "Debug");
+}
+
 describe("new session menu action", () => {
   it("routes Cmd/Ctrl+N to the current window without replacing the New Window action", (t) => {
     const harness = loadMainHarness();
@@ -232,6 +243,43 @@ describe("new session menu action", () => {
     newSessionItem.click();
 
     assert.deepEqual(harness.calls.sent, [{ channel: "omnigent:open-path", payload: "/" }]);
+  });
+});
+
+describe("developer-mode menu wiring", () => {
+  it("keeps the Debug menu in development builds", (t) => {
+    const harness = loadMainHarness({ isPackaged: false, platform: "linux" });
+    t.after(harness.cleanup);
+
+    harness.api.buildMenu();
+
+    assert.equal(hasDebugMenu(harness.calls.setApplicationMenu.at(-1)), true);
+  });
+
+  it("hides the Debug menu in packaged builds by default", (t) => {
+    const harness = loadMainHarness({
+      isPackaged: true,
+      platform: "darwin",
+      developerMode: false,
+    });
+    t.after(harness.cleanup);
+
+    harness.api.buildMenu();
+
+    assert.equal(hasDebugMenu(harness.calls.setApplicationMenu.at(-1)), false);
+  });
+
+  it("shows the Debug menu when a packaged macOS build opts in", (t) => {
+    const harness = loadMainHarness({
+      isPackaged: true,
+      platform: "darwin",
+      developerMode: true,
+    });
+    t.after(harness.cleanup);
+
+    harness.api.buildMenu();
+
+    assert.equal(hasDebugMenu(harness.calls.setApplicationMenu.at(-1)), true);
   });
 });
 


### PR DESCRIPTION
## Related issue

N/A — maintainer-requested Electron debugging support.

## Summary

- Keep the production Electron shell locked down by default while allowing packaged macOS builds to opt into DevTools through `defaults write ai.omnigent.desktop DeveloperMode -bool true`.
- Use the same developer-mode decision for the Debug menu and the main window's DevTools capability, without relaxing update security gates.
- Document the opt-in and cover the preference decision and main-process wiring.

ELI5: development builds keep their debugging tools; a production build only unlocks them when the local macOS user explicitly sets the app preference.

```text
app launch
  ├─ unpackaged build ───────────────────────> DevTools enabled
  └─ packaged build + macOS DeveloperMode ──> DevTools enabled
                   otherwise ────────────────> DevTools disabled
```

## Test Plan

- `node --test web/electron/test/developer_mode.test.js web/electron/test/main.test.js web/electron/test/update-main.test.js`
- `web/node_modules/.bin/oxlint --deny-warnings --report-unused-disable-directives web/electron/src/developer_mode.js web/electron/src/main.js web/electron/test/developer_mode.test.js web/electron/test/main.test.js web/electron/test/update-main.test.js`
- `(cd web && node_modules/.bin/tsc -b)`
- `git diff --check`

## Demo

N/A — this is an opt-in main-process configuration change with no default UI change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit matrix covers development, packaged macOS opt-in/out, unsupported platforms, and read failures. The main-process harness verifies Debug-menu gating, and a wiring guard verifies the shell window uses the same decision.

## Changelog

Packaged macOS builds can opt into Electron Developer Tools with a local `defaults` setting.
