### PR TITLE
perf(import): persist appended items in one bulk insert

### DIFF
--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     delete,
     desc,
     func,
+    insert,
     literal_column,
     or_,
     select,
@@ -2041,7 +2042,10 @@ class SqlAlchemyConversationStore(ConversationStore):
                     + 1
                 )
 
+            workspace_id = current_workspace_id()
+            completed_status = encode_item_status("completed")  # items are final on append
             fts_rows: list[tuple[str, str, str]] = []
+            row_values: list[dict[str, object]] = []
             for item in items:
                 position = next_pos
                 next_pos += 1
@@ -2053,38 +2057,46 @@ class SqlAlchemyConversationStore(ConversationStore):
                 data = self._encode_item_data(strip_nul_bytes(json.dumps(data_dict)))
                 search = self._item_search_text(item)
                 item_id = generate_item_id(item.type)
-                row = SqlConversationItem(
-                    id=item_id,
-                    conversation_id=conversation_id,
-                    response_id=item.response_id,
-                    created_at=now,
-                    status=encode_item_status("completed"),  # items are final on append
-                    position=position,
-                    type=encode_item_type(item.type),
-                    data=data,
-                    created_by=item.created_by,
-                )
-                # A backend may omit search_text (see _item_search_text); leaving
-                # the attribute unset drops it from the INSERT so a schema without
-                # the column still works, and skips its FTS row.
+                values: dict[str, object] = {
+                    "workspace_id": workspace_id,
+                    "id": item_id,
+                    "conversation_id": conversation_id,
+                    "response_id": item.response_id,
+                    "created_at": now,
+                    "status": completed_status,
+                    "position": position,
+                    "type": encode_item_type(item.type),
+                    "data": data,
+                    "created_by": item.created_by,
+                }
+                # A backend may omit search_text (see _item_search_text): when it
+                # returns None we drop the column so a schema without it still
+                # works, and skip its FTS row. The hook is all-or-nothing per
+                # store, so the key set stays uniform across the executemany.
                 if search is not None:
-                    row.search_text = search
+                    values["search_text"] = search
                     fts_rows.append((item_id, conversation_id, search))
-                session.add(row)
+                row_values.append(values)
                 persisted.append(
                     ConversationItem(
-                        id=row.id,
+                        id=item_id,
                         # The row stores int codes; the entity carries the
                         # string names. item.type is the source string and
                         # the status was just written as "completed".
                         type=item.type,
                         status="completed",
-                        response_id=row.response_id,
-                        created_at=row.created_at,
+                        response_id=item.response_id,
+                        created_at=now,
                         data=item.data,
                         created_by=item.created_by,
                     )
                 )
+            # One executemany for the batch: positions are pre-allocated above so
+            # the rows carry no inter-row dependency, and a single round-trip
+            # persists all N. A per-row ORM add round-trips per item, which
+            # dominates append latency against a remote managed Postgres.
+            if row_values:
+                session.execute(insert(SqlConversationItem), row_values)
             insert_fts_bulk(session, fts_rows)
 
             # Persist the advanced counter so the next append reads it instead

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -4884,6 +4884,37 @@ def test_append_reads_counter_not_max_scan(
     assert _stored_next_position(conversation_store, conv.id) == 101
 
 
+def test_append_persists_batch_in_single_insert(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A multi-item append writes every item in one bulk INSERT, not one
+    statement per row — a per-row round-trip dominates import latency against a
+    remote managed Postgres, so guard against a regression to it."""
+    import re
+
+    conv = conversation_store.create_conversation()
+
+    statements: list[str] = []
+
+    def _record(conn, cursor, statement, parameters, context, executemany):  # type: ignore[no-untyped-def]
+        statements.append(statement)
+
+    # Attach after create_conversation so only the append's SQL is captured.
+    event.listen(conversation_store._conv_engine, "before_cursor_execute", _record)
+    try:
+        conversation_store.append(conv.id, [_user_message(f"m{i}") for i in range(10)])
+    finally:
+        event.remove(conversation_store._conv_engine, "before_cursor_execute", _record)
+
+    # The FTS mirror is a separate table (conversation_items_fts); the regex
+    # keeps it out by requiring the base table name to be followed by "(".
+    item_inserts = [
+        s for s in statements if re.search(r"insert into conversation_items\s*\(", s, re.I)
+    ]
+    assert len(item_inserts) == 1, item_inserts
+    assert _stored_positions(conversation_store, conv.id) == list(range(10))
+
+
 @pytest.mark.parametrize("preexisting", [0, 1, 3])
 def test_append_falls_back_to_scan_when_counter_null(
     conversation_store: SqlAlchemyConversationStore,


### PR DESCRIPTION
## Related issue

N/A — internal performance change (Refactor / chore).

## Summary

- `ConversationStore.append` added conversation items one ORM row at a time, so importing a chat issued one INSERT round-trip per item. Against a remote managed Postgres that per-item round-trip dominated import latency for large sessions (a ~225-item chat spent seconds just on the appends).
- Item positions are already pre-allocated from the maintained `next_position` counter, so the rows carry no inter-row dependency. Persist the whole batch with a single `insert()` executemany inside the same transaction. The conversation row lock and the bulk FTS insert are unchanged, so ordering and concurrency behavior are preserved.

ELI5: instead of mailing 225 letters one at a time and waiting for each to arrive, put them all in one envelope.

```
before: for item in items: session.add(row)   ->  N INSERT round-trips
after:  session.execute(insert(Item), rows)   ->  1 INSERT
```

## Test Plan

- `pytest tests/stores/test_conversation_store.py` — includes the new `test_append_persists_batch_in_single_insert`, plus the existing position-counter, concurrent-append, search-text, and author-attribution cases.
- `pytest tests/stores/test_conversation_store_split_db.py tests/e2e/test_conversation_append_race_e2e.py` — split-db routing and the concurrent-append position-collision race.
- `ruff check` / `ruff format --check` and `pre-commit` on the changed files.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No behavior change: the same rows, positions, and FTS entries are written, verified by the existing append/position/search tests. The new test asserts a multi-item append emits exactly one item INSERT, guarding against a regression to per-row writes.

## Changelog

Importing large chats is faster: a session import now writes all of its items in a single database insert.
