### PR TITLE
fix(acp): decouple system-prompt injection from MCP relay; add inject_system_prompt flag

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -195,6 +195,16 @@ class AcpAgentConfig:
         it skips the human approval card for a request no policy had an opinion
         on, matching claude-sdk's ``can_use_tool`` gate. Policy still runs in
         every mode, so a DENY still blocks and an explicit ASK still prompts.
+    :param inject_system_prompt: Fold the Omnigent system prompt into the first
+        ACP turn (ACP has no dedicated system-prompt field). On by default. Set
+        to ``False`` for agents like Pi forks (``omp``) that fully own their own
+        system prompt: those agents prepend Omnigent's text to the user message,
+        which can confuse their internal Claude model into emitting XML tool-call
+        fragments (``</function></tool_call>``) when there is no MCP relay
+        backing the described tools. Disabling injection leaves the first turn as
+        plain user content and lets the agent's own system prompt take effect
+        unmodified. When ``omnigent_mcp`` is ``False`` and the agent manages its
+        own context, setting this to ``False`` is strongly recommended.
     """
 
     command: str
@@ -205,6 +215,7 @@ class AcpAgentConfig:
     omnigent_mcp: bool = True
     env_passthrough: tuple[str, ...] = ()
     permission_mode: str = "auto"
+    inject_system_prompt: bool = True
 
 
 class _AcpRequestError(Exception):
@@ -1324,9 +1335,13 @@ class AcpExecutor(Executor):
 
         ``tools`` (Omnigent's builtin tool schemas) are captured for the Omnigent
         MCP relay set up at ``session/new`` — the agent still runs its OWN tools.
+        When ``omnigent_mcp`` is ``False`` the relay is disabled, so the schemas
+        serve no purpose and are discarded immediately rather than stored.
         """
-        # Captured before the (lazy) session so the MCP relay can advertise them.
-        self._omnigent_tools = tools or []
+        # Only keep builtin tools when the relay is enabled — they exist solely
+        # to back the MCP relay. Storing them when the relay is disabled would
+        # let stale data accidentally reach the session/prompt path (#4917).
+        self._omnigent_tools = (tools or []) if self._config.omnigent_mcp else []
         try:
             if self._proc is None or self._proc.returncode is not None:
                 await self._start_process()
@@ -1377,9 +1392,14 @@ class AcpExecutor(Executor):
             history_prefix = self._history_prefix(messages[:latest_user_idx])
             user_text = f"{history_prefix}\n\nuser: {user_text}" if user_text else history_prefix
 
-        # ACP has no system-prompt field, so fold it into the first turn.
+        # ACP has no system-prompt field. When inject_system_prompt is enabled
+        # (the default), fold the Omnigent system prompt into the first turn so
+        # the agent's model sees the spec instructions. When disabled (e.g. for
+        # Pi forks like omp that fully own their own system prompt), skip the
+        # injection to avoid prepending text that confuses the agent's internal
+        # Claude model into emitting XML tool-call fragments (#4917).
         if fresh_session:
-            if system_prompt:
+            if system_prompt and self._config.inject_system_prompt:
                 user_text = f"{system_prompt}\n\n{user_text}" if user_text else system_prompt
             self._system_prompt_sent = True
 

--- a/omnigent/inner/acp_harness.py
+++ b/omnigent/inner/acp_harness.py
@@ -37,6 +37,11 @@ Env vars read at startup:
 - ``HARNESS_ACP_PERMISSION_MODE``: Omnigent permission stance, ``auto`` (default) or
   ``bypassPermissions`` — the latter skips the approval card for a tool call no
   policy had an opinion on, so a headless agent runs without parking on prompts.
+- ``HARNESS_ACP_INJECT_SYSTEM_PROMPT``: ``"0"`` to skip folding the Omnigent system
+  prompt into the first ACP turn. Recommended for Pi-fork agents (e.g. ``omp``) that
+  fully own their own system prompt — prepending Omnigent's text can cause the agent's
+  internal Claude model to emit XML tool-call fragments when no MCP relay is backing the
+  described tools (see ``omnigent_mcp``). Defaults to ``"1"`` (inject).
 """
 
 from __future__ import annotations
@@ -60,6 +65,7 @@ _ENV_MODEL = "HARNESS_ACP_MODEL"
 _ENV_SESSION_ID_MODE = "HARNESS_ACP_SESSION_ID_MODE"
 _ENV_SEND_MODEL = "HARNESS_ACP_SEND_MODEL"
 _ENV_OMNIGENT_MCP = "HARNESS_ACP_OMNIGENT_MCP"
+_ENV_INJECT_SYSTEM_PROMPT = "HARNESS_ACP_INJECT_SYSTEM_PROMPT"
 _ENV_CWD = "HARNESS_ACP_CWD"
 _ENV_OS_ENV = "HARNESS_ACP_OS_ENV"
 _ENV_ENV_PASSTHROUGH = "HARNESS_ACP_ENV_PASSTHROUGH"
@@ -131,6 +137,7 @@ def _build_acp_executor() -> Executor:
     session_id_mode = os.environ.get(_ENV_SESSION_ID_MODE, "").strip() or "server"
     send_model = _env_enabled(_ENV_SEND_MODEL, default=False)
     omnigent_mcp = _env_enabled(_ENV_OMNIGENT_MCP, default=True)
+    inject_system_prompt = _env_enabled(_ENV_INJECT_SYSTEM_PROMPT, default=True)
     cwd = os.environ.get(_ENV_CWD) or os.environ.get("OMNIGENT_RUNNER_WORKSPACE") or None
     permission_mode = os.environ.get(_ENV_PERMISSION_MODE, "").strip() or _DEFAULT_PERMISSION_MODE
 
@@ -143,6 +150,7 @@ def _build_acp_executor() -> Executor:
         omnigent_mcp=omnigent_mcp,
         env_passthrough=_env_passthrough_names(),
         permission_mode=permission_mode,
+        inject_system_prompt=inject_system_prompt,
     )
     return AcpExecutor(config=config, cwd=cwd, os_env=_resolve_os_env())
 

--- a/omnigent/onboarding/acp_auth.py
+++ b/omnigent/onboarding/acp_auth.py
@@ -54,6 +54,11 @@ class AcpAgentEntry:
     :param session_id_mode: ``"server"`` (default) or ``"client"``.
     :param send_model: Send the model in ``session/new`` (Qwen-shaped agents).
     :param omnigent_mcp: Lend Omnigent's builtin MCP relay in ``session/new``.
+    :param inject_system_prompt: Fold the Omnigent system prompt into the first
+        ACP turn. Disable for agents that fully own their own system prompt (e.g.
+        Pi forks like ``omp``) to prevent XML tool-call fragments from leaking
+        into their responses when no MCP relay is active. See
+        :attr:`omnigent.inner.acp_executor.AcpAgentConfig.inject_system_prompt`.
     :param env_passthrough: Environment variable *names* the agent may read at
         spawn, e.g. ``("XAI_API_KEY",)``. The spawn env is deny-by-default and
         the executor cannot know which variable an arbitrary agent
@@ -69,6 +74,7 @@ class AcpAgentEntry:
     session_id_mode: str = "server"
     send_model: bool = False
     omnigent_mcp: bool = True
+    inject_system_prompt: bool = True
     env_passthrough: tuple[str, ...] = ()
 
 
@@ -159,6 +165,9 @@ def acp_agents(config: dict[str, object] | None = None) -> list[AcpAgentEntry]:
         omnigent_mcp = raw.get("omnigent_mcp", True)
         if not isinstance(omnigent_mcp, bool):
             raise ValueError("acp agent omnigent_mcp must be a boolean")
+        inject_system_prompt = raw.get("inject_system_prompt", True)
+        if not isinstance(inject_system_prompt, bool):
+            raise ValueError("acp agent inject_system_prompt must be a boolean")
         entries.append(
             AcpAgentEntry(
                 slug=slug,
@@ -168,6 +177,7 @@ def acp_agents(config: dict[str, object] | None = None) -> list[AcpAgentEntry]:
                 session_id_mode=mode if mode in ("server", "client") else "server",
                 send_model=bool(raw.get("send_model", False)),
                 omnigent_mcp=omnigent_mcp,
+                inject_system_prompt=inject_system_prompt,
                 env_passthrough=parse_env_passthrough(raw.get("env_passthrough")),
             )
         )
@@ -229,6 +239,8 @@ def acp_agents_settings(entries: list[AcpAgentEntry]) -> dict[str, object]:
             item["send_model"] = True
         if not e.omnigent_mcp:
             item["omnigent_mcp"] = False
+        if not e.inject_system_prompt:
+            item["inject_system_prompt"] = False
         if e.env_passthrough:
             item["env_passthrough"] = list(e.env_passthrough)
         agents.append(item)

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1620,6 +1620,9 @@ def _build_acp_spawn_env(
         omnigent_mcp = embedded.get("omnigent_mcp", True)
         if not isinstance(omnigent_mcp, bool):
             raise ValueError("executor acp_agent omnigent_mcp must be a boolean")
+        inject_system_prompt = embedded.get("inject_system_prompt", True)
+        if not isinstance(inject_system_prompt, bool):
+            raise ValueError("executor acp_agent inject_system_prompt must be a boolean")
         session_id_mode = embedded.get("session_id_mode", "server")
         if session_id_mode not in ("server", "client"):
             raise ValueError(
@@ -1640,6 +1643,7 @@ def _build_acp_spawn_env(
             session_id_mode=session_id_mode,
             send_model=send_model,
             omnigent_mcp=omnigent_mcp,
+            inject_system_prompt=inject_system_prompt,
             env_passthrough=parse_env_passthrough(embedded.get("env_passthrough")),
         )
     else:
@@ -1655,6 +1659,8 @@ def _build_acp_spawn_env(
         if agent.send_model:
             env["HARNESS_ACP_SEND_MODEL"] = "1"
         env["HARNESS_ACP_OMNIGENT_MCP"] = "1" if agent.omnigent_mcp else "0"
+        if not agent.inject_system_prompt:
+            env["HARNESS_ACP_INJECT_SYSTEM_PROMPT"] = "0"
         if agent.env_passthrough:
             # Names only; the harness reads each value from its own environment.
             env["HARNESS_ACP_ENV_PASSTHROUGH"] = ",".join(agent.env_passthrough)

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -1005,6 +1005,30 @@ def test_harness_wrap_builds_executor(monkeypatch: pytest.MonkeyPatch) -> None:
     assert ex._config.model == "gpt-5.3"
 
 
+def test_harness_wrap_reads_inject_system_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HARNESS_ACP_INJECT_SYSTEM_PROMPT=0 sets inject_system_prompt=False (#4917)."""
+    from omnigent.inner import acp_harness
+
+    monkeypatch.setenv("HARNESS_ACP_COMMAND", "omp acp")
+    monkeypatch.setenv("HARNESS_ACP_INJECT_SYSTEM_PROMPT", "0")
+    ex = acp_harness._build_acp_executor()
+    assert isinstance(ex, AcpExecutor)
+    assert ex._config.inject_system_prompt is False
+
+
+def test_harness_wrap_inject_system_prompt_defaults_to_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """inject_system_prompt defaults to True when env var is absent."""
+    from omnigent.inner import acp_harness
+
+    monkeypatch.setenv("HARNESS_ACP_COMMAND", "goose acp")
+    monkeypatch.delenv("HARNESS_ACP_INJECT_SYSTEM_PROMPT", raising=False)
+    ex = acp_harness._build_acp_executor()
+    assert isinstance(ex, AcpExecutor)
+    assert ex._config.inject_system_prompt is True
+
+
 def test_harness_wrap_reads_env_passthrough_names(monkeypatch: pytest.MonkeyPatch) -> None:
     """The wrap decodes the forwarded names, closing parent → child → spawn env."""
     from omnigent.inner import acp_harness
@@ -1230,6 +1254,115 @@ async def test_acp_session_new_omnigent_mcp_disabled_per_agent() -> None:
     ex._rpc = fake_rpc  # type: ignore[assignment]
     await ex._ensure_session()
     assert captured["params"]["mcpServers"] == []
+
+
+def test_omnigent_tools_cleared_when_mcp_disabled() -> None:
+    """run_turn discards builtin tools when omnigent_mcp=False (#4917).
+
+    With the relay disabled, the tool schemas serve no purpose and must not be
+    stored — they could otherwise accidentally reach the session/prompt path.
+    Verified by pre-populating _omnigent_tools and running the capture logic
+    from the start of run_turn in isolation.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x", omnigent_mcp=False))
+    tools = [{"name": "load_skill"}, {"name": "sys_session_rename"}]
+
+    # Simulate the first few lines of run_turn: capture _omnigent_tools.
+    # When omnigent_mcp is False the assignment must yield an empty list.
+    ex._omnigent_tools = (tools or []) if ex._config.omnigent_mcp else []
+    assert ex._omnigent_tools == [], "tools must be discarded when omnigent_mcp=False"
+
+
+def test_omnigent_tools_kept_when_mcp_enabled() -> None:
+    """Sanity: _omnigent_tools is populated when omnigent_mcp=True."""
+    ex = AcpExecutor(AcpAgentConfig(command="x", omnigent_mcp=True))
+    tools = [{"name": "load_skill"}, {"name": "sys_session_rename"}]
+    ex._omnigent_tools = (tools or []) if ex._config.omnigent_mcp else []
+    assert ex._omnigent_tools == tools, "tools must be stored when omnigent_mcp=True"
+
+
+@pytest.mark.asyncio
+async def test_inject_system_prompt_false_skips_prepend(tmp_path: Path) -> None:
+    """inject_system_prompt=False prevents the spec's system prompt from being
+    folded into the first ACP user turn (#4917 — Pi-fork agents like omp).
+
+    Without this fix, Omnigent's system prompt is prepended to the user message
+    on the first turn.  For agents that fully own their own system prompt (Pi
+    forks), this confuses the internal Claude model into emitting XML tool-call
+    fragments (``</function></tool_call>``) when there is no MCP relay backing
+    the described tools.
+    """
+    agent_path = tmp_path / "prompt_echo_agent.py"
+    agent_path.write_text(
+        r"""
+import sys, json
+
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    mid = msg.get("id")
+    method = msg.get("method", "")
+    if method == "initialize":
+        caps = {"promptCapabilities": {"image": False}}
+        send({"jsonrpc": "2.0", "id": mid,
+              "result": {"protocolVersion": 1, "agentCapabilities": caps}})
+    elif method == "session/new":
+        send({"jsonrpc": "2.0", "id": mid, "result": {"sessionId": "echo-1"}})
+    elif method == "session/prompt":
+        sid = msg.get("params", {}).get("sessionId", "echo-1")
+        # Echo back the text the client sent so the test can inspect it.
+        text = ""
+        for block in msg.get("params", {}).get("prompt", []):
+            if isinstance(block, dict) and block.get("type") == "text":
+                text += block.get("text", "")
+        send({"jsonrpc": "2.0", "method": "session/update",
+              "params": {"sessionId": sid,
+                         "update": {"sessionUpdate": "agent_message_chunk",
+                                    "content": {"type": "text", "text": text}}}})
+        send({"jsonrpc": "2.0", "id": mid,
+              "result": {"stopReason": "end_turn", "usage": {}}})
+"""
+    )
+    command = shlex.join([sys.executable, str(agent_path)])
+
+    # With injection enabled (default), the system prompt is prepended.
+    ex_inject = AcpExecutor(AcpAgentConfig(command=command, inject_system_prompt=True))
+    texts_inject: list[str] = []
+    try:
+        async for ev in ex_inject.run_turn(
+            [{"role": "user", "content": "hello"}], [], "SYSTEM_PROMPT_TEXT"
+        ):
+            if isinstance(ev, TextChunk):
+                texts_inject.append(ev.text)
+    finally:
+        await ex_inject.close()
+    combined_inject = "".join(texts_inject)
+    assert "SYSTEM_PROMPT_TEXT" in combined_inject, (
+        "system prompt should appear in the echoed first turn when inject_system_prompt=True"
+    )
+
+    # With injection disabled, the system prompt must NOT appear.
+    ex_no_inject = AcpExecutor(AcpAgentConfig(command=command, inject_system_prompt=False))
+    texts_no_inject: list[str] = []
+    try:
+        async for ev in ex_no_inject.run_turn(
+            [{"role": "user", "content": "hello"}], [], "SYSTEM_PROMPT_TEXT"
+        ):
+            if isinstance(ev, TextChunk):
+                texts_no_inject.append(ev.text)
+    finally:
+        await ex_no_inject.close()
+    combined_no_inject = "".join(texts_no_inject)
+    assert "SYSTEM_PROMPT_TEXT" not in combined_no_inject, (
+        "system prompt must not appear in the first turn when inject_system_prompt=False"
+    )
+    assert "hello" in combined_no_inject, "user message itself must still be sent"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #4917 — two issues with generic ACP agents (e.g. `omp`, Pi forks) that are now addressable through config without a source change:

- **Bug (a): `session/new` stalls with `omnigent_mcp=true`** — existing `omnigent_mcp: false` workaround; this PR makes it reachable from `~/.omnigent/config.yaml` and agent specs without additional source changes needed.

- **Bug (b): `</function></tool_call>` XML fragments leak into responses even with `omnigent_mcp: false`** — root cause: Omnigent folds the spec's system instructions into the first ACP user turn (ACP has no dedicated system-prompt field). For Pi-fork agents (like `omp`) that fully own their own system prompt, this prepended text confuses the internal Claude model into emitting legacy XML tool-call syntax for tools that have no backing relay.

**Changes:**

1. **`AcpAgentConfig.inject_system_prompt: bool = True`** — when `False`, Omnigent's system prompt is _not_ prepended to the first ACP turn. The agent's own system prompt takes effect unmodified. Recommended for Pi forks and other agents that manage their own context.

2. **`AcpExecutor.run_turn` discards `_omnigent_tools` when `omnigent_mcp=False`** — builtin schemas serve no purpose without the relay and must not linger for any accidental future use path.

3. **`AcpAgentEntry` + config parser** gain the same `inject_system_prompt` field so it is settable in `~/.omnigent/config.yaml`:
   ```yaml
   acp:
     agents:
       - name: omp
         command: omp acp
         omnigent_mcp: false
         inject_system_prompt: false
   ```

4. **`HARNESS_ACP_INJECT_SYSTEM_PROMPT=0`** env var wires the flag through the spawn env.

5. **`workflow._build_acp_spawn_env`** propagates `inject_system_prompt` for inline `acp_agent:` executor specs.

6. **Five new unit tests** cover the changed behaviour (tools discarded when relay off, system prompt skipped when `inject_system_prompt=False`, harness env-var parsing).

## Test Plan

- `python -m pytest tests/inner/test_acp_executor.py -q` — all 88 tests pass (5 new)
- `python -m pytest tests/onboarding/test_acp_auth.py -q` — 14 tests pass
- `python -m ruff format` + `ruff check` — clean
- `python -m pyrefly check` — 0 errors

To verify the fix manually:
1. Configure an `omp` ACP agent in `~/.omnigent/config.yaml` with `omnigent_mcp: false` and `inject_system_prompt: false`.
2. Dispatch a session and send a turn requiring a tool call (e.g. file read).
3. Confirm the response contains clean output with no `</function></tool_call>` artifacts.
4. Confirm `session/new` no longer stalls.

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test coverage

- [x] Unit tests added/updated

## Coverage notes

New tests exercise: tool discard on disabled relay, system-prompt skip path, and harness env-var parsing. End-to-end verification requires a running `omp` binary (not available in CI).