### PR TITLE
feat(host): bind daemon lifetime to its registry record

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import concurrent.futures
 import contextlib
 import copy
-import hashlib
 import json
 import logging
 import os
@@ -56,6 +55,18 @@ from omnigent.config import (
     load_local_config,
 )
 from omnigent.harness_aliases import canonicalize_harness
+from omnigent.host.daemon_lifecycle import (
+    daemon_record_path as _daemon_record_path_for,
+)
+from omnigent.host.daemon_lifecycle import (
+    daemon_registry_dir as _daemon_registry_dir_for,
+)
+from omnigent.host.daemon_lifecycle import (
+    normalize_daemon_target as _normalize_daemon_target_impl,
+)
+from omnigent.host.daemon_lifecycle import (
+    record_flock_is_held as _record_flock_is_held,
+)
 from omnigent.host.local_server import (
     _DEFAULT_LOCAL_PORT,
     _pid_alive,
@@ -2520,7 +2531,7 @@ def _normalize_daemon_target(server_url: str | None) -> str:
     :returns: ``"local"`` for local mode, otherwise the URL without a
         trailing slash.
     """
-    return _LOCAL_DAEMON_MARKER if not server_url else server_url.rstrip("/")
+    return _normalize_daemon_target_impl(server_url)
 
 
 def _daemon_host_online(record: _HostDaemonRecord, *, timeout_s: float = 2.0) -> bool:
@@ -2571,7 +2582,7 @@ def _daemon_registry_dir() -> Path:
     :returns: Registry directory path, e.g.
         ``Path("~/.omnigent/daemons")``.
     """
-    return _HOST_PID_PATH.parent / "daemons"
+    return _daemon_registry_dir_for(_HOST_PID_PATH.parent)
 
 
 def _daemon_record_path(target: str) -> Path:
@@ -2582,8 +2593,7 @@ def _daemon_record_path(target: str) -> Path:
         ``"https://example.databricksapps.com"`` or ``"local"``.
     :returns: JSON registry path for the target.
     """
-    digest = hashlib.sha256(target.encode("utf-8")).hexdigest()[:16]
-    return _daemon_registry_dir() / f"{digest}.json"
+    return _daemon_record_path_for(target, base_dir=_HOST_PID_PATH.parent)
 
 
 def _record_from_json(raw: _HostJsonObject) -> _HostDaemonRecord | None:
@@ -2870,11 +2880,32 @@ class _DaemonReuseDecision:
     config_changed: bool
 
 
+def _daemon_owner_is_live(record: _HostDaemonRecord, target: str) -> bool:
+    """Whether the daemon that wrote *record* is still alive.
+
+    A held record flock is a definitive live owner (the kernel drops it on
+    death), so it is the fast positive signal. When the lock is free or can't
+    be probed (no ``fcntl``, unreadable), fall back to whether the PID is
+    alive — so a daemon still mid-startup (hasn't grabbed the lock yet) is not
+    reaped. Reaping therefore requires both signals dead: a free lock and a
+    dead PID.
+
+    :param record: Existing daemon record for *target*.
+    :param target: Normalized daemon target, e.g. ``"local"``.
+    :returns: ``True`` if the daemon should be treated as alive.
+    """
+    if _record_flock_is_held(_daemon_record_path(target)) is True:
+        return True
+    return _pid_alive(record.pid)
+
+
 def _reuse_existing_daemon_record(target: str) -> _DaemonReuseDecision:
     """
     Decide whether an existing daemon for *target* can be reused.
 
-    Reuse requires more than a live PID: a daemon whose process is alive
+    Liveness is judged by the record's flock, falling back to a PID check (see
+    :func:`_daemon_owner_is_live`). Reuse requires more than a live owner: a
+    daemon whose process is alive
     but whose server tunnel is down (server restart, ungraceful death,
     flapping tunnel) is a zombie — the host reads ``offline`` and the
     caller would poll until timeout. And a daemon spawned under a
@@ -2897,7 +2928,7 @@ def _reuse_existing_daemon_record(target: str) -> _DaemonReuseDecision:
     existing = _find_daemon_record(target)
     if existing is None:
         return _DaemonReuseDecision(reuse=False, config_changed=False)
-    if not _pid_alive(existing.pid):
+    if not _daemon_owner_is_live(existing, target):
         _delete_daemon_record(existing)
         return _DaemonReuseDecision(reuse=False, config_changed=False)
 
@@ -3057,18 +3088,25 @@ def _live_daemon_conflict(record: _HostDaemonRecord) -> _HostDaemonRecord | None
     """
     Find a live daemon that already serves a foreground record target.
 
+    Liveness uses the record flock, falling back to a PID check (see
+    :func:`_daemon_owner_is_live`).
+
     :param record: Foreground daemon record this process wants to claim.
     :returns: Conflicting live record, or ``None``.
     """
     existing = _find_daemon_record(record.target)
-    if existing is not None and existing.pid != record.pid and _pid_alive(existing.pid):
+    if (
+        existing is not None
+        and existing.pid != record.pid
+        and _daemon_owner_is_live(existing, record.target)
+    ):
         return existing
     if record.mode == "server" and record.server_url is not None:
         local_record = _find_daemon_record(_LOCAL_DAEMON_MARKER)
         if (
             local_record is not None
             and local_record.pid != record.pid
-            and _pid_alive(local_record.pid)
+            and _daemon_owner_is_live(local_record, _LOCAL_DAEMON_MARKER)
             and local_record.resolved_server_url == record.server_url.rstrip("/")
         ):
             return local_record
@@ -8347,7 +8385,7 @@ def host(
         # (or a headless invocation) fails loud with the command to run.
         if remote_mode:
             _ensure_databricks_server_auth(server, non_interactive=non_interactive)
-        run_host_process(server_url=server)
+        run_host_process(server_url=server, daemon_target=target)
         stopped_cleanly = True
     except KeyboardInterrupt:
         # Ctrl-C is the normal way to stop the foreground daemon — swallow it

--- a/omnigent/host/_daemon_entry.py
+++ b/omnigent/host/_daemon_entry.py
@@ -51,17 +51,21 @@ def main() -> None:
         # Both or neither — the CLI always passes exactly one; fail loud.
         parser.error("exactly one of --server <url> or --local is required")
 
+    from omnigent.host.daemon_lifecycle import normalize_daemon_target
+
     if args.local:
         # The daemon owns the local server: start/reuse it, then connect.
         from omnigent.host.local_server import ensure_local_omnigent_server
 
         server_url = ensure_local_omnigent_server().url
+        daemon_target = normalize_daemon_target(None)
     else:
         server_url = args.server
+        daemon_target = normalize_daemon_target(args.server)
 
     from omnigent.host.connect import run_host_process
 
-    run_host_process(server_url=server_url)
+    run_host_process(server_url=server_url, daemon_target=daemon_target)
 
 
 if __name__ == "__main__":

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -33,6 +33,7 @@ from omnigent.gateway_inference import gateway_inference_map
 from omnigent.harness_aliases import canonicalize_harness, is_claude_sdk_harness_name
 from omnigent.harness_availability import HARNESS_BINARY_MISSING, HarnessAvailability
 from omnigent.host import HOST_FATAL_EXIT_CODE
+from omnigent.host.daemon_lifecycle import DaemonLifecycleLock
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
     WORKSPACE_MISSING_ERROR_CODE,
@@ -330,6 +331,15 @@ def _connection_refused(exc: BaseException) -> bool:
 _RECONNECT_BASE_S = 0.5
 _RECONNECT_CAP_S = 3.0
 _RECONNECT_JITTER = 0.5
+# How often the lifecycle monitor re-checks that this daemon still owns its
+# registry record. Cheap local-file read; a stale daemon retiring within a
+# minute is prompt enough, and 60s keeps polling churn negligible.
+# ``OMNIGENT_HOST_LIFECYCLE_POLL_S`` overrides it (e2e tests set it low so the
+# self-terminate path is observable without a minute-long wait).
+try:
+    _LIFECYCLE_POLL_INTERVAL_S = float(os.environ.get("OMNIGENT_HOST_LIFECYCLE_POLL_S", "60"))
+except ValueError:
+    _LIFECYCLE_POLL_INTERVAL_S = 60.0
 # Keep first startup tolerant of a cold server, but do not spend the library's
 # full default timeout on each reconnect after an established tunnel drops.
 _INITIAL_CONNECT_OPEN_TIMEOUT_S = 10.0
@@ -841,11 +851,15 @@ class HostProcess:
         self,
         identity: HostIdentity,
         server_url: str,
+        lifecycle_lock: DaemonLifecycleLock | None = None,
     ) -> None:
         """Initialize the host process.
 
         :param identity: Host identity from ``config.yaml``.
         :param server_url: Server URL to connect to.
+        :param lifecycle_lock: Optional guard binding this daemon's lifetime
+            to its registry record. When present, the daemon holds the lock
+            and self-terminates once the record is deleted or reassigned.
         """
         self._identity = identity
         self._server_url = server_url.rstrip("/")
@@ -946,6 +960,13 @@ class HostProcess:
         # detected resume; read+cleared in run()'s reconnect handler to force a
         # prompt reconnect (skip the backoff).
         self._woke_from_suspend = False
+        # Lifecycle guard: hold the target's flock and watch its registry
+        # record. When the record is deleted/reassigned the monitor sets
+        # _lifecycle_lost and aborts the live tunnel so run() breaks out of its
+        # serve and tears down cleanly instead of lingering as a stale daemon.
+        self._lifecycle_lock = lifecycle_lock
+        self._lifecycle_task: asyncio.Task[None] | None = None
+        self._lifecycle_lost = asyncio.Event()
 
     def _tracked_runner_pids(self) -> set[int]:
         """PIDs of runners this host spawned and still tracks directly.
@@ -2711,6 +2732,61 @@ class HostProcess:
         self._gateway_inference = gateway
         self._capabilities_initialized = True
 
+    async def _lifecycle_monitor_loop(self) -> None:
+        """Self-terminate once this daemon no longer owns its registry record.
+
+        Polls the record; a delete (``omnigent host stop``) or pid change (a
+        newer daemon claimed the target) after we have owned it at least once
+        means this process is stale. It then sets ``_lifecycle_lost`` and aborts
+        the live tunnel (same mechanism as the suspend watcher) so an in-flight
+        :meth:`_connect_and_serve` returns now; :meth:`run` sees the flag and
+        breaks, and its ``finally`` reaps runners and releases the lock.
+
+        The "owned at least once" latch tolerates the startup window where the
+        launching CLI has not written the record yet, so a fresh daemon is not
+        killed before it is registered.
+
+        :returns: None.
+        """
+        lock = self._lifecycle_lock
+        if lock is None:
+            return
+        confirmed = False
+        while True:
+            await asyncio.sleep(_LIFECYCLE_POLL_INTERVAL_S)
+            if await asyncio.to_thread(lock.still_owner):
+                confirmed = True
+                continue
+            if not confirmed:
+                continue
+            _logger.warning(
+                "Host daemon record for %s is gone or reassigned; self-terminating.",
+                lock.target,
+            )
+            self._lifecycle_lost.set()
+            self._abort_live_tunnel()
+            return
+
+    def _abort_live_tunnel(self) -> None:
+        """Abort the live tunnel transport, if any, to break the serve loop.
+
+        Reads ``self._ws`` and aborts synchronously on the event loop, so it is
+        atomic w.r.t. ``_serve_frames``. A no-op when nothing is connected — the
+        top-of-loop / backoff checks in :meth:`run` handle that case.
+
+        :returns: None.
+        """
+        ws = self._ws
+        transport = getattr(ws, "transport", None) if ws is not None else None
+        if transport is not None:
+            # Best-effort: aborting an already-closing/dead transport can raise
+            # a socket-level error. It's harmless here (run() still exits via
+            # _lifecycle_lost), but log it rather than swallow it silently.
+            try:
+                transport.abort()
+            except OSError:
+                _logger.debug("lifecycle tunnel abort raised", exc_info=True)
+
     async def run(self) -> None:
         """Run the host process with reconnection.
 
@@ -2743,6 +2819,13 @@ class HostProcess:
         self._suspend_task = asyncio.create_task(
             watch_for_resume(self._on_resume_from_suspend), name="host-suspend-watch"
         )
+        # Bind this daemon's lifetime to its registry record: hold the target's
+        # flock and watch the record so a stale daemon retires itself.
+        if self._lifecycle_lock is not None:
+            self._lifecycle_lock.acquire()
+            self._lifecycle_task = asyncio.create_task(
+                self._lifecycle_monitor_loop(), name="host-lifecycle-monitor"
+            )
         # Warm the runner zygote now: start() blocks on its one-time import
         # of the runner graph (~1-2s), which otherwise lands inside the first
         # session launch of the daemon's life. Best-effort — a failure
@@ -2755,6 +2838,8 @@ class HostProcess:
         backoff = _RECONNECT_BASE_S
         try:
             while True:
+                if self._lifecycle_lost.is_set():
+                    break
                 try:
                     await self._connect_and_serve()
                     backoff = _RECONNECT_BASE_S
@@ -2766,6 +2851,11 @@ class HostProcess:
                     # ``run_host_process`` can fail loud.
                     raise
                 except Exception as exc:
+                    if self._lifecycle_lost.is_set():
+                        # The lifecycle monitor aborted the tunnel to retire this
+                        # stale daemon; the resulting disconnect is expected, so
+                        # exit cleanly rather than logging a spurious reconnect.
+                        break
                     if not isinstance(exc, InvalidURI):
                         # Any non-redirect failure (5xx bounce, network
                         # blip, mid-serve drop) breaks a login-redirect
@@ -2882,7 +2972,11 @@ class HostProcess:
                         if woke
                         else (" (recycle — prompt reconnect)" if recycle else ""),
                     )
-                    await asyncio.sleep(wait_s)
+                    # Interruptible backoff: wake early if the lifecycle
+                    # monitor loses ownership mid-backoff so the top-of-loop
+                    # check breaks instead of reconnecting one more time.
+                    with contextlib.suppress(asyncio.TimeoutError):
+                        await asyncio.wait_for(self._lifecycle_lost.wait(), timeout=wait_s)
                     import random
 
                     if recycle:
@@ -2907,6 +3001,15 @@ class HostProcess:
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await self._suspend_task
                 self._suspend_task = None
+            if self._lifecycle_task is not None:
+                self._lifecycle_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self._lifecycle_task
+                self._lifecycle_task = None
+            # Release the flock but leave the record deletion to the CLI stop /
+            # takeover paths that own it (this daemon may have been superseded).
+            if self._lifecycle_lock is not None:
+                self._lifecycle_lock.release()
             if self._zygote_prestart_task is not None:
                 self._zygote_prestart_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -3460,6 +3563,8 @@ class HostProcess:
 def run_host_process(
     server_url: str,
     config_path: Path | None = None,
+    *,
+    daemon_target: str | None = None,
 ) -> None:
     """Entry point for ``omnigent host``.
 
@@ -3470,6 +3575,10 @@ def run_host_process(
         ``"https://omnigent-app.databricksapps.com"``.
     :param config_path: Optional path to ``config.yaml``.
         Defaults to ``~/.omnigent/config.yaml``.
+    :param daemon_target: Normalized registry target this process owns, e.g.
+        ``"local"`` or a server URL. When given, the daemon binds its lifetime
+        to that record (flock + self-terminate on delete/reassign). ``None``
+        (the historical default) runs without the lifecycle guard.
     :raises SystemExit: With :data:`HOST_FATAL_EXIT_CODE` when the tunnel
         fails permanently (auth / authorization / outdated server, or a
         loopback server that is gone). The actionable cause is printed
@@ -3504,7 +3613,10 @@ def run_host_process(
     if _cli_log is not None and _cli_log != host_log_path:
         print(f"CLI diagnostics: {display_log_path(_cli_log)}")
 
-    host = HostProcess(identity, server_url)
+    lifecycle_lock = (
+        DaemonLifecycleLock.for_target(daemon_target) if daemon_target is not None else None
+    )
+    host = HostProcess(identity, server_url, lifecycle_lock=lifecycle_lock)
     try:
         asyncio.run(host.run())
     except HostConnectError as exc:

--- a/omnigent/host/daemon_lifecycle.py
+++ b/omnigent/host/daemon_lifecycle.py
@@ -1,0 +1,227 @@
+"""Kernel-backed lifecycle guard binding a host daemon to its registry record.
+
+A host daemon's record lives at ``<data-dir>/daemons/<target-hash>.json`` and
+carries the owning ``pid``. This module lets the daemon *hold* that ownership
+from inside its own process: it takes an exclusive ``flock`` on that record
+file for its whole life (a held lock is a live daemon, immune to PID reuse) and
+watches the same file. If the record is deleted (``omnigent host stop``) or its
+``pid`` no longer matches (a newer daemon claimed the target), the daemon knows
+it is stale and terminates itself.
+
+The flock also serves reuse: :func:`record_flock_is_held` probes it so a
+spin-up can tell a live daemon (reuse it) from a dead one (reap + respawn),
+with a PID check as the fallback when the lock is free or unprobeable. This
+relies on the record being rewritten in place (``Path.write_text``, see
+``cli._write_daemon_record``): an atomic-rename write would swap the inode and
+strand the daemon's flock on the old one, so takeover must keep modifying the
+existing file.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+
+from omnigent.process_logging import data_dir
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows has no flock.
+    fcntl = None  # type: ignore[assignment]
+
+_logger = logging.getLogger(__name__)
+
+_LOCAL_DAEMON_MARKER = "local"
+
+
+def normalize_daemon_target(server_url: str | None) -> str:
+    """Return the registry key for a daemon target.
+
+    :param server_url: Requested server URL, or ``None`` / empty for local mode.
+    :returns: ``"local"`` for local mode, else the URL without a trailing slash.
+    """
+    return _LOCAL_DAEMON_MARKER if not server_url else server_url.rstrip("/")
+
+
+def _target_digest(target: str) -> str:
+    return hashlib.sha256(target.encode("utf-8")).hexdigest()[:16]
+
+
+def daemon_registry_dir(base_dir: Path | None = None) -> Path:
+    """Return the directory holding per-target daemon records.
+
+    :param base_dir: Data-directory override; defaults to :func:`data_dir`.
+    :returns: ``<base>/daemons``.
+    """
+    return (base_dir if base_dir is not None else data_dir()) / "daemons"
+
+
+def daemon_record_path(target: str, *, base_dir: Path | None = None) -> Path:
+    """Return the JSON record path for *target*.
+
+    :param target: Normalized daemon target, e.g. ``"local"``.
+    :param base_dir: Data-directory override; defaults to :func:`data_dir`.
+    :returns: JSON record path.
+    """
+    return daemon_registry_dir(base_dir) / f"{_target_digest(target)}.json"
+
+
+def record_flock_is_held(record_path: Path) -> bool | None:
+    """Return whether a live process holds the record's flock.
+
+    The owning daemon holds this lock for its whole life and the kernel
+    releases it on death (crash / ``SIGKILL`` included), so it is a liveness
+    signal immune to PID reuse: a held lock means the owner is alive; a free
+    lock means it is gone even if its PID was recycled.
+
+    :param record_path: The daemon's ``<hash>.json`` record.
+    :returns: ``True`` if the lock is held (owner alive), ``False`` if it is
+        free (owner dead), or ``None`` when it can't be determined (no
+        ``fcntl``, or the record is missing / unreadable) so the caller falls
+        back to a PID check.
+    """
+    if fcntl is None:
+        return None
+    try:
+        fd = os.open(record_path, os.O_RDONLY)
+    except OSError:
+        return None
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return True
+        except OSError:
+            return None
+        # We took it — the owner is dead. Release at once so we never linger
+        # holding another daemon's lock.
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        return False
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+
+
+class DaemonLifecycleLock:
+    """Kernel-backed ownership handle for one daemon target's registry record."""
+
+    def __init__(
+        self,
+        *,
+        target: str,
+        record_path: Path,
+        pid: int,
+    ) -> None:
+        """Initialize the lifecycle lock.
+
+        :param target: Normalized daemon target, e.g. ``"local"``.
+        :param record_path: JSON record this daemon flocks and must keep owning.
+        :param pid: This daemon's process id.
+        """
+        self._target = target
+        self._record_path = record_path
+        self._pid = pid
+        self._fd: int | None = None
+
+    @classmethod
+    def for_target(
+        cls,
+        target: str,
+        *,
+        base_dir: Path | None = None,
+        pid: int | None = None,
+    ) -> DaemonLifecycleLock:
+        """Build a lock for *target* from the standard registry layout.
+
+        :param target: Normalized daemon target, e.g. ``"local"``.
+        :param base_dir: Data-directory override; defaults to :func:`data_dir`.
+        :param pid: Process id to claim; defaults to the current process.
+        :returns: An unacquired :class:`DaemonLifecycleLock`.
+        """
+        return cls(
+            target=target,
+            record_path=daemon_record_path(target, base_dir=base_dir),
+            pid=pid if pid is not None else os.getpid(),
+        )
+
+    @property
+    def target(self) -> str:
+        """Return the daemon target this lock guards."""
+        return self._target
+
+    def acquire(self) -> bool:
+        """Take the exclusive lifetime lock on the record file.
+
+        Best-effort: a failure (no ``fcntl``, contended lock, IO error) is
+        logged and reported, never raised — the record-based ownership check
+        still guards the daemon even without a held lock. The record's content
+        is owned by the CLI, so we only open + lock it, never truncate or write
+        (that would clobber the record the launching CLI wrote).
+
+        :returns: ``True`` if the flock is now held by this process.
+        """
+        if fcntl is None:
+            return False
+        fd: int | None = None
+        try:
+            self._record_path.parent.mkdir(parents=True, exist_ok=True)
+            fd = os.open(
+                self._record_path,
+                os.O_CREAT | os.O_RDWR | getattr(os, "O_CLOEXEC", 0),
+                0o600,
+            )
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            _logger.warning(
+                "daemon lifecycle lock acquire failed for %s", self._target, exc_info=True
+            )
+            if fd is not None:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+            return False
+        self._fd = fd
+        return True
+
+    def still_owner(self) -> bool:
+        """Return whether the on-disk record still names this process.
+
+        A missing record (``host stop`` deleted it) or a different ``pid`` (a
+        newer daemon claimed the target) both mean this daemon is stale. A
+        transient read error or a partially-written record is treated as
+        "still owner" so a momentary glitch never triggers self-termination;
+        the next poll re-checks.
+
+        :returns: ``True`` while the record exists and its ``pid`` matches;
+            ``False`` when the record is gone or reassigned.
+        """
+        try:
+            raw = self._record_path.read_text()
+        except FileNotFoundError:
+            return False
+        except OSError:
+            return True
+        try:
+            payload = json.loads(raw)
+            record_pid = int(payload["pid"])
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            return True
+        return record_pid == self._pid
+
+    def release(self) -> None:
+        """Release the flock and close the fd, leaving the record in place.
+
+        :returns: None.
+        """
+        if self._fd is None:
+            return
+        if fcntl is not None:
+            with contextlib.suppress(OSError):
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+        with contextlib.suppress(OSError):
+            os.close(self._fd)
+        self._fd = None

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -789,7 +789,7 @@ def test_foreground_connect_registers_status_record(
     monkeypatch.setattr(cli, "_ensure_databricks_server_auth", lambda server, **kw: None)
     observed: list[cli._HostDaemonRecord] = []
 
-    def _fake_run_host_process(server_url: str) -> None:
+    def _fake_run_host_process(server_url: str, **_kw: object) -> None:
         """Capture the foreground registry record during connect execution."""
         observed.extend(cli._list_daemon_records(include_legacy=False))
         assert server_url == "https://server.example.com"
@@ -825,7 +825,7 @@ def test_foreground_connect_refuses_duplicate_live_daemon(
         server_url="https://server.example.com",
     )
 
-    def _unexpected_run_host_process(server_url: str) -> None:
+    def _unexpected_run_host_process(server_url: str, **_kw: object) -> None:
         """Fail if duplicate detection lets the foreground daemon start."""
         raise AssertionError(f"unexpected foreground connect: {server_url}")
 
@@ -877,7 +877,9 @@ def test_foreground_connect_local_prompts_and_stops_server_on_yes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Answering yes at the exit prompt stops the detached local server."""
-    _patch_foreground_host_local(monkeypatch, tmp_path, run_host_process=lambda server_url: None)
+    _patch_foreground_host_local(
+        monkeypatch, tmp_path, run_host_process=lambda server_url, **_kw: None
+    )
     monkeypatch.setattr(cli, "local_server_url_if_healthy", lambda: "http://127.0.0.1:8000")
     stopped: list[bool] = []
     monkeypatch.setattr(cli, "stop_local_omnigent_server", lambda: stopped.append(True))
@@ -894,7 +896,9 @@ def test_foreground_connect_local_prompt_declined_leaves_server(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Answering no at the exit prompt leaves the server running."""
-    _patch_foreground_host_local(monkeypatch, tmp_path, run_host_process=lambda server_url: None)
+    _patch_foreground_host_local(
+        monkeypatch, tmp_path, run_host_process=lambda server_url, **_kw: None
+    )
     monkeypatch.setattr(cli, "local_server_url_if_healthy", lambda: "http://127.0.0.1:8000")
     monkeypatch.setattr(
         cli,
@@ -917,7 +921,9 @@ def test_foreground_connect_local_prompt_aborted_leaves_server(
     or a second Ctrl-C. The prompt must treat that as "no" — never stop the
     server and still exit 0 rather than dying with an ``Aborted!`` trace.
     """
-    _patch_foreground_host_local(monkeypatch, tmp_path, run_host_process=lambda server_url: None)
+    _patch_foreground_host_local(
+        monkeypatch, tmp_path, run_host_process=lambda server_url, **_kw: None
+    )
     monkeypatch.setattr(cli, "local_server_url_if_healthy", lambda: "http://127.0.0.1:8000")
     monkeypatch.setattr(
         cli,
@@ -946,7 +952,7 @@ def test_foreground_connect_local_prompts_after_keyboard_interrupt(
 ) -> None:
     """A Ctrl-C stop (KeyboardInterrupt) still reaches the exit prompt."""
 
-    def _interrupt(server_url: str) -> None:
+    def _interrupt(server_url: str, **_kw: object) -> None:
         """Simulate Ctrl-C stopping the foreground daemon."""
         raise KeyboardInterrupt
 
@@ -968,7 +974,9 @@ def test_foreground_connect_local_no_prompt_when_server_absent(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """No prompt fires when no healthy local server is found at exit."""
-    _patch_foreground_host_local(monkeypatch, tmp_path, run_host_process=lambda server_url: None)
+    _patch_foreground_host_local(
+        monkeypatch, tmp_path, run_host_process=lambda server_url, **_kw: None
+    )
     monkeypatch.setattr(cli, "local_server_url_if_healthy", lambda: None)
     monkeypatch.setattr(
         cli,
@@ -994,7 +1002,7 @@ def test_foreground_connect_reused_server_omits_prompt(
     _patch_foreground_host_local(
         monkeypatch,
         tmp_path,
-        run_host_process=lambda server_url: None,
+        run_host_process=lambda server_url, **_kw: None,
         spawned=False,
     )
     # A healthy server exists, but since we reused it the prompt must not even
@@ -1021,7 +1029,7 @@ def test_foreground_connect_connection_failure_skips_prompt(
 ) -> None:
     """A connection failure (SystemExit) does not prompt over the error."""
 
-    def _fail(server_url: str) -> None:
+    def _fail(server_url: str, **_kw: object) -> None:
         """Simulate a permanent connection failure exiting non-zero."""
         raise SystemExit(1)
 
@@ -1052,7 +1060,7 @@ def test_foreground_connect_remote_omits_local_server_prompt(
     )
     monkeypatch.setattr(
         "omnigent.host.connect.run_host_process",
-        lambda server_url: None,
+        lambda server_url, **_kw: None,
     )
 
     result = CliRunner().invoke(cli_group, ["host", "--server", "https://server.example.com"])
@@ -1924,7 +1932,7 @@ def _patch_foreground_host(
     connected: list[str] = []
     monkeypatch.setattr(
         "omnigent.host.connect.run_host_process",
-        lambda server_url: connected.append(server_url),
+        lambda server_url, **_kw: connected.append(server_url),
     )
     return connected
 
@@ -2252,7 +2260,7 @@ def test_host_command_defaults_scheme_and_accepts_omnigent_web_url(
     observed: list[str] = []
     monkeypatch.setattr(
         "omnigent.host.connect.run_host_process",
-        lambda server_url: observed.append(server_url),
+        lambda server_url, **_kw: observed.append(server_url),
     )
 
     result = CliRunner().invoke(

--- a/tests/e2e/omnigent/test_host_daemon_lifecycle_lock_e2e.py
+++ b/tests/e2e/omnigent/test_host_daemon_lifecycle_lock_e2e.py
@@ -1,0 +1,417 @@
+"""E2E coverage for the host daemon lifecycle-lock self-termination guard.
+
+A running host daemon binds its lifetime to its registry record: it holds an
+exclusive ``flock`` on ``~/.omnigent/daemons/<hash>.json`` and watches that
+same file. When the record is deleted (``omnigent host stop``) or its ``pid``
+is reassigned (a newer daemon claimed the target), the daemon retires itself
+instead of lingering as a stale process.
+
+The guard is exercised against both daemon flavors:
+
+- The **foreground** ``omnigent host ""`` daemon, driven under a PTY. Local
+  mode spawns a detached server, so a clean return from the run loop surfaces
+  the ``Stop it too?`` prompt — its appearance is end-to-end proof that the
+  guard fired and broke the run loop (a daemon that ignored the record would
+  keep serving and never prompt).
+- The **detached background** ``omnigent host --background ""`` daemon (spawned
+  via ``omnigent.host._daemon_entry``) — the real stale-daemon case. There is
+  no terminal, so the test observes the daemon *process* itself: it must die
+  after the record is mutated, and its flock must then be free.
+
+Each flavor is tested for both self-terminate triggers: the record being
+deleted, and its ``pid`` being reassigned to a foreign owner.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pexpect
+
+from tests.e2e.omnigent.test_host_ctrl_c_stop_server import (
+    _BOOT_TIMEOUT,
+    _EXIT_TIMEOUT,
+    _LEFT_RUNNING_MARKER,
+    _POLL_PAUSE,
+    _PROMPT_MARKER,
+    _boot_connect_and_get_server,
+    _connect_env,
+    _force_stop_server,
+    _read_local_server_record,
+    _server_healthy,
+    _spawn_connect,
+)
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows has no flock.
+    fcntl = None  # type: ignore[assignment]
+
+# Production polls the lifecycle record every 60s; drive it fast here so the
+# self-terminate path is observable without a minute-long wait per test.
+_FAST_LIFECYCLE_POLL_S = "1"
+
+# A few fast poll cycles plus daemon teardown; generous so a loaded CI box
+# still observes the self-termination.
+_SELF_TERMINATE_TIMEOUT = 30.0
+_PROMPT_TIMEOUT = 30.0
+
+
+def _lifecycle_env(base_env: dict[str, str], home: Path) -> dict[str, str]:
+    """Isolated subprocess env with the lifecycle monitor polling fast.
+
+    ``OMNIGENT_HOST_LIFECYCLE_POLL_S`` is on the daemon env allowlist (the
+    ``OMNIGENT_`` prefix), so it reaches the detached background daemon too.
+
+    :param base_env: Fixture credential environment.
+    :param home: Isolated HOME for this run.
+    :returns: Environment dict for the CLI/daemon subprocess.
+    """
+    env = _connect_env(base_env, home)
+    env["OMNIGENT_HOST_LIFECYCLE_POLL_S"] = _FAST_LIFECYCLE_POLL_S
+    return env
+
+
+def _wait_for_daemon_record(daemons_dir: Path, *, timeout: float) -> Path:
+    """Wait for the daemon to write its record, then return its path.
+
+    :param daemons_dir: ``<home>/.omnigent/daemons`` for the isolated run.
+    :param timeout: Max seconds to poll for the record to appear.
+    :returns: The ``<hash>.json`` record path for the (single) local daemon.
+    :raises AssertionError: If no record appears within *timeout*.
+    """
+    elapsed = 0.0
+    while elapsed < timeout:
+        records = sorted(daemons_dir.glob("*.json")) if daemons_dir.is_dir() else []
+        if records:
+            return records[0]
+        _POLL_PAUSE.wait(0.25)
+        elapsed += 0.25
+    raise AssertionError(f"daemon record never appeared under {daemons_dir}")
+
+
+def _lock_is_held(record_path: Path) -> bool:
+    """Return whether another process holds the exclusive flock on the record.
+
+    :param record_path: The daemon's ``<hash>.json`` record file.
+    :returns: ``True`` if a non-blocking exclusive lock attempt is refused
+        (i.e. the daemon holds it); ``False`` if we could take it ourselves or
+        the record is gone (a deleted record obviously holds no lock).
+    """
+    assert fcntl is not None, "flock unavailable on this platform"
+    try:
+        fd = os.open(record_path, os.O_RDWR)
+    except FileNotFoundError:
+        return False
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return True
+        # We took it — the daemon is not holding it. Release before reporting.
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        return False
+    finally:
+        os.close(fd)
+
+
+def _assert_daemon_owns_record(record: Path, pid: int) -> None:
+    """Assert the daemon holds the record's flock and the record names its pid.
+
+    :param record: The daemon's JSON registry record (also the flocked file).
+    :param pid: The daemon process id.
+    """
+    assert _lock_is_held(record), f"daemon did not hold the flock on {record}"
+    assert json.loads(record.read_text())["pid"] == pid, "record does not name the daemon pid"
+
+
+def _drive_self_termination(
+    child: pexpect.spawn,
+    home: Path,
+    port: int,
+    mutate: str,
+) -> None:
+    """Mutate the daemon's record, then assert it self-terminates cleanly.
+
+    :param child: Booted ``omnigent host`` pexpect child (the daemon itself).
+    :param home: Isolated HOME holding the daemon registry.
+    :param port: Detached local server port (asserted still up at the end).
+    :param mutate: ``"delete"`` to unlink the record, ``"reassign"`` to
+        rewrite it with a foreign pid.
+    """
+    daemons = home / ".omnigent" / "daemons"
+    record = _wait_for_daemon_record(daemons, timeout=_BOOT_TIMEOUT)
+    _assert_daemon_owns_record(record, child.pid)
+
+    # The monitor self-terminates only after it has confirmed ownership at
+    # least once (the startup-grace latch). One poll cycle guarantees that.
+    _POLL_PAUSE.wait(6.0)
+
+    if mutate == "delete":
+        record.unlink()
+    else:
+        payload = json.loads(record.read_text())
+        payload["pid"] = 999_999  # a pid this daemon can never be
+        record.write_text(json.dumps(payload))
+
+    # Clean return from the run loop surfaces the local-mode stop prompt.
+    child.expect(_PROMPT_MARKER, timeout=_SELF_TERMINATE_TIMEOUT)
+    child.send("n\r")
+    child.expect(_LEFT_RUNNING_MARKER, timeout=_PROMPT_TIMEOUT)
+    child.expect(pexpect.EOF, timeout=_EXIT_TIMEOUT)
+    assert _server_healthy(port), "detached server should survive the daemon retiring"
+
+
+def test_host_daemon_self_terminates_when_record_deleted(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    mock_credentials_env: dict[str, str],
+    tmp_path: Path,
+) -> None:
+    """Deleting the registry record retires the running daemon.
+
+    :param omnigent_python: Python interpreter fixture.
+    :param omnigent_repo_root: Repo root fixture (subprocess cwd).
+    :param mock_credentials_env: Mock-LLM credential environment fixture.
+    :param tmp_path: Per-test temp directory.
+    """
+    home = tmp_path / "home"
+    env = _lifecycle_env(mock_credentials_env, home)
+    child = _spawn_connect(omnigent_python, omnigent_repo_root, env)
+    server_pid = -1
+    try:
+        server_pid, port = _boot_connect_and_get_server(child, home)
+        _drive_self_termination(child, home, port, mutate="delete")
+    finally:
+        if server_pid > 0:
+            _force_stop_server(server_pid)
+        if not child.closed:
+            child.close(force=True)
+
+
+def test_host_daemon_self_terminates_when_record_reassigned(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    mock_credentials_env: dict[str, str],
+    tmp_path: Path,
+) -> None:
+    """Reassigning the record's pid (a newer owner) retires the running daemon.
+
+    :param omnigent_python: Python interpreter fixture.
+    :param omnigent_repo_root: Repo root fixture (subprocess cwd).
+    :param mock_credentials_env: Mock-LLM credential environment fixture.
+    :param tmp_path: Per-test temp directory.
+    """
+    home = tmp_path / "home"
+    env = _lifecycle_env(mock_credentials_env, home)
+    child = _spawn_connect(omnigent_python, omnigent_repo_root, env)
+    server_pid = -1
+    try:
+        server_pid, port = _boot_connect_and_get_server(child, home)
+        _drive_self_termination(child, home, port, mutate="reassign")
+    finally:
+        if server_pid > 0:
+            _force_stop_server(server_pid)
+        if not child.closed:
+            with contextlib.suppress(Exception):
+                child.close(force=True)
+
+
+# ── Detached background daemon (``omnigent host --background``) ──────────────
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return whether *pid* names a live process (signal 0 probe)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _wait_pid_gone(pid: int, *, timeout: float) -> bool:
+    """Poll until *pid* is no longer alive, up to *timeout* seconds."""
+    elapsed = 0.0
+    while elapsed < timeout:
+        if not _pid_alive(pid):
+            return True
+        _POLL_PAUSE.wait(0.25)
+        elapsed += 0.25
+    return not _pid_alive(pid)
+
+
+def _spawn_background_daemon(
+    omnigent_python: Path,
+    repo_root: Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Run ``omnigent host --background ""`` (spawns a detached local daemon).
+
+    :param omnigent_python: Python interpreter fixture.
+    :param repo_root: Checkout root used as the subprocess cwd.
+    :param env: Subprocess environment (isolated HOME) from ``_connect_env``.
+    :returns: The completed process (returns once the daemon has registered).
+    """
+    return subprocess.run(
+        [str(omnigent_python), "-m", "omnigent", "host", "--background", ""],
+        env=dict(env),
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        timeout=_BOOT_TIMEOUT,
+    )
+
+
+def _drive_background_self_termination(home: Path, mutate: str) -> None:
+    """Spawn a detached daemon, mutate its record, and assert it dies.
+
+    :param home: Isolated HOME holding the daemon registry + server pidfile.
+    :param mutate: ``"delete"`` to unlink the record, ``"reassign"`` to rewrite
+        it with a foreign pid.
+    """
+    daemons = home / ".omnigent" / "daemons"
+    record = _wait_for_daemon_record(daemons, timeout=_BOOT_TIMEOUT)
+    daemon_pid = json.loads(record.read_text())["pid"]
+
+    assert _pid_alive(daemon_pid), "background daemon should be alive after spawn"
+    _assert_daemon_owns_record(record, daemon_pid)
+
+    # Confirm-ownership latch: one poll cycle before the guard will act.
+    _POLL_PAUSE.wait(6.0)
+
+    if mutate == "delete":
+        record.unlink()
+    else:
+        payload = json.loads(record.read_text())
+        payload["pid"] = 999_999
+        record.write_text(json.dumps(payload))
+
+    assert _wait_pid_gone(daemon_pid, timeout=_SELF_TERMINATE_TIMEOUT), (
+        f"detached daemon pid {daemon_pid} did not self-terminate after the record was {mutate}d"
+    )
+    # The dead daemon's flock must be free for the next owner to take (a
+    # deleted record trivially holds none; a reassigned one must be unlocked).
+    assert not _lock_is_held(record), "flock was not released after the daemon exited"
+
+
+def _run_background_lifecycle_test(
+    omnigent_python: Path,
+    repo_root: Path,
+    env: dict[str, str],
+    home: Path,
+    mutate: str,
+) -> None:
+    """Boot a detached daemon + server, drive self-termination, then clean up."""
+    proc = _spawn_background_daemon(omnigent_python, repo_root, env)
+    assert proc.returncode == 0, f"background spawn failed (rc={proc.returncode}):\n{proc.stderr}"
+    assert "background" in proc.stdout.lower(), f"unexpected spawn output:\n{proc.stdout}"
+
+    server_pid = -1
+    daemon_pid = -1
+    try:
+        # The detached server outlives the daemon; capture its pid/port so the
+        # assertion can confirm it survived and teardown can stop it.
+        server_pid, port = _read_local_server_record(home)
+        record = next((home / ".omnigent" / "daemons").glob("*.json"))
+        daemon_pid = json.loads(record.read_text())["pid"]
+
+        _drive_background_self_termination(home, mutate)
+
+        assert _server_healthy(port), "detached server should survive the daemon retiring"
+    finally:
+        if daemon_pid > 0 and _pid_alive(daemon_pid):
+            _force_stop_server(daemon_pid)
+        if server_pid > 0:
+            _force_stop_server(server_pid)
+
+
+def test_background_daemon_self_terminates_when_record_deleted(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    mock_credentials_env: dict[str, str],
+    tmp_path: Path,
+) -> None:
+    """A detached ``--background`` daemon dies when its record is deleted.
+
+    :param omnigent_python: Python interpreter fixture.
+    :param omnigent_repo_root: Repo root fixture (subprocess cwd).
+    :param mock_credentials_env: Mock-LLM credential environment fixture.
+    :param tmp_path: Per-test temp directory.
+    """
+    home = tmp_path / "home"
+    env = _lifecycle_env(mock_credentials_env, home)
+    _run_background_lifecycle_test(omnigent_python, omnigent_repo_root, env, home, "delete")
+
+
+def test_background_daemon_self_terminates_when_record_reassigned(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    mock_credentials_env: dict[str, str],
+    tmp_path: Path,
+) -> None:
+    """A detached ``--background`` daemon dies when its record pid is reassigned.
+
+    :param omnigent_python: Python interpreter fixture.
+    :param omnigent_repo_root: Repo root fixture (subprocess cwd).
+    :param mock_credentials_env: Mock-LLM credential environment fixture.
+    :param tmp_path: Per-test temp directory.
+    """
+    home = tmp_path / "home"
+    env = _lifecycle_env(mock_credentials_env, home)
+    _run_background_lifecycle_test(omnigent_python, omnigent_repo_root, env, home, "reassign")
+
+
+def test_background_spawn_reuses_daemon_when_flock_held(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    mock_credentials_env: dict[str, str],
+    tmp_path: Path,
+) -> None:
+    """A second spin-up reuses the live daemon whose record flock is held.
+
+    The first ``--background`` spawn leaves a daemon holding its record's
+    flock. A second spawn must probe that held lock, conclude the owner is
+    alive, and reuse it — same pid, no duplicate daemon.
+
+    :param omnigent_python: Python interpreter fixture.
+    :param omnigent_repo_root: Repo root fixture (subprocess cwd).
+    :param mock_credentials_env: Mock-LLM credential environment fixture.
+    :param tmp_path: Per-test temp directory.
+    """
+    home = tmp_path / "home"
+    env = _lifecycle_env(mock_credentials_env, home)
+    proc1 = _spawn_background_daemon(omnigent_python, omnigent_repo_root, env)
+    assert proc1.returncode == 0, f"first spawn failed (rc={proc1.returncode}):\n{proc1.stderr}"
+
+    daemons = home / ".omnigent" / "daemons"
+    record = _wait_for_daemon_record(daemons, timeout=_BOOT_TIMEOUT)
+    pid1 = json.loads(record.read_text())["pid"]
+    server_pid = -1
+    try:
+        server_pid, _port = _read_local_server_record(home)
+        assert _lock_is_held(record), "first daemon should hold the record flock"
+
+        proc2 = _spawn_background_daemon(omnigent_python, omnigent_repo_root, env)
+        assert proc2.returncode == 0, (
+            f"second spawn failed (rc={proc2.returncode}):\n{proc2.stderr}"
+        )
+        pid2 = json.loads(record.read_text())["pid"]
+        assert pid2 == pid1, (
+            f"flock-held daemon should be reused, not duplicated (pid1={pid1}, pid2={pid2})"
+        )
+        assert "already running" in proc2.stdout.lower(), (
+            f"second spawn should report reuse, got:\n{proc2.stdout}"
+        )
+    finally:
+        if pid1 > 0 and _pid_alive(pid1):
+            _force_stop_server(pid1)
+        if server_pid > 0:
+            _force_stop_server(server_pid)

--- a/tests/host/test_daemon_lifecycle.py
+++ b/tests/host/test_daemon_lifecycle.py
@@ -1,0 +1,231 @@
+"""Tests for the host daemon lifecycle guard (flock + record self-monitor)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from omnigent.host import connect
+from omnigent.host.connect import HostProcess
+from omnigent.host.daemon_lifecycle import (
+    DaemonLifecycleLock,
+    daemon_record_path,
+    normalize_daemon_target,
+    record_flock_is_held,
+)
+from omnigent.host.identity import HostIdentity
+
+
+def _write_record(path: Path, pid: int) -> None:
+    """Write a minimal daemon record naming *pid* as the owner."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"pid": pid, "target": "local", "mode": "local"}))
+
+
+def test_normalize_daemon_target() -> None:
+    assert normalize_daemon_target(None) == "local"
+    assert normalize_daemon_target("") == "local"
+    assert normalize_daemon_target("https://x.example.com/") == "https://x.example.com"
+
+
+def test_record_path_uses_digest(tmp_path: Path) -> None:
+    record = daemon_record_path("local", base_dir=tmp_path)
+    assert record.parent == tmp_path / "daemons"
+    assert record.suffix == ".json"
+    # Same target → same path (stable digest); different target → different.
+    assert daemon_record_path("local", base_dir=tmp_path) == record
+    assert daemon_record_path("https://x.example.com", base_dir=tmp_path) != record
+
+
+def test_acquire_flocks_the_record_and_preserves_content(tmp_path: Path) -> None:
+    record = daemon_record_path("local", base_dir=tmp_path)
+    _write_record(record, 4242)
+    lock = DaemonLifecycleLock.for_target("local", base_dir=tmp_path, pid=4242)
+    assert lock.acquire() is True
+    # Acquiring must not clobber the CLI-owned record content.
+    assert json.loads(record.read_text())["pid"] == 4242
+
+    # A second holder cannot take the record's exclusive lock while held.
+    import fcntl
+
+    fd = os.open(record, os.O_RDWR)
+    try:
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    finally:
+        os.close(fd)
+
+    # After release the lock is free and the record still exists.
+    lock.release()
+    assert record.exists()
+    fd = os.open(record, os.O_RDWR)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def test_acquire_creates_record_when_absent(tmp_path: Path) -> None:
+    # Auto-spawn can start the daemon before the launching CLI writes the
+    # record, so acquire() must create + flock the file rather than fail.
+    lock = DaemonLifecycleLock.for_target("local", base_dir=tmp_path, pid=7)
+    assert lock.acquire() is True
+    assert daemon_record_path("local", base_dir=tmp_path).exists()
+    lock.release()
+
+
+def test_still_owner_delete_and_mismatch(tmp_path: Path) -> None:
+    lock = DaemonLifecycleLock.for_target("local", base_dir=tmp_path, pid=100)
+    record = daemon_record_path("local", base_dir=tmp_path)
+
+    # Missing record: not owner.
+    assert lock.still_owner() is False
+
+    # Matching pid: owner.
+    _write_record(record, 100)
+    assert lock.still_owner() is True
+
+    # Reassigned pid: not owner.
+    _write_record(record, 200)
+    assert lock.still_owner() is False
+
+    # Malformed record: treated as still-owner (transient), never a false kill.
+    record.write_text("{ not json")
+    assert lock.still_owner() is True
+
+
+def test_record_flock_is_held_states(tmp_path: Path) -> None:
+    record = daemon_record_path("local", base_dir=tmp_path)
+
+    # No record file yet → indeterminate.
+    assert record_flock_is_held(record) is None
+
+    # Record exists but unlocked → free (owner dead / never locked).
+    _write_record(record, 100)
+    assert record_flock_is_held(record) is False
+
+    # A held lock → probe reports it held; freed after release.
+    lock = DaemonLifecycleLock.for_target("local", base_dir=tmp_path, pid=100)
+    assert lock.acquire() is True
+    assert record_flock_is_held(record) is True
+    lock.release()
+    assert record_flock_is_held(record) is False
+
+
+def _record(target: str, pid: int) -> object:
+    from omnigent import cli
+
+    return cli._HostDaemonRecord(
+        pid=pid,
+        target=target,
+        mode="local",
+        server_url=None,
+        log_path="x",
+        started_at=100,
+    )
+
+
+def test_daemon_owner_is_live_flock_then_pid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from omnigent import cli
+
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    target = "local"
+    record_path = cli._daemon_record_path(target)
+    _write_record(record_path, 999)
+
+    # Held lock → alive, regardless of the PID check.
+    lock = DaemonLifecycleLock.for_target(target, base_dir=tmp_path, pid=999)
+    assert lock.acquire() is True
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: False)
+    assert cli._daemon_owner_is_live(_record(target, 999), target) is True
+    lock.release()
+
+    # Free lock → fall back to the PID: alive PID (e.g. still starting) → alive.
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    assert cli._daemon_owner_is_live(_record(target, 999), target) is True
+
+    # Free lock + dead PID → dead (the only case that reaps).
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: False)
+    assert cli._daemon_owner_is_live(_record(target, 999), target) is False
+
+
+def test_live_daemon_conflict_uses_flock_then_pid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from omnigent import cli
+
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    target = "local"
+    claimer = _record(target, 111)
+
+    # A different-pid record whose flock is held → a real live conflict.
+    cli._write_daemon_record(_record(target, 222))
+    lock = DaemonLifecycleLock.for_target(target, base_dir=tmp_path, pid=222)
+    assert lock.acquire() is True
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    assert cli._live_daemon_conflict(claimer) is not None
+    lock.release()
+
+    # Free lock + dead PID → the owner is gone, so not a conflict.
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: False)
+    assert cli._live_daemon_conflict(claimer) is None
+
+
+def _host_with_lock(lock: DaemonLifecycleLock) -> HostProcess:
+    return HostProcess(
+        identity=HostIdentity(host_id="host_lifecycle", name="test"),
+        server_url="http://localhost:8000",
+        lifecycle_lock=lock,
+    )
+
+
+async def test_monitor_terminates_after_record_delete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(connect, "_LIFECYCLE_POLL_INTERVAL_S", 0.01)
+    pid = os.getpid()
+    lock = DaemonLifecycleLock.for_target("local", base_dir=tmp_path, pid=pid)
+    record = daemon_record_path("local", base_dir=tmp_path)
+    _write_record(record, pid)
+
+    host = _host_with_lock(lock)
+
+    monitor = asyncio.create_task(host._lifecycle_monitor_loop())
+    try:
+        # Let it confirm ownership, then delete the record.
+        await asyncio.sleep(0.05)
+        assert not host._lifecycle_lost.is_set()
+        record.unlink()
+        # On loss it sets the flag (and aborts the tunnel — a no-op here, no
+        # live _ws) so run() breaks, then returns on its own.
+        await asyncio.wait_for(host._lifecycle_lost.wait(), timeout=2.0)
+        await asyncio.wait_for(monitor, timeout=1.0)
+    finally:
+        if not monitor.done():
+            monitor.cancel()
+
+
+async def test_monitor_startup_grace_before_first_ownership(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No record exists yet (the launching CLI has not written it). The monitor
+    # must not self-terminate until it has owned the record at least once.
+    monkeypatch.setattr(connect, "_LIFECYCLE_POLL_INTERVAL_S", 0.01)
+    lock = DaemonLifecycleLock.for_target("local", base_dir=tmp_path, pid=os.getpid())
+    host = _host_with_lock(lock)
+
+    monitor = asyncio.create_task(host._lifecycle_monitor_loop())
+    try:
+        await asyncio.sleep(0.1)
+        assert not host._lifecycle_lost.is_set()
+    finally:
+        monitor.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await monitor


### PR DESCRIPTION
## Related issue

N/A — reliability fix for stale/lingering host daemons.

## Summary

A host daemon's record (`~/.omnigent/daemons/<hash>.json`) carries the owning pid, but nothing tied the running process to it, so a superseded or stopped daemon could linger. This binds the daemon's lifetime to its record with an `flock`:

- The daemon **flocks its own record** for its whole life. The kernel drops the lock the instant the process dies (crash / SIGKILL included), so a held lock is a live owner.
- It **watches the record** and self-terminates (cancels its serve loop, tears down cleanly) when the record is **deleted** (`omnigent host stop`) or its **pid is reassigned** (a newer daemon claimed the target).
- **Spin-up reuse and foreground conflict detection judge liveness by the flock, falling back to a pid check**: a held lock → reuse the live host; when the lock is free or can't be probed, the pid decides. So a daemon is reaped only when the lock is **free and the pid is dead** — the pid fallback keeps a daemon that's still mid-startup (hasn't grabbed the lock yet) from being reaped.

The target-hash + normalize helpers move to a new `omnigent/host/daemon_lifecycle.py`; `cli.py` delegates so the CLI and daemon never drift on the record path. Best-effort throughout: without `fcntl` (Windows) liveness falls back to the pid check.

ELI5: each daemon holds a key to its own name-tag and keeps glancing at the tag. Tear the tag off or rename it and the daemon packs up and leaves. Anyone starting a host checks whether the key is held (or, failing that, whether the pid is still alive) before deciding to reuse it or start fresh.

```
running daemon ─▶ record deleted / pid reassigned ─▶ cancel serve, exit
spin up host   ─▶ record flock held? ─ yes ─▶ reuse the live daemon
                                     └ no  ─▶ pid alive? ─ yes ─▶ reuse
                                                          └ no  ─▶ reap, spawn fresh
```

## Test Plan

- `pytest tests/host/test_daemon_lifecycle.py` — unit: the flock probe (`record_flock_is_held`) held/free/absent states, `acquire` flocks the record without clobbering its content, `still_owner` delete/mismatch/malformed, the liveness helper (held → alive; free + live pid → alive; free + dead pid → dead), the flock-then-pid conflict check, and the monitor self-terminating on delete + startup-grace latch.
- `pytest tests/host/test_connect.py tests/host/test_cli_host.py tests/cli/test_backend.py` — 250+ passing (serve-loop restructuring + reuse/conflict + foreground-connect regression check).
- `pytest tests/e2e/omnigent/test_host_daemon_lifecycle_lock_e2e.py` — 5 E2E against a live local server: the **foreground** `omnigent host` daemon and the **detached** `omnigent host --background` daemon each self-terminate on record delete and pid reassign (background asserts the process dies and its flock frees); and a second `--background` spin-up **reuses** the flock-held daemon instead of duplicating it.
- `pytest tests/e2e/omnigent/test_host_ctrl_c_stop_server.py` — 3 passing (clean-shutdown path unchanged).
- `ruff format` / `ruff check` / `pyrefly` clean.

## Demo

N/A — non-visual (host daemon lifecycle).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the live-CLI E2E above (real `omnigent host` + local server, record mutated out from under the daemon, and a real second spin-up reusing the flock-held daemon). Unit tests cover the flock probe and the liveness/conflict decision; E2E covers end-to-end self-termination, clean teardown, and reuse.

## Changelog

Stale host daemons now retire themselves when their registry record is removed or claimed by a newer daemon, and a second host spin-up reuses the running daemon instead of duplicating it.
