### PR TITLE
OMNI-3741: update Worked collapsibles

### DIFF
--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -466,6 +466,59 @@ describe("BlockRenderer dispatch", () => {
       expect(screen.getByText("Worked for 1m 46s")).toBeDefined();
     });
 
+    it("uses a compact accessible trigger and pins expanded work to a vertical line", () => {
+      const items: RenderItem[] = [
+        tool(1),
+        { kind: "text", itemId: "m1", text: "Done.", final: true },
+      ];
+      render(<BlockRenderer items={items} sessionStatus="idle" />);
+
+      const trigger = screen.getByRole("button", { name: "Worked" });
+      expect(trigger).toHaveAttribute("type", "button");
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+      expect(trigger).toHaveClass("gap-2", "py-1");
+      expect(trigger).not.toHaveClass("w-full");
+      expect(trigger.querySelector(".border-t")).toBeNull();
+
+      trigger.focus();
+      expect(document.activeElement).toBe(trigger);
+      fireEvent.click(trigger);
+
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+      expect(trigger).toHaveAttribute("aria-controls");
+      const pinLine = screen.getByTestId("turn-worked-fold-pin-line");
+      expect(pinLine).toHaveAttribute("aria-hidden", "true");
+      expect(pinLine).toHaveClass("top-2", "bottom-0", "left-1", "w-px", "bg-border");
+      expect(pinLine.parentElement).toHaveClass("relative", "gap-2", "pt-2", "pl-4");
+      expect(screen.getByText("Called 1 tool")).toBeDefined();
+
+      fireEvent.click(trigger);
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+      expect(screen.queryByTestId("turn-worked-fold-pin-line")).toBeNull();
+    });
+
+    it("preserves an expanded Worked section when its duration updates", () => {
+      const items: RenderItem[] = [
+        tool(1),
+        { kind: "text", itemId: "m1", text: "Done.", final: true },
+      ];
+      const view = (workedForS: number) => (
+        <BlockRenderer items={items} sessionStatus="idle" workedForS={workedForS} />
+      );
+      const { rerender } = render(view(106));
+
+      fireEvent.click(screen.getByRole("button", { name: "Worked for 1m 46s" }));
+      expect(screen.getByText("Called 1 tool")).toBeDefined();
+
+      rerender(view(107));
+      expect(screen.getByRole("button", { name: "Worked for 1m 47s" })).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+      expect(screen.getByTestId("turn-worked-fold-pin-line")).toBeDefined();
+      expect(screen.getByText("Called 1 tool")).toBeDefined();
+    });
+
     describe("expand scroll-into-view", () => {
       // jsdom has no scrollIntoView — install a spy so the scroll path is
       // observable (and its absence provable).

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -452,7 +452,16 @@ describe("BlockRenderer dispatch", () => {
 
       fireEvent.click(screen.getByText("Worked"));
       expect(screen.getByText("Planning the run.")).toBeDefined();
-      expect(screen.getByText("Ran 2 shell commands, called 3 other tools")).toBeDefined();
+      const runLabel = screen.getByText("Ran 2 shell commands, called 3 other tools");
+      const runTrigger = runLabel.closest("button");
+      expect(runTrigger?.firstElementChild).toBe(runLabel);
+      expect(runTrigger?.lastElementChild?.tagName.toLowerCase()).toBe("svg");
+      expect(runTrigger).toHaveClass("text-chat");
+      expect(runTrigger).not.toHaveClass("text-sm");
+      fireEvent.click(runTrigger!);
+      const individualToolTrigger = screen.getByText(/tool_3/).closest("button");
+      expect(individualToolTrigger).toHaveClass("text-chat");
+      expect(individualToolTrigger).not.toHaveClass("text-sm");
       // The answer remains visible after expansion too.
       expect(screen.getByText("All done here.")).toBeDefined();
     });
@@ -477,8 +486,12 @@ describe("BlockRenderer dispatch", () => {
       expect(trigger).toHaveAttribute("type", "button");
       expect(trigger).toHaveAttribute("aria-expanded", "false");
       expect(trigger).toHaveClass("gap-2", "py-1");
+      expect(trigger).toHaveClass("text-chat");
+      expect(trigger).not.toHaveClass("text-sm");
       expect(trigger).not.toHaveClass("w-full");
       expect(trigger.querySelector(".border-t")).toBeNull();
+      expect(trigger.firstElementChild).toBe(screen.getByText("Worked"));
+      expect(trigger.lastElementChild?.tagName.toLowerCase()).toBe("svg");
 
       trigger.focus();
       expect(document.activeElement).toBe(trigger);
@@ -489,7 +502,7 @@ describe("BlockRenderer dispatch", () => {
       const pinLine = screen.getByTestId("turn-worked-fold-pin-line");
       expect(pinLine).toHaveAttribute("aria-hidden", "true");
       expect(pinLine).toHaveClass("top-2", "bottom-0", "left-1", "w-px", "bg-border");
-      expect(pinLine.parentElement).toHaveClass("relative", "gap-2", "pt-2", "pl-4");
+      expect(pinLine.parentElement).toHaveClass("relative", "gap-1", "pt-2", "pl-4");
       expect(screen.getByText("Called 1 tool")).toBeDefined();
 
       fireEvent.click(trigger);

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -514,9 +514,9 @@ function isProvisionalTrace(items: RenderItem[]): boolean {
 /**
  * Codex-style demarcation for a completed turn: the whole process
  * trace (narration, tool folds, reasoning) collapses behind one muted
- * "Worked for Xs" row with a hairline rule, so the final answer below
- * is unambiguously where reading starts. Expanding replays the trace
- * inline.
+ * "Worked for Xs" disclosure, so the final answer below is
+ * unambiguously where reading starts. Expanding replays the trace
+ * beside a compact vertical guide.
  *
  * `animateCollapse` marks the render where the fold appeared while the
  * user was watching. The fold then MOUNTS OPEN — showing exactly the
@@ -616,10 +616,9 @@ function TurnWorkedFold({
       {/* Height animation lives in index.css (it needs Radix's measured
           --radix-collapsible-content-height) and is disabled under
           prefers-reduced-motion. */}
-      {/* No padding/border on the animated element: any chrome here is
-          height that appears before the collapse starts, i.e. the jolt
-          this animation exists to remove. Expanded spacing comes from
-          the row's hairline above and the message column's gap below. */}
+      {/* Keep pt-2/pl-4 and the vertical pin inside the collapsible
+          content so the spacing and guide shrink with its existing
+          height animation. */}
       <CollapsibleContent
         className={cn("turn-fold-content", userOpened && "turn-fold-content-instant")}
       >

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -608,10 +608,9 @@ function TurnWorkedFold({
       data-testid="turn-worked-fold"
     >
       <div ref={rowRef} className={cn("turn-fold-row", animateCollapse && "turn-fold-row-enter")}>
-        <CollapsibleTrigger className="flex w-full cursor-pointer items-center gap-1 py-0.5 text-left text-muted-foreground text-sm transition-colors hover:text-foreground">
+        <CollapsibleTrigger className="flex cursor-pointer items-center gap-2 rounded-sm py-1 text-left text-muted-foreground text-sm outline-none transition-colors hover:text-foreground focus-visible:ring-3 focus-visible:ring-ring/50">
           <span className="shrink-0">{label}</span>
-          <ChevronRightIcon className="size-3.5 shrink-0 transition-transform group-data-[state=open]/turn-fold:rotate-90" />
-          <span aria-hidden className="ml-1 flex-1 border-border border-t" />
+          <ChevronRightIcon className="size-2.5 shrink-0 transition-transform group-data-[state=open]/turn-fold:rotate-90" />
         </CollapsibleTrigger>
       </div>
       {/* Height animation lives in index.css (it needs Radix's measured
@@ -624,7 +623,14 @@ function TurnWorkedFold({
       <CollapsibleContent
         className={cn("turn-fold-content", userOpened && "turn-fold-content-instant")}
       >
-        <div className="flex flex-col gap-2">{children}</div>
+        <div className="relative flex flex-col gap-2 pt-2 pl-4">
+          <span
+            aria-hidden
+            className="absolute top-2 bottom-0 left-1 w-px bg-border"
+            data-testid="turn-worked-fold-pin-line"
+          />
+          {children}
+        </div>
       </CollapsibleContent>
     </Collapsible>
   );

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -608,7 +608,7 @@ function TurnWorkedFold({
       data-testid="turn-worked-fold"
     >
       <div ref={rowRef} className={cn("turn-fold-row", animateCollapse && "turn-fold-row-enter")}>
-        <CollapsibleTrigger className="flex cursor-pointer items-center gap-2 rounded-sm py-1 text-left text-muted-foreground text-sm outline-none transition-colors hover:text-foreground focus-visible:ring-3 focus-visible:ring-ring/50">
+        <CollapsibleTrigger className="flex cursor-pointer items-center gap-2 rounded-sm py-1 text-left text-muted-foreground text-chat outline-none transition-colors hover:text-foreground focus-visible:ring-3 focus-visible:ring-ring/50">
           <span className="shrink-0">{label}</span>
           <ChevronRightIcon className="size-2.5 shrink-0 transition-transform group-data-[state=open]/turn-fold:rotate-90" />
         </CollapsibleTrigger>
@@ -622,7 +622,7 @@ function TurnWorkedFold({
       <CollapsibleContent
         className={cn("turn-fold-content", userOpened && "turn-fold-content-instant")}
       >
-        <div className="relative flex flex-col gap-2 pt-2 pl-4">
+        <div className="relative flex flex-col gap-1 pt-2 pl-4">
           <span
             aria-hidden
             className="absolute top-2 bottom-0 left-1 w-px bg-border"

--- a/web/src/components/blocks/ToolCard.tsx
+++ b/web/src/components/blocks/ToolCard.tsx
@@ -244,9 +244,9 @@ export function ToolGroupSummary({ tools }: { tools: RenderItem[] }) {
     // any ancestor `.group[data-state=open]` and incorrectly rotate
     // chevrons of inner tool cards when this outer group is open).
     <Collapsible defaultOpen={false} className="group/tool-summary not-prose w-full">
-      <CollapsibleTrigger className="flex cursor-pointer items-center gap-1.5 py-0.5 text-left text-muted-foreground text-sm transition-colors hover:text-foreground">
-        <ChevronRightIcon className="size-3.5 shrink-0 transition-transform group-data-[state=open]/tool-summary:rotate-90" />
+      <CollapsibleTrigger className="flex cursor-pointer items-center gap-1.5 py-0.5 text-left text-muted-foreground text-chat transition-colors hover:text-foreground">
         <span>{label}</span>
+        <ChevronRightIcon className="size-3.5 shrink-0 transition-transform group-data-[state=open]/tool-summary:rotate-90" />
       </CollapsibleTrigger>
       <CollapsibleContent className="mt-1 ml-2 space-y-1 border-l pl-3 pt-1 pb-0 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=open]:animate-in">
         {tools.map((item) => {
@@ -318,7 +318,7 @@ function ToolTriggerRow({
   return (
     <CollapsibleTrigger
       title={tooltip}
-      className="flex w-full cursor-pointer items-center gap-1.5 py-0.5 text-left text-muted-foreground text-sm transition-colors hover:text-foreground"
+      className="flex w-full cursor-pointer items-center gap-1.5 py-0.5 text-left text-muted-foreground text-chat transition-colors hover:text-foreground"
     >
       <StatusIcon name={name} nativeToolType={nativeToolType} state={state} />
       <span className="min-w-0 flex-1 truncate">


### PR DESCRIPTION
## Related issue

[OMNI-3741](https://linear.app/omnigent/issue/OMNI-3741/update-worked-collapsible-sections-in-the-chat-thread-to-match-the)

Design reference: https://agentic-ux-2026-omnigent.vercel.app/s/churn-analysis

## Summary

- Match the UX prototype's compact `Worked for …` disclosure layout: label followed by a small chevron, without the old trailing horizontal rule.
- Indent expanded work beneath a full-height vertical pin line while preserving Omnigent's existing theme tokens, Radix collapsible semantics, snap-to-top behavior, and settle animation.
- Add focused coverage for collapsed/expanded ARIA state, focusability, pin-line layout, interaction, and preserving user-open state when the duration updates.

ELI5: completed work now opens under a quiet vertical guide instead of stretching a horizontal divider across the chat, so the hidden steps read as one connected activity trace.

```text
Collapsed:  Worked for 3m 38s  ›

Expanded:   Worked for 3m 38s  ⌄
             │ narration / tool summaries
             │ more completed work
             final answer remains outside the fold
```

## Test Plan

- `cd web && npm test -- src/components/blocks/BlockRenderer.test.tsx` — 72 passed.
- `cd web && npm run type-check` — passed.
- `cd web && npm run lint` — passed.
- `cd web && npm test` — 294 files passed, 5,849 tests passed, 3 expected failures, 1 skipped.
- `uv run --offline --group lint pre-commit run web-prettier --files ...` — passed.
- `uv run --offline --group lint pre-commit run web-oxlint --files ...` — passed.
- `uv run --offline --group lint pre-commit run web-tsc --files ...` — passed.
- Real three-process stack: server + host on `:6767`, feature-worktree Vite on isolated `:5176` because `:5173`/`:5174` were owned by other tasks. Verified through the SP2K browser DOM in light and dark themes.
- Expanded a long settled trace: vertical line measured 1,290px high, content inset 16px, no trailing horizontal rule, correct `aria-expanded`, and stable snap-to-top interaction.

Repo-wide `pre-commit run --all-files` also ran: all frontend hooks passed; unrelated repo-wide `pyrefly` failed because the task-local lint environment lacks optional OpenTelemetry packages, and the VS Code extension typecheck exited without diagnostics.

## Demo

Collapsed, Light theme:

![Collapsed Worked section in Light theme](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-omni-3741-demo/tmp-screenshots/omni-3741/worked-collapsed-light.png)

Expanded with vertical pin line, Light theme:

![Expanded Worked section in Light theme](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-omni-3741-demo/tmp-screenshots/omni-3741/worked-expanded-light.png)

Expanded with vertical pin line, Dark theme:

![Expanded Worked section in Dark theme](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-omni-3741-demo/tmp-screenshots/omni-3741/worked-expanded-dark.png)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used the real Omnigent server, host, and feature-worktree Vite app. I checked collapsed and expanded sections, a long multi-step trace, snap-to-top behavior, focusable button semantics, alignment, the 16px content inset, vertical rail extent, and theme-token contrast in explicit Light and Dark modes. Existing lifecycle tests continue to cover live/streaming suppression, settle transitions, errors, pending elicitations, scheduled wakes, and revive behavior.

## Changelog

Completed work sections now use a compact disclosure and vertical activity guide that makes expanded steps easier to follow.