### PR TITLE
fix(web): label the prompting permission mode "Default" again

### DIFF
--- a/tests/e2e_ui/chat/test_claude_model_picker.py
+++ b/tests/e2e_ui/chat/test_claude_model_picker.py
@@ -844,7 +844,7 @@ def test_claude_native_permission_mode_switch_persists(
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)`` for a real server-backed
         session; the browser snapshot is patched to a claude-native session
-        already in ``default`` (Manual) mode.
+        already in ``default`` mode.
     :returns: None.
     """
     base_url, session_id = seeded_session

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -583,7 +583,7 @@ async def _drive_permission_mode(base_url: str, session_id: str) -> None:
             await expect(perm).to_be_visible()
             await perm.click()
             perm_labels = (
-                "Manual",
+                "Default",
                 "Auto",
                 "Accept edits",
                 "Plan",

--- a/web/src/lib/claudePermissionMode.test.ts
+++ b/web/src/lib/claudePermissionMode.test.ts
@@ -30,10 +30,10 @@ describe("claudePermissionMode", () => {
     expect(startup).toContain("bypassPermissions");
   });
 
-  it("labels the prompting mode the way Claude Code does", () => {
-    // Claude's own TUI renders "manual mode on" for the `default` value, so
-    // the web label matches what users see in the pane.
-    expect(claudePermissionModeLabel("default")).toBe("Manual");
+  it("labels the prompting mode after its wire value", () => {
+    // The `default` value is labelled "Default" here, matching the other
+    // unset-state selects in the dialog rather than Claude's TUI wording.
+    expect(claudePermissionModeLabel("default")).toBe("Default");
     expect(claudePermissionModeLabel("auto")).toBe("Auto");
   });
 

--- a/web/src/lib/claudePermissionMode.ts
+++ b/web/src/lib/claudePermissionMode.ts
@@ -27,9 +27,9 @@ export const CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE = "default";
 
 // Claude Code's `claude --permission-mode` choices (v2.1). Keep in sync
 // with `claude --help`. The prompting mode is spelled `default` on the
-// wire and labelled "Manual" in Claude's own UI, which this mirrors.
+// wire and labelled "Default" here (Claude's own TUI calls it "manual").
 export const CLAUDE_NATIVE_PERMISSION_MODES: ClaudePermissionModeOption[] = [
-  { value: "default", label: "Manual", description: "Prompts before edits and commands" },
+  { value: "default", label: "Default", description: "Prompts before edits and commands" },
   {
     value: "auto",
     label: "Auto",
@@ -72,7 +72,7 @@ export function claudePermissionModeLabel(mode: string | null | undefined): stri
  * Prefers the label the server stamps after a confirmed switch, then the
  * launch flag. Returns `null` rather than assuming Claude's default: a
  * `permissions.defaultMode` in a settings file boots the session into a mode
- * that never appears in `terminal_launch_args`, so guessing "Manual" would
+ * that never appears in `terminal_launch_args`, so guessing "Default" would
  * display a mode the session isn't in. Callers hide the picker on `null`.
  */
 export function claudePermissionModeFromSession(

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -914,11 +914,11 @@ describe("NewChatLandingScreen create flow", () => {
     // in — the permission select sits at its Default.
     openAgentConfig("ag_native");
     expect(screen.queryByTestId("new-chat-landing-config-approval")).toBeNull();
-    // The permission select's trigger displays its current value — "Manual"
-    // (Claude's own label for the prompting `default` mode), not Codex's
-    // stored "full-access" (which isn't even a valid value here).
+    // The permission select's trigger displays its current value — "Default"
+    // (the label for the prompting `default` mode), not Codex's stored
+    // "full-access" (which isn't even a valid value here).
     expect(screen.getByTestId("new-chat-landing-config-permission").textContent).toContain(
-      "Manual",
+      "Default",
     );
   });
 

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -3210,10 +3210,10 @@ describe("NewChatLandingScreen agent picker + config gear", () => {
     fireEvent.click(screen.getByTestId("new-chat-landing-config-cancel"));
     expect(screen.queryByTestId("new-chat-landing-config-modal")).toBeNull();
     fireEvent.click(screen.getByTestId("new-chat-landing-config-gear"));
-    // Reopened: Plan was discarded, the permission select is back at Manual
-    // (Claude's label for the prompting `default` mode).
+    // Reopened: Plan was discarded, the permission select is back at Default
+    // (the label for the prompting `default` mode).
     expect(screen.getByTestId("new-chat-landing-config-permission").textContent).toContain(
-      "Manual",
+      "Default",
     );
   });
 
@@ -4264,14 +4264,14 @@ describe("NewChatLandingScreen Smart Routing harness row", () => {
     const permission = screen.getByTestId("new-chat-landing-config-permission");
     expect(permission.textContent).toContain("Default");
     expect(permission.textContent).not.toContain("Plan");
-    // Reads the state behind the locked row, not the row's own constant: the
-    // wrapper's full modal is back and shows the reset value.
+    // Reads the state behind the locked row: the wrapper's full modal is back
+    // and shows the reset value, with the remembered "plan" gone.
     fireEvent.click(screen.getByTestId("new-chat-landing-config-cancel"));
     selectAgent("a1");
     fireEvent.click(screen.getByTestId("new-chat-landing-config-gear"));
-    expect(screen.getByTestId("new-chat-landing-config-permission").textContent).toContain(
-      "Manual",
-    );
+    const reopened = screen.getByTestId("new-chat-landing-config-permission");
+    expect(reopened.textContent).toContain("Default");
+    expect(reopened.textContent).not.toContain("Plan");
   });
 
   it("leaves Smart Routing by re-picking a harness row", () => {


### PR DESCRIPTION
## Related issue

Closes #

<!-- UI copy tweak with no tracking issue. -->

## Summary

The claude-native permission picker labelled the `default` mode **"Manual"**, mirroring Claude Code's own TUI wording (its pane footer reads `manual mode on`). In the web UI that wording is the odd one out:

- The option means *no override* — picking it sends no `--permission-mode` flag at all (`NewChatDialog.tsx:3961`), and it's the value the picker starts on (`NewChatDialog.tsx:2340`).
- Every other unset-state select in the same modal — Model, Effort — already says "Default", so "Manual" sat between two "Default"s meaning the same thing.

This renames the label back to "Default". The wire value (`default`), the switchable mode set, and the pane-footer parsing in `claude_native_bridge.py` (which must keep matching Claude's real `manual mode on` output) are all untouched — only the string users read changes.

## Test Plan

- `pnpm vitest run src/lib/claudePermissionMode.test.ts src/shell/NewChatDialog.test.tsx src/shell/NewChatDialog.flow.test.tsx` — 351 passed.
- `pnpm vitest run src/pages/ChatPage.composer.test.tsx src/store/chatStore.test.ts src/lib/sessionsApi.test.ts` — 556 passed (in-chat switcher + PATCH path).
- `pytest tests/e2e_ui/start_session/test_start_session.py::test_start_session_select_permission_mode` — passed; this test asserts all six option labels, so it pins the rename end-to-end in a real browser.
- `pre-commit run` on the staged files — all hooks pass (prettier, oxlint, tsc, ruff).
- Manually captured the modal in the e2e browser harness (see Demo).

## Demo
<img width="530" height="581" alt="Screenshot 2026-08-21 at 3 54 39 PM" src="https://github.com/user-attachments/assets/fa4d5693-d46b-4ba8-8111-df26b2efd600" />

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The label is asserted in three places that all moved with it: the `claudePermissionModeLabel` unit test, the two `NewChatDialog` suites that read the select's trigger text, and the `test_start_session_select_permission_mode` e2e test that enumerates every option label in a real browser.

## Changelog

The Claude Code permission picker calls the prompting mode "Default" again instead of "Manual"
