### PR TITLE
fix(e2e): de-flake test_repl_approve_always_caches_for_later_turns PTY timing race

### DIFF
--- a/tests/e2e/test_repl_approval_e2e.py
+++ b/tests/e2e/test_repl_approval_e2e.py
@@ -722,14 +722,15 @@ def test_repl_approve_always_caches_for_later_turns(
         _read_pending(child, seconds=1.5)
 
         # Turn 2: the auto-approved audit line must appear
-        # AND the banner must NOT. After .expect() lands on
-        # the elapsed-time marker, ``child.before`` holds the
-        # full span from the last expect up to (but not
-        # including) the match. That's the whole turn 2
-        # output — banner (if any) + auto-approved line (if
-        # any) + LLM response + elapsed-time prefix.
+        # AND the banner must NOT. Sync on the scripted reply text
+        # (deterministic content) instead of the racy ``· ready``
+        # toolbar marker, which can match prematurely before the
+        # turn's output renders. The scripted response only appears
+        # after the LLM call completes, proving the full turn has
+        # rendered (including the "auto-approved" audit line that
+        # must precede it).
         child.send("follow up please" + "\r")
-        _wait_for_turn_complete(child, timeout=45)
+        child.expect("Following up as requested", timeout=45)
         turn_two_raw = child.before or ""
         if isinstance(turn_two_raw, bytes):
             turn_two_raw = turn_two_raw.decode("utf-8", errors="replace")


### PR DESCRIPTION
## Summary
- Fixes a PTY timing race in the approval cache e2e test
- Test was using `_wait_for_turn_complete()` which matches a racy toolbar marker that can appear before Turn 2's output renders
- Fix: wait for deterministic LLM response content ("Following up as requested.") instead

## Test plan
- Verified: 10 consecutive test runs all passed (was flaky ~1-3% in CI)
- Ran `uv run --group test python -m pytest tests/e2e/test_repl_approval_e2e.py::test_repl_approve_always_caches_for_later_turns --timeout=180` repeatedly

## Demo
N/A

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Test coverage
- [x] Manual verification completed

## Coverage notes
Ran the flaky test 10 times consecutively on the fixed code with 100% pass rate. The original flake manifests as assertion failure on missing "auto-approved" audit line due to premature pexpect buffer capture before Turn 2's output renders.

This pull request and its description were written by Isaac.