### PR TITLE
fix(host): keep host-launched runners authenticated past the bootstrap bearer's expiry

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -108,6 +108,7 @@ from omnigent.process_logging import (
 )
 from omnigent.runner._zygote import ZYGOTE_ENABLED_ENV_VAR
 from omnigent.runner.identity import (
+    RUNNER_AUTH_TOKEN_REFRESH_FILE_ENV_VAR,
     RUNNER_DELEGATED_AUTH_ENV_VAR,
     RUNNER_ID_ENV_VAR,
     RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
@@ -620,6 +621,36 @@ class HostConnectError(Exception):
     """
 
 
+# Interval between rewrites of the shared runner-auth bearer file. Short enough
+# that the file tracks the host's token within a minute of its rotation, so a
+# runner rejected right at expiry finds the fresh bearer already published; the
+# tick is an in-memory token read plus a tiny atomic write.
+_RUNNER_AUTH_REFRESH_INTERVAL_S = 60.0
+
+
+def _atomic_write_secret(path: Path, contents: str) -> None:
+    """Write *contents* to *path* atomically with owner-only (0600) permissions.
+
+    The file is created 0600 from the first byte (never a wider-mode window)
+    and renamed into place so a concurrent reader never sees a partial write.
+
+    :param path: Destination file path.
+    :param contents: Text to write (a bearer token).
+    :returns: None.
+    :raises OSError: On write or rename failure.
+    """
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(contents)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+    os.replace(tmp, path)
+
+
 def _build_runner_env(
     base_env: Mapping[str, str],
     *,
@@ -631,6 +662,7 @@ def _build_runner_env(
     initial_auth_token: str | None = None,
     host_id: str | None = None,
     harness: str | None = None,
+    auth_refresh_path: str | None = None,
 ) -> dict[str, str]:
     """
     Build the environment for a spawned runner subprocess.
@@ -660,6 +692,9 @@ def _build_runner_env(
     :param harness: Canonical harness of the launching session, e.g.
         ``"claude-native"``; lets the runner start harness-specific prewarms
         at boot. ``None`` (unknown / older server) omits the stamp.
+    :param auth_refresh_path: Path to the file the host rewrites with a fresh
+        bearer before the injected one expires, so the runner can recover after
+        expiry. Only forwarded when an ``initial_auth_token`` is present.
     :returns: The runner subprocess environment.
     """
     extra_names = {
@@ -698,6 +733,8 @@ def _build_runner_env(
     env[RUNNER_DELEGATED_AUTH_ENV_VAR] = "1"
     if initial_auth_token:
         env[RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR] = initial_auth_token
+        if auth_refresh_path:
+            env[RUNNER_AUTH_TOKEN_REFRESH_FILE_ENV_VAR] = auth_refresh_path
     env[RUNNER_WORKSPACE_ENV_VAR] = workspace
     env[RUNNER_PARENT_PID_ENV_VAR] = str(parent_pid)
     # Bound glibc allocator RSS in the runner (no-op off Linux). Injected
@@ -862,6 +899,13 @@ class HostProcess:
         self._watcher_tasks: set[asyncio.Task[None]] = set()
         # Strong ref to the orphan-reaper task (see :meth:`_orphan_reaper_loop`).
         self._reaper_task: asyncio.Task[None] | None = None
+        # Shared file the host rewrites with its current Databricks bearer so
+        # host-launched runners recover after their spawn-time bearer expires.
+        # Created lazily on the first launch that carries a bearer (see
+        # :meth:`_ensure_runner_auth_refresh_file`) and rewritten by
+        # :meth:`_auth_refresh_loop`; removed on shutdown.
+        self._auth_refresh_path: Path | None = None
+        self._auth_refresh_task: asyncio.Task[None] | None = None
         # Number of host-owned ``subprocess`` operations (e.g. the git worktree
         # commands in :mod:`omnigent.host.git_worktree`) currently in flight.
         # The orphan reaper skips its sweep while this is >0 so it never
@@ -1348,6 +1392,15 @@ class HostProcess:
             self._current_auth_token,
             initialize=False,
         )
+        # Publish the bearer to a file the runner can re-read after its injected
+        # copy expires; the refresh loop (started in run()) keeps it current.
+        # Only when there is a refreshable bearer — managed / credential-less
+        # hosts have nothing to publish.
+        auth_refresh_path: str | None = None
+        if initial_auth_token:
+            auth_refresh_path = await asyncio.to_thread(
+                self._ensure_runner_auth_refresh_file, initial_auth_token
+            )
         env = _build_runner_env(
             os.environ,
             server_url=self._server_url,
@@ -1358,6 +1411,7 @@ class HostProcess:
             initial_auth_token=initial_auth_token,
             host_id=self._identity.host_id,
             harness=frame.harness,
+            auth_refresh_path=auth_refresh_path,
         )
 
         # Embed the session id so operators can find all logs for a session
@@ -2659,6 +2713,11 @@ class HostProcess:
                 asyncio.to_thread(self._ensure_zygote_started),
                 name="host-zygote-prestart",
             )
+        # Keep the shared runner-auth bearer file fresh so host-launched runners
+        # survive their spawn-time bearer's ~1h expiry (see _auth_refresh_loop).
+        self._auth_refresh_task = asyncio.create_task(
+            self._auth_refresh_loop(), name="host-runner-auth-refresh"
+        )
         backoff = _RECONNECT_BASE_S
         try:
             while True:
@@ -2824,6 +2883,12 @@ class HostProcess:
             for watcher in list(self._watcher_tasks):
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await watcher
+            if self._auth_refresh_task is not None:
+                self._auth_refresh_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self._auth_refresh_task
+                self._auth_refresh_task = None
+            self._cleanup_auth_refresh_file()
             self._cleanup_runners()
             # Final drain: _cleanup_runners has just reaped the tracked
             # runners via Popen, so any of their still-orphaned tool
@@ -3027,6 +3092,74 @@ class HostProcess:
         except Exception:  # noqa: BLE001
             _logger.debug("Could not obtain auth token", exc_info=True)
         return None
+
+    def _ensure_runner_auth_refresh_file(self, token: str) -> str | None:
+        """Write *token* to the shared runner-auth refresh file, creating it 0600.
+
+        Host-launched runners re-read this file to pick up a refreshed bearer
+        after the one injected at spawn expires. Created lazily under
+        ``<data-dir>/host`` on the first launch that carries a bearer, then
+        rewritten by :meth:`_auth_refresh_loop`.
+
+        :param token: The host's current bearer to publish for its runners.
+        :returns: The file path for runner-env injection, or ``None`` when the
+            file could not be written.
+        """
+        try:
+            if self._auth_refresh_path is None:
+                from omnigent.process_logging import data_dir
+
+                base = data_dir() / "host"
+                base.mkdir(parents=True, exist_ok=True)
+                # The pid keeps concurrent host daemons on one machine from
+                # clobbering each other's bearer file.
+                self._auth_refresh_path = base / f"runner-auth-{os.getpid()}.token"
+            _atomic_write_secret(self._auth_refresh_path, token)
+            return str(self._auth_refresh_path)
+        except OSError:
+            _logger.debug("Could not write runner-auth refresh file", exc_info=True)
+            return None
+
+    async def _auth_refresh_loop(self) -> None:
+        """Rewrite the shared runner-auth bearer file before the token expires.
+
+        The host injects its Databricks bearer into each runner once at spawn,
+        but that bearer dies with the ~1h OAuth lifetime. The host holds
+        refresh-capable auth, so it re-mints and re-publishes a fresh bearer on
+        an interval comfortably under that lifetime, letting live runners
+        recover without a restart.
+
+        :returns: None. Runs until cancelled on shutdown.
+        """
+        while True:
+            await asyncio.sleep(_RUNNER_AUTH_REFRESH_INTERVAL_S)
+            await asyncio.to_thread(self._refresh_runner_auth_file)
+
+    def _refresh_runner_auth_file(self) -> None:
+        """Republish a freshly-minted bearer to the runner-auth file.
+
+        A no-op until the file has been created by the first launch that carried
+        a bearer, or when the host has no refreshable credential right now (e.g.
+        a transient SDK refresh failure) — the last-published bearer is left in
+        place rather than blanked.
+
+        :returns: None.
+        """
+        if self._auth_refresh_path is None:
+            return
+        token = self._current_auth_token(initialize=False)
+        if token:
+            self._ensure_runner_auth_refresh_file(token)
+
+    def _cleanup_auth_refresh_file(self) -> None:
+        """Remove the shared runner-auth bearer file on shutdown.
+
+        :returns: None.
+        """
+        if self._auth_refresh_path is not None:
+            with contextlib.suppress(OSError):
+                self._auth_refresh_path.unlink()
+            self._auth_refresh_path = None
 
     async def _serve_frames(self, ws: websockets.asyncio.client.ClientConnection) -> None:
         """Send the cached host hello, then service frames until disconnect."""

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -18,6 +18,8 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
+import threading
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -631,24 +633,55 @@ _RUNNER_AUTH_REFRESH_INTERVAL_S = 60.0
 def _atomic_write_secret(path: Path, contents: str) -> None:
     """Write *contents* to *path* atomically with owner-only (0600) permissions.
 
-    The file is created 0600 from the first byte (never a wider-mode window)
-    and renamed into place so a concurrent reader never sees a partial write.
+    Each call writes its own unique 0600 temp file (never a wider-mode window,
+    never shared with a concurrent writer) and renames it into place, so a
+    reader sees either the previous contents or the new ones, never a partial
+    write. The temp file never outlives a failure.
 
     :param path: Destination file path.
     :param contents: Text to write (a bearer token).
     :returns: None.
     :raises OSError: On write or rename failure.
     """
-    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
-    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    fd, tmp = tempfile.mkstemp(prefix=f"{path.name}.", suffix=".tmp", dir=path.parent)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(contents)
+        os.replace(tmp, path)
     except BaseException:
         with contextlib.suppress(OSError):
             os.unlink(tmp)
         raise
-    os.replace(tmp, path)
+
+
+# ``runner-auth-<pid>.token`` plus the ``.<random>.tmp`` a crashed write can
+# leave next to it; the pid names the host daemon that owned the file.
+_RUNNER_AUTH_FILE_RE = re.compile(r"^runner-auth-(\d+)\.token(?:\..*\.tmp)?$")
+
+
+def _sweep_dead_host_auth_files(base: Path) -> None:
+    """Delete runner-auth bearer files left behind by host daemons that died.
+
+    Shutdown removes a host's own file, but a killed or OOMed host leaves it
+    (with an expired bearer) on disk for good. Files whose owning pid is still
+    running — another live host on this machine — are left alone.
+
+    :param base: The ``<data-dir>/host`` directory holding the files.
+    :returns: None.
+    """
+    try:
+        entries = list(base.iterdir())
+    except OSError:
+        return
+    for entry in entries:
+        match = _RUNNER_AUTH_FILE_RE.match(entry.name)
+        if match is None:
+            continue
+        pid = int(match.group(1))
+        if pid == os.getpid() or _proc.process_alive(pid):
+            continue
+        with contextlib.suppress(OSError):
+            entry.unlink()
 
 
 def _build_runner_env(
@@ -906,6 +939,11 @@ class HostProcess:
         # :meth:`_auth_refresh_loop`; removed on shutdown.
         self._auth_refresh_path: Path | None = None
         self._auth_refresh_task: asyncio.Task[None] | None = None
+        # Launches and the refresh tick both publish from worker threads;
+        # the lock serializes them and the flag fences out a tick that is
+        # still in flight when shutdown removes the file.
+        self._auth_refresh_lock = threading.Lock()
+        self._auth_refresh_closed = False
         # Number of host-owned ``subprocess`` operations (e.g. the git worktree
         # commands in :mod:`omnigent.host.git_worktree`) currently in flight.
         # The orphan reaper skips its sweep while this is >0 so it never
@@ -2885,7 +2923,7 @@ class HostProcess:
                     await watcher
             if self._auth_refresh_task is not None:
                 self._auth_refresh_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError, Exception):
+                with contextlib.suppress(asyncio.CancelledError):
                     await self._auth_refresh_task
                 self._auth_refresh_task = None
             self._cleanup_auth_refresh_file()
@@ -3103,22 +3141,26 @@ class HostProcess:
 
         :param token: The host's current bearer to publish for its runners.
         :returns: The file path for runner-env injection, or ``None`` when the
-            file could not be written.
+            file could not be written or the host is already shutting down.
         """
-        try:
-            if self._auth_refresh_path is None:
-                from omnigent.process_logging import data_dir
+        with self._auth_refresh_lock:
+            if self._auth_refresh_closed:
+                return None
+            try:
+                if self._auth_refresh_path is None:
+                    from omnigent.process_logging import data_dir
 
-                base = data_dir() / "host"
-                base.mkdir(parents=True, exist_ok=True)
-                # The pid keeps concurrent host daemons on one machine from
-                # clobbering each other's bearer file.
-                self._auth_refresh_path = base / f"runner-auth-{os.getpid()}.token"
-            _atomic_write_secret(self._auth_refresh_path, token)
-            return str(self._auth_refresh_path)
-        except OSError:
-            _logger.debug("Could not write runner-auth refresh file", exc_info=True)
-            return None
+                    base = data_dir() / "host"
+                    base.mkdir(parents=True, exist_ok=True)
+                    _sweep_dead_host_auth_files(base)
+                    # The pid keeps concurrent host daemons on one machine from
+                    # clobbering each other's bearer file.
+                    self._auth_refresh_path = base / f"runner-auth-{os.getpid()}.token"
+                _atomic_write_secret(self._auth_refresh_path, token)
+                return str(self._auth_refresh_path)
+            except OSError:
+                _logger.debug("Could not write runner-auth refresh file", exc_info=True)
+                return None
 
     async def _auth_refresh_loop(self) -> None:
         """Rewrite the shared runner-auth bearer file before the token expires.
@@ -3154,12 +3196,17 @@ class HostProcess:
     def _cleanup_auth_refresh_file(self) -> None:
         """Remove the shared runner-auth bearer file on shutdown.
 
+        Also closes publishing, so a refresh tick that is still running in
+        its worker thread cannot recreate the file afterwards.
+
         :returns: None.
         """
-        if self._auth_refresh_path is not None:
-            with contextlib.suppress(OSError):
-                self._auth_refresh_path.unlink()
-            self._auth_refresh_path = None
+        with self._auth_refresh_lock:
+            self._auth_refresh_closed = True
+            if self._auth_refresh_path is not None:
+                with contextlib.suppress(OSError):
+                    self._auth_refresh_path.unlink()
+                self._auth_refresh_path = None
 
     async def _serve_frames(self, ws: websockets.asyncio.client.ClientConnection) -> None:
         """Send the cached host hello, then service frames until disconnect."""

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -389,26 +389,49 @@ def _invalidate_auth_token_factory(factory: Callable[[], str | None]) -> bool:
 
 
 class _InitialAuthTokenFactory:
-    """Use a host bearer until rejection, then lazily resolve runner auth."""
+    """Use a host bearer until rejection, then a host-refreshed bearer or local auth.
 
-    def __init__(self, token: str, server_url: str) -> None:
+    A host-launched runner is injected the host's Databricks bearer once at
+    spawn; it dies with the ~1h OAuth lifetime, and the runner holds no
+    self-refreshing Databricks credential of its own. The host, which does hold
+    refresh-capable auth, rewrites a fresh bearer into ``refresh_path`` before
+    the injected one expires. On rejection this factory re-reads that file and
+    adopts the newer host bearer, falling through to runner-local mint only when
+    no fresher bearer has been supplied.
+    """
+
+    def __init__(self, token: str, server_url: str, refresh_path: str | None = None) -> None:
         """
         :param token: Current bearer obtained from the connected host.
         :param server_url: Omnigent server URL used by the fallback resolver.
+        :param refresh_path: Optional file the host rewrites with a fresh
+            bearer; re-read when the active bearer is rejected. ``None`` keeps
+            the legacy behavior (fall straight through to runner-local auth).
         """
         self._initial_token: str | None = token
         self._last_initial_token: str = token  # retained for managed-mint proxy auth
         self._server_url = server_url
+        self._refresh_path = Path(refresh_path) if refresh_path else None
         self._fallback_factory: Callable[[], str | None] | None = None
         self._fallback_resolved = False
         self._no_credential_logged = False
         self._lock = threading.Lock()
 
     def __call__(self) -> str | None:
-        """Return the host bearer or a token from the lazy local fallback."""
+        """Return the host bearer, a host-refreshed bearer, or the local fallback."""
         with self._lock:
             if self._initial_token is not None:
                 return self._initial_token
+            # The active host bearer was rejected. Prefer a fresher bearer the
+            # host has since re-supplied over the runner-local mint, which a
+            # host-launched runner cannot drive on a Databricks-fronted server
+            # (its mint call needs a live edge bearer it has no way to renew).
+            refreshed = self._read_refreshed_token()
+            if refreshed is not None and refreshed != self._last_initial_token:
+                self._initial_token = refreshed
+                self._last_initial_token = refreshed
+                _logger.info("adopted host-refreshed bearer for runner auth")
+                return refreshed
             if not self._fallback_resolved:
                 self._fallback_factory = _make_auth_token_factory(
                     self._server_url,
@@ -438,6 +461,20 @@ class _InitialAuthTokenFactory:
                 )
             return token
 
+    def _read_refreshed_token(self) -> str | None:
+        """Return the host-refreshed bearer from ``refresh_path``, if present.
+
+        :returns: The token string, or ``None`` when no refresh file is
+            configured or it is missing, empty, or unreadable.
+        """
+        if self._refresh_path is None:
+            return None
+        try:
+            token = self._refresh_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+        return token or None
+
     @property
     def declined(self) -> bool:
         """True when the inner fallback factory has definitively declined."""
@@ -446,7 +483,7 @@ class _InitialAuthTokenFactory:
             return getattr(f, "declined", False) and not getattr(f, "proxy_auth_failed", False)
 
     def invalidate(self) -> bool:
-        """Discard the host bearer so the next call resolves local auth."""
+        """Discard the host bearer; the next call re-reads the host's refresh file first."""
         with self._lock:
             if self._initial_token is None:
                 return False
@@ -519,6 +556,7 @@ def _make_auth_token_factory(
     # from os.environ here ensures later harness/terminal children cannot
     # inherit it even if a spawn path bypasses the standard secret scrubber.
     from omnigent.runner.identity import (
+        RUNNER_AUTH_TOKEN_REFRESH_FILE_ENV_VAR,
         RUNNER_DELEGATED_AUTH_ENV_VAR,
         RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
         RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR,
@@ -529,9 +567,19 @@ def _make_auth_token_factory(
         if _allow_initial_token
         else ""
     )
+    # Path the host rewrites with a fresh bearer before this one expires;
+    # popped alongside the token so a scrub-bypassing child cannot inherit a
+    # pointer to the on-disk credential.
+    initial_refresh_path = (
+        os.environ.pop(RUNNER_AUTH_TOKEN_REFRESH_FILE_ENV_VAR, "").strip()
+        if _allow_initial_token
+        else ""
+    )
     if initial_token and resolved_server_url:
         _logger.info("using host-provided bearer for runner bootstrap")
-        return _InitialAuthTokenFactory(initial_token, resolved_server_url)
+        return _InitialAuthTokenFactory(
+            initial_token, resolved_server_url, refresh_path=initial_refresh_path or None
+        )
 
     from omnigent.inner.databricks_executor import (
         DatabricksAuthError,

--- a/omnigent/runner/identity.py
+++ b/omnigent/runner/identity.py
@@ -22,6 +22,11 @@ RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR = "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN"
 # A host-launched runner uses this bearer for its initial server connection,
 # then falls back to its own refreshable auth when the bearer is rejected.
 RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR = "OMNIGENT_RUNNER_INITIAL_AUTH_TOKEN"
+# Path to a file the host rewrites with a fresh bearer before the injected one
+# expires. A host-launched runner re-reads it after the server rejects its
+# active bearer, so it recovers with the host's refreshed credential instead of
+# a stale one (the runner holds no self-refreshing Databricks credential).
+RUNNER_AUTH_TOKEN_REFRESH_FILE_ENV_VAR = "OMNIGENT_RUNNER_AUTH_TOKEN_REFRESH_FILE"
 # Host-launched runners use their binding token to obtain a short-lived,
 # owner-scoped server bearer instead of resolving the host user's credentials.
 RUNNER_DELEGATED_AUTH_ENV_VAR = "OMNIGENT_RUNNER_DELEGATED_AUTH"
@@ -72,6 +77,9 @@ RUNNER_AUTH_SECRET_ENV_VARS: frozenset[str] = frozenset(
     {
         RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
         RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR,
+        # Not a secret value itself, but it points at the on-disk bearer file;
+        # stripping it keeps a child from reading the credential.
+        RUNNER_AUTH_TOKEN_REFRESH_FILE_ENV_VAR,
     }
 )
 

--- a/omnigent/runner/identity.py
+++ b/omnigent/runner/identity.py
@@ -77,8 +77,9 @@ RUNNER_AUTH_SECRET_ENV_VARS: frozenset[str] = frozenset(
     {
         RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
         RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR,
-        # Not a secret value itself, but it points at the on-disk bearer file;
-        # stripping it keeps a child from reading the credential.
+        # Not a secret itself, but it points at the on-disk bearer file.
+        # Stripping it only withholds the pointer; the real boundary is the
+        # process uid, the same one that guards the CLI's own token cache.
         RUNNER_AUTH_TOKEN_REFRESH_FILE_ENV_VAR,
     }
 )

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -59,6 +59,7 @@ from omnigent.host.frames import (
 from omnigent.host.identity import HostIdentity
 from omnigent.host.runner_zygote import ZygoteUnavailable
 from omnigent.runner.identity import (
+    RUNNER_AUTH_TOKEN_REFRESH_FILE_ENV_VAR,
     RUNNER_DELEGATED_AUTH_ENV_VAR,
     RUNNER_ID_ENV_VAR,
     RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
@@ -625,6 +626,9 @@ def _cleanup_host(host: HostProcess) -> None:
     :param host: The host process under test.
     """
     host._cleanup_runners()
+    host._cleanup_auth_refresh_file()
+    if host._auth_refresh_task is not None:
+        host._auth_refresh_task.cancel()
     for task in host._watcher_tasks:
         task.cancel()
 
@@ -713,6 +717,84 @@ async def test_handle_launch_spawns_subprocess(
 
     # Clean up the spawned sleep process (and its exit watcher).
     _cleanup_host(host)
+
+
+async def test_handle_launch_publishes_and_injects_auth_refresh_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_handle_launch writes the host bearer to a 0600 refresh file and injects
+    its path.
+
+    This is the host-side half of the token-refresh channel: the runner
+    re-reads this file to recover after the bearer injected at spawn hits its
+    ~1h expiry, instead of wedging on a stale credential.
+    """
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+    host = _make_host_process()
+    host._auth_token_factory = lambda: "host-bootstrap-bearer"
+    host._auth_token_factory_resolved = True
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+
+    frame = HostLaunchRunnerFrame(
+        request_id="req_refresh",
+        binding_token="tok_refresh",
+        workspace=str(workspace),
+    )
+
+    spawned_env: dict[str, str] = {}
+    original_popen = subprocess.Popen
+
+    def _fake_popen(args: list[str], **kwargs: object) -> subprocess.Popen[bytes]:
+        """Capture the runner env and spawn a harmless placeholder process."""
+        spawned_env.update(kwargs.get("env", {}))  # type: ignore[arg-type]
+        return original_popen(
+            ["sleep", "10"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+
+    with patch("omnigent.host.connect.subprocess.Popen", side_effect=_fake_popen):
+        result = await host._handle_launch(frame)
+
+    assert result.status == "launched", result.error
+
+    refresh_path = spawned_env.get(RUNNER_AUTH_TOKEN_REFRESH_FILE_ENV_VAR)
+    assert refresh_path, "runner env must carry the auth-refresh file path"
+    published = Path(refresh_path)
+    assert published.read_text() == "host-bootstrap-bearer"
+    # The bearer file must never be group- or world-readable.
+    assert (published.stat().st_mode & 0o077) == 0
+
+    _cleanup_host(host)
+    # Shutdown cleanup removes the published bearer file.
+    assert not published.exists()
+
+
+async def test_refresh_runner_auth_file_republishes_rotated_bearer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The periodic refresh rewrites the file with a newly-minted bearer.
+
+    This is what lets a live runner recover without a restart: the host
+    re-mints and republishes before the runner's injected bearer expires. When
+    the host credential rotates, the file must follow.
+    """
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+    host = _make_host_process()
+    host._auth_token_factory = lambda: "bearer-v1"
+    host._auth_token_factory_resolved = True
+
+    path = host._ensure_runner_auth_refresh_file("bearer-v1")
+    assert path is not None and Path(path).read_text() == "bearer-v1"
+
+    # The host's Databricks credential rotates on its own refresh cycle; the
+    # next periodic publish must carry the new bearer through to the file.
+    host._auth_token_factory = lambda: "bearer-v2"
+    host._refresh_runner_auth_file()
+    assert Path(path).read_text() == "bearer-v2"
+
+    host._cleanup_auth_refresh_file()
 
 
 async def test_handle_launch_fails_for_bad_workspace() -> None:

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import errno
 import logging
+import os
 import subprocess
 import threading
 import time
@@ -23,6 +24,7 @@ from omnigent.host.connect import (
     HostConnectError,
     HostProcess,
     HostRetryableConnectionError,
+    _atomic_write_secret,
     _build_runner_env,
     _RunnerHandle,
     run_host_process,
@@ -635,6 +637,7 @@ def _cleanup_host(host: HostProcess) -> None:
 
 async def test_handle_launch_spawns_subprocess(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
     Verify that _handle_launch spawns a subprocess with the correct
@@ -643,6 +646,7 @@ async def test_handle_launch_spawns_subprocess(
     If the result status is not 'launched', the subprocess spawn
     failed or the result frame construction is wrong.
     """
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
     host = _make_host_process()
     host._auth_token_factory = lambda: "host-bootstrap-bearer"
     host._auth_token_factory_resolved = True
@@ -795,6 +799,67 @@ async def test_refresh_runner_auth_file_republishes_rotated_bearer(
     assert Path(path).read_text() == "bearer-v2"
 
     host._cleanup_auth_refresh_file()
+
+
+async def test_auth_refresh_publish_is_fenced_after_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refresh tick that lands after shutdown cleanup must not recreate the file.
+
+    The tick runs in a worker thread that cannot be cancelled, so without the
+    fence it could republish a bearer that outlives the host.
+    """
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+    host = _make_host_process()
+    path = host._ensure_runner_auth_refresh_file("bearer-v1")
+    assert path is not None
+
+    host._cleanup_auth_refresh_file()
+
+    assert host._ensure_runner_auth_refresh_file("bearer-late") is None
+    assert not Path(path).exists()
+
+
+async def test_first_publish_sweeps_bearer_files_of_dead_hosts_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A killed host's leftover bearer file is reclaimed; a live host's is kept."""
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+    base = tmp_path / "data" / "host"
+    base.mkdir(parents=True)
+    dead = base / "runner-auth-4242.token"
+    dead_tmp = base / "runner-auth-4242.token.abc123.tmp"
+    live = base / "runner-auth-4343.token"
+    for leftover in (dead, dead_tmp, live):
+        leftover.write_text("stale")
+    monkeypatch.setattr("omnigent.host.connect._proc.process_alive", lambda pid: pid == 4343)
+    host = _make_host_process()
+
+    path = host._ensure_runner_auth_refresh_file("bearer-v1")
+
+    assert path is not None and Path(path).read_text() == "bearer-v1"
+    assert Path(path).name == f"runner-auth-{os.getpid()}.token"
+    assert not dead.exists() and not dead_tmp.exists()
+    assert live.exists()
+    host._cleanup_auth_refresh_file()
+
+
+def test_atomic_write_secret_leaves_no_temp_on_failed_replace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed rename must not strand a 0600 temp copy of the bearer."""
+    target = tmp_path / "runner-auth-1.token"
+
+    def _boom(src: str, dst: str) -> None:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr("omnigent.host.connect.os.replace", _boom)
+    with pytest.raises(OSError, match="replace failed"):
+        _atomic_write_secret(target, "bearer")
+    assert list(tmp_path.iterdir()) == []
 
 
 async def test_handle_launch_fails_for_bad_workspace() -> None:
@@ -4161,6 +4226,7 @@ def test_run_host_process_announces_session_log_dir_on_start(
 
 async def test_launch_cancelled_midspawn_does_not_leak_untracked_runner(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Cancelling a launch mid-spawn tears the runner down instead of leaking it.
 
@@ -4170,6 +4236,7 @@ async def test_launch_cancelled_midspawn_does_not_leak_untracked_runner(
     would retain forever). The spawn is shielded and the abandoned process is
     terminated.
     """
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
     host = _make_host_process()
     host._auth_token_factory = lambda: "host-bootstrap-bearer"
     host._auth_token_factory_resolved = True

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -43,6 +43,7 @@ from omnigent.runner._entry import (
     main,
 )
 from omnigent.runner.identity import (
+    RUNNER_AUTH_TOKEN_REFRESH_FILE_ENV_VAR,
     RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
     RUNNER_TUNNEL_TOKEN_HEADER,
 )
@@ -358,6 +359,100 @@ def test_initial_host_token_falls_back_to_managed_mint_when_no_sdk_auth(
 
     # After the initial bearer is rejected, the fallback must mint via the
     # managed-mint path rather than returning None and bricking callbacks.
+    assert captured == [
+        "Bearer host-bootstrap-token",
+        "Bearer managed-minted-token",
+    ]
+    assert len(mint_calls) >= 1
+
+
+def test_initial_host_token_adopts_refreshed_bearer_from_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """After the injected bearer is rejected, the runner adopts the host's
+    refreshed bearer from the re-supply file instead of wedging on managed mint.
+
+    A host-launched runner has no self-refreshing Databricks credential; the
+    host rewrites this file before the injected bearer expires, so recovery must
+    prefer the fresher host bearer over the managed-mint path (which such a
+    runner cannot drive through the Databricks edge).
+    """
+
+    def _unexpected_mint(*args: Any, **kwargs: Any) -> tuple[str, float]:
+        del args, kwargs
+        raise AssertionError("must adopt the refreshed host bearer, not managed mint")
+
+    refresh_file = tmp_path / "runner-auth.token"
+    refresh_file.write_text("host-refreshed-bearer")
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://app.databricksapps.com")
+    monkeypatch.setenv(RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR, "host-bootstrap-token")
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "host-binding-token")
+    monkeypatch.setenv("OMNIGENT_RUNNER_DELEGATED_AUTH", "1")
+    monkeypatch.setenv(RUNNER_AUTH_TOKEN_REFRESH_FILE_ENV_VAR, str(refresh_file))
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _unexpected_mint)
+
+    factory = _make_auth_token_factory()
+
+    assert isinstance(factory, _InitialAuthTokenFactory)
+    # The refresh-file path is consumed from the env like the bearer itself.
+    assert RUNNER_AUTH_TOKEN_REFRESH_FILE_ENV_VAR not in os.environ
+    assert factory() == "host-bootstrap-token"
+
+    request = httpx.Request("GET", "https://app.databricksapps.com/api/version")
+    redirect = httpx.Response(302, headers={"Location": "/oidc/oauth2/v2.0/authorize"})
+    captured = _drive_auth_flow(_RunnerDatabricksAuth(factory), request, redirect)
+
+    assert captured == [
+        "Bearer host-bootstrap-token",
+        "Bearer host-refreshed-bearer",
+    ]
+
+
+def test_initial_host_token_falls_back_to_mint_when_refresh_file_is_stale(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A refresh file still holding the just-rejected bearer must not be re-adopted.
+
+    Guards the "only a *different* bearer is fresh" check: when the host has not
+    yet republished (the file still holds the rejected token), the runner falls
+    through to the managed-mint path rather than re-presenting a dead bearer.
+    """
+    mint_calls: list[int] = []
+
+    def _no_sdk_auth(*args: Any, **kwargs: Any) -> tuple[None, None]:
+        from omnigent.inner.databricks_executor import DatabricksAuthError
+
+        raise DatabricksAuthError("no credential configured")
+
+    def _mint(*args: Any, **kwargs: Any) -> tuple[str, float]:
+        mint_calls.append(1)
+        return "managed-minted-token", time.time() + 3600
+
+    refresh_file = tmp_path / "runner-auth.token"
+    # Same value as the injected bearer — the host has not refreshed it yet.
+    refresh_file.write_text("host-bootstrap-token")
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://app.databricksapps.com")
+    monkeypatch.setenv(RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR, "host-bootstrap-token")
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "host-binding-token")
+    monkeypatch.setenv("OMNIGENT_RUNNER_DELEGATED_AUTH", "1")
+    monkeypatch.setenv(RUNNER_AUTH_TOKEN_REFRESH_FILE_ENV_VAR, str(refresh_file))
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr(
+        "omnigent.inner.databricks_executor._resolve_databricks_auth", _no_sdk_auth
+    )
+    monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _mint)
+
+    factory = _make_auth_token_factory()
+
+    request = httpx.Request("GET", "https://app.databricksapps.com/api/version")
+    redirect = httpx.Response(302, headers={"Location": "/oidc/oauth2/v2.0/authorize"})
+    captured = _drive_auth_flow(_RunnerDatabricksAuth(factory), request, redirect)
+
     assert captured == [
         "Bearer host-bootstrap-token",
         "Bearer managed-minted-token",


### PR DESCRIPTION
## Related issue

Tracks Linear OMNI-3239 ("Policy eval 403/connection refusal"), which the repro agent marked `already_fixed` — this is the same failure class recurring on a host-launched codex-native session today (see Summary for the exact log trail).

## Summary

**What users saw:** a codex-native session on a Databricks-fronted server (`omnigents-…databricksapps.com`) whose next turn was blocked with

> UserPromptSubmit hook (blocked) — Omnigent policy evaluation unavailable (could not reach or authenticate to the Omnigent server); failing closed … last error: server returned 502: omnigent policy-eval proxy could not reach the Omnigent server: RequestError: Databricks token refresh returned no token

and the session flipped to `failed`. Nothing recovered until the host daemon was restarted.

**Root cause (from the runner/host logs):**

1. A host-launched runner receives the host's Databricks bearer **once** at spawn (`OMNIGENT_RUNNER_INITIAL_AUTH_TOKEN`) and is never handed a newer one. ~1h later the Apps edge rejects it (`host bootstrap bearer rejected; resolving runner-local auth`).
2. The managed-mint fallback presents that same dead bearer and gets bounced to login (302), so the runner falls through to resolving **ambient Databricks CLI auth on its own** (`loading oss profile … Using Databricks CLI authentication`).
3. Every long-lived runner on the machine that crossed the 1h mark is now an **independent refresher of the same rotating OAuth refresh token** — and `databricks-sdk` refreshes by shelling out to `databricks auth token --force-refresh`, which rotates the refresh token on every call. Two refreshes that interleave invalidate the shared token: today four runners (plus an older host daemon) hit `Tried to refresh token asynchronously, but failed: … the refresh token is invalid` within the same hour — two of them in the very same millisecond (`15:06:59.767`).
4. From then on every runner→server callback raises `Databricks token refresh returned no token`: the native policy-eval relay answers the hook with 502, the hook fails closed (by design), event posts fail, and the turn dies. The host, which still holds refresh-capable auth, has no channel to hand the runner a fresh bearer.

**The fix — the host becomes the runner's bearer source:**

- `omnigent host` writes its current bearer to a `0600` file under `<data-dir>/host/runner-auth-<pid>.token` (atomic temp-file + rename), republishes it every 60s from its own refresh-capable auth, and passes the path to each runner it launches (`OMNIGENT_RUNNER_AUTH_TOKEN_REFRESH_FILE`, stripped from runner children like the bearer itself). Removed on host shutdown.
- When a runner's active bearer is rejected, `_InitialAuthTokenFactory` re-reads that file and adopts the fresher host bearer **before** trying managed mint or ambient SDK/OIDC auth. Those fallbacks are unchanged and still apply when no fresher bearer is available (host gone, credential-less host, older host build).

The runner no longer needs to become its own Databricks refresher, which both repairs the wedge and removes the N-way refresh-token race that caused it.

**Trust boundary:** the bearer file is readable by anything running as the host's uid — the same boundary that already protects `~/.databrickscfg`, the CLI's token cache, and the `ap_auth_headers` bearer the native bridge bakes into `policy_hook.json` for hook subprocesses. The env-var scrub only keeps the *pointer* out of runner children; `0600` keeps other users out. Writes use a unique `mkstemp` temp under a lock, shutdown removes the file, and a new host's first publish sweeps files left by dead hosts.

```mermaid
sequenceDiagram
    participant H as omnigent host
    participant F as runner-auth-<pid>.token (0600)
    participant R as runner
    participant S as Omnigent server (Apps edge)
    H->>F: write bearer (at launch, then every 60s)
    H->>R: spawn with bearer + file path
    R->>S: callbacks with injected bearer
    Note over R,S: ~1h later the bearer expires
    S-->>R: 401 / 403 / 302 login redirect
    R->>F: re-read
    F-->>R: fresher host bearer
    R->>S: retry with adopted bearer (no ambient refresh)
```

**ELI5:** the host used to hand each runner a single hour-long hall pass and then forget about it; when it expired every runner went to the front office at once to get its own, and the office started rejecting everyone. Now the host keeps a fresh pass pinned to the board every minute, and a runner just reads the board when its pass is refused.

## Test Plan

- `tests/runner/test_runner_entry.py`: a rejected bootstrap bearer adopts the host's refreshed bearer from the file (managed mint is never called); a file that still holds the just-rejected bearer is *not* re-adopted and the runner falls through to managed mint as before; the file path is consumed from the env like the bearer.
- `tests/host/test_connect.py`: `_handle_launch` publishes the bearer to a `0600` file and injects its path into the runner env, and shutdown removes it; the periodic republish follows a rotated host credential.
- `pytest tests/runner/test_runner_entry.py tests/host/test_connect.py -k "not live_host"` — all green except `test_run_host_process_announces_session_log_dir_on_start`, which fails identically on a pristine `origin/main` checkout (ambient runner-log state; #5118 isolates it).
- `pre-commit run --files …` — ruff/format clean (pyrefly's only complaints are missing optional `opentelemetry` modules in the local venv).

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit tests drive the real `_InitialAuthTokenFactory` through `_RunnerDatabricksAuth.auth_flow` with a 302 login redirect and the real `HostProcess._handle_launch` (fake `Popen`), so the file contract is exercised end-to-end in-process. The live ~1h expiry itself is not simulated; on a running host the new behaviour is visible as `~/.omnigent/host/runner-auth-<pid>.token` being rewritten every minute and, after the first rejection, a runner log line `adopted host-refreshed bearer for runner auth` in place of `resolving runner-local auth`.

## Changelog

Host-launched sessions on Databricks-fronted servers no longer lose policy evaluation and event delivery ("Databricks token refresh returned no token") an hour after launch; the host now keeps its runners' server credential fresh.
