### PR TITLE
fix(runner): count native terminal turns as active

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1480,12 +1480,14 @@ async def _run_tunnel_from_env() -> None:
         """Record real runner work for the inactivity watchdog.
 
         Called by the WebSocket tunnel frame dispatcher for non-keepalive
-        request frames.
+        request frames and by native terminal lifecycle events.
 
         :returns: None.
         """
         nonlocal last_activity_at
         last_activity_at = loop.time()
+
+    app.state.mark_activity = _mark_activity
 
     def _last_activity() -> float:
         """Return the last real runner activity time.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -265,6 +265,9 @@ for _builder_name in (
 # Servers before 0.3.0 cannot serialize the runner's "waiting" status.
 # Unknown versions also downgrade to "running" so old servers never return 500.
 _WAITING_STATUS_MIN_SERVER_VERSION = "0.3.0"
+# Native status edges are sparse, so terminal activity refreshes this bounded
+# liveness window while a turn is running.
+_NATIVE_PANE_RUNNING_STALE_S = 120.0
 # Cached server version from the /api/version probe; ``None`` until a probe
 # succeeds. A failed probe stays ``None`` and is retried on the next
 # session-create — the GET is cheap and self-heals a transient failure.
@@ -1821,6 +1824,22 @@ def _has_live_async_tasks(
     )
 
 
+def _has_fresh_native_pane_running(
+    statuses: Mapping[str, str],
+    activity_at: Mapping[str, float],
+    *,
+    now: float | None = None,
+) -> bool:
+    """Return whether a native pane has recently shown running activity."""
+    stamp = time.monotonic() if now is None else now
+    return any(
+        status == "running"
+        and (seen_at := activity_at.get(session_id)) is not None
+        and stamp - seen_at <= _NATIVE_PANE_RUNNING_STALE_S
+        for session_id, status in statuses.items()
+    )
+
+
 def register_timer(
     session_id: str,
     timer_id: str,
@@ -2090,6 +2109,8 @@ def create_runner_app(
     app.state.active_turns = _active_turns
     _native_pane_status: dict[str, str] = {}
     app.state.native_pane_status = _native_pane_status
+    _native_pane_activity_at: dict[str, float] = {}
+    app.state.native_pane_activity_at = _native_pane_activity_at
     # Detached watchers answering a /model confirm dialog that pops after
     # the active turn settles (a mid-turn switch queues in the composer).
     _model_dialog_watchers: set[asyncio.Task[None]] = set()
@@ -2124,6 +2145,14 @@ def create_runner_app(
     _session_inboxes = _session_inboxes_ref
     _session_async_tasks: dict[str, dict[str, tuple[asyncio.Task[str], asyncio.Event]]] = {}
 
+    def _set_native_pane_status(session_id: str, status: str) -> None:
+        _native_pane_status[session_id] = status
+        _native_pane_activity_at[session_id] = time.monotonic()
+
+    def _touch_native_pane_running(session_id: str) -> None:
+        if _native_pane_status.get(session_id) == "running":
+            _native_pane_activity_at[session_id] = time.monotonic()
+
     def _has_active_work() -> bool:
         if _active_turns:
             return True
@@ -2139,6 +2168,11 @@ def create_runner_app(
             session_ids = set(_session_start_cache) | set(_session_agent_ids)
             if any(process_manager.has_active_turn(session_id) for session_id in session_ids):
                 return True
+        if _has_fresh_native_pane_running(
+            _native_pane_status,
+            _native_pane_activity_at,
+        ):
+            return True
         return False
 
     app.state.has_active_work = _has_active_work
@@ -2156,10 +2190,20 @@ def create_runner_app(
             queue = asyncio.Queue()
             _session_event_queues[session_id] = queue
         queue.put_nowait(event_body)
-        if event_body.get("type") == "session.status":
+        event_type = event_body.get("type")
+        if event_type == "session.status":
             _status_value = event_body.get("status")
             if isinstance(_status_value, str):
-                _native_pane_status[session_id] = _status_value
+                if session_id in _native_pane_status or _is_native_harness(session_id):
+                    _set_native_pane_status(session_id, _status_value)
+                mark_activity = getattr(app.state, "mark_activity", None)
+                if callable(mark_activity):
+                    mark_activity()
+        elif event_type == "session.terminal.activity":
+            _touch_native_pane_running(session_id)
+            mark_activity = getattr(app.state, "mark_activity", None)
+            if callable(mark_activity):
+                mark_activity()
         _fan_out_child_delta_to_parent(session_id, event_body)
 
     def _child_preview_from_status(
@@ -3458,6 +3502,7 @@ def create_runner_app(
         _desync_terminalized.pop(session_id, None)
         _desynced_sessions.discard(session_id)
         _native_pane_status.pop(session_id, None)
+        _native_pane_activity_at.pop(session_id, None)
         _ingest_next_seq.pop(session_id, None)
         _ingest_now_serving.pop(session_id, None)
         _ingest_cond.pop(session_id, None)
@@ -7064,6 +7109,7 @@ def create_runner_app(
             delivery_ack: _SubagentDeliveryAck | None = None
             recovered_entry: _SubagentWorkEntry | None = None
             if status in ("running", "waiting", "idle", "failed"):
+                _set_native_pane_status(conversation_id, status)
                 resource_registry.note_external_session_status(conversation_id, status)
                 _fan_out_child_delta_to_parent(
                     conversation_id,

--- a/tests/runner/test_app_sessions_native_supervision.py
+++ b/tests/runner/test_app_sessions_native_supervision.py
@@ -539,6 +539,7 @@ async def test_external_session_status_running_fans_out_child_busy_to_parent() -
         entry = runner_app.get_subagent_work(child_id)
         assert entry is not None
         assert entry.status == "running"
+        assert app.state.has_active_work() is True
 
         events = _drain_session_event_queue(runner_app._session_event_queues_ref.get(parent_id))
     finally:

--- a/tests/runner/test_runner_idle_active_work.py
+++ b/tests/runner/test_runner_idle_active_work.py
@@ -9,6 +9,7 @@ the pin so a short idle timeout can shut down.
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any
 
 import pytest
@@ -335,7 +336,9 @@ def test_native_terminal_activity_refreshes_running_pin_and_idle_timer() -> None
     app.state.native_pane_status["conv_native"] = "idle"
     app.state.native_pane_activity_at["conv_native"] = 0.0
     publish_status("conv_native", "running")
-    app.state.native_pane_activity_at["conv_native"] = 0.0
+    app.state.native_pane_activity_at["conv_native"] = (
+        time.monotonic() - _NATIVE_PANE_RUNNING_STALE_S - 1.0
+    )
     assert app.state.has_active_work() is False
 
     publish_activity("conv_native", "terminal_codex_main")

--- a/tests/runner/test_runner_idle_active_work.py
+++ b/tests/runner/test_runner_idle_active_work.py
@@ -17,6 +17,8 @@ from fastapi import FastAPI
 from omnigent.runner import create_runner_app, pending_approvals
 from omnigent.runner._entry import _run_inactivity_monitor
 from omnigent.runner.app import (
+    _NATIVE_PANE_RUNNING_STALE_S,
+    _has_fresh_native_pane_running,
     _has_live_async_tasks,
     _session_timers,
     register_timer,
@@ -278,6 +280,70 @@ async def test_parked_approval_blocks_idle_shutdown() -> None:
         release=_release,
     )
     assert app.state.has_active_work() is False
+
+
+@pytest.mark.asyncio
+async def test_native_pane_running_blocks_idle_shutdown() -> None:
+    """A native terminal turn keeps the runner alive until it becomes idle."""
+    app = _scaffold_app()
+    registry = app.state.session_resource_registry
+    publish_status = registry._session_status_publisher
+    assert callable(publish_status)
+
+    app.state.native_pane_status["conv_native"] = "idle"
+    app.state.native_pane_activity_at["conv_native"] = 0.0
+    publish_status("conv_native", "running")
+    assert app.state.has_active_work() is True
+
+    async def _release() -> None:
+        publish_status("conv_native", "idle")
+
+    await _assert_monitor_blocked_then_shuts_down(
+        has_active_work=app.state.has_active_work,
+        release=_release,
+    )
+    assert app.state.has_active_work() is False
+
+
+def test_native_pane_running_pin_expires_without_activity() -> None:
+    """A stale native status cannot keep an abandoned runner alive forever."""
+    statuses = {"conv_native": "running"}
+    activity_at = {"conv_native": 100.0}
+
+    assert _has_fresh_native_pane_running(statuses, activity_at, now=100.0) is True
+    assert (
+        _has_fresh_native_pane_running(
+            statuses,
+            activity_at,
+            now=100.0 + _NATIVE_PANE_RUNNING_STALE_S + 1.0,
+        )
+        is False
+    )
+
+
+def test_native_terminal_activity_refreshes_running_pin_and_idle_timer() -> None:
+    """Terminal activity refreshes both native liveness and runner activity."""
+    app = _scaffold_app()
+    registry = app.state.session_resource_registry
+    publish_status = registry._session_status_publisher
+    publish_activity = registry._terminal_activity_publisher
+    assert callable(publish_status)
+    assert callable(publish_activity)
+    activity_marks: list[str] = []
+    app.state.mark_activity = lambda: activity_marks.append("activity")
+
+    app.state.native_pane_status["conv_native"] = "idle"
+    app.state.native_pane_activity_at["conv_native"] = 0.0
+    publish_status("conv_native", "running")
+    app.state.native_pane_activity_at["conv_native"] = 0.0
+    assert app.state.has_active_work() is False
+
+    publish_activity("conv_native", "terminal_codex_main")
+    assert app.state.has_active_work() is True
+
+    publish_status("conv_native", "idle")
+    assert app.state.has_active_work() is False
+    assert activity_marks == ["activity", "activity", "activity"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Closes #5205

## Summary

- Count a recently active native terminal pane as active runner work, so the runner idle watchdog cannot terminate a live Codex/Claude-native turn.
- Refresh the runner activity clock from native status and terminal-activity events.
- Bound the native-running pin to 120 seconds without activity, preventing an abandoned pane from keeping the runner alive forever.

ELI5: native Codex runs in its own terminal, so the runner could see its output without realizing it was still working. This connects that terminal's working signal to the runner's idle watchdog.

```text
native turn running ──> fresh pane status ──> has_active_work() ──> runner stays alive
terminal goes quiet  ──> 120s freshness expires ──> normal idle timeout applies
```

## Test Plan

- `uv run pytest tests/runner/test_runner_entry.py tests/runner/test_runner_idle_active_work.py tests/runner/test_app_sessions_native_workflow_init.py -q` — 172 passed.
- Targeted native status and existing recovery-wake tests — 14 passed.
- `uv run pre-commit run --files omnigent/runner/_entry.py omnigent/runner/app.py tests/runner/test_runner_idle_active_work.py tests/runner/test_app_sessions_native_supervision.py` — passed.

## Demo

The regression scenarios demonstrate all three runner-watchdog states: a fresh native turn blocks idle shutdown, an abandoned pane becomes stale after 120 seconds, and new terminal activity refreshes both the running pin and idle timer.

<img width="1228" height="650" alt="omnigent-5206-demo" src="https://github.com/user-attachments/assets/e231f56b-427a-4218-ab90-9e66bb12a74a" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression coverage drives the idle monitor with a native pane in `running`, `idle`, refreshed, and stale states. The external native-status route also asserts that a forwarded `running` edge counts as active work.

## Changelog

Long-running native terminal turns no longer stop when the runner's idle timeout expires.
