### PR TITLE
Let an agent spec supply its own picker blurb

### DIFF
--- a/omnigent/server/routes/builtin_agents.py
+++ b/omnigent/server/routes/builtin_agents.py
@@ -54,6 +54,7 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
     skills: list[SkillSummary] = []
     terminals: list[str] = []
     harness: str | None = None
+    short_description: str | None = None
     # Prefer the stored entity's description; fall back to the spec's
     # top-level description when the stored value is unset (single-file
     # YAML agents don't persist it at registration today). Lets the
@@ -69,6 +70,7 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
         )
         if description is None:
             description = loaded.spec.description
+        short_description = loaded.spec.short_description
         # Declared terminal names, in spec order (mirrors the
         # session-agent endpoint so both report it consistently).
         terminals = list(loaded.spec.terminals or {})
@@ -102,6 +104,7 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
         name=agent.name,
         version=agent.version,
         description=description,
+        short_description=short_description,
         created_at=agent.created_at,
         updated_at=agent.updated_at,
         harness=harness,

--- a/omnigent/server/routes/sessions/routes_permissions.py
+++ b/omnigent/server/routes/sessions/routes_permissions.py
@@ -391,6 +391,7 @@ def _to_agent_object(agent: Agent, cache: AgentCache | None) -> AgentObject:
     # Harness/kind for the UI; None until the spec loads (mirrors the
     # GET /v1/agents catalog so both endpoints report it consistently).
     harness: str | None = None
+    short_description: str | None = None
     # Prefer the stored entity's description; fall back to the spec's
     # top-level description when the stored value is unset (single-file
     # YAML agents don't persist it at registration today). Lets the
@@ -404,6 +405,7 @@ def _to_agent_object(agent: Agent, cache: AgentCache | None) -> AgentObject:
             harness = loaded.spec.executor.harness_kind
             if description is None:
                 description = loaded.spec.description
+            short_description = loaded.spec.short_description
             # Declared terminal names, in spec order — the Web UI
             # gates its "new terminal" affordance on this list.
             terminals = list(loaded.spec.terminals or {})
@@ -450,6 +452,7 @@ def _to_agent_object(agent: Agent, cache: AgentCache | None) -> AgentObject:
         name=agent.name,
         version=agent.version,
         description=description,
+        short_description=short_description,
         created_at=agent.created_at,
         updated_at=agent.updated_at,
         harness=harness,

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -224,6 +224,11 @@ class AgentObject(BaseModel):
         incremented on each update.
     :param description: Optional free-text description of the
         agent's purpose.
+    :param short_description: Optional one-line blurb from the
+        spec's ``short_description:``, for compact UI surfaces
+        (e.g. a picker row) where ``description`` would truncate
+        badly. ``None`` when the spec declares none or the bundle
+        cannot be loaded.
     :param created_at: Unix epoch timestamp of creation.
     :param updated_at: Unix epoch timestamp of the last update,
         or ``None`` if never updated.
@@ -278,6 +283,7 @@ class AgentObject(BaseModel):
     name: str
     version: int = 1
     description: str | None = None
+    short_description: str | None = None
     created_at: int
     updated_at: int | None = None
     harness: str | None = None

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -290,6 +290,7 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
         spec_version=spec_version,
         name=raw.get("name"),
         description=raw.get("description"),
+        short_description=raw.get("short_description"),
         llm=llm,
         interaction=interaction,
         tools=tools_config,

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -1413,6 +1413,10 @@ class AgentSpec:  # type: ignore[explicit-any]  # params: dict[str, Any] field (
         must be ``1``.
     :param name: Human-readable agent name, e.g. ``"code-reviewer"``.
     :param description: Short summary of the agent's purpose.
+    :param short_description: Optional one-line blurb for compact
+        UI surfaces (e.g. a picker row) where ``description`` would
+        truncate badly. ``None`` means the agent declares no
+        ``short_description:``.
     :param llm: LLM configuration. ``None`` means the agent does not
         declare an LLM preference.
     :param interaction: Conversational mode and modality settings.
@@ -1525,6 +1529,7 @@ class AgentSpec:  # type: ignore[explicit-any]  # params: dict[str, Any] field (
     spec_version: int
     name: str | None = None
     description: str | None = None
+    short_description: str | None = None
     llm: LLMConfig | None = None
     interaction: InteractionConfig = field(default_factory=InteractionConfig)
     tools: ToolsConfig = field(default_factory=ToolsConfig)

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -672,6 +672,7 @@ def register_test_runner(
 def build_agent_bundle(
     name: str,
     description: str | None = None,
+    short_description: str | None = None,
     sub_agents: list[dict[str, Any]] | None = None,
     max_iterations: int | None = None,
     executor: dict[str, Any] | None = None,
@@ -690,6 +691,7 @@ def build_agent_bundle(
 
     :param name: Agent name, e.g. ``"test-agent"``.
     :param description: Optional description.
+    :param short_description: Optional one-line picker blurb.
     :param sub_agents: Optional list of sub-agent config dicts.
         Each must have at least a ``"name"`` key, e.g.
         ``[{"name": "researcher", "description": "..."}]``.
@@ -733,6 +735,8 @@ def build_agent_bundle(
         }
     if description is not None:
         config["description"] = description
+    if short_description is not None:
+        config["short_description"] = short_description
     if guardrails is not None:
         config["guardrails"] = guardrails
     if terminals is not None:
@@ -894,6 +898,7 @@ async def create_test_session(
     client: httpx.AsyncClient,
     name: str = "test-agent",
     description: str | None = None,
+    short_description: str | None = None,
     title: str | None = None,
     labels: dict[str, str] | None = None,
     max_iterations: int | None = None,
@@ -912,6 +917,7 @@ async def create_test_session(
     :param name: Agent name to write into the uploaded bundle, e.g.
         ``"test-agent"``.
     :param description: Optional agent description.
+    :param short_description: Optional one-line picker blurb.
     :param title: Optional session title, e.g. ``"debug run"``.
     :param labels: Optional initial labels, e.g.
         ``{"env": "test"}``.
@@ -931,6 +937,7 @@ async def create_test_session(
     bundle = build_agent_bundle(
         name=name,
         description=description,
+        short_description=short_description,
         max_iterations=max_iterations,
         executor=executor,
         skills=skills,

--- a/tests/server/integration/test_builtin_agents.py
+++ b/tests/server/integration/test_builtin_agents.py
@@ -216,6 +216,70 @@ async def test_list_builtin_agents_exposes_declared_terminals_from_spec(
     assert entry["terminals"] == ["shell", "py"]
 
 
+async def test_list_builtin_agents_exposes_short_description_from_spec(
+    agent_store: SqlAlchemyAgentStore,
+    artifact_store: LocalArtifactStore,
+    agents_client: httpx.AsyncClient,
+) -> None:
+    """
+    ``GET /v1/agents`` reports each agent's declared ``short_description:``.
+
+    The Web UI picker prefers this over its hardcoded blurb map so any
+    agent — not just the two entries in that map — can supply its own
+    compact picker-row text.
+    """
+    bundle = build_agent_bundle(
+        name="short-desc-agent",
+        description="A much longer paragraph meant for a hover tooltip.",
+        short_description="One-line picker blurb",
+    )
+    _register_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_id="9a6a0e0f9e6a4c6cbf5f6a0a4a6a6a6a",
+        name="short-desc-agent",
+        bundle=bundle,
+    )
+
+    resp = await agents_client.get("/v1/agents")
+
+    assert resp.status_code == 200, resp.text
+    entry = next(a for a in resp.json()["data"] if a["id"] == "9a6a0e0f9e6a4c6cbf5f6a0a4a6a6a6a")
+    # Proves the spec's short_description traversed the load → AgentObject
+    # path verbatim, independent of the long-form description.
+    assert entry["short_description"] == "One-line picker blurb"
+    assert entry["description"] == "A much longer paragraph meant for a hover tooltip."
+
+
+async def test_list_builtin_agents_short_description_absent_when_undeclared(
+    agent_store: SqlAlchemyAgentStore,
+    artifact_store: LocalArtifactStore,
+    agents_client: httpx.AsyncClient,
+) -> None:
+    """
+    ``short_description`` is ``None`` when the spec declares none —
+    the new field must not change the response for every existing
+    agent that doesn't set it.
+    """
+    bundle = build_agent_bundle(name="no-short-desc-agent")
+    _register_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_id="1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b",
+        name="no-short-desc-agent",
+        bundle=bundle,
+    )
+
+    resp = await agents_client.get("/v1/agents")
+
+    assert resp.status_code == 200, resp.text
+    entry = next(a for a in resp.json()["data"] if a["id"] == "1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b")
+    # Matches the sibling nullable fields on AgentObject (description,
+    # harness, updated_at), which this endpoint also emits as null rather
+    # than omitting — the model deliberately does not use exclude_none.
+    assert entry["short_description"] is None
+
+
 async def test_list_builtin_agents_exposes_bundled_skills_from_spec(
     agent_store: SqlAlchemyAgentStore,
     artifact_store: LocalArtifactStore,

--- a/tests/server/integration/test_session_mcp_servers.py
+++ b/tests/server/integration/test_session_mcp_servers.py
@@ -284,6 +284,56 @@ async def test_update_mcp_server_clears_headers_when_empty_dict_sent(
     assert "headers" not in mcp_file
 
 
+# GET /v1/sessions/{id}/agent shares its AgentObject-building code with
+# GET /v1/agents (both call a `_to_agent_object`), so this module — the one
+# that already exercises this route for mcp_servers — is also where its
+# other spec-sourced fields get covered, not just MCP-specific ones.
+async def test_session_agent_exposes_short_description_from_spec(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    ``GET /v1/sessions/{id}/agent`` reports the agent's declared
+    ``short_description:``, independent of the long-form ``description``.
+
+    Proves the field traverses this endpoint's spec-load path too, not
+    just the ``GET /v1/agents`` catalog's.
+    """
+    session = await create_test_session(
+        client,
+        name="short-desc-session-agent",
+        description="A much longer paragraph meant for a hover tooltip.",
+        short_description="One-line picker blurb",
+    )
+    session_id = session["id"]
+
+    agent_resp = await client.get(f"/v1/sessions/{session_id}/agent")
+
+    assert agent_resp.status_code == 200, agent_resp.text
+    entry = agent_resp.json()
+    assert entry["short_description"] == "One-line picker blurb"
+    assert entry["description"] == "A much longer paragraph meant for a hover tooltip."
+
+
+async def test_session_agent_short_description_none_when_undeclared(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    ``short_description`` is ``None`` on ``GET /v1/sessions/{id}/agent``
+    when the spec declares none.
+
+    Matches the sibling nullable fields on AgentObject (description,
+    harness, updated_at), which this endpoint also emits as null rather
+    than omitting — the model deliberately does not use exclude_none.
+    """
+    session = await create_test_session(client, name="no-short-desc-session-agent")
+    session_id = session["id"]
+
+    agent_resp = await client.get(f"/v1/sessions/{session_id}/agent")
+
+    assert agent_resp.status_code == 200, agent_resp.text
+    assert agent_resp.json()["short_description"] is None
+
+
 async def _agent_bundle(client: httpx.AsyncClient, session_id: str) -> bytes:
     """Download the session agent bundle."""
     resp = await client.get(f"/v1/sessions/{session_id}/agent/contents")

--- a/web/src/hooks/useAvailableAgents.test.tsx
+++ b/web/src/hooks/useAvailableAgents.test.tsx
@@ -309,6 +309,41 @@ describe("useAvailableAgents", () => {
     ]);
   });
 
+  it("passes through a spec-provided short_description, omitting the key when the server doesn't send one", async () => {
+    routeFetch({
+      [BUILTINS_URL]: mockResponse({
+        object: "list",
+        data: [
+          {
+            id: "ag_custom",
+            name: "custom-reviewer",
+            description: "A much longer paragraph meant for a hover tooltip.",
+            short_description: "Reviews PRs",
+            harness: "claude-sdk",
+          },
+          // No short_description at all — mirrors an older server that
+          // predates the field.
+          { id: "ag_plain", name: "plain-agent", harness: "claude-sdk" },
+        ],
+        has_more: false,
+      }),
+      [SCAN_URL]: EMPTY_SCAN,
+    });
+
+    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const custom = result.current.data?.find((a) => a.id === "ag_custom");
+    expect(custom?.short_description).toBe("Reviews PRs");
+
+    const plain = result.current.data?.find((a) => a.id === "ag_plain");
+    // Absent on the wire → absent on the mapped object (not `null`), so
+    // the picker's `??` fallback to AGENT_PICKER_DESCRIPTIONS still applies
+    // and existing `toEqual` assertions elsewhere in this file don't gain
+    // an unexpected key.
+    expect(plain).not.toHaveProperty("short_description");
+  });
+
   it("defaults a missing harness to null", async () => {
     routeFetch({
       [BUILTINS_URL]: mockResponse({

--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -14,6 +14,11 @@ export interface AvailableAgent {
   name: string;
   display_name: string;
   description: string | null;
+  // One-line picker blurb from the spec's `short_description:`, e.g.
+  // "Multi-agent coding". null when the spec declares none or the
+  // server predates the field. The picker prefers this over its
+  // hardcoded AGENT_PICKER_DESCRIPTIONS fallback map.
+  short_description?: string | null;
   // Harness/kind from GET /v1/agents, e.g. "codex", "codex-native",
   // "claude-native", or "claude-sdk". null when the server couldn't load
   // the agent's spec. Lets the picker recognise Codex vs Claude agents
@@ -97,6 +102,7 @@ interface BuiltinAgentWire {
   id: string;
   name: string;
   description?: string | null;
+  short_description?: string | null;
   harness?: string | null;
   skills?: { name: string; description: string }[];
   // True only for server-seeded built-ins (deterministic id). Absent on
@@ -147,6 +153,11 @@ async function fetchBuiltinAgents(): Promise<AvailableAgent[]> {
     description: a.description ?? null,
     harness: a.harness ?? null,
     skills: a.skills ?? [],
+    // Omit rather than set to null/undefined so toEqual comparisons aren't
+    // sensitive to an absent key — mirrors the builtin/created_at spreads
+    // below. The picker's `agent.short_description ?? fallbackMap[name]`
+    // treats a missing key the same as null.
+    ...(a.short_description !== undefined ? { short_description: a.short_description } : {}),
     // Omit rather than set to undefined so toEqual comparisons aren't
     // sensitive to absent-vs-undefined. Logic that reads builtin treats
     // undefined as "protected" (same as true), so omission is safe.

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2708,6 +2708,71 @@ describe("NewChatLandingScreen skills menu", () => {
   });
 });
 
+// Picker-row blurb: an agent's own spec `short_description` takes
+// precedence over the hardcoded AGENT_PICKER_DESCRIPTIONS fallback map,
+// so any agent can supply its own compact picker text, not just polly/debby.
+describe("NewChatLandingScreen agent picker blurb", () => {
+  beforeEach(setupLandingMocks);
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("prefers a spec-provided short_description over the fallback map", () => {
+    mockAgents([
+      {
+        id: "a_polly",
+        name: "polly",
+        display_name: "Polly",
+        description: null,
+        short_description: "Spec-provided blurb",
+        harness: "claude-sdk",
+        skills: [],
+      },
+    ]);
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    const row = screen.getByTestId("new-chat-landing-agent-a_polly");
+    expect(row.textContent).toContain("Spec-provided blurb");
+    expect(row.textContent).not.toContain("Multi-agent coding");
+  });
+
+  it("keeps polly's fallback blurb unchanged when its spec sets no short_description", () => {
+    mockAgents([
+      {
+        id: "a_polly",
+        name: "polly",
+        display_name: "Polly",
+        description: null,
+        harness: "claude-sdk",
+        skills: [],
+      },
+    ]);
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    const row = screen.getByTestId("new-chat-landing-agent-a_polly");
+    expect(row.textContent).toContain("Multi-agent coding");
+  });
+
+  it("renders a spec-provided short_description for an agent outside the fallback map", () => {
+    mockAgents([
+      {
+        id: "a2",
+        name: "codex-native-ui",
+        display_name: "Codex",
+        description: "A much longer paragraph meant for a hover tooltip.",
+        short_description: "Fast agentic coding",
+        harness: "codex-native",
+        skills: [],
+      },
+    ]);
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    const row = screen.getByTestId("new-chat-landing-agent-a2");
+    expect(row.textContent).toContain("Fast agentic coding");
+  });
+});
+
 // Always-visible skill pills under the landing composer for allowlisted
 // orchestrators (polly/debby): pills surface bundled skills without
 // typing "/", and clicking one prefills the composer — it never sends.

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -227,6 +227,9 @@ const NEW_SESSION_HIDDEN_AGENTS = new Set(["nessie", "kimi", "kimi-code"]);
 
 // Short picker-row blurbs — the spec descriptions are long paragraphs that
 // truncate badly in the dropdown; other dialogs keep the server values.
+// Fallback only: an agent's own spec `short_description:` (surfaced as
+// `AvailableAgent.short_description`) takes precedence over this map, so
+// only agents without one need an entry here.
 const AGENT_PICKER_DESCRIPTIONS: Record<string, string> = {
   polly: "Multi-agent coding",
   debby: "Multi-agent debate",
@@ -1063,7 +1066,7 @@ export function AgentHarnessPicker({
   // hover. Run-config knobs now live in the gear-icon config modal, not here —
   // this picker only selects the agent / harness.
   const renderRowInner = (agent: AvailableAgent, withTooltip: boolean) => {
-    const blurb = AGENT_PICKER_DESCRIPTIONS[agent.name];
+    const blurb = agent.short_description ?? AGENT_PICKER_DESCRIPTIONS[agent.name];
     const inner = (
       <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
         <span className="truncate">{agent.display_name}</span>


### PR DESCRIPTION
### The gap

The new-session picker shows a short blurb beside an agent's name, sourced from a hardcoded map in `web/src/shell/NewChatDialog.tsx`:

```ts
// Short picker-row blurbs — the spec descriptions are long paragraphs that
// truncate badly in the dropdown; other dialogs keep the server values.
const AGENT_PICKER_DESCRIPTIONS: Record<string, string> = {
  polly: "Multi-agent coding",
  debby: "Multi-agent debate",
};
```

It has two entries, keyed on literal agent name. Every other agent — including other built-ins, and any agent an operator seeds via `OMNIGENT_BUILTIN_AGENT_DIRS` — renders with no blurb at all, leaving only the full spec `description`, which is exactly the truncation problem the comment describes. There is no spec field that can supply one.

### The change

Add an optional `AgentSpec.short_description`, parsed the same way as `description`, and surface it on `AgentObject` from both agent-serialising endpoints (`GET /v1/agents` and `GET /v1/sessions/{id}/agent`). The picker prefers it, falling back to the existing map.

Precedence: spec `short_description` → `AGENT_PICKER_DESCRIPTIONS` → no blurb.

### Compatibility

Backwards compatible by design:

- The field is optional everywhere; with it absent, behaviour is unchanged.
- `AGENT_PICKER_DESCRIPTIONS` is **retained**, so `polly` and `debby` render exactly as they do today.
- `short_description` serialises as `null` when undeclared, matching the existing nullable siblings on `AgentObject` (`description`, `harness`, `updated_at`) — this model deliberately does not use `exclude_none`.
- The frontend types it as optional, so an older server that omits it degrades cleanly.

### Tests

Present and absent cases for **both** endpoints, plus frontend coverage that the mapper and the picker's precedence behave correctly and that an agent without the field is unaffected.

### Notes for maintainers

Happy to rename the field or take a different approach — `short_description` was chosen to match the existing snake_case spec/API convention and to read as a sibling of `description`, but it is your call. I have deliberately not set it on the packaged example specs, to keep the diff small; say the word if you would prefer it added there.
