### PR TITLE
docs(deploy): document OMNIGENT_BUILTIN_AGENT_DIRS for docker-compose

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -21,6 +21,20 @@ POSTGRES_PASSWORD=change-me-please
 # change rollout behavior. Current keys: usage_page, harness_install.
 # OMNIGENT_FEATURES=usage_page
 
+# ── Built-in agents ──────────────────────────────────────
+# Seed extra always-available built-in agents at server startup, on
+# top of the packaged claude-native-ui / codex-native-ui / polly set.
+# Colon-separated (os.pathsep) list of paths, each either a single-file
+# agent spec (some-agent.yaml) or a bundle directory; the resulting
+# agent name is the file's stem or the directory's name. Each path
+# must be readable INSIDE the container, so bind-mount the host
+# directory holding your specs and point this at the mounted path
+# (e.g. /agents/my-agent.yaml), not the host path — see the compose
+# file's `volumes:` for where to add the mount. A bad or missing entry
+# is logged and skipped rather than failing startup. Applied once at
+# boot only — recreate the container after adding or editing a spec.
+# OMNIGENT_BUILTIN_AGENT_DIRS=/agents/my-agent.yaml:/agents/my-bundle
+
 # ── Image ────────────────────────────────────────────────
 # The compose stack pulls a pre-built image from GHCR (built by CI on
 # every main-branch merge). Default: ghcr.io/omnigent-ai/omnigent-server.

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -22,8 +22,8 @@ POSTGRES_PASSWORD=change-me-please
 # OMNIGENT_FEATURES=usage_page
 
 # ── Built-in agents ──────────────────────────────────────
-# Seed extra always-available built-in agents at server startup, on
-# top of the packaged claude-native-ui / codex-native-ui / polly set.
+# Seed extra always-available built-in agents at server startup, after
+# the packaged native, configured/available ACP, Debby, and Polly agents.
 # Colon-separated (os.pathsep) list of paths, each either a single-file
 # agent spec (some-agent.yaml) or a bundle directory; the resulting
 # agent name is the file's stem or the directory's name. Each path
@@ -32,7 +32,8 @@ POSTGRES_PASSWORD=change-me-please
 # (e.g. /agents/my-agent.yaml), not the host path — see the compose
 # file's `volumes:` for where to add the mount. A bad or missing entry
 # is logged and skipped rather than failing startup. Applied once at
-# boot only — recreate the container after adding or editing a spec.
+# boot only — restart the omnigent service after editing a mounted spec;
+# force-recreate it after changing mounts or other Compose configuration.
 # OMNIGENT_BUILTIN_AGENT_DIRS=/agents/my-agent.yaml:/agents/my-bundle
 
 # ── Image ────────────────────────────────────────────────

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -63,11 +63,11 @@ and reload the web app.
 ## Extra built-in agents
 
 `OMNIGENT_BUILTIN_AGENT_DIRS` seeds extra agents that are always available
-to every user, on top of the packaged claude-native-ui / codex-native-ui /
-polly set. It's a colon-separated (`os.pathsep`) list of paths; each entry
-is either a single-file agent spec (`some-agent.yaml`) or a bundle
-directory, and the resulting agent's name is that path's file stem or
-directory name.
+to every user. They are registered after the server's packaged native agents,
+configured or locally available ACP agents, Debby, and Polly. It's a
+colon-separated (`os.pathsep`) list of paths; each entry is either a
+single-file agent spec (`some-agent.yaml`) or a bundle directory, and the
+resulting agent's name is that path's file stem or directory name.
 
 The path is resolved INSIDE the container, so bind-mount the host
 directory that holds your spec(s) and point the env var at the mounted
@@ -94,9 +94,25 @@ docker compose logs omnigent | grep "built-in agent"
 ```
 
 A bad or missing path is logged and skipped rather than failing startup —
-the packaged built-ins still seed. Registration runs once, at startup
-only (there's no live reload), so recreate the container
-(`docker compose up -d`) after adding or editing a spec.
+the packaged built-ins still seed. Registration runs once, at startup only
+(there's no live reload). After editing a spec in an existing bind mount,
+restart the service so startup seeding runs again:
+
+```bash
+docker compose restart omnigent
+```
+
+After adding or changing the mount, environment variable, or other Compose
+configuration, recreate the service instead:
+
+```bash
+docker compose up -d --force-recreate omnigent
+```
+
+Built-ins are keyed by name. If an extra's file stem or directory name matches
+an existing built-in, startup refreshes that stable row with the extra bundle;
+it does not create a second agent. Use a distinct name unless that override is
+intentional.
 
 ## Multi-user mode (accounts — default)
 

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -60,6 +60,44 @@ server startup so a typo cannot silently produce the wrong rollout. To roll
 back, remove the key (or empty the variable), run `docker compose up -d` again,
 and reload the web app.
 
+## Extra built-in agents
+
+`OMNIGENT_BUILTIN_AGENT_DIRS` seeds extra agents that are always available
+to every user, on top of the packaged claude-native-ui / codex-native-ui /
+polly set. It's a colon-separated (`os.pathsep`) list of paths; each entry
+is either a single-file agent spec (`some-agent.yaml`) or a bundle
+directory, and the resulting agent's name is that path's file stem or
+directory name.
+
+The path is resolved INSIDE the container, so bind-mount the host
+directory that holds your spec(s) and point the env var at the mounted
+path, not the host path. Neither the mount nor the env var is wired into
+`docker-compose.yaml` by default — add both yourself:
+
+```yaml
+# In docker-compose.yaml, on the omnigent service:
+    environment:
+      OMNIGENT_BUILTIN_AGENT_DIRS: "${OMNIGENT_BUILTIN_AGENT_DIRS:-}"
+    volumes:
+      - artifact-data:/data
+      - ./agents:/agents:ro    # host directory holding your agent spec(s)
+```
+
+```dotenv
+# In .env:
+OMNIGENT_BUILTIN_AGENT_DIRS=/agents/my-agent.yaml
+```
+
+```bash
+docker compose up -d
+docker compose logs omnigent | grep "built-in agent"
+```
+
+A bad or missing path is logged and skipped rather than failing startup —
+the packaged built-ins still seed. Registration runs once, at startup
+only (there's no live reload), so recreate the container
+(`docker compose up -d`) after adding or editing a spec.
+
 ## Multi-user mode (accounts — default)
 
 Built-in accounts auth: no IdP to register, no proxy to host.
@@ -256,6 +294,7 @@ trusts whatever value reaches it.
 | `OMNIGENT_AUTH_HEADER` | `X-Forwarded-Email` | Header-mode only: name of the trusted identity header. Set for proxies that use another name, e.g. `Cf-Access-Authenticated-User-Email` (Cloudflare Access). |
 | `OMNIGENT_AUTH_HEADER_STRIP_PREFIX` | unset (strip nothing) | Header-mode only: prefix removed from the identity header value. Set to `accounts.google.com:` for Google IAP's `X-Goog-Authenticated-User-Email`. |
 | `OMNIGENT_OIDC_*` | unset | OIDC config — required in oidc mode (issuer set, or `AUTH_PROVIDER=oidc`). See `.env.example`. |
+| `OMNIGENT_BUILTIN_AGENT_DIRS` | unset | Colon-separated paths (in-container) to extra always-available built-in agents, seeded once at startup. See [Extra built-in agents](#extra-built-in-agents). |
 | `PYPI_INDEX_URL` | `https://pypi.org/simple` | Build-time PyPI index — override only behind a corporate proxy. |
 
 `DATABASE_URL` and `ARTIFACT_DIR` are computed by compose and


### PR DESCRIPTION
## Related issue

N/A. Docs-only change, no issue required per the "Docs" type of change.

## Summary

`OMNIGENT_BUILTIN_AGENT_DIRS` is fully implemented in `omnigent/server/app.py`, but it appears in no deployment documentation. I found it only by reading the source while trying to figure out how to get a custom agent registered as a built-in on a self-hosted Docker deployment.

- `_EXTRA_BUILTIN_AGENTS_ENV = "OMNIGENT_BUILTIN_AGENT_DIRS"` ([app.py#L535](https://github.com/omnigent-ai/omnigent/blob/f7861ec4/omnigent/server/app.py#L535))
- `_ensure_extra_builtin_agents()` reads it, splits on `os.pathsep`, and registers each entry as a built-in agent via `_ensure_builtin_agent` / `builtin_agent_id(name)`, where `name` is the entry's file stem (single-file spec) or directory name (bundle dir) ([app.py#L538-L594](https://github.com/omnigent-ai/omnigent/blob/f7861ec4/omnigent/server/app.py#L538-L594))
- It's reached from `_ensure_default_agents` ([app.py#L525](https://github.com/omnigent-ai/omnigent/blob/f7861ec4/omnigent/server/app.py#L525)), called from the FastAPI `_lifespan` startup hook ([app.py#L1215](https://github.com/omnigent-ai/omnigent/blob/f7861ec4/omnigent/server/app.py#L1215)), bound in `create_app()` via `lifespan=_lifespan`
- A bad/missing path is logged and skipped, not fatal (`except Exception: ... continue` at [app.py#L586-L593](https://github.com/omnigent-ai/omnigent/blob/f7861ec4/omnigent/server/app.py#L586-L593))
- It only runs once, at startup: there's no live-reload path, so a container recreate is needed to pick up a change

For a Docker deployment this is the only supported way to register an always-available built-in agent, since the CLI's `omnigent server --agent` flag isn't reachable through the Docker entrypoint.

I confirmed the gap by grepping the whole repo: the only hits for `OMNIGENT_BUILTIN_AGENT_DIRS` outside `app.py` itself are test fixtures (`tests/e2e_ui/conftest.py`, `tests/e2e/conftest.py`, a couple of e2e test files). It's absent from `deploy/docker/README.md`, `deploy/docker/.env.example`, `deploy/docker/docker-compose.yaml`, `CHANGELOG.md`, and the rest of `deploy/` and `docs/`. I also searched for prior art (`gh search prs`/`gh search issues` in this repo for the env var name and related phrasing): the only hit was #3065, a much larger, unmerged feature PR (added a whole `custom-agents/` tree) that incidentally touched `docker-compose.yaml` with a commented example. Nothing merged documents just the env var itself.

**This is documentation only, with no behaviour change.** It adds:
- `deploy/docker/.env.example`: a new commented "Built-in agents" section (mirrors the existing "Release features" section's structure)
- `deploy/docker/README.md`: a new "Extra built-in agents" section with a worked bind-mount + env var example, plus a row in the existing "Environment variables" table

`docker-compose.yaml` is untouched: every env var in its `environment:` block is already actively wired, with no commented-example convention to extend. Per the README's existing precedent for this exact situation (see the `OMNIGENT_OIDC_REDIRECT_URI` passthrough note), the new section shows operators the line to add themselves.

## Test Plan

Docs-only, no code path changed. Verified:
- Read the current `omnigent/server/app.py` on `main` and traced the full call chain from `create_app()` through `_lifespan` to `_ensure_extra_builtin_agents` (line references above).
- `grep -rl OMNIGENT_BUILTIN_AGENT_DIRS` across the repo before and after the change, confirming only `app.py` and test fixtures referenced it beforehand, and now the two edited docs files do too.
- Matched the exact header/comment style of the surrounding entries in both edited files (line width, wrapping, table format).

## Demo

N/A, docs change, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only change to `deploy/docker/.env.example` and `deploy/docker/README.md`, no code paths touched, so no test coverage applies.

## Changelog

Documented the existing `OMNIGENT_BUILTIN_AGENT_DIRS` env var (extra always-available built-in agents) in the Docker deployment docs
