### PR TITLE
feat(cli): drive the wrapper guard from config instead of env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,26 @@ checked first. Spend caps and access limits ship as builtins.
 
 See the [policy guide](https://github.com/omnigent-ai/omnigent/blob/main/docs/POLICIES.md) for the full catalog and trust model.
 
+<details>
+<summary>Requiring a CLI wrapper (operator control)</summary>
+
+Fronting Omnigent with your own launcher (e.g. `isaac omni`)? Refuse direct
+`omni` / `omnigent` calls so everyone goes through it:
+
+```bash
+omnigent config set --global require_wrapper=true             # refuse naked calls
+omnigent config set --global wrapper_command="isaac omni"     # command to suggest
+omnigent config unset --global require_wrapper                # turn it back off
+```
+
+Your wrapper passes through by setting `OMNIGENT_WRAPPER_BYPASS=1` on the child
+it launches; that stays an env var since it's a per-launch signal, not a stored
+preference. A refused call prints the suggested command and that same escape
+hatch, so `OMNIGENT_WRAPPER_BYPASS=1 omnigent config unset --global require_wrapper`
+always gets you back in. Drop `--global` to scope it to one project.
+
+</details>
+
 ---
 
 ## Write your own agent

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -595,6 +595,12 @@ _LOCAL_CONFIG_RELPATH: Path = Path(".omnigent") / "config.yaml"
 # Keys that ``omnigent config`` accepts.  Mirrors the option names in
 # the ``run`` command so the mapping is explicit and auditable.
 _AUTO_OPEN_CONVERSATION_CONFIG_KEY = "auto_open_conversation"
+# Operator policy: refuse naked ``omni``/``omnigent`` calls so use goes through
+# a wrapper (e.g. ``isaac omni``). ``wrapper_command`` names the command to
+# suggest. The wrapper passes through per launch via OMNIGENT_WRAPPER_BYPASS on
+# the child it spawns, so bypass stays an env var (see the guard below).
+_REQUIRE_WRAPPER_CONFIG_KEY = "require_wrapper"
+_WRAPPER_COMMAND_CONFIG_KEY = "wrapper_command"
 _GLOBAL_CONFIG_KEYS: frozenset[str] = frozenset(
     {
         "default_agent",
@@ -605,9 +611,13 @@ _GLOBAL_CONFIG_KEYS: frozenset[str] = frozenset(
         "opencode_model",
         "server",
         _AUTO_OPEN_CONVERSATION_CONFIG_KEY,
+        _REQUIRE_WRAPPER_CONFIG_KEY,
+        _WRAPPER_COMMAND_CONFIG_KEY,
     }
 )
-_BOOLEAN_CONFIG_KEYS: frozenset[str] = frozenset({_AUTO_OPEN_CONVERSATION_CONFIG_KEY})
+_BOOLEAN_CONFIG_KEYS: frozenset[str] = frozenset(
+    {_AUTO_OPEN_CONVERSATION_CONFIG_KEY, _REQUIRE_WRAPPER_CONFIG_KEY}
+)
 _CONFIG_TRUE_VALUES: frozenset[str] = frozenset({"1", "true", "yes", "on"})
 _CONFIG_FALSE_VALUES: frozenset[str] = frozenset({"0", "false", "no", "off"})
 _ConfigValue: TypeAlias = (
@@ -1930,24 +1940,29 @@ def _warn_deprecated_harness_path_env_vars() -> None:
         )
 
 
-REQUIRE_WRAPPER_ENV = "OMNIGENT_REQUIRE_WRAPPER"
-WRAPPER_COMMAND_ENV = "OMNIGENT_WRAPPER_COMMAND"
 WRAPPER_BYPASS_ENV = "OMNIGENT_WRAPPER_BYPASS"
 
 
-def _wrapper_guard_error(env: Mapping[str, str], prog: str) -> str | None:
+def _wrapper_guard_error(
+    *,
+    require_wrapper: bool,
+    wrapper_command: str,
+    bypass: bool,
+    prog: str,
+) -> str | None:
     """Return the block message when a naked ``omni`` call is refused, else ``None``.
 
-    A deployment that wraps the CLI (e.g. ``isaac omni``) sets
-    ``OMNIGENT_REQUIRE_WRAPPER`` so direct calls are refused; the wrapper sets
-    ``OMNIGENT_WRAPPER_BYPASS`` around its own invocation to pass through, and
-    ``OMNIGENT_WRAPPER_COMMAND`` names the command to suggest instead.
+    An operator opts a deployment into the guard with the ``require_wrapper``
+    config so direct calls are refused in favour of a wrapper (e.g.
+    ``isaac omni``); ``wrapper_command`` names the command to suggest. The
+    wrapper sets ``OMNIGENT_WRAPPER_BYPASS`` on the child it launches to pass
+    through, which is why bypass stays a per-launch env signal, not config.
     """
-    if not env_truthy(env.get(REQUIRE_WRAPPER_ENV)):
+    if not require_wrapper:
         return None
-    if env_truthy(env.get(WRAPPER_BYPASS_ENV)):
+    if bypass:
         return None
-    redirect = (env.get(WRAPPER_COMMAND_ENV) or "").strip()
+    redirect = wrapper_command.strip()
     if redirect:
         detail = f"Use `{redirect}` instead, or set {WRAPPER_BYPASS_ENV}=1 to run it directly."
     else:
@@ -1955,14 +1970,40 @@ def _wrapper_guard_error(env: Mapping[str, str], prog: str) -> str | None:
     return f"Error: running `{prog}` directly is disabled in this environment.\n{detail}"
 
 
+def _resolve_wrapper_guard_config() -> tuple[bool, str]:
+    """Read the wrapper-guard policy from effective (user + project) config.
+
+    Fails open: a missing, unreadable, or malformed config yields "guard off"
+    so the opt-in guard never blocks an unrelated command (``version``,
+    ``--help``) when config can't be parsed.
+
+    :returns: ``(require_wrapper, wrapper_command)``.
+    """
+    try:
+        cfg = _load_effective_config()
+        require = _parse_config_bool(
+            _REQUIRE_WRAPPER_CONFIG_KEY, cfg.get(_REQUIRE_WRAPPER_CONFIG_KEY, False)
+        )
+    except (OSError, yaml.YAMLError, click.ClickException):
+        return False, ""
+    command = cfg.get(_WRAPPER_COMMAND_CONFIG_KEY)
+    return require, command.strip() if isinstance(command, str) else ""
+
+
 def _enforce_wrapper_guard() -> None:
     """Exit early when a naked ``omni``/``omnigent`` call is blocked by an operator."""
+    require_wrapper, wrapper_command = _resolve_wrapper_guard_config()
     # argv[0] is the console-script name (``omni``/``omnigent``); ``python -m
     # omnigent`` reports ``__main__.py``, so fall back to the canonical name.
     prog = os.path.basename(sys.argv[0])
     if not prog or prog == "__main__.py":
         prog = "omnigent"
-    message = _wrapper_guard_error(os.environ, prog)
+    message = _wrapper_guard_error(
+        require_wrapper=require_wrapper,
+        wrapper_command=wrapper_command,
+        bypass=env_truthy(os.environ.get(WRAPPER_BYPASS_ENV)),
+        prog=prog,
+    )
     if message is not None:
         click.echo(message, err=True)
         raise SystemExit(2)
@@ -2000,8 +2041,9 @@ def main() -> None:
     install_crash_handler(app_name="omnigent", repo="omnigent-ai/omnigent")
 
     # Operators can force all use through a wrapper (e.g. `isaac omni`) by
-    # setting OMNIGENT_REQUIRE_WRAPPER; the wrapper sets OMNIGENT_WRAPPER_BYPASS
-    # to pass through. Refuse naked calls before any work happens.
+    # setting the `require_wrapper` config; the wrapper sets
+    # OMNIGENT_WRAPPER_BYPASS to pass through. Refuse naked calls before any
+    # work happens.
     _enforce_wrapper_guard()
 
     cwd = os.getcwd()
@@ -9860,17 +9902,18 @@ def config_set(is_global: bool, settings: tuple[str, ...]) -> None:
     ``~/.gitconfig``). Project values take precedence.
 
     Supported keys: auto_open_conversation, default_agent, harness,
-    model, server.
-
-    :param is_global: When ``True``, write to ``~/.omnigent/config.yaml``;
-        when ``False``, to ``.omnigent/config.yaml`` in cwd.
-    :param settings: ``KEY=VALUE`` pairs to set, e.g.
-        ``("default_agent=examples/hello.yaml", "model=gpt-5.4-mini")``.
+    model, opencode_model, require_wrapper, server, wrapper_command.
 
     \b
     Examples:
       omnigent config set default_agent=examples/hello_world.yaml
       omnigent config set --global server=https://<app>.databricksapps.com
+
+    \f
+    :param is_global: When ``True``, write to ``~/.omnigent/config.yaml``;
+        when ``False``, to ``.omnigent/config.yaml`` in cwd.
+    :param settings: ``KEY=VALUE`` pairs to set, e.g.
+        ``("default_agent=examples/hello.yaml", "model=gpt-5.4-mini")``.
     """
     if is_global:
         parsed = _parse_config_settings(settings, resolve_paths=True)
@@ -9897,6 +9940,7 @@ def config_set(is_global: bool, settings: tuple[str, ...]) -> None:
 def config_unset(is_global: bool, keys: tuple[str, ...]) -> None:
     """Remove one or more Omnigent defaults.
 
+    \f
     :param is_global: When ``True``, remove from ``~/.omnigent/config.yaml``;
         when ``False``, from ``.omnigent/config.yaml`` in cwd.
     :param keys: Keys to remove, e.g. ``("server", "model")``.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -24,9 +24,9 @@ from omnigent.cli import (
     _CLICK_SUBCOMMANDS,
     _GLOBAL_CONFIG_KEYS,
     _NATIVE_TERMINAL_DISPATCH_SPECS,
-    REQUIRE_WRAPPER_ENV,
+    _REQUIRE_WRAPPER_CONFIG_KEY,
+    _WRAPPER_COMMAND_CONFIG_KEY,
     WRAPPER_BYPASS_ENV,
-    WRAPPER_COMMAND_ENV,
     _bundle,
     _bundled_example_path,
     _dispatch_native_terminal_harness,
@@ -48,6 +48,7 @@ from omnigent.cli import (
     _resolve_default_agent_target,
     _resolve_first_run_plan,
     _resolve_server_url,
+    _resolve_wrapper_guard_config,
     _save_global_config,
     _save_local_config,
     _server_uvicorn_log_config,
@@ -145,7 +146,9 @@ def test_python_module_entrypoint_uses_unified_click_cli() -> None:
     assert "Omnigent quick chat" not in result.stdout
 
 
-def _run_entrypoint(*args: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+def _run_entrypoint(
+    *args: str, env: dict[str, str], cwd: str | None = None
+) -> subprocess.CompletedProcess[str]:
     """Invoke the real CLI entry point in a subprocess with an augmented env."""
     return subprocess.run(
         [sys.executable, "-m", "omnigent", *args],
@@ -153,15 +156,26 @@ def _run_entrypoint(*args: str, env: dict[str, str]) -> subprocess.CompletedProc
         text=True,
         timeout=30,
         env={**os.environ, **env},
+        cwd=cwd,
     )
 
 
-def test_wrapper_guard_blocks_naked_call_end_to_end() -> None:
-    """With the toggle set, a naked call is refused before any CLI dispatch."""
-    result = _run_entrypoint(
-        "--help",
-        env={REQUIRE_WRAPPER_ENV: "1", WRAPPER_COMMAND_ENV: "isaac omni"},
-    )
+def _write_guard_config(tmp_path: Path, **values: object) -> dict[str, str]:
+    """Write a config.yaml with *values* and return the env pointing the CLI at it.
+
+    Used to exercise the wrapper guard end-to-end: the CLI reads
+    ``$OMNIGENT_CONFIG_HOME/config.yaml`` as its user-level config.
+    """
+    config_home = tmp_path / "config-home"
+    config_home.mkdir()
+    (config_home / "config.yaml").write_text(yaml.safe_dump(values))
+    return {"OMNIGENT_CONFIG_HOME": str(config_home)}
+
+
+def test_wrapper_guard_blocks_naked_call_end_to_end(tmp_path: Path) -> None:
+    """With require_wrapper config set, a naked call is refused before dispatch."""
+    env = _write_guard_config(tmp_path, require_wrapper=True, wrapper_command="isaac omni")
+    result = _run_entrypoint("--help", env=env, cwd=str(tmp_path))
 
     assert result.returncode == 2
     assert "running `omnigent` directly is disabled" in result.stderr
@@ -170,16 +184,11 @@ def test_wrapper_guard_blocks_naked_call_end_to_end() -> None:
     assert "Usage: python -m omnigent" not in result.stdout
 
 
-def test_wrapper_guard_bypass_reaches_cli_end_to_end() -> None:
-    """The bypass token lets the wrapped call dispatch normally."""
-    result = _run_entrypoint(
-        "--help",
-        env={
-            REQUIRE_WRAPPER_ENV: "1",
-            WRAPPER_COMMAND_ENV: "isaac omni",
-            WRAPPER_BYPASS_ENV: "1",
-        },
-    )
+def test_wrapper_guard_bypass_reaches_cli_end_to_end(tmp_path: Path) -> None:
+    """The bypass env token lets the wrapped call dispatch normally."""
+    env = _write_guard_config(tmp_path, require_wrapper=True, wrapper_command="isaac omni")
+    env[WRAPPER_BYPASS_ENV] = "1"
+    result = _run_entrypoint("--help", env=env, cwd=str(tmp_path))
 
     assert result.returncode == 0
     assert "Usage: python -m omnigent [OPTIONS] COMMAND [ARGS]..." in result.stdout
@@ -211,15 +220,20 @@ def test_removed_ad_hoc_detection(argv: list[str], expected: bool) -> None:
 
 
 def test_wrapper_guard_inactive_when_toggle_unset() -> None:
-    """No block without the opt-in toggle, whatever else is set."""
-    assert _wrapper_guard_error({WRAPPER_COMMAND_ENV: "isaac omni"}, "omni") is None
+    """No block without the opt-in config, whatever else is set."""
+    assert (
+        _wrapper_guard_error(
+            require_wrapper=False, wrapper_command="isaac omni", bypass=False, prog="omni"
+        )
+        is None
+    )
 
 
 def test_wrapper_guard_blocks_naked_call_and_suggests_redirect() -> None:
     """A naked call is refused with the configured redirect command."""
-    env = {REQUIRE_WRAPPER_ENV: "1", WRAPPER_COMMAND_ENV: "isaac omni"}
-
-    message = _wrapper_guard_error(env, "omni")
+    message = _wrapper_guard_error(
+        require_wrapper=True, wrapper_command="isaac omni", bypass=False, prog="omni"
+    )
 
     assert message is not None
     assert "running `omni` directly is disabled" in message
@@ -229,7 +243,9 @@ def test_wrapper_guard_blocks_naked_call_and_suggests_redirect() -> None:
 
 def test_wrapper_guard_message_without_redirect() -> None:
     """With no redirect command the block only offers the bypass escape hatch."""
-    message = _wrapper_guard_error({REQUIRE_WRAPPER_ENV: "1"}, "omnigent")
+    message = _wrapper_guard_error(
+        require_wrapper=True, wrapper_command="", bypass=False, prog="omnigent"
+    )
 
     assert message is not None
     assert "instead" not in message
@@ -238,19 +254,71 @@ def test_wrapper_guard_message_without_redirect() -> None:
 
 def test_wrapper_guard_bypass_passes_through() -> None:
     """The wrapper's bypass token lets the wrapped call proceed."""
-    env = {
-        REQUIRE_WRAPPER_ENV: "1",
-        WRAPPER_COMMAND_ENV: "isaac omni",
-        WRAPPER_BYPASS_ENV: "1",
-    }
+    assert (
+        _wrapper_guard_error(
+            require_wrapper=True, wrapper_command="isaac omni", bypass=True, prog="omni"
+        )
+        is None
+    )
 
-    assert _wrapper_guard_error(env, "omni") is None
+
+def test_resolve_wrapper_guard_config_reads_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """require_wrapper / wrapper_command come from the effective config."""
+    monkeypatch.setattr(
+        "omnigent.cli._load_effective_config",
+        lambda: {
+            _REQUIRE_WRAPPER_CONFIG_KEY: True,
+            _WRAPPER_COMMAND_CONFIG_KEY: "  isaac omni  ",
+        },
+    )
+
+    assert _resolve_wrapper_guard_config() == (True, "isaac omni")
 
 
-@pytest.mark.parametrize("falsey", ["", "0", "false", "no", "off"])
-def test_wrapper_guard_toggle_falsey_values_do_not_block(falsey: str) -> None:
-    """Falsey toggle values are treated as unset."""
-    assert _wrapper_guard_error({REQUIRE_WRAPPER_ENV: falsey}, "omni") is None
+def test_resolve_wrapper_guard_config_defaults_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty config leaves the guard off with no redirect."""
+    monkeypatch.setattr("omnigent.cli._load_effective_config", dict)
+
+    assert _resolve_wrapper_guard_config() == (False, "")
+
+
+def test_resolve_wrapper_guard_config_fails_open_on_bad_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed config never blocks an unrelated command — the guard reads off."""
+
+    def _raise() -> dict[str, object]:
+        raise yaml.YAMLError("broken config")
+
+    monkeypatch.setattr("omnigent.cli._load_effective_config", _raise)
+
+    assert _resolve_wrapper_guard_config() == (False, "")
+
+
+@pytest.mark.parametrize("truthy", [True, "1", "true", "yes", "on"])
+def test_resolve_wrapper_guard_config_truthy_values(
+    monkeypatch: pytest.MonkeyPatch, truthy: object
+) -> None:
+    """require_wrapper accepts the same truthy spellings as other bool config."""
+    monkeypatch.setattr(
+        "omnigent.cli._load_effective_config",
+        lambda: {_REQUIRE_WRAPPER_CONFIG_KEY: truthy},
+    )
+
+    assert _resolve_wrapper_guard_config()[0] is True
+
+
+@pytest.mark.parametrize("falsey", [False, "0", "false", "no", "off"])
+def test_resolve_wrapper_guard_config_falsey_values(
+    monkeypatch: pytest.MonkeyPatch, falsey: object
+) -> None:
+    """Falsey require_wrapper values leave the guard off."""
+    monkeypatch.setattr(
+        "omnigent.cli._load_effective_config",
+        lambda: {_REQUIRE_WRAPPER_CONFIG_KEY: falsey},
+    )
+
+    assert _resolve_wrapper_guard_config()[0] is False
 
 
 def test_extract_global_logging_flags_preserves_run_shorthand() -> None:
@@ -4607,6 +4675,49 @@ def test_config_set_global_writes_auto_open_conversation_bool(
     cfg = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     assert cfg["auto_open_conversation"] is True
     assert _resolve_auto_open_conversation_from_config(cfg) is True
+
+
+def test_config_set_global_writes_wrapper_guard_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``require_wrapper`` / ``wrapper_command`` round-trip through config.
+
+    ``require_wrapper`` persists as a real YAML boolean and
+    :func:`_resolve_wrapper_guard_config` reads both back.
+    """
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr("omnigent.cli._GLOBAL_CONFIG_PATH", config_path)
+    # Keep the effective read hermetic: no project-local config bleeds in.
+    monkeypatch.setattr("omnigent.cli._load_local_config", dict)
+
+    result = CliRunner().invoke(
+        cli,
+        ["config", "set", "--global", "require_wrapper=true", "wrapper_command=isaac omni"],
+    )
+
+    assert result.exit_code == 0, result.output
+    cfg = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert cfg["require_wrapper"] is True
+    assert cfg["wrapper_command"] == "isaac omni"
+    assert _resolve_wrapper_guard_config() == (True, "isaac omni")
+
+
+def test_config_set_rejects_invalid_require_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``require_wrapper`` accepts only explicit boolean values."""
+    monkeypatch.setattr("omnigent.cli._GLOBAL_CONFIG_PATH", tmp_path / "config.yaml")
+
+    result = CliRunner().invoke(
+        cli,
+        ["config", "set", "--global", "require_wrapper=maybe"],
+    )
+
+    assert result.exit_code != 0
+    assert "require_wrapper" in result.output
+    assert "must be a boolean" in result.output
 
 
 def test_config_set_global_reports_effective_config_home(


### PR DESCRIPTION
## Related issue

[OMNI-3221](https://linear.app/omnigent/issue/OMNI-3221/hint-folks-to-use-isaac-omni) — follow-up to #4766, which shipped the guard behind env vars.

## Summary

The naked-`omni` wrapper guard from #4766 read `OMNIGENT_REQUIRE_WRAPPER` and `OMNIGENT_WRAPPER_COMMAND` from the environment. This moves both to the config file so an operator sets the policy once, user- or project-level, rather than exporting env vars into every shell:

```
omnigent config set --global require_wrapper=true "wrapper_command=isaac omni"
```

- `OMNIGENT_WRAPPER_BYPASS` stays an env var — it is the token a wrapper (e.g. `isaac omni`) sets on the child it launches per invocation, not a stored preference.
- The guard reads effective (user + project) config and **fails open** on a missing or malformed file, so it can never block an unrelated command (`version`, `--help`) when config can't be parsed.
- Contract from #4766 is unchanged: an enabled guard blocks all naked calls. Recovery from a guarded shell is the documented bypass: `OMNIGENT_WRAPPER_BYPASS=1 omnigent config unset --global require_wrapper`.
- Follows the repo convention for a notable operator config (per-harness startup #2933, runner lifetime): keys added to the `config set` help, a README `<details>` blurb under *Govern your agents*, and a changelog line.

## Test Plan

- `uv run pytest tests/cli/test_cli.py` — 304 passed (rewrote the guard tests for the config-driven API; added `_resolve_wrapper_guard_config` coverage for config read, defaults-off, fail-open, and truthy/falsey spellings; a `config set` round-trip asserting `require_wrapper` persists as a real YAML bool; and invalid-bool rejection).
- `uv run pre-commit run --files omnigent/cli.py tests/cli/test_cli.py README.md` — clean (ruff, ruff-format, pyrefly).
- Manual E2E against the real `python -m omnigent`:
  - `config set --global require_wrapper=true "wrapper_command=isaac omni"` then a naked call is refused (exit 2) with the redirect message.
  - `OMNIGENT_WRAPPER_BYPASS=1` passes through.
  - Empty config → guard off.
  - `config list` renders the new keys; `config unset --global require_wrapper` removes only that key.

## Demo

N/A — non-visual CLI change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual E2E covered the operator flow end to end against the real entry point: enabling the guard via `config set`, the block on a naked call, the `OMNIGENT_WRAPPER_BYPASS` passthrough, empty-config passthrough, and the `config list`/`unset` recovery loop.

## Changelog

The wrapper guard is now configured with `omnigent config set require_wrapper=true wrapper_command="isaac omni"` instead of `OMNIGENT_REQUIRE_WRAPPER` / `OMNIGENT_WRAPPER_COMMAND` env vars (`OMNIGENT_WRAPPER_BYPASS` unchanged)