### PR TITLE
fix(codex): serialize stdin writes to prevent parallel tool-call output loss

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -2123,6 +2123,9 @@ class _CodexAppServerSession:
         # on the next ``turn/completed`` so each TurnComplete carries the
         # usage for the turn that just finished.
         self._last_turn_usage: dict[str, object] | None = None
+        # Serialize concurrent writes to the subprocess stdin so that parallel
+        # tool-call responses don't interleave bytes on the pipe.
+        self._stdin_lock = asyncio.Lock()
 
     async def start(self) -> None:
         if self._started:
@@ -2947,8 +2950,9 @@ class _CodexAppServerSession:
 
     async def _send_message(self, payload: CodexMessage) -> None:
         assert self._proc is not None and self._proc.stdin is not None
-        self._proc.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
-        await self._proc.stdin.drain()
+        async with self._stdin_lock:
+            self._proc.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
+            await self._proc.stdin.drain()
 
     @staticmethod
     async def _iter_stream_chunks(stream: asyncio.StreamReader) -> AsyncIterator[bytes]:


### PR DESCRIPTION
## Related issue

Closes #

(Reported in Slack: parallel Codex tool calls get stuck — 3 of 4 outputs missing/delayed 18+ min)

## Summary

When Codex emits parallel tool calls, the harness processes `item/tool/call` events sequentially but `_send_message`'s `write()` + `drain()` sequence is not atomic.  A concurrent caller can interleave its `write()` between another caller's `write()` and `drain()`, corrupting the JSON-RPC line on the subprocess stdin pipe.  The Codex app-server reads a malformed message, drops the response, and the remaining tool outputs never arrive — stalling the turn for 20–30 minutes.

**Fix:** guard `_send_message` with an `asyncio.Lock` (`_stdin_lock`) so the write/drain pair is atomic.

```
Before                          After
──────────────────────────────  ──────────────────────────────────
write(tool1_response)           async with self._stdin_lock:
write(tool2_response)  ← races      write(tool1_response)
drain()                              drain()
drain()                         async with self._stdin_lock:
                                     write(tool2_response)
                                     drain()
```

## Test Plan

- Manual: ran a Codex agent in Omni that emits 4 parallel `shell` calls; all 4 outputs now stream immediately without delay or corruption.
- Existing Codex executor unit/integration tests pass.

## Demo

<img width="728" height="615" alt="image" src="https://github.com/user-attachments/assets/e99a0365-710a-4c5a-bd74-54c6d90ae911" />


## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

The race is timing-dependent and hard to reproduce deterministically in a unit test. Manual verification confirmed all 4 parallel tool outputs stream correctly after the fix. Existing tests exercise `_send_message` and pass.

## Changelog

Fixed Codex parallel tool calls getting stuck — all tool outputs now stream immediately instead of stalling for 20+ minutes.