### PR TITLE
fix(web): copy tmux selections to the system clipboard

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -294,8 +294,9 @@ def _tmux_input_option_commands(scrollback: int) -> list[list[str]]:
     Build tmux options for scrollback and pane input behavior.
 
     ``history-limit`` is generated per terminal because it comes from
-    ``TerminalEnvSpec.scrollback``. ``mouse on`` makes the attached web
-    terminal scrollable. ``focus-events on`` lets interactive programs
+    ``TerminalEnvSpec.scrollback``. ``set-clipboard external`` exports tmux
+    copy-mode selections without trusting pane OSC 52 requests. ``mouse on``
+    makes the attached web terminal scrollable. ``focus-events on`` lets interactive programs
     observe pane focus changes. ``extended-keys`` with CSI-u formatting
     lets programs inside tmux receive Kitty Keyboard Protocol keys such
     as Shift+Enter when the attached terminal supports them. Terminals
@@ -311,6 +312,9 @@ def _tmux_input_option_commands(scrollback: int) -> list[list[str]]:
         ["set-option", "-g", "history-limit", str(scrollback)],
         ["set-option", "-sq", "extended-keys", "on"],
         ["set-option", "-sq", "extended-keys-format", "csi-u"],
+        # Export tmux copy-mode selections to attached terminals without letting
+        # pane applications create tmux buffers through OSC 52.
+        ["set-option", "-sq", "set-clipboard", "external"],
         ["set-option", "-g", "mouse", "on"],
         ["set-option", "-g", "focus-events", "on"],
         ["set-option", "-g", "escape-time", "0"],

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7824,18 +7824,23 @@ def create_runner_app(
             override=transport,
             spec_transport=entry.instance.terminal_transport,
         )
-        bridge = (
-            bridge_tmux_control_to_websocket
-            if resolved_transport == TERMINAL_TRANSPORT_CONTROL
-            else bridge_tmux_pty_to_websocket
-        )
-        await bridge(
-            websocket,
-            socket_path=str(entry.instance.socket_path),
-            tmux_target=entry.instance.tmux_target,
-            read_only=read_only,
-            on_client_interaction=entry.instance.note_client_interaction,
-        )
+        if resolved_transport == TERMINAL_TRANSPORT_CONTROL:
+            await bridge_tmux_control_to_websocket(
+                websocket,
+                socket_path=str(entry.instance.socket_path),
+                tmux_target=entry.instance.tmux_target,
+                read_only=read_only,
+                on_client_interaction=entry.instance.note_client_interaction,
+            )
+        else:
+            await bridge_tmux_pty_to_websocket(
+                websocket,
+                socket_path=str(entry.instance.socket_path),
+                tmux_target=entry.instance.tmux_target,
+                read_only=read_only,
+                on_client_interaction=entry.instance.note_client_interaction,
+                allow_osc52_clipboard=not entry.instance.tmux_allow_passthrough,
+            )
 
     # Reused by the loopback direct-attach listener (see
     # ``omnigent.runner.direct_attach``): same attach handler served on a

--- a/omnigent/server/routes/terminal_attach.py
+++ b/omnigent/server/routes/terminal_attach.py
@@ -32,10 +32,12 @@ to resolving the terminal in the local registry.
 Wire protocol on the WebSocket
 ------------------------------
 
-- **Server → client**: every PTY read is forwarded as a *binary*
-  WebSocket frame. xterm.js's ``term.write()`` accepts ``Uint8Array``
-  directly and runs it through its ANSI parser, so colors, cursor
-  motion, alternate screen, mouse modes all work transparently.
+- **Server → client**: terminal output is forwarded as *binary* WebSocket
+  frames. xterm.js's ``term.write()`` accepts ``Uint8Array`` directly and runs
+  it through its ANSI parser, so colors, cursor motion, alternate screen, and
+  mouse modes work transparently. Control-mode attaches may also send a text
+  ``clipboard-write`` JSON frame after tmux reports a copy-mode selection; PTY
+  attaches advertise whether OSC 52 is safe before terminal output begins.
 - **Client → server**:
     - **Text frames** are JSON control messages:
       ``{"type": "resize", "cols": N, "rows": M}``. Parsed and applied
@@ -274,17 +276,21 @@ def create_terminal_attach_router(
                 "terminal.transport": resolved_transport,
             },
         ):
-            bridge = (
-                bridge_tmux_control_to_websocket
-                if resolved_transport == TERMINAL_TRANSPORT_CONTROL
-                else bridge_tmux_pty_to_websocket
-            )
-            await bridge(
-                websocket,
-                socket_path=str(entry.instance.socket_path),
-                tmux_target=entry.instance.tmux_target,
-                read_only=read_only,
-            )
+            if resolved_transport == TERMINAL_TRANSPORT_CONTROL:
+                await bridge_tmux_control_to_websocket(
+                    websocket,
+                    socket_path=str(entry.instance.socket_path),
+                    tmux_target=entry.instance.tmux_target,
+                    read_only=read_only,
+                )
+            else:
+                await bridge_tmux_pty_to_websocket(
+                    websocket,
+                    socket_path=str(entry.instance.socket_path),
+                    tmux_target=entry.instance.tmux_target,
+                    read_only=read_only,
+                    allow_osc52_clipboard=not entry.instance.tmux_allow_passthrough,
+                )
 
     return router
 

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -28,10 +28,11 @@ Design notes learned from the protocol (see ``control_bridge`` spike):
   the client exits; the hex channel is byte-exact for ESC sequences, control
   chars, and UTF-8 multibyte alike.
 
-The browser-facing wire protocol is identical to the PTY bridge (binary frames
-out = raw pane bytes; text frames in = JSON ``{"type":"resize",...}``; binary
-frames in = input bytes), so the two transports are interchangeable behind the
-same ``/attach`` WebSocket and a client cannot tell which one served it.
+The browser-facing terminal stream matches the PTY bridge (binary frames out =
+raw pane bytes; text frames in = JSON ``{"type":"resize",...}``; binary frames
+in = input bytes). Control mode additionally sends a typed text JSON frame when
+tmux reports a copied paste buffer, because its outer-client OSC 52 is not part
+of ``%output``. Both remain interchangeable behind the same ``/attach`` URL.
 
 Known limitation vs the PTY bridge: tmux's own overlays (``display-popup``,
 copy-mode, status line) are NOT delivered to a control-mode client, so the
@@ -47,6 +48,7 @@ attach transport, so they behave identically under either bridge.
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import json
 import logging
@@ -117,6 +119,21 @@ _CONTROL_STDOUT_BUFFER_LIMIT: Final[int] = 16 * 1024 * 1024
 # stuck-slow client can't hang the close; a normal drain completes well within.
 _FORWARD_DRAIN_TIMEOUT_S: Final[float] = 5.0
 
+# tmux emits this control notification after copy-mode stores a selection in a
+# paste buffer. Only default-style, shell-safe names are accepted; copy-mode's
+# generated names (for example ``buffer0``) are covered without letting an
+# untrusted protocol line select an arbitrary command target.
+_CLIPBOARD_BUFFER_CHANGED_PREFIX: Final = b"%paste-buffer-changed "
+_CLIPBOARD_BUFFER_NAME_RE: Final = re.compile(rb"[A-Za-z0-9_.:-]{1,128}\Z")
+# Browser clipboard writes should stay text-sized. Bound the raw buffer before
+# base64/JSON expansion so a huge tmux buffer cannot become a websocket DoS.
+_CLIPBOARD_MAX_BYTES: Final[int] = 1024 * 1024
+_CLIPBOARD_READ_TIMEOUT_S: Final[float] = 2.0
+# A copy-mode commit follows the initiating key or mouse release immediately.
+# Correlating the notification with this client's recent input prevents one
+# attached browser from overwriting every other viewer's local clipboard.
+_CLIPBOARD_RECENT_INPUT_WINDOW_S: Final[float] = 5.0
+
 
 def unescape_control_output(value: bytes) -> bytes:
     """Un-escape a ``%output`` value back to raw pane bytes.
@@ -131,6 +148,79 @@ def unescape_control_output(value: bytes) -> bytes:
     :returns: The raw bytes, e.g. ``b"\\x1b[31mRED\\x1b[0m\\r\\n"``.
     """
     return _OCTAL_ESCAPE_RE.sub(lambda m: bytes([int(m.group(1), 8)]), value)
+
+
+async def _read_tmux_buffer(
+    tmux: str,
+    socket_path: str,
+    buffer_name: str,
+) -> bytes | None:
+    """Read one named tmux buffer exactly, rejecting failures and oversized data.
+
+    ``save-buffer ... -`` writes the raw bytes without ``show-buffer``'s display
+    formatting. ``readexactly(limit + 1)`` distinguishes an in-range buffer
+    (EOF with a partial result) from an oversized one without first buffering
+    an unbounded subprocess result in Python.
+
+    :param tmux: Absolute tmux executable path.
+    :param socket_path: Private tmux server socket.
+    :param buffer_name: Validated tmux buffer name, e.g. ``"buffer0"``.
+    :returns: Raw buffer bytes, or ``None`` when unavailable/oversized.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            tmux,
+            "-S",
+            socket_path,
+            "save-buffer",
+            "-b",
+            buffer_name,
+            "-",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except (OSError, ValueError):
+        return None
+    assert proc.stdout is not None
+    try:
+        try:
+            data = await asyncio.wait_for(
+                proc.stdout.readexactly(_CLIPBOARD_MAX_BYTES + 1),
+                timeout=_CLIPBOARD_READ_TIMEOUT_S,
+            )
+            oversized = True
+        except asyncio.IncompleteReadError as exc:
+            data = exc.partial
+            oversized = False
+        if oversized:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+        await asyncio.wait_for(proc.wait(), timeout=_CLIPBOARD_READ_TIMEOUT_S)
+    except asyncio.CancelledError:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        with contextlib.suppress(Exception):
+            await asyncio.shield(proc.wait())
+        raise
+    except (asyncio.TimeoutError, OSError):
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.wait()
+        return None
+    if oversized or proc.returncode != 0:
+        return None
+    return data
+
+
+def _clipboard_buffer_name(line: bytes) -> str | None:
+    """Extract a safe buffer name from a tmux clipboard notification."""
+    if not line.startswith(_CLIPBOARD_BUFFER_CHANGED_PREFIX):
+        return None
+    raw_name = line[len(_CLIPBOARD_BUFFER_CHANGED_PREFIX) :]
+    if _CLIPBOARD_BUFFER_NAME_RE.fullmatch(raw_name) is None:
+        return None
+    return raw_name.decode("ascii")
 
 
 def _hex_send_keys_commands(target: str, data: bytes) -> list[bytes]:
@@ -404,7 +494,8 @@ async def bridge_tmux_control_to_websocket(
 
     Drop-in alternative to
     :func:`omnigent.terminals.ws_bridge.bridge_tmux_pty_to_websocket` with the
-    same signature and browser wire protocol. Caller must have called
+    same signature and terminal byte stream. Control mode additionally emits
+    server-to-browser clipboard JSON frames. Caller must have called
     ``websocket.accept()``. On exit (any branch) the control client is torn
     down and the websocket closed best-effort with the shared 4404/4405 codes.
 
@@ -476,9 +567,16 @@ async def bridge_tmux_control_to_websocket(
     # one bounded ``send_bytes``, so when the browser send lags tmux's firehose
     # a backlog of tiny per-line payloads collapses into a few large frames.
     output_chunks: asyncio.Queue[bytes | None] = asyncio.Queue()
+    # Clipboard notifications are handled outside the raw output hot path: each
+    # item names the immutable tmux buffer created by copy-mode; None is EOF.
+    clipboard_buffers: asyncio.Queue[str | None] = asyncio.Queue()
+    # Terminal bytes and clipboard JSON have separate producer tasks but one
+    # websocket. Serialize sends so ASGI never sees concurrent send calls.
+    ws_send_lock = asyncio.Lock()
     # Monotonic stamp of the last forwarded browser input; the forwarder reads
     # it to shrink the frame cap right after a keystroke (keeps the echo on
-    # xterm's synchronous paint path — see the PTY bridge).
+    # xterm's synchronous paint path — see the PTY bridge) and clipboard
+    # forwarding uses it to identify which attached client initiated a copy.
     last_client_input_at: float | None = None
 
     def _current_ws_coalesce_limit() -> int:
@@ -511,6 +609,15 @@ async def bridge_tmux_control_to_websocket(
             parts = line.split(b" ", 2)
             if len(parts) == 3:
                 output_chunks.put_nowait(unescape_control_output(parts[2]))
+            return True
+        buffer_name = _clipboard_buffer_name(line)
+        if buffer_name is not None:
+            if (
+                not read_only
+                and last_client_input_at is not None
+                and _monotonic() - last_client_input_at <= _CLIPBOARD_RECENT_INPUT_WINDOW_S
+            ):
+                clipboard_buffers.put_nowait(buffer_name)
             return True
         if line.startswith(b"%exit"):
             return False
@@ -549,8 +656,48 @@ async def bridge_tmux_control_to_websocket(
                         return
         finally:
             output_chunks.put_nowait(None)
+            clipboard_buffers.put_nowait(None)
             if reader_done is not None:
                 reader_done.set()
+
+    async def _forward_clipboard_updates() -> None:
+        """Read copied tmux buffers and send bounded clipboard control frames."""
+        while True:
+            buffer_name = await clipboard_buffers.get()
+            if buffer_name is None:
+                return
+
+            # When several copies arrive before the subprocess starts, only the
+            # newest clipboard value matters. Preserve an EOF sentinel so the
+            # task exits after forwarding that final value.
+            eof_seen = False
+            while True:
+                try:
+                    next_name = clipboard_buffers.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if next_name is None:
+                    eof_seen = True
+                    break
+                buffer_name = next_name
+
+            data = await _read_tmux_buffer(tmux, socket_path, buffer_name)
+            if data is not None:
+                message = json.dumps(
+                    {
+                        "type": "clipboard-write",
+                        "encoding": "base64",
+                        "data": base64.b64encode(data).decode("ascii"),
+                    },
+                    separators=(",", ":"),
+                )
+                try:
+                    async with ws_send_lock:
+                        await websocket.send_text(message)
+                except (RuntimeError, WebSocketDisconnect):
+                    return
+            if eof_seen:
+                return
 
     async def _ws_to_control() -> None:
         """Read browser frames; resize via refresh-client -C, input via -H hex."""
@@ -600,9 +747,15 @@ async def bridge_tmux_control_to_websocket(
     read_task = asyncio.create_task(_read_control(), name="tmux-control-read")
     forward_task = asyncio.create_task(
         _forward_pty_to_ws(
-            websocket, output_chunks, max_coalesce_bytes=_current_ws_coalesce_limit
+            websocket,
+            output_chunks,
+            max_coalesce_bytes=_current_ws_coalesce_limit,
+            send_lock=ws_send_lock,
         ),
         name="tmux-control-forward",
+    )
+    clipboard_task = asyncio.create_task(
+        _forward_clipboard_updates(), name="tmux-control-clipboard"
     )
     if forward_done is not None:
         forward_task.add_done_callback(lambda _task: forward_done.set())
@@ -612,6 +765,9 @@ async def bridge_tmux_control_to_websocket(
     # finishing is downstream (it drains, then sees the EOF sentinel).
     control_ended_first = False
     try:
+        # The clipboard task is intentionally not a FIRST_COMPLETED trigger: it
+        # may finish after the reader's EOF sentinel, but the reader itself is
+        # the authoritative control-side completion signal.
         done, pending = await asyncio.wait(
             {read_task, forward_task, ws_task}, return_when=asyncio.FIRST_COMPLETED
         )
@@ -636,13 +792,18 @@ async def bridge_tmux_control_to_websocket(
                 await asyncio.wait_for(
                     asyncio.shield(forward_task), timeout=_FORWARD_DRAIN_TIMEOUT_S
                 )
-        for task in pending:
+        if control_ended_first and not clipboard_task.done():
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(
+                    asyncio.shield(clipboard_task), timeout=_FORWARD_DRAIN_TIMEOUT_S
+                )
+        for task in {*pending, clipboard_task}:
             if task.done():
                 continue
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
-        for task in {read_task, forward_task, ws_task}:
+        for task in {read_task, forward_task, clipboard_task, ws_task}:
             if task.done() and not task.cancelled():
                 exc = task.exception()
                 if exc is not None:

--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -16,7 +16,9 @@ Used by:
 
 Wire protocol (same as the original server route):
 
-- **Server → client**: every PTY read becomes a *binary* WS frame.
+- **Server → client**: every PTY read becomes a *binary* WS frame. Production
+  attaches first send a text OSC 52 capability frame so the browser can reject
+  clipboard escapes when tmux passthrough weakens the normal trust boundary.
 - **Client → server**:
     - **Text frames** are JSON control messages. Currently only
       ``{"type": "resize", "cols": N, "rows": M}`` (applied via
@@ -417,6 +419,7 @@ async def _forward_pty_to_ws(
     pty_chunks: asyncio.Queue[bytes | None],
     *,
     max_coalesce_bytes: int | Callable[[], int] = _WS_COALESCE_MAX_BYTES,
+    send_lock: asyncio.Lock | None = None,
 ) -> None:
     """
     Forward queued PTY output to *websocket*, coalescing ready chunks.
@@ -440,6 +443,9 @@ async def _forward_pty_to_ws(
         :data:`_WS_COALESCE_MAX_BYTES`; ``bridge_tmux_pty_to_websocket``
         supplies a callable so recently-typed redraws can use the smaller
         interactive cap while normal output keeps the larger flood cap.
+    :param send_lock: Optional lock shared with another server-to-browser
+        sender. Control mode uses it to serialize terminal bytes with clipboard
+        control frames; PTY mode has only this sender and leaves it unset.
     :returns: None on EOF or websocket disconnect.
     """
     pending = bytearray()
@@ -468,7 +474,11 @@ async def _forward_pty_to_ws(
             frame = bytes(pending[:limit])
             del pending[:limit]
             try:
-                await websocket.send_bytes(frame)
+                if send_lock is None:
+                    await websocket.send_bytes(frame)
+                else:
+                    async with send_lock:
+                        await websocket.send_bytes(frame)
             except (RuntimeError, WebSocketDisconnect):
                 return
         if eof_seen:
@@ -517,6 +527,7 @@ async def bridge_tmux_pty_to_websocket(
     tmux_target: str,
     read_only: bool,
     on_client_interaction: Callable[[], None] | None = None,
+    allow_osc52_clipboard: bool | None = None,
 ) -> None:
     """
     Bridge a tmux attach PTY to an already-accepted *websocket*.
@@ -545,12 +556,31 @@ async def bridge_tmux_pty_to_websocket(
         mis-reading them as agent activity. ``None`` (e.g. the
         server-direct attach path, which is out-of-process from the
         watcher) disables that attribution.
+    :param allow_osc52_clipboard: Whether the browser may honor OSC 52 from this
+        PTY. Production passes ``False`` when tmux passthrough is enabled, since
+        pane output could otherwise bypass ``set-clipboard external``. ``None``
+        omits the capability frame for low-level test compatibility.
     """
     # Attaching is itself a client interaction: tmux resizes the window to
     # the new client, which reflows the pane. Stamp it before the bridge
     # starts so that reflow is discounted.
     if on_client_interaction is not None:
         on_client_interaction()
+
+    if allow_osc52_clipboard is not None:
+        try:
+            await websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "osc52-clipboard-capability",
+                        "enabled": allow_osc52_clipboard and not read_only,
+                    },
+                    separators=(",", ":"),
+                )
+            )
+        except (RuntimeError, WebSocketDisconnect):
+            return
+
     argv = ["tmux", "-S", socket_path, "attach"]
     if read_only:
         argv.append("-r")

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -605,6 +605,12 @@ async def test_launch_enables_csi_u_extended_keys_quietly(
         cmd,
         ["set-option", "-sq", "extended-keys-format", "csi-u"],
     )
+    # tmux copy-mode may export selections to an attached terminal, but pane
+    # applications must not be allowed to create paste buffers through OSC 52.
+    assert contains_subsequence(
+        cmd,
+        ["set-option", "-sq", "set-clipboard", "external"],
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_terminal_resource_attach_ws.py
+++ b/tests/runner/test_terminal_resource_attach_ws.py
@@ -176,15 +176,16 @@ def test_runner_resource_attach_selects_control_bridge_on_transport_query(
 ) -> None:
     """``?transport=control`` dispatches to the control-mode bridge, not the PTY one.
 
-    Both bridges share the same signature and browser wire protocol, so the
-    route just picks one. Patch each to record which was invoked and close the
+    The route selects one bridge and gives PTY attaches the explicit OSC 52
+    trust capability. Patch each to record which was invoked and close the
     socket cleanly, then assert on the selection per query.
 
     :param tmp_path: Pytest tmp directory.
     :param monkeypatch: Pytest monkeypatch fixture.
     """
     registry = TerminalRegistry()
-    _seed_registry(registry, "conv_abc", _make_running_instance("bash", "s1", tmp_path))
+    instance = _make_running_instance("bash", "s1", tmp_path)
+    _seed_registry(registry, "conv_abc", instance)
     app = create_runner_app(
         terminal_registry=registry,
         server_client=NullServerClient(),  # type: ignore[arg-type]
@@ -196,8 +197,8 @@ def test_runner_resource_attach_selects_control_bridge_on_transport_query(
         calls.append("control")
         await websocket.close()
 
-    async def fake_pty(websocket, **_kwargs):  # type: ignore[no-untyped-def]
-        calls.append("pty")
+    async def fake_pty(websocket, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(f"pty:{kwargs.get('allow_osc52_clipboard')}")
         await websocket.close()
 
     monkeypatch.setattr("omnigent.runner.app.bridge_tmux_control_to_websocket", fake_control)
@@ -218,8 +219,14 @@ def test_runner_resource_attach_selects_control_bridge_on_transport_query(
     with contextlib.suppress(WebSocketDisconnect):
         with client.websocket_connect(base):  # no query → control default
             pass
+    # Passthrough can carry pane-crafted OSC 52 around tmux's external-only
+    # clipboard policy, so PTY attaches must explicitly disable browser OSC 52.
+    instance.tmux_allow_passthrough = True
+    with contextlib.suppress(WebSocketDisconnect):
+        with client.websocket_connect(f"{base}?transport=pty"):
+            pass
 
-    assert calls == ["control", "pty", "control"], (
+    assert calls == ["control", "pty:True", "control", "pty:False"], (
         f"transport query did not select the expected bridge: {calls!r}"
     )
 

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -11,7 +11,9 @@ and the detach close code.
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
+import json
 import os
 import shutil
 import tempfile
@@ -19,9 +21,12 @@ from pathlib import Path
 
 import pytest
 
+import omnigent.terminals.control_bridge as control_bridge
 from omnigent.terminals.control_bridge import (
     _SEND_KEYS_HEX_BYTES_PER_CALL,
+    _clipboard_buffer_name,
     _hex_send_keys_commands,
+    _read_tmux_buffer,
     bridge_tmux_control_to_websocket,
     unescape_control_output,
 )
@@ -36,6 +41,52 @@ def test_unescape_control_output_round_trips_control_bytes() -> None:
     assert unescape_control_output(rb"a\134b") == b"a\\b"
     # Printable bytes pass through untouched.
     assert unescape_control_output(b"plain text 123") == b"plain text 123"
+
+
+def test_clipboard_buffer_name_accepts_only_safe_notifications() -> None:
+    """Only ordinary tmux copy-buffer names are accepted as command targets."""
+    assert _clipboard_buffer_name(b"%paste-buffer-changed buffer0") == "buffer0"
+    assert _clipboard_buffer_name(b"%paste-buffer-changed named-buffer.1") == "named-buffer.1"
+    assert _clipboard_buffer_name(b"%paste-buffer-changed bad name") is None
+    assert _clipboard_buffer_name(b"%paste-buffer-changed ../bad") is None
+    assert _clipboard_buffer_name(b"%output %0 text") is None
+
+
+@pytest.mark.asyncio
+async def test_tmux_buffer_read_cancellation_reaps_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling an in-flight clipboard read kills and awaits its tmux child."""
+
+    class _BlockedProcess:
+        def __init__(self) -> None:
+            self.stdout = asyncio.StreamReader()
+            self.returncode: int | None = None
+            self.killed = False
+
+        def kill(self) -> None:
+            self.killed = True
+            self.returncode = -9
+            self.stdout.feed_eof()
+
+        async def wait(self) -> int:
+            while self.returncode is None:
+                await asyncio.sleep(0)
+            return self.returncode
+
+    proc = _BlockedProcess()
+
+    async def _spawn(*_args: object, **_kwargs: object) -> _BlockedProcess:
+        return proc
+
+    monkeypatch.setattr(control_bridge.asyncio, "create_subprocess_exec", _spawn)
+    task = asyncio.create_task(_read_tmux_buffer("tmux", "socket", "buffer0"))
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert proc.killed is True
+    assert proc.returncode == -9
 
 
 def test_hex_send_keys_commands_encodes_and_chunks() -> None:
@@ -61,6 +112,7 @@ class _FakeWebSocket:
     def __init__(self, inbound: list[dict[str, object]], send_delay_s: float = 0.0) -> None:
         self._inbound = list(inbound)
         self.sent: list[bytes] = []
+        self.sent_text: list[str] = []
         self.close_code: int | None = None
         self.close_reason: str | None = None
         self._recv_gate = asyncio.Event()
@@ -72,6 +124,11 @@ class _FakeWebSocket:
         if self._send_delay_s:
             await asyncio.sleep(self._send_delay_s)
         self.sent.append(data)
+
+    async def send_text(self, data: str) -> None:
+        if self._send_delay_s:
+            await asyncio.sleep(self._send_delay_s)
+        self.sent_text.append(data)
 
     async def receive(self) -> dict[str, object]:
         if self._inbound:
@@ -544,6 +601,123 @@ async def test_seed_plain_shell_replays_no_modes() -> None:
 
 @pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
 @pytest.mark.asyncio
+async def test_tmux_clipboard_buffer_read_is_exact_and_bounded(tmp_path: Path) -> None:
+    """Named buffer reads preserve bytes and reject missing/oversized buffers."""
+    sock, _target = await _new_private_tmux("sleep 30")
+    tmux = shutil.which("tmux")
+    assert tmux
+    try:
+        payload = b"exact\x00bytes\n"
+        payload_path = tmp_path / "clipboard.bin"
+        payload_path.write_bytes(payload)
+        proc = await asyncio.create_subprocess_exec(
+            tmux,
+            "-S",
+            str(sock),
+            "load-buffer",
+            "-b",
+            "buffer-exact",
+            str(payload_path),
+        )
+        await proc.communicate()
+        assert proc.returncode == 0
+        assert await _read_tmux_buffer(tmux, str(sock), "buffer-exact") == payload
+        assert await _read_tmux_buffer(tmux, str(sock), "buffer-missing") is None
+
+        payload_path.write_bytes(b"X" * (1024 * 1024 + 1))
+        proc = await asyncio.create_subprocess_exec(
+            tmux,
+            "-S",
+            str(sock),
+            "load-buffer",
+            "-b",
+            "buffer-oversized",
+            str(payload_path),
+        )
+        await proc.communicate()
+        assert proc.returncode == 0
+        assert await _read_tmux_buffer(tmux, str(sock), "buffer-oversized") is None
+    finally:
+        await _kill_tmux(sock)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_bridge_forwards_recent_copy_buffer_as_text_frame() -> None:
+    """A copy after input on this attach becomes a bounded clipboard message."""
+    sock, target = await _new_private_tmux("sleep 30")
+    await asyncio.sleep(0.2)
+
+    ws = _FakeWebSocket(inbound=[{"type": "websocket.receive", "bytes": b"x"}])
+    task = asyncio.create_task(
+        bridge_tmux_control_to_websocket(
+            ws, socket_path=str(sock), tmux_target=target, read_only=False
+        )
+    )
+    await asyncio.sleep(0.5)
+
+    tmux = shutil.which("tmux")
+    assert tmux
+    # TUI applications may update tmux's paste buffer directly rather than
+    # entering tmux's outer copy-mode UI, especially over control transport.
+    copied = "copied λ\nsecond line".encode()
+    proc = await asyncio.create_subprocess_exec(
+        tmux,
+        "-S",
+        str(sock),
+        "set-buffer",
+        "-b",
+        "buffer-copy-test",
+        copied.decode(),
+    )
+    await proc.communicate()
+    assert proc.returncode == 0
+
+    async def _clipboard_arrived() -> bool:
+        for _ in range(50):
+            if ws.sent_text:
+                return True
+            await asyncio.sleep(0.05)
+        return False
+
+    assert await _clipboard_arrived(), "clipboard control frame was not sent"
+    message = json.loads(ws.sent_text[-1])
+    assert message["type"] == "clipboard-write"
+    assert message["encoding"] == "base64"
+    assert base64.b64decode(message["data"]) == copied
+
+    await _kill_and_join(sock, task)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_bridge_ignores_copy_without_recent_input() -> None:
+    """A buffer update not attributable to this attach must not copy locally."""
+    sock, target = await _new_private_tmux("sleep 30")
+    await asyncio.sleep(0.2)
+
+    ws = _FakeWebSocket(inbound=[])
+    task = asyncio.create_task(
+        bridge_tmux_control_to_websocket(
+            ws, socket_path=str(sock), tmux_target=target, read_only=False
+        )
+    )
+    await asyncio.sleep(0.5)
+
+    tmux = shutil.which("tmux")
+    assert tmux
+    proc = await asyncio.create_subprocess_exec(
+        tmux, "-S", str(sock), "set-buffer", "-b", "buffer-unrelated", "secret"
+    )
+    await proc.communicate()
+    await asyncio.sleep(0.3)
+    assert ws.sent_text == []
+
+    await _kill_and_join(sock, task)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
 async def test_control_bridge_read_only_drops_input() -> None:
     """read_only=True must not inject typed bytes into the pane."""
     sock, target = await _new_private_tmux("cat")
@@ -557,5 +731,14 @@ async def test_control_bridge_read_only_drops_input() -> None:
     )
     await asyncio.sleep(0.8)
     assert b"should-not-appear" not in b"".join(ws.sent)
+
+    tmux = shutil.which("tmux")
+    assert tmux
+    proc = await asyncio.create_subprocess_exec(
+        tmux, "-S", str(sock), "set-buffer", "-b", "buffer-read-only", "secret"
+    )
+    await proc.communicate()
+    await asyncio.sleep(0.2)
+    assert ws.sent_text == []
 
     await _kill_and_join(sock, task)

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -438,6 +438,11 @@ class _ParkingFakeWebSocket:
         self._parked = asyncio.Event()  # never set: parks ``receive``
         self.close_code: int | None = None
         self.close_reason: str | None = None
+        self.sent_text: list[str] = []
+
+    async def send_text(self, data: str) -> None:
+        """Capture server-to-browser capability frames."""
+        self.sent_text.append(data)
 
     async def send_bytes(self, data: bytes) -> None:
         """Record that the PTY produced output (tmux attached, drawing)."""
@@ -452,6 +457,36 @@ class _ParkingFakeWebSocket:
         """Capture the bridge's chosen close code and reason."""
         self.close_code = code
         self.close_reason = reason
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("read_only", "allow", "expected"),
+    [(False, True, True), (False, False, False), (True, True, False)],
+)
+async def test_bridge_advertises_safe_osc52_capability(
+    monkeypatch: pytest.MonkeyPatch,
+    read_only: bool,
+    allow: bool,
+    expected: bool,
+) -> None:
+    """PTY OSC 52 is explicitly enabled only for trusted writable attaches."""
+    monkeypatch.setattr(ws_bridge.shutil, "which", lambda _command: None)
+    websocket = _ParkingFakeWebSocket()
+
+    await bridge_tmux_pty_to_websocket(
+        websocket,  # type: ignore[arg-type]
+        socket_path="unused",
+        tmux_target="main",
+        read_only=read_only,
+        allow_osc52_clipboard=allow,
+    )
+
+    assert len(websocket.sent_text) == 1
+    assert json.loads(websocket.sent_text[0]) == {
+        "type": "osc52-clipboard-capability",
+        "enabled": expected,
+    }
 
 
 @pytest.mark.skipif(not _HAS_TMUX, reason="tmux required")

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -15,9 +15,14 @@ import {
   TerminalSession,
   WHEEL_REPORTS_MAX_PER_EVENT,
   applyTerminalCopy,
+  decodeTerminalClipboardBase64,
+  hadRecentTerminalInput,
   isUnexpectedTerminalClose,
   loadWebglRenderer,
   openTerminalLink,
+  parseOsc52Clipboard,
+  parseTerminalClipboardMessage,
+  parseTerminalOsc52Capability,
   sgrWheelReports,
   shouldEchoSynchronously,
   terminalTheme,
@@ -122,6 +127,53 @@ describe("applyTerminalCopy", () => {
     expect(applyTerminalCopy(event, "")).toBe(false);
     expect(setData).not.toHaveBeenCalled();
     expect(preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+describe("tmux clipboard parsing", () => {
+  function utf8Base64(text: string): string {
+    const bytes = new TextEncoder().encode(text);
+    return btoa(String.fromCharCode(...bytes));
+  }
+
+  it("decodes bounded UTF-8 base64", () => {
+    expect(decodeTerminalClipboardBase64(utf8Base64("hello λ\nworld"))).toBe("hello λ\nworld");
+    expect(decodeTerminalClipboardBase64("not base64")).toBeNull();
+    expect(decodeTerminalClipboardBase64("")).toBeNull();
+  });
+
+  it("accepts tmux OSC 52 writes but rejects reads and other selections", () => {
+    const encoded = utf8Base64("copied");
+    expect(parseOsc52Clipboard(`;${encoded}`)).toBe("copied");
+    expect(parseOsc52Clipboard(`c;${encoded}`)).toBe("copied");
+    expect(parseOsc52Clipboard("c;?")).toBeNull();
+    expect(parseOsc52Clipboard(`p;${encoded}`)).toBeNull();
+  });
+
+  it("accepts only the clipboard-write websocket schema", () => {
+    const encoded = utf8Base64("from control mode");
+    expect(
+      parseTerminalClipboardMessage(
+        JSON.stringify({ type: "clipboard-write", encoding: "base64", data: encoded }),
+      ),
+    ).toBe("from control mode");
+    expect(
+      parseTerminalClipboardMessage(JSON.stringify({ type: "resize", data: encoded })),
+    ).toBeNull();
+    expect(parseTerminalClipboardMessage("not json")).toBeNull();
+    expect(
+      parseTerminalOsc52Capability(
+        JSON.stringify({ type: "osc52-clipboard-capability", enabled: true }),
+      ),
+    ).toBe(true);
+    expect(parseTerminalOsc52Capability(JSON.stringify({ type: "resize" }))).toBeNull();
+  });
+
+  it("requires positive, recent input timing", () => {
+    expect(hadRecentTerminalInput(9000, 10_000)).toBe(true);
+    expect(hadRecentTerminalInput(0, 100)).toBe(false);
+    expect(hadRecentTerminalInput(1000, 10_000)).toBe(false);
+    expect(hadRecentTerminalInput(2000, 1000)).toBe(false);
   });
 });
 
@@ -475,7 +527,13 @@ describe("TerminalSession", () => {
     vi.restoreAllMocks();
   });
 
-  function makeSession(onActivity?: () => void, onInput?: () => void) {
+  function makeSession(
+    onActivity?: () => void,
+    onInput?: () => void,
+    clipboardEnabled = true,
+    onClipboardRequest?: (text: string) => void,
+    nativeSelection = false,
+  ) {
     const states: ConnectionState[] = [];
     const container = document.createElement("div");
     document.body.appendChild(container);
@@ -486,6 +544,9 @@ describe("TerminalSession", () => {
       false,
       onActivity,
       onInput,
+      nativeSelection,
+      clipboardEnabled,
+      onClipboardRequest,
     );
     return { session, states, container, socket: FakeWebSocket.instances.at(-1)! };
   }
@@ -560,6 +621,77 @@ describe("TerminalSession", () => {
 
     socket.emit("message", { data: "text frame" });
     expect(onActivity).toHaveBeenCalledTimes(1); // unchanged — text ignored
+    session.dispose();
+  });
+
+  it("handles PTY OSC 52 but does not trust raw control-mode pane OSC", async () => {
+    vi.spyOn(performance, "now").mockReturnValue(10_000);
+    const ptyClipboard = vi.fn();
+    const pty = makeSession(undefined, undefined, true, ptyClipboard);
+    (pty.session as unknown as { lastUserInputAt: number }).lastUserInputAt = 9000;
+    const sequence = `\x1b]52;;${btoa("from pty")}\x07`;
+    const ptyTerm = (pty.session as unknown as { term: Terminal }).term;
+    ptyTerm.focus();
+    pty.socket.emit("message", {
+      data: JSON.stringify({ type: "osc52-clipboard-capability", enabled: true }),
+    });
+    await new Promise<void>((resolve) => {
+      ptyTerm.write(sequence, resolve);
+    });
+    expect(ptyClipboard).toHaveBeenCalledWith("from pty");
+    pty.session.dispose();
+
+    const controlClipboard = vi.fn();
+    const control = makeSession(undefined, undefined, true, controlClipboard, true);
+    (control.session as unknown as { lastUserInputAt: number }).lastUserInputAt = 9000;
+    const controlTerm = (control.session as unknown as { term: Terminal }).term;
+    controlTerm.focus();
+    control.socket.emit("message", {
+      data: JSON.stringify({ type: "osc52-clipboard-capability", enabled: true }),
+    });
+    await new Promise<void>((resolve) => {
+      controlTerm.write(sequence, resolve);
+    });
+    expect(controlClipboard).not.toHaveBeenCalled();
+    control.session.dispose();
+  });
+
+  it("forwards validated clipboard frames only after recent input", () => {
+    vi.spyOn(performance, "now").mockReturnValue(10_000);
+    const onClipboardRequest = vi.fn();
+    const { socket, session } = makeSession(undefined, undefined, true, onClipboardRequest);
+    (session as unknown as { lastUserInputAt: number }).lastUserInputAt = 9000;
+    const encoded = btoa("copied text");
+
+    socket.emit("message", {
+      data: JSON.stringify({ type: "clipboard-write", encoding: "base64", data: encoded }),
+    });
+    expect(onClipboardRequest).toHaveBeenCalledWith("copied text");
+
+    (session as unknown as { lastUserInputAt: number }).lastUserInputAt = 1000;
+    socket.emit("message", {
+      data: JSON.stringify({ type: "clipboard-write", encoding: "base64", data: encoded }),
+    });
+    socket.emit("message", { data: '{"type":"unknown"}' });
+    expect(onClipboardRequest).toHaveBeenCalledTimes(1);
+    session.dispose();
+  });
+
+  it("does not forward clipboard frames when the surface is disabled", () => {
+    vi.spyOn(performance, "now").mockReturnValue(10_000);
+    const onClipboardRequest = vi.fn();
+    const { socket, session } = makeSession(undefined, undefined, false, onClipboardRequest);
+    (session as unknown as { lastUserInputAt: number }).lastUserInputAt = 9000;
+    (session as unknown as { term: Terminal }).term.focus();
+
+    socket.emit("message", {
+      data: JSON.stringify({
+        type: "clipboard-write",
+        encoding: "base64",
+        data: btoa("secret"),
+      }),
+    });
+    expect(onClipboardRequest).not.toHaveBeenCalled();
     session.dispose();
   });
 

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -5,7 +5,8 @@
 // down on the matching detach.
 //
 // Wire protocol (mirrors `omnigent/server/routes/terminal_attach.py`):
-//   - Server → client: binary frames, raw PTY bytes → `term.write`.
+//   - Server → client: binary frames, raw PTY bytes → `term.write`; text
+//     frames for JSON control messages (currently tmux clipboard writes).
 //   - Client → server: binary frames for keystrokes (`term.onData`);
 //     text frames for JSON control messages (currently only resize).
 
@@ -304,6 +305,94 @@ export function applyTerminalCopy(
   return true;
 }
 
+/** Largest tmux selection accepted for a browser clipboard write. */
+export const TERMINAL_CLIPBOARD_MAX_BYTES = 1024 * 1024;
+/** A tmux copy notification must closely follow input on this attachment. */
+export const TERMINAL_CLIPBOARD_INPUT_WINDOW_MS = 5000;
+
+const STRICT_BASE64_RE = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+/** Decode one bounded, canonical base64 terminal clipboard payload. */
+export function decodeTerminalClipboardBase64(encoded: string): string | null {
+  if (
+    encoded.length === 0 ||
+    encoded.length > Math.ceil(TERMINAL_CLIPBOARD_MAX_BYTES / 3) * 4 ||
+    encoded.length % 4 !== 0 ||
+    !STRICT_BASE64_RE.test(encoded)
+  ) {
+    return null;
+  }
+  let binary: string;
+  try {
+    binary = atob(encoded);
+  } catch {
+    return null;
+  }
+  if (binary.length === 0 || binary.length > TERMINAL_CLIPBOARD_MAX_BYTES) return null;
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+/** Parse a tmux-compatible OSC 52 clipboard-set payload. */
+export function parseOsc52Clipboard(data: string): string | null {
+  const separator = data.indexOf(";");
+  if (separator < 0) return null;
+  const selector = data.slice(0, separator);
+  const encoded = data.slice(separator + 1);
+  // tmux uses the empty selector; `c` is the standard system clipboard.
+  if ((selector !== "" && selector !== "c") || encoded === "?") return null;
+  return decodeTerminalClipboardBase64(encoded);
+}
+
+/** Parse the strict server→browser clipboard control-message schema. */
+export function parseTerminalClipboardMessage(message: string): string | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(message);
+  } catch {
+    return null;
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    (value as { type?: unknown }).type !== "clipboard-write" ||
+    (value as { encoding?: unknown }).encoding !== "base64" ||
+    typeof (value as { data?: unknown }).data !== "string"
+  ) {
+    return null;
+  }
+  return decodeTerminalClipboardBase64((value as { data: string }).data);
+}
+
+/** Parse the server's explicit PTY OSC 52 trust capability. */
+export function parseTerminalOsc52Capability(message: string): boolean | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(message);
+  } catch {
+    return null;
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    (value as { type?: unknown }).type !== "osc52-clipboard-capability" ||
+    typeof (value as { enabled?: unknown }).enabled !== "boolean"
+  ) {
+    return null;
+  }
+  return (value as { enabled: boolean }).enabled;
+}
+
+/** Whether a clipboard event is attributable to recent input on this attach. */
+export function hadRecentTerminalInput(lastInputAt: number, now: number): boolean {
+  return (
+    lastInputAt > 0 && now >= lastInputAt && now - lastInputAt <= TERMINAL_CLIPBOARD_INPUT_WINDOW_MS
+  );
+}
+
+/** Listener for tmux copy-mode text destined for the user's clipboard. */
+export type TerminalClipboardListener = (text: string) => void;
+
 /**
  * Ceiling on synthesized wheel reports for a single DOM wheel event, so a
  * page-mode or pathological delta can't flood the input channel.
@@ -442,6 +531,12 @@ export class TerminalSession {
   private readonly listenerCtl: AbortController;
   private readonly resizeObserver: ResizeObserver;
   private readonly dataDispose: { dispose: () => void };
+  private readonly osc52Dispose: { dispose: () => void };
+  private readonly onClipboardRequest?: TerminalClipboardListener;
+  /** Whether this visible, interactive attach may write the local clipboard. */
+  private clipboardEnabled: boolean;
+  /** Explicit server capability; defaults off so old/unknown servers fail safe. */
+  private osc52ClipboardEnabled = false;
   /** ``performance.now()`` of the last keystroke; gates the echo fast path. */
   private lastUserInputAt = 0;
   /** Guards {@link dispose} so calling it twice is a safe no-op. */
@@ -476,6 +571,8 @@ export class TerminalSession {
    *     workaround and the custom ``copy`` listener are skipped. When
    *     ``false`` (PTY transport, the default), tmux runs with ``mouse on``
    *     and captures drags, so both workarounds stay wired.
+   * :param clipboardEnabled: Whether tmux copies may write the local clipboard.
+   * :param onClipboardRequest: Receives validated tmux copy-mode text.
    */
   constructor(
     container: HTMLElement,
@@ -485,7 +582,11 @@ export class TerminalSession {
     onActivity?: TerminalActivityListener,
     onInput?: TerminalInputListener,
     nativeSelection = false,
+    clipboardEnabled = true,
+    onClipboardRequest?: TerminalClipboardListener,
   ) {
+    this.clipboardEnabled = clipboardEnabled;
+    this.onClipboardRequest = onClipboardRequest;
     // Read the user's code-font preference (Settings → Appearance) at
     // construction; a mid-session change is applied live via setFont(). The
     // xterm.js defaults (15px, no theme) feel out of place inside the app
@@ -513,6 +614,18 @@ export class TerminalSession {
       macOptionClickForcesSelection: !nativeSelection,
       // Opt into xterm's proposed APIs, matching openui's terminal setup.
       allowProposedApi: true,
+    });
+    // PTY tmux clients emit OSC 52 after copy-mode commits. Consume only
+    // bounded write requests; clipboard reads/queries are deliberately absent.
+    this.osc52Dispose = this.term.parser.registerOscHandler(52, (data) => {
+      // Control mode forwards raw pane output, so accepting pane OSC 52 there
+      // would bypass tmux's `set-clipboard external` trust boundary. Its copy
+      // path is the typed websocket message emitted from tmux notifications.
+      if (!nativeSelection && this.osc52ClipboardEnabled) {
+        const text = parseOsc52Clipboard(data);
+        if (text !== null) this.requestClipboardWrite(text);
+      }
+      return true;
     });
     this.fit = new FitAddon();
     this.term.loadAddon(this.fit);
@@ -584,9 +697,16 @@ export class TerminalSession {
             lastActivityTs = now;
             onActivity?.();
           }
+        } else if (typeof ev.data === "string") {
+          const capability = parseTerminalOsc52Capability(ev.data);
+          if (capability !== null) {
+            this.osc52ClipboardEnabled = capability;
+          } else {
+            const text = parseTerminalClipboardMessage(ev.data);
+            if (text !== null) this.requestClipboardWrite(text);
+            // Unknown text frames stay ignored for protocol forward compatibility.
+          }
         }
-        // Server doesn't currently send text frames; ignore if it ever
-        // does so they aren't interpreted as terminal output.
       },
       { signal },
     );
@@ -672,6 +792,11 @@ export class TerminalSession {
     this.term.options.theme = terminalTheme(isDark);
   }
 
+  /** Enable clipboard bridging only for the visible, interactive surface. */
+  setClipboardEnabled(enabled: boolean): void {
+    this.clipboardEnabled = enabled;
+  }
+
   /**
    * Give the terminal keyboard focus. The WS-open handler focuses
    * automatically, but that call is a browser no-op while the surface is
@@ -712,6 +837,7 @@ export class TerminalSession {
     this.listenerCtl.abort();
     this.resizeObserver.disconnect();
     this.dataDispose.dispose();
+    this.osc52Dispose.dispose();
     try {
       this.ws.close();
     } catch {
@@ -734,6 +860,16 @@ export class TerminalSession {
    * Correctness never depends on the private API; it only shaves a frame
    * off the echo when present.
    */
+  private requestClipboardWrite(text: string): void {
+    if (
+      !this.clipboardEnabled ||
+      !hadRecentTerminalInput(this.lastUserInputAt, performance.now())
+    ) {
+      return;
+    }
+    this.onClipboardRequest?.(text);
+  }
+
   private writeOutput(bytes: Uint8Array): void {
     if (shouldEchoSynchronously(bytes.length, performance.now() - this.lastUserInputAt)) {
       // eslint-disable-next-line no-underscore-dangle

--- a/web/src/components/blocks/TerminalView.test.tsx
+++ b/web/src/components/blocks/TerminalView.test.tsx
@@ -20,14 +20,25 @@ import {
   selectionHintText,
 } from "./TerminalView";
 
+const clipboardMock = vi.hoisted(() => ({
+  copyText: vi.fn<(text: string) => Promise<void>>(),
+  showToast: vi.fn(),
+}));
+
+vi.mock("@/lib/clipboard", () => ({ copyText: clipboardMock.copyText }));
+vi.mock("@/components/ui/toast", () => ({ showToast: clipboardMock.showToast }));
+
 const terminalSessionMock = vi.hoisted(() => ({
   instances: [] as {
     url: string;
     container: HTMLDivElement;
     nativeSelection: boolean;
+    clipboardEnabled: boolean;
+    onClipboardRequest?: (text: string) => void;
     onState: (state: ConnectionState) => void;
     dispose: ReturnType<typeof vi.fn>;
     setTheme: ReturnType<typeof vi.fn>;
+    setClipboardEnabled: ReturnType<typeof vi.fn>;
     focus: ReturnType<typeof vi.fn>;
   }[],
 }));
@@ -39,6 +50,7 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
   TerminalSession: class {
     dispose = vi.fn();
     setTheme = vi.fn();
+    setClipboardEnabled = vi.fn();
     focus = vi.fn();
 
     constructor(
@@ -49,14 +61,19 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
       _onActivity?: () => void,
       _onInput?: () => void,
       nativeSelection = false,
+      clipboardEnabled = true,
+      onClipboardRequest?: (text: string) => void,
     ) {
       terminalSessionMock.instances.push({
         url,
         container,
         nativeSelection,
+        clipboardEnabled,
+        onClipboardRequest,
         onState,
         dispose: this.dispose,
         setTheme: this.setTheme,
+        setClipboardEnabled: this.setClipboardEnabled,
         focus: this.focus,
       });
     }
@@ -65,6 +82,7 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
 
 beforeEach(() => {
   terminalSessionMock.instances = [];
+  clipboardMock.copyText.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -151,6 +169,19 @@ describe("control-mode transport", () => {
     expect(inst.nativeSelection).toBe(true);
   });
 
+  it("disables clipboard bridging for read-only attaches", async () => {
+    render(
+      <TerminalView
+        sessionId="conv_abc"
+        terminalId="terminal_bash_s1"
+        transport="control"
+        readOnly
+      />,
+    );
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+    expect(terminalSessionMock.instances[0].clipboardEnabled).toBe(false);
+  });
+
   it("hides the selection hint bar in control mode", async () => {
     render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" transport="control" />);
     await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
@@ -164,6 +195,38 @@ describe("control-mode transport", () => {
     expect(inst.url).not.toContain("transport");
     expect(inst.nativeSelection).toBe(false);
     expect(screen.getByTestId("terminal-selection-hint")).toBeInTheDocument();
+  });
+});
+
+describe("tmux clipboard", () => {
+  it("writes validated terminal copies through the shared clipboard helper", async () => {
+    render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />);
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+
+    terminalSessionMock.instances[0].onClipboardRequest?.("copied text");
+
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledWith("copied text"));
+    expect(clipboardMock.showToast).toHaveBeenCalledWith("Copied from terminal.", {
+      duration: 1500,
+    });
+    expect(terminalSessionMock.instances[0].focus).toHaveBeenCalled();
+  });
+
+  it("offers a gesture-backed retry when automatic clipboard access fails", async () => {
+    clipboardMock.copyText
+      .mockRejectedValueOnce(new Error("permission denied"))
+      .mockResolvedValueOnce(undefined);
+    render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />);
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+
+    terminalSessionMock.instances[0].onClipboardRequest?.("retry text");
+    await waitFor(() => expect(clipboardMock.showToast).toHaveBeenCalled());
+    const retryContent = clipboardMock.showToast.mock.calls[0][0];
+    render(retryContent);
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledTimes(2));
+    expect(clipboardMock.copyText).toHaveBeenLastCalledWith("retry text");
   });
 });
 
@@ -191,6 +254,19 @@ describe("hidden pre-warmed surface", () => {
     rerender(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" active={false} />);
     expect(inst.dispose).not.toHaveBeenCalled();
     expect(inst.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles clipboard bridging when a warm surface is revealed", async () => {
+    const { rerender } = render(
+      <TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" active={false} />,
+    );
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+    const inst = terminalSessionMock.instances[0];
+    expect(inst.clipboardEnabled).toBe(false);
+
+    rerender(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" active />);
+    await waitFor(() => expect(inst.setClipboardEnabled).toHaveBeenCalledWith(true));
+    expect(terminalSessionMock.instances).toHaveLength(1);
   });
 
   it("does not focus on a plain active mount (WS-open handles it)", async () => {

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -12,6 +12,8 @@ import { Loader2Icon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
+import { showToast } from "@/components/ui/toast";
+import { copyText } from "@/lib/clipboard";
 import { isDatabricksWorkspace, resolveWebSocketUrl } from "@/lib/host";
 import { subscribeCodeFont } from "@/lib/codeFontPreferences";
 import { resolveInitialAttachUrl, watchDirectUpgrade, withAttachParams } from "@/lib/terminals";
@@ -157,6 +159,8 @@ export function TerminalView({
   onActivityRef.current = onActivity;
   const onInputRef = useRef(onInput);
   onInputRef.current = onInput;
+  const activeRef = useRef(active);
+  activeRef.current = active;
   // Track whether this terminal has already tried a keyless re-dial after a
   // 4400 wrong-replica close. If keyless still fails with 4400, the host is
   // genuinely unreachable — stop retrying.
@@ -181,6 +185,29 @@ export function TerminalView({
 
   const notifyInput = useCallback(() => {
     onInputRef.current?.();
+  }, []);
+
+  const notifyClipboardRequest = useCallback((text: string) => {
+    const copyAndRefocus = () => copyText(text).finally(() => sessionRef.current?.focus());
+    const copied = () => showToast("Copied from terminal.", { duration: 1500 });
+    const failed = () =>
+      showToast("Couldn't copy terminal selection to the clipboard.", { duration: 0 });
+    void copyAndRefocus().then(copied, () => {
+      showToast(
+        <span className="flex items-center gap-2">
+          <span>Terminal copy is ready.</span>
+          <Button
+            type="button"
+            size="xs"
+            variant="secondary"
+            onClick={() => void copyAndRefocus().then(copied, failed)}
+          >
+            Copy
+          </Button>
+        </span>,
+        { duration: 0 },
+      );
+    });
   }, []);
 
   // Dispose the outgoing session before a remount re-dials. React 18
@@ -276,6 +303,8 @@ export function TerminalView({
           notifyActivity,
           notifyInput,
           controlMode,
+          !readOnly && activeRef.current,
+          notifyClipboardRequest,
         );
         sessionRef.current = terminalSession;
         // Relay-connected with a direct URL on offer: negotiate the
@@ -309,6 +338,7 @@ export function TerminalView({
       notifyState,
       notifyActivity,
       notifyInput,
+      notifyClipboardRequest,
       disposeActiveSession,
     ],
   );
@@ -317,6 +347,10 @@ export function TerminalView({
   useEffect(() => {
     sessionRef.current?.setTheme(isDark);
   }, [isDark]);
+
+  useEffect(() => {
+    sessionRef.current?.setClipboardEnabled(!readOnly && active);
+  }, [readOnly, active]);
 
   // On the hidden→visible edge of a pre-warmed surface: focus the
   // terminal (the session's WS-open focus is a no-op while the element is


### PR DESCRIPTION
## Related issue

[OMNI-4259](https://linear.app/omnigent/issue/OMNI-4259/cannot-copy-out-of-tui-in-web-desktop-app)

## Summary

- Forward tmux paste-buffer changes from control-mode terminals to the active owner’s browser clipboard, with payload limits, recent-input gating, and read-only isolation.
- Support safe tmux-generated OSC 52 writes for PTY terminals while disabling them when passthrough could let pane output bypass tmux’s clipboard policy.
- Add browser permission fallback UI, preserve terminal focus, and cover the bridge, routing, parser, and clipboard behavior with focused tests.

**ELI5:** When a terminal app says “copy this,” the runner now carries that text back to the browser, which places it on the computer’s real clipboard instead of leaving it only inside tmux.

```text
tmux copy buffer ── control notification ──> WebSocket JSON ──┐
tmux PTY copy   ── safe OSC 52 ───────────────────────────────┤
                                                              v
                                                     browser clipboard
```

## Test Plan

- `uv run pytest tests/terminals/test_control_bridge.py -q`
- `uv run pytest tests/terminals/test_ws_bridge.py -k 'osc52_capability or forward_pty_to_ws' -q`
- `TMPDIR=/tmp uv run pytest tests/inner/test_terminal.py::test_server_survives_inner_process_exit_real_tmux tests/inner/test_terminal.py::test_launch_enables_csi_u_extended_keys_quietly -q`
- `uv run pytest tests/runner/test_terminal_resource_attach_ws.py -k 'selects_control_bridge_on_transport_query' -q`
- `cd web && npm test -- --run src/components/blocks/TerminalSession.test.ts src/components/blocks/TerminalView.test.tsx`
- `cd web && npx tsc -p tsconfig.app.json --noEmit`
- Targeted Ruff, Oxlint, Prettier, and `git diff --check`.

## Demo

N/A — no screenshot or recording was captured for the terminal protocol integration.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused tests cover tmux buffer notifications, bounded reads, cancellation cleanup, read-only and recent-input behavior, PTY OSC 52 capability negotiation, passthrough hardening, browser parsing, permission fallback, focus restoration, and transport routing.

## Changelog

Text copied by terminal apps now reaches your system clipboard in the web terminal.
