### PR TITLE
feat(android): side-by-side installs, background-poll notifications, and background battery-drain fix

### DIFF
--- a/web/android/app/build.gradle.kts
+++ b/web/android/app/build.gradle.kts
@@ -39,16 +39,32 @@ fun buildProperty(key: String): String? =
 val appVersionCode = buildProperty("versionCode")?.toIntOrNull() ?: 9
 val appVersionName = buildProperty("versionName") ?: "0.1.3"
 
+// Side-by-side installs for personal/nightly builds: -PapplicationIdSuffix=.dev
+// gives the APK its own package id (and a launcher label naming the suffix) so
+// it never collides with the store-signed app. Absent/blank keeps the canonical
+// id and label.
+val appIdSuffix = buildProperty("applicationIdSuffix")
+
 android {
     namespace = "ai.omnigent.android"
     compileSdk = 36
 
     defaultConfig {
-        applicationId = "ai.omnigent.android"
+        // Guarded with isNullOrBlank (not just null): a blank
+        // -PapplicationIdSuffix= must keep the canonical id AND label — a
+        // null-only guard would render the label as "Omnigent ()".
+        applicationId =
+            "ai.omnigent.android" + (appIdSuffix.takeUnless { it.isNullOrBlank() } ?: "")
         minSdk = 28
         targetSdk = 36
         versionCode = appVersionCode
         versionName = appVersionName
+        manifestPlaceholders["appLabel"] =
+            if (!appIdSuffix.isNullOrBlank()) {
+                "Omnigent (${appIdSuffix.trimStart('.')})"
+            } else {
+                "@string/app_name"
+            }
 
         // Instrumented (androidTest) runner — required for UI Automator / Espresso
         // screenshot tests. Mirrors the androidx.test stable line pinned below.
@@ -123,6 +139,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.webkit)
+    implementation(libs.androidx.work.runtime.ktx)
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)

--- a/web/android/app/src/main/AndroidManifest.xml
+++ b/web/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:allowBackup="false"
         android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="${appLabel}"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"

--- a/web/android/app/src/main/java/ai/omnigent/android/AppVisibility.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/AppVisibility.kt
@@ -1,0 +1,68 @@
+package ai.omnigent.android
+
+import java.util.Collections
+import java.util.IdentityHashMap
+
+/**
+ * Process-wide "is the app on screen" signal for [SessionPollWorker].
+ *
+ * While [MainActivity] is started, the SPA's own `useIdleNotifications` hook is
+ * live and posts its in-app notification for the very same running → idle /
+ * elicitation edges the background poller detects — and the two use different
+ * notification-id spaces, so nothing collapses. The worker therefore skips
+ * POSTING while the app is visible (holding the un-posted edges; see
+ * holdSuppressedTransitions).
+ *
+ * Deliberately an in-memory tracker rather than a ProcessLifecycleOwner
+ * dependency: WorkManager runs the worker in this same process, so the state
+ * is reachable and correct — a cold background-only process never starts an
+ * Activity and reads as not visible.
+ *
+ * Tracks the IDENTITIES of started activities (not a bare count) so an
+ * unmatched or duplicated lifecycle callback cannot skew the edges: with a
+ * counter, an unmatched stop at count 1 would fake a 1 → 0 (pausing WebView
+ * timers under a still-visible activity), and an unmatched start would absorb
+ * the eventual genuine 1 → 0. With a set, a stop only counts if that same
+ * activity is currently started, and a repeated start of the same activity is
+ * a no-op.
+ */
+object AppVisibility {
+    private val lock = Any()
+    private val startedActivities =
+        Collections.newSetFromMap(IdentityHashMap<Any, Boolean>())
+
+    /** True while at least one tracked Activity is between onStart and onStop. */
+    val isAppVisible: Boolean get() = synchronized(lock) { startedActivities.isNotEmpty() }
+
+    /**
+     * Returns true only on the none-started → some-started transition — "the
+     * app just came on screen". Callers gate process-global work
+     * (WebView.resumeTimers) on this rather than acting per-activity: during
+     * in-process recreation the NEW instance's onStart can run BEFORE the old
+     * instance's onStop, and per-activity calls would let the dying instance
+     * later act on state the live one owns.
+     */
+    fun onActivityStarted(activity: Any): Boolean =
+        synchronized(lock) {
+            val wasHidden = startedActivities.isEmpty()
+            startedActivities.add(activity) && wasHidden
+        }
+
+    /**
+     * Returns true only on the some-started → none-started transition — "the
+     * app just left the screen". Only then may process-global work
+     * (WebView.pauseTimers) run: with the overlap ordering above, the old
+     * instance's onStop leaves the new instance in the set and must NOT pause
+     * the timers of the already-foregrounded new instance (that would freeze
+     * all WebView JS until the user backgrounds and returns). The
+     * recreate()/locale ordering (old stop, then new start) yields a transient
+     * pause immediately followed by a resume — both idempotent, so that's
+     * harmless. A stop for an activity that was never started (or already
+     * stopped) removes nothing and signals no edge.
+     */
+    fun onActivityStopped(activity: Any): Boolean =
+        synchronized(lock) {
+            startedActivities.remove(activity) &&
+                startedActivities.isEmpty()
+        }
+}

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -57,6 +57,11 @@ class MainActivity : AppCompatActivity() {
     private var pendingNavigatePath: String? = null
     private var lastInsets: Insets? = null
     private var pageLoaded = false
+
+    // True between onStop and onStart. A deep link arriving while stopped is
+    // held for onStart, which emits it after resumeTimers() so the JS side is
+    // guaranteed to be running.
+    private var stopped = false
     private var bridgeTransportInstalled = false
     private var bridgeScriptHandler: ScriptHandler? = null
     private var loginAttempts = 0 // capped browser-login retries; reset in onPageReady
@@ -277,7 +282,49 @@ class MainActivity : AppCompatActivity() {
         )
 
         ensureNotificationPermission()
+        // Interim background-poll notifications: fire local notifications when a
+        // session finishes or raises a prompt while the app isn't foregrounded.
+        // Idempotent (KEEP), so scheduling every launch is safe.
+        SessionPollScheduler.ensureScheduled(applicationContext)
         webView.loadUrl(serverUrl)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        stopped = true
+        // Background poller resumes posting once the SPA is off-screen.
+        val appLeftScreen = AppVisibility.onActivityStopped(this)
+        if (::webView.isInitialized && appLeftScreen) {
+            // Suspend JS timers while off-screen: the SPA's heartbeat and reconnect
+            // loops otherwise burn CPU/radio until the OS freezes the process. Timers
+            // only (webView.onPause() would kill audio on screen-off). pauseTimers()
+            // is PROCESS-GLOBAL, so it is gated on the AppVisibility 1 → 0
+            // transition, not run per-activity: during in-process recreation the
+            // new instance's onStart can precede this onStop, and an unconditional
+            // pause here would freeze the foregrounded instance's JS until the
+            // user backgrounds and returns.
+            webView.pauseTimers()
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        stopped = false
+        // While visible, the SPA's useIdleNotifications posts its own in-app
+        // notification for the same edges — the background poller must not
+        // duplicate it (see AppVisibility).
+        val appCameOnScreen = AppVisibility.onActivityStarted(this)
+        if (::webView.isInitialized) {
+            // Mirror of the pause gate above: resume only on the 0 → 1
+            // transition. In the recreate() ordering (old stop 1 → 0 paused,
+            // then this start 0 → 1) this undoes the transient pause; in the
+            // overlap ordering the counter never hit 0, timers never paused,
+            // and there's nothing to resume.
+            if (appCameOnScreen) webView.resumeTimers()
+            // A notification tap that arrived while stopped deferred its deep
+            // link (see onNewIntent); emit it now that JS timers run again.
+            if (pageLoaded) flushPendingActivation()
+        }
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -406,6 +453,17 @@ class MainActivity : AppCompatActivity() {
                 if (secure) append("; Secure")
                 append("; SameSite=Lax")
             }
+        // Identity-keyed cleanup: atomically bind the marker while clearing the
+        // previous account's baseline. Cancellation shares that lock with each
+        // worker post, so an old-account notification can only land before the
+        // cancelAll() or be rejected after the new identity becomes visible.
+        // Re-injection for the SAME account keeps the baseline.
+        // Re-arm the periodic poll in case it was never scheduled (login before
+        // a server was pinned) — KEEP makes an already-scheduled poll a no-op.
+        val snapshotStore = SessionSnapshotStore(applicationContext)
+        val accountIdentity = sessionAccountIdentity(origin, token)
+        snapshotStore.bindAccount(accountIdentity, notifications::cancelAll)
+        SessionPollScheduler.ensureScheduled(applicationContext)
         val cookies = CookieManager.getInstance()
         cookies.setAcceptCookie(true)
         authLog("onSessionToken: injecting $name (token len=${token.length})")
@@ -505,8 +563,11 @@ class MainActivity : AppCompatActivity() {
 
         val path = navigatePathOf(intent) ?: return
         pendingNavigatePath = path
-        // Replay now if the page is up; otherwise onPageReady will flush it.
-        if (pageLoaded) flushPendingActivation()
+        // Replay now if the page is up — unless we're stopped with JS timers
+        // paused, where an evaluateJavascript could be dropped on older
+        // WebViews; onStart re-flushes after resumeTimers(). A cold page
+        // flushes from onPageReady instead.
+        if (pageLoaded && !stopped) flushPendingActivation()
     }
 
     /**
@@ -524,6 +585,7 @@ class MainActivity : AppCompatActivity() {
         // cookie store. cancel() also resets inFlight so the new server can start
         // its own login immediately rather than waiting up to 5 minutes.
         loginManager.cancel()
+        SessionSnapshotStore(applicationContext).unbindAccount(notifications::cancelAll)
         removeBridge()
         pinnedOrigin = newOrigin
         pageLoaded = false
@@ -606,6 +668,7 @@ class MainActivity : AppCompatActivity() {
         // page (chrome-error://) or a foreign redirect must NOT drain
         // pendingNavigatePath or push insets into a page that can't consume them.
         if (originOf(url) != pinnedOrigin) return
+        syncPollAccount(url)
         // First authenticated app page: drop everything before it from the
         // back/forward list — the pre-auth root, any IdP pages, and the post-login
         // reload all bounce to login or show a blank if Back reaches them. After
@@ -618,6 +681,33 @@ class MainActivity : AppCompatActivity() {
         loginAttempts = 0 // reached a pinned-origin page — we're past the login redirect
         flushPendingActivation()
         emitInsets()
+    }
+
+    /** Bind accounts-mode/WebView-side login state to the background poller. */
+    private fun syncPollAccount(url: String?) {
+        val origin = pinnedOrigin ?: return
+        val onLoginPage =
+            Uri
+                .parse(url)
+                .path
+                ?.trimEnd('/')
+                ?.endsWith("/login") == true
+        val cookieIdentity =
+            if (onLoginPage) {
+                null
+            } else {
+                val secure = origin.startsWith("https://")
+                extractCookieValue(
+                    CookieManager.getInstance().getCookie(origin),
+                    sessionCookieName(secure),
+                )?.let { sessionAccountIdentity(origin, it) }
+            }
+        val store = SessionSnapshotStore(applicationContext)
+        if (cookieIdentity == null) {
+            store.unbindAccount(notifications::cancelAll)
+        } else {
+            store.bindAccount(cookieIdentity, notifications::cancelAll)
+        }
     }
 
     private fun flushPendingActivation() {

--- a/web/android/app/src/main/java/ai/omnigent/android/NativeNotificationManager.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/NativeNotificationManager.kt
@@ -6,6 +6,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import java.util.concurrent.atomic.AtomicInteger
@@ -44,6 +45,18 @@ class NativeNotificationManager(
     private var lastBadge: BadgeState? = null
 
     init {
+        ensureChannel()
+    }
+
+    /**
+     * Create the notification channel, idempotently. `createNotificationChannel`
+     * is a no-op when the channel already exists, so this is cheap to call
+     * repeatedly. Exposed (and re-run from the constructor) so a WorkManager-only
+     * process — one that spawned in the background with no Activity ever
+     * on-screen — still has the channel before it posts; otherwise an O+ post to
+     * a missing channel is silently dropped. A no-op on pre-O.
+     */
+    fun ensureChannel() {
         val channel =
             NotificationChannel(
                 CHANNEL_ID,
@@ -57,8 +70,20 @@ class NativeNotificationManager(
         title: String,
         body: String?,
         navigatePath: String?,
+        // A caller-supplied STABLE id (e.g. per-session, via notificationIdFor)
+        // so a re-fire updates the same notification instead of stacking, and
+        // distinct subjects never collide. When null, an incrementing per-
+        // instance id is used — fine for one-off in-app toasts, but NOT for the
+        // background worker, which builds a fresh manager each run (the counter
+        // would restart and collide across runs).
+        notificationId: Int? = null,
+        // Optional notification TAG (e.g. the session id). Distinct session ids
+        // can share a String.hashCode-derived numeric id ("Aa"/"BB"), so tagging
+        // with the full session id is what actually guarantees distinctness —
+        // the numeric id stays stable so a re-fire still updates in place.
+        tag: String? = null,
     ) {
-        val id = nextId.getAndIncrement()
+        val id = notificationId ?: nextId.getAndIncrement()
         val builder =
             NotificationCompat
                 .Builder(context, CHANNEL_ID)
@@ -72,7 +97,7 @@ class NativeNotificationManager(
             builder.setContentIntent(activationIntent(navigatePath, id))
         }
 
-        post(id, builder.build())
+        post(id, builder.build(), tag)
     }
 
     /**
@@ -132,6 +157,17 @@ class NativeNotificationManager(
     }
 
     /**
+     * Cancel every notification this app has posted. Called on a fresh login so
+     * per-session notifications (id >= 2) left over from the PRIOR account don't
+     * linger — they'd expose the old account's titles and deep-link into its
+     * session ids. The badge (id 1) is withdrawn too; the web layer re-pushes
+     * the current count on its next tick, so it self-heals for the new account.
+     */
+    fun cancelAll() {
+        manager.cancelAll()
+    }
+
+    /**
      * Post a notification, tolerating a missing notification grant. The
      * `POST_NOTIFICATIONS` permission is revocable on API 33+, so `notify` can
      * throw `SecurityException` even after `areNotificationsEnabled()` — we drop
@@ -140,18 +176,27 @@ class NativeNotificationManager(
     private fun post(
         id: Int,
         notification: Notification,
+        tag: String? = null,
     ) {
         if (!manager.areNotificationsEnabled()) return
         try {
-            manager.notify(id, notification)
+            // Tag-qualified post: (tag, id) is the notification key, so two
+            // sessions whose hash-derived numeric ids collide still coexist.
+            // cancelAll() (the only cancel path for tagged posts) cancels
+            // tagged and untagged notifications alike.
+            manager.notify(tag, id, notification)
         } catch (_: SecurityException) {
             // POST_NOTIFICATIONS not granted — drop; web falls back.
         }
     }
 
-    // requestCode is the notification's own id, so each notification gets a
-    // distinct PendingIntent — otherwise FLAG_UPDATE_CURRENT would let two paths
-    // with colliding hashes overwrite each other's extras and mis-route a tap.
+    // requestCode is the notification's own id AND the intent carries a unique
+    // data Uri derived from navigatePath: PendingIntents are keyed by
+    // (requestCode, Intent.filterEquals), and filterEquals ignores extras — so
+    // two paths whose hash-derived ids collide would otherwise share one
+    // PendingIntent, FLAG_UPDATE_CURRENT would overwrite its extras, and both
+    // taps would mis-route to the later path. The data Uri makes the intents
+    // non-filterEqual even on an id collision.
     private fun activationIntent(
         navigatePath: String,
         requestCode: Int,
@@ -159,6 +204,7 @@ class NativeNotificationManager(
         val intent =
             Intent(context, MainActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                data = Uri.parse("omnigent://notification$navigatePath")
                 putExtra(EXTRA_NAVIGATE_PATH, navigatePath)
             }
         return PendingIntent.getActivity(

--- a/web/android/app/src/main/java/ai/omnigent/android/SessionAccountIdentity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/SessionAccountIdentity.kt
@@ -1,0 +1,72 @@
+package ai.omnigent.android
+
+import org.json.JSONObject
+import java.security.MessageDigest
+import java.util.Base64
+
+/**
+ * Stable per-account identity marker for an (origin, session token) pair, used
+ * by MainActivity.onSessionToken to decide whether an injected token actually
+ * belongs to a DIFFERENT account than the last one — only then may the poll
+ * snapshot / notifications be cleared. An unconditional clear on every token
+ * hand-off (e.g. a cold start re-injecting the SAME session) wipes the
+ * baseline, and a running → idle edge completing in that window is lost
+ * forever (the empty-previous gate suppresses first-run firing).
+ *
+ * Identity is the JWT's `sub` claim scoped to the origin, so a re-login that
+ * mints a NEW token for the SAME account keeps the baseline too. When the
+ * payload is undecodable the raw token stands in — conservative: an
+ * unidentifiable new token then reads as a new account and clears, which is
+ * the pre-existing behavior. Persisted as a SHA-256 digest so the marker never
+ * stores the subject (or, on the fallback path, the live credential) in plain
+ * text.
+ *
+ * Pure JVM (no Android imports) so it's unit-testable; `org.json` matches
+ * [parseSessionList]'s existing use.
+ */
+fun sessionAccountIdentity(
+    origin: String,
+    token: String,
+): String {
+    val subject = jwtSubject(token)
+    val material = if (subject != null) "sub:$subject" else "tok:$token"
+    // NUL separator: neither origin nor material can contain it, so distinct
+    // (origin, material) pairs can never concatenate to the same digest input.
+    return sha256Hex("$origin\u0000$material")
+}
+
+/**
+ * True when the poll worker must NOT act on the credential it read: a
+ * [persisted] identity marker is absent or names a different account than the
+ * cookie's own [cookieIdentity]. A null marker is unverified: accounts-mode
+ * login/logout happens entirely inside the WebView, so acting before its next
+ * pinned page load binds the cookie could notify or persist across accounts.
+ */
+fun identityMismatch(
+    persisted: String?,
+    cookieIdentity: String,
+): Boolean = persisted == null || persisted != cookieIdentity
+
+/**
+ * The JWT payload's `sub` claim, or null when the token isn't a decodable JWT
+ * or the claim is absent/empty. Never throws — any malformed input is null.
+ */
+fun jwtSubject(token: String): String? {
+    val parts = token.split('.')
+    if (parts.size != 3) return null
+    return try {
+        val payload = String(Base64.getUrlDecoder().decode(parts[1]), Charsets.UTF_8)
+        JSONObject(payload)
+            .takeUnless { it.isNull("sub") }
+            ?.optString("sub")
+            ?.ifEmpty { null }
+    } catch (_: Throwable) {
+        null
+    }
+}
+
+private fun sha256Hex(input: String): String =
+    MessageDigest
+        .getInstance("SHA-256")
+        .digest(input.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }

--- a/web/android/app/src/main/java/ai/omnigent/android/SessionListParser.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/SessionListParser.kt
@@ -1,0 +1,81 @@
+package ai.omnigent.android
+
+import org.json.JSONObject
+
+/**
+ * Parses a `GET /v1/sessions` response body into [SessionState]s. Pure (no
+ * Android/HTTP), so the parse is unit-testable. Tolerant of missing/extra
+ * fields: only `id` and `status` are required per item; anything malformed is
+ * skipped rather than throwing, so one bad row can't sink a whole poll.
+ *
+ * Response shape (see the server's `SessionList`):
+ * `{ "object": "list", "data": [ SessionListItem, ... ], ... }`.
+ */
+fun parseSessionList(body: String): List<SessionState> {
+    val root =
+        try {
+            JSONObject(body)
+        } catch (_: Throwable) {
+            return emptyList()
+        }
+    val data = root.optJSONArray("data") ?: return emptyList()
+    val out = ArrayList<SessionState>(data.length())
+    for (i in 0 until data.length()) {
+        val item = data.optJSONObject(i) ?: continue
+        // Required fields, isNull-aware: optString turns an explicit JSON null
+        // into the literal string "null", so two malformed `"id": null` rows
+        // would BOTH parse as session "null" — manufacturing fake transitions
+        // between them and a /c/null deep link — instead of being skipped as
+        // documented above.
+        val id = item.stringOrNull("id") ?: continue
+        val status = item.stringOrNull("status") ?: continue
+        out.add(
+            SessionState(
+                id = id,
+                status = status,
+                pendingElicitations = item.optInt("pending_elicitations_count", 0),
+                // Same isNull-aware read; a null title would otherwise surface
+                // as a notification titled "null" instead of the "New session"
+                // fallback.
+                title = item.stringOrNull("title"),
+                // Present only on richer responses; the list omits it, so this
+                // is usually null (treated as online by the diff).
+                runnerOnline =
+                    item
+                        .takeUnless {
+                            it.isNull(
+                                "runner_online",
+                            )
+                        }?.optBoolean("runner_online"),
+            ),
+        )
+    }
+    return out
+}
+
+/** Parse the batch `/health?session_ids=...` response's known runner states. */
+fun parseRunnerLiveness(body: String): Map<String, Boolean> {
+    val sessions =
+        try {
+            JSONObject(body).optJSONObject("sessions")
+        } catch (_: Throwable) {
+            null
+        } ?: return emptyMap()
+    return buildMap {
+        for (id in sessions.keys()) {
+            val state = sessions.optJSONObject(id) ?: continue
+            val online = state.opt("runner_online") as? Boolean ?: continue
+            put(id, online)
+        }
+    }
+}
+
+/**
+ * A string field's value, or null when the key is absent, explicitly JSON
+ * null, or empty — never the literal string "null" that [JSONObject.optString]
+ * produces for an explicit null.
+ */
+private fun JSONObject.stringOrNull(key: String): String? =
+    takeUnless { isNull(key) }
+        ?.optString(key)
+        ?.ifEmpty { null }

--- a/web/android/app/src/main/java/ai/omnigent/android/SessionPollDiff.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/SessionPollDiff.kt
@@ -1,0 +1,265 @@
+package ai.omnigent.android
+
+// Pure snapshot-diff logic for the background session poller, mirroring the web
+// SPA's `idleTransitions.ts`. Kept free of Android imports so the "which
+// sessions newly need attention" decision is unit-testable without a device,
+// exactly as the web module is testable without React.
+//
+// SessionPollWorker owns the I/O (HTTP fetch, snapshot persistence); this
+// module only diffs two snapshots.
+
+// Statuses that mean "the agent stopped and is waiting on the user".
+private val TERMINAL_STATUSES = setOf("idle", "failed")
+
+/** One session as seen in a `GET /v1/sessions` list item — the fields we diff. */
+data class SessionState(
+    val id: String,
+    val status: String,
+    val pendingElicitations: Int,
+    // Best-effort display name; the list carries `title` and a fallback name.
+    val title: String?,
+    // The HTTP list omits `runner_online`; the worker fills this from /health
+    // before posting and treats null as unverified.
+    val runnerOnline: Boolean?,
+)
+
+/**
+ * Prior-run snapshot of a single session, keyed by id in the persisted map.
+ *
+ * [status] and [pendingElicitations] are the last ACKNOWLEDGED values per
+ * dimension — advanced when a transition was posted (or none existed), rolled
+ * back per-dimension by [holdSuppressedTransitions] when a detected transition
+ * was suppressed because the app was on screen.
+ *
+ * [held] marks an entry carrying such an un-posted edge. It exists for cap
+ * eviction: a held elicitation edge is (status = current, pending = rolled
+ * back, often 0), which looks settled to the mid-flight priority test — at the
+ * snapshot cap it would evict, and the edge would be lost. [mergeSnapshot]
+ * treats held entries as mid-flight. Cleared automatically the first time the
+ * session is saved without a hold (edge posted, or it evaporated in-app).
+ * [offWindowPolls] bounds how long any absent running/held entry can retain cap
+ * priority. Current-window observations reset it to zero.
+ */
+data class SessionSnapshot(
+    val status: String,
+    val pendingElicitations: Int,
+    val held: Boolean = false,
+    val offWindowPolls: Int = 0,
+)
+
+/** Snapshot the current list into the map persisted between poll runs. */
+fun buildSnapshot(sessions: List<SessionState>): Map<String, SessionSnapshot> =
+    sessions.associate { it.id to SessionSnapshot(it.status, it.pendingElicitations) }
+
+/** Cap on the persisted snapshot so carried-forward off-window entries can't grow unbounded. */
+const val MAX_SNAPSHOT_ENTRIES = 500
+
+/** Twenty-four absent polls (at least six hours at WorkManager's cadence). */
+const val MAX_OFF_WINDOW_POLLS = 24
+
+/**
+ * Merge the current poll's snapshot over the previous one, carrying forward
+ * prior entries for sessions NOT in this poll's window.
+ *
+ * The list endpoint returns only the top window (`limit=20`, no `since`), so a
+ * `running` session can scroll off the window between polls and reappear later
+ * as terminal. A full-replace snapshot would drop its prior `running` status
+ * while it's off-window, so the eventual `running` → terminal edge would be
+ * missed. Merging keeps the off-window entry until we actually observe it
+ * terminal — then the current window's terminal status overwrites it.
+ *
+ * Bounded by [cap]: current-window entries are always kept; carried-forward
+ * prior entries fill the remaining slots until [MAX_OFF_WINDOW_POLLS], ordered
+ * by transition priority and then recency. The TTL bounds unresolved zombies;
+ * the cap is large enough for a full 20-row window plus every retained cohort,
+ * including migration from the former 200-entry cap.
+ */
+fun mergeSnapshot(
+    previous: Map<String, SessionSnapshot>,
+    sessions: List<SessionState>,
+    cap: Int = MAX_SNAPSHOT_ENTRIES,
+): Map<String, SessionSnapshot> {
+    val current = buildSnapshot(sessions)
+    val merged = LinkedHashMap<String, SessionSnapshot>(current)
+    val room = cap - current.size
+    if (room <= 0) return merged
+    val carried =
+        previous
+            .filterKeys { it !in current }
+            .mapValues { (_, snapshot) ->
+                snapshot.copy(offWindowPolls = snapshot.offWindowPolls + 1)
+            }.filterValues { it.offWindowPolls <= MAX_OFF_WINDOW_POLLS }
+            .entries
+            // Keep mid-flight sessions first so a cap can never drop a `running`
+            // (or elicitation-bearing) entry in favor of a settled one. A held
+            // entry (un-posted suppressed edge) counts as mid-flight: its
+            // rolled-back values can look settled (e.g. pending 0), but
+            // evicting it would lose the edge exactly like evicting a running
+            // one.
+            .sortedWith(
+                compareByDescending<Map.Entry<String, SessionSnapshot>> {
+                    it.value.status == "running" ||
+                        it.value.pendingElicitations > 0 ||
+                        it.value.held
+                }.thenBy { it.value.offWindowPolls },
+            )
+    for ((id, snapshot) in carried.take(room)) merged[id] = snapshot
+    return merged
+}
+
+/** Terminal candidates that are still terminal in a short confirmation poll. */
+fun confirmIdleTransitions(
+    candidates: List<SessionState>,
+    confirmation: List<SessionState>,
+): List<SessionState> {
+    val confirmedStatuses = confirmation.associate { it.id to it.status }
+    return candidates.filter { confirmedStatuses[it.id] in TERMINAL_STATUSES }
+}
+
+/**
+ * Roll back — PER DIMENSION — the parts of [merged] whose transitions were
+ * DETECTED but not POSTED (the app was on screen, so posting was skipped in
+ * favor of the SPA's in-app path), so the un-posted edge is not consumed by
+ * the snapshot advance.
+ *
+ * Without this, "worker saw the edge while visible, activity stopped before
+ * the SPA settled it" silently loses the notification on both paths forever —
+ * violating the poller's own duplicate-over-miss policy. Holding the prior
+ * value keeps the edge pending: every visible poll re-detects (and re-holds),
+ * and the first poll that runs with the app off screen posts it. If the user
+ * did see it in-app, that post is a duplicate — accepted by policy.
+ *
+ * The rollback is per-dimension, NOT the whole prior record: a visible poll
+ * seeing running/0 → waiting/1 suppresses only the elicitation edge, so only
+ * the pending count is rolled back — status advances to `waiting`. Restoring
+ * the entire prior record would rewrite status to `running`, and after the
+ * user answers in-app, the next background poll's idle/0 would fabricate a
+ * stale running → idle "finished" notification. With the per-dimension hold,
+ * the acknowledged status is `waiting`, so no idle edge exists — and the
+ * answered elicitation (pending back at 0) fires nothing either.
+ *
+ * Held entries are flagged [SessionSnapshot.held] so cap eviction keeps them
+ * (their rolled-back values can look settled). Sessions in the suppressed
+ * lists always have a [previous] entry (both detectors require one); an id
+ * unexpectedly missing there is left at its merged value.
+ */
+fun holdSuppressedTransitions(
+    merged: Map<String, SessionSnapshot>,
+    previous: Map<String, SessionSnapshot>,
+    suppressedIdle: List<SessionState>,
+    suppressedElicitations: List<SessionState>,
+): Map<String, SessionSnapshot> {
+    if (suppressedIdle.isEmpty() && suppressedElicitations.isEmpty()) return merged
+    val idleIds = suppressedIdle.map { it.id }.toSet()
+    val elicitationIds = suppressedElicitations.map { it.id }.toSet()
+    return merged.mapValues { (id, snapshot) ->
+        val holdIdle = id in idleIds
+        val holdElicitation = id in elicitationIds
+        if (!holdIdle && !holdElicitation) return@mapValues snapshot
+        val prior = previous[id] ?: return@mapValues snapshot
+        SessionSnapshot(
+            status = if (holdIdle) prior.status else snapshot.status,
+            pendingElicitations =
+                if (holdElicitation) prior.pendingElicitations else snapshot.pendingElicitations,
+            held = true,
+        )
+    }
+}
+
+/**
+ * Sessions whose status went `running` → `idle`/`failed` between the previous
+ * snapshot and the current list.
+ *
+ * Requiring the *previous* status to be exactly `running` means a first run
+ * (empty [previous]) fires nothing, and steady-state idle rows never re-notify
+ * on a later poll — only a genuine finish does. This is what dedups a
+ * transition across runs: once notified, the persisted status is the terminal
+ * one, so the next poll's `previous` is no longer `running`.
+ */
+fun detectIdleTransitions(
+    previous: Map<String, SessionSnapshot>,
+    sessions: List<SessionState>,
+): List<SessionState> =
+    sessions.filter { session ->
+        session.status in TERMINAL_STATUSES && previous[session.id]?.status == "running"
+    }
+
+/**
+ * Sessions whose pending-elicitation count *increased* between the previous
+ * snapshot and the current list — the agent just raised a new prompt.
+ *
+ * Requiring a previous entry means a first run with already-pending
+ * elicitations fires nothing; only an increase this client observed does. A
+ * 0 → 1 change fires; a steady count or a decrease (the user answered) does
+ * not. Persisting the new count dedups the increase across runs.
+ */
+fun detectNewElicitations(
+    previous: Map<String, SessionSnapshot>,
+    sessions: List<SessionState>,
+): List<SessionState> =
+    sessions.filter { session ->
+        val prior = previous[session.id] ?: return@filter false
+        session.pendingElicitations > prior.pendingElicitations
+    }
+
+/**
+ * The session-cookie name the server issues, matching MainActivity's injection
+ * and the server's `session_cookie_name`: the `__Host-` prefix on HTTPS.
+ */
+fun sessionCookieName(secure: Boolean): String = if (secure) "__Host-ap_session" else "ap_session"
+
+/**
+ * Pull one cookie's value out of a `CookieManager.getCookie` string
+ * ("a=1; b=2; …"), or null if [name] isn't present. Returned trimmed; a
+ * present-but-empty value is treated as absent (null).
+ */
+fun extractCookieValue(
+    cookieHeader: String?,
+    name: String,
+): String? {
+    if (cookieHeader.isNullOrBlank()) return null
+    for (part in cookieHeader.split(';')) {
+        val eq = part.indexOf('=')
+        if (eq <= 0) continue
+        if (part.substring(0, eq).trim() != name) continue
+        return part.substring(eq + 1).trim().ifEmpty { null }
+    }
+    return null
+}
+
+/**
+ * Display label for a session notification, mirroring the web
+ * `conversationDisplayLabel` fallback chain (title, then a generic label). The
+ * background poll has no access to the wrapper-label lookup the SPA uses for
+ * native coding-agent names, so it falls back straight to the generic label.
+ */
+fun sessionDisplayLabel(title: String?): String = title?.takeIf { it.isNotBlank() } ?: "New session"
+
+/**
+ * Lowest notification id a per-session notification may use. Kept strictly
+ * above the reserved badge-summary id (1, `BADGE_NOTIFICATION_ID`) so a session
+ * notification can never replace the badge.
+ */
+const val MIN_SESSION_NOTIFICATION_ID = 2
+
+/**
+ * Stable per-session notification id, derived deterministically from the
+ * session id and mapped into `[MIN_SESSION_NOTIFICATION_ID, Int.MAX_VALUE]`.
+ *
+ * Deterministic across worker runs and manager instances (same id → same
+ * notification id), so a session that finishes, is re-observed, and fires again
+ * UPDATES its own notification instead of spawning a duplicate — and, crucially,
+ * distinct sessions get distinct ids so a later session's finish never silently
+ * replaces an earlier, still-undismissed one. `String.hashCode` is a specified,
+ * stable algorithm, so the mapping is reproducible. Guarded to never land on the
+ * reserved badge id (1).
+ */
+fun notificationIdFor(sessionId: String): Int {
+    val span = (Int.MAX_VALUE - MIN_SESSION_NOTIFICATION_ID).toLong() + 1
+    val unsigned = sessionId.hashCode().toLong() and 0xFFFFFFFFL
+    return MIN_SESSION_NOTIFICATION_ID + (unsigned % span).toInt()
+}
+
+/** The list query the poller hits — the existing endpoint, no new params. */
+const val SESSIONS_LIST_PATH =
+    "/v1/sessions?order=desc&sort_by=updated_at&limit=20&include_archived=true"

--- a/web/android/app/src/main/java/ai/omnigent/android/SessionPollScheduler.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/SessionPollScheduler.kt
@@ -1,0 +1,55 @@
+package ai.omnigent.android
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.util.concurrent.TimeUnit
+
+/**
+ * Enqueues the background session poll ([SessionPollWorker]) as unique periodic
+ * work. Scheduled at app start and after a successful login; WorkManager
+ * persists the request across process death and reboots, so the poll survives
+ * without a boot receiver.
+ */
+object SessionPollScheduler {
+    private const val UNIQUE_WORK_NAME = "ai.omnigent.android.session-poll"
+
+    /**
+     * Ensure the periodic poll is enqueued. [ExistingPeriodicWorkPolicy.KEEP]
+     * makes this idempotent — calling it every launch won't reset the interval
+     * or drop an in-flight run; the existing schedule is kept.
+     */
+    fun ensureScheduled(context: Context) {
+        val constraints =
+            Constraints
+                .Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+        // 15 min is WorkManager's PeriodicWork floor; a shorter interval is
+        // silently clamped to it. This is the interim latency ceiling.
+        val request =
+            PeriodicWorkRequestBuilder<SessionPollWorker>(15, TimeUnit.MINUTES)
+                .setConstraints(constraints)
+                .build()
+        try {
+            WorkManager
+                .getInstance(context)
+                .enqueueUniquePeriodicWork(
+                    UNIQUE_WORK_NAME,
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    request,
+                )
+        } catch (e: IllegalStateException) {
+            // WorkManager has no initializer in this process (JVM unit tests).
+            // The poll is a best-effort convenience; never fail activity start.
+            android.util.Log.w(
+                "SessionPollScheduler",
+                "WorkManager unavailable; poll not scheduled",
+                e,
+            )
+        }
+    }
+}

--- a/web/android/app/src/main/java/ai/omnigent/android/SessionPollWorker.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/SessionPollWorker.kt
@@ -1,0 +1,423 @@
+package ai.omnigent.android
+
+import android.content.Context
+import android.webkit.CookieManager
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+
+/**
+ * Background session poller. Fires local notifications when a session finishes
+ * (`running` → `idle`/`failed`) or gains a new pending elicitation, without the
+ * app being foregrounded — an interim, OS-scheduled mirror of the web SPA's
+ * `useIdleNotifications` hook, driven by WorkManager instead of a live poll.
+ *
+ * Client-only: it reuses the JWT the shell already injected into the WebView's
+ * [CookieManager] (see MainActivity.onSessionToken) rather than duplicating
+ * credential storage, and hits the existing `GET /v1/sessions` endpoint. No
+ * server change.
+ *
+ * Terminal transitions get the same 10-second settle check as the SPA: a
+ * second list read must still show the session terminal before it can post.
+ *
+ * Order within a successful poll is detect → notify → save (see doWork): a
+ * mid-run process kill after notifying must not advance the snapshot, or the
+ * finish would be silently missed. The snapshot is MERGED, not replaced, so a
+ * `running` session that scrolls off the fixed top-window keeps its prior
+ * status until observed terminal. Posting goes through
+ * [NativeNotificationManager], whose constructor (re-)creates the channel so a
+ * cold background process still has it, and which no-ops when the
+ * POST_NOTIFICATIONS grant is missing.
+ *
+ * Graceful no-ops (always [Result.success], never a crash or retry storm):
+ *   * not logged in / cookie expired → no session cookie → nothing to poll
+ *   * no pinned server → nothing to poll
+ *   * network/HTTP error → skip this run, prior snapshot untouched, retry next tick
+ */
+class SessionPollWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+    override suspend fun doWork(): Result =
+        withContext(Dispatchers.IO) {
+            val origin = pinnedOrigin() ?: return@withContext Result.success()
+
+            // Capture the snapshot generation FIRST — before even the cookie
+            // read. MainActivity's account binding bumps it
+            // BEFORE injecting the new account's cookie, so any ordering of
+            // "worker reads cookie" vs "login lands" is caught: a capture
+            // taken after the bump but paired with the OLD account's cookie
+            // would sail through every later generation recheck.
+            val store = SessionSnapshotStore(applicationContext)
+            val generationAtStart = store.generation()
+
+            val secure = origin.startsWith("https://")
+            val jwt =
+                extractCookieValue(
+                    CookieManager.getInstance().getCookie(origin),
+                    sessionCookieName(secure),
+                )
+                    ?: return@withContext Result.success() // not logged in / expired — no-op
+
+            // Bind the CREDENTIAL to the account identity, at the worker. The
+            // generation guard alone cannot order us against the login's async
+            // setCookie: onSessionToken bumps the generation and persists the
+            // new identity BEFORE the cookie commit lands, so a worker can
+            // capture the post-bump generation yet read the PRE-switch cookie
+            // — and pass every generation recheck (including the CAS, whose
+            // generation genuinely matches). Comparing the cookie's own
+            // computed identity against the persisted marker closes every such
+            // interleaving regardless of injection timing. Null also aborts:
+            // onPageReady binds WebView-side accounts-mode sessions before the
+            // worker is allowed to persist or post.
+            val cookieIdentity = sessionAccountIdentity(origin, jwt)
+            if (identityMismatch(
+                    store.lastAccountIdentity(),
+                    cookieIdentity,
+                )
+            ) {
+                return@withContext Result.success()
+            }
+            // Generation recheck immediately after the cookie read stays as
+            // the second barrier against an intervening account bind/unbind.
+            if (store.generation() != generationAtStart) return@withContext Result.success()
+
+            val body = fetchSessions(origin, jwt, secure) ?: return@withContext Result.success()
+            val sessions = parseSessionList(body)
+
+            // Multi-account guards: a poll started against account A can land
+            // after account B logs in. Re-read the pinned origin (a server
+            // switch re-points ServerStore) AND the snapshot generation (a
+            // same-server account switch bumps it) right after the fetch — the
+            // long pole; if either changed mid-poll, bail without notifying or
+            // saving so we don't post A's titles/deep-links after the
+            // account-switch cancelAll(), or re-persist A's snapshot over the
+            // clear (the next poll would then diff B against A).
+            if (!isPollCurrent(store, origin, generationAtStart, cookieIdentity)) {
+                return@withContext Result.success()
+            }
+
+            val previous = store.load()
+
+            // Diff FIRST, then notify, then save (in that order). If the process
+            // is killed after notifying but before saving, the next run diffs
+            // against the un-advanced snapshot and re-fires — an occasional
+            // duplicate beats a silently-missed finish alert. Saving first would
+            // turn a mid-run kill into a permanent miss.
+            //
+            // A first run (empty `previous`) yields no transitions, so nothing
+            // fires; we still fall through to save so the next run has a baseline.
+            var toSave = mergeSnapshot(previous, sessions)
+            if (previous.isNotEmpty()) {
+                val idleTransitions = detectIdleTransitions(previous, sessions)
+                val newElicitations = detectNewElicitations(previous, sessions)
+                if (AppVisibility.isAppVisible) {
+                    // App on screen: the SPA's live useIdleNotifications hook
+                    // surfaces these edges in-app, so don't post a duplicate —
+                    // but do NOT consume them either. If the activity stops
+                    // before the SPA settles the edge, a consumed snapshot
+                    // would lose it on both paths forever. Hold the suppressed
+                    // sessions at their prior state so every poll re-detects
+                    // until one runs with the app off screen and posts
+                    // (duplicate-over-miss, the poller's stated policy).
+                    toSave =
+                        holdSuppressedTransitions(
+                            toSave,
+                            previous,
+                            idleTransitions,
+                            newElicitations,
+                        )
+                } else {
+                    // Constructing this ensures the notification channel exists
+                    // in THIS process — the worker often runs in a cold
+                    // background process where no Activity created it, and an
+                    // O+ post to a missing channel is silently dropped. post()
+                    // itself no-ops when POST_NOTIFICATIONS is not granted, so
+                    // an ungranted background run never crashes.
+                    val notifications = NativeNotificationManager(applicationContext)
+
+                    // Elicitations are actionable immediately, but only a fresh
+                    // /health batch can establish that their runner is online.
+                    val elicitationLiveness =
+                        fetchRunnerLiveness(origin, jwt, secure, newElicitations)
+                    val onlineElicitations =
+                        newElicitations.withLiveness(elicitationLiveness).filter {
+                            it.runnerOnline == true
+                        }
+                    val unknownElicitations =
+                        newElicitations.filter { elicitationLiveness?.get(it.id) == null }
+                    if (AppVisibility.isAppVisible) {
+                        toSave =
+                            holdSuppressedTransitions(
+                                toSave,
+                                previous,
+                                emptyList(),
+                                newElicitations,
+                            )
+                    } else {
+                        notify(
+                            store,
+                            generationAtStart,
+                            cookieIdentity,
+                            notifications,
+                            onlineElicitations,
+                            ELICITATION_BODY,
+                        )
+                        // A temporary/older-server liveness omission must not
+                        // consume the edge; retry once liveness is known.
+                        toSave =
+                            holdSuppressedTransitions(
+                                toSave,
+                                previous,
+                                emptyList(),
+                                unknownElicitations,
+                            )
+                    }
+
+                    // A prompt supersedes a turn-end cue for the same session.
+                    // For the remainder, wait the SPA's settle interval and
+                    // require a second list observation to remain terminal.
+                    val elicitationIds = newElicitations.mapTo(mutableSetOf()) { it.id }
+                    val idleCandidates = idleTransitions.filter { it.id !in elicitationIds }
+                    if (idleCandidates.isNotEmpty()) {
+                        delay(IDLE_SETTLE_MS)
+                        if (!isPollCurrent(
+                                store,
+                                origin,
+                                generationAtStart,
+                                cookieIdentity,
+                            )
+                        ) {
+                            return@withContext Result.success()
+                        }
+                        val confirmationBody = fetchSessions(origin, jwt, secure)
+                        if (confirmationBody == null) {
+                            toSave =
+                                holdSuppressedTransitions(
+                                    toSave,
+                                    previous,
+                                    idleCandidates,
+                                    emptyList(),
+                                )
+                        } else {
+                            val confirmation = parseSessionList(confirmationBody)
+                            val confirmationById = confirmation.associateBy { it.id }
+                            val idleCandidateIds = idleCandidates.mapTo(mutableSetOf()) { it.id }
+                            val observed = idleCandidates.filter { it.id in confirmationById }
+                            toSave =
+                                toSave.mapValues { (id, snapshot) ->
+                                    val status = confirmationById[id]?.status
+                                    if (id !in idleCandidateIds || status == null) {
+                                        snapshot
+                                    } else {
+                                        snapshot.copy(status = status)
+                                    }
+                                }
+                            val absent = idleCandidates.filter { it.id !in confirmationById }
+                            toSave =
+                                holdSuppressedTransitions(
+                                    toSave,
+                                    previous,
+                                    absent,
+                                    emptyList(),
+                                )
+
+                            val confirmed = confirmIdleTransitions(observed, confirmation)
+                            if (AppVisibility.isAppVisible) {
+                                toSave =
+                                    holdSuppressedTransitions(
+                                        toSave,
+                                        previous,
+                                        confirmed,
+                                        emptyList(),
+                                    )
+                            } else {
+                                val idleLiveness =
+                                    fetchRunnerLiveness(origin, jwt, secure, confirmed)
+                                val onlineIdle =
+                                    confirmed.withLiveness(idleLiveness).filter {
+                                        it.runnerOnline == true
+                                    }
+                                notify(
+                                    store,
+                                    generationAtStart,
+                                    cookieIdentity,
+                                    notifications,
+                                    onlineIdle,
+                                    IDLE_BODY,
+                                )
+                                val unknownIdle =
+                                    confirmed.filter { idleLiveness?.get(it.id) == null }
+                                toSave =
+                                    holdSuppressedTransitions(
+                                        toSave,
+                                        previous,
+                                        unknownIdle,
+                                        emptyList(),
+                                    )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // MERGE rather than replace (see mergeSnapshot): carrying recent
+            // off-window entries forward preserves a scrolled-off `running`
+            // session's eventual finish, while the absent-poll TTL eventually
+            // expires entries that can no longer resolve.
+            //
+            // Account-aware compare-and-swap: an unbound or switched account
+            // cannot be overwritten even if a future caller misses a recheck.
+            store.saveIfCurrentAccount(toSave, generationAtStart, cookieIdentity)
+            Result.success()
+        }
+
+    /** The pinned server's origin, or null when no server is set. */
+    private fun pinnedOrigin(): String? =
+        ServerStore(applicationContext).let {
+            if (it.hasServer()) originOf(it.currentServerUrl()) else null
+        }
+
+    private fun isPollCurrent(
+        store: SessionSnapshotStore,
+        origin: String,
+        generation: Long,
+        identity: String,
+    ): Boolean =
+        pinnedOrigin() == origin &&
+            store.generation() == generation &&
+            !identityMismatch(store.lastAccountIdentity(), identity)
+
+    /**
+     * Post one known-online notification per session, with the account check
+     * and post sharing the store's account lock. An account switch therefore
+     * either cancels a completed old-account post or invalidates it before it
+     * can post. Each is keyed by the session id as the notification
+     * TAG plus a stable [notificationIdFor] numeric id: the tag carries the
+     * distinctness (String.hashCode-derived ids can collide across sessions,
+     * e.g. "Aa"/"BB", and a collision would silently replace the other
+     * session's notification), while the stable id keeps a re-fire updating the
+     * same notification instead of stacking. Deep-links to the session.
+     */
+    private fun notify(
+        store: SessionSnapshotStore,
+        generation: Long,
+        identity: String,
+        notifications: NativeNotificationManager,
+        sessions: List<SessionState>,
+        body: String,
+    ) {
+        for (session in sessions) {
+            if (session.runnerOnline != true) continue
+            store.runIfCurrentAccount(generation, identity) {
+                notifications.notify(
+                    title = sessionDisplayLabel(session.title),
+                    body = body,
+                    navigatePath = "/c/${session.id}",
+                    notificationId = notificationIdFor(session.id),
+                    tag = session.id,
+                )
+            }
+        }
+    }
+
+    private fun List<SessionState>.withLiveness(
+        liveness: Map<String, Boolean>?,
+    ): List<SessionState> = map { it.copy(runnerOnline = liveness?.get(it.id)) }
+
+    private fun fetchRunnerLiveness(
+        origin: String,
+        jwt: String,
+        secure: Boolean,
+        sessions: List<SessionState>,
+    ): Map<String, Boolean>? {
+        if (sessions.isEmpty()) return emptyMap()
+        val ids = sessions.map { it.id }.distinct().joinToString(",")
+        val encoded = URLEncoder.encode(ids, "UTF-8")
+        val body = fetch(origin, "/health?session_ids=$encoded", jwt, secure) ?: return null
+        return parseRunnerLiveness(body)
+    }
+
+    /**
+     * GET the sessions list, authenticating with the reused JWT as both a
+     * `Cookie` (matching the WebView) and `Authorization: Bearer` (the server
+     * accepts either). Returns the body on 200, or null on any non-200 /
+     * network error so the run no-ops and retries next tick.
+     */
+    private fun fetchSessions(
+        origin: String,
+        jwt: String,
+        secure: Boolean,
+    ): String? = fetch(origin, SESSIONS_LIST_PATH, jwt, secure)
+
+    private fun fetch(
+        origin: String,
+        path: String,
+        jwt: String,
+        secure: Boolean,
+    ): String? {
+        // Build the connection INSIDE the try: a malformed/legacy non-HTTP
+        // persisted origin makes URL(...)/openConnection()/the cast throw, and
+        // that must no-op like every other error path rather than fail the run.
+        var conn: HttpURLConnection? = null
+        return try {
+            conn = URL(origin + path).openConnection() as HttpURLConnection
+            conn.requestMethod = "GET"
+            // This request carries the session JWT (Cookie + Bearer). Do NOT
+            // auto-follow redirects: a cross-origin or HTTPS→HTTP-downgrade 3xx
+            // would otherwise resend the credential off the pinned origin. A 3xx
+            // now surfaces as a non-200 responseCode and is treated as a no-op.
+            conn.instanceFollowRedirects = false
+            conn.setRequestProperty("Cookie", "${sessionCookieName(secure)}=$jwt")
+            conn.setRequestProperty("Authorization", "Bearer $jwt")
+            conn.setRequestProperty("Accept", "application/json")
+            conn.connectTimeout = HTTP_TIMEOUT_MS
+            conn.readTimeout = HTTP_TIMEOUT_MS
+            if (conn.responseCode != 200) return null
+            // Cheap size cap: the endpoint is limit=20 so a well-behaved body is
+            // small, but readText() is otherwise unbounded. Read in fixed chunks
+            // into a StringBuilder that grows to the actual body size, capped at
+            // MAX_RESPONSE_BYTES; a larger body is treated as a no-op (null)
+            // rather than buffered whole. Sizing the buffer to the response (a
+            // sane page is a few KB) avoids allocating the full cap every poll.
+            conn.inputStream.bufferedReader().use { reader ->
+                val chunk = CharArray(READ_CHUNK_CHARS)
+                val out = StringBuilder()
+                while (true) {
+                    val n = reader.read(chunk)
+                    if (n < 0) break
+                    // Appending this chunk would exceed the cap → oversized, bail.
+                    if (out.length + n > MAX_RESPONSE_BYTES) return null
+                    out.append(chunk, 0, n)
+                }
+                out.toString()
+            }
+        } catch (_: Throwable) {
+            null
+        } finally {
+            conn?.disconnect()
+        }
+    }
+
+    companion object {
+        // Mirrors useIdleNotifications' IDLE_BODY / ELICITATION_BODY.
+        const val IDLE_BODY = "Agent finished and is ready for your input."
+        const val ELICITATION_BODY = "Agent is asking for your input."
+        private const val IDLE_SETTLE_MS = 10_000L
+        private const val HTTP_TIMEOUT_MS = 15_000
+
+        // Upper bound on the list-response body we buffer. The endpoint is
+        // limit=20, so a sane page is well under this; a larger body is treated
+        // as a no-op rather than read whole. ~1M chars.
+        private const val MAX_RESPONSE_BYTES = 1_048_576
+
+        // Per-read chunk size. Small and fixed so the buffer footprint tracks
+        // the actual (tiny) response rather than the cap above.
+        private const val READ_CHUNK_CHARS = 8_192
+    }
+}

--- a/web/android/app/src/main/java/ai/omnigent/android/SessionSnapshotStore.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/SessionSnapshotStore.kt
@@ -1,0 +1,168 @@
+package ai.omnigent.android
+
+import android.content.Context
+import org.json.JSONObject
+
+/**
+ * Persists the prior-run session snapshot (id → {status, pending_elicitations})
+ * between [SessionPollWorker] runs, so the worker can diff the current poll
+ * against what it last saw and only notify on a genuine transition. Backed by
+ * SharedPreferences, mirroring [ServerStore]'s minimal style.
+ *
+ * The snapshot is the dedup mechanism: once a transition is notified, the new
+ * (terminal / higher-count) state is persisted, so the next poll's diff no
+ * longer sees the same edge.
+ */
+class SessionSnapshotStore(
+    context: Context,
+) {
+    private val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    /**
+     * The last persisted snapshot, or an empty map when nothing has been stored
+     * yet (a first run, or after login cleared it). An empty map makes the
+     * first diff fire nothing — matching the SPA's "seed from first observed
+     * value" semantics.
+     */
+    fun load(): Map<String, SessionSnapshot> {
+        val raw = prefs.getString(KEY_SNAPSHOT, null) ?: return emptyMap()
+        return try {
+            val json = JSONObject(raw)
+            buildMap {
+                for (id in json.keys()) {
+                    // Quarantine keys no valid parse can produce (the parser
+                    // skips null/blank ids): a blob poisoned by an older build
+                    // with "null" entries would otherwise carry them forward at
+                    // cap priority forever, able to evict a genuine mid-flight
+                    // session.
+                    if (id.isBlank() || id == "null") continue
+                    val entry = json.optJSONObject(id) ?: continue
+                    val status = entry.optString(FIELD_STATUS).ifEmpty { null } ?: continue
+                    put(
+                        id,
+                        SessionSnapshot(
+                            status,
+                            entry.optInt(FIELD_PENDING, 0),
+                            entry.optBoolean(FIELD_HELD, false),
+                            entry.optInt(FIELD_OFF_WINDOW_POLLS, 0).coerceAtLeast(0),
+                        ),
+                    )
+                }
+            }
+        } catch (_: Throwable) {
+            // Corrupt/legacy blob — treat as no prior snapshot rather than crash.
+            emptyMap()
+        }
+    }
+
+    /**
+     * Compare-and-swap save — the ONLY snapshot write path. Both generation
+     * and account identity must still match, so an unbound cookie can never
+     * seed a baseline and an account switch cannot be overwritten by an old
+     * worker.
+     */
+    fun saveIfCurrentAccount(
+        snapshot: Map<String, SessionSnapshot>,
+        expectedGeneration: Long,
+        expectedIdentity: String,
+    ): Boolean =
+        synchronized(generationLock) {
+            if (generation() != expectedGeneration) return false
+            if (lastAccountIdentity() != expectedIdentity) return false
+            prefs.edit().putString(KEY_SNAPSHOT, encode(snapshot)).apply()
+            true
+        }
+
+    private fun encode(snapshot: Map<String, SessionSnapshot>): String {
+        val json = JSONObject()
+        for ((id, state) in snapshot) {
+            val entry =
+                JSONObject()
+                    .put(FIELD_STATUS, state.status)
+                    .put(FIELD_PENDING, state.pendingElicitations)
+            // Written only when set — the common (un-held) entry stays compact
+            // and byte-identical to the pre-`held` format.
+            if (state.held) entry.put(FIELD_HELD, true)
+            if (state.offWindowPolls > 0) {
+                entry.put(FIELD_OFF_WINDOW_POLLS, state.offWindowPolls)
+            }
+            json.put(id, entry)
+        }
+        return json.toString()
+    }
+
+    /**
+     * Bind [identity], clearing the previous baseline and advancing its
+     * generation in the same locked preference edit. [onChanged] runs under
+     * that lock so notification cancellation cannot race a guarded worker post.
+     */
+    fun bindAccount(
+        identity: String,
+        onChanged: () -> Unit,
+    ): Boolean =
+        synchronized(generationLock) {
+            if (lastAccountIdentity() == identity) return false
+            prefs
+                .edit()
+                .remove(KEY_SNAPSHOT)
+                .putLong(KEY_GENERATION, generation() + 1)
+                .putString(KEY_IDENTITY, identity)
+                .apply()
+            onChanged()
+            true
+        }
+
+    /** Unbind the current account and invalidate its worker state atomically. */
+    fun unbindAccount(onChanged: () -> Unit): Boolean =
+        synchronized(generationLock) {
+            if (lastAccountIdentity() == null && !prefs.contains(KEY_SNAPSHOT)) return false
+            prefs
+                .edit()
+                .remove(KEY_SNAPSHOT)
+                .remove(KEY_IDENTITY)
+                .putLong(KEY_GENERATION, generation() + 1)
+                .apply()
+            onChanged()
+            true
+        }
+
+    /**
+     * Monotonic snapshot epoch, bumped by every account bind/unbind. Persisted
+     * because the worker often runs in a different process incarnation.
+     */
+    fun generation(): Long = prefs.getLong(KEY_GENERATION, 0L)
+
+    /**
+     * Identity marker (see [sessionAccountIdentity]) bound to the WebView's
+     * current session cookie, or null while logged out/unverified.
+     */
+    fun lastAccountIdentity(): String? = prefs.getString(KEY_IDENTITY, null)
+
+    /** Run [action] only while the worker still belongs to the bound account. */
+    fun runIfCurrentAccount(
+        expectedGeneration: Long,
+        expectedIdentity: String,
+        action: () -> Unit,
+    ): Boolean =
+        synchronized(generationLock) {
+            if (generation() != expectedGeneration) return false
+            if (lastAccountIdentity() != expectedIdentity) return false
+            action()
+            true
+        }
+
+    private companion object {
+        // Makes account transitions atomic against guarded saves and posts.
+        // MainActivity and WorkManager share this process.
+        val generationLock = Any()
+
+        const val PREFS = "ai.omnigent.android.session_snapshot"
+        const val KEY_SNAPSHOT = "snapshot_json"
+        const val KEY_GENERATION = "snapshot_generation"
+        const val KEY_IDENTITY = "account_identity"
+        const val FIELD_STATUS = "status"
+        const val FIELD_PENDING = "pending"
+        const val FIELD_HELD = "held"
+        const val FIELD_OFF_WINDOW_POLLS = "off_window_polls"
+    }
+}

--- a/web/android/app/src/test/java/ai/omnigent/android/AppVisibilityTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/AppVisibilityTest.kt
@@ -1,0 +1,107 @@
+package ai.omnigent.android
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Plain-JVM tests for the started-activity identity tracker gating
+ * background-poll notification posting AND the process-global WebView
+ * pauseTimers()/resumeTimers() calls. Activities are stand-in objects — the
+ * tracker only uses identity. Each test balances its starts with stops so the
+ * process-wide singleton doesn't leak state across tests.
+ */
+class AppVisibilityTest {
+    @Test
+    fun `app is visible between start and stop only, with edge signals`() {
+        val activity = Any()
+        assertFalse(AppVisibility.isAppVisible)
+        // Came on screen — the ONLY start allowed to resumeTimers().
+        assertTrue(AppVisibility.onActivityStarted(activity))
+        assertTrue(AppVisibility.isAppVisible)
+        // Left the screen — the ONLY stop allowed to pauseTimers().
+        assertTrue(AppVisibility.onActivityStopped(activity))
+        assertFalse(AppVisibility.isAppVisible)
+    }
+
+    @Test
+    fun `overlap recreation never signals a pause while the app stays on screen`() {
+        // In-process recreation ordering: the NEW instance's onStart runs
+        // BEFORE the old instance's onStop. The old instance's stop leaves the
+        // new one started and must NOT report an edge — an unconditional
+        // per-activity pauseTimers() there would freeze the foregrounded
+        // instance's JS.
+        val old = Any()
+        val new = Any()
+        assertTrue(AppVisibility.onActivityStarted(old))
+        assertFalse(AppVisibility.onActivityStarted(new)) // no resume needed
+        assertFalse(AppVisibility.onActivityStopped(old)) // MUST not pause
+        assertTrue(AppVisibility.isAppVisible)
+        assertTrue(AppVisibility.onActivityStopped(new)) // pause
+        assertFalse(AppVisibility.isAppVisible)
+    }
+
+    @Test
+    fun `distinct equal activity objects are tracked by reference identity`() {
+        val old = EqualActivity(1)
+        val replacement = EqualActivity(1)
+        assertTrue(old == replacement)
+
+        assertTrue(AppVisibility.onActivityStarted(old))
+        assertFalse(AppVisibility.onActivityStarted(replacement))
+        assertFalse(AppVisibility.onActivityStopped(old))
+        assertTrue(AppVisibility.isAppVisible)
+        assertTrue(AppVisibility.onActivityStopped(replacement))
+    }
+
+    @Test
+    fun `recreate ordering yields a transient pause immediately undone by resume`() {
+        // recreate()/locale ordering: old onStop THEN new onStart. Transient
+        // pause followed by resume — both idempotent, harmless.
+        val old = Any()
+        val new = Any()
+        assertTrue(AppVisibility.onActivityStarted(old))
+        assertTrue(AppVisibility.onActivityStopped(old)) // transient pause
+        assertTrue(AppVisibility.onActivityStarted(new)) // immediate resume
+        assertTrue(AppVisibility.isAppVisible)
+        assertTrue(AppVisibility.onActivityStopped(new))
+    }
+
+    @Test
+    fun `an unmatched stop under a visible activity cannot fake a pause`() {
+        // The identity set is what makes this safe: with a bare counter, this
+        // stray stop would decrement 1 -> 0 and pause WebView timers under a
+        // still-visible activity.
+        val visible = Any()
+        val neverStarted = Any()
+        assertTrue(AppVisibility.onActivityStarted(visible))
+        assertFalse(AppVisibility.onActivityStopped(neverStarted))
+        assertTrue(AppVisibility.isAppVisible)
+        assertTrue(AppVisibility.onActivityStopped(visible))
+    }
+
+    @Test
+    fun `a duplicated start cannot absorb the genuine hide edge`() {
+        // With a bare counter, a doubled onStart callback would leave the
+        // count at 1 after the genuine stop — visible forever, and the real
+        // 1 -> 0 edge (the pause) never fires.
+        val activity = Any()
+        assertTrue(AppVisibility.onActivityStarted(activity))
+        assertFalse(AppVisibility.onActivityStarted(activity)) // duplicate: no-op
+        assertTrue(AppVisibility.onActivityStopped(activity)) // genuine hide still edges
+        assertFalse(AppVisibility.isAppVisible)
+    }
+
+    @Test
+    fun `a doubled stop signals the edge exactly once`() {
+        val activity = Any()
+        assertTrue(AppVisibility.onActivityStarted(activity))
+        assertTrue(AppVisibility.onActivityStopped(activity))
+        assertFalse(AppVisibility.onActivityStopped(activity)) // already gone: no edge
+        assertFalse(AppVisibility.isAppVisible)
+    }
+
+    private data class EqualActivity(
+        val value: Int,
+    )
+}

--- a/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
@@ -1,14 +1,17 @@
 package ai.omnigent.android
 
+import android.app.NotificationManager
 import android.content.Context
 import android.content.RestrictionsManager
 import android.content.res.Configuration
 import android.os.Bundle
+import android.webkit.CookieManager
 import android.webkit.WebView
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -100,10 +103,77 @@ class MainActivityTest {
         assertEquals("https://example.com", shadowOf(activity.webView()).lastLoadedUrl)
     }
 
+    @Test
+    fun `pinned page load binds an accounts-mode WebView login and clears prior account state`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val origin = "https://example.com"
+        val tokenB = jwt("user-b")
+        val store = seedPriorAccount(context, origin)
+        CookieManager.getInstance().setCookie(origin, "__Host-ap_session=$tokenB")
+
+        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
+        activity.invokePageReady("$origin/")
+
+        assertEquals(sessionAccountIdentity(origin, tokenB), store.lastAccountIdentity())
+        assertTrue(store.load().isEmpty())
+        val systemNotifications = context.getSystemService(NotificationManager::class.java)
+        assertEquals(0, shadowOf(systemNotifications).size())
+    }
+
+    @Test
+    fun `pinned login page unbinds an accounts-mode WebView logout`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val origin = "https://example.com"
+        CookieManager.getInstance().removeAllCookies(null)
+        val store = seedPriorAccount(context, origin)
+
+        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
+        activity.invokePageReady("$origin/login")
+
+        assertNull(store.lastAccountIdentity())
+        assertTrue(store.load().isEmpty())
+        val systemNotifications = context.getSystemService(NotificationManager::class.java)
+        assertEquals(0, shadowOf(systemNotifications).size())
+    }
+
+    /**
+     * Seed the store + notifications with a prior account "user-a" (bound,
+     * a persisted snapshot, and a leftover per-session notification), returning
+     * the store the account-transition tests then assert against.
+     */
+    private fun seedPriorAccount(
+        context: Context,
+        origin: String,
+    ): SessionSnapshotStore {
+        ServerStore(context).connect(origin)
+        val store = SessionSnapshotStore(context)
+        val accountA = sessionAccountIdentity(origin, jwt("user-a"))
+        store.bindAccount(accountA) {}
+        assertTrue(
+            store.saveIfCurrentAccount(
+                mapOf("conv_a" to SessionSnapshot("running", 0)),
+                store.generation(),
+                accountA,
+            ),
+        )
+        NativeNotificationManager(context).notify("A", "finished", "/c/conv_a", tag = "conv_a")
+        return store
+    }
+
     private fun MainActivity.webView(): WebView =
         MainActivity::class
             .java
             .getDeclaredField("webView")
             .apply { isAccessible = true }
             .get(this) as WebView
+
+    private fun MainActivity.invokePageReady(url: String) {
+        MainActivity::class
+            .java
+            .getDeclaredMethod("onPageReady", String::class.java)
+            .apply { isAccessible = true }
+            .invoke(this, url)
+    }
+
+    private fun jwt(subject: String): String = TestJwt.forSubject(subject)
 }

--- a/web/android/app/src/test/java/ai/omnigent/android/NativeNotificationManagerTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/NativeNotificationManagerTest.kt
@@ -1,6 +1,7 @@
 package ai.omnigent.android
 
 import android.app.Application
+import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
@@ -19,6 +20,7 @@ class NativeNotificationManagerTest {
     private lateinit var context: Application
     private lateinit var manager: NativeNotificationManager
     private lateinit var shadow: ShadowNotificationManager
+    private lateinit var notificationManager: NotificationManager
 
     // The reserved badge-summary notification id (NativeNotificationManager's
     // BADGE_NOTIFICATION_ID is private; the contract is "id 1").
@@ -28,13 +30,34 @@ class NativeNotificationManagerTest {
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
         manager = NativeNotificationManager(context)
-        shadow =
-            shadowOf(
-                context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager,
-            )
+        notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        shadow = shadowOf(notificationManager)
     }
 
     private fun badgeNotification() = shadow.getNotification(badgeId)
+
+    @Test
+    fun `constructing the manager creates the sessions channel`() {
+        // The background poll worker constructs a fresh manager in a process
+        // where no Activity ran; the channel must exist so an O+ post isn't
+        // silently dropped. `manager` is built in setUp — assert the channel is
+        // present with the expected id and importance.
+        val channel: NotificationChannel? =
+            notificationManager.getNotificationChannel(
+                "omnigent.sessions",
+            )
+        assertNotNull(channel)
+        assertEquals(NotificationManager.IMPORTANCE_HIGH, channel!!.importance)
+    }
+
+    @Test
+    fun `ensureChannel is idempotent and keeps the channel present`() {
+        // Cheap to call repeatedly — the worker path relies on this being safe.
+        manager.ensureChannel()
+        manager.ensureChannel()
+        assertNotNull(notificationManager.getNotificationChannel("omnigent.sessions"))
+    }
 
     @Test
     fun `badge posts a summary notification with the count and tap intent`() {
@@ -88,6 +111,100 @@ class NativeNotificationManagerTest {
         manager.setBadgeCount(0)
         manager.replayBadge()
         assertNull(badgeNotification())
+    }
+
+    @Test
+    fun `tagged posts with a colliding numeric id coexist instead of replacing`() {
+        // "Aa" and "BB" have equal String.hashCode, so their derived numeric
+        // notification ids collide. The session-id tag must keep them distinct —
+        // an untagged post would let the second silently replace the first.
+        val idA = notificationIdFor("Aa")
+        val idB = notificationIdFor("BB")
+        assertEquals(idA, idB)
+
+        manager.notify(
+            title = "A",
+            body = "a",
+            navigatePath = "/c/Aa",
+            notificationId = idA,
+            tag = "Aa",
+        )
+        manager.notify(
+            title = "B",
+            body = "b",
+            navigatePath = "/c/BB",
+            notificationId = idB,
+            tag = "BB",
+        )
+
+        assertEquals(2, shadow.size())
+        assertNotNull(shadow.getNotification("Aa", idA))
+        assertNotNull(shadow.getNotification("BB", idB))
+    }
+
+    @Test
+    fun `re-posting the same tag and id updates in place`() {
+        val id = notificationIdFor("conv_a")
+        manager.notify(
+            title = "first",
+            body = "b",
+            navigatePath = "/c/conv_a",
+            notificationId = id,
+            tag = "conv_a",
+        )
+        manager.notify(
+            title = "second",
+            body = "b",
+            navigatePath = "/c/conv_a",
+            notificationId = id,
+            tag = "conv_a",
+        )
+        assertEquals(1, shadow.size())
+    }
+
+    @Test
+    fun `cancelAll cancels tagged session notifications too`() {
+        manager.notify(
+            title = "A",
+            body = "a",
+            navigatePath = "/c/Aa",
+            notificationId = notificationIdFor("Aa"),
+            tag = "Aa",
+        )
+        manager.setBadgeCount(1)
+        assertEquals(2, shadow.size())
+
+        manager.cancelAll()
+
+        assertEquals(0, shadow.size())
+    }
+
+    @Test
+    fun `colliding-id tap intents route to their own session`() {
+        // Same numeric id ⇒ same PendingIntent requestCode. The intents must
+        // still be distinct (unique data Uri), or FLAG_UPDATE_CURRENT would
+        // overwrite the first session's extras and both taps would deep-link
+        // to the second session.
+        val idA = notificationIdFor("Aa")
+        manager.notify(
+            title = "A",
+            body = "a",
+            navigatePath = "/c/Aa",
+            notificationId = idA,
+            tag = "Aa",
+        )
+        manager.notify(
+            title = "B",
+            body = "b",
+            navigatePath = "/c/BB",
+            notificationId = idA,
+            tag = "BB",
+        )
+
+        val intentA = shadowOf(shadow.getNotification("Aa", idA)!!.contentIntent).savedIntent
+        val intentB = shadowOf(shadow.getNotification("BB", idA)!!.contentIntent).savedIntent
+        assertEquals("/c/Aa", intentA.getStringExtra(NativeNotificationManager.EXTRA_NAVIGATE_PATH))
+        assertEquals("/c/BB", intentB.getStringExtra(NativeNotificationManager.EXTRA_NAVIGATE_PATH))
     }
 
     @Test

--- a/web/android/app/src/test/java/ai/omnigent/android/SessionAccountIdentityTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/SessionAccountIdentityTest.kt
@@ -1,0 +1,107 @@
+package ai.omnigent.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for the account-identity marker keying onSessionToken's cleanup.
+ * Robolectric because jwtSubject uses `org.json` (an unmocked stub on a plain
+ * JVM), matching SessionListParserTest.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SessionAccountIdentityTest {
+    private val origin = "https://omnigent.example.com"
+
+    private fun jwt(payload: String): String = TestJwt.forPayload(payload)
+
+    @Test
+    fun `re-injecting the same token keeps the same identity`() {
+        // A cold start re-handing the SAME session must not read as an account
+        // change — that's what stops the unconditional-clear baseline wipe.
+        val token = jwt("""{"sub":"user-a"}""")
+        assertEquals(sessionAccountIdentity(origin, token), sessionAccountIdentity(origin, token))
+    }
+
+    @Test
+    fun `a new token for the same account keeps the same identity`() {
+        // Re-login mints a new JWT (different iat/exp) for the same `sub`; the
+        // baseline must survive that too.
+        val first = jwt("""{"sub":"user-a","iat":1}""")
+        val second = jwt("""{"sub":"user-a","iat":2}""")
+        assertEquals(sessionAccountIdentity(origin, first), sessionAccountIdentity(origin, second))
+    }
+
+    @Test
+    fun `a different account on the same server changes the identity`() {
+        val a = jwt("""{"sub":"user-a"}""")
+        val b = jwt("""{"sub":"user-b"}""")
+        assertNotEquals(sessionAccountIdentity(origin, a), sessionAccountIdentity(origin, b))
+    }
+
+    @Test
+    fun `the same account on a different server changes the identity`() {
+        val token = jwt("""{"sub":"user-a"}""")
+        assertNotEquals(
+            sessionAccountIdentity("https://a.example.com", token),
+            sessionAccountIdentity("https://b.example.com", token),
+        )
+    }
+
+    @Test
+    fun `an undecodable token falls back to per-token identity`() {
+        // Conservative fallback: with no extractable subject, only the exact
+        // same token reads as the same account — a different opaque token
+        // clears, matching the pre-existing behavior.
+        val opaque = "not-a-jwt"
+        assertEquals(sessionAccountIdentity(origin, opaque), sessionAccountIdentity(origin, opaque))
+        assertNotEquals(
+            sessionAccountIdentity(origin, opaque),
+            sessionAccountIdentity(origin, "also-not-a-jwt"),
+        )
+    }
+
+    @Test
+    fun `identity never contains the raw subject or token`() {
+        val token = jwt("""{"sub":"user-a@example.com"}""")
+        val identity = sessionAccountIdentity(origin, token)
+        // A SHA-256 hex digest: fixed length, no credential material.
+        assertEquals(64, identity.length)
+        assertFalse(identity.contains("user-a"))
+        assertFalse(identity.contains(token))
+    }
+
+    @Test
+    fun `identityMismatch fails closed without a bound account`() {
+        val a = sessionAccountIdentity(origin, jwt("""{"sub":"user-a"}"""))
+        val b = sessionAccountIdentity(origin, jwt("""{"sub":"user-b"}"""))
+        // The worker holds A's cookie while B's login already persisted its
+        // marker — every such interleaving must abort, regardless of when the
+        // async setCookie commits.
+        assertEquals(true, identityMismatch(persisted = b, cookieIdentity = a))
+        // Same account: proceed.
+        assertEquals(false, identityMismatch(persisted = a, cookieIdentity = a))
+        // No marker means the cookie has not been bound to the WebView's current
+        // account. Acting on it could seed or notify across an accounts-mode
+        // logout/login that never passed through onSessionToken.
+        assertEquals(true, identityMismatch(persisted = null, cookieIdentity = a))
+    }
+
+    @Test
+    fun `jwtSubject extracts sub and tolerates malformed input`() {
+        assertEquals("user-a", jwtSubject(jwt("""{"sub":"user-a"}""")))
+        assertNull(jwtSubject(jwt("""{"iat":1}"""))) // no sub
+        assertNull(jwtSubject(jwt("""{"sub":null}"""))) // explicit null
+        assertNull(jwtSubject(jwt("""{"sub":""}"""))) // empty
+        assertNull(jwtSubject(jwt("not json")))
+        assertNull(jwtSubject("two.parts"))
+        assertNull(jwtSubject("header.!!!not-base64url!!!.sig"))
+        assertNull(jwtSubject(""))
+    }
+}

--- a/web/android/app/src/test/java/ai/omnigent/android/SessionListParserTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/SessionListParserTest.kt
@@ -1,0 +1,138 @@
+package ai.omnigent.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for the `GET /v1/sessions` response parser. Runs under Robolectric
+ * because the parser uses `org.json`, which is an unmocked Android stub in a
+ * plain JVM unit test — Robolectric supplies the real implementation. No device.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SessionListParserTest {
+    @Test
+    fun `parses the documented list shape`() {
+        val body =
+            """
+            {
+              "object": "list",
+              "data": [
+                {"id": "conv_a", "agent_id": "ag", "status": "idle", "created_at": 1, "updated_at": 2,
+                 "title": "First", "pending_elicitations_count": 0},
+                {"id": "conv_b", "agent_id": "ag", "status": "waiting", "created_at": 1, "updated_at": 3,
+                 "pending_elicitations_count": 2}
+              ],
+              "first_id": "conv_a", "last_id": "conv_b", "has_more": false
+            }
+            """.trimIndent()
+        val sessions = parseSessionList(body)
+        assertEquals(2, sessions.size)
+        assertEquals(SessionState("conv_a", "idle", 0, "First", null), sessions[0])
+        assertEquals(SessionState("conv_b", "waiting", 2, null, null), sessions[1])
+    }
+
+    @Test
+    fun `reads runner_online when present and null when explicit null`() {
+        val body =
+            """
+            {"object":"list","data":[
+              {"id":"a","status":"idle","runner_online":false},
+              {"id":"b","status":"idle","runner_online":null}
+            ]}
+            """.trimIndent()
+        val sessions = parseSessionList(body)
+        assertEquals(false, sessions[0].runnerOnline)
+        assertNull(sessions[1].runnerOnline)
+    }
+
+    @Test
+    fun `parses only known boolean runner liveness`() {
+        val parsed =
+            parseRunnerLiveness(
+                """{
+                  "sessions": {
+                    "online": {"runner_online": true},
+                    "offline": {"runner_online": false},
+                    "unknown": {"runner_online": null},
+                    "malformed": {"runner_online": "true"}
+                  }
+                }""",
+            )
+
+        assertEquals(mapOf("online" to true, "offline" to false), parsed)
+    }
+
+    @Test
+    fun `malformed runner liveness response is unknown`() {
+        assertTrue(parseRunnerLiveness("not json").isEmpty())
+        assertTrue(parseRunnerLiveness("""{"status":"ok"}""").isEmpty())
+    }
+
+    @Test
+    fun `skips rows missing id or status but keeps the rest`() {
+        val body =
+            """
+            {"object":"list","data":[
+              {"id":"a","status":"idle"},
+              {"status":"idle"},
+              {"id":"c"},
+              {"id":"d","status":"running"}
+            ]}
+            """.trimIndent()
+        assertEquals(listOf("a", "d"), parseSessionList(body).map { it.id })
+    }
+
+    @Test
+    fun `explicit JSON null title parses as null, not the string "null"`() {
+        val body =
+            """
+            {"object":"list","data":[
+              {"id":"a","status":"idle","title":null},
+              {"id":"b","status":"idle","title":""}
+            ]}
+            """.trimIndent()
+        val sessions = parseSessionList(body)
+        // optString would have produced the literal "null" here, which would
+        // notify as a session titled "null" instead of the generic fallback.
+        assertNull(sessions[0].title)
+        assertNull(sessions[1].title)
+        assertEquals("New session", sessionDisplayLabel(sessions[0].title))
+    }
+
+    @Test
+    fun `explicit JSON null id or status skips the row instead of parsing "null"`() {
+        // optString would turn `"id": null` into the literal string "null":
+        // two consecutive malformed rows would BOTH become session "null",
+        // manufacturing a fake running -> idle transition (and a /c/null deep
+        // link) between them. They must be skipped like missing fields.
+        val body =
+            """
+            {"object":"list","data":[
+              {"id":null,"status":"running"},
+              {"id":null,"status":"idle"},
+              {"id":"real","status":null},
+              {"id":"kept","status":"idle"}
+            ]}
+            """.trimIndent()
+        val sessions = parseSessionList(body)
+        assertEquals(listOf("kept"), sessions.map { it.id })
+
+        // End to end: even with a poisoned prior snapshot containing "null",
+        // the skipped rows can never produce a transition for it.
+        val previous = mapOf("null" to SessionSnapshot("running", 0))
+        assertTrue(detectIdleTransitions(previous, sessions).isEmpty())
+    }
+
+    @Test
+    fun `malformed or empty body yields an empty list`() {
+        assertTrue(parseSessionList("not json").isEmpty())
+        assertTrue(parseSessionList("{}").isEmpty())
+        assertTrue(parseSessionList("""{"object":"list"}""").isEmpty())
+    }
+}

--- a/web/android/app/src/test/java/ai/omnigent/android/SessionPollDiffTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/SessionPollDiffTest.kt
@@ -1,0 +1,474 @@
+package ai.omnigent.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure snapshot-diff logic, mirroring the web SPA's
+ * `idleTransitions.test.ts`. No Android/Robolectric — this logic is a plain
+ * Kotlin function set, testable without a device.
+ */
+class SessionPollDiffTest {
+    private fun session(
+        id: String,
+        status: String,
+        pending: Int = 0,
+        title: String? = null,
+        runnerOnline: Boolean? = null,
+    ) = SessionState(id, status, pending, title, runnerOnline)
+
+    // --- idle transitions (running -> terminal) ---------------------------
+
+    @Test
+    fun `running to idle is an idle transition`() {
+        val previous = mapOf("a" to SessionSnapshot("running", 0))
+        val transitions = detectIdleTransitions(previous, listOf(session("a", "idle")))
+        assertEquals(listOf("a"), transitions.map { it.id })
+    }
+
+    @Test
+    fun `running to failed is an idle transition`() {
+        val previous = mapOf("a" to SessionSnapshot("running", 0))
+        val transitions = detectIdleTransitions(previous, listOf(session("a", "failed")))
+        assertEquals(listOf("a"), transitions.map { it.id })
+    }
+
+    @Test
+    fun `no prior snapshot fires no idle transition`() {
+        // First run: empty previous — a session already idle must not notify.
+        val transitions = detectIdleTransitions(emptyMap(), listOf(session("a", "idle")))
+        assertTrue(transitions.isEmpty())
+    }
+
+    @Test
+    fun `steady idle does not re-notify on a later poll`() {
+        // Previous already terminal (as persisted after the first notify) — the
+        // dedup: the same idle session must not fire again next run.
+        val previous = mapOf("a" to SessionSnapshot("idle", 0))
+        val transitions = detectIdleTransitions(previous, listOf(session("a", "idle")))
+        assertTrue(transitions.isEmpty())
+    }
+
+    @Test
+    fun `waiting to idle is not an idle transition`() {
+        // Only an exact running -> terminal edge counts.
+        val previous = mapOf("a" to SessionSnapshot("waiting", 0))
+        val transitions = detectIdleTransitions(previous, listOf(session("a", "idle")))
+        assertTrue(transitions.isEmpty())
+    }
+
+    // --- new elicitations (pending count increased) -----------------------
+
+    @Test
+    fun `elicitation count increase fires`() {
+        val previous = mapOf("a" to SessionSnapshot("running", 0))
+        val fired = detectNewElicitations(previous, listOf(session("a", "running", pending = 1)))
+        assertEquals(listOf("a"), fired.map { it.id })
+    }
+
+    @Test
+    fun `no prior snapshot fires no elicitation`() {
+        // Already-pending on the first observation must not notify.
+        val fired = detectNewElicitations(emptyMap(), listOf(session("a", "waiting", pending = 2)))
+        assertTrue(fired.isEmpty())
+    }
+
+    @Test
+    fun `steady elicitation count does not fire`() {
+        val previous = mapOf("a" to SessionSnapshot("waiting", 2))
+        val fired = detectNewElicitations(previous, listOf(session("a", "waiting", pending = 2)))
+        assertTrue(fired.isEmpty())
+    }
+
+    @Test
+    fun `answered elicitation decrease does not fire`() {
+        val previous = mapOf("a" to SessionSnapshot("waiting", 2))
+        val fired = detectNewElicitations(previous, listOf(session("a", "waiting", pending = 1)))
+        assertTrue(fired.isEmpty())
+    }
+
+    // --- snapshot round-trip (the dedup key) ------------------------------
+
+    @Test
+    fun `buildSnapshot captures status and pending count per id`() {
+        val snapshot =
+            buildSnapshot(listOf(session("a", "running", pending = 1), session("b", "idle")))
+        assertEquals(SessionSnapshot("running", 1), snapshot["a"])
+        assertEquals(SessionSnapshot("idle", 0), snapshot["b"])
+    }
+
+    @Test
+    fun `re-running the diff against the saved snapshot yields nothing`() {
+        // Simulates run N notifying, persisting, then run N+1 diffing the same
+        // list against that persisted snapshot — the transition must not repeat.
+        val current = listOf(session("a", "idle"), session("b", "waiting", pending = 1))
+        val afterNotify = buildSnapshot(current)
+        assertTrue(detectIdleTransitions(afterNotify, current).isEmpty())
+        assertTrue(detectNewElicitations(afterNotify, current).isEmpty())
+    }
+
+    // --- merge: off-window running sessions survive (Blocking 1) -----------
+
+    @Test
+    fun `merge carries forward a prior session absent from the current poll`() {
+        // "a" was running last poll but scrolled off the top-window this poll.
+        // Its prior running status must survive in the merged snapshot.
+        val previous = mapOf("a" to SessionSnapshot("running", 0))
+        val current = listOf(session("b", "idle"))
+        val merged = mergeSnapshot(previous, current)
+        assertEquals(SessionSnapshot("running", 0, offWindowPolls = 1), merged["a"])
+        assertEquals(SessionSnapshot("idle", 0), merged["b"])
+    }
+
+    @Test
+    fun `off-window running session still fires an idle transition when it reappears`() {
+        // Poll 1: "a" running, in window. Poll 2: "a" off-window (only "b").
+        // Poll 3: "a" reappears idle. The finish must STILL fire — which only
+        // works if the merge kept "a"=running through poll 2.
+        var snapshot = buildSnapshot(listOf(session("a", "running"), session("b", "idle")))
+        // Poll 2 — "a" absent from the window.
+        val poll2 = listOf(session("b", "idle"))
+        assertTrue(detectIdleTransitions(snapshot, poll2).isEmpty()) // "a" not seen terminal yet
+        snapshot = mergeSnapshot(snapshot, poll2)
+        assertEquals("running", snapshot["a"]?.status) // survived the off-window poll
+        // Poll 3 — "a" reappears, now idle.
+        val poll3 = listOf(session("a", "idle"), session("b", "idle"))
+        assertEquals(listOf("a"), detectIdleTransitions(snapshot, poll3).map { it.id })
+    }
+
+    @Test
+    fun `empty poll ages but does not immediately drop a prior running entry`() {
+        // A poll whose data is legitimately empty (or all-invalid) must not wipe
+        // the prior snapshot — otherwise an off-window finish is lost forever.
+        val previous = mapOf("a" to SessionSnapshot("running", 0))
+        val merged = mergeSnapshot(previous, emptyList())
+        assertEquals(SessionSnapshot("running", 0, offWindowPolls = 1), merged["a"])
+    }
+
+    @Test
+    fun `merge caps size, keeping current window and mid-flight priors`() {
+        // Current window (idle) always kept; a running prior is carried even when
+        // the cap forces settled priors to be dropped.
+        val previous =
+            buildMap {
+                put("run", SessionSnapshot("running", 0)) // mid-flight — must survive
+                // settled priors — droppable when the cap is tight
+                for (i in 0 until 10) put("old$i", SessionSnapshot("idle", 0))
+            }
+        val current = listOf(session("cur", "idle"))
+        val merged = mergeSnapshot(previous, current, cap = 3)
+        assertEquals(3, merged.size)
+        assertTrue("current window entry kept", merged.containsKey("cur"))
+        assertTrue("mid-flight running prior kept over settled", merged.containsKey("run"))
+    }
+
+    @Test
+    fun `legacy full snapshot fits beside the current window during ttl migration`() {
+        val previous =
+            buildMap {
+                for (i in 0 until 200) put("old$i", SessionSnapshot("running", 0))
+            }
+        val current = (0 until 20).map { session("cur$it", "running") }
+
+        val merged = mergeSnapshot(previous, current)
+
+        assertEquals(220, merged.size)
+        assertTrue((0 until 200).all { merged.containsKey("old$it") })
+    }
+
+    @Test
+    fun `off-window zombie expires after the retention ttl`() {
+        val previous =
+            mapOf(
+                "zombie" to
+                    SessionSnapshot(
+                        "running",
+                        0,
+                        held = true,
+                        offWindowPolls = MAX_OFF_WINDOW_POLLS,
+                    ),
+            )
+
+        assertTrue(mergeSnapshot(previous, emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `more recently observed mid-flight entries win a forced cap tie`() {
+        val previous =
+            mapOf(
+                "stale" to SessionSnapshot("running", 0, offWindowPolls = 10),
+                "recent" to SessionSnapshot("running", 0, offWindowPolls = 1),
+            )
+
+        val merged = mergeSnapshot(previous, listOf(session("current", "idle")), cap = 2)
+
+        assertTrue(merged.containsKey("recent"))
+        assertTrue(!merged.containsKey("stale"))
+    }
+
+    // --- ordering: crash between notify and save re-fires (Blocking 2) -----
+
+    @Test
+    fun `a finish missed by a save-skipping crash still fires on the next run`() {
+        // doWork detects -> notifies -> saves. If the process dies after
+        // notifying but before saving, the snapshot is NOT advanced, so the next
+        // run diffs the SAME prior and re-detects the transition (a duplicate,
+        // never a silent miss). Save-first would instead lose it permanently.
+        val previous = mapOf("a" to SessionSnapshot("running", 0))
+        val current = listOf(session("a", "idle"))
+        // Run 1 detects the transition (would notify)...
+        assertEquals(listOf("a"), detectIdleTransitions(previous, current).map { it.id })
+        // ...then the process dies before save, so `previous` is unchanged.
+        // Run 2 (same prior, same list) still detects it.
+        assertEquals(listOf("a"), detectIdleTransitions(previous, current).map { it.id })
+    }
+
+    // --- cookie extraction ------------------------------------------------
+
+    @Test
+    fun `extractCookieValue pulls the named cookie`() {
+        val header = "__Host-ap_session=abc.def.ghi; other=1"
+        assertEquals("abc.def.ghi", extractCookieValue(header, "__Host-ap_session"))
+    }
+
+    @Test
+    fun `extractCookieValue returns null when absent or empty`() {
+        assertNull(extractCookieValue("other=1", "__Host-ap_session"))
+        assertNull(extractCookieValue(null, "ap_session"))
+        assertNull(extractCookieValue("ap_session=", "ap_session"))
+    }
+
+    @Test
+    fun `sessionCookieName uses the Host prefix on https only`() {
+        assertEquals("__Host-ap_session", sessionCookieName(secure = true))
+        assertEquals("ap_session", sessionCookieName(secure = false))
+    }
+
+    @Test
+    fun `sessionDisplayLabel falls back to a generic label`() {
+        assertEquals("My session", sessionDisplayLabel("My session"))
+        assertEquals("New session", sessionDisplayLabel(null))
+        assertEquals("New session", sessionDisplayLabel("   "))
+    }
+
+    // --- stable per-session notification ids ------------------------------
+
+    @Test
+    fun `notificationIdFor is stable for the same session id`() {
+        // Same id across worker runs / manager instances must map to the same
+        // notification id, so a re-fire updates rather than duplicates.
+        assertEquals(notificationIdFor("conv_abc123"), notificationIdFor("conv_abc123"))
+    }
+
+    @Test
+    fun `notificationIdFor differs across distinct session ids`() {
+        // Distinct sessions must not collide, or a later finish would silently
+        // replace an earlier, still-undismissed notification.
+        val ids = listOf("conv_a", "conv_b", "conv_c", "ecaf7591", "refactor-auth", "42")
+        val mapped = ids.map { notificationIdFor(it) }
+        assertEquals(ids.size, mapped.toSet().size)
+    }
+
+    @Test
+    fun `notificationIdFor never collides with the badge id`() {
+        // Must stay strictly above the reserved badge id (1) for every input,
+        // including ones whose raw hash would otherwise land low or negative.
+        val samples =
+            listOf("", "1", "a", "conv_1", " ", "z".repeat(200)) +
+                (0 until 1000).map { "conv_$it" }
+        for (id in samples) {
+            val n = notificationIdFor(id)
+            assertTrue(
+                "id for '$id' = $n must be >= $MIN_SESSION_NOTIFICATION_ID",
+                n >= MIN_SESSION_NOTIFICATION_ID,
+            )
+        }
+    }
+
+    // --- holding transitions suppressed while the app was visible ----------
+
+    @Test
+    fun `a held idle transition re-fires on the next non-visible poll`() {
+        // Poll 1 runs while the app is visible: the finish is detected but not
+        // posted (SPA path), so the snapshot must keep the session's
+        // acknowledged status at `running` — not consume the edge — and flag
+        // the entry held.
+        val previous = mapOf("conv_a" to SessionSnapshot("running", 0))
+        val current = listOf(session("conv_a", "idle"))
+        val suppressedIdle = detectIdleTransitions(previous, current)
+        assertEquals(listOf("conv_a"), suppressedIdle.map { it.id })
+
+        val saved =
+            holdSuppressedTransitions(
+                mergeSnapshot(previous, current),
+                previous,
+                suppressedIdle,
+                emptyList(),
+            )
+        assertEquals(SessionSnapshot("running", 0, held = true), saved["conv_a"])
+
+        // Poll 2 runs with the app off screen: the un-consumed edge re-fires
+        // and posts. Duplicate-over-miss: if the SPA did surface it, the user
+        // gets a duplicate; if the activity stopped before the SPA settled,
+        // this is the only notification.
+        assertEquals(listOf("conv_a"), detectIdleTransitions(saved, current).map { it.id })
+    }
+
+    @Test
+    fun `a held elicitation increase re-fires on the next non-visible poll`() {
+        val previous = mapOf("conv_a" to SessionSnapshot("idle", 0))
+        val current = listOf(session("conv_a", "idle", pending = 2))
+        val suppressedElicitations = detectNewElicitations(previous, current)
+        assertEquals(listOf("conv_a"), suppressedElicitations.map { it.id })
+
+        val saved =
+            holdSuppressedTransitions(
+                mergeSnapshot(previous, current),
+                previous,
+                emptyList(),
+                suppressedElicitations,
+            )
+        assertEquals(SessionSnapshot("idle", 0, held = true), saved["conv_a"])
+        assertEquals(listOf("conv_a"), detectNewElicitations(saved, current).map { it.id })
+    }
+
+    @Test
+    fun `holding is per-dimension - an answered elicitation cannot fabricate a stale finish`() {
+        // Visible poll sees running/0 -> waiting/1: ONLY the elicitation edge
+        // is suppressed, so only the pending count rolls back — status must
+        // advance to `waiting`. (Restoring the whole prior record would keep
+        // `running`, and after the user answers in-app, the next background
+        // poll's idle/0 would fabricate a stale running -> idle "finished".)
+        val previous = mapOf("conv_a" to SessionSnapshot("running", 0))
+        val visiblePoll = listOf(session("conv_a", "waiting", pending = 1))
+        assertTrue(detectIdleTransitions(previous, visiblePoll).isEmpty())
+        val suppressedElicitations = detectNewElicitations(previous, visiblePoll)
+        assertEquals(listOf("conv_a"), suppressedElicitations.map { it.id })
+
+        val saved =
+            holdSuppressedTransitions(
+                mergeSnapshot(previous, visiblePoll),
+                previous,
+                emptyList(),
+                suppressedElicitations,
+            )
+        assertEquals(SessionSnapshot("waiting", 0, held = true), saved["conv_a"])
+
+        // User answers in-app; the next background poll sees idle/0. No stale
+        // "finished" (acknowledged status is waiting, not running) and no
+        // elicitation (pending is back at 0).
+        val backgroundPoll = listOf(session("conv_a", "idle", pending = 0))
+        assertTrue(detectIdleTransitions(saved, backgroundPoll).isEmpty())
+        assertTrue(detectNewElicitations(saved, backgroundPoll).isEmpty())
+    }
+
+    @Test
+    fun `a session with both edges suppressed holds both dimensions`() {
+        val previous = mapOf("conv_a" to SessionSnapshot("running", 0))
+        val current = listOf(session("conv_a", "idle", pending = 3))
+        val saved =
+            holdSuppressedTransitions(
+                mergeSnapshot(previous, current),
+                previous,
+                detectIdleTransitions(previous, current),
+                detectNewElicitations(previous, current),
+            )
+        assertEquals(SessionSnapshot("running", 0, held = true), saved["conv_a"])
+        assertEquals(listOf("conv_a"), detectIdleTransitions(saved, current).map { it.id })
+        assertEquals(listOf("conv_a"), detectNewElicitations(saved, current).map { it.id })
+    }
+
+    @Test
+    fun `holding only rolls back the suppressed sessions`() {
+        val previous =
+            mapOf(
+                "held" to SessionSnapshot("running", 0),
+                "other" to SessionSnapshot("running", 0),
+            )
+        val current = listOf(session("held", "idle"), session("other", "running", pending = 1))
+        val saved =
+            holdSuppressedTransitions(
+                mergeSnapshot(previous, current),
+                previous,
+                detectIdleTransitions(previous, current),
+                emptyList(),
+            )
+        // The non-suppressed session's fresh state is kept as merged, un-held.
+        assertEquals(SessionSnapshot("running", 0, held = true), saved["held"])
+        assertEquals(SessionSnapshot("running", 1), saved["other"])
+    }
+
+    @Test
+    fun `holding nothing returns the merge unchanged`() {
+        val previous = mapOf("conv_a" to SessionSnapshot("idle", 0))
+        val current = listOf(session("conv_a", "idle"))
+        val merged = mergeSnapshot(previous, current)
+        assertEquals(merged, holdSuppressedTransitions(merged, previous, emptyList(), emptyList()))
+    }
+
+    @Test
+    fun `a held entry survives cap eviction like a mid-flight one`() {
+        // A held elicitation entry's rolled-back values look settled
+        // (idle/0) — without the held flag the cap would evict it in favor of
+        // nothing, and the reappearing session (pending back visible, but no
+        // prior row) would never fire.
+        val previous =
+            buildMap {
+                put("heldElic", SessionSnapshot("idle", 0, held = true))
+                for (i in 0 until 10) put("old$i", SessionSnapshot("idle", 0))
+            }
+        val current = listOf(session("cur", "idle"))
+        val merged = mergeSnapshot(previous, current, cap = 3)
+        assertEquals(3, merged.size)
+        assertTrue("current window entry kept", merged.containsKey("cur"))
+        assertTrue("held entry kept over settled priors", merged.containsKey("heldElic"))
+        // The carried held entry keeps its flag, so it stays protected on the
+        // NEXT poll's cap too.
+        assertEquals(
+            SessionSnapshot("idle", 0, held = true, offWindowPolls = 1),
+            merged["heldElic"],
+        )
+    }
+
+    @Test
+    fun `the held flag clears once the session is saved without a hold`() {
+        // Background poll posts the held edge, then saves the observed state
+        // via buildSnapshot/mergeSnapshot — the fresh entry must be un-held so
+        // it stops consuming a protected cap slot.
+        val previous = mapOf("conv_a" to SessionSnapshot("running", 0, held = true))
+        val current = listOf(session("conv_a", "idle"))
+        val merged = mergeSnapshot(previous, current)
+        assertEquals(SessionSnapshot("idle", 0), merged["conv_a"])
+    }
+
+    @Test
+    fun `terminal transition requires a terminal confirmation`() {
+        val candidates = listOf(session("settled", "idle"), session("resumed", "idle"))
+        val confirmation =
+            listOf(session("settled", "idle"), session("resumed", "running"))
+
+        assertEquals(
+            listOf("settled"),
+            confirmIdleTransitions(candidates, confirmation).map { it.id },
+        )
+    }
+
+    @Test
+    fun `terminal transition absent from confirmation is not posted`() {
+        val candidates = listOf(session("off-window", "idle"))
+
+        assertTrue(confirmIdleTransitions(candidates, emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `distinct session ids CAN share a numeric id - the tag carries distinctness`() {
+        // "Aa" and "BB" are the canonical String.hashCode collision. This is
+        // exactly why the worker posts with the session id as the notification
+        // TAG: the numeric id alone cannot distinguish these sessions, and an
+        // untagged post would let one silently replace the other.
+        assertEquals("Aa".hashCode(), "BB".hashCode())
+        assertEquals(notificationIdFor("Aa"), notificationIdFor("BB"))
+    }
+}

--- a/web/android/app/src/test/java/ai/omnigent/android/SessionSnapshotStoreTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/SessionSnapshotStoreTest.kt
@@ -1,0 +1,220 @@
+package ai.omnigent.android
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+/** SharedPreferences round-trip for the persisted poll snapshot. */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SessionSnapshotStoreTest {
+    private lateinit var store: SessionSnapshotStore
+
+    @Before
+    fun setUp() {
+        store = SessionSnapshotStore(ApplicationProvider.getApplicationContext<Application>())
+    }
+
+    /** Persist via the only write path — the CAS — against the live generation. */
+    private fun save(snapshot: Map<String, SessionSnapshot>) {
+        val identity = store.lastAccountIdentity() ?: "digest-a"
+        store.bindAccount(identity) {}
+        assertTrue(store.saveIfCurrentAccount(snapshot, store.generation(), identity))
+    }
+
+    @Test
+    fun `load is empty before anything is saved`() {
+        assertTrue(store.load().isEmpty())
+    }
+
+    @Test
+    fun `save then load round-trips the snapshot, including the held flag`() {
+        val snapshot =
+            mapOf(
+                "conv_a" to SessionSnapshot("running", 0),
+                "conv_b" to SessionSnapshot("waiting", 3),
+                "conv_held" to SessionSnapshot("idle", 0, held = true),
+                "conv_old" to SessionSnapshot("running", 0, offWindowPolls = 3),
+            )
+        save(snapshot)
+        assertEquals(snapshot, store.load())
+    }
+
+    @Test
+    fun `unbinding drops the snapshot so the next load seeds fresh`() {
+        save(mapOf("conv_a" to SessionSnapshot("idle", 1)))
+        store.unbindAccount {}
+        assertTrue(store.load().isEmpty())
+    }
+
+    @Test
+    fun `unbinding bumps the generation so an in-flight poll can detect it`() {
+        // The worker captures generation() before its fetch and aborts when it
+        // changed after — this is the same-server account-switch guard.
+        store.bindAccount("digest-a") {}
+        val before = store.generation()
+        store.unbindAccount {}
+        assertEquals(before + 1, store.generation())
+        store.bindAccount("digest-b") {}
+        val rebound = store.generation()
+        store.unbindAccount {}
+        assertEquals(rebound + 1, store.generation())
+    }
+
+    @Test
+    fun `save does not change the generation`() {
+        store.bindAccount("digest-a") {}
+        val before = store.generation()
+        save(mapOf("conv_a" to SessionSnapshot("running", 0)))
+        assertEquals(before, store.generation())
+    }
+
+    @Test
+    fun `account binding atomically clears the snapshot and advances generation`() {
+        assertNull(store.lastAccountIdentity())
+        store.bindAccount("digest-a") {}
+        assertEquals("digest-a", store.lastAccountIdentity())
+        save(mapOf("conv_a" to SessionSnapshot("running", 0)))
+        val before = store.generation()
+
+        assertTrue(store.bindAccount("digest-b") {})
+
+        assertEquals("digest-b", store.lastAccountIdentity())
+        assertTrue(store.load().isEmpty())
+        assertEquals(before + 1, store.generation())
+    }
+
+    @Test
+    fun `binding the same account preserves its baseline`() {
+        store.bindAccount("digest-a") {}
+        save(mapOf("conv_a" to SessionSnapshot("running", 0)))
+        val before = store.generation()
+
+        assertFalse(store.bindAccount("digest-a") {})
+
+        assertEquals(mapOf("conv_a" to SessionSnapshot("running", 0)), store.load())
+        assertEquals(before, store.generation())
+    }
+
+    @Test
+    fun `unbinding removes identity and snapshot together`() {
+        store.bindAccount("digest-a") {}
+        save(mapOf("conv_a" to SessionSnapshot("running", 0)))
+
+        store.unbindAccount {}
+
+        assertNull(store.lastAccountIdentity())
+        assertTrue(store.load().isEmpty())
+    }
+
+    @Test
+    fun `saveIfCurrentAccount persists while generation and identity are unchanged`() {
+        val snapshot = mapOf("conv_a" to SessionSnapshot("running", 0))
+        store.bindAccount("digest-a") {}
+        val boundGeneration = store.generation()
+        assertTrue(store.saveIfCurrentAccount(snapshot, boundGeneration, "digest-a"))
+        assertEquals(snapshot, store.load())
+    }
+
+    @Test
+    fun `saveIfCurrentAccount refuses a stale generation and leaves the store untouched`() {
+        // The worker captured its generation, then a new account bind bumped it:
+        // the CAS must lose, or the worker's save would overwrite the new
+        // account's cleared baseline and the next poll would diff B against A.
+        store.bindAccount("digest-a") {}
+        val staleGeneration = store.generation()
+        store.bindAccount("digest-b") {}
+        assertFalse(
+            store.saveIfCurrentAccount(
+                mapOf("conv_a" to SessionSnapshot("running", 0)),
+                staleGeneration,
+                "digest-a",
+            ),
+        )
+        assertTrue(store.load().isEmpty())
+    }
+
+    @Test
+    fun `saveIfCurrentAccount succeeds against the new account generation`() {
+        store.bindAccount("digest-b") {}
+        val snapshot = mapOf("conv_b" to SessionSnapshot("idle", 1))
+        assertTrue(store.saveIfCurrentAccount(snapshot, store.generation(), "digest-b"))
+        assertEquals(snapshot, store.load())
+    }
+
+    @Test
+    fun `save refuses to seed a snapshot without a bound identity`() {
+        assertFalse(
+            store.saveIfCurrentAccount(
+                mapOf("conv_a" to SessionSnapshot("running", 0)),
+                store.generation(),
+                "digest-a",
+            ),
+        )
+        assertTrue(store.load().isEmpty())
+    }
+
+    @Test
+    fun `notification guard excludes an account switch until cancellation finishes`() {
+        store.bindAccount("digest-a") {}
+        val generation = store.generation()
+        val postEntered = CountDownLatch(1)
+        val releasePost = CountDownLatch(1)
+        val switchFinished = CountDownLatch(1)
+        val post =
+            thread {
+                store.runIfCurrentAccount(generation, "digest-a") {
+                    postEntered.countDown()
+                    releasePost.await()
+                }
+            }
+        assertTrue(postEntered.await(1, TimeUnit.SECONDS))
+
+        val accountSwitch =
+            thread {
+                store.bindAccount("digest-b") {}
+                switchFinished.countDown()
+            }
+        assertFalse(switchFinished.await(100, TimeUnit.MILLISECONDS))
+
+        releasePost.countDown()
+        post.join(1_000)
+        accountSwitch.join(1_000)
+        assertTrue(switchFinished.await(1, TimeUnit.SECONDS))
+        assertFalse(store.runIfCurrentAccount(generation, "digest-a") {})
+    }
+
+    @Test
+    fun `save overwrites rather than merges`() {
+        save(mapOf("conv_a" to SessionSnapshot("running", 0)))
+        save(mapOf("conv_b" to SessionSnapshot("idle", 0)))
+        assertEquals(setOf("conv_b"), store.load().keys)
+    }
+
+    @Test
+    fun `load quarantines poisoned invalid-id entries`() {
+        // A blob written by an older build whose parser produced the literal
+        // "null" id (or a blank one) must not resurrect those entries — held
+        // at cap priority they could evict a genuine mid-flight session.
+        save(
+            mapOf(
+                "null" to SessionSnapshot("running", 0),
+                "" to SessionSnapshot("running", 0),
+                " " to SessionSnapshot("running", 0),
+                "conv_ok" to SessionSnapshot("running", 0),
+            ),
+        )
+        assertEquals(setOf("conv_ok"), store.load().keys)
+    }
+}

--- a/web/android/app/src/test/java/ai/omnigent/android/TestJwt.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/TestJwt.kt
@@ -1,0 +1,21 @@
+package ai.omnigent.android
+
+import java.util.Base64
+
+/**
+ * Shared test builder for HS256-shaped JWTs with an unverified signature. The
+ * account-identity code only reads the payload's `sub` claim, so the signature
+ * is a fixed placeholder. Used by the identity and MainActivity account tests.
+ */
+internal object TestJwt {
+    /** A JWT whose body is [payload] verbatim (arbitrary claims / malformed shapes). */
+    fun forPayload(payload: String): String {
+        val enc = Base64.getUrlEncoder().withoutPadding()
+        val header = enc.encodeToString("""{"alg":"HS256","typ":"JWT"}""".toByteArray())
+        val body = enc.encodeToString(payload.toByteArray())
+        return "$header.$body.c2ln"
+    }
+
+    /** A JWT carrying just `{"sub": subject}`. */
+    fun forSubject(subject: String): String = forPayload("""{"sub":"$subject"}""")
+}

--- a/web/android/gradle/libs.versions.toml
+++ b/web/android/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidxActivity = "1.12.4"
 androidxWebkit = "1.15.0"
 # AppCompat 1.8.x is currently in preview; stick with the latest stable 1.7.x.
 androidxAppcompat = "1.7.1"
+androidxWork = "2.10.1"
 junit = "4.13.2"
 robolectric = "4.16.1"
 androidxTestCore = "1.7.0"
@@ -24,6 +25,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-activity = { group = "androidx.activity", name = "activity-ktx", version.ref = "androidxActivity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppcompat" }
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "androidxWebkit" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidxWork" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }

--- a/web/src/lib/sessionUpdatesSocket.test.ts
+++ b/web/src/lib/sessionUpdatesSocket.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   HEARTBEAT_WATCHDOG_MS,
+  HIDDEN_RECONNECT_MAX_MS,
+  RECONNECT_MAX_MS,
   nextPushedSession,
   sessionUpdatesSocket,
 } from "./sessionUpdatesSocket";
@@ -125,6 +127,132 @@ describe("sessionUpdatesSocket heartbeat watchdog", () => {
 // Reconnect backoff is capped at 5 s + jitter; advancing past 5 s guarantees
 // the scheduled reconnect timer has fired regardless of the random jitter.
 const RECONNECT_CEILING_MS = 5_001;
+
+/** Shadow `document.hidden` (jsdom defines it on the prototype). */
+function setDocumentHidden(value: boolean): void {
+  Object.defineProperty(document, "hidden", { configurable: true, get: () => value });
+}
+
+describe("sessionUpdatesSocket hidden-page backoff", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+    // Pin jitter to its ceiling so each delay equals its base exactly.
+    vi.spyOn(Math, "random").mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    sessionUpdatesSocket.stop();
+    delete (document as { hidden?: boolean }).hidden;
+    vi.clearAllTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  /**
+   * Fail enough opens that the doubling backoff reaches whichever cap
+   * applies. Starts from a fresh campaign: the afterEach `stop()` resets
+   * `failedAttempts`, so ten doublings from the 250 ms base saturate either
+   * cap deterministically regardless of test order.
+   */
+  function exhaustBackoff(): void {
+    sessionUpdatesSocket.start();
+    for (let i = 0; i < 10; i += 1) {
+      latestWs().close();
+      vi.advanceTimersByTime(HIDDEN_RECONNECT_MAX_MS);
+    }
+  }
+
+  it("saturates at exactly HIDDEN_RECONNECT_MAX_MS while hidden", () => {
+    setDocumentHidden(true);
+    exhaustBackoff();
+
+    // Schedule one more retry at the saturated cap (jitter pinned, so the
+    // delay is exactly the cap).
+    latestWs().close();
+    const scheduled = FakeWebSocket.instances.length;
+
+    // One tick short of the hidden cap: no attempt — a hidden page no longer
+    // retries on the ≤5 s foreground cadence, nor on any shorter stretch.
+    vi.advanceTimersByTime(HIDDEN_RECONNECT_MAX_MS - 1);
+    expect(FakeWebSocket.instances.length).toBe(scheduled);
+
+    // Crossing the cap fires exactly one reconnect.
+    vi.advanceTimersByTime(1);
+    expect(FakeWebSocket.instances.length).toBe(scheduled + 1);
+  });
+
+  it("reconnects immediately when a hidden page becomes visible", () => {
+    setDocumentHidden(true);
+    exhaustBackoff();
+
+    // A retry is pending at the saturated 60 s cap.
+    latestWs().close();
+    const scheduled = FakeWebSocket.instances.length;
+
+    // Becoming visible skips the stretched delay and reconnects at once,
+    // with no timer advance at all.
+    setDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(FakeWebSocket.instances.length).toBe(scheduled + 1);
+  });
+
+  it("does not open a second socket when visibility flips while one exists", () => {
+    setDocumentHidden(true);
+    sessionUpdatesSocket.start();
+    const connecting = FakeWebSocket.instances.length;
+
+    // Still CONNECTING: a visibility flip must not double-connect.
+    setDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(FakeWebSocket.instances.length).toBe(connecting);
+
+    // Same while OPEN.
+    latestWs().open();
+    setDocumentHidden(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+    setDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(FakeWebSocket.instances.length).toBe(connecting);
+  });
+
+  it("starts a fresh backoff campaign after stop()/start()", () => {
+    setDocumentHidden(true);
+    exhaustBackoff();
+
+    // A deliberate stop ends the campaign; the next start must not inherit
+    // the saturated (60 s hidden) delay from the finished outage.
+    sessionUpdatesSocket.stop();
+    sessionUpdatesSocket.start();
+
+    latestWs().close();
+    const scheduled = FakeWebSocket.instances.length;
+
+    // First failure of the new campaign: base delay (250 ms with jitter
+    // pinned), not the inherited cap.
+    vi.advanceTimersByTime(250);
+    expect(FakeWebSocket.instances.length).toBe(scheduled + 1);
+  });
+
+  it("keeps the exact 5 s saturated cap when the page is visible", () => {
+    setDocumentHidden(false);
+    exhaustBackoff();
+
+    latestWs().close();
+    const scheduled = FakeWebSocket.instances.length;
+
+    // Both sides of the boundary: still waiting one tick short of the cap
+    // (so the foreground cadence wasn't accidentally shortened) ...
+    vi.advanceTimersByTime(RECONNECT_MAX_MS - 1);
+    expect(FakeWebSocket.instances.length).toBe(scheduled);
+
+    // ... and reconnecting the tick it lands (not lengthened either).
+    vi.advanceTimersByTime(1);
+    expect(FakeWebSocket.instances.length).toBe(scheduled + 1);
+  });
+});
 
 describe("nextPushedSession", () => {
   beforeEach(() => {

--- a/web/src/lib/sessionUpdatesSocket.ts
+++ b/web/src/lib/sessionUpdatesSocket.ts
@@ -31,10 +31,19 @@ export type SessionUpdatesFrame =
 type FrameListener = (frame: SessionUpdatesFrame) => void;
 
 // Reconnect backoff — mirrors the chat stream pump (chatStore.ts): 250 ms
-// base, doubling, capped at 5 s, with ±50% jitter so many tabs reconnecting
-// after a server blip don't synchronize into a thundering herd.
+// base, doubling, capped at 5 s visible / 60 s hidden, with ±50% jitter so
+// many tabs reconnecting after a server blip don't synchronize into a
+// thundering herd.
 const RECONNECT_BASE_MS = 250;
-const RECONNECT_MAX_MS = 5_000;
+// Exported so the backoff tests can assert the exact saturated delay rather
+// than hard-coding the literal (same pattern as HEARTBEAT_WATCHDOG_MS).
+export const RECONNECT_MAX_MS = 5_000;
+
+// A hidden page doesn't need sub-second freshness: while `document.hidden`
+// the retry cap stretches, so a backgrounded tab or mobile WebView facing an
+// unreachable server doesn't wake the CPU/radio every few seconds. Returning
+// to the foreground reconnects immediately (see `onVisibilityChange`).
+export const HIDDEN_RECONNECT_MAX_MS = 60_000;
 
 // The server pushes a heartbeat every 30 s when a watch-set is idle (see
 // `_SESSION_UPDATES_HEARTBEAT_INTERVAL_S`). If we go appreciably longer than
@@ -50,7 +59,9 @@ const RECONNECT_MAX_MS = 5_000;
 export const HEARTBEAT_WATCHDOG_MS = 70_000;
 
 function nextReconnectDelay(failedAttempts: number): number {
-  const base = Math.min(RECONNECT_BASE_MS * 2 ** (failedAttempts - 1), RECONNECT_MAX_MS);
+  const max =
+    typeof document !== "undefined" && document.hidden ? HIDDEN_RECONNECT_MAX_MS : RECONNECT_MAX_MS;
+  const base = Math.min(RECONNECT_BASE_MS * 2 ** (failedAttempts - 1), max);
   return base / 2 + Math.random() * (base / 2);
 }
 
@@ -110,12 +121,22 @@ class SessionUpdatesSocket {
   start(): void {
     if (this.started) return;
     this.started = true;
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", this.onVisibilityChange);
+    }
     this.connect();
   }
 
   /** Close the connection and stop reconnecting. */
   stop(): void {
     this.started = false;
+    // A deliberate stop ends the current reconnect campaign: a later start()
+    // begins fresh at the 250 ms base instead of inheriting a saturated
+    // (up to 60 s hidden) delay from an outage that may be long over.
+    this.failedAttempts = 0;
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", this.onVisibilityChange);
+    }
     this.clearWatchdog();
     if (this.reconnectTimer !== null) {
       clearTimeout(this.reconnectTimer);
@@ -253,6 +274,19 @@ class SessionUpdatesSocket {
     // close() drives onclose → setConnected(false) → scheduleReconnect.
     this.ws.close();
   }
+
+  /**
+   * Coming back to the foreground: a pending retry may have been scheduled
+   * under the stretched hidden-page cap, so skip the wait and reconnect now.
+   */
+  private readonly onVisibilityChange = (): void => {
+    if (document.hidden || !this.started) return;
+    if (this.reconnectTimer !== null && this.ws === null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+      this.connect();
+    }
+  };
 
   private scheduleReconnect(): void {
     if (!this.started || this.reconnectTimer !== null) return;

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -80,6 +80,12 @@ import type {
 } from "@/lib/events";
 import { createPresenceIdleTracker } from "@/lib/presenceIdle";
 import { conversationRegistry, type ConversationEntry } from "./conversationRegistry";
+import {
+  abortableDelay,
+  awaitReconnectDelay,
+  backgroundReconnectJitter,
+  nextReconnectDelay,
+} from "./streamReconnect";
 import { createInitialConversationState, isConversationStateKey } from "./conversationState";
 import { getStreamSlotManager, type StreamSlot } from "./streamSlots";
 import {
@@ -1091,13 +1097,8 @@ async function uploadFileBlocks(
 const FLASH_DURATION_MS = 800;
 const WORKSPACE_INVALIDATION_DEBOUNCE_MS = 750;
 
-// Reconnect backoff for the session SSE stream. Databricks Apps' ingress
-// hard-caps a single HTTP/2 stream at ~5 min, so the client must re-subscribe
-// when it's dropped. Backoff applies only between consecutive failed opens
-// (see nextReconnectDelay); a drop after a healthy connection reconnects
-// instantly.
-const STREAM_RECONNECT_BASE_MS = 250;
-const STREAM_RECONNECT_MAX_MS = 5_000;
+// Reconnect backoff constants and pacing helpers for the session SSE stream
+// live in streamReconnect.ts (unit-testable without this module's graph).
 // A reverse proxy serves 404 for the stream route for the ~10-60s a backend
 // container takes to restart (upgrade, config change, re-seed bounce), so a
 // 404 mid-restart must not be treated as permanent. Bound the retries instead
@@ -3380,41 +3381,9 @@ async function bindStream(
   }
 }
 
-/**
- * Resolve after `ms`, or immediately when `signal` aborts (so switchTo /
- * unmount interrupts a pending reconnect backoff instead of stalling the
- * loop's teardown).
- */
-function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
-  return new Promise((resolve) => {
-    const onAbort = (): void => {
-      clearTimeout(timer);
-      signal.removeEventListener("abort", onAbort);
-      resolve();
-    };
-    const timer = setTimeout(() => {
-      signal.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-    signal.addEventListener("abort", onAbort, { once: true });
-    // Register first, then re-check: an abort that fired before the listener
-    // was attached won't dispatch to it, so resolve now if already aborted.
-    // (`resolve` is idempotent; this closes any registration-ordering gap.)
-    if (signal.aborted) onAbort();
-  });
-}
-
-/**
- * Halved-to-full jittered exponential backoff between CONSECUTIVE failed
- * opens. Only called with `failedOpens >= 1` — a drop after a healthy
- * connection reconnects instantly (no delay), so the first attempt
- * (`failedOpens === 1`) backs off from the base, doubling per failure up
- * to the cap.
- */
-function nextReconnectDelay(failedOpens: number): number {
-  const base = Math.min(STREAM_RECONNECT_BASE_MS * 2 ** (failedOpens - 1), STREAM_RECONNECT_MAX_MS);
-  return base / 2 + Math.random() * (base / 2);
-}
+// abortableDelay / nextReconnectDelay / awaitReconnectDelay live in
+// streamReconnect.ts so the pacing logic is unit-testable without this
+// module's dependency graph.
 
 /**
  * Drop the ephemeral (un-persisted) streamed blocks ahead of a reconnect.
@@ -4042,7 +4011,9 @@ export async function startStreamPump(
       // healthy connection (the benign ~5-min ingress recycle) leaves
       // failedOpens at 0, so it reconnects instantly with no delay.
       if (failedOpens > 0) {
-        await abortableDelay(nextReconnectDelay(failedOpens), controller.signal);
+        await awaitReconnectDelay(nextReconnectDelay(failedOpens), controller.signal, () =>
+          conversationRegistry.getActive()?.id === id ? 0 : backgroundReconnectJitter(),
+        );
         if (controller.signal.aborted || isConversationDisposed(id)) break;
       } else if (hasConnected && conversationRegistry.getActive()?.id !== id) {
         // Stagger a BACKGROUND conversation's reconnect. The ingress caps every
@@ -4199,15 +4170,8 @@ export async function startStreamPump(
   /* eslint-enable no-await-in-loop */
 }
 
-// Spread background reconnects over a few seconds so N conversations recycling
-// at the same ingress deadline don't fire N snapshot fetches at once. Small
-// enough that a backgrounded conversation is still current well before the user
-// could switch to it.
-const BACKGROUND_RECONNECT_JITTER_MAX_MS = 3_000;
-
-function backgroundReconnectJitter(): number {
-  return Math.random() * BACKGROUND_RECONNECT_JITTER_MAX_MS;
-}
+// backgroundReconnectJitter lives in streamReconnect.ts with the other pacing
+// helpers.
 
 /**
  * Coalesces a frame's worth of work onto a single callback.

--- a/web/src/store/streamReconnect.test.ts
+++ b/web/src/store/streamReconnect.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  STREAM_HIDDEN_RECONNECT_MAX_MS,
+  STREAM_RECONNECT_MAX_MS,
+  awaitReconnectDelay,
+  nextReconnectDelay,
+} from "./streamReconnect";
+
+/** Shadow `document.hidden` (jsdom defines it on the prototype). */
+function setDocumentHidden(value: boolean): void {
+  Object.defineProperty(document, "hidden", { configurable: true, get: () => value });
+}
+
+describe("streamReconnect pacing", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Pin jitter to its ceiling so each delay equals its base exactly.
+    vi.spyOn(Math, "random").mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    delete (document as { hidden?: boolean }).hidden;
+    vi.clearAllTimers();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("caps the saturated delay at the hidden ceiling only while hidden", () => {
+    setDocumentHidden(true);
+    expect(nextReconnectDelay(20)).toBe(STREAM_HIDDEN_RECONNECT_MAX_MS);
+    setDocumentHidden(false);
+    expect(nextReconnectDelay(20)).toBe(STREAM_RECONNECT_MAX_MS);
+  });
+
+  it("waits out a stretched hidden delay to its exact deadline", async () => {
+    setDocumentHidden(true);
+    const controller = new AbortController();
+    let resolved = false;
+    void awaitReconnectDelay(STREAM_HIDDEN_RECONNECT_MAX_MS, controller.signal).then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(STREAM_HIDDEN_RECONNECT_MAX_MS - 1);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(resolved).toBe(true);
+  });
+
+  it("wakes immediately on becoming visible when no jitter is requested", async () => {
+    setDocumentHidden(true);
+    const controller = new AbortController();
+    let resolved = false;
+    void awaitReconnectDelay(STREAM_HIDDEN_RECONNECT_MAX_MS, controller.signal).then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    setDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(true);
+  });
+
+  it("staggers a background conversation's visible wake by the provided jitter", async () => {
+    setDocumentHidden(true);
+    const controller = new AbortController();
+    let resolved = false;
+    void awaitReconnectDelay(STREAM_HIDDEN_RECONNECT_MAX_MS, controller.signal, () => 2_000).then(
+      () => {
+        resolved = true;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    setDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(resolved).toBe(true);
+  });
+
+  it("resumes the stretched wait when the page re-hides within the jitter window", async () => {
+    setDocumentHidden(true);
+    const controller = new AbortController();
+    let resolved = false;
+    void awaitReconnectDelay(STREAM_HIDDEN_RECONNECT_MAX_MS, controller.signal, () => 2_000).then(
+      () => {
+        resolved = true;
+      },
+    );
+
+    // Brief foreground visit at t=10s arms the jittered wake for t=12s...
+    await vi.advanceTimersByTimeAsync(10_000);
+    setDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    // ...but the page re-hides at t=11s, before the wake fires.
+    await vi.advanceTimersByTimeAsync(1_000);
+    setDocumentHidden(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    // Jitter expiry while hidden must NOT reconnect; the remaining stretched
+    // wait resumes and resolves only at the original 60 s deadline.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(STREAM_HIDDEN_RECONNECT_MAX_MS - 12_000 - 1);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(resolved).toBe(true);
+  });
+
+  it("wakes a short (≤ visible-cap) hidden delay when the page becomes visible", async () => {
+    // A hidden-sampled delay can come out ≤ 5 s; it must still take the
+    // visibility-aware path, or a tab foregrounded mid-wait sits out the
+    // remainder disconnected.
+    setDocumentHidden(true);
+    const controller = new AbortController();
+    let resolved = false;
+    void awaitReconnectDelay(3_000, controller.signal).then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(resolved).toBe(false);
+    setDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(true);
+  });
+
+  it("still runs a short hidden delay to its deadline when the page stays hidden", async () => {
+    setDocumentHidden(true);
+    const controller = new AbortController();
+    let resolved = false;
+    void awaitReconnectDelay(3_000, controller.signal).then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(2_999);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(resolved).toBe(true);
+  });
+
+  it("resolves immediately when the signal aborts mid-wait", async () => {
+    setDocumentHidden(true);
+    const controller = new AbortController();
+    let resolved = false;
+    void awaitReconnectDelay(STREAM_HIDDEN_RECONNECT_MAX_MS, controller.signal).then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(true);
+  });
+
+  it("resolves immediately for an already-aborted signal", async () => {
+    setDocumentHidden(true);
+    const controller = new AbortController();
+    controller.abort();
+    let resolved = false;
+    void awaitReconnectDelay(STREAM_HIDDEN_RECONNECT_MAX_MS, controller.signal).then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(true);
+  });
+});

--- a/web/src/store/streamReconnect.ts
+++ b/web/src/store/streamReconnect.ts
@@ -1,0 +1,123 @@
+// Reconnect pacing for the session SSE stream pump (chatStore.ts). Split out
+// so the delay/backoff logic is unit-testable without the store's dependency
+// graph. Mirrors sessionUpdatesSocket.ts, which documents the shared policy:
+// 250 ms base, doubling, capped at 5 s visible / 60 s hidden, ±50% jitter.
+
+// Databricks Apps' ingress hard-caps a single HTTP/2 stream at ~5 min, so the
+// client must re-subscribe when it's dropped. Backoff applies only between
+// consecutive failed opens (see nextReconnectDelay); a drop after a healthy
+// connection reconnects instantly.
+export const STREAM_RECONNECT_BASE_MS = 250;
+export const STREAM_RECONNECT_MAX_MS = 5_000;
+// Hidden-page retry cap — a hidden tab facing an unreachable server doesn't
+// need to dial every ≤5 s. Returning to the foreground ends a stretched wait
+// promptly (see awaitReconnectDelay).
+export const STREAM_HIDDEN_RECONNECT_MAX_MS = 60_000;
+
+// Spread background reconnects over a few seconds so N conversations recycling
+// at the same ingress deadline don't fire N snapshot fetches at once. Small
+// enough that a backgrounded conversation is still current well before the user
+// could switch to it.
+export const BACKGROUND_RECONNECT_JITTER_MAX_MS = 3_000;
+
+export function backgroundReconnectJitter(): number {
+  return Math.random() * BACKGROUND_RECONNECT_JITTER_MAX_MS;
+}
+
+/**
+ * Resolve after `ms`, or immediately when `signal` aborts (so switchTo /
+ * unmount interrupts a pending reconnect backoff instead of stalling the
+ * loop's teardown).
+ */
+export function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+    // Register first, then re-check: an abort that fired before the listener
+    // was attached won't dispatch to it, so resolve now if already aborted.
+    // (`resolve` is idempotent; this closes any registration-ordering gap.)
+    if (signal.aborted) onAbort();
+  });
+}
+
+/**
+ * Halved-to-full jittered exponential backoff between CONSECUTIVE failed
+ * opens. Only called with `failedOpens >= 1` — a drop after a healthy
+ * connection reconnects instantly (no delay), so the first attempt
+ * (`failedOpens === 1`) backs off from the base, doubling per failure up
+ * to the cap.
+ */
+export function nextReconnectDelay(failedOpens: number): number {
+  const max =
+    typeof document !== "undefined" && document.hidden
+      ? STREAM_HIDDEN_RECONNECT_MAX_MS
+      : STREAM_RECONNECT_MAX_MS;
+  const base = Math.min(STREAM_RECONNECT_BASE_MS * 2 ** (failedOpens - 1), max);
+  return base / 2 + Math.random() * (base / 2);
+}
+
+/**
+ * Wait out a reconnect delay. Any delay scheduled while the page is hidden is
+ * raced against a visibility flip, so returning to the tab reconnects promptly
+ * — for stretched waits (up to 60 s) but also for short sampled ones, where a
+ * plain timer would let a just-foregrounded tab sit out the remainder.
+ * `wakeJitterMs` staggers that wake (0 = immediate): every stretched wait in
+ * the tab resolves on the same visibilitychange, so background conversations
+ * add jitter — the same herd-avoidance as backgroundReconnectJitter(). A page
+ * re-hidden before the jittered wake fires resumes the remaining stretched
+ * wait instead of reconnecting while hidden.
+ */
+export async function awaitReconnectDelay(
+  ms: number,
+  signal: AbortSignal,
+  wakeJitterMs: () => number = () => 0,
+): Promise<void> {
+  // Visible pages (and non-DOM environments) have no visibility wake to wait
+  // for — a plain abortable timer suffices. EVERY hidden-page delay takes the
+  // visibility-aware path, regardless of length: gating on ms > cap would let
+  // a hidden-sampled delay ≤ 5 s keep the page disconnected after it becomes
+  // visible mid-wait.
+  if (typeof document === "undefined" || !document.hidden) {
+    return abortableDelay(ms, signal);
+  }
+  return new Promise<void>((resolve) => {
+    const deadline = Date.now() + ms;
+    const done = () => {
+      clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      signal.removeEventListener("abort", done);
+      resolve();
+    };
+    const fireIfVisible = () => {
+      const remaining = deadline - Date.now();
+      // The wake jitter can expire after the page re-hid (visible → hidden
+      // within the jitter window): resume the remaining stretched wait
+      // instead of reconnecting while hidden.
+      if (document.hidden && remaining > 0) {
+        timer = setTimeout(fireIfVisible, remaining);
+        return;
+      }
+      done();
+    };
+    const onVisibilityChange = () => {
+      if (document.hidden) return;
+      clearTimeout(timer);
+      timer = setTimeout(fireIfVisible, wakeJitterMs());
+    };
+    let timer = setTimeout(done, ms);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    signal.addEventListener("abort", done, { once: true });
+    // Same guard as abortableDelay: an abort that fired before the listener
+    // attached never dispatches, and would otherwise wait out the full
+    // stretched delay.
+    if (signal.aborted) done();
+  });
+}


### PR DESCRIPTION
## Related issue

Closes #5197

## Summary

- Installing a personal/CI-built APK on a device that already has the store-signed app fails with `INSTALL_FAILED_UPDATE_INCOMPATIBLE` — same application id `ai.omnigent.android`, different signing key.
- Adds an opt-in `-PapplicationIdSuffix` build property (mirroring the existing `-PversionCode`/`-PversionName` overrides): `./gradlew assembleDebug -PapplicationIdSuffix=.dev` produces `ai.omnigent.android.dev` with launcher label `Omnigent (dev)`, installing side by side with the official app.
- Absent/blank property keeps the id and label exactly as today; the label goes through a manifest placeholder that resolves to `@string/app_name` in that case, so store/release builds are unaffected.

## Test Plan

- `./gradlew assembleDebug -PapplicationIdSuffix=.dev` → `aapt2 dump badging`: `package: name='ai.omnigent.android.dev'`, `application-label:'Omnigent (dev)'`.
- `./gradlew assembleDebug` (no property) → `package: name='ai.omnigent.android'`, `application-label:'Omnigent'` (unchanged).
- `./gradlew testDebugUnitTest`: 71/72 pass; the one failure (`MainActivityTest > configuration change updates system bar icon polarity`) fails identically on unmodified `main` in the same environment, so it is pre-existing and unrelated.
- Installed a `.dev`-suffixed debug APK on a device carrying the release-signed app: both installed side by side.

## Demo

N/A (non-visual; launcher label change shown in the badging output above).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change

## Coverage notes

Verified via `aapt2 dump badging` on both build variants (suffixed and default) and an on-device side-by-side install; the default path is byte-identical behavior, and the suffix path is a build-configuration concern that unit tests don't reach.

## Changelog

Android builds accept `-PapplicationIdSuffix=.dev` to install a personal build alongside the official app

This pull request and its description were written by Isaac.

---

# Absorbed: Android background notifications + battery-drain fix

This PR now also carries the full content of #3182 (WorkManager background-poll
notifications) and the fix for #5760 (background battery drain) — merged here
because the three changes are one Android story and the open-PR budget favors a
single omnibus. Closes #5760.

The original #3182 description (poller design, test plan, demo) remains on that
PR for reference; its addendum below covers the battery fix.

## Addendum: background battery-drain fix (commit `b759e43eb`)

This PR now also carries the fix for #5760 — the two changes depend on each
other, so they land together: the lifecycle fix below freezes in-page
notifications while backgrounded, and this PR's WorkManager poller is the
designed replacement path.

**The drain:** the Android shell never suspended its WebView, so the SPA's 5 s
native heartbeat and both reconnect loops (session-updates WebSocket and chat
SSE stream pump, each capped at 5 s forever) kept the CPU and radio busy after
backgrounding — measured ~1.08 mAh of cached-state CPU over ~17 min.

**The fix (three parts):**
- `MainActivity` calls `webView.pauseTimers()` in `onStop` / `resumeTimers()`
  in `onStart`. Timers only — `webView.onPause()` would kill screen-off audio
  and capture — and `onStop` (not `onPause`) so a visible multi-window pane
  never freezes. A notification deep link arriving while stopped is held and
  emitted after `resumeTimers()`.
- `sessionUpdatesSocket`: reconnect cap 5 s visible / 60 s hidden, instant
  reconnect on becoming visible, and `stop()` resets the backoff campaign.
- The chat stream pump gets the same hidden cap; its pacing moved to a new
  `web/src/store/streamReconnect.ts`, where `awaitReconnectDelay` races a
  stretched wait against the visibility flip (active conversation immediate,
  background conversations jittered; a page re-hidden within the jitter
  window resumes the remaining stretched wait).

**Verification:** 12 new unit tests with pinned jitter and exact boundaries
(5 socket, 7 pacing — including the hidden→visible→re-hidden race and both
abort timings); all pass standalone plus under `--sequence.shuffle`. The diff
went through an adversarial review loop (Codex gpt-5.6-sol @ xhigh, Kimi, and
an independent Claude reviewer) iterated until all three attested clean.
Manual checks: heartbeat logcat lines stop on leaving the screen; no
cached-state CPU accrual; split-screen pane stays live; screen-off audio keeps
playing; hidden reconnects slow to ≥30 s and resume instantly on foreground;
deep links survive a stopped-state notification tap.

This addendum was written by Claude on behalf of the PR author.


## Update (2026-08-29): account-switch hardening + rebase

Five adversarial review rounds (2 independent reviewers each) hardened the notification poller's account-switch identity window, then the branch was rebased onto current `main`:

- the account-identity marker is written **inside the same locked edit** as the snapshot-generation bump, so a racing worker can never pair a new generation with a stale identity;
- the pre-notify identity+generation recheck is atomic with posting — a cross-account `clear()`/`cancelAll()` can no longer be followed by the old account's notifications landing in the new account's shade;
- a **null identity marker fails closed** (no notify, no persist) until a real identity is bound, covering WebView-side account transitions;
- held/mid-flight snapshot entries get TTL/revalidation so zombie entries can't evict live ones at the cap (no permanently lost notifications);
- `runner_online: null` is treated as *unknown* — terminal/actionable notifications require a known-online runner;
- terminal states are confirmed across a settle window before notifying (no phantom "Agent finished" for a briefly idle session);
- `AppVisibility` tracks activity identities with reference semantics (no `identityHashCode` collision edge).

Final round verdicts: **CLEAN from both reviewers.** The single failing unit test on this branch (`MainActivityTest > configuration change updates system bar icon polarity`) was bisected to pristine `main` — it fails identically there (pre-existing Robolectric issue, untouched by this branch).

This addendum was written by Claude on behalf of the PR author.

## 🎥 Demo

https://github.com/user-attachments/assets/2dd69bd8-4ba5-4aca-a5ae-d13f373c569e


- [Demo video (50s, MP4)](https://github.com/btli/omnigent/releases/download/pr-demos-2026-08-29/demo-5198-android.mp4) — side-by-side installs on an Android 14 emulator, both package ids live, and the 60-test account-switch/notification suite running green.
