### PR TITLE
feat(harnesses): declare skills, hooks, MCP and plan-mode support

### DIFF
--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -70,12 +70,16 @@ Declaring a new harness:
 - **`unavailable` must carry a `limitations` reason.** "It does not work" is a
   bug report; "the relay does not carry these tools" is something the next
   contributor can act on. A test enforces this.
-- **`skills` is derived, not declared.** A native harness ignores
-  `request.tools` and sees only `_NATIVE_RELAY_BUILTIN_TOOLS`, which omits
-  `load_skill` / `read_skill_file` — so the answer follows from the integration
-  mode. `tests/test_harness_capabilities.py` asserts the derivation against the
-  relay's own tool set, so adding the skill tools to the relay fails the test
-  until the declaration moves with it.
+- **Do not infer an axis from one mechanism.** `skills` is the cautionary
+  example: the native tool relay does not carry `load_skill` /
+  `read_skill_file`, which looks like "native harnesses cannot load skills" and
+  is not true. The native launch paths wire skills through the vendor's own
+  discovery instead — `claude_native_skill_args` hands the bundle to the real
+  `claude` binary via `--plugin-dir`, and `populate_codex_skills_from_bundle`
+  links them into the per-bridge `CODEX_HOME`. Both load `SKILL.md` files the
+  relay never sees. A cell is only as good as the mechanism you did not check.
+- **A declared cell carries `last_verified`.** A test enforces it: anything
+  other than `unknown` needs a bench run behind it.
 - **`plan_mode` means one specific thing:** a read-only planning phase where
   the harness proposes without editing. Not the vendor's UI mode of the same
   name, and not a policy that denies writes.

--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -42,6 +42,44 @@ the vendor's tool-calling interface.
 | **Images** | Image content (screenshots, diagrams) is forwarded — full binary, path reference, or text-flattened |
 | **Cost tracking** | Harness reports token usage and cost data back to Omnigent for each turn |
 
+### Declaring skills, hooks, MCP and plan mode
+
+Four axes on `HarnessCapabilities` are structured rather than boolean, because
+a bool cannot say the thing that matters about them — whether a feature works
+because the vendor implements it, or because Omnigent emulates it over a vendor
+that does not:
+
+```python
+skills: FeatureSupport   # can an agent here load an Omnigent SKILL.md?
+hooks: FeatureSupport    # can Omnigent interpose on this harness's tool calls?
+mcp: FeatureSupport      # is an MCP server from the agent YAML callable here?
+plan_mode: FeatureSupport  # can the harness propose a change without making it?
+```
+
+Each carries `support` (`native` / `shimmed` / `unavailable` / `unknown`),
+`mode` for the mechanism or the hook events covered, `limitations` for what
+does not work, and `last_verified` for a bench run id when the value was
+observed rather than read off the code.
+
+Declaring a new harness:
+
+- **Leave an axis `unknown` until you have checked it.** `unknown` and
+  `unavailable` are different claims, and guessing at one costs more than
+  leaving it blank — a published matrix is only worth having if its cells are
+  true.
+- **`unavailable` must carry a `limitations` reason.** "It does not work" is a
+  bug report; "the relay does not carry these tools" is something the next
+  contributor can act on. A test enforces this.
+- **`skills` is derived, not declared.** A native harness ignores
+  `request.tools` and sees only `_NATIVE_RELAY_BUILTIN_TOOLS`, which omits
+  `load_skill` / `read_skill_file` — so the answer follows from the integration
+  mode. `tests/test_harness_capabilities.py` asserts the derivation against the
+  relay's own tool set, so adding the skill tools to the relay fails the test
+  until the declaration moves with it.
+- **`plan_mode` means one specific thing:** a read-only planning phase where
+  the harness proposes without editing. Not the vendor's UI mode of the same
+  name, and not a policy that denies writes.
+
 ### MCP connectivity
 
 The harness must bridge Omnigent's builtin MCP tools so the model can call

--- a/omnigent/harness_capabilities.py
+++ b/omnigent/harness_capabilities.py
@@ -84,6 +84,56 @@ class ForkHistory(str, Enum):
     PREAMBLE = "preamble"  # replay prior turns as a text preamble (server-backed vendors)
 
 
+class Support(str, Enum):
+    """How a feature is provided, when it is provided at all.
+
+    The distinction that a plain bool cannot carry: a feature can be present
+    because the vendor implements it, or present because Omnigent emulates it
+    for a vendor that does not. Those are different things to a user deciding
+    which harness to reach for, and different work to a contributor closing a
+    gap.
+    """
+
+    NATIVE = "native"  # the vendor harness provides it directly
+    SHIMMED = "shimmed"  # Omnigent emulates it over a harness that lacks it
+    UNAVAILABLE = "unavailable"  # not reachable on this harness; needs vendor work
+    UNKNOWN = "unknown"  # not yet declared or verified
+
+
+@dataclass(frozen=True)
+class FeatureSupport:
+    """One feature's support on one harness.
+
+    :param support: Whether it is native, shimmed, unavailable, or undeclared.
+    :param mode: Vendor-specific detail — which mechanism provides it, or which
+        events a hook family covers, e.g. ``"PreToolUse,PostToolUse"``.
+    :param limitations: What does not work, in a sentence. A ``native`` cell
+        with a caveat is more useful than a ``shimmed`` one without.
+    :param last_verified: Bench run id and date behind a live-verified claim,
+        e.g. ``"bench-2026-08-20/run-14"``. ``None`` means the value is
+        declared from the code rather than observed.
+    """
+
+    support: Support = Support.UNKNOWN
+    mode: str | None = None
+    limitations: str | None = None
+    last_verified: str | None = None
+
+    def as_dict(self) -> dict[str, str | None]:
+        """Return a JSON-serializable view for the ``/v1/harnesses`` catalog."""
+        return {
+            "support": self.support.value,
+            "mode": self.mode,
+            "limitations": self.limitations,
+            "last_verified": self.last_verified,
+        }
+
+
+#: Default for an undeclared feature. Shared so every harness that has not
+#: declared one points at the same object rather than allocating a new one.
+UNKNOWN_SUPPORT = FeatureSupport()
+
+
 @dataclass(frozen=True)
 class HarnessCapabilities:
     """The declared feature set one harness supports.
@@ -119,6 +169,20 @@ class HarnessCapabilities:
     :param shell_tool_prompt: The prompt the bench sends to provoke that tool.
         Must contain the ``omnigent-bench-ok`` placeholder the probe token-swaps.
         ``None`` skips the probe.
+    :param skills: Whether an agent on this harness can load an Omnigent skill
+        (``load_skill`` / ``read_skill_file`` over a ``SKILL.md`` directory).
+        This is about reaching *Omnigent's* skills, not about whether the
+        vendor ships a skills feature of its own — an agent author writes one
+        skill and needs to know which harnesses will see it.
+    :param hooks: Whether Omnigent can interpose on the harness's tool calls.
+        ``mode`` names the events covered, since this is a family rather than
+        one switch, e.g. ``"PreToolUse"``.
+    :param mcp: Whether an MCP server declared in the agent YAML is callable
+        from this harness.
+    :param plan_mode: Whether the harness can be held in a read-only planning
+        phase — proposing a change without making it. Deliberately not the
+        vendor's UI mode of the same name, nor a policy that denies writes:
+        those are different things that have been conflated before.
     """
 
     integration_mode: IntegrationMode
@@ -137,8 +201,12 @@ class HarnessCapabilities:
     fork_history: ForkHistory = ForkHistory.NONE
     shell_tool_name: str | None = None
     shell_tool_prompt: str | None = None
+    skills: FeatureSupport = UNKNOWN_SUPPORT
+    hooks: FeatureSupport = UNKNOWN_SUPPORT
+    mcp: FeatureSupport = UNKNOWN_SUPPORT
+    plan_mode: FeatureSupport = UNKNOWN_SUPPORT
 
-    def as_dict(self) -> dict[str, str | bool | None]:
+    def as_dict(self) -> dict[str, str | bool | None | dict[str, str | None]]:
         """Return a JSON-serializable view for the ``/v1/harnesses`` catalog."""
         return {
             "integration_mode": self.integration_mode.value,
@@ -157,4 +225,8 @@ class HarnessCapabilities:
             "fork_history": self.fork_history.value,
             "shell_tool_name": self.shell_tool_name,
             "shell_tool_prompt": self.shell_tool_prompt,
+            "skills": self.skills.as_dict(),
+            "hooks": self.hooks.as_dict(),
+            "mcp": self.mcp.as_dict(),
+            "plan_mode": self.plan_mode.as_dict(),
         }

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -11,7 +11,7 @@ import importlib
 import importlib.metadata
 import logging
 from collections.abc import Callable, Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TypeVar, cast
 
 from omnigent._wrapper_labels import (
@@ -35,11 +35,13 @@ from omnigent.harness_capabilities import (
     AuthModel,
     EffortFamily,
     Elicitation,
+    FeatureSupport,
     ForkHistory,
     HarnessCapabilities,
     IntegrationMode,
     ModelFamily,
     Resume,
+    Support,
 )
 from omnigent.harness_install_spec import HarnessInstallSpec
 
@@ -647,6 +649,37 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
 # same generic wrap as the "acp" harness, so they share its declared profile.
 for _acp_cli_name in ACP_CLI_HARNESSES:
     _BUILTIN_CAPABILITIES[_acp_cli_name] = _BUILTIN_CAPABILITIES["acp"]
+
+# The skills axis follows from the tool surface rather than from anything a row
+# chooses, so it is derived here instead of repeated on eleven rows. A native
+# harness ignores ``request.tools`` and sees only the relay in
+# ``runner/tool_dispatch.py``, whose builtin set omits ``load_skill`` /
+# ``read_skill_file`` — so an agent on one cannot reach an Omnigent skill at
+# all. Every other integration mode gets the ordinary tool surface, where the
+# skill tools are Omnigent's own rather than the vendor's, hence ``shimmed``.
+# tests/test_harness_capabilities.py asserts this against the relay's actual
+# tool set so the declaration cannot drift away from the code behind it.
+_SKILLS_UNAVAILABLE = FeatureSupport(
+    support=Support.UNAVAILABLE,
+    limitations=(
+        "Native harnesses see only the Omnigent tool relay, which does not carry "
+        "load_skill / read_skill_file, so a SKILL.md directory is unreachable from "
+        "this harness."
+    ),
+)
+_SKILLS_SHIMMED = FeatureSupport(
+    support=Support.SHIMMED,
+    mode="load_skill / read_skill_file over a SKILL.md directory",
+)
+for _harness_name, _declared in _BUILTIN_CAPABILITIES.items():
+    _relay_only = _declared.integration_mode in (
+        IntegrationMode.NATIVE_TUI,
+        IntegrationMode.NATIVE_SERVER,
+    )
+    _BUILTIN_CAPABILITIES[_harness_name] = replace(
+        _declared,
+        skills=_SKILLS_UNAVAILABLE if _relay_only else _SKILLS_SHIMMED,
+    )
 
 
 _BUILTIN_CONTRIBUTION = HarnessContribution(

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -11,7 +11,7 @@ import importlib
 import importlib.metadata
 import logging
 from collections.abc import Callable, Iterable, Mapping
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from typing import TypeVar, cast
 
 from omnigent._wrapper_labels import (
@@ -35,13 +35,11 @@ from omnigent.harness_capabilities import (
     AuthModel,
     EffortFamily,
     Elicitation,
-    FeatureSupport,
     ForkHistory,
     HarnessCapabilities,
     IntegrationMode,
     ModelFamily,
     Resume,
-    Support,
 )
 from omnigent.harness_install_spec import HarnessInstallSpec
 
@@ -650,36 +648,19 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
 for _acp_cli_name in ACP_CLI_HARNESSES:
     _BUILTIN_CAPABILITIES[_acp_cli_name] = _BUILTIN_CAPABILITIES["acp"]
 
-# The skills axis follows from the tool surface rather than from anything a row
-# chooses, so it is derived here instead of repeated on eleven rows. A native
-# harness ignores ``request.tools`` and sees only the relay in
-# ``runner/tool_dispatch.py``, whose builtin set omits ``load_skill`` /
-# ``read_skill_file`` — so an agent on one cannot reach an Omnigent skill at
-# all. Every other integration mode gets the ordinary tool surface, where the
-# skill tools are Omnigent's own rather than the vendor's, hence ``shimmed``.
-# tests/test_harness_capabilities.py asserts this against the relay's actual
-# tool set so the declaration cannot drift away from the code behind it.
-_SKILLS_UNAVAILABLE = FeatureSupport(
-    support=Support.UNAVAILABLE,
-    limitations=(
-        "Native harnesses see only the Omnigent tool relay, which does not carry "
-        "load_skill / read_skill_file, so a SKILL.md directory is unreachable from "
-        "this harness."
-    ),
-)
-_SKILLS_SHIMMED = FeatureSupport(
-    support=Support.SHIMMED,
-    mode="load_skill / read_skill_file over a SKILL.md directory",
-)
-for _harness_name, _declared in _BUILTIN_CAPABILITIES.items():
-    _relay_only = _declared.integration_mode in (
-        IntegrationMode.NATIVE_TUI,
-        IntegrationMode.NATIVE_SERVER,
-    )
-    _BUILTIN_CAPABILITIES[_harness_name] = replace(
-        _declared,
-        skills=_SKILLS_UNAVAILABLE if _relay_only else _SKILLS_SHIMMED,
-    )
+# The four parity axes are left undeclared on every builtin harness, and that
+# is deliberate. An earlier cut derived ``skills`` from the native tool relay —
+# which does not carry ``load_skill`` / ``read_skill_file`` — and concluded that
+# no native harness can load a skill. That is wrong: the relay is one mechanism
+# of several, and the native launch paths wire skills through the vendor's own
+# discovery instead. ``claude_native_skill_args`` passes the bundle to the real
+# ``claude`` binary via ``--plugin-dir``; ``populate_codex_skills_from_bundle``
+# links them into the per-bridge ``CODEX_HOME``. Both load ``SKILL.md`` files
+# the relay never carries.
+#
+# So the honest value is ``unknown`` until the harness bench observes each one.
+# Deriving a published claim from a single mechanism is how a parity matrix
+# stops being true, which is the failure this axis exists to prevent.
 
 
 _BUILTIN_CONTRIBUTION = HarnessContribution(

--- a/tests/test_harness_capabilities.py
+++ b/tests/test_harness_capabilities.py
@@ -364,34 +364,30 @@ def test_every_harness_declares_the_four_parity_axes() -> None:
             assert isinstance(support, Support), f"{harness}.{axis} is not a Support"
 
 
-def test_skills_declaration_matches_the_relay_that_enforces_it() -> None:
-    """The skills axis must not drift from the tool surface behind it.
+def test_no_parity_axis_is_declared_without_a_bench_observation() -> None:
+    """An unverified cell must read ``unknown``, not a guess.
 
-    A native harness ignores ``request.tools`` and sees only the relay set in
-    ``runner/tool_dispatch.py``. If someone adds the skill tools to that relay,
-    this test fails and the declaration has to move with it — which is the
-    point, because the alternative is a published parity matrix that quietly
-    stops being true.
+    An earlier cut derived ``skills`` from the native tool relay and published
+    ``unavailable`` for every native harness. That was wrong — the relay is one
+    mechanism among several, and the native launch paths wire skills through
+    the vendor's own discovery (``claude_native_skill_args`` passes the bundle
+    to the real ``claude`` binary; ``populate_codex_skills_from_bundle`` links
+    them into ``CODEX_HOME``). A published matrix that infers from one
+    mechanism is how the matrix stops being true.
+
+    Filling these in is the harness bench's job, and a bench result carries
+    ``last_verified``. So: no declared support without one.
     """
-    from omnigent.harness_capabilities import IntegrationMode, Support
-    from omnigent.runner.tool_dispatch import (
-        _NATIVE_RELAY_BUILTIN_TOOLS,
-        _SKILL_TOOLS,
-    )
-
-    relay_carries_skills = bool(_SKILL_TOOLS & _NATIVE_RELAY_BUILTIN_TOOLS)
-    expected_for_native = Support.SHIMMED if relay_carries_skills else Support.UNAVAILABLE
+    from omnigent.harness_capabilities import Support
 
     for harness, capability in harness_capabilities().items():
-        relay_only = capability.integration_mode in (
-            IntegrationMode.NATIVE_TUI,
-            IntegrationMode.NATIVE_SERVER,
-        )
-        expected = expected_for_native if relay_only else Support.SHIMMED
-        assert capability.skills.support is expected, (
-            f"{harness} declares skills={capability.skills.support.value} "
-            f"but its tool surface says {expected.value}"
-        )
+        for axis in ("skills", "hooks", "mcp", "plan_mode"):
+            feature = getattr(capability, axis)
+            if feature.support is not Support.UNKNOWN:
+                assert feature.last_verified, (
+                    f"{harness}.{axis} claims {feature.support.value} with no bench run "
+                    "behind it — declare it unknown until the bench observes it"
+                )
 
 
 def test_an_unavailable_axis_says_why() -> None:

--- a/tests/test_harness_capabilities.py
+++ b/tests/test_harness_capabilities.py
@@ -118,6 +118,14 @@ def test_optional_bench_capabilities_default_to_unknown() -> None:
     assert capability.fork_history is ForkHistory.NONE
     assert capability.shell_tool_name is None
     assert capability.shell_tool_prompt is None
+    # The parity axes default to "unknown" rather than to a guess, so an
+    # undeclared feature is distinguishable from one checked and found absent.
+    unknown_feature = {
+        "support": "unknown",
+        "mode": None,
+        "limitations": None,
+        "last_verified": None,
+    }
     assert capability.as_dict() == {
         "integration_mode": "sdk-in-process",
         "elicitation": "none",
@@ -135,6 +143,10 @@ def test_optional_bench_capabilities_default_to_unknown() -> None:
         "fork_history": "none",
         "shell_tool_name": None,
         "shell_tool_prompt": None,
+        "skills": unknown_feature,
+        "hooks": unknown_feature,
+        "mcp": unknown_feature,
+        "plan_mode": unknown_feature,
     }
 
 
@@ -171,8 +183,13 @@ def test_catalog_rows_include_capabilities() -> None:
     for row in rows:
         if row["id"] in caps:
             assert "capabilities" in row, row["id"]
-            # JSON-serializable: values are primitives, not enums.
+            # JSON-serializable: primitives, or a flat dict of primitives for a
+            # structured axis. Nothing may still be an enum by this point.
             for value in row["capabilities"].values():
+                if isinstance(value, dict):
+                    for nested in value.values():
+                        assert nested is None or isinstance(nested, str)
+                    continue
                 assert value is None or isinstance(value, (str, bool))
 
 
@@ -328,3 +345,76 @@ def test_native_tui_harnesses_declare_shell_tool_provocation() -> None:
         assert capability.shell_tool_name, harness
         assert capability.shell_tool_prompt, harness
         assert "omnigent-bench-ok" in capability.shell_tool_prompt, harness
+
+
+# ── skills / hooks / MCP / plan-mode axes ──────────────────
+
+
+def test_every_harness_declares_the_four_parity_axes() -> None:
+    """The axes exist on every harness, even when the answer is "unknown".
+
+    An undeclared axis has to read as ``unknown`` rather than as absent, so a
+    consumer can tell "nobody has checked" apart from "checked, and no".
+    """
+    from omnigent.harness_capabilities import Support
+
+    for harness, capability in harness_capabilities().items():
+        for axis in ("skills", "hooks", "mcp", "plan_mode"):
+            support = getattr(capability, axis).support
+            assert isinstance(support, Support), f"{harness}.{axis} is not a Support"
+
+
+def test_skills_declaration_matches_the_relay_that_enforces_it() -> None:
+    """The skills axis must not drift from the tool surface behind it.
+
+    A native harness ignores ``request.tools`` and sees only the relay set in
+    ``runner/tool_dispatch.py``. If someone adds the skill tools to that relay,
+    this test fails and the declaration has to move with it — which is the
+    point, because the alternative is a published parity matrix that quietly
+    stops being true.
+    """
+    from omnigent.harness_capabilities import IntegrationMode, Support
+    from omnigent.runner.tool_dispatch import (
+        _NATIVE_RELAY_BUILTIN_TOOLS,
+        _SKILL_TOOLS,
+    )
+
+    relay_carries_skills = bool(_SKILL_TOOLS & _NATIVE_RELAY_BUILTIN_TOOLS)
+    expected_for_native = Support.SHIMMED if relay_carries_skills else Support.UNAVAILABLE
+
+    for harness, capability in harness_capabilities().items():
+        relay_only = capability.integration_mode in (
+            IntegrationMode.NATIVE_TUI,
+            IntegrationMode.NATIVE_SERVER,
+        )
+        expected = expected_for_native if relay_only else Support.SHIMMED
+        assert capability.skills.support is expected, (
+            f"{harness} declares skills={capability.skills.support.value} "
+            f"but its tool surface says {expected.value}"
+        )
+
+
+def test_an_unavailable_axis_says_why() -> None:
+    """An `unavailable` cell without a reason is not an honest grading.
+
+    "It does not work" is a bug report. "It does not work because the relay
+    does not carry these tools" is something a contributor can act on.
+    """
+    from omnigent.harness_capabilities import Support
+
+    for harness, capability in harness_capabilities().items():
+        for axis in ("skills", "hooks", "mcp", "plan_mode"):
+            feature = getattr(capability, axis)
+            if feature.support is Support.UNAVAILABLE:
+                assert feature.limitations, f"{harness}.{axis} is unavailable with no reason"
+
+
+def test_the_axes_reach_the_catalog() -> None:
+    """``GET /v1/harnesses`` has to carry them, or nothing can consume them."""
+    catalog = harness_catalog()
+    row = next(entry for entry in catalog if entry.get("capabilities"))
+    capabilities = row["capabilities"]
+
+    for axis in ("skills", "hooks", "mcp", "plan_mode"):
+        assert axis in capabilities, f"{axis} missing from the catalog"
+        assert set(capabilities[axis]) == {"support", "mode", "limitations", "last_verified"}


### PR DESCRIPTION
## Related issue

Closes #5152

## Summary

`HarnessCapabilities` has sixteen axes and none for skills, hooks, MCP or plan
mode — the four things people actually compare harnesses on. Today the only way
to answer "can an agent load a `SKILL.md` on `claude-native`?" is to read
`runner/tool_dispatch.py`.

This adds them as **structured values, not booleans**:

```python
support:       native | shimmed | unavailable | unknown
mode:          which mechanism, or which hook events
limitations:   what does not work
last_verified: bench run id, when observed rather than read off the code
```

A bool cannot distinguish a feature the vendor provides from one Omnigent
emulates over a vendor that lacks it, and those are different answers — to a
user picking a harness, and to a contributor deciding whether a gap is theirs
or the vendor's. `unknown` is the default, so "nobody has checked" stays
distinguishable from "checked, and no".

**All four axes start at `unknown`, and a test keeps them there until a bench
run says otherwise.** An earlier revision of this PR derived `skills` from
`_NATIVE_RELAY_BUILTIN_TOOLS` — which does not carry `load_skill` /
`read_skill_file` — and published `unavailable` for all eleven native
harnesses. That was wrong, and it is worth saying why, because it is the exact
failure the axis is meant to prevent.

The relay is one mechanism of several. The native launch paths wire skills
through the vendor's own discovery instead:

- `claude_native_skill_args` (`omnigent/inner/bundle_skills.py`) hands the
  bundle to the real `claude` binary via `--plugin-dir`, and its own docstring
  says the binary "discovers a bundle's `skills/<dir>/SKILL.md` files as plugin
  skills";
- `populate_codex_skills_from_bundle` links them into the per-bridge
  `CODEX_HOME`, where "Codex discovers `$CODEX_HOME/skills/<name>/` at startup".

So a `SKILL.md` does load on those harnesses, by a route the relay never sees.
Inferring a published claim from a single mechanism is how a parity matrix
stops being true.

`test_no_parity_axis_is_declared_without_a_bench_observation` now enforces the
rule: anything other than `unknown` must carry a `last_verified` bench run.
Filling the cells honestly is the bench's job (OMNI-14 / a follow-up), not this
PR's.

**Plan mode is defined here as one specific thing** — a read-only planning
phase where the harness proposes without editing — because it otherwise gets
read as the vendor's UI mode of the same name, or as a policy that denies
writes.

Purely additive: new fields with an `unknown` default, no behaviour change, and
`GET /v1/harnesses` gains four keys without losing any.

## Test Plan

Four new tests in `tests/test_harness_capabilities.py`:

- **`test_no_parity_axis_is_declared_without_a_bench_observation`** — the one
  that earns its keep. Any cell that is not `unknown` must carry a
  `last_verified`, so a future declaration cannot be asserted from reading one
  code path the way the first cut of this PR did.
- `test_every_harness_declares_the_four_parity_axes` — an undeclared axis reads
  as `unknown`, never as absent.
- `test_an_unavailable_axis_says_why` — an `unavailable` cell without a
  `limitations` reason is a bug report, not a grading.
- `test_the_axes_reach_the_catalog` — they survive to `GET /v1/harnesses`.

Two existing tests pinned the exact `as_dict()` shape and were updated for the
four new keys (`test_optional_bench_capabilities_default_to_unknown`,
`test_catalog_rows_include_capabilities`).

```
pytest tests/test_harness_capabilities.py     22 passed
pytest tests/harness_bench tests/cli          passed
ruff check . && ruff format --check .          clean
pyrefly check                                  0 errors
```

`tests/inner/test_seccomp.py` and `test_bwrap_sandbox.py` fail on this machine
(macOS — those are Linux kernel features) and fail identically on `main`;
confirmed by stashing the branch.

Checked the wire-shape change is safe: the capabilities dict is not in
`openapi.json`, and nothing under `web/src` reads these fields.

## Demo

No UI renders these keys, so the demo is the API response: the same request
against a server on `main` and one on this branch.

![capability axes](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/harness-capability-axes.gif)

On `main` a client cannot ask the question — the keys are not there:

![before](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/axes-before.png)

On this branch every harness carries all four axes:

![after](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/axes-all.png)

Each axis is a four-field object (`support` / `mode` / `limitations` /
`last_verified`), and every harness ships `unknown` deliberately. That is the
point of the change: a consumer can now ask, and the harness bench has
somewhere to write an *observed* answer. An earlier cut of this work derived
`skills` from the native tool relay and concluded no native harness could load
one — which is false, because the native launch paths wire skills through the
vendor's own discovery instead. A declaration nobody measured is exactly how a
parity matrix stops being true.

Reproduced by three one-line `curl | jq` scripts and a `vhs` tape, all
[committed with the media](https://github.com/Paldom/omnigent/tree/agent-army/docs/agent-army/media).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No e2e test: this adds declarative fields and changes no runtime behaviour, so
there is no flow for one to drive. The meaningful coverage is the invariant that
no cell may claim support without a bench run behind it — that is what stops the
next person declaring a value by reading one code path, which is the mistake
this PR made and corrected.

## Changelog

`GET /v1/harnesses` now carries skills, hooks, MCP and plan-mode support for
each harness, distinguishing native from shimmed support and "not checked yet"
from "checked, and no".

