### PR TITLE
fix(bench): complete #4604 — the CLI gate still demands gateway creds

### DIFF
--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -43,7 +43,12 @@ non-zero exit means at least one `DRIFT` cell was found.
 ### Flags
 
 - `--live` / `--no-live` -- force live probing or the declared-only matrix.
-  `--live` requires resolvable gateway credentials.
+  `--live` requires resolvable gateway credentials, unless every selected
+  harness authenticates its own model (`agy`, cursor, goose, hermes, kimi,
+  kiro, pi and qwen natives), in which case the vendor CLI's own login is
+  enough. Auto-live is still keyed on the gateway, so a bare run on a
+  credential-less machine renders the declared matrix rather than starting
+  vendor CLIs unasked.
 - `--profile NAME` -- optional Databricks profile override; it is not required
   when config or ambient `OPENAI_*` already supplies credentials.
 - `--harness NAME[=MODEL]` -- probe one harness (repeatable), optionally

--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -10,6 +10,7 @@ from dataclasses import replace
 from tests.harness_bench.bench import run_bench
 from tests.harness_bench.events import LineSink
 from tests.harness_bench.manifest import OFFICIAL_PROFILES
+from tests.harness_bench.native_tui_driver import NativeTuiDriver, requires_gateway
 from tests.harness_bench.probes import ALL_PROBES, PROBES_BY_NAME, CapabilityProbe
 from tests.harness_bench.profile import BenchProfile, resolve_profile
 from tests.harness_bench.report import render_json, render_markdown, render_table
@@ -53,8 +54,9 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         dest="live",
         action="store_true",
         default=None,
-        help="Force the live layer (needs resolvable creds: --profile, a "
-        "configured ~/.omnigent profile, or ambient OPENAI_*).",
+        help="Force the live layer. Needs resolvable gateway creds (--profile, "
+        "a configured ~/.omnigent profile, or ambient OPENAI_*) unless every "
+        "selected harness authenticates its own model.",
     )
     parser.add_argument(
         "--no-live",
@@ -162,6 +164,33 @@ def _resolve_probes(values: list[str] | None) -> list[CapabilityProbe]:
     return [probe for probe in ALL_PROBES if probe.name in selected]
 
 
+def _all_own_auth_native(
+    profiles: list[BenchProfile], *, transport: str | None, fast: bool
+) -> bool:
+    """Whether every selected harness authenticates its own model.
+
+    Defers to :func:`~tests.harness_bench.native_tui_driver.requires_gateway`,
+    the predicate the driver itself uses, so this gate cannot drift from the one
+    ``NativeTuiDriver.unavailable`` applies a moment later.
+
+    :param profiles: The selected harness profiles.
+    :param transport: The ``--transport`` override, or ``None``.
+    :param fast: The ``--fast`` flag.
+    :returns: ``True`` when every profile lands on the native-tui driver with a
+        vendor that authenticates itself, so the run needs no gateway
+        credentials.
+    """
+    if not profiles:
+        return False
+    for profile in profiles:
+        resolved = resolve_transport_name(profile, override=transport, fast=fast)
+        if driver_registry().get(resolved) is not NativeTuiDriver:
+            return False
+        if requires_gateway(profile):
+            return False
+    return True
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv if argv is not None else sys.argv[1:])
 
@@ -197,7 +226,19 @@ def main(argv: list[str] | None = None) -> int:
     from tests.harness_bench.runtime_env import bench_creds_skip_reason
 
     creds_skip = bench_creds_skip_reason(args.profile)
+    # Auto-live stays keyed on the gateway: with no explicit --live, a
+    # credential-less box gets the declared-only render rather than a surprise
+    # run that launches vendor CLIs.
     live = args.live if args.live is not None else creds_skip is None
+    if (
+        live
+        and creds_skip is not None
+        and _all_own_auth_native(profiles, transport=args.transport, fast=args.fast)
+    ):
+        # Every selected harness logs its own model in, so the run never reaches
+        # the gateway. NativeTuiDriver.unavailable() already waives the check for
+        # these; refusing here would skip them on any box without a gateway.
+        creds_skip = None
     if live and creds_skip is not None:
         print(f"--live needs resolvable gateway creds: {creds_skip}", file=sys.stderr)
         return 2

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -191,6 +191,27 @@ def native_vendor(harness: str) -> NativeVendor | None:
     )
 
 
+def requires_gateway(profile: BenchProfile) -> bool:
+    """
+    Whether running *profile* needs OpenAI-compatible gateway credentials.
+
+    An own_auth vendor logs its own model in through its CLI, so the resolved
+    creds are never consumed — ``_provision`` only routes a model through the
+    gateway ``when not vendor.own_auth``. Requiring them anyway skips every
+    own_auth native for a contributor with no Databricks or OpenAI account.
+
+    Callers outside this module use it too, so the rule lives in one place: a
+    second copy is a second thing to update when a vendor's auth model changes.
+
+    :param profile: The harness under test.
+    :returns: ``True`` unless the profile is a native-tui harness whose vendor
+        authenticates itself. Anything this module does not recognise needs the
+        gateway, since that is the safe answer.
+    """
+    vendor = native_vendor(profile.harness)
+    return vendor is None or not vendor.own_auth
+
+
 class NativeTuiDriver:
     """Drive a native-tui harness through a live server + host daemon.
 
@@ -223,11 +244,8 @@ class NativeTuiDriver:
         vendor = native_vendor(profile.harness)
         if vendor is None:
             return f"{profile.harness!r} is not a native-tui harness"
-        # An own_auth vendor logs its own model in, so it needs no gateway creds
-        # to run — only the vendor CLI. Requiring them would wrongly skip every
-        # own_auth native for a contributor with no Databricks/OpenAI gateway.
         creds_skip = bench_creds_skip_reason(
-            databricks_profile, require_gateway=not vendor.own_auth
+            databricks_profile, require_gateway=requires_gateway(profile)
         )
         if creds_skip is not None:
             return creds_skip

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -18,7 +18,7 @@ import json
 import pytest
 
 from omnigent.runtime.harnesses import _HARNESS_MODULES
-from tests.harness_bench.bench import run_bench, run_harness
+from tests.harness_bench.bench import BenchMatrix, run_bench, run_harness
 from tests.harness_bench.driver import SdkInprocDriver
 from tests.harness_bench.manifest import OFFICIAL_PROFILES
 from tests.harness_bench.probes import ALL_PROBES
@@ -1008,3 +1008,73 @@ def test_full_server_skips_native_with_accurate_message() -> None:
     reason = FullServerDriver.unavailable(claude_native, databricks_profile="oss")
     assert reason is not None
     assert "native-tui" in reason and "sdk-inproc" not in reason
+
+
+@pytest.fixture
+def _no_gateway_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Present a box with no Databricks profile and no ambient OPENAI_* creds."""
+    import tests.harness_bench.runtime_env as runtime_env
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setattr(runtime_env, "_profile_from_config", lambda: None)
+
+
+def test_live_runs_an_own_auth_native_without_gateway_creds(
+    _no_gateway_creds: None, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--live`` on an own_auth native must not be refused for missing creds.
+
+    A cursor/pi/kimi native logs its own model in through the vendor CLI, so the
+    run never reaches the gateway. ``NativeTuiDriver.unavailable`` already
+    waives the check for those; when the CLI's own gate does not, every
+    own_auth native is unreachable on a box with no Databricks or OpenAI
+    credentials — which is most contributors' boxes.
+    """
+    from tests.harness_bench.__main__ import main
+
+    reached: list[bool] = []
+
+    async def _fake_run_bench(*args: object, **kwargs: object) -> BenchMatrix:
+        reached.append(bool(kwargs.get("live")))
+        return BenchMatrix(reports=[])
+
+    monkeypatch.setattr("tests.harness_bench.__main__.run_bench", _fake_run_bench)
+
+    assert main(["--live", "--harness", "pi-native", "--dimension", "basic_turn"]) == 0
+    assert reached == [True]
+    assert "needs resolvable gateway creds" not in capsys.readouterr().err
+
+
+def test_live_is_still_refused_when_a_selected_harness_needs_the_gateway(
+    _no_gateway_creds: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The waiver is per-run, not blanket.
+
+    claude-native takes an Omnigent-supplied credential, so a selection that
+    names it — alone, or mixed with own_auth natives — still has to resolve the
+    gateway. Same for the SDK family, and for an own_auth native forced onto
+    full-server, where turns route through the server again.
+    """
+    from tests.harness_bench.__main__ import main
+
+    assert main(["--live", "--harness", "claude-native", "--dimension", "basic_turn"]) == 2
+    assert main(["--live", "--harness", "pi-native", "--harness", "claude-sdk"]) == 2
+    assert main(["--live", "--harness", "pi-native", "--transport", "full-server"]) == 2
+    assert capsys.readouterr().err.count("needs resolvable gateway creds") == 3
+
+
+def test_omitting_live_still_renders_declared_only_without_creds(
+    _no_gateway_creds: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The waiver must not turn a plain run into a surprise live one.
+
+    Auto-live is keyed on the gateway, so on a credential-less box a bare
+    invocation renders the declared matrix. Waiving the gateway for own_auth
+    natives here would silently start launching vendor CLIs for someone who
+    never asked to.
+    """
+    from tests.harness_bench.__main__ import main
+
+    assert main(["--harness", "pi-native", "--dimension", "basic_turn"]) == 0
+    assert "declared, not observed" in capsys.readouterr().out


### PR DESCRIPTION
## Related issue

Closes #5187

## Summary

**This completes #4604 rather than reporting something new.** That PR — merged
2026-08-12 — set out to stop `--live` demanding gateway credentials for a
native harness that authenticates its own model, and fixed `unavailable()` and
`_provision()`. The CLI gate in `__main__.py` runs before either, so the
symptom its summary names — *"an external contributor with no Databricks
account can't bench-verify an own_auth native"* — still reproduces on `main`.

Eight harnesses are affected, not the five #4604 lists: `antigravity`,
`cursor`, `goose`, `hermes`, `kimi`, `kiro`, `pi` and `qwen` natives. Only
`claude-native` and `codex-native` genuinely need the gateway.

The waiver here is deliberately narrow, in two ways that are easy to get wrong:

- **Explicit `--live` only.** `creds_skip` also decides auto-live
  (`live = args.live if args.live is not None else creds_skip is None`).
  Waiving it there would turn a bare `--harness pi-native` on a credential-less
  box from a declared-only render into a run that launches vendor CLIs unasked.
  A test pins that it does not.
- **All-selected, not per-profile.** Every selected profile must land on the
  native-tui driver with an `own_auth` vendor. A mixed selection, an SDK
  harness, or `--transport full-server` still has to resolve the gateway.

The own_auth rule now lives in one place — `requires_gateway` — which both the
driver and the CLI consult. That the set has grown from five to eight since
#4604 is the argument against a second copy, in a bench whose whole job is
catching drift.

`--live`'s help text and the bench README both still stated the old rule.
Both now state the new one.

## Test Plan

Three tests in `tests/harness_bench/test_bench.py`, all asserting exit codes
and output rather than internal wiring. The first fails without the change:

```
FAILED test_live_runs_an_own_auth_native_without_gateway_creds
```

The other two are the guards: one that `--live` is still refused for
claude-native, a mixed selection, and `--transport full-server`; one that
omitting `--live` still renders the declared matrix.

`pytest tests/harness_bench` — 162 passed, 19 skipped.

Verified live on a box with no gateway credentials configured:

```
$ python -m tests.harness_bench --harness pi-native --dimension basic_turn --live
[pi-native]   Basic turn: SUPPORTED (marker echoed; round-trip works)

$ python -m tests.harness_bench --harness pi-native --dimension basic_turn
Harness capability matrix (declared, not observed)
```

All eight clear the gate and report their real obstacle rather than a
credentials error they could do nothing about:

```
[pi-native]   Basic turn: SUPPORTED (marker echoed; round-trip works)
[kimi-native] skipped: native forwarder did not wire up within 45.0s
[cursor-native] skipped: harness not configured on this host
[goose-native] skipped: 'goose' CLI is not on PATH
[qwen-native] skipped: 'qwen' CLI is not on PATH
[kiro-native] skipped: 'kiro-cli' CLI is not on PATH
[hermes-native] skipped: 'hermes' CLI is not on PATH
[antigravity-native] skipped: 'antigravity' CLI is not on PATH
```

A full-dimension run in that configuration observes **nine** of twelve
dimensions for `pi-native`, so the waiver is exercised for all eight harnesses
and the run is proven end-to-end for one.

> **Correction.** This section first said "ten of twelve … with no drift",
> counting Model override as observed. It is not. `ModelOverrideProbe` returns
> SUPPORTED when a turn completes, on the premise stated in its docstring that
> "the driver launches the harness with the profile's model in
> `{env_prefix}MODEL`". `native_tui_driver.py` never does — the word "model"
> appears in it three times, all comments — so for native-TUI harnesses the
> probe reports a capability it never exercised. Filed as #5192; it is not
> introduced or touched by this PR.
>
> I checked whether the other eleven share the flaw. They do not: each
> conditions SUPPORTED on an observable specific to its capability (delta
> counts, `tool_call_denied`, `elicitation_requested`, a non-zero cost, and so
> on). `tool_calling` looked like a second case — its SUPPORTED branch tests
> `result.completed` — but it returns SKIPPED first if the tool was never
> dispatched.
>
> The `antigravity-native` line above also needs its retraction: I presented it
> as the harness's real obstacle, and it is not. `_NATIVE_CLI_BINARY` special-
> cases only cursor and kiro, so the check looks for a binary named
> `antigravity`, while omnigent's own code calls it `agy` — and `agy` *is*
> installed on this machine. Filed as #5193.

Two of the remaining skips are worth their own look, and neither is this PR's
business: `cursor-agent` is on PATH here, yet the host daemon reports the
harness unconfigured; and the kimi forwarder times out reproducibly. Both
messages name a log directory that has already been removed by the time the run
prints it.

## Demo

_Demo media was added after `demo-check` labelled this PR; the check is add-only, so the `needs-demo` label is stale rather than outstanding._

![a credentials error on main; the real reason with the fix](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/bench-live-gate.gif)

Same machine, no Databricks profile and no `OPENAI_API_KEY`, both halves. On
`main` the bench answers with a credentials error for a harness that never
touches the gateway. With the fix it answers `'goose' CLI is not on PATH` —
the thing the contributor can actually act on.

The tape is [here](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/bench-live-gate.tape).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the live run above — a real `pi` session provisioned
through the native-tui transport with no gateway credential anywhere, checked
against the same command on `main`.

Everything changed is under `tests/`, but this is a behaviour fix to a
developer-facing CLI rather than test upkeep, so it is filed as a bug with an
issue rather than claimed under the `Test / CI` exemption.

The issue also names the larger alternative — drop the CLI gate and let each
driver report `SKIPPED (no creds)` like any other skip — which is cleaner and a
much bigger change. Happy to take that instead if you would rather.

## Changelog

`--live` bench runs work without a gateway credential for the eight native
harnesses that log their own model in.

