### PR TITLE
fix(files): browse outside the workspace behind a slash-merging proxy

### DIFF
--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -478,6 +478,40 @@ def register_resources_routes(
         """
         return LEVEL_OWNER if ntpath.isabs(client_path) else within_workspace
 
+    def _resolve_browse_path(request: Request, client_path: str) -> tuple[bool, str]:
+        """Resolve a filesystem request path against its declared base.
+
+        The ``{path}`` segment names a location two ways can reach:
+
+        - **workspace-relative** (``base=workspace``, the default) — a path
+          under the session's workspace root, e.g. ``src/app.ts``.
+        - **host-absolute** (``base=host``) — an absolute path on the host,
+          sent WITHOUT its leading slash so the ``{path}`` converter carries
+          it, exactly as ``/v1/hosts/{id}/filesystem/{path}`` already does.
+          The leading slash is re-added here.
+
+        Naming the base in the query — rather than marking absolute paths with
+        a leading ``%2F`` in the segment — is what makes browsing outside the
+        workspace survive a reverse proxy. A leading ``%2F`` decodes to a
+        boundary ``//`` that proxies such as the Databricks Apps front door
+        merge back to a single ``/`` (``//x`` 301-redirects to ``/x``), which
+        silently turns ``/Users/me`` into a workspace-relative ``Users/me`` and
+        lists a nonexistent path. A query value rides through that merge
+        untouched, and a plain path segment never forms a ``//`` to begin with.
+
+        A genuine leading slash on ``{path}`` is still honored, so a direct
+        (unproxied) caller that sends ``%2F`` keeps working.
+
+        :param request: Incoming request, for the ``base`` query value.
+        :param client_path: Path captured from the route's ``{path}``.
+        :returns: ``(absolute, path)`` — ``path`` carries a leading slash iff
+            ``absolute``.
+        """
+        absolute = request.query_params.get("base") == "host" or client_path.startswith("/")
+        if absolute:
+            return True, "/" + client_path.lstrip("/")
+        return False, client_path
+
     async def _authorize_absolute_browse(
         conversation: Conversation,
         absolute_path: str,
@@ -1735,6 +1769,22 @@ def register_resources_routes(
         :param order: Sort order, ``"asc"`` or ``"desc"``.
         :returns: PaginatedList of filesystem entries.
         """
+        # A host-absolute browse of the filesystem root reaches here: its path
+        # segment is empty, so it lands on the no-path route, and only
+        # ``base=host`` distinguishes it from a workspace-root listing. Hand it
+        # to the path handler so it gets the same owner gate and reach check as
+        # any other absolute location instead of listing the workspace root.
+        if request.query_params.get("base") == "host":
+            return await read_or_list_environment_path(
+                request,
+                session_id,
+                environment_id,
+                "/",
+                limit=limit,
+                after=after,
+                before=before,
+                order=order,
+            )
         params: dict[str, str] = {"limit": str(limit), "order": order}
         if after is not None:
             params["after"] = after
@@ -1866,7 +1916,7 @@ def register_resources_routes(
         if exclude is not None:
             params["exclude"] = exclude
 
-        absolute = path.startswith("/")
+        absolute, path = _resolve_browse_path(request, path)
         conv = await _validate_session(
             session_id, request, _browse_level(path, within_workspace=LEVEL_READ)
         )
@@ -2004,7 +2054,7 @@ def register_resources_routes(
         # shared context, everything past it is the owner's own machine. See
         # `_mutating_level` for why anything weaker would make this route a
         # way around the owner-scoped host filesystem endpoint.
-        absolute = relative_path.startswith("/")
+        absolute, relative_path = _resolve_browse_path(request, relative_path)
         conv = await _validate_session(
             session_id, request, _browse_level(relative_path, within_workspace=LEVEL_READ)
         )
@@ -2069,6 +2119,7 @@ def register_resources_routes(
         :returns: Write result.
         """
         body = await request.json()
+        _, relative_path = _resolve_browse_path(request, relative_path)
         path = _mutating_runner_path(session_id, environment_id, relative_path)
         return await _proxy_fs_response(
             session_id,
@@ -2101,6 +2152,7 @@ def register_resources_routes(
         :returns: Edit result.
         """
         body = await request.json()
+        _, relative_path = _resolve_browse_path(request, relative_path)
         path = _mutating_runner_path(session_id, environment_id, relative_path)
         return await _proxy_fs_response(
             session_id,
@@ -2132,6 +2184,7 @@ def register_resources_routes(
         :param relative_path: Path relative to environment root.
         :returns: Delete result.
         """
+        _, relative_path = _resolve_browse_path(request, relative_path)
         path = _mutating_runner_path(session_id, environment_id, relative_path)
         return await _proxy_fs_response(
             session_id,

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -1774,6 +1774,9 @@ def register_resources_routes(
         # ``base=host`` distinguishes it from a workspace-root listing. Hand it
         # to the path handler so it gets the same owner gate and reach check as
         # any other absolute location instead of listing the workspace root.
+        # ``read_or_list_environment_path`` runs its own ``_validate_session``
+        # at the owner level for an absolute path, so this delegation is gated
+        # there, not here.
         if request.query_params.get("base") == "host":
             return await read_or_list_environment_path(
                 request,

--- a/tests/e2e_ui/collaboration/test_browse_outside_workspace.py
+++ b/tests/e2e_ui/collaboration/test_browse_outside_workspace.py
@@ -213,6 +213,17 @@ def _absolute_fs_url(base_url: str, session_id: str, target: Path) -> str:
     )
 
 
+def _absolute_fs_url_base_host(base_url: str, session_id: str, target: Path) -> str:
+    """The proxy-safe wire form the web uses: a bare path (no leading ``%2F``)
+    named absolute by ``?base=host``. The owner gate must apply to this exactly
+    as it does to the ``%2F`` form, or the fix would be a way around it.
+    """
+    return (
+        f"{base_url}/v1/sessions/{session_id}/resources/environments/default"
+        f"/filesystem/{str(target).lstrip('/')}?base=host"
+    )
+
+
 def test_owner_browses_outside_workspace_but_shared_collaborator_cannot(
     browser: Browser,
     live_server: str,
@@ -288,6 +299,12 @@ def test_owner_browses_outside_workspace_but_shared_collaborator_cannot(
 
         refused = bob_page.request.get(_absolute_fs_url(live_server, session_id, outside))
         assert refused.status == 403, refused.text()
+        # The proxy-safe wire form is gated identically -- base=host is not a
+        # way around the owner check.
+        refused_base_host = bob_page.request.get(
+            _absolute_fs_url_base_host(live_server, session_id, outside)
+        )
+        assert refused_base_host.status == 403, refused_base_host.text()
     finally:
         bob_page.unroute_all(behavior="ignoreErrors")
         bob_page.close()
@@ -299,6 +316,10 @@ def test_owner_browses_outside_workspace_but_shared_collaborator_cannot(
         _absolute_fs_url(live_server, session_id, outside).removeprefix(live_server)
     )
     assert allowed.status_code == 200, allowed.text
+    allowed_base_host = shared_browse.owner.get(
+        _absolute_fs_url_base_host(live_server, session_id, outside).removeprefix(live_server)
+    )
+    assert allowed_base_host.status_code == 200, allowed_base_host.text
 
 
 def test_shared_collaborator_double_clicks_into_a_workspace_folder(

--- a/tests/e2e_ui/files/test_files_panel_header.py
+++ b/tests/e2e_ui/files/test_files_panel_header.py
@@ -29,7 +29,7 @@ import re
 import shutil
 from collections.abc import Iterator
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import pytest
 from playwright.sync_api import Page, Route, expect
@@ -365,3 +365,100 @@ def test_opening_the_directory_browser_does_not_flash_a_header_tooltip(
     # A deliberate hover is still answered.
     up.hover()
     expect(page.get_by_text("Up one level", exact=True)).to_be_visible(timeout=15_000)
+
+
+def _simulate_frontdoor_slash_merge(page: Page, session_id: str) -> None:
+    """Rewrite the session's filesystem/search requests the way the Databricks
+    Apps front door does, so a local server (which has no such proxy) exercises
+    the exact production condition.
+
+    That front door percent-decodes ``%2F`` and then merges any resulting
+    ``//`` in the path to a single ``/`` — ``//health`` 301-redirects to
+    ``/health`` — while preserving the query string across the merge. This
+    handler reproduces both: it decodes ``%2F`` and collapses repeated slashes
+    in the path, leaving the query untouched.
+
+    The old wire form marked an absolute browse with a leading ``%2F`` in the
+    ``{path}`` segment; once merged that leading slash is gone, so the server
+    reads ``/Users/me`` back as a workspace-relative ``Users/me`` and lists a
+    nonexistent path — an empty tree. The fix carries the base out of band
+    (``?base=host``) and sends the path with literal slashes, so nothing in the
+    path merges and the query survives.
+
+    Only the session's own filesystem/search endpoints are rewritten. The host
+    picker endpoint (``/v1/hosts/{id}/filesystem``) already uses the
+    slash-merge-safe form, so leaving it alone keeps the picker (the "paths
+    show in the dropdown" half of the bug) working, exactly as in production.
+
+    :param page: Playwright page, before navigation.
+    :param session_id: Session whose filesystem requests to rewrite.
+    """
+    fs_re = re.compile(
+        rf"/v1/sessions/{re.escape(session_id)}/resources/environments/[^/]+/(filesystem|search)"
+    )
+
+    def _merge(route: Route) -> None:
+        parts = urlparse(route.request.url)
+        decoded = parts.path.replace("%2F", "/").replace("%2f", "/")
+        merged = re.sub(r"/{2,}", "/", decoded)
+        if merged == parts.path:
+            route.continue_()
+            return
+        route.continue_(url=urlunparse(parts._replace(path=merged)))
+
+    page.route(fs_re, _merge)
+
+
+def test_absolute_browse_survives_a_slash_merging_proxy(
+    page: Page,
+    seeded_session: tuple[str, str],
+    tmp_path: Path,
+    _drop_routes: None,
+) -> None:
+    """Browsing outside the workspace shows files even behind a proxy that
+    merges the encoded slashes marking an absolute path.
+
+    Regression test for the deployed file browser showing "No files in
+    workspace" for any directory above/outside the working folder: the
+    Databricks Apps front door merges the ``//`` that the old ``%2F`` wire form
+    decodes to, so the absolute path arrived at the server looking
+    workspace-relative and listed nothing — even though the picker dropdown
+    (a different, merge-safe endpoint) showed the very same directories.
+
+    Drives the real re-root flow with a handler that reproduces the front
+    door's path normalization on the session's filesystem/search requests. The
+    re-rooted tree is served by the real runner off the real filesystem, so a
+    green assertion means the absolute browse survived the merge end to end.
+    """
+    base_url, session_id = seeded_session
+
+    outside = tmp_path / "outside-workspace"
+    outside.mkdir()
+    (outside / "sentinel.txt").write_text("proof the tree re-rooted behind the proxy\n")
+
+    _bind_host_with_listing(page, session_id, entry=outside)
+    _simulate_frontdoor_slash_merge(page, session_id)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("^Files")).click()
+
+    path_button = rail.get_by_test_id("browse-location-path")
+    expect(path_button).to_be_visible(timeout=30_000)
+    path_button.click()
+
+    picker = page.get_by_test_id("workspace-picker")
+    expect(picker).to_be_visible(timeout=15_000)
+    picker.get_by_test_id(f"workspace-picker-entry-{outside.name}").click()
+
+    # Re-rooted through the proxy: the tree lists the outside directory's real
+    # contents rather than collapsing to an empty "No files in workspace".
+    expect(path_button).to_contain_text(outside.name, timeout=30_000)
+    expect(rail.get_by_text("sentinel.txt")).to_be_visible(timeout=30_000)
+    expect(rail.get_by_text("No files in workspace")).to_have_count(0)
+
+    # Search of the absolute location survives the same merge.
+    page.keyboard.press("Escape")
+    rail.get_by_role("searchbox", name="Search all files").fill("sentinel")
+    expect(rail.get_by_text("sentinel.txt")).to_be_visible(timeout=30_000)

--- a/tests/e2e_ui/files/test_files_panel_header.py
+++ b/tests/e2e_ui/files/test_files_panel_header.py
@@ -315,6 +315,18 @@ def test_files_panel_browses_to_a_directory_outside_the_workspace(
     expect(rail.get_by_text("sentinel.txt")).to_be_visible(timeout=30_000)
     rail.get_by_role("searchbox", name="Search all files").fill("")
 
+    # Opening a file swaps the panel for the viewer (unmounting it); closing
+    # the viewer must land back in THIS directory, not snap to the workspace
+    # root. The header path button only exists while the panel is mounted, so
+    # it naming the outside directory again is the whole assertion.
+    rail.get_by_role("button", name=re.compile(r"sentinel\.txt")).first.click()
+    expect(rail.get_by_role("searchbox", name="Search all files")).to_have_count(0, timeout=30_000)
+    rail.get_by_role("button", name="Close sentinel.txt", exact=True).click()
+    expect(path_button).to_contain_text(outside.name, timeout=30_000)
+    expect(rail.get_by_role("button", name=re.compile(r"sentinel\.txt")).first).to_be_visible(
+        timeout=30_000
+    )
+
     # One click back to where the agent actually is.
     path_button.click()
     page.get_by_test_id("workspace-picker-workspace").click()

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -2825,6 +2825,80 @@ async def test_filesystem_path_omits_absent_cursors(
 
 
 @pytest.mark.asyncio
+async def test_filesystem_base_host_forwards_an_absolute_path(
+    client: httpx.AsyncClient,
+) -> None:
+    """``?base=host`` reads a bare ``{path}`` as an absolute host path and
+    forwards it to the runner ``%2F``-encoded.
+
+    This is the wire form that survives a reverse proxy which merges the ``//``
+    the old leading-``%2F`` marker decoded to (the Databricks Apps front door
+    does exactly that). The path arrives here with literal slashes and no
+    leading marker; ``base=host`` is what restores its absoluteness, so a
+    directory above the workspace lists instead of showing an empty tree.
+    """
+    fake_runner = _FakeRunnerClient(payload=_fs_list_payload())
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+
+    resp = await client.get(
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default"
+        "/filesystem/Users/me/reports?limit=1000&order=asc&base=host",
+    )
+
+    assert resp.status_code == 200
+    forwarded_url = fake_runner.calls[0][1]
+    # The runner receives an absolute path: the leading slash re-added and
+    # sent as %2F, interior slashes literal.
+    assert "/filesystem/%2FUsers/me/reports?" in forwarded_url
+
+
+@pytest.mark.asyncio
+async def test_filesystem_bare_path_without_base_is_workspace_relative(
+    client: httpx.AsyncClient,
+) -> None:
+    """Without ``base=host`` a bare ``{path}`` stays workspace-relative.
+
+    This is the exact shape a slash-merging proxy produced from the old
+    absolute wire form — the regression. Pinned as the contrast that documents
+    why ``base=host`` is load-bearing: the runner must NOT receive a ``%2F``
+    absolute path here.
+    """
+    fake_runner = _FakeRunnerClient(payload=_fs_list_payload())
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+
+    resp = await client.get(
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default"
+        "/filesystem/Users/me/reports?limit=1000&order=asc",
+    )
+
+    assert resp.status_code == 200
+    forwarded_url = fake_runner.calls[0][1]
+    assert "/filesystem/Users/me/reports?" in forwarded_url
+    assert "%2F" not in forwarded_url
+
+
+@pytest.mark.asyncio
+async def test_filesystem_root_base_host_forwards_filesystem_root(
+    client: httpx.AsyncClient,
+) -> None:
+    """``?base=host`` on the no-path route browses the filesystem root, not the
+    workspace root: navigating up to ``/`` must not silently show the workspace.
+    """
+    fake_runner = _FakeRunnerClient(payload=_fs_list_payload())
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+
+    resp = await client.get(
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default"
+        "/filesystem?limit=1000&order=asc&base=host",
+    )
+
+    assert resp.status_code == 200
+    forwarded_url = fake_runner.calls[0][1]
+    # Root reconstructs to "/" -> %2F with an empty remainder.
+    assert "/filesystem/%2F?" in forwarded_url
+
+
+@pytest.mark.asyncio
 async def test_filesystem_read_proxies_to_runner(
     client: httpx.AsyncClient,
 ) -> None:

--- a/web/src/hooks/useFileContent.test.tsx
+++ b/web/src/hooks/useFileContent.test.tsx
@@ -321,6 +321,28 @@ describe("useFileContent gating", () => {
     );
   });
 
+  it("fetches an absolute file path by its bare path plus base=host", async () => {
+    // A file opened while browsing OUTSIDE the workspace has an absolute path.
+    // It must be requested WITHOUT a leading "%2F" (which a reverse proxy such
+    // as the Databricks Apps front door would merge away) and named
+    // `base=host` -- otherwise it is looked up by its bare name under the
+    // workspace root and 404s (the regression this covers).
+    onlineMock.mockReturnValue(true);
+    hostOnlineMock.mockReturnValue(true);
+    stubChatStore();
+
+    render(
+      <Wrap>
+        <Probe id="conv_abs" path="/tmp/dbexec.log" />
+      </Wrap>,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/v1/sessions/conv_abs/resources/environments/default/filesystem/tmp/dbexec.log?base=host",
+    );
+  });
+
   it("does not fetch when path is null", async () => {
     onlineMock.mockReturnValue(true);
     stubChatStore();

--- a/web/src/hooks/useFileContent.ts
+++ b/web/src/hooks/useFileContent.ts
@@ -29,11 +29,18 @@ export async function fetchFileContent(
   conversationId: string,
   path: string,
 ): Promise<FileContentResponse> {
-  // Encode each path segment individually so slashes remain structural.
-  const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+  // Encode each path segment individually so slashes stay structural. An
+  // absolute path (a file opened while browsing outside the workspace) is sent
+  // WITHOUT its leading slash and named `?base=host`, exactly as the directory
+  // listing does — a leading "%2F" would decode to a "//" that reverse proxies
+  // (the Databricks Apps front door) merge to a single "/", turning it into a
+  // workspace-relative path and opening the wrong file (or none).
+  const absolute = path.startsWith("/");
+  const encodedPath = path.replace(/^\//, "").split("/").map(encodeURIComponent).join("/");
   const url =
     `/v1/sessions/${encodeURIComponent(conversationId)}` +
-    `/resources/environments/${DEFAULT_ENVIRONMENT_ID}/filesystem/${encodedPath}`;
+    `/resources/environments/${DEFAULT_ENVIRONMENT_ID}/filesystem/${encodedPath}` +
+    (absolute ? "?base=host" : "");
   const res = await authenticatedFetch(url);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return (await res.json()) as FileContentResponse;

--- a/web/src/hooks/useFileContent.ts
+++ b/web/src/hooks/useFileContent.ts
@@ -8,7 +8,11 @@
 import { useEffect, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
-import { useWorkspaceServeable } from "@/hooks/useWorkspaceChangedFiles";
+import {
+  browseLocationBase,
+  browseLocationSegment,
+  useWorkspaceServeable,
+} from "@/hooks/useWorkspaceChangedFiles";
 import { useChatStore } from "@/store/chatStore";
 
 // The primary workspace environment is always "default".  This hook targets
@@ -29,18 +33,17 @@ export async function fetchFileContent(
   conversationId: string,
   path: string,
 ): Promise<FileContentResponse> {
-  // Encode each path segment individually so slashes stay structural. An
-  // absolute path (a file opened while browsing outside the workspace) is sent
-  // WITHOUT its leading slash and named `?base=host`, exactly as the directory
-  // listing does — a leading "%2F" would decode to a "//" that reverse proxies
-  // (the Databricks Apps front door) merge to a single "/", turning it into a
-  // workspace-relative path and opening the wrong file (or none).
-  const absolute = path.startsWith("/");
-  const encodedPath = path.replace(/^\//, "").split("/").map(encodeURIComponent).join("/");
+  // Reuse the shared browse-location wire form: a per-segment-encoded path with
+  // literal slashes and, for an absolute path (a file opened while browsing
+  // outside the workspace), the base named by `?base=host`. Keeping this on the
+  // shared helpers means the slash-merge-safe contract lives in one place (see
+  // `browseLocationSegment`).
+  const encodedPath = browseLocationSegment(path);
+  const base = browseLocationBase(path);
   const url =
     `/v1/sessions/${encodeURIComponent(conversationId)}` +
     `/resources/environments/${DEFAULT_ENVIRONMENT_ID}/filesystem/${encodedPath}` +
-    (absolute ? "?base=host" : "");
+    (base ? `?base=${base}` : "");
   const res = await authenticatedFetch(url);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return (await res.json()) as FileContentResponse;

--- a/web/src/hooks/useWorkspaceChangedFiles.test.tsx
+++ b/web/src/hooks/useWorkspaceChangedFiles.test.tsx
@@ -18,6 +18,8 @@ import {
   type WorkspaceEnvironment,
   MAX_RUNNER_OFFLINE_RETRIES,
   RunnerOfflineError,
+  browseLocationBase,
+  browseLocationSegment,
   isRunnerUnavailable503,
   looksLikeWorkspaceFilePath,
   relativizeToWorkspace,
@@ -177,6 +179,11 @@ function DirectoryPathsProbe({
   useEffect(() => {
     if (query.isSuccess) onPaths(query.data.map((f) => f.path));
   }, [query.isSuccess, query.data, onPaths]);
+  return null;
+}
+
+function AllFilesProbeAt({ id, location }: { id: string; location: string }) {
+  useWorkspaceAllFiles(id, {}, location);
   return null;
 }
 
@@ -1127,5 +1134,75 @@ describe("browse-location listings normalize to paths relative to the location",
     await waitFor(() => expect(onPaths).toHaveBeenCalled());
 
     expect(onPaths).toHaveBeenLastCalledWith(["quarterly/q3.csv"]);
+  });
+});
+
+describe("browse-location wire form (survives a slash-merging proxy)", () => {
+  // The absolute/relative distinction must NOT ride on a leading "%2F" in the
+  // path: that decodes to a "//" which reverse proxies (the Databricks Apps
+  // front door) merge to a single "/", turning an absolute path into a
+  // workspace-relative one. Paths go out with literal slashes and no leading
+  // "%2F"; the base is named out of band via `?base=host`.
+  describe("browseLocationSegment", () => {
+    it.each([
+      ["", "", "root is empty"],
+      ["/", "", "filesystem root is empty (base names it)"],
+      ["src/app.ts", "src/app.ts", "relative path is bare"],
+      ["/Users/me", "Users/me", "absolute path drops its leading slash"],
+      ["/a/b/c", "a/b/c", "deep absolute path drops only the leading slash"],
+      ["/my docs/f", "my%20docs/f", "segments are still percent-encoded"],
+    ])("%s -> %s (%s)", (location, expected) => {
+      const seg = browseLocationSegment(location);
+      expect(seg, expected).toBe(expected);
+      expect(seg.includes("%2F"), "no %2F leading marker").toBe(false);
+    });
+  });
+
+  describe("browseLocationBase", () => {
+    it.each([
+      ["", null],
+      ["src/app.ts", null],
+      ["/", "host"],
+      ["/Users/me", "host"],
+    ])("%s -> %s", (location, expected) => {
+      expect(browseLocationBase(location)).toBe(expected);
+    });
+  });
+
+  it("requests an absolute location with a bare path plus base=host", async () => {
+    onlineMock.mockReturnValue(true);
+    fetchMock
+      .mockResolvedValueOnce(environmentResponse())
+      .mockResolvedValueOnce(jsonResponse({ object: "list", data: [], has_more: false }));
+
+    render(
+      <Wrap>
+        <AllFilesProbeAt id="conv_abs_url" location="/Users/me/reports" />
+      </Wrap>,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    const url = String(fetchMock.mock.calls[1][0]);
+    expect(url).toContain("/filesystem/Users/me/reports?");
+    expect(url).toContain("base=host");
+    expect(url.includes("%2F"), "no %2F in the absolute request").toBe(false);
+  });
+
+  it("requests a workspace-relative location with no base param", async () => {
+    onlineMock.mockReturnValue(true);
+    fetchMock
+      .mockResolvedValueOnce(environmentResponse())
+      .mockResolvedValueOnce(jsonResponse({ object: "list", data: [], has_more: false }));
+
+    render(
+      <Wrap>
+        <AllFilesProbeAt id="conv_rel_url" location="src/inner" />
+      </Wrap>,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    const url = String(fetchMock.mock.calls[1][0]);
+    expect(url).toContain("/filesystem/src/inner?");
+    expect(url).not.toContain("base=");
   });
 });

--- a/web/src/hooks/useWorkspaceChangedFiles.ts
+++ b/web/src/hooks/useWorkspaceChangedFiles.ts
@@ -357,8 +357,11 @@ async function fetchWorkspaceAllFiles(
   location = "",
 ): Promise<WorkspaceAllFilesResult> {
   const segment = browseLocationSegment(location);
+  const params = new URLSearchParams({ limit: "1000", order: "asc" });
+  const base = browseLocationBase(location);
+  if (base) params.set("base", base);
   const res = await authenticatedFetch(
-    `/v1/sessions/${encodeURIComponent(conversationId)}/resources/environments/${DEFAULT_ENVIRONMENT_ID}/filesystem${segment ? `/${segment}` : ""}?limit=1000&order=asc`,
+    `/v1/sessions/${encodeURIComponent(conversationId)}/resources/environments/${DEFAULT_ENVIRONMENT_ID}/filesystem${segment ? `/${segment}` : ""}?${params}`,
   );
   if (res.status === 404) {
     return { available: false, data: [] };
@@ -438,12 +441,29 @@ export function useWorkspaceAllFiles(
  * @returns The encoded path segment to append to a filesystem route.
  */
 export function browseLocationSegment(location: string): string {
-  if (location === "" || location === "/") {
-    return location === "/" ? "%2F" : "";
-  }
-  const absolute = location.startsWith("/");
-  const encoded = location.replace(/^\//, "").split("/").map(encodeURIComponent).join("/");
-  return absolute ? `%2F${encoded}` : encoded;
+  if (location === "" || location === "/") return "";
+  // A per-segment-encoded path with LITERAL slash separators and NO leading
+  // "%2F" — for BOTH workspace-relative and host-absolute locations. An
+  // absolute location's leading slash is stripped here and re-added by the
+  // server, exactly as the host filesystem endpoint does; its base is named
+  // out of band via `?base=host` (see `browseLocationBase`). A "%2F" leading
+  // marker would decode to a "//" that reverse proxies — the Databricks Apps
+  // front door among them — merge back to a single "/", silently turning an
+  // absolute path into a workspace-relative one and listing a nonexistent
+  // path under the workspace.
+  return location.replace(/^\//, "").split("/").map(encodeURIComponent).join("/");
+}
+
+/**
+ * The `base` query value naming how a browse location's `{path}` is rooted:
+ * `"host"` for an absolute path on the host, `null` for a workspace-relative
+ * one (the default, omitted from the URL).
+ *
+ * @param location Browse location, ``""`` for the workspace root.
+ * @returns ``"host"`` when absolute, else ``null``.
+ */
+export function browseLocationBase(location: string): "host" | null {
+  return location.startsWith("/") ? "host" : null;
 }
 
 /**
@@ -500,6 +520,8 @@ async function fetchWorkspaceFileSearch(
   if (include) params.set("include", include);
   if (exclude) params.set("exclude", exclude);
   const segment = browseLocationSegment(location);
+  const base = browseLocationBase(location);
+  if (base) params.set("base", base);
   const res = await authenticatedFetch(
     `/v1/sessions/${encodeURIComponent(conversationId)}/resources/environments/${DEFAULT_ENVIRONMENT_ID}/search${segment ? `/${segment}` : ""}?${params}`,
   );
@@ -564,8 +586,11 @@ async function fetchWorkspaceDirectory(
 ): Promise<WorkspaceFile[]> {
   const target = joinBrowseLocation(location, dirPath);
   const encodedPath = browseLocationSegment(target);
+  const params = new URLSearchParams({ limit: "1000", order: "asc" });
+  const base = browseLocationBase(target);
+  if (base) params.set("base", base);
   const res = await authenticatedFetch(
-    `/v1/sessions/${encodeURIComponent(conversationId)}/resources/environments/${DEFAULT_ENVIRONMENT_ID}/filesystem/${encodedPath}?limit=1000&order=asc`,
+    `/v1/sessions/${encodeURIComponent(conversationId)}/resources/environments/${DEFAULT_ENVIRONMENT_ID}/filesystem/${encodedPath}?${params}`,
   );
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   // The tree addresses children relative to the location it is rooted at, one

--- a/web/src/hooks/useWriteFileContent.ts
+++ b/web/src/hooks/useWriteFileContent.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
+import { browseLocationBase, browseLocationSegment } from "@/hooks/useWorkspaceChangedFiles";
 import type { FileContentResponse } from "./useFileContent";
 
 const DEFAULT_ENVIRONMENT_ID = "default";
@@ -9,17 +10,15 @@ async function writeFileContent(
   path: string,
   content: string,
 ): Promise<void> {
-  // An absolute path (saving a file edited outside the workspace) is sent
-  // WITHOUT its leading slash and named `?base=host`, matching the read path:
-  // a leading "%2F" would decode to a "//" that reverse proxies (the
-  // Databricks Apps front door) merge to a single "/", writing to the wrong
-  // (workspace-relative) location. See `browseLocationSegment`.
-  const absolute = path.startsWith("/");
-  const encodedPath = path.replace(/^\//, "").split("/").map(encodeURIComponent).join("/");
+  // Same slash-merge-safe wire form as the read path, via the shared helpers:
+  // a bare per-segment-encoded path, and `?base=host` for an absolute location
+  // (saving a file edited outside the workspace). See `browseLocationSegment`.
+  const encodedPath = browseLocationSegment(path);
+  const base = browseLocationBase(path);
   const url =
     `/v1/sessions/${encodeURIComponent(conversationId)}` +
     `/resources/environments/${DEFAULT_ENVIRONMENT_ID}/filesystem/${encodedPath}` +
-    (absolute ? "?base=host" : "");
+    (base ? `?base=${base}` : "");
   const res = await authenticatedFetch(url, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },

--- a/web/src/hooks/useWriteFileContent.ts
+++ b/web/src/hooks/useWriteFileContent.ts
@@ -9,10 +9,17 @@ async function writeFileContent(
   path: string,
   content: string,
 ): Promise<void> {
-  const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+  // An absolute path (saving a file edited outside the workspace) is sent
+  // WITHOUT its leading slash and named `?base=host`, matching the read path:
+  // a leading "%2F" would decode to a "//" that reverse proxies (the
+  // Databricks Apps front door) merge to a single "/", writing to the wrong
+  // (workspace-relative) location. See `browseLocationSegment`.
+  const absolute = path.startsWith("/");
+  const encodedPath = path.replace(/^\//, "").split("/").map(encodeURIComponent).join("/");
   const url =
     `/v1/sessions/${encodeURIComponent(conversationId)}` +
-    `/resources/environments/${DEFAULT_ENVIRONMENT_ID}/filesystem/${encodedPath}`;
+    `/resources/environments/${DEFAULT_ENVIRONMENT_ID}/filesystem/${encodedPath}` +
+    (absolute ? "?base=host" : "");
   const res = await authenticatedFetch(url, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -1443,6 +1443,62 @@ describe("FilesPanel browse location", () => {
     );
   });
 
+  it("restores the browsed location across unmount/remount (file-viewer round trip)", () => {
+    // Opening a file swaps the panel for the FileViewer, unmounting it.
+    // Closing the viewer must land back in the directory the file was opened
+    // from, not snap to the workspace root.
+    const first = renderPanel({
+      conversationId: "conv_viewer_roundtrip",
+      files: [],
+      workingDir: "/home/user/proj",
+      reachable: UNCONFINED,
+    });
+    fireEvent.click(screen.getByTestId("browse-location-path"));
+    fireEvent.click(screen.getByTestId("stub-picker-navigate"));
+    expect(useAllFilesMock).toHaveBeenLastCalledWith(
+      "conv_viewer_roundtrip",
+      expect.anything(),
+      "/etc",
+    );
+
+    first.unmount();
+    renderPanel({
+      conversationId: "conv_viewer_roundtrip",
+      files: [],
+      workingDir: "/home/user/proj",
+      reachable: UNCONFINED,
+    });
+
+    expect(useAllFilesMock).toHaveBeenLastCalledWith(
+      "conv_viewer_roundtrip",
+      expect.anything(),
+      "/etc",
+    );
+  });
+
+  it("keeps a remembered location scoped to its own conversation", () => {
+    // The cache must not leak one session's directory into another: a
+    // different conversation opens at ITS root, exactly as before.
+    const first = renderPanel({
+      conversationId: "conv_loc_owner",
+      files: [],
+      workingDir: "/home/user/proj",
+      reachable: UNCONFINED,
+    });
+    fireEvent.click(screen.getByTestId("browse-location-path"));
+    fireEvent.click(screen.getByTestId("stub-picker-navigate"));
+    first.unmount();
+
+    renderPanel({
+      conversationId: "conv_loc_other",
+      files: [],
+      workingDir: "/home/user/proj",
+      reachable: UNCONFINED,
+    });
+
+    expect(useAllFilesMock).toHaveBeenLastCalledWith("conv_loc_other", expect.anything(), "");
+  });
+
   it("surfaces a refused location instead of an empty tree", () => {
     // An empty tree reads as "this directory is empty", which is a different
     // fact from "you may not look here".

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -1393,6 +1393,32 @@ describe("FilesPanel browse location", () => {
     expect(trigger).toHaveTextContent("/home/user/proj");
   });
 
+  it("opens a file at an absolute browse location by its absolute path", () => {
+    // Regression: after navigating OUTSIDE the workspace (e.g. /etc), the tree
+    // lists files by bare name relative to that location. Opening one must
+    // hand the viewer the file's ABSOLUTE path (/etc/hosts) -- otherwise the
+    // viewer looks the bare name up under the workspace root and 404s.
+    const onFileSelect = vi.fn();
+    renderPanel({
+      conversationId: "conv_open_abs",
+      files: [],
+      workingDir: "/home/user/proj",
+      reachable: UNCONFINED,
+      onFileSelect,
+    });
+
+    // Re-rooting to /etc swaps the listing for one whose file is bare-named.
+    useAllFilesMock.mockImplementation((_id: unknown, _opts: unknown, location?: string) =>
+      location === "/etc" ? allFilesResult([file("hosts")]) : allFilesResult([]),
+    );
+    fireEvent.click(screen.getByTestId("browse-location-path"));
+    fireEvent.click(screen.getByTestId("stub-picker-navigate"));
+
+    fireEvent.click(screen.getByText("hosts"));
+
+    expect(onFileSelect).toHaveBeenCalledWith("/etc/hosts");
+  });
+
   it("re-roots both the tree and search when a directory is picked", () => {
     // The bug this feature fixes is a tree showing one directory while search
     // reports on another, so both queries must move together.

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -303,14 +303,16 @@ export function FilesPanel({
 
   /**
    * Open a file the TREE named. Tree paths are relative to the browsed
-   * location while the viewer resolves against the workspace root, so an
-   * in-workspace location has to be re-attached — otherwise a file opened
-   * after navigating into a folder is looked for in the wrong place. An
-   * absolute location has no workspace-relative form to hand over, so it is
-   * passed through as before.
+   * location, so the location is re-attached before handing the file to the
+   * viewer. For an in-workspace location that yields a workspace-relative
+   * path; for a location OUTSIDE the workspace it yields the file's absolute
+   * path, which the viewer fetches host-absolutely (see `fetchFileContent`).
+   * Without this a file opened while browsing an absolute location like
+   * `/tmp` would be looked up by its bare name under the workspace root and
+   * 404.
    */
   function openTreeFile(path: string) {
-    onFileSelect(locationParam.startsWith("/") ? path : joinBrowseLocation(locationParam, path));
+    onFileSelect(joinBrowseLocation(locationParam, path));
   }
 
   const allFilesQuery = useWorkspaceAllFiles(conversationId, { enabled: !flatView }, locationParam);

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -207,6 +207,17 @@ function SearchFilterInput({
 // ---------------------------------------------------------------------------
 
 /**
+ * Browse location per conversation, surviving unmount/remount within a JS
+ * session. Opening a file swaps this panel for the FileViewer (see
+ * WorkspacePanel's content slot), which unmounts it — with plain state,
+ * closing the viewer snapped the tree back to the workspace root instead of
+ * the directory the file was opened from. Same pattern as FolderTree's
+ * expandedPathsCache. Keyed by conversation, so a session switch still lands
+ * on that session's own last location (or its root), never another's.
+ */
+const browseLocationCache = new Map<string, string>();
+
+/**
  * Right-side Files card. Always visible on desktop.
  *
  * - Flat view: changed files only (registry-backed, any depth).
@@ -272,13 +283,21 @@ export function FilesPanel({
   // The picker browses the host's filesystem, the same source the new-session
   // workspace chip uses.
   const { session } = useSession(conversationId);
-  // Absolute path currently browsed. Null tracks the workspace root, so the
-  // panel keeps opening there and a session switch never strands the user in
-  // a directory belonging to the session they just left.
-  const [browseLocation, setBrowseLocation] = useState<string | null>(null);
+  // Absolute path currently browsed. Null tracks the workspace root. Seeded
+  // from the per-conversation cache so the location survives the panel
+  // unmounting while a file is open in the viewer.
+  const [browseLocation, setBrowseLocation] = useState<string | null>(
+    () => (conversationId && browseLocationCache.get(conversationId)) || null,
+  );
   const [browseError, setBrowseError] = useState<string | null>(null);
+  // On an in-place conversation switch (no remount), land on the NEW
+  // session's own cached location or its root — never the previous
+  // session's directory. The ref keeps mount itself from wiping the seed.
+  const browseForRef = useRef(conversationId);
   useEffect(() => {
-    setBrowseLocation(null);
+    if (browseForRef.current === conversationId) return;
+    browseForRef.current = conversationId;
+    setBrowseLocation((conversationId && browseLocationCache.get(conversationId)) || null);
     setBrowseError(null);
   }, [conversationId]);
   const workingDir = browseLocation ?? workspaceRoot;
@@ -292,7 +311,12 @@ export function FilesPanel({
 
   function navigateTo(absolutePath: string) {
     setBrowseError(null);
-    setBrowseLocation(absolutePath === workspaceRoot ? null : absolutePath);
+    const next = absolutePath === workspaceRoot ? null : absolutePath;
+    if (conversationId) {
+      if (next === null) browseLocationCache.delete(conversationId);
+      else browseLocationCache.set(conversationId, next);
+    }
+    setBrowseLocation(next);
   }
 
   /** Re-root onto a directory of the current tree (double-click to open). */


### PR DESCRIPTION
## Related issue

Closes #5173

## Summary

The file panel showed **"No files in workspace"** for any directory above or outside the working folder when the app is served through the Databricks Apps front door — even though the picker dropdown listed those same directories (paths in the dropdown, empty tree).

- **Root cause:** absolute browse locations were marked by a leading `%2F` in the filesystem route's `{path}` segment. That `%2F` decodes to a boundary `//` which the front door merges back to a single `/` (`//health` 301-redirects to `/health`), so `/Users/me` arrived at the server as a workspace-relative `Users/me` and listed a nonexistent path under the workspace. The picker uses the host filesystem endpoint, which already sends bare slashes, so it was unaffected.
- **Fix:** follow the host endpoint's own convention — send the path with literal slashes and no leading `%2F` (nothing for a proxy to merge) and name an absolute location out of band with `?base=host`. The server re-adds the leading slash, applies the same owner gate (an absolute path is owner-only, so `base=host` is not a way around it), and re-encodes `%2F` only on the internal server→runner leg, which is not proxied.

Covers list, lazy directory expand, search, file read, and write; the filesystem root (`base=host` with an empty segment) is handled on the no-path route. A genuine leading slash still works for a direct, unproxied client.

<details><summary>ELI5</summary>

The web app told the server "list `/Users/me`" by writing the leading slash as `%2F`. A proxy in front of the deployed app "tidies up" web addresses by collapsing double slashes — and `%2F` becomes a slash, so `//Users` became `/Users`, which the server read as "a folder *inside* the project called `Users`". There's no such folder, so the panel showed nothing. The picker used a different, tidy-proof form all along, which is why its dropdown still worked. The fix sends the path in that same tidy-proof form and puts the "this is an absolute path" bit in the query string, where the proxy leaves it alone.
</details>

## Test Plan

- `pytest tests/e2e_ui/files/test_files_panel_header.py tests/e2e_ui/collaboration/test_browse_outside_workspace.py --ui-skip-build` → 8 passed.
- `pytest tests/server/routes/test_session_resources.py` → 146 passed (3 new).
- `vitest run` on the affected web suites → 195 passed (12 new).
- Live, against a running server: navigated the tree up to a parent, `/Users/corey.zumar`, `/Users`, and `/` — all list. Confirmed the browser now sends bare-slash URLs (no `%2F`) with `?base=host`.

## Demo

This bug only reproduces **behind a slash-merging proxy** (the deployed Databricks App); a local dev server has no such front door, so a local screenshot looks identical before and after. The reproduction is therefore an e2e test that replays the front door's normalization on the session's filesystem/search requests:

`test_absolute_browse_survives_a_slash_merging_proxy` — mutation-tested against the pre-fix web code:

```
# pre-fix web (leading %2F): the reported symptom
E  AssertionError: Locator expected to be visible
E    - paragraph: No files in workspace
E    - waiting for get_by_text("sentinel.txt")
1 failed

# post-fix (bare slashes + ?base=host)
1 passed
```

The front-door behavior the test replays was confirmed directly against the deployed app: `GET //health` → `301 Location: /health` (it merges `//` and preserves the query string).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: reproduced the empty-tree failure against the deployed app, root-caused the front-door `//`-merge (`//health` → `301 /health`, query preserved), then verified the fix end-to-end in a real browser against a running server (bare-slash URLs + `?base=host`, tree lists parent/home/`/`). Automated coverage: e2e reproduction (mutation-tested), collaboration test extends the owner gate to the `base=host` form (collaborator 403, owner 200 — not an escape hatch), route tests pin the `base=host` → absolute forwarding and the bare-path-stays-relative contrast.

## Changelog

Fixed the file browser showing no files for directories above or outside the working folder when the app runs behind a reverse proxy
