### PR TITLE
Default the session sidebar filter to My sessions

### DIFF
--- a/tests/e2e_ui/collaboration/test_leave_shared_session.py
+++ b/tests/e2e_ui/collaboration/test_leave_shared_session.py
@@ -110,10 +110,10 @@ def test_shared_viewer_leaves_session_and_row_disappears(
         page = ctx.new_page()
         page.goto(f"{server.public_url}/c/{sid}")
 
-        # The shared session is visible before leaving, under both the default
-        # filter and the shared one.
+        # The shared session is hidden under the default "My sessions" filter
+        # (it isn't the viewer's own); it shows under the "Shared sessions"
+        # filter, where the viewer leaves it from.
         expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
-        expect(_row(page, sid)).to_be_visible(timeout=30_000)
         page.locator(_FILTER).click()
         page.locator(_FILTER_SHARED).click()
         expect(_row(page, sid)).to_be_visible(timeout=30_000)

--- a/tests/e2e_ui/sessions/test_sidebar_ownership_gating.py
+++ b/tests/e2e_ui/sessions/test_sidebar_ownership_gating.py
@@ -111,7 +111,7 @@ def test_owner_sees_session_under_my_sessions_with_enabled_actions(
         page = ctx.new_page()
         page.goto(f"{server.public_url}/c/{sid}")
 
-        # Owned → shows under the default "All sessions" filter.
+        # Owned → shows under the default "My sessions" filter.
         expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
         expect(_row(page, sid)).to_be_visible(timeout=30_000)
 
@@ -154,12 +154,9 @@ def test_shared_viewer_sees_session_under_shared_filter_with_owner_only_actions(
         page = ctx.new_page()
         page.goto(f"{server.public_url}/c/{sid}")
 
-        # The shared session is not the viewer's own, but "All sessions" (the
-        # default filter) includes it, so it is visible up front...
+        # The shared session is not the viewer's own, so the default "My
+        # sessions" filter hides it; it shows under the "Shared sessions" filter.
         expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
-        expect(_row(page, sid)).to_be_visible(timeout=30_000)
-
-        # ...and it stays visible under the "Shared sessions" filter.
         page.locator(_FILTER).click()
         page.locator(_FILTER_SHARED).click()
         expect(_row(page, sid)).to_be_visible(timeout=30_000)

--- a/tests/e2e_ui/sessions/test_sidebar_pinned_projects_filter_independence.py
+++ b/tests/e2e_ui/sessions/test_sidebar_pinned_projects_filter_independence.py
@@ -172,7 +172,9 @@ def test_pinned_section_ignores_the_session_filter(
         page.goto(f"{server.public_url}/c/{owned}")
         expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
 
-        # Pin both from the default "All sessions" view, where both rows show.
+        # Switch to "All sessions" so both rows show, then pin both. (The
+        # default "My sessions" hides the shared row, leaving nothing to pin.)
+        _set_filter(page, "all")
         _pin_row(page, owned)
         _pin_row(page, shared)
         _pinned_has(page, owned)
@@ -281,6 +283,9 @@ def test_shared_session_stays_in_flat_list_on_project_name_collision(
         page = ctx.new_page()
         page.goto(f"{server.public_url}/c/{owned}")
         expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
+        # The shared row is hidden under the default "My sessions"; switch to
+        # "All sessions", since this test is about where that shared row lands.
+        _set_filter(page, "all")
 
         # The folder exists (the owned session filed it), but the shared session
         # is NOT filed away: it stays in the flat Sessions list, not the folder.

--- a/tests/e2e_ui/sessions/test_sidebar_session_filter_persistence.py
+++ b/tests/e2e_ui/sessions/test_sidebar_session_filter_persistence.py
@@ -2,7 +2,7 @@
 
 The sidebar's session filter (the funnel: All / My sessions / Shared /
 Archived) used to live only in React state, so every reload snapped the list
-back to "All sessions" — a viewer who works out of "My sessions" had to
+back to the default — a viewer who picked a different slice had to
 re-pick it after each refresh. The pick is now persisted per-device
 (``omnigent:session-filter`` in ``localStorage``) and seeded back on mount.
 
@@ -119,20 +119,23 @@ def multi_user_server(
 
 
 @pytest.mark.flaky(reruns=2, reruns_delay=5)
-def test_my_sessions_filter_survives_a_reload(
+def test_all_sessions_filter_survives_a_reload(
     browser: Browser,
     multi_user_server: MultiUserServer,
 ) -> None:
-    """Picking "My sessions" still scopes the list after a full page reload.
+    """Picking "All sessions" still scopes the list after a full page reload.
 
-    Seeds a session the viewer owns and one the admin shared with them, picks
-    "My sessions" (dropping the shared row), then reloads. Before the fix the
-    filter reset to "All sessions" on load, so the shared row came back and the
-    viewer had to re-pick after every refresh.
+    The default filter is "My sessions", which hides sessions shared to the
+    viewer by others. Seeds a session the viewer owns and one the admin shared
+    with them, picks "All sessions" (bringing the shared row in), then reloads.
+    Without persistence the filter would snap back to the "My sessions" default
+    on load, dropping the shared row again.
 
-    Asserts both the visible effect (shared row stays out, owned row stays in)
-    and the menu state (the radio item reads checked), so a list that happened
-    to look right for another reason can't pass.
+    "All" is a non-default slice, so this genuinely exercises persistence: a
+    reload that landed on the default would fail here. Asserts both the visible
+    effect (shared row returns and stays) and the menu state (the radio item
+    reads checked), so a list that happened to look right for another reason
+    can't pass.
     """
     server = multi_user_server
     uniq = uuid.uuid4().hex[:6]
@@ -148,22 +151,22 @@ def test_my_sessions_filter_survives_a_reload(
         page.goto(f"{server.public_url}/c/{owned}")
         expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
 
-        # Default "All sessions": both rows visible, so the scoping below is a
-        # real change rather than a row that was never there.
+        # Default "My sessions": the owned row shows and the shared one is
+        # hidden, so picking "All" below is a real change rather than a no-op.
         expect(_row(page, owned)).to_be_visible(timeout=30_000)
-        expect(_row(page, shared)).to_be_visible(timeout=30_000)
+        expect(_row(page, shared)).to_have_count(0, timeout=30_000)
 
-        _set_filter(page, "mine")
-        expect(_row(page, shared)).to_have_count(0, timeout=15_000)
+        _set_filter(page, "all")
+        expect(_row(page, shared)).to_be_visible(timeout=15_000)
         expect(_row(page, owned)).to_be_visible()
 
         # The reload the fix is about: a fresh document, so the sidebar must
-        # re-seed the filter from storage rather than default to "All sessions".
+        # re-seed the filter from storage rather than snap back to "My sessions".
         page.reload()
         expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
         expect(_row(page, owned)).to_be_visible(timeout=30_000)
-        expect(_row(page, shared)).to_have_count(0)
-        _expect_checked_filter(page, "mine")
+        expect(_row(page, shared)).to_be_visible(timeout=30_000)
+        _expect_checked_filter(page, "all")
     finally:
         ctx.close()
 
@@ -192,8 +195,8 @@ def test_shared_sessions_filter_survives_a_reload(
         page = ctx.new_page()
         page.goto(f"{server.public_url}/c/{owned}")
         expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
-        expect(_row(page, shared)).to_be_visible(timeout=30_000)
-
+        # Default "My sessions" hides the shared row; picking "Shared" brings it
+        # in and drops the owned one.
         _set_filter(page, "shared")
         expect(_row(page, shared)).to_be_visible(timeout=15_000)
         expect(_row(page, owned)).to_have_count(0, timeout=15_000)
@@ -218,9 +221,9 @@ def test_stored_shared_filter_is_dropped_on_a_single_user_server(
     ``live_server`` is loopback-only, so the funnel drops "Shared sessions" —
     there's one user and the slice is meaningless. Seeding the stored value
     that a multi-user server would have written (or a hand-edited entry) must
-    therefore fall back to "All sessions": honoring it would scope the list to
-    a slice with no menu entry to leave it by, i.e. an empty list the viewer
-    can't escape.
+    therefore fall back to the "My sessions" default: honoring it would scope
+    the list to a slice with no menu entry to leave it by, i.e. an empty list
+    the viewer can't escape.
 
     Uses ``add_init_script`` so the value is in storage *before* any app script
     runs, which is what a returning viewer's first paint actually sees.
@@ -232,10 +235,11 @@ def test_stored_shared_filter_is_dropped_on_a_single_user_server(
     expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
 
     # The viewer's own session renders (an honored "shared" would hide it), and
-    # the menu shows All checked with no Shared option to have selected.
+    # the menu falls back to the "My sessions" default with no Shared option to
+    # have selected.
     expect(_row(page, session_id)).to_be_visible(timeout=30_000)
     page.locator(_FILTER).click()
-    expect(page.locator('[data-testid="session-filter-all"]')).to_have_attribute(
+    expect(page.locator('[data-testid="session-filter-mine"]')).to_have_attribute(
         "aria-checked", "true", timeout=15_000
     )
     expect(page.locator('[data-testid="session-filter-shared"]')).to_have_count(0)

--- a/web/src/lib/sessionFilterPreferences.test.ts
+++ b/web/src/lib/sessionFilterPreferences.test.ts
@@ -11,10 +11,10 @@ afterEach(() => {
 });
 
 describe("sessionFilterPreferences", () => {
-  it('defaults to "all" when nothing is stored', () => {
-    // A first-time viewer sees the whole list, as before persistence existed.
-    expect(DEFAULT_SESSION_FILTER).toBe("all");
-    expect(readSessionFilter(true)).toBe("all");
+  it('defaults to "mine" when nothing is stored', () => {
+    // A first-time viewer lands on their own sessions rather than the whole list.
+    expect(DEFAULT_SESSION_FILTER).toBe("mine");
+    expect(readSessionFilter(true)).toBe("mine");
   });
 
   it("round-trips every filter value", () => {
@@ -28,17 +28,17 @@ describe("sessionFilterPreferences", () => {
     // Guards against a hand-edited entry or a filter this build dropped:
     // scoping the list to a slice with no menu entry would strand the viewer.
     localStorage.setItem("omnigent:session-filter", "starred");
-    expect(readSessionFilter(true)).toBe("all");
+    expect(readSessionFilter(true)).toBe("mine");
 
     localStorage.setItem("omnigent:session-filter", "");
-    expect(readSessionFilter(true)).toBe("all");
+    expect(readSessionFilter(true)).toBe("mine");
   });
 
   it('ignores a stored "shared" on a single-user server', () => {
     // A loopback-only server drops "Shared sessions" from the menu, so honoring
     // it would show an empty list the viewer has no control to leave.
     writeSessionFilter("shared");
-    expect(readSessionFilter(false)).toBe("all");
+    expect(readSessionFilter(false)).toBe("mine");
     // Still honored where the option exists.
     expect(readSessionFilter(true)).toBe("shared");
   });
@@ -59,6 +59,6 @@ describe("sessionFilterPreferences", () => {
       throw new Error("access denied");
     });
     expect(() => writeSessionFilter("mine")).not.toThrow();
-    expect(readSessionFilter(true)).toBe("all");
+    expect(readSessionFilter(true)).toBe("mine");
   });
 });

--- a/web/src/lib/sessionFilterPreferences.ts
+++ b/web/src/lib/sessionFilterPreferences.ts
@@ -5,7 +5,7 @@
 // The sidebar keeps its live React state as the source of truth; these helpers
 // only seed that state on mount and snapshot it when the visible tab changes,
 // so a reload lands on the slice the viewer was last looking at instead of
-// snapping back to "All sessions". It's a device-local view preference — no
+// snapping back to the default. It's a device-local view preference — no
 // account or session state is changed — so it lives in localStorage like the
 // other `*Preferences` helpers.
 
@@ -17,7 +17,12 @@ const STORAGE_KEY = "omnigent:session-filter";
  */
 export type SessionFilter = "all" | "mine" | "shared" | "archived";
 
-export const DEFAULT_SESSION_FILTER: SessionFilter = "all";
+// A first-time viewer lands on their own sessions ("My sessions") rather than
+// the full list: on a shared server the account's own work is what they almost
+// always want first, and on a single-user server "mine" and "all" show the same
+// set, so this is a safe default there too. It's a device-local view
+// preference, so anyone can switch to "All sessions" and the pick persists.
+export const DEFAULT_SESSION_FILTER: SessionFilter = "mine";
 
 const SESSION_FILTERS = new Set<string>(["all", "mine", "shared", "archived"]);
 

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -689,6 +689,16 @@ describe("leave a shared session", () => {
     mockConversations([{ ...CONV, owner: "other@example.com" }]);
     renderSidebar(undefined, serverInfo({ single_user: true }));
 
+    // The default filter is "My sessions", which scopes out this owner:other
+    // row; the single-user menu still offers "All sessions", so switch to it to
+    // surface the row this test is about.
+    fireEvent.pointerDown(screen.getByTestId("session-filter"), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse",
+    });
+    fireEvent.click(screen.getByTestId("session-filter-all"));
+
     fireEvent.contextMenu(screen.getByRole("link", { name: /My Session/ }));
 
     expect(screen.queryByTestId("leave-conversation")).toBeNull();

--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -340,6 +340,15 @@ describe("Sidebar shift-click selection", () => {
     mockConversations([mine, theirs]);
     renderSidebar();
 
+    // Mixed ownership only shows on "All sessions"; the default "My sessions"
+    // filter hides the shared row, so switch to All before selecting.
+    fireEvent.pointerDown(screen.getByTestId("session-filter"), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse",
+    });
+    fireEvent.click(screen.getByTestId("session-filter-all"));
+
     fireEvent.click(screen.getByRole("button", { name: /select/i }));
 
     // Select both rows — "2 selected", but only the owned one is deletable.

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -364,7 +364,7 @@ describe("Sidebar session list", () => {
     expect(row.className).not.toContain("focus-within");
   });
 
-  it("offers the four display filters and defaults to All sessions", () => {
+  it("offers the four display filters and defaults to My sessions", () => {
     mockConversations(THREE_TYPE_CONVERSATIONS);
     renderSidebar();
 
@@ -377,9 +377,9 @@ describe("Sidebar session list", () => {
     for (const value of ["all", "mine", "shared", "archived"]) {
       expect(screen.getByTestId(`session-filter-${value}`)).toBeInTheDocument();
     }
-    // Radio semantics: exactly one option is checked, and it's "All sessions".
-    expect(screen.getByTestId("session-filter-all")).toHaveAttribute("aria-checked", "true");
-    expect(screen.getByTestId("session-filter-mine")).toHaveAttribute("aria-checked", "false");
+    // Radio semantics: exactly one option is checked, and it's "My sessions".
+    expect(screen.getByTestId("session-filter-mine")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("session-filter-all")).toHaveAttribute("aria-checked", "false");
   });
 
   it("keeps the picked filter across a remount", () => {
@@ -389,22 +389,24 @@ describe("Sidebar session list", () => {
     ]);
     renderSidebar();
 
-    selectSessionFilter("mine");
-    expect(screen.queryByText("conv_shared")).toBeNull();
+    // Pick a non-default slice (default is "mine") so the remount below proves
+    // the pick was persisted, not just that we landed back on the default.
+    selectSessionFilter("shared");
+    expect(screen.queryByText("conv_mine")).toBeNull();
 
-    // Fresh mount re-reads localStorage: still scoped to the viewer's own
-    // sessions. If this fails, the pick lived only in memory and a reload
-    // silently snapped the list back to "All sessions".
+    // Fresh mount re-reads localStorage: still scoped to shared sessions. If
+    // this fails, the pick lived only in memory and a reload silently snapped
+    // the list back to the default.
     cleanup();
     renderSidebar();
-    expect(screen.getByText("conv_mine")).toBeInTheDocument();
-    expect(screen.queryByText("conv_shared")).toBeNull();
+    expect(screen.getByText("conv_shared")).toBeInTheDocument();
+    expect(screen.queryByText("conv_mine")).toBeNull();
     fireEvent.pointerDown(screen.getByTestId("session-filter"), {
       button: 0,
       ctrlKey: false,
       pointerType: "mouse",
     });
-    expect(screen.getByTestId("session-filter-mine")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("session-filter-shared")).toHaveAttribute("aria-checked", "true");
   });
 
   it("drops a persisted Shared filter on a single-user server", () => {
@@ -422,7 +424,7 @@ describe("Sidebar session list", () => {
       ctrlKey: false,
       pointerType: "mouse",
     });
-    expect(screen.getByTestId("session-filter-all")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("session-filter-mine")).toHaveAttribute("aria-checked", "true");
     expect(screen.queryByTestId("session-filter-shared")).toBeNull();
   });
 
@@ -460,11 +462,11 @@ describe("Sidebar session list", () => {
       archived: screen.queryByText("conv_archived") !== null,
     });
 
-    // Default: everything except archived.
-    expect(visible()).toEqual({ owned: true, shared: true, archived: false });
-
-    selectSessionFilter("mine");
+    // Default: the viewer's own sessions only ("My sessions").
     expect(visible()).toEqual({ owned: true, shared: false, archived: false });
+
+    selectSessionFilter("all");
+    expect(visible()).toEqual({ owned: true, shared: true, archived: false });
 
     selectSessionFilter("shared");
     expect(visible()).toEqual({ owned: false, shared: true, archived: false });
@@ -472,9 +474,9 @@ describe("Sidebar session list", () => {
     selectSessionFilter("archived");
     expect(visible()).toEqual({ owned: false, shared: false, archived: true });
 
-    // Back to All: leaving Archived restores the unarchived rows.
-    selectSessionFilter("all");
-    expect(visible()).toEqual({ owned: true, shared: true, archived: false });
+    // Back to My sessions: leaving Archived restores the viewer's own rows.
+    selectSessionFilter("mine");
+    expect(visible()).toEqual({ owned: true, shared: false, archived: false });
 
     // And Archived is still reachable a second time (state isn't one-shot).
     selectSessionFilter("archived");
@@ -999,7 +1001,8 @@ describe("Sidebar sections", () => {
     ]);
     renderSidebar();
 
-    // Default ("All sessions"): everything the viewer can see.
+    // "All sessions": everything the viewer can see.
+    selectSessionFilter("all");
     const recentSection = screen.getByText("Sessions").closest("section")!;
     expect(within(recentSection).getByText("conv_mine_legacy")).toBeInTheDocument();
     expect(within(recentSection).getByText("conv_mine_acl")).toBeInTheDocument();
@@ -1158,9 +1161,11 @@ describe("Sidebar tabs", () => {
     ]);
     renderSidebar();
 
-    // The owned session is filed (peeled out of the flat list into its
-    // collapsed folder), but the shared collision stays in the flat Sessions
-    // list rather than being pulled into the viewer's folder.
+    // The shared session shows on "All sessions" (the default "My sessions" tab
+    // scopes it out). The owned session is filed (peeled out of the flat list
+    // into its collapsed folder), but the shared collision stays in the flat
+    // Sessions list rather than being pulled into the viewer's folder.
+    selectSessionFilter("all");
     const sessionsSection = screen.getByText("Sessions").closest("section")!;
     expect(within(sessionsSection).queryByText("conv_owned")).toBeNull();
     expect(within(sessionsSection).getByText("conv_shared_alpha")).toBeInTheDocument();


### PR DESCRIPTION
The sidebar's session-filter preference (`DEFAULT_SESSION_FILTER` in `sessionFilterPreferences.ts`) defaulted to **All sessions** for a first-time viewer with nothing persisted yet. Default it to **My sessions** instead, so a viewer lands on their own sessions rather than the whole server's list.

It stays a device-local, per-viewer preference: anyone can switch to All sessions from the filter menu and the pick persists across reloads. On a single-user (loopback) server "mine" and "all" resolve to the same set, so the default is safe there too.

Tests updated: `sessionFilterPreferences.test.ts` (default value + single-user fallback) and `Sidebar.test.tsx` (default-tab assertion; the persistence test now picks a non-default slice to keep proving persistence; two tests that relied on the old default showing shared sessions now select All first).

tested here:
<img width="320" height="215" alt="image" src="https://github.com/user-attachments/assets/c9f54f83-115c-4d51-af6b-a12ea4f4bb60" />


Co-authored-by: Isaac