### PR TITLE
fix(server): stamp OpenAPI numeric format for generated clients

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -23,6 +23,7 @@
           },
           "end_index": {
             "description": "0-based absolute character offset (exclusive) within the file where the anchor range ends.",
+            "format": "int64",
             "title": "End Index",
             "type": "integer"
           },
@@ -33,6 +34,7 @@
           },
           "start_index": {
             "description": "0-based absolute character offset (inclusive) within the file where the anchor range begins.",
+            "format": "int64",
             "title": "Start Index",
             "type": "integer"
           }
@@ -57,6 +59,7 @@
           },
           "created_at": {
             "description": "Unix epoch timestamp of creation.",
+            "format": "int64",
             "title": "Created At",
             "type": "integer"
           },
@@ -141,6 +144,7 @@
           "updated_at": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -153,6 +157,7 @@
           "version": {
             "default": 1,
             "description": "Monotonic version counter. Starts at 1, incremented on each update.",
+            "format": "int64",
             "title": "Version",
             "type": "integer"
           }
@@ -358,6 +363,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -393,6 +399,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -498,6 +505,7 @@
           },
           "created_at": {
             "description": "Unix epoch timestamp of child creation.",
+            "format": "int64",
             "title": "Created At",
             "type": "integer"
           },
@@ -585,6 +593,7 @@
           "pending_elicitations_count": {
             "default": 0,
             "description": "Number of approval / input prompts the child is currently blocked on, read from the server's `omnigent.runtime.pending_elicitations` index. `> 0` means the sub-agent is parked awaiting user input \u2014 the Agents rail renders an \"awaiting input\" badge so a fanned-out sub-agent that needs attention is visible without opening its chat. Mirrors `SessionListItem.pending_elicitations_count`.",
+            "format": "int64",
             "title": "Pending Elicitations Count",
             "type": "integer"
           },
@@ -661,6 +670,7 @@
           },
           "updated_at": {
             "description": "Unix epoch timestamp of the child's most recent update.",
+            "format": "int64",
             "title": "Updated At",
             "type": "integer"
           }
@@ -708,6 +718,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -742,6 +753,7 @@
           "created_at": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -768,6 +780,7 @@
           },
           "time_used_seconds": {
             "description": "Wall-clock seconds spent on this goal, e.g. `60`.",
+            "format": "int64",
             "minimum": 0.0,
             "title": "Time Used Seconds",
             "type": "integer"
@@ -776,6 +789,7 @@
             "anyOf": [
               {
                 "exclusiveMinimum": 0.0,
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -787,6 +801,7 @@
           },
           "tokens_used": {
             "description": "Tokens spent while pursuing this goal, e.g. `1024`.",
+            "format": "int64",
             "minimum": 0.0,
             "title": "Tokens Used",
             "type": "integer"
@@ -794,6 +809,7 @@
           "updated_at": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -857,6 +873,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -895,6 +912,7 @@
           "total_tokens": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -960,12 +978,14 @@
           },
           "token_count": {
             "description": "Approximate token count of the summary text, for budget tracking, e.g. `342`.",
+            "format": "int64",
             "title": "Token Count",
             "type": "integer"
           },
           "window_id": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -989,6 +1009,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -1017,6 +1038,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -1049,6 +1071,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -1104,6 +1127,7 @@
         "properties": {
           "created_at": {
             "description": "Unix epoch timestamp of creation.",
+            "format": "int64",
             "title": "Created At",
             "type": "integer"
           },
@@ -1359,6 +1383,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -1387,6 +1412,7 @@
         "properties": {
           "cost_usd": {
             "default": 0.0,
+            "format": "double",
             "title": "Cost Usd",
             "type": "number"
           },
@@ -1423,6 +1449,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -1563,6 +1590,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -1688,6 +1716,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -1745,6 +1774,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -1826,6 +1856,7 @@
         "properties": {
           "level": {
             "description": "Numeric permission level: `1` = read, `2` = edit, `3` = manage.",
+            "format": "int64",
             "maximum": 3.0,
             "minimum": 1.0,
             "title": "Level",
@@ -1863,6 +1894,7 @@
           "last_event_seq": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -1876,6 +1908,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -1999,6 +2032,7 @@
         "description": "Result of importing or locating one source session.",
         "properties": {
           "item_count": {
+            "format": "int64",
             "title": "Item Count",
             "type": "integer"
           },
@@ -2030,6 +2064,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2078,6 +2113,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2297,6 +2333,7 @@
           "cache_creation_input_tokens": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2309,6 +2346,7 @@
           "cache_read_input_tokens": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2321,6 +2359,7 @@
           "input_tokens": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2333,6 +2372,7 @@
           "output_tokens": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2345,6 +2385,7 @@
           "total_cost_usd": {
             "anyOf": [
               {
+                "format": "double",
                 "type": "number"
               },
               {
@@ -2357,6 +2398,7 @@
           "total_tokens": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2515,6 +2557,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2550,6 +2593,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2597,6 +2641,7 @@
           "index": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2623,6 +2668,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2705,6 +2751,7 @@
           },
           "level": {
             "description": "Numeric permission level (1=read, 2=edit, 3=manage).",
+            "format": "int64",
             "title": "Level",
             "type": "integer"
           },
@@ -2745,6 +2792,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2847,6 +2895,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2876,6 +2925,7 @@
         "properties": {
           "last_seen": {
             "description": "Wall-clock baseline in seconds, e.g. `1717000000`. Marking seen sets this to \"now\"; marking unread pins it to `updated_at - 1` so the row reads unseen.",
+            "format": "int64",
             "title": "Last Seen",
             "type": "integer"
           },
@@ -2954,6 +3004,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2987,6 +3038,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -3021,6 +3073,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -3096,6 +3149,7 @@
           "completed_at": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -3120,6 +3174,7 @@
           },
           "created_at": {
             "description": "Unix epoch timestamp of creation.",
+            "format": "int64",
             "title": "Created At",
             "type": "integer"
           },
@@ -3287,11 +3342,13 @@
         "properties": {
           "attempt": {
             "description": "1-based count of the upcoming attempt (i.e. attempt that will run AFTER this delay), e.g. `2` for the first retry.",
+            "format": "int64",
             "title": "Attempt",
             "type": "integer"
           },
           "delay_seconds": {
             "description": "Seconds the producer will sleep before retrying, rounded to two decimals, e.g. `1.5`.",
+            "format": "double",
             "title": "Delay Seconds",
             "type": "number"
           },
@@ -3301,12 +3358,14 @@
           },
           "max_attempts": {
             "description": "Total tries allowed by the retry policy, e.g. `3`. Lets clients render \"attempt 2 of 3\".",
+            "format": "int64",
             "title": "Max Attempts",
             "type": "integer"
           },
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -3902,6 +3961,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -3939,6 +3999,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -3989,6 +4050,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4030,6 +4092,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4096,6 +4159,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4203,6 +4267,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4248,6 +4313,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4335,6 +4401,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4363,6 +4430,7 @@
         "properties": {
           "requested_at": {
             "description": "Unix epoch seconds when the interrupt request reached the server, e.g. `1704067200`.",
+            "format": "int64",
             "title": "Requested At",
             "type": "integer"
           },
@@ -4485,12 +4553,14 @@
           "comments_count": {
             "default": 0,
             "description": "Total number of review comments (any status) on this session. Together with `comments_updated_at` it forms a change fingerprint: an add or edit bumps the timestamp, a delete changes the count, so the web client can invalidate its cached comment list when either field changes in a `WS /v1/sessions/updates` frame. `0` when the session has no comments or the server has no comment store wired.",
+            "format": "int64",
             "title": "Comments Count",
             "type": "integer"
           },
           "comments_updated_at": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4502,6 +4572,7 @@
           },
           "created_at": {
             "description": "Unix epoch seconds of creation.",
+            "format": "int64",
             "title": "Created At",
             "type": "integer"
           },
@@ -4592,12 +4663,14 @@
           "pending_elicitations_count": {
             "default": 0,
             "description": "Number of approval prompts currently waiting on this session. Powers the sidebar's \"needs attention\" badge so a user with several sessions running can tell which ones are blocked on them without opening each chat. Sourced from the Omnigent server's in-memory `omnigent.runtime.pending_elicitations` index, which mirrors every `response.elicitation_request` event passing through `session_stream` and decrements when a verdict is dispatched. `0` when the session has no outstanding elicitations.",
+            "format": "int64",
             "title": "Pending Elicitations Count",
             "type": "integer"
           },
           "permission_level": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4691,12 +4764,14 @@
           },
           "updated_at": {
             "description": "Unix epoch seconds of last update.",
+            "format": "int64",
             "title": "Updated At",
             "type": "integer"
           },
           "viewer_last_seen": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4746,6 +4821,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4794,6 +4870,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4829,6 +4906,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4868,6 +4946,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4903,6 +4982,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -4998,6 +5078,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -5033,6 +5114,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -5072,6 +5154,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -5254,6 +5337,7 @@
           "background_task_count": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -5266,6 +5350,7 @@
           "context_window": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -5289,6 +5374,7 @@
           },
           "created_at": {
             "description": "Unix epoch seconds of creation.",
+            "format": "int64",
             "title": "Created At",
             "type": "integer"
           },
@@ -5402,6 +5488,7 @@
           "last_total_tokens": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -5490,6 +5577,7 @@
           "permission_level": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -5657,6 +5745,7 @@
           "total_cost_usd": {
             "anyOf": [
               {
+                "format": "double",
                 "type": "number"
               },
               {
@@ -5669,6 +5758,7 @@
           "updated_at": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -5739,6 +5829,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -5787,6 +5878,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -5816,6 +5908,7 @@
           "background_task_count": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -5871,6 +5964,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -5925,6 +6019,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -5976,6 +6071,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -6026,6 +6122,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -6061,6 +6158,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -6101,6 +6199,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -6151,11 +6250,13 @@
           "cost_usd": {
             "default": 0.0,
             "description": "Authoritative cumulative USD spend for this session's subtree.",
+            "format": "double",
             "title": "Cost Usd",
             "type": "number"
           },
           "created_at": {
             "description": "Unix epoch seconds of creation.",
+            "format": "int64",
             "title": "Created At",
             "type": "integer"
           },
@@ -6188,6 +6289,7 @@
           },
           "models": {
             "additionalProperties": {
+              "format": "double",
               "type": "number"
             },
             "description": "Per-model recorded cost, keyed by the raw harness model id (e.g. `{\"claude-opus-4-8\": 14.03}`). Empty when no per-model cost was recorded. May not sum to `cost_usd` (see above).",
@@ -6222,6 +6324,7 @@
           },
           "updated_at": {
             "description": "Unix epoch seconds of last activity.",
+            "format": "int64",
             "title": "Updated At",
             "type": "integer"
           }
@@ -6240,6 +6343,7 @@
           "context_tokens": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -6253,6 +6357,7 @@
           "context_window": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -6271,6 +6376,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -6283,6 +6389,7 @@
           "total_cost_usd": {
             "anyOf": [
               {
+                "format": "double",
                 "type": "number"
               },
               {
@@ -6354,6 +6461,7 @@
             "anyOf": [
               {
                 "exclusiveMinimum": 0.0,
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -6632,6 +6740,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -6662,6 +6771,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -6696,6 +6806,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -6736,6 +6847,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -6770,6 +6882,7 @@
           "sequence_number": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -7234,18 +7347,21 @@
           "cache_creation_input_tokens": {
             "default": 0,
             "description": "Prompt tokens written to the provider prompt cache (cache creation), billed at a premium rate. Like `cache_read_input_tokens`, this is separate from `input_tokens`; `0` when not reported.",
+            "format": "int64",
             "title": "Cache Creation Input Tokens",
             "type": "integer"
           },
           "cache_read_input_tokens": {
             "default": 0,
             "description": "Prompt tokens served from a provider prompt cache (cache hit), billed at a reduced rate. Reported by Anthropic-style providers as a count *separate* from `input_tokens` (which carries only the non-cached portion); `0` when the provider does not break out cache usage. Consumed by the cache-aware server-side cost path.",
+            "format": "int64",
             "title": "Cache Read Input Tokens",
             "type": "integer"
           },
           "context_tokens": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -7259,6 +7375,7 @@
           "cost_usd": {
             "anyOf": [
               {
+                "format": "double",
                 "type": "number"
               },
               {
@@ -7272,6 +7389,7 @@
           "input_tokens": {
             "default": 0,
             "description": "Number of input (prompt) tokens consumed.",
+            "format": "int64",
             "title": "Input Tokens",
             "type": "integer"
           },
@@ -7291,6 +7409,7 @@
           "output_tokens": {
             "default": 0,
             "description": "Number of output (completion) tokens generated.",
+            "format": "int64",
             "title": "Output Tokens",
             "type": "integer"
           },
@@ -7301,6 +7420,7 @@
           "total_tokens": {
             "default": 0,
             "description": "Sum of input and output tokens across all LLM sub-calls for this turn (billing total).",
+            "format": "int64",
             "title": "Total Tokens",
             "type": "integer"
           }
@@ -7314,6 +7434,7 @@
           "reasoning_tokens": {
             "default": 0,
             "description": "Number of tokens consumed by chain-of-thought reasoning.",
+            "format": "int64",
             "title": "Reasoning Tokens",
             "type": "integer"
           }
@@ -7327,18 +7448,21 @@
           "cost_last_30d": {
             "default": 0.0,
             "description": "Total spend over the last 30 UTC days (incl. today).",
+            "format": "double",
             "title": "Cost Last 30D",
             "type": "number"
           },
           "cost_last_7d": {
             "default": 0.0,
             "description": "Total spend over the last 7 UTC days (incl. today).",
+            "format": "double",
             "title": "Cost Last 7D",
             "type": "number"
           },
           "cost_today": {
             "default": 0.0,
             "description": "Total spend on the current UTC day.",
+            "format": "double",
             "title": "Cost Today",
             "type": "number"
           },
@@ -7366,6 +7490,7 @@
           "total_cost_usd": {
             "default": 0.0,
             "description": "All-time total spend from the daily rollup.",
+            "format": "double",
             "title": "Total Cost Usd",
             "type": "number"
           }
@@ -7389,6 +7514,7 @@
                   "type": "string"
                 },
                 {
+                  "format": "int64",
                   "type": "integer"
                 }
               ]

--- a/scripts/dump_openapi.py
+++ b/scripts/dump_openapi.py
@@ -20,7 +20,10 @@ This script:
 5. Rewrites the ``text/event-stream`` content entries on the SSE
    routes to use the OAS 3.2 ``itemSchema`` keyword in place of
    FastAPI's 3.1 ``schema`` keyword.
-6. Writes the result to ``openapi.json`` at the repo root.
+6. Stamps numeric ``format`` (``int64`` / ``double``) onto formatless
+   component schemas so typed-language generators pick the same
+   width as the Python producer.
+7. Writes the result to ``openapi.json`` at the repo root.
 
 Run with no arguments to (re)generate the file. Pass ``--check``
 in CI to verify the on-disk file is up to date — non-zero exit
@@ -711,6 +714,43 @@ def _reformat_component_schemas(components: dict[str, Any]) -> None:
             _reformat_schema_node(schema)
 
 
+# Payload keys that can hold numbers without being schema nodes. Walking
+# them would stamp ``format`` onto example values, not types.
+_SCHEMA_PAYLOAD_KEYS: frozenset[str] = frozenset(
+    {"default", "example", "examples", "const", "enum"},
+)
+
+
+def _annotate_number_formats(components: dict[str, Any]) -> None:
+    """
+    Stamp numeric ``format`` on formatless schema nodes.
+
+    Pydantic emits no numeric format, so generators guess: a formatless
+    ``number`` becomes float32 / BigDecimal and a formatless
+    ``integer`` becomes int32, neither of which matches Python's float
+    (binary64) or int (arbitrary width). Uses setdefault so the model
+    layer stays authoritative wherever it sets a format itself.
+
+    Scoped to ``components.schemas`` so request examples and other
+    data payloads are not rewritten. See issue #5119.
+    """
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            if node.get("type") == "number":
+                node.setdefault("format", "double")
+            elif node.get("type") == "integer":
+                node.setdefault("format", "int64")
+            for key, value in node.items():
+                if key not in _SCHEMA_PAYLOAD_KEYS:
+                    walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(components.get("schemas", {}))
+
+
 def _normalize_inline_descriptions(node: Any) -> None:
     """
     Final safety net: normalize inline reST in any remaining description.
@@ -741,7 +781,8 @@ def _enrich_spec(spec: dict[str, Any]) -> None:
     human-readable descriptions, and ``components.securitySchemes`` —
     none of which FastAPI emits — tags the untagged utility routes, and
     rewrites reST docstrings (operations, parameters, and component
-    schemas) as Markdown.
+    schemas) as Markdown, and stamps numeric ``format`` on formatless
+    component schemas.
     Mutates ``spec`` in place. See the module-level enrichment
     constants for the rationale behind each value.
 
@@ -760,6 +801,7 @@ def _enrich_spec(spec: dict[str, Any]) -> None:
     _retag_session_resources(paths)
     _reformat_descriptions(paths)
     _reformat_component_schemas(components)
+    _annotate_number_formats(components)
     _normalize_inline_descriptions(spec)
 
 

--- a/tests/server/test_openapi_drift.py
+++ b/tests/server/test_openapi_drift.py
@@ -209,3 +209,89 @@ def test_openapi_json_matches_generator_output() -> None:
             generated_spec=generated_spec,
         ),
     )
+
+
+def test_annotate_number_formats_stamps_formatless_nodes_only() -> None:
+    """Formatless number/integer schemas get double/int64; existing formats stay.
+
+    Production breakage that causes this to fail: ``_annotate_number_formats``
+    stopped using ``setdefault``, overwrote a model-authored format, or
+    walked ``example``/``enum`` payloads and stamped ``format`` onto values.
+    """
+    dump_module = _load_dump_openapi_module()
+    components: dict[str, Any] = {
+        "schemas": {
+            "Cost": {
+                "type": "object",
+                "properties": {
+                    "total_cost_usd": {"type": "number", "default": 0.0},
+                    "already_double": {"type": "number", "format": "double"},
+                    "count": {"type": "integer"},
+                    "already_int32": {"type": "integer", "format": "int32"},
+                    "when": {
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "by_model": {"type": "object", "additionalProperties": {"type": "number"}},
+                },
+                "example": {"total_cost_usd": 1.5, "count": 3},
+            },
+        },
+    }
+    dump_module._annotate_number_formats(components)
+    props = components["schemas"]["Cost"]["properties"]
+    assert props["total_cost_usd"]["format"] == "double"
+    assert props["already_double"]["format"] == "double"
+    assert props["count"]["format"] == "int64"
+    assert props["already_int32"]["format"] == "int32"
+    assert props["when"]["anyOf"][0]["format"] == "int64"
+    assert props["by_model"]["additionalProperties"]["format"] == "double"
+    assert "format" not in components["schemas"]["Cost"]["example"]
+
+
+def test_openapi_json_numeric_schemas_declare_width_format() -> None:
+    """Committed openapi.json stamps int64/double on every numeric schema node.
+
+    Without ``format``, generators map integers to int32 and numbers to
+    float32, which cannot hold microsecond timestamps or Python floats
+    (issue #5119). ``dump_openapi.py`` must keep those annotations in the
+    checked-in artifact.
+    """
+    assert _OPENAPI_JSON_PATH.exists(), (
+        f"openapi.json not found at {_OPENAPI_JSON_PATH}. "
+        f"Run `.venv/bin/python scripts/dump_openapi.py` to generate it."
+    )
+    spec = json.loads(_OPENAPI_JSON_PATH.read_text())
+    schemas = spec["components"]["schemas"]
+    comments = schemas["SessionListItem"]["properties"]["comments_updated_at"]
+    integer_branch = next(b for b in comments["anyOf"] if b.get("type") == "integer")
+    assert integer_branch.get("format") == "int64", (
+        "SessionListItem.comments_updated_at must declare format=int64 so "
+        "generated clients decode microsecond timestamps as 64-bit ints."
+    )
+
+    formatless_number: list[str] = []
+    formatless_integer: list[str] = []
+
+    def walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            t = node.get("type")
+            fmt = node.get("format")
+            if t == "number" and fmt != "double":
+                formatless_number.append(path)
+            elif t == "integer" and fmt != "int64":
+                formatless_integer.append(path)
+            for key, value in node.items():
+                if key in {"default", "example", "examples", "const", "enum"}:
+                    continue
+                walk(value, f"{path}.{key}")
+        elif isinstance(node, list):
+            for i, item in enumerate(node):
+                walk(item, f"{path}[{i}]")
+
+    walk(schemas, "components.schemas")
+    assert not formatless_number, "formatless or non-double number schemas: " + ", ".join(
+        formatless_number[:12]
+    )
+    assert not formatless_integer, "formatless or non-int64 integer schemas: " + ", ".join(
+        formatless_integer[:12]
+    )


### PR DESCRIPTION
## Related issue

Closes #5119

## Summary

- Pydantic emits no numeric format, so typed-language generators guess:
  a formatless integer becomes int32 and a formatless number becomes
  float32/BigDecimal. Neither matches the Python producer, and int32
  overflows on the microsecond epoch timestamps the API returns
  (e.g. SessionListItem.comments_updated_at).
- scripts/dump_openapi.py now stamps int64 on integer nodes and
  double on number nodes under components.schemas, using
  setdefault so any format the model layer already declares stays
  authoritative. Example/enum/default payloads are skipped so literal
  values are never rewritten.
- Scope note: 12 formatless integers remain on pagination query params
  under paths (limit, offset, depth), where int32 is correct.
  One inline response schema (POST /v1/runners/{runner_id}/token)
  also stays formatless; its expires_at is epoch seconds, not the
  microseconds this issue is about, so it is deliberately out of scope.

## Test Plan

- uv run python scripts/dump_openapi.py --check — on-disk spec is up to date
- uv run pytest tests/server/test_openapi_drift.py tests/server/test_stream_events.py — 23 passed
- uv run ruff check and uv run ruff format --check — clean on both changed files

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Changelog

Generated API clients now decode numeric fields at the right width — 64-bit
integers and doubles — instead of overflowing on microsecond timestamps.
