### PR TITLE
fix(cli): close daemon stdin to release terminal on shell exit

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2820,6 +2820,7 @@ def _spawn_host_daemon_process(
             proc = subprocess.Popen(
                 args,
                 env=env,
+                stdin=subprocess.DEVNULL,
                 stdout=log_fh,
                 stderr=log_fh,
                 **_proc.spawn_kwargs(),


### PR DESCRIPTION
## Related issue

Closes OMNI-3274

## Summary

After an `isaac omni codex` session exits, the host daemon held an open file descriptor to the parent shell's pseudo-terminal (`/dev/pts/N`). The shell waits for all processes holding that fd before `exit` can return — so users were stuck with a hanging shell and had to manually kill the daemon.

The daemon was already spawned with `start_new_session=True`, which puts it in its own session, but that doesn't close inherited fds. The fix is one line: pass `stdin=subprocess.DEVNULL` to `Popen` in `_spawn_host_daemon_process`, so the daemon's stdin is wired to `/dev/null` at spawn time and never holds a reference to the terminal.

## Test Plan

- [x] Start an `isaac omni codex` session in arca, exit the session, then run `exit` — shell returns immediately without hanging
- [x] Confirmed the daemon's fd table no longer contains a `/dev/pts/*` entry after spawn

## Demo


<img width="905" height="185" alt="image" src="https://github.com/user-attachments/assets/80b7a895-15e5-4a5b-b4c8-feb9ec9adeb8" />


## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed

## Coverage notes

Single-argument change to a `subprocess.Popen` call. Automated testing would require PTY setup to reproduce the hanging-shell scenario; manual verification in arca confirms the fix.

## Changelog

The shell no longer hangs on `exit` after an omnigent codex session ends.