### PR TITLE
fix(codex-native): honor Max/Ultra reasoning levels instead of coercing to xhigh

### DIFF
--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -40,7 +40,11 @@ from omnigent.inner.native_attachments import (
     parse_data_uri,
     unresolved_attachment_marker,
 )
-from omnigent.reasoning_effort import CODEX_EFFORTS, effort_for_model_switch, validate_effort
+from omnigent.reasoning_effort import (
+    CODEX_NATIVE_EFFORTS,
+    effort_for_model_switch,
+    validate_effort,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -379,7 +383,7 @@ def _model_effort_overrides(config: ExecutorConfig | None) -> dict[str, object]:
         overrides["model"] = model
     raw_effort = config.extra.get("reasoning_effort")
     try:
-        effort = validate_effort(raw_effort, "codex", CODEX_EFFORTS)
+        effort = validate_effort(raw_effort, "codex", CODEX_NATIVE_EFFORTS)
     except ValueError:
         # A bad effort must not sink the turn — drop it and keep Codex's
         # current effort rather than failing the whole dispatch.

--- a/omnigent/reasoning_effort.py
+++ b/omnigent/reasoning_effort.py
@@ -8,23 +8,29 @@ from types import MappingProxyType
 
 from omnigent.llms.errors import PermanentLLMError
 
-EFFORT_VALUES = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max"})
+EFFORT_VALUES = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"})
 EFFORT_CLEAR_VALUES = frozenset({"default", "off", "reset"})
 
-# Deprecated / vendor-written effort values mapped to the canonical value to
-# use instead. The ChatGPT desktop app writes ``model_reasoning_effort =
-# "ultra"`` into ``~/.codex/config.toml``, and the codex CLI forwards it as
-# the retired ``max`` wire value — the OpenAI Responses API accepts neither
-# (its ladder tops out at ``xhigh``). ``validate_effort`` coerces an alias
-# only when the raw value is unsupported but the canonical value IS
-# supported, so providers that genuinely support ``max`` (Anthropic) keep it
-# unchanged.
+# Fold a value to a canonical one, but only where the target ladder lacks it:
+# ``validate_effort`` applies an alias only when the raw value is unsupported
+# but the canonical one is. On the SDK/Responses codex ladder (``CODEX_EFFORTS``,
+# capped at ``xhigh``) the ChatGPT app's ``ultra`` / retired ``max`` fold to
+# ``xhigh``; ladders that carry them (codex-native ``CODEX_NATIVE_EFFORTS``,
+# Anthropic's ``max``) keep them unchanged.
 EFFORT_ALIASES: dict[str, str] = {"ultra": "xhigh", "max": "xhigh"}
 
 OPENAI_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh"})
 ANTHROPIC_EFFORTS = frozenset({"low", "medium", "high", "xhigh", "max"})
 CLAUDE_EFFORTS = ANTHROPIC_EFFORTS
 CODEX_EFFORTS = OPENAI_EFFORTS
+# Codex-native drives the real codex process, which is the per-model authority
+# on reasoning levels — it advertises them via ``model/list`` and validates the
+# pairing itself. Sol reaches ``ultra``; the picker already gates which levels a
+# model offers, so accept codex's full ladder here rather than re-clamping a
+# valid pick down to ``xhigh``.
+CODEX_NATIVE_EFFORTS = frozenset(
+    {"none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"}
+)
 OPENAI_AGENTS_EFFORTS = OPENAI_EFFORTS
 GEMINI_EFFORTS = frozenset({"low", "medium", "high"})
 ANTIGRAVITY_EFFORTS = GEMINI_EFFORTS
@@ -36,7 +42,7 @@ COPILOT_EFFORTS = frozenset({"low", "medium", "high", "xhigh"})
 
 def format_supported(values: Iterable[str]) -> str:
     """Return a stable comma-separated supported-values string."""
-    order = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+    order = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
     values_set = set(values)
     return ", ".join(value for value in order if value in values_set)
 

--- a/omnigent/reasoning_effort.py
+++ b/omnigent/reasoning_effort.py
@@ -67,8 +67,10 @@ def unsupported_effort_message(effort: str, provider: str, supported: Iterable[s
 # above stay frozen: they are the wire APIs' own vocabularies.
 _MODEL_EFFORT_FALLBACK: Mapping[str, str] = MappingProxyType({"glm-5-2": "medium"})
 # Efforts a fallback model cannot accept, so a pinned high value coerces down.
+# GLM tops out at ``high``, so every rung above it (``xhigh``/``max``/``ultra``)
+# is unsupported.
 _MODEL_EFFORT_UNSUPPORTED: Mapping[str, frozenset[str]] = MappingProxyType(
-    {"glm-5-2": frozenset({"xhigh", "max"})}
+    {"glm-5-2": frozenset({"xhigh", "max", "ultra"})}
 )
 
 

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -4814,7 +4814,7 @@ async def _cmd_theme(
     host.output(_build_preview(selected.name))
 
 
-_EFFORT_VALUES = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+_EFFORT_VALUES = ("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra")
 _EFFORT_CLEAR_ALIASES = {"default", "off", "reset"}
 
 
@@ -4880,7 +4880,8 @@ async def _cmd_effort(
         host.output(
             Text.from_markup(
                 "  [bold red]Invalid effort: "
-                f"{value} · expected none, minimal, low, medium, high, xhigh, max, or default[/]"
+                f"{value} · expected none, minimal, low, medium, high, "
+                "xhigh, max, ultra, or default[/]"
             )
         )
         return

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1485,7 +1485,7 @@ class SessionCreateMetadata(BaseModel):
     :param reasoning_effort: Optional per-session reasoning-effort
         hint. Accepted metadata values are ``"none"``,
         ``"minimal"``, ``"low"``, ``"medium"``, ``"high"``,
-        ``"xhigh"``, and ``"max"``. Provider-specific support is
+        ``"xhigh"``, ``"max"``, and ``"ultra"``. Provider-specific support is
         validated when a turn executes. ``None`` means use the agent
         default.
     :param host_id: Optional host to launch the runner on, e.g.

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -973,6 +973,40 @@ def test_settings_update_drops_invalid_effort_keeps_model(
     assert "effort" not in params
 
 
+@pytest.mark.parametrize("effort", ["ultra", "max"])
+def test_settings_update_forwards_codex_high_reasoning_levels(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    effort: str,
+) -> None:
+    """
+    Sol's ``max``/``ultra`` reach the wire instead of coercing to ``xhigh``.
+
+    Codex advertises these as per-model reasoning levels and honors a turn at
+    them (Sol's ``ultra`` runs subagents), so a web-picked level must ride
+    through on ``thread/settings/update`` unchanged rather than being clamped.
+    """
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    _start_state(tmp_path)
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    _run_turn_with_config(
+        executor,
+        "hi",
+        ExecutorConfig(model="gpt-5.6-sol", extra={"reasoning_effort": effort}),
+    )
+
+    method, params = _FakeCodexNativeClient.requests[0]
+    assert method == "thread/settings/update"
+    assert params["effort"] == effort
+
+
 def test_run_turn_surfaces_recorded_startup_error(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/runner/test_app_sessions_native_events_options.py
+++ b/tests/runner/test_app_sessions_native_events_options.py
@@ -34,12 +34,11 @@ from tests.runner.helpers import NullServerClient
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "effort_value",
-    # ``EFFORT_VALUES`` is a superset of ``CLAUDE_EFFORTS``:
-    # PATCH accepts {none, minimal, low, medium, high, xhigh, max}
-    # but Claude Code's ``/effort`` slash only accepts the last five.
-    # ``none`` and ``minimal`` must skip injection (typing ``/effort
-    # none`` would land as a TUI error). ``None`` (clear) must skip
-    # too — Claude has no slash form for "use spawn default".
+    # ``EFFORT_VALUES`` is a superset of ``CLAUDE_EFFORTS``: PATCH accepts the
+    # full effort vocabulary, but Claude Code's ``/effort`` slash only accepts
+    # low/medium/high/xhigh/max. ``none`` and ``minimal`` must skip injection
+    # (typing ``/effort none`` would land as a TUI error). ``None`` (clear) must
+    # skip too — Claude has no slash form for "use spawn default".
     ["none", "minimal", None],
 )
 async def test_events_effort_change_on_native_session_skips_inject_for_unsupported_level(

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -17,6 +17,7 @@ import pytest
 from omnigent.reasoning_effort import (
     ANTHROPIC_EFFORTS,
     CODEX_EFFORTS,
+    CODEX_NATIVE_EFFORTS,
     DEFAULT_MODEL_EFFORT_CAPS,
     EFFORT_VALUES,
     ModelEffortCaps,
@@ -37,14 +38,25 @@ def test_max_coerces_to_xhigh_for_codex() -> None:
     assert validate_effort("max", "codex", CODEX_EFFORTS) == "xhigh"
 
 
-def test_ultra_coerces_for_session_metadata_vocabulary() -> None:
-    """A terminal-observed ``ultra`` effort change is accepted as ``xhigh``.
+def test_codex_native_accepts_max_and_ultra() -> None:
+    """Codex-native honors the real per-model ladder — max/ultra pass through.
 
-    Regression: the codex-native forwarder posts the effort the codex TUI
-    reports; a ChatGPT-app-configured terminal reports ``ultra``, which the
-    server used to reject with ``invalid_input``.
+    The SDK/Responses codex ladder still caps at ``xhigh`` (see the tests
+    above), but codex-native drives the real codex process, which accepts
+    Sol's ``max``/``ultra``, so they must not fold to ``xhigh``.
     """
-    assert validate_effort("ultra", "session metadata", EFFORT_VALUES) == "xhigh"
+    assert validate_effort("ultra", "codex", CODEX_NATIVE_EFFORTS) == "ultra"
+    assert validate_effort("max", "codex", CODEX_NATIVE_EFFORTS) == "max"
+
+
+def test_ultra_preserved_in_session_metadata_vocabulary() -> None:
+    """A terminal-observed ``ultra`` effort change is stored as ``ultra``.
+
+    The codex-native forwarder mirrors the level the codex TUI reports; Sol's
+    ``ultra`` is a real reasoning level, so the session metadata keeps it
+    verbatim (the UI shows the true level) rather than folding it to ``xhigh``.
+    """
+    assert validate_effort("ultra", "session metadata", EFFORT_VALUES) == "ultra"
 
 
 def test_max_stays_max_where_supported() -> None:

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -95,9 +95,9 @@ def test_none_and_empty_clear_effort() -> None:
     "model",
     ["glm-5-2", "databricks-glm-5-2", "system.ai.glm-5-2", "GLM-5-2", "system.ai.glm-5.2"],
 )
-@pytest.mark.parametrize("effort", ["xhigh", "max"])
+@pytest.mark.parametrize("effort", ["xhigh", "max", "ultra"])
 def test_glm_clamps_unsupported_effort_to_medium(model: str, effort: str) -> None:
-    """Every GLM spelling coerces xhigh/max down to medium."""
+    """Every GLM spelling coerces every above-high rung (xhigh/max/ultra) to medium."""
     assert clamp_effort_for_model(effort, model) == "medium"
 
 

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -2071,6 +2071,76 @@ describe("Composer config gear", () => {
     expect(calls).toEqual(["model", "effort"]);
   });
 
+  it("recomputes the Codex effort ladder for the drafted model and drops an unsupported level", async () => {
+    // Codex advertises a per-model effort ladder. Drafting a lower-ceiling
+    // model (Luna, no "ultra") must refresh the dropdown to that model's levels
+    // and drop a picked level it can't run — else Save would send Sol's "ultra"
+    // to Luna, and the dropdown would show a rung Luna rejects.
+    const codexOptions = [
+      {
+        id: "gpt-5.6-sol",
+        model: "gpt-5.6-sol",
+        displayName: "GPT-5.6-Sol",
+        isDefault: true,
+        supportedReasoningEfforts: [
+          { reasoningEffort: "low" },
+          { reasoningEffort: "medium" },
+          { reasoningEffort: "high" },
+          { reasoningEffort: "xhigh" },
+          { reasoningEffort: "max" },
+          { reasoningEffort: "ultra" },
+        ],
+      },
+      {
+        id: "gpt-5.6-luna",
+        model: "gpt-5.6-luna",
+        displayName: "GPT-5.6-Luna",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "low" },
+          { reasoningEffort: "medium" },
+          { reasoningEffort: "high" },
+          { reasoningEffort: "xhigh" },
+          { reasoningEffort: "max" },
+        ],
+      },
+    ] as never;
+    useChatStore.setState({
+      setModel: vi.fn().mockResolvedValue(undefined),
+      setEffort: vi.fn().mockResolvedValue(undefined),
+      selectedEffort: "ultra",
+      llmModel: "gpt-5.6-sol",
+      codexModelOptions: codexOptions,
+      refreshSessionOverrides: vi.fn().mockResolvedValue(undefined),
+    });
+    renderWithTooltips(
+      <Composer
+        {...composerProps({
+          showModels: true,
+          showEffort: true,
+          modelPickerKind: "codex",
+          effortLevels: ["low", "medium", "high", "xhigh", "max", "ultra"],
+          codexModelOptions: codexOptions,
+        })}
+      />,
+    );
+    fireEvent.click(gear()!);
+    await screen.findByTestId("composer-config-modal");
+
+    // Sol starts on ultra.
+    expect(screen.getByTestId("composer-config-effort")).toHaveTextContent("ultra");
+
+    // Draft a switch to Luna, whose ceiling is "max".
+    fireEvent.click(document.querySelector('[data-testid="composer-config-model"]') as Element);
+    fireEvent.click(document.querySelector('[data-model-id="gpt-5.6-luna"]') as Element);
+
+    // The picked ultra is dropped (back to Default) and no longer offered,
+    // while Luna's own max stays.
+    expect(screen.getByTestId("composer-config-effort")).toHaveTextContent("Default");
+    fireEvent.click(document.querySelector('[data-testid="composer-config-effort"]') as Element);
+    expect(document.querySelector('[data-effort-level="ultra"]')).toBeNull();
+    expect(document.querySelector('[data-effort-level="max"]')).not.toBeNull();
+  });
+
   it("skips unchanged knobs on Save (no spurious slash-command injection)", async () => {
     const setModel = vi.fn().mockResolvedValue(undefined);
     const setEffort = vi.fn().mockResolvedValue(undefined);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -6379,6 +6379,33 @@ function SessionConfigModal({
   // drafted model, else the "Default" sentinel (no override).
   const modelValue = draftRoutingOn ? MODEL_SELECT_SMART : (draftModelId ?? MODEL_SELECT_DEFAULT);
 
+  // Codex advertises a per-model effort ladder, so the dropdown must follow the
+  // DRAFTED model, not the committed one the parent computed — else picking
+  // Luna still lists Sol's "ultra". "Default" (null) resolves to the catalog
+  // default; non-codex harnesses use a model-independent ladder, so keep the
+  // parent's list.
+  const draftEffortLevels = useMemo(() => {
+    if (modelPickerKind !== "codex") return effortLevels;
+    const modelForEffort =
+      draftModelId ?? codexModelOptions.find((o) => o.isDefault)?.id ?? llmModel;
+    const levels = codexEffortLevelsForModel(codexModelOptions, modelForEffort);
+    return levels.length > 0 ? levels : effortLevels;
+  }, [modelPickerKind, codexModelOptions, draftModelId, llmModel, effortLevels]);
+
+  // Drop a picked level the newly-drafted model doesn't offer (Sol's "ultra"
+  // when switching to Luna) so no stale rung shows and Save never submits a
+  // level the model rejects.
+  const clampDraftEffortToModel = (modelId: string | null) => {
+    if (modelPickerKind !== "codex") return;
+    setDraftEffort((prev) => {
+      if (prev === null) return null;
+      const modelForEffort = modelId ?? codexModelOptions.find((o) => o.isDefault)?.id ?? llmModel;
+      return codexEffortLevelsForModel(codexModelOptions, modelForEffort).includes(prev)
+        ? prev
+        : null;
+    });
+  };
+
   const onModelChange = (value: string) => {
     if (value === MODEL_SELECT_SMART) {
       setDraftRoutingOn(true);
@@ -6389,10 +6416,12 @@ function SessionConfigModal({
     } else if (value === MODEL_SELECT_DEFAULT) {
       setDraftModelId(null);
       setDraftRoutingOn(false);
+      clampDraftEffortToModel(null);
     } else {
       // Pinning a model turns routing off (mutually exclusive).
       setDraftModelId(value);
       setDraftRoutingOn(false);
+      clampDraftEffortToModel(value);
     }
   };
 
@@ -6538,7 +6567,7 @@ function SessionConfigModal({
                   className="w-(--radix-select-trigger-width)"
                 >
                   <SelectItem value={EFFORT_SELECT_NONE}>Default</SelectItem>
-                  {effortLevels.map((level) => (
+                  {draftEffortLevels.map((level) => (
                     <SelectItem
                       key={level}
                       value={level}


### PR DESCRIPTION
## Related issue

OMNI-4255 (Linear — auto-linked via the branch name). Supersedes the suppression approach in #5122 (now closed).

## Summary

- **Max and Ultra are real, per-model Codex reasoning levels** — not a separate "mode." Codex's `model/list` advertises them in `supportedReasoningEfforts` (Sol reaches `ultra`, Luna reaches `max`), and a turn at them completes end-to-end (Sol's `ultra` runs subagents — verified live in the codex TUI).
- Omnigent's picker already surfaces them, but the **codex-native effort override validated against the `xhigh`-capped `CODEX_EFFORTS` ladder**, so a web-picked Max/Ultra was silently coerced to `xhigh` before the wire (`_codex_session_overrides`). The TUI→web effort mirror also stored `ultra` as `xhigh`, so the status label showed the wrong level.
- Fix: validate codex-native efforts against the **full codex ladder** (`CODEX_NATIVE_EFFORTS`) — codex is the per-model authority and the picker already gates which levels a model offers — and add `ultra` to the session-metadata vocabulary so the real level is stored and shown.
- The **SDK/Responses** codex path keeps the `xhigh` cap + `ultra`/`max`→`xhigh` alias, preserving OMNI-1694's defensive fold on that different backend.

### Follow-up in this PR — effort ladder follows the drafted model

Once Max/Ultra work, a related UI bug surfaced: the Configure Codex **Effort** dropdown mapped a static list computed from the *committed* model, so switching the model inside the modal (Sol → Luna) still listed Sol's `ultra`, with the stale level left selected — Save would then send `ultra` to Luna, which rejects it. Fixed in `SessionConfigModal`: the effort ladder is recomputed from the **drafted** model, and a picked level the new model doesn't offer is dropped (reset to Default). Regression test in `ChatPage.composer.test.tsx`.

### Background

This replaces #5122, which took the opposite (wrong) approach — hiding Max/Ultra from the picker to match the coercion. Verification on a live codex-native Sol session showed a turn at Ultra completes, so the correct fix is to let the levels through, not suppress them.

## Test Plan

- `uv run --group test python -m pytest tests/test_reasoning_effort.py tests/inner/test_codex_native_executor.py` — 59 passed, including new coverage:
  - `test_codex_native_accepts_max_and_ultra` — `validate_effort(..., CODEX_NATIVE_EFFORTS)` returns `ultra`/`max` unchanged.
  - `test_settings_update_forwards_codex_high_reasoning_levels[ultra|max]` — a web-picked level rides through on `thread/settings/update` unchanged.
  - `test_ultra_preserved_in_session_metadata_vocabulary` — the TUI mirror stores `ultra` as `ultra`.
- `vitest run src/pages/ChatPage.composer.test.tsx src/pages/effortLevels.test.ts src/pages/modelPicker.test.ts` — 180 passed, including the new "recomputes the Codex effort ladder for the drafted model and drops an unsupported level" case.
- `ruff format` / `ruff check` / `pyrefly check` clean on the Python files; `tsc` / `oxlint` / prettier clean on the frontend files.
- Endpoints effort test + runtime effort-validation suites pass. (Two pre-existing `test_app_sessions_native_events_options.py` failures — `Terminal registry not configured` — reproduce on stock `main` and are unrelated to this change.)
- Manual (live codex-native Sol session): composer gear → Configure Codex → Effort → pick **Ultra** → send a turn → it completes and the status label reads `ultra` (not `xhigh`).


<img width="924" height="954" alt="image" src="https://github.com/user-attachments/assets/be692518-f33e-4679-a394-4a88d51359f1" />


<img width="924" height="954" alt="image" src="https://github.com/user-attachments/assets/2b74c3ce-576d-4f19-a325-a9f6a2dabffb" />

<img width="924" height="954" alt="image" src="https://github.com/user-attachments/assets/5b5b875a-bd6f-4156-8521-2d5762ba3c50" />


## Demo

Live codex TUI, Sol session at Ultra (subagents spawned, turn completed):

```
Model changed to gpt-5.6-sol ultra for this conversation
> Say hello to 3 subagents please
  Spawned … (gpt-5.6-sol ultra) ×3  → Completed
status bar: gpt-5.6-sol ultra
```

Per-model ladders (from `supportedReasoningEfforts`): Sol offers Max **and** Ultra; Luna offers Max only — which this change now honors instead of collapsing to `xhigh`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: confirmed on a live codex-native GPT-5.6-Sol session that a turn at Ultra completes and the effort mirrors back as `ultra`. Automated coverage pins the server passthrough (`_model_effort_overrides`), the vocabulary (`CODEX_NATIVE_EFFORTS`, `EFFORT_VALUES`), and the session-metadata mirror.

## Changelog

Codex-native sessions can now select Max/Ultra reasoning levels on models that support them (e.g. Sol), instead of silently running at xhigh.
