### PR TITLE
fix(server): idempotent external-item persists keyed by the forwarder's source_id

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -4033,6 +4033,11 @@ async def _post_external_conversation_item(
                     "item_type": item.item_type,
                     "item_data": item.data,
                     "response_id": item.response_id,
+                    # Server-side idempotency key: the forwarder retries a
+                    # timed-out POST it cannot know the disposition of, so
+                    # the server derives the item's id from this and treats
+                    # a re-post as a no-op instead of a duplicate.
+                    "source_id": item.source_id,
                 },
             },
         )

--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -782,6 +782,13 @@ class NewConversationItem(BaseModel):
     response_id: str
     data: ItemData
     created_by: str | None = None
+    # Deterministic item id for idempotent appends. When set, the store uses
+    # it as the item's id and treats an already-persisted item with this id
+    # as the append's result instead of inserting a duplicate — the retry
+    # contract for at-least-once producers (a transcript forwarder cannot
+    # know whether a timed-out POST committed). Same 32-hex shape the store
+    # mints itself; ``None`` keeps the store-assigned random id.
+    stable_id: str | None = None
 
     @model_validator(mode="after")
     def check_type_matches_data(self) -> NewConversationItem:
@@ -792,6 +799,8 @@ class NewConversationItem(BaseModel):
         :raises ValueError: If ``type`` does not match ``data``.
         """
         _validate_type_matches_data(self.type, self.data)
+        if self.stable_id is not None and not re.fullmatch(r"[0-9a-f]{32}", self.stable_id):
+            raise ValueError("stable_id must be a 32-char lowercase hex string")
         return self
 
 
@@ -818,6 +827,10 @@ class ConversationItem(BaseModel):
     created_at: int
     data: ItemData
     created_by: str | None = None
+    # In-process signal only (excluded from every dump / API shape): ``True``
+    # when an idempotent append found this item already persisted under its
+    # ``stable_id``, so the caller can skip a duplicate's side effects.
+    deduplicated: bool = Field(default=False, exclude=True)
 
     @model_validator(mode="after")
     def check_type_matches_data(self) -> ConversationItem:

--- a/omnigent/runtime/pending_inputs.py
+++ b/omnigent/runtime/pending_inputs.py
@@ -284,6 +284,30 @@ def resolve_oldest(conversation_id: str) -> DrainedInput | None:
         )
 
 
+def restore(conversation_id: str, drained: DrainedInput) -> None:
+    """
+    Put a drained entry back at the FRONT of the pending queue.
+
+    Compensation for a drain whose persist turned out to be a duplicate
+    (an idempotent external-item append deduplicated the retry): the
+    entry belongs to the NEXT user message, and it was the oldest when
+    drained, so it returns to the head to keep FIFO intact.
+
+    :param conversation_id: Conversation/session id, e.g.
+        ``"conv_abc123"``.
+    :param drained: The entry returned by :func:`resolve_oldest` or
+        :func:`resolve_matching_text`.
+    """
+    entry = _Entry(
+        pending_id=drained.pending_id,
+        content=copy.deepcopy(drained.content),
+        created_by=drained.created_by,
+    )
+    with _lock:
+        entries = _pending.get(conversation_id, {})
+        _pending[conversation_id] = {drained.pending_id: entry, **entries}
+
+
 def resolve_matching_text(conversation_id: str, text: str) -> MatchedDrain:
     """
     Drain through the first pending entry whose text matches ``text``.

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -2950,11 +2950,12 @@ def _parse_external_conversation_item(
             "external_conversation_item data.response_id must be a non-empty string",
             code=ErrorCode.INVALID_INPUT,
         )
-    # NOTE: external conversation items are persisted with a random
-    # primary key like any other item — there is no server-side dedup.
-    # Producers (the claude-native / codex-native forwarders) are
-    # responsible for not re-posting records they have already sent;
-    # they no longer emit a ``source_id`` dedup key to the server.
+    # NOTE: producers that can re-post (the native transcript forwarders
+    # retry timed-out POSTs whose disposition they cannot know) send a
+    # ``data.source_id`` dedup key; the persist path derives the item's
+    # stable id from it so the append is idempotent (see
+    # ``_persist_external_conversation_item``). Items without one keep the
+    # store-assigned random id and no server-side dedup.
     # Cap a native tool result so a multi-MB output isn't persisted + broadcast as one frame.
     if item_type == "function_call_output" and isinstance(item_data.get("output"), str):
         item_data = {**item_data, "output": cap_tool_output(item_data["output"])}

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2167,6 +2167,23 @@ async def _persist_external_conversation_item(
             # No pending entry — direct terminal input. Fall back to the
             # identity authenticated on the forwarder's own request.
             item = item.model_copy(update={"created_by": created_by})
+    # Skipped Kiro entries persist BEFORE the matched item so their stored
+    # positions precede it, matching the live broadcast order — unless the
+    # matched item is a duplicate re-post, in which case the skipped drains
+    # belong to LATER messages and are restored (below), not persisted.
+    skipped_persisted = False
+    if skipped_kiro_pending:
+        matched_already_persisted = item.stable_id is not None and await asyncio.to_thread(
+            conversation_store.has_item, session_id, item.stable_id
+        )
+        if not matched_already_persisted:
+            for skipped in skipped_kiro_pending:
+                await _persist_skipped_kiro_pending_input(
+                    session_id,
+                    skipped,
+                    conversation_store,
+                )
+            skipped_persisted = True
     pending_background_title = prepare_background_session_title(
         coordinator=background_title_coordinator,
         conversation=conv,
@@ -2179,17 +2196,22 @@ async def _persist_external_conversation_item(
         # title, and every pending entry the drain above consumed belongs
         # to a LATER user message — put them back at the front in their
         # original queue order (skipped entries preceded the match; restore
-        # prepends, so restore in reverse).
-        for entry in reversed([*skipped_kiro_pending, drained]):
+        # prepends, so restore in reverse). Skipped entries persisted above
+        # (the probe raced a concurrent retry) stay persisted.
+        restorable = [drained] if skipped_persisted else [*skipped_kiro_pending, drained]
+        for entry in reversed(restorable):
             if entry is not None:
                 pending_inputs.restore(session_id, entry)
         return persisted.id
-    for skipped in skipped_kiro_pending:
-        await _persist_skipped_kiro_pending_input(
-            session_id,
-            skipped,
-            conversation_store,
-        )
+    if not skipped_persisted:
+        # Probe said duplicate but the append inserted anyway (row vanished
+        # in between): persist the skipped drains late rather than lose them.
+        for skipped in skipped_kiro_pending:
+            await _persist_skipped_kiro_pending_input(
+                session_id,
+                skipped,
+                conversation_store,
+            )
     await _seed_missing_title_from_user_message(conv, item, conversation_store)
     if pending_background_title is not None:
         pending_background_title.schedule()

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -12,6 +12,7 @@ import contextlib
 import json
 import secrets
 import time
+import uuid
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Literal, cast
 
@@ -2103,6 +2104,29 @@ async def _persist_external_conversation_item(
     :returns: Store-assigned conversation item id.
     """
     item = _parse_external_conversation_item(body)
+    # An at-least-once producer (the native transcript forwarders) retries a
+    # timed-out POST it cannot know the disposition of, so the item's id is
+    # derived from its ``source_id`` and the append is idempotent — the
+    # dedupe check rides the append's own transaction, under its
+    # conversation lock, costing the hot path no extra query. A dedupe hit
+    # comes back flagged so the duplicate's side effects are unwound below
+    # (no re-broadcast, and a wrongly-drained pending input is restored).
+    source_id = body.data.get("source_id")
+    if source_id is not None:
+        if not isinstance(source_id, str) or not source_id.strip() or len(source_id) > 256:
+            raise OmnigentError(
+                "external_conversation_item data.source_id must be a "
+                "non-empty string of at most 256 characters",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        item = item.model_copy(
+            update={
+                "stable_id": uuid.uuid5(
+                    uuid.NAMESPACE_URL,
+                    f"omnigent-external-item:{session_id}:{source_id.strip()}",
+                ).hex
+            }
+        )
     # A native user message round-tripping back from the transcript:
     # drain its optimistic pending-input entry (FIFO) and fold the
     # entry's file blocks (image / file) into the item BEFORE persisting.
@@ -2112,6 +2136,7 @@ async def _persist_external_conversation_item(
     # Claude (not a queued web message) and has no pending entry, so
     # draining for it would hand the queued message's uploads to the marker.
     cleared_pending_id: str | None = None
+    drained: pending_inputs.DrainedInput | None = None
     skipped_kiro_pending: list[pending_inputs.DrainedInput] = []
     if (
         item.type == "message"
@@ -2142,22 +2167,32 @@ async def _persist_external_conversation_item(
             # No pending entry — direct terminal input. Fall back to the
             # identity authenticated on the forwarder's own request.
             item = item.model_copy(update={"created_by": created_by})
-    for skipped in skipped_kiro_pending:
-        await _persist_skipped_kiro_pending_input(
-            session_id,
-            skipped,
-            conversation_store,
-        )
     pending_background_title = prepare_background_session_title(
         coordinator=background_title_coordinator,
         conversation=conv,
         event=SessionEventInput(type=item.type, data=item.data.model_dump()),
     )
     persisted_items = await asyncio.to_thread(conversation_store.append, session_id, [item])
+    persisted = persisted_items[0]
+    if persisted.deduplicated:
+        # A re-post of an already-committed item: nothing new to render or
+        # title, and every pending entry the drain above consumed belongs
+        # to a LATER user message — put them back at the front in their
+        # original queue order (skipped entries preceded the match; restore
+        # prepends, so restore in reverse).
+        for entry in reversed([*skipped_kiro_pending, drained]):
+            if entry is not None:
+                pending_inputs.restore(session_id, entry)
+        return persisted.id
+    for skipped in skipped_kiro_pending:
+        await _persist_skipped_kiro_pending_input(
+            session_id,
+            skipped,
+            conversation_store,
+        )
     await _seed_missing_title_from_user_message(conv, item, conversation_store)
     if pending_background_title is not None:
         pending_background_title.schedule()
-    persisted = persisted_items[0]
     _publish_external_conversation_item(
         session_id, persisted, cleared_pending_id=cleared_pending_id
     )

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -589,6 +589,12 @@ class ConversationStore(ABC):
         Append items to a conversation. Assigns a globally unique
         ID and timestamp to each item.
 
+        An item carrying ``stable_id`` appends idempotently: its id is the
+        stable id, and when an item with that id already exists the stored
+        item is returned in its place — flagged ``deduplicated`` — instead
+        of inserting a duplicate. The existence check rides the append's
+        own transaction, so idempotency costs no extra query.
+
         :param conversation_id: Unique conversation identifier,
             e.g. ``"conv_abc123"``.
         :param items: List of :class:`NewConversationItem` objects

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -605,6 +605,24 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def has_item(self, conversation_id: str, item_id: str) -> bool:
+        """
+        Return whether an item with ``item_id`` exists in a conversation.
+
+        Existence probe for idempotent-append callers that must know
+        *before* appending whether a stable-id item is a duplicate
+        re-post, e.g. to decide whether order-sensitive sibling persists
+        that precede the append should run at all.
+
+        :param conversation_id: Unique conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :param item_id: Item id to probe, e.g. a stable id derived
+            from a forwarder ``source_id``.
+        :returns: ``True`` when the item is already persisted.
+        """
+        ...
+
+    @abstractmethod
     def list_conversations(
         self,
         limit: int = 20,

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2011,6 +2011,46 @@ class SqlAlchemyConversationStore(ConversationStore):
             # SQLite the database-level lock already serializes.
             self._lock_conversation(session, conversation_id)
 
+            # Idempotent-append probe: one query for the whole batch. Rows
+            # already persisted under a stable id ARE those items' append
+            # result; running under the lock just taken serializes with a
+            # concurrent retry (READ COMMITTED gives this statement a fresh
+            # snapshot after the lock wait), so it cannot double-insert.
+            stable_ids = [item.stable_id for item in items if item.stable_id is not None]
+            existing_by_id: dict[str, SqlConversationItem] = {}
+            deduped_by_id: dict[str, ConversationItem] = {}
+            if stable_ids:
+                existing_rows = (
+                    session.execute(
+                        select(SqlConversationItem).where(
+                            SqlConversationItem.workspace_id == current_workspace_id(),
+                            SqlConversationItem.conversation_id == conversation_id,
+                            SqlConversationItem.id.in_(stable_ids),
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                decoded = self._decode_item_data_batch([row.data for row in existing_rows])
+                existing_by_id = {row.id: row for row in existing_rows}
+                deduped_by_id.update(
+                    {
+                        row.id: _to_item(row, data).model_copy(update={"deduplicated": True})
+                        for row, data in zip(existing_rows, decoded, strict=True)
+                    }
+                )
+                if len(existing_by_id) == len(items):
+                    # Pure duplicate re-post: nothing inserts, so leave
+                    # ``updated_at`` and the position counter untouched — a
+                    # retry must not make an old conversation look active.
+                    # Equality with len(items) implies every item carried a
+                    # stable id and every one was found.
+                    return [
+                        deduped_by_id[item.stable_id]
+                        for item in items
+                        if item.stable_id is not None
+                    ]
+
             # Bump updated_at on the conversation.
             conv_row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if conv_row is not None:
@@ -2046,7 +2086,20 @@ class SqlAlchemyConversationStore(ConversationStore):
             completed_status = encode_item_status("completed")  # items are final on append
             fts_rows: list[tuple[str, str, str]] = []
             row_values: list[dict[str, object]] = []
+            batch_stable: dict[str, ConversationItem] = {}
             for item in items:
+                if item.stable_id is not None:
+                    if item.stable_id in existing_by_id:
+                        persisted.append(deduped_by_id[item.stable_id])
+                        continue
+                    if item.stable_id in batch_stable:
+                        # Same stable id twice in one batch: the first
+                        # occurrence is this one's result too (inserting both
+                        # would collide on the primary key).
+                        persisted.append(
+                            batch_stable[item.stable_id].model_copy(update={"deduplicated": True})
+                        )
+                        continue
                 position = next_pos
                 next_pos += 1
                 data_dict = item.data.model_dump(exclude_none=True)
@@ -2056,7 +2109,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 # the whole INSERT aborts and the item never persists.
                 data = self._encode_item_data(strip_nul_bytes(json.dumps(data_dict)))
                 search = self._item_search_text(item)
-                item_id = generate_item_id(item.type)
+                item_id = item.stable_id or generate_item_id(item.type)
                 values: dict[str, object] = {
                     "workspace_id": workspace_id,
                     "id": item_id,
@@ -2091,6 +2144,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                         created_by=item.created_by,
                     )
                 )
+                if item.stable_id is not None:
+                    batch_stable[item.stable_id] = persisted[-1]
             # One executemany for the batch: positions are pre-allocated above so
             # the rows carry no inter-row dependency, and a single round-trip
             # persists all N. A per-row ORM add round-trips per item, which

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2039,12 +2039,12 @@ class SqlAlchemyConversationStore(ConversationStore):
                         for row, data in zip(existing_rows, decoded, strict=True)
                     }
                 )
-                if len(existing_by_id) == len(items):
+                if all(item.stable_id in existing_by_id for item in items):
                     # Pure duplicate re-post: nothing inserts, so leave
                     # ``updated_at`` and the position counter untouched — a
                     # retry must not make an old conversation look active.
-                    # Equality with len(items) implies every item carried a
-                    # stable id and every one was found.
+                    # Membership (not a length compare) so a batch repeating
+                    # one persisted stable id still counts as pure.
                     return [
                         deduped_by_id[item.stable_id]
                         for item in items
@@ -2160,6 +2160,30 @@ class SqlAlchemyConversationStore(ConversationStore):
                 conv_row.next_position = next_pos
 
         return persisted
+
+    def has_item(self, conversation_id: str, item_id: str) -> bool:
+        """
+        Return whether an item with ``item_id`` exists in a conversation.
+
+        Point lookup on the (workspace_id, conversation_id, id) primary
+        key; loads no item data. Used as the pre-append duplicate probe
+        for stable-id items (see :meth:`append`).
+
+        :param conversation_id: Unique conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :param item_id: Item id to probe, e.g. a stable id derived
+            from a forwarder ``source_id``.
+        :returns: ``True`` when the item is already persisted.
+        """
+        with self._conv_session("has_conversation_item") as session:
+            row = session.execute(
+                select(SqlConversationItem.id).where(
+                    SqlConversationItem.workspace_id == current_workspace_id(),
+                    SqlConversationItem.conversation_id == conversation_id,
+                    SqlConversationItem.id == item_id,
+                )
+            ).first()
+            return row is not None
 
     def list_projects(
         self,

--- a/tests/runtime/test_pending_inputs.py
+++ b/tests/runtime/test_pending_inputs.py
@@ -330,3 +330,25 @@ def test_stale_entries_evicted_after_ttl(monkeypatch: pytest.MonkeyPatch) -> Non
     # Past the TTL: the lazy sweep on the next access evicts the ghost.
     clock["t"] = 1000.0 + pending_inputs._TTL_S + 0.1
     assert pending_inputs.snapshot_for("conv_a") == []
+
+
+def test_restore_returns_a_drained_entry_to_the_front() -> None:
+    """A restored entry reclaims the head of the FIFO.
+
+    Compensation for a drain whose persist deduplicated (the entry
+    belongs to the NEXT user message): the entry was the oldest when
+    drained, so it must come back ahead of everything queued after it.
+    """
+    first = pending_inputs.record("conv_r", [_text_block("first")])
+    second = pending_inputs.record("conv_r", [_text_block("second")])
+
+    drained = pending_inputs.resolve_oldest("conv_r")
+    assert drained is not None and drained.pending_id == first
+
+    pending_inputs.restore("conv_r", drained)
+    order = [e["pending_id"] for e in pending_inputs.snapshot_for("conv_r")]
+    assert order == [first, second]
+
+    # The restored entry drains again as the oldest.
+    redrained = pending_inputs.resolve_oldest("conv_r")
+    assert redrained is not None and redrained.pending_id == first

--- a/tests/server/integration/test_sessions_external_item_idempotency.py
+++ b/tests/server/integration/test_sessions_external_item_idempotency.py
@@ -1,0 +1,153 @@
+"""A re-posted external item with a ``source_id`` must persist exactly once.
+
+The native transcript forwarders deliver at-least-once: a timed-out POST's
+disposition is unknown, so the same item may be re-posted — and leaked
+concurrent forwarders tailing one transcript post the same records in
+parallel. ``data.source_id`` makes the persist idempotent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.runtime import pending_inputs
+from tests.server.helpers import create_test_agent
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_session(client: httpx.AsyncClient, name: str) -> str:
+    agent = await create_test_agent(client, name=name)
+    resp = await client.post("/v1/sessions", json={"agent_id": agent["id"]})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _post_item(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    text: str,
+    source_id: str | None,
+    role: str = "user",
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "item_type": "message",
+        "item_data": {
+            "role": role,
+            "content": [{"type": "input_text", "text": text}],
+            **({"agent": "worker"} if role == "assistant" else {}),
+        },
+        "response_id": "resp_claude_echo",
+    }
+    if source_id is not None:
+        data["source_id"] = source_id
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={"type": "external_conversation_item", "data": data},
+    )
+    assert resp.status_code in (200, 201, 202), resp.text
+    return resp.json()
+
+
+async def _message_texts(client: httpx.AsyncClient, session_id: str) -> list[str]:
+    items = (await client.get(f"/v1/sessions/{session_id}/items")).json()["data"]
+    return [
+        block.get("text", "")
+        for item in items
+        if item.get("type") == "message"
+        for block in item.get("content", [])
+    ]
+
+
+async def test_reposted_item_with_source_id_persists_once(
+    client: httpx.AsyncClient,
+) -> None:
+    session_id = await _create_session(client, "idem-repost")
+    first = await _post_item(client, session_id, text="hello once", source_id="rec-1:0:message")
+    second = await _post_item(client, session_id, text="hello once", source_id="rec-1:0:message")
+    assert first["item_id"] == second["item_id"]
+    assert await _message_texts(client, session_id) == ["hello once"]
+
+
+async def test_distinct_source_ids_persist_separately(
+    client: httpx.AsyncClient,
+) -> None:
+    session_id = await _create_session(client, "idem-distinct")
+    await _post_item(client, session_id, text="same text", source_id="rec-1:0:message")
+    await _post_item(client, session_id, text="same text", source_id="rec-2:0:message")
+    assert await _message_texts(client, session_id) == ["same text", "same text"]
+
+
+async def test_repost_without_source_id_keeps_legacy_behavior(
+    client: httpx.AsyncClient,
+) -> None:
+    session_id = await _create_session(client, "idem-legacy")
+    await _post_item(client, session_id, text="legacy", source_id=None)
+    await _post_item(client, session_id, text="legacy", source_id=None)
+    assert await _message_texts(client, session_id) == ["legacy", "legacy"]
+
+
+async def test_duplicate_repost_restores_the_drained_pending_input(
+    client: httpx.AsyncClient,
+) -> None:
+    """A duplicate must not consume the NEXT queued web message's entry.
+
+    The persist path drains the oldest pending input before it knows the
+    item is a duplicate; the dedupe result restores that entry to the
+    front of the queue so the next genuine message still claims it.
+    """
+    session_id = await _create_session(client, "idem-pending")
+    await _post_item(client, session_id, text="first msg", source_id="rec-1:0:message")
+
+    next_pending = pending_inputs.record(
+        session_id,
+        [{"type": "input_text", "text": "second msg"}],
+        created_by="alice@example.com",
+    )
+    # Duplicate of the already-persisted first message arrives late.
+    await _post_item(client, session_id, text="first msg", source_id="rec-1:0:message")
+
+    snapshot = pending_inputs.snapshot_for(session_id)
+    assert [entry["pending_id"] for entry in snapshot] == [next_pending]
+    assert await _message_texts(client, session_id) == ["first msg"]
+
+
+async def test_bad_source_id_is_rejected(client: httpx.AsyncClient) -> None:
+    session_id = await _create_session(client, "idem-bad")
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "message",
+                "item_data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "x"}],
+                },
+                "response_id": "resp_claude_echo",
+                "source_id": "x" * 300,
+            },
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_client_cannot_smuggle_a_stable_id() -> None:
+    """``stable_id`` is internal-only: a client key inside event data is
+    dropped by the item builder, never bound onto the entity."""
+    from omnigent.server.routes._sessions.helpers import _build_new_item
+    from omnigent.server.schemas import SessionEventInput
+
+    body = SessionEventInput(
+        type="message",
+        data={
+            "role": "user",
+            "content": [{"type": "input_text", "text": "x"}],
+            "stable_id": "ab" * 16,
+        },
+    )
+    assert _build_new_item(body, "resp").stable_id is None

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -214,6 +214,16 @@ class _ConversationStore:
             result.append(persisted)
         return result
 
+    def has_item(self, conversation_id: str, item_id: str) -> bool:
+        """Return whether an appended item carries ``item_id``.
+
+        :param conversation_id: The conversation id (unused).
+        :param item_id: Item id to probe.
+        :returns: ``True`` when a recorded item has that id.
+        """
+        del conversation_id
+        return any(item.id == item_id for item in self.appended_items)
+
     def list_items(
         self,
         conversation_id: str,
@@ -3991,6 +4001,130 @@ async def test_kiro_external_prompt_matches_pending_and_reports_skipped_input() 
         assert matched_user.data.content == [{"type": "input_text", "text": "tell me a joke"}]
         assert matched_user.created_by == "alice@example.com"
         assert first != second
+    finally:
+        pending_inputs.reset_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_kiro_skipped_entries_persist_before_the_matched_item() -> None:
+    """Failed Kiro prompts must precede the accepted prompt in stored order."""
+    from omnigent.runtime import pending_inputs
+    from omnigent.server.routes.sessions import _persist_external_conversation_item
+
+    pending_inputs.reset_for_tests()
+    store = _ConversationStore()
+    sid = "823dbd1aab969b5a813fac59bb977a77"
+    conv = store.get_conversation(sid)
+    assert conv is not None
+    for text in ("first failed", "second failed", "tell me a joke"):
+        pending_inputs.record(
+            sid, [{"type": "input_text", "text": text}], created_by="alice@example.com"
+        )
+    body = SessionEventInput(
+        type="external_conversation_item",
+        data={
+            "item_type": "message",
+            "item_data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "tell me a joke"}],
+            },
+            "response_id": "kiro:prompt-joke",
+            "source_id": "kiro:prompt-joke:0",
+        },
+    )
+
+    try:
+        item_id = await _persist_external_conversation_item(
+            sid,
+            conv,
+            body,
+            store,  # type: ignore[arg-type]
+        )
+
+        # Stored order mirrors the live broadcast: both skipped web inputs
+        # (each a user message + error pair) precede the accepted prompt.
+        assert [i.type for i in store.appended_items] == [
+            "message",
+            "error",
+            "message",
+            "error",
+            "message",
+        ]
+        first_user, _err1, second_user, _err2, matched_user = store.appended_items
+        assert first_user.data.content == [{"type": "input_text", "text": "first failed"}]
+        assert second_user.data.content == [{"type": "input_text", "text": "second failed"}]
+        assert matched_user.data.content == [{"type": "input_text", "text": "tell me a joke"}]
+        assert item_id == matched_user.id
+        assert pending_inputs.snapshot_for(sid) == []
+    finally:
+        pending_inputs.reset_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_kiro_duplicate_repost_restores_skipped_entries_unpersisted() -> None:
+    """A duplicate re-post restores skipped drains instead of persisting them."""
+    from omnigent.runtime import pending_inputs
+    from omnigent.server.routes.sessions import _persist_external_conversation_item
+
+    class _DedupingStore(_ConversationStore):
+        """Store whose matched item is already persisted: every append dedupes."""
+
+        def has_item(self, conversation_id: str, item_id: str) -> bool:
+            del conversation_id, item_id
+            return True
+
+        def append(self, conversation_id: str, items: list[Any]) -> list[Any]:
+            del conversation_id
+            return [
+                ConversationItem(
+                    id=item.stable_id,
+                    type=item.type,
+                    status="completed",
+                    response_id=item.response_id,
+                    created_at=1,
+                    data=item.data,
+                    deduplicated=True,
+                )
+                for item in items
+            ]
+
+    pending_inputs.reset_for_tests()
+    store = _DedupingStore()
+    sid = "823dbd1aab969b5a813fac59bb977a77"
+    conv = store.get_conversation(sid)
+    assert conv is not None
+    recorded = [
+        pending_inputs.record(
+            sid, [{"type": "input_text", "text": text}], created_by="alice@example.com"
+        )
+        for text in ("first failed", "second failed", "tell me a joke")
+    ]
+    body = SessionEventInput(
+        type="external_conversation_item",
+        data={
+            "item_type": "message",
+            "item_data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "tell me a joke"}],
+            },
+            "response_id": "kiro:prompt-joke",
+            "source_id": "kiro:prompt-joke:0",
+        },
+    )
+
+    try:
+        await _persist_external_conversation_item(
+            sid,
+            conv,
+            body,
+            store,  # type: ignore[arg-type]
+        )
+
+        # Nothing persisted (no error items for the skipped drains), and the
+        # queue is back in its original order for the next genuine message.
+        assert store.appended_items == []
+        snapshot = pending_inputs.snapshot_for(sid)
+        assert [entry["pending_id"] for entry in snapshot] == recorded
     finally:
         pending_inputs.reset_for_tests()
 

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -5654,3 +5654,121 @@ def test_item_search_text_seam_redirects_persisted_value(db_uri: str) -> None:
             ).scalars()
         )
     assert stored == ["custom-search-text"]
+
+
+# ── Idempotent append (stable_id) ─────────────────────
+
+
+def test_append_with_stable_id_is_idempotent(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A re-append under the same stable id returns the stored item once.
+
+    The retry contract for at-least-once producers (transcript
+    forwarders): a timed-out POST's disposition is unknown, so the same
+    item may arrive again — and concurrent forwarders tailing one
+    transcript derive the same stable id for the same record.
+    """
+    conv = conversation_store.create_conversation()
+    stable = "ab" * 16
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+        stable_id=stable,
+    )
+    [first] = conversation_store.append(conv.id, [item])
+    assert first.id == stable
+    assert first.deduplicated is False
+
+    [second] = conversation_store.append(conv.id, [item])
+    assert second.id == stable
+    assert second.deduplicated is True
+
+    page = conversation_store.list_items(conv.id)
+    assert [i.id for i in page.data if i.id == stable] == [stable]
+
+
+def test_append_without_stable_id_still_duplicates(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """No stable id keeps the legacy contract: every append inserts."""
+    conv = conversation_store.create_conversation()
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+    )
+    [a] = conversation_store.append(conv.id, [item])
+    [b] = conversation_store.append(conv.id, [item])
+    assert a.id != b.id
+    assert b.deduplicated is False
+
+
+def test_append_dedupe_does_not_burn_a_position(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A dedupe hit allocates no position: later items stay contiguous."""
+    conv = conversation_store.create_conversation()
+    stable = "cd" * 16
+    dup = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "one"}]),
+        stable_id=stable,
+    )
+    conversation_store.append(conv.id, [dup])
+    # duplicate + a genuinely new item in one batch
+    fresh = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(
+            role="assistant",
+            content=[{"type": "output_text", "text": "two"}],
+            agent="worker",
+        ),
+    )
+    [got_dup, got_fresh] = conversation_store.append(conv.id, [dup, fresh])
+    assert got_dup.deduplicated is True
+    assert got_fresh.deduplicated is False
+    page = conversation_store.list_items(conv.id)
+    assert len(page.data) == 2
+
+
+def test_pure_dedupe_append_leaves_conversation_metadata_alone(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A duplicate-only re-post must not make the conversation look active."""
+    conv = conversation_store.create_conversation()
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+        stable_id="ef" * 16,
+    )
+    conversation_store.append(conv.id, [item])
+    before = conversation_store.get_conversation(conv.id)
+    assert before is not None
+
+    conversation_store.append(conv.id, [item])
+    after = conversation_store.get_conversation(conv.id)
+    assert after is not None
+    assert after.updated_at == before.updated_at
+
+
+def test_same_stable_id_twice_in_one_batch_inserts_once(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """In-batch twins collapse instead of colliding on the primary key."""
+    conv = conversation_store.create_conversation()
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+        stable_id="0a" * 16,
+    )
+    [a, b] = conversation_store.append(conv.id, [item, item])
+    assert a.id == b.id
+    assert a.deduplicated is False
+    assert b.deduplicated is True
+    assert len(conversation_store.list_items(conv.id).data) == 1

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -5772,3 +5772,55 @@ def test_same_stable_id_twice_in_one_batch_inserts_once(
     assert a.deduplicated is False
     assert b.deduplicated is True
     assert len(conversation_store.list_items(conv.id).data) == 1
+
+
+def test_repeated_persisted_twin_batch_leaves_conversation_metadata_alone(
+    conversation_store: SqlAlchemyConversationStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retry batch repeating one already-persisted stable id is a pure duplicate.
+
+    Concurrent forwarders can deliver the same record twice in one batch
+    after it already persisted: every item resolves to the stored row, so
+    nothing inserts and the conversation must not look active.
+    """
+    import omnigent.stores.conversation_store.sqlalchemy_store as store_mod
+
+    monkeypatch.setattr(store_mod, "now_epoch", lambda: 1000)
+    conv = conversation_store.create_conversation()
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+        stable_id="1b" * 16,
+    )
+    conversation_store.append(conv.id, [item])
+
+    monkeypatch.setattr(store_mod, "now_epoch", lambda: 2000)
+    [a, b] = conversation_store.append(conv.id, [item, item])
+    assert a.deduplicated is True
+    assert b.deduplicated is True
+    assert a.id == b.id
+    after = conversation_store.get_conversation(conv.id)
+    assert after is not None
+    assert after.updated_at == 1000
+    assert len(conversation_store.list_items(conv.id).data) == 1
+
+
+def test_has_item_probes_persisted_ids(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """``has_item`` sees a persisted stable id, scoped to its conversation."""
+    conv = conversation_store.create_conversation()
+    other = conversation_store.create_conversation()
+    stable = "2c" * 16
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+        stable_id=stable,
+    )
+    assert conversation_store.has_item(conv.id, stable) is False
+    conversation_store.append(conv.id, [item])
+    assert conversation_store.has_item(conv.id, stable) is True
+    assert conversation_store.has_item(other.id, stable) is False

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -1205,6 +1205,9 @@ async def test_forwarder_posts_visible_transcript_items(tmp_path: Path) -> None:
         "terminal_command",
         "terminal_command",
     ]
+    # Every item carries its server-side idempotency key: a retried or
+    # concurrently re-posted record must dedupe on the server.
+    assert all(isinstance(item.get("source_id"), str) and item["source_id"] for item in posted)
     assert posted[0]["item_data"] == {
         "role": "user",
         "content": [{"type": "input_text", "text": "read TODO"}],


### PR DESCRIPTION
## Related issue

Closes #5180

## Summary

- The native transcript forwarders deliver **at-least-once**: a timed-out item POST's disposition is unknowable client-side, so it's retried — and leaked runner processes can tail the same transcript concurrently, each posting the same records (three duplication mechanisms detailed in #5180). Every re-post inserted another `conversation_items` row; cold resume then rebuilt Claude's local transcript from the duplicated items, so a real session accumulated **~20% duplicated model context**, replayed and re-billed on every turn.
- Each transcript record already carries a stable per-item `source_id` — documented in the bridge as an idempotency key — but it was never sent (the parser even carried a NOTE that producers "no longer emit a source_id dedup key"). This PR sends it and enforces it server-side: the item's id is derived from `uuid5(conversation_id, source_id)`, and the store's `append` treats an existing item under that id as the append's result (returned flagged `deduplicated`, an API-excluded field) instead of inserting.
- Duplicate side effects are unwound at the persist site: no re-broadcast, no title seeding, and every pending web input the drain consumed is restored to the front of the queue in order (including Kiro's matched-text drains, whose skipped-entry error persists now only happen for genuinely new items).

ELI5: the mail carrier sometimes can't tell whether a letter was delivered, so they deliver it again — and sometimes three carriers deliver the same letter. The mailbox now checks the letter's serial number and keeps one copy.

```
forwarder ──POST item {…, source_id}──► /events
                                          │ derive stable_id = uuid5(conv, source_id)
                                          ▼
                    append(): one probe for the batch's stable ids
                    inside the SAME locked txn (FOR UPDATE serialized)
                      ├─ new  → insert (id = stable_id)
                      └─ seen → return stored item, deduplicated=True
                                  └─ route: skip broadcast/title, restore drained pending inputs
```

## Design constraints honored

- **No schema change** (DB portability rules: application-enforced uniqueness). The stable id IS the primary-key id; the existence probe runs under the append's existing per-conversation `FOR UPDATE` lock, so concurrent re-posts — including cross-replica — serialize (READ COMMITTED gives the probe a fresh statement snapshot after the lock wait).
- **No hot-path query cost**: one bulk `id IN (...)` probe per append batch, inside the already-open transaction — not per item, and zero probes for items without `source_id` (all non-forwarder paths are unchanged).
- **Pure-duplicate re-posts leave conversation metadata alone**: no `updated_at` bump, no position-counter write — a retry can't make an old session look active.
- **Backward/forward compatible**: old runner + new server → no `source_id`, legacy behavior; new runner + old server → unknown key ignored.
- `stable_id` is internal-only: every client-facing `NewConversationItem` construction site builds field-by-field, and a smuggled key in event data is dropped (pinned by test).

## Adversarial review (Codex/gpt-5.6-sol) — disposition

- **Confirmed & fixed**: Kiro skipped-entry persists fired before the dedupe decision (moved after, with order-preserving restore); per-item probe under the lock (now one bulk probe per batch); duplicate re-posts bumped `updated_at`/position counter (now untouched); same stable id twice in one batch would have collided on the PK (now collapses in-batch).
- **Refuted with evidence**: "clients can set `stable_id` via `initial_items`" — no `NewConversationItem` site binds client dicts (probed live; pinned by `test_client_cannot_smuggle_a_stable_id`). Cross-replica/READ-COMMITTED interleavings verified safe (lock-wait then fresh statement snapshot).
- **Accepted, documented**: a millisecond drain/restore race under concurrent genuine messages can transiently reorder pending inputs — strictly better than the status quo, where every duplicate permanently consumed an entry AND inserted a row; a crash between commit and broadcast now means the retry doesn't re-broadcast (clients recover on reload — re-broadcasting per duplicate would reintroduce the SSE spam this fixes).

## Test Plan

- 13 new tests, mutation-verified (fix disabled → the dependent tests go red, at both the store and route layers):
  - store: idempotent re-append, legacy no-`stable_id` duplication preserved, no position burned, pure-dedupe metadata untouched, in-batch twins collapse
  - route (integration, real store): re-post persists once with same `item_id`, distinct `source_id`s persist separately, legacy behavior without the key, duplicate re-post restores the drained pending input, >256-char `source_id` rejected, client `stable_id` smuggling dropped
  - `pending_inputs.restore` returns a drained entry to the FIFO head
  - forwarder: every posted item carries a non-empty `source_id`
- Full touched-file suite: `test_claude_native_forwarder.py`, `test_conversation_store.py`, `test_pending_inputs.py`, the new integration file, `test_sessions_native_kickoff_duplicate.py`, `test_sessions_attribution.py`, `test_sessions_endpoints.py` — **607 passed, 1 skipped**.
- Real-world validation of the failure mode is in #5180: byte-identical duplicate rows matching retry attempt counts, and triplicated items from three concurrent leaked forwarders — both of which this collapses by construction.

## Demo

N/A (non-visual — persistence-path fix). Before/after evidence in #5180.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = the production incident in #5180: measured the duplicate multiplicity histogram matching retry attempts, reproduced triplication from concurrent leaked forwarders, and confirmed the same `source_id` is derived by every forwarder generation for a given record (deterministic uuid5 chain), which is what the server-side key collapses.

## Changelog

Native session history no longer accumulates duplicated messages when the transcript forwarder retries or runs concurrently; resumed sessions stop re-paying for duplicated context.

---
cc @bbqiu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
