### PR TITLE
chore(electron): set desktop version to 0.10.0

### DIFF
--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnigent-desktop-electron",
   "productName": "Omnigent",
-  "version": "0.11.0-dev.0",
+  "version": "0.10.0",
   "description": "Omnigent desktop shell (Electron edition) — a thin native wrapper around the server-served web UI.",
   "private": true,
   "main": "src/main.js",


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Stamp the Omnigent Electron desktop package as version 0.10.0 for the desktop release.
- Leave the Python package versions at 0.11.0.dev0 because this is a desktop-only release stamp.

## Test Plan

- `node -e "const p=require('./web/electron/package.json'); if (p.version !== '0.10.0') throw new Error(p.version); console.log(p.name + '@' + p.version)"`
- `git diff --check`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

This is a package metadata-only version stamp; the package JSON was loaded directly to verify the resulting version.
