### PR TITLE
feat(web): Allow comment on rendered notebook previews

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -2088,6 +2088,7 @@ async def _create_thread_replacement_session(
                 if state is not None
                 else str(codex_home_for_bridge_dir(bridge_dir))
             ),
+            cwd=state.cwd if state is not None else None,
         ),
     )
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4111,6 +4111,7 @@ async def _auto_create_codex_terminal(
                 socket_path=codex_ws_url,
                 thread_id=launch_config.external_session_id,
                 codex_home=str(codex_home),
+                cwd=workspace,
             ),
         )
 
@@ -4210,6 +4211,7 @@ async def _auto_create_codex_terminal(
                 bridge_dir=bridge_dir,
                 codex_ws_url=codex_ws_url,
                 codex_home=codex_home,
+                workspace=workspace,
                 event_client=event_client,
                 routing_summary=_codex_launch.summary,
                 subagent_router=_codex_router,
@@ -4259,6 +4261,7 @@ async def _codex_discover_thread_and_forward(
     bridge_dir: Path,
     codex_ws_url: str,
     codex_home: Path,
+    workspace: str,
     event_client: CodexAppServerClient,
     routing_summary: str,
     subagent_router: SubagentRouter | None = None,
@@ -4281,6 +4284,7 @@ async def _codex_discover_thread_and_forward(
         app-server) and re-persisted by the forwarder's thread-rotation
         path so a native ``/clear`` keeps the ws:// transport.
     :param codex_home: Per-session private ``CODEX_HOME`` path.
+    :param workspace: Session workspace used for injected Codex turns.
     :param event_client: Connected app-server listener that will observe the
         TUI's ``thread/started``; reused to subscribe the forwarder.
     :param routing_summary: One-line description of the resolved launch
@@ -4340,6 +4344,7 @@ async def _codex_discover_thread_and_forward(
                 socket_path=codex_ws_url,
                 thread_id=thread_id,
                 codex_home=str(codex_home),
+                cwd=workspace,
             ),
         )
 

--- a/omnigent/server/routes/comments.py
+++ b/omnigent/server/routes/comments.py
@@ -7,6 +7,7 @@ Comments can be sent to the agent as a formatted message via the
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import asdict
 from typing import Any
 
@@ -26,6 +27,8 @@ from omnigent.server.routes._errors import session_not_found
 from omnigent.stores import ConversationStore
 from omnigent.stores.comment_store import CommentStore
 from omnigent.stores.permission_store import PermissionStore
+
+_RENDERED_PREVIEW_ANCHOR_PREFIX = "__OMNIGENT_RENDERED_PREVIEW_ANCHOR__:"
 
 
 def _format_message(comments: list[Comment]) -> str:
@@ -49,8 +52,41 @@ def _format_message(comments: list[Comment]) -> str:
         lines.append("")
         lines.append(f"File: {path}")
         for c in sorted(by_path[path], key=lambda c: c.start_index):
-            anchor = f'"{c.anchor_content.strip()}" ' if c.anchor_content else ""
-            lines.append(f"• {anchor}(offset {c.start_index}–{c.end_index}): {c.body}")
+            anchor_content = c.anchor_content.strip() if c.anchor_content else ""
+            location = f"offset {c.start_index}–{c.end_index}"
+            if anchor_content.startswith(_RENDERED_PREVIEW_ANCHOR_PREFIX):
+                try:
+                    rendered_anchor = json.loads(
+                        anchor_content.removeprefix(_RENDERED_PREVIEW_ANCHOR_PREFIX)
+                    )
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    if isinstance(rendered_anchor, dict):
+                        text = rendered_anchor.get("text")
+                        surface = rendered_anchor.get("surface")
+                        region = rendered_anchor.get("region")
+                        start = rendered_anchor.get("start")
+                        end = rendered_anchor.get("end")
+                        if (
+                            isinstance(text, str)
+                            and text.strip()
+                            and isinstance(surface, str)
+                            and surface.strip()
+                            and isinstance(region, str)
+                            and region.strip()
+                            and isinstance(start, int)
+                            and not isinstance(start, bool)
+                            and isinstance(end, int)
+                            and not isinstance(end, bool)
+                            and 0 <= start < end
+                        ):
+                            anchor_content = text.strip()
+                            surface = " ".join(surface.split())
+                            region = " ".join(region.split())
+                            location = f"{surface} preview, {region}"
+            anchor = f'"{anchor_content}" ' if anchor_content else ""
+            lines.append(f"• {anchor}({location}): {c.body}")
 
     return "\n".join(lines)
 

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -631,6 +631,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     assert bridge_state is not None
     assert bridge_state.thread_id == thread_id
     assert bridge_state.socket_path == app_server.listen_url
+    assert bridge_state.cwd == str((tmp_path / "workspace").resolve())
 
 
 @pytest.mark.asyncio
@@ -1311,6 +1312,7 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
         :returns: None.
         """
         assert kwargs["bridge_dir"] == bridge_dir
+        assert kwargs["workspace"] == str(worktree.resolve())
         assert codex_native_bridge.read_bridge_state(bridge_dir) is None, (
             "fresh Codex launch must clear stale bridge state before the "
             "discovery forwarder publishes the new thread"
@@ -3021,6 +3023,58 @@ async def test_codex_session_needs_runner_terminal_false_without_client() -> Non
 
 
 @pytest.mark.asyncio
+async def test_codex_discover_thread_records_session_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Fresh runner-owned Codex turns inherit the session workspace."""
+    from omnigent import codex_native_bridge, codex_native_forwarder
+    from omnigent.runner import app as runner_app_mod
+    from omnigent.runner.native import orchestration as orchestration_mod
+
+    closed = {"client": False, "app_server": False}
+
+    class _Client:
+        async def close(self) -> None:
+            closed["client"] = True
+
+    class _AppServer:
+        async def close(self) -> None:
+            closed["app_server"] = True
+
+    async def _thread_started(*_args: object, **_kwargs: object) -> str:
+        return "019e96aa-1111-7222-8333-444455556666"
+
+    def _stop_after_state_write(name: str) -> str:
+        assert name == "RUNNER_SERVER_URL"
+        raise RuntimeError("stop after bridge state write")
+
+    monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", _thread_started)
+    monkeypatch.setattr(orchestration_mod, "_required_runner_env", _stop_after_state_write)
+
+    session_id = "3053b47e49239a8c24e3cd30cdb21c8f"
+    workspace = tmp_path / "session-workspace"
+    runner_app_mod._AUTO_CODEX_APP_SERVERS[session_id] = _AppServer()
+    try:
+        with pytest.raises(RuntimeError, match="stop after bridge state write"):
+            await runner_app_mod._codex_discover_thread_and_forward(
+                session_id=session_id,
+                bridge_dir=tmp_path,
+                codex_ws_url="ws://127.0.0.1:1",
+                codex_home=tmp_path / "codex-home",
+                workspace=str(workspace),
+                event_client=_Client(),  # type: ignore[arg-type]
+                routing_summary="provider 'test' (model=gpt-test)",
+            )
+    finally:
+        runner_app_mod._AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+
+    state = codex_native_bridge.read_bridge_state(tmp_path)
+    assert state is not None
+    assert state.cwd == str(workspace)
+    assert closed == {"client": True, "app_server": True}
+
+
+@pytest.mark.asyncio
 async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -3061,6 +3115,7 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
             bridge_dir=tmp_path,
             codex_ws_url="ws://127.0.0.1:1",
             codex_home=tmp_path / "codex-home",
+            workspace=str(tmp_path / "workspace"),
             event_client=_Client(),  # type: ignore[arg-type]
             routing_summary="provider 'test' (model=gpt-test)",
         )
@@ -3124,6 +3179,7 @@ async def test_codex_discover_thread_and_forward_records_accurate_startup_error(
             bridge_dir=tmp_path,
             codex_ws_url="ws://127.0.0.1:1",
             codex_home=tmp_path / "codex-home",
+            workspace=str(tmp_path / "workspace"),
             event_client=_Client(),  # type: ignore[arg-type]
             routing_summary="provider 'test' (model=gpt-test)",
         )

--- a/tests/server/routes/test_format_message.py
+++ b/tests/server/routes/test_format_message.py
@@ -11,6 +11,8 @@ without needing a running HTTP server.
 
 from __future__ import annotations
 
+import json
+
 from omnigent.entities import Comment
 from omnigent.server.routes.comments import _format_message
 
@@ -225,3 +227,50 @@ def test_format_message_anchor_content_is_stripped() -> None:
     assert '"indented line"' in result, (
         f"Expected stripped anchor_content in bullet, got: {result!r}"
     )
+
+
+def test_format_message_decodes_rendered_preview_anchor() -> None:
+    """Rendered preview comments expose useful text and region, not protocol data."""
+    prefix = "__OMNIGENT_RENDERED_PREVIEW_ANCHOR__:"
+    comment = _make_comment(
+        path="report.ipynb",
+        start_index=1_139_701_368,
+        end_index=1_139_701_398,
+        body="Remove this part",
+        anchor_content=prefix
+        + json.dumps(
+            {
+                "surface": "notebook",
+                "region": "cell:0:source",
+                "start": 50,
+                "end": 80,
+                "text": "This notebook has two parts:\n\n",
+            }
+        ),
+    )
+
+    result = _format_message([comment])
+
+    assert (
+        '• "This notebook has two parts:" (notebook preview, cell:0:source): Remove this part'
+        in result
+    )
+    assert prefix not in result
+    assert "offset 1139701368" not in result
+
+
+def test_format_message_preserves_malformed_rendered_preview_anchor() -> None:
+    """Malformed preview payloads keep the legacy raw-anchor and offset format."""
+    prefix = "__OMNIGENT_RENDERED_PREVIEW_ANCHOR__:"
+    comment = _make_comment(
+        path="report.ipynb",
+        start_index=10,
+        end_index=20,
+        body="Check this",
+        anchor_content=prefix + json.dumps({"surface": "notebook", "text": "Sales"}),
+    )
+
+    result = _format_message([comment])
+
+    assert prefix in result
+    assert "(offset 10–20): Check this" in result

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -1870,6 +1870,7 @@ def test_forwarder_rotates_session_on_new_codex_thread_and_posts_to_new_session(
             socket_path=str(tmp_path / "app-server.sock"),
             thread_id="thread_old",
             codex_home=str(tmp_path / "codex-home"),
+            cwd=str(tmp_path / "workspace"),
         ),
     )
     fake_client = _FakeCodexAppServerClient()
@@ -2004,6 +2005,7 @@ def test_forwarder_rotates_session_on_new_codex_thread_and_posts_to_new_session(
     # clobbered unix path — otherwise the executor would dial a dead unix
     # socket after /clear and steering/interrupt would silently fail.
     assert state.socket_path == "ws://127.0.0.1:9876"
+    assert state.cwd == str(tmp_path / "workspace")
     assert fake_client.requests == [
         ("thread/resume", {"threadId": "thread_old", "excludeTurns": True}),
         ("thread/resume", {"threadId": "thread_new", "excludeTurns": True}),

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1482,6 +1482,13 @@ aside[aria-label="Workspace"][data-maximized] {
   background-color: color-mix(in oklch, var(--warning) 70%, transparent);
 }
 
+::highlight(rendered-preview-comment) {
+  background-color: color-mix(in oklch, var(--warning) 30%, transparent);
+}
+::highlight(rendered-preview-comment-active) {
+  background-color: color-mix(in oklch, var(--warning) 60%, transparent);
+}
+
 /* TipTap editor prose styling */
 .tiptap-md-content .ProseMirror {
   outline: none;

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -67,6 +67,7 @@ import {
   lineOverlapsSelection,
 } from "./codeViewerHelpers";
 import { NotebookPreview } from "./NotebookPreview";
+import { isRenderedPreviewAnchor } from "./RenderedPreviewCommentSurface";
 import { useScrollRestore } from "./useScrollRestore";
 import { PreviewSearchBar } from "./PreviewSearchBar";
 import { renderLineTokens } from "./codeViewerRendering";
@@ -219,6 +220,10 @@ function PreviewWithSearch({
   searchInputRef,
   scrollKey,
   scrollReady,
+  comments,
+  activeSelection,
+  onSetActiveSelection,
+  canComment,
 }: {
   content: string;
   isNotebook: boolean;
@@ -230,6 +235,10 @@ function PreviewWithSearch({
   scrollKey: string | null;
   /** True once the file content backing the preview is present. */
   scrollReady: boolean;
+  comments: Comment[];
+  activeSelection: ActiveSelection | null;
+  onSetActiveSelection: (selection: ActiveSelection | null) => void;
+  canComment: boolean;
 }) {
   const previewRef = useRef<HTMLDivElement>(null);
   // The preview div (not the FileViewer content area) is the real scroller
@@ -245,7 +254,15 @@ function PreviewWithSearch({
     />
   );
   const preview = isNotebook ? (
-    <NotebookPreview content={content} rootRef={previewRef} onScroll={handleScroll} />
+    <NotebookPreview
+      content={content}
+      rootRef={previewRef}
+      onScroll={handleScroll}
+      comments={comments}
+      activeSelection={activeSelection}
+      onSetActiveSelection={onSetActiveSelection}
+      canComment={canComment}
+    />
   ) : (
     <MarkdownPreview content={content} rootRef={previewRef} onScroll={handleScroll} />
   );
@@ -761,6 +778,10 @@ export function CodeViewer({
         searchInputRef={searchInputRef}
         scrollKey={conversationId && path ? `viewer-preview:${conversationId}:${path}` : null}
         scrollReady={fileQuery.data !== undefined}
+        comments={comments}
+        activeSelection={activeSelection}
+        onSetActiveSelection={onSetActiveSelection}
+        canComment={canEdit && !truncated}
       />
     );
   }
@@ -784,8 +805,10 @@ export function CodeViewer({
           onSaveStatusChange={onSaveStatusChange}
           searchOpen={searchOpen}
           onSearchHandled={handleSearchHandled}
-          comments={comments}
-          activeSelection={activeSelection}
+          comments={comments.filter((comment) => !isRenderedPreviewAnchor(comment.anchor_content))}
+          activeSelection={
+            isRenderedPreviewAnchor(activeSelection?.anchor_content) ? null : activeSelection
+          }
           onSetActiveSelection={onSetActiveSelection}
           pendingBodyRef={pendingBodyRef}
         />

--- a/web/src/shell/FileViewer.test.tsx
+++ b/web/src/shell/FileViewer.test.tsx
@@ -147,6 +147,7 @@ import { getSeenCommentIds } from "@/hooks/useSeenComments";
 import { useWorkspaceChangedFiles } from "@/hooks/useWorkspaceChangedFiles";
 import { classifyAndRemapComments, FileViewer } from "./FileViewer";
 import { encodePdfAnchor } from "./pdfCommentHelpers";
+import { encodeRenderedPreviewAnchor } from "./RenderedPreviewCommentSurface";
 import { writeFileViewPreferences } from "@/lib/fileViewPreferences";
 import type { ChangedSort } from "./FlatFileList";
 
@@ -866,6 +867,27 @@ describe("classifyAndRemapComments", () => {
     });
 
     const result = classifyAndRemapComments([c], "%PDF-1.4 binary bytes");
+
+    expect(result.open).toHaveLength(1);
+    expect(result.open[0]).toEqual(c);
+  });
+
+  it("skips source-offset remapping for rendered preview anchors", () => {
+    const anchor = encodeRenderedPreviewAnchor({
+      surface: "notebook",
+      region: "cell:0:source",
+      start: 0,
+      end: 5,
+      text: "Sales",
+    });
+    const c = makeAnchoredComment({
+      id: "c_notebook",
+      start_index: anchor.start_index,
+      end_index: anchor.end_index,
+      anchor_content: anchor.anchor_content,
+    });
+
+    const result = classifyAndRemapComments([c], anchor.anchor_content);
 
     expect(result.open).toHaveLength(1);
     expect(result.open[0]).toEqual(c);

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -98,6 +98,7 @@ import {
 import { CommentsPanel, type ActiveSelection } from "./CommentsPanel";
 import { useScrollRestore } from "./useScrollRestore";
 import { isPdfAnchor } from "./pdfCommentHelpers";
+import { isRenderedPreviewAnchor } from "./RenderedPreviewCommentSurface";
 
 // Monaco diff is heavy (~MBs + worker); load it only when the diff view is
 // actually shown.
@@ -135,9 +136,8 @@ export function classifyAndRemapComments(
       open.push(c);
       continue;
     }
-    // PDF anchors store geometry in anchor_content; byte-offset remapping does
-    // not apply to binary PDF content.
-    if (isPdfAnchor(c.anchor_content)) {
+    // Opaque preview anchors do not contain source-file text offsets.
+    if (isPdfAnchor(c.anchor_content) || isRenderedPreviewAnchor(c.anchor_content)) {
       open.push(c);
       continue;
     }

--- a/web/src/shell/NotebookPreview.test.tsx
+++ b/web/src/shell/NotebookPreview.test.tsx
@@ -1,6 +1,10 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { NotebookPreview } from "./NotebookPreview";
+import {
+  decodeRenderedPreviewAnchor,
+  resolveRenderedPreviewOffsets,
+} from "./RenderedPreviewCommentSurface";
 
 // Stub Shiki (same rationale as CodeViewer.test.tsx) — render code verbatim so
 // assertions can target cell source without async highlighting.
@@ -15,6 +19,89 @@ import brokenRaw from "./__fixtures__/03_broken.ipynb?raw";
 afterEach(cleanup);
 
 describe("NotebookPreview — typical notebook", () => {
+  it("re-anchors rendered selections after nearby text changes", () => {
+    expect(
+      resolveRenderedPreviewOffsets("Updated Sales Analysis", {
+        start: 0,
+        end: 5,
+        text: "Sales",
+      }),
+    ).toEqual({ start: 8, end: 13 });
+  });
+
+  it("does not treat a distant duplicate as a nearby re-anchor", () => {
+    const content = `Sales${"x".repeat(1_195)}Sales`;
+    expect(
+      resolveRenderedPreviewOffsets(content, {
+        start: 600,
+        end: 605,
+        text: "Sales",
+      }),
+    ).toEqual({ start: 0, end: 5 });
+  });
+
+  it("creates a comment anchor from rendered notebook text", () => {
+    const onSetActiveSelection = vi.fn();
+    render(
+      <NotebookPreview
+        content={typicalRaw}
+        canComment
+        onSetActiveSelection={onSetActiveSelection}
+      />,
+    );
+    const heading = screen.getByRole("heading", { name: "Sales Analysis" });
+    const text = heading.firstChild!;
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.setEnd(text, 5);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    fireEvent.mouseUp(heading);
+    fireEvent.click(screen.getByRole("button", { name: "Add comment" }));
+
+    const active = onSetActiveSelection.mock.calls[0]![0];
+    expect(decodeRenderedPreviewAnchor(active.anchor_content)).toEqual({
+      surface: "notebook",
+      region: "cell:0:source",
+      start: 0,
+      end: 5,
+      text: "Sales",
+    });
+  });
+
+  it("clears the add-comment button for whitespace-only selections", () => {
+    const onSetActiveSelection = vi.fn();
+    render(
+      <NotebookPreview
+        content={typicalRaw}
+        canComment
+        onSetActiveSelection={onSetActiveSelection}
+      />,
+    );
+    const heading = screen.getByRole("heading", { name: "Sales Analysis" });
+    const headingText = heading.firstChild!;
+    const range = document.createRange();
+    range.setStart(headingText, 0);
+    range.setEnd(headingText, 5);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    fireEvent.mouseUp(heading);
+    expect(screen.getByRole("button", { name: "Add comment" })).toBeInTheDocument();
+
+    const code = screen.getAllByTestId("code-cell")[0];
+    const whitespace = code.firstChild!;
+    range.setStart(whitespace, 6);
+    range.setEnd(whitespace, 7);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    fireEvent.mouseUp(code);
+
+    expect(screen.queryByRole("button", { name: "Add comment" })).toBeNull();
+  });
+
   it("renders markdown cells as formatted markdown", () => {
     render(<NotebookPreview content={typicalRaw} />);
     expect(screen.getByRole("heading", { name: "Sales Analysis" })).toBeInTheDocument();

--- a/web/src/shell/NotebookPreview.tsx
+++ b/web/src/shell/NotebookPreview.tsx
@@ -4,7 +4,10 @@ import AnsiDefault from "ansi-to-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { CodeBlockContent } from "@/components/ai-elements/code-block";
+import type { Comment } from "@/hooks/useComments";
 import { cn } from "@/lib/utils";
+import type { ActiveSelection } from "./codeViewerHelpers";
+import { RenderedPreviewCommentSurface } from "./RenderedPreviewCommentSurface";
 
 // ansi-to-react is CJS with a TS-compiled `exports.default`; depending on the
 // bundler interop (Vite dev prebundle vs vitest vs production build) the
@@ -117,13 +120,22 @@ function parseNotebook(content: string): { notebook?: Notebook; error?: string }
   return { notebook: nb };
 }
 
-function AnsiText({ text, className }: { text: string; className?: string }) {
+function AnsiText({
+  text,
+  className,
+  region,
+}: {
+  text: string;
+  className?: string;
+  region?: string;
+}) {
   // Outputs (tracebacks especially) contain long unbroken runs — separator
   // rules, file paths — that word-wrapping can't split. Wrap where possible
   // (overflow-wrap) but let anything unbreakable scroll horizontally within the
   // cell rather than pushing the whole preview wide.
   return (
     <pre
+      data-rendered-preview-comment-region={region}
       className={cn(
         "overflow-x-auto whitespace-pre-wrap [overflow-wrap:anywhere] font-mono text-sm p-2",
         className,
@@ -134,18 +146,25 @@ function AnsiText({ text, className }: { text: string; className?: string }) {
   );
 }
 
-function OutputView({ output }: { output: NotebookOutput }) {
+function OutputView({ output, region }: { output: NotebookOutput; region: string }) {
   if (output.output_type === "stream") {
     return (
       <AnsiText
         text={joinSource(output.text)}
+        region={region}
         className={output.name === "stderr" ? "bg-destructive/10" : undefined}
       />
     );
   }
 
   if (output.output_type === "error") {
-    return <AnsiText text={(output.traceback ?? []).join("\n")} className="bg-destructive/10" />;
+    return (
+      <AnsiText
+        text={(output.traceback ?? []).join("\n")}
+        region={region}
+        className="bg-destructive/10"
+      />
+    );
   }
 
   // execute_result / display_data carry a mime bundle; pick the richest safe
@@ -185,12 +204,20 @@ function OutputView({ output }: { output: NotebookOutput }) {
           Rich HTML output hidden — showing plain text.
         </div>
       )}
-      {plain !== undefined && <AnsiText text={plain} />}
+      {plain !== undefined && <AnsiText text={plain} region={region} />}
     </div>
   );
 }
 
-function CodeCell({ cell, language }: { cell: NotebookCell; language: BundledLanguage }) {
+function CodeCell({
+  cell,
+  cellIndex,
+  language,
+}: {
+  cell: NotebookCell;
+  cellIndex: number;
+  language: BundledLanguage;
+}) {
   const count = cell.execution_count;
   return (
     <div className="flex gap-2">
@@ -198,27 +225,40 @@ function CodeCell({ cell, language }: { cell: NotebookCell; language: BundledLan
         In [{count ?? " "}]:
       </div>
       <div className="min-w-0 flex-1 space-y-1">
-        <div className="rounded border bg-muted/30 text-sm">
+        <div
+          data-rendered-preview-comment-region={`cell:${cellIndex}:source`}
+          className="rounded border bg-muted/30 text-sm"
+        >
           <CodeBlockContent code={joinSource(cell.source)} language={language} />
         </div>
         {(cell.outputs ?? []).map((output, i) => (
           // eslint-disable-next-line react/no-array-index-key
-          <OutputView key={i} output={output} />
+          <OutputView key={i} output={output} region={`cell:${cellIndex}:output:${i}`} />
         ))}
       </div>
     </div>
   );
 }
 
+interface NotebookPreviewProps {
+  content: string;
+  rootRef?: RefObject<HTMLDivElement | null>;
+  onScroll?: (event: UIEvent<HTMLElement>) => void;
+  comments?: Comment[];
+  activeSelection?: ActiveSelection | null;
+  onSetActiveSelection?: (selection: ActiveSelection | null) => void;
+  canComment?: boolean;
+}
+
 export function NotebookPreview({
   content,
   rootRef,
   onScroll,
-}: {
-  content: string;
-  rootRef?: RefObject<HTMLDivElement | null>;
-  onScroll?: (event: UIEvent<HTMLElement>) => void;
-}) {
+  comments,
+  activeSelection = null,
+  onSetActiveSelection,
+  canComment = false,
+}: NotebookPreviewProps) {
   const { notebook, error } = parseNotebook(content);
 
   if (error || !notebook) {
@@ -236,29 +276,43 @@ export function NotebookPreview({
   const language = langName as BundledLanguage;
 
   return (
-    <div
-      ref={rootRef}
-      data-preview-scroll
+    <RenderedPreviewCommentSurface
+      surface="notebook"
+      rootRef={rootRef}
+      comments={comments}
+      activeSelection={activeSelection}
+      onSetActiveSelection={onSetActiveSelection}
+      canComment={canComment}
       onScroll={onScroll}
       className="h-full space-y-4 overflow-auto px-6 py-4"
     >
       {(notebook.cells ?? []).map((cell, i) => {
         if (cell.cell_type === "markdown") {
           return (
-            // eslint-disable-next-line react/no-array-index-key
-            <div key={i} className="prose dark:prose-invert prose-sm max-w-none pl-16">
+            <div
+              // eslint-disable-next-line react/no-array-index-key
+              key={i}
+              data-rendered-preview-comment-region={`cell:${i}:source`}
+              className="prose dark:prose-invert prose-sm max-w-none pl-16"
+            >
               <ReactMarkdown remarkPlugins={[remarkGfm]}>{joinSource(cell.source)}</ReactMarkdown>
             </div>
           );
         }
         if (cell.cell_type === "code") {
           // eslint-disable-next-line react/no-array-index-key
-          return <CodeCell key={i} cell={cell} language={language} />;
+          return <CodeCell key={i} cell={cell} cellIndex={i} language={language} />;
         }
-        // raw (and any unknown cell type): show the source verbatim.
-        // eslint-disable-next-line react/no-array-index-key
-        return <AnsiText key={i} text={joinSource(cell.source)} className="pl-16 opacity-70" />;
+        return (
+          <AnsiText
+            // eslint-disable-next-line react/no-array-index-key
+            key={i}
+            text={joinSource(cell.source)}
+            region={`cell:${i}:source`}
+            className="pl-16 opacity-70"
+          />
+        );
       })}
-    </div>
+    </RenderedPreviewCommentSurface>
   );
 }

--- a/web/src/shell/RenderedPreviewCommentSurface.tsx
+++ b/web/src/shell/RenderedPreviewCommentSurface.tsx
@@ -1,0 +1,394 @@
+import { createPortal } from "react-dom";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+  type RefObject,
+  type UIEvent,
+} from "react";
+import { MessageSquarePlusIcon } from "lucide-react";
+import type { Comment } from "@/hooks/useComments";
+import { getEmbedRoot } from "@/lib/host";
+import type { ActiveSelection } from "./codeViewerHelpers";
+
+export const RENDERED_PREVIEW_ANCHOR_PREFIX = "__OMNIGENT_RENDERED_PREVIEW_ANCHOR__:";
+export const RENDERED_PREVIEW_REGION_ATTR = "data-rendered-preview-comment-region";
+
+export interface RenderedPreviewAnchorData {
+  surface: string;
+  region: string;
+  start: number;
+  end: number;
+  text: string;
+}
+
+interface FloatingComment {
+  x: number;
+  y: number;
+  selection: ActiveSelection;
+}
+
+interface RenderedPreviewCommentSurfaceProps {
+  surface: string;
+  rootRef?: RefObject<HTMLDivElement | null>;
+  comments?: Comment[];
+  activeSelection?: ActiveSelection | null;
+  onSetActiveSelection?: (selection: ActiveSelection | null) => void;
+  canComment?: boolean;
+  onScroll?: (event: UIEvent<HTMLElement>) => void;
+  className?: string;
+  children: ReactNode;
+}
+
+const COMMENT_HIGHLIGHT = "rendered-preview-comment";
+const ACTIVE_COMMENT_HIGHLIGHT = "rendered-preview-comment-active";
+const EMPTY_COMMENTS: Comment[] = [];
+const commentRangesBySurface = new Map<symbol, Range[]>();
+const activeRangesBySurface = new Map<symbol, Range[]>();
+
+// React-owned previews opt in by wrapping their rendered DOM with this
+// component and marking independently anchored text regions with
+// `data-rendered-preview-comment-region`.
+
+function anchorIndex(data: RenderedPreviewAnchorData): number {
+  let hash = 2166136261;
+  const value = `${data.surface}:${data.region}:${data.start}:${data.end}`;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return 1_000_000_000 + ((hash >>> 0) % 800_000_000);
+}
+
+export function encodeRenderedPreviewAnchor(data: RenderedPreviewAnchorData): ActiveSelection {
+  const start_index = anchorIndex(data);
+  return {
+    start_index,
+    end_index: start_index + Math.min(Math.max(1, data.end - data.start), 1_000_000),
+    anchor_content: RENDERED_PREVIEW_ANCHOR_PREFIX + JSON.stringify(data),
+  };
+}
+
+export function decodeRenderedPreviewAnchor(
+  anchorContent: string | null | undefined,
+): RenderedPreviewAnchorData | null {
+  if (!anchorContent?.startsWith(RENDERED_PREVIEW_ANCHOR_PREFIX)) return null;
+  try {
+    const data = JSON.parse(
+      anchorContent.slice(RENDERED_PREVIEW_ANCHOR_PREFIX.length),
+    ) as RenderedPreviewAnchorData;
+    if (
+      typeof data.surface !== "string" ||
+      !data.surface.trim() ||
+      typeof data.region !== "string" ||
+      !data.region.trim() ||
+      !Number.isInteger(data.start) ||
+      !Number.isInteger(data.end) ||
+      data.start < 0 ||
+      data.end <= data.start ||
+      typeof data.text !== "string" ||
+      !data.text.trim() ||
+      data.text.length !== data.end - data.start
+    ) {
+      return null;
+    }
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export function isRenderedPreviewAnchor(anchorContent: string | null | undefined): boolean {
+  return decodeRenderedPreviewAnchor(anchorContent) !== null;
+}
+
+function commentRegion(node: Node, root: HTMLElement): HTMLElement | null {
+  const element = node instanceof Element ? node : node.parentElement;
+  const region = element?.closest<HTMLElement>(`[${RENDERED_PREVIEW_REGION_ATTR}]`) ?? null;
+  return region && root.contains(region) ? region : null;
+}
+
+function textOffset(root: HTMLElement, node: Node, offset: number): number | null {
+  try {
+    const range = document.createRange();
+    range.selectNodeContents(root);
+    range.setEnd(node, offset);
+    return range.toString().length;
+  } catch {
+    return null;
+  }
+}
+
+function textRange(root: HTMLElement, start: number, end: number): Range | null {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let position = 0;
+  let startPoint: { node: Node; offset: number } | null = null;
+  let endPoint: { node: Node; offset: number } | null = null;
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const length = node.nodeValue?.length ?? 0;
+    if (!startPoint && start <= position + length) {
+      startPoint = { node, offset: Math.max(0, start - position) };
+    }
+    if (end <= position + length) {
+      endPoint = { node, offset: Math.max(0, end - position) };
+      break;
+    }
+    position += length;
+  }
+  if (!startPoint || !endPoint) return null;
+  const range = document.createRange();
+  range.setStart(startPoint.node, startPoint.offset);
+  range.setEnd(endPoint.node, endPoint.offset);
+  return range;
+}
+
+export function resolveRenderedPreviewOffsets(
+  text: string,
+  anchor: Pick<RenderedPreviewAnchorData, "start" | "end" | "text">,
+): { start: number; end: number } | null {
+  if (text.slice(anchor.start, anchor.end) === anchor.text) {
+    return { start: anchor.start, end: anchor.end };
+  }
+  const searchWindow = 500;
+  const windowStart = Math.max(0, anchor.start - searchWindow);
+  const windowEnd = Math.min(text.length, anchor.end + searchWindow);
+  const nearby = text.indexOf(anchor.text, windowStart);
+  const start = nearby !== -1 && nearby <= windowEnd ? nearby : text.indexOf(anchor.text);
+  return start === -1 ? null : { start, end: start + anchor.text.length };
+}
+
+function findRegion(root: HTMLElement, key: string): HTMLElement | null {
+  return (
+    Array.from(root.querySelectorAll<HTMLElement>(`[${RENDERED_PREVIEW_REGION_ATTR}]`)).find(
+      (region) => region.getAttribute(RENDERED_PREVIEW_REGION_ATTR) === key,
+    ) ?? null
+  );
+}
+
+function sameOffsets(a: ActiveSelection, b: Pick<Comment, "start_index" | "end_index">): boolean {
+  return a.start_index === b.start_index && a.end_index === b.end_index;
+}
+
+function highlightsSupported(): boolean {
+  return typeof CSS !== "undefined" && !!CSS.highlights && typeof Highlight !== "undefined";
+}
+
+function syncHighlights(): void {
+  if (!highlightsSupported()) return;
+  CSS.highlights.set(
+    COMMENT_HIGHLIGHT,
+    new Highlight(...Array.from(commentRangesBySurface.values()).flat()),
+  );
+  CSS.highlights.set(
+    ACTIVE_COMMENT_HIGHLIGHT,
+    new Highlight(...Array.from(activeRangesBySurface.values()).flat()),
+  );
+}
+
+export function RenderedPreviewCommentSurface({
+  surface,
+  rootRef,
+  comments = EMPTY_COMMENTS,
+  activeSelection = null,
+  onSetActiveSelection,
+  canComment = false,
+  onScroll,
+  className,
+  children,
+}: RenderedPreviewCommentSurfaceProps) {
+  const internalRootRef = useRef<HTMLDivElement>(null);
+  const previewRef = rootRef ?? internalRootRef;
+  const highlightKey = useRef(Symbol()).current;
+  const [floating, setFloating] = useState<FloatingComment | null>(null);
+
+  useLayoutEffect(() => {
+    if (!highlightsSupported()) return;
+    const root = previewRef.current;
+    if (!root) return;
+    const activeRanges: Range[] = [];
+    const commentRanges: Range[] = [];
+
+    for (const comment of comments) {
+      const anchor = decodeRenderedPreviewAnchor(comment.anchor_content);
+      if (!anchor || anchor.surface !== surface) continue;
+      const region = findRegion(root, anchor.region);
+      const offsets = region && resolveRenderedPreviewOffsets(region.textContent ?? "", anchor);
+      const range = region && offsets && textRange(region, offsets.start, offsets.end);
+      if (!range) continue;
+      (activeSelection && sameOffsets(activeSelection, comment)
+        ? activeRanges
+        : commentRanges
+      ).push(range);
+    }
+
+    const activeAnchor = decodeRenderedPreviewAnchor(activeSelection?.anchor_content);
+    if (
+      activeAnchor?.surface === surface &&
+      !comments.some((comment) => sameOffsets(activeSelection!, comment))
+    ) {
+      const region = findRegion(root, activeAnchor.region);
+      const offsets =
+        region && resolveRenderedPreviewOffsets(region.textContent ?? "", activeAnchor);
+      const range = region && offsets && textRange(region, offsets.start, offsets.end);
+      if (range) activeRanges.push(range);
+    }
+
+    commentRangesBySurface.set(highlightKey, commentRanges);
+    activeRangesBySurface.set(highlightKey, activeRanges);
+    syncHighlights();
+    return () => {
+      commentRangesBySurface.delete(highlightKey);
+      activeRangesBySurface.delete(highlightKey);
+      syncHighlights();
+    };
+  }, [activeSelection, children, comments, highlightKey, previewRef, surface]);
+
+  useEffect(() => {
+    const anchor = decodeRenderedPreviewAnchor(activeSelection?.anchor_content);
+    const root = previewRef.current;
+    if (!anchor || anchor.surface !== surface || !root) return;
+    findRegion(root, anchor.region)?.scrollIntoView?.({ block: "center" });
+    const selection = window.getSelection();
+    if (selection && !selection.isCollapsed) selection.removeAllRanges();
+  }, [activeSelection, previewRef, surface]);
+
+  useEffect(() => {
+    const dismiss = (event: MouseEvent) => {
+      if (!(event.target instanceof Element && event.target.closest("[data-add-comment-btn]"))) {
+        setFloating(null);
+      }
+    };
+    document.addEventListener("mousedown", dismiss);
+    return () => document.removeEventListener("mousedown", dismiss);
+  }, []);
+
+  useEffect(() => {
+    if (!canComment) setFloating(null);
+  }, [canComment]);
+
+  const handleMouseUp = (event: ReactMouseEvent<HTMLDivElement>) => {
+    const root = previewRef.current;
+    const selection = window.getSelection();
+    if (!root || !selection || selection.rangeCount === 0 || !onSetActiveSelection) {
+      setFloating(null);
+      return;
+    }
+    const range = selection.getRangeAt(0);
+    if (!root.contains(range.commonAncestorContainer)) {
+      setFloating(null);
+      return;
+    }
+
+    const startRegion = commentRegion(range.startContainer, root);
+    const endRegion = commentRegion(range.endContainer, root);
+    if (!startRegion || startRegion !== endRegion) {
+      setFloating(null);
+      return;
+    }
+    const region = startRegion.getAttribute(RENDERED_PREVIEW_REGION_ATTR);
+    const start = textOffset(startRegion, range.startContainer, range.startOffset);
+    const end = textOffset(startRegion, range.endContainer, range.endOffset);
+    if (!region || start == null || end == null) {
+      setFloating(null);
+      return;
+    }
+
+    if (selection.isCollapsed) {
+      const comment = comments.find((candidate) => {
+        const anchor = decodeRenderedPreviewAnchor(candidate.anchor_content);
+        const offsets =
+          anchor && resolveRenderedPreviewOffsets(startRegion.textContent ?? "", anchor);
+        return (
+          anchor?.surface === surface &&
+          anchor.region === region &&
+          offsets !== null &&
+          offsets.start <= start &&
+          start < offsets.end
+        );
+      });
+      if (comment) {
+        onSetActiveSelection({
+          start_index: comment.start_index,
+          end_index: comment.end_index,
+          anchor_content: comment.anchor_content ?? "",
+        });
+      } else if (!(
+        event.target instanceof Element && event.target.closest("[data-add-comment-btn]")
+      )) {
+        onSetActiveSelection(null);
+      }
+      setFloating(null);
+      return;
+    }
+
+    const text = range.toString();
+    if (!canComment || !text.trim()) {
+      setFloating(null);
+      return;
+    }
+    const next = encodeRenderedPreviewAnchor({ surface, region, start, end, text });
+    const existing = comments.find((comment) => {
+      const anchor = decodeRenderedPreviewAnchor(comment.anchor_content);
+      const offsets =
+        anchor && resolveRenderedPreviewOffsets(startRegion.textContent ?? "", anchor);
+      return (
+        anchor?.surface === surface &&
+        anchor.region === region &&
+        offsets?.start === start &&
+        offsets.end === end
+      );
+    });
+    if (existing) {
+      onSetActiveSelection({
+        start_index: existing.start_index,
+        end_index: existing.end_index,
+        anchor_content: existing.anchor_content ?? "",
+      });
+      setFloating(null);
+      return;
+    }
+
+    const rect = range.getClientRects?.()[0] ?? range.getBoundingClientRect?.();
+    setFloating({ x: rect?.left ?? 8, y: (rect?.top ?? 8) - 6, selection: next });
+  };
+
+  return (
+    <>
+      <div
+        ref={previewRef}
+        data-preview-scroll
+        onMouseUp={handleMouseUp}
+        onScroll={(event) => {
+          setFloating(null);
+          onScroll?.(event);
+        }}
+        className={className}
+      >
+        {children}
+      </div>
+      {floating &&
+        canComment &&
+        onSetActiveSelection &&
+        createPortal(
+          <button
+            data-add-comment-btn
+            type="button"
+            className="fixed z-50 flex items-center gap-1.5 rounded-md border border-border bg-popover backdrop-blur-xl backdrop-saturate-150 px-2.5 py-1 text-sm font-medium text-foreground shadow-md hover:bg-secondary transition-colors"
+            style={{ left: floating.x, top: floating.y, transform: "translateY(-100%)" }}
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => {
+              onSetActiveSelection(floating.selection);
+              setFloating(null);
+            }}
+          >
+            <MessageSquarePlusIcon className="size-3.5" />
+            Add comment
+          </button>,
+          getEmbedRoot() ?? document.body,
+        )}
+    </>
+  );
+}

--- a/web/src/shell/pdfCommentHelpers.test.ts
+++ b/web/src/shell/pdfCommentHelpers.test.ts
@@ -9,6 +9,7 @@ import {
   isPdfAnchor,
 } from "./pdfCommentHelpers";
 import type { Comment } from "@/hooks/useComments";
+import { encodeRenderedPreviewAnchor } from "./RenderedPreviewCommentSurface";
 
 function makeComment(overrides: Partial<Comment> = {}): Comment {
   return {
@@ -54,6 +55,17 @@ describe("displayAnchorContent", () => {
 
   it("passes through plain-text anchors unchanged", () => {
     expect(displayAnchorContent("plain anchor")).toBe("plain anchor");
+  });
+
+  it("returns the selected text for rendered-preview anchors", () => {
+    const selection = encodeRenderedPreviewAnchor({
+      surface: "notebook",
+      region: "cell:0:source",
+      start: 0,
+      end: 5,
+      text: "Sales",
+    });
+    expect(displayAnchorContent(selection.anchor_content)).toBe("Sales");
   });
 });
 

--- a/web/src/shell/pdfCommentHelpers.ts
+++ b/web/src/shell/pdfCommentHelpers.ts
@@ -5,6 +5,7 @@
 
 import type { Comment } from "@/hooks/useComments";
 import type { ActiveSelection } from "./codeViewerHelpers";
+import { decodeRenderedPreviewAnchor } from "./RenderedPreviewCommentSurface";
 
 /** Prefix that marks anchor_content as a PDF geometry payload, not raw text. */
 export const PDF_ANCHOR_PREFIX = "__pdf__";
@@ -40,6 +41,8 @@ export function decodePdfAnchor(anchorContent: string | null | undefined): PdfAn
 export function displayAnchorContent(anchorContent: string | null | undefined): string {
   const decoded = decodePdfAnchor(anchorContent);
   if (decoded) return decoded.text;
+  const preview = decodeRenderedPreviewAnchor(anchorContent);
+  if (preview) return preview.text;
   return anchorContent?.trim() ?? "";
 }
 


### PR DESCRIPTION
## Related issue

Closes https://github.com/omnigent-ai/omnigent/issues/5162

## Summary

- Add a reusable rendered-preview comment surface and use it for notebook markdown, code, and text output selections, with stable anchors, re-anchoring, highlights, and comment navigation.
- Keep rendered anchors out of source-offset remapping, validate malformed payloads with legacy fallback, and send agents readable notebook cell locations instead of serialized anchor data.
- Persist the native Codex workspace across fresh starts, resumes, and `/clear` thread rotation so notebook comments are handled in the session repository rather than the runner worktree.

**ELI5:** A notebook comment now remembers the rendered cell and selected text, while Codex remembers which project folder that notebook belongs to.

```text
notebook selection -> rendered cell anchor -> comment store -> UI highlight / agent message
                                                               |
native Codex bridge cwd ---------------------------------> session workspace
```

## Test Plan

- `uvx pre-commit run --all-files`
- `pnpm --dir web exec vitest run src/shell/NotebookPreview.test.tsx src/shell/FileViewer.test.tsx src/shell/pdfCommentHelpers.test.ts` — 100 passed, 1 expected failure
- `pnpm --dir web type-check`
- `pnpm --dir web lint`
- `pnpm --dir web format:check`
- `uv run pytest -q tests/server/routes/test_format_message.py tests/runner/test_app_sessions_native_terminals_runtime.py -k 'format_message or auto_create_codex_terminal_uses_persisted_resume_launch_config or auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir or codex_discover_thread'` — 18 passed
- `uv run pytest -q tests/test_codex_native.py -k 'forwarder_rotates_session_on_new_codex_thread_and_posts_to_new_session'` — 1 passed
- Attempted the full web suite: 5,849 tests passed; 3 unrelated failures remain in `NewChatDialog.test.tsx`. The notebook test failure found during that run was fixed and the focused suite above was rerun green.

Manual verification after restarting the app/runner:
1. Reopen the existing session and its `.ipynb` file in Preview mode.
2. Select text in a markdown cell, code cell, and text output; add comments and confirm highlights survive reopening the file.
3. Send the comments to the agent and confirm the prompt contains readable `notebook preview, cell:...` locations.
4. Confirm Codex's first shell action runs in the session workspace; run `/clear` and confirm the replacement thread keeps the same workspace.

## Demo

Supports commenting on the markdown parts of a notebook preview content
<img width="1676" height="813" alt="Screenshot 2026-08-21 at 13 00 25" src="https://github.com/user-attachments/assets/509f6184-7319-48b5-a3fe-542ae8164aa6" />

<img width="1678" height="811" alt="Screenshot 2026-08-21 at 13 00 37" src="https://github.com/user-attachments/assets/26037814-bb28-47d2-b413-010b8354224c" />

Supports for commenting code in notebook preview content as well
<img width="879" height="469" alt="Screenshot 2026-08-21 at 13 04 19" src="https://github.com/user-attachments/assets/ce868152-c721-4ead-a17a-ecd47a26564c" />

## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage includes anchor validation and fallback, nearby re-anchoring, source-remap exclusion, notebook selection behavior, readable agent formatting, and Codex workspace persistence for fresh, resumed, and rotated threads. Manual visual verification and a demo attachment remain before review.

## Changelog

Comment directly on rendered notebook cells and outputs, and keep the agent in the notebook's session workspace.
