### PR TITLE
feat(cli): make followup command hints wrapper-aware

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -46,6 +46,7 @@ from omnigent._wrapper_labels import (
 from omnigent._wrapper_labels import (
     WRAPPER_LABEL_KEY as _CLAUDE_NATIVE_WRAPPER_LABEL_KEY,
 )
+from omnigent.cli_invocation import cli_invocation
 from omnigent.conversation_browser import open_conversation_link_if_enabled
 from omnigent.errors import OmnigentError
 from omnigent.harness_aliases import canonicalize_harness
@@ -565,7 +566,7 @@ def run_attach(
             f"Session {conversation_id} has no online runner on "
             f"{display_server_url(base_url)} — its "
             "host is offline. `attach` never starts a runner; bring the host back "
-            "(`omnigent run` locally, or reconnect it with `omnigent host`), "
+            f"(`{cli_invocation()} run` locally, or reconnect it with `{cli_invocation()} host`), "
             "then attach again."
         )
 
@@ -1535,7 +1536,7 @@ def _unreachable_server_message(base_url: str) -> str:
     if is_loopback_url(base_url):
         return (
             f"Could not connect to the local Omnigent server at {base_url}. "
-            "It may have stopped — run `omnigent stop`, then try again. "
+            f"It may have stopped — run `{cli_invocation()} stop`, then try again. "
             f"Server logs are under {process_log_dir_reference('server')}."
         )
     from omnigent.server_url import display_server_url
@@ -1946,7 +1947,8 @@ def _poll_remote_runner(
             if resp.status_code in {401, 403}:
                 raise click.ClickException(
                     f"Remote runner status check was rejected ({resp.status_code}); "
-                    "run `omnigent login <server-url>` or check remote auth credentials."
+                    f"run `{cli_invocation()} login <server-url>` "
+                    "or check remote auth credentials."
                     f"{format_runner_log_tail(log_path)}"
                 )
         except httpx.HTTPError as exc:
@@ -2287,13 +2289,13 @@ async def _query_sessions_once(
         if runner_id is None:
             raise RuntimeError(
                 "This server has no online runner to run the turn. Start one against "
-                "it with `omnigent host --server <url>` (or run the agent locally "
-                "with `omnigent run <agent.yaml>`), then retry."
+                f"it with `{cli_invocation()} host --server <url>` (or run the agent locally "
+                f"with `{cli_invocation()} run <agent.yaml>`), then retry."
             )
     if runner_id is None:
         raise RuntimeError(
             "Sessions API headless prompt requires a registered runner id. "
-            "Start through `omnigent run <agent>` or pass --server so the CLI "
+            f"Start through `{cli_invocation()} run <agent>` or pass --server so the CLI "
             "can launch and bind a runner."
         )
     tool_callables = _sessions_tool_callables(tool_handler, agent_name)

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -105,6 +105,7 @@ from omnigent.claude_native_state import (
     redirect_launch_state,
     write_launch_state,
 )
+from omnigent.cli_invocation import cli_invocation
 from omnigent.conversation_browser import conversation_url, open_conversation_link_if_enabled
 from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.host.daemon_launch import (
@@ -2510,7 +2511,7 @@ def _ucode_config_for_profile(
     if agent_state is None:
         raise click.ClickException(
             f"ucode state for profile {profile!r} does not include a Claude agent entry. "
-            "Run `omnigent setup --internal-beta` to refresh ucode configuration."
+            f"Run `{cli_invocation()} setup --internal-beta` to refresh ucode configuration."
         )
 
     base_url = agent_state.env.get(_UCODE_CLAUDE_BASE_URL_ENV) or agent_state.base_url
@@ -2520,12 +2521,12 @@ def _ucode_config_for_profile(
         raise click.ClickException(
             f"ucode state for profile {profile!r} is missing Claude base URL "
             f"({_UCODE_CLAUDE_BASE_URL_ENV} / base_url). "
-            "Run `omnigent setup --internal-beta` to refresh ucode configuration."
+            f"Run `{cli_invocation()} setup --internal-beta` to refresh ucode configuration."
         )
     if not agent_state.auth_command:
         raise click.ClickException(
             f"ucode state for profile {profile!r} is missing Claude auth_command. "
-            "Run `omnigent setup --internal-beta` to refresh ucode configuration."
+            f"Run `{cli_invocation()} setup --internal-beta` to refresh ucode configuration."
         )
 
     refresh_interval_ms = (
@@ -4554,7 +4555,7 @@ async def _fetch_claude_session_labels(
     if resp.status_code == 404:
         raise click.ClickException(
             f"Conversation {session_id!r} not found on the server. "
-            "Run `omnigent claude` (no --resume) to start a new session.",
+            f"Run `{cli_invocation()} claude` (no --resume) to start a new session.",
         )
     if resp.status_code >= 400:
         raise click.ClickException(
@@ -4598,7 +4599,7 @@ async def _resolve_cold_resume_args(
     if resp.status_code == 404:
         raise click.ClickException(
             f"Conversation {session_id!r} not found on the server. "
-            "Run `omnigent claude` (no --resume) to start a new session.",
+            f"Run `{cli_invocation()} claude` (no --resume) to start a new session.",
         )
     if resp.status_code >= 400:
         raise click.ClickException(
@@ -4616,7 +4617,7 @@ async def _resolve_cold_resume_args(
     if wrapper != _WRAPPER_LABEL_VALUE:
         raise click.ClickException(
             f"Conversation {session_id!r} is not a claude-native session "
-            f"(wrapper={wrapper!r}). Use `omnigent run --resume "
+            f"(wrapper={wrapper!r}). Use `{cli_invocation()} run --resume "
             f"{session_id}` to resume it through the right runtime.",
         )
     external_session_id = payload.get("external_session_id")

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -45,6 +45,7 @@ from omnigent.cli_config import (
     _run_configure_harnesses_interactive,
     _warn_missing_harness_dependencies,
 )
+from omnigent.cli_invocation import WRAPPER_COMMAND_ENV, cli_invocation
 from omnigent.cli_native import register_native_commands as _register_native_commands
 from omnigent.cli_sandbox import lakebox as _lakebox_alias_group
 from omnigent.cli_sandbox import sandbox as _sandbox_group
@@ -589,7 +590,7 @@ def _migrate_legacy_state_dir() -> None:
         if legacy_pid is not None and _pid_alive(legacy_pid):
             click.echo(
                 f"Note: found pre-rename state at {legacy_src} but a host daemon "
-                "is still running from it; skipping migration. Run `omnigent stop` "
+                f"is still running from it; skipping migration. Run `{cli_invocation()} stop` "
                 "and re-run to migrate, or move it manually to ~/.omnigent.",
                 err=True,
             )
@@ -1760,7 +1761,8 @@ class _OmnigentCLI(click.Group):
             formatter.write_paragraph()
             formatter.write_text(
                 _cli_style(
-                    "Some harnesses need an optional extra — run `omnigent setup` to enable them.",
+                    f"Some harnesses need an optional extra — run `{cli_invocation()} setup` "
+                    "to enable them.",
                     dim=True,
                 )
             )
@@ -2053,7 +2055,6 @@ def _warn_deprecated_harness_path_env_vars() -> None:
 
 
 REQUIRE_WRAPPER_ENV = "OMNIGENT_REQUIRE_WRAPPER"
-WRAPPER_COMMAND_ENV = "OMNIGENT_WRAPPER_COMMAND"
 WRAPPER_BYPASS_ENV = "OMNIGENT_WRAPPER_BYPASS"
 
 
@@ -2175,7 +2176,7 @@ def main() -> None:
     if argv and _is_server_url(argv[0]):
         click.echo(
             "Error: server URLs must be passed with --server. "
-            f"Use `omnigent run --server {argv[0]}`.",
+            f"Use `{cli_invocation()} run --server {argv[0]}`.",
             err=True,
         )
         raise SystemExit(2)
@@ -2183,8 +2184,8 @@ def main() -> None:
     if _is_removed_ad_hoc_invocation(argv):
         click.echo(
             "Error: top-level ad-hoc chat was removed. Use "
-            "`omnigent run <agent.yaml>` or "
-            "`omnigent run --harness <harness>`.",
+            f"`{cli_invocation()} run <agent.yaml>` or "
+            f"`{cli_invocation()} run --harness <harness>`.",
             err=True,
         )
         raise SystemExit(2)
@@ -3142,7 +3143,7 @@ def _claim_foreground_daemon_record(
         raise click.ClickException(
             "A host daemon is already running for this server "
             f"(pid={conflict.pid}, target={conflict.target}). "
-            f"Run `omnigent host status` to inspect it or `{stop_command}` "
+            f"Run `{cli_invocation()} host status` to inspect it or `{stop_command}` "
             "to stop it first."
         )
     previous = _find_daemon_record(record.target)
@@ -3488,9 +3489,9 @@ def _exit_for_auth_mode_change(base_url: str) -> None:
             "(it may have opened automatically),",
             err=True,
         )
-        click.echo("  then re-run `omnigent run` to start.", err=True)
+        click.echo(f"  then re-run `{cli_invocation()} run` to start.", err=True)
     else:
-        click.echo("  Re-run `omnigent run` to start.", err=True)
+        click.echo(f"  Re-run `{cli_invocation()} run` to start.", err=True)
     click.echo("", err=True)
     raise SystemExit(0)
 
@@ -4378,7 +4379,7 @@ def server_start() -> None:
     :returns: None.
     """
     click.echo(
-        "omnigent: `server start` is deprecated; use `omnigent server --background`.",
+        f"omnigent: `server start` is deprecated; use `{cli_invocation()} server --background`.",
         err=True,
     )
     _run_background_server()
@@ -4465,7 +4466,7 @@ def server_status(json_output: bool) -> None:
     default=False,
     help=(
         "Never prompt for sign-in. When the server requires auth and you "
-        "are not logged in, fail with the `omnigent login` hint instead of "
+        f"are not logged in, fail with the `{cli_invocation()} login` hint instead of "
         "launching the browser login flow. Use this in scripts and CI."
     ),
 )
@@ -4492,7 +4493,7 @@ def start(server: str | None, non_interactive: bool) -> None:
     """
     _run_background_host(
         _resolve_host_server(server),
-        stop_command="omnigent stop",
+        stop_command=f"{cli_invocation()} stop",
         non_interactive=non_interactive,
     )
 
@@ -5012,7 +5013,9 @@ def _upgrade_vcs_install(
         return
     # Couldn't read the new commit — the re-pull ran, but don't assert a
     # result we can't confirm.
-    click.echo("Re-pulled the git ref. Run `omni upgrade --check` to confirm.")
+    click.echo(
+        f"Re-pulled the git ref. Run `{cli_invocation(name='omni')} upgrade --check` to confirm."
+    )
 
 
 def _upgrade_to_nightly(
@@ -5088,8 +5091,8 @@ def _upgrade_to_nightly(
         if info.detected_installer == "pip":
             click.echo(
                 "omnigent was installed with pip, and pip does not record which "
-                "extras were requested. `omni upgrade --nightly` cannot preserve "
-                "them safely, so install the nightly manually:\n\n"
+                f"extras were requested. `{cli_invocation(name='omni')} upgrade --nightly` "
+                "cannot preserve them safely, so install the nightly manually:\n\n"
                 f"    pip install --force-reinstall '{manual}'\n"
                 "    # or, if you need extras:\n"
                 f"    pip install --force-reinstall '{manual}#egg=omnigent[your,extras,here]'"
@@ -5099,8 +5102,8 @@ def _upgrade_to_nightly(
             click.echo(
                 "omnigent was installed with `uv pip`, not `uv tool install`. "
                 "`uv pip` does not record which extras were requested, so "
-                "`omni upgrade --nightly` cannot preserve them safely. Install "
-                "the nightly manually:\n\n"
+                f"`{cli_invocation(name='omni')} upgrade --nightly` cannot preserve them "
+                "safely. Install the nightly manually:\n\n"
                 f"    uv pip install --force-reinstall '{manual}'\n"
                 "    # or, if you need extras:\n"
                 f"    uv pip install --force-reinstall '{manual}#egg=omnigent[your,extras,here]'"
@@ -5143,7 +5146,7 @@ def _upgrade_to_nightly(
     if new_version is None:
         click.echo(
             "Ran the upgrade command, but couldn't confirm the installed version. "
-            "Run `omni upgrade --nightly --check` to verify."
+            f"Run `{cli_invocation(name='omni')} upgrade --nightly --check` to verify."
         )
         return
     raise click.ClickException(
@@ -5268,7 +5271,7 @@ def upgrade(
     if _find_repo_root() is not None:
         raise click.ClickException(
             "This is a source checkout — update it with `git pull` (and reinstall "
-            "dependencies), not `omni upgrade`."
+            f"dependencies), not `{cli_invocation(name='omni')} upgrade`."
         )
     info = _read_installed_wheel_info()
     if info is None:
@@ -5277,7 +5280,8 @@ def upgrade(
         )
     if info.is_editable:
         raise click.ClickException(
-            "This is an editable install — update it with `git pull`, not `omni upgrade`."
+            "This is an editable install — update it with `git pull`, "
+            f"not `{cli_invocation(name='omni')} upgrade`."
         )
 
     # Nightly channel: resolved from git tags, not the index, and applies to
@@ -5319,8 +5323,8 @@ def upgrade(
         if info.detected_installer == "pip":
             click.echo(
                 "omnigent was installed with pip, and pip does not record which extras "
-                "were requested. `omni upgrade` cannot preserve them safely, so you "
-                "should upgrade manually:\n\n"
+                f"were requested. `{cli_invocation(name='omni')} upgrade` cannot preserve them "
+                "safely, so you should upgrade manually:\n\n"
                 "    pip install -U omnigent\n"
                 "    # or, if you need extras:\n"
                 "    pip install -U 'omnigent[your,extras,here]'"
@@ -5330,7 +5334,8 @@ def upgrade(
             click.echo(
                 "omnigent was installed with `uv pip`, not `uv tool install`. "
                 "`uv pip` does not record which extras were requested, so "
-                "`omni upgrade` cannot preserve them safely. Upgrade manually:\n\n"
+                f"`{cli_invocation(name='omni')} upgrade` cannot preserve them safely. "
+                "Upgrade manually:\n\n"
                 "    uv pip install -U omnigent\n"
                 "    # or, if you need extras:\n"
                 "    uv pip install -U 'omnigent[your,extras,here]'"
@@ -5410,7 +5415,7 @@ def upgrade(
     if new_version is None:
         click.echo(
             "Ran the upgrade command, but couldn't confirm the installed version. "
-            "Run `omni upgrade --check` to verify."
+            f"Run `{cli_invocation(name='omni')} upgrade --check` to verify."
         )
         return
     expected_version = target_version or latest
@@ -6635,13 +6640,18 @@ _RESUME_HELP = (
 )
 _CONTINUE_HELP = "Continue the most recent conversation for this agent."
 _NO_SESSION_HELP = "Use a fresh temporary local session store for this run."
+
+
 #: ``run --smart-routing`` is gone; the flag survives only to say where routing
 #: moved. Remove the option (and the check that raises this) in 0.11.
-_RUN_SMART_ROUTING_REMOVED = (
-    "CLI smart routing is per-harness first-message only; use the web UI for "
-    "router-picked harnesses. Run `omnigent claude --smart-routing` or "
-    "`omnigent codex --smart-routing` to route this harness's first typed message."
-)
+def _run_smart_routing_removed() -> str:
+    # Wrapper resolved at call time so the hint honors OMNIGENT_WRAPPER_COMMAND.
+    return (
+        "CLI smart routing is per-harness first-message only; use the web UI for "
+        f"router-picked harnesses. Run `{cli_invocation()} claude --smart-routing` or "
+        f"`{cli_invocation()} codex --smart-routing` to route this harness's first typed message."
+    )
+
 
 _FORK_HELP = "Fork an existing session by id and open the REPL on the fork."
 _LOG_HELP = "Write a JSON dump of the conversation to ~/.omnigent/logs/ on exit."
@@ -7332,7 +7342,7 @@ def _dispatch_run(
     if target is not None and _is_server_url(target):
         raise click.ClickException(
             "Server URLs are no longer accepted as the AGENT argument. "
-            f"Use `omnigent run --server {target}` instead."
+            f"Use `{cli_invocation()} run --server {target}` instead."
         )
 
     if target is None:
@@ -7619,13 +7629,13 @@ def _require_live_conversation(
             f"Couldn't reach a server at {display_server_url(base_url)}: "
             f"{_host_error_text(result.body)}. "
             "`attach` never starts a server — check the URL, or start one with "
-            "`omnigent run`."
+            f"`{cli_invocation()} run`."
         )
     if result.status_code != 200:
         raise click.ClickException(
             f"No live session '{conversation_id}' on {display_server_url(base_url)} "
-            f"(server returned {result.status_code}). Run `omnigent host status` "
-            "to list live sessions, or `omnigent run <agent.yaml>` to start one."
+            f"(server returned {result.status_code}). Run `{cli_invocation()} host status` "
+            f"to list live sessions, or `{cli_invocation()} run <agent.yaml>` to start one."
         )
 
 
@@ -7680,16 +7690,17 @@ def attach(
     if base_url is None:
         raise click.ClickException(
             "No server to attach to. `attach` joins a LIVE session on a running "
-            "server — start one with `omnigent run`, or point at one with "
+            f"server — start one with `{cli_invocation()} run`, or point at one with "
             "`--server <url>`."
         )
     if conversation is None:
         from omnigent.server_url import display_server_url
 
+        server_display = display_server_url(base_url)
         raise click.ClickException(
             "Nothing to attach to: `attach` joins a LIVE session by id. "
-            f"Run `omnigent host status` to list sessions on {display_server_url(base_url)}, or "
-            "`omnigent run <agent.yaml>` to start a new one."
+            f"Run `{cli_invocation()} host status` to list sessions on {server_display}, or "
+            f"`{cli_invocation()} run <agent.yaml>` to start a new one."
         )
     _require_live_conversation(base_url=base_url, conversation_id=conversation)
     auto_open_conversation = _resolve_auto_open_conversation_from_config(cfg)
@@ -7727,7 +7738,7 @@ def attach(
     is_flag=True,
     default=False,
     hidden=True,
-    help="[REMOVED] Use `omnigent claude|codex --smart-routing` or the web UI.",
+    help=f"[REMOVED] Use `{cli_invocation()} claude|codex --smart-routing` or the web UI.",
 )
 @click.option(
     "--from-openclaw",
@@ -7776,7 +7787,7 @@ def attach(
         "remote --server with. Sets DATABRICKS_CONFIG_PROFILE so the SDK "
         "credential chain (service-principal M2M, PAT, OAuth) resolves that "
         "profile. Use for headless service-principal access to a Databricks "
-        "App without a prior `omnigent login`."
+        f"App without a prior `{cli_invocation()} login`."
     ),
 )
 @click.option(
@@ -7797,7 +7808,7 @@ def attach(
     default=False,
     help=(
         "Register this machine as a host with the remote server "
-        "(inline equivalent of `omnigent host`). Requires --server."
+        f"(inline equivalent of `{cli_invocation()} host`). Requires --server."
     ),
 )
 def run(
@@ -7854,7 +7865,7 @@ def run(
     # Rejected before anything is resolved: `run` never routed in-harness, and
     # its create-time route is gone.
     if smart_routing:
-        raise click.ClickException(_RUN_SMART_ROUTING_REMOVED)
+        raise click.ClickException(_run_smart_routing_removed())
     # Apply config defaults for any value the user did not pass explicitly.
     # Explicit CLI args always take precedence; project-local config overrides
     # global config, which provides user-level defaults.
@@ -8317,9 +8328,9 @@ def _host_stop_command(explicit_server: str | None) -> str:
     :returns: A copy-pasteable command, e.g. ``"omnigent host stop"``.
     """
     if explicit_server is None:
-        return "omnigent host stop"
+        return f"{cli_invocation()} host stop"
     stop_target = explicit_server if explicit_server else '""'
-    return f"omnigent host stop --server {stop_target}"
+    return f"{cli_invocation()} host stop --server {stop_target}"
 
 
 @cli.group("host", cls=_HostGroup, invoke_without_command=True)
@@ -8343,7 +8354,7 @@ def _host_stop_command(explicit_server: str | None) -> str:
     default=False,
     help=(
         "Never prompt for sign-in. When the server requires auth and you "
-        "are not logged in, fail with the `omnigent login` hint instead of "
+        f"are not logged in, fail with the `{cli_invocation()} login` hint instead of "
         "launching the browser login flow. Use this in scripts and CI."
     ),
 )
@@ -9916,8 +9927,8 @@ def _print_config_defaults() -> None:
     local_cfg = {k: v for k, v in _load_local_config().items() if k in _GLOBAL_CONFIG_KEYS}
     if not global_cfg and not local_cfg:
         click.echo(
-            "  (none set — `omnigent config set key=value` for project,\n"
-            "   or `omnigent config set --global key=value` for user-level)"
+            f"  (none set — `{cli_invocation()} config set key=value` for project,\n"
+            f"   or `{cli_invocation()} config set --global key=value` for user-level)"
         )
         return
     global_path = _effective_global_config_path()
@@ -9956,17 +9967,17 @@ class _ConfigGroup(click.Group):
         :returns: A hint string for a recognized legacy form, else ``None``.
         """
         if first == "--list":
-            return "`config --list` is now `omnigent config list`."
+            return f"`config --list` is now `{cli_invocation()} config list`."
         if first == "--unset":
-            return "`config --unset KEY` is now `omnigent config unset KEY`."
+            return f"`config --unset KEY` is now `{cli_invocation()} config unset KEY`."
         if first == "--global":
             return (
                 "`--global` now goes on the subcommand — "
-                "`omnigent config set --global KEY=VALUE` or "
-                "`omnigent config unset --global KEY`."
+                f"`{cli_invocation()} config set --global KEY=VALUE` or "
+                f"`{cli_invocation()} config unset --global KEY`."
             )
         if "=" in first and not first.startswith("-"):
-            return f"setting defaults is now `omnigent config set {first}`."
+            return f"setting defaults is now `{cli_invocation()} config set {first}`."
         return None
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
@@ -10095,8 +10106,8 @@ def slack(ctx: click.Context, background: bool) -> None:
     if existing is not None:
         raise click.ClickException(
             f"A background Slack bot is already running (pid {existing.pid}). "
-            "Stop it first with `omni integration slack stop`, or view it with "
-            "`omni integration slack status`."
+            f"Stop it first with `{cli_invocation(name='omni')} integration slack stop`, "
+            f"or view it with `{cli_invocation(name='omni')} integration slack status`."
         )
     # Foreground: inherit stdio, block until the bot exits (Ctrl-C). Config
     # comes from the inherited environment only (no .env loading — matches
@@ -10321,7 +10332,7 @@ def setup(internal_beta: bool) -> None:
         except ImportError:
             raise click.ClickException(
                 "Databricks internal-beta setup is not available in this build. "
-                "Run `omnigent setup` for the standard model/credential setup."
+                f"Run `{cli_invocation()} setup` for the standard model/credential setup."
             ) from None
         # Internal-beta routing mints workspace OAuth tokens via
         # databricks-sdk at runtime, and the SDK ships in the `databricks`
@@ -10369,7 +10380,9 @@ def setup(internal_beta: bool) -> None:
             }
         )
         click.echo(f"Set default_agent={agent_path} in {_GLOBAL_CONFIG_PATH}")
-        click.echo("Type `omnigent claude` to get started with Claude Code on omnigent.")
+        click.echo(
+            f"Type `{cli_invocation()} claude` to get started with Claude Code on omnigent."
+        )
         return
 
     # --no-internal-beta: the standard model/credential picker. It warns
@@ -12050,7 +12063,7 @@ def _reject_reserved_kiro_resume_args(kiro_args: tuple[str, ...]) -> None:
     if any(arg == flag or arg.startswith(f"{flag}=") for arg in kiro_args for flag in reserved):
         raise click.UsageError(
             "Kiro resume flags are reserved for Omnigent resume handling; use "
-            "`omnigent kiro --resume [CONVERSATION]` instead."
+            f"`{cli_invocation()} kiro --resume [CONVERSATION]` instead."
         )
 
 

--- a/omnigent/cli_common.py
+++ b/omnigent/cli_common.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import click
 
 from omnigent._platform import IS_WINDOWS
+from omnigent.cli_invocation import cli_invocation
 
 # Click ``flag_value`` for bare ``--resume`` (no arg). Must exist before any
 # command's decorator evaluates.
@@ -36,7 +37,7 @@ def reject_native_on_windows(harness: str) -> None:
     """
     if IS_WINDOWS:
         raise click.ClickException(
-            f"`omnigent {harness}` (native tmux/PTY terminal) is not supported on "
-            "Windows. Use an SDK-based harness via `omnigent run <agent.yaml>` "
+            f"`{cli_invocation()} {harness}` (native tmux/PTY terminal) is not supported on "
+            f"Windows. Use an SDK-based harness via `{cli_invocation()} run <agent.yaml>` "
             "or the web UI."
         )

--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from omnigent.cli_invocation import cli_invocation
 from omnigent.inner import ui
 from omnigent.onboarding.ucode_setup import (
     build_ucode_configure_command,
@@ -3356,7 +3357,8 @@ def _print_opencode_auth_help() -> None:
         "    • Databricks gateway: set an agent ``profile`` (configured under Claude / Codex);\n"
         "      Omnigent synthesizes opencode's per-session provider config from it.\n"
         "  Omnigent stores no OpenCode credential of its own.\n"
-        "  [dim]Tip:[/dim] 'Set default model' picks which model `omni opencode` launches on\n"
+        f"  [dim]Tip:[/dim] 'Set default model' picks which model "
+        f"`{cli_invocation(name='omni')} opencode` launches on\n"
         "  (otherwise OpenCode uses its built-in default, opencode/big-pickle)."
     )
 

--- a/omnigent/cli_diagnostics.py
+++ b/omnigent/cli_diagnostics.py
@@ -36,6 +36,7 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import cast
 
+from omnigent.cli_invocation import cli_invocation
 from omnigent.process_logging import (
     TerminalLogFormatter,
     effective_log_level,
@@ -412,8 +413,8 @@ def print_stale_host_hint() -> None:
     dest = getattr(sys.stderr, "_original_stderr", sys.stderr)
     print(
         "If this is a runner tunnel rejection (HTTP 401), stale host processes "
-        "may be the cause. Run `omnigent stop` to stop existing Omnigent host instances, "
-        "then try again.",
+        f"may be the cause. Run `{cli_invocation()} stop` to stop existing Omnigent "
+        "host instances, then try again.",
         file=dest,
     )
 

--- a/omnigent/cli_invocation.py
+++ b/omnigent/cli_invocation.py
@@ -1,0 +1,32 @@
+"""How to spell an ``omnigent`` command back to the user.
+
+When a deployment wraps the CLI (e.g. ``isaac omni``) it sets
+``OMNIGENT_WRAPPER_COMMAND`` and refuses naked ``omnigent`` calls (see the
+wrapper guard in :mod:`omnigent.cli`). Followup hints that tell the user to run
+a command must then name the wrapper (``isaac omni stop``) rather than the
+naked binary (``omnigent stop``), or they suggest exactly the command the guard
+rejects. :func:`cli_invocation` centralizes that spelling: hints interpolate it
+in place of the leading ``omnigent``/``omni`` token so every one honors the
+configured wrapper.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+DEFAULT_CLI_NAME = "omnigent"
+WRAPPER_COMMAND_ENV = "OMNIGENT_WRAPPER_COMMAND"
+
+
+def cli_invocation(*, name: str = DEFAULT_CLI_NAME, env: Mapping[str, str] | None = None) -> str:
+    """Return the token that invokes the CLI: the configured wrapper, else ``name``.
+
+    ``name`` is the naked binary the hint would otherwise use (``omnigent`` or
+    its ``omni`` alias); it is kept verbatim when no wrapper is configured, so a
+    hint reads ``omnigent stop`` normally and ``isaac omni stop`` when
+    ``OMNIGENT_WRAPPER_COMMAND=isaac omni``.
+    """
+    if env is None:
+        env = os.environ
+    return (env.get(WRAPPER_COMMAND_ENV) or "").strip() or name

--- a/omnigent/cli_sandbox.py
+++ b/omnigent/cli_sandbox.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import click
 
+from omnigent.cli_invocation import cli_invocation
 from omnigent.inner import ui
 from omnigent.onboarding.sandboxes import (
     SandboxHostLauncher,
@@ -220,8 +221,8 @@ def sandbox() -> None:
     help=(
         "Server URL the sandbox will register with. Determines the "
         "Databricks workspace the sandbox is created in (same "
-        "inference as `omnigent login`), and the bootstrap finishes "
-        "by logging the sandbox in to it (`omnigent login` inside the "
+        f"inference as `{cli_invocation()} login`), and the bootstrap finishes "
+        f"by logging the sandbox in to it (`{cli_invocation()} login` inside the "
         "sandbox — one browser step)."
     ),
 )
@@ -314,7 +315,7 @@ def sandbox_create(
     required=True,
     help=(
         "Server URL to log the sandbox in to. The in-sandbox "
-        "`omnigent login` infers the fronting Databricks workspace "
+        f"`{cli_invocation()} login` infers the fronting Databricks workspace "
         "from it automatically."
     ),
 )

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from omnigent.onboarding.provider_config import ProviderEntry
     from omnigent.spec.types import AgentSpec
 
+from omnigent.cli_invocation import cli_invocation
 from omnigent.codex_model_vocabulary import codex_spawn_model
 from omnigent.codex_native_bridge import write_policy_hook_config
 from omnigent.codex_native_process_registry import (
@@ -2834,8 +2835,8 @@ def resolve_native_codex_launch(
             summary=(
                 "Codex CLI login (no provider configured for the codex harness, no "
                 "Databricks profile) — the TUI likely renders the ChatGPT sign-in "
-                "screen and never starts a thread; run `omnigent setup` to route through "
-                "a provider"
+                f"screen and never starts a thread; run `{cli_invocation()} setup` "
+                "to route through a provider"
             ),
         )
     if entry.kind == SUBSCRIPTION_KIND:

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -27,6 +27,7 @@ import websockets.asyncio.client
 from websockets.exceptions import ConnectionClosed, InvalidStatus, InvalidURI
 
 from omnigent._platform import IS_POSIX, WINDOWS_ENV_PASSTHROUGH
+from omnigent.cli_invocation import cli_invocation
 from omnigent.debug_logging import PRIMARY_SESSION_ID_ENV_VAR, USER_ID_ENV_VAR
 from omnigent.env_credentials import env_names_with_omnigent_prefix
 from omnigent.gateway_inference import gateway_inference_map
@@ -1219,7 +1220,7 @@ class HostProcess:
             command, e.g. ``"Run `omnigent login <url>` ..."``.
         """
         return (
-            f"Run `omnigent login {self._login_hint_url()}` to authenticate (it "
+            f"Run `{cli_invocation()} login {self._login_hint_url()}` to authenticate (it "
             "detects Databricks-fronted servers and logs in to the right "
             "workspace), or check your ambient Databricks credentials."
         )
@@ -1241,7 +1242,7 @@ class HostProcess:
         """
         return (
             "If this server uses Omnigent accounts or OIDC login, run "
-            f"`omnigent login {self._login_hint_url()}` to authenticate."
+            f"`{cli_invocation()} login {self._login_hint_url()}` to authenticate."
         )
 
     def _fatal_upgrade_error(self, exc: InvalidURI | InvalidStatus) -> HostConnectError | None:
@@ -1340,7 +1341,7 @@ class HostProcess:
                         f"{self._auth_retry_streak} times in a row — this is no "
                         "longer a transient network blip. If it persists, the "
                         "stored credential is likely no longer valid: run "
-                        f"`omnigent login {self._login_hint_url()}` and restart the "
+                        f"`{cli_invocation()} login {self._login_hint_url()}` and restart the "
                         "host. Still retrying."
                     )
                     _logger.warning("%s", escalated)
@@ -2902,7 +2903,7 @@ class HostProcess:
                                 f"{self._refused_streak} consecutive connection "
                                 "attempts — nothing is listening on that local "
                                 "address anymore. Start the server, then run "
-                                "`omnigent host` again."
+                                f"`{cli_invocation()} host` again."
                             ) from exc
                     else:
                         self._refused_streak = 0

--- a/omnigent/inner/acp_harness.py
+++ b/omnigent/inner/acp_harness.py
@@ -52,6 +52,7 @@ import os
 
 from fastapi import FastAPI
 
+from omnigent.cli_invocation import cli_invocation
 from omnigent.inner.acp_executor import AcpAgentConfig, AcpExecutor
 from omnigent.inner.acp_extension import NO_ACP_EXTENSION, AcpExtension
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
@@ -135,7 +136,7 @@ def _build_acp_executor(extension: AcpExtension = NO_ACP_EXTENSION) -> Executor:
     if not command:
         raise RuntimeError(
             f"{_ENV_COMMAND} is not set — no ACP agent command configured. "
-            "Add one via `omnigent setup` → configure harnesses → Custom ACP agent."
+            f"Add one via `{cli_invocation()} setup` → configure harnesses → Custom ACP agent."
         )
     name = os.environ.get(_ENV_NAME, "").strip() or "ACP agent"
     model = os.environ.get(_ENV_MODEL, "").strip() or None

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -44,6 +44,7 @@ from typing import Any, Protocol, TypeAlias, cast
 
 from omnigent import model_catalog
 from omnigent._platform import resolve_cli_binary, stable_user_id
+from omnigent.cli_invocation import cli_invocation
 from omnigent.databricks_ai_gateway import is_databricks_ai_gateway_url
 from omnigent.inner import _proc
 from omnigent.inner.bundle_skills import ensure_bundle_plugin_manifest
@@ -1507,7 +1508,7 @@ class ClaudeSDKExecutor(Executor):
                 f"Model {model!r} is a Databricks-hosted model but gateway "
                 "routing is disabled (gateway=False). "
                 "Set executor.profile in the agent spec, or configure a "
-                "Databricks provider with `omnigent setup`, to route through "
+                f"Databricks provider with `{cli_invocation()} setup`, to route through "
                 "the Databricks Anthropic gateway."
             )
         self._cwd = cwd

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, TypeAlias
 
 from omnigent._platform import IS_WINDOWS
+from omnigent.cli_invocation import cli_invocation
 from omnigent.runner.identity import strip_runner_auth_secrets
 
 from . import _proc
@@ -1966,7 +1967,7 @@ def create_terminal_instance(
     if IS_WINDOWS:
         raise RuntimeError(
             "Native terminal harnesses (tmux/PTY) are not supported on Windows. "
-            "Run an SDK-based harness via `omnigent run <agent.yaml>` (e.g. the "
+            f"Run an SDK-based harness via `{cli_invocation()} run <agent.yaml>` (e.g. the "
             "claude-sdk, cursor, copilot, or codex harness) or use the web UI."
         )
     if not _tmux_available():

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -50,6 +50,7 @@ from packaging.version import InvalidVersion, Version
 
 from omnigent._platform import resolve_cli_binary
 from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
+from omnigent.cli_invocation import cli_invocation
 from omnigent.harness_install_spec import HarnessInstallSpec, SetupStep
 from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, GEMINI_FAMILY, OPENAI_FAMILY
 from omnigent.opencode_native_client import (
@@ -697,7 +698,10 @@ def harness_setup_hint(harness: str | None) -> str:
         elif spec.auth_hint:
             login = f", then {spec.auth_hint}"
         return f"install the {spec.binary} CLI on that machine with `{spec.install_hint}`{login}"
-    return "run `omni setup` on that machine to install the CLI and set a default credential"
+    return (
+        f"run `{cli_invocation(name='omni')} setup` on that machine to install "
+        "the CLI and set a default credential"
+    )
 
 
 _VERSION_RE = re.compile(r"(\d+\.\d+\.\d+(?:[-.][0-9A-Za-z]+)*)")

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -49,6 +49,7 @@ import os
 from dataclasses import dataclass, field, replace
 from typing import Literal
 
+from omnigent.cli_invocation import cli_invocation
 from omnigent.env_credentials import (
     _ENV_REF_RE,
     env_names_with_omnigent_prefix,
@@ -520,7 +521,7 @@ def resolve_secret(ref: str) -> str:
         if value is None:
             raise OmnigentError(
                 f"no stored secret named {name!r}; run "
-                "`omnigent setup --no-internal-beta` to set it.",
+                f"`{cli_invocation()} setup --no-internal-beta` to set it.",
                 code=ErrorCode.INVALID_INPUT,
             )
         return value

--- a/omnigent/onboarding/sandboxes/bootstrap.py
+++ b/omnigent/onboarding/sandboxes/bootstrap.py
@@ -43,6 +43,8 @@ from urllib.parse import parse_qs, urlparse
 import click
 import httpx
 
+from omnigent.cli_invocation import cli_invocation
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
@@ -569,7 +571,7 @@ def _complete_browser_login(
         returncode = login.wait()
         if returncode != 0:
             raise click.ClickException(
-                f"`omnigent login` inside sandbox '{sandbox_id}' exited "
+                f"`{cli_invocation()} login` inside sandbox '{sandbox_id}' exited "
                 f"with code {returncode} before printing a verification "
                 "URL. Run it inside the sandbox manually to debug."
             )
@@ -590,7 +592,8 @@ def _complete_browser_login(
         returncode = login.wait()
         if returncode != 0:
             raise click.ClickException(
-                f"`omnigent login` inside sandbox '{sandbox_id}' exited with code {returncode}."
+                f"`{cli_invocation()} login` inside sandbox '{sandbox_id}' "
+                f"exited with code {returncode}."
             )
 
 
@@ -679,11 +682,11 @@ def connect_sandbox_host(
     # The executed command keeps the wire URL — it must work verbatim in-sandbox.
     if host_name is not None:
         set_sandbox_host_name(launcher, sandbox_id, host_name)
-    click.echo("  → running `omnigent host` in the sandbox (Ctrl-C to detach)")
+    click.echo(f"  → running `{cli_invocation()} host` in the sandbox (Ctrl-C to detach)")
     returncode = launcher.exec_foreground(sandbox_id, f"omnigent host --server {server_url}")
     if returncode != 0:
         raise click.ClickException(
-            f"`omnigent host` on sandbox '{sandbox_id}' exited with code {returncode}."
+            f"`{cli_invocation()} host` on sandbox '{sandbox_id}' exited with code {returncode}."
         )
 
 

--- a/omnigent/onboarding/sandboxes/e2b.py
+++ b/omnigent/onboarding/sandboxes/e2b.py
@@ -49,6 +49,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import click
 
+from omnigent.cli_invocation import cli_invocation
 from omnigent.inner import ui
 from omnigent.onboarding.sandboxes.base import (
     RemoteCommandResult,
@@ -425,7 +426,7 @@ class E2BSandboxLauncher(SandboxLauncher):
                     f"E2B sandbox '{sandbox_id}' not found — it may have passed its "
                     "lifetime cap. Managed sessions provision a replacement on the "
                     "next message; for a CLI host create a fresh one with "
-                    "`omnigent sandbox create --provider e2b`."
+                    f"`{cli_invocation()} sandbox create --provider e2b`."
                 ) from exc
             self._sandboxes[sandbox_id] = handle
         return handle
@@ -591,7 +592,7 @@ class E2BSandboxLauncher(SandboxLauncher):
             raise click.ClickException(
                 f"E2B sandbox '{sandbox_id}' is not running (it may have passed its "
                 "lifetime cap). Create a fresh one with "
-                "`omnigent sandbox create --provider e2b`."
+                f"`{cli_invocation()} sandbox create --provider e2b`."
             )
 
     def keep_alive(self, sandbox_id: str) -> None:

--- a/omnigent/onboarding/sandboxes/modal.py
+++ b/omnigent/onboarding/sandboxes/modal.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import click
 
+from omnigent.cli_invocation import cli_invocation
 from omnigent.onboarding.sandboxes.base import (
     DEFAULT_HOST_IMAGE,
     RemoteCommandResult,
@@ -149,7 +150,7 @@ def _lookup_sandbox(sandbox_id: str) -> modal.Sandbox:
         raise click.ClickException(
             f"Modal sandbox '{sandbox_id}' not found — it may have passed its "
             "24-hour lifetime. Create a fresh one with "
-            "`omnigent sandbox create --provider modal`."
+            f"`{cli_invocation()} sandbox create --provider modal`."
         ) from exc
 
 
@@ -413,7 +414,7 @@ class ModalSandboxLauncher(SandboxLauncher):
             raise click.ClickException(
                 f"Modal sandbox '{sandbox_id}' has terminated (sandboxes live "
                 "at most 24 hours). Create a fresh one with "
-                "`omnigent sandbox create --provider modal`."
+                f"`{cli_invocation()} sandbox create --provider modal`."
             )
 
     def keep_alive(self, sandbox_id: str) -> None:

--- a/omnigent/onboarding/setup.py
+++ b/omnigent/onboarding/setup.py
@@ -34,6 +34,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+from omnigent.cli_invocation import cli_invocation
+
 if TYPE_CHECKING:
     from rich.console import Console
 
@@ -650,6 +652,6 @@ def maybe_run_onboarding() -> None:
         run_onboarding()
     else:
         console.print(
-            "  [dim]run `omnigent setup --internal-beta` when ready "
+            f"  [dim]run `{cli_invocation()} setup --internal-beta` when ready "
             f"(or `{SKIP_ENV_VAR}=1` to silence).[/dim]"
         )

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -68,6 +68,7 @@ from rich.console import RenderableType
 from rich.markup import escape
 from rich.text import Text
 
+from omnigent.cli_invocation import cli_invocation
 from omnigent.spec.types import SkillSpec
 
 if TYPE_CHECKING:
@@ -1890,12 +1891,12 @@ class _SessionsChatReplAdapter:
                     # online runners at create time and found none.
                     raise RuntimeError(
                         "This server has no online runner to run the turn. Start one "
-                        "against it with `omnigent host --server <url>` (or run the "
-                        "agent locally with `omnigent run <agent.yaml>`), then retry."
+                        f"against it with `{cli_invocation()} host --server <url>` (or run the "
+                        f"agent locally with `{cli_invocation()} run <agent.yaml>`), then retry."
                     )
                 raise RuntimeError(
                     "Sessions API dispatch requires a registered runner id. "
-                    "Start through `omnigent run <agent>` or pass --server so the CLI "
+                    f"Start through `{cli_invocation()} run <agent>` or pass --server so the CLI "
                     "can launch and bind a runner."
                 )
             if self._bound_runner_id == self._runner_id:
@@ -5024,7 +5025,8 @@ def _build_model_readout_lines(
         else:
             lines.append("Active:  None  ·  None")
             lines.append(
-                "no model configured — run `omnigent setup --no-internal-beta` to add one"
+                f"no model configured — run `{cli_invocation()} setup --no-internal-beta` "
+                "to add one"
             )
         lines.append("usage: /model <name> · /model default | off | reset to clear")
         return lines
@@ -5266,7 +5268,7 @@ async def _cmd_model(
         host.output(
             Text.from_markup(
                 f"  [{fmt.muted}]Active provider: {active_label}. To use {target_label}, run "
-                f"`omnigent setup --no-internal-beta` and select it as the "
+                f"`{cli_invocation()} setup --no-internal-beta` and select it as the "
                 f"default, then restart. "
                 f"(You can still change the model within {active_label}: /model <model-name>.)"
                 f"[/{fmt.muted}]"

--- a/omnigent/resume_dispatch.py
+++ b/omnigent/resume_dispatch.py
@@ -31,6 +31,7 @@ import httpx
 from omnigent._wrapper_labels import (
     WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY,
 )
+from omnigent.cli_invocation import cli_invocation
 from omnigent.native_coding_agents import native_coding_agent_for_wrapper_label
 from omnigent.native_dispatch import resolve_hook_for_key
 
@@ -75,8 +76,8 @@ def run_resume(
     if target is None:
         if server is None:
             raise click.UsageError(
-                "`omnigent resume` (no id) requires `--server <url>`. "
-                "Pass a conversation id (`omnigent resume conv_...`) "
+                f"`{cli_invocation()} resume` (no id) requires `--server <url>`. "
+                f"Pass a conversation id (`{cli_invocation()} resume conv_...`) "
                 "to use the persistent local store.",
             )
         target = _pick_conversation_for_resume(server=server)
@@ -247,7 +248,7 @@ def _dispatch_by_runtime(
         raise click.ClickException(
             f"Conversation {target!r} is not a terminal-native session "
             f"(wrapper={wrapper!r}). To resume it, run "
-            f"`omnigent run --resume {target} <agent.yaml> --server "
+            f"`{cli_invocation()} run --resume {target} <agent.yaml> --server "
             f"{server}`. The agentless form is tracked separately.",
         )
 
@@ -261,7 +262,7 @@ def _dispatch_by_runtime(
     raise click.ClickException(
         f"Conversation {target!r} is not a terminal-native session "
         f"(wrapper={wrapper!r}). To resume it, run "
-        f"`omnigent run --resume {target} <agent.yaml>`. "
+        f"`{cli_invocation()} run --resume {target} <agent.yaml>`. "
         "The agentless form is tracked separately.",
     )
 

--- a/omnigent/runner/launch_failure.py
+++ b/omnigent/runner/launch_failure.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from omnigent.cli_invocation import cli_invocation
+
 __all__ = [
     "FailureDiagnosis",
     "classify_terminal_failure",
@@ -124,7 +126,7 @@ _TERMINAL_EXIT_MATCHERS: tuple[_TerminalMatcher, ...] = (
                 "The host couldn't find the agent's CLI on its PATH, so the terminal "
                 "exited before the session could start."
             ),
-            remediation="Install the harness on the host (e.g. run `omnigent setup`).",
+            remediation=f"Install the harness on the host (e.g. run `{cli_invocation()} setup`).",
         ),
     ),
     _TerminalMatcher(
@@ -137,7 +139,8 @@ _TERMINAL_EXIT_MATCHERS: tuple[_TerminalMatcher, ...] = (
                 "host — it needs to be logged in before it can run a session."
             ),
             remediation=(
-                "Sign the agent in on the host (e.g. run its `/login`, or `omnigent login`)."
+                f"Sign the agent in on the host (e.g. run its `/login`, "
+                f"or `{cli_invocation()} login`)."
             ),
         ),
     ),

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -26,6 +26,7 @@ from urllib.parse import quote, urlsplit, urlunsplit
 from starlette.types import ASGIApp, Message, Scope
 from websockets.exceptions import ConnectionClosedOK, InvalidURI, WebSocketException
 
+from omnigent.cli_invocation import cli_invocation
 from omnigent.debug_logging import runner_primary_session_id
 from omnigent.runner.identity import (
     OMNIGENT_INTERNAL_WS_ORIGIN,
@@ -439,8 +440,8 @@ async def serve_tunnel(
                         f"(redirect to non-WebSocket URL {redirect_url} "
                         f"persisted across {login_redirect_streak} attempts); "
                         "the server likely requires auth — "
-                        f"run `omnigent login {display_server_url(server_url)}` or "
-                        "`omnigent setup` to configure credentials"
+                        f"run `{cli_invocation()} login {display_server_url(server_url)}` or "
+                        f"`{cli_invocation()} setup` to configure credentials"
                     ) from exc
                 retry_reason = (
                     f"login-page redirect during upgrade ({redirect_url}); "

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     # import annotations`` is in effect).
     from omnigent.inner.datamodel import OSEnvSpec
 
+from omnigent.cli_invocation import cli_invocation
 from omnigent.entities import (
     NON_CONTENT_ITEM_TYPES,
     CompactionData,
@@ -1045,7 +1046,7 @@ def _resolve_provider_for_build(
             raise OmnigentError(
                 f"executor.auth references provider {auth.name!r}, but no such provider is "
                 "configured under 'providers:' in ~/.omnigent/config.yaml. "
-                "Run `omnigent setup --no-internal-beta` to configure one.",
+                f"Run `{cli_invocation()} setup --no-internal-beta` to configure one.",
                 code=ErrorCode.INVALID_INPUT,
             )
         return entry

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -23,6 +23,7 @@ from fastapi import (
 from fastapi.responses import Response
 from pydantic import ValidationError
 
+from omnigent.cli_invocation import cli_invocation
 from omnigent.db.utils import generate_agent_id, generate_task_id
 from omnigent.debug_logging import debug_event
 from omnigent.entities import (
@@ -3986,7 +3987,8 @@ async def _persist_host_launch_failure_turn(
             # the code, but the banner must stay actionable if a
             # third-party host omits it.
             else (
-                "the agent's harness is not configured on the selected host — run `omnigent setup`"
+                f"the agent's harness is not configured on the selected host — "
+                f"run `{cli_invocation()} setup`"
             )
         ),
     )
@@ -7299,7 +7301,7 @@ def _ungatewayed_auto_routing_error(ungatewayed: Sequence[str]) -> str:
         f"{verb} not AI-Gateway-backed, so the workspace router's picks would not be "
         "reachable, and this server has no built-in routing model to fall back on. Pick a "
         "harness directly, configure a server `llm:` block, or point the harness at the "
-        "workspace AI Gateway (`omnigent configure harnesses`)."
+        f"workspace AI Gateway (`{cli_invocation()} configure harnesses`)."
     )
 
 
@@ -7318,7 +7320,7 @@ def _ungatewayed_model_routing_error(harness: str) -> str:
         "picks would not be reachable from the pane, and this server has no built-in routing "
         'model to fall back on. Create the session without cost_control_mode_override="on", '
         "configure a server `llm:` block, or point the harness at the workspace AI Gateway "
-        "(`omnigent configure harnesses`)."
+        f"(`{cli_invocation()} configure harnesses`)."
     )
 
 

--- a/omnigent/smart_routing_cli.py
+++ b/omnigent/smart_routing_cli.py
@@ -34,6 +34,7 @@ from typing import Any
 import click
 import httpx
 
+from omnigent.cli_invocation import cli_invocation
 from omnigent.db.utils import builtin_agent_id
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.native_coding_agents import native_coding_agent_for_harness
@@ -165,7 +166,7 @@ def check_smart_routing_available(
             f"Smart Routing is unavailable for {harness} on this host: its inference "
             f"is not AI-Gateway-backed ({reason}), so a routed model would not be "
             "reachable from the pane. Re-run without --smart-routing, or point the "
-            "harness at the workspace AI Gateway (`omnigent configure harnesses`)."
+            f"harness at the workspace AI Gateway (`{cli_invocation()} configure harnesses`)."
         )
 
 

--- a/tests/cli/test_cli_diagnostics.py
+++ b/tests/cli/test_cli_diagnostics.py
@@ -269,6 +269,22 @@ def test_stale_host_hint_recommends_generic_stop_command(
     assert "omnigent setup" not in hint
 
 
+def test_stale_host_hint_names_configured_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Under a wrapper deployment the hint suggests the wrapper, not naked `omnigent`."""
+    terminal_stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", terminal_stderr)
+    monkeypatch.setenv("OMNIGENT_WRAPPER_COMMAND", "isaac omni")
+
+    cli_diagnostics.print_stale_host_hint()
+
+    hint = terminal_stderr.getvalue()
+    assert "`isaac omni stop`" in hint
+    # The naked binary token must not be suggested when it would be refused.
+    assert "`omnigent stop`" not in hint
+
+
 def test_redirect_stderr_to_log_retargets_existing_logging_stderr_handlers(
     isolated_cli_diagnostics: None,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/cli/test_cli_invocation.py
+++ b/tests/cli/test_cli_invocation.py
@@ -1,0 +1,50 @@
+"""Tests for :mod:`omnigent.cli_invocation`.
+
+Followup hints must name the configured wrapper (``isaac omni stop``) when
+``OMNIGENT_WRAPPER_COMMAND`` is set, and fall back to the naked binary token
+otherwise so default output is unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.cli_invocation import DEFAULT_CLI_NAME, WRAPPER_COMMAND_ENV, cli_invocation
+
+
+def test_defaults_to_omnigent_when_wrapper_unset() -> None:
+    assert cli_invocation(env={}) == "omnigent"
+    assert DEFAULT_CLI_NAME == "omnigent"
+
+
+def test_preserves_omni_alias_when_wrapper_unset() -> None:
+    # A hint that spells the short ``omni`` alias keeps it verbatim.
+    assert cli_invocation(name="omni", env={}) == "omni"
+
+
+def test_wrapper_command_overrides_both_names() -> None:
+    env = {WRAPPER_COMMAND_ENV: "isaac omni"}
+    assert cli_invocation(env=env) == "isaac omni"
+    assert cli_invocation(name="omni", env=env) == "isaac omni"
+
+
+def test_blank_wrapper_command_is_ignored() -> None:
+    assert cli_invocation(env={WRAPPER_COMMAND_ENV: "   "}) == "omnigent"
+    assert cli_invocation(env={WRAPPER_COMMAND_ENV: ""}) == "omnigent"
+
+
+def test_wrapper_command_is_stripped() -> None:
+    assert cli_invocation(env={WRAPPER_COMMAND_ENV: "  isaac omni  "}) == "isaac omni"
+
+
+def test_reads_process_environment_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(WRAPPER_COMMAND_ENV, "isaac omni")
+    assert cli_invocation() == "isaac omni"
+    monkeypatch.delenv(WRAPPER_COMMAND_ENV, raising=False)
+    assert cli_invocation() == "omnigent"
+
+
+def test_rendered_hint_names_the_wrapper() -> None:
+    env = {WRAPPER_COMMAND_ENV: "isaac omni"}
+    assert f"Run `{cli_invocation(env=env)} stop`" == "Run `isaac omni stop`"
+    assert f"Run `{cli_invocation(env={})} stop`" == "Run `omnigent stop`"


### PR DESCRIPTION
## Related issue

Follow-up to #4766 (added `OMNIGENT_WRAPPER_COMMAND` + the wrapper guard). No separate issue.

Closes #

## Summary

- #4766 lets a deployment wrap the CLI (e.g. `isaac omni`) via `OMNIGENT_WRAPPER_COMMAND` and refuses naked `omnigent`/`omni` calls. But the followup hints we print still said `Run \`omnigent stop\``, `omnigent setup`, etc. — exactly the spelling the guard rejects.
- Adds `omnigent/cli_invocation.py` with `cli_invocation(name=..., env=...)`: returns `OMNIGENT_WRAPPER_COMMAND` when set, else the naked binary token (`omnigent`, or the `omni` alias where a hint used it).
- User-facing hints across the CLI now interpolate it in place of the leading `omnigent`/`omni` token, so a wrapped deployment sees `isaac omni stop`. The naked default is preserved verbatim, so output is byte-identical when no wrapper is configured.
- Comments, docstrings, and internal `logger` strings are intentionally left untouched.

## Test Plan

- `uv run pytest tests/cli/test_cli_invocation.py tests/cli/test_cli_diagnostics.py` — 21 passed.
- `uv run ruff check` + `uv run ruff format --check` on the changed files — clean.
- `uv run pre-commit run --files <changed>` — all hooks pass.
- Manual, both directions:
  - `OMNIGENT_WRAPPER_BYPASS=1 omnigent attach` → hints read `omnigent host status` / `omnigent run <agent.yaml>` / `omnigent stop`.
  - `OMNIGENT_WRAPPER_BYPASS=1 OMNIGENT_WRAPPER_COMMAND="isaac omni" omnigent attach` → same hints read `isaac omni host status` / `isaac omni run <agent.yaml>` / `isaac omni stop`.

## Demo

N/A (non-visual CLI text change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests (`tests/cli/test_cli_invocation.py`) cover the wrapper-set / unset / blank / stripped cases and hint interpolation; `test_cli_diagnostics.py` gains a wrapper-set case for the runner-tunnel 401 hint. Existing diagnostics tests already pin the default (`omnigent stop`) spelling and still pass, confirming default output is unchanged. Manual verification exercised the live CLI with and without `OMNIGENT_WRAPPER_COMMAND`.

## Changelog

CLI followup hints (e.g. `stop`, `setup`, `run`) now name the configured wrapper command when `OMNIGENT_WRAPPER_COMMAND` is set.
