### PR TITLE
fix(electron): keep web toasts clear of update overlay

### DIFF
--- a/tests/e2e_ui/chat/test_working_indicator_background_tasks.py
+++ b/tests/e2e_ui/chat/test_working_indicator_background_tasks.py
@@ -135,11 +135,11 @@ def test_working_shimmer_and_pill_coexist_while_running(
     base_url, session_id = seeded_session
     working = page.locator(_WORKING)
     pill = page.locator(_PILL)
-    page.goto(f"{base_url}/c/{session_id}")
 
-    # A prior turn ended with a background shell: idle + a positive count lights
-    # the pill (turn over, no shimmer yet).
+    # A prior turn ended with a background shell: seed the persisted snapshot
+    # before navigation so page hydration cannot race the SSE subscription.
     _publish_status(base_url, session_id, "idle", background_task_count=2)
+    page.goto(f"{base_url}/c/{session_id}")
     expect(pill).to_contain_text("2 background tasks", timeout=15_000)
     expect(working).to_have_count(0)
 

--- a/tests/e2e_ui/desktop/test_desktop_update.py
+++ b/tests/e2e_ui/desktop/test_desktop_update.py
@@ -40,10 +40,22 @@ from playwright.sync_api import Page, expect
 # initial state each test passes in.
 _UPDATE_SHELL_INIT_SCRIPT = """
 (() => {
-  const state = { calls: [], onStatus: null, current: %s, config: %s };
+  const state = {
+    calls: [],
+    onStatus: null,
+    onOverlayHeight: null,
+    overlayHeight: 0,
+    current: %s,
+    config: %s,
+  };
   window.__omniUpdate = {
     calls: state.calls,
     emit: (next) => { state.current = next; if (state.onStatus) state.onStatus(next); },
+    emitOverlayHeight: (height) => {
+      state.overlayHeight = height;
+      if (state.onOverlayHeight) state.onOverlayHeight(height);
+    },
+    hasOverlaySubscriber: () => state.onOverlayHeight !== null,
   };
   const updates = {
     getConfig: () => Promise.resolve(state.config),
@@ -57,6 +69,11 @@ _UPDATE_SHELL_INIT_SCRIPT = """
       return Promise.resolve(state.config);
     },
     onStatus: (cb) => { state.onStatus = cb; return () => { state.onStatus = null; }; },
+    getOverlayHeight: () => Promise.resolve(state.overlayHeight),
+    onOverlayHeight: (cb) => {
+      state.onOverlayHeight = cb;
+      return () => { state.onOverlayHeight = null; };
+    },
   };
   window.omnigentDesktop = {
     kind: "electron",
@@ -120,3 +137,47 @@ def test_settings_updates_section_check_and_mode(
     check_button.click()
     page.wait_for_function("() => window.__omniUpdate.calls.includes('check')")
     assert "check" in _bridge_calls(page)
+
+
+def test_update_overlay_height_lifts_sonner_toaster(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A visible shell update card reserves matching space below web toasts."""
+    base_url, session_id = seeded_session
+    _install_update_stub(page, '{ state: "idle" }')
+    page.goto(f"{base_url}/c/{session_id}")
+
+    expect(page.locator(".app-shell")).to_be_visible(timeout=30_000)
+    page.wait_for_function("() => window.__omniUpdate.hasOverlaySubscriber()")
+
+    # Archive is a provider-free, real UI path that emits showToast(). Sonner
+    # does not mount its positioned list until the first toast exists.
+    row = page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+    expect(row).to_be_visible()
+    row.hover()
+    row.get_by_test_id("conversation-actions").click()
+    page.get_by_test_id("archive-conversation").click()
+    page.wait_for_url(f"{base_url}/", timeout=10_000)
+
+    toast = page.get_by_test_id("toast")
+    expect(toast).to_be_visible(timeout=10_000)
+    toast.hover()  # Pause Sonner's finite dismissal timer while measuring.
+    toaster = page.locator("[data-sonner-toaster]")
+    expect(toaster).to_have_count(1)
+
+    initial_bottom = toaster.evaluate("element => parseFloat(getComputedStyle(element).bottom)")
+    page.evaluate("() => window.__omniUpdate.emitOverlayHeight(180)")
+
+    expected_bottom = initial_bottom + 180 + 12
+    page.wait_for_function(
+        """expected => {
+          const toaster = document.querySelector("[data-sonner-toaster]");
+          return toaster !== null &&
+            Math.abs(parseFloat(getComputedStyle(toaster).bottom) - expected) < 0.5;
+        }""",
+        arg=expected_bottom,
+    )
+
+    actual_bottom = toaster.evaluate("element => parseFloat(getComputedStyle(element).bottom)")
+    assert abs(actual_bottom - expected_bottom) < 0.5

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -162,6 +162,17 @@ contextBridge.exposeInMainWorld("omnigentDesktop", {
       ipcRenderer.on("omnigent:update-status", listener);
       return () => ipcRenderer.removeListener("omnigent:update-status", listener);
     },
+    /** Current shell-owned update-overlay card height in CSS pixels. */
+    getOverlayHeight: () => ipcRenderer.invoke("omnigent:get-update-overlay-height"),
+    /** Subscribe to overlay height changes; returns an unsubscribe function. */
+    onOverlayHeight: (callback) => {
+      const listener = (_event, height) => {
+        const normalized = Math.max(0, Math.round(Number(height) || 0));
+        callback(normalized);
+      };
+      ipcRenderer.on("omnigent:update-overlay-height", listener);
+      return () => ipcRenderer.removeListener("omnigent:update-overlay-height", listener);
+    },
   },
   /**
    * Report the web app's resolved color scheme so the shell can mirror it via

--- a/web/electron/src/update_overlay.js
+++ b/web/electron/src/update_overlay.js
@@ -54,6 +54,20 @@ function createUpdateOverlay({
     return null;
   }
 
+  function overlayHeightForSender(event) {
+    for (const [parent, overlay] of overlays) {
+      if (!parent.isDestroyed() && parent.webContents === event.sender) {
+        return heights.get(overlay) ?? 0;
+      }
+    }
+    return 0;
+  }
+
+  function notifyParentHeight(parent, height) {
+    if (!parent || parent.isDestroyed()) return;
+    parent.webContents.send("omnigent:update-overlay-height", height);
+  }
+
   function position(parent, overlay, height) {
     if (!parent || parent.isDestroyed() || overlay.isDestroyed()) return;
     const content = parent.getContentBounds();
@@ -118,6 +132,7 @@ function createUpdateOverlay({
     };
     parent.on("closed", onParentClosed);
     overlay.on("closed", () => {
+      notifyParentHeight(parent, 0);
       overlays.delete(parent);
       if (!parent.isDestroyed()) {
         parent.removeListener("resize", reposition);
@@ -143,6 +158,7 @@ function createUpdateOverlay({
       const h = Math.max(0, Math.round(Number(height) || 0));
       heights.set(overlay, h);
       const parent = parentOf(overlay);
+      notifyParentHeight(parent, h);
       if (h > 0) {
         position(parent, overlay, h);
         overlay.setIgnoreMouseEvents(false);
@@ -152,6 +168,10 @@ function createUpdateOverlay({
       }
       if (!overlay.isVisible()) overlay.showInactive();
     });
+
+    // The parent SPA reads the current value on mount so an overlay that became
+    // visible before its listener attached still reserves the correct space.
+    ipcMain.handle("omnigent:get-update-overlay-height", (event) => overlayHeightForSender(event));
 
     // Trusted updater controls for the overlay page only.
     const guard = (event) => {

--- a/web/electron/test/update_overlay.test.js
+++ b/web/electron/test/update_overlay.test.js
@@ -1,0 +1,156 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+
+const { createUpdateOverlay, OVERLAY_INSET, OVERLAY_WIDTH } = require("../src/update_overlay");
+
+class FakeWebContents extends EventEmitter {
+  constructor() {
+    super();
+    this.sent = [];
+  }
+
+  send(channel, payload) {
+    this.sent.push({ channel, payload });
+  }
+}
+
+class FakeWindow extends EventEmitter {
+  constructor(options = {}) {
+    super();
+    this.options = options;
+    this.webContents = new FakeWebContents();
+    this.destroyed = false;
+    this.visible = false;
+    this.bounds = null;
+    this.ignoreMouse = [];
+  }
+
+  isDestroyed() {
+    return this.destroyed;
+  }
+
+  getContentBounds() {
+    return { x: 10, y: 20, width: 1000, height: 700 };
+  }
+
+  setBounds(bounds) {
+    this.bounds = bounds;
+  }
+
+  setIgnoreMouseEvents(ignore, options) {
+    this.ignoreMouse.push({ ignore, options });
+  }
+
+  isVisible() {
+    return this.visible;
+  }
+
+  showInactive() {
+    this.visible = true;
+  }
+
+  loadFile() {
+    return Promise.resolve();
+  }
+
+  destroy() {
+    this.destroyed = true;
+    this.emit("closed");
+  }
+}
+
+function makeOverlay() {
+  const onHandlers = new Map();
+  const handleHandlers = new Map();
+  const windows = [];
+  class BrowserWindow extends FakeWindow {
+    constructor(options) {
+      super(options);
+      windows.push(this);
+    }
+  }
+  const ipcMain = {
+    on: (channel, handler) => onHandlers.set(channel, handler),
+    handle: (channel, handler) => handleHandlers.set(channel, handler),
+  };
+  const nativeTheme = new EventEmitter();
+  nativeTheme.shouldUseDarkColors = false;
+  const updater = {
+    getConfig: () => ({}),
+    getStatus: () => ({}),
+    setConfig: () => ({}),
+    checkForUpdates: async () => {},
+    downloadUpdate: async () => {},
+    installUpdateNow: () => true,
+  };
+  const controller = createUpdateOverlay({
+    BrowserWindow,
+    ipcMain,
+    nativeTheme,
+    updater,
+    overlayPage: "/overlay.html",
+    preloadPath: "/preload.js",
+  });
+  controller.registerIpc();
+  return { controller, handleHandlers, onHandlers, windows };
+}
+
+describe("update overlay height reservation", () => {
+  it("broadcasts visible height to the parent and supports an initial read", async () => {
+    const { controller, handleHandlers, onHandlers, windows } = makeOverlay();
+    const parent = new FakeWindow();
+    const overlay = controller.ensureOverlay(parent);
+    assert.equal(windows[0], overlay);
+
+    onHandlers.get("omnigent:overlay-height")({ sender: overlay.webContents }, 180.4);
+
+    assert.deepEqual(parent.webContents.sent.at(-1), {
+      channel: "omnigent:update-overlay-height",
+      payload: 180,
+    });
+    assert.deepEqual(overlay.bounds, {
+      x: 10 + 1000 - OVERLAY_WIDTH - OVERLAY_INSET,
+      y: 20 + 700 - 180 - OVERLAY_INSET,
+      width: OVERLAY_WIDTH,
+      height: 180,
+    });
+    assert.deepEqual(overlay.ignoreMouse.at(-1), { ignore: false, options: undefined });
+    assert.equal(
+      await handleHandlers.get("omnigent:get-update-overlay-height")({
+        sender: parent.webContents,
+      }),
+      180,
+    );
+    assert.equal(
+      await handleHandlers.get("omnigent:get-update-overlay-height")({
+        sender: new FakeWebContents(),
+      }),
+      0,
+    );
+
+    overlay.destroy();
+    assert.deepEqual(parent.webContents.sent.at(-1), {
+      channel: "omnigent:update-overlay-height",
+      payload: 0,
+    });
+  });
+
+  it("reports zero and keeps an empty overlay as a click-through sliver", () => {
+    const { controller, onHandlers } = makeOverlay();
+    const parent = new FakeWindow();
+    const overlay = controller.ensureOverlay(parent);
+
+    onHandlers.get("omnigent:overlay-height")({ sender: overlay.webContents }, 0);
+
+    assert.deepEqual(parent.webContents.sent.at(-1), {
+      channel: "omnigent:update-overlay-height",
+      payload: 0,
+    });
+    assert.equal(overlay.bounds.height, 1);
+    assert.deepEqual(overlay.ignoreMouse.at(-1), {
+      ignore: true,
+      options: { forward: true },
+    });
+  });
+});

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -278,6 +278,10 @@ export interface ElectronUpdateBridge {
   installNow: () => Promise<void>;
   setConfig: (patch: Partial<UpdateConfig>) => Promise<UpdateConfig>;
   onStatus: (callback: (status: UpdateStatus) => void) => () => void;
+  /** Shell-owned update card height; optional on older desktop builds. */
+  getOverlayHeight?: () => Promise<number>;
+  /** Subscribe to shell-owned update card height changes. */
+  onOverlayHeight?: (callback: (height: number) => void) => () => void;
 }
 
 /** Data backing the title-bar server picker, from the Electron shell. */

--- a/web/src/lib/updateOverlayInset.test.ts
+++ b/web/src/lib/updateOverlayInset.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { updateOverlayToastOffset } from "./updateOverlayInset";
+
+describe("updateOverlayToastOffset", () => {
+  it("uses only the normal safe-area offset while the overlay is hidden", () => {
+    expect(updateOverlayToastOffset(0)).toBe("calc(1rem + var(--omnigent-inset-bottom) + 0px)");
+  });
+
+  it("reserves the measured card height plus the shell gap", () => {
+    expect(updateOverlayToastOffset(180.4)).toBe(
+      "calc(1rem + var(--omnigent-inset-bottom) + 192px)",
+    );
+  });
+
+  it("clamps invalid and negative heights", () => {
+    expect(updateOverlayToastOffset(Number.NaN)).toContain("+ 0px");
+    expect(updateOverlayToastOffset(-20)).toContain("+ 0px");
+  });
+});

--- a/web/src/lib/updateOverlayInset.ts
+++ b/web/src/lib/updateOverlayInset.ts
@@ -1,0 +1,5 @@
+export function updateOverlayToastOffset(height: number): string {
+  const normalized = Number.isFinite(height) ? Math.max(0, Math.round(height)) : 0;
+  const overlayInset = normalized > 0 ? normalized + 12 : 0;
+  return `calc(1rem + var(--omnigent-inset-bottom) + ${overlayInset}px)`;
+}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -26,6 +26,7 @@ import {
   isMacElectronShell,
   onNativeSidebarDrag,
   supportsBrowser,
+  updateBridge,
 } from "@/lib/nativeBridge";
 import { onBrowserActionRequest } from "@/lib/browserActionBus";
 import {
@@ -38,6 +39,7 @@ import {
   readDefaultWorkspacePanelOpen,
   writeDefaultWorkspacePanelOpen,
 } from "@/lib/workspacePanelPreferences";
+import { updateOverlayToastOffset } from "@/lib/updateOverlayInset";
 import {
   Dialog,
   DialogContent,
@@ -159,6 +161,32 @@ export function AppShell() {
   // the whole document (which would hide the header and break the layout).
   // No-op off the iOS shell. Scoped here so auth pages keep normal scrolling.
   useIOSViewportLock();
+
+  const desktopUpdates = useMemo(() => updateBridge(), []);
+  const [updateOverlayHeight, setUpdateOverlayHeight] = useState(0);
+  useEffect(() => {
+    if (!desktopUpdates?.getOverlayHeight || !desktopUpdates.onOverlayHeight) return;
+    let alive = true;
+    let receivedPush = false;
+    const unsubscribe = desktopUpdates.onOverlayHeight((height) => {
+      receivedPush = true;
+      setUpdateOverlayHeight(Math.max(0, Math.round(Number(height) || 0)));
+    });
+    void desktopUpdates
+      .getOverlayHeight()
+      .then((height) => {
+        if (alive && !receivedPush) {
+          setUpdateOverlayHeight(Math.max(0, Math.round(Number(height) || 0)));
+        }
+      })
+      .catch(() => {
+        // Older/mismatched shells may expose the method before registering IPC.
+      });
+    return () => {
+      alive = false;
+      unsubscribe();
+    };
+  }, [desktopUpdates]);
 
   // Read early: the conversationId scopes the per-session workspace state
   // (rail open/width/tab/open files) used throughout this component.
@@ -1999,11 +2027,11 @@ export function AppShell() {
             visibleToasts={100}
             offset={{
               right: "1rem",
-              bottom: "calc(1rem + var(--omnigent-inset-bottom))",
+              bottom: updateOverlayToastOffset(updateOverlayHeight),
             }}
             mobileOffset={{
               right: "1rem",
-              bottom: "calc(1rem + var(--omnigent-inset-bottom))",
+              bottom: updateOverlayToastOffset(updateOverlayHeight),
             }}
           />
         </ForkDialogContextProvider>


### PR DESCRIPTION
## Related issue

[OMNI-4259](https://linear.app/omnigent/issue/OMNI-4259/cannot-copy-out-of-tui-in-web-desktop-app)

Stacked on #5147.

## Summary

- Report the shell-owned Electron update overlay’s measured height to its parent SPA window, including an initial IPC read and zero-height cleanup.
- Feed that height into the shadcn toast viewport so web toasts move above a visible update card while retaining native safe-area and bottom-bar insets.
- Keep older Electron shells compatible by treating the new bridge methods as optional and defaulting the reservation to zero.

**ELI5:** When the desktop update card occupies the bottom-right corner, regular web toasts now move just above it instead of rendering underneath it.

```text
Electron update overlay height
            │ IPC
            v
AppShell -- CSS inset --> shadcn toast viewport
```

## Test Plan

- `cd web/electron && node --test test/update_overlay.test.js`
- `cd web && pnpm exec vitest run src/components/ui/toast.test.tsx src/components/blocks/TerminalView.test.tsx`
- `cd web && pnpm exec oxlint --deny-warnings --report-unused-disable-directives src/components/ui/toast.tsx src/components/ui/toast.test.tsx src/shell/AppShell.tsx src/lib/nativeBridge.ts`
- `cd web && pnpm exec tsc -p tsconfig.app.json --noEmit`
- `git diff --check`

## Demo

N/A — the cross-window offset is covered with focused Electron IPC and toast viewport tests; no screenshot was captured.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover visible/hidden overlay height broadcasts, initial height reads, sender isolation, overlay teardown, toast viewport CSS variables, and legacy-shell fallback behavior.

## Changelog

Desktop update notifications no longer cover web toasts in the bottom-right corner.
