### PR TITLE
fix(electron): restore version lockstep

### DIFF
--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnigent-desktop-electron",
   "productName": "Omnigent",
-  "version": "0.10.0",
+  "version": "0.11.0-dev.0",
   "description": "Omnigent desktop shell (Electron edition) — a thin native wrapper around the server-served web UI.",
   "private": true,
   "main": "src/main.js",


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Restore the Electron package version to the semver translation of the repository's Python package version.
- Make the Version lockstep check pass after the desktop version drifted to `0.10.0` on `main`.

## Test Plan

- `uv run --frozen --project ../.. python ../../scripts/update_versions.py check`
- `git diff --check`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing version-update tests cover Electron version stamping and desktop-version drift detection.
