### PR TITLE
Cache the databricks-sdk Config per profile when resolving credentials

### DIFF
--- a/omnigent/runtime/credentials/databricks.py
+++ b/omnigent/runtime/credentials/databricks.py
@@ -37,12 +37,14 @@ the same module. Once the ``inner/`` package is sunset (see
 ``designs/UNIFICATION.md``), both functions there should be deleted in
 favor of calling this helper.
 
-**v1 limitation (documented):** the SDK-minted token is fetched once
-per call and then cached in the returned :class:`WorkspaceCreds`. OAuth
-access tokens typically expire after ~1 hour. Long-running sessions
-will therefore hit expiry mid-stream. v2 will refactor callers to
-hold the SDK ``Config`` object and re-call ``authenticate()`` on
-demand (which performs refresh-token handling transparently).
+**Token freshness:** the SDK ``Config`` is cached per profile for the
+life of the process (:func:`_sdk_config_for`), and every resolution
+re-calls ``authenticate()`` on it. The SDK's own token source returns
+its cached token while valid and refreshes transparently on expiry, so
+repeat resolutions in one process do not re-spawn the Databricks CLI,
+and long-running processes still rotate tokens. The returned
+:class:`WorkspaceCreds` is a point-in-time snapshot; callers that hold
+it for longer than a token's lifetime should re-resolve instead.
 """
 
 from __future__ import annotations
@@ -50,8 +52,13 @@ from __future__ import annotations
 import configparser
 import logging
 import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from databricks.sdk.config import Config
 
 _logger = logging.getLogger(__name__)
 
@@ -66,6 +73,42 @@ ENV_DATABRICKS_CONFIG_FILE: str = "DATABRICKS_CONFIG_FILE"
 
 # Section name used by ConfigParser for the implicit default section.
 DEFAULT_SECTION: str = "DEFAULT"
+
+# One SDK Config per profile per process. Constructing Config eagerly
+# resolves the credential chain — for ``databricks-cli`` profiles that
+# shells out to the CLI — while ``authenticate()`` on an existing Config
+# reuses its cached token until expiry, so the cache turns N resolutions
+# into one CLI spawn without pinning a stale token.
+_SDK_CONFIG_LOCK = threading.Lock()
+_SDK_CONFIG_CACHE: dict[str | None, Config] = {}
+
+
+def _sdk_config_for(profile: str | None) -> Config:
+    """
+    Return the process-wide SDK ``Config`` for *profile*, creating it once.
+
+    Construction failures (e.g. an unknown profile) are not cached: the
+    cfg file may be fixed between resolutions, and construction is the
+    SDK's own retry point. Re-calling ``authenticate()`` on the returned
+    Config performs refresh handling transparently.
+
+    :param profile: The resolved profile name, or ``None`` for the SDK's
+        default chain.
+    """
+    from databricks.sdk.config import Config
+
+    with _SDK_CONFIG_LOCK:
+        cfg = _SDK_CONFIG_CACHE.get(profile)
+        if cfg is None:
+            cfg = Config(profile=profile)
+            _SDK_CONFIG_CACHE[profile] = cfg
+        return cfg
+
+
+def _clear_sdk_config_cache() -> None:
+    """Drop cached SDK Configs; for tests that swap cfg files or profiles."""
+    with _SDK_CONFIG_LOCK:
+        _SDK_CONFIG_CACHE.clear()
 
 
 @dataclass(frozen=True)
@@ -295,22 +338,20 @@ def _call_sdk_authenticate(profile: str | None) -> WorkspaceCreds | None:
         or ``None`` if the SDK could not produce one (import failed,
         config invalid, non-Bearer auth scheme).
     """
+    # ``None`` means "let the SDK decide" (env var / DEFAULT section).
+    sdk_profile = profile or os.environ.get("DATABRICKS_CONFIG_PROFILE")
     try:
-        from databricks.sdk.config import Config
+        cfg = _sdk_config_for(sdk_profile)
+        headers = cfg.authenticate()
     except ImportError as exc:
         # Pinned dep missing = real env bug, not routine auth failure.
+        # Raised by the import inside ``_sdk_config_for``.
         _logger.warning(
             "databricks-sdk is not importable: %s — OAuth profiles will be invisible "
             "to the resolver, falling through to configparser path.",
             exc,
         )
         return None
-
-    # ``None`` means "let the SDK decide" (env var / DEFAULT section).
-    sdk_profile = profile or os.environ.get("DATABRICKS_CONFIG_PROFILE")
-    try:
-        cfg = Config(profile=sdk_profile)
-        headers = cfg.authenticate()
     except ValueError as exc:
         # INFO (not WARNING): expired tokens raise here. WARNING would
         # surface via root's lastResort handler to stderr, drowning the
@@ -342,7 +383,7 @@ def _try_resolve_via_sdk(profile: str | None) -> WorkspaceCreds | None:
     The SDK's ``Config(profile=...).authenticate()`` covers every
     ``auth_type`` in ``~/.databrickscfg`` (``pat``, ``databricks-cli`` /
     OAuth-U2M, service-principal OAuth, Azure CLI, env-OIDC, metadata-
-    service, etc.) and always returns a freshly-minted bearer. For
+    service, etc.) and returns a bearer the SDK refreshes as needed. For
     OAuth profiles whose cfg has no static ``token`` field, this is
     the ONLY path that yields a usable token — the raw configparser
     fallback returns ``None`` for those.

--- a/tests/runtime/credentials/test_databricks.py
+++ b/tests/runtime/credentials/test_databricks.py
@@ -9,6 +9,7 @@ import pytest
 
 from omnigent.runtime.credentials.databricks import (
     WorkspaceCreds,
+    _clear_sdk_config_cache,
     resolve_databricks_workspace,
 )
 
@@ -30,6 +31,7 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     Each test that wants to exercise the SDK path explicitly
     overrides this monkeypatch (see ``test_resolves_via_sdk_*``).
     """
+    _clear_sdk_config_cache()
     for var in (
         "DATABRICKS_CONFIG_FILE",
         "DATABRICKS_CONFIG_PROFILE",
@@ -466,6 +468,76 @@ def test_sdk_value_error_does_not_emit_warning(
     assert exc_info is not None and exc_info[2] is not None, (
         "INFO record must carry exc_info with a real traceback."
     )
+
+
+def test_sdk_config_constructed_once_per_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A single launch resolves the same profile through several call
+    # sites (host resolution, model catalog, policy build, executor).
+    # Constructing Config per resolution shells out to the Databricks
+    # CLI each time, so the resolver must construct once per profile
+    # and lean on the SDK's own token caching for freshness.
+    constructions: list[str | None] = []
+    authentications = 0
+
+    class _CountingConfig:
+        def __init__(self, *, profile: str | None) -> None:
+            constructions.append(profile)
+            self.host = "https://sdk.example.com"
+
+        def authenticate(self) -> dict[str, str]:
+            nonlocal authentications
+            authentications += 1
+            return {"Authorization": "Bearer sdk-minted-token"}
+
+    monkeypatch.setattr("databricks.sdk.config.Config", _CountingConfig)
+
+    creds1 = resolve_databricks_workspace(profile="dev")
+    creds2 = resolve_databricks_workspace(profile="dev")
+    resolve_databricks_workspace(profile="other")
+
+    assert constructions == ["dev", "other"]
+    # Every resolution still authenticates — token freshness is the
+    # SDK's job, not skipped by the shared Config.
+    assert authentications == 3
+    assert (
+        creds1
+        == creds2
+        == WorkspaceCreds(host="https://sdk.example.com", token="sdk-minted-token")
+    )
+
+
+def test_failed_sdk_construction_is_not_cached(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A Config that fails to construct (e.g. unknown profile) must not
+    # be pinned in the cache: the user can fix the cfg file and the next
+    # resolution has to retry construction rather than replay the failure.
+    class _FlakyConfig:
+        constructions = 0
+
+        def __init__(self, *, profile: str | None) -> None:
+            type(self).constructions += 1
+            if type(self).constructions == 1:
+                raise ValueError("unknown profile")
+            self.host = "https://sdk.example.com"
+
+        def authenticate(self) -> dict[str, str]:
+            return {"Authorization": "Bearer sdk-minted-token"}
+
+    monkeypatch.setattr("databricks.sdk.config.Config", _FlakyConfig)
+    cfg = _write_cfg(
+        tmp_path,
+        "[dev]\nhost = https://cfg-fallback.example.com\ntoken = cfg-token\n",
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+
+    # First resolve: construction fails, falls through to the cfg file.
+    assert resolve_databricks_workspace(profile="dev").host == "https://cfg-fallback.example.com"
+    # Second resolve: construction retried and succeeds — the earlier
+    # failure was not cached.
+    creds = resolve_databricks_workspace(profile="dev")
+    assert creds == WorkspaceCreds(host="https://sdk.example.com", token="sdk-minted-token")
+    assert _FlakyConfig.constructions == 2
 
 
 def test_honors_databricks_config_file_env(


### PR DESCRIPTION
## Related issue

N/A — no tracking issue; found by profiling `omnigent claude` launch latency.

## Summary

Each `omnigent claude` launch resolves the same Databricks profile at several call sites (host resolution, model catalog, policy build, executor), and every resolution constructed a fresh `databricks.sdk.config.Config`. For `databricks-cli` profiles, `Config` construction eagerly shells out to `databricks auth token --force-refresh` — so one launch minted ~6 tokens through the CLI at ~0.25s of subprocess each.

This caches one SDK `Config` per profile per process and re-calls `authenticate()` on every resolution. The SDK's token source serves its cached token while valid and refreshes transparently on expiry, so freshness is preserved while repeat resolutions no longer re-spawn the CLI. Construction failures are deliberately **not** cached, so a fixed cfg file is retried.

**ELI5:** asking the SDK "who am I?" used to re-run the whole login dance every time, including re-minting a token via the CLI. Now we do the login dance once per profile and just ask the SDK for the current token afterwards — the SDK already knows how to refresh it when it expires.

```
before:  resolve() ─┬─> Config() → CLI mint ─> token
                    ├─> Config() → CLI mint ─> token   (same profile!)
                    └─> Config() → CLI mint ─> token   (×~6 per launch)

after:   resolve() ─┬─> Config() → CLI mint ─> token   (once per profile)
                    ├─> cfg.authenticate() ─> SDK-cached token
                    └─> cfg.authenticate() ─> SDK-cached token (SDK refreshes on expiry)
```

## Test Plan

- `uv run --no-sync pytest tests/runtime/credentials/test_databricks.py` — 20 passed, including two new tests:
  - `test_sdk_config_constructed_once_per_profile`: three resolutions across two profiles construct `Config` once per profile while still authenticating every time (freshness is the SDK's job, not skipped).
  - `test_failed_sdk_construction_is_not_cached`: a `Config` construction failure is not pinned; the next resolution retries and succeeds.
- Dependent suites: `tests/runtime/policies` (361 passed) and `-k "databricks_adapter or model_catalog"` (120 passed).
- `pre-commit run` clean on both changed files.
- Manual: strace of an `omnigent claude` launch before/after — `databricks auth token` CLI spawns during credential resolution dropped from 6 to 2 (the CLI version probe plus a single mint).

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: counted `databricks auth token` `execve`s in an strace of a real `omnigent claude` launch before and after the change (6 → 2), and confirmed the launch resolves the same host/token either way. The new unit tests pin the construct-once-per-profile and failure-not-cached behavior with a fake `Config`.

## Changelog

Faster `omnigent claude` startup: repeated Databricks CLI token mints during credential resolution are gone
