### PR TITLE
perf(claude-native): read the Claude terminal's tmux coords in one request

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -3808,7 +3808,7 @@ async def _wait_for_claude_terminal_ready(
     session_id: str,
     *,
     timeout_s: float,
-) -> str:
+) -> _RunningClaudeTerminal:
     """
     Poll until the runner has auto-created the Claude terminal.
 
@@ -3820,14 +3820,15 @@ async def _wait_for_claude_terminal_ready(
     :param client: HTTP client pointed at the Omnigent server.
     :param session_id: Session id, e.g. ``"conv_abc123"``.
     :param timeout_s: Max seconds to wait, e.g. ``60.0``.
-    :returns: The terminal resource id, e.g. ``"terminal_claude_main"``.
+    :returns: The terminal and the tmux coordinates its resource
+        advertised, both read from the poll's final response.
     :raises click.ClickException: If no terminal appears in time.
     """
     deadline = asyncio.get_event_loop().time() + timeout_s
     while asyncio.get_event_loop().time() < deadline:
-        terminal_id = await _find_running_claude_terminal(client, session_id)
-        if terminal_id is not None:
-            return terminal_id
+        terminal = await _find_running_claude_terminal(client, session_id)
+        if terminal is not None:
+            return terminal
         await asyncio.sleep(DAEMON_POLL_INTERVAL_S)
     raise click.ClickException(
         f"The runner did not create the Claude terminal for {session_id!r} "
@@ -4062,7 +4063,7 @@ async def _prepare_claude_terminal_via_daemon(
                 startup_progress=startup_progress,
                 progress_message="Starting Claude terminal...",
             )
-            terminal_id = await _wait_for_claude_terminal_ready(
+            terminal = await _wait_for_claude_terminal_ready(
                 client, session_id, timeout_s=_DAEMON_TERMINAL_READY_TIMEOUT_S
             )
         else:
@@ -4079,7 +4080,7 @@ async def _prepare_claude_terminal_via_daemon(
                 startup_progress=startup_progress,
                 progress_message="Starting Claude terminal...",
             )
-            _, terminal_id = await asyncio.gather(
+            _, terminal = await asyncio.gather(
                 wait_for_runner_online(
                     client, runner_id, timeout_s=_DAEMON_RUNNER_ONLINE_TIMEOUT_S
                 ),
@@ -4087,25 +4088,21 @@ async def _prepare_claude_terminal_via_daemon(
                     client, session_id, timeout_s=_DAEMON_TERMINAL_READY_TIMEOUT_S
                 ),
             )
+        # The readiness poll's final response already carried the tmux
+        # coordinates, so the direct-attach fast path costs no extra request.
         _mark_startup_step(
             startup_profiler,
             "claude terminal ready",
             startup_progress=startup_progress,
             progress_message="Claude terminal ready.",
         )
-        tmux = await _read_claude_terminal_tmux(client, session_id)
-        _mark_startup_step(
-            startup_profiler,
-            "daemon terminal tmux metadata read",
-            startup_progress=startup_progress,
-        )
     return PreparedClaudeTerminal(
         session_id=session_id,
-        terminal_id=terminal_id,
+        terminal_id=terminal.terminal_id,
         bridge_dir=bridge_dir_for_conversation_id(session_id),
         reattached=reattached,
-        tmux_socket=tmux.socket,
-        tmux_target=tmux.target,
+        tmux_socket=terminal.tmux.socket,
+        tmux_target=terminal.tmux.target,
     )
 
 
@@ -4419,26 +4416,21 @@ async def _prepare_claude_terminal(
                 "checking existing terminal",
                 startup_progress=startup_progress,
             )
-            existing_terminal_id = await _find_running_claude_terminal(client, session_id)
-            if existing_terminal_id is not None:
+            existing_terminal = await _find_running_claude_terminal(client, session_id)
+            if existing_terminal is not None:
+                # The lookup's response already carried the tmux coordinates.
                 _mark_startup_step(
                     startup_profiler,
                     "existing terminal found",
                     startup_progress=startup_progress,
                 )
-                reattach_tmux = await _read_claude_terminal_tmux(client, session_id)
-                _mark_startup_step(
-                    startup_profiler,
-                    "existing terminal tmux metadata read",
-                    startup_progress=startup_progress,
-                )
                 return PreparedClaudeTerminal(
                     session_id=session_id,
-                    terminal_id=existing_terminal_id,
+                    terminal_id=existing_terminal.terminal_id,
                     bridge_dir=bridge_dir_for_bridge_id(bridge_id),
                     reattached=True,
-                    tmux_socket=reattach_tmux.socket,
-                    tmux_target=reattach_tmux.target,
+                    tmux_socket=existing_terminal.tmux.socket,
+                    tmux_target=existing_terminal.tmux.target,
                 )
             # Session exists but no live terminal — recover claude's prior transcript via --resume.
             _mark_startup_step(
@@ -5460,9 +5452,9 @@ async def _launch_claude_terminal(
 async def _find_running_claude_terminal(
     client: httpx.AsyncClient,
     session_id: str,
-) -> str | None:
+) -> _RunningClaudeTerminal | None:
     """
-    Return the existing running ``claude/main`` terminal id if present.
+    Return the existing running ``claude/main`` terminal if present.
 
     Lookup happens before rebinding an existing session to this
     invocation's local runner. That preserves reattach behavior for a
@@ -5471,11 +5463,15 @@ async def _find_running_claude_terminal(
     callers deterministically bind the current local runner and launch
     a fresh terminal.
 
+    The resource carries the runner's tmux coordinates in the same
+    payload, so they ride along on this response rather than costing a
+    second identical GET.
+
     :param client: HTTP client pointed at the Omnigent server.
     :param session_id: Session/conversation id, e.g.
         ``"conv_abc123"``.
-    :returns: The deterministic Claude terminal id, or ``None`` when
-        the wrapper should launch a new terminal.
+    :returns: The running terminal and its tmux coordinates, or ``None``
+        when the wrapper should launch a new terminal.
     :raises click.ClickException: If the server rejects the lookup for
         a reason other than "not currently attachable".
     """
@@ -5496,7 +5492,10 @@ async def _find_running_claude_terminal(
         metadata = payload.get("metadata")
         if isinstance(metadata, dict) and metadata.get("running") is False:
             return None
-        return terminal_id
+        return _RunningClaudeTerminal(
+            terminal_id=terminal_id,
+            tmux=_tmux_from_terminal_metadata(metadata),
+        )
     if resp.status_code in {404, 409, 502, 503}:
         return None
     if resp.status_code >= 400:
@@ -5521,6 +5520,40 @@ class _ClaudeTerminalTmux:
 
     socket: Path | None
     target: str | None
+
+
+@dataclass(frozen=True)
+class _RunningClaudeTerminal:
+    """
+    A live Claude terminal resource and how to attach to it locally.
+
+    :param terminal_id: The deterministic Claude terminal resource id,
+        e.g. ``"terminal_claude_main"``.
+    :param tmux: tmux coordinates read from the same resource payload;
+        ``(None, None)`` when the runner advertised none.
+    """
+
+    terminal_id: str
+    tmux: _ClaudeTerminalTmux
+
+
+def _tmux_from_terminal_metadata(metadata: object) -> _ClaudeTerminalTmux:
+    """
+    Parse tmux coordinates out of a terminal resource's ``metadata``.
+
+    :param metadata: The resource payload's ``metadata`` value; anything
+        other than a dict carrying both string fields yields
+        ``(None, None)``.
+    :returns: The tmux coordinates, or ``_ClaudeTerminalTmux(None, None)``
+        when unavailable.
+    """
+    if not isinstance(metadata, dict):
+        return _ClaudeTerminalTmux(socket=None, target=None)
+    raw_socket = metadata.get("tmux_socket")
+    raw_target = metadata.get("tmux_target")
+    socket = Path(raw_socket) if isinstance(raw_socket, str) and raw_socket else None
+    target = raw_target if isinstance(raw_target, str) and raw_target else None
+    return _ClaudeTerminalTmux(socket=socket, target=target)
 
 
 async def _read_claude_terminal_tmux(
@@ -5552,14 +5585,7 @@ async def _read_claude_terminal_tmux(
         return _ClaudeTerminalTmux(socket=None, target=None)
     if resp.status_code != 200:
         return _ClaudeTerminalTmux(socket=None, target=None)
-    metadata = resp.json().get("metadata")
-    if not isinstance(metadata, dict):
-        return _ClaudeTerminalTmux(socket=None, target=None)
-    raw_socket = metadata.get("tmux_socket")
-    raw_target = metadata.get("tmux_target")
-    socket = Path(raw_socket) if isinstance(raw_socket, str) and raw_socket else None
-    target = raw_target if isinstance(raw_target, str) and raw_target else None
-    return _ClaudeTerminalTmux(socket=socket, target=target)
+    return _tmux_from_terminal_metadata(resp.json().get("metadata"))
 
 
 def _claude_terminal_request(

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -1717,36 +1717,38 @@ async def test_prepare_daemon_terminal_reports_progress_steps(
         session_id: str,
         *,
         timeout_s: float,
-    ) -> str:
+    ) -> claude_native._RunningClaudeTerminal:
         """
-        Return the Claude terminal id once the wait phase is reached.
+        Return the Claude terminal once the wait phase is reached.
 
         :param client: HTTP client created by the prepare helper.
         :param session_id: Created conversation id.
         :param timeout_s: Timeout supplied by production.
-        :returns: Fixed terminal id.
+        :returns: Fixed terminal id and its tmux coordinates.
         """
         del client, timeout_s
         assert session_id == "conv_daemon_progress"
-        return claude_native.claude_terminal_resource_id()
+        return claude_native._RunningClaudeTerminal(
+            terminal_id=claude_native.claude_terminal_resource_id(),
+            tmux=claude_native._ClaudeTerminalTmux(
+                socket=tmp_path / "tmux.sock",
+                target="claude:main",
+            ),
+        )
 
-    async def fake_read_tmux(
+    async def fail_read_tmux(
         client: object,
         session_id: str,
     ) -> claude_native._ClaudeTerminalTmux:
         """
-        Return local tmux metadata for direct attach.
+        Fail if prepare re-reads tmux metadata the poll already returned.
 
         :param client: HTTP client created by the prepare helper.
         :param session_id: Created conversation id.
-        :returns: Fake tmux coordinates.
+        :returns: Never returns.
         """
         del client
-        assert session_id == "conv_daemon_progress"
-        return claude_native._ClaudeTerminalTmux(
-            socket=tmp_path / "tmux.sock",
-            target="claude:main",
-        )
+        raise AssertionError(f"unexpected second terminal GET for {session_id}")
 
     monkeypatch.setattr(claude_native, "_create_claude_session", fake_create_session)
     monkeypatch.setattr(claude_native, "wait_for_host_online", fake_wait_for_host_online)
@@ -1761,7 +1763,7 @@ async def test_prepare_daemon_terminal_reports_progress_steps(
         "_wait_for_claude_terminal_ready",
         fake_wait_for_terminal_ready,
     )
-    monkeypatch.setattr(claude_native, "_read_claude_terminal_tmux", fake_read_tmux)
+    monkeypatch.setattr(claude_native, "_read_claude_terminal_tmux", fail_read_tmux)
 
     prepared = await claude_native._prepare_claude_terminal_via_daemon(
         base_url="https://example.com",
@@ -2170,17 +2172,22 @@ async def test_prepare_reattaches_existing_claude_terminal(
     """
     calls: list[str] = []
 
-    async def fake_find(client: object, session_id: str) -> str | None:
+    async def fake_find(
+        client: object, session_id: str
+    ) -> claude_native._RunningClaudeTerminal | None:
         """
         Return the existing terminal and record lookup order.
 
         :param client: HTTP client created by the prepare helper.
         :param session_id: Existing session id.
-        :returns: Existing terminal id.
+        :returns: The existing terminal and its tmux coordinates.
         """
         del client
         calls.append(f"find:{session_id}")
-        return claude_native.claude_terminal_resource_id()
+        return claude_native._RunningClaudeTerminal(
+            terminal_id=claude_native.claude_terminal_resource_id(),
+            tmux=claude_native._ClaudeTerminalTmux(socket=None, target=None),
+        )
 
     async def fail_bind(client: object, session_id: str, runner_id: str) -> None:
         """
@@ -2256,7 +2263,9 @@ async def test_find_running_claude_terminal_reads_resource_endpoint() -> None:
 
     The helper must use the session resource endpoint rather than
     issuing a create request, otherwise lookup itself could duplicate
-    ``claude/main``.
+    ``claude/main``. The tmux coordinates ride along on that same
+    response, so a single request answers both "is it running?" and
+    "can I attach to its tmux directly?".
     """
     requested_urls: list[str] = []
     terminal_id = claude_native.claude_terminal_resource_id()
@@ -2274,7 +2283,11 @@ async def test_find_running_claude_terminal_reads_resource_endpoint() -> None:
             json={
                 "id": terminal_id,
                 "type": "terminal",
-                "metadata": {"running": True},
+                "metadata": {
+                    "running": True,
+                    "tmux_socket": "/tmp/claude.sock",
+                    "tmux_target": "main",
+                },
             },
         )
 
@@ -2282,7 +2295,11 @@ async def test_find_running_claude_terminal_reads_resource_endpoint() -> None:
     async with httpx.AsyncClient(transport=transport, base_url="https://example.com") as client:
         found = await claude_native._find_running_claude_terminal(client, "conv with space")
 
-    assert found == terminal_id
+    assert found is not None
+    assert found.terminal_id == terminal_id
+    assert found.tmux.socket == Path("/tmp/claude.sock")
+    assert found.tmux.target == "main"
+    # One request answers both questions — no second identical GET.
     assert requested_urls == [
         "https://example.com/v1/sessions/conv%20with%20space"
         "/resources/terminals/terminal_claude_main"


### PR DESCRIPTION
## Related issue

N/A — internal startup-latency work, no tracking issue.

## Summary

`GET /v1/sessions/{id}/resources/terminals/{tid}` returns the terminal's `running` flag **and** its `tmux_socket` / `tmux_target` in one payload. The startup path fetched it twice: once to learn the terminal exists, then again — same URL — purely to read the tmux coordinates for the direct-attach fast path.

Two call sites paid that extra round trip on every launch:
- the daemon path, right after the readiness poll returned;
- the local reattach path, right after the existing-terminal lookup.

- `_find_running_claude_terminal` now returns the terminal id *together with* the tmux coordinates parsed from the response it already received, so the second GET disappears.
- `_read_claude_terminal_tmux` stays for the one site that genuinely needs it — after POSTing a brand-new terminal, whose create response does not carry the coordinates — and now shares the metadata parser instead of duplicating it.

Part of a series of independent `omni claude` startup-latency fixes.

## Test Plan

- `test_prepare_daemon_terminal_reports_progress_steps` now stubs `_read_claude_terminal_tmux` to **raise** — so the test fails if the redundant GET ever comes back. It passes, proving the request is gone.
- `test_find_running_claude_terminal_reads_resource_endpoint` extended: the mock now serves tmux metadata, and the test asserts both the terminal id and the parsed tmux coords come from the **single** recorded request.
- `test_prepare_reattaches_existing_claude_terminal` updated for the new return shape.
- `pytest tests/test_claude_native.py tests/test_claude_native_daemon.py` → 324 passed.
- Verified no other references to the three touched helpers exist repo-wide (`grep` across all `*.py`).
- `pre-commit run` → ruff format/check pass. `pyrefly check` reports the same **58 errors** as `main` for these files, so no new type errors.
- Confirmed the module still imports cleanly despite the forward reference in the annotation.

Pre-existing on `main` and unrelated: `test_resolve_native_claude_config_ambient_key` / `..._ambient_prefixed_key` fail on my box because an ambient `~/.databrickscfg` leaks into ambient detection.

Measure with `omni claude --profile-startup`: the `daemon terminal tmux metadata read` step is gone.

## Demo

N/A — non-visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the updated unit tests, one of which now actively fails if the removed request returns.

## Changelog

`omnigent claude` drops a redundant server round trip when starting or reattaching to a Claude terminal.

---

This pull request and its description were written by Isaac.
