### PR TITLE
perf(databricks): issue both Claude model listings concurrently

### DIFF
--- a/omnigent/databricks_model_discovery.py
+++ b/omnigent/databricks_model_discovery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import logging
 import re
 import warnings
@@ -234,7 +235,10 @@ def discover_databricks_claude_catalog(
     named Claude models — short-circuiting on the UC hit would cost one HTTP
     round trip less per launch, but UC only ever spells ids ``system.ai.``, so
     the spelling a consumer sees would depend on whether the (transiently
-    failing) UC call answered.
+    failing) UC call answered. Since both are always issued and neither feeds
+    the other, they are issued concurrently: this runs on the
+    ``omnigent claude`` startup path, where the two listings' latencies would
+    otherwise add up.
 
     :param workspace_url: Workspace origin, e.g. ``"https://example.com"``.
     :param token: Workspace bearer token.
@@ -251,13 +255,24 @@ def discover_databricks_claude_catalog(
     gateway_error: Exception | None = None
     model_service_ids: list[str] = []
     gateway_ids: list[str] = []
-    with httpx.Client(transport=transport, timeout=_HTTP_TIMEOUT_S) as client:
+    # Both listings are always issued (see above) and neither feeds the other,
+    # so they run concurrently on one connection pool: the stage costs
+    # max(uc, gateway) instead of their sum. Pagination stays sequential inside
+    # each listing, which its page tokens require.
+    with (
+        httpx.Client(transport=transport, timeout=_HTTP_TIMEOUT_S) as client,
+        concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool,
+    ):
+        model_services_future = pool.submit(
+            _list_model_service_ids, client, workspace_url, headers
+        )
+        gateway_future = pool.submit(_list_anthropic_gateway_ids, client, workspace_url, headers)
         try:
-            model_service_ids = _list_model_service_ids(client, workspace_url, headers)
+            model_service_ids = model_services_future.result()
         except (httpx.HTTPError, ValueError) as exc:
             primary_error = exc
         try:
-            gateway_ids = _list_anthropic_gateway_ids(client, workspace_url, headers)
+            gateway_ids = gateway_future.result()
         except (httpx.HTTPError, ValueError) as exc:
             gateway_error = exc
 

--- a/tests/test_databricks_model_discovery.py
+++ b/tests/test_databricks_model_discovery.py
@@ -371,3 +371,42 @@ def test_select_servable_model_matches_legacy_spelling() -> None:
     assert select_servable_model("databricks-gpt-5-6-luna", servable) == "system.ai.gpt-5-6-luna"
     # A model the workspace does not serve is left for the caller to pass through.
     assert select_servable_model("databricks-gpt-9-9", servable) is None
+
+
+def test_claude_catalog_issues_both_listings_concurrently() -> None:
+    """
+    The UC and legacy-gateway listings overlap rather than serialize.
+
+    Both are always issued and neither feeds the other, so discovery runs
+    them together — it sits on the ``omnigent claude`` startup path, where
+    serializing them adds a whole round trip. A barrier proves the
+    overlap: it only releases once *both* handlers have arrived, so a
+    sequential implementation blocks here until the barrier times out and
+    the test fails.
+    """
+    import threading
+
+    barrier = threading.Barrier(2, timeout=10.0)
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Answer only after its counterpart request has also arrived.
+
+        :param request: The intercepted discovery request.
+        :returns: A minimal successful listing for the matched endpoint.
+        """
+        barrier.wait()
+        if request.url.path.endswith("/model-services"):
+            return httpx.Response(
+                200,
+                json={"model_services": [{"name": "model-services/system.ai.claude-opus-5"}]},
+                request=request,
+            )
+        return httpx.Response(200, json={"data": []}, request=request)
+
+    catalog = discover_databricks_claude_catalog(
+        "https://workspace.example.com",
+        "token",
+        transport=httpx.MockTransport(_handler),
+    )
+
+    assert catalog.families == {"opus": "system.ai.claude-opus-5"}


### PR DESCRIPTION
## Related issue

N/A — internal startup-latency work, no tracking issue.

## Summary

Claude model discovery queries two endpoints and **always issues both** — the Unity Catalog model-services listing and the legacy Anthropic gateway listing. That is deliberate and this PR keeps it: UC only ever spells ids `system.ai.`, so short-circuiting on a UC hit would make the spelling a consumer sees depend on whether the (transiently failing) UC call answered.

But they were issued *sequentially*, so their latencies added up — on the `omnigent claude` startup path, with a 10s timeout each.

- Submit both listings on one shared connection pool so the stage costs `max(uc, gateway)` instead of their sum.
- Pagination stays sequential *inside* each listing, which its page tokens require.
- Error semantics unchanged: each listing's failure is still captured separately, and a double failure still raises the gateway error chained from the primary one.

Part of a series of independent `omni claude` startup-latency fixes.

## Test Plan

- New `test_claude_catalog_issues_both_listings_concurrently` uses a `threading.Barrier(2)` that only releases once *both* handlers have arrived, so it proves overlap rather than just asserting the result.
- **Verified the test has teeth**: reverted to the sequential implementation and the new test fails with `threading.BrokenBarrierError` after the 10s barrier timeout; it passes with this change.
- `pytest tests/test_databricks_model_discovery.py` → 20 passed.
- `pre-commit run --files omnigent/databricks_model_discovery.py tests/test_databricks_model_discovery.py` → ruff format/check pass; `pyrefly check` on both files reports **0 errors**, same as `main`.

## Demo

N/A — non-visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the new unit test, which was verified to fail against the previous sequential implementation.

## Changelog

Databricks Claude model discovery runs its two workspace listings in parallel, cutting a round trip off `omnigent claude` startup.

---

This pull request and its description were written by Isaac.
