### PR TITLE
Add icon when creating project

### DIFF
--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -1802,7 +1802,8 @@ export function useDeleteProject() {
 export function useCreateProject() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (name: string) => apiCreateProject(name),
+    mutationFn: ({ name, icon }: { name: string; icon?: string }) =>
+      apiCreateProject(name, icon ? { icon } : undefined),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["projects"] });
     },

--- a/web/src/shell/NewProjectButton.tsx
+++ b/web/src/shell/NewProjectButton.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { PlusIcon } from "lucide-react";
+import { type CSSProperties, useState } from "react";
+import { FolderIcon, PlusIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -9,8 +9,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { EmojiPicker } from "@/components/ProjectIconPicker";
 import { useCreateProject } from "@/hooks/useConversations";
+import { cn } from "@/lib/utils";
 
 /**
  * "New project" control in the Projects group header. Opens a dialog that
@@ -21,18 +24,24 @@ import { useCreateProject } from "@/hooks/useConversations";
 export function NewProjectButton({ onCreated }: { onCreated: (name: string) => void }) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
+  const [icon, setIcon] = useState<string | undefined>(undefined);
+  const [emojiOpen, setEmojiOpen] = useState(false);
   const createProject = useCreateProject();
 
   const submit = () => {
     const trimmed = name.trim();
     if (trimmed === "") return;
-    createProject.mutate(trimmed, {
-      onSuccess: (project) => {
-        setOpen(false);
-        setName("");
-        onCreated(project.name);
+    createProject.mutate(
+      { name: trimmed, icon },
+      {
+        onSuccess: (project) => {
+          setOpen(false);
+          setName("");
+          setIcon(undefined);
+          onCreated(project.name);
+        },
       },
-    });
+    );
   };
 
   return (
@@ -49,6 +58,7 @@ export function NewProjectButton({ onCreated }: { onCreated: (name: string) => v
             onClick={(e) => {
               e.stopPropagation();
               setName("");
+              setIcon(undefined);
               setOpen(true);
             }}
           >
@@ -58,26 +68,94 @@ export function NewProjectButton({ onCreated }: { onCreated: (name: string) => v
         <TooltipContent side="bottom">New project</TooltipContent>
       </Tooltip>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent onClick={(e) => e.stopPropagation()}>
+        <DialogContent
+          onClick={(e) => e.stopPropagation()}
+          // emoji-mart preventDefaults the pointer event, so Radix's own
+          // outside-dismissal never fires for clicks elsewhere in the modal.
+          // Catch them in the capture phase and close the picker ourselves,
+          // unless the pointer is inside the picker or on its trigger tile.
+          onPointerDownCapture={(e) => {
+            if (!emojiOpen) return;
+            const target = e.target as Element;
+            if (
+              target.closest('[data-slot="popover-content"]') ||
+              target.closest('[data-testid="new-project-icon"]')
+            )
+              return;
+            setEmojiOpen(false);
+          }}
+        >
           <DialogHeader>
             <DialogTitle>New project</DialogTitle>
             <DialogDescription>
               Create an empty project, then file sessions into it from a session's menu.
             </DialogDescription>
           </DialogHeader>
-          <input
-            autoFocus
-            className="w-full rounded-md border bg-transparent px-3 py-2 text-ui outline-none"
-            placeholder="Project name…"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                submit();
-              }
-            }}
-          />
+          {/* One combined control: emoji tile (left) + name (right) share a
+              single border, so it reads as a single input. */}
+          <div className="flex items-stretch overflow-hidden rounded-lg border border-input">
+            <Popover open={emojiOpen} onOpenChange={setEmojiOpen}>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Choose project icon"
+                  data-testid="new-project-icon"
+                  className={cn(
+                    "flex size-[38px] shrink-0 cursor-pointer items-center justify-center outline-none transition-colors",
+                    icon ? "bg-muted" : "bg-tag-pink",
+                  )}
+                >
+                  {icon ? (
+                    <span className="text-xl leading-none">{icon}</span>
+                  ) : (
+                    <FolderIcon className="size-4 text-brand-accent" />
+                  )}
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                align="start"
+                // Publish the collision-aware available viewport height (Radix
+                // exposes it as a CSS var), capped at the picker's natural size,
+                // so the .emoji-picker-popover rule in index.css shrinks
+                // emoji-mart to fit — it then scrolls its grid internally
+                // instead of clipping on short screens.
+                collisionPadding={8}
+                style={
+                  {
+                    "--emoji-picker-height":
+                      "min(420px, var(--radix-popover-content-available-height))",
+                  } as CSSProperties
+                }
+                className="emoji-picker-popover flex max-h-[var(--radix-popover-content-available-height)] w-auto flex-col overflow-hidden p-0"
+                // The Dialog's scroll lock (react-remove-scroll) preventDefaults
+                // wheel events over the picker — it can't see emoji-mart's scroll
+                // region inside shadow DOM. Stop the wheel from reaching the
+                // document-level lock so the grid scrolls.
+                onWheel={(e) => e.stopPropagation()}
+                onInteractOutside={() => setEmojiOpen(false)}
+              >
+                <EmojiPicker
+                  onSelect={(native) => {
+                    setIcon(native);
+                    setEmojiOpen(false);
+                  }}
+                />
+              </PopoverContent>
+            </Popover>
+            <input
+              autoFocus
+              className="w-full bg-transparent px-3 py-2 text-ui outline-none"
+              placeholder="Project name…"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  submit();
+                }
+              }}
+            />
+          </div>
           {createProject.isError && (
             <p className="text-ui text-destructive" role="alert">
               {(createProject.error as Error).message}

--- a/web/src/shell/NewProjectButton.tsx
+++ b/web/src/shell/NewProjectButton.tsx
@@ -1,5 +1,5 @@
 import { type CSSProperties, useState } from "react";
-import { FolderIcon, PlusIcon } from "lucide-react";
+import { PlusIcon, SmilePlusIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -108,7 +108,7 @@ export function NewProjectButton({ onCreated }: { onCreated: (name: string) => v
                   {icon ? (
                     <span className="text-xl leading-none">{icon}</span>
                   ) : (
-                    <FolderIcon className="size-4 text-brand-accent" />
+                    <SmilePlusIcon className="size-4 text-brand-accent" />
                   )}
                 </button>
               </PopoverTrigger>

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -43,6 +43,7 @@ import {
   SearchIcon,
   Settings2Icon,
   ShareIcon,
+  SmilePlusIcon,
   SquareIcon,
   SquareCheckIcon,
   SquarePenIcon,
@@ -4158,7 +4159,7 @@ function ProjectFolderMenu({
                     {displayIcon ? (
                       <span className="text-xl leading-none">{displayIcon}</span>
                     ) : (
-                      <FolderIcon className="size-4 text-brand-accent" />
+                      <SmilePlusIcon className="size-4 text-brand-accent" />
                     )}
                   </button>
                 </PopoverTrigger>


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Let users pick an emoji icon while creating a project, instead of only being able to add one afterward.

- The **New project** modal now has a combined control: an emoji tile on the left and the name input on the right sharing one border, matching the rename modal. Clicking the tile opens the emoji picker; the pick is held locally and sent with the create request.
- `useCreateProject` now accepts an optional `icon` and forwards it as the new project's `config.icon` (the create API already accepted `config` — only the hook was dropping it).
- Icon is optional; creating without one behaves exactly as before.

## Test Plan

Manual verification against the dev server:

- **New project** (＋ in the Projects group header) → click the pink folder tile → the emoji picker opens (emoji-mart) → pick an emoji → the tile shows it → type a name → **Create** → the new folder appears with the chosen icon.
- Create **without** picking an icon → folder is created with the default (no icon), as before.
- Picker behaves on short screens (fits viewport, grid scrolls internally, mouse wheel scrolls it), and closes on outside click.
- `npm run type-check` passes; `vitest run src/shell/Sidebar.test.tsx src/hooks/useConversations.test.ts` passes (154/154).

## Demo

https://github.com/user-attachments/assets/53b5efa8-de5f-4f45-b171-bffbf482ab49

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually in the browser (icon-picked create, no-icon create, picker open/close and short-screen scrolling). The change is small and UI-centric; the hook change forwards an already-supported API field, which the existing Sidebar/hook suites still cover (154 passing).

## Changelog

Choose an emoji icon for a project right in the New project dialog
