### PR TITLE
Improve icon picking

### DIFF
--- a/web/src/components/ProjectIconPicker.tsx
+++ b/web/src/components/ProjectIconPicker.tsx
@@ -7,7 +7,7 @@
 
 import { lazy, Suspense, useState } from "react";
 import { useTheme } from "next-themes";
-import { FolderIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import { FolderIcon, Loader2Icon, PencilIcon, Trash2Icon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
@@ -124,11 +124,13 @@ export function ProjectLandingIcon({
             data-testid="project-icon-tile"
             onClick={openPicker}
             className={cn(
-              "flex size-14 items-center justify-center rounded-xl transition-colors",
+              "flex size-14 cursor-pointer items-center justify-center rounded-xl transition-colors",
               icon ? "bg-muted" : "bg-tag-pink",
             )}
           >
-            {icon ? (
+            {update.isPending ? (
+              <Loader2Icon className="size-6 animate-spin text-muted-foreground" />
+            ) : icon ? (
               <span className="text-[30px] leading-none">{icon}</span>
             ) : (
               <FolderIcon className="size-6 text-brand-accent" />

--- a/web/src/components/ProjectIconPicker.tsx
+++ b/web/src/components/ProjectIconPicker.tsx
@@ -5,7 +5,7 @@
 //     — pink folder by default, the chosen emoji in a gray tile once set, with
 //     hover-revealed edit/remove affordances (the OMNI-3742 design).
 
-import { lazy, Suspense, useState } from "react";
+import { type CSSProperties, lazy, Suspense, useState } from "react";
 import { useTheme } from "next-themes";
 import { FolderIcon, Loader2Icon, PencilIcon, Trash2Icon } from "lucide-react";
 
@@ -139,7 +139,16 @@ export function ProjectLandingIcon({
         </PopoverAnchor>
         <PopoverContent
           align="center"
-          className="w-auto border-0 bg-transparent p-0 shadow-none ring-0"
+          // Publish the collision-aware available viewport height (capped at the
+          // picker's natural size) so the .emoji-picker-popover rule in index.css
+          // shrinks emoji-mart to fit and it scrolls internally on short screens.
+          collisionPadding={8}
+          style={
+            {
+              "--emoji-picker-height": "min(420px, var(--radix-popover-content-available-height))",
+            } as CSSProperties
+          }
+          className="emoji-picker-popover w-auto border-0 bg-transparent p-0 shadow-none ring-0"
         >
           <EmojiPicker onSelect={save} />
         </PopoverContent>

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -21,6 +21,7 @@ import {
   useProjects,
   useProjectConfig,
   useProjectSessions,
+  useRenameProject,
   useUpdateProjectConfig,
   useMoveToProject,
   useRenameConversation,
@@ -340,6 +341,46 @@ describe("fetchAllArchivedProjectNames", () => {
 
     expect(names).toEqual([]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useRenameProject", () => {
+  function renderRenameHook() {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    return renderHook(() => useRenameProject(), { wrapper });
+  }
+
+  // Regression: promoting a label-only folder must return the created id so a
+  // follow-up icon write targets that row instead of re-creating it (409).
+  it("creates and returns the new id when promoting a label-only folder", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ id: "proj_new", name: "Renamed" })); // POST create
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ data: [], first_id: null, last_id: null, has_more: false }), // members page
+    );
+
+    const { result } = renderRenameHook();
+    const id = await result.current.mutateAsync({ id: null, oldName: "old", newName: "Renamed" });
+
+    expect(id).toBe("proj_new");
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/projects");
+  });
+
+  it("returns the existing id for a first-class rename", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ id: "proj_1", name: "Renamed" })); // PATCH rename
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ data: [], first_id: null, last_id: null, has_more: false }),
+    );
+
+    const { result } = renderRenameHook();
+    const id = await result.current.mutateAsync({
+      id: "proj_1",
+      oldName: "old",
+      newName: "Renamed",
+    });
+
+    expect(id).toBe("proj_1");
   });
 });
 

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -1863,6 +1863,10 @@ export function useRenameProject() {
           if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
         }),
       );
+      // Return the resolved id so a caller promoting a label-only folder can
+      // target the just-created row for a follow-up write instead of passing
+      // the stale `null` and re-creating it (which 409s on the duplicate name).
+      return projectId;
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2394,3 +2394,14 @@ aside[aria-label="Workspace"][data-maximized] {
     animation: none;
   }
 }
+
+/* Project emoji picker (rename modal + new-session landing). emoji-mart's web
+ * component hard-codes `:host { height: 435px; min-height: 230px }`, which
+ * overflows and clips on short / mobile screens. Force it down to the height the
+ * popover published in `--emoji-picker-height` so emoji-mart scrolls its own
+ * grid internally (one scrollbar, nav + search pinned). A Tailwind arbitrary
+ * variant can't target the custom element, so this lives here. */
+.emoji-picker-popover em-emoji-picker {
+  height: var(--emoji-picker-height, 420px) !important;
+  min-height: 0 !important;
+}

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -4151,7 +4151,24 @@ function ProjectFolderMenu({
                 </PopoverTrigger>
                 <PopoverContent
                   align="start"
-                  className="w-auto overflow-hidden p-0"
+                  // Publish the collision-aware available viewport height (Radix
+                  // exposes it as a CSS var), less the optional "Remove icon"
+                  // header and capped at the picker's natural size, so the
+                  // .emoji-picker-popover rule in index.css shrinks emoji-mart to
+                  // fit — it then scrolls its grid internally (nav + search
+                  // pinned) instead of clipping on short screens.
+                  collisionPadding={8}
+                  style={
+                    {
+                      "--emoji-picker-height": `min(420px, calc(var(--radix-popover-content-available-height) - ${displayIcon ? "38px" : "0px"}))`,
+                    } as CSSProperties
+                  }
+                  className="emoji-picker-popover flex max-h-[var(--radix-popover-content-available-height)] w-auto flex-col overflow-hidden p-0"
+                  // The rename Dialog's scroll lock (react-remove-scroll)
+                  // preventDefaults wheel events over the picker — it can't see
+                  // emoji-mart's scroll region inside shadow DOM. Stop the wheel
+                  // from reaching the document-level lock so the grid scrolls.
+                  onWheel={(e) => e.stopPropagation()}
                   // Nested in the rename Dialog, emoji-mart's own focus handling
                   // swallows Radix's default outside-pointer dismissal, so a
                   // click elsewhere in the modal wouldn't close the picker.
@@ -4159,7 +4176,7 @@ function ProjectFolderMenu({
                   onInteractOutside={() => setEmojiOpen(false)}
                 >
                   {displayIcon ? (
-                    <div className="border-b p-1">
+                    <div className="shrink-0 border-b p-1">
                       <Button
                         type="button"
                         variant="ghost"

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -43,8 +43,6 @@ import {
   SearchIcon,
   Settings2Icon,
   ShareIcon,
-  SmileIcon,
-  SmilePlusIcon,
   SquareIcon,
   SquareCheckIcon,
   SquarePenIcon,
@@ -103,6 +101,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   type Conversation,
   type PinnedConversationsResult,
@@ -3988,43 +3987,30 @@ function ProjectFolderMenu({
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [iconOpen, setIconOpen] = useState(false);
+  const [emojiOpen, setEmojiOpen] = useState(false);
   const [renameValue, setRenameValue] = useState(projectName);
+  // The icon staged in the rename modal, committed only on Confirm:
+  //   undefined = untouched (show the saved icon), string = a picked emoji,
+  //   null = staged removal. Reset to `undefined` each time the modal opens.
+  const [pendingIcon, setPendingIcon] = useState<string | null | undefined>(undefined);
   const deleteProject = useDeleteProject();
   const renameProject = useRenameProject();
   const updateConfig = useUpdateProjectConfig();
-  // Fetch the full config only while the menu or picker is open, so we can
+  // Fetch the full config only while the menu or rename modal is open, so we can
   // merge the icon onto the other stored defaults (host / workspace / agent)
   // without a per-folder request on every sidebar render — and without wiping
-  // those defaults on set/remove.
-  const { data: iconConfig, isLoading: iconConfigLoading } = useProjectConfig(
-    menuOpen || iconOpen ? projectId : null,
-  );
-  // The config PATCH replaces the whole blob, so a set/remove must merge onto a
+  // those defaults on save.
+  const { data: iconConfig } = useProjectConfig(menuOpen || renameOpen ? projectId : null);
+  // The config PATCH replaces the whole blob, so a save must merge onto a
   // fully-loaded config or it silently wipes the other defaults. "Ready" means
   // the config actually resolved (`!== undefined` — `isLoading` alone is false
   // on a query *error* too, leaving no data to merge onto) — except a
   // label-only folder (`projectId === null`), whose base is legitimately `{}`.
   const configReady = projectId === null || iconConfig !== undefined;
-  const setIcon = (native: string) => {
-    if (!configReady) return;
-    updateConfig.mutate(
-      { id: projectId, name: projectName, config: { ...(iconConfig ?? {}), icon: native } },
-      {
-        onSuccess: () => {
-          setIconOpen(false);
-          setMenuOpen(false);
-        },
-      },
-    );
-  };
-  const removeIcon = () => {
-    if (!configReady) return;
-    const next = { ...(iconConfig ?? {}) };
-    delete next.icon;
-    updateConfig.mutate({ id: projectId, name: projectName, config: next });
-    setMenuOpen(false);
-  };
+  const savedIcon = iconConfig !== undefined ? iconConfig?.icon : icon;
+  // What the modal's tile shows: the staged pick when touched, else the saved
+  // icon. `null` (staged removal) renders as the empty folder.
+  const displayIcon = pendingIcon !== undefined ? pendingIcon : savedIcon;
 
   return (
     <>
@@ -4062,6 +4048,7 @@ function ProjectFolderMenu({
             data-testid="rename-project"
             onSelect={() => {
               setRenameValue(projectName);
+              setPendingIcon(undefined);
               setRenameOpen(true);
             }}
           >
@@ -4072,20 +4059,6 @@ function ProjectFolderMenu({
             <Settings2Icon className="size-3.5" />
             Project settings
           </DropdownMenuItem>
-          <DropdownMenuItem data-testid="change-project-icon" onSelect={() => setIconOpen(true)}>
-            <SmilePlusIcon className="size-3.5" />
-            Change icon…
-          </DropdownMenuItem>
-          {icon ? (
-            <DropdownMenuItem
-              data-testid="remove-project-icon"
-              disabled={!configReady}
-              onSelect={removeIcon}
-            >
-              <SmileIcon className="size-3.5" />
-              Remove icon
-            </DropdownMenuItem>
-          ) : null}
           <DropdownMenuItem
             data-testid="delete-project"
             variant="destructive"
@@ -4097,7 +4070,23 @@ function ProjectFolderMenu({
         </DropdownMenuContent>
       </DropdownMenu>
       <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
-        <DialogContent onClick={(e) => e.stopPropagation()}>
+        <DialogContent
+          onClick={(e) => e.stopPropagation()}
+          // emoji-mart preventDefaults the pointer event, so Radix's own
+          // outside-dismissal never fires for clicks elsewhere in the modal.
+          // Catch them in the capture phase and close the picker ourselves,
+          // unless the pointer is inside the picker or on its trigger tile.
+          onPointerDownCapture={(e) => {
+            if (!emojiOpen) return;
+            const target = e.target as Element;
+            if (
+              target.closest('[data-slot="popover-content"]') ||
+              target.closest('[data-testid="rename-project-icon"]')
+            )
+              return;
+            setEmojiOpen(false);
+          }}
+        >
           <DialogHeader>
             <DialogTitle>Rename project</DialogTitle>
           </DialogHeader>
@@ -4105,34 +4094,105 @@ function ProjectFolderMenu({
               doesn't wrap children in one) instead of relying on a manual
               key handler + button lookup. */}
           <form
-            onSubmit={(e) => {
+            onSubmit={async (e) => {
               e.preventDefault();
+              if (!configReady) return;
               const newName = renameValue.trim();
-              if (newName === "" || newName === projectName) {
-                setRenameOpen(false);
-                setMenuOpen(false);
+              const nameChanged = newName !== "" && newName !== projectName;
+              const iconChanged = pendingIcon !== undefined && pendingIcon !== (savedIcon ?? null);
+              try {
+                // Name first: it promotes a label-only folder and reconciles
+                // members, so a following icon write can target the same id
+                // (via name) instead of promoting a second time.
+                if (nameChanged) {
+                  await renameProject.mutateAsync({ id: projectId, oldName: projectName, newName });
+                }
+                if (iconChanged) {
+                  const next = { ...(iconConfig ?? {}) };
+                  if (pendingIcon === null) delete next.icon;
+                  else next.icon = pendingIcon;
+                  await updateConfig.mutateAsync({
+                    id: projectId,
+                    name: nameChanged ? newName : projectName,
+                    config: next,
+                  });
+                }
+              } catch {
+                // Errors surface via the mutation state below; keep the modal
+                // open so the user can retry.
                 return;
               }
-              renameProject.mutate(
-                { id: projectId, oldName: projectName, newName },
-                {
-                  onSuccess: () => {
-                    setRenameOpen(false);
-                    setMenuOpen(false);
-                  },
-                },
-              );
+              setRenameOpen(false);
+              setMenuOpen(false);
             }}
           >
-            <input
-              autoFocus
-              className="w-full rounded-md border bg-transparent px-3 py-2 text-ui outline-none"
-              value={renameValue}
-              onChange={(e) => setRenameValue(e.target.value)}
-            />
-            {renameProject.isError && (
+            {/* One combined control: emoji tile (left) + name (right) share a
+                single border, so it reads as a single input. The tile opens a
+                picker popover; the pick is staged and committed on Confirm. */}
+            <div className="flex items-stretch overflow-hidden rounded-lg border border-input">
+              <Popover open={emojiOpen} onOpenChange={setEmojiOpen}>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Change project icon"
+                    data-testid="rename-project-icon"
+                    disabled={!configReady}
+                    className={cn(
+                      "flex size-[38px] shrink-0 cursor-pointer items-center justify-center outline-none transition-colors disabled:cursor-default disabled:opacity-50",
+                      displayIcon ? "bg-muted" : "bg-tag-pink",
+                    )}
+                  >
+                    {displayIcon ? (
+                      <span className="text-xl leading-none">{displayIcon}</span>
+                    ) : (
+                      <FolderIcon className="size-4 text-brand-accent" />
+                    )}
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="start"
+                  className="w-auto overflow-hidden p-0"
+                  // Nested in the rename Dialog, emoji-mart's own focus handling
+                  // swallows Radix's default outside-pointer dismissal, so a
+                  // click elsewhere in the modal wouldn't close the picker.
+                  // Close it explicitly on any outside interaction.
+                  onInteractOutside={() => setEmojiOpen(false)}
+                >
+                  {displayIcon ? (
+                    <div className="border-b p-1">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="w-full justify-start"
+                        data-testid="rename-project-remove-icon"
+                        onClick={() => {
+                          setPendingIcon(null);
+                          setEmojiOpen(false);
+                        }}
+                      >
+                        <Trash2Icon className="size-3.5" />
+                        Remove icon
+                      </Button>
+                    </div>
+                  ) : null}
+                  <EmojiPicker
+                    onSelect={(native) => {
+                      setPendingIcon(native);
+                      setEmojiOpen(false);
+                    }}
+                  />
+                </PopoverContent>
+              </Popover>
+              <input
+                className="w-full bg-transparent px-3 py-2 text-ui outline-none"
+                value={renameValue}
+                onChange={(e) => setRenameValue(e.target.value)}
+              />
+            </div>
+            {(renameProject.isError || updateConfig.isError) && (
               <p className="text-ui text-destructive" role="alert">
-                {(renameProject.error as Error).message}
+                {((renameProject.error ?? updateConfig.error) as Error).message}
               </p>
             )}
             <DialogFooter className="border-t-0 bg-transparent">
@@ -4140,17 +4200,17 @@ function ProjectFolderMenu({
                 type="button"
                 variant="ghost"
                 onClick={() => setRenameOpen(false)}
-                disabled={renameProject.isPending}
+                disabled={renameProject.isPending || updateConfig.isPending}
               >
                 Cancel
               </Button>
               <Button
                 type="submit"
                 data-testid="rename-project-confirm"
-                loading={renameProject.isPending}
-                disabled={renameValue.trim() === ""}
+                loading={renameProject.isPending || updateConfig.isPending}
+                disabled={!configReady || renameValue.trim() === ""}
               >
-                Rename
+                Confirm
               </Button>
             </DialogFooter>
           </form>
@@ -4165,33 +4225,6 @@ function ProjectFolderMenu({
         projectId={projectId}
         projectName={projectName}
       />
-      <Dialog
-        open={iconOpen}
-        onOpenChange={(o) => {
-          setIconOpen(o);
-          if (!o) setMenuOpen(false);
-        }}
-      >
-        <DialogContent
-          onClick={(e) => e.stopPropagation()}
-          className="w-auto items-center gap-3 p-4"
-        >
-          <DialogHeader>
-            <DialogTitle>Choose an icon</DialogTitle>
-          </DialogHeader>
-          {configReady ? (
-            <EmojiPicker onSelect={setIcon} />
-          ) : iconConfigLoading ? (
-            <div className="flex h-[420px] w-[352px] items-center justify-center">
-              <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
-            </div>
-          ) : (
-            <div className="flex h-[420px] w-[352px] items-center justify-center px-6 text-center text-ui text-muted-foreground">
-              Couldn&apos;t load this project&apos;s settings. Close and try again.
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
       <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <DialogContent onClick={(e) => e.stopPropagation()}>
           <DialogHeader>

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -4101,25 +4101,33 @@ function ProjectFolderMenu({
               const nameChanged = newName !== "" && newName !== projectName;
               const iconChanged = pendingIcon !== undefined && pendingIcon !== (savedIcon ?? null);
               try {
-                // Name first: it promotes a label-only folder and reconciles
-                // members, so a following icon write can target the same id
-                // (via name) instead of promoting a second time.
+                // Name first: it promotes a label-only folder (creating the
+                // first-class row) and reconciles members. Capture the resolved
+                // id so the icon write below targets that row — passing the
+                // stale render-time `null` would make the config write try to
+                // create the project a second time and 409 on the duplicate.
+                let targetId = projectId;
                 if (nameChanged) {
-                  await renameProject.mutateAsync({ id: projectId, oldName: projectName, newName });
+                  targetId = await renameProject.mutateAsync({
+                    id: projectId,
+                    oldName: projectName,
+                    newName,
+                  });
                 }
                 if (iconChanged) {
                   const next = { ...(iconConfig ?? {}) };
                   if (pendingIcon === null) delete next.icon;
                   else next.icon = pendingIcon;
                   await updateConfig.mutateAsync({
-                    id: projectId,
+                    id: targetId,
                     name: nameChanged ? newName : projectName,
                     config: next,
                   });
                 }
               } catch {
-                // Errors surface via the mutation state below; keep the modal
-                // open so the user can retry.
+                // Errors surface via the mutation state below. A rename that
+                // lands before a failed icon write is already persisted; only
+                // the icon needs retrying.
                 return;
               }
               setRenameOpen(false);

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -4000,12 +4000,15 @@ function ProjectFolderMenu({
   // merge the icon onto the other stored defaults (host / workspace / agent)
   // without a per-folder request on every sidebar render — and without wiping
   // those defaults on save.
-  const { data: iconConfig } = useProjectConfig(menuOpen || renameOpen ? projectId : null);
-  // The config PATCH replaces the whole blob, so a save must merge onto a
+  const { data: iconConfig, isError: iconConfigError } = useProjectConfig(
+    menuOpen || renameOpen ? projectId : null,
+  );
+  // The config PATCH replaces the whole blob, so an ICON save must merge onto a
   // fully-loaded config or it silently wipes the other defaults. "Ready" means
   // the config actually resolved (`!== undefined` — `isLoading` alone is false
   // on a query *error* too, leaving no data to merge onto) — except a
   // label-only folder (`projectId === null`), whose base is legitimately `{}`.
+  // This gates only the icon path; renaming the name never needs the config.
   const configReady = projectId === null || iconConfig !== undefined;
   const savedIcon = iconConfig !== undefined ? iconConfig?.icon : icon;
   // What the modal's tile shows: the staged pick when touched, else the saved
@@ -4096,10 +4099,12 @@ function ProjectFolderMenu({
           <form
             onSubmit={async (e) => {
               e.preventDefault();
-              if (!configReady) return;
               const newName = renameValue.trim();
               const nameChanged = newName !== "" && newName !== projectName;
               const iconChanged = pendingIcon !== undefined && pendingIcon !== (savedIcon ?? null);
+              // Only the icon write needs a loaded config to merge onto; a
+              // name-only rename must proceed even if the config fetch failed.
+              if (iconChanged && !configReady) return;
               try {
                 // Name first: it promotes a label-only folder (creating the
                 // first-class row) and reconciles members. Capture the resolved
@@ -4181,7 +4186,6 @@ function ProjectFolderMenu({
                   // swallows Radix's default outside-pointer dismissal, so a
                   // click elsewhere in the modal wouldn't close the picker.
                   // Close it explicitly on any outside interaction.
-                  onInteractOutside={() => setEmojiOpen(false)}
                 >
                   {displayIcon ? (
                     <div className="shrink-0 border-b p-1">
@@ -4215,6 +4219,12 @@ function ProjectFolderMenu({
                 onChange={(e) => setRenameValue(e.target.value)}
               />
             </div>
+            {iconConfigError && (
+              <p className="text-ui text-destructive" role="alert">
+                Couldn&apos;t load this project&apos;s icon settings. You can still rename it;
+                changing the icon is unavailable until this loads.
+              </p>
+            )}
             {(renameProject.isError || updateConfig.isError) && (
               <p className="text-ui text-destructive" role="alert">
                 {((renameProject.error ?? updateConfig.error) as Error).message}
@@ -4233,7 +4243,7 @@ function ProjectFolderMenu({
                 type="submit"
                 data-testid="rename-project-confirm"
                 loading={renameProject.isPending || updateConfig.isPending}
-                disabled={!configReady || renameValue.trim() === ""}
+                disabled={renameValue.trim() === ""}
               >
                 Confirm
               </Button>


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Reworks how a project's emoji icon is set so there's one obvious place to do it, and fixes the picker's behaviour on short/mobile screens.

- **Moved icon editing into the "Rename project" modal.** Dropped the standalone `Change icon…` / `Remove icon` context-menu items (and the separate "Choose an icon" dialog). The rename modal now has a single combined control — an emoji tile on the left and the name input on the right sharing one border — so it reads as one field. The tile opens an emoji picker; "Remove icon" lives inside that picker's header.
- **Staged, atomic saves in the modal.** The icon pick is now staged and only written on **Confirm** (the button was relabeled from "Rename" to "Confirm"). Changing just the name saves the name; just the icon saves the icon; both saves both; **Cancel** discards everything. Name is written before icon so a label-only folder is promoted once and the icon write targets the same project.
- **New-session landing icon keeps its immediate write** but now shows a spinner while the config PATCH is in flight.
- **Fixed the picker on short screens.** It now shrinks to the collision-aware available viewport height and scrolls its emoji grid internally instead of clipping, and scrolls correctly with the mouse wheel inside the rename modal.

### Why

Icon setting was scattered across two context-menu items and a separate dialog, and it wrote to the API on every pick regardless of whether the modal was confirmed. Consolidating it into the rename modal gives a single primary UI (alongside the new-session page) and makes Confirm/Cancel behave as users expect. The short-screen fixes address the picker being cut off and unscrollable on mobile.

## Test Plan

Manual verification against the dev server (`localhost:5173`):

- Rename modal: open a project's ⋯ menu → **Rename project**.
  - Change **only the name** → Confirm → name updates, icon unchanged.
  - Change **only the icon** (open tile, pick emoji) → Confirm → icon updates, name unchanged.
  - Change **both** → Confirm → both persist.
  - Change either and hit **Cancel** → nothing persists.
  - Confirm button shows a loader while saving.
- Emoji picker: opens from the tile; "Remove icon" appears in its header only when an icon is set; clicking elsewhere in the modal closes the picker.
- **Short screen / mobile:** picker fits the viewport (nav + search pinned), the emoji grid scrolls internally, and the **mouse wheel** scrolls the grid inside the modal.
- New-session landing icon: still writes immediately and shows a spinner during the PATCH.
- `npm run type-check` passes; `vitest run src/components/ProjectIconPicker.test.tsx` passes (4/4).

## Demo

https://github.com/user-attachments/assets/97ace6c6-4499-4e92-891b-ec9c2ba22d85

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually in the browser across the scenarios in the Test Plan (name-only / icon-only / both / cancel saves, picker dismissal, short-screen scrolling and mouse-wheel scrolling, and the landing-icon loader). Existing `ProjectIconPicker` tests still pass; the changes are UI-behaviour and layout that manual verification covers best.

## Changelog

Set and remove a project's emoji icon from the "Rename project" modal, with a combined icon + name control
