### PR TITLE
feat(web): count pill on collapsed sidebar section headers

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_collapsed_count.py
+++ b/tests/e2e_ui/sessions/test_sidebar_collapsed_count.py
@@ -1,0 +1,54 @@
+"""Browser e2e for the collapsed-section hidden-row count pill.
+
+A collapsed sidebar section header carries no at-rest cue, so before the
+count pill a collapsed section was indistinguishable from an empty one —
+with every session filed into projects, the sidebar could read as having
+no sessions at all. Collapsing a section now surfaces a count pill
+(Inbox-badge styling) on its header showing how many rows it hides;
+expanding removes it.
+
+This drives the full chain the Sidebar unit test can't: a real session
+row in a live server's list, the header toggle persisting to
+localStorage, and the pill rendering against the built bundle.
+"""
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Page, expect
+
+
+def test_collapsed_sessions_header_shows_hidden_count(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Collapsing the Sessions header shows a hidden-row count pill.
+
+    - Expanded (default): no pill anywhere in the sidebar.
+    - Collapsed: the header shows a pill counting the hidden rows, and the
+      rows themselves are gone.
+    - Re-expanded: the pill disappears and the rows return.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # The collapsed header appends the count to its accessible name, so
+    # match the title prefix to address it in both states.
+    header = page.get_by_role("button", name=re.compile(r"^Sessions"))
+    pill = page.get_by_test_id("section-collapsed-count")
+
+    expect(header).to_be_visible()
+    expect(pill).to_have_count(0)
+
+    header.click()
+    expect(pill).to_be_visible()
+    assert int(pill.inner_text()) >= 1
+    expect(pill).to_have_attribute("aria-label", re.compile(r"hidden item"))
+
+    header.click()
+    expect(pill).to_have_count(0)

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -1228,7 +1228,8 @@ describe("Sidebar collapsible sections", () => {
     fireEvent.click(screen.getByRole("button", { name: "Sessions" }));
     expect(screen.queryByText("conv_mine")).toBeNull();
     expect(screen.queryByText("conv_mine_two")).toBeNull();
-    expect(screen.getByRole("button", { name: "Sessions" })).toBeInTheDocument();
+    // Collapsed headers append the hidden-row count to their accessible name.
+    expect(screen.getByRole("button", { name: /^Sessions/ })).toBeInTheDocument();
 
     // Fresh mount re-reads localStorage: still collapsed. If this fails,
     // the toggle wrote state only to memory and reloads lose it.
@@ -1236,9 +1237,51 @@ describe("Sidebar collapsible sections", () => {
     renderSidebar();
     expect(screen.queryByText("conv_mine")).toBeNull();
 
-    // Expanding brings the rows back.
-    fireEvent.click(screen.getByRole("button", { name: "Sessions" }));
+    // Expanding brings the rows back. (Collapsed headers append the hidden-row
+    // count to their accessible name, so match on the title prefix.)
+    fireEvent.click(screen.getByRole("button", { name: /^Sessions/ }));
     expect(screen.getByText("conv_mine")).toBeInTheDocument();
+  });
+});
+
+// A collapsed section surfaces a count pill of the rows it hides — without
+// it, a collapsed section is indistinguishable from an empty one and the
+// sidebar can read as having no sessions at all.
+describe("Sidebar collapsed section count pill", () => {
+  it("shows the hidden-row count on a collapsed Sessions header and removes it on expand", () => {
+    mockConversations([conv("conv_mine", "Claude Code"), conv("conv_mine_two", "Claude Code")]);
+    renderSidebar();
+
+    // Expanded: no pill — the rows themselves are visible.
+    expect(screen.queryByTestId("section-collapsed-count")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Sessions" }));
+    const pill = screen.getByTestId("section-collapsed-count");
+    expect(pill).toHaveTextContent("2");
+    expect(pill).toHaveAttribute("aria-label", "2 hidden items");
+
+    fireEvent.click(screen.getByRole("button", { name: /^Sessions/ }));
+    expect(screen.queryByTestId("section-collapsed-count")).toBeNull();
+  });
+
+  it("shows the project count on the collapsed Projects group header", () => {
+    projectsMock.push("Customer X", "Customer Y");
+    mockConversations([
+      conv("conv_filed", "Claude Code", { labels: { omni_project: "Customer X" } }),
+    ]);
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Projects" }));
+    const projectsSection = screen.getByText("Projects").closest("section")!;
+    expect(within(projectsSection).getByTestId("section-collapsed-count")).toHaveTextContent("2");
+  });
+
+  it("shows no pill when the collapsed section is genuinely empty", () => {
+    mockConversations([]);
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Sessions" }));
+    expect(screen.queryByTestId("section-collapsed-count")).toBeNull();
   });
 });
 
@@ -1269,7 +1312,7 @@ describe("Sidebar load-more vs collapsed Sessions", () => {
     // Collapsed Sessions hides its rows AND the pagination affordance.
     expect(screen.queryByText("conv_mine")).toBeNull();
     expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Sessions" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Sessions/ }));
     expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
   });
 
@@ -1620,8 +1663,9 @@ describe("Sidebar project sections", () => {
     expect(screen.queryByTestId("collapse-all-projects")).toBeNull();
     closeProjectsMenu();
 
-    // Re-expanding the group brings it back.
-    fireEvent.click(screen.getByRole("button", { name: "Projects" }));
+    // Re-expanding the group brings it back. (Collapsed headers append the
+    // hidden-row count to their accessible name.)
+    fireEvent.click(screen.getByRole("button", { name: /^Projects/ }));
     openProjectsMenu();
     expect(screen.getByTestId("expand-all-projects")).toBeInTheDocument();
   });

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1907,6 +1907,7 @@ function ConversationList({
                     <ConversationSection
                       title="Pinned"
                       conversations={sections.pinned}
+                      count={sections.pinned.length}
                       pinnedConversationIds={pinnedConversationIds}
                       collapsed={effectiveCollapsedSections.includes("Pinned")}
                       onToggleCollapsed={() => effectiveToggleSectionCollapsed("Pinned")}
@@ -1928,6 +1929,7 @@ function ConversationList({
               vanish when switching to Shared or Archived. */}
                 <SectionGroup
                   title="Projects"
+                  count={sections.projectGroups.length}
                   collapsed={effectiveCollapsedSections.includes("Projects")}
                   onToggleCollapsed={() => effectiveToggleSectionCollapsed("Projects")}
                   afterHeader={
@@ -2005,6 +2007,7 @@ function ConversationList({
                     <ConversationSection
                       title="Sessions"
                       conversations={sections.sessions}
+                      count={sections.sessions.length}
                       emptyMessage={SIDEBAR_FILTER_EMPTY[activeTab]}
                       pinnedConversationIds={pinnedConversationIds}
                       collapsed={effectiveCollapsedSections.includes("Chats")}
@@ -2204,30 +2207,50 @@ function SectionHeader({
   title,
   icon,
   marker,
+  count,
   active = false,
   hasAction,
+  mobileAction = true,
+  hasPersistentAction,
   collapsed,
   onToggleCollapsed,
 }: {
   title: string;
   icon?: ReactNode;
   marker?: SessionState | null;
+  /** When collapsed, how many rows the section hides — shown as a count pill
+      so a collapsed section can't read as an empty one. */
+  count?: number;
   /** Whether this header represents the current page context. */
   active?: boolean;
   /** Whether the section also renders a hover-revealed header action (the
       project-folder kebab), which shares the header's right edge with the
       collapsed marker. */
   hasAction?: boolean;
+  /** Whether that hover-revealed action is also always shown on mobile,
+      reserving right-edge space there. False for desktop-only overlays
+      (the Projects group's controls). */
+  mobileAction?: boolean;
+  /** Whether an always-visible control sits at the header's right edge (the
+      Sessions filter), which the count pill must clear at rest. */
+  hasPersistentAction?: boolean;
   collapsed: boolean;
   onToggleCollapsed: () => void;
 }) {
+  const showCount = collapsed && count != null && count > 0;
   return (
     <h2>
       <button
         type="button"
         aria-expanded={!collapsed}
         aria-current={active ? "page" : undefined}
-        onClick={onToggleCollapsed}
+        onClick={(event) => {
+          // A pointer click would otherwise leave the header focus-within,
+          // keeping the hover-revealed controls up and the count pill faded
+          // at rest. Keyboard toggles (detail 0) keep focus for the ring.
+          if (event.detail > 0) event.currentTarget.blur();
+          onToggleCollapsed();
+        }}
         className={
           icon
             ? cn(
@@ -2270,6 +2293,25 @@ function SectionHeader({
               : "md:opacity-0 md:group-hover:opacity-100 md:group-focus-visible:opacity-100",
           )}
         />
+        {/* Collapsed sections surface how many rows they hide as a count pill
+            at the right edge (same column as the Inbox badge) — without it a
+            collapsed section is indistinguishable from an empty one. It clears
+            a persistent right-edge control at rest and fades while the
+            hover-revealed controls take that edge. */}
+        {showCount && (
+          <span
+            aria-label={count === 1 ? "1 hidden item" : `${count} hidden items`}
+            data-testid="section-collapsed-count"
+            className={cn(
+              "ml-auto inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-[var(--sidebar-active)] px-1 font-medium text-10 text-[var(--sidebar-active-foreground)] tabular-nums transition-opacity",
+              hasAction && mobileAction ? "mr-14" : "mr-2",
+              hasPersistentAction ? "md:mr-7" : "md:mr-2",
+              hasAction && "md:group-hover/header:opacity-0 md:group-focus-within/header:opacity-0",
+            )}
+          >
+            {count}
+          </span>
+        )}
         {/* A hidden row inside this collapsed section carries a marker — surface
             the exact same badge a row would show, pinned to the right edge. */}
         {collapsed && marker && (
@@ -2434,6 +2476,7 @@ function SectionGroup({
   title,
   collapsed,
   onToggleCollapsed,
+  count,
   headerAction,
   afterHeader,
   children,
@@ -2441,6 +2484,8 @@ function SectionGroup({
   title: string;
   collapsed: boolean;
   onToggleCollapsed: () => void;
+  /** When collapsed, how many child sections the group hides (count pill). */
+  count?: number;
   /** Optional control overlaid at the group header's right edge (e.g. the
       "collapse all projects" toggle). Hover/focus-revealed on desktop. */
   headerAction?: ReactNode;
@@ -2454,7 +2499,9 @@ function SectionGroup({
       <div className="group/header relative">
         <SectionHeader
           title={title}
+          count={count}
           hasAction={headerAction != null}
+          mobileAction={false}
           collapsed={collapsed}
           onToggleCollapsed={onToggleCollapsed}
         />
@@ -2481,6 +2528,7 @@ function ConversationSection({
   title,
   icon,
   marker,
+  count,
   active,
   conversations,
   pinnedConversationIds,
@@ -2504,6 +2552,10 @@ function ConversationSection({
   icon?: ReactNode;
   /** When collapsed, the aggregate marker of hidden rows (same badge as a row). */
   marker?: SessionState | null;
+  /** When collapsed, how many rows the section hides (count pill). Omitted on
+      project folders — a collapsed folder hasn't fetched its own sessions, so
+      its window count would under-report. */
+  count?: number;
   /** Whether this section header represents the current page context. */
   active?: boolean;
   conversations: Conversation[];
@@ -2548,8 +2600,10 @@ function ConversationSection({
             title={title}
             icon={icon}
             marker={marker}
+            count={count}
             active={active}
             hasAction={headerAction != null || persistentHeaderAction != null}
+            hasPersistentAction={persistentHeaderAction != null}
             collapsed={isCollapsed}
             onToggleCollapsed={onToggleCollapsed}
           />


### PR DESCRIPTION
## Related issue

Closes #5201

## Summary

A collapsed sidebar section header had no at-rest cue, so it was indistinguishable from an empty one. With every session filed into projects and the Projects group collapsed, the sidebar read as having no sessions at all — presenting as data loss (see the issue for the multi-hour debugging session this caused).

- Collapsed **Pinned / Projects / Sessions** headers now show a count pill (Inbox-badge styling, same right-edge column as the Inbox badge) with the number of rows they hide; expanding removes it.
- The pill clears a persistent right-edge control (the Sessions filter) at rest, and fades while the hover-revealed header controls take that edge — mirroring how the collapsed-state marker badge already yields.
- Pointer clicks on a section header now blur it: without this, the toggle click left the header focus-within, which kept the hover-revealed controls up and the pill faded at rest — hiding it right after the collapse that makes it relevant. Keyboard toggles keep focus (and the focus ring); keyboard users get the count through the accessible name.
- Project folder rows deliberately carry no count: a collapsed folder hasn't fetched its own sessions, so a count from the global list window would under-report.
- The pill's `aria-label` joins the header button's accessible name (collapsed headers read as e.g. "Sessions 2 hidden items"), matching how folder rows already extend their names.

Per the issue discussion, the always-visible-chevron alternative was rejected as counter to the current hover-only chevron design.

**ELI5:** when you fold a sidebar section shut, a little numbered badge — same look and position as the Inbox badge — appears on its header telling you how many things are tucked inside, so a folded section can't be mistaken for an empty one.

## Test Plan

- `vitest run src/shell/Sidebar.test.tsx` — 80/80 pass, including 3 new tests: pill shows the hidden-row count on a collapsed Sessions header and clears on expand; the collapsed Projects group header shows the project count; a genuinely empty collapsed section shows no pill.
- New e2e (`tests/e2e_ui/sessions/test_sidebar_collapsed_count.py`) drives the built bundle against the live harness: collapse the Sessions header → pill present with count ≥ 1 and a "hidden item(s)" aria-label → expand → pill gone.
- Full `src/shell` vitest suite: the only failures (3 in `NewChatDialog.test.tsx`) fail identically on clean `origin/main` — pre-existing, unrelated.
- `tsc -b` and `pre-commit` (prettier, oxlint, type check) pass.

## Demo

At rest, the collapsed Projects group shows how many projects it hides, right-aligned in the Inbox badge's column:

![Collapsed Projects header with count pill at rest](https://raw.githubusercontent.com/btli/omnigent/demo-assets/sidebar-count-pill-rest.png)

On hover, the header controls take the right edge and the pill fades out of their way:

![Hovered collapsed Projects header showing controls, pill faded](https://raw.githubusercontent.com/btli/omnigent/demo-assets/sidebar-count-pill-hover.png)

A collapsed Sessions section: the pill sits clear of the persistent filter control (and an empty collapsed Projects section correctly shows no pill):

![Collapsed Sessions header with count pill beside the filter icon](https://raw.githubusercontent.com/btli/omnigent/demo-assets/sidebar-count-pill-sessions.png)

Before (the reported confusion — collapsed Projects looked empty, "No sessions" below): see the screenshot in #5201.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: captured the demo screenshots above from the live e2e harness (built bundle, real server) — collapsed state at rest, hovered state to confirm the pill yields to the hover-revealed controls, and a collapsed Sessions section to confirm the pill clears the persistent filter control.

## Changelog

Collapsed sidebar sections (Pinned, Projects, Sessions) now show a count badge of the items they hide, so a collapsed section can't be mistaken for an empty one.

---
This pull request and its description were written by Isaac.
