### PR TITLE
fix(runner): keep native harness alive during terminal activity

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2297,6 +2297,8 @@ def create_runner_app(
     app.state.session_resource_registry = resource_registry
 
     def _publish_terminal_activity(session_id: str, terminal_id: str) -> None:
+        if process_manager is not None:
+            process_manager.note_activity(session_id)
         _publish_event(
             session_id,
             {

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -989,6 +989,20 @@ class HarnessProcessManager:
         """
         return conversation_id in self._in_flight_response_ids
 
+    def note_activity(self, conversation_id: str) -> None:
+        """Refresh the idle lease for an existing harness subprocess.
+
+        Native terminal turns do not pass through ``proxy_stream``, so their
+        terminal activity calls this method instead. No-op when the
+        conversation has no registered subprocess.
+
+        :param conversation_id: AP-allocated conversation id,
+            e.g. ``"conv_abc123"``.
+        """
+        entry = self._entries.get(conversation_id)
+        if entry is not None:
+            entry.last_used_at = time.monotonic()
+
     def mark_in_flight(self, conversation_id: str, response_id: str) -> None:
         """
         Record that *conversation_id* has a live harness turn.

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -249,6 +249,7 @@ class _FakeProcessManager:
         # idle reaper's guard is actually populated for a live turn.
         self.marked_in_flight: list[tuple[str, str]] = []
         self.cleared_in_flight: list[str] = []
+        self.activity_noted: list[str] = []
 
     async def get_client(
         self, conversation_id: str, harness: str, env: Any = None
@@ -265,6 +266,10 @@ class _FakeProcessManager:
     def has_active_turn(self, conversation_id: str) -> bool:
         """Check if a turn is marked active for this conversation."""
         return conversation_id in self._active_turns
+
+    def note_activity(self, conversation_id: str) -> None:
+        """Record an activity lease refresh for a conversation."""
+        self.activity_noted.append(conversation_id)
 
     def mark_turn_active(self, conversation_id: str) -> None:
         """Mark a conversation as having an active turn (test helper)."""

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -39,6 +39,7 @@ from omnigent.runner.resource_registry import (
 )
 from omnigent.spec.types import AgentSpec, ExecutorSpec
 from omnigent.terminals import TerminalListEntry, TerminalRegistry
+from tests.runner.conftest import _FakeProcessManager, _ScriptedHarnessClient
 from tests.runner.helpers import NullServerClient, make_test_terminal_instance
 
 
@@ -280,6 +281,21 @@ class _CapturingResourceRegistry:
                 instance=instance,
             ),
         )
+
+
+def test_terminal_activity_refreshes_harness_idle_lease(tmp_path: Path) -> None:
+    """Runner terminal activity refreshes the owning harness subprocess."""
+    resource_registry = _CapturingResourceRegistry(tmp_path)
+    process_manager = _FakeProcessManager(_ScriptedHarnessClient([]))
+
+    create_runner_app(
+        process_manager=process_manager,  # type: ignore[arg-type]
+        resource_registry=resource_registry,  # type: ignore[arg-type]
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    resource_registry._terminal_activity_publisher("conv_native", "terminal:codex:main")
+
+    assert process_manager.activity_noted == ["conv_native"]
 
 
 @pytest.fixture

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -745,6 +745,36 @@ async def test_idle_reaper_skips_in_flight_turn(
         await fast.shutdown()
 
 
+async def test_native_activity_refresh_prevents_idle_reaping(tmp_path: Path) -> None:
+    """Native terminal activity keeps a harness alive without proxy response ids."""
+    mgr = HarnessProcessManager(idle_timeout_s=0.5, reaper_interval_s=0.05, tmp_parent=tmp_path)
+    entry = _SubprocessEntry(
+        _FakeReapProc(),
+        _SlowCloseClient(0.0),
+        _FakeEndpoint(),
+        "codex-native",
+    )  # type: ignore[arg-type]
+    entry.last_used_at = time.monotonic()
+    mgr._entries = {"conv_native": entry}
+
+    reaper = asyncio.create_task(mgr._idle_reaper_loop())
+    try:
+        for _ in range(10):
+            await asyncio.sleep(0.1)
+            mgr.note_activity("conv_native")
+            assert not entry.process.killed, "active native harness was reaped"
+        assert not mgr.has_active_turn("conv_native")
+
+        deadline = time.monotonic() + 2.0
+        while not entry.process.killed:
+            assert time.monotonic() < deadline, "inactive native harness was never reaped"
+            await asyncio.sleep(0.02)
+    finally:
+        reaper.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await reaper
+
+
 class _FakeReapProc:
     """Minimal process stand-in recording whether the reaper killed it."""
 
@@ -813,9 +843,9 @@ async def test_idle_reaper_spares_turn_started_during_pass(tmp_path: Path) -> No
             assert time.monotonic() < deadline, "reaper never started a pass"
             await asyncio.sleep(0.01)
 
-        # While conv1 tears down, a new turn arrives for conv2: get_client
-        # refreshes last_used_at and the runner marks the response in flight.
-        e2.last_used_at = time.monotonic()
+        # While conv1 tears down, activity refreshes conv2's lease and the
+        # runner marks the response in flight.
+        mgr.note_activity("conv2")
         mgr.mark_in_flight("conv2", "resp_live")
 
         await asyncio.sleep(1.0)


### PR DESCRIPTION
## Related issue

Closes #5067

## Summary

- Refresh an existing harness subprocess's idle lease whenever its session publishes terminal activity, covering native turns that bypass `proxy_stream` and therefore have no in-flight harness response ID.
- Keep proxy response-ID tracking unchanged so cancellation and proxy-turn reaper protection retain their existing semantics.
- Add process-manager and runner-wiring regressions for active native terminals.

This complements #5206: that PR protects the runner-level `runner.idle_timeout_s` watchdog, while this PR protects the harness subprocess reaper controlled by `OMNIGENT_HARNESS_IDLE_TIMEOUT_S`.

ELI5: the native agent works in a terminal outside the usual response stream. Its visible terminal activity now tells the harness reaper that the subprocess is still in use.

```text
native terminal output -> session.terminal.activity -> refresh last_used_at
                                                        |
                                                        v
                                              harness reaper spares it

terminal becomes quiet -> configured idle window elapses -> normal reap
```

## Test Plan

- `uv run --no-sync pytest tests/runtime/harnesses/test_process_manager.py -q` — 40 passed.
- `uv run --no-sync pytest tests/runner/test_session_resources.py -q` — 47 passed.
- `uv run --no-sync pre-commit run --files omnigent/runtime/harnesses/process_manager.py omnigent/runner/app.py tests/runtime/harnesses/test_process_manager.py tests/runner/conftest.py tests/runner/test_session_resources.py` — passed.

## Demo

The two regression scenarios demonstrate that native terminal activity refreshes the harness lease, keeps the subprocess alive past the configured idle timeout, and still permits normal reaping after activity stops.

<img width="1228" height="650" alt="omnigent-5212-demo" src="https://github.com/user-attachments/assets/7493ff44-2283-4df1-9ec7-50e9fe4526b2" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The process-manager regression holds a native harness beyond its idle timeout using activity pulses without an in-flight proxy response, then verifies that it becomes reapable after activity stops. The runner integration test verifies terminal activity reaches that lease-refresh API.

## Changelog

Active native terminal turns no longer lose their harness subprocess when the harness idle timeout expires.
