### PR TITLE
feat(electron): notarize macOS DMG releases

### DIFF
--- a/web/electron/README.md
+++ b/web/electron/README.md
@@ -374,7 +374,7 @@ From `web/electron/`:
 ```bash
 pnpm run build             # current platform
 pnpm run build:mac         # .dmg + .zip (signed if an identity is available, not notarized)
-pnpm run build:mac:release # .dmg + .zip, signed + notarized (requires credentials, see below)
+pnpm run build:mac:release # .dmg + .zip; app and DMG signed + notarized (see below)
 pnpm run build:linux       # AppImage + .deb
 pnpm run build:win         # NSIS installer
 ```
@@ -394,7 +394,7 @@ build:
 | ------------------------------------------------------------------ | -------------------------------------------------------------------- |
 | none                                                               | ad-hoc–signed app; runs locally, other Macs see a Gatekeeper warning |
 | Developer ID cert                                                  | signed app; downloads still warn until notarized                     |
-| Developer ID cert + Apple notarization creds (`build:mac:release`) | signed + notarized; installs cleanly everywhere                      |
+| Developer ID cert + Apple notarization creds (`build:mac:release`) | app and DMG signed + notarized; installs cleanly everywhere          |
 
 ### 1. Get a signing certificate
 
@@ -446,17 +446,21 @@ then:
 pnpm run build:mac:release
 ```
 
-This is the same build with `mac.notarize=true` switched on; expect the
-notarization step to add a few minutes (Apple-side processing). Verify the
+This release build signs and notarizes the app first so both the DMG and ZIP
+contain a trusted app. It then signs each finished DMG, submits it to Apple,
+and staples and validates the resulting ticket. Expect the notarization steps
+to add a few minutes per architecture (Apple-side processing). Verify the
 result with:
 
 ```bash
 spctl -a -vv dist/mac-arm64/Omnigent.app   # → "accepted, source=Notarized Developer ID"
+codesign --verify --verbose=2 dist/Omnigent-*-arm64.dmg
+xcrun stapler validate -v dist/Omnigent-*-arm64.dmg
 ```
 
-`build:mac:release` **fails loudly** if signing or notarization
-credentials are missing — that's intentional, so a release artifact can't
-silently ship unsigned.
+`build:mac:release` **fails loudly** if signing or notarization credentials
+are missing, if Apple rejects a DMG, or if stapling fails. That's intentional,
+so a release artifact can't silently ship unsigned or unnotarized.
 
 ## Getting a server to point at
 

--- a/web/electron/build/afterAllArtifactBuild.js
+++ b/web/electron/build/afterAllArtifactBuild.js
@@ -1,0 +1,97 @@
+const { spawnSync } = require("child_process");
+
+function getNotarytoolAuthArgs(env = process.env) {
+  const apiKeyValues = [env.APPLE_API_KEY, env.APPLE_API_KEY_ID, env.APPLE_API_ISSUER];
+  if (apiKeyValues.some(Boolean)) {
+    if (!apiKeyValues.every(Boolean)) {
+      throw new Error(
+        "DMG notarization requires APPLE_API_KEY, APPLE_API_KEY_ID, and APPLE_API_ISSUER.",
+      );
+    }
+    return [
+      "--key",
+      env.APPLE_API_KEY,
+      "--key-id",
+      env.APPLE_API_KEY_ID,
+      "--issuer",
+      env.APPLE_API_ISSUER,
+    ];
+  }
+
+  const appleIdValues = [env.APPLE_ID, env.APPLE_APP_SPECIFIC_PASSWORD, env.APPLE_TEAM_ID];
+  if (appleIdValues.some(Boolean)) {
+    if (!appleIdValues.every(Boolean)) {
+      throw new Error(
+        "DMG notarization requires APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID.",
+      );
+    }
+    return [
+      "--apple-id",
+      env.APPLE_ID,
+      "--password",
+      env.APPLE_APP_SPECIFIC_PASSWORD,
+      "--team-id",
+      env.APPLE_TEAM_ID,
+    ];
+  }
+
+  throw new Error(
+    "DMG notarization credentials are missing; configure an Apple API key or Apple ID credentials.",
+  );
+}
+
+function runXcrun(args, { captureOutput = false } = {}) {
+  const result = spawnSync("xcrun", args, {
+    encoding: "utf8",
+    stdio: captureOutput ? ["ignore", "pipe", "pipe"] : "inherit",
+  });
+
+  if (captureOutput) {
+    if (result.stdout) process.stdout.write(result.stdout);
+    if (result.stderr) process.stderr.write(result.stderr);
+  }
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`xcrun ${args[0]} failed with exit code ${result.status}.`);
+  }
+
+  return result.stdout;
+}
+
+function notarizeDmg(dmgPath, authArgs, run = runXcrun) {
+  run(["codesign", "--verify", "--verbose=2", dmgPath]);
+
+  const output = run(
+    ["notarytool", "submit", dmgPath, ...authArgs, "--wait", "--output-format", "json"],
+    { captureOutput: true },
+  );
+  const result = JSON.parse(output);
+  if (result.status !== "Accepted") {
+    throw new Error(
+      `Apple notarization did not accept ${dmgPath} (status: ${result.status ?? "unknown"}).`,
+    );
+  }
+
+  run(["stapler", "staple", "-v", dmgPath]);
+  run(["stapler", "validate", "-v", dmgPath]);
+}
+
+module.exports = async function afterAllArtifactBuild(context) {
+  if (process.env.OMNIGENT_NOTARIZE_DMG !== "true") return [];
+
+  const dmgPaths = context.artifactPaths.filter((artifactPath) => artifactPath.endsWith(".dmg"));
+  if (dmgPaths.length === 0) {
+    throw new Error("DMG notarization was requested, but electron-builder produced no DMG files.");
+  }
+
+  const authArgs = getNotarytoolAuthArgs();
+  for (const dmgPath of dmgPaths) {
+    console.log(`Notarizing and stapling ${dmgPath}`);
+    notarizeDmg(dmgPath, authArgs);
+  }
+
+  return [];
+};
+
+module.exports.getNotarytoolAuthArgs = getNotarytoolAuthArgs;
+module.exports.notarizeDmg = notarizeDmg;

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -20,7 +20,7 @@
     "test": "node --test",
     "build": "electron-builder",
     "build:mac": "electron-builder --mac",
-    "build:mac:release": "electron-builder --mac -c.mac.notarize=true",
+    "build:mac:release": "OMNIGENT_NOTARIZE_DMG=true electron-builder --mac -c.mac.notarize=true -c.dmg.sign=true",
     "build:linux": "electron-builder --linux",
     "build:win": "electron-builder --win",
     "build:overlay": "pnpm --filter web run build:overlay",
@@ -57,6 +57,7 @@
       }
     ],
     "afterPack": "build/afterPack.js",
+    "afterAllArtifactBuild": "build/afterAllArtifactBuild.js",
     "files": [
       "src/**/*",
       "setup/**/*",

--- a/web/electron/test/notarizeDmg.test.js
+++ b/web/electron/test/notarizeDmg.test.js
@@ -1,0 +1,80 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { getNotarytoolAuthArgs, notarizeDmg } = require("../build/afterAllArtifactBuild");
+
+describe("DMG notarization", () => {
+  it("maps App Store Connect API credentials to notarytool arguments", () => {
+    assert.deepEqual(
+      getNotarytoolAuthArgs({
+        APPLE_API_KEY: "/tmp/AuthKey_TEST.p8",
+        APPLE_API_KEY_ID: "KEYID",
+        APPLE_API_ISSUER: "issuer-id",
+      }),
+      ["--key", "/tmp/AuthKey_TEST.p8", "--key-id", "KEYID", "--issuer", "issuer-id"],
+    );
+  });
+
+  it("maps Apple ID credentials to notarytool arguments", () => {
+    assert.deepEqual(
+      getNotarytoolAuthArgs({
+        APPLE_ID: "developer@example.com",
+        APPLE_APP_SPECIFIC_PASSWORD: "app-password",
+        APPLE_TEAM_ID: "TEAMID",
+      }),
+      ["--apple-id", "developer@example.com", "--password", "app-password", "--team-id", "TEAMID"],
+    );
+  });
+
+  it("rejects incomplete credentials", () => {
+    assert.throws(
+      () => getNotarytoolAuthArgs({ APPLE_API_KEY: "/tmp/key.p8" }),
+      /APPLE_API_KEY_ID/,
+    );
+  });
+
+  it("verifies, notarizes, staples, and validates a DMG", () => {
+    const calls = [];
+    const run = (args, options) => {
+      calls.push({ args, options });
+      return args[0] === "notarytool" ? JSON.stringify({ status: "Accepted" }) : undefined;
+    };
+
+    notarizeDmg("dist/Omnigent.dmg", ["--key", "/tmp/key.p8"], run);
+
+    assert.deepEqual(calls, [
+      {
+        args: ["codesign", "--verify", "--verbose=2", "dist/Omnigent.dmg"],
+        options: undefined,
+      },
+      {
+        args: [
+          "notarytool",
+          "submit",
+          "dist/Omnigent.dmg",
+          "--key",
+          "/tmp/key.p8",
+          "--wait",
+          "--output-format",
+          "json",
+        ],
+        options: { captureOutput: true },
+      },
+      {
+        args: ["stapler", "staple", "-v", "dist/Omnigent.dmg"],
+        options: undefined,
+      },
+      {
+        args: ["stapler", "validate", "-v", "dist/Omnigent.dmg"],
+        options: undefined,
+      },
+    ]);
+  });
+
+  it("fails when Apple does not accept the DMG", () => {
+    const run = (args) =>
+      args[0] === "notarytool" ? JSON.stringify({ status: "Invalid" }) : undefined;
+
+    assert.throws(() => notarizeDmg("dist/Omnigent.dmg", [], run), /status: Invalid/);
+  });
+});


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Sign, notarize, staple, and validate each final macOS DMG from the existing one-command release build.
- Reuse the app notarization credentials and fail the release if Apple rejects a DMG or stapling fails.
- ELI5: the app was already sealed and checked by Apple; this also seals and checks the downloadable disk image around it.

```mermaid
flowchart LR
  A[Sign and notarize app] --> B[Build and sign DMG]
  B --> C[Notarize DMG]
  C --> D[Staple and validate]
```

## Test Plan

- `cd web/electron && node --test test/notarizeDmg.test.js`
- `uv run pre-commit run --files web/electron/package.json web/electron/build/afterAllArtifactBuild.js web/electron/test/notarizeDmg.test.js web/electron/README.md`
- Live Apple submission was not run locally because it requires release credentials.

## Demo

N/A — non-visual release packaging change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover credential argument construction, release command sequencing, successful notarization, and rejection handling. The release hook also validates the real codesign and stapling commands when run with Apple credentials.

## Changelog

macOS DMG releases are now signed, notarized, and stapled for stronger download verification.
