### PR TITLE
feat(host): auto-open the web UI on `omnigent host` / `start`

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -8157,13 +8157,7 @@ def _confirm_background_host_registered(record: _HostDaemonRecord) -> None:
 
 
 def _stdin_is_tty() -> bool:
-    """Whether stdin is an interactive terminal.
-
-    A one-line seam over ``sys.stdin.isatty()`` so callers gating an
-    interactive-only action stay readable and tests can force the answer.
-
-    :returns: ``True`` when stdin is a TTY.
-    """
+    """Return whether stdin is an interactive terminal."""
     return sys.stdin.isatty()
 
 
@@ -8173,24 +8167,7 @@ def _maybe_open_host_web_ui(
     non_interactive: bool,
     cfg: dict[str, Any] | None = None,  # type: ignore[explicit-any]
 ) -> None:
-    """Open the Omnigent web UI in the browser when a host comes up.
-
-    Honors the shared ``auto_open_conversation`` setting — the same switch
-    ``omnigent run`` reads — defaulting ON when the user has not configured
-    it, so ``host``/``start`` open the web page without extra setup while
-    still respecting an explicit ``auto_open_conversation: false``. Skips in
-    ``--non-interactive`` (scripts/CI). A failed open (headless box, no
-    browser) falls back to printing the URL instead of raising.
-
-    :param server_url: Resolved server URL the host serves/connects to, e.g.
-        ``"http://127.0.0.1:6767"`` or ``"https://ws/api/2.0/omnigent"``.
-    :param non_interactive: When ``True``, never open a browser.
-    :param cfg: Effective config the caller already loaded, reused to resolve
-        ``auto_open_conversation``; loaded lazily when ``None`` (only after
-        the interactive gate passes, so a skipped open reads no config).
-    """
-    # Mirror the adjacent sign-in flow: a pipe/CI/systemd context has no one
-    # watching a browser, so treat "no TTY" like --non-interactive.
+    """Open the host web UI when interactive and enabled."""
     if non_interactive or not _stdin_is_tty():
         return
     if cfg is None:
@@ -8441,8 +8418,6 @@ def host(
         # (or a headless invocation) fails loud with the command to run.
         if remote_mode:
             _ensure_databricks_server_auth(server, non_interactive=non_interactive)
-        # Open the web UI before the daemon blocks in the foreground, so the
-        # user lands in Omnigent web without a second command.
         _maybe_open_host_web_ui(server, non_interactive=non_interactive, cfg=cfg)
         run_host_process(server_url=server, daemon_target=target)
         stopped_cleanly = True

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -8156,6 +8156,48 @@ def _confirm_background_host_registered(record: _HostDaemonRecord) -> None:
         time.sleep(0.2)
 
 
+def _stdin_is_tty() -> bool:
+    """Whether stdin is an interactive terminal.
+
+    A one-line seam over ``sys.stdin.isatty()`` so callers gating an
+    interactive-only action stay readable and tests can force the answer.
+
+    :returns: ``True`` when stdin is a TTY.
+    """
+    return sys.stdin.isatty()
+
+
+def _maybe_open_host_web_ui(server_url: str, *, non_interactive: bool) -> None:
+    """Open the Omnigent web UI in the browser when a host comes up.
+
+    Honors the shared ``auto_open_conversation`` setting — the same switch
+    ``omnigent run`` reads — defaulting ON when the user has not configured
+    it, so ``host``/``start`` open the web page without extra setup while
+    still respecting an explicit ``auto_open_conversation: false``. Skips in
+    ``--non-interactive`` (scripts/CI). A failed open (headless box, no
+    browser) falls back to printing the URL instead of raising.
+
+    :param server_url: Resolved server URL the host serves/connects to, e.g.
+        ``"http://127.0.0.1:6767"`` or ``"https://ws/api/2.0/omnigent"``.
+    :param non_interactive: When ``True``, never open a browser.
+    """
+    # Mirror the adjacent sign-in flow: a pipe/CI/systemd context has no one
+    # watching a browser, so treat "no TTY" like --non-interactive.
+    if non_interactive or not _stdin_is_tty():
+        return
+    if _resolve_auto_open_conversation_setting(_load_effective_config()) is False:
+        return
+    from omnigent.conversation_browser import display_server_url, open_conversation_url
+
+    web_url = display_server_url(server_url)
+    try:
+        opened = open_conversation_url(web_url)
+    except OSError:
+        opened = False
+    if not opened:
+        click.echo(f"Open the Omnigent web UI: {web_url}", err=True)
+
+
 def _run_background_host(
     server: str | None,
     *,
@@ -8233,6 +8275,7 @@ def _run_background_host(
     click.echo()
     click.echo(_cli_style("Stop it with:", dim=True))
     click.echo(f"  {_cli_style(stop_command, bold=True)}")
+    _maybe_open_host_web_ui(server_url, non_interactive=non_interactive)
 
 
 def _echo_host_field(label: str, value: str) -> None:
@@ -8388,6 +8431,9 @@ def host(
         # (or a headless invocation) fails loud with the command to run.
         if remote_mode:
             _ensure_databricks_server_auth(server, non_interactive=non_interactive)
+        # Open the web UI before the daemon blocks in the foreground, so the
+        # user lands in Omnigent web without a second command.
+        _maybe_open_host_web_ui(server, non_interactive=non_interactive)
         run_host_process(server_url=server, daemon_target=target)
         stopped_cleanly = True
     except KeyboardInterrupt:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -8167,7 +8167,12 @@ def _stdin_is_tty() -> bool:
     return sys.stdin.isatty()
 
 
-def _maybe_open_host_web_ui(server_url: str, *, non_interactive: bool) -> None:
+def _maybe_open_host_web_ui(
+    server_url: str,
+    *,
+    non_interactive: bool,
+    cfg: dict[str, Any] | None = None,  # type: ignore[explicit-any]
+) -> None:
     """Open the Omnigent web UI in the browser when a host comes up.
 
     Honors the shared ``auto_open_conversation`` setting — the same switch
@@ -8180,12 +8185,17 @@ def _maybe_open_host_web_ui(server_url: str, *, non_interactive: bool) -> None:
     :param server_url: Resolved server URL the host serves/connects to, e.g.
         ``"http://127.0.0.1:6767"`` or ``"https://ws/api/2.0/omnigent"``.
     :param non_interactive: When ``True``, never open a browser.
+    :param cfg: Effective config the caller already loaded, reused to resolve
+        ``auto_open_conversation``; loaded lazily when ``None`` (only after
+        the interactive gate passes, so a skipped open reads no config).
     """
     # Mirror the adjacent sign-in flow: a pipe/CI/systemd context has no one
     # watching a browser, so treat "no TTY" like --non-interactive.
     if non_interactive or not _stdin_is_tty():
         return
-    if _resolve_auto_open_conversation_setting(_load_effective_config()) is False:
+    if cfg is None:
+        cfg = _load_effective_config()
+    if _resolve_auto_open_conversation_setting(cfg) is False:
         return
     from omnigent.conversation_browser import display_server_url, open_conversation_url
 
@@ -8433,7 +8443,7 @@ def host(
             _ensure_databricks_server_auth(server, non_interactive=non_interactive)
         # Open the web UI before the daemon blocks in the foreground, so the
         # user lands in Omnigent web without a second command.
-        _maybe_open_host_web_ui(server, non_interactive=non_interactive)
+        _maybe_open_host_web_ui(server, non_interactive=non_interactive, cfg=cfg)
         run_host_process(server_url=server, daemon_target=target)
         stopped_cleanly = True
     except KeyboardInterrupt:

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -1005,23 +1005,12 @@ def test_start_hosts_on_explicit_server(
     ]
 
 
-# ── auto-open web UI ──────────────────────────────────────────────
-
-
 @pytest.mark.parametrize(
     ("is_tty", "extra_args", "config_content", "expected_opened"),
     [
-        # Interactive TTY, default (unconfigured) auto_open: the local
-        # server's URL is opened once, before the blocking loop starts —
-        # the daemon otherwise occupies the terminal.
         pytest.param(True, [], None, ["http://127.0.0.1:8123"], id="interactive-opens"),
-        # ``--non-interactive`` never opens a browser, even on a TTY (scripts/CI).
         pytest.param(True, ["--non-interactive"], None, [], id="non-interactive-skips"),
-        # A non-terminal context (pipe / nohup / systemd) never opens: else
-        # ``webbrowser.open`` shells out to ``xdg-open`` with no display, so
-        # "no TTY" is treated like ``--non-interactive``.
         pytest.param(False, [], None, [], id="no-tty-skips"),
-        # An explicit ``auto_open_conversation: false`` suppresses it on a TTY.
         pytest.param(
             True, [], "auto_open_conversation: false\n", [], id="auto-open-disabled-skips"
         ),
@@ -1035,14 +1024,7 @@ def test_host_web_ui_open_gates(
     config_content: str | None,
     expected_opened: list[str],
 ) -> None:
-    """
-    Foreground ``omnigent host`` opens the web UI only when appropriate.
-
-    It opens the local server's URL before the daemon blocks so the user
-    lands in the web app without a second command — but stays quiet on
-    ``--non-interactive``, without a TTY, or when ``auto_open_conversation``
-    is explicitly ``false``. Each parametrization exercises one gate.
-    """
+    """Open the host web UI only when interactive and enabled."""
     if config_content is not None:
         (tmp_path / "config.yaml").write_text(config_content)
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
@@ -1071,12 +1053,7 @@ def test_start_opens_web_ui_when_interactive(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    ``omnigent start`` opens the web UI after the background daemon registers.
-
-    ``start`` brings up the local server (which serves the web UI) and
-    returns; on a TTY it also opens that server's URL in the browser.
-    """
+    """Open the web UI after the background host registers."""
     _patch_background_host_spawn(monkeypatch, tmp_path)
     monkeypatch.setattr("omnigent.cli._stdin_is_tty", lambda: True)
     opened: list[str] = []
@@ -1088,5 +1065,4 @@ def test_start_opens_web_ui_when_interactive(
         result = CliRunner().invoke(cli, ["start"])
 
     assert result.exit_code == 0, result.output
-    # The daemon-owned local server URL (see _patch_background_host_spawn).
     assert opened == ["http://127.0.0.1:6767"]

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -1003,3 +1003,153 @@ def test_start_hosts_on_explicit_server(
             "https://example.databricksapps.com",
         ]
     ]
+
+
+# ── auto-open web UI ──────────────────────────────────────────────
+
+
+def test_host_opens_web_ui_when_interactive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Foreground ``omnigent host`` opens the web UI before it blocks.
+
+    The daemon otherwise occupies the terminal, so a user had to open a
+    second tab to reach the web app. On an interactive terminal, with the
+    default (unconfigured) ``auto_open_conversation``, the local server's
+    URL is opened once, before the blocking loop starts.
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr("omnigent.cli._HOST_PID_PATH", tmp_path / "host.pid")
+    monkeypatch.setattr("omnigent.cli._stdin_is_tty", lambda: True)
+    opened: list[str] = []
+
+    with (
+        patch(
+            "omnigent.cli.ensure_local_omnigent_server",
+            lambda: LocalServerStartup(url="http://127.0.0.1:8123", spawned=False),
+        ),
+        patch("omnigent.host.connect.run_host_process", lambda server_url, **kwargs: None),
+        patch(
+            "omnigent.conversation_browser.open_conversation_url",
+            lambda url: opened.append(url) or True,
+        ),
+    ):
+        result = CliRunner().invoke(cli, ["host"])
+
+    assert result.exit_code == 0, result.output
+    # The local server's own URL is the web UI's URL.
+    assert opened == ["http://127.0.0.1:8123"]
+
+
+def test_host_skips_web_ui_when_non_interactive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--non-interactive`` never opens a browser, even on a TTY (scripts/CI)."""
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr("omnigent.cli._HOST_PID_PATH", tmp_path / "host.pid")
+    monkeypatch.setattr("omnigent.cli._stdin_is_tty", lambda: True)
+    opened: list[str] = []
+
+    with (
+        patch(
+            "omnigent.cli.ensure_local_omnigent_server",
+            lambda: LocalServerStartup(url="http://127.0.0.1:8123", spawned=False),
+        ),
+        patch("omnigent.host.connect.run_host_process", lambda server_url, **kwargs: None),
+        patch(
+            "omnigent.conversation_browser.open_conversation_url",
+            lambda url: opened.append(url) or True,
+        ),
+    ):
+        result = CliRunner().invoke(cli, ["host", "--non-interactive"])
+
+    assert result.exit_code == 0, result.output
+    assert opened == []
+
+
+def test_host_skips_web_ui_without_tty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A non-terminal context (pipe / nohup / systemd) never opens a browser.
+
+    ``webbrowser.open`` would otherwise shell out to ``xdg-open`` with no
+    display, so "no TTY" is treated like ``--non-interactive``.
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr("omnigent.cli._HOST_PID_PATH", tmp_path / "host.pid")
+    monkeypatch.setattr("omnigent.cli._stdin_is_tty", lambda: False)
+    opened: list[str] = []
+
+    with (
+        patch(
+            "omnigent.cli.ensure_local_omnigent_server",
+            lambda: LocalServerStartup(url="http://127.0.0.1:8123", spawned=False),
+        ),
+        patch("omnigent.host.connect.run_host_process", lambda server_url, **kwargs: None),
+        patch(
+            "omnigent.conversation_browser.open_conversation_url",
+            lambda url: opened.append(url) or True,
+        ),
+    ):
+        result = CliRunner().invoke(cli, ["host"])
+
+    assert result.exit_code == 0, result.output
+    assert opened == []
+
+
+def test_host_respects_auto_open_conversation_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``auto_open_conversation: false`` suppresses the open on a TTY."""
+    (tmp_path / "config.yaml").write_text("auto_open_conversation: false\n")
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr("omnigent.cli._HOST_PID_PATH", tmp_path / "host.pid")
+    monkeypatch.setattr("omnigent.cli._stdin_is_tty", lambda: True)
+    opened: list[str] = []
+
+    with (
+        patch(
+            "omnigent.cli.ensure_local_omnigent_server",
+            lambda: LocalServerStartup(url="http://127.0.0.1:8123", spawned=False),
+        ),
+        patch("omnigent.host.connect.run_host_process", lambda server_url, **kwargs: None),
+        patch(
+            "omnigent.conversation_browser.open_conversation_url",
+            lambda url: opened.append(url) or True,
+        ),
+    ):
+        result = CliRunner().invoke(cli, ["host"])
+
+    assert result.exit_code == 0, result.output
+    assert opened == []
+
+
+def test_start_opens_web_ui_when_interactive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``omnigent start`` opens the web UI after the background daemon registers.
+
+    ``start`` brings up the local server (which serves the web UI) and
+    returns; on a TTY it also opens that server's URL in the browser.
+    """
+    _patch_background_host_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr("omnigent.cli._stdin_is_tty", lambda: True)
+    opened: list[str] = []
+
+    with patch(
+        "omnigent.conversation_browser.open_conversation_url",
+        lambda url: opened.append(url) or True,
+    ):
+        result = CliRunner().invoke(cli, ["start"])
+
+    assert result.exit_code == 0, result.output
+    # The daemon-owned local server URL (see _patch_background_host_spawn).
+    assert opened == ["http://127.0.0.1:6767"]

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -1049,6 +1049,33 @@ def test_host_web_ui_open_gates(
     assert opened == expected_opened
 
 
+def test_host_opens_remote_web_ui_when_interactive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Open the browser-facing URL for a remote workspace host."""
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr("omnigent.cli._HOST_PID_PATH", tmp_path / "host.pid")
+    monkeypatch.setattr("omnigent.cli._stdin_is_tty", lambda: True)
+    opened: list[str] = []
+
+    with (
+        patch("omnigent.cli._ensure_databricks_server_auth"),
+        patch("omnigent.host.connect.run_host_process", lambda server_url, **kwargs: None),
+        patch(
+            "omnigent.conversation_browser.open_conversation_url",
+            lambda url: opened.append(url) or True,
+        ),
+    ):
+        result = CliRunner().invoke(
+            cli,
+            ["host", "--server", "https://example.databricks.com/api/2.0/omnigent"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert opened == ["https://example.databricks.com/omnigent"]
+
+
 def test_start_opens_web_ui_when_interactive(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -1008,21 +1008,46 @@ def test_start_hosts_on_explicit_server(
 # ── auto-open web UI ──────────────────────────────────────────────
 
 
-def test_host_opens_web_ui_when_interactive(
+@pytest.mark.parametrize(
+    ("is_tty", "extra_args", "config_content", "expected_opened"),
+    [
+        # Interactive TTY, default (unconfigured) auto_open: the local
+        # server's URL is opened once, before the blocking loop starts —
+        # the daemon otherwise occupies the terminal.
+        pytest.param(True, [], None, ["http://127.0.0.1:8123"], id="interactive-opens"),
+        # ``--non-interactive`` never opens a browser, even on a TTY (scripts/CI).
+        pytest.param(True, ["--non-interactive"], None, [], id="non-interactive-skips"),
+        # A non-terminal context (pipe / nohup / systemd) never opens: else
+        # ``webbrowser.open`` shells out to ``xdg-open`` with no display, so
+        # "no TTY" is treated like ``--non-interactive``.
+        pytest.param(False, [], None, [], id="no-tty-skips"),
+        # An explicit ``auto_open_conversation: false`` suppresses it on a TTY.
+        pytest.param(
+            True, [], "auto_open_conversation: false\n", [], id="auto-open-disabled-skips"
+        ),
+    ],
+)
+def test_host_web_ui_open_gates(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    is_tty: bool,
+    extra_args: list[str],
+    config_content: str | None,
+    expected_opened: list[str],
 ) -> None:
     """
-    Foreground ``omnigent host`` opens the web UI before it blocks.
+    Foreground ``omnigent host`` opens the web UI only when appropriate.
 
-    The daemon otherwise occupies the terminal, so a user had to open a
-    second tab to reach the web app. On an interactive terminal, with the
-    default (unconfigured) ``auto_open_conversation``, the local server's
-    URL is opened once, before the blocking loop starts.
+    It opens the local server's URL before the daemon blocks so the user
+    lands in the web app without a second command — but stays quiet on
+    ``--non-interactive``, without a TTY, or when ``auto_open_conversation``
+    is explicitly ``false``. Each parametrization exercises one gate.
     """
+    if config_content is not None:
+        (tmp_path / "config.yaml").write_text(config_content)
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
     monkeypatch.setattr("omnigent.cli._HOST_PID_PATH", tmp_path / "host.pid")
-    monkeypatch.setattr("omnigent.cli._stdin_is_tty", lambda: True)
+    monkeypatch.setattr("omnigent.cli._stdin_is_tty", lambda: is_tty)
     opened: list[str] = []
 
     with (
@@ -1036,98 +1061,10 @@ def test_host_opens_web_ui_when_interactive(
             lambda url: opened.append(url) or True,
         ),
     ):
-        result = CliRunner().invoke(cli, ["host"])
+        result = CliRunner().invoke(cli, ["host", *extra_args])
 
     assert result.exit_code == 0, result.output
-    # The local server's own URL is the web UI's URL.
-    assert opened == ["http://127.0.0.1:8123"]
-
-
-def test_host_skips_web_ui_when_non_interactive(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``--non-interactive`` never opens a browser, even on a TTY (scripts/CI)."""
-    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
-    monkeypatch.setattr("omnigent.cli._HOST_PID_PATH", tmp_path / "host.pid")
-    monkeypatch.setattr("omnigent.cli._stdin_is_tty", lambda: True)
-    opened: list[str] = []
-
-    with (
-        patch(
-            "omnigent.cli.ensure_local_omnigent_server",
-            lambda: LocalServerStartup(url="http://127.0.0.1:8123", spawned=False),
-        ),
-        patch("omnigent.host.connect.run_host_process", lambda server_url, **kwargs: None),
-        patch(
-            "omnigent.conversation_browser.open_conversation_url",
-            lambda url: opened.append(url) or True,
-        ),
-    ):
-        result = CliRunner().invoke(cli, ["host", "--non-interactive"])
-
-    assert result.exit_code == 0, result.output
-    assert opened == []
-
-
-def test_host_skips_web_ui_without_tty(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """
-    A non-terminal context (pipe / nohup / systemd) never opens a browser.
-
-    ``webbrowser.open`` would otherwise shell out to ``xdg-open`` with no
-    display, so "no TTY" is treated like ``--non-interactive``.
-    """
-    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
-    monkeypatch.setattr("omnigent.cli._HOST_PID_PATH", tmp_path / "host.pid")
-    monkeypatch.setattr("omnigent.cli._stdin_is_tty", lambda: False)
-    opened: list[str] = []
-
-    with (
-        patch(
-            "omnigent.cli.ensure_local_omnigent_server",
-            lambda: LocalServerStartup(url="http://127.0.0.1:8123", spawned=False),
-        ),
-        patch("omnigent.host.connect.run_host_process", lambda server_url, **kwargs: None),
-        patch(
-            "omnigent.conversation_browser.open_conversation_url",
-            lambda url: opened.append(url) or True,
-        ),
-    ):
-        result = CliRunner().invoke(cli, ["host"])
-
-    assert result.exit_code == 0, result.output
-    assert opened == []
-
-
-def test_host_respects_auto_open_conversation_disabled(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """An explicit ``auto_open_conversation: false`` suppresses the open on a TTY."""
-    (tmp_path / "config.yaml").write_text("auto_open_conversation: false\n")
-    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
-    monkeypatch.setattr("omnigent.cli._HOST_PID_PATH", tmp_path / "host.pid")
-    monkeypatch.setattr("omnigent.cli._stdin_is_tty", lambda: True)
-    opened: list[str] = []
-
-    with (
-        patch(
-            "omnigent.cli.ensure_local_omnigent_server",
-            lambda: LocalServerStartup(url="http://127.0.0.1:8123", spawned=False),
-        ),
-        patch("omnigent.host.connect.run_host_process", lambda server_url, **kwargs: None),
-        patch(
-            "omnigent.conversation_browser.open_conversation_url",
-            lambda url: opened.append(url) or True,
-        ),
-    ):
-        result = CliRunner().invoke(cli, ["host"])
-
-    assert result.exit_code == 0, result.output
-    assert opened == []
+    assert opened == expected_opened
 
 
 def test_start_opens_web_ui_when_interactive(


### PR DESCRIPTION
## Related issue

Linear: [OMNI-3488 — have `omnigent host` running in background print message to open](https://linear.app/omnigent/issue/OMNI-3488/have-omnigent-host-running-in-background-print-message-to-open)

(No GitHub issue; tracked in Linear.) This implements the ask and goes one step further — instead of only *printing* a URL, it opens the web UI in the browser (printing the URL as a fallback), and covers the foreground `omnigent host` path too.

## Summary

- `omnigent host <URL>` runs the host daemon in the **foreground** and blocks, so users had to open a second terminal to reach the web app. Now, when a host comes up, the web UI opens in the browser automatically.
- Wired into **both** entry points: foreground `omnigent host` (opens right before the blocking loop) and the background daemon path — `omnigent start` and `omnigent host --background` (opens after the daemon registers).
- Reuses the **existing `auto_open_conversation` setting** (the same switch `omnigent run` reads) — no new config. Defaults on when unconfigured, honors an explicit `auto_open_conversation: false`.
- Safe by default: **skips** on `--non-interactive` and when stdin is not a TTY (pipes / CI / systemd), and **falls back to printing** the URL if the browser can't be opened.

### ELI5

Before, starting a host was like turning on a server and then having to walk to another room to actually use it. Now, when you start it, the app just opens in your browser for you — unless you're a script or a robot, in which case it stays quiet.

## Implementation details

New helper `_maybe_open_host_web_ui(server_url, *, non_interactive)` in `omnigent/cli.py`:

1. Return early if `non_interactive` **or** stdin is not a TTY (via a small testable `_stdin_is_tty()` seam). This mirrors the adjacent Databricks sign-in pre-flight, which already gates its interactive browser flow on `non_interactive or not sys.stdin.isatty()`.
2. Return early if `auto_open_conversation` is explicitly `false` (resolved through `_resolve_auto_open_conversation_setting`, the same resolver `omnigent run` uses; `None`/unset ⇒ defaults **on**).
3. Compute the user-facing web URL with the existing `display_server_url()` helper — local servers stay `http://127.0.0.1:<port>`, Databricks-fronted servers map `…/api/2.0/omnigent` → `…/omnigent`.
4. Open it with the existing platform-aware `open_conversation_url()` helper (macOS `open`, else `webbrowser`); on failure (or `OSError`) print `Open the Omnigent web UI: <url>` to stderr.

Call sites:

- **Foreground** `host()` — right after the auth pre-flight and just before `run_host_process(server_url=server)`, so the browser opens once, before the daemon blocks. No change to the blocking behavior itself.
- **Background** `_run_background_host()` — after `_confirm_background_host_registered(...)`, using the `server_url` it already resolves (local loopback via `_discover_local_server_url()`, or the remote target). This one function backs both `omnigent start` and `omnigent host --background`.

```mermaid
flowchart TD
    A["omnigent host / start"] --> B{"background?"}
    B -->|foreground host| C["auth pre-flight"]
    C --> D["_maybe_open_host_web_ui"]
    D --> E["run_host_process — blocks"]
    B -->|"start / host --background"| F["spawn detached daemon"]
    F --> G["confirm registered"]
    G --> H["_maybe_open_host_web_ui"]
    H --> I["return"]
    D --> J{"non-interactive / no TTY / auto_open=false?"}
    H --> J
    J -->|yes| K["skip"]
    J -->|no| L["open display_server_url in browser; print URL on failure"]
```

## Before / after behavior

| Scenario | Before | After |
|---|---|---|
| `omnigent host <URL>` in a terminal | Blocks as daemon; user opens a second tab to reach the web app | Browser opens to the web UI, then the daemon blocks as before |
| `omnigent start` (local) | Brings up local server + registers host, returns | Same, **plus** opens the local server's web UI |
| `omnigent host --background` | Detaches daemon, returns | Same, **plus** opens the web UI |
| `--non-interactive` (scripts/CI) | — | No browser (unchanged behavior) |
| Piped / `nohup` / systemd (no TTY) | — | No browser — never shells out to `xdg-open` with no display |
| `auto_open_conversation: false` | — | No browser |
| Browser can't open (headless) | — | Prints `Open the Omnigent web UI: <url>` |

The daemon lifecycle is unchanged: foreground `host` still blocks; `start` / `--background` still return immediately. This PR purely **adds** the browser open.

## Test Plan

Automated — `tests/host/test_cli_host.py` (new tests, full file green: 30 passed):

- `test_host_opens_web_ui_when_interactive` — foreground `host` opens the resolved local URL on a TTY with default config.
- `test_host_skips_web_ui_when_non_interactive` — `--non-interactive` never opens.
- `test_host_skips_web_ui_without_tty` — no TTY never opens.
- `test_host_respects_auto_open_conversation_disabled` — explicit `false` suppresses it.
- `test_start_opens_web_ui_when_interactive` — `start` opens after the daemon registers.

```
uv run pytest tests/host/test_cli_host.py
```

Manual (in a real terminal):

```
omnigent host ""                      # local: opens http://127.0.0.1:<port>/
omnigent host https://<server>        # remote: opens that server's web UI
omnigent start                        # returns immediately; browser opens
omnigent host "" --non-interactive    # no browser
echo | omnigent host ""               # no TTY -> no browser
# auto_open_conversation: false in ~/.omnigent/config.yaml -> no browser
```

## Demo

N/A — no UI/frontend surface changed; the behavior is opening the existing web UI in the browser. Manual reproduction steps above.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover all four gates (interactive, `--non-interactive`, no-TTY, `auto_open_conversation: false`) for foreground `host` plus the `start` background path, using the existing daemon-spawn stubs and patching `open_conversation_url`. Manual verification is listed above for the real-browser behavior that unit tests deliberately stub out.

### Risks to check during review

- **Correct web URL for remote/Databricks servers.** `display_server_url()` maps `…/api/2.0/omnigent` → `…/omnigent`. Confirm the server variable at each call site is the resolved form that mapping expects (the foreground call passes the post-resolution `server`; the background call passes the `server_url` resolved inside `_run_background_host`).
- **TTY gate correctness.** Gating on `sys.stdin.isatty()` is intended to suppress the browser in pipes/CI/systemd. Confirm no legitimate interactive path (e.g. certain terminal multiplexers or wrappers) reports a non-TTY stdin and thus silently loses the open.
- **Reused-daemon path.** `_run_background_host` has an early `return` when a healthy local daemon already serves the target (before reaching the new open call). Decide whether re-running `start`/`--background` against an already-running daemon should also open the browser — current behavior does not open in that specific reuse branch.
- **Default-on vs. surprise.** Defaulting on (honoring explicit `false`) means users who run `host`/`start` and previously relied on a quiet foreground daemon now get a browser window. This is intended per the ticket; flagging for product sign-off.
- **`open_conversation_url` failure modes.** We catch `OSError` and treat a falsy return as "not opened"; confirm no other exception type can escape `open_conversation_url` on supported platforms.

## Changelog

`omnigent host` and `omnigent start` now open the Omnigent web UI in your browser automatically (respects `auto_open_conversation`).

