### PR TITLE
perf(claude-native): skip Databricks model discovery on the remote path

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -1341,22 +1341,24 @@ def run_claude_native(
     if prompt and prompt.strip():
         sanitized_args = (*sanitized_args, prompt)
     startup_profiler.mark("claude args normalized")
-    # Resolve the launch config across all offerings: a configured provider
-    # (configure harnesses), the Databricks ucode profile, or Claude's own
-    # login — so `omnigent claude` honors the provider selection just like
-    # the in-process claude-sdk harness. ``use_claude_config`` forces the
-    # CLI's own ~/.claude config (skips all of it).
-    startup_profiler.mark("resolving claude config")
-    claude_config = None if use_claude_config else resolve_native_claude_config(spec=None)
-    startup_profiler.mark(
-        "claude config resolved",
-        detail="native config" if claude_config is not None else "claude cli config",
-    )
-
     with TemporaryDirectory(prefix="omnigent-claude-native-") as tmpdir:
         spec_path = _materialize_claude_agent_spec(Path(tmpdir))
         startup_profiler.mark("agent spec materialized")
         if server is None:
+            # Resolve the launch config across all offerings: a configured
+            # provider (configure harnesses), the Databricks ucode profile, or
+            # Claude's own login — so `omnigent claude` honors the provider
+            # selection just like the in-process claude-sdk harness.
+            # ``use_claude_config`` forces the CLI's own ~/.claude config
+            # (skips all of it). Local-only: resolving mints a workspace token
+            # and lists the workspace's Claude model services, so the remote
+            # path — which never consumes the result — must not pay for it.
+            startup_profiler.mark("resolving claude config")
+            claude_config = None if use_claude_config else resolve_native_claude_config(spec=None)
+            startup_profiler.mark(
+                "claude config resolved",
+                detail="native config" if claude_config is not None else "claude cli config",
+            )
             _run_with_local_server(
                 spec_path,
                 session_id=session_id,

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -1317,6 +1317,53 @@ def test_run_preflights_local_tmux(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("server", "expected_calls"),
+    [(None, 1), ("https://example.com/", 0)],
+    ids=["local-resolves", "remote-skips"],
+)
+def test_run_resolves_claude_config_only_for_the_local_path(
+    monkeypatch: pytest.MonkeyPatch,
+    server: str | None,
+    expected_calls: int,
+) -> None:
+    """
+    Only the local path resolves the native Claude launch config.
+
+    Resolving mints a Databricks workspace token and lists the
+    workspace's Claude model services — two HTTP round trips. The
+    daemon-spawned runner on the remote path derives its own config from
+    the provider config and never receives this one, so paying for it
+    there is pure startup latency.
+    """
+    calls = 0
+
+    def fake_resolve(**kwargs: object) -> None:
+        """Count resolutions without touching Databricks.
+
+        :param kwargs: Ignored ``spec`` / ``refresh_models`` arguments.
+        :returns: ``None``, i.e. "use Claude's own login".
+        """
+        del kwargs
+        nonlocal calls
+        calls += 1
+        return None
+
+    monkeypatch.setattr(claude_native.shutil, "which", lambda command: f"/usr/bin/{command}")
+    monkeypatch.setattr(claude_native, "resolve_native_claude_config", fake_resolve)
+    monkeypatch.setattr(claude_native, "_run_with_local_server", lambda *a, **k: None)
+    monkeypatch.setattr(claude_native, "_run_with_remote_server", lambda *a, **k: None)
+
+    claude_native.run_claude_native(
+        server=server,
+        session_id=None,
+        extra_args=(),
+        command="claude",
+    )
+
+    assert calls == expected_calls
+
+
 def test_local_run_persists_launch_state_on_fresh_session(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Starting a session against a remote server spends most of its wall clock waiting on the host / runner / terminal status endpoints, which answer in 0.5–2.5s each. Two of those waits were self-inflicted.

- **A duplicate terminal fetch.** `_prepare_claude_terminal_via_daemon` polled the terminal resource until it was ready, then immediately re-fetched *the same resource* just to read its tmux coordinates — paying that ~2.3s lookup twice on every launch and every resume. The readiness poll now returns a `_ClaudeTerminalSnapshot` carrying both the resource id and the tmux coordinates from the one response it already had. `_read_claude_terminal_tmux` stays for the launch path (which holds no snapshot) and now shares its parsing with the poll.
- **Idle gaps between polls.** The wait loops slept a full `DAEMON_POLL_INTERVAL_S` *after* each response, on top of a request that had usually already outlasted that interval — so a resource that came up mid-call sat unnoticed for another half second. `next_poll_delay_s` measures the gap from the *start* of the request, keeping the same ceiling of one poll per interval while dropping the dead time.

Together this takes roughly **2.8s off a fresh `omnigent claude` launch**. The poll-cadence half benefits every harness and `omnigent run`.

ELI5: we were asking the server the same question twice, and then twiddling our thumbs between questions.

```
before:  [poll terminal ~2.3s] -> [sleep 0.5s] -> ... -> ready -> [fetch tmux ~2.3s]
after:   [poll terminal ~2.3s] -> [sleep 0s]   -> ... -> ready (tmux included)
```

## Test Plan

- `pytest tests/host/test_daemon_launch.py tests/test_claude_native.py tests/test_claude_native_daemon.py` — 312 passed.
- Both new tests were verified to actually fail when the optimization is reverted: re-adding a second fetch trips `test_prepare_daemon_terminal_reports_progress_steps`, and restoring the full-interval sleep trips `test_next_poll_delay_s_treats_the_interval_as_a_floor`.
- Manual: `OMNIGENT_CLAUDE_STARTUP_PROFILE=1 omnigent claude --server <remote>` — the `daemon terminal tmux metadata read` mark is gone, and `claude terminal ready` now carries a `terminal=...` detail. Also resumed into a live session to confirm the direct tmux attach still happens; the coordinates now come from the poll response, so a mistake there would show up as a slower WebSocket-bridge attach rather than an error.

Note: `test_resolve_native_claude_config_ambient_key` and `..._ambient_prefixed_key` fail identically on pristine `origin/main` in this environment — pre-existing, unrelated files.

## Demo

N/A — no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The two new unit tests pin the properties that matter: `_wait_for_claude_terminal_ready` returns tmux coordinates from a single round trip, and the poll interval behaves as a floor rather than an added delay. Both were confirmed to fail when the change is reverted. The end-to-end latency win itself was verified manually with the startup profiler, since it isn't something a unit test can measure.

## Changelog

Sessions start faster — `omnigent claude` no longer refetches the terminal it just found, and status polls no longer idle between attempts.
