### PR TITLE
fix(repl): match the web composer's slash-command surface in the terminal

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -64,6 +64,7 @@ from omnigent.process_logging import (
 from omnigent.spec import load as load_spec
 from omnigent.spec._omnigent_compat import OMNIGENT_EXECUTOR_TYPE
 from omnigent.spec.parser import discover_host_skills
+from omnigent.spec.skill_sources import SkillSourceContext, resolve_harness_skills
 from omnigent.spec.types import AgentSpec, SkillSpec
 
 if TYPE_CHECKING:
@@ -393,7 +394,10 @@ def run_chat(
             )
         # Discover host-scope skills from cwd so ``/skill-name`` slash
         # commands work even when connecting to a remote server with no
-        # local agent spec.
+        # local agent spec. The generic walk rather than the harness-aware
+        # resolver: without a spec there is no harness to dispatch on until
+        # the session exists, so vendor extras (Claude plugin skills) stay
+        # out of this menu.
         host_skills = discover_host_skills(Path.cwd(), "all")
         _chat_with_server(
             target,
@@ -3343,11 +3347,20 @@ def _merge_host_skills(
     spec_path: Path,
 ) -> list[SkillSpec]:
     """
-    Merge bundled skills with host-scope skills for the REPL.
+    Merge bundled skills with the ones the session's harness exposes.
 
-    Discovers ``.claude/skills/`` and ``.agents/skills/`` walking
-    up from the agent root, deduplicates by name (bundled wins),
-    and returns the combined list.
+    Resolution goes through :func:`resolve_harness_skills`, the same
+    entry point the runner's ``_resolve_session_skills`` uses to build
+    the web composer's slash-command menu, so the two composers offer
+    the same commands for the same session. For a Claude harness that
+    means enabled plugin skills (``<plugin>:<skill>``) as well as the
+    ``.claude/skills`` / ``.agents/skills`` walk; a harness with no
+    dedicated provider keeps the generic walk.
+
+    The workspace is searched ahead of the agent root, matching the
+    runner: a generated launcher spec (``omnigent run --harness
+    claude``) lives in a temp directory, and the ``.claude/skills`` the
+    user cares about is next to the code they are working on.
 
     :param agent_spec: Parsed AgentSpec with ``.skills`` and
         ``.skills_filter``.
@@ -3355,14 +3368,35 @@ def _merge_host_skills(
     :returns: Combined skill list, or empty list.
     """
     bundled: list[SkillSpec] = agent_spec.skills or []
-    skills_filter = agent_spec.skills_filter
     agent_root = spec_path if spec_path.is_dir() else spec_path.parent
-    host = discover_host_skills(agent_root, skills_filter)
-    bundled_names = {s.name for s in bundled}
+    roots: list[Path] = []
+    for candidate in (Path.cwd(), agent_root):
+        resolved = candidate.resolve()
+        if resolved not in roots:
+            roots.append(resolved)
+    ctx = SkillSourceContext(
+        roots=tuple(roots),
+        home=Path.home(),
+        skills_filter=agent_spec.skills_filter,
+        bundle_dir=agent_root,
+    )
+    harness = canonicalize_harness(agent_spec.executor.harness_kind)
+    seen = {s.name for s in bundled}
+    # Also by directory: a bundled skill whose folder and frontmatter ``name``
+    # differ is one skill, and the runner drops the host copy on either match.
+    # Registering it twice would put a second command in the menu that resolves
+    # to nothing.
+    seen_dirs = {s.skill_dir.resolve() for s in bundled if s.skill_dir is not None}
     merged = list(bundled)
-    for hs in host:
-        if hs.name not in bundled_names:
-            merged.append(hs)
+    for hs in resolve_harness_skills(ctx, harness):
+        if hs.name in seen:
+            continue
+        if hs.skill_dir is not None and hs.skill_dir.resolve() in seen_dirs:
+            continue
+        seen.add(hs.name)
+        if hs.skill_dir is not None:
+            seen_dirs.add(hs.skill_dir.resolve())
+        merged.append(hs)
     return merged
 
 

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -3954,13 +3954,13 @@ async def run_repl(
     # nested closure can rebind the value.
     _bang_cwd: list[str] = [os.getcwd()]
 
-    # Paint the composer in the omnigent-logo green while the line is a "!"
-    # shell command, so bang mode is visible before Enter is pressed.
+    # Tint the composer while the line is a "!" shell command or a "/" slash
+    # command, so the routing is visible before Enter is pressed.
     # ``PromptSession`` reads ``.lexer`` through a ``DynamicLexer``, so setting
     # it here takes effect live.
     _prompt_session = getattr(host, "_prompt", None)
     if _prompt_session is not None:
-        _prompt_session.lexer = _BangInputLexer()
+        _prompt_session.lexer = _ComposerLexer()
 
     async def on_input(text: str, attachments: list[PendingAttachment] | None = None) -> None:
         nonlocal conversation_id, is_streaming
@@ -4042,11 +4042,8 @@ async def run_repl(
         if text.startswith("!!"):
             text = text[1:]  # drop one "!"; fall through as a normal prompt
 
-        # Slash commands are short tokens like "/help", "/clear".
-        # File paths like "/Users/foo/bar.jpg" start with "/" but
-        # contain more path separators — don't treat those as commands.
-        first_token = text.split()[0] if text.split() else ""
-        if first_token.startswith("/") and "/" not in first_token[1:]:
+        first_token = _slash_command_token(text)
+        if first_token:
             # Starting a new conversation orphans any buffered "!" output — it
             # belonged to the prior conversation. Drop it so it can't leak into
             # the fresh conversation's first turn.
@@ -8325,6 +8322,26 @@ def _render_history_item(
 _SLASH_COMMAND_ALIASES: frozenset[str] = frozenset({"/?", "/exit"})
 
 
+def _slash_command_token(text: str) -> str:
+    """
+    Return the leading slash-command token in *text*, or ``""`` if it has none.
+
+    Slash commands are short tokens like ``/help`` or ``/code-review``. A file
+    path such as ``/Users/me/shot.png`` also opens with ``/`` but carries more
+    separators, so it stays an ordinary message. One definition shared by the
+    dispatcher and the composer's highlight, so a tinted token is one the
+    dispatcher really does intercept.
+
+    :param text: Raw composer input, e.g. ``"/effort high"``.
+    :returns: The token including its ``/``, e.g. ``"/effort"``.
+    """
+    parts = text.split(maxsplit=1)
+    first_token = parts[0] if parts else ""
+    if first_token.startswith("/") and "/" not in first_token[1:]:
+        return first_token
+    return ""
+
+
 # A skill name must read as a slash-command token: an alphanumeric start then
 # word chars, ``:`` (Claude ``plugin:skill``), or ``-`` (Cursor ``plugin--skill``).
 # Rejects whitespace, ``/``, and control characters. Mirrors the web composer's
@@ -8506,23 +8523,59 @@ _BANG_INPUT_STYLE = f"fg:{_BANG_GREEN} bold"  # prompt-toolkit composer style
 _BANG_ECHO_MARKUP = f"bold {_BANG_GREEN}"
 
 
-class _BangInputLexer(Lexer):
+# The terminal's own brand accent — the one the formatter paints ``❯`` with.
+# The web overlay uses its accent for the same job (``text-brand-accent`` in
+# ChatPage.tsx); the two palettes differ, the treatment is what matches.
+_SLASH_COMMAND_STYLE = "fg:#F43BA6"
+
+
+class _ComposerLexer(Lexer):
     """
-    Color the composer green while the current line is a "!" shell command.
+    Tint composer input that the REPL will route somewhere other than the agent.
 
     A line that begins with ``!`` (but not the ``!!`` literal-escape) runs in
     the shell via the passthrough; painting it in the omnigent-logo green is
-    live feedback that bang mode is active. Any other input renders unstyled.
+    live feedback that bang mode is active. A leading ``/token`` goes to the
+    command dispatcher rather than to the model — including one that names no
+    registered command, which the dispatcher answers itself — so it gets the
+    brand accent, the same treatment the web composer's highlight overlay
+    gives it. Arguments after the token stay unstyled so a path or URL in them
+    reads normally. Any other input is a message to the agent and renders
+    unstyled.
+
+    What the tint reports is this dispatcher's routing, not the web's: the
+    terminal intercepts a bare ``/`` and a non-ASCII name that the web
+    composer's narrower shape rejects, and both surfaces should say what
+    their own Enter key will do.
+
+    Both tints describe routing from an idle composer. A modal prompt — a
+    pending schema field, an approval — consumes the line before either
+    branch is reached, as it already did for ``!``.
     """
 
     def lex_document(self, document: Document) -> Callable[[int], StyleAndTextTuples]:
         text = document.text
         is_bang = text.startswith("!") and not text.startswith("!!")
-        style = _BANG_INPUT_STYLE if is_bang else ""
         lines = document.lines
+        # The dispatcher reads the first token of the whole input, and that
+        # token sits on the first line that isn't blank — so paint it there
+        # and the two always agree, pasted leading newline included.
+        head_no = next((i for i, line in enumerate(lines) if line.strip()), 0)
+        command = "" if is_bang else _slash_command_token(lines[head_no])
 
         def get_line(lineno: int) -> StyleAndTextTuples:
-            return [(style, lines[lineno])]
+            line = lines[lineno]
+            if is_bang:
+                return [(_BANG_INPUT_STYLE, line)]
+            if lineno == head_no and command:
+                indent = len(line) - len(line.lstrip())
+                end = indent + len(command)
+                return [
+                    ("", line[:indent]),
+                    (_SLASH_COMMAND_STYLE, line[indent:end]),
+                    ("", line[end:]),
+                ]
+            return [("", line)]
 
         return get_line
 

--- a/tests/cli/test_repl_skill_parity.py
+++ b/tests/cli/test_repl_skill_parity.py
@@ -1,0 +1,206 @@
+"""The REPL's slash commands are the ones the web composer offers.
+
+Both surfaces answer "what can I type after ``/``" for the same session. The
+runner builds the web menu with ``resolve_harness_skills``; the REPL used to
+walk ``.claude/skills`` directly, which meant a Claude plugin's skills reached
+the web menu and never reached the terminal. These tests pin the two together.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from omnigent.chat import _merge_host_skills
+from omnigent.spec.skill_sources import SkillSourceContext, resolve_harness_skills
+from omnigent.spec.types import AgentSpec, ExecutorSpec, SkillSpec
+
+
+def _write_skill(skills_dir: Path, name: str) -> None:
+    """Write a minimal ``<skills_dir>/<name>/SKILL.md``."""
+    d = skills_dir / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(f"---\nname: {name}\ndescription: {name} desc\n---\nbody\n")
+
+
+def _claude_home_with_plugin(home: Path, *, plugin: str, skill: str) -> None:
+    """Seed a fake ``~/.claude`` carrying one enabled, installed plugin."""
+    install = home / ".claude" / "plugins" / "cache" / "mkt" / plugin / "1.0.0"
+    _write_skill(install / "skills", skill)
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {f"{plugin}@mkt": True}})
+    )
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "plugins": {
+                    f"{plugin}@mkt": [
+                        {"scope": "user", "installPath": str(install), "version": "1.0.0"}
+                    ]
+                },
+            }
+        )
+    )
+
+
+def _spec(harness: str, *, bundled: list[SkillSpec] | None = None) -> AgentSpec:
+    """An agent spec that declares only a harness (and optional bundled skills)."""
+    return AgentSpec(
+        spec_version=1,
+        executor=ExecutorSpec(type=harness),
+        skills=bundled or [],
+    )
+
+
+def test_repl_offers_a_claude_plugin_skill(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plugin's skill is typeable in the REPL, not just in the web menu.
+
+    Claude Code registers an enabled plugin's skills as ``<plugin>:<skill>``
+    slash commands, and the web composer lists them. The terminal walked only
+    ``.claude/skills``, so the same session offered a shorter menu depending on
+    which surface you typed into.
+    """
+    home = tmp_path / "home"
+    _claude_home_with_plugin(home, plugin="superpowers", skill="using-superpowers")
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.chdir(workspace)
+
+    names = [s.name for s in _merge_host_skills(_spec("claude-native"), workspace)]
+
+    assert "superpowers:using-superpowers" in names
+
+
+def test_repl_matches_the_web_menu_for_the_same_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One resolver, so the two composers cannot drift apart again.
+
+    This is the invariant the bug broke: whatever the runner resolves for the
+    web menu is what the REPL registers. Asserted as set equality rather than
+    a membership check so an extra command on either side fails too.
+    """
+    home = tmp_path / "home"
+    _claude_home_with_plugin(home, plugin="superpowers", skill="using-superpowers")
+    workspace = tmp_path / "ws"
+    _write_skill(workspace / ".claude" / "skills", "code-review")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.chdir(workspace)
+
+    repl = {s.name for s in _merge_host_skills(_spec("claude-native"), workspace)}
+    web = {
+        s.name
+        for s in resolve_harness_skills(
+            SkillSourceContext(
+                roots=(workspace.resolve(),),
+                home=home,
+                skills_filter="all",
+                bundle_dir=workspace,
+            ),
+            "claude-native",
+        )
+    }
+
+    assert repl == web
+    assert {"code-review", "superpowers:using-superpowers"} <= repl
+
+
+def test_the_workspace_is_searched_not_only_the_agent_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``omnigent run --harness claude`` writes its spec to a temp directory.
+
+    Walking up from that generated root reaches ``/`` without ever passing the
+    directory the user is working in, so a project's own ``.claude/skills``
+    would be invisible — the one place a project keeps its skills.
+    """
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    workspace = tmp_path / "ws"
+    _write_skill(workspace / ".claude" / "skills", "project-only")
+    generated_spec_root = tmp_path / "generated"
+    generated_spec_root.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.chdir(workspace)
+
+    names = [s.name for s in _merge_host_skills(_spec("claude-sdk"), generated_spec_root)]
+
+    assert "project-only" in names
+
+
+def test_a_codex_session_lists_what_codex_registers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The shrink for a replacing provider is deliberate, so pin it.
+
+    ``select_codex_skill_dirs`` is the single source of truth for what gets
+    symlinked into ``$CODEX_HOME/skills/``, so a ``~/.claude/skills`` entry is
+    never registered by Codex. Offering it was a menu item that resolved to
+    ``skill_not_found``. Without this test, unioning the generic walk back in
+    would look like an improvement and pass every other test here.
+    """
+    home = tmp_path / "home"
+    _write_skill(home / ".claude" / "skills", "claude-only")
+    _write_skill(home / ".codex" / "skills", "codex-only")
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.chdir(workspace)
+
+    names = [s.name for s in _merge_host_skills(_spec("codex-native"), workspace)]
+
+    assert "codex-only" in names
+    assert "claude-only" not in names
+
+
+def test_a_bundled_skill_is_not_offered_twice_under_its_directory_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One skill, one command, even when its folder and its name differ.
+
+    Codex names a skill by its *directory*, and its sources include the
+    bundle's own ``skills/``. So a bundled skill in ``sra--triage/`` whose
+    frontmatter says ``triage`` comes back from the provider under the other
+    name, and deduplicating on the name alone lets it in a second time. The
+    extra command resolves to nothing — the runner drops it on the directory
+    match, so the REPL has to as well.
+    """
+    home = tmp_path / "home"
+    (home / ".codex").mkdir(parents=True)
+    bundle = tmp_path / "bundle"
+    shared_dir = bundle / "skills" / "sra--triage"
+    shared_dir.mkdir(parents=True)
+    (shared_dir / "SKILL.md").write_text("---\nname: triage\ndescription: d\n---\nbody\n")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.chdir(tmp_path)
+    bundled = SkillSpec(
+        name="triage", description="the bundled one", content="body", skill_dir=shared_dir
+    )
+
+    names = [s.name for s in _merge_host_skills(_spec("codex-native", bundled=[bundled]), bundle)]
+
+    assert names == ["triage"], names
+
+
+def test_a_bundled_skill_still_wins_on_a_name_collision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The agent's own skill is the one it ships with; the host copy loses."""
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    workspace = tmp_path / "ws"
+    _write_skill(workspace / ".claude" / "skills", "code-review")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.chdir(workspace)
+    bundled = SkillSpec(name="code-review", description="the bundled one", content="bundled body")
+
+    merged = _merge_host_skills(_spec("claude-sdk", bundled=[bundled]), workspace)
+
+    assert [s.description for s in merged if s.name == "code-review"] == ["the bundled one"]

--- a/tests/repl/test_bang_command.py
+++ b/tests/repl/test_bang_command.py
@@ -19,9 +19,9 @@ from omnigent.repl import _repl
 from omnigent.repl._repl import (
     _BANG_INPUT_STYLE,
     _bang_shell_argv,
-    _BangInputLexer,
     _build_bang_context,
     _clip_text,
+    _ComposerLexer,
     _resolve_cd,
     _run_bang_command,
     _write_bang_overflow,
@@ -198,7 +198,7 @@ def test_build_context_notes_overflow_path() -> None:
     assert "/tmp/x.log" in block and "full output" in block
 
 
-# ── _BangInputLexer (composer coloring) ─────────────────
+# ── _ComposerLexer (composer coloring) ──────────────────
 
 
 def test_bang_input_style_is_the_logo_green() -> None:
@@ -218,7 +218,7 @@ def test_bang_input_style_is_the_logo_green() -> None:
     ],
 )
 def test_bang_input_lexer_colors_only_bang_lines(text: str, colored: bool) -> None:
-    get_line = _BangInputLexer().lex_document(Document(text))
+    get_line = _ComposerLexer().lex_document(Document(text))
     style, rendered = get_line(0)[0]
     assert rendered == text
     assert (style == _BANG_INPUT_STYLE) is colored

--- a/tests/repl/test_slash_command_highlight.py
+++ b/tests/repl/test_slash_command_highlight.py
@@ -1,0 +1,170 @@
+"""The REPL composer tints a slash-command token as it is typed.
+
+Until Enter is pressed, ``/code-review`` and ``send this to the agent`` render
+identically in the terminal composer, so there is no signal that the line is
+about to be dispatched as a command rather than sent to the model. The web
+composer already tints the token via its highlight overlay
+(``splitSlashCommand`` + ``text-brand-accent`` in ``ChatPage.tsx``); these
+tests pin the terminal to the same treatment. Each surface uses its own
+palette, so what matches is the treatment, not the hex.
+"""
+
+from __future__ import annotations
+
+import pytest
+from omnigent_ui_sdk.terminal import RichBlockFormatter
+from prompt_toolkit.document import Document
+from prompt_toolkit.formatted_text import StyleAndTextTuples
+
+from omnigent.repl._repl import (
+    _BANG_INPUT_STYLE,
+    _SLASH_COMMAND_STYLE,
+    _ComposerLexer,
+    _slash_command_token,
+)
+
+
+def _fragments(text: str, lineno: int = 0) -> StyleAndTextTuples:
+    """Lex *text* and return line *lineno*'s ``(style, text)`` fragments."""
+    return list(_ComposerLexer().lex_document(Document(text))(lineno))
+
+
+def _spans(text: str, lineno: int = 0) -> list[tuple[str, str]]:
+    """The fragments that carry text, so assertions pin styling not padding.
+
+    An empty fragment is an artefact of where the token happens to end; only
+    ``test_fragments_reproduce_the_line_exactly`` should care about those.
+    """
+    return [(style, part) for style, part in _fragments(text, lineno) if part]
+
+
+def test_slash_style_is_the_terminal_accent() -> None:
+    """The tint is the accent the rest of the REPL already paints with.
+
+    The literal mirrors the ``_BANG_GREEN`` precedent in the same module
+    rather than reaching into the formatter at import time; this pins the two
+    together so a re-themed accent fails here instead of drifting.
+    """
+    assert f"fg:{RichBlockFormatter().accent}" == _SLASH_COMMAND_STYLE
+
+
+@pytest.mark.parametrize(
+    ("text", "token"),
+    [
+        ("/code-review", "/code-review"),  # a host-scope skill command
+        ("/help", "/help"),  # a built-in
+        ("  /help", "/help"),  # the dispatcher splits, so indent is tolerated
+        # A Claude plugin's skill, namespaced by its plugin. These now reach
+        # the REPL as well as the web menu, so the tint has to accept the ":".
+        ("/superpowers:using-superpowers", "/superpowers:using-superpowers"),
+        ("/", "/"),  # bare "/" still dispatches (and reports unknown)
+        ("/Users/me/shot.png", ""),  # a pasted path is a message, not a command
+        ("//", ""),  # more separators — not a command token
+        ("tell me about /help", ""),  # only the first token can be a command
+        ("", ""),  # empty composer
+    ],
+)
+def test_slash_command_token_matches_the_dispatcher(text: str, token: str) -> None:
+    """The highlight and the dispatch decision come from one predicate."""
+    assert _slash_command_token(text) == token
+
+
+def test_command_token_is_tinted_and_args_are_not() -> None:
+    """The token carries the accent; the argument stays in the default color.
+
+    An argument is frequently a path or URL, which reads badly when it is
+    swept into the command's color.
+    """
+    assert _spans("/code-review is this diff correct?") == [
+        (_SLASH_COMMAND_STYLE, "/code-review"),
+        ("", " is this diff correct?"),
+    ]
+
+
+def test_indentation_is_not_part_of_the_token() -> None:
+    """Only the token is tinted, not the whitespace the dispatcher skips.
+
+    Invisible today, since the accent sets a foreground and nothing else, but
+    the span should say what it means: an underline or reverse accent later
+    would otherwise trail off to the left of the ``/``.
+    """
+    assert _spans("   /help me") == [
+        ("", "   "),
+        (_SLASH_COMMAND_STYLE, "/help"),
+        ("", " me"),
+    ]
+
+
+def test_a_namespaced_plugin_skill_is_tinted_whole() -> None:
+    """The ``:`` is inside the command name, not a separator before an argument.
+
+    Claude registers a plugin's skill as ``<plugin>:<skill>``, so tinting up to
+    the colon would split one command into two coloured halves.
+    """
+    assert _spans("/superpowers:using-superpowers go") == [
+        (_SLASH_COMMAND_STYLE, "/superpowers:using-superpowers"),
+        ("", " go"),
+    ]
+
+
+def test_a_pasted_path_stays_unstyled() -> None:
+    """``/Users/...`` is sent to the agent, so tinting it would be a lie."""
+    assert _spans("/Users/me/shot.png") == [("", "/Users/me/shot.png")]
+
+
+def test_bang_still_wins_over_the_slash_tint() -> None:
+    """``!/usr/bin/env`` runs in the shell — it is green, not accent, in full."""
+    assert _spans("!/usr/bin/env") == [(_BANG_INPUT_STYLE, "!/usr/bin/env")]
+
+
+def test_only_the_first_line_carries_the_tint() -> None:
+    """A pasted second line is argument text, not a second command."""
+    assert _spans("/code-review\n/help", 0) == [(_SLASH_COMMAND_STYLE, "/code-review")]
+    assert _spans("/code-review\n/help", 1) == [("", "/help")]
+
+
+def test_a_leading_blank_line_does_not_lose_the_tint() -> None:
+    """A paste can open with a newline, and the dispatcher looks past it.
+
+    ``str.split`` treats the newline as whitespace, so ``"\\n/help"`` is
+    dispatched as ``/help``. The tint has to follow the token onto the line it
+    is actually on, or the composer stays silent about a routing that happens.
+    """
+    assert _spans("\n/help me", 0) == []
+    assert _spans("\n/help me", 1) == [(_SLASH_COMMAND_STYLE, "/help"), ("", " me")]
+
+
+def test_an_unregistered_command_is_still_tinted() -> None:
+    """The tint means "the dispatcher takes this", not "this command exists".
+
+    ``/does-not-exist`` is intercepted and answered with ``Unknown command``;
+    it never reaches the model, so painting it as a message would be the lie.
+    Shape-based, like the web composer.
+    """
+    assert _spans("/does-not-exist") == [(_SLASH_COMMAND_STYLE, "/does-not-exist")]
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "/code-review some args",
+        "  /help",
+        "plain message",
+        "",
+        "/Users/me/x.png",
+        "\n/help",
+        "/日本語 テスト",
+    ],
+)
+def test_fragments_reproduce_the_line_exactly(text: str) -> None:
+    """A lexer must never drop or duplicate a glyph — the composer shows this.
+
+    The token is a character-exact prefix of the line, so a wide or combining
+    character can only ever sit wholly inside one fragment; prompt_toolkit
+    measures display width after this split.
+    """
+    lexer = _ComposerLexer().lex_document(Document(text))
+    rejoined = "".join(
+        fragment[1] for lineno in range(len(text.split("\n"))) for fragment in lexer(lineno)
+    )
+    assert rejoined == text.replace("\n", "")


### PR DESCRIPTION
## Related issue

Closes #5195

## Summary

Both composers answer "what can I type after `/`" for the same session, and
they answered it differently.

- **The REPL's menu was missing the harness's skills.** The runner resolves a
  session's commands with `resolve_harness_skills`, which knows what each
  vendor registers — for Claude that includes every enabled plugin's skills,
  namespaced `<plugin>:<skill>`. The REPL called `discover_host_skills`
  directly, so on one `claude-native` session the web menu listed **159**
  commands and the terminal **110**: `/figma:figma-use` was typeable in the
  browser and absent from the terminal. Both now go through the one resolver.
- **Discovery started from the wrong root.** It walked up from the *agent*
  root; `omnigent run --harness claude` writes its generated spec to a temp
  directory, which never passes the project the user is in. The workspace is
  searched first now, as the runner already does.
- **Nothing marked a command as a command.** `/code-review is this right?`
  rendered exactly like a message to the model. The token now takes the brand
  accent and the argument keeps the default color, matching the web composer's
  highlight overlay. Each surface keeps its own palette, so the parity is the
  treatment.

The tint decision comes from one predicate the dispatcher also uses, so a
tinted token is one the dispatcher really does intercept: a pasted
`/Users/me/shot.png` stays plain, as it already did at dispatch, and
`/does-not-exist` is tinted because it is answered here rather than sent on.

**This narrows the menu for codex and cursor, on purpose.** Their providers
deliberately replace the generic walk. `select_codex_skill_dirs` is, in its own
words, "the single source of truth for which skills does this Codex session
expose", shared with the code that symlinks them into `$CODEX_HOME/skills/` —
so the ~101 `~/.claude/skills` entries the REPL used to offer a codex session
were commands Codex never registers. That is the web menu's existing behaviour;
this brings the terminal in line rather than deciding it anew. Happy to gate it
if you would rather keep the old superset in the terminal.

## Test Plan

`tests/cli/test_repl_skill_parity.py` — new. A plugin skill reaching the REPL,
set-equality against what `resolve_harness_skills` gives the web menu for the
same session, the workspace root, and bundled-wins-on-collision. Three of the
four fail without the `chat.py` change (the fourth is the precedence guard,
which held before and must keep holding).

`tests/repl/test_slash_command_highlight.py` — new. Token/argument split, a
namespaced `<plugin>:<skill>` tinted whole, the path guard, bang precedence, an
unregistered command, a paste opening with a blank line, indentation left
outside the accent span, a table pinning `_slash_command_token` against the
dispatcher's cases, and a round-trip check that fragments reproduce each line
byte for byte, CJK included.

```
pytest tests/repl tests/cli    1616 passed
pre-commit run --files …       ruff, ruff format, pyrefly, hygiene — all pass
```

Manual, against a PostgreSQL-backed server, in a scratch workspace so nothing
resumed and no turn ran. Composer colors were sampled from the recording's
pixels rather than eyeballed — on `main` the command and its argument are the
same `#cdd0e6`; on this branch the token is `#f36dac` and the argument stays
`#d0d7ed`, with `/Users/me/shot.png` at `#dadef4` and `!ls` on its unchanged
`#26a079`.

## Demo

Same REPL, same server, same input — first `main`, then this branch.

![composer](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/slash-command-highlight.gif)

Typing `/figma` on `main`. The figma plugin is enabled in Claude Code and the
web composer lists its skills for this very session; the terminal offers
nothing:

![menu before](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/slash-menu-before.png)

The same keystrokes after the change:

![menu after](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/slash-menu-after.png)

And the tint — `main` on the left, this branch on the right. The `:` is part of
the command name, so the token is tinted whole:

![tint before](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/slash-highlight-before.png)

![tint after](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/slash-highlight-after.png)

The `vhs` tape that produced these is
[committed alongside them](https://github.com/Paldom/omnigent/blob/agent-army/docs/agent-army/media/slash-command-highlight.tape).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The resolver swap and the lexer's output are both pure and unit-tested. What
unit tests cannot show is prompt-toolkit rendering those fragments in a real
terminal, or the completion popup opening on a plugin skill, so the manual pass
ran the actual REPL against a Postgres-backed server and read the colors out of
the recording's pixels.

## Changelog

The terminal REPL offers the same slash commands as the web composer, including Claude plugin skills, and tints the command as you type it.
