### PR TITLE
feat(telemetry): emit TurnTokenUsageEvent after each LLM turn

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -342,6 +342,7 @@ from omnigent.stores.host_store import Host, HostStore, host_is_live
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.telemetry import emit as _tel_emit
 from omnigent.telemetry.events import SessionCreatedEvent as _TelSessionCreatedEvent
+from omnigent.telemetry.events import TurnTokenUsageEvent as _TelTurnTokenUsageEvent
 from omnigent.telemetry.installation_id import get_installation_id as _get_installation_id
 from omnigent.telemetry.surface import classify_surface as _classify_surface
 
@@ -1529,6 +1530,26 @@ async def _persist_external_session_usage(
         body.data,
         conversation_store,
     )
+    _native_in = body.data.get("cumulative_input_tokens")
+    _native_out = body.data.get("cumulative_output_tokens")
+    _native_cost = body.data.get("cumulative_cost_usd")
+    _native_model: str | None = body.data.get("model") or None
+    if _native_in is not None or _native_out is not None:
+        _tel_emit(
+            _TelTurnTokenUsageEvent(
+                installation_id=_get_installation_id(),
+                session_id=session_id,
+                input_tokens=int(_native_in) if _native_in is not None else None,
+                output_tokens=int(_native_out) if _native_out is not None else None,
+                cost_usd=(
+                    float(_native_cost)
+                    if isinstance(_native_cost, (int, float))
+                    else None
+                ),
+                model=_native_model,
+                is_cumulative=True,
+            )
+        )
 
     label_updates: dict[str, str] = {}
     if raw_tokens is not None:
@@ -6155,6 +6176,31 @@ async def _relay_runner_stream_once(
                             session_id,
                             conversation_store,
                         )
+                        _resp_usage = event.get("response", {}).get("usage") or {}
+                        _turn_in = _resp_usage.get("input_tokens")
+                        _turn_out = _resp_usage.get("output_tokens")
+                        _turn_cost = _resp_usage.get("cost_usd")
+                        _turn_model: str | None = _resp_usage.get("model") or None
+                        if _turn_in or _turn_out:
+                            _tel_emit(
+                                _TelTurnTokenUsageEvent(
+                                    installation_id=_get_installation_id(),
+                                    session_id=session_id,
+                                    input_tokens=(
+                                        int(_turn_in) if _turn_in is not None else None
+                                    ),
+                                    output_tokens=(
+                                        int(_turn_out) if _turn_out is not None else None
+                                    ),
+                                    cost_usd=(
+                                        float(_turn_cost)
+                                        if isinstance(_turn_cost, (int, float))
+                                        else None
+                                    ),
+                                    model=_turn_model,
+                                    is_cumulative=False,
+                                )
+                            )
                         # Push the server-computed cost AND token breakdown
                         # to the web client's session indicator, rolled up
                         # over the spawn subtree. The session's own event

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -341,6 +341,7 @@ from omnigent.stores.file_store import FileStore
 from omnigent.stores.host_store import Host, HostStore, host_is_live
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.telemetry import emit as _tel_emit
+from omnigent.telemetry.events import NativeSessionUsageEvent as _TelNativeSessionUsageEvent
 from omnigent.telemetry.events import SessionCreatedEvent as _TelSessionCreatedEvent
 from omnigent.telemetry.events import TurnEndEvent as _TelTurnEndEvent
 from omnigent.telemetry.installation_id import get_installation_id as _get_installation_id
@@ -1530,6 +1531,21 @@ async def _persist_external_session_usage(
         body.data,
         conversation_store,
     )
+    _n_in = body.data.get("cumulative_input_tokens")
+    _n_out = body.data.get("cumulative_output_tokens")
+    _n_cost = body.data.get("cumulative_cost_usd")
+    _n_model: str | None = body.data.get("model") or None
+    if _n_in is not None or _n_out is not None or _n_cost is not None:
+        _tel_emit(
+            _TelNativeSessionUsageEvent(
+                installation_id=_get_installation_id(),
+                session_id=session_id,
+                input_tokens=int(_n_in) if _n_in is not None else None,
+                output_tokens=int(_n_out) if _n_out is not None else None,
+                cost_usd=(float(_n_cost) if isinstance(_n_cost, (int, float)) else None),
+                model=_n_model,
+            )
+        )
     label_updates: dict[str, str] = {}
     if raw_tokens is not None:
         label_updates[_LAST_CONTEXT_TOKENS_LABEL_KEY] = str(raw_tokens)

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -1541,11 +1541,7 @@ async def _persist_external_session_usage(
                 session_id=session_id,
                 input_tokens=int(_native_in) if _native_in is not None else None,
                 output_tokens=int(_native_out) if _native_out is not None else None,
-                cost_usd=(
-                    float(_native_cost)
-                    if isinstance(_native_cost, (int, float))
-                    else None
-                ),
+                cost_usd=(float(_native_cost) if isinstance(_native_cost, (int, float)) else None),
                 model=_native_model,
                 is_cumulative=True,
             )
@@ -6186,9 +6182,7 @@ async def _relay_runner_stream_once(
                                 _TelTurnTokenUsageEvent(
                                     installation_id=_get_installation_id(),
                                     session_id=session_id,
-                                    input_tokens=(
-                                        int(_turn_in) if _turn_in is not None else None
-                                    ),
+                                    input_tokens=(int(_turn_in) if _turn_in is not None else None),
                                     output_tokens=(
                                         int(_turn_out) if _turn_out is not None else None
                                     ),

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -6190,47 +6190,50 @@ async def _relay_runner_stream_once(
                                 ),
                             )
                         )
-                        # Push the server-computed cost AND token breakdown
-                        # to the web client's session indicator, rolled up
-                        # over the spawn subtree. The session's own event
-                        # carries its SUBTREE total (this conversation + its
-                        # sub-agents), and each ancestor gets its own subtree
-                        # total on its own stream — so a supervisor's badge
-                        # includes its sub-agents and a parent updates live
-                        # when a relay sub-agent spends. Mirrors the native
-                        # path (_persist_external_session_usage); the roll-up
-                        # was wired for native only, but relay agents (e.g.
-                        # claude-sdk) need it too. Cost is included only when
-                        # priced; the token breakdown rides along whenever any
-                        # bucket is recorded (so an unpriced session still
-                        # surfaces tokens). context_tokens/window already ride
-                        # on the response.completed event. Threaded: store
-                        # reads + SSE fan-out.
-                        _subtree_usage = await asyncio.to_thread(
-                            load_session_usage,
-                            session_id,
-                            conversation_store,
-                        )
-                        _subtree_cost = _priced_cost_for_display(_subtree_usage)
-                        _usage_by_model = _usage_by_model_for_display(_subtree_usage)
-                        if _subtree_cost is not None or _usage_by_model is not None:
-                            _usage_payload: dict[str, Any] = {
-                                "type": "session.usage",
-                                "conversation_id": session_id,
-                            }
-                            if _subtree_cost is not None:
-                                _usage_payload["total_cost_usd"] = _subtree_cost
-                            if _usage_by_model is not None:
-                                _usage_payload["usage_by_model"] = _usage_by_model
-                            session_stream.publish(
+                        if evt_type == "response.completed":
+                            # Push the server-computed cost AND token breakdown
+                            # to the web client's session indicator, rolled up
+                            # over the spawn subtree. The session's own event
+                            # carries its SUBTREE total (this conversation + its
+                            # sub-agents), and each ancestor gets its own subtree
+                            # total on its own stream — so a supervisor's badge
+                            # includes its sub-agents and a parent updates live
+                            # when a relay sub-agent spends. Mirrors the native
+                            # path (_persist_external_session_usage); the roll-up
+                            # was wired for native only, but relay agents (e.g.
+                            # claude-sdk) need it too. Cost is included only when
+                            # priced; the token breakdown rides along whenever any
+                            # bucket is recorded (so an unpriced session still
+                            # surfaces tokens). context_tokens/window already ride
+                            # on the response.completed event. Threaded: store
+                            # reads + SSE fan-out.
+                            _subtree_usage = await asyncio.to_thread(
+                                load_session_usage,
                                 session_id,
-                                SessionUsageEvent(**_usage_payload).model_dump(exclude_none=True),
-                            )
-                            await asyncio.to_thread(
-                                _publish_subtree_cost_to_ancestors,
                                 conversation_store,
-                                session_id,
                             )
+                            _subtree_cost = _priced_cost_for_display(_subtree_usage)
+                            _usage_by_model = _usage_by_model_for_display(_subtree_usage)
+                            if _subtree_cost is not None or _usage_by_model is not None:
+                                _usage_payload: dict[str, Any] = {
+                                    "type": "session.usage",
+                                    "conversation_id": session_id,
+                                }
+                                if _subtree_cost is not None:
+                                    _usage_payload["total_cost_usd"] = _subtree_cost
+                                if _usage_by_model is not None:
+                                    _usage_payload["usage_by_model"] = _usage_by_model
+                                session_stream.publish(
+                                    session_id,
+                                    SessionUsageEvent(**_usage_payload).model_dump(
+                                        exclude_none=True
+                                    ),
+                                )
+                                await asyncio.to_thread(
+                                    _publish_subtree_cost_to_ancestors,
+                                    conversation_store,
+                                    session_id,
+                                )
 
                     # Reset the turn-scoped response_id on any
                     # terminal event so it doesn't leak to the

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -342,7 +342,7 @@ from omnigent.stores.host_store import Host, HostStore, host_is_live
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.telemetry import emit as _tel_emit
 from omnigent.telemetry.events import SessionCreatedEvent as _TelSessionCreatedEvent
-from omnigent.telemetry.events import TurnTokenUsageEvent as _TelTurnTokenUsageEvent
+from omnigent.telemetry.events import TurnEndEvent as _TelTurnEndEvent
 from omnigent.telemetry.installation_id import get_installation_id as _get_installation_id
 from omnigent.telemetry.surface import classify_surface as _classify_surface
 
@@ -1530,23 +1530,6 @@ async def _persist_external_session_usage(
         body.data,
         conversation_store,
     )
-    _native_in = body.data.get("cumulative_input_tokens")
-    _native_out = body.data.get("cumulative_output_tokens")
-    _native_cost = body.data.get("cumulative_cost_usd")
-    _native_model: str | None = body.data.get("model") or None
-    if _native_in is not None or _native_out is not None:
-        _tel_emit(
-            _TelTurnTokenUsageEvent(
-                installation_id=_get_installation_id(),
-                session_id=session_id,
-                input_tokens=int(_native_in) if _native_in is not None else None,
-                output_tokens=int(_native_out) if _native_out is not None else None,
-                cost_usd=(float(_native_cost) if isinstance(_native_cost, (int, float)) else None),
-                model=_native_model,
-                is_cumulative=True,
-            )
-        )
-
     label_updates: dict[str, str] = {}
     if raw_tokens is not None:
         label_updates[_LAST_CONTEXT_TOKENS_LABEL_KEY] = str(raw_tokens)
@@ -5831,6 +5814,9 @@ async def _relay_runner_stream_once(
     # Model/agent label from the turn header, stamped on text segments
     # flushed at tool-call boundaries (the boundary event carries no model).
     current_model: str | None = None
+    # Wall-clock time when the current turn's response.in_progress arrived,
+    # used to compute per-turn latency in TurnEndEvent.
+    _turn_start_s: float | None = None
     # Map tool call_id → response_id so a function_call_output that
     # arrives after a new response.in_progress (different response_id)
     # still pairs with its matching function_call. Without this, the
@@ -5973,6 +5959,7 @@ async def _relay_runner_stream_once(
                     # Track the turn's response_id from lifecycle
                     # events so persisted items share one id.
                     if evt_type == "response.in_progress":
+                        _turn_start_s = time.monotonic()
                         resp_obj = event.get("response", {})
                         _rid = resp_obj.get("id")
                         if isinstance(_rid, str) and _rid:
@@ -6172,29 +6159,37 @@ async def _relay_runner_stream_once(
                             session_id,
                             conversation_store,
                         )
-                        _resp_usage = event.get("response", {}).get("usage") or {}
+                    if evt_type in _TERMINAL_RESPONSE_EVENT_TYPES:
+                        _turn_status = evt_type.split(".", 1)[1]  # "completed" etc.
+                        _latency_ms: float | None = None
+                        if _turn_start_s is not None:
+                            _latency_ms = (time.monotonic() - _turn_start_s) * 1000
+                        _turn_start_s = None
+                        _resp_usage = (
+                            event.get("response", {}).get("usage") or {}
+                            if evt_type == "response.completed"
+                            else {}
+                        )
                         _turn_in = _resp_usage.get("input_tokens")
                         _turn_out = _resp_usage.get("output_tokens")
                         _turn_cost = _resp_usage.get("cost_usd")
-                        _turn_model: str | None = _resp_usage.get("model") or None
-                        if _turn_in or _turn_out:
-                            _tel_emit(
-                                _TelTurnTokenUsageEvent(
-                                    installation_id=_get_installation_id(),
-                                    session_id=session_id,
-                                    input_tokens=(int(_turn_in) if _turn_in is not None else None),
-                                    output_tokens=(
-                                        int(_turn_out) if _turn_out is not None else None
-                                    ),
-                                    cost_usd=(
-                                        float(_turn_cost)
-                                        if isinstance(_turn_cost, (int, float))
-                                        else None
-                                    ),
-                                    model=_turn_model,
-                                    is_cumulative=False,
-                                )
+                        _turn_model: str | None = _resp_usage.get("model") or current_model or None
+                        _tel_emit(
+                            _TelTurnEndEvent(
+                                installation_id=_get_installation_id(),
+                                session_id=session_id,
+                                status=_turn_status,
+                                latency_ms=_latency_ms,
+                                model=_turn_model,
+                                input_tokens=(int(_turn_in) if _turn_in is not None else None),
+                                output_tokens=(int(_turn_out) if _turn_out is not None else None),
+                                cost_usd=(
+                                    float(_turn_cost)
+                                    if isinstance(_turn_cost, (int, float))
+                                    else None
+                                ),
                             )
+                        )
                         # Push the server-computed cost AND token breakdown
                         # to the web client's session indicator, rolled up
                         # over the spawn subtree. The session's own event

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -213,6 +213,7 @@ from omnigent.stores.permission_store import PermissionStore
 from omnigent.telemetry import emit as _tel_emit
 from omnigent.telemetry.events import SessionDeletedEvent as _TelSessionDeletedEvent
 from omnigent.telemetry.events import SessionStoppedEvent as _TelSessionStoppedEvent
+from omnigent.telemetry.events import TurnEndEvent as _TelTurnEndEvent
 from omnigent.telemetry.installation_id import get_installation_id as _get_installation_id
 from omnigent.tools.client_specified import parse_client_side_tool_specs
 
@@ -1068,6 +1069,22 @@ def register_events_routes(
                 background_task_count=bg_count,
                 blocked_on=blocked_on,
             )
+            # Emit a turn-end telemetry event for native harnesses. "idle"
+            # means the turn completed normally; "failed" means it errored.
+            # No latency or token deltas are available on this path.
+            if status in {"idle", "failed"}:
+                _tel_emit(
+                    _TelTurnEndEvent(
+                        installation_id=_get_installation_id(),
+                        session_id=session_id,
+                        status="completed" if status == "idle" else "failed",
+                        latency_ms=None,
+                        model=None,
+                        input_tokens=None,
+                        output_tokens=None,
+                        cost_usd=None,
+                    )
+                )
             forward_body = body.model_dump()
             forward_body["data"] = await _enrich_idle_status_with_subagent_output(
                 forward_body["data"], status, session_id, conversation_store

--- a/omnigent/telemetry/events.py
+++ b/omnigent/telemetry/events.py
@@ -86,6 +86,38 @@ class SessionDeletedEvent:
 
 
 @dataclass
+class TurnTokenUsageEvent:
+    """Fired after each LLM turn that carries token usage data.
+
+    Emitted once per ``response.completed`` event on the relay path and once per
+    ``external_session_usage`` broadcast on the native path.  Captures the
+    per-turn delta (relay) or cumulative totals (native) so token spend can be
+    aggregated without waiting for session deletion.
+
+    :param installation_id: Server-side installation ID.
+    :param session_id: Omnigent conversation/session identifier.
+    :param input_tokens: Input tokens consumed this turn (relay: delta;
+        native: cumulative session total at time of report).
+    :param output_tokens: Output tokens consumed this turn (relay: delta;
+        native: cumulative session total at time of report).
+    :param cost_usd: Cost for this turn in USD (relay: delta; native:
+        cumulative).  ``None`` when the model is unpriced.
+    :param model: LLM model name, e.g. ``"claude-3-7-sonnet-20250219"``.
+        ``None`` when not reported by the harness.
+    :param is_cumulative: ``True`` for native-path events that carry a
+        cumulative total rather than a per-turn delta.
+    """
+
+    installation_id: str | None
+    session_id: str
+    input_tokens: int | None
+    output_tokens: int | None
+    cost_usd: float | None
+    model: str | None
+    is_cumulative: bool
+
+
+@dataclass
 class PolicyRegisteredEvent:
     """Fired when a policy is created via the API.
 

--- a/omnigent/telemetry/events.py
+++ b/omnigent/telemetry/events.py
@@ -87,15 +87,21 @@ class SessionDeletedEvent:
 
 @dataclass
 class TurnEndEvent:
-    """Fired at the end of each LLM turn (relay path only).
+    """Fired at the end of each LLM turn.
 
-    Emitted once per terminal ``response.*`` event (``completed``,
-    ``failed``, ``cancelled``, ``incomplete``) so per-turn latency,
-    status, and token spend can be tracked without waiting for session
-    deletion.
+    Emitted on two paths:
 
-    Token fields are only present on ``status="completed"`` turns; they
-    are ``None`` for ``failed`` / ``cancelled`` / ``incomplete``.
+    - **Relay / SDK harnesses**: once per terminal ``response.*`` event
+      (``completed``, ``failed``, ``cancelled``, ``incomplete``).
+      ``latency_ms`` and token fields are populated when available.
+    - **Native harnesses** (claude-native, codex-native): once per
+      ``external_session_status`` event with ``status`` in
+      ``{"idle", "failed"}``.  ``latency_ms`` and token fields are
+      always ``None`` on this path (native harnesses report cumulative
+      totals separately via ``SessionDeletedEvent``).
+
+    Token fields are only present on ``status="completed"`` relay turns;
+    they are ``None`` for all other statuses and for the native path.
 
     :param installation_id: Server-side installation ID.
     :param session_id: Omnigent conversation/session identifier.

--- a/omnigent/telemetry/events.py
+++ b/omnigent/telemetry/events.py
@@ -131,6 +131,36 @@ class TurnEndEvent:
 
 
 @dataclass
+class NativeSessionUsageEvent:
+    """Fired on each ``external_session_usage`` flush from a native harness.
+
+    Native harnesses (claude-native, codex-native) report *cumulative*
+    session totals rather than per-turn deltas, so this event carries
+    running totals at the time of the flush.  Multiple events per session
+    are expected; consumers should take the last one (or compute deltas
+    between consecutive events) to derive per-turn spend.
+
+    :param installation_id: Server-side installation ID.
+    :param session_id: Omnigent conversation/session identifier.
+    :param input_tokens: Cumulative input tokens at time of flush.
+        ``None`` when not reported in this flush.
+    :param output_tokens: Cumulative output tokens at time of flush.
+        ``None`` when not reported in this flush.
+    :param cost_usd: Cumulative cost in USD at time of flush.
+        ``None`` when the session is unpriced or not reported.
+    :param model: LLM model name forwarded by the harness, e.g.
+        ``"claude-opus-4-5"``.  ``None`` when not reported.
+    """
+
+    installation_id: str | None
+    session_id: str
+    input_tokens: int | None
+    output_tokens: int | None
+    cost_usd: float | None
+    model: str | None
+
+
+@dataclass
 class PolicyRegisteredEvent:
     """Fired when a policy is created via the API.
 

--- a/omnigent/telemetry/events.py
+++ b/omnigent/telemetry/events.py
@@ -86,35 +86,42 @@ class SessionDeletedEvent:
 
 
 @dataclass
-class TurnTokenUsageEvent:
-    """Fired after each LLM turn that carries token usage data.
+class TurnEndEvent:
+    """Fired at the end of each LLM turn (relay path only).
 
-    Emitted once per ``response.completed`` event on the relay path and once per
-    ``external_session_usage`` broadcast on the native path.  Captures the
-    per-turn delta (relay) or cumulative totals (native) so token spend can be
-    aggregated without waiting for session deletion.
+    Emitted once per terminal ``response.*`` event (``completed``,
+    ``failed``, ``cancelled``, ``incomplete``) so per-turn latency,
+    status, and token spend can be tracked without waiting for session
+    deletion.
+
+    Token fields are only present on ``status="completed"`` turns; they
+    are ``None`` for ``failed`` / ``cancelled`` / ``incomplete``.
 
     :param installation_id: Server-side installation ID.
     :param session_id: Omnigent conversation/session identifier.
-    :param input_tokens: Input tokens consumed this turn (relay: delta;
-        native: cumulative session total at time of report).
-    :param output_tokens: Output tokens consumed this turn (relay: delta;
-        native: cumulative session total at time of report).
-    :param cost_usd: Cost for this turn in USD (relay: delta; native:
-        cumulative).  ``None`` when the model is unpriced.
+    :param status: Terminal status of the turn: ``"completed"``,
+        ``"failed"``, ``"cancelled"``, or ``"incomplete"``.
+    :param latency_ms: Wall-clock turn duration in milliseconds from
+        ``response.in_progress`` to the terminal event.  ``None`` when
+        the start timestamp was not captured (e.g. stream reconnect).
     :param model: LLM model name, e.g. ``"claude-3-7-sonnet-20250219"``.
         ``None`` when not reported by the harness.
-    :param is_cumulative: ``True`` for native-path events that carry a
-        cumulative total rather than a per-turn delta.
+    :param input_tokens: Input tokens for this turn (per-turn delta).
+        ``None`` for non-completed turns or when not reported.
+    :param output_tokens: Output tokens for this turn (per-turn delta).
+        ``None`` for non-completed turns or when not reported.
+    :param cost_usd: Cost for this turn in USD (per-turn delta).
+        ``None`` when the model is unpriced or the turn did not complete.
     """
 
     installation_id: str | None
     session_id: str
+    status: str
+    latency_ms: float | None
+    model: str | None
     input_tokens: int | None
     output_tokens: int | None
     cost_usd: float | None
-    model: str | None
-    is_cumulative: bool
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Add `TurnTokenUsageEvent` dataclass to `omnigent/telemetry/events.py`
- Emit it after every `response.completed` on the relay path (per-turn delta)
- Emit it after every `external_session_usage` broadcast on the native path (cumulative totals)

Previously token usage was only captured in `SessionDeletedEvent`, which fires at explicit session deletion. Sessions lost to crashes or evictions emitted no usage telemetry at all. This closes that gap by recording token spend at each turn boundary.

**Relay path** (`is_cumulative=False`): reads `input_tokens`, `output_tokens`, and `cost_usd` directly from `response.usage` — the same fields `_accumulate_session_usage` already processes.

**Native path** (`is_cumulative=True`): reads `cumulative_input_tokens`, `cumulative_output_tokens`, and `cumulative_cost_usd` from the `external_session_usage` event body. Native harnesses report running totals rather than per-turn deltas, so `is_cumulative=True` flags this distinction for consumers.

Both paths forward the `model` field when the harness reports it, enabling per-model breakdowns without a separate lookup.

## Test Plan

- Manual: start a relay session, observe `TurnTokenUsageEvent` emitted in telemetry after each turn
- Manual: start a native (claude-native) session, observe `TurnTokenUsageEvent` emitted on each `external_session_usage` flush
- Existing telemetry tests pass (no changes to existing event shapes)

## Demo

N/A — internal telemetry change, no UI impact.

## Type of change

- [x] New feature

## Test coverage

- [x] Manual verification completed

## Coverage notes

Telemetry events fire asynchronously via the existing queue-based `_tel_emit`. No new test infrastructure added; the event dataclass shape can be covered by the existing telemetry unit tests in a follow-up.