### PR TITLE
fix(web): require consent for terminal clipboard writes

### DIFF
--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -182,9 +182,18 @@ async def _read_tmux_buffer(
     except (OSError, ValueError):
         return None
     assert proc.stdout is not None
+
+    async def _kill_and_reap() -> None:
+        """Kill the buffer reader and bound the wait for its process record."""
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(proc.wait(), timeout=_CLIPBOARD_READ_TIMEOUT_S)
+
+    data = b""
     try:
         try:
-            data = await asyncio.wait_for(
+            await asyncio.wait_for(
                 proc.stdout.readexactly(_CLIPBOARD_MAX_BYTES + 1),
                 timeout=_CLIPBOARD_READ_TIMEOUT_S,
             )
@@ -197,16 +206,10 @@ async def _read_tmux_buffer(
                 proc.kill()
         await asyncio.wait_for(proc.wait(), timeout=_CLIPBOARD_READ_TIMEOUT_S)
     except asyncio.CancelledError:
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-        with contextlib.suppress(Exception):
-            await asyncio.shield(proc.wait())
+        await _kill_and_reap()
         raise
     except (asyncio.TimeoutError, OSError):
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-        with contextlib.suppress(Exception):
-            await proc.wait()
+        await _kill_and_reap()
         return None
     if oversized or proc.returncode != 0:
         return None
@@ -567,9 +570,9 @@ async def bridge_tmux_control_to_websocket(
     # one bounded ``send_bytes``, so when the browser send lags tmux's firehose
     # a backlog of tiny per-line payloads collapses into a few large frames.
     output_chunks: asyncio.Queue[bytes | None] = asyncio.Queue()
-    # Clipboard notifications are handled outside the raw output hot path: each
-    # item names the immutable tmux buffer created by copy-mode; None is EOF.
-    clipboard_buffers: asyncio.Queue[str | None] = asyncio.Queue()
+    # Keep at most the newest pending clipboard buffer plus the EOF sentinel.
+    # A noisy pane cannot build an unbounded queue of names/subprocess reads.
+    clipboard_buffers: asyncio.Queue[str | None] = asyncio.Queue(maxsize=2)
     # Terminal bytes and clipboard JSON have separate producer tasks but one
     # websocket. Serialize sends so ASGI never sees concurrent send calls.
     ws_send_lock = asyncio.Lock()
@@ -582,6 +585,21 @@ async def bridge_tmux_control_to_websocket(
     def _current_ws_coalesce_limit() -> int:
         """Per-frame cap: small right after input, larger for output floods."""
         return _coalesce_limit_after_input(last_client_input_at)
+
+    def _queue_clipboard_buffer(buffer_name: str) -> None:
+        """Replace pending clipboard names with the newest notification."""
+        eof_seen = False
+        while True:
+            try:
+                queued = clipboard_buffers.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if queued is None:
+                eof_seen = True
+        if eof_seen:
+            clipboard_buffers.put_nowait(None)
+        else:
+            clipboard_buffers.put_nowait(buffer_name)
 
     async def _send_command(line: bytes) -> None:
         """Write one newline-terminated control command, ignoring a dead pipe."""
@@ -617,7 +635,7 @@ async def bridge_tmux_control_to_websocket(
                 and last_client_input_at is not None
                 and _monotonic() - last_client_input_at <= _CLIPBOARD_RECENT_INPUT_WINDOW_S
             ):
-                clipboard_buffers.put_nowait(buffer_name)
+                _queue_clipboard_buffer(buffer_name)
             return True
         if line.startswith(b"%exit"):
             return False
@@ -809,6 +827,16 @@ async def bridge_tmux_control_to_websocket(
                 if exc is not None:
                     _logger.warning("control-attach: bridge task crashed: %r", exc)
     finally:
+        # Outer route cancellation can bypass the normal post-wait cleanup.
+        # Always stop and join every child task before detaching the tmux client.
+        bridge_tasks = {read_task, forward_task, clipboard_task, ws_task}
+        for task in bridge_tasks:
+            if not task.done():
+                task.cancel()
+        task_results = await asyncio.gather(*bridge_tasks, return_exceptions=True)
+        for result in task_results:
+            if isinstance(result, Exception):
+                _logger.warning("control-attach: bridge task failed during teardown: %r", result)
         # Detach reflows the pane back to remaining clients — stamp it.
         if on_client_interaction is not None:
             on_client_interaction()
@@ -822,7 +850,7 @@ async def bridge_tmux_control_to_websocket(
             with contextlib.suppress(ProcessLookupError):
                 proc.kill()
             with contextlib.suppress(Exception):
-                await proc.wait()
+                await asyncio.wait_for(proc.wait(), timeout=2.0)
         with contextlib.suppress(RuntimeError):
             if control_ended_first:
                 # The control client ended: distinguish a genuine session-gone

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,7 +141,7 @@ importers:
         version: 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation':
         specifier: ^0.219.0
-        version: 0.219.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+        version: 0.219.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/instrumentation-fetch':
         specifier: ^0.219.0
         version: 0.219.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
@@ -319,6 +319,9 @@ importers:
       shiki:
         specifier: 4.2.0
         version: 4.2.0
+      sonner:
+        specifier: ^2.0.8
+        version: 2.0.8(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@10.2.2)
@@ -7883,6 +7886,16 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
+  sonner@2.0.8:
+    resolution: {integrity: sha512-UM/ByIoFra8yzV75n1o0Puu0bw5U/9UNnDacrJNspekBewIfsQ3D6ez1nvlWpt7aTsO6rujQtifBpycwIivqlg==}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -10618,15 +10631,6 @@ snapshots:
       '@opentelemetry/api-logs': 0.219.0
       import-in-the-middle: 3.3.1
       require-in-the-middle: 8.0.1(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation@0.219.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.219.0
-      import-in-the-middle: 3.3.1
-      require-in-the-middle: 8.0.1(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17418,13 +17422,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  require-in-the-middle@8.0.1(supports-color@7.2.0):
-    dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      module-details-from-path: 1.0.4
-    transitivePeerDependencies:
-      - supports-color
-
   resedit@1.7.2:
     dependencies:
       pe-library: 0.4.1
@@ -17770,6 +17767,13 @@ snapshots:
       ansi-styles: 4.3.0
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
+
+  sonner@2.0.8(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   source-map-js@1.2.1: {}
 

--- a/tests/e2e_ui/shells/test_terminal_clipboard_consent.py
+++ b/tests/e2e_ui/shells/test_terminal_clipboard_consent.py
@@ -1,0 +1,172 @@
+"""E2E: terminal clipboard frames require consent before writing locally.
+
+The terminal resource and attach WebSocket are browser-route mocks. This keeps
+this test tmux-free while exercising the built SPA's real TerminalView,
+TerminalSession, xterm input bookkeeping, WebSocket parsing, Sonner consent UI,
+and browser Clipboard API.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import time
+import uuid
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, Route, WebSocketRoute, expect
+
+from tests.e2e_ui.conftest import _build_hello_world_bundle, open_right_rail
+
+_TERMINAL_ID = "terminal_clipboard_e2e"
+_TERMINAL_LABEL = "bash · clipboard-e2e"
+
+
+@pytest.fixture
+def clipboard_ui_session(live_server: str) -> Iterator[tuple[str, str]]:
+    """Create an unbound session; no runner or tmux terminal is launched."""
+    response = httpx.post(
+        f"{live_server}/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={
+            "bundle": (
+                "agent.tar.gz",
+                _build_hello_world_bundle(),
+                "application/gzip",
+            )
+        },
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    session_id = response.json()["session_id"]
+    try:
+        yield live_server, session_id
+    finally:
+        httpx.delete(
+            f"{live_server}/v1/sessions/{session_id}",
+            timeout=10.0,
+        ).raise_for_status()
+
+
+def _clipboard_frame(text: str) -> str:
+    encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
+    return json.dumps(
+        {
+            "type": "clipboard-write",
+            "encoding": "base64",
+            "data": encoded,
+        },
+        separators=(",", ":"),
+    )
+
+
+def _expect_clipboard(page: Page, expected: str) -> None:
+    """Poll because navigator.clipboard.writeText resolves asynchronously."""
+    deadline = time.monotonic() + 5
+    actual = ""
+    while time.monotonic() < deadline:
+        actual = page.evaluate("() => navigator.clipboard.readText()")
+        if actual == expected:
+            return
+        page.wait_for_timeout(100)
+    raise AssertionError(f"clipboard was {actual!r}, expected {expected!r}")
+
+
+def test_terminal_clipboard_prompt_and_session_grant(
+    page: Page,
+    clipboard_ui_session: tuple[str, str],
+) -> None:
+    """The first copy asks; a session grant makes the next copy automatic."""
+    base_url, session_id = clipboard_ui_session
+    sockets: list[WebSocketRoute] = []
+
+    terminal_list = re.compile(
+        rf"/v1/sessions/{re.escape(session_id)}/resources/terminals(?:\?|$)"
+    )
+
+    def _serve_terminal(route: Route) -> None:
+        if route.request.method != "GET":
+            route.continue_()
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": _TERMINAL_ID,
+                            "object": "terminal",
+                            "name": "bash",
+                            "metadata": {
+                                "terminal_name": "bash",
+                                "session_key": "clipboard-e2e",
+                                "running": True,
+                                "terminal_transport": "control",
+                            },
+                        }
+                    ],
+                    "first_id": _TERMINAL_ID,
+                    "last_id": _TERMINAL_ID,
+                    "has_more": False,
+                }
+            ),
+        )
+
+    def _attach(ws: WebSocketRoute) -> None:
+        sockets.append(ws)
+        # Swallow resize/input frames; the test injects server frames below.
+        ws.on_message(lambda _message: None)
+
+    page.route(terminal_list, _serve_terminal)
+    page.route_web_socket(
+        re.compile(rf"/resources/terminals/{re.escape(_TERMINAL_ID)}/attach"),
+        _attach,
+    )
+    page.context.grant_permissions(
+        ["clipboard-read", "clipboard-write"],
+        origin=base_url,
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+    open_right_rail(page)
+
+    rail = page.get_by_role("complementary", name="Workspace")
+    shell_tab = rail.get_by_text(_TERMINAL_LABEL, exact=True)
+    expect(shell_tab).to_be_visible(timeout=30_000)
+    shell_tab.click()
+
+    terminal = rail.get_by_test_id("terminal-view")
+    expect(terminal).to_have_attribute("data-state", "connected", timeout=20_000)
+    assert sockets, "mock terminal attach WebSocket did not connect"
+
+    textarea = terminal.locator("textarea.xterm-helper-textarea")
+    consent = page.get_by_test_id("terminal-clipboard-consent")
+
+    first = f"terminal-first-{uuid.uuid4().hex}"
+    textarea.focus()
+    page.keyboard.type("a")  # Satisfy TerminalSession's recent-input gate.
+    sockets[-1].send(_clipboard_frame(first))
+
+    expect(consent).to_be_visible()
+    expect(consent).to_contain_text("Allow this terminal to copy to your clipboard?")
+    expect(consent.get_by_role("button", name="Allow for this session")).to_be_visible()
+    expect(consent.get_by_role("button", name="Copy once")).to_be_visible()
+    expect(consent.get_by_role("button", name="Block")).to_be_visible()
+
+    consent.get_by_role("button", name="Allow for this session").click()
+    _expect_clipboard(page, first)
+    expect(consent).to_have_count(0)
+
+    # A second frame in the same mounted TerminalView copies automatically.
+    second = f"terminal-second-{uuid.uuid4().hex}"
+    textarea.focus()
+    page.keyboard.type("b")
+    sockets[-1].send(_clipboard_frame(second))
+
+    _expect_clipboard(page, second)
+    expect(consent).to_have_count(0)

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -21,7 +21,6 @@ from pathlib import Path
 
 import pytest
 
-import omnigent.terminals.control_bridge as control_bridge
 from omnigent.terminals.control_bridge import (
     _SEND_KEYS_HEX_BYTES_PER_CALL,
     _clipboard_buffer_name,
@@ -79,10 +78,10 @@ async def test_tmux_buffer_read_cancellation_reaps_subprocess(
     async def _spawn(*_args: object, **_kwargs: object) -> _BlockedProcess:
         return proc
 
-    monkeypatch.setattr(control_bridge.asyncio, "create_subprocess_exec", _spawn)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn)
     task = asyncio.create_task(_read_tmux_buffer("tmux", "socket", "buffer0"))
     await asyncio.sleep(0)
-    task.cancel()
+    assert task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
     assert proc.killed is True
@@ -214,6 +213,36 @@ async def _kill_and_join(sock: Path, task: asyncio.Task[None]) -> None:
         # return value is discarded but the wait is the point.
         with contextlib.suppress(asyncio.CancelledError):
             await task
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_bridge_outer_cancellation_joins_child_tasks() -> None:
+    """Cancelling the route cannot leave bridge reader/sender tasks detached."""
+    sock, target = await _new_private_tmux("sleep 30")
+    ws = _FakeWebSocket(inbound=[])
+    task = asyncio.create_task(
+        bridge_tmux_control_to_websocket(
+            ws, socket_path=str(sock), tmux_target=target, read_only=False
+        )
+    )
+    try:
+        await asyncio.sleep(0.2)
+        assert task.cancel()
+        [task_result] = await asyncio.gather(task, return_exceptions=True)
+        assert isinstance(task_result, asyncio.CancelledError)
+        await asyncio.sleep(0)
+        names = {pending.get_name() for pending in asyncio.all_tasks() if not pending.done()}
+        assert not names.intersection(
+            {
+                "tmux-control-read",
+                "tmux-control-forward",
+                "tmux-control-clipboard",
+                "tmux-ws-to-control",
+            }
+        )
+    finally:
+        await _kill_tmux(sock)
 
 
 @pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")

--- a/web/package.json
+++ b/web/package.json
@@ -89,6 +89,7 @@
     "rrule": "^2.8.1",
     "shadcn": "0.0.0-beta.9d3f70e54",
     "shiki": "^4.0.2",
+    "sonner": "^2.0.8",
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.5.0",
     "three": "0.185.1",

--- a/web/src/components/blocks/TerminalView.test.tsx
+++ b/web/src/components/blocks/TerminalView.test.tsx
@@ -8,9 +8,11 @@
 
 import type * as TerminalSessionModule from "./TerminalSession";
 
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Toaster } from "@/components/ui/sonner";
+import { toast } from "sonner";
 import type { ConnectionState } from "./TerminalSession";
 import {
   TerminalView,
@@ -22,11 +24,9 @@ import {
 
 const clipboardMock = vi.hoisted(() => ({
   copyText: vi.fn<(text: string) => Promise<void>>(),
-  showToast: vi.fn(),
 }));
 
 vi.mock("@/lib/clipboard", () => ({ copyText: clipboardMock.copyText }));
-vi.mock("@/components/ui/toast", () => ({ showToast: clipboardMock.showToast }));
 
 const terminalSessionMock = vi.hoisted(() => ({
   instances: [] as {
@@ -81,13 +81,16 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
 }));
 
 beforeEach(() => {
+  act(() => toast.dismiss());
+  render(<Toaster visibleToasts={100} />);
   terminalSessionMock.instances = [];
-  clipboardMock.copyText.mockResolvedValue(undefined);
+  clipboardMock.copyText.mockReset().mockResolvedValue(undefined);
 });
 
 afterEach(() => {
+  act(() => toast.dismiss());
   cleanup();
-  vi.clearAllMocks();
+  vi.restoreAllMocks();
 });
 
 describe("buildAttachPath", () => {
@@ -199,33 +202,226 @@ describe("control-mode transport", () => {
 });
 
 describe("tmux clipboard", () => {
-  it("writes validated terminal copies through the shared clipboard helper", async () => {
+  async function renderClipboardView() {
     render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />);
     await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+    return terminalSessionMock.instances[0];
+  }
 
-    terminalSessionMock.instances[0].onClipboardRequest?.("copied text");
+  function requestClipboard(text: string): void {
+    act(() => terminalSessionMock.instances[0].onClipboardRequest?.(text));
+  }
 
+  function visibleClipboardConsent(): HTMLElement | null {
+    const active = toast
+      .getToasts()
+      .some((item) => !("dismiss" in item) && item.testId === "terminal-clipboard-consent");
+    if (!active) return null;
+    return (
+      screen
+        .queryAllByTestId("terminal-clipboard-consent")
+        .filter((element) => element.getAttribute("data-removed") !== "true")
+        .sort(
+          (left, right) =>
+            Number(left.getAttribute("data-index") ?? 999) -
+            Number(right.getAttribute("data-index") ?? 999),
+        )[0] ?? null
+    );
+  }
+
+  function clickConsentButton(name: "Allow for this session" | "Copy once" | "Block"): void {
+    const prompt = visibleClipboardConsent();
+    expect(prompt).not.toBeNull();
+    fireEvent.click(within(prompt!).getByRole("button", { name }));
+  }
+
+  async function requestClipboardConsent(text: string): Promise<HTMLElement> {
+    requestClipboard(text);
+    await waitFor(() => expect(visibleClipboardConsent()).not.toBeNull());
+    return visibleClipboardConsent()!;
+  }
+
+  it("requires consent before the first terminal clipboard write", async () => {
+    const terminal = await renderClipboardView();
+
+    const prompt = await requestClipboardConsent("copied text");
+
+    expect(clipboardMock.copyText).not.toHaveBeenCalled();
+    expect(prompt).not.toBeNull();
+    expect(
+      screen.getAllByText("Allow this terminal to copy to your clipboard?").length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("Terminal applications may replace clipboard contents.").length,
+    ).toBeGreaterThan(0);
+    clickConsentButton("Copy once");
     await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledWith("copied text"));
-    expect(clipboardMock.showToast).toHaveBeenCalledWith("Copied from terminal.", {
-      duration: 1500,
-    });
-    expect(terminalSessionMock.instances[0].focus).toHaveBeenCalled();
+    await waitFor(() => expect(visibleClipboardConsent()).toBeNull());
+    expect(terminal.focus).toHaveBeenCalled();
+
+    await requestClipboardConsent("next text");
+    expect(visibleClipboardConsent()).toBeInTheDocument();
+    expect(clipboardMock.copyText).toHaveBeenCalledTimes(1);
   });
 
-  it("offers a gesture-backed retry when automatic clipboard access fails", async () => {
+  it("allows automatic copies for the rest of the mounted terminal session", async () => {
+    await renderClipboardView();
+    await requestClipboardConsent("first text");
+
+    clickConsentButton("Allow for this session");
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledWith("first text"));
+
+    requestClipboard("second text");
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenLastCalledWith("second text"));
+    expect(clipboardMock.copyText).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(visibleClipboardConsent()).toBeNull());
+  });
+
+  it("resets clipboard consent when the view switches terminals", async () => {
+    const { rerender } = render(
+      <TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />,
+    );
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+    await requestClipboardConsent("first terminal");
+    clickConsentButton("Allow for this session");
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledTimes(1));
+
+    let rejectOldCopy: ((reason: Error) => void) | undefined;
+    clipboardMock.copyText.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectOldCopy = reject;
+        }),
+    );
+    requestClipboard("pending old terminal");
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledTimes(2));
+    act(() => toast.dismiss());
+
+    rerender(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s2" />);
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(2));
+    await act(async () => rejectOldCopy?.(new Error("old terminal closed")));
+    await waitFor(() => expect(visibleClipboardConsent()).toBeNull());
+    expect(screen.queryByText("Couldn't copy terminal selection to the clipboard.")).toBeNull();
+
+    act(() => terminalSessionMock.instances[1].onClipboardRequest?.("second terminal"));
+    await waitFor(() => expect(visibleClipboardConsent()).not.toBeNull());
+    expect(visibleClipboardConsent()).toBeInTheDocument();
+    expect(clipboardMock.copyText).toHaveBeenCalledTimes(2);
+  });
+
+  it("discards an unanswered prompt while the terminal is hidden", async () => {
+    const { rerender } = render(
+      <TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />,
+    );
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+    await requestClipboardConsent("stale text");
+    expect(visibleClipboardConsent()).toBeInTheDocument();
+
+    rerender(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" active={false} />);
+    rerender(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" active />);
+    await waitFor(() => expect(visibleClipboardConsent()).toBeNull());
+
+    await requestClipboardConsent("fresh text");
+    expect(visibleClipboardConsent()).toBeInTheDocument();
+  });
+
+  it("resets clipboard consent after a read-only permission transition", async () => {
+    const { rerender } = render(
+      <TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />,
+    );
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+    await requestClipboardConsent("initial text");
+    clickConsentButton("Allow for this session");
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledTimes(1));
+
+    rerender(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" readOnly />);
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(2));
+    rerender(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />);
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(3));
+    act(() => terminalSessionMock.instances[2].onClipboardRequest?.("after read-only"));
+    await waitFor(() => expect(visibleClipboardConsent()).not.toBeNull());
+
+    expect(visibleClipboardConsent()).toBeInTheDocument();
+    expect(clipboardMock.copyText).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses stale clipboard completion after the terminal unmounts", async () => {
+    const { unmount } = render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />);
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+    await requestClipboardConsent("initial text");
+    clickConsentButton("Allow for this session");
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledTimes(1));
+
+    let rejectInFlight: ((reason: Error) => void) | undefined;
+    clipboardMock.copyText.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectInFlight = reject;
+        }),
+    );
+    requestClipboard("pending text");
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledTimes(2));
+    act(() => toast.dismiss());
+    const terminal = terminalSessionMock.instances[0];
+
+    unmount();
+    await act(async () => rejectInFlight?.(new Error("unmounted")));
+
+    expect(screen.queryByText("Couldn't copy terminal selection to the clipboard.")).toBeNull();
+    expect(terminal.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces session-approved automatic copies to the newest pending text", async () => {
+    await renderClipboardView();
+    await requestClipboardConsent("initial text");
+    clickConsentButton("Allow for this session");
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledTimes(1));
+
+    let resolveInFlight: (() => void) | undefined;
+    clipboardMock.copyText.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveInFlight = resolve;
+        }),
+    );
+    requestClipboard("superseded text");
+    requestClipboard("newest text");
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledTimes(2));
+    expect(clipboardMock.copyText).toHaveBeenLastCalledWith("superseded text");
+
+    await act(async () => resolveInFlight?.());
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledTimes(3));
+    expect(clipboardMock.copyText).toHaveBeenLastCalledWith("newest text");
+  });
+
+  it("blocks clipboard requests for the rest of the mounted terminal session", async () => {
+    await renderClipboardView();
+    await requestClipboardConsent("blocked text");
+
+    clickConsentButton("Block");
+    requestClipboard("still blocked");
+
+    expect(clipboardMock.copyText).not.toHaveBeenCalled();
+    await waitFor(() => expect(visibleClipboardConsent()).toBeNull());
+  });
+
+  it("asks again when a session-approved automatic copy lacks browser permission", async () => {
+    await renderClipboardView();
+    await requestClipboardConsent("first text");
+    clickConsentButton("Allow for this session");
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledTimes(1));
+
     clipboardMock.copyText
       .mockRejectedValueOnce(new Error("permission denied"))
       .mockResolvedValueOnce(undefined);
-    render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />);
-    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+    act(() => toast.dismiss());
+    requestClipboard("retry text");
 
-    terminalSessionMock.instances[0].onClipboardRequest?.("retry text");
-    await waitFor(() => expect(clipboardMock.showToast).toHaveBeenCalled());
-    const retryContent = clipboardMock.showToast.mock.calls[0][0];
-    render(retryContent);
-    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    await waitFor(() => expect(visibleClipboardConsent()).toBeInTheDocument());
+    expect(screen.queryByText("Couldn't copy terminal selection to the clipboard.")).toBeNull();
+    clickConsentButton("Copy once");
 
-    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(clipboardMock.copyText).toHaveBeenCalledTimes(3));
     expect(clipboardMock.copyText).toHaveBeenLastCalledWith("retry text");
   });
 });

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -9,10 +9,10 @@
 // guard against a missing `ref.current`.
 
 import { Loader2Icon } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
-import { showToast } from "@/components/ui/toast";
+import { toast } from "sonner";
 import { copyText } from "@/lib/clipboard";
 import { isDatabricksWorkspace, resolveWebSocketUrl } from "@/lib/host";
 import { subscribeCodeFont } from "@/lib/codeFontPreferences";
@@ -142,6 +142,53 @@ export function TerminalView({
   const [state, setState] = useState<ConnectionState>({ kind: "connecting" });
   const [connectAttempt, setConnectAttempt] = useState(0);
   const [resumeError, setResumeError] = useState<string | null>(null);
+  const clipboardScope = `${sessionId}\0${terminalId}\0${readOnly ? "read-only" : "writable"}`;
+  const [clipboardPrompt, setClipboardPrompt] = useState<{
+    scope: string;
+    epoch: number;
+    generation: number;
+    text: string;
+  } | null>(null);
+  const clipboardScopeRef = useRef({ scope: clipboardScope, epoch: 0 });
+  // Consent is scoped to one terminal identity and never persisted. A WS
+  // reconnect keeps it; switching terminals starts from "ask" synchronously.
+  const clipboardConsentRef = useRef<{
+    scope: string;
+    decision: "ask" | "session" | "blocked";
+  }>({ scope: clipboardScope, decision: "ask" });
+  const clipboardRequestGenerationRef = useRef(0);
+  const clipboardMountedRef = useRef(true);
+  const clipboardActiveRef = useRef(active);
+  const clipboardWorkerEpochRef = useRef(0);
+  const clipboardConsentToastKey = useId();
+  const clipboardConsentToastIdRef = useRef<string | number | null>(null);
+  const clipboardAutoRunningRef = useRef<number | null>(null);
+  const clipboardAutoPendingRef = useRef<{
+    scope: string;
+    epoch: number;
+    workerEpoch: number;
+    generation: number;
+    text: string;
+    kind: "automatic" | "user";
+  } | null>(null);
+  const [clipboardScopeEpoch, setClipboardScopeEpoch] = useState(0);
+  useLayoutEffect(() => {
+    if (clipboardActiveRef.current !== active) {
+      clipboardActiveRef.current = active;
+      clipboardRequestGenerationRef.current += 1;
+      clipboardWorkerEpochRef.current += 1;
+      if (!active) clipboardAutoPendingRef.current = null;
+    }
+    if (clipboardScopeRef.current.scope !== clipboardScope) {
+      const epoch = clipboardScopeRef.current.epoch + 1;
+      clipboardScopeRef.current = { scope: clipboardScope, epoch };
+      clipboardConsentRef.current = { scope: clipboardScope, decision: "ask" };
+      clipboardRequestGenerationRef.current += 1;
+      clipboardWorkerEpochRef.current += 1;
+      clipboardAutoPendingRef.current = null;
+      setClipboardScopeEpoch(epoch);
+    }
+  }, [active, clipboardScope]);
   // True between an unexpected close and the re-dial it scheduled, so
   // the overlay reads "Reconnecting…" instead of the dead-end
   // "Bridge closed" message during automatic recovery.
@@ -190,6 +237,16 @@ export function TerminalView({
   // otherwise holds a loopback socket open for its full timeout.
   const upgradeCtlRef = useRef<AbortController | null>(null);
 
+  useEffect(() => {
+    clipboardMountedRef.current = true;
+    return () => {
+      clipboardMountedRef.current = false;
+      clipboardRequestGenerationRef.current += 1;
+      clipboardWorkerEpochRef.current += 1;
+      clipboardAutoPendingRef.current = null;
+    };
+  }, []);
+
   // Stable dispatcher: updates local state and notifies the parent.
   const notifyState = useCallback((next: ConnectionState) => {
     setState(next);
@@ -204,29 +261,237 @@ export function TerminalView({
     onInputRef.current?.();
   }, []);
 
-  const notifyClipboardRequest = useCallback((text: string) => {
-    const copyAndRefocus = () => copyText(text).finally(() => sessionRef.current?.focus());
-    const copied = () => showToast("Copied from terminal.", { duration: 1500 });
-    const failed = () =>
-      showToast("Couldn't copy terminal selection to the clipboard.", { duration: 0 });
-    void copyAndRefocus().then(copied, () => {
-      showToast(
-        <span className="flex items-center gap-2">
-          <span>Terminal copy is ready.</span>
-          <Button
-            type="button"
-            size="xs"
-            variant="secondary"
-            onClick={() => void copyAndRefocus().then(copied, failed)}
-            componentId="diagnostics.terminal.copy"
-          >
-            Copy
-          </Button>
-        </span>,
-        { duration: 0 },
-      );
-    });
+  const copyTerminalText = useCallback(async (text: string): Promise<boolean> => {
+    try {
+      await copyText(text);
+      return true;
+    } catch {
+      return false;
+    }
   }, []);
+
+  const queueSessionClipboardCopy = useCallback(
+    (request: {
+      scope: string;
+      epoch: number;
+      generation: number;
+      text: string;
+      kind: "automatic" | "user";
+    }) => {
+      // At most one browser clipboard promise is in flight per live terminal
+      // epoch; newer requests replace the single pending text value.
+      const workerEpoch = clipboardWorkerEpochRef.current;
+      clipboardAutoPendingRef.current = { ...request, workerEpoch };
+      if (clipboardAutoRunningRef.current === workerEpoch) return;
+      clipboardAutoRunningRef.current = workerEpoch;
+      void (async () => {
+        try {
+          while (
+            clipboardWorkerEpochRef.current === workerEpoch &&
+            clipboardAutoPendingRef.current?.workerEpoch === workerEpoch
+          ) {
+            const next = clipboardAutoPendingRef.current;
+            clipboardAutoPendingRef.current = null;
+            if (
+              !clipboardMountedRef.current ||
+              !clipboardActiveRef.current ||
+              clipboardScopeRef.current.scope !== next.scope ||
+              clipboardScopeRef.current.epoch !== next.epoch ||
+              (next.kind === "automatic" && clipboardConsentRef.current.decision !== "session")
+            ) {
+              continue;
+            }
+            // oxlint-disable-next-line no-await-in-loop
+            const copied = await copyTerminalText(next.text);
+            if (
+              !clipboardMountedRef.current ||
+              !clipboardActiveRef.current ||
+              clipboardRequestGenerationRef.current !== next.generation ||
+              clipboardConsentRef.current.scope !== next.scope ||
+              clipboardScopeRef.current.epoch !== next.epoch
+            ) {
+              continue;
+            }
+            if (copied) {
+              toast.success("Copied from terminal.", { duration: 1500 });
+            } else if (next.kind === "automatic") {
+              clipboardConsentRef.current = { scope: next.scope, decision: "ask" };
+              setClipboardPrompt(next);
+            } else {
+              toast.error("Couldn't copy terminal selection to the clipboard.", {
+                duration: Number.POSITIVE_INFINITY,
+              });
+            }
+          }
+        } finally {
+          if (clipboardAutoRunningRef.current === workerEpoch) {
+            clipboardAutoRunningRef.current = null;
+          }
+        }
+      })();
+    },
+    [copyTerminalText],
+  );
+
+  const notifyClipboardRequest = useCallback(
+    (text: string) => {
+      if (
+        clipboardScopeRef.current.scope !== clipboardScope ||
+        clipboardScopeRef.current.epoch !== clipboardScopeEpoch
+      ) {
+        return;
+      }
+      const generation = (clipboardRequestGenerationRef.current += 1);
+      if (clipboardConsentRef.current.scope !== clipboardScope) {
+        clipboardConsentRef.current = { scope: clipboardScope, decision: "ask" };
+      }
+      if (clipboardConsentRef.current.decision === "blocked") return;
+      if (clipboardConsentRef.current.decision === "session") {
+        queueSessionClipboardCopy({
+          scope: clipboardScope,
+          epoch: clipboardScopeEpoch,
+          generation,
+          text,
+          kind: "automatic",
+        });
+        return;
+      }
+      // Keep only the newest request while the prompt is open. This avoids a
+      // malicious/noisy pane stacking prompts and copies the latest tmux buffer.
+      setClipboardPrompt({
+        scope: clipboardScope,
+        epoch: clipboardScopeEpoch,
+        generation,
+        text,
+      });
+    },
+    [clipboardScope, clipboardScopeEpoch, queueSessionClipboardCopy],
+  );
+
+  const handleClipboardConsent = useCallback(
+    (decision: "session" | "once" | "blocked") => {
+      if (clipboardConsentToastIdRef.current !== null) {
+        toast.dismiss(clipboardConsentToastIdRef.current);
+        clipboardConsentToastIdRef.current = null;
+      }
+      const prompt =
+        clipboardPrompt?.scope === clipboardScope &&
+        clipboardPrompt.epoch === clipboardScopeEpoch &&
+        clipboardPrompt.generation === clipboardRequestGenerationRef.current
+          ? clipboardPrompt
+          : null;
+      setClipboardPrompt(null);
+      const generation = (clipboardRequestGenerationRef.current += 1);
+      if (decision === "blocked") {
+        clipboardConsentRef.current = { scope: clipboardScope, decision: "blocked" };
+        sessionRef.current?.focus();
+        return;
+      }
+      clipboardConsentRef.current = {
+        scope: clipboardScope,
+        decision: decision === "session" ? "session" : "ask",
+      };
+      if (prompt !== null) {
+        queueSessionClipboardCopy({
+          scope: clipboardScope,
+          epoch: clipboardScopeEpoch,
+          generation,
+          text: prompt.text,
+          kind: "user",
+        });
+      }
+      sessionRef.current?.focus();
+    },
+    [clipboardPrompt, clipboardScope, clipboardScopeEpoch, queueSessionClipboardCopy],
+  );
+
+  useEffect(() => {
+    const prompt =
+      clipboardPrompt?.scope === clipboardScope &&
+      clipboardPrompt.epoch === clipboardScopeEpoch &&
+      clipboardPrompt.generation === clipboardRequestGenerationRef.current &&
+      active &&
+      !readOnly
+        ? clipboardPrompt
+        : null;
+    if (prompt === null) {
+      if (clipboardConsentToastIdRef.current !== null) {
+        toast.dismiss(clipboardConsentToastIdRef.current);
+        clipboardConsentToastIdRef.current = null;
+      }
+      return;
+    }
+
+    const toastId = `${clipboardConsentToastKey}-${prompt.generation}`;
+    if (
+      clipboardConsentToastIdRef.current !== null &&
+      clipboardConsentToastIdRef.current !== toastId
+    ) {
+      toast.dismiss(clipboardConsentToastIdRef.current);
+    }
+    toast("Allow this terminal to copy to your clipboard?", {
+      id: toastId,
+      description: (
+        <div className="flex flex-col gap-2">
+          <div>Terminal applications may replace clipboard contents.</div>
+          <div className="flex flex-wrap gap-2 pt-1">
+            <Button
+              type="button"
+              size="xs"
+              onClick={() => handleClipboardConsent("session")}
+              componentId="diagnostics.terminal.copy"
+            >
+              Allow for this session
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              variant="secondary"
+              onClick={() => handleClipboardConsent("once")}
+              componentId="diagnostics.terminal.copy"
+            >
+              Copy once
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              variant="ghost"
+              onClick={() => handleClipboardConsent("blocked")}
+            >
+              Block
+            </Button>
+          </div>
+        </div>
+      ),
+      duration: Number.POSITIVE_INFINITY,
+      closeButton: true,
+      testId: "terminal-clipboard-consent",
+      onDismiss: () => {
+        setClipboardPrompt((current) =>
+          current?.scope === prompt.scope &&
+          current.epoch === prompt.epoch &&
+          current.generation === prompt.generation
+            ? null
+            : current,
+        );
+      },
+    });
+    clipboardConsentToastIdRef.current = toastId;
+    return () => {
+      if (clipboardConsentToastIdRef.current === toastId) {
+        toast.dismiss(toastId);
+        clipboardConsentToastIdRef.current = null;
+      }
+    };
+  }, [
+    active,
+    clipboardConsentToastKey,
+    clipboardPrompt,
+    clipboardScope,
+    clipboardScopeEpoch,
+    handleClipboardConsent,
+    readOnly,
+  ]);
 
   // Dispose the outgoing session before a remount re-dials. React 18
   // ignores the cleanup function attachSession returns (ref cleanups

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -1,0 +1,43 @@
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  TriangleAlertIcon,
+  OctagonXIcon,
+  Loader2Icon,
+} from "lucide-react";
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/web/src/components/ui/toast.test.tsx
+++ b/web/src/components/ui/toast.test.tsx
@@ -1,26 +1,49 @@
-// Unit tests for the minimal toast system: showToast() renders content into a
-// mounted <Toaster />, and the dismiss control removes it.
+// Tests for the shadcn Sonner renderer and the legacy showToast wrapper.
 
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { showToast, Toaster } from "./toast";
+import { toast } from "sonner";
+import { Toaster } from "./sonner";
+import { showToast } from "./toast";
 
-afterEach(cleanup);
+afterEach(() => {
+  act(() => toast.dismiss());
+  cleanup();
+});
 
 describe("Toaster", () => {
   it("renders nothing until a toast is shown", () => {
     render(<Toaster />);
-    expect(screen.queryByTestId("toast")).toBeNull();
+    expect(document.querySelector("[data-sonner-toast]")).toBeNull();
   });
 
-  it("shows toast content and dismisses on the close button", () => {
+  it("shows compatibility content and dismisses on the close button", async () => {
     render(<Toaster />);
     act(() => showToast(<span>Hello there</span>, { duration: 0 }));
 
-    const toast = screen.getByTestId("toast");
-    expect(toast).toHaveTextContent("Hello there");
+    const toastRoot = await screen.findByTestId("toast");
+    expect(toastRoot).toHaveTextContent("Hello there");
 
-    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
-    expect(screen.queryByTestId("toast")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Close toast" }));
+    await waitFor(() => expect(screen.queryByTestId("toast")).toBeNull());
+  });
+
+  it("renders Sonner descriptions and actions", async () => {
+    render(<Toaster />);
+    act(() => {
+      const id = toast("Permission required", {
+        description: "Choose whether to continue.",
+        duration: Number.POSITIVE_INFINITY,
+        action: {
+          label: "Continue",
+          onClick: () => toast.dismiss(id),
+        },
+      });
+    });
+
+    expect(await screen.findByText("Permission required")).toBeInTheDocument();
+    expect(screen.getByText("Choose whether to continue.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => expect(screen.queryByText("Permission required")).toBeNull());
   });
 });

--- a/web/src/components/ui/toast.tsx
+++ b/web/src/components/ui/toast.tsx
@@ -1,91 +1,21 @@
-// A minimal, dependency-free toast system.
-//
-// Self-contained in the same spirit as KeyboardShortcutsDialog: a module-level
-// `showToast()` dispatches a window event, and a single `<Toaster />` (mounted
-// once near the app shell) listens and renders a top-center stack. Toasts
-// auto-dismiss after a timeout and carry a manual dismiss control.
-//
-// Content is an arbitrary ReactNode so callers can embed links/actions (e.g.
-// a routing <Link>); it renders inside the Toaster, which sits within the
-// Router, so links resolve normally.
+import type { ReactNode } from "react";
+import { toast } from "sonner";
 
-import { type ReactNode, useCallback, useEffect, useState } from "react";
-import { XIcon } from "lucide-react";
-
-const TOAST_EVENT = "omnigent:toast";
-const DEFAULT_DURATION_MS = 6000;
-
-interface ToastItem {
-  id: number;
-  content: ReactNode;
-  duration: number;
-}
-
-let counter = 0;
-
-/** Show a transient toast. `duration <= 0` keeps it until manually dismissed. */
-export function showToast(content: ReactNode, opts?: { duration?: number }): void {
-  if (typeof window === "undefined") return;
-  counter += 1;
-  const detail: ToastItem = {
-    id: counter,
-    content,
-    duration: opts?.duration ?? DEFAULT_DURATION_MS,
-  };
-  window.dispatchEvent(new CustomEvent(TOAST_EVENT, { detail }));
-}
-
-/** Mount once near the app shell; renders the active toast stack. */
-export function Toaster() {
-  const [toasts, setToasts] = useState<ToastItem[]>([]);
-
-  const dismiss = useCallback((id: number) => {
-    setToasts((prev) => prev.filter((t) => t.id !== id));
-  }, []);
-
-  useEffect(() => {
-    const onToast = (e: Event) => {
-      const item = (e as CustomEvent<ToastItem>).detail;
-      setToasts((prev) => [...prev, item]);
-    };
-    window.addEventListener(TOAST_EVENT, onToast);
-    return () => window.removeEventListener(TOAST_EVENT, onToast);
-  }, []);
-
-  if (toasts.length === 0) return null;
-
-  return (
-    <div className="pointer-events-none fixed inset-x-0 top-4 z-[100] flex flex-col items-center gap-2 px-4">
-      {toasts.map((t) => (
-        <ToastRow key={t.id} item={t} onDismiss={dismiss} />
-      ))}
-    </div>
-  );
-}
-
-function ToastRow({ item, onDismiss }: { item: ToastItem; onDismiss: (id: number) => void }) {
-  useEffect(() => {
-    if (item.duration <= 0) return;
-    const timer = setTimeout(() => onDismiss(item.id), item.duration);
-    return () => clearTimeout(timer);
-  }, [item.id, item.duration, onDismiss]);
-
-  return (
-    <div
-      role="status"
-      aria-live="polite"
-      data-testid="toast"
-      className="pointer-events-auto flex max-w-full items-center gap-3 rounded-full border border-border bg-card px-4 py-2 text-ui shadow-lg"
-    >
-      <span className="min-w-0">{item.content}</span>
-      <button
-        type="button"
-        aria-label="Dismiss"
-        onClick={() => onDismiss(item.id)}
-        className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <XIcon className="size-4" />
-      </button>
-    </div>
-  );
+/**
+ * Compatibility wrapper for existing call sites while they migrate to Sonner.
+ * The window event remains for lightweight consumers and legacy tests that
+ * observe toast activity without mounting the renderer.
+ */
+export function showToast(content: ReactNode, opts?: { duration?: number }): string | number {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent("omnigent:toast", { detail: { content } }));
+  }
+  return toast(content, {
+    closeButton: true,
+    duration:
+      opts?.duration !== undefined && opts.duration <= 0
+        ? Number.POSITIVE_INFINITY
+        : opts?.duration,
+    testId: "toast",
+  });
 }

--- a/web/src/lib/clipboard.test.ts
+++ b/web/src/lib/clipboard.test.ts
@@ -32,7 +32,11 @@ describe("copyText", () => {
     const selectedRange = document.createRange();
     const existingText = document.createTextNode("existing selection");
     const selectionContainer = document.createElement("p");
+    const focusTarget = document.createElement("button");
 
+    focusTarget.textContent = "keep focus";
+    document.body.appendChild(focusTarget);
+    focusTarget.focus();
     selectionContainer.appendChild(existingText);
     document.body.appendChild(selectionContainer);
     selectedRange.selectNodeContents(existingText);
@@ -86,7 +90,8 @@ describe("copyText", () => {
     expect(setData).toHaveBeenCalledWith("text/plain", "first line\nsecond line");
     expect(document.querySelector("textarea")).toBeNull();
     expect(document.getSelection()?.rangeCount).toBe(1);
-    expect(document.getSelection()?.getRangeAt(0)).toBe(selectedRange);
+    expect(document.getSelection()?.toString()).toBe("existing selection");
+    expect(document.activeElement).toBe(focusTarget);
   });
 
   it("falls back to selected-textarea copy when async clipboard rejects", async () => {

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -24,6 +24,8 @@ function copyTextWithExecCommand(text: string): boolean {
   }
 
   const selection = document.getSelection();
+  const previouslyFocused =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
   const selectedRanges = selection
     ? Array.from({ length: selection.rangeCount }, (_, index) => selection.getRangeAt(index))
     : [];
@@ -64,6 +66,9 @@ function copyTextWithExecCommand(text: string): boolean {
   } finally {
     document.removeEventListener("copy", handleCopy);
     textArea.remove();
+    if (previouslyFocused?.isConnected) {
+      previouslyFocused.focus({ preventScroll: true });
+    }
     if (selection) {
       selection.removeAllRanges();
       for (const range of selectedRanges) {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -104,7 +104,7 @@ import { TerminalsPanel } from "./TerminalsPanel";
 import { PermissionsModal } from "@/components/PermissionsModal";
 import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
 import { CommandPalette } from "./CommandPalette";
-import { Toaster } from "@/components/ui/toast";
+import { Toaster } from "@/components/ui/sonner";
 import { CloseShellDialog } from "./CloseShellDialog";
 import { ForkSessionDialog } from "./ForkSessionDialog";
 import { ForkDialogContextProvider, type ForkDialogContextValue } from "./ForkDialogContext";
@@ -1992,7 +1992,20 @@ export function AppShell() {
           />
           {/* Transient toasts (e.g. "session archived"). Mounted once here so
               any surface can fire one via showToast(). */}
-          <Toaster />
+          {/* Match the previous toast system's effectively unbounded stack so
+              security prompts cannot be hidden behind ordinary notifications. */}
+          <Toaster
+            position="bottom-right"
+            visibleToasts={100}
+            offset={{
+              right: "1rem",
+              bottom: "calc(1rem + var(--omnigent-inset-bottom))",
+            }}
+            mobileOffset={{
+              right: "1rem",
+              bottom: "calc(1rem + var(--omnigent-inset-bottom))",
+            }}
+          />
         </ForkDialogContextProvider>
       </TerminalFirstContextProvider>
     </FileViewerContext.Provider>

--- a/web/src/shell/Sidebar.archive.test.tsx
+++ b/web/src/shell/Sidebar.archive.test.tsx
@@ -66,7 +66,7 @@ vi.mock("@/hooks/useConversations", () => ({
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
 
 import { type Conversation, useConversations } from "@/hooks/useConversations";
-import { Toaster } from "@/components/ui/toast";
+import { Toaster } from "@/components/ui/sonner";
 import { Sidebar } from "./Sidebar";
 
 const useConvMock = vi.mocked(useConversations);
@@ -160,7 +160,7 @@ describe("archive flow", () => {
     expect(mocks.stop.mutate).not.toHaveBeenCalled();
   });
 
-  it("toasts a pointer to Settings once the archive succeeds", () => {
+  it("toasts a pointer to Settings once the archive succeeds", async () => {
     mockConversations([CONV]);
     renderSidebar();
     clickArchive();
@@ -169,7 +169,7 @@ describe("archive flow", () => {
     const archiveArgs = mocks.archive.mutate.mock.calls[0];
     act(() => (archiveArgs[1] as { onSuccess: () => void }).onSuccess());
 
-    const toast = screen.getByTestId("toast");
+    const toast = await screen.findByTestId("toast");
     expect(within(toast).getByText(/View archived sessions in/)).toBeInTheDocument();
     expect(within(toast).getByRole("link", { name: "Settings" })).toHaveAttribute(
       "href",


### PR DESCRIPTION
## Related issue

[OMNI-4259](https://linear.app/omnigent/issue/OMNI-4259/cannot-copy-out-of-tui-in-web-desktop-app)

Follow-up to #5136.

## Summary

- Ask once before allowing a terminal to write the system clipboard, with **Allow for this session**, **Copy once**, and **Block** decisions scoped in memory to one writable terminal view.
- Serialize and coalesce clipboard writes, invalidate pending text and async completions across hide, unmount, terminal, and permission transitions, and restore focus without stealing it later.
- Bound tmux clipboard notification queues and subprocess/task teardown, addressing the security and lifecycle findings from the #5136 Polly review.

**ELI5:** A terminal app can request a copy, but it cannot silently replace the computer clipboard until the user explicitly allows it. After choosing **Allow for this session**, normal copies remain automatic for that terminal.

```text
terminal clipboard request
          |
          v
  Ask / session allowed / blocked
          |
          v
 serialized browser clipboard write
```

## Test Plan

- `uv run --no-sync pytest tests/terminals/test_control_bridge.py -q`
- `cd web && npm test -- --run src/components/blocks/TerminalView.test.tsx src/components/blocks/TerminalSession.test.ts src/lib/clipboard.test.ts`
- `cd web && npx oxlint --deny-warnings --report-unused-disable-directives src/components/blocks/TerminalView.tsx src/components/blocks/TerminalView.test.tsx src/lib/clipboard.ts src/lib/clipboard.test.ts`
- `cd web && npx tsc -p tsconfig.app.json --noEmit`
- `uv run --no-sync ruff check omnigent/terminals/control_bridge.py tests/terminals/test_control_bridge.py`
- `git diff --check`

## Demo

N/A — the consent prompt is covered by focused interaction tests; no screenshot was captured.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover all three consent choices, session-scoped automatic copies, terminal/read-only/visibility/unmount invalidation, stale promise suppression, automatic-copy coalescing, focus restoration, bounded tmux notifications, cancellation cleanup, and clipboard API fallback behavior.

## Changelog

Terminal applications now ask for permission before writing to your system clipboard.
