### PR TITLE
fix(electron): preserve Databricks organization in server URLs

### DIFF
--- a/tests/e2e_ui/desktop/test_setup_connect.py
+++ b/tests/e2e_ui/desktop/test_setup_connect.py
@@ -123,8 +123,9 @@ def test_recent_server_connect_and_copy_actions_are_independent(page: Page) -> N
     _open_setup_page(page, [recent_url])
 
     recent = page.locator(".recent-btn")
-    expect(recent).to_have_text(recent_url)
-    expect(recent).to_have_attribute("title", recent_url)
+    label = "dbc-x.cloud.databricks.com/?o=12345678901234567890"
+    expect(recent).to_have_text(label)
+    expect(recent).to_have_attribute("title", label)
 
     page.click(".recent-copy")
     page.wait_for_function("() => window.__copiedTexts.length === 1")
@@ -148,13 +149,15 @@ def test_shared_url_module_defaults_scheme_in_browser(page: Page) -> None:
     """
     _open_setup_page(page)
 
-    # Remote host → https root; the main process then probes and appends the
-    # canonical /omnigent workspace mount when this is a Databricks workspace.
+    # Remote host → https root while retaining the Databricks organization;
+    # the main process then probes and appends the canonical /omnigent mount.
     assert (
         page.evaluate(
-            "() => window.omnigentUrl.normalizeUrl('dbc-x.cloud.databricks.com/omnigent')"
+            """() => window.omnigentUrl.normalizeUrl(
+              'dbc-x.cloud.databricks.com/omnigent?ignored=yes&o=1965859176160743#page'
+            )"""
         )
-        == "https://dbc-x.cloud.databricks.com/"
+        == "https://dbc-x.cloud.databricks.com/?o=1965859176160743"
     )
     # Loopback stays http for local dev.
     assert (

--- a/web/electron/setup/index.html
+++ b/web/electron/setup/index.html
@@ -443,7 +443,7 @@
     <script>
       // Shared URL helpers (electron/src/url.js), exposed as window.omnigentUrl
       // — the same module the main process uses, so the two never drift.
-      const { isPlainHttpRemote } = window.omnigentUrl;
+      const { isPlainHttpRemote, serverDisplayLabel } = window.omnigentUrl;
       // Uses the Electron preload bridge (electron/src/preload.js).
       const setup = window.omnigentSetup;
       const input = document.getElementById("url");
@@ -497,15 +497,16 @@
         .then((recents) => {
           if (!Array.isArray(recents) || recents.length === 0) return;
           for (const url of recents) {
+            const label = serverDisplayLabel(url);
             const row = document.createElement("div");
             row.className = "recent-row";
 
             const serverButton = document.createElement("button");
             serverButton.type = "button";
             serverButton.className = "recent-btn";
-            serverButton.textContent = url;
-            serverButton.title = url;
-            serverButton.setAttribute("aria-label", `Connect to recent server ${url}`);
+            serverButton.textContent = label;
+            serverButton.title = label;
+            serverButton.setAttribute("aria-label", `Connect to recent server ${label}`);
             serverButton.addEventListener("click", () => {
               input.value = url;
               void connect();
@@ -515,7 +516,7 @@
             copyButton.type = "button";
             copyButton.className = "recent-copy";
             copyButton.title = "Copy URL";
-            copyButton.setAttribute("aria-label", `Copy recent server URL ${url}`);
+            copyButton.setAttribute("aria-label", `Copy recent server URL ${label}`);
             copyButton.innerHTML = `
               <svg class="copy-icon" viewBox="0 0 24 24" aria-hidden="true">
                 <rect width="8" height="4" x="8" y="2" rx="1"></rect>
@@ -531,11 +532,11 @@
                 await setup.copyText(url);
                 copyButton.dataset.copied = "true";
                 copyButton.title = "Copied";
-                copyButton.setAttribute("aria-label", `Copied recent server URL ${url}`);
+                copyButton.setAttribute("aria-label", `Copied recent server URL ${label}`);
                 setTimeout(() => {
                   delete copyButton.dataset.copied;
                   copyButton.title = "Copy URL";
-                  copyButton.setAttribute("aria-label", `Copy recent server URL ${url}`);
+                  copyButton.setAttribute("aria-label", `Copy recent server URL ${label}`);
                 }, 1500);
               } catch {
                 err.textContent = "Could not copy recent server URL.";

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -39,6 +39,7 @@ const { execFile } = require("node:child_process");
 const { registerLocalhostCors } = require("./localhost_cors");
 const {
   normalizeUrl,
+  normalizeRecentServers,
   expandDatabricksWorkspaceUrl,
   fetchServerManifest,
   PRE_MANIFEST_BASELINE,
@@ -2185,9 +2186,7 @@ function registerIpc() {
     if (!isSetupPageSender(event)) {
       throw new Error("get-recent-servers is only available to the setup page");
     }
-    const recents = loadSettings().recent_servers;
-    // Same hand-edited-settings tolerance as rememberRecentServer.
-    return Array.isArray(recents) ? recents.filter((u) => typeof u === "string") : [];
+    return normalizeRecentServers(loadSettings().recent_servers);
   });
 
   ipcMain.handle("omnigent:copy-setup-text", (event, text) => {

--- a/web/electron/src/url.js
+++ b/web/electron/src/url.js
@@ -48,8 +48,10 @@
   /**
    * Normalize a user-entered server URL to its origin. Accepts a bare
    * `host[:port][/path]`, defaults the scheme (https://, or http:// for loopback
-   * hosts), trims whitespace, and discards paths, queries, and fragments. A
-   * server connection always starts at the canonical root; workspace mounts
+   * hosts), trims whitespace, and discards paths, fragments, and query
+   * parameters. For Databricks workspace hosts only, it preserves `o` (the
+   * workspace organization selector). A server connection always starts at the
+   * canonical root; workspace mounts
    * are discovered separately by expandDatabricksWorkspaceUrl.
    *
    * @param {string} raw
@@ -70,7 +72,65 @@
     if (url.protocol !== "http:" && url.protocol !== "https:") {
       throw new Error(`unsupported scheme '${url.protocol}' (use http/https)`);
     }
-    return `${url.origin}/`;
+    const normalized = new URL(`${url.origin}/`);
+    if (isDatabricksWorkspaceHost(url.hostname)) {
+      for (const organization of url.searchParams.getAll("o")) {
+        normalized.searchParams.append("o", organization);
+      }
+    }
+    return normalized.toString();
+  }
+
+  /**
+   * Normalize persisted recent-server targets for the setup-page picker. The
+   * stored target may include an internal mount such as `/omnigent`; the picker
+   * shows and reconnects through the user-facing root URL instead. Invalid and
+   * duplicate entries are omitted.
+   *
+   * @param {unknown} rawRecents
+   * @returns {string[]}
+   */
+  function normalizeRecentServers(rawRecents) {
+    if (!Array.isArray(rawRecents)) return [];
+    const normalized = [];
+    const seen = new Set();
+    for (const candidate of rawRecents) {
+      if (typeof candidate !== "string") continue;
+      let url;
+      try {
+        url = normalizeUrl(candidate);
+      } catch {
+        continue;
+      }
+      if (seen.has(url)) continue;
+      seen.add(url);
+      normalized.push(url);
+    }
+    return normalized;
+  }
+
+  /**
+   * Compact label for a server in the setup-page recent list: host (including
+   * a non-default port), plus `/?o=…` for a Databricks organization selector.
+   *
+   * @param {string} rawUrl
+   * @returns {string}
+   */
+  function serverDisplayLabel(rawUrl) {
+    let url;
+    try {
+      url = new URL(rawUrl);
+    } catch {
+      return String(rawUrl ?? "");
+    }
+    const query = new URLSearchParams();
+    if (isDatabricksWorkspaceHost(url.hostname)) {
+      for (const organization of url.searchParams.getAll("o")) {
+        query.append("o", organization);
+      }
+    }
+    const serialized = query.toString();
+    return `${url.host}${serialized ? `/?${serialized}` : ""}`;
   }
 
   /**
@@ -199,7 +259,8 @@
     if ((probe.headers.get("server") ?? "").toLowerCase() !== "databricks") {
       return normalized;
     }
-    return `${url.origin}${WORKSPACE_UI_PATH}`;
+    url.pathname = WORKSPACE_UI_PATH;
+    return url.toString();
   }
 
   /**
@@ -299,6 +360,8 @@
     LOCAL_HOSTS,
     defaultSchemeFor,
     normalizeUrl,
+    normalizeRecentServers,
+    serverDisplayLabel,
     isPlainHttpRemote,
     WORKSPACE_UI_PATH,
     WORKSPACE_PROBE_TIMEOUT_MS,

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -197,6 +197,13 @@ describe("recent-server startup wiring (src/main.js)", () => {
       ].join(" "),
     );
   });
+
+  it("normalizes persisted targets before returning setup-page recents", () => {
+    assert.match(
+      liveCode,
+      /ipcMain\.handle\("omnigent:get-recent-servers"[\s\S]{0,300}return normalizeRecentServers\(loadSettings\(\)\.recent_servers\)/,
+    );
+  });
 });
 
 // Guard for the deep-link path join in createWindow. A basename-less SPA path

--- a/web/electron/test/url.test.js
+++ b/web/electron/test/url.test.js
@@ -9,6 +9,8 @@ const assert = require("node:assert/strict");
 const {
   defaultSchemeFor,
   normalizeUrl,
+  normalizeRecentServers,
+  serverDisplayLabel,
   isPlainHttpRemote,
   databricksWorkspaceUiUrl,
   expandDatabricksWorkspaceUrl,
@@ -61,10 +63,23 @@ describe("normalizeUrl", () => {
     assert.equal(normalizeUrl("http://example.databricks.com"), "http://example.databricks.com/");
   });
 
-  it("trims whitespace and removes paths, queries, and fragments", () => {
+  it("preserves the Databricks organization while removing other URL state", () => {
     assert.equal(
-      normalizeUrl("  example.com/omnigent/c/123?view=chat#latest  "),
+      normalizeUrl(
+        "  https://isaac.databricks.com/omnigent/c/123?view=chat&o=1965859176160743#latest  ",
+      ),
+      "https://isaac.databricks.com/?o=1965859176160743",
+    );
+  });
+
+  it("removes every query parameter for non-Databricks hosts", () => {
+    assert.equal(
+      normalizeUrl("example.com/path?o=1965859176160743&view=chat#latest"),
       "https://example.com/",
+    );
+    assert.equal(
+      normalizeUrl("https://my-app.aws.databricksapps.com/?o=1965859176160743"),
+      "https://my-app.aws.databricksapps.com/",
     );
   });
 
@@ -86,6 +101,47 @@ describe("normalizeUrl", () => {
         return true;
       },
     );
+  });
+});
+
+describe("normalizeRecentServers", () => {
+  it("shows root URLs, preserves organizations, and deduplicates", () => {
+    assert.deepEqual(
+      normalizeRecentServers([
+        "https://isaac.databricks.com/omnigent?o=1965859176160743",
+        "https://isaac.databricks.com/c/123?ignored=yes&o=1965859176160743",
+        "http://localhost:6767/conversation/123",
+        "not a URL",
+        null,
+      ]),
+      ["https://isaac.databricks.com/?o=1965859176160743", "http://localhost:6767/"],
+    );
+  });
+
+  it("returns an empty list for a malformed setting", () => {
+    assert.deepEqual(normalizeRecentServers("https://example.com"), []);
+  });
+});
+
+describe("serverDisplayLabel", () => {
+  it("shows only the host and optional Databricks organization", () => {
+    assert.equal(
+      serverDisplayLabel("https://isaac.databricks.com/omnigent?o=1965859176160743"),
+      "isaac.databricks.com/?o=1965859176160743",
+    );
+    assert.equal(serverDisplayLabel("http://localhost:6767/sessions"), "localhost:6767");
+  });
+
+  it("does not show organization queries for non-workspace hosts", () => {
+    assert.equal(serverDisplayLabel("https://example.com/?o=123"), "example.com");
+    assert.equal(
+      serverDisplayLabel("https://my-app.aws.databricksapps.com/?o=123"),
+      "my-app.aws.databricksapps.com",
+    );
+  });
+
+  it("falls back to the raw value when the URL is invalid", () => {
+    assert.equal(serverDisplayLabel("not a URL"), "not a URL");
   });
 });
 
@@ -182,11 +238,11 @@ describe("expandDatabricksWorkspaceUrl", () => {
         const normalized = normalizeUrl(
           "https://ws.cloud.databricks.com/some/copied/path?o=123#fragment",
         );
-        assert.equal(normalized, "https://ws.cloud.databricks.com/");
+        assert.equal(normalized, "https://ws.cloud.databricks.com/?o=123");
         assert.equal(WORKSPACE_UI_PATH, "/omnigent");
         assert.equal(
           await expandDatabricksWorkspaceUrl(normalized),
-          "https://ws.cloud.databricks.com/omnigent",
+          "https://ws.cloud.databricks.com/omnigent?o=123",
         );
       },
     );


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Preserve the Databricks `o` organization selector while normalizing workspace URLs, but strip query parameters from non-workspace and Databricks Apps URLs.
- Keep `?o` through workspace expansion and normalize persisted recent targets before returning them to the setup page.
- Render recent servers as `host` or `host/?o=…`, hiding schemes and the internal `/omnigent` mount without changing the reconnect target.

ELI5: keep the workspace identifier users need, while hiding internal URL details and unrelated query parameters.

```text
stored target -> normalized reconnect URL -> compact recent-server label
```

## Test Plan

- `node --test web/electron/test/url.test.js web/electron/test/main.test.js`
- `uv run --no-sync pytest tests/e2e_ui/desktop/test_setup_connect.py::test_recent_server_connect_and_copy_actions_are_independent tests/e2e_ui/desktop/test_setup_connect.py::test_shared_url_module_defaults_scheme_in_browser`
- `pre-commit run --files tests/e2e_ui/desktop/test_setup_connect.py web/electron/setup/index.html web/electron/src/main.js web/electron/src/url.js web/electron/test/main.test.js web/electron/test/url.test.js`

## Demo

N/A — this changes recent-server text and URL normalization without changing layout.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit and browser E2E coverage verify Databricks-only `o` preservation, workspace expansion, recent-target normalization, and compact labels.

## Changelog

Electron recent servers now retain Databricks organization links while showing compact server names.
