### PR TITLE
fix(runner): relay the skill tools to native harnesses

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -472,6 +472,10 @@ _NATIVE_RELAY_BUILTIN_TOOLS = (
     # Memory builtins are relayed to native harnesses too — unlike web_search,
     # native harnesses have no built-in long-term memory of their own.
     | _HINDSIGHT_TOOLS
+    # Skills ride the relay for the same reason memory does: ``load_skill`` is
+    # what discovers host-scope skills (``.agents/skills`` and friends), and a
+    # native session's only tool surface is this relay.
+    | _SKILL_TOOLS
 )
 
 

--- a/tests/e2e/test_session_tools_claude_native.py
+++ b/tests/e2e/test_session_tools_claude_native.py
@@ -525,3 +525,12 @@ def test_claude_native_relay_advertises_broadened_orchestrator_surface(
             f"without any spawn opt-in — native relay gating diverged from the "
             f"ToolManager gate."
         )
+
+        # ``load_skill`` is what discovers host-scope skills, and the relay is
+        # this session's only tool surface — without it, a skill dropped in
+        # ~/.agents/skills is invisible here however the docs describe it.
+        assert "load_skill" in relay_tools, (
+            f"tool_relay.json does not advertise load_skill. "
+            f"Relay advertised: {sorted(relay_tools)}. Host-scope skill discovery "
+            f"is unreachable from this session."
+        )

--- a/tests/runner/test_skill_relay.py
+++ b/tests/runner/test_skill_relay.py
@@ -1,0 +1,90 @@
+"""Skill tools reach native harnesses through the relay.
+
+A native session ignores ``request.tools`` and sees only
+``build_native_relay_tool_schemas``. ``load_skill`` is what discovers
+host-scope skills — ``.agents/skills``, ``.claude/skills`` and their
+home-directory equivalents — so if it is absent from the relay, a skill dropped
+where the docs say every agent picks it up is invisible to every native
+harness, silently.
+
+The per-family sources do not cover it: codex walks its bundle plus
+``~/.codex/skills``, cursor walks ``~/.cursor/skills``, and the agy provider
+skips the generic walk entirely.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omnigent.runner.tool_dispatch import (
+    _NATIVE_RELAY_BUILTIN_TOOLS,
+    _SKILL_TOOLS,
+    build_native_relay_tool_schemas,
+)
+from omnigent.spec.types import AgentSpec
+
+
+def test_skill_tools_are_in_the_native_relay_union() -> None:
+    """Without this membership the relay filters skill schemas out."""
+    assert _SKILL_TOOLS <= _NATIVE_RELAY_BUILTIN_TOOLS
+
+
+def test_load_skill_reaches_a_bare_spec() -> None:
+    """A spec declaring no skills of its own still gets ``load_skill``.
+
+    That is the point rather than an oversight: ``ToolManager`` registers
+    ``load_skill`` unconditionally *because* its discovery covers host-scope
+    directories, which an agent does not declare. Gating it on bundled skills
+    would leave exactly the documented case — drop a folder in
+    ``~/.agents/skills`` and every agent picks it up — still broken.
+    """
+    schemas = build_native_relay_tool_schemas(AgentSpec(spec_version=1))
+
+    names = {schema["name"] for schema in schemas}
+    assert "load_skill" in names
+
+
+def test_relayed_skill_schemas_are_the_flat_shape() -> None:
+    """The bridges consume ``{name, description, parameters}`` directly.
+
+    A schema that arrives nested or without parameters is one the harness
+    cannot register, which fails at spawn rather than at call time.
+
+    Pinned on ``load_skill`` alone: ``ToolManager`` registers that one
+    unconditionally, while ``read_skill_file`` is meant to appear only once a
+    skill actually has resources to read.
+    """
+    schemas = build_native_relay_tool_schemas(AgentSpec(spec_version=1))
+    relayed = {s["name"]: s for s in schemas if s["name"] in _SKILL_TOOLS}
+
+    assert "load_skill" in relayed
+    for schema in relayed.values():
+        assert schema["description"]
+        parameters = schema["parameters"]
+        assert isinstance(parameters, dict)
+        assert parameters["type"] == "object"
+
+
+def test_relayed_load_skill_discovers_a_host_scope_skill(tmp_path: Path) -> None:
+    """The relayed tool reaches the directories the docs advertise.
+
+    Membership in the union is only half the claim; the other half is that
+    ``load_skill`` run from a native session's workspace actually finds a skill
+    dropped in ``.claude/skills``, which is what makes relaying it worth doing.
+    """
+    from omnigent.runner.tool_dispatch import _execute_skill_tool
+
+    skill_dir = tmp_path / ".claude" / "skills" / "host-only"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: host-only\ndescription: a host-scope skill\n---\n\nthe skill body\n"
+    )
+
+    loaded = _execute_skill_tool(
+        "load_skill",
+        {"name": "host-only"},
+        agent_spec=None,
+        runner_workspace=tmp_path,
+    )
+
+    assert "the skill body" in loaded, loaded[:300]


### PR DESCRIPTION
## Related issue

Closes #5105

## Summary

A native session ignores `request.tools` and sees only the Omnigent surface
that `build_native_relay_tool_schemas` builds. (Not its *only* tools — the
vendor's own are untouched, and vendor-native skill mechanisms like
`--plugin-dir` still work. What is missing is Omnigent's own skill discovery.)

`_SKILL_TOOLS` is defined a few lines above `_NATIVE_RELAY_BUILTIN_TOOLS` and
was never added to it, so `load_skill` — the tool whose discovery walks
`.agents/skills`, `.claude/skills` and their home-directory equivalents — could
not be called from any native harness.

The per-family skill sources do not cover it: `codex_skill_sources` is the
bundle plus `~/.codex/skills`, `cursor_host_skills` is `~/.cursor/skills`, and
the agy provider skips the generic walk deliberately. So a skill dropped where
`/docs/build/prompts` says every agent picks it up was silently invisible to a
native session — no error, just a skill nobody could reach.

Skills arrive by two independent routes, and only one of them was working:

```
                         before                        after
  bundle skills   ──vendor dirs──▶  ✓        ──vendor dirs──▶  ✓
                    (--plugin-dir,             (unchanged)
                     $CODEX_HOME/skills)

  host-scope      ──relay────────▶  ✗        ──relay────────▶  ✓
  skills            (load_skill not             (load_skill
                     in the union)               relayed)
```

This adds `_SKILL_TOOLS` to the union — the same reasoning that put the memory
builtins there ("unlike web_search, native harnesses have no built-in long-term
memory of their own"). The union is a filter over
`ToolManager(spec).get_tool_schemas()`, so this lets the skill tools through
rather than injecting anything the manager did not already produce.

## Test Plan

`tests/runner/test_skill_relay.py` (new, 4 tests). Three of them fail without
the union member; the fourth is the evidence that relaying it is worth doing —
it runs `_execute_skill_tool` against a real `.claude/skills` directory and
asserts the body comes back.

The e2e in `tests/e2e/test_session_tools_claude_native.py` already launches the
real `claude` CLI headlessly against a mock LLM server and asserts on the
`tool_relay.json` the runner writes, so I extended it rather than adding a
second launch. Run live on this branch, both ways:

```
$ OMNIGENT_E2E_CLAUDE_NATIVE_SESSION_TOOLS=1 pytest \
    tests/e2e/test_session_tools_claude_native.py::test_claude_native_relay_advertises_broadened_orchestrator_surface

# on main
E  AssertionError: tool_relay.json does not advertise load_skill. Relay
   advertised: ['browser_click', ..., 'sys_session_rename', 'update_comment'].
   Host-scope skill discovery is unreachable from this session.
1 failed in 11.86s

# with this change
1 passed in 9.60s
```

That is the real relay file for a real claude-native session, not a
reconstruction — which is why I trust the claim more than the unit test.

Also run: every dispatch and tool-manager suite the relay touches —
`tests/runner/test_runner_dispatch.py`, the browser / hindsight / web-search /
nimble / scheduled-task / session-rename dispatch tests, and `tests/tools` —
1123 passed. `ruff` and `pyrefly` clean on the changed files.

## Demo

_Demo media was added after `demo-check` labelled this PR; the check is add-only, so the `needs-demo` label is stale rather than outstanding._

![28 tools and none can load a skill; then 29, and a real claude-native session passes](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/native-relay-skills.gif)

Left of the cut is `main`: 28 tools relayed to a native session, none of which
can load a skill. Right of it is this branch — 29, with `load_skill` among
them, and the e2e driving a real `claude` CLI in tmux against a mock LLM
passing on the `tool_relay.json` the runner wrote.

`show_relay.py` calls `build_native_relay_tool_schemas`, the same function the
runner uses to write that file. The tape is
[here](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/native-relay-skills.tape).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the e2e run quoted above — a live server and runner, the
real `claude` CLI in a tmux window, and the `tool_relay.json` the runner
actually wrote, checked with and without the change.

**Why the pair rides together.** The obvious smaller change is to relay
`load_skill` alone and leave `read_skill_file` until #4625 lands. That does not
work, because `load_skill`'s own output tells the agent to use the other tool:

```
$ load_skill({"name": "withres"})
body

## Available files
Use the read_skill_file tool to read these:
- references/detail.md
```

Relative paths and a named tool. Relaying one without the other hands a native
agent an instruction to call something it has not been given.

**A pre-existing seam this makes more visible.** `build_native_relay_tool_schemas`
builds its `ToolManager` without a workspace, so the *advertised* set is
computed against the server process's `Path.cwd()`, while execution uses
`runner_workspace`. Measured on this branch with an isolated `HOME`:

```
cwd with no resource-bearing skill:  ['load_skill']
cwd with one:                        ['load_skill', 'read_skill_file']
```

`load_skill` is unconditional, so what this PR fixes is unaffected. But
`read_skill_file`'s advertisement can disagree with the registry that would
serve it. That is true on `main` for every SDK session already; this change
means native sessions inherit it too. Worth its own issue rather than widening
this one — happy to file it if you agree it is a bug and not a deliberate
simplification.

**Ordering against #4625:** relaying the pair also exposes `read_skill_file` to
native sessions, and that tool currently resolves a bundled-only registry
(#4597, with #4625 open against it). Bundled skills are unaffected; a
host-scope skill would load but fail to read its own auxiliary files until
#4625 lands. I hit that asymmetry independently and had written the same fix
before finding #4625, so I have left it out of this PR rather than compete with
an older open one.

The schema-shape test here pins only `load_skill` for the same reason:
`ToolManager` registers that one unconditionally and gates `read_skill_file`
behind `any_skill_has_resources`, so asserting on both would couple this test
to a gate that has nothing to do with the relay.

## Changelog

Skills in `~/.agents/skills` and `.claude/skills` now reach native-harness
sessions, matching what the docs promise for every agent.

