### PR TITLE
perf(import): import batched sessions concurrently

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5793,6 +5793,25 @@ def resume(
     )
 
 
+_IMPORT_BATCH_MAX_WORKERS = 8
+
+
+@dataclass
+class _SessionImportResult:
+    """Outcome of importing one source session.
+
+    Shared by the single-session path and the parallel batch path so both
+    interpret the same statuses.
+    """
+
+    session_id: str
+    status: Literal["imported", "already", "unreachable", "failed", "load_error"]
+    item_count: int = 0
+    link: str | None = None
+    message: str | None = None
+    raw_exc: BaseException | None = None
+
+
 @cli.command("import")
 @click.option(
     "--harness",
@@ -5891,24 +5910,14 @@ def import_session_command(
     if base_url is None:
         base_url = ensure_local_omnigent_server().url
     base_url = base_url.rstrip("/")
-    imported_count = 0
-    already_imported_count = 0
-    failed_count = 0
-    for current_source_session_id in source_session_ids:
+
+    def _import_one(sid: str) -> _SessionImportResult:
         try:
-            imported = load_local_session(source, current_source_session_id)
+            imported = load_local_session(source, sid)
         except SessionImportNotFoundError as exc:
-            if not is_batch:
-                raise click.ClickException(str(exc)) from exc
-            failed_count += 1
-            click.echo(f"Failed {current_source_session_id}: {exc}", err=True)
-            continue
+            return _SessionImportResult(sid, "load_error", message=str(exc), raw_exc=exc)
         except (OSError, TypeError, ValueError) as exc:
-            if not is_batch:
-                raise
-            failed_count += 1
-            click.echo(f"Failed {current_source_session_id}: {exc}", err=True)
-            continue
+            return _SessionImportResult(sid, "load_error", message=str(exc), raw_exc=exc)
 
         payload = {
             "source": imported.source,
@@ -5932,12 +5941,13 @@ def import_session_command(
                 timeout=120.0,
             )
         except httpx.RequestError as exc:
-            raise click.ClickException(f"Could not reach the Omnigent server: {exc}") from exc
+            return _SessionImportResult(
+                sid,
+                "unreachable",
+                message=f"Could not reach the Omnigent server: {exc}",
+                raw_exc=exc,
+            )
 
-        if response.status_code == 409 and is_batch:
-            already_imported_count += 1
-            click.echo(f"Already imported {current_source_session_id}; skipped.")
-            continue
         if response.is_error:
             try:
                 body = response.json()
@@ -5945,44 +5955,84 @@ def import_session_command(
             except (ValueError, AttributeError):
                 detail = None
             message = f"Import failed ({response.status_code}): {detail or response.text}"
-            if not is_batch:
-                raise click.ClickException(message)
-            failed_count += 1
-            click.echo(f"Failed {current_source_session_id}: {message}", err=True)
-            continue
+            status = "already" if response.status_code == 409 else "failed"
+            return _SessionImportResult(sid, status, message=message)
 
         try:
             result = response.json()
             session_id = result["session_id"]
             item_count = result["item_count"]
         except (AttributeError, KeyError, TypeError, ValueError) as exc:
-            if not is_batch:
-                raise click.ClickException("Import returned an invalid server response") from exc
-            failed_count += 1
-            click.echo(
-                f"Failed {current_source_session_id}: import returned an invalid server response",
-                err=True,
+            return _SessionImportResult(
+                sid,
+                "failed",
+                message="Import returned an invalid server response",
+                raw_exc=exc,
             )
-            continue
-        imported_count += 1
         # Surface the browser URL, not the bare id, so the user can open the
         # imported session straight into the web (where it offers the resume
         # picker). Maps a Databricks API base to its workspace SPA link.
-        session_link = conversation_url(base_url, session_id)
-        if is_batch:
-            click.echo(
-                f"Imported {item_count} item(s) from {current_source_session_id} "
-                f"into {session_link}"
-            )
-        else:
-            click.echo(f"Imported {item_count} item(s) into {session_link}")
+        return _SessionImportResult(
+            sid,
+            "imported",
+            item_count=item_count,
+            link=conversation_url(base_url, session_id),
+        )
 
-    if is_batch:
-        click.echo(f"\nImported: {imported_count}")
-        click.echo(f"Already imported: {already_imported_count}")
-        click.echo(f"Failed: {failed_count}")
-        if failed_count:
-            raise click.ClickException(f"{failed_count} session(s) failed to import")
+    if not is_batch:
+        result = _import_one(source_session_ids[0])
+        if result.status == "imported":
+            click.echo(f"Imported {result.item_count} item(s) into {result.link}")
+            return
+        if result.status == "load_error":
+            # A missing session is a clean CLI error; a corrupt transcript keeps
+            # its original exception so the traceback points at the parse fault.
+            if isinstance(result.raw_exc, SessionImportNotFoundError):
+                raise click.ClickException(str(result.raw_exc)) from result.raw_exc
+            assert result.raw_exc is not None
+            raise result.raw_exc
+        raise click.ClickException(result.message or "Import failed")
+
+    # Distinct sessions are independent conversations on the server (their own
+    # ids, row locks, and position counters), so importing them concurrently
+    # never contends. Resolve the remote auth token once up front to populate
+    # the per-URL SDK cache before the workers fan out, rather than have each
+    # worker cold-mint it in parallel.
+    _remote_headers(server_url=base_url, host_id=None)
+    results: dict[str, _SessionImportResult] = {}
+    max_workers = min(len(source_session_ids), _IMPORT_BATCH_MAX_WORKERS)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(_import_one, sid): sid for sid in source_session_ids}
+        for future in concurrent.futures.as_completed(futures):
+            outcome = future.result()
+            results[outcome.session_id] = outcome
+
+    # A network failure is fatal for the whole batch, matching the serial import.
+    unreachable = next((r for r in results.values() if r.status == "unreachable"), None)
+    if unreachable is not None:
+        raise click.ClickException(unreachable.message or "Could not reach the Omnigent server")
+
+    imported_count = 0
+    already_imported_count = 0
+    failed_count = 0
+    # Report in the caller's requested order, not worker completion order.
+    for sid in source_session_ids:
+        outcome = results[sid]
+        if outcome.status == "imported":
+            imported_count += 1
+            click.echo(f"Imported {outcome.item_count} item(s) from {sid} into {outcome.link}")
+        elif outcome.status == "already":
+            already_imported_count += 1
+            click.echo(f"Already imported {sid}; skipped.")
+        else:
+            failed_count += 1
+            click.echo(f"Failed {sid}: {outcome.message}", err=True)
+
+    click.echo(f"\nImported: {imported_count}")
+    click.echo(f"Already imported: {already_imported_count}")
+    click.echo(f"Failed: {failed_count}")
+    if failed_count:
+        raise click.ClickException(f"{failed_count} session(s) failed to import")
 
 
 def _render_usage(report: dict[str, Any], limit: int) -> None:  # type: ignore[explicit-any]

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -232,18 +232,18 @@ def test_import_command_imports_last_sessions_oldest_first_and_skips_duplicates(
             text=f"prompt {modified_at}",
             modified_at=modified_at,
         )
-    route = respx.post(f"{_BASE}/v1/imports").mock(
-        side_effect=[
-            httpx.Response(
-                201,
-                json={"session_id": "imported-middle", "status": "imported", "item_count": 1},
-            ),
-            httpx.Response(
-                409,
-                json={"error": {"message": "already imported"}},
-            ),
-        ]
-    )
+
+    # Batch sessions import concurrently, so the response can't be keyed to POST
+    # arrival order: key it to the session so the assertions stay deterministic.
+    def _respond(request: httpx.Request) -> httpx.Response:
+        ext = json.loads(request.content)["external_session_id"]
+        if ext == session_ids[2]:
+            return httpx.Response(409, json={"error": {"message": "already imported"}})
+        return httpx.Response(
+            201, json={"session_id": "imported-middle", "status": "imported", "item_count": 1}
+        )
+
+    route = respx.post(f"{_BASE}/v1/imports").mock(side_effect=_respond)
 
     with patch("omnigent.cli._resolve_attach_server", return_value=_BASE):
         result = CliRunner().invoke(
@@ -253,11 +253,58 @@ def test_import_command_imports_last_sessions_oldest_first_and_skips_duplicates(
         )
 
     assert result.exit_code == 0, result.output
-    payloads = [json.loads(call.request.content) for call in route.calls]
-    assert [payload["external_session_id"] for payload in payloads] == list(session_ids[1:])
+    # Both most-recent sessions were posted (order-independent under concurrency).
+    posted = {json.loads(call.request.content)["external_session_id"] for call in route.calls}
+    assert posted == set(session_ids[1:])
+    # Reported oldest-first regardless of which worker finished first.
+    assert result.output.index(session_ids[1]) < result.output.index(session_ids[2])
     assert "Imported: 1" in result.output
     assert "Already imported: 1" in result.output
     assert "Failed: 0" in result.output
+
+
+@respx.mock
+def test_import_command_batch_reports_oldest_first_despite_completion_order(
+    tmp_path: Path,
+) -> None:
+    """Batch output follows the requested oldest-first order even when the
+    slowest session's worker completes last."""
+    import time
+
+    session_ids = (
+        "a1b2c3d4-1234-5678-9abc-def0123456a1",
+        "a1b2c3d4-1234-5678-9abc-def0123456a2",
+        "a1b2c3d4-1234-5678-9abc-def0123456a3",
+    )
+    for modified_at, session_id in enumerate(session_ids, start=1):
+        _write_claude_transcript(
+            tmp_path, session_id, text=f"p{modified_at}", modified_at=modified_at
+        )
+
+    # --last 3 imports oldest-first (ascending modified order). Delay the oldest
+    # the most so it finishes last; a completion-ordered report would misorder.
+    delays = {session_ids[0]: 0.15, session_ids[1]: 0.05, session_ids[2]: 0.0}
+
+    def _respond(request: httpx.Request) -> httpx.Response:
+        ext = json.loads(request.content)["external_session_id"]
+        time.sleep(delays[ext])
+        return httpx.Response(
+            201, json={"session_id": f"c-{ext[-2:]}", "status": "imported", "item_count": 1}
+        )
+
+    respx.post(f"{_BASE}/v1/imports").mock(side_effect=_respond)
+
+    with patch("omnigent.cli._resolve_attach_server", return_value=_BASE):
+        result = CliRunner().invoke(
+            cli,
+            ["import", "--harness", "claude", "--last", "3"],
+            env={"HOME": str(tmp_path)},
+        )
+
+    assert result.exit_code == 0, result.output
+    positions = [result.output.index(sid) for sid in session_ids]
+    assert positions == sorted(positions), result.output
+    assert "Imported: 3" in result.output
 
 
 @respx.mock


### PR DESCRIPTION
## Related issue

N/A — internal performance change (Refactor / chore).

## Summary

- `omnigent import --last N` imported sessions in a serial loop: one `POST /v1/imports` per session, each blocking on the previous. So a batch paid every session's network round-trip and server-side append end to end, one after another, plus the CLI's fixed per-invocation floor once.
- Distinct sessions are independent conversations on the server — their own ids, row locks, and position counters — so nothing forces them to be serial. Fan the per-session imports out over a bounded thread pool (`_IMPORT_BATCH_MAX_WORKERS = 8`) and resolve the remote auth token once up front so the workers don't each cold-mint it.
- Behavior preserved: results are still reported in the requested oldest-first order (not worker completion order), a network failure still fails the whole batch, and the single `--session` path is unchanged.

ELI5: importing 6 chats used to be "send one, wait, send the next"; now they go out together.

```
before:  session1 ─▶ wait ─▶ session2 ─▶ wait ─▶ session3   (sum of round-trips)
after:   session1 ┐
         session2 ┼─▶ (concurrent, bounded pool)             (max of round-trips)
         session3 ┘
```

## Test Plan
E2E tested on managed server.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The batch tests that keyed a mocked response to POST arrival order were updated to key on the session id instead, since arrival order is no longer deterministic; they now assert the real contract (which sessions were posted, oldest-first output order, and the counts).

## Changelog

Importing many chats at once (`omnigent import --last N`) is faster: sessions now import concurrently instead of one at a time.
