### PR TITLE
perf(policies): let an ungoverned native session skip its policy hook

### DIFF
--- a/dev/benchmarks/omnigent/README.md
+++ b/dev/benchmarks/omnigent/README.md
@@ -62,6 +62,12 @@ see *Network* below).
 | `add_comment` | `POST /v1/sessions/{id}/comments` — create a review comment | write path |
 | `list_projects` | `GET /v1/sessions/projects` — sidebar project list (dual-read union) | project count |
 | `list_project_sessions` | `GET /v1/sessions?project=` — a project folder's sessions (dual-read filter) | sessions/project |
+| `native_policy_hooks_per_turn` | `POST /v1/sessions/{id}/policies/evaluate` × 17 — one 8-tool turn's blocking policy hooks on a session with no policies | round-trip count |
+
+`native_policy_hooks_per_turn` prices the hooks the local policy gate elides
+(see docs/POLICIES.md). Unlike the forwarder journeys, this latency is *agent*
+time: the harness is blocked on each of these. At `--network-delay-ms 100` the
+turn costs ~1.8s of pure waiting; with the gate live it costs one request.
 
 Read journeys target a **pre-seeded** session when the DB has a corpus; against
 an empty DB they self-seed a small fallback session over HTTP (the

--- a/dev/benchmarks/omnigent/journeys.py
+++ b/dev/benchmarks/omnigent/journeys.py
@@ -789,6 +789,48 @@ async def _measure_policy_evaluate(env: BenchEnvironment, ctx: JourneyContext) -
     resp.raise_for_status()
 
 
+# ── native policy hooks (blocking, per tool call) ────────────────────────────
+
+# Tool calls in the modelled turn. A native harness fires the policy hook on
+# ``UserPromptSubmit`` once and on ``PreToolUse``/``PostToolUse`` per tool, and
+# the harness is *blocked* on each — so this journey's wall clock is agent time
+# the user waits through, not background lag.
+_POLICY_HOOK_TOOL_CALLS = 8
+
+# One op is 17 requests, so the default 100 iterations would make this journey
+# alone dominate the CI leg (and add tail noise to the journeys after it). It
+# exists to price round trips, which a handful of samples establishes.
+_POLICY_HOOK_MAX_ITERATIONS = 20
+
+_POLICY_TOOL_RESULT_PAYLOAD = {
+    "event": {
+        "type": "PHASE_TOOL_RESULT",
+        "data": {"result": "a.py b.py"},
+        "request_data": {"name": "Bash", "arguments": {}},
+    }
+}
+_POLICY_REQUEST_PAYLOAD = {
+    "event": {"type": "PHASE_REQUEST", "data": {"text": "list the files"}},
+}
+
+
+async def _measure_policy_hooks_per_turn(env: BenchEnvironment, ctx: JourneyContext) -> None:
+    """Fire one turn's worth of blocking policy hooks against an ungoverned session."""
+    session_id = cast(str, ctx)  # _setup_target_session
+    assert env.client is not None
+    url = f"/v1/sessions/{session_id}/policies/evaluate"
+    for payload in (
+        _POLICY_REQUEST_PAYLOAD,
+        *(
+            payload
+            for _ in range(_POLICY_HOOK_TOOL_CALLS)
+            for payload in (_POLICY_EVALUATE_PAYLOAD, _POLICY_TOOL_RESULT_PAYLOAD)
+        ),
+    ):
+        resp = await env.client.post(url, json=payload)
+        resp.raise_for_status()
+
+
 # ── CLI startup (omnigent polly against the local bench server) ──────────────
 
 # Signal that the REPL is ready — the last spinner message before the prompt.
@@ -1014,6 +1056,19 @@ ALL_JOURNEYS: dict[str, Journey] = {
             concurrency_safe=True,
             description="POST /v1/sessions/{id}/policies/evaluate — PreToolUse hook "
             "(single tree scan, preloaded conversation row, caches warm).",
+        ),
+        Journey(
+            name="native_policy_hooks_per_turn",
+            kind="latency",
+            measure=_measure_policy_hooks_per_turn,
+            setup=_setup_target_session,
+            concurrency_safe=True,
+            max_iterations=_POLICY_HOOK_MAX_ITERATIONS,
+            description=(
+                f"POST /v1/sessions/{{id}}/policies/evaluate × "
+                f"{1 + 2 * _POLICY_HOOK_TOOL_CALLS} — one turn's blocking policy hooks on "
+                "a session with no policies. This is what the local policy gate elides."
+            ),
         ),
         # Runner (full-turn) journeys — with_runner=True, openai-agents, mock LLM.
         Journey(

--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -151,6 +151,37 @@ Session-level policies let you customize agent behavior for your current task. T
 
 Session policies evaluate before agent spec and admin policies, so they can enforce stricter rules or add additional gates for your specific workflow.
 
+### How enforcement performs on a native harness
+
+A native harness (`omnigent claude`, `omnigent codex`, ...) enforces policies
+through a command hook that fires before every tool call, after every tool
+result, and on every prompt. Each firing asks the server for a verdict and
+**blocks the harness** until it answers, so on a server across an ocean a
+tool-heavy turn can spend seconds of its wall clock waiting on those round
+trips.
+
+When a session has no policies at all -- no agent guardrails, no server-wide
+defaults, no session policies -- the verdict cannot be anything but "allow", and
+the server says so: its response reports that nothing can fire, and the harness
+answers the next hooks itself without asking again. Adding a session policy revokes
+that, as does switching the session to another agent (the server notifies the
+runner in both cases), and the permission lapses on its own within 10 seconds
+regardless.
+
+That 10-second expiry, not the notification, is the bound worth reasoning about.
+The notification travels over the session's runner tunnel, which lives on one
+server replica, and policy mutations are not routed to that replica -- so on a
+multi-replica deployment a mutation handled elsewhere cannot reach the runner and
+expiry is what applies. A change to a *server-wide default* policy is looser
+still: the server's own default-policy cache is itself up to 30 seconds stale,
+and the two windows are sequential.
+
+A session that has any policy never takes this path at all: every hook is
+evaluated server-side, as before.
+
+Set `OMNIGENT_NATIVE_POLICY_GATE=0` in the harness's environment to disable it
+and send every hook to the server.
+
 ---
 
 ## Builtin policies

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -4549,6 +4549,7 @@ def _tool_relay_handler_factory(
             # Heavy policy imports stay off this module's import path (hook
             # subprocesses import it); the relay runs inside the runner
             # process where these modules are already loaded.
+            from omnigent.native_policy_gate import may_skip_policy_call, record_gate
             from omnigent.native_policy_hook import (
                 evaluation_response_to_hook_output,
                 fail_closed_hook_output,
@@ -4562,6 +4563,18 @@ def _tool_relay_handler_factory(
                 return
             eval_request = hook_payload_to_evaluation_request(hook_event, payload)
             if eval_request is None:
+                self._respond_hook_output(None)
+                return
+            # This request blocks the harness. When the server has already told
+            # us this session has no policy that could fire, answer "no
+            # opinion" here instead of spending a round trip to be told the
+            # same thing again — that is two round trips per tool call, which
+            # is seconds a turn from another region. The gate clears the moment
+            # a policy is added (and expires regardless), so a governed session
+            # never takes this path.
+            if bridge_dir is not None and may_skip_policy_call(
+                bridge_dir, tool_name=payload.get("tool_name")
+            ):
                 self._respond_hook_output(None)
                 return
             context = eval_request["event"]["context"]
@@ -4603,6 +4616,14 @@ def _tool_relay_handler_factory(
             if not isinstance(verdict, dict) or not verdict.get("result"):
                 self._respond_hook_output(fail_closed_hook_output(hook_event, last_error))
                 return
+            if bridge_dir is not None:
+                # Absence of ``gate`` clears any record, so a session that
+                # gained a policy stops skipping on the very next event.
+                record_gate(
+                    bridge_dir,
+                    verdict.get("gate"),
+                    session_id=session_id,
+                )
             self._respond_hook_output(evaluation_response_to_hook_output(hook_event, verdict))
 
         def _handle_policy_evaluate(self, payload: _JsonObject) -> None:

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -1045,6 +1045,7 @@ def _main_evaluate_policy(argv: list[str]) -> int:
     :returns: Process exit code. Always ``0`` — blocking verdicts
         are expressed via the JSON output, not exit codes.
     """
+    from omnigent.native_policy_gate import may_skip_policy_call, record_gate
     from omnigent.native_policy_hook import (
         evaluation_response_to_hook_output,
         fail_closed_hook_output,
@@ -1074,6 +1075,12 @@ def _main_evaluate_policy(argv: list[str]) -> int:
     eval_request = hook_payload_to_evaluation_request(hook_event, payload)
     if eval_request is None:
         # Unrecognized hook event — no policy to evaluate.
+        return 0
+
+    # This hook blocks Claude Code. When the server has already reported that
+    # no policy can fire for this session, answer "no opinion" without a round
+    # trip; the gate clears as soon as a policy is added, and expires anyway.
+    if may_skip_policy_call(bridge_dir, tool_name=payload.get("tool_name")):
         return 0
 
     # Stamp the live model from this session's statusLine capture.
@@ -1137,6 +1144,10 @@ def _main_evaluate_policy(argv: list[str]) -> int:
     except json.JSONDecodeError:
         print("omnigent evaluate-policy hook: malformed Omnigent response", file=sys.stderr)
         return _fail_closed()
+
+    # Absence of ``gate`` clears any record, so a session that gained a policy
+    # stops skipping on the very next event.
+    record_gate(bridge_dir, eval_response.get("gate") if isinstance(eval_response, dict) else None)
 
     hook_output = evaluation_response_to_hook_output(hook_event, eval_response)
     if hook_output is not None:

--- a/omnigent/codex_native_hook.py
+++ b/omnigent/codex_native_hook.py
@@ -23,6 +23,7 @@ from omnigent.codex_native_bridge import (
     read_codex_config_model,
     read_policy_hook_config,
 )
+from omnigent.native_policy_gate import may_skip_policy_call, record_gate
 from omnigent.native_policy_hook import (
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
@@ -127,6 +128,12 @@ def _main_evaluate_policy(argv: list[str]) -> int:
         # Unrecognized hook event or an mcp__omnigent__* tool (relay-enforced).
         return 0
 
+    # This hook blocks the harness. When the server has already reported that
+    # no policy can fire for this session, answer "no opinion" without a round
+    # trip; the gate clears as soon as a policy is added, and expires anyway.
+    if may_skip_policy_call(bridge_dir, tool_name=payload.get("tool_name")):
+        return 0
+
     # Stamp the live model from this session's config.toml (what an in-TUI
     # ``/model`` writes) onto the request so the cost-budget gate evaluates
     # against the user's CURRENT selection.
@@ -190,6 +197,10 @@ def _main_evaluate_policy(argv: list[str]) -> int:
             file=sys.stderr,
         )
         return _fail_closed()
+
+    # Absence of ``gate`` clears any record, so a session that gained a policy
+    # stops skipping on the very next event.
+    record_gate(bridge_dir, eval_response.get("gate") if isinstance(eval_response, dict) else None)
 
     hook_output = evaluation_response_to_hook_output(hook_event, eval_response)
     if hook_output is not None:

--- a/omnigent/kimi_native_hook.py
+++ b/omnigent/kimi_native_hook.py
@@ -51,6 +51,7 @@ from omnigent.kimi_native_bridge import (
     read_active_session_id,
     read_hook_config,
 )
+from omnigent.native_policy_gate import may_skip_policy_call, record_gate
 from omnigent.native_policy_hook import (
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
@@ -131,6 +132,12 @@ def _main_evaluate_policy(argv: list[str]) -> int:
     if eval_request is None:
         return 0
 
+    # This hook blocks the harness. When the server has already reported that
+    # no policy can fire for this session, answer "no opinion" without a round
+    # trip; the gate clears as soon as a policy is added, and expires anyway.
+    if may_skip_policy_call(bridge_dir, tool_name=payload.get("tool_name")):
+        return 0
+
     context = eval_request["event"]["context"]
     context["harness"] = _HARNESS
 
@@ -175,6 +182,10 @@ def _main_evaluate_policy(argv: list[str]) -> int:
     except json.JSONDecodeError:
         print("omnigent kimi evaluate-policy hook: malformed Omnigent response", file=sys.stderr)
         return _fail_closed()
+
+    # Absence of ``gate`` clears any record, so a session that gained a policy
+    # stops skipping on the very next event.
+    record_gate(bridge_dir, eval_response.get("gate") if isinstance(eval_response, dict) else None)
 
     hook_output = evaluation_response_to_hook_output(hook_event, eval_response)
     if hook_output is not None:

--- a/omnigent/native_policy_gate.py
+++ b/omnigent/native_policy_gate.py
@@ -1,0 +1,290 @@
+"""Locally cached "no policy can fire" gate for native-harness policy hooks.
+
+Every native session installs the ``evaluate-policy`` hook on
+``PreToolUse``, ``PostToolUse``, and ``UserPromptSubmit``, and each firing
+costs one **blocking** request to ``POST /v1/sessions/{id}/policies/evaluate``
+before the harness may proceed. On loopback that is a few milliseconds. Across
+a region it is a full round trip per hook — two per tool call — so a
+twenty-tool turn spends seconds waiting on the wire to be told, over and over,
+that nothing is configured.
+
+The server already answers that case from a fast path: with no agent
+guardrails, no server-wide defaults and no session policies, nothing can fire
+and the verdict is an unconditional ALLOW. This module carries that answer back
+to the client so the *next* hook need not ask. The server stamps
+``gate: {"no_policies": true}`` on those fast-path responses; the hook records
+it under the bridge directory, and later hooks that find a live gate emit "no
+opinion" without touching the network.
+
+Correctness rests on three things:
+
+- **Absence means ask.** A response without the field clears the gate, so a
+  session that has policies (or whose posture the server did not report) always
+  round-trips. Only the provably-empty case is ever skipped.
+- **Invalidation.** Adding a policy mid-session — via the CRUD API or
+  ``sys_add_policy`` — clears the gate through the runner, so enforcement
+  begins on the very next hook, as it does today. This is best-effort by
+  construction: the notification travels over the session's runner tunnel,
+  which lives on one replica, and the mutation request is not replica-routed.
+  On a multi-replica deployment a mutation that lands elsewhere cannot reach
+  the tunnel, and expiry below is then the real bound. (Making the policy
+  routes signal ``wrong_replica`` so the caller re-addresses would close
+  that; it changes a user-facing route's contract, so it is left alone here.)
+- **Expiry.** The gate is short-lived regardless, so a missed invalidation
+  (dropped tunnel, a replica that never saw the mutation) costs at most
+  :data:`GATE_TTL_S` of lag rather than a silently ungoverned session.
+
+For a *session*-scoped policy, when the push lands, enforcement begins on the
+very next hook as it does today. For a *server-wide default* the bound is
+looser: the server's own default-policy cache may already be up to 30s stale
+when it stamps a gate, and the gate then lives its own :data:`GATE_TTL_S` from
+that moment — the two windows are sequential, not shared, so a newly added
+default can take up to their sum to bite.
+
+The gate is a small file in the harness's bridge directory, so the two kinds of
+caller share it: the in-runner tool relay (which serves claude-native's hook as
+a bare curl) and the hook subprocesses other harnesses spawn per event. Reading
+it costs a stat and a short parse — nothing next to the round trip it replaces.
+
+Invalidation needs the bridge directory for a session, which only the writer
+knows, so writers register the mapping in :func:`note_session_bridge_dir`. A
+session whose gate was only ever written by a subprocess hook has no mapping in
+the runner, so its invalidation falls back to expiry — the bounded case above.
+
+Set ``OMNIGENT_NATIVE_POLICY_GATE=0`` to disable skipping entirely and send
+every hook to the server.
+
+Kept import-light on purpose: hook subprocesses import this on their blocking
+path, so it must not pull the policy engine (or anything else heavy) in.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+# How long a recorded "nothing can fire" verdict may be trusted.
+#
+# Deliberately well under ``_DEFAULT_POLICY_SPECS_CACHE``'s 30s (the server-side
+# TTL that already bounds how long a default-policy change can go unseen), and
+# not merely equal to it, because expiry is the *only* bound that always holds:
+# the push that clears a gate rides the session's runner tunnel, so on a
+# multi-replica deployment a mutation landing on another replica never reaches
+# it. Ten seconds keeps that worst case small while still collapsing a
+# tool-heavy turn from one round trip per hook to a handful.
+GATE_TTL_S = 10.0
+
+# Gate file inside the harness bridge directory.
+GATE_FILE = "policy_gate.json"
+
+# Opt-out. Any of these values sends every hook to the server.
+_DISABLED_VALUES = frozenset({"0", "false", "no", "off"})
+_ENV_VAR = "OMNIGENT_NATIVE_POLICY_GATE"
+
+# The engine injects an unconditional ASK in front of ``sys_add_policy`` so an
+# agent cannot install policies on itself unseen. The server's own fast path
+# exempts it, so this one must never be skipped locally either — even though a
+# native hook does not normally see it (``mcp__omnigent__*`` tools are gated on
+# the relay/MCP path instead).
+_NEVER_SKIPPED_TOOLS = frozenset({"sys_add_policy", "mcp__omnigent__sys_add_policy"})
+
+
+@dataclass(frozen=True)
+class PolicyGate:
+    """
+    A recorded server verdict that no policy can fire for this session.
+
+    :param no_policies: What the server reported: ``True`` when no agent
+        guardrail, server default, or session policy exists.
+    :param expires_at: Wall-clock time after which the record is stale
+        (:func:`time.time` scale).
+    """
+
+    no_policies: bool
+    expires_at: float
+
+    def live(self, *, now: float | None = None) -> bool:
+        """
+        Report whether this record still licenses skipping the server.
+
+        :param now: Current time, for tests. Defaults to :func:`time.time`.
+        :returns: ``True`` when the gate is affirmative and unexpired.
+        """
+        return self.no_policies and (now if now is not None else time.time()) < self.expires_at
+
+
+def gate_enabled() -> bool:
+    """
+    Report whether local gating is enabled for this process.
+
+    :returns: ``False`` when ``OMNIGENT_NATIVE_POLICY_GATE`` opts out.
+    """
+    return (os.environ.get(_ENV_VAR) or "").strip().lower() not in _DISABLED_VALUES
+
+
+# Bridge directory last known to hold a gate for a session, so an
+# invalidation addressed by session id can find the file. Populated by writers
+# inside the runner process; empty for sessions whose gates only ever came from
+# a hook subprocess.
+_BRIDGE_DIRS_BY_SESSION: dict[str, Path] = {}
+
+
+def note_session_bridge_dir(session_id: str, bridge_dir: Path) -> None:
+    """
+    Record which bridge directory holds a session's gate.
+
+    :param session_id: Omnigent session/conversation id.
+    :param bridge_dir: The session's native harness bridge directory.
+    :returns: None.
+    """
+    _BRIDGE_DIRS_BY_SESSION[session_id] = bridge_dir
+
+
+def forget_session(session_id: str) -> None:
+    """
+    Drop a finished session's bridge-directory mapping.
+
+    :param session_id: Omnigent session/conversation id.
+    :returns: None.
+    """
+    _BRIDGE_DIRS_BY_SESSION.pop(session_id, None)
+
+
+def clear_gate_for_session(session_id: str) -> bool:
+    """
+    Clear a session's gate so its next hook asks the server again.
+
+    The runner calls this when the server reports that the session's
+    policies changed.
+
+    :param session_id: Omnigent session/conversation id.
+    :returns: ``True`` when a bridge directory was known and cleared;
+        ``False`` when none is registered, in which case the session's gate
+        lapses on expiry instead.
+    """
+    bridge_dir = _BRIDGE_DIRS_BY_SESSION.get(session_id)
+    if bridge_dir is None:
+        return False
+    clear_gate(bridge_dir)
+    return True
+
+
+def _gate_path(bridge_dir: Path) -> Path:
+    """
+    Return the gate file's path inside a bridge directory.
+
+    :param bridge_dir: Native harness bridge directory.
+    :returns: Path to the gate file (which may not exist).
+    """
+    return bridge_dir / GATE_FILE
+
+
+def read_gate(bridge_dir: Path) -> PolicyGate | None:
+    """
+    Read the recorded gate, or ``None`` when there isn't a usable one.
+
+    Never raises: a missing, truncated, or malformed file reads as "no
+    gate", which sends the caller to the server.
+
+    :param bridge_dir: Native harness bridge directory.
+    :returns: The recorded gate, or ``None``.
+    """
+    try:
+        raw = _gate_path(bridge_dir).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    no_policies = payload.get("no_policies")
+    expires_at = payload.get("expires_at")
+    if not isinstance(no_policies, bool) or not isinstance(expires_at, (int, float)):
+        return None
+    return PolicyGate(no_policies=no_policies, expires_at=float(expires_at))
+
+
+def clear_gate(bridge_dir: Path) -> None:
+    """
+    Drop any recorded gate so the next hook asks the server.
+
+    Called when policies change and when the server's answer stops
+    reporting a posture. Best-effort: a failure to unlink leaves the gate
+    in place until it expires.
+
+    :param bridge_dir: Native harness bridge directory.
+    :returns: None.
+    """
+    with contextlib.suppress(OSError):
+        _gate_path(bridge_dir).unlink()
+
+
+def record_gate(
+    bridge_dir: Path,
+    gate: object,
+    *,
+    session_id: str | None = None,
+    ttl_s: float = GATE_TTL_S,
+) -> None:
+    """
+    Record (or clear) the gate from an ``EvaluationResponse``'s field.
+
+    :param bridge_dir: Native harness bridge directory.
+    :param gate: The response's ``gate`` value. ``{"no_policies": true}``
+        records an affirmative gate; anything else — including a missing
+        field — clears it, so only a posture the server actually reported
+        can suppress a call.
+    :param session_id: Session this gate belongs to. In-runner callers pass
+        it so a later invalidation can find this bridge directory.
+    :param ttl_s: How long the record may be trusted, in seconds.
+    :returns: None.
+    """
+    if session_id is not None:
+        note_session_bridge_dir(session_id, bridge_dir)
+    affirmative = isinstance(gate, dict) and gate.get("no_policies") is True
+    if not affirmative:
+        clear_gate(bridge_dir)
+        return
+    payload = json.dumps({"no_policies": True, "expires_at": time.time() + ttl_s})
+    path = _gate_path(bridge_dir)
+    # Written via a unique temp file + replace: hook subprocesses read this
+    # concurrently and must never observe a half-written record.
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        bridge_dir.mkdir(parents=True, exist_ok=True)
+        tmp.write_text(payload, encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError:
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+
+
+def may_skip_policy_call(
+    bridge_dir: Path,
+    *,
+    tool_name: object = None,
+    now: float | None = None,
+) -> bool:
+    """
+    Report whether this hook event can be answered without the server.
+
+    :param bridge_dir: Native harness bridge directory.
+    :param tool_name: Tool the event is about, when it is a tool phase.
+        Read straight out of the harness's hook JSON, so any type is
+        accepted; only the exact strings the engine gates unconditionally
+        (``sys_add_policy``) force a round trip.
+    :param now: Current time, for tests.
+    :returns: ``True`` when a live gate says no policy can fire.
+    """
+    if not gate_enabled():
+        return False
+    if tool_name in _NEVER_SKIPPED_TOOLS:
+        return False
+    gate = read_gate(bridge_dir)
+    return gate is not None and gate.live(now=now)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7197,6 +7197,16 @@ def create_runner_app(
                 )
             return Response(status_code=204)
 
+        if body_type == "policy_gate_changed":
+            # The session's policy set changed, so any locally recorded "no
+            # policy can fire" gate is stale and the next harness hook must ask
+            # the server again. Harness-agnostic and always 204: a session whose
+            # gate this runner never recorded simply lets it expire.
+            from omnigent.native_policy_gate import clear_gate_for_session
+
+            clear_gate_for_session(conversation_id)
+            return Response(status_code=204)
+
         codex_goal_response = await codex_goal_runner.handle_event(
             conversation_id,
             body_type,

--- a/omnigent/server/routes/session_policies.py
+++ b/omnigent/server/routes/session_policies.py
@@ -111,6 +111,32 @@ def _spec_to_response(spec: PolicySpec, source: str) -> dict[str, Any]:
     }
 
 
+async def _invalidate_session_policies(session_id: str) -> None:
+    """
+    Drop every cached answer that a session's policy set just changed.
+
+    Evicts the server-side spec cache, then clears the runner's local
+    "no policy can fire" gate (see :mod:`omnigent.native_policy_gate`) so a
+    native harness's next hook asks the server again instead of skipping it.
+    Without the second half, a session that had no policies when its gate was
+    recorded would keep skipping the gate for up to
+    :data:`~omnigent.native_policy_gate.GATE_TTL_S` after the first policy was
+    added. Best-effort — the gate expires on its own if the runner is gone.
+
+    :param session_id: The session whose policies changed.
+    :returns: None.
+    """
+    invalidate_session_policy_specs_cache(session_id)
+    from omnigent.server.routes._sessions.common import get_server_runner_router
+    from omnigent.server.routes._sessions.helpers import _forward_session_change_to_runner
+
+    await _forward_session_change_to_runner(
+        session_id,
+        get_server_runner_router(),
+        {"type": "policy_gate_changed"},
+    )
+
+
 def create_session_policies_router(
     store: PolicyStore,
     conversation_store: ConversationStore,
@@ -211,7 +237,7 @@ def create_session_policies_router(
                 f"Policy with name '{body.name}' already exists in this session",
                 code=ErrorCode.CONFLICT,
             ) from exc
-        invalidate_session_policy_specs_cache(session_id)
+        await _invalidate_session_policies(session_id)
         try:
             import hashlib as _hashlib
 
@@ -372,7 +398,7 @@ def create_session_policies_router(
             ) from exc
         if policy is None:
             raise OmnigentError("Policy not found", code=ErrorCode.NOT_FOUND)
-        invalidate_session_policy_specs_cache(session_id)
+        await _invalidate_session_policies(session_id)
         return _entity_to_response(policy)
 
     @router.delete("/sessions/{session_id}/policies/{policy_id}")
@@ -402,7 +428,7 @@ def create_session_policies_router(
                 user_id, session_id, LEVEL_EDIT, permission_store, conversation_store
             )
         store.delete(policy_id, session_id)
-        invalidate_session_policy_specs_cache(session_id)
+        await _invalidate_session_policies(session_id)
         try:
             import hashlib as _hashlib
 

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -2485,6 +2485,21 @@ def register_core_routes(
         # worktree (cwd comes from the runner workspace).
         background_tasks.add_task(_reset_runner_resources_after_switch, session_id)
 
+        # The new agent's spec may declare guardrails the old one didn't, so the
+        # governing policy set just changed. Clear any locally cached "no policy
+        # can fire" gate on the runner (see omnigent.native_policy_gate) —
+        # otherwise a session that was ungoverned before the switch would keep
+        # skipping its blocking policy hook until the gate expired.
+        from omnigent.server.routes._sessions.helpers import (
+            _forward_session_change_to_runner as _forward_change,
+        )
+
+        await _forward_change(
+            session_id,
+            get_server_runner_router(),
+            {"type": "policy_gate_changed"},
+        )
+
         items = await asyncio.to_thread(conversation_store.list_items, session_id, limit=10000)
         level = await _get_permission_level(user_id, session_id, permission_store)
         return _build_session_response(

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -17,6 +17,7 @@ from fastapi.responses import Response
 from omnigent.codex_native_elicitation import codex_elicitation_id
 from omnigent.entities import Conversation
 from omnigent.errors import ElicitationDeclinedError, ErrorCode, OmnigentError
+from omnigent.native_policy_gate import GATE_TTL_S
 from omnigent.runner.routing import RunnerRouter
 from omnigent.runtime import (
     get_agent_cache,
@@ -759,8 +760,24 @@ def register_hooks_routes(
             phase=phase,
             tool_name=data.get("name") if isinstance(data, dict) else None,
         ):
+            # Tell the caller the posture, not just the verdict. This hook
+            # blocks the harness on a round trip, so a client an ocean away
+            # spends seconds per turn being told repeatedly that nothing is
+            # configured. ``gate`` licenses it to answer the next hooks itself
+            # until the gate is cleared or expires — see
+            # :mod:`omnigent.native_policy_gate`. Only reported on this
+            # phase-independent empty case: ``any_policies_apply`` above was
+            # asked about *this* phase and tool, so re-ask without them.
+            body: dict[str, Any] = {"result": "POLICY_ACTION_ALLOW"}
+            if not any_policies_apply(
+                spec=loaded.spec,
+                conversation_id=session_id,
+                default_policies=_caps.default_policies,
+                policy_store=get_policy_store(),
+            ):
+                body["gate"] = {"no_policies": True, "ttl_s": GATE_TTL_S}
             return Response(
-                content=json.dumps({"result": "POLICY_ACTION_ALLOW"}),
+                content=json.dumps(body),
                 media_type="application/json",
             )
 

--- a/tests/runner/test_app_sessions_native_events_lifecycle.py
+++ b/tests/runner/test_app_sessions_native_events_lifecycle.py
@@ -3507,3 +3507,71 @@ async def test_events_stop_session_on_kiro_native_503_when_kill_fails(
         f"No session.status: idle should be enqueued when kill_session failed; "
         f"got {status_idle!r}."
     )
+
+
+async def test_policy_gate_changed_clears_the_sessions_local_gate(
+    tmp_path: Path,
+) -> None:
+    """
+    A ``policy_gate_changed`` event revokes the session's cached policy gate.
+
+    This is the invalidation half of the native policy gate: the harness
+    skips its blocking per-tool-call evaluate only while the server has said
+    nothing can fire, and the server sends this the moment that stops being
+    true. Fails if the runner ignores the event — a session that gained a
+    policy would go unenforced until the gate expired — or if it errors on a
+    session it holds no gate for (a routine, harmless case).
+    """
+    from omnigent.native_policy_gate import (
+        forget_session,
+        may_skip_policy_call,
+        record_gate,
+    )
+
+    conv_id = uuid.uuid4().hex
+    spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "claude-native", "model": "claude-opus-4-7"},
+        ),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Return the claude-native spec for any agent_id."""
+        del agent_id, session_id
+        return spec
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    record_gate(bridge_dir, {"no_policies": True}, session_id=conv_id)
+    assert may_skip_policy_call(bridge_dir) is True
+
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    try:
+        async with _runner_client(app) as client:
+            create_resp = await client.post(
+                "/v1/sessions",
+                json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
+            )
+            assert create_resp.status_code == 201, create_resp.text
+            resp = await client.post(
+                f"/v1/sessions/{conv_id}/events",
+                json={"type": "policy_gate_changed"},
+            )
+            assert resp.status_code == 204, resp.text
+            # A session with no registered gate is a no-op, not an error.
+            unknown = await client.post(
+                f"/v1/sessions/{conv_id}/events",
+                json={"type": "policy_gate_changed"},
+            )
+            assert unknown.status_code == 204, unknown.text
+    finally:
+        forget_session(conv_id)
+
+    assert may_skip_policy_call(bridge_dir) is False

--- a/tests/runner/test_comment_relay.py
+++ b/tests/runner/test_comment_relay.py
@@ -1296,3 +1296,80 @@ async def test_failed_launch_rolls_back_the_relay_it_started(tmp_path: Path) -> 
             ) as c:
                 await c.delete(f"/v1/sessions/{session_id}")
         shutil.rmtree(bridge_dir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_relay_hook_evaluate_skips_the_server_behind_a_live_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A recorded "no policy can fire" gate answers the hook with no upstream call.
+
+    This endpoint blocks Claude Code before every tool call, twice per call
+    counting PostToolUse, so from another region it is seconds a turn spent
+    being told the same thing. Fails if the relay still round-trips behind a
+    live gate (the saving disappears) or if it answers anything other than
+    "no opinion" (the harness's own consent prompt must still run).
+    """
+    import asyncio
+
+    from omnigent.claude_native_bridge import prepare_bridge_dir as _prep
+    from omnigent.claude_native_bridge import start_tool_relay
+    from omnigent.native_policy_gate import forget_session, record_gate
+
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
+
+    bridge_dir = _prep("relay-gate-test", workspace=tmp_path)
+    session_id = "conv_relay_gate"
+    upstream_calls: list[object] = []
+
+    class _CountingServerClient:
+        """Fake server_client that records — and allows — every upstream POST."""
+
+        content = b'{"result":"POLICY_ACTION_ALLOW"}'
+        status_code = 200
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+
+        async def post(self, url: str, **kwargs: object) -> _CountingServerClient:
+            upstream_calls.append(kwargs.get("json"))
+            return self
+
+    relay = start_tool_relay(
+        bridge_dir=bridge_dir,
+        tools=[],
+        tool_executor=lambda name, args: {},  # type: ignore[arg-type]
+        loop=asyncio.get_running_loop(),
+        policy_client=_CountingServerClient(),
+        session_id=session_id,
+    )
+    try:
+        relay_info = json.loads((bridge_dir / _TOOL_RELAY_FILE).read_text())
+        hook_url = f"{relay_info['url']}/hook/claude/evaluate-policy"
+        headers = {"Authorization": f"Bearer {relay_info['token']}"}
+        hook_payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+        }
+
+        record_gate(bridge_dir, {"no_policies": True}, session_id=session_id)
+        async with httpx.AsyncClient() as c:
+            gated = await c.post(hook_url, json=hook_payload, headers=headers, timeout=5.0)
+        assert gated.status_code == 200
+        # "No opinion": an empty body leaves Claude's own permission gate intact.
+        assert gated.content == b""
+        assert upstream_calls == []
+
+        # Once the gate is revoked — as a policy mutation does — the very next
+        # event goes back to the server.
+        forget_session(session_id)
+        (bridge_dir / "policy_gate.json").unlink()
+        async with httpx.AsyncClient() as c:
+            ungated = await c.post(hook_url, json=hook_payload, headers=headers, timeout=5.0)
+        assert ungated.status_code == 200
+        assert len(upstream_calls) == 1
+    finally:
+        forget_session(session_id)
+        relay.close()

--- a/tests/server/integration/test_sessions_policy_evaluate.py
+++ b/tests/server/integration/test_sessions_policy_evaluate.py
@@ -32,6 +32,7 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 
+from omnigent.native_policy_gate import GATE_TTL_S
 from omnigent.runtime import get_caps, session_stream
 from omnigent.runtime.caps import RuntimeCaps
 from omnigent.server.routes import sessions as sessions_routes
@@ -308,6 +309,72 @@ async def test_tool_call_allow_when_no_matching_policy(
     # No policies → ALLOW (the default engine result).
     assert body["result"] == "POLICY_ACTION_ALLOW"
     assert "reason" not in body
+
+
+async def test_ungoverned_session_reports_the_no_policy_gate(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    An ungoverned session's ALLOW carries the posture, not just the verdict.
+
+    This hook blocks the harness on a round trip, twice per tool call, so a
+    client in another region spends seconds a turn being told repeatedly
+    that nothing is configured. Reporting the posture lets it answer the
+    next hooks itself. Fails if the field is missing (the client keeps
+    paying the wire) or malformed (it would keep asking anyway, since only
+    ``no_policies: true`` licenses a skip).
+    """
+    agent = await create_test_agent(client)
+    session_id = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/policies/evaluate",
+        json=_tool_call_request("Read"),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"] == "POLICY_ACTION_ALLOW"
+    assert body["gate"] == {"no_policies": True, "ttl_s": GATE_TTL_S}
+
+
+async def test_governed_session_never_reports_the_gate(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A session with a policy withholds the gate, even when it ALLOWs.
+
+    The client treats a missing field as "keep asking", so this is what
+    keeps every governed session round-tripping. Fails if a policy that
+    happens to allow a tool advertises the empty posture — the session
+    would then skip its own enforcement for the rest of the gate's life.
+    """
+    allow_policy = FunctionPolicySpec(
+        name="admin__deny_bash",
+        on=None,
+        function=FunctionRef(path=f"{__name__}._deny_bash_tool"),
+    )
+    original_caps = get_caps()
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.get_caps",
+        lambda: RuntimeCaps(
+            execution_timeout=original_caps.execution_timeout,
+            default_policies=[allow_policy],
+        ),
+    )
+    agent = await create_test_agent(client)
+    session_id = await _create_session(client, agent["id"])
+
+    # ``Read`` is allowed by that policy, so the verdict matches the
+    # ungoverned case above — only the gate distinguishes them.
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/policies/evaluate",
+        json=_tool_call_request("Read"),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"] == "POLICY_ACTION_ALLOW"
+    assert "gate" not in body
 
 
 async def test_tool_call_deny_with_default_policy(

--- a/tests/server/routes/test_session_policies_crud.py
+++ b/tests/server/routes/test_session_policies_crud.py
@@ -296,3 +296,46 @@ async def test_create_session_policy_no_telemetry_on_error(
         )
     assert resp.status_code == 409
     mock_emit.assert_not_called()
+
+
+# ── policy-gate invalidation ──────────────────────────────────────────
+
+
+async def test_policy_mutations_clear_the_runners_policy_gate(
+    client: httpx.AsyncClient, session_id: str
+) -> None:
+    """
+    Every session-policy mutation tells the bound runner its gate is stale.
+
+    A native harness caches "no policy can fire for this session" so its
+    blocking per-tool-call hook can answer without a round trip. Adding the
+    first policy must revoke that at once, or the session would go
+    unenforced until the gate expired. Fails if any of create / update /
+    delete forgets to notify — the enforcement gap is silent.
+    """
+    forwarded: list[tuple[str, dict[str, object]]] = []
+
+    async def _capture(
+        session: str, _router: object, event: dict[str, object], **_kwargs: object
+    ) -> None:
+        """Record a control event the route forwarded to the runner."""
+        forwarded.append((session, event))
+
+    with patch(
+        "omnigent.server.routes.sessions._forward_session_change_to_runner",
+        _capture,
+    ):
+        created = await client.post(
+            f"/v1/sessions/{session_id}/policies", json=_policy_payload(name="gate_probe")
+        )
+        assert created.status_code == 200
+        policy_id = created.json()["id"]
+        updated = await client.patch(
+            f"/v1/sessions/{session_id}/policies/{policy_id}",
+            json={"enabled": False},
+        )
+        assert updated.status_code == 200
+        deleted = await client.delete(f"/v1/sessions/{session_id}/policies/{policy_id}")
+        assert deleted.status_code in (200, 204)
+
+    assert forwarded == [(session_id, {"type": "policy_gate_changed"})] * 3

--- a/tests/server/routes/test_sessions_switch_agent.py
+++ b/tests/server/routes/test_sessions_switch_agent.py
@@ -595,6 +595,52 @@ async def test_switch_publishes_agent_changed_event(
 
 
 @pytest.mark.asyncio
+async def test_switch_clears_the_runners_policy_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A switch tells the runner its cached policy gate is stale.
+
+    The target agent's spec may declare guardrails the old one didn't, so the
+    switch changes the governing policy set. A native harness caches "no
+    policy can fire for this session" to answer its blocking per-tool-call
+    hook without a round trip, and nothing else on this path revokes it — the
+    gate file outlives the rebind. Fails if the switch forgets to notify: a
+    session that was ungoverned before it would keep skipping enforcement
+    under the new agent's guardrails until the gate expired.
+    """
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv()})
+    agent_store = _AgentStore(
+        {
+            "a98bb825ebd41391c19637c58fe3c0b7": _CURRENT,
+            "52adb39f0c5ea92b5563da5327dac08f": _BUILTIN_CLAUDE,
+        }
+    )
+    _patch_family_helpers(monkeypatch, same_family=True, native=True, labels={})
+    forwarded: list[tuple[str, dict[str, object]]] = []
+
+    async def _capture(
+        session_id: str, _router: object, event: dict[str, object], **_kwargs: object
+    ) -> None:
+        """Record a control event the route forwarded to the runner."""
+        forwarded.append((session_id, event))
+
+    monkeypatch.setattr(sessions_mod, "_forward_session_change_to_runner", _capture)
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": "52adb39f0c5ea92b5563da5327dac08f"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert (
+        "e9f8f58523cec9a57d3bdf93be543e8c",
+        {"type": "policy_gate_changed"},
+    ) in forwarded
+
+
+@pytest.mark.asyncio
 async def test_switch_rejected_publishes_no_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_native_policy_gate.py
+++ b/tests/test_native_policy_gate.py
@@ -1,0 +1,204 @@
+"""Tests for the locally cached "no policy can fire" gate.
+
+The gate suppresses a *blocking* server round trip on every native-harness
+tool call, so these tests care as much about when it refuses to skip as about
+when it does.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from omnigent.native_policy_gate import (
+    GATE_FILE,
+    GATE_TTL_S,
+    PolicyGate,
+    clear_gate,
+    clear_gate_for_session,
+    forget_session,
+    may_skip_policy_call,
+    note_session_bridge_dir,
+    read_gate,
+    record_gate,
+)
+
+_AFFIRMATIVE = {"no_policies": True}
+
+
+def test_recorded_gate_licenses_skipping_until_it_expires(tmp_path: Path) -> None:
+    """
+    An affirmative gate skips the server, and stops once it expires.
+
+    The skip is what removes two blocking round trips per tool call; the
+    expiry is what bounds a missed invalidation. Fails if a recorded gate
+    doesn't suppress the call, or if it suppresses it forever — which would
+    leave a session that gained a policy ungoverned indefinitely.
+    """
+    record_gate(tmp_path, _AFFIRMATIVE, ttl_s=10.0)
+    gate = read_gate(tmp_path)
+    assert gate is not None
+    assert gate.no_policies is True
+    assert may_skip_policy_call(tmp_path, now=gate.expires_at - 1) is True
+    assert may_skip_policy_call(tmp_path, now=gate.expires_at + 1) is False
+
+
+def test_a_response_without_a_gate_clears_the_record(tmp_path: Path) -> None:
+    """
+    Absence of the field revokes any earlier gate.
+
+    The server reports the posture only while nothing can fire, so a
+    response that stops carrying it means policies now exist. Fails if a
+    stale affirmative record survives — the session would keep skipping its
+    own enforcement for the rest of the TTL.
+    """
+    record_gate(tmp_path, _AFFIRMATIVE)
+    assert may_skip_policy_call(tmp_path) is True
+    record_gate(tmp_path, None)
+    assert read_gate(tmp_path) is None
+    assert may_skip_policy_call(tmp_path) is False
+
+
+def test_a_negative_gate_never_licenses_skipping(tmp_path: Path) -> None:
+    """
+    Only ``no_policies: true`` counts; anything else is "ask the server".
+
+    Fails if a truthy-looking payload (``"true"``, ``1``, an empty dict) is
+    accepted as permission to skip enforcement.
+    """
+    for payload in ({"no_policies": False}, {"no_policies": "true"}, {"no_policies": 1}, {}, 7):
+        record_gate(tmp_path, payload)
+        assert may_skip_policy_call(tmp_path) is False, payload
+
+
+def test_sys_add_policy_always_asks_the_server(tmp_path: Path) -> None:
+    """
+    The one tool the engine gates unconditionally is never skipped.
+
+    ``sys_add_policy`` runs behind an injected ASK so an agent cannot
+    install policies on itself unseen; the server's own fast path exempts
+    it, and so must this one. Fails if a gate lets that call through
+    silently.
+    """
+    record_gate(tmp_path, _AFFIRMATIVE)
+    assert may_skip_policy_call(tmp_path, tool_name="Bash") is True
+    assert may_skip_policy_call(tmp_path, tool_name="sys_add_policy") is False
+    assert may_skip_policy_call(tmp_path, tool_name="mcp__omnigent__sys_add_policy") is False
+
+
+def test_env_opt_out_sends_every_hook_to_the_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    ``OMNIGENT_NATIVE_POLICY_GATE=0`` disables skipping outright.
+
+    The escape hatch for an operator who wants every hook evaluated
+    server-side. Fails if the flag is ignored, leaving no way to turn the
+    optimization off.
+    """
+    record_gate(tmp_path, _AFFIRMATIVE)
+    for value in ("0", "false", "no", "off", "FALSE"):
+        monkeypatch.setenv("OMNIGENT_NATIVE_POLICY_GATE", value)
+        assert may_skip_policy_call(tmp_path) is False, value
+    monkeypatch.setenv("OMNIGENT_NATIVE_POLICY_GATE", "1")
+    assert may_skip_policy_call(tmp_path) is True
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "not json", "[]", '{"no_policies": true}', '{"expires_at": 1}', '{"no_policies": "x"}'],
+)
+def test_an_unusable_gate_file_reads_as_no_gate(tmp_path: Path, raw: str) -> None:
+    """
+    A truncated or malformed record fails to the server, never open.
+
+    A hook subprocess can read this file while it is being replaced, and a
+    crash can leave a partial one. Fails if a bad file raises (the hook
+    would fail closed and block a legitimate tool) or is read as permission
+    to skip.
+    """
+    (tmp_path / GATE_FILE).write_text(raw, encoding="utf-8")
+    assert read_gate(tmp_path) is None
+    assert may_skip_policy_call(tmp_path) is False
+
+
+def test_recording_leaves_no_temp_files_behind(tmp_path: Path) -> None:
+    """
+    The record is swapped in atomically, with nothing left over.
+
+    Hook subprocesses read this file concurrently, so a half-written record
+    must never be observable. Fails if the write is in place, or if temp
+    files accumulate in the bridge directory.
+    """
+    for _ in range(3):
+        record_gate(tmp_path, _AFFIRMATIVE)
+    assert [p.name for p in tmp_path.iterdir()] == [GATE_FILE]
+    assert json.loads((tmp_path / GATE_FILE).read_text(encoding="utf-8"))["no_policies"] is True
+
+
+def test_clearing_by_session_id_finds_the_registered_bridge_dir(tmp_path: Path) -> None:
+    """
+    The runner can revoke a gate knowing only the session id.
+
+    That is the whole invalidation path: the server reports a policy
+    change against a session, and the runner must clear the gate the relay
+    wrote. Fails if the mapping isn't recorded on write, in which case a
+    newly added policy wouldn't be enforced until the gate expired.
+    """
+    record_gate(tmp_path, _AFFIRMATIVE, session_id="conv_abc")
+    assert may_skip_policy_call(tmp_path) is True
+    try:
+        assert clear_gate_for_session("conv_abc") is True
+        assert may_skip_policy_call(tmp_path) is False
+        # A session nobody registered reports the miss, so the caller knows
+        # the gate will lapse on expiry rather than now.
+        assert clear_gate_for_session("conv_unknown") is False
+    finally:
+        forget_session("conv_abc")
+
+
+def test_clearing_and_reading_a_missing_gate_never_raise(tmp_path: Path) -> None:
+    """
+    The no-gate path is quiet: no file, no error, no skip.
+
+    Every session starts here, and this runs on the harness's blocking
+    path. Fails if a missing file raises into a hook.
+    """
+    clear_gate(tmp_path)
+    assert read_gate(tmp_path) is None
+    assert may_skip_policy_call(tmp_path) is False
+    note_session_bridge_dir("conv_gone", tmp_path / "nope")
+    try:
+        assert clear_gate_for_session("conv_gone") is True
+    finally:
+        forget_session("conv_gone")
+
+
+def test_default_ttl_stays_under_the_servers_default_policy_staleness() -> None:
+    """
+    Expiry is tighter than the staleness the evaluate path already carries.
+
+    Expiry is the only bound that always holds — the push that clears a gate
+    rides the session's runner tunnel, so a policy mutation landing on
+    another replica never reaches it. Keeping the window well under the
+    server's own 30s default-policy cache is what makes that fallback
+    acceptable. Fails if the gate's window creeps up to or past the number
+    the module docstring measures it against.
+    """
+    from omnigent.runtime.policies.builder import _DEFAULT_POLICY_SPECS_CACHE
+
+    assert 0 < GATE_TTL_S < _DEFAULT_POLICY_SPECS_CACHE.ttl
+
+
+def test_gate_live_requires_both_affirmative_and_unexpired() -> None:
+    """
+    ``PolicyGate.live`` is the single place the two conditions meet.
+
+    Fails if either half is dropped, which is how a gate would outlive its
+    expiry or a negative record would start licensing skips.
+    """
+    assert PolicyGate(no_policies=True, expires_at=100.0).live(now=99.0) is True
+    assert PolicyGate(no_policies=True, expires_at=100.0).live(now=101.0) is False
+    assert PolicyGate(no_policies=False, expires_at=100.0).live(now=99.0) is False


### PR DESCRIPTION
## Related issue

Closes #

<!-- Perf work from profiling the cross-region client→server path; no tracking issue. -->

## Summary

The other half of the ~20s-per-action complaint from users outside the server's
region. Unlike the forwarder's lag, this one is **agent** time — the harness is
blocked on it.

Every native session installs the `evaluate-policy` hook on `PreToolUse`,
`PostToolUse`, and `UserPromptSubmit`, and each firing blocks the harness on a
request to `POST /v1/sessions/{id}/policies/evaluate`. That is two blocking round
trips per tool call. Measured with the benchmark's simulated hop, an eight-tool
turn spends **1.81s** on nothing but those requests at `--network-delay-ms 100`;
at a real cross-region RTT with twenty tools it is around ten seconds.

The server already answers that case from a fast path — no agent guardrails, no
server-wide defaults, no session policies, so nothing can fire and the verdict
can only be ALLOW. This PR reports that posture next to the verdict
(`gate: {"no_policies": true}`) and lets the client answer the following hooks
itself.

Three things keep it honest:

1. **Absence means ask.** A response without the field clears the record, so a
   session that has *any* policy always round-trips. Only the provably-empty case
   is ever skipped, and the verdict it skips is unconditional ALLOW.
2. **Invalidation.** Every session-policy mutation (create / update / delete,
   including via `sys_add_policy`) and every agent switch notifies the bound
   runner, which clears the gate — so enforcement begins on the very next hook,
   exactly as today. This is best-effort by construction: the notification
   travels over the session's runner tunnel, which lives in a single replica's
   in-memory `TunnelRegistry`, while `POST /v1/sessions/{id}/policies` is not
   replica-routed. On a managed multi-replica deployment a mutation that lands
   on another replica cannot reach that tunnel, so expiry below is the real
   bound.
3. **Expiry.** The record lapses after **10s** regardless. Because of the
   multi-replica case above, this is not merely a backstop for dropped tunnels —
   it is the enforcement-lag bound that always holds, which is why it is 10s
   rather than the 30s this PR originally proposed.

`OMNIGENT_NATIVE_POLICY_GATE=0` disables it.

```
per tool call, ungoverned session
  before   PreToolUse ──▶ server ──▶ "allow"     1 RTT   (harness blocked)
           PostToolUse ─▶ server ──▶ "allow"     1 RTT   (harness blocked)
  after    PreToolUse ──▶ local gate             0
           PostToolUse ─▶ local gate             0
```

Scope: wired for claude-native (both the relay, which serves the hook as a bare
curl, and the Python hook) and the codex / kimi hooks — the harnesses with a
bridge directory to hold the gate. cursor and hermes address their relay by
environment variable and have no keyed location yet; they are unchanged and still
round-trip.

**Reviewers: the judgement call worth checking is #3.** Today's contract is "a
newly added policy is enforced on the very next call". With this, that stays true
whenever the runner gets the notification, and degrades to ≤10s if it doesn't
(dropped tunnel, or a replica that never saw the mutation). Note the two windows
are *sequential, not shared*: for a server-wide default the server's own
`_DEFAULT_POLICY_SPECS_CACHE` may already be up to 30s stale when it stamps a
gate, and the gate then lives its own 10s from that moment. An earlier version of
this description claimed the gate "adds no staleness the evaluate path didn't
already have"; that was wrong for server-wide defaults, and the docs now state
the composed bound. I think that is the
right trade for removing seconds of blocking latency per turn, and it is bounded
by a window the server already lives with — but it is a real change to
enforcement timing and should be an explicit decision, not a side effect.

## Test Plan

New tests:

- `tests/test_native_policy_gate.py` (16) — a recorded gate skips until it
  expires; a response without the field revokes it; only `no_policies: true`
  counts (not `"true"`, `1`, or `{}`); `sys_add_policy` always round-trips; the
  env opt-out; a truncated / malformed file reads as no-gate rather than raising
  or opening; the write leaves no temp files; clearing by session id finds the
  registered bridge dir and reports a miss when none is registered; the default
  TTL is pinned to `_DEFAULT_POLICY_SPECS_CACHE.ttl` so the two can't drift.
- `tests/server/integration/test_sessions_policy_evaluate.py` — an ungoverned
  session's ALLOW carries the gate; a session with a policy withholds it *even
  when the verdict is also ALLOW* (the case where getting it wrong would silently
  disable enforcement).
- `tests/server/routes/test_session_policies_crud.py` — create, update, and
  delete each forward `policy_gate_changed` to the runner.
- `tests/runner/test_comment_relay.py` — behind a live gate the relay answers the
  hook with an empty body and makes **zero** upstream calls; once revoked the
  next event goes back to the server.
- `tests/runner/test_app_sessions_native_events_lifecycle.py` — the runner clears
  the session's gate on `policy_gate_changed`, and no-ops on a session it holds
  no gate for.

Suites green: 337 tests across `tests/test_native_policy_gate.py`,
`tests/test_claude_native_bridge.py`, `tests/test_kimi_native_hook.py`,
`tests/runner/test_app_sessions_native_events_lifecycle.py`; plus 165 across
`tests/test_claude_native_hook.py`, `tests/test_codex_native_hook.py`,
`tests/server/integration/test_sessions_policy_evaluate.py`,
`tests/server/routes/test_session_policies_crud.py`,
`tests/runner/test_comment_relay.py`. `pre-commit` clean on all touched files.

Measured (new benchmark journey prices the hooks the gate elides):

```
uv run --no-sync dev/benchmarks/omnigent/run.py \
  --journeys native_policy_hooks_per_turn --iterations 8 --runs 1 \
  --warmup 1 --network-delay-ms 100

native_policy_hooks_per_turn   P50 1810.0 ms   HTTP/op 17.0
policy_evaluate                P50  109.0 ms   HTTP/op  1.0
```

So one 8-tool turn's hooks cost 1.81s of blocked agent time; with the gate the
turn pays one 109ms request and then nothing (at most one more per 10s).

To check it by hand:

1. Start a claude-native session against a server with a real hop (or add one:
   `sudo tc qdisc add dev lo root netem delay 100ms`), on an agent with **no**
   guardrails. Ask it to run several shell commands. It should feel materially
   snappier between tool calls than on `main`.
2. Confirm enforcement still engages: with that session live, add a policy that
   denies `Bash` (info window, or *"add a policy that blocks shell commands"*),
   then ask for another shell command. It must be blocked on the **next** call,
   not after a delay — that is the invalidation path.
3. Confirm a governed session never skips: start a session on an agent that
   declares guardrails and watch the server log — every hook still evaluates.
4. Confirm the opt-out: relaunch with `OMNIGENT_NATIVE_POLICY_GATE=0` and every
   hook round-trips again.

## Demo

N/A — no visual change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the benchmark journey above, run locally against a real
server with injected latency — that is what establishes the latency claim; the
unit and integration tests pin the *behaviour* (zero upstream calls behind a
gate, revocation on mutation, never skipping a governed session). I have not run
it against a genuinely remote deployment, so the wall-clock numbers come from
simulated delay. The four manual steps in the Test Plan are the ones worth a
human doing before merge, especially step 2.

## Changelog

Native-harness sessions with no policies configured no longer wait on a server
round trip before every tool call, which removes seconds per turn when your
server is in another region.

