### PR TITLE
fix(server): persist outstanding elicitations so they survive a restart

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3977,6 +3977,7 @@ def server(
     # with "unable to open database file".
     _ensure_sqlite_parent_dir(db_uri)
 
+    from omnigent.stores.elicitation_store.sqlalchemy_store import SqlAlchemyElicitationStore
     from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
     from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
     from omnigent.stores.scheduled_task_store.sqlalchemy_store import (
@@ -3990,6 +3991,7 @@ def server(
     policy_store = SqlAlchemyPolicyStore(db_uri)
     permission_store = SqlAlchemyPermissionStore(db_uri)
     scheduled_task_store = SqlAlchemyScheduledTaskStore(db_uri)
+    elicitation_store = SqlAlchemyElicitationStore(db_uri)
     project_store = SqlAlchemyProjectStore(db_uri)
     artifact_store = _create_artifact_store(art_loc)
 
@@ -4134,6 +4136,7 @@ def server(
         runner_tunnel_tokens=_runner_tunnel_tokens,
         permission_store=permission_store,
         scheduled_task_store=scheduled_task_store,
+        elicitation_store=elicitation_store,
         project_store=project_store,
         auth_provider=auth_provider,
         host_store=host_store,

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1587,3 +1587,57 @@ class SqlScheduledTaskRun(OmnigentBase):
             "conversation_id",
         ),
     )
+
+
+class SqlElicitation(OmnigentBase):
+    """
+    SQLAlchemy model for the ``elicitations`` table.
+
+    One row per approval prompt still waiting on a human. A resolved prompt is
+    deleted, so the table holds the parked set and never grows with history —
+    the durable mirror of
+    :mod:`omnigent.runtime.pending_elicitations`, which is otherwise
+    process-local and dies with the server.
+
+    :param id: The prompt's correlation id, e.g. ``"elicit_abc123"``. A plain
+        String, not :class:`Uuid16`: several native harnesses mint deterministic
+        ids from the session plus the gated tool call (see
+        ``cursor_tool_call_elicitation_id``), so the value is opaque text.
+    :param workspace_id: Tenant partition key owning this row (0 = default).
+    :param conversation_id: Session the prompt was raised on (relates to
+        ``conversations.id``; no DB foreign key, Rule R032 — the application
+        deletes these alongside the conversation).
+    :param created_at: Unix epoch seconds the prompt was raised, used to age
+        out prompts whose session or runner never came back.
+    :param event: The ``response.elicitation_request`` payload as JSON, stored
+        verbatim so a restored prompt replays byte-identically into the UI.
+        Opaque, never SQL-queried — stored compressed like other blobs.
+    """
+
+    __tablename__ = "elicitations"
+
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
+    )
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    # Relates to conversations.id. No DB foreign key (Rule R032); the
+    # application deletes these with the conversation.
+    conversation_id: Mapped[str] = mapped_column(Uuid16, nullable=False)
+    created_at: Mapped[int] = mapped_column(Integer, nullable=False)
+    # Opaque JSON blob, never SQL-queried — stored compressed.
+    event: Mapped[str] = mapped_column(CompressedText, nullable=False)
+
+    __table_args__ = (
+        # The only read path: "what is still parked on this session?", served
+        # when a session snapshot finds its in-memory index empty.
+        Index(
+            "ix_elicitations_conversation_id",
+            "workspace_id",
+            "conversation_id",
+        ),
+    )

--- a/omnigent/db/migrations/versions/zb2b3c4d5e6f_add_elicitations_table.py
+++ b/omnigent/db/migrations/versions/zb2b3c4d5e6f_add_elicitations_table.py
@@ -1,0 +1,68 @@
+"""add elicitations table
+
+Revision ID: zb2b3c4d5e6f
+Revises: za2b3c4d5e6f
+Create Date: 2026-08-21 00:00:00.000000
+
+Adds the ``elicitations`` table: one row per approval prompt still waiting on a
+human, so an outstanding prompt survives a server restart instead of dying with
+the in-process index in ``omnigent/runtime/pending_elicitations.py``.
+
+Resolving a prompt deletes its row, so the table holds only the parked set and
+never accumulates history. The row is the durable mirror of an index that is
+otherwise process-local; the count mirrored onto
+``omnigent_conversation_metadata.pending_elicitation_count`` already assumed
+such a mirror existed, but carried no payload to replay.
+
+The table is brand-new and created at the current schema state, so it carries
+the tenant-partition ``workspace_id`` column as the leading primary-key member
+(matching every other table after ``r1a2b3c4d5e6``). There is no foreign-key
+constraint on ``conversation_id`` (schema Rule R032 — see ``p1a2b3c4d5e6``):
+the application deletes these rows alongside the conversation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from omnigent.db.db_models import Uuid16
+
+revision: str = "zb2b3c4d5e6f"
+down_revision: str | None = "za2b3c4d5e6f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``elicitations`` table."""
+    op.create_table(
+        "elicitations",
+        sa.Column("workspace_id", sa.BigInteger(), nullable=False, server_default="0"),
+        # The prompt's correlation id. A plain String, not Uuid16: native
+        # harnesses mint deterministic ids from the session plus the gated tool
+        # call (e.g. "elicit_cursor_<session>_<digest>"), so it is opaque text.
+        sa.Column("id", sa.String(128), nullable=False),
+        # Relates to conversations.id (no DB FK, Rule R032).
+        sa.Column("conversation_id", Uuid16(), nullable=False),
+        sa.Column("created_at", sa.Integer(), nullable=False),
+        # The response.elicitation_request payload as JSON, stored verbatim so a
+        # restored prompt replays identically. Opaque, never SQL-queried —
+        # stored compressed (CompressedText → LargeBinary).
+        sa.Column("event", sa.LargeBinary(), nullable=False),
+        sa.PrimaryKeyConstraint("workspace_id", "id"),
+    )
+    op.create_index(
+        "ix_elicitations_conversation_id",
+        "elicitations",
+        ["workspace_id", "conversation_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``elicitations`` table."""
+    op.drop_index("ix_elicitations_conversation_id", table_name="elicitations")
+    op.drop_table("elicitations")

--- a/omnigent/db/migrations/versions/zb2b3c4d5e6f_add_elicitations_table.py
+++ b/omnigent/db/migrations/versions/zb2b3c4d5e6f_add_elicitations_table.py
@@ -1,7 +1,7 @@
 """add elicitations table
 
 Revision ID: zb2b3c4d5e6f
-Revises: za2b3c4d5e6f
+Revises: za1b2c3d4e5f
 Create Date: 2026-08-21 00:00:00.000000
 
 Adds the ``elicitations`` table: one row per approval prompt still waiting on a
@@ -31,7 +31,7 @@ from alembic import op
 from omnigent.db.db_models import Uuid16
 
 revision: str = "zb2b3c4d5e6f"
-down_revision: str | None = "za2b3c4d5e6f"
+down_revision: str | None = "za1b2c3d4e5f"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/omnigent/entities/__init__.py
+++ b/omnigent/entities/__init__.py
@@ -24,6 +24,7 @@ from omnigent.entities.conversation import (
     synthesize_conversation_title,
 )
 from omnigent.entities.device_grant import DeviceGrant
+from omnigent.entities.elicitation import Elicitation
 from omnigent.entities.file import StoredFile
 from omnigent.entities.pagination import PagedList
 from omnigent.entities.permission import ResolvedAccess, SessionPermission
@@ -50,6 +51,7 @@ __all__ = [
     "Conversation",
     "ConversationItem",
     "DeviceGrant",
+    "Elicitation",
     "ErrorData",
     "FunctionCallData",
     "FunctionCallOutputData",

--- a/omnigent/entities/elicitation.py
+++ b/omnigent/entities/elicitation.py
@@ -1,0 +1,41 @@
+"""Elicitation entity — persisted in the ``elicitations`` table.
+
+One row per approval prompt that is still waiting on a human. The row exists
+only while the prompt is outstanding: resolving it deletes the row, so the
+table holds the parked set and nothing else. Durable history of *answered*
+approvals is not this table's job.
+
+The row stores the whole ``response.elicitation_request`` event rather than its
+parts, because that event is exactly what
+``GET /v1/sessions/{id}`` replays into the UI — see
+:func:`omnigent.runtime.pending_elicitations.snapshot_for`. Keeping it opaque
+means a new field on the event needs no migration here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Elicitation:
+    """
+    One outstanding approval prompt.
+
+    :param id: Correlation id the prompt was minted with, e.g.
+        ``"elicit_abc123"``. Not a UUID — several native harnesses derive
+        deterministic ids from the session and the gated tool call (see
+        ``cursor_tool_call_elicitation_id``), so this is an opaque string.
+    :param workspace_id: Tenant partition key that owns this row.
+    :param conversation_id: Session the prompt was raised on, e.g.
+        ``"conv_abc123"``.
+    :param created_at: Unix epoch seconds the prompt was raised.
+    :param event: The ``response.elicitation_request`` event payload, verbatim.
+    """
+
+    id: str
+    workspace_id: int
+    conversation_id: str
+    created_at: int
+    event: dict[str, Any]

--- a/omnigent/runtime/pending_elicitations.py
+++ b/omnigent/runtime/pending_elicitations.py
@@ -26,12 +26,22 @@ UI's chat blocks on cold load — the SSE stream itself has no replay,
 so an elicitation emitted before the user opened the chat would
 otherwise render as nothing.
 
+Outstanding entries are also mirrored to the ``elicitations`` table when a
+store is wired (:func:`set_store` — the server does this at startup; the runner
+and unit tests leave it unset and are unaffected). The index stays the read
+path; the rows exist so a server restart does not take the parked set with it.
+:func:`restore_for` reads them back. Unlike the count mirror on the
+conversation row, which is best-effort because a stale count self-corrects on
+the next transition, these writes are synchronous and lead the index — losing
+one is the very failure the mirror exists to prevent.
+
 Limitations:
 
-* In-memory only; multi-replica Omnigent deploys would each see their own
-  slice. This matches the existing ``_harness_elicitation_registry``
-  constraint — when a shared backplane is added for the registry,
-  this index should be wired through the same backplane.
+* Without a store the index is in-memory only; multi-replica Omnigent deploys
+  would each see their own slice. This matches the existing
+  ``_harness_elicitation_registry`` constraint — when a shared backplane is
+  added for the registry, this index should be wired through the same
+  backplane.
 * Events emitted before the Omnigent server starts (e.g. between turns,
   with the session_stream having dropped them) are not tracked,
   same as every other AP-server-side in-memory state.
@@ -40,9 +50,22 @@ Limitations:
 from __future__ import annotations
 
 import copy
+import logging
 import threading
+import time
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from omnigent.stores.elicitation_store import ElicitationStore
+
+_logger = logging.getLogger(__name__)
+
+# Longest a prompt can still have something waiting on it. The runner parks an
+# ASK for at most ``pending_approvals._DEFAULT_WAIT_SECONDS`` (one day), so a
+# restored row older than this has no awaiter left to release and is dropped on
+# read rather than shown as answerable.
+_MAX_PARK_SECONDS = 86400
 
 # Per-conversation mapping of outstanding elicitation_id → original
 # event payload. Storing the full event (not just the id) lets
@@ -104,6 +127,132 @@ def _notify_count_hook(conversation_id: str, count: int) -> None:
         hook(conversation_id, count)
 
 
+# Durable mirror of the index. ``None`` (runner, unit tests) keeps the index
+# purely in-memory and every store call below a no-op.
+_store: ElicitationStore | None = None
+
+
+def set_store(store: ElicitationStore | None) -> None:
+    """
+    Wire (or clear) the store outstanding prompts are mirrored to.
+
+    :param store: The server's elicitation store, or ``None`` to keep the
+        index in-memory only (the runner process and unit tests).
+    """
+    global _store
+    _store = store
+
+
+def _persist_add(conversation_id: str, elicitation_id: str, event: dict[str, Any]) -> None:
+    """
+    Write an outstanding prompt to the store, ahead of indexing it.
+
+    Write-ahead so a crash between the two leaves a row for a prompt the index
+    never learned about — recoverable — rather than an indexed prompt with no
+    row, which is the loss this mirror exists to prevent.
+
+    Failures log and are dropped: a prompt that cannot be persisted should
+    still be raised. The session keeps working; only its restart-survival is
+    lost, which is the behaviour before this mirror existed.
+
+    :param conversation_id: Session the prompt was raised on.
+    :param elicitation_id: The prompt's correlation id.
+    :param event: The ``response.elicitation_request`` payload.
+    """
+    store = _store
+    if store is None:
+        return
+    from omnigent.db.db_models import current_workspace_id
+    from omnigent.entities import Elicitation
+
+    try:
+        store.put(
+            Elicitation(
+                id=elicitation_id,
+                workspace_id=current_workspace_id(),
+                conversation_id=conversation_id,
+                created_at=int(time.time()),
+                event=event,
+            )
+        )
+    except Exception:  # never block raising the prompt
+        _logger.warning(
+            "Could not persist elicitation %r; it will not survive a restart",
+            elicitation_id,
+            exc_info=True,
+        )
+
+
+def _persist_remove(conversation_id: str, elicitation_id: str) -> None:
+    """
+    Drop a resolved prompt from the store, ahead of dropping it from the index.
+
+    Store-first for the same reason :func:`_persist_add` is: a crash between
+    the two leaves the index holding a prompt whose row is already gone, so the
+    next restart forgets it — correct, since it was answered. The reverse order
+    would resurrect an answered prompt and ask the user twice.
+
+    :param conversation_id: Session the prompt was raised on.
+    :param elicitation_id: The prompt's correlation id.
+    """
+    store = _store
+    if store is None:
+        return
+    try:
+        store.delete(conversation_id, elicitation_id)
+    except Exception:  # never block resolving the prompt
+        _logger.warning(
+            "Could not delete resolved elicitation %r",
+            elicitation_id,
+            exc_info=True,
+        )
+
+
+def restore_for(conversation_id: str) -> list[dict[str, Any]]:
+    """
+    Reload one session's outstanding prompts from the store into the index.
+
+    Called when a session snapshot finds its index empty but the conversation
+    row still reports outstanding prompts — the signature of a server restart,
+    since the count is mirrored to the row and the payloads were not.
+
+    Prompts older than :data:`_MAX_PARK_SECONDS` are skipped: nothing can still
+    be parked on them, so surfacing one would offer the user a button that
+    resolves nothing. They are left in the store for a reaper to collect rather
+    than deleted from a read path.
+
+    Restoring does not fire the count hook. The count is what sent us here, so
+    rewriting it would be a no-op at best, and at worst would race the mirror
+    that is already correct.
+
+    :param conversation_id: Session to restore, e.g. ``"conv_abc123"``.
+    :returns: The restored event payloads, oldest first. Empty when no store
+        is wired, the store fails, or nothing survives the age check.
+    """
+    store = _store
+    if store is None:
+        return []
+    try:
+        rows = store.list_for_conversation(
+            conversation_id,
+            not_before=int(time.time()) - _MAX_PARK_SECONDS,
+        )
+    except Exception:  # a failed restore degrades to the pre-mirror behaviour
+        _logger.warning(
+            "Could not restore outstanding elicitations for %s",
+            conversation_id,
+            exc_info=True,
+        )
+        return []
+    if not rows:
+        return []
+    with _lock:
+        ids = _pending.setdefault(conversation_id, {})
+        for row in rows:
+            ids.setdefault(row.id, row.event)
+        return [copy.deepcopy(event) for event in ids.values()]
+
+
 def record_publish(conversation_id: str, event: dict[str, Any]) -> None:
     """
     Update the index when an SSE event is published.
@@ -145,6 +294,7 @@ def record_publish(conversation_id: str, event: dict[str, Any]) -> None:
         elicitation_id = event.get("elicitation_id")
         if not isinstance(elicitation_id, str) or not elicitation_id:
             return
+        _persist_add(conversation_id, elicitation_id, event)
         with _lock:
             ids = _pending.setdefault(conversation_id, {})
             ids[elicitation_id] = event
@@ -202,6 +352,10 @@ def resolve(conversation_id: str, elicitation_id: str) -> None:
     :param elicitation_id: The elicitation correlation id from the
         approval payload, e.g. ``"elicit_abc123"``.
     """
+    # Unconditional, and before the index drop: this call may be the second
+    # resolve for an id the index already forgot (the runner publishes a
+    # resolved event on every exit path), and the row must go either way.
+    _persist_remove(conversation_id, elicitation_id)
     with _lock:
         ids = _pending.get(conversation_id)
         if ids is None:
@@ -377,7 +531,8 @@ def reset_for_tests() -> None:
     production callers — there is no legitimate use case for
     wiping the index at runtime.
     """
-    global _observer
+    global _observer, _store
     with _lock:
         _pending.clear()
     _observer = None
+    _store = None

--- a/omnigent/runtime/pending_elicitations.py
+++ b/omnigent/runtime/pending_elicitations.py
@@ -131,6 +131,12 @@ def _notify_count_hook(conversation_id: str, count: int) -> None:
 # purely in-memory and every store call below a no-op.
 _store: ElicitationStore | None = None
 
+# Conversations this process has already asked the store about. Bounds
+# :func:`restore_for` to one query per conversation per process, which is what
+# lets it run without a precondition — a restore is only ever needed once,
+# after which the index is authoritative for the rest of the process's life.
+_restored: set[str] = set()
+
 
 def set_store(store: ElicitationStore | None) -> None:
     """
@@ -141,6 +147,35 @@ def set_store(store: ElicitationStore | None) -> None:
     """
     global _store
     _store = store
+    with _lock:
+        _restored.clear()
+
+
+def _owns_elicitation(conversation_id: str, event: dict[str, Any]) -> bool:
+    """
+    Whether this conversation owns the prompt, rather than mirroring it.
+
+    A child's prompt is republished into every ancestor's stream so an
+    ancestor chat can render and resolve it, carrying ``target_session_id`` to
+    say which session actually owns the parked awaiter. Only the owner may
+    persist: the durable row is keyed by elicitation id alone, so letting a
+    mirror write would move the child's only row onto whichever ancestor
+    published last, and the child would restore nothing.
+
+    The index still tracks mirrors — that is what makes the ancestor's card
+    render — but the index is per-conversation and cannot collide this way.
+
+    :param conversation_id: Conversation the event was published on.
+    :param event: The ``response.elicitation_request`` payload.
+    :returns: ``True`` when *conversation_id* owns the prompt.
+    """
+    params = event.get("params")
+    if not isinstance(params, dict):
+        return True
+    target = params.get("target_session_id")
+    if not isinstance(target, str) or not target:
+        return True
+    return target == conversation_id
 
 
 def _persist_add(conversation_id: str, elicitation_id: str, event: dict[str, Any]) -> None:
@@ -212,18 +247,25 @@ def restore_for(conversation_id: str) -> list[dict[str, Any]]:
     """
     Reload one session's outstanding prompts from the store into the index.
 
-    Called when a session snapshot finds its index empty but the conversation
-    row still reports outstanding prompts — the signature of a server restart,
-    since the count is mirrored to the row and the payloads were not.
+    Called whenever a session's index is empty. It deliberately does **not**
+    take the conversation's mirrored count as a precondition: that count is
+    written best-effort on a background executor, so a crash between the row
+    commit and the count write leaves a durable row that a count-gated read
+    would never ask for — which is precisely the crash this whole mechanism
+    exists to survive.
+
+    The cost of dropping that gate is bounded by remembering which
+    conversations have already been looked up, so a process pays at most one
+    indexed query per conversation however many times the session is loaded.
+    Once the index holds an entry there is nothing to restore anyway.
 
     Prompts older than :data:`_MAX_PARK_SECONDS` are skipped: nothing can still
     be parked on them, so surfacing one would offer the user a button that
     resolves nothing. They are left in the store for a reaper to collect rather
     than deleted from a read path.
 
-    Restoring does not fire the count hook. The count is what sent us here, so
-    rewriting it would be a no-op at best, and at worst would race the mirror
-    that is already correct.
+    Restoring does not fire the count hook. Whether the count is right or
+    stale, the rows are the truth, and rewriting it here would race the mirror.
 
     :param conversation_id: Session to restore, e.g. ``"conv_abc123"``.
     :returns: The restored event payloads, oldest first. Empty when no store
@@ -232,12 +274,21 @@ def restore_for(conversation_id: str) -> list[dict[str, Any]]:
     store = _store
     if store is None:
         return []
+    with _lock:
+        if conversation_id in _restored:
+            return []
+        _restored.add(conversation_id)
     try:
         rows = store.list_for_conversation(
             conversation_id,
             not_before=int(time.time()) - _MAX_PARK_SECONDS,
         )
     except Exception:  # a failed restore degrades to the pre-mirror behaviour
+        # Let the next read try again: a store that was briefly unavailable
+        # must not cost this conversation its only restore for the lifetime of
+        # the process.
+        with _lock:
+            _restored.discard(conversation_id)
         _logger.warning(
             "Could not restore outstanding elicitations for %s",
             conversation_id,
@@ -294,7 +345,8 @@ def record_publish(conversation_id: str, event: dict[str, Any]) -> None:
         elicitation_id = event.get("elicitation_id")
         if not isinstance(elicitation_id, str) or not elicitation_id:
             return
-        _persist_add(conversation_id, elicitation_id, event)
+        if _owns_elicitation(conversation_id, event):
+            _persist_add(conversation_id, elicitation_id, event)
         with _lock:
             ids = _pending.setdefault(conversation_id, {})
             ids[elicitation_id] = event
@@ -534,5 +586,6 @@ def reset_for_tests() -> None:
     global _observer, _store
     with _lock:
         _pending.clear()
+        _restored.clear()
     _observer = None
     _store = None

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -94,6 +94,7 @@ from omnigent.stores import (
 )
 from omnigent.stores.comment_store import CommentStore
 from omnigent.stores.conversation_store import SessionConnectivity, runner_seen_is_fresh
+from omnigent.stores.elicitation_store import ElicitationStore
 from omnigent.stores.host_store import HostStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.policy_store import PolicyStore
@@ -911,6 +912,7 @@ def create_app(
     policy_store: PolicyStore | None = None,
     permission_store: PermissionStore | None = None,
     scheduled_task_store: ScheduledTaskStore | None = None,
+    elicitation_store: ElicitationStore | None = None,
     project_store: ProjectStore | None = None,
     auth_provider: AuthProvider | None = None,
     host_store: HostStore | None = None,
@@ -958,6 +960,10 @@ def create_app(
         starts an :class:`ScheduledTaskScheduler` that arms a timer per
         active task and fires the injected ``on_fire`` callback on
         schedule. ``None`` disables the scheduler entirely.
+    :param elicitation_store: Store backing outstanding approval prompts, so a
+        prompt parked when the server goes down is still there and still
+        answerable when it comes back. ``None`` keeps the pending-elicitation
+        index in memory only, i.e. the behaviour before the table existed.
     :param project_store: Store for first-class projects (owner-private
         containers that group sessions). ``None`` disables the
         ``/v1/projects`` CRUD endpoints.
@@ -1458,6 +1464,11 @@ def create_app(
     # _publish_status when a fired conversation's turn reaches terminal.
     session_live_state.configure(conversation_store, scheduled_task_store)
     pending_elicitations.set_count_persist_hook(session_live_state.persist_pending_count)
+    # The count above is a best-effort mirror — a stale one self-corrects on the
+    # next transition. The prompt itself gets a durable home instead, so a
+    # restart cannot leave the count asserting an approval the session can no
+    # longer render.
+    pending_elicitations.set_store(elicitation_store)
 
     @app.middleware("http")
     async def _record_server_metrics(

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -1497,12 +1497,14 @@ def _pending_elicitation_snapshot_for_session(
     other than ``conv`` has an outstanding prompt in the in-memory
     index (the common case is none anywhere).
 
-    An index with nothing for a session whose row still counts prompts is the
-    signature of a server restart: the count is mirrored to the conversation
-    row, the payloads were not. That case reloads the payloads from the
-    ``elicitations`` table so the prompt renders and stays answerable. The row
-    count is read from the conversation already loaded here, so a session with
-    nothing parked costs no extra query.
+    An index with nothing for a session is the signature of a server restart,
+    so the payloads are reloaded from the ``elicitations`` table and the prompt
+    renders and stays answerable. This deliberately does not first consult the
+    conversation's mirrored count: that count is written best-effort on a
+    background executor, so a crash between the row commit and the count write
+    would hide a real row from a count-gated read — the exact crash the durable
+    rows exist to survive. ``restore_for`` bounds itself to one query per
+    conversation per process instead.
 
     :param conv_store: Store used to list descendant sub-agents.
     :param conv: Session conversation being snapshotted.
@@ -1510,7 +1512,7 @@ def _pending_elicitation_snapshot_for_session(
         :class:`SessionResponse.pending_elicitations`.
     """
     events = pending_elicitations.snapshot_for(conv.id)
-    if not events and (conv.pending_elicitation_count or 0) > 0:
+    if not events:
         events = pending_elicitations.restore_for(conv.id)
     if not (set(pending_elicitations.pending_session_ids()) - {conv.id}):
         return events

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -1497,12 +1497,21 @@ def _pending_elicitation_snapshot_for_session(
     other than ``conv`` has an outstanding prompt in the in-memory
     index (the common case is none anywhere).
 
+    An index with nothing for a session whose row still counts prompts is the
+    signature of a server restart: the count is mirrored to the conversation
+    row, the payloads were not. That case reloads the payloads from the
+    ``elicitations`` table so the prompt renders and stays answerable. The row
+    count is read from the conversation already loaded here, so a session with
+    nothing parked costs no extra query.
+
     :param conv_store: Store used to list descendant sub-agents.
     :param conv: Session conversation being snapshotted.
     :returns: Pending elicitation event dicts suitable for
         :class:`SessionResponse.pending_elicitations`.
     """
     events = pending_elicitations.snapshot_for(conv.id)
+    if not events and (conv.pending_elicitation_count or 0) > 0:
+        events = pending_elicitations.restore_for(conv.id)
     if not (set(pending_elicitations.pending_session_ids()) - {conv.id}):
         return events
     seen = {

--- a/omnigent/server/routes/sessions/routes_elicitations.py
+++ b/omnigent/server/routes/sessions/routes_elicitations.py
@@ -147,9 +147,13 @@ def register_elicitations_routes(
         Used by the frontend's standalone approval page
         (``/approve/:sessionId/:elicitationId``) to fetch the
         elicitation prompt and render approve/reject controls.
-        The payload is read from the in-memory
-        :mod:`omnigent.runtime.pending_elicitations` index — no
-        database persistence required.
+        Served from the in-memory
+        :mod:`omnigent.runtime.pending_elicitations` index, falling
+        back to the durable rows when the index has nothing for the
+        session. That fallback matters here more than anywhere: this
+        is the link someone opens on a phone, and after a server
+        restart the index is empty, so an index-only read would tell
+        them a still-pending approval had been resolved.
 
         :param request: The inbound request, used for identity
             extraction.
@@ -172,6 +176,12 @@ def register_elicitations_routes(
                 raise _session_not_found()
 
         found = pending_elicitations.lookup(elicitation_id)
+        if found is None:
+            # Nothing indexed for this id. Before calling it resolved, give the
+            # durable rows a chance — on a restarted server the index is empty
+            # and every genuinely-pending prompt would otherwise read as done.
+            await asyncio.to_thread(pending_elicitations.restore_for, session_id)
+            found = pending_elicitations.lookup(elicitation_id)
         if found is None or found[0] != session_id:
             return {"status": "resolved"}
 

--- a/omnigent/stores/__init__.py
+++ b/omnigent/stores/__init__.py
@@ -3,6 +3,7 @@
 from omnigent.stores.agent_store import AgentStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.conversation_store import ConversationStore
+from omnigent.stores.elicitation_store import ElicitationStore
 from omnigent.stores.file_store import FileStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.project_store import ProjectStore
@@ -12,6 +13,7 @@ __all__ = [
     "AgentStore",
     "ArtifactStore",
     "ConversationStore",
+    "ElicitationStore",
     "FileStore",
     "PermissionStore",
     "ProjectStore",

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -33,6 +33,7 @@ from omnigent.db.db_models import (
     SqlConversationItem,
     SqlConversationLabel,
     SqlConversationMetadata,
+    SqlElicitation,
     SqlPolicy,
     SqlProject,
     SqlSessionPermission,
@@ -4029,6 +4030,12 @@ class SqlAlchemyConversationStore(ConversationStore):
                 delete(SqlConversationMetadata).where(
                     SqlConversationMetadata.workspace_id == current_workspace_id(),
                     SqlConversationMetadata.id.in_(subtree_ids),
+                )
+            )
+            session.execute(
+                delete(SqlElicitation).where(
+                    SqlElicitation.workspace_id == current_workspace_id(),
+                    SqlElicitation.conversation_id.in_(subtree_ids),
                 )
             )
             if bound_agent_ids:

--- a/omnigent/stores/elicitation_store/__init__.py
+++ b/omnigent/stores/elicitation_store/__init__.py
@@ -1,0 +1,95 @@
+"""Elicitation store — persists approval prompts that are still waiting.
+
+Owns the ``elicitations`` table. One row per outstanding prompt; resolving a
+prompt deletes its row, so the table holds the parked set and never grows into
+a history log.
+
+This is the durable side of :mod:`omnigent.runtime.pending_elicitations`, which
+keeps the same set in process memory to serve the sidebar badge and the session
+snapshot. The in-memory index stays the read path; the rows exist so a restart
+does not take the parked set with it.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from omnigent.entities import Elicitation
+
+
+class ElicitationStore(ABC):
+    """
+    Abstract base for outstanding-approval persistence.
+
+    Writes are on the elicitation publish path, which runs at human-approval
+    rate — one row per question actually asked — so implementations may be
+    synchronous.
+    """
+
+    def __init__(self, storage_location: str) -> None:
+        """
+        Initialize the elicitation store.
+
+        :param storage_location: Backend-specific storage URI,
+            e.g. ``"sqlite:///chat.db"`` for SQLAlchemy.
+        """
+        self.storage_location = storage_location
+
+    @abstractmethod
+    def put(self, elicitation: Elicitation) -> None:
+        """
+        Record an outstanding prompt, replacing any row with the same id.
+
+        Upsert rather than insert: a prompt may be re-published for the same
+        ``elicitation_id`` (the in-memory index treats a repeat publish as an
+        overwrite), and several harnesses mint deterministic ids that repeat
+        across polls for the same gated tool call.
+
+        :param elicitation: The prompt to record.
+        """
+        ...
+
+    @abstractmethod
+    def delete(self, conversation_id: str, elicitation_id: str) -> bool:
+        """
+        Drop a prompt that is no longer outstanding.
+
+        Conditional on the row existing, so a verdict racing another resolve
+        path has exactly one winner and the loser can tell it lost.
+
+        :param conversation_id: Session the prompt was raised on.
+        :param elicitation_id: The prompt's correlation id.
+        :returns: ``True`` if a row was deleted, ``False`` if none matched.
+        """
+        ...
+
+    @abstractmethod
+    def list_for_conversation(
+        self,
+        conversation_id: str,
+        *,
+        not_before: int | None = None,
+    ) -> list[Elicitation]:
+        """
+        Return the prompts still outstanding for one session, oldest first.
+
+        :param conversation_id: Session to query.
+        :param not_before: When given, skip prompts raised earlier than this
+            Unix epoch second. Callers pass it to drop prompts too old for any
+            awaiter to still be parked on them.
+        :returns: Outstanding prompts, in the order they were raised.
+        """
+        ...
+
+    @abstractmethod
+    def delete_for_conversation(self, conversation_id: str) -> int:
+        """
+        Drop every prompt for a session, for referential cleanup on delete.
+
+        The schema has no foreign keys (Rule R032), so deleting a conversation
+        must delete its prompts explicitly.
+
+        :param conversation_id: Session being deleted.
+        :returns: Number of rows deleted.
+        """
+        ...

--- a/omnigent/stores/elicitation_store/sqlalchemy_store.py
+++ b/omnigent/stores/elicitation_store/sqlalchemy_store.py
@@ -1,0 +1,134 @@
+"""SQLAlchemy-backed elicitation store."""
+
+from __future__ import annotations
+
+import json
+from typing import Protocol, cast
+
+from sqlalchemy import delete, select
+
+from omnigent.db.db_models import (
+    DEFAULT_WORKSPACE_ID,
+    SqlElicitation,
+    current_workspace_id,
+)
+from omnigent.db.utils import (
+    get_or_create_engine,
+    make_named_managed_session_maker,
+)
+from omnigent.entities import Elicitation
+from omnigent.stores.elicitation_store import ElicitationStore
+
+
+class _RowCountResult(Protocol):
+    rowcount: int
+
+
+def _to_entity(row: SqlElicitation) -> Elicitation:
+    """
+    Convert a :class:`SqlElicitation` ORM row to an :class:`Elicitation`.
+
+    :param row: The SQLAlchemy ORM row to convert.
+    :returns: An :class:`Elicitation` dataclass instance.
+    """
+    return Elicitation(
+        id=row.id,
+        workspace_id=row.workspace_id or DEFAULT_WORKSPACE_ID,
+        conversation_id=row.conversation_id,
+        created_at=row.created_at,
+        event=json.loads(row.event),
+    )
+
+
+class SqlAlchemyElicitationStore(ElicitationStore):
+    """
+    SQLAlchemy-backed implementation of :class:`ElicitationStore`.
+
+    Persists outstanding approval prompts in a relational database via the
+    SQLAlchemy ORM.
+    """
+
+    def __init__(self, storage_location: str) -> None:
+        """
+        Initialize the SQLAlchemy elicitation store.
+
+        Creates or reuses a SQLAlchemy engine and session factory for the
+        given database URI.
+
+        :param storage_location: SQLAlchemy database URI,
+            e.g. ``"sqlite:///chat.db"``.
+        """
+        super().__init__(storage_location)
+        self._engine = get_or_create_engine(storage_location)
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.elicitation_store",
+        )
+
+    def put(self, elicitation: Elicitation) -> None:
+        """Record an outstanding prompt, replacing any row with the same id."""
+        payload = json.dumps(elicitation.event)
+        with self._session("upsert_elicitation") as session:
+            row = session.get(
+                SqlElicitation,
+                (current_workspace_id(), elicitation.id),
+            )
+            if row is None:
+                session.add(
+                    SqlElicitation(
+                        id=elicitation.id,
+                        conversation_id=elicitation.conversation_id,
+                        created_at=elicitation.created_at,
+                        event=payload,
+                    )
+                )
+                return
+            row.conversation_id = elicitation.conversation_id
+            row.created_at = elicitation.created_at
+            row.event = payload
+
+    def delete(self, conversation_id: str, elicitation_id: str) -> bool:
+        """Drop a prompt that is no longer outstanding."""
+        with self._session("delete_elicitation") as session:
+            result = cast(
+                _RowCountResult,
+                session.execute(
+                    delete(SqlElicitation).where(
+                        SqlElicitation.workspace_id == current_workspace_id(),
+                        SqlElicitation.id == elicitation_id,
+                        SqlElicitation.conversation_id == conversation_id,
+                    )
+                ),
+            )
+            return result.rowcount > 0
+
+    def list_for_conversation(
+        self,
+        conversation_id: str,
+        *,
+        not_before: int | None = None,
+    ) -> list[Elicitation]:
+        """Return the prompts still outstanding for one session, oldest first."""
+        with self._session("list_elicitations_for_conversation") as session:
+            stmt = select(SqlElicitation).where(
+                SqlElicitation.workspace_id == current_workspace_id(),
+                SqlElicitation.conversation_id == conversation_id,
+            )
+            if not_before is not None:
+                stmt = stmt.where(SqlElicitation.created_at >= not_before)
+            rows = session.scalars(stmt.order_by(SqlElicitation.created_at, SqlElicitation.id))
+            return [_to_entity(row) for row in rows]
+
+    def delete_for_conversation(self, conversation_id: str) -> int:
+        """Drop every prompt for a session, for referential cleanup on delete."""
+        with self._session("delete_elicitations_for_conversation") as session:
+            result = cast(
+                _RowCountResult,
+                session.execute(
+                    delete(SqlElicitation).where(
+                        SqlElicitation.workspace_id == current_workspace_id(),
+                        SqlElicitation.conversation_id == conversation_id,
+                    )
+                ),
+            )
+            return result.rowcount

--- a/tests/db/test_migration_elicitations.py
+++ b/tests/db/test_migration_elicitations.py
@@ -69,6 +69,6 @@ def test_downgrade_drops_the_table(tmp_path: Path) -> None:
             {"conv": bytes(16), "event": b"{}"},
         )
 
-    _downgrade(uri, engine, "za2b3c4d5e6f")
+    _downgrade(uri, engine, "za1b2c3d4e5f")
 
     assert "elicitations" not in sa.inspect(engine).get_table_names()

--- a/tests/db/test_migration_elicitations.py
+++ b/tests/db/test_migration_elicitations.py
@@ -1,0 +1,74 @@
+"""Tests for the elicitations-table migration (zb2b3c4d5e6f)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import command
+
+from omnigent.db.utils import _build_alembic_config
+
+
+def _upgrade(uri: str, engine: sa.Engine, revision: str) -> None:
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.upgrade(config, revision)
+
+
+def _downgrade(uri: str, engine: sa.Engine, revision: str) -> None:
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, revision)
+
+
+def test_upgrade_creates_the_table_and_its_index(tmp_path: Path) -> None:
+    """The table and the one read path's index both land."""
+    uri = f"sqlite:///{tmp_path / 'elicitations.db'}"
+    engine = sa.create_engine(uri)
+
+    _upgrade(uri, engine, "zb2b3c4d5e6f")
+
+    inspector = sa.inspect(engine)
+    assert "elicitations" in inspector.get_table_names()
+    columns = {col["name"] for col in inspector.get_columns("elicitations")}
+    assert columns == {"workspace_id", "id", "conversation_id", "created_at", "event"}
+    indexes = {index["name"] for index in inspector.get_indexes("elicitations")}
+    assert "ix_elicitations_conversation_id" in indexes
+
+
+def test_primary_key_is_workspace_scoped(tmp_path: Path) -> None:
+    """Two tenants may hold the same elicitation id without colliding.
+
+    Every other table partitions on ``workspace_id`` as the leading primary-key
+    member; a prompt id that is only unique per tenant must not be global here.
+    """
+    uri = f"sqlite:///{tmp_path / 'elicitations_pk.db'}"
+    engine = sa.create_engine(uri)
+    _upgrade(uri, engine, "zb2b3c4d5e6f")
+
+    pk = sa.inspect(engine).get_pk_constraint("elicitations")
+
+    assert pk["constrained_columns"] == ["workspace_id", "id"]
+
+
+def test_downgrade_drops_the_table(tmp_path: Path) -> None:
+    """The migration is reversible: it only adds, so undoing it only drops."""
+    uri = f"sqlite:///{tmp_path / 'elicitations_down.db'}"
+    engine = sa.create_engine(uri)
+    _upgrade(uri, engine, "zb2b3c4d5e6f")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO elicitations"
+                " (workspace_id, id, conversation_id, created_at, event)"
+                " VALUES (0, 'elicit_x', :conv, 1, :event)"
+            ),
+            {"conv": bytes(16), "event": b"{}"},
+        )
+
+    _downgrade(uri, engine, "za2b3c4d5e6f")
+
+    assert "elicitations" not in sa.inspect(engine).get_table_names()

--- a/tests/runtime/test_pending_elicitations.py
+++ b/tests/runtime/test_pending_elicitations.py
@@ -686,3 +686,187 @@ def test_snapshot_for_returns_independent_copies() -> None:
     # the index; if "tampered-top-level", the top-level copy is
     # there but nested values are still shared.
     assert snap2[0]["params"]["message"] == "original"
+
+
+class _FakeStore:
+    """In-memory stand-in for the elicitation store.
+
+    Records call order so tests can pin that the durable write leads the index
+    mutation — the ordering the mirror depends on to be recoverable.
+    """
+
+    def __init__(self) -> None:
+        self.rows: dict[str, Any] = {}
+        self.calls: list[str] = []
+        self.fail_on_put = False
+
+    def put(self, elicitation: Any) -> None:
+        self.calls.append(f"put:{elicitation.id}")
+        if self.fail_on_put:
+            raise RuntimeError("store is down")
+        self.rows[elicitation.id] = elicitation
+
+    def delete(self, conversation_id: str, elicitation_id: str) -> bool:
+        self.calls.append(f"delete:{elicitation_id}")
+        return self.rows.pop(elicitation_id, None) is not None
+
+    def list_for_conversation(
+        self,
+        conversation_id: str,
+        *,
+        not_before: int | None = None,
+    ) -> list[Any]:
+        self.calls.append(f"list:{conversation_id}")
+        return [
+            row
+            for row in self.rows.values()
+            if row.conversation_id == conversation_id
+            and (not_before is None or row.created_at >= not_before)
+        ]
+
+
+def _request_event(elicitation_id: str, message: str = "Approve?") -> dict[str, Any]:
+    """Build a ``response.elicitation_request`` event."""
+    return {
+        "type": "response.elicitation_request",
+        "elicitation_id": elicitation_id,
+        "params": {"message": message},
+    }
+
+
+def test_no_store_leaves_the_index_in_memory_only() -> None:
+    """The runner and unit tests never wire a store; nothing may break there."""
+    pending_elicitations.record_publish("conv_a", _request_event("elicit_1"))
+    pending_elicitations.resolve("conv_a", "elicit_1")
+
+    assert pending_elicitations.count_for("conv_a") == 0
+    assert pending_elicitations.restore_for("conv_a") == []
+
+
+def test_publish_writes_the_row_before_indexing_it() -> None:
+    """Write-ahead: a crash between the two must not lose the prompt.
+
+    A row for a prompt the index never learned about is recoverable; an indexed
+    prompt with no row is the loss this mirror exists to prevent.
+    """
+    store = _FakeStore()
+    pending_elicitations.set_store(store)
+
+    pending_elicitations.record_publish("conv_a", _request_event("elicit_1"))
+
+    assert store.calls == ["put:elicit_1"]
+    assert store.rows["elicit_1"].event == _request_event("elicit_1")
+    assert store.rows["elicit_1"].conversation_id == "conv_a"
+    assert pending_elicitations.count_for("conv_a") == 1
+
+
+def test_resolve_deletes_the_row() -> None:
+    """An answered prompt must not come back after a restart."""
+    store = _FakeStore()
+    pending_elicitations.set_store(store)
+    pending_elicitations.record_publish("conv_a", _request_event("elicit_1"))
+
+    pending_elicitations.resolve("conv_a", "elicit_1")
+
+    assert store.rows == {}
+    assert store.calls == ["put:elicit_1", "delete:elicit_1"]
+
+
+def test_resolve_deletes_the_row_even_when_the_index_already_forgot() -> None:
+    """The runner publishes a resolved event on every exit path.
+
+    A second resolve for the same id finds nothing in the index, but the row
+    must still go — otherwise a timed-out prompt is restored as answerable.
+    """
+    store = _FakeStore()
+    pending_elicitations.set_store(store)
+    pending_elicitations.record_publish("conv_a", _request_event("elicit_1"))
+    pending_elicitations.resolve("conv_a", "elicit_1")
+    store.rows["elicit_1"] = object()  # a row the index no longer knows about
+
+    pending_elicitations.resolve("conv_a", "elicit_1")
+
+    assert store.rows == {}
+
+
+def test_a_failed_write_still_raises_the_prompt() -> None:
+    """Losing durability is not a reason to refuse to ask the human."""
+    store = _FakeStore()
+    store.fail_on_put = True
+    pending_elicitations.set_store(store)
+
+    pending_elicitations.record_publish("conv_a", _request_event("elicit_1"))
+
+    assert pending_elicitations.count_for("conv_a") == 1
+    assert pending_elicitations.snapshot_for("conv_a")[0]["elicitation_id"] == "elicit_1"
+
+
+def test_restore_repopulates_the_index_after_a_restart() -> None:
+    """The whole point: a prompt outstanding across a restart is answerable."""
+    store = _FakeStore()
+    pending_elicitations.set_store(store)
+    pending_elicitations.record_publish("conv_a", _request_event("elicit_1", "gate me"))
+
+    # A restart wipes the index but not the store.
+    rows = dict(store.rows)
+    pending_elicitations.reset_for_tests()
+    store.rows = rows
+    pending_elicitations.set_store(store)
+    assert pending_elicitations.snapshot_for("conv_a") == []
+
+    restored = pending_elicitations.restore_for("conv_a")
+
+    assert [event["elicitation_id"] for event in restored] == ["elicit_1"]
+    assert restored[0]["params"]["message"] == "gate me"
+    assert pending_elicitations.count_for("conv_a") == 1
+    # And it is now resolvable through the ordinary path.
+    pending_elicitations.resolve("conv_a", "elicit_1")
+    assert pending_elicitations.count_for("conv_a") == 0
+    assert store.rows == {}
+
+
+def test_restore_skips_prompts_too_old_to_have_an_awaiter() -> None:
+    """A day-old prompt has no parked awaiter, so offering it is a lie."""
+    import time as _time
+
+    store = _FakeStore()
+    pending_elicitations.set_store(store)
+    pending_elicitations.record_publish("conv_a", _request_event("elicit_stale"))
+    # The entity is frozen, so age it by rebuilding rather than mutating.
+    stale = store.rows["elicit_stale"]
+    store.rows["elicit_stale"] = type(stale)(
+        id=stale.id,
+        workspace_id=stale.workspace_id,
+        conversation_id=stale.conversation_id,
+        created_at=int(_time.time()) - 90_000,
+        event=stale.event,
+    )
+    pending_elicitations.reset_for_tests()
+    pending_elicitations.set_store(store)
+
+    assert pending_elicitations.restore_for("conv_a") == []
+    assert pending_elicitations.count_for("conv_a") == 0
+
+
+def test_restore_does_not_clobber_a_live_index_entry() -> None:
+    """A prompt raised since the restart must not be replaced by its old row."""
+    store = _FakeStore()
+    pending_elicitations.set_store(store)
+    pending_elicitations.record_publish("conv_a", _request_event("elicit_1", "old"))
+    pending_elicitations.record_publish("conv_a", _request_event("elicit_1", "new"))
+
+    restored = pending_elicitations.restore_for("conv_a")
+
+    assert [event["params"]["message"] for event in restored] == ["new"]
+
+
+def test_a_failed_restore_degrades_to_an_empty_snapshot() -> None:
+    """A store outage must not 500 a session snapshot."""
+
+    class _BrokenStore(_FakeStore):
+        def list_for_conversation(self, conversation_id: str, **kwargs: Any) -> list[Any]:
+            raise RuntimeError("store is down")
+
+    pending_elicitations.set_store(_BrokenStore())
+
+    assert pending_elicitations.restore_for("conv_a") == []

--- a/tests/runtime/test_pending_elicitations.py
+++ b/tests/runtime/test_pending_elicitations.py
@@ -870,3 +870,97 @@ def test_a_failed_restore_degrades_to_an_empty_snapshot() -> None:
     pending_elicitations.set_store(_BrokenStore())
 
     assert pending_elicitations.restore_for("conv_a") == []
+
+
+def test_restore_does_not_depend_on_the_conversation_count() -> None:
+    """The durable row is the truth; the mirrored count is best-effort.
+
+    The count is written on a background executor and dropped on failure, so a
+    crash between the row commit and the count write leaves a real row behind.
+    Gating the read on that count would hide it — in exactly the crash the rows
+    exist to survive.
+    """
+    store = _FakeStore()
+    pending_elicitations.set_store(store)
+    pending_elicitations.record_publish("conv_a", _request_event("elicit_1"))
+
+    rows = dict(store.rows)
+    pending_elicitations.reset_for_tests()
+    store.rows = rows
+    pending_elicitations.set_store(store)
+
+    # No count was ever persisted for this conversation; the row must still
+    # come back.
+    restored = pending_elicitations.restore_for("conv_a")
+
+    assert [event["elicitation_id"] for event in restored] == ["elicit_1"]
+
+
+def test_restore_asks_the_store_once_per_conversation() -> None:
+    """Dropping the count gate must not become a query on every session read."""
+    store = _FakeStore()
+    pending_elicitations.set_store(store)
+
+    for _ in range(5):
+        pending_elicitations.restore_for("conv_quiet")
+
+    assert store.calls.count("list:conv_quiet") == 1
+
+
+def test_a_failed_restore_can_be_retried() -> None:
+    """A briefly-unavailable store must not cost the only restore attempt.
+
+    ``restore_for`` remembers which conversations it has asked about so it
+    queries once per process. A failure has to un-remember, or one blip
+    permanently hides that session's parked prompts.
+    """
+
+    class _FlakyStore(_FakeStore):
+        fail_next = True
+
+        def list_for_conversation(self, conversation_id: str, **kwargs: Any) -> list[Any]:
+            if self.fail_next:
+                self.fail_next = False
+                raise RuntimeError("store is down")
+            return super().list_for_conversation(conversation_id, **kwargs)
+
+    store = _FlakyStore()
+    pending_elicitations.set_store(store)
+    pending_elicitations.record_publish("conv_a", _request_event("elicit_1"))
+    rows = dict(store.rows)
+
+    # Restart: index gone, rows kept, and the first read hits the outage.
+    pending_elicitations.reset_for_tests()
+    store.rows = rows
+    pending_elicitations.set_store(store)
+    assert pending_elicitations.restore_for("conv_a") == []
+
+    # The store recovers; the next read must try again rather than stay silent.
+    restored = pending_elicitations.restore_for("conv_a")
+
+    assert [event["elicitation_id"] for event in restored] == ["elicit_1"]
+
+
+def test_an_ancestor_mirror_does_not_steal_the_child_row() -> None:
+    """A child's prompt is mirrored into every ancestor's stream.
+
+    The durable row is keyed by elicitation id alone, so if a mirror persisted
+    too, the last ancestor to publish would move the child's only row onto
+    itself and the child would restore nothing.
+    """
+    store = _FakeStore()
+    pending_elicitations.set_store(store)
+
+    child_event = _request_event("elicit_1")
+    pending_elicitations.record_publish("conv_child", child_event)
+
+    mirrored = {
+        **child_event,
+        "params": {**child_event["params"], "target_session_id": "conv_child"},
+    }
+    pending_elicitations.record_publish("conv_parent", mirrored)
+
+    assert store.rows["elicit_1"].conversation_id == "conv_child"
+    # The ancestor still renders it — the index tracks mirrors, only the
+    # durable row is owner-only.
+    assert pending_elicitations.count_for("conv_parent") == 1

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -41,6 +41,7 @@ from omnigent.server.routes import sessions as sessions_routes
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.artifact_store.local import LocalArtifactStore
 from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
+from omnigent.stores.elicitation_store.sqlalchemy_store import SqlAlchemyElicitationStore
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
@@ -594,6 +595,7 @@ def app(runtime_init: None, db_uri: str, tmp_path: Path) -> FastAPI:
             cache_dir=tmp_path / "cache",
         ),
         comment_store=SqlAlchemyCommentStore(db_uri),
+        elicitation_store=SqlAlchemyElicitationStore(db_uri),
     )
 
 

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -41,10 +41,10 @@ from omnigent.server.routes import sessions as sessions_routes
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.artifact_store.local import LocalArtifactStore
 from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
-from omnigent.stores.elicitation_store.sqlalchemy_store import SqlAlchemyElicitationStore
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
+from omnigent.stores.elicitation_store.sqlalchemy_store import SqlAlchemyElicitationStore
 from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
 
 # ── Controllable mock LLM ─────────────────────────────

--- a/tests/server/integration/test_sessions_elicitation_restart.py
+++ b/tests/server/integration/test_sessions_elicitation_restart.py
@@ -1,0 +1,91 @@
+"""An outstanding approval survives losing the in-process index.
+
+The in-memory pending-elicitations index dies with the server process. The
+count it mirrors onto the conversation row does not, so before the
+``elicitations`` table existed a restart left the sidebar claiming an approval
+was waiting while ``GET /v1/sessions/{id}`` replayed nothing for the user to
+answer.
+
+These tests wipe the index to stand in for that restart — the process boundary
+itself is what a unit or integration test cannot cross — and drive the real
+HTTP snapshot endpoint on either side of it.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tests.server.helpers import create_test_agent
+from tests.server.integration.test_sessions_elicitation_resolve_url import (
+    _create_session,
+    _park_permission_hook,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _pending_ids(client: httpx.AsyncClient, session_id: str) -> list[str]:
+    """Return the elicitation ids the session snapshot replays."""
+    resp = await client.get(f"/v1/sessions/{session_id}")
+    assert resp.status_code == 200, resp.text
+    return [item["elicitation_id"] for item in resp.json().get("pending_elicitations", [])]
+
+
+async def test_snapshot_replays_a_prompt_after_the_index_is_lost(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """The prompt comes back on the snapshot, so the user can still answer it."""
+    from omnigent.runtime import pending_elicitations
+
+    agent = await create_test_agent(client, "test-elicitation-restart")
+    session_id = await _create_session(client, agent["id"])
+    hook_task, elicitation_id = await _park_permission_hook(client, session_id)
+
+    try:
+        assert await _pending_ids(client, session_id) == [elicitation_id]
+
+        # Stand in for the restart: the index is gone, the row is not.
+        pending_elicitations.reset_for_tests()
+        assert pending_elicitations.count_for(session_id) == 0
+
+        # Rewire the store the way the server does at startup. Only the index
+        # was lost, so this is the whole of what a restart re-establishes.
+        from omnigent.stores.elicitation_store.sqlalchemy_store import (
+            SqlAlchemyElicitationStore,
+        )
+
+        pending_elicitations.set_store(SqlAlchemyElicitationStore(db_uri))
+
+        assert await _pending_ids(client, session_id) == [elicitation_id]
+    finally:
+        hook_task.cancel()
+
+
+async def test_resolved_prompt_does_not_come_back(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """An answered approval must not be asked again after a restart."""
+    from omnigent.runtime import pending_elicitations
+
+    agent = await create_test_agent(client, "test-elicitation-restart-resolved")
+    session_id = await _create_session(client, agent["id"])
+    hook_task, elicitation_id = await _park_permission_hook(client, session_id)
+
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+        json={"action": "accept"},
+    )
+    assert resp.status_code in (200, 202), resp.text
+    await hook_task
+
+    from omnigent.stores.elicitation_store.sqlalchemy_store import (
+        SqlAlchemyElicitationStore,
+    )
+
+    pending_elicitations.reset_for_tests()
+    pending_elicitations.set_store(SqlAlchemyElicitationStore(db_uri))
+
+    assert await _pending_ids(client, session_id) == []

--- a/tests/server/integration/test_sessions_elicitation_restart.py
+++ b/tests/server/integration/test_sessions_elicitation_restart.py
@@ -89,3 +89,73 @@ async def test_resolved_prompt_does_not_come_back(
     pending_elicitations.set_store(SqlAlchemyElicitationStore(db_uri))
 
     assert await _pending_ids(client, session_id) == []
+
+
+async def test_snapshot_restores_when_the_mirrored_count_was_lost(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """The durable row must not be gated behind the best-effort count.
+
+    ``pending_elicitation_count`` is mirrored onto the conversation row by a
+    background executor that logs and drops failures. So a crash between the
+    row commit and the count write leaves a real, still-parked prompt whose
+    count says zero — and a count-gated read would never ask for it. That is
+    the same crash the durable rows exist to survive, so it must not be the
+    thing that hides them.
+    """
+    from omnigent.runtime import pending_elicitations
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+    from omnigent.stores.elicitation_store.sqlalchemy_store import (
+        SqlAlchemyElicitationStore,
+    )
+
+    agent = await create_test_agent(client, "test-elicitation-count-lost")
+    session_id = await _create_session(client, agent["id"])
+    hook_task, elicitation_id = await _park_permission_hook(client, session_id)
+
+    try:
+        # The row is durable; now make the mirror say nothing is parked, which
+        # is what a dropped count write leaves behind.
+        SqlAlchemyConversationStore(db_uri).set_pending_elicitation_count(session_id, 0)
+        pending_elicitations.reset_for_tests()
+        pending_elicitations.set_store(SqlAlchemyElicitationStore(db_uri))
+
+        assert await _pending_ids(client, session_id) == [elicitation_id]
+    finally:
+        hook_task.cancel()
+
+
+async def test_the_standalone_approval_page_survives_a_restart(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """The approval link is the phone path; a restart must not blank it.
+
+    ``GET /v1/sessions/{id}/elicitations/{eid}`` backs
+    ``/approve/:sessionId/:elicitationId``. Reading only the in-memory index
+    means that after a restart it reports every genuinely-pending prompt as
+    ``resolved`` — telling someone their approval was already handled when the
+    work is still parked on it.
+    """
+    from omnigent.runtime import pending_elicitations
+    from omnigent.stores.elicitation_store.sqlalchemy_store import (
+        SqlAlchemyElicitationStore,
+    )
+
+    agent = await create_test_agent(client, "test-elicitation-approve-page")
+    session_id = await _create_session(client, agent["id"])
+    hook_task, elicitation_id = await _park_permission_hook(client, session_id)
+
+    try:
+        pending_elicitations.reset_for_tests()
+        pending_elicitations.set_store(SqlAlchemyElicitationStore(db_uri))
+
+        resp = await client.get(f"/v1/sessions/{session_id}/elicitations/{elicitation_id}")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "pending"
+    finally:
+        hook_task.cancel()

--- a/tests/stores/test_elicitation_store.py
+++ b/tests/stores/test_elicitation_store.py
@@ -1,0 +1,171 @@
+"""Tests for the SQLAlchemy elicitation store."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.entities import Elicitation
+from omnigent.stores.elicitation_store.sqlalchemy_store import SqlAlchemyElicitationStore
+
+
+@pytest.fixture()
+def elicitation_store(db_uri: str) -> SqlAlchemyElicitationStore:
+    """
+    :returns: A SqlAlchemyElicitationStore backed by the test database.
+    """
+    return SqlAlchemyElicitationStore(db_uri)
+
+
+def _make(
+    elicitation_id: str = "elicit_abc",
+    conversation_id: str = "conv_11111111111111111111111111111111",
+    created_at: int = 1_000,
+    message: str = "Approve `rm -rf /tmp/x`?",
+) -> Elicitation:
+    """Build an :class:`Elicitation` with a realistic event payload."""
+    return Elicitation(
+        id=elicitation_id,
+        workspace_id=0,
+        conversation_id=conversation_id,
+        created_at=created_at,
+        event={
+            "type": "response.elicitation_request",
+            "elicitation_id": elicitation_id,
+            "method": "elicitation/create",
+            "params": {"mode": "form", "message": message},
+        },
+    )
+
+
+def test_put_then_list_round_trips_the_event(
+    elicitation_store: SqlAlchemyElicitationStore,
+) -> None:
+    """The stored payload comes back byte-identical, so a restore replays it.
+
+    ``conversation_id`` is the one field that does not round-trip verbatim:
+    like every other id column, it is a ``Uuid16``, which strips the ``conv_``
+    prefix on the way in and hands back the bare hex. Both forms resolve to the
+    same row on query, and the restore path keys the index off the id it was
+    called with rather than the one it read back.
+    """
+    original = _make()
+    elicitation_store.put(original)
+
+    rows = elicitation_store.list_for_conversation(original.conversation_id)
+
+    assert len(rows) == 1
+    assert rows[0].id == original.id
+    assert rows[0].conversation_id == original.conversation_id.removeprefix("conv_")
+    assert rows[0].created_at == original.created_at
+    assert rows[0].event == original.event
+
+
+def test_put_is_an_upsert(elicitation_store: SqlAlchemyElicitationStore) -> None:
+    """A re-published prompt overwrites rather than raising or duplicating.
+
+    Native harnesses mint deterministic ids that repeat across polls for the
+    same gated tool call, so the same id genuinely arrives more than once.
+    """
+    elicitation_store.put(_make(message="first"))
+    elicitation_store.put(_make(message="second", created_at=2_000))
+
+    rows = elicitation_store.list_for_conversation(_make().conversation_id)
+
+    assert len(rows) == 1
+    assert rows[0].event["params"]["message"] == "second"
+    assert rows[0].created_at == 2_000
+
+
+def test_delete_reports_whether_it_won(
+    elicitation_store: SqlAlchemyElicitationStore,
+) -> None:
+    """Two racing resolves must not both believe they resolved the prompt."""
+    elicitation = _make()
+    elicitation_store.put(elicitation)
+
+    first = elicitation_store.delete(elicitation.conversation_id, elicitation.id)
+    second = elicitation_store.delete(elicitation.conversation_id, elicitation.id)
+
+    assert first is True
+    assert second is False
+    assert elicitation_store.list_for_conversation(elicitation.conversation_id) == []
+
+
+def test_delete_refuses_a_mismatched_conversation(
+    elicitation_store: SqlAlchemyElicitationStore,
+) -> None:
+    """An id alone must not let one session resolve another session's prompt."""
+    elicitation = _make()
+    elicitation_store.put(elicitation)
+
+    deleted = elicitation_store.delete(
+        "conv_22222222222222222222222222222222",
+        elicitation.id,
+    )
+
+    assert deleted is False
+    assert len(elicitation_store.list_for_conversation(elicitation.conversation_id)) == 1
+
+
+def test_list_is_scoped_to_one_conversation(
+    elicitation_store: SqlAlchemyElicitationStore,
+) -> None:
+    """A session must not see another session's outstanding prompts."""
+    mine = _make(elicitation_id="elicit_mine")
+    theirs = _make(
+        elicitation_id="elicit_theirs",
+        conversation_id="conv_22222222222222222222222222222222",
+    )
+    elicitation_store.put(mine)
+    elicitation_store.put(theirs)
+
+    rows = elicitation_store.list_for_conversation(mine.conversation_id)
+
+    assert [row.id for row in rows] == ["elicit_mine"]
+
+
+def test_list_orders_oldest_first(elicitation_store: SqlAlchemyElicitationStore) -> None:
+    """Restored prompts render in the order they were raised."""
+    elicitation_store.put(_make(elicitation_id="elicit_second", created_at=2_000))
+    elicitation_store.put(_make(elicitation_id="elicit_first", created_at=1_000))
+
+    rows = elicitation_store.list_for_conversation(_make().conversation_id)
+
+    assert [row.id for row in rows] == ["elicit_first", "elicit_second"]
+
+
+def test_list_can_skip_prompts_too_old_to_have_an_awaiter(
+    elicitation_store: SqlAlchemyElicitationStore,
+) -> None:
+    """Nothing can still be parked on a prompt older than the maximum park."""
+    elicitation_store.put(_make(elicitation_id="elicit_stale", created_at=1_000))
+    elicitation_store.put(_make(elicitation_id="elicit_fresh", created_at=5_000))
+
+    rows = elicitation_store.list_for_conversation(
+        _make().conversation_id,
+        not_before=4_000,
+    )
+
+    assert [row.id for row in rows] == ["elicit_fresh"]
+
+
+def test_delete_for_conversation_clears_the_session(
+    elicitation_store: SqlAlchemyElicitationStore,
+) -> None:
+    """Deleting a conversation must not leave its prompts orphaned.
+
+    The schema has no foreign keys, so this cleanup is the application's job.
+    """
+    elicitation_store.put(_make(elicitation_id="elicit_one"))
+    elicitation_store.put(_make(elicitation_id="elicit_two"))
+    survivor = _make(
+        elicitation_id="elicit_other_session",
+        conversation_id="conv_22222222222222222222222222222222",
+    )
+    elicitation_store.put(survivor)
+
+    deleted = elicitation_store.delete_for_conversation(_make().conversation_id)
+
+    assert deleted == 2
+    assert elicitation_store.list_for_conversation(_make().conversation_id) == []
+    assert len(elicitation_store.list_for_conversation(survivor.conversation_id)) == 1


### PR DESCRIPTION
## Related issue

Closes #5144

## Summary

An outstanding approval lives only in the in-process pending-elicitations
index, which its own docstring calls "In-memory only". The *count* it feeds is
already mirrored to `omnigent_conversation_metadata.pending_elicitation_count`
so any replica can render the sidebar badge — but the payload never was. So
after a restart the two disagree permanently:

```python
pending_elicitations_count=(
    max(pending_count, conv.pending_elicitation_count or 0)
    if conv.runner_id is not None
    else pending_count
),
```

`pending_count` is `0` (index wiped), the row still says `1`, `max()` keeps the
badge lit — and `snapshot_for()` returns nothing, so opening the session shows
no card to answer. Nothing clears it, because the decrement only runs for an
elicitation the index still knows about.

A server-only restart is the common case (deploy, replica failover) and the
damaging one: the runner keeps its `asyncio.Future` parked, so the work is
still alive, but the question that would release it is gone. The turn then
waits out `_DEFAULT_WAIT_SECONDS` (86400s) and `wait_for_user_approval` returns
`False` — the gated call is **silently denied a day later**.

This gives the prompt a durable home:

- **An `elicitations` table** holding just the outstanding set. Keyed by the
  correlation id — a `String`, not `Uuid16`, because native harnesses mint
  deterministic non-UUID ids (`elicit_cursor_<session>_<digest>`) — and
  partitioned on `workspace_id` like every other table. Resolving deletes the
  row, so it never becomes a history log.
- **Writes on the publish path, synchronous and ahead of the index.** The
  count mirror stays best-effort on its ordered executor because a stale count
  self-corrects on the next transition. Losing *this* row is the failure being
  fixed, so it does not get the same treatment.
- **A session snapshot whose index is empty while its row still counts prompts
  reloads them.** The count is already on the `Conversation` loaded there, so a
  session with nothing parked costs no extra query.

A restored prompt then resolves through the existing path with no changes:
`_resolve_elicitation` publishes `elicitation_resolved` and forwards to the
runner, which still holds the Future under the same id. That is what makes this
complete on its own terms rather than half a fix.

### How this sits against #4868

Worth naming, since the overlap is real. PR #4868's turn operation journal is an
append-only record of what a turn *did*, for idempotency and crash recovery.
This is queryable state for what a session is *currently waiting on* — a set
that shrinks, read on the session-snapshot path. Different lifetimes, different
access patterns. If maintainers would rather this ride the journal once it is
wired to dispatch, I am happy to rebase onto it; I did not want to block a
user-visible defect on a PR whose own scope says it "cannot start work or change
current runtime behavior" yet.

### Two things reviewers usually ask about

**Payloads on disk.** An elicitation's `content_preview` can carry the gated
tool's arguments, so this does put more on disk than before. Mitigated by the
row being deleted on resolve and skipped past the maximum park on read — the
table holds only questions currently being asked. Flagging it rather than
waiting to be asked.

**A synchronous write on the publish path.** `record_publish` acts on two event
types and returns after one dict lookup for everything else, so this only costs
anything when an approval is actually raised — one row per question put to a
human, at human latency. Making it best-effort would reintroduce exactly the
loss being fixed.

### Three holes an external review found, now closed

Worth naming rather than quietly fixing, because each one made the durable rows
unreachable in a different way and the tests I had did not catch any of them.

1. **The restore was gated on the best-effort count.** It only ran when the
   conversation's mirrored `pending_elicitation_count` was above zero — but that
   count is written on a background executor that logs and drops failures, so a
   crash between the row commit and the count write left a real parked prompt
   that a count-gated read would never ask for. That is the same crash the rows
   exist to survive. Restore no longer consults the count; it bounds itself by
   remembering which conversations it has asked about, so a process pays at most
   one indexed query per conversation.

2. **The ancestor mirror stole the child's row.** A child's prompt is
   republished into every ancestor's stream so an ancestor chat can render it.
   Each publish also persisted, and the row is keyed by elicitation id alone, so
   the last ancestor to publish moved the child's only row onto itself. Mirrors
   carry `target_session_id`; only the owner persists now.

3. **The standalone approval page reported pending prompts as resolved.**
   `GET /v1/sessions/{id}/elicitations/{eid}` — which backs
   `/approve/:sessionId/:elicitationId`, the link you open on a phone — read
   only the in-memory index and returned `resolved` on a miss. After a restart
   that is every genuinely-pending approval. It falls back to the durable rows.

Each has a test that fails without its fix.

### Deliberately not in scope

- Reaping rows whose session or runner never came back. Needs its own decision
  about what an orphan means and is a separate change.
- Resuming a turn whose runner also died. A parked coroutine cannot be revived;
  restoring the prompt makes it answerable again only where the awaiter
  survived, which is the common restart. Worth doing properly on top of a
  durable turn journal rather than guessed at here.

## Test Plan

`tests/server/integration/test_sessions_elicitation_restart.py` is the one that
matters. It parks a real Claude PermissionRequest hook, drives the real
`GET /v1/sessions/{id}` endpoint, wipes the index to stand in for the process
boundary a test cannot cross, and asserts the prompt comes back.

**It fails on `main` and passes here**, which is the point:

```
$ pytest tests/server/integration/test_sessions_elicitation_restart.py
>   assert await _pending_ids(client, session_id) == [elicitation_id]
E   AssertionError: assert [] == ['elicit_905c...9afe3486859b']
1 failed, 1 passed          # without the restore
2 passed                    # with it
```

Also covered:

- `tests/stores/test_elicitation_store.py` — round-trip, upsert (harnesses
  re-publish deterministic ids), conditional delete so two racing resolves have
  one winner, cross-session isolation on both read and delete, age filtering,
  conversation cleanup.
- `tests/runtime/test_pending_elicitations.py` — write-ahead ordering, delete
  on resolve including the second resolve the runner always publishes, restore
  not clobbering a prompt raised since the restart, and a store outage
  degrading to today's behaviour rather than refusing to ask or 500-ing a
  snapshot.
- `tests/db/test_migration_elicitations.py` — upgrade, workspace-scoped primary
  key, downgrade with a row present.

Full runs on this branch:

```
pytest tests/server          3755 passed, 1 skipped, 3 xfailed
pytest tests/db tests/stores tests/runtime tests/entities
                             2432 passed, 2 skipped, 4 pre-existing failures
ruff check . && ruff format --check .    clean
pyrefly check                            0 errors
```

The four failures are on `main` too (a missing optional Databricks module in
`tests/db/test_utils.py`, and one credential-environment test) — verified by
stashing this branch and re-running.

Manually: raise an approval, `kill -9` the server, start it again with the host
left running, reload the UI. On `main` the prompt is gone; here it is still
there and answering it releases the runner's parked turn. That is what the
recording above shows.

**On the benchmark check.** It compares against a nightly baseline built on
different hardware, at `--threshold 1.0`. Ran the same tool on this branch
against `main` locally, same machine, same seed:

| Journey | Status | Base P50 ms | Cand P50 ms | Δ P50 | Base P95 ms | Cand P95 ms | Δ P95 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| list_sessions | ok | 7.4 | 7.1 | -4.0% | 8.1 | 8.3 | +1.5% |
| get_session | ok | 7.1 | 7.0 | -1.4% | 8.4 | 8.2 | -2.9% |
| load_conversation_history | ok | 2.4 | 2.4 | -0.0% | 3.2 | 3.0 | -6.4% |

**PASS** — no regressions detected. (800 sessions x 40 items, 100 iterations,
3 runs, same machine for both sides.)

That is the expected result: `restore_for` is gated on
`conv.pending_elicitation_count > 0`, which is NULL on every seeded row, so the
snapshot path gains one attribute read and a comparison. Happy to re-run
against a fresher baseline if that is easier to trust.

## Demo

_Demo media was added after `demo-check` labelled this PR; the check is add-only, so the `needs-demo` label is stale rather than outstanding._

Two servers, one on stock `main` and one on this branch. Same session, same
approval, same `kill -9` and restart:

![main loses the approval; this branch keeps it](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/durable-approvals.gif)

First half is `main` — the session is still there, the question it was blocked
on is not. Second half is this branch: the card came back whole, with the
command intact and both buttons live.

Recorded against a real server, not a mockup; the scenario is
[here](https://github.com/Paldom/omnigent/blob/agent-army/docs/agent-army/media/durable-approvals.scenario.yaml)
if you want to re-run it.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The integration test is the regression test: it fails against `main` and passes
here, per the bug-fix expectation in `CONTRIBUTING.md`. Manual verification
covered the one thing no test can — an actual process restart with the runner
left alive — by stopping and starting the server between raising an approval
and answering it.

No new e2e test: this restores existing user-facing behaviour across a restart
rather than adding a new flow, and an e2e run cannot restart the server
mid-test anyway. Happy to add one if you would rather have it.

## Changelog

An approval you have not answered yet survives a server restart, instead of
leaving the sidebar showing a pending prompt that the session can no longer
display.

