### PR TITLE
fix(onboarding): Recognize Kimi pay-per-use API-key auth

### DIFF
--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -2558,43 +2558,74 @@ def _print_kimi_auth_help() -> None:
     """Print Kimi Code's authentication options.
 
     Kimi authenticates against Moonshot AI's backend rather than an Omnigent
-    credential: ``kimi login`` (OAuth or a Moonshot API key) for the default
-    provider, and ``kimi provider add`` to register any other provider (an
-    OpenAI-compatible endpoint, a Databricks gateway, …) in
-    ``~/.kimi/config.toml``. Omnigent has no per-spawn provider override for
-    upstream kimi, so all of this lives in the kimi CLI's own config —
-    Omnigent-side injection remains a deferred follow-up.
+    credential. Membership accounts use ``kimi login`` (OAuth). Pay-per-use
+    accounts are rejected by OAuth ("unable to verify your membership
+    benefits"), so they configure an API-key provider instead — and which one
+    depends on where the credit lives:
+
+    - **Moonshot open platform** (keys from platform.moonshot.ai): import the
+      catalog provider with ``kimi provider catalog add moonshotai --api-key
+      …`` — the catalog supplies the type, base URL, and model.
+    - **Kimi Code coding endpoint** (keys from the Kimi API platform,
+      ``api.kimi.com``): add a ``type = "kimi"`` provider block pointed at
+      ``https://api.kimi.com/coding/v1`` to ``~/.kimi-code/config.toml``.
+
+    Both are covered below so a user on either platform can complete auth.
+    Omnigent stores no kimi credential and cannot thread one per spawn, so all
+    of this lives in the kimi CLI's own config.
     """
     from omnigent.onboarding.interactive import console
 
     console.print(
         "\n  [bold]Authenticate Kimi Code[/bold] (kimi manages its own config in "
-        "~/.kimi/config.toml):\n"
-        "    • Default provider: run [bold]kimi login[/bold] "
-        "(Moonshot OAuth, or paste a Moonshot API key)\n"
-        "    • Other providers: run [bold]kimi provider add[/bold] "
-        "(OpenAI-compatible endpoint, gateway, …), then pin that model id in "
-        "the agent spec\n"
+        "[bold]$KIMI_CODE_HOME/config.toml[/bold], default "
+        "~/.kimi-code/config.toml):\n"
+        "    • [bold]Membership[/bold]: run [bold]kimi login[/bold] "
+        "(OAuth device flow — grants membership benefits)\n"
+        "    • [bold]Pay-per-use[/bold] (API credit, no membership): [bold]kimi "
+        "login[/bold] is rejected — add an API-key provider for whichever "
+        "platform your credit is on:\n"
+        "        [bold]a) Moonshot open platform[/bold] (keys from "
+        "platform.moonshot.ai) — run [bold]kimi provider catalog list[/bold] to "
+        "find the Moonshot provider id (e.g. [dim]moonshotai[/dim]) and a model "
+        "id, then:\n"
+        "            [dim]kimi provider catalog add moonshotai --api-key <key> "
+        "--default-model <model>[/dim]\n"
+        "        [bold]b) Kimi Code coding endpoint[/bold] (keys from the Kimi "
+        "API platform, api.kimi.com) — add this block to your kimi config "
+        "([bold]$KIMI_CODE_HOME/config.toml[/bold], default "
+        "~/.kimi-code/config.toml):\n"
+        # Escape the leading ``[`` so Rich renders the TOML table header verbatim
+        # instead of parsing ``[providers...]`` as a markup tag.
+        '            [dim]\\[providers."kimi-code"]\n'
+        '            type = "kimi"\n'
+        '            base_url = "https://api.kimi.com/coding/v1"\n'
+        '            api_key = "sk-…"[/dim]\n'
         "    • Omnigent stores no kimi credential and cannot thread one per "
         "spawn — configure it once in the kimi CLI\n"
     )
 
 
 def _manage_kimi_harness() -> None:
-    """Run the level-2 loop for Kimi Code: install the CLI and drive ``kimi login``.
+    """Run the level-2 loop for Kimi Code: install the CLI and drive sign-in.
 
-    Kimi ships a real ``kimi login`` (Moonshot OAuth or API key), so this
-    drill-in offers sign-in directly. It has **no** ``kimi logout`` subcommand
-    (verified against kimi CLI v0.29.1), so there is no sign-out row — the user
-    clears credentials by removing kimi's own credential file. Kimi has no
-    first-class "am I logged in?" exit-code probe (its install spec sets
-    ``status_args=None``), so
+    Kimi authenticates two ways: ``kimi login`` (OAuth, membership benefits) and
+    a pay-per-use API key in ``~/.kimi-code/config.toml`` (OAuth is rejected for
+    accounts without an active membership). This drill-in offers the membership
+    ``kimi login`` directly and points pay-per-use users at the API-key path,
+    which lives entirely in the kimi CLI's own config.
+
+    It has **no** ``kimi logout`` subcommand (verified against kimi CLI v0.29.1),
+    so there is no sign-out row — the user clears credentials by removing kimi's
+    own credential file. Kimi has no first-class "am I logged in?" exit-code
+    probe (its install spec sets ``status_args=None``), so
     :func:`~omnigent.onboarding.harness_install.harness_cli_logged_in` always
     reports ``False`` for it — meaning ``harness_login`` runs ``kimi login``
     every time it is asked (the interactive flow lets the user cancel if
     already authenticated) and its boolean return is not a reliable success
-    signal. We therefore treat login as a best-effort side effect and report
-    that the flow finished rather than asserting an auth state.
+    signal. We therefore treat login as a best-effort side effect and reflect
+    the detected auth state via ``kimi_auth_configured`` rather than asserting
+    the login call succeeded.
 
     Like the other CLI-backed harnesses, a missing CLI gates the drill-in —
     there is nothing to configure for a harness you can't run.
@@ -2609,6 +2640,7 @@ def _manage_kimi_harness() -> None:
         harness_login,
     )
     from omnigent.onboarding.interactive import console, select
+    from omnigent.onboarding.kimi_auth import kimi_auth_configured
 
     # Gate on the CLI. Kimi ships a single binary via a curl installer (not
     # npm), so there's no in-process auto-install — name the command and let
@@ -2624,12 +2656,14 @@ def _manage_kimi_harness() -> None:
         )
         return
 
-    # Carry the prior action's confirmation as a transient status line.
-    status: str | None = None
+    # Seed the status line with the detected auth state so a pay-per-use user who
+    # already set an API key isn't nudged to run a login that will be rejected.
+    configured_status = "✓ Kimi is configured (login credential or API key detected)"
+    status: str | None = configured_status if kimi_auth_configured() else None
     while True:
         rows: list[_HarnessMenuRow] = [
-            _HarnessMenuRow("Sign in (kimi login)", action="login"),
-            _HarnessMenuRow("Show auth options", action="help"),
+            _HarnessMenuRow("Sign in with membership (kimi login)", action="login"),
+            _HarnessMenuRow("Set up pay-per-use (API key)", action="help"),
             _HarnessMenuRow("← Back", action="back"),
         ]
         idx = select(
@@ -2644,12 +2678,19 @@ def _manage_kimi_harness() -> None:
         if action == "back":
             return
         if action == "login":
-            # ``kimi login`` runs in the foreground (OAuth / API-key prompt);
-            # its boolean return is unreliable for kimi (no status probe), so
-            # don't assert success — just confirm the flow finished.
+            # ``kimi login`` runs in the foreground (OAuth device flow); its
+            # boolean return is unreliable for kimi (no status probe), so
+            # re-derive the auth state from disk instead of asserting success.
             console.print("  [dim]Signing in to Kimi (its login will open)…[/dim]")
             harness_login(KIMI_KEY)
-            status = "kimi login flow finished — kimi stores its own credentials"
+            status = (
+                configured_status
+                if kimi_auth_configured()
+                else (
+                    "kimi login flow finished — if it reported a membership error,"
+                    " use the pay-per-use API-key option instead"
+                )
+            )
         elif action == "help":
             _print_kimi_auth_help()
             status = None
@@ -3875,19 +3916,29 @@ def _run_configure_harnesses_interactive() -> None:
                 (_KIRO, "Kiro", _cli_absence_label(KIRO_KEY), "missing", _install_hint(kiro_hint))
             )
 
-        # Kimi Code — native CLI, own auth via `kimi login`. There is no CLI
-        # login-status probe, but `kimi login` writes a credential file, so a
-        # subprocess-free file check (`kimi_login_detected`) distinguishes
-        # "signed in" (green) from "installed but not configured" (yellow).
-        # Curl-installed (no npm package), so use its install_hint when absent.
+        # Kimi Code — native CLI, own auth via `kimi login` (membership OAuth) or
+        # a Kimi API key in `~/.kimi-code/config.toml` (pay-per-use). There is no
+        # CLI login-status probe, so a subprocess-free check
+        # (`kimi_auth_configured`) distinguishes "signed in / API key set"
+        # (green) from "installed but not configured" (yellow). Curl-installed
+        # (no npm package), so use its install_hint when absent.
         if harness_cli_installed(KIMI_KEY):
-            from omnigent.onboarding.kimi_auth import kimi_login_detected
+            from omnigent.onboarding.kimi_auth import kimi_auth_configured
 
-            if kimi_login_detected():
+            if kimi_auth_configured():
                 rows.append((_KIMI, "Kimi Code", "Signed in", "ready", ""))
             else:
                 rows.append(
-                    (_KIMI, "Kimi Code", "Not configured", "warn", "Sign in with `kimi login`.")
+                    (
+                        _KIMI,
+                        "Kimi Code",
+                        "Not configured",
+                        "warn",
+                        (
+                            "Sign in with `kimi login`, or (pay-per-use) set a Kimi"
+                            " API key in `~/.kimi-code/config.toml`."
+                        ),
+                    )
                 )
         else:
             kimi_spec = harness_install_spec(KIMI_KEY)

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -245,12 +245,14 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         min_version=_CURSOR_MIN_VERSION,
     ),
     # Kimi Code CLI ships a single-binary ``kimi`` via a curl installer (no
-    # npm). ``kimi login`` is the interactive provider login (OAuth or a
-    # Moonshot API key). ``status_args`` is intentionally ``None``: kimi has
-    # no first-class "am I logged in?" exit-code probe — login state is
-    # inspected file-based via ``kimi_auth.kimi_login_detected`` instead. With
-    # ``None`` the login path runs every time the operator asks for it
-    # (interactive, so they can cancel if already authenticated).
+    # npm). ``kimi login`` is the interactive OAuth device flow (membership);
+    # pay-per-use users instead set a Kimi API key in
+    # ``~/.kimi-code/config.toml``. ``status_args`` is intentionally ``None``:
+    # kimi has no first-class "am I logged in?" exit-code probe — readiness is
+    # inspected file-based via ``kimi_auth.kimi_auth_configured`` instead (login
+    # credential OR configured API key). With ``None`` the login path runs every
+    # time the operator asks for it (interactive, so they can cancel if already
+    # authenticated).
     # ``logout_args`` is ``None`` because kimi has no ``kimi logout`` subcommand
     # (verified against kimi CLI v0.29.1 — ``kimi logout`` errors "unknown
     # command"), so ``harness_logout`` is a no-op for it (same as Qwen / agy).

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -83,16 +83,17 @@ _SDK_HARNESSES: frozenset[str] = frozenset(
 # than a CLI login-status command. For these, ``harness_is_configured`` checks
 # BOTH the binary (via ``harness_cli_installed``) AND the credential (via the
 # callable here). ``agy`` writes an OAuth token on its first interactive run;
-# ``kimi login`` writes ``~/.kimi-code/credentials/kimi-code.json`` (kimi has no
-# login-status probe). The ``anthropic`` / ``openai`` families authenticate via
-# subscription provider config and do not appear here. Each lambda resolves
-# through its module at call time so a test can monkeypatch
-# ``…gemini_auth.gemini_login_detected`` / ``…kimi_auth.kimi_login_detected``
-# and have the patch take effect without this dict caching the old function
-# object.
+# ``kimi login`` writes ``~/.kimi-code/credentials/kimi-code.json``, and
+# pay-per-use users instead set an API key in ``~/.kimi-code/config.toml`` (kimi
+# has no login-status probe) — ``kimi_auth_configured`` accepts either. The
+# ``anthropic`` / ``openai`` families authenticate via subscription provider
+# config and do not appear here. Each lambda resolves through its module at call
+# time so a test can monkeypatch ``…gemini_auth.gemini_login_detected`` /
+# ``…kimi_auth.kimi_auth_configured`` and have the patch take effect without
+# this dict caching the old function object.
 _FAMILY_CREDENTIAL_CHECK: dict[str, Callable[[], bool]] = {
     GEMINI_FAMILY: lambda: _gemini_auth.gemini_login_detected(),
-    KIMI_KEY: lambda: _kimi_auth.kimi_login_detected(),
+    KIMI_KEY: lambda: _kimi_auth.kimi_auth_configured(),
 }
 
 # CLI-wrapping pi harnesses. Both the bare ``pi`` surface and the native

--- a/omnigent/onboarding/kimi_auth.py
+++ b/omnigent/onboarding/kimi_auth.py
@@ -1,53 +1,205 @@
-"""Detect a Kimi Code (``kimi``) login for the ``kimi`` harness.
+"""Detect a usable Kimi Code (``kimi``) credential for the ``kimi`` harness.
 
-The ``kimi`` CLI authenticates against Moonshot AI's backend via ``kimi login``
-(an interactive OAuth flow or a Moonshot API key). It has **no** ``kimi logout``
-subcommand and no first-class "am I logged in?" exit-code probe, so login state
-can only be inspected from the credential file the login flow writes (verified
-live against kimi CLI v0.29.1):
+The ``kimi`` CLI authenticates against Moonshot AI's backend two ways:
 
-- ``kimi login`` writes ``~/.kimi-code/credentials/kimi-code.json`` — the file is
-  present exactly when a login has completed and absent (or empty) otherwise.
+- ``kimi login`` runs an interactive OAuth device flow. This grants
+  **membership** benefits and writes ``$KIMI_CODE_HOME/credentials/kimi-code.json``
+  (default ``~/.kimi-code/credentials/kimi-code.json``) — present exactly when
+  an interactive login has completed.
+- **Pay-per-use / API-platform** users cannot use ``kimi login``: the Kimi Code
+  coding endpoint rejects OAuth credentials without an active membership. They
+  authenticate instead by configuring a Kimi provider with an ``api_key`` (or an
+  ``env.KIMI_API_KEY``) in ``$KIMI_CODE_HOME/config.toml``. When such a provider
+  exists, ``kimi`` authenticates without an interactive login.
 
-Detection is file-based and subprocess-free: a non-empty credential file counts
-as a completed login. Like
+Detection is subprocess-free and reads only local state (verified live against
+kimi CLI v0.29.1): a non-empty credential file, or a Kimi provider with an API
+key in the config. Like
 :func:`omnigent.onboarding.gemini_auth.gemini_login_detected`, it cannot detect
-server-side revocation — its only job is to reject the "no-credential /
-file-empty" case so the readiness layer can distinguish a signed-in kimi from an
+server-side revocation — its only job is to reject the "no usable credential"
+case so the readiness layer can distinguish a configured kimi from an
 installed-but-unconfigured one without spawning a subprocess.
 """
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
+from urllib.parse import urlparse
 
-# Where ``kimi login`` writes its credential after a completed sign-in
-# (verified against kimi CLI v0.29.1). Present and non-empty exactly when the
-# user is logged in.
-KIMI_CREDENTIALS_PATH: Path = (
-    Path(os.path.expanduser("~")) / ".kimi-code" / "credentials" / "kimi-code.json"
+import tomllib
+
+from omnigent.kimi_native_credentials import resolve_user_kimi_home
+
+# Provider ``type`` values that identify a Kimi / Moonshot API-key provider in
+# ``config.toml``. The manual coding-endpoint block uses ``kimi``; a provider
+# imported via ``kimi provider catalog add moonshotai`` carries the catalog's
+# own type (``moonshotai`` / its China variant, or ``moonshot``). Match all of
+# them so both pay-per-use paths are recognized.
+_KIMI_PROVIDER_TYPES: frozenset[str] = frozenset(
+    {"kimi", "moonshot", "moonshotai", "moonshotai-cn"}
 )
+# Endpoint hosts that identify a Kimi / Moonshot provider when its ``type`` is
+# opaque (an unrecognized catalog spelling): the Moonshot open platform
+# (``api.moonshot.ai`` / China ``api.moonshot.cn``) and the Kimi Code coding
+# endpoint (``api.kimi.com``).
+_KIMI_PROVIDER_HOSTS: tuple[str, ...] = ("moonshot.ai", "moonshot.cn", "kimi.com")
+# Env var names a Kimi / Moonshot API key is conventionally set under inside a
+# provider's ``[providers.<name>.env]`` table.
+_KIMI_API_KEY_ENV_VARS: tuple[str, ...] = ("KIMI_API_KEY", "MOONSHOT_API_KEY")
+
+
+def _kimi_config_path() -> Path:
+    """Return the path to the user's Kimi Code ``config.toml``.
+
+    Mirrors :func:`~omnigent.kimi_native_credentials.resolve_user_kimi_home`
+    (``$KIMI_CODE_HOME`` when set, else ``~/.kimi-code``) and appends
+    ``config.toml``.
+    """
+    return resolve_user_kimi_home() / "config.toml"
+
+
+def _kimi_credentials_path() -> Path:
+    """Return the credential file ``kimi login`` writes on a completed sign-in.
+
+    ``$KIMI_CODE_HOME/credentials/kimi-code.json`` (default
+    ``~/.kimi-code/credentials/kimi-code.json``), resolved at call time via
+    :func:`~omnigent.kimi_native_credentials.resolve_user_kimi_home` so it
+    honors ``$KIMI_CODE_HOME`` — matching where kimi actually stores auth.
+    """
+    return resolve_user_kimi_home() / "credentials" / "kimi-code.json"
+
+
+def _host_is_kimi(base_url: object) -> bool:
+    """Return whether *base_url* points at a Kimi / Moonshot endpoint host."""
+    if not isinstance(base_url, str) or not base_url.strip():
+        return False
+    # Parse a scheme-relative form when the value omits a scheme, so a bare
+    # ``api.moonshot.ai/v1`` still resolves a hostname instead of ``None``.
+    value = base_url.strip()
+    if "://" not in value:
+        value = f"//{value}"
+    host = (urlparse(value).hostname or "").lower()
+    return any(host == h or host.endswith(f".{h}") for h in _KIMI_PROVIDER_HOSTS)
+
+
+def _provider_is_kimi(provider: dict[str, object]) -> bool:
+    """Return whether *provider* is a Kimi / Moonshot provider.
+
+    Identified by a known ``type`` (covers the manual ``kimi`` block and the
+    ``moonshotai`` catalog import) or, when the type is unrecognized, by a
+    ``base_url`` on a Moonshot / Kimi host. This keeps an unrelated provider
+    (e.g. an OpenAI entry the user added to kimi) from counting as Kimi auth.
+    """
+    provider_type = provider.get("type")
+    if isinstance(provider_type, str) and provider_type.lower() in _KIMI_PROVIDER_TYPES:
+        return True
+    return _host_is_kimi(provider.get("base_url"))
+
+
+def _provider_has_key(provider: dict[str, object]) -> bool:
+    """Return whether *provider* carries a non-empty API key.
+
+    Accepts an inline ``api_key`` or a non-empty ``KIMI_API_KEY`` /
+    ``MOONSHOT_API_KEY`` entry in the provider's ``env`` sub-table — the two
+    shapes ``config.toml`` uses for a credential.
+    """
+    api_key = provider.get("api_key")
+    if isinstance(api_key, str) and api_key.strip():
+        return True
+    env = provider.get("env")
+    if isinstance(env, dict):
+        for var in _KIMI_API_KEY_ENV_VARS:
+            value = env.get(var)
+            if isinstance(value, str) and value.strip():
+                return True
+    return False
+
+
+def _has_kimi_api_key(config: dict[str, object]) -> bool:
+    """Return whether *config* declares a usable Kimi / Moonshot API-key provider.
+
+    A usable provider is a Kimi / Moonshot provider (by ``type`` or endpoint
+    host) that carries a non-empty API key — covering both pay-per-use paths:
+    the Moonshot open platform (``kimi provider catalog add moonshotai``) and
+    the Kimi Code coding endpoint (a manual ``type = "kimi"`` block).
+    """
+    providers = config.get("providers")
+    if not isinstance(providers, dict):
+        return False
+    for provider in providers.values():
+        if not isinstance(provider, dict):
+            continue
+        if _provider_is_kimi(provider) and _provider_has_key(provider):
+            return True
+    return False
+
+
+def kimi_api_key_configured(config_path: Path | None = None) -> bool:
+    """Return whether a Kimi API key is configured in ``config.toml``.
+
+    Reads the user's Kimi Code config (respecting ``$KIMI_CODE_HOME``) and
+    checks for at least one Kimi / Moonshot provider (by ``type`` or endpoint
+    host) carrying a non-empty API key — the pay-per-use / API-platform path
+    that does not require an interactive ``kimi login``. Covers both the
+    Moonshot open platform and the Kimi Code coding endpoint.
+
+    :param config_path: A specific config file to check; ``None`` uses
+        ``$KIMI_CODE_HOME/config.toml``.
+    :returns: ``True`` when a Kimi API-key provider is configured; ``False``
+        when the file is missing, malformed, or has no usable key.
+    """
+    path = config_path if config_path is not None else _kimi_config_path()
+    try:
+        with path.open("rb") as f:
+            config = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        # Missing, unreadable, or broken TOML is treated as "no API key" rather
+        # than crashing the readiness refresh.
+        return False
+    return _has_kimi_api_key(config)
 
 
 def kimi_login_detected(creds_path: Path | None = None) -> bool:
-    """Return whether ``kimi`` has a completed login on this machine.
+    """Return whether ``kimi`` has a completed interactive login on this machine.
 
     Subprocess-free file check: ``kimi login`` writes its credential to
-    :data:`KIMI_CREDENTIALS_PATH`, so a present, non-empty file is treated as a
-    completed sign-in. This cannot detect server-side revocation — it only
-    rejects the "no-credential / file-empty" case. Used by the readiness layer
-    to distinguish a signed-in kimi from an installed-but-unconfigured one.
+    :func:`_kimi_credentials_path` (honoring ``$KIMI_CODE_HOME``), so a present,
+    non-empty file is treated as a completed OAuth sign-in. This cannot detect
+    server-side revocation — it only rejects the "no-credential / file-empty"
+    case.
 
     :param creds_path: A specific credential file to check; ``None`` uses
-        :data:`KIMI_CREDENTIALS_PATH`.
+        ``$KIMI_CODE_HOME/credentials/kimi-code.json``.
     :returns: ``True`` when the credential file exists and is non-empty;
         ``False`` when it is missing, empty, or unreadable.
     """
-    path = creds_path if creds_path is not None else KIMI_CREDENTIALS_PATH
+    path = creds_path if creds_path is not None else _kimi_credentials_path()
     try:
         return path.is_file() and path.stat().st_size > 0
     except OSError:
         # A stat/permission error on the credential path is treated as "no
         # usable credential" rather than crashing the readiness refresh.
         return False
+
+
+def kimi_auth_configured(
+    *,
+    creds_path: Path | None = None,
+    config_path: Path | None = None,
+) -> bool:
+    """Return whether ``kimi`` has any usable credential on this machine.
+
+    Combines the interactive-login credential check with the API-key config
+    check: either a non-empty ``kimi-code.json`` from ``kimi login`` (membership
+    OAuth) or a configured Kimi API-key provider (pay-per-use) counts as
+    configured. Used by the readiness layer so API-platform users are not
+    wrongly reported as unconfigured just because they never ran ``kimi login``.
+
+    :param creds_path: A specific credential file to check; ``None`` uses
+        ``$KIMI_CODE_HOME/credentials/kimi-code.json``.
+    :param config_path: A specific config file to check; ``None`` uses
+        ``$KIMI_CODE_HOME/config.toml``.
+    :returns: ``True`` when an interactive-login credential exists or a Kimi
+        API key is configured; ``False`` when neither is present.
+    """
+    return kimi_login_detected(creds_path) or kimi_api_key_configured(config_path)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -6664,10 +6664,13 @@ def test_manage_kimi_harness_back_does_not_login(
 
     monkeypatch.setattr(hi, "harness_cli_installed", lambda key: True)
     monkeypatch.setattr(it, "console", Mock())
+    # The drill-in seeds its status line from the auth probe; pin it so the test
+    # stays hermetic instead of reading the dev machine's real ~/.kimi-code.
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_auth_configured", lambda: False)
     login = Mock()
     monkeypatch.setattr(hi, "harness_login", login)
-    # rows = [Sign in, Show auth options, ← Back]; pick Back (2). There is no
-    # "Sign out" row — kimi has no ``kimi logout`` subcommand.
+    # rows = [Sign in with membership, Set up pay-per-use (API key), ← Back];
+    # pick Back (2). There is no "Sign out" row — kimi has no ``kimi logout``.
     monkeypatch.setattr(it, "select", lambda *a, **k: 2)
 
     _manage_kimi_harness()
@@ -6688,6 +6691,8 @@ def test_manage_kimi_harness_has_no_sign_out_row(
 
     monkeypatch.setattr(hi, "harness_cli_installed", lambda key: True)
     monkeypatch.setattr(it, "console", Mock())
+    # Pin the auth probe so the status-line seed doesn't read real local state.
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_auth_configured", lambda: False)
     monkeypatch.setattr(hi, "harness_login", Mock())
     captured: list[str] = []
 
@@ -6714,6 +6719,8 @@ def test_manage_kimi_harness_login_runs_kimi_login(
 
     monkeypatch.setattr(hi, "harness_cli_installed", lambda key: True)
     monkeypatch.setattr(it, "console", Mock())
+    # Pin the auth probe (seed + post-login) so the test stays hermetic.
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_auth_configured", lambda: False)
     login = Mock(return_value=False)  # kimi has no status probe; return is ignored
     monkeypatch.setattr(hi, "harness_login", login)
     # First iteration: Sign in (0); second: ← Back (2) to exit the loop.

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -2173,16 +2173,16 @@ def test_installed_native_cli_auth_unknown_rows_are_not_configured(
     (Hermes, like Goose, *does* have a config probe now — its ``model`` is read
     from ``~/.hermes/config.yaml`` — so its ready/unconfigured split is covered
     by ``test_overview_hermes_row_reflects_configured_model`` instead. Kimi now
-    has a file-based login probe too, so its signed-in split is covered by
-    ``test_overview_kimi_row_reflects_detected_login`` — here we pin the
-    not-signed-in case, so ``kimi_login_detected`` is forced ``False``.)
+    has a file-based login + API-key config probe too, so its signed-in split is
+    covered by ``test_overview_kimi_row_reflects_detected_login`` — here we pin
+    the not-configured case, so ``kimi_auth_configured`` is forced ``False``.)
     """
     monkeypatch.setattr(
         "omnigent.onboarding.harness_install.harness_cli_installed", lambda family: True
     )
-    # Kimi's row now consults a file-based login probe; force "no login" so the
-    # not-configured assertion is deterministic regardless of the dev machine.
-    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_login_detected", lambda: False)
+    # Kimi's row now consults a combined auth probe; force "not configured" so
+    # the assertion is deterministic regardless of the dev machine.
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_auth_configured", lambda: False)
     options, selectable, descriptions, _compact, _max_visible = _capture_setup_overview(
         monkeypatch
     )
@@ -2193,17 +2193,17 @@ def test_installed_native_cli_auth_unknown_rows_are_not_configured(
 
 
 def test_overview_kimi_row_reflects_detected_login(isolated_config, monkeypatch) -> None:
-    """An installed kimi with a detected ``kimi login`` renders green "Signed in".
+    """An installed kimi with detected auth renders green "Signed in".
 
     Bug fix: the kimi row was hardcoded to yellow "Not configured" whenever the
     CLI was installed, so a successful ``kimi login`` never showed. It now
-    consults the subprocess-free file probe ``kimi_login_detected`` and renders
-    a green ready row when a credential is present.
+    consults the combined auth probe ``kimi_auth_configured`` and renders a green
+    ready row when a login credential or a pay-per-use API key is present.
     """
     monkeypatch.setattr(
         "omnigent.onboarding.harness_install.harness_cli_installed", lambda family: True
     )
-    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_login_detected", lambda: True)
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_auth_configured", lambda: True)
     options, selectable, descriptions, _compact, _max_visible = _capture_setup_overview(
         monkeypatch
     )
@@ -2238,9 +2238,9 @@ def test_overview_descriptions_map_to_their_rows(isolated_config, monkeypatch) -
         lambda family: family != GEMINI_FAMILY,
     )
     monkeypatch.setattr("omnigent.onboarding.copilot_auth.copilot_sdk_installed", lambda: True)
-    # Kimi's row consults a file-based login probe; force "no login" so the
-    # "Sign in with `kimi login`" hint is asserted deterministically.
-    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_login_detected", lambda: False)
+    # Kimi's row consults a combined auth probe; force "not configured" so the
+    # hint is asserted deterministically.
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_auth_configured", lambda: False)
     monkeypatch.setattr(
         "omnigent.onboarding.opencode_auth.opencode_auth_summary",
         lambda: OpenCodeAuthSummary(installed=True, stored_providers=(), env_providers=()),
@@ -2275,7 +2275,11 @@ def test_overview_descriptions_map_to_their_rows(isolated_config, monkeypatch) -
     assert desc_by_name["Goose"] == "Open to run `goose configure`."
     assert desc_by_name["Copilot"] == "Open to add the GitHub token."
     assert desc_by_name["Kiro"] == "Sign in with `kiro-cli login`."
-    assert desc_by_name["Kimi Code"] == "Sign in with `kimi login`."
+    assert (
+        desc_by_name["Kimi Code"]
+        == "Sign in with `kimi login`, or (pay-per-use) set a Kimi API key in"
+        " `~/.kimi-code/config.toml`."
+    )
     assert desc_by_name["Quit"] == ""
 
 

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -462,8 +462,9 @@ def test_configured_harness_map_all_true_with_clis(
     cursor (key-gated) is satisfied by a ``CURSOR_API_KEY``, copilot
     (token-gated) by a ``GH_TOKEN``, antigravity-native (binary + credential
     gated) by a detected Gemini OAuth credential, kimi (binary + credential
-    gated) by a detected ``kimi login`` credential, and the generic ACP harness
-    (config-gated) by a registered agent — so nothing is reported unconfigured.
+    gated) by a detected ``kimi login`` credential or a Kimi API key in
+    ``~/.kimi-code/config.toml``, and the generic ACP harness (config-gated) by
+    a registered agent — so nothing is reported unconfigured.
     """
     import omnigent.onboarding.gemini_auth as _ga
     import omnigent.onboarding.kimi_auth as _ka
@@ -477,7 +478,7 @@ def test_configured_harness_map_all_true_with_clis(
     # antigravity-native also needs a credential (not just the ``agy`` binary).
     monkeypatch.setattr(_ga, "gemini_login_detected", lambda: True)
     # kimi also needs a credential (not just the ``kimi`` binary).
-    monkeypatch.setattr(_ka, "kimi_login_detected", lambda: True)
+    monkeypatch.setattr(_ka, "kimi_auth_configured", lambda: True)
     monkeypatch.setenv("GH_TOKEN", "gho_ready")
     # claude / pi are auth-aware on the credential axis now: satisfy the provider
     # check deterministically (don't depend on the dev machine's real config).
@@ -518,30 +519,31 @@ def test_configured_harness_map_probes_codex_readiness_once(
 def test_kimi_readiness_keys_off_binary_and_credential(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Kimi is configured iff the ``kimi`` binary is on PATH AND a login exists.
+    """Kimi is configured iff the ``kimi`` binary is on PATH AND auth exists.
 
-    Kimi authenticates against Moonshot AI's backend via ``kimi login`` (OAuth
-    or a Moonshot API key), which writes a credential file. Like agy, the
-    daemon has no CLI login-status probe, so readiness is binary presence PLUS
-    a subprocess-free credential check (``kimi_login_detected``). The alias
-    ``kimi-code`` resolves to the same verdict via canonicalization.
+    Kimi authenticates against Moonshot AI's backend via ``kimi login`` (OAuth,
+    membership) or a Moonshot API key in ``~/.kimi-code/config.toml``
+    (pay-per-use). Like agy, the daemon has no CLI login-status probe, so
+    readiness is binary presence PLUS a subprocess-free credential check
+    (``kimi_auth_configured``). The alias ``kimi-code`` resolves to the same
+    verdict via canonicalization.
     """
     import omnigent.onboarding.kimi_auth as _ka
 
     # No binary → not configured regardless of credential.
     _no_clis_installed(monkeypatch)
-    monkeypatch.setattr(_ka, "kimi_login_detected", lambda: True)
+    monkeypatch.setattr(_ka, "kimi_auth_configured", lambda: True)
     assert harness_is_configured("kimi") is False
     assert harness_is_configured("kimi-code") is False
 
-    # Binary present but no login → still not configured.
+    # Binary present but no auth → still not configured.
     _all_clis_installed(monkeypatch)
-    monkeypatch.setattr(_ka, "kimi_login_detected", lambda: False)
+    monkeypatch.setattr(_ka, "kimi_auth_configured", lambda: False)
     assert harness_is_configured("kimi") is False
     assert harness_is_configured("kimi-code") is False
 
-    # Binary present and login detected → configured.
-    monkeypatch.setattr(_ka, "kimi_login_detected", lambda: True)
+    # Binary present and auth detected → configured.
+    monkeypatch.setattr(_ka, "kimi_auth_configured", lambda: True)
     assert harness_is_configured("kimi") is True
     assert harness_is_configured("kimi-code") is True
 

--- a/tests/onboarding/test_kimi_auth.py
+++ b/tests/onboarding/test_kimi_auth.py
@@ -2,7 +2,9 @@
 
 ``kimi login`` writes ``~/.kimi-code/credentials/kimi-code.json`` (verified
 against kimi CLI v0.29.1). Detection is a subprocess-free file check: a present,
-non-empty file is a completed login; a missing or empty file is not.
+non-empty file is a completed login; a missing or empty file is not. Pay-per-use
+users authenticate instead by configuring a Kimi provider with ``api_key`` or
+``env.KIMI_API_KEY`` in ``~/.kimi-code/config.toml``.
 """
 
 from __future__ import annotations
@@ -38,17 +40,195 @@ def test_credential_directory_not_detected(tmp_path: Path) -> None:
     assert ka.kimi_login_detected(creds) is False
 
 
-def test_default_path_uses_home_credentials(monkeypatch, tmp_path: Path) -> None:
-    """With no argument, detection checks the real ``~/.kimi-code`` location.
+def test_default_path_respects_kimi_code_home(monkeypatch, tmp_path: Path) -> None:
+    """With no argument, detection resolves the credential via ``$KIMI_CODE_HOME``.
 
-    Point ``HOME`` at a tmp dir and recompute the module default so the check is
-    deterministic and never depends on the developer's real credential file.
+    Point ``KIMI_CODE_HOME`` at a tmp dir so the check is deterministic, never
+    depends on the developer's real credential file, and confirms the login path
+    honors the same home override as the config-key path.
     """
-    fake_creds = tmp_path / ".kimi-code" / "credentials" / "kimi-code.json"
+    fake_home = tmp_path / "custom-kimi-home"
+    fake_creds = fake_home / "credentials" / "kimi-code.json"
     fake_creds.parent.mkdir(parents=True, exist_ok=True)
     fake_creds.write_text('{"access_token": "sk-xyz"}', encoding="utf-8")
-    monkeypatch.setattr(ka, "KIMI_CREDENTIALS_PATH", fake_creds)
+    monkeypatch.setenv("KIMI_CODE_HOME", str(fake_home))
     assert ka.kimi_login_detected() is True
 
     fake_creds.unlink()
     assert ka.kimi_login_detected() is False
+
+
+def _write_config(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_api_key_in_provider_detected(tmp_path: Path) -> None:
+    """A Kimi provider with a non-empty ``api_key`` counts as configured."""
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.moonshot-ai]\ntype = "kimi"\napi_key = "sk-abc123"\n',
+    )
+    assert ka.kimi_api_key_configured(config) is True
+
+
+def test_api_key_in_provider_env_detected(tmp_path: Path) -> None:
+    """A Kimi provider with ``env.KIMI_API_KEY`` counts as configured."""
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        """\
+[providers.moonshot-ai]
+type = "kimi"
+
+[providers.moonshot-ai.env]
+KIMI_API_KEY = "sk-abc123"
+""",
+    )
+    assert ka.kimi_api_key_configured(config) is True
+
+
+def test_moonshotai_catalog_provider_detected(tmp_path: Path) -> None:
+    """A ``moonshotai`` catalog import (open-platform pay-per-use) counts.
+
+    ``kimi provider catalog add moonshotai`` writes the catalog's own provider
+    ``type`` (``moonshotai``), not ``kimi`` — detection must still recognize it.
+    """
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.moonshotai]\ntype = "moonshotai"\napi_key = "sk-abc123"\n',
+    )
+    assert ka.kimi_api_key_configured(config) is True
+
+
+def test_provider_detected_by_moonshot_host(tmp_path: Path) -> None:
+    """A provider with an opaque type but a Moonshot ``base_url`` counts."""
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.custom]\ntype = "custom"\n'
+        'base_url = "https://api.moonshot.ai/v1"\napi_key = "sk-abc123"\n',
+    )
+    assert ka.kimi_api_key_configured(config) is True
+
+
+def test_provider_detected_by_moonshot_cn_host(tmp_path: Path) -> None:
+    """The China Moonshot endpoint (``api.moonshot.cn``) counts as Kimi."""
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.custom]\ntype = "custom"\n'
+        'base_url = "https://api.moonshot.cn/v1"\napi_key = "sk-abc123"\n',
+    )
+    assert ka.kimi_api_key_configured(config) is True
+
+
+def test_provider_detected_by_schemeless_host(tmp_path: Path) -> None:
+    """A scheme-less ``base_url`` still resolves a Moonshot / Kimi host."""
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.custom]\ntype = "custom"\n'
+        'base_url = "api.moonshot.ai/v1"\napi_key = "sk-abc123"\n',
+    )
+    assert ka.kimi_api_key_configured(config) is True
+
+
+def test_lookalike_host_not_detected(tmp_path: Path) -> None:
+    """A look-alike parent domain (``moonshot.ai.evil.com``) is not a Kimi host."""
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.custom]\ntype = "custom"\n'
+        'base_url = "https://moonshot.ai.evil.com/v1"\napi_key = "sk-abc123"\n',
+    )
+    assert ka.kimi_api_key_configured(config) is False
+
+
+def test_provider_env_moonshot_api_key_detected(tmp_path: Path) -> None:
+    """A Kimi provider with ``env.MOONSHOT_API_KEY`` counts as configured."""
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.kimi-code]\ntype = "kimi"\n'
+        '[providers.kimi-code.env]\nMOONSHOT_API_KEY = "sk-abc123"\n',
+    )
+    assert ka.kimi_api_key_configured(config) is True
+
+
+def test_non_kimi_provider_ignored(tmp_path: Path) -> None:
+    """A provider that is neither a Kimi type nor a Kimi host is ignored.
+
+    An unrelated provider the user added to kimi's config (e.g. OpenAI) must not
+    make the Kimi harness read as configured.
+    """
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.openai]\ntype = "openai"\n'
+        'base_url = "https://api.openai.com/v1"\napi_key = "sk-abc123"\n',
+    )
+    assert ka.kimi_api_key_configured(config) is False
+
+
+def test_empty_api_key_not_detected(tmp_path: Path) -> None:
+    """An empty or whitespace-only ``api_key`` does not count as configured."""
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.moonshot-ai]\ntype = "kimi"\napi_key = "   "\n',
+    )
+    assert ka.kimi_api_key_configured(config) is False
+
+
+def test_missing_config_not_detected(tmp_path: Path) -> None:
+    """A missing config file means no API key is configured."""
+    assert ka.kimi_api_key_configured(tmp_path / "config.toml") is False
+
+
+def test_malformed_config_not_detected(tmp_path: Path) -> None:
+    """A malformed config file is treated as "no API key" rather than raising."""
+    config = tmp_path / "config.toml"
+    _write_config(config, "this is not valid TOML\n[")
+    assert ka.kimi_api_key_configured(config) is False
+
+
+def test_auth_configured_prefers_credential_file(tmp_path: Path) -> None:
+    """``kimi_auth_configured`` is True when only the credential file exists."""
+    creds = tmp_path / "kimi-code.json"
+    config = tmp_path / "config.toml"
+    creds.write_text('{"access_token": "sk-abc"}', encoding="utf-8")
+    assert ka.kimi_auth_configured(creds_path=creds, config_path=config) is True
+
+
+def test_auth_configured_falls_back_to_api_key(tmp_path: Path) -> None:
+    """``kimi_auth_configured`` is True when only an API key is configured."""
+    creds = tmp_path / "kimi-code.json"
+    config = tmp_path / "config.toml"
+    _write_config(
+        config,
+        '[providers.moonshot-ai]\ntype = "kimi"\napi_key = "sk-abc123"\n',
+    )
+    assert ka.kimi_auth_configured(creds_path=creds, config_path=config) is True
+
+
+def test_auth_configured_false_when_nothing_present(tmp_path: Path) -> None:
+    """``kimi_auth_configured`` is False when neither credential nor key exists."""
+    creds = tmp_path / "kimi-code.json"
+    config = tmp_path / "config.toml"
+    assert ka.kimi_auth_configured(creds_path=creds, config_path=config) is False
+
+
+def test_api_key_config_respects_kimi_code_home(monkeypatch, tmp_path: Path) -> None:
+    """``kimi_api_key_configured`` reads ``$KIMI_CODE_HOME/config.toml``."""
+    fake_home = tmp_path / "custom-kimi-home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    config = fake_home / "config.toml"
+    _write_config(
+        config,
+        '[providers.moonshot-ai]\ntype = "kimi"\napi_key = "sk-abc123"\n',
+    )
+    monkeypatch.setenv("KIMI_CODE_HOME", str(fake_home))
+    assert ka.kimi_api_key_configured() is True


### PR DESCRIPTION
## Related issue

Closes #5126

## Summary

- Recognize a pay-per-use **API-key provider** in `$KIMI_CODE_HOME/config.toml` as valid Kimi auth, so API-credit users aren't stuck on `kimi login` (OAuth) — which the Kimi Code endpoint rejects without a membership ("unable to verify your membership benefits").
- Detect a Kimi/Moonshot provider by `type` **or** endpoint host (incl. China `moonshot.cn` and scheme-less base_urls) carrying an `api_key` / `env.KIMI_API_KEY` / `env.MOONSHOT_API_KEY`; wire it into the readiness layer and the `omnigent config` overview so those users read as ready.
- Guide **both** pay-per-use paths from the setup drill-in: the Moonshot open platform (`kimi provider catalog add moonshotai …`) and the Kimi Code coding endpoint (a `type = "kimi"` config block).
- Also resolve the login-credential path via `$KIMI_CODE_HOME` (was hardcoded to `~/.kimi-code`). Detection returns only booleans — it never reads, returns, or logs the key.
- ELI5: if you pay per-use instead of holding a membership, Omnigent now sees your API key as "signed in" and tells you exactly how to set it up.

## Test Plan

- `uv run --no-sync pytest tests/onboarding/test_kimi_auth.py tests/onboarding/test_harness_readiness.py tests/cli/test_configure_models.py tests/cli/test_cli.py -k "kimi or Kimi or overview or readiness or configured or harness"`
- `uv run --no-sync ruff check . && uv run --no-sync ruff format --check . && uv run --no-sync pyrefly check`
- Manually verified on a real pay-per-use Moonshot account: set the API-key provider, saw the Kimi row flip to "Signed in", and drove a live Kimi turn through the web UI against pay-per-use credit.

## Demo

When configuring Kimi, there's now a new option to select API based token config, besides only the membership login
<img width="614" height="255" alt="Screenshot 2026-08-20 at 19 40 27" src="https://github.com/user-attachments/assets/58b6ac57-0c41-4470-a166-f910de96017b" />

Instructions on what to run were added to login successfully
<img width="995" height="449" alt="image" src="https://github.com/user-attachments/assets/a820efcb-94e1-4efc-8018-98e29f4adf4e" />

User run the command and pass the token
<img width="890" height="43" alt="Screenshot 2026-08-20 at 20 00 17" src="https://github.com/user-attachments/assets/540d98a7-799f-4814-a815-f8f319ff719a" />

Omni now recognizes the login 
<img width="615" height="447" alt="Screenshot 2026-08-20 at 20 01 25" src="https://github.com/user-attachments/assets/361bea4f-1f65-4938-83e2-384e434f07bc" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: configured a pay-per-use API-key provider in `~/.kimi-code/config.toml`, confirmed the `omnigent config` Kimi row shows "Signed in", and ran a live Kimi turn via the web UI on pay-per-use credit. Unit tests cover both provider `type`s, host-based detection (`moonshot.cn`, scheme-less, and look-alike-host rejection), env-var keys, and `$KIMI_CODE_HOME` resolution.


## Changelog

Kimi Code setup now recognizes pay-per-use API-key auth (Moonshot open platform or the Kimi Code coding endpoint), not just `kimi login`.

co-authored by Claude Opus 5