### PR TITLE
fix(server): keep a session's skills through a snapshot refresh

### DIFF
--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -521,6 +521,12 @@ _session_mcp_startup_cache: dict[str, dict[str, McpServerStartup]] = {}
 _runner_skills_cache: dict[str, list[SkillSummary]] = {}
 
 
+# Sessions whose cached skills need a re-fetch but should keep serving until it
+# lands. A browser reload asks for one, and dropping the entry outright would
+# empty the composer's slash-command menu for the reload that requested it.
+_runner_skills_stale: set[str] = set()
+
+
 _runner_skills_inflight: dict[str, asyncio.Task[None]] = {}
 
 
@@ -956,6 +962,7 @@ __all__ = [
     "_runner_relay_tasks",
     "_runner_skills_cache",
     "_runner_skills_inflight",
+    "_runner_skills_stale",
     "_server_host_registry",
     "_server_runner_router",
     "_session_active_response_cache",

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -205,6 +205,7 @@ from omnigent.server.routes._sessions.common import (  # noqa: F401
     _read_last_seen,
     _runner_skills_cache,
     _runner_skills_inflight,
+    _runner_skills_stale,
     _session_active_response_cache,
     _session_background_task_count_cache,
     _session_mcp_startup_cache,
@@ -4233,13 +4234,16 @@ def _invalidate_runner_backed_snapshot_state(
     """
     Drop runner-derived session snapshot overlays for one session.
 
-    Skills are discovered from the bound runner, so they are dropped and
-    re-fetched at the next snapshot. The native model catalog is instead
-    marked stale by default: it must outlive runner death so the model
-    picker stays populated (and offline model/effort changes stay possible)
-    while the session is asleep — a stale catalog keeps serving until a
-    live-runner re-fetch replaces it. Runner teardown additionally cancels
-    any in-flight fetch so a dead runner cannot land a late stale value.
+    Skills are discovered from the bound runner, so they are marked stale
+    and re-fetched at the next snapshot — but they keep serving until that
+    lands, because the request asking for the refresh is the same one whose
+    response fills the composer's slash-command menu. The native model
+    catalog is marked stale for the same reason, and additionally must
+    outlive runner death so the model picker stays populated (and offline
+    model/effort changes stay possible) while the session is asleep. Runner
+    teardown cancels any in-flight fetch so a dead runner cannot land a late
+    stale value, and drops the skills outright — they belong to the runner
+    that went away.
 
     :param session_id: Session/conversation identifier,
         e.g. ``"conv_abc123"``.
@@ -4254,12 +4258,18 @@ def _invalidate_runner_backed_snapshot_state(
     """
     from omnigent.server.smart_routing import invalidate_runner_catalog
 
-    _runner_skills_cache.pop(session_id, None)
+    # Only worth marking when there is something to keep serving: a session
+    # with no cached skills already re-fetches on the next read, and marking
+    # it would leave an id behind for every cold session ever opened.
+    if session_id in _runner_skills_cache:
+        _runner_skills_stale.add(session_id)
     # Routing's candidate catalog is runner-derived too: a rebind or a relaunch
     # can change which models the session can be switched onto, so it must not
     # keep routing off the previous runner's list.
     invalidate_runner_catalog(session_id)
     if cancel_inflight:
+        _runner_skills_cache.pop(session_id, None)
+        _runner_skills_stale.discard(session_id)
         inflight = _runner_skills_inflight.pop(session_id, None)
         if inflight is not None:
             inflight.cancel()
@@ -9342,6 +9352,7 @@ async def _load_runner_skills(
         _logger.debug("Runner skills payload malformed for %s", session_id)
         return
     _runner_skills_cache[session_id] = skills
+    _runner_skills_stale.discard(session_id)
     # Nudge any subscribed client to re-read the (now-warm) snapshot so
     # its slash-command menu fills without waiting for the next bind.
     _publish_runner_skills(session_id)

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -177,6 +177,7 @@ from omnigent.server.routes._sessions.common import (  # noqa: F401
     _runner_relay_tasks,
     _runner_skills_cache,
     _runner_skills_inflight,
+    _runner_skills_stale,
     _session_active_response_cache,
     _session_background_task_count_cache,
     _session_mcp_startup_cache,
@@ -8902,12 +8903,12 @@ async def _fetch_runner_skills(
     if runner_client is None:
         return []
     cached = _runner_skills_cache.get(session_id)
-    if cached is not None:
+    if cached is not None and session_id not in _runner_skills_stale:
         return cached
     # Don't await the runner here: this snapshot is polled continuously
     # (incl. mid-turn), and a per-poll runner round-trip pins the runner's
     # event loop and wedges the turn. Kick one background fetch (single-
-    # flight) and return ``[]``; a later poll serves the cached result.
+    # flight); a later poll serves the fresh result.
     if session_id not in _runner_skills_inflight:
         task = asyncio.create_task(_load_runner_skills(runner_client, session_id))
         _runner_skills_inflight[session_id] = task
@@ -8916,7 +8917,17 @@ async def _fetch_runner_skills(
             _runner_skills_inflight.pop(session_id, None)
 
         task.add_done_callback(_clear_skills_inflight)
-    return []
+    # Stale skills serve while that runs, so a browser reload — which asks for
+    # the refresh — still gets a populated slash-command menu on the response
+    # to its own request. Success publishes ``session.skills`` and open clients
+    # re-read the snapshot.
+    #
+    # A runner that keeps failing the fetch leaves the entry stale, so each poll
+    # starts one more single-flight. That is the same ceiling a cold cache has
+    # always had — one in-flight fetch per session, bounded by the poll rate —
+    # and the alternative, clearing the mark on failure, would serve the old
+    # list until something else invalidated it.
+    return cached or []
 
 
 async def _fetch_model_options(

--- a/tests/server/test_runner_skills_refresh.py
+++ b/tests/server/test_runner_skills_refresh.py
@@ -1,0 +1,181 @@
+"""A snapshot refresh must not empty the composer's slash-command menu.
+
+The web chat loads a session with ``?refresh_state=true`` so a reload re-reads
+live capabilities instead of serving stale caches. Runner-derived skills were
+*dropped* on that path, and the snapshot's skill read is deliberately
+non-blocking — it kicks a background fetch and returns what it has. So the
+refresh emptied the cache and then answered its own request with ``[]``, and
+the menu the response feeds had nothing in it but the built-ins.
+
+The native model catalog in the same invalidator already avoids this by
+marking stale and serving the previous value; these tests hold skills to the
+same contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from omnigent.server.routes._sessions.common import (
+    _runner_skills_cache,
+    _runner_skills_inflight,
+    _runner_skills_stale,
+)
+from omnigent.server.routes._sessions.helpers import (
+    _invalidate_runner_backed_snapshot_state,
+    _load_runner_skills,
+)
+from omnigent.server.routes._sessions.orchestration import _fetch_runner_skills
+from omnigent.server.schemas import SkillSummary
+
+SESSION = "conv_refresh_probe"
+
+
+class _StubRunner:
+    """Minimal stand-in for the runner's httpx client.
+
+    Only ``get`` is exercised; the loader treats anything non-200 or
+    unparseable as a miss, which is what the failure cases below need.
+    """
+
+    def __init__(self, payload: object, status: int = 200) -> None:
+        self._payload = payload
+        self._status = status
+        self.calls = 0
+
+    async def get(self, url: str, timeout: float = 5.0) -> object:
+        self.calls += 1
+        payload, status = self._payload, self._status
+
+        class _Resp:
+            status_code = status
+
+            def json(self) -> object:
+                return payload
+
+        return _Resp()
+
+
+@pytest.fixture(autouse=True)
+def _clean_caches() -> object:
+    """Keep this module's writes out of the process-wide caches."""
+    for store in (_runner_skills_cache, _runner_skills_inflight):
+        store.pop(SESSION, None)
+    _runner_skills_stale.discard(SESSION)
+    yield
+    for store in (_runner_skills_cache, _runner_skills_inflight):
+        store.pop(SESSION, None)
+    _runner_skills_stale.discard(SESSION)
+
+
+def _seed(*names: str) -> None:
+    """Put *names* in the runner-skills cache as a warm entry."""
+    _runner_skills_cache[SESSION] = [SkillSummary(name=n, description=f"{n} desc") for n in names]
+
+
+def test_a_browser_refresh_keeps_the_skills_it_asked_to_refresh() -> None:
+    """The reload's own response still carries the menu.
+
+    ``cancel_inflight=False`` is the browser-refresh call. Dropping the entry
+    here is what emptied the menu: the snapshot being built for this very
+    request reads the cache immediately afterwards.
+    """
+    _seed("code-review", "figma:figma-use")
+
+    _invalidate_runner_backed_snapshot_state(
+        SESSION, cancel_inflight=False, drop_model_options=True
+    )
+
+    assert [s.name for s in _runner_skills_cache[SESSION]] == ["code-review", "figma:figma-use"]
+    assert SESSION in _runner_skills_stale
+
+
+def test_runner_teardown_still_drops_them() -> None:
+    """Skills belong to the runner that went away.
+
+    ``cancel_inflight=True`` is the disconnect path, where serving the old
+    list would advertise commands nothing can resolve.
+    """
+    _seed("code-review")
+
+    _invalidate_runner_backed_snapshot_state(
+        SESSION, cancel_inflight=True, drop_model_options=True
+    )
+
+    assert SESSION not in _runner_skills_cache
+    assert SESSION not in _runner_skills_stale
+
+
+async def test_a_real_refill_clears_the_stale_mark() -> None:
+    """Otherwise every later snapshot re-fetches forever.
+
+    Driven through ``_load_runner_skills`` rather than by writing the cache
+    here: a test that performs the production write itself cannot notice the
+    production code dropping it.
+    """
+    _seed("code-review")
+    _invalidate_runner_backed_snapshot_state(
+        SESSION, cancel_inflight=False, drop_model_options=True
+    )
+    assert SESSION in _runner_skills_stale
+
+    runner = _StubRunner({"skills": [{"name": "code-review", "description": "fresh"}]})
+    await _load_runner_skills(cast(Any, runner), SESSION)
+
+    assert SESSION not in _runner_skills_stale
+    assert [s.description for s in _runner_skills_cache[SESSION]] == ["fresh"]
+
+
+async def test_a_failed_refill_keeps_serving_and_keeps_retrying() -> None:
+    """A runner that cannot answer must not empty the menu.
+
+    The mark stays set so a later poll tries again — the same ceiling a cold
+    cache has always had — while the previous list keeps serving.
+    """
+    _seed("code-review")
+    _invalidate_runner_backed_snapshot_state(
+        SESSION, cancel_inflight=False, drop_model_options=True
+    )
+
+    await _load_runner_skills(cast(Any, _StubRunner({"skills": []}, status=503)), SESSION)
+
+    assert SESSION in _runner_skills_stale
+    assert [s.name for s in _runner_skills_cache[SESSION]] == ["code-review"]
+
+
+async def test_the_snapshot_serves_stale_skills_and_starts_one_refetch() -> None:
+    """The read half: a refreshing snapshot answers with the list it has.
+
+    This is the behaviour the browser depends on — the response to the
+    request that asked for the refresh is the one that fills the menu — and
+    it must also register exactly one in-flight fetch rather than firing per
+    poll.
+    """
+    _seed("code-review", "figma:figma-use")
+    _invalidate_runner_backed_snapshot_state(
+        SESSION, cancel_inflight=False, drop_model_options=True
+    )
+    runner = _StubRunner({"skills": [{"name": "code-review", "description": "fresh"}]})
+
+    served = await _fetch_runner_skills(cast(Any, runner), SESSION)
+
+    assert [s.name for s in served] == ["code-review", "figma:figma-use"]
+    inflight = _runner_skills_inflight.get(SESSION)
+    assert inflight is not None
+    await inflight
+    assert SESSION not in _runner_skills_stale
+
+
+async def test_a_session_with_no_cached_skills_is_not_marked() -> None:
+    """Nothing to serve means nothing to remember.
+
+    Every cold session a browser opens would otherwise leave an id in the
+    stale set for the life of the process.
+    """
+    _invalidate_runner_backed_snapshot_state(
+        SESSION, cancel_inflight=False, drop_model_options=True
+    )
+
+    assert SESSION not in _runner_skills_stale


### PR DESCRIPTION
## Related issue

Closes #5219

## Summary

Type `/` in the web composer and the menu lists the built-ins and nothing else
— no bundled skills, no host-scope skills, none of the enabled Claude plugins'
`<plugin>:<skill>` commands.

The data is there. Bisecting the query string against a live server, one
parameter does it:

| request | `skills` |
|---|---|
| `GET /v1/sessions/{id}` | 149 |
| `…?include_items=false` | 149 |
| `…?include_liveness=false` | 149 |
| `…?refresh_state=true` | **0** |

And `refresh_state=true` is exactly what the web chat sends on load.

`refresh_state` calls `_invalidate_runner_backed_snapshot_state`, which popped
`_runner_skills_cache`. The snapshot's skill read is deliberately non-blocking
— on a miss it kicks one background fetch and returns what it has, so a
mid-turn poll can't pin the runner's event loop. Together: the refresh empties
the cache, then the snapshot being built *for that same request* reads the
empty cache and answers `[]`.

Mark the entry stale and serve it while the single-flight re-fetch runs. The
native model catalog in the same invalidator already works this way, for the
same reason.

Two edges kept deliberate:

- **Runner teardown still drops them.** Those skills belong to the runner that
  went away, and serving them would advertise commands nothing can resolve.
- **A session with nothing cached is not marked.** There would be nothing to
  keep serving, and the id would outlive every cold session a browser opens.

Known and unchanged: a refresh landing while a fetch is already in flight is
swallowed, because that fetch clears the mark on success. The window is one
runner RPC, the next reload re-marks and heals it, and the model catalog two
lines away has the identical property — so this mirrors the precedent rather
than diverging from it. A runner that keeps failing the fetch retries once per
poll, which is the ceiling a cold cache has always had.

## Test Plan

`tests/server/test_runner_skills_refresh.py` — new, six tests driving the
production functions (`_invalidate_runner_backed_snapshot_state`,
`_load_runner_skills` against a stub runner, and `_fetch_runner_skills`) rather
than re-performing their writes: a browser refresh keeping its list, a real
refill clearing the mark, a failed refill still serving, the snapshot serving
stale while registering exactly one in-flight fetch, teardown still dropping,
and a cold session not being marked. Reverting the behaviour while keeping the
symbols fails four of the six.

```
pytest tests/server                     3770 passed, 1 skipped, 3 xfailed
pytest tests/server/routes …             991 passed
pre-commit run --files …                 ruff, ruff format, pyrefly, hygiene — pass
```

End to end, Playwright driving a real browser against a PostgreSQL-backed
server, typing `/figma` with that plugin enabled in Claude Code:

| | menu items |
|---|---|
| before | 0 |
| after | 12 |

Before the fix the menu also stayed empty for the full 61 seconds it was
watched, and the page made no further snapshot fetch after load.

## Demo

`main` first, then this branch — same session, same keystrokes.

![web composer menu](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/web-slash-menu.gif)

Typing `/figma` on `main` — no menu:

![before](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/web-before.png)

The same keystrokes after the fix:

![after](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/web-after.png)

The composer's `/figma` tint is present in both — that half was already
working; only the menu was empty. The Playwright driver that produced these is
[committed alongside them](https://github.com/Paldom/omnigent/blob/agent-army/docs/agent-army/media/web-slash-menu-record.py).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The cache contract is unit-tested through the production functions. What those
cannot show is the browser end of it — that the response to the page's own
refresh is what fills the menu — so the manual pass drove a real Chromium
against a Postgres-backed server and counted the rendered menu items.

## Changelog

The web composer's slash-command menu lists a session's skills again instead of only the built-ins.
