### PR TITLE
test(tools): stop the ToolManager suite reading the developer's host skills

### DIFF
--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -192,6 +192,10 @@ def _make_spec(
         skills=skills or [],
         mcp_servers=mcp_servers or [],
         local_tools=local_tools or [],
+        # Without this, ``LoadSkillTool`` merges in host-scope skills from
+        # ~/.claude/skills and every .claude/skills above cwd, and these tests
+        # assert on whatever the developer happens to have installed.
+        skills_filter="none",
     )
 
 


### PR DESCRIPTION
## Related issue

None — test-only change, which the template exempts.

## Summary

Five tests in `tests/tools/test_manager.py` fail on a fresh clone of `main` for
anyone who has host-scope skills installed:

```
FAILED test_schemas_exclude_read_skill_file_without_resources
FAILED test_schemas_empty_when_no_skills
FAILED test_client_tools_registered_in_schemas
FAILED test_client_tools_none_equivalent_to_empty
FAILED test_local_tools_skipped_without_workdir
5 failed, 39 passed
```

`ToolManager._register_skill_tools` builds a `LoadSkillTool`, and that
constructor merges in host-scope skills — `~/.claude/skills/`, plus
`.claude/skills/` and `.agents/skills/` at every level walking up from cwd. The
tests pass a spec with known skills and assert on the resulting schema set, so
whatever the developer has installed is silently merged in. `read_skill_file`
turns up because one of *their* skills has a `references/` directory, and the
"no skills" assertions see skills.

CI is green because a CI checkout has no host skills anywhere in its parent
chain. The failure is invisible to CI and unavoidable for contributors — and on
a project whose docs tell you to keep skills in `~/.claude/skills/`, that is
most of them. `CONTRIBUTING.md` prescribes plain `uv run --no-sync pytest`, so
there is no hermetic runner that would have hidden this.

Both discovery sources contribute, and either alone is enough — measured on
`main` at 3d537bb:

| checkout location | `HOME` | result |
| --- | --- | --- |
| under `$HOME` | real | 5 failed |
| under `$HOME` | empty dir | 5 failed — the upward walk still reaches `$HOME/.claude/skills` |
| outside `$HOME` | real | 5 failed — the explicit `~/.claude/skills` scan |
| outside `$HOME` | empty dir | 44 passed |

That second row is why this pins `skills_filter` rather than `$HOME`: a
`monkeypatch.setenv("HOME", ...)` fixture looks like it should work and does
not, for any checkout living under the home directory.

`skills_filter="none"` is the switch the loader already honours —
`discover_host_skills` returns before touching the filesystem, and the spec's
own skills are unaffected, since the filter only ever applied to discovered
ones. So the tests keep asserting exactly what their names say.

`tests/spec/test_parser.py` is the one place that exercises discovery
deliberately, and it already documents this hazard in a docstring ("We pin
`$HOME` at a fresh tmp dir to keep the developer's real `~/.claude/skills/` …
out of this test"). This is the same guard, applied where it was missing.

## Test Plan

`pytest tests/tools` from a checkout under `$HOME` with a populated
`~/.claude/skills` — the configuration that fails on `main`:

```
before:  5 failed, 871 passed
after:   876 passed
```

Also run with `HOME` pointed at an empty directory, to confirm the result no
longer depends on the environment at all: `876 passed` either way. `ruff` and
`ruff format` clean.

## Demo

N/A — non-visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change is to the test suite, so the verification is the suite itself, run
in both the failing and the clean environment as above.

Deliberately scoped to `_make_spec`, which is where all five failures route
through. A directory-wide or suite-wide autouse fixture would cover future
tests that build a `ToolManager` by hand, but it would also have to carve out
`tests/spec/test_parser.py`, and that is a bigger call than this fix needs.
Happy to follow up with it if you want the broader guard.
