### PR TITLE
fix(cli): forward non-uuid session ids on remote resume

### DIFF
--- a/omnigent/resume_dispatch.py
+++ b/omnigent/resume_dispatch.py
@@ -221,17 +221,20 @@ def _dispatch_by_runtime(
     """
     from omnigent.db.db_models import InvalidUuidError, uuid_to_bytes
 
-    # Resolve the id the argument contains, then canonicalize to bare hex
-    # before any lookup: a paste drags punctuation along (trailing period,
-    # wrapping quotes or backticks), and none of it can ever be part of a
-    # valid id — so strip it and resume rather than erroring. A malformed
-    # id would otherwise surface as a raw StatementError traceback from
-    # the local store's Uuid16 bind, and downstream consumers key
-    # sessions on the bare spelling.
-    try:
-        target = uuid_to_bytes(target.strip(_PASTE_PUNCTUATION)).hex()
-    except InvalidUuidError as exc:
-        raise click.ClickException("Invalid session id.") from exc
+    # Paste punctuation (trailing period, wrapping quotes/backticks) is never
+    # part of an id, so strip it. Only the local path binds the id to the sqlite
+    # store's Uuid16 column, so it must be a real uuid — reject a malformed one
+    # loudly rather than surfacing a raw StatementError. The remote server owns
+    # its id space (a managed deployment keys sessions on non-uuid ids) and
+    # validates the id itself, so forward it untouched, like the runner and SDK.
+    stripped = target.strip(_PASTE_PUNCTUATION)
+    if server is None:
+        try:
+            target = uuid_to_bytes(stripped).hex()
+        except InvalidUuidError as exc:
+            raise click.ClickException("Invalid session id.") from exc
+    else:
+        target = stripped
 
     if server is not None:
         wrapper = _read_wrapper_label_remote(server=server, conv_id=target)

--- a/tests/test_resume_dispatch.py
+++ b/tests/test_resume_dispatch.py
@@ -480,6 +480,42 @@ def test_dispatch_by_runtime_legacy_prefixed_id_canonicalized_to_bare_hex(
     assert captured["session_id"] == "415c9954e2fe4b9276083a4d2c66f689"
 
 
+def test_dispatch_by_runtime_remote_forwards_non_uuid_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A remote server owns its id space, so a non-uuid id (e.g. a managed
+    deployment's numeric node id) must reach the lookup and wrapper
+    unchanged. Forcing the local uuid rule on the remote path would
+    reject a valid id before the server — the one thing the server is
+    there to resolve — ever sees it.
+    """
+    seen: dict[str, str] = {}
+
+    def _label(*, server: str, conv_id: str) -> str:
+        """Record the id the remote lookup receives."""
+        seen["conv_id"] = conv_id
+        return "claude-code-native-ui"
+
+    monkeypatch.setattr(resume_dispatch, "_read_wrapper_label_remote", _label)
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> None:
+        """Record the kwargs ``run_claude_native`` was called with."""
+        captured.update(kwargs)
+
+    monkeypatch.setattr("omnigent.claude_native.run_claude_native", _capture)
+
+    resume_dispatch._dispatch_by_runtime(
+        target="2048200000527758",
+        server="https://example.com",
+    )
+
+    # The raw non-uuid id flows through untouched — not rejected, not reshaped.
+    assert seen["conv_id"] == "2048200000527758"
+    assert captured["session_id"] == "2048200000527758"
+
+
 def test_dispatch_by_runtime_non_wrapper_local_raises_with_hint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

No public tracking issue — surfaced on the Databricks-managed deployment, whose
server keys sessions on numeric WHS node ids rather than uuids.

## Summary

`omnigent resume <id>` (`_dispatch_by_runtime`) canonicalized **every** id through
the local sqlite store's uuid rule (`uuid_to_bytes`), even when `--server` points at
a remote server that owns its own id space. A deployment that keys sessions on
non-uuid ids (e.g. a numeric node id like `2048200000527758`) had every id rejected
client-side with `"Invalid session id."` **before any request was sent** — even though
the remote server would resolve it fine.

- **Local path (`server is None`)** binds the id straight to the `Uuid16` column, so it
  keeps the strict uuid guard (a malformed id must fail loud, not surface a raw
  `StatementError`).
- **Remote path** now forwards the id untouched and lets the server resolve it —
  matching how the runner and SDK already pass the id straight through.

ELI5: the CLI was checking your session id against the *local* database's rules even
when it was about to hand the id to a *remote* server that plays by different rules. It
now just forwards the id and lets that server decide.

## Test Plan

- `uv run --no-sync pytest tests/test_resume_dispatch.py -q` → 27 passed (new test +
  existing local-path reject test both green).
- `uv run --no-sync ruff check` / `ruff format --check` on the changed files → clean.
- Added `test_dispatch_by_runtime_remote_forwards_non_uuid_id`: asserts a non-uuid id
  reaches both the remote lookup and the wrapper unchanged.

## Demo

N/A — non-visual CLI behavior change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit-tested at the dispatch boundary (remote pass-through + local reject). Full
end-to-end resume against a non-uuid-id deployment can only be exercised on that
deployment, not in this repo's test env.

## Changelog

`omnigent resume` now works against servers that key sessions on non-uuid ids

---
This pull request and its description were written by Isaac.
