### PR TITLE
fix(claude-native): accept persisted canonical model ids at cold resume

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -399,13 +399,16 @@ class ClaudeNativeUcodeConfig:
     routable_models: tuple[str, ...] = ()
 
 
-def _serves_canonical_anthropic_ids(claude_config: ClaudeNativeUcodeConfig) -> bool:
+def _serves_canonical_anthropic_ids(claude_config: ClaudeNativeUcodeConfig | None) -> bool:
     """Whether the config's endpoint accepts canonical Anthropic ids and aliases.
 
     Bedrock and custom gateways route their own model ids only; the Anthropic
-    API (and a config with no endpoint override) resolves family aliases
-    natively, so aliases must not be rewritten for it.
+    API (a direct login's ``None`` config, or a config with no endpoint
+    override) resolves family aliases natively, so aliases must not be
+    rewritten for it.
     """
+    if claude_config is None:
+        return True
     if claude_config.env.get(_ANTHROPIC_BEDROCK_BASE_URL_ENV):
         return False
     base_url = claude_config.env.get(_UCODE_CLAUDE_BASE_URL_ENV)
@@ -1087,7 +1090,7 @@ async def claude_model_catalog(
     if probe is None:
         return None
     rows = list(probe.alias_rows)
-    if claude_config is not None and not _serves_canonical_anthropic_ids(claude_config):
+    if not _serves_canonical_anthropic_ids(claude_config):
         rows = [row for row in rows if not str(row.get("model", "")).startswith("claude-")]
 
     configured_pin = claude_config.model if claude_config is not None else None
@@ -1109,10 +1112,8 @@ async def claude_model_catalog(
         # Append the observed default as its own honest row — but never
         # claim a bare Anthropic id is launchable on an endpoint that
         # rejects that spelling.
-        servable = (
-            claude_config is None
-            or _serves_canonical_anthropic_ids(claude_config)
-            or not default_model.startswith("claude-")
+        servable = _serves_canonical_anthropic_ids(claude_config) or not default_model.startswith(
+            "claude-"
         )
         if servable:
             # The probe's printed label describes the ENUMERATION run's
@@ -1153,6 +1154,46 @@ async def claude_launch_catalog(
     return await model_catalog_store.ensure_catalog(
         "claude-native", fingerprint, lambda: claude_model_catalog(claude_config)
     )
+
+
+def claude_catalog_accepts(
+    rows: list[dict[str, object]],
+    token: str,
+    claude_config: ClaudeNativeUcodeConfig | None,
+) -> bool:
+    """Whether *token* names a model this launch config can start.
+
+    An exact catalog row is authoritative. Beyond that, a canonical
+    Anthropic id launches verbatim (``--model`` takes any string) on an
+    endpoint that serves canonical spellings — and a live ``/model``
+    persists exactly that spelling, so the exact-row test alone strands a
+    resumed session whose catalog lists only the family aliases. Accept
+    the id when its family alias-folds onto a catalog row; a gateway that
+    rejects canonical spellings vouches for nothing here. The fold cannot
+    tell a retired generation from a live one (the catalog spells neither),
+    so a stale ``claude-*`` id passes the gate and fails visibly at the
+    pane instead — the deliberate trade-off, since the reverse (rejecting
+    every unspelled canonical id) strands resumable sessions.
+
+    :param rows: Catalog rows from :func:`claude_launch_catalog`.
+    :param token: A picker row id, family alias, or canonical model id.
+    :param claude_config: The resolved launch config, or ``None`` for a
+        direct Claude login.
+    :returns: ``True`` when the launch should proceed with *token*.
+    """
+    from omnigent.claude_model_vocabulary import claude_model_alias
+    from omnigent.model_catalog_store import catalog_contains
+
+    if catalog_contains(rows, token):
+        return True
+    if not _serves_canonical_anthropic_ids(claude_config):
+        return False
+    # Case-sensitive on purpose: canonical ids are lowercase, and vouching
+    # for a respelled variant would launch a spelling nothing validated.
+    if not token.startswith("claude-"):
+        return False
+    alias = claude_model_alias(token, claude_config.env if claude_config else {})
+    return alias is not None and catalog_contains(rows, alias)
 
 
 def build_native_claude_terminal_env(

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -6486,8 +6486,8 @@ async def _auto_create_claude_terminal(
     # or to resolve a Default launch that would otherwise pass no ``--model``
     # and leave the model to invisible CLI-private state.
     if session_model_override or launch_model is None:
-        from omnigent.claude_native import claude_launch_catalog
-        from omnigent.model_catalog_store import catalog_contains, default_row
+        from omnigent.claude_native import claude_catalog_accepts, claude_launch_catalog
+        from omnigent.model_catalog_store import default_row
 
         launch_catalog: list[dict[str, object]] | None = None
         try:
@@ -6502,8 +6502,8 @@ async def _auto_create_claude_terminal(
                 or session_model_override
             )
             if not (
-                catalog_contains(launch_catalog, session_model_override)
-                or catalog_contains(launch_catalog, resolved_request)
+                claude_catalog_accepts(launch_catalog, session_model_override, claude_config)
+                or claude_catalog_accepts(launch_catalog, resolved_request, claude_config)
             ):
                 raise click.ClickException(
                     f"the requested model {session_model_override!r} is not in this "

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -9488,6 +9488,118 @@ async def test_claude_model_catalog_never_appends_an_unservable_default(
     assert all(row.get("isDefault") is not True for row in rows)
 
 
+def _direct_login_catalog() -> list[dict[str, object]]:
+    """The catalog a direct Claude login's probe yields: aliases + default."""
+    return [
+        {"id": "sonnet", "model": "sonnet", "displayName": "sonnet"},
+        {"id": "opus", "model": "opus", "displayName": "opus"},
+        {"id": "fable", "model": "fable", "displayName": "fable"},
+        {"id": "fable[1m]", "model": "fable[1m]", "displayName": "fable[1m]"},
+        {
+            "id": "claude-opus-4-8[1m]",
+            "model": "claude-opus-4-8[1m]",
+            "displayName": "Opus 4.8 (1M context)",
+            "isDefault": True,
+        },
+    ]
+
+
+def test_claude_catalog_accepts_exact_rows() -> None:
+    """An exact row hit accepts, on any config shape."""
+    rows = _direct_login_catalog()
+    assert claude_native.claude_catalog_accepts(rows, "fable", None)
+    assert claude_native.claude_catalog_accepts(rows, "claude-opus-4-8[1m]", None)
+    assert claude_native.claude_catalog_accepts(rows, "fable", _gateway_probe_config())
+
+
+def test_claude_catalog_accepts_canonical_id_on_direct_login() -> None:
+    """A persisted canonical id relaunches when its family alias is a row.
+
+    A live ``/model fable`` echoes the pane's resolved ``claude-fable-5``
+    into the session's model override, but the direct-login catalog only
+    lists the family aliases — the exact-row test alone strands the session
+    at cold resume even though ``--model claude-fable-5`` launches verbatim.
+    """
+    rows = _direct_login_catalog()
+    assert claude_native.claude_catalog_accepts(rows, "claude-fable-5", None)
+    assert claude_native.claude_catalog_accepts(rows, "claude-fable-5[1m]", None)
+
+
+def test_claude_catalog_rejects_canonical_id_on_a_gateway() -> None:
+    """A gateway endpoint rejects canonical spellings, so the gate must too."""
+    rows = _direct_login_catalog()
+    assert not claude_native.claude_catalog_accepts(
+        rows, "claude-fable-5", _gateway_probe_config()
+    )
+
+
+def test_claude_catalog_rejects_ids_with_no_catalog_family() -> None:
+    """Alias-folding cannot vouch for a family the catalog does not list."""
+    rows = _direct_login_catalog()
+    assert not claude_native.claude_catalog_accepts(rows, "claude-nova-1", None)
+    assert not claude_native.claude_catalog_accepts(rows, "gpt-5.4", None)
+
+
+def test_claude_catalog_rejects_respelled_canonical_ids() -> None:
+    """A non-lowercase ``claude-*`` spelling is nothing the API serves.
+
+    The exact-row test is case-sensitive, so vouching for a respelled
+    variant via the (internally lowercasing) alias fold would pass the gate
+    for a spelling the launch then hands over unvalidated.
+    """
+    rows = _direct_login_catalog()
+    assert not claude_native.claude_catalog_accepts(rows, "Claude-Fable-5", None)
+    assert not claude_native.claude_catalog_accepts(rows, "CLAUDE-FABLE-5", None)
+
+
+def test_claude_catalog_accepts_unspelled_generations_by_design() -> None:
+    """Any generation of a catalog family passes; staleness fails at the pane.
+
+    The fold has no oracle for live generations (the catalog spells only the
+    aliases — the very gap that strands resumed sessions), so a stale or
+    fabricated id of a listed family passes the gate and fails visibly at
+    inference rather than fast. Deliberate: the reverse re-strands sessions.
+    """
+    rows = _direct_login_catalog()
+    assert claude_native.claude_catalog_accepts(rows, "claude-opus-0-0", None)
+
+
+def test_claude_catalog_pin_normalization_is_symmetric() -> None:
+    """``[1m]`` spellings normalize the same in the token and in the pin."""
+    rows = _direct_login_catalog()
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_DEFAULT_FABLE_MODEL": "claude-fable-5[1m]"},
+    )
+    assert claude_native.claude_catalog_accepts(rows, "claude-fable-5", config)
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_DEFAULT_FABLE_MODEL": "claude-fable-5"},
+    )
+    assert claude_native.claude_catalog_accepts(rows, "claude-fable-5[1m]", config)
+
+
+def test_claude_catalog_ignores_empty_pin_values() -> None:
+    """An empty-string pin is no pin: segment fallback still vouches."""
+    rows = _direct_login_catalog()
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_DEFAULT_OPUS_MODEL": ""},
+    )
+    assert claude_native.claude_catalog_accepts(rows, "claude-fable-5", config)
+
+
+def test_claude_catalog_accepts_canonical_id_matching_a_pin() -> None:
+    """On a pinned canonical endpoint, an exact pin match vouches for the id."""
+    rows = _direct_login_catalog()
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_DEFAULT_FABLE_MODEL": "claude-fable-5"},
+    )
+    assert claude_native.claude_catalog_accepts(rows, "claude-fable-5", config)
+    # A MISMATCHED pin means the alias resolves elsewhere; no vouching.
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_DEFAULT_FABLE_MODEL": "claude-fable-6"},
+    )
+    assert not claude_native.claude_catalog_accepts(rows, "claude-fable-5", config)
+
+
 async def test_claude_model_catalog_marks_the_launch_pin_as_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #5158

## Summary

- A live `/model` switch persists the pane's resolved **canonical id** (e.g. `claude-fable-5`) as the session's model override, but a direct Claude login's launch catalog lists only the family aliases plus the probed default — so the exact-row gate in `_auto_create_claude_terminal` refused every cold resume of such a session with *"the requested model … is not in this host's current model list"*, even though `--model` takes the exact id verbatim on that endpoint.
- Adds `claude_catalog_accepts(rows, token, claude_config)` next to the catalog helpers in `omnigent/claude_native.py`: an exact catalog row still wins; beyond that, a canonical Anthropic id is accepted when the endpoint serves canonical spellings (`_serves_canonical_anthropic_ids`) and the id's family alias-folds (`claude_model_alias`) onto a catalog row. The launch gate now calls it instead of bare `catalog_contains`.
- Gateways that reject canonical spellings, ids whose family the catalog doesn't list, and mismatched alias pins are still refused — the gate keeps failing fast on genuinely stale picks. The change strictly widens acceptance, so no launch that passes today can regress.

ELI5: picking a model in a running session saves its full name (`claude-fable-5`), but the "can this host run it?" checklist only has nicknames (`fable`). Next restart, the bouncer doesn't recognize the full name and refuses entry to a model the host runs fine. Now the bouncer also checks whether the full name's nickname is on the list.

```
live /model fable ──► pane echoes claude-fable-5 ──► persisted override
                                                          │ cold resume
                       catalog: [sonnet, opus, fable, …]  ▼
        before: catalog_contains("claude-fable-5") ──► ✗ launch refused
        after:  claude_catalog_accepts: alias-fold ──► fable ∈ catalog ──► ✓ launch
```

## Test Plan

- New unit tests in `tests/test_claude_native.py` (written red-first against the missing helper, then green): exact-row hits, canonical-id acceptance on a direct login (incl. `[1m]` spelling), rejection on a gateway config, rejection of families the catalog doesn't list, and pinned-endpoint exact-match/mismatch behaviour.
- `pytest tests/test_claude_native.py` — 308 passed.
- Reproduced the incident live: a real session stranded on `model_override: "claude-fable-5"` (direct-login host whose cached catalog held only aliases + `claude-opus-4-8[1m]`); verified `claude_catalog_accepts` accepts that exact catalog/override pair and still rejects e.g. `gpt-5`.
- `pre-commit` on the touched files: passes (pyrefly reports only pre-existing `opentelemetry.*` missing-import noise from optional deps, none in the touched files).

## Demo

N/A (non-visual — launch-path fix).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The helper is unit-tested exhaustively; the call-site change is a two-line substitution inside `_auto_create_claude_terminal`, which has no existing test harness (the surrounding launch path is exercised end-to-end). Manually verified against the real failing session: the exact persisted override + cached catalog from the incident now pass the gate, and the launch proceeds with the canonical id verbatim.

## Changelog

Resuming a Claude session after switching its model no longer fails with "not in this host's current model list".
