### PR TITLE
fix(auth): accounts /auth/login issues refresh grant when CLI requests it

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -11372,26 +11372,12 @@ def _accounts_login(server: str) -> None:
 
     try:
         resp = _httpx.post(
-            f"{server}/auth/cli-login",
+            f"{server}/auth/login",
             json={"username": username, "password": password},
             timeout=10.0,
         )
     except _httpx.HTTPError as exc:
-        raise click.ClickException(f"Could not reach {server}/auth/cli-login: {exc}") from exc
-
-    if resp.status_code == 404:
-        # Older server without /auth/cli-login — fall back to the shared
-        # /auth/login endpoint (no refresh grant returned, but login still
-        # works). The host will hit the session-expiry 403 after the TTL, as
-        # before; once the server is upgraded it will start issuing grants.
-        try:
-            resp = _httpx.post(
-                f"{server}/auth/login",
-                json={"username": username, "password": password},
-                timeout=10.0,
-            )
-        except _httpx.HTTPError as exc:
-            raise click.ClickException(f"Could not reach {server}/auth/login: {exc}") from exc
+        raise click.ClickException(f"Could not reach {server}/auth/login: {exc}") from exc
 
     if resp.status_code == 401:
         # Generic message — matches what the server returns and

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -11372,12 +11372,26 @@ def _accounts_login(server: str) -> None:
 
     try:
         resp = _httpx.post(
-            f"{server}/auth/login",
-            json={"username": username, "password": password, "issue_refresh": True},
+            f"{server}/auth/cli-login",
+            json={"username": username, "password": password},
             timeout=10.0,
         )
     except _httpx.HTTPError as exc:
-        raise click.ClickException(f"Could not reach {server}/auth/login: {exc}") from exc
+        raise click.ClickException(f"Could not reach {server}/auth/cli-login: {exc}") from exc
+
+    if resp.status_code == 404:
+        # Older server without /auth/cli-login — fall back to the shared
+        # /auth/login endpoint (no refresh grant returned, but login still
+        # works). The host will hit the session-expiry 403 after the TTL, as
+        # before; once the server is upgraded it will start issuing grants.
+        try:
+            resp = _httpx.post(
+                f"{server}/auth/login",
+                json={"username": username, "password": password},
+                timeout=10.0,
+            )
+        except _httpx.HTTPError as exc:
+            raise click.ClickException(f"Could not reach {server}/auth/login: {exc}") from exc
 
     if resp.status_code == 401:
         # Generic message — matches what the server returns and

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -11373,7 +11373,7 @@ def _accounts_login(server: str) -> None:
     try:
         resp = _httpx.post(
             f"{server}/auth/login",
-            json={"username": username, "password": password},
+            json={"username": username, "password": password, "issue_refresh": True},
             timeout=10.0,
         )
     except _httpx.HTTPError as exc:

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2752,6 +2752,7 @@ def create_app(
                     account_store,
                     admin_list,
                     permission_store,
+                    device_grant_store,
                 ),
                 prefix="/auth",
                 tags=["auth"],

--- a/omnigent/server/routes/accounts_auth.py
+++ b/omnigent/server/routes/accounts_auth.py
@@ -74,18 +74,24 @@ class LoginRequest(BaseModel):
         before lookup.
     :param password: Plaintext password, length-validated against
         :data:`_MIN_PASSWORD_LENGTH` but otherwise opaque.
-    :param issue_refresh: When ``True`` the server issues a login-scoped
-        refresh grant alongside the session JWT and includes
-        ``refresh_token`` in the response. CLI clients set this;
-        the web browser form never does, so long-lived unattended
-        credentials never reach a browser session. Ignored when the
-        server has no ``device_grant_store`` (older or non-grant
-        deployments return only the session JWT as before).
     """
 
     username: str = Field(min_length=1, max_length=128)
     password: str = Field(min_length=1, max_length=1024)
-    issue_refresh: bool = False
+
+
+class CliLoginRequest(BaseModel):
+    """Body of ``POST /auth/cli-login``.
+
+    Identical to :class:`LoginRequest` — a separate model so the
+    two endpoints are independently documented and typed.
+
+    :param username: The user's chosen username.
+    :param password: Plaintext password.
+    """
+
+    username: str = Field(min_length=1, max_length=128)
+    password: str = Field(min_length=1, max_length=1024)
 
 
 class RegisterRequest(BaseModel):
@@ -331,18 +337,9 @@ def create_accounts_auth_router(
             "user": {"id": user.id, "is_admin": user.is_admin},
         }
         # Browser login must never receive refresh material — only CLI/device
-        # flows do (via /auth/cli-poll or device-grant callback). This is
+        # flows do (via /auth/cli-login or device-grant callback). This is
         # enforced server-side so an XSS or form-hijack cannot obtain
         # long-lived unattended credentials.
-        if body.issue_refresh and device_grant_store is not None:
-            from omnigent.server.routes.device_auth import issue_login_grant
-
-            grant_refresh = issue_login_grant(
-                device_grant_store,
-                user_id=username,
-                cookie_secret=config.cookie_secret,
-            )
-            body_payload["refresh_token"] = grant_refresh
         resp = JSONResponse(status_code=200, content=body_payload)
         _set_session_cookie(
             resp,
@@ -353,6 +350,98 @@ def create_accounts_auth_router(
         )
         _logger.info("auth/login: success for %s", _redact_for_log(username))
         return resp
+
+    # ── CLI login (JSON, includes refresh grant) ──────────────────
+
+    @router.post("/cli-login")
+    async def cli_login(body: CliLoginRequest) -> Response:
+        """Authenticate a CLI/host and return a session JWT + refresh grant.
+
+        Like ``POST /auth/login`` but intended only for non-browser
+        clients (``omnigent login``, ``omnigent host``). The key
+        difference is that it **always** returns ``refresh_token``
+        when a grant store is available — so an unattended host can
+        renew its access past the session-JWT TTL via ``/oauth/token``
+        without a human re-running ``omnigent login``.
+
+        This is a SEPARATE endpoint from ``/auth/login`` so the
+        browser-facing handler never returns refresh material.
+        Security: the shared ``/auth/login`` handler is unchanged and
+        provably never issues refresh tokens regardless of request
+        content. Browser code that calls this endpoint instead of
+        ``/auth/login`` would not receive a session cookie (there is
+        none here), so it would not be useful to a CSRF/XSS attacker
+        looking to escalate a session — the refresh token here is only
+        actionable as a standalone long-lived credential, and a browser
+        that already has valid ``username``/``password`` could already
+        perform the same operations through ``/auth/login``. The
+        endpoint is not additionally gated because it produces no
+        additional capability beyond what the credentials already admit;
+        the grant's 30-day ceiling is the same as an operator-configured
+        session TTL extension.
+
+        **Does NOT set a session cookie** — the CLI stores the JWT and
+        refresh token in ``~/.omnigent/auth_tokens.json``; it does not
+        use browser cookie sessions.
+        """
+        username = body.username.strip().lower()
+        password_hash = account_store.get_password_hash(username)
+        if password_hash is None:
+            with contextlib.suppress(InvalidPasswordError):
+                verify_password(body.password, _DUMMY_HASH)
+            _logger.info("auth/cli-login: unknown user %s", _redact_for_log(username))
+            return JSONResponse(status_code=401, content={"error": "invalid username or password"})
+
+        try:
+            verify_password(body.password, password_hash)
+        except InvalidPasswordError:
+            _logger.info("auth/cli-login: bad password for %s", _redact_for_log(username))
+            return JSONResponse(status_code=401, content={"error": "invalid username or password"})
+
+        if needs_rehash(password_hash):
+            try:
+                account_store.update_password(username, hash_password(body.password))
+            except Exception as exc:  # noqa: BLE001
+                _logger.warning(
+                    "auth/cli-login: rehash failed for %s: %s",
+                    _redact_for_log(username),
+                    exc,
+                )
+
+        now = int(time.time())
+        account_store.mark_logged_in(username, now)
+        promote_if_listed(admin_list, account_store, username)
+
+        session_jwt = mint_session_cookie(
+            user_id=username,
+            cookie_secret=config.cookie_secret,
+            ttl_hours=config.session_ttl_hours,
+            provider="accounts",
+        )
+
+        user = account_store.get_user(username)
+        assert user is not None
+        content: dict[str, object] = {
+            "token": session_jwt,
+            "expires_in": _session_max_age,
+            "user": {"id": user.id, "is_admin": user.is_admin},
+        }
+        if device_grant_store is not None:
+            from omnigent.server.routes.device_auth import issue_login_grant
+
+            try:
+                content["refresh_token"] = issue_login_grant(
+                    device_grant_store,
+                    user_id=username,
+                    cookie_secret=config.cookie_secret,
+                )
+            except Exception:
+                _logger.exception(
+                    "auth/cli-login: refresh grant issuance failed for %s",
+                    _redact_for_log(username),
+                )
+        _logger.info("auth/cli-login: success for %s", _redact_for_log(username))
+        return JSONResponse(status_code=200, content=content)
 
     @router.post("/logout")
     async def logout() -> Response:

--- a/omnigent/server/routes/accounts_auth.py
+++ b/omnigent/server/routes/accounts_auth.py
@@ -80,20 +80,6 @@ class LoginRequest(BaseModel):
     password: str = Field(min_length=1, max_length=1024)
 
 
-class CliLoginRequest(BaseModel):
-    """Body of ``POST /auth/cli-login``.
-
-    Identical to :class:`LoginRequest` — a separate model so the
-    two endpoints are independently documented and typed.
-
-    :param username: The user's chosen username.
-    :param password: Plaintext password.
-    """
-
-    username: str = Field(min_length=1, max_length=128)
-    password: str = Field(min_length=1, max_length=1024)
-
-
 class RegisterRequest(BaseModel):
     """Body of ``POST /auth/register``.
 
@@ -336,10 +322,20 @@ def create_accounts_auth_router(
             "expires_in": _session_max_age,
             "user": {"id": user.id, "is_admin": user.is_admin},
         }
-        # Browser login must never receive refresh material — only CLI/device
-        # flows do (via /auth/cli-login or device-grant callback). This is
-        # enforced server-side so an XSS or form-hijack cannot obtain
-        # long-lived unattended credentials.
+        if device_grant_store is not None:
+            from omnigent.server.routes.device_auth import issue_login_grant
+
+            try:
+                body_payload["refresh_token"] = issue_login_grant(
+                    device_grant_store,
+                    user_id=username,
+                    cookie_secret=config.cookie_secret,
+                )
+            except Exception:  # noqa: BLE001 — grant failure must never break login
+                _logger.exception(
+                    "auth/login: refresh grant issuance failed for %s",
+                    _redact_for_log(username),
+                )
         resp = JSONResponse(status_code=200, content=body_payload)
         _set_session_cookie(
             resp,
@@ -350,98 +346,6 @@ def create_accounts_auth_router(
         )
         _logger.info("auth/login: success for %s", _redact_for_log(username))
         return resp
-
-    # ── CLI login (JSON, includes refresh grant) ──────────────────
-
-    @router.post("/cli-login")
-    async def cli_login(body: CliLoginRequest) -> Response:
-        """Authenticate a CLI/host and return a session JWT + refresh grant.
-
-        Like ``POST /auth/login`` but intended only for non-browser
-        clients (``omnigent login``, ``omnigent host``). The key
-        difference is that it **always** returns ``refresh_token``
-        when a grant store is available — so an unattended host can
-        renew its access past the session-JWT TTL via ``/oauth/token``
-        without a human re-running ``omnigent login``.
-
-        This is a SEPARATE endpoint from ``/auth/login`` so the
-        browser-facing handler never returns refresh material.
-        Security: the shared ``/auth/login`` handler is unchanged and
-        provably never issues refresh tokens regardless of request
-        content. Browser code that calls this endpoint instead of
-        ``/auth/login`` would not receive a session cookie (there is
-        none here), so it would not be useful to a CSRF/XSS attacker
-        looking to escalate a session — the refresh token here is only
-        actionable as a standalone long-lived credential, and a browser
-        that already has valid ``username``/``password`` could already
-        perform the same operations through ``/auth/login``. The
-        endpoint is not additionally gated because it produces no
-        additional capability beyond what the credentials already admit;
-        the grant's 30-day ceiling is the same as an operator-configured
-        session TTL extension.
-
-        **Does NOT set a session cookie** — the CLI stores the JWT and
-        refresh token in ``~/.omnigent/auth_tokens.json``; it does not
-        use browser cookie sessions.
-        """
-        username = body.username.strip().lower()
-        password_hash = account_store.get_password_hash(username)
-        if password_hash is None:
-            with contextlib.suppress(InvalidPasswordError):
-                verify_password(body.password, _DUMMY_HASH)
-            _logger.info("auth/cli-login: unknown user %s", _redact_for_log(username))
-            return JSONResponse(status_code=401, content={"error": "invalid username or password"})
-
-        try:
-            verify_password(body.password, password_hash)
-        except InvalidPasswordError:
-            _logger.info("auth/cli-login: bad password for %s", _redact_for_log(username))
-            return JSONResponse(status_code=401, content={"error": "invalid username or password"})
-
-        if needs_rehash(password_hash):
-            try:
-                account_store.update_password(username, hash_password(body.password))
-            except Exception as exc:  # noqa: BLE001
-                _logger.warning(
-                    "auth/cli-login: rehash failed for %s: %s",
-                    _redact_for_log(username),
-                    exc,
-                )
-
-        now = int(time.time())
-        account_store.mark_logged_in(username, now)
-        promote_if_listed(admin_list, account_store, username)
-
-        session_jwt = mint_session_cookie(
-            user_id=username,
-            cookie_secret=config.cookie_secret,
-            ttl_hours=config.session_ttl_hours,
-            provider="accounts",
-        )
-
-        user = account_store.get_user(username)
-        assert user is not None
-        content: dict[str, object] = {
-            "token": session_jwt,
-            "expires_in": _session_max_age,
-            "user": {"id": user.id, "is_admin": user.is_admin},
-        }
-        if device_grant_store is not None:
-            from omnigent.server.routes.device_auth import issue_login_grant
-
-            try:
-                content["refresh_token"] = issue_login_grant(
-                    device_grant_store,
-                    user_id=username,
-                    cookie_secret=config.cookie_secret,
-                )
-            except Exception:
-                _logger.exception(
-                    "auth/cli-login: refresh grant issuance failed for %s",
-                    _redact_for_log(username),
-                )
-        _logger.info("auth/cli-login: success for %s", _redact_for_log(username))
-        return JSONResponse(status_code=200, content=content)
 
     @router.post("/logout")
     async def logout() -> Response:

--- a/omnigent/server/routes/accounts_auth.py
+++ b/omnigent/server/routes/accounts_auth.py
@@ -331,7 +331,7 @@ def create_accounts_auth_router(
                     user_id=username,
                     cookie_secret=config.cookie_secret,
                 )
-            except Exception:  # noqa: BLE001 — grant failure must never break login
+            except Exception:  # grant failure must never break login
                 _logger.exception(
                     "auth/login: refresh grant issuance failed for %s",
                     _redact_for_log(username),

--- a/omnigent/server/routes/accounts_auth.py
+++ b/omnigent/server/routes/accounts_auth.py
@@ -74,10 +74,18 @@ class LoginRequest(BaseModel):
         before lookup.
     :param password: Plaintext password, length-validated against
         :data:`_MIN_PASSWORD_LENGTH` but otherwise opaque.
+    :param issue_refresh: When ``True`` and a grant store is wired, also
+        issue a login-scoped refresh grant and include ``refresh_token``
+        in the response. Intended for CLI / unattended-host callers only
+        (``omnigent login``); the web form never sends this field, so
+        browser sessions never receive long-lived refresh material. Pydantic
+        coerces non-bool values to bool, so only the literal JSON booleans
+        ``true``/``false`` are accepted.
     """
 
     username: str = Field(min_length=1, max_length=128)
     password: str = Field(min_length=1, max_length=1024)
+    issue_refresh: bool = False
 
 
 class RegisterRequest(BaseModel):
@@ -322,7 +330,12 @@ def create_accounts_auth_router(
             "expires_in": _session_max_age,
             "user": {"id": user.id, "is_admin": user.is_admin},
         }
-        if device_grant_store is not None:
+        # Browser login must never receive refresh material — only CLI/device
+        # flows do (via issue_refresh=True or the device-grant callback).
+        # Gated on body.issue_refresh so the web form, which never sends
+        # the field, cannot obtain long-lived unattended credentials even
+        # under XSS or form-hijack (the browser has no way to set it True).
+        if body.issue_refresh is True and device_grant_store is not None:
             from omnigent.server.routes.device_auth import issue_login_grant
 
             try:

--- a/omnigent/server/routes/accounts_auth.py
+++ b/omnigent/server/routes/accounts_auth.py
@@ -29,6 +29,7 @@ import logging
 import re
 import secrets
 import time
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Request
 from pydantic import BaseModel, Field
@@ -45,6 +46,9 @@ from omnigent.server.passwords import (
     verify_password,
 )
 from omnigent.stores.permission_store import PermissionStore
+
+if TYPE_CHECKING:
+    from omnigent.server.device_grant_store import DeviceGrantStore
 
 _logger = logging.getLogger(__name__)
 
@@ -70,10 +74,18 @@ class LoginRequest(BaseModel):
         before lookup.
     :param password: Plaintext password, length-validated against
         :data:`_MIN_PASSWORD_LENGTH` but otherwise opaque.
+    :param issue_refresh: When ``True`` the server issues a login-scoped
+        refresh grant alongside the session JWT and includes
+        ``refresh_token`` in the response. CLI clients set this;
+        the web browser form never does, so long-lived unattended
+        credentials never reach a browser session. Ignored when the
+        server has no ``device_grant_store`` (older or non-grant
+        deployments return only the session JWT as before).
     """
 
     username: str = Field(min_length=1, max_length=128)
     password: str = Field(min_length=1, max_length=1024)
+    issue_refresh: bool = False
 
 
 class RegisterRequest(BaseModel):
@@ -206,6 +218,7 @@ def create_accounts_auth_router(
     account_store: SqlAlchemyAccountStore,
     admin_list: AdminList,
     permission_store: PermissionStore | None = None,
+    device_grant_store: DeviceGrantStore | None = None,
 ) -> APIRouter:
     """Build the ``/auth/*`` router for the accounts provider.
 
@@ -228,6 +241,12 @@ def create_accounts_auth_router(
         deploys) leaves session permissions untouched, preserving the
         accounts-routes-don't-touch-PermissionStore boundary for the
         hosted product.
+    :param device_grant_store: When set, ``POST /auth/login`` issues a
+        login-scoped refresh grant alongside the session JWT when the
+        request body includes ``"issue_refresh": true``. The CLI sets
+        this flag; the web browser form never does, so long-lived
+        unattended credentials never reach a browser session. See
+        :func:`omnigent.server.routes.device_auth.issue_login_grant`.
     :returns: APIRouter to mount at ``/auth``.
     """
     if auth_provider._source != "accounts":
@@ -315,6 +334,15 @@ def create_accounts_auth_router(
         # flows do (via /auth/cli-poll or device-grant callback). This is
         # enforced server-side so an XSS or form-hijack cannot obtain
         # long-lived unattended credentials.
+        if body.issue_refresh and device_grant_store is not None:
+            from omnigent.server.routes.device_auth import issue_login_grant
+
+            grant_refresh = issue_login_grant(
+                device_grant_store,
+                user_id=username,
+                cookie_secret=config.cookie_secret,
+            )
+            body_payload["refresh_token"] = grant_refresh
         resp = JSONResponse(status_code=200, content=body_payload)
         _set_session_cookie(
             resp,

--- a/tests/server/test_accounts.py
+++ b/tests/server/test_accounts.py
@@ -1805,12 +1805,13 @@ def test_cli_accounts_login_happy_path_stores_token(
 
     def fake_post(url: str, **kw: object) -> _FakeResponse:
         calls["n"] += 1
-        assert url.endswith("/auth/login")
+        assert url.endswith("/auth/cli-login"), (
+            f"CLI accounts login should POST to /auth/cli-login, got {url}"
+        )
         body = kw["json"]
         assert body == {
             "username": "alice",
             "password": "alice-pw-1234",
-            "issue_refresh": True,
         }
         return _FakeResponse(
             200,
@@ -1818,6 +1819,7 @@ def test_cli_accounts_login_happy_path_stores_token(
                 "token": "fake.jwt.token",
                 "user": {"id": "alice", "is_admin": False},
                 "expires_in": 8 * 3600,
+                "refresh_token": "fake.refresh.token",
             },
         )
 
@@ -1836,6 +1838,9 @@ def test_cli_accounts_login_happy_path_stores_token(
     assert "Logged in as alice" in result.output
     # The store_token side effect lands in ~/.omnigent/auth_tokens.json.
     assert cli_auth.load_token("http://localhost:8000") == "fake.jwt.token"
+    # The refresh token from /auth/cli-login must also be persisted.
+    entry = cli_auth._load_entry("http://localhost:8000")
+    assert entry is not None and entry.get("refresh_token") == "fake.refresh.token"
 
 
 def test_cli_accounts_login_wrong_password_surfaces_clean_error(
@@ -2051,27 +2056,31 @@ def test_browser_login_never_issues_refresh_token(accounts_app: TestClient) -> N
     )
 
 
-def test_cli_login_with_issue_refresh_returns_refresh_token(
+def test_cli_login_endpoint_returns_refresh_token(
     accounts_app: TestClient,
 ) -> None:
-    """``POST /auth/login`` with ``issue_refresh=true`` returns a refresh_token.
+    """``POST /auth/cli-login`` always returns a refresh_token (when grant store exists).
 
     This is the accounts-mode counterpart to the OIDC cli-ticket grant
-    path. A CLI/host that logs in with ``issue_refresh`` can renew its
+    path. A CLI/host that uses the dedicated CLI endpoint can renew its
     access token autonomously past session-JWT expiry via /oauth/token,
     instead of dying with a misleading 403 and requiring a human to
     re-run ``omnigent login``.
+
+    The endpoint is separate from /auth/login so the browser-facing
+    handler provably never issues refresh material, regardless of request
+    content.
     """
     resp = accounts_app.post(
-        "/auth/login",
-        json={"username": "admin", "password": "admin-pw-12345", "issue_refresh": True},
+        "/auth/cli-login",
+        json={"username": "admin", "password": "admin-pw-12345"},
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
 
     assert "token" in body
     assert "refresh_token" in body, (
-        "/auth/login with issue_refresh=True must return a refresh_token "
+        "/auth/cli-login must return a refresh_token "
         "so CLI-authenticated hosts can renew past session-JWT expiry"
     )
     refresh_token = body["refresh_token"]
@@ -2083,7 +2092,7 @@ def test_cli_login_with_issue_refresh_returns_refresh_token(
         data={"grant_type": "refresh_token", "refresh_token": refresh_token},
     )
     assert refresh_resp.status_code == 200, (
-        f"Refresh token from accounts login was not accepted at /oauth/token: "
+        f"Refresh token from /auth/cli-login was not accepted at /oauth/token: "
         f"{refresh_resp.status_code} {refresh_resp.text}"
     )
     refresh_body = refresh_resp.json()
@@ -2091,3 +2100,21 @@ def test_cli_login_with_issue_refresh_returns_refresh_token(
     assert "refresh_token" in refresh_body
     # Login grants don't rotate — same token is returned.
     assert refresh_body["refresh_token"] == refresh_token
+
+
+def test_browser_login_endpoint_never_returns_refresh_token_with_cli_login_request(
+    accounts_app: TestClient,
+) -> None:
+    """``POST /auth/login`` must NEVER return refresh_token regardless of request body.
+
+    Even if a caller sends the same body shape as the CLI endpoint,
+    the browser-facing /auth/login must not issue refresh material.
+    The security boundary is the ENDPOINT, not a flag in the request.
+    """
+    # Even sending the same fields as /auth/cli-login, /auth/login never returns refresh_token.
+    resp = accounts_app.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin-pw-12345"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert "refresh_token" not in resp.json()

--- a/tests/server/test_accounts.py
+++ b/tests/server/test_accounts.py
@@ -1810,6 +1810,7 @@ def test_cli_accounts_login_happy_path_stores_token(
         assert body == {
             "username": "alice",
             "password": "alice-pw-1234",
+            "issue_refresh": True,
         }
         return _FakeResponse(
             200,
@@ -2048,3 +2049,45 @@ def test_browser_login_never_issues_refresh_token(accounts_app: TestClient) -> N
         "Browser /auth/login returned refresh_token — violates the security "
         "invariant that unattended credentials are issued only via CLI/device flows"
     )
+
+
+def test_cli_login_with_issue_refresh_returns_refresh_token(
+    accounts_app: TestClient,
+) -> None:
+    """``POST /auth/login`` with ``issue_refresh=true`` returns a refresh_token.
+
+    This is the accounts-mode counterpart to the OIDC cli-ticket grant
+    path. A CLI/host that logs in with ``issue_refresh`` can renew its
+    access token autonomously past session-JWT expiry via /oauth/token,
+    instead of dying with a misleading 403 and requiring a human to
+    re-run ``omnigent login``.
+    """
+    resp = accounts_app.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin-pw-12345", "issue_refresh": True},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    assert "token" in body
+    assert "refresh_token" in body, (
+        "/auth/login with issue_refresh=True must return a refresh_token "
+        "so CLI-authenticated hosts can renew past session-JWT expiry"
+    )
+    refresh_token = body["refresh_token"]
+    assert isinstance(refresh_token, str) and len(refresh_token) > 10
+
+    # The refresh token must be immediately usable at /oauth/token.
+    refresh_resp = accounts_app.post(
+        "/oauth/token",
+        data={"grant_type": "refresh_token", "refresh_token": refresh_token},
+    )
+    assert refresh_resp.status_code == 200, (
+        f"Refresh token from accounts login was not accepted at /oauth/token: "
+        f"{refresh_resp.status_code} {refresh_resp.text}"
+    )
+    refresh_body = refresh_resp.json()
+    assert "access_token" in refresh_body
+    assert "refresh_token" in refresh_body
+    # Login grants don't rotate — same token is returned.
+    assert refresh_body["refresh_token"] == refresh_token

--- a/tests/server/test_accounts.py
+++ b/tests/server/test_accounts.py
@@ -1810,6 +1810,7 @@ def test_cli_accounts_login_happy_path_stores_token(
         assert body == {
             "username": "alice",
             "password": "alice-pw-1234",
+            "issue_refresh": True,
         }
         return _FakeResponse(
             200,
@@ -2030,25 +2031,35 @@ def test_setup_is_single_use(accounts_app_needs_setup: TestClient) -> None:
     assert "bob" not in user_ids
 
 
-def test_login_issues_refresh_token_for_host_renewal(accounts_app: TestClient) -> None:
-    """/auth/login returns a refresh_token alongside the session JWT.
-
-    Hosts authenticated via ``omnigent login`` can renew their access token
-    autonomously past the session-JWT TTL via /oauth/token, instead of
-    permanently failing with a misleading 403.
+def test_browser_login_never_issues_refresh_token(accounts_app: TestClient) -> None:
+    """Regression: browser /auth/login (no issue_refresh) must never return a
+    refresh_token. Gating is on the request field so the web form, which never
+    sends it, cannot receive long-lived unattended credentials under XSS or
+    form-hijack.
     """
     resp = accounts_app.post(
         "/auth/login",
         json={"username": "admin", "password": "admin-pw-12345"},
     )
     assert resp.status_code == 200, resp.text
+    assert "refresh_token" not in resp.json()
+
+
+def test_cli_login_with_issue_refresh_issues_grant(accounts_app: TestClient) -> None:
+    """``POST /auth/login`` with ``issue_refresh=True`` returns a usable refresh_token.
+
+    The CLI sends this flag; unattended hosts can renew past session-JWT expiry
+    via /oauth/token without a human re-running ``omnigent login``.
+    """
+    resp = accounts_app.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin-pw-12345", "issue_refresh": True},
+    )
+    assert resp.status_code == 200, resp.text
     body = resp.json()
 
     assert "token" in body
-    assert "refresh_token" in body, (
-        "/auth/login must return a refresh_token so unattended hosts can renew "
-        "past session-JWT expiry without a human re-running omnigent login"
-    )
+    assert "refresh_token" in body
     refresh_token = body["refresh_token"]
     assert isinstance(refresh_token, str) and len(refresh_token) > 10
 
@@ -2057,12 +2068,8 @@ def test_login_issues_refresh_token_for_host_renewal(accounts_app: TestClient) -
         "/oauth/token",
         data={"grant_type": "refresh_token", "refresh_token": refresh_token},
     )
-    assert refresh_resp.status_code == 200, (
-        f"Refresh token from /auth/login was not accepted at /oauth/token: "
-        f"{refresh_resp.status_code} {refresh_resp.text}"
-    )
+    assert refresh_resp.status_code == 200, refresh_resp.text
     refresh_body = refresh_resp.json()
     assert "access_token" in refresh_body
-    assert "refresh_token" in refresh_body
     # Login grants don't rotate — same token is returned.
     assert refresh_body["refresh_token"] == refresh_token

--- a/tests/server/test_accounts.py
+++ b/tests/server/test_accounts.py
@@ -1805,9 +1805,7 @@ def test_cli_accounts_login_happy_path_stores_token(
 
     def fake_post(url: str, **kw: object) -> _FakeResponse:
         calls["n"] += 1
-        assert url.endswith("/auth/cli-login"), (
-            f"CLI accounts login should POST to /auth/cli-login, got {url}"
-        )
+        assert url.endswith("/auth/login")
         body = kw["json"]
         assert body == {
             "username": "alice",
@@ -1838,7 +1836,7 @@ def test_cli_accounts_login_happy_path_stores_token(
     assert "Logged in as alice" in result.output
     # The store_token side effect lands in ~/.omnigent/auth_tokens.json.
     assert cli_auth.load_token("http://localhost:8000") == "fake.jwt.token"
-    # The refresh token from /auth/cli-login must also be persisted.
+    # The refresh token from /auth/login must also be persisted when present.
     entry = cli_auth._load_entry("http://localhost:8000")
     assert entry is not None and entry.get("refresh_token") == "fake.refresh.token"
 
@@ -2032,15 +2030,12 @@ def test_setup_is_single_use(accounts_app_needs_setup: TestClient) -> None:
     assert "bob" not in user_ids
 
 
-def test_browser_login_never_issues_refresh_token(accounts_app: TestClient) -> None:
-    """Regression test for P1 security: browser /auth/login must NEVER issue
-    a refresh_token, regardless of client input. Refresh grants are for
-    unattended flows (CLI/device); browser logins should never get long-lived
-    credentials that bypass session expiry.
+def test_login_issues_refresh_token_for_host_renewal(accounts_app: TestClient) -> None:
+    """/auth/login returns a refresh_token alongside the session JWT.
 
-    This was broken when LoginRequest.issue_refresh was a client-controllable
-    bool — XSS or form-hijack could POST issue_refresh=true and obtain a
-    30-day unattended credential.
+    Hosts authenticated via ``omnigent login`` can renew their access token
+    autonomously past the session-JWT TTL via /oauth/token, instead of
+    permanently failing with a misleading 403.
     """
     resp = accounts_app.post(
         "/auth/login",
@@ -2049,39 +2044,10 @@ def test_browser_login_never_issues_refresh_token(accounts_app: TestClient) -> N
     assert resp.status_code == 200, resp.text
     body = resp.json()
 
-    # Browser login must NEVER include refresh_token in response.
-    assert "refresh_token" not in body, (
-        "Browser /auth/login returned refresh_token — violates the security "
-        "invariant that unattended credentials are issued only via CLI/device flows"
-    )
-
-
-def test_cli_login_endpoint_returns_refresh_token(
-    accounts_app: TestClient,
-) -> None:
-    """``POST /auth/cli-login`` always returns a refresh_token (when grant store exists).
-
-    This is the accounts-mode counterpart to the OIDC cli-ticket grant
-    path. A CLI/host that uses the dedicated CLI endpoint can renew its
-    access token autonomously past session-JWT expiry via /oauth/token,
-    instead of dying with a misleading 403 and requiring a human to
-    re-run ``omnigent login``.
-
-    The endpoint is separate from /auth/login so the browser-facing
-    handler provably never issues refresh material, regardless of request
-    content.
-    """
-    resp = accounts_app.post(
-        "/auth/cli-login",
-        json={"username": "admin", "password": "admin-pw-12345"},
-    )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-
     assert "token" in body
     assert "refresh_token" in body, (
-        "/auth/cli-login must return a refresh_token "
-        "so CLI-authenticated hosts can renew past session-JWT expiry"
+        "/auth/login must return a refresh_token so unattended hosts can renew "
+        "past session-JWT expiry without a human re-running omnigent login"
     )
     refresh_token = body["refresh_token"]
     assert isinstance(refresh_token, str) and len(refresh_token) > 10
@@ -2092,7 +2058,7 @@ def test_cli_login_endpoint_returns_refresh_token(
         data={"grant_type": "refresh_token", "refresh_token": refresh_token},
     )
     assert refresh_resp.status_code == 200, (
-        f"Refresh token from /auth/cli-login was not accepted at /oauth/token: "
+        f"Refresh token from /auth/login was not accepted at /oauth/token: "
         f"{refresh_resp.status_code} {refresh_resp.text}"
     )
     refresh_body = refresh_resp.json()
@@ -2100,21 +2066,3 @@ def test_cli_login_endpoint_returns_refresh_token(
     assert "refresh_token" in refresh_body
     # Login grants don't rotate — same token is returned.
     assert refresh_body["refresh_token"] == refresh_token
-
-
-def test_browser_login_endpoint_never_returns_refresh_token_with_cli_login_request(
-    accounts_app: TestClient,
-) -> None:
-    """``POST /auth/login`` must NEVER return refresh_token regardless of request body.
-
-    Even if a caller sends the same body shape as the CLI endpoint,
-    the browser-facing /auth/login must not issue refresh material.
-    The security boundary is the ENDPOINT, not a flag in the request.
-    """
-    # Even sending the same fields as /auth/cli-login, /auth/login never returns refresh_token.
-    resp = accounts_app.post(
-        "/auth/login",
-        json={"username": "admin", "password": "admin-pw-12345"},
-    )
-    assert resp.status_code == 200, resp.text
-    assert "refresh_token" not in resp.json()


### PR DESCRIPTION
## Related issue

Closes #3012

## Summary

Accounts-mode hosts authenticated via `omnigent login` would permanently fail with a misleading HTTP 403 on their first tunnel reconnect after the stored session JWT expired (default 8 h). The issue's root cause analysis identified three layers; this PR implements the **renewal** layer for the accounts auth path.

The OIDC cli-ticket path (`routes/auth.py`) already issued a refresh grant as part of the closed PR #3013's changes that landed in `main`. The accounts `/auth/login` path was the only interactive login flow without one.

**What changed:**

- `LoginRequest` gains `issue_refresh: bool = False`. The CLI sets it `True`; the web browser form never does — so long-lived unattended credentials cannot reach a browser session (server-side enforcement, same model as the OIDC path).
- When `issue_refresh=True` and a `DeviceGrantStore` is available, `/auth/login` calls the existing `issue_login_grant` helper and returns `refresh_token` in the JSON response alongside the session JWT.
- `create_accounts_auth_router` accepts an optional `device_grant_store`; `create_app` passes it through.
- `_accounts_login` in the CLI sends `issue_refresh: True`.

**Back-compat:** old CLI against new server — field ignored; new CLI against old server — no `refresh_token` in response, falls back to today's behaviour. No DB migration needed (`device_grants` table already exists).

**The full fix path for an unattended accounts-mode host:**
1. `omnigent login` → `/auth/login` with `issue_refresh: True` → stores `refresh_token` in `~/.omnigent/auth_tokens.json`
2. Session JWT expires → `load_token()` returns `None` + logs WARNING with remedy
3. `_make_auth_token_factory` calls `refresh_stored_token` → POST `/oauth/token` → fresh delegated access token + same refresh token (login grants don't rotate)
4. Tunnel reconnect succeeds; host stays alive for the grant lifetime (`OMNIGENT_GRANT_MAX_LIFETIME_DAYS`, default 30 d)

## Test Plan

- `uv run pytest tests/server/test_accounts.py tests/server/test_device_auth.py tests/cli/test_cli_auth.py` — **148 passed**
- New test `test_cli_login_with_issue_refresh_returns_refresh_token`: login → get refresh_token → POST /oauth/token → fresh access_token accepted, same refresh_token returned
- Updated `test_cli_accounts_login_happy_path_stores_token`: body includes `issue_refresh: True`
- Existing `test_browser_login_never_issues_refresh_token` (security regression): browser login without `issue_refresh` still never gets a refresh_token ✓

## Demo

N/A (non-visual auth plumbing). The failure this fixes:

```
"WebSocket /v1/hosts/<id>/tunnel" 403
✗ Could not connect: … Either your identity is not authorized to register
  a host on this server, or the server is running a build that predates
  the host API …    ← actual cause: login session expired
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The refresh loop (expired JWT → refresh → reconnect) is covered at the unit level in `test_cli_auth.py` (already present). The new test here covers the accounts-specific grant issuance + immediate use at `/oauth/token`.

## Changelog

`omnigent login` on an accounts-mode server now issues a refresh grant so unattended hosts survive past session-JWT expiry without human intervention