### PR TITLE
docs(readme): document the Grok Build and Devin harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,40 @@ omnigent pi                          # Pi
 Using OpenClaw? See the [OpenClaw integration guide](docs/openclaw.md) to import
 its coding agents or drive a live OpenClaw Gateway session over ACP.
 
+<details>
+<summary>Grok Build and Devin</summary>
+
+Two more coding agents are built in but have no `omnigent <name>` launcher of
+their own, because each ships a CLI that holds its own login. Install the vendor
+CLI, log in with it, then name the harness:
+
+```bash
+# Grok Build (xAI)
+curl -fsSL https://x.ai/cli/install.sh | bash
+grok login --device-auth              # xAI OAuth
+omnigent run --harness grok           # 'grok-build' also works
+
+# Devin (Cognition)
+curl -fsSL https://cli.devin.ai/install.sh | bash
+devin auth login
+omnigent run --harness devin
+```
+
+Both speak the [Agent Client Protocol](https://agentclientprotocol.com) over
+stdio, and Omnigent stores no credential for either — each CLI reads back the
+login it wrote to disk. That also means `--model` is refused rather than
+silently dropped: both run their account-default model. To pin one, configure an
+`acp:` agent whose command passes the vendor's own model flag.
+
+Use the vendor login rather than an API key. A builtin ACP row has no
+`env_passthrough` of its own, and `XAI_API_KEY` is not in the host-to-runner
+credential allowlist, so exporting it in your shell does not reach the agent.
+If you need the key route, pass it explicitly with
+`OMNIGENT_RUNNER_ENV_PASSTHROUGH=XAI_API_KEY`, or configure an `acp:` agent that
+declares the passthrough.
+
+</details>
+
 #### 🐙 Polly and 🟠🔵 Debby
 
 Two example agents ship with the repo, and they make good first sessions:


### PR DESCRIPTION
## Related issue

None — this is a `Docs` change, which `CONTRIBUTING.md` exempts from the
issue requirement.

## Summary

Grok Build and Devin are both first-class builtin harnesses — two rows in
`omnigent/acp_cli_harnesses.py`, registered as valid harnesses in
`harness_plugins.py` — but neither appears anywhere a user would look:

- no `omnigent <name>` launcher, unlike `claude` / `codex` / `kimi` / `pi`,
  because each ships a CLI that holds its own login;
- no mention in the README;
- not in the `--harness` help text, which lists a fixed subset.

So `--harness grok` works today and there is no way to find that out short of
reading the harness catalog. This adds a short README section covering both:
vendor install, vendor login, harness id.

It also states the consequences of their own-auth model, taken from the catalog
rows rather than invented: Omnigent stores no credential for either, and
`--model` is refused up front rather than silently dropped, so both run their
account-default model.

One correction worth flagging. The catalog's own `auth_hint` for Grok reads
"run `grok login --device-auth` (xAI OAuth) **or set `XAI_API_KEY`**", and an
earlier draft of this section repeated that. Exporting the key does not work
through the normal host path: a builtin ACP row has no `env_passthrough` of its
own — the module docstring says as much — and `XAI_API_KEY` is not in
`HARNESS_CREDENTIAL_ENV_VARS`, so it is never forwarded host-to-runner. The
section now documents OAuth as the path that works and names
`OMNIGENT_RUNNER_ENV_PASSTHROUGH=XAI_API_KEY` for anyone who needs the key
route. The `auth_hint` string itself is arguably misleading for the same reason,
but changing it is a behaviour-adjacent edit and belongs in its own PR.

## Test Plan

Docs only — no code paths touched.

- `pre-commit run --files README.md` passes.
- Every command in the new section comes from the `HarnessInstallSpec` in
  `omnigent/acp_cli_harnesses.py`, so the install hints, login commands and
  the `grok-build` alias match what the code actually does.
- Confirmed the harness ids the section tells people to type are real:
  `valid_harnesses()` contains `grok` and `devin`, and `harness_aliases()`
  maps `grok-build` to `grok`.
- Confirmed the auth claim rather than repeating the hint: `XAI_API_KEY` is
  absent from `HARNESS_CREDENTIAL_ENV_VARS`, and `OMNIGENT_RUNNER_ENV_PASSTHROUGH`
  is honoured in `omnigent/host/connect.py`.
- Rebased onto current `main` so CI runs against a base that includes
  `733234c30` ("restore version lockstep"), which the first run predated.

## Demo

N/A — no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

No behaviour changes, so there is nothing to assert in a test. Verified by
checking each documented command against the `HarnessInstallSpec` it came from,
and by confirming `--harness grok` is accepted by the harness registry.

## Changelog

The README now covers the Grok Build and Devin harnesses, including how to
install, log in, and select them.
