### PR TITLE
chore(packaging): remove deprecated memory extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,12 +246,6 @@ cursor = ["cursor-sdk>=0.1.7"]
 # _reflect). The tools import the client lazily, so only users who enable a
 # Hindsight memory tool need this extra.
 hindsight = ["hindsight-client>=0.4.0"]
-# Backwards-compatibility alias: this extra was renamed to `hindsight` (see
-# above) in #2605. Keep `memory` pulling the same client so existing
-# `omnigent[memory]` / `--extra memory` invocations keep working.
-# TODO(0.70): remove this `memory` alias extra — it exists only to keep the
-# pre-rename install command working during the deprecation window.
-memory = ["hindsight-client>=0.4.0"]
 # Nimble research runs (the `nimble_research` builtin). The tool imports the
 # nimble-python client lazily, so only users who enable nimble_research need
 # this extra. nimble_extract talks raw httpx and needs no extra.

--- a/uv.lock
+++ b/uv.lock
@@ -3224,9 +3224,6 @@ kubernetes = [
 loadtest = [
     { name = "locust" },
 ]
-memory = [
-    { name = "hindsight-client" },
-]
 modal = [
     { name = "modal" },
 ]
@@ -3333,7 +3330,6 @@ requires-dist = [
     { name = "google-antigravity", marker = "extra == 'antigravity'", specifier = ">=0.1,<1" },
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0,<3" },
     { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = ">=0.4.0" },
-    { name = "hindsight-client", marker = "extra == 'memory'", specifier = ">=0.4.0" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "islo", marker = "extra == 'islo'", specifier = ">=0.3.5,<0.4" },
     { name = "json5", specifier = ">=0.10,<1" },
@@ -3392,7 +3388,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=10.4,<15" },
     { name = "zstandard", specifier = ">=0.22,<1" },
 ]
-provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "blaxel", "boxlite", "cwsandbox", "e2b", "islo", "openshell", "kubernetes", "tracing", "agents-sdk", "antigravity", "copilot", "dictation", "cursor", "hindsight", "memory", "nimble", "slack", "databricks", "loadtest"]
+provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "blaxel", "boxlite", "cwsandbox", "e2b", "islo", "openshell", "kubernetes", "tracing", "agents-sdk", "antigravity", "copilot", "dictation", "cursor", "hindsight", "nimble", "slack", "databricks", "loadtest"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Related issue

https://linear.app/omnigent/issue/OMNI-4270/remove-memory-extra

## Summary

- Remove the deprecated `memory` compatibility alias now that `hindsight` is the canonical extra.
- Regenerate the normalized lockfile so published package metadata no longer advertises `memory`.

## Test Plan

- `uv run --no-sync pytest -q tests/onboarding/test_extra_install.py`
- Built the wheel and inspected its `METADATA` to confirm `hindsight` remains in `Provides-Extra` and `memory` does not.
- `git diff --check`

## Demo

N/A — packaging-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [x] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the built wheel's optional dependency metadata directly; the existing onboarding extra tests continue to pass.

## Changelog

The deprecated `omnigent[memory]` extra has been removed; use `omnigent[hindsight]` instead.
