### PR TITLE
fix(cli): preserve Databricks profile shorthand

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1894,7 +1894,7 @@ def _extract_global_logging_flags(argv: list[str]) -> tuple[list[str], bool, boo
 
 @click.group(cls=_OmnigentCLI)
 @click.option(
-    "--profile",
+    "--profiling",
     is_flag=True,
     is_eager=True,
     expose_value=False,
@@ -2142,7 +2142,7 @@ def main() -> None:
             "--help",
             "-h",
             "--version",
-            "--profile",
+            "--profiling",
         }
     ):
         argv = ["run", *argv]
@@ -2316,7 +2316,7 @@ def _is_removed_ad_hoc_invocation(argv: list[str]) -> bool:
         return False
     # A root profiling flag may precede an eager help/version flag or stand
     # alone. These are valid Click invocations, not removed ad-hoc chat.
-    if all(token in {"--profile", "--help", "-h", "--version"} for token in argv):
+    if all(token in {"--profiling", "--help", "-h", "--version"} for token in argv):
         return False
     # Skip leading flags to find the first positional. If all
     # tokens are flags (e.g. ``omnigent --system-prompt "..."``),

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -120,14 +120,14 @@ def _restore_logging_state() -> Iterator[None]:
         logger.propagate = propagate
 
 
-def test_global_profile_writes_summary_and_timestamped_stats(tmp_path: Path) -> None:
+def test_global_profiling_writes_summary_and_timestamped_stats(tmp_path: Path) -> None:
     """The real entry point profiles any command selected after the root flag."""
     repo_root = Path(__file__).resolve().parents[2]
     pythonpath = os.pathsep.join(
         part for part in (str(repo_root), os.environ.get("PYTHONPATH")) if part
     )
     result = subprocess.run(
-        [sys.executable, "-m", "omnigent", "--profile", "version"],
+        [sys.executable, "-m", "omnigent", "--profiling", "version"],
         capture_output=True,
         text=True,
         timeout=30,
@@ -224,7 +224,7 @@ def test_wrapper_guard_bypass_reaches_cli_end_to_end() -> None:
         (["run", "tests/resources/examples/hello_world.yaml"], False),
         (["attach", "tests/resources/examples/hello_world.yaml"], False),
         (["--help"], False),
-        (["--profile", "--help"], False),
+        (["--profiling", "--help"], False),
         (["what does this repo do?"], True),
         (["--system-prompt", "You are terse"], True),
         # A single command-shaped word is an unknown subcommand, not
@@ -1080,7 +1080,7 @@ def test_help_groups_harnesses_and_other_commands() -> None:
     result = CliRunner().invoke(cli, ["--help"])
 
     assert result.exit_code == 0, result.output
-    assert "--profile" in result.output
+    assert "--profiling" in result.output
     assert "Harnesses:" in result.output
     assert "Commands:" in result.output
     # A harness launcher lands under Harnesses; a management command
@@ -3493,7 +3493,34 @@ def test_run_profile_sets_databricks_config_profile_env(
     assert seen["value"] == "my-sp"
 
 
-def test_global_cpu_profile_coexists_with_run_databricks_profile(
+def test_bare_run_profile_shorthand_still_selects_databricks_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The new root flag must not consume the historical bare-run spelling."""
+    from omnigent.cli import main
+
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    seen = _capture_profile_env_at_dispatch(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "omnigent",
+            "--profile",
+            "my-sp",
+            "--server",
+            "https://example.com",
+            "-p",
+            "hi",
+        ],
+    )
+
+    main()
+
+    assert seen["value"] == "my-sp"
+
+
+def test_global_profiling_coexists_with_run_databricks_profile(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -3505,7 +3532,7 @@ def test_global_cpu_profile_coexists_with_run_databricks_profile(
     result = CliRunner().invoke(
         cli,
         [
-            "--profile",
+            "--profiling",
             "run",
             "--server",
             "https://example.com",


### PR DESCRIPTION
## Related issue

[OMNI-4272](https://linear.app/omnigent/issue/OMNI-4272/add-a-global-profile-option-to-omni-cli-for-profiling)

Follow-up to #5141.

## Summary

- Rename the global CPU profiler flag from `--profile` to `--profiling` so it no longer collides with the existing Databricks `--profile NAME` option.
- Preserve the historical bare-run shorthand `omni --profile my-sp ...` while keeping CPU profiling available for every explicit command.
- Add regression coverage for both options used independently and together.

**ELI5:** `--profiling` measures performance; `--profile NAME` continues to choose Databricks credentials.

```text
omni --profiling COMMAND       -> CPU profile
omni --profile my-sp -p "..."  -> run with Databricks profile my-sp
```

## Test Plan

- `uv run ruff format omnigent/cli.py tests/cli/test_cli.py`
- `uv run ruff check omnigent/cli.py tests/cli/test_cli.py`
- `uv run pytest -q tests/cli/test_cli.py::test_global_profiling_writes_summary_and_timestamped_stats tests/cli/test_cli.py::test_removed_ad_hoc_detection tests/cli/test_cli.py::test_help_groups_harnesses_and_other_commands tests/cli/test_cli.py::test_run_profile_sets_databricks_config_profile_env tests/cli/test_cli.py::test_bare_run_profile_shorthand_still_selects_databricks_profile tests/cli/test_cli.py::test_global_profiling_coexists_with_run_databricks_profile`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The tests exercise the real module entry point for CPU profiling and `main()` argv rewriting for the historical Databricks profile shorthand.

## Changelog

Use `omni --profiling COMMAND` for CPU profiling without conflicting with Databricks `--profile NAME` selection.
