### PR TITLE
Add session actions menu to chat header

### DIFF
--- a/tests/e2e_ui/sessions/test_header_session_menu.py
+++ b/tests/e2e_ui/sessions/test_header_session_menu.py
@@ -1,0 +1,74 @@
+"""E2E coverage for the chat-header session actions menu.
+
+The owner path exercises the real REST-backed rename flow from the header.
+The child path proves sub-agent breadcrumbs stay navigation-only.
+"""
+
+from __future__ import annotations
+
+import httpx
+from playwright.sync_api import Page, expect
+
+
+def test_header_session_menu_renames_owner_and_hides_for_subagent(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Owner menu opens in order, renames the session, and stays off children."""
+    base_url, session_id = seeded_session
+    child_id: str | None = None
+
+    try:
+        page.goto(f"{base_url}/c/{session_id}")
+
+        trigger = page.get_by_test_id("header-conversation-actions")
+        expect(trigger).to_be_visible(timeout=30_000)
+        trigger.click()
+
+        menu_items = page.get_by_role("menuitem")
+        expect(menu_items).to_have_count(6)
+        assert menu_items.all_inner_texts() == [
+            "Pin",
+            "Rename",
+            "Mark as unread",
+            "Add to project",
+            "Archive",
+            "Delete",
+        ]
+
+        page.get_by_role("menuitem", name="Rename").click()
+        rename_input = page.get_by_role("textbox", name="Session name")
+        expect(rename_input).to_be_visible()
+        renamed_title = "Header menu renamed session"
+        rename_input.fill(renamed_title)
+        page.get_by_role("button", name="Rename").click()
+
+        breadcrumb = page.get_by_role("navigation", name="Conversation")
+        expect(breadcrumb.get_by_text(renamed_title, exact=True)).to_be_visible(timeout=15_000)
+
+        agent_resp = httpx.get(
+            f"{base_url}/v1/sessions/{session_id}/agent",
+            timeout=10.0,
+        )
+        agent_resp.raise_for_status()
+        child_resp = httpx.post(
+            f"{base_url}/v1/sessions",
+            json={
+                "agent_id": agent_resp.json()["id"],
+                "parent_session_id": session_id,
+                "title": "header-menu-child",
+            },
+            timeout=10.0,
+        )
+        child_resp.raise_for_status()
+        child_id = str(child_resp.json()["id"])
+
+        page.goto(f"{base_url}/c/{child_id}")
+
+        expect(page.get_by_role("link", name="Back to parent session")).to_be_visible(
+            timeout=30_000
+        )
+        expect(page.get_by_test_id("header-conversation-actions")).to_have_count(0)
+    finally:
+        if child_id is not None:
+            httpx.delete(f"{base_url}/v1/sessions/{child_id}", timeout=10.0)

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -544,6 +544,62 @@ describe("AppShell header", () => {
     expect(screen.getByRole("button", { name: /sidebar/i })).toBeInTheDocument();
   });
 
+  it("shows owner actions for a top-level session omitted from conversation pages", () => {
+    mockConversations([]);
+    useSessionMock.mockReturnValue({
+      session: {
+        id: "conv_off_window",
+        agentId: "ag_owner",
+        agentName: "developer",
+        runnerId: null,
+        status: "idle",
+        createdAt: 1_700_000_000,
+        title: "Off-window owner session",
+        labels: {},
+        items: [],
+        pendingElicitations: [],
+        permissionLevel: 4,
+        parentSessionId: null,
+        subAgentName: null,
+        kind: "default",
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_off_window");
+
+    expect(screen.getByRole("button", { name: "Conversation actions" })).toBeInTheDocument();
+  });
+
+  it("keeps owner actions hidden for an off-window sub-agent", () => {
+    mockConversations([]);
+    useSessionMock.mockReturnValue({
+      session: {
+        id: "conv_child",
+        agentId: "ag_owner",
+        agentName: "developer",
+        runnerId: null,
+        status: "idle",
+        createdAt: 1_700_000_000,
+        title: "Child session",
+        labels: {},
+        items: [],
+        pendingElicitations: [],
+        permissionLevel: 4,
+        parentSessionId: "conv_parent",
+        subAgentName: "researcher",
+        kind: "sub_agent",
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_child");
+
+    expect(screen.queryByRole("button", { name: "Conversation actions" })).toBeNull();
+  });
+
   it("defaults to chat view on a native Claude session", () => {
     // The shell used to auto-open the terminals panel for terminal-first
     // sessions. The new behavior is: default to Chat, let the user opt

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1,7 +1,12 @@
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Outlet, useParams, useSearchParams } from "@/lib/routing";
-import { PROJECT_LABEL_KEY, useConversations, useProjects } from "@/hooks/useConversations";
+import {
+  PROJECT_LABEL_KEY,
+  type Conversation,
+  useConversations,
+  useProjects,
+} from "@/hooks/useConversations";
 import { conversationDisplayLabel, UNTITLED_CONVERSATION_LABEL } from "./sidebarNav";
 import { useSessionAgent } from "@/hooks/useAgents";
 import { useApproveHotkey } from "@/hooks/useApproveHotkey";
@@ -468,8 +473,30 @@ export function AppShell() {
   // revealed ``parentSessionId``. A session present in the sidebar list is
   // known top-level immediately (children are omitted from that query);
   // otherwise we wait for the snapshot rather than optimistically showing.
+  const activeSessionMatchesRoute = activeSession?.id === conversationId;
   const isKnownTopLevel =
-    activeConv != null || (activeSession != null && activeSession.parentSessionId == null);
+    activeConv != null ||
+    (activeSessionMatchesRoute && activeSession != null && activeSession.parentSessionId == null);
+  const actionConversation = useMemo<Conversation | null>(() => {
+    if (!isKnownTopLevel || !isOwnerLevel(permissionLevel)) return null;
+    if (activeConv) return activeConv;
+    if (!activeSessionMatchesRoute || !activeSession) return null;
+    return {
+      id: activeSession.id,
+      object: "conversation",
+      title: activeSession.title,
+      created_at: activeSession.createdAt,
+      updated_at: activeSession.createdAt,
+      labels: activeSession.labels ?? {},
+      permission_level: activeSession.permissionLevel,
+      runner_id: activeSession.runnerId ?? null,
+      host_id: activeSession.hostId ?? null,
+      workspace: activeSession.workspace ?? null,
+      agent_id: activeSession.agentId,
+      agent_name: activeSession.agentName,
+      git_branch: activeSession.gitBranch ?? null,
+    };
+  }, [activeConv, activeSession, activeSessionMatchesRoute, isKnownTopLevel, permissionLevel]);
   // Header action gating, hoisted so the desktop buttons and the mobile
   // three-dot menu render the exact same set (they can't drift apart).
   // Stop session is not a header action — it lives in the sidebar row's
@@ -1682,9 +1709,7 @@ export function AppShell() {
                   }}
                   isChildSession={isChildSession}
                   conversationId={conversationId}
-                  actionConversation={
-                    isKnownTopLevel && isOwnerLevel(permissionLevel) ? activeConv : null
-                  }
+                  actionConversation={actionConversation}
                   conversationTitle={headerConversationTitle}
                   projectName={headerProjectName}
                   titleLinkTo={headerTitleLinkTo}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1682,6 +1682,9 @@ export function AppShell() {
                   }}
                   isChildSession={isChildSession}
                   conversationId={conversationId}
+                  actionConversation={
+                    isKnownTopLevel && isOwnerLevel(permissionLevel) ? activeConv : null
+                  }
                   conversationTitle={headerConversationTitle}
                   projectName={headerProjectName}
                   titleLinkTo={headerTitleLinkTo}

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Agent } from "@/hooks/useAgents";
+import type { Conversation } from "@/hooks/useConversations";
 import type * as NativeBridgeModule from "@/lib/nativeBridge";
 import { ChatHeader } from "./ChatHeader";
 import {
@@ -54,6 +55,7 @@ function renderHeader(props: {
   sidebarOpen: boolean;
   isChildSession?: boolean;
   conversationId?: string;
+  actionConversation?: Conversation | null;
   conversationTitle?: string | null;
   projectName?: string | null;
   titleLinkTo?: string;
@@ -76,6 +78,7 @@ function renderHeader(props: {
             // right-panel toggle / mobile FAB all gate on conversationId and
             // stay unmounted, isolating the left-slot affordances under test.
             conversationId={props.conversationId}
+            actionConversation={props.actionConversation}
             conversationTitle={props.conversationTitle ?? null}
             projectName={props.projectName ?? null}
             titleLinkTo={props.titleLinkTo}
@@ -388,5 +391,47 @@ describe("ChatHeader — Chat/Terminal switcher wiring", () => {
   it("omits the toggle when there is no TerminalFirst context", () => {
     renderHeaderWithSession(null);
     expect(screen.queryByRole("group", { name: /switch between chat and terminal/i })).toBeNull();
+  });
+});
+
+describe("ChatHeader — title-adjacent conversation actions", () => {
+  const conversation: Conversation = {
+    id: "conv-1",
+    object: "conversation",
+    title: "A very long session title that must truncate before the overflow trigger",
+    created_at: 1_700_000_000,
+    updated_at: 1_700_000_100,
+    labels: {},
+    permission_level: 3,
+  };
+
+  it("keeps the overflow trigger immediately after a truncating title", () => {
+    renderHeader({
+      sidebarOpen: true,
+      conversationId: conversation.id,
+      conversationTitle: conversation.title,
+      actionConversation: conversation,
+    });
+
+    const title = screen.getByText(conversation.title as string);
+    const trigger = screen.getByRole("button", { name: "Conversation actions" });
+    expect(title).toHaveClass("min-w-0", "truncate");
+    expect(title.parentElement).toBe(trigger.parentElement);
+    expect(title.compareDocumentPosition(trigger) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("does not add a management menu to a sub-agent breadcrumb", () => {
+    renderHeader({
+      sidebarOpen: true,
+      conversationId: "child-9",
+      isChildSession: true,
+      conversationTitle: "Parent session",
+      titleLinkTo: "/c/parent-123",
+      boundAgent: { id: "a1", name: "reviewer" },
+    });
+
+    expect(screen.queryByRole("button", { name: "Conversation actions" })).toBeNull();
+    expect(screen.getByRole("link", { name: "Back to parent session" })).toBeInTheDocument();
+    expect(screen.getByText("reviewer")).toBeInTheDocument();
   });
 });

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -22,9 +22,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { AgentInfoButton } from "@/components/AgentInfo";
 import { ConversationBreadcrumb } from "./ConversationBreadcrumb";
+import { HeaderConversationMenu } from "./HeaderConversationMenu";
 import { UNTITLED_CONVERSATION_LABEL } from "./sidebarNav";
 import { PresenceAvatars } from "@/components/PresenceAvatars";
 import type { Agent } from "@/hooks/useAgents";
+import type { Conversation } from "@/hooks/useConversations";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { cn } from "@/lib/utils";
 import { TAB_BADGE_BASE } from "./railTabs";
@@ -95,6 +97,8 @@ interface ChatHeaderProps {
   isChildSession: boolean;
   /** Active session id, or undefined on the landing composer. */
   conversationId: string | undefined;
+  /** Owner-managed top-level row backing the title-adjacent action menu. */
+  actionConversation?: Conversation | null;
   /**
    * Breadcrumb title: the active conversation's display name, or its
    * immediate parent's when viewing a sub-agent. ``null`` while unresolved.
@@ -177,6 +181,7 @@ export function ChatHeader({
   onOpenSidebar,
   isChildSession,
   conversationId,
+  actionConversation = null,
   conversationTitle,
   projectName,
   titleLinkTo,
@@ -290,6 +295,20 @@ export function ChatHeader({
             isChildSession={isChildSession}
             boundAgent={boundAgent}
             wrapperLabel={wrapperLabel}
+            actions={
+              actionConversation ? (
+                <HeaderConversationMenu
+                  conversation={actionConversation}
+                  currentProject={projectName}
+                  canShare={canShare}
+                  shareDisabled={shareDisabled}
+                  shareDisabledReason={shareDisabledReason}
+                  onShare={onShare}
+                  hasAgentInfo={isMobile && hasAgentInfo}
+                  onAgentInfo={onAgentInfo}
+                />
+              ) : undefined
+            }
             className="pr-1"
           />
         )}
@@ -315,7 +334,7 @@ export function ChatHeader({
             (Share · Agent info) so the header stays
             uncluttered on a phone. The right-panel/rail control is
             deliberately left out — it has its own affordance below. */}
-        {hasHeaderMenu && (
+        {hasHeaderMenu && (!actionConversation || !isMobile) && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button

--- a/web/src/shell/ConversationBreadcrumb.tsx
+++ b/web/src/shell/ConversationBreadcrumb.tsx
@@ -1,4 +1,5 @@
 import { BotIcon, ChevronLeftIcon, FolderIcon } from "lucide-react";
+import type { ReactNode } from "react";
 import { Link } from "@/lib/routing";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { isAndroidShell, isIOSShell } from "@/lib/nativeBridge";
@@ -27,6 +28,7 @@ export function ConversationBreadcrumb({
   isChildSession,
   boundAgent,
   wrapperLabel,
+  actions,
   className,
 }: {
   /** The conversation's display name. */
@@ -41,6 +43,8 @@ export function ConversationBreadcrumb({
   boundAgent: Agent | undefined;
   /** The session's `omnigent.wrapper` label — names a native sub-agent's vendor. */
   wrapperLabel: string | null;
+  /** Session-management menu rendered immediately after the title. */
+  actions?: ReactNode;
   /** Extra classes for the context (header vs title-bar strip). */
   className?: string;
 }) {
@@ -92,7 +96,7 @@ export function ConversationBreadcrumb({
           to={titleLinkTo}
           aria-label="Back to parent session"
           className={cn(
-            "breadcrumb-parent-link text-muted-foreground hover:text-foreground",
+            "breadcrumb-parent-link min-w-0 text-muted-foreground hover:text-foreground",
             nativeMobileBack
               ? "inline-flex shrink-0 items-center gap-0.5"
               : "truncate hover:underline",
@@ -108,8 +112,9 @@ export function ConversationBreadcrumb({
           )}
         </Link>
       ) : (
-        <span className="truncate text-foreground">{conversationTitle}</span>
+        <span className="min-w-0 truncate text-foreground">{conversationTitle}</span>
       )}
+      {actions}
       {isChildSession && (
         <>
           <span aria-hidden className="shrink-0 text-muted-foreground opacity-40">

--- a/web/src/shell/HeaderConversationMenu.test.tsx
+++ b/web/src/shell/HeaderConversationMenu.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import type { Conversation } from "@/hooks/useConversations";
@@ -53,9 +53,17 @@ const CONVERSATION: Conversation = {
   git_branch: "feature/quarterly-planning",
 };
 
-function renderMenu(overrides: Partial<Parameters<typeof HeaderConversationMenu>[0]> = {}) {
-  return render(
-    <MemoryRouter initialEntries={["/c/conv-1"]}>
+const SECOND_CONVERSATION: Conversation = {
+  ...CONVERSATION,
+  id: "conv-2",
+  title: "Release planning",
+  updated_at: 1_700_000_200,
+  git_branch: "feature/release-planning",
+};
+
+function menuTree(overrides: Partial<Parameters<typeof HeaderConversationMenu>[0]> = {}) {
+  return (
+    <MemoryRouter initialEntries={[`/c/${overrides.conversation?.id ?? CONVERSATION.id}`]}>
       <HeaderConversationMenu
         conversation={CONVERSATION}
         currentProject={null}
@@ -63,8 +71,12 @@ function renderMenu(overrides: Partial<Parameters<typeof HeaderConversationMenu>
         onShare={() => {}}
         {...overrides}
       />
-    </MemoryRouter>,
+    </MemoryRouter>
   );
+}
+
+function renderMenu(overrides: Partial<Parameters<typeof HeaderConversationMenu>[0]> = {}) {
+  return render(menuTree(overrides));
 }
 
 function openMenu() {
@@ -121,10 +133,32 @@ describe("HeaderConversationMenu", () => {
 
     openMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
-    const input = screen.getByTestId("header-rename-conversation-input");
+    const input = screen.getByRole("textbox", { name: "Session name" });
     fireEvent.change(input, { target: { value: "Roadmap planning" } });
     fireEvent.click(screen.getByRole("button", { name: "Rename" }));
     expect(mocks.rename).toHaveBeenCalledWith({ id: "conv-1", title: "Roadmap planning" });
+  });
+
+  it("runs archive and delete actions for the active session", () => {
+    const view = renderMenu();
+
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Archive" }));
+    expect(mocks.archive).toHaveBeenCalledWith(
+      { id: "conv-1", archived: true },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+
+    view.unmount();
+    renderMenu();
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    fireEvent.click(screen.getByTestId("header-delete-branch-checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(mocks.deleteConversation).toHaveBeenCalledWith({
+      id: "conv-1",
+      deleteBranch: true,
+    });
   });
 
   it("labels project actions for filed and unfiled sessions", () => {
@@ -149,8 +183,56 @@ describe("HeaderConversationMenu", () => {
 
     expect(screen.getByTestId("header-project-picker-back")).toBeInTheDocument();
     expect(screen.queryByTestId("header-rename-conversation")).toBeNull();
+    expect(screen.getByRole("textbox", { name: "Search projects" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("menuitem", { name: "Sprint 42" }));
     expect(mocks.moveToProject).toHaveBeenCalledWith({ id: "conv-1", project: "Sprint 42" });
+  });
+
+  it("closes and resets Rename when the conversation id changes", async () => {
+    const view = renderMenu();
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Session name" }), {
+      target: { value: "Stale session A title" },
+    });
+
+    view.rerender(menuTree({ conversation: SECOND_CONVERSATION }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: "Rename session" })).toBeNull();
+    });
+    expect(mocks.rename).not.toHaveBeenCalled();
+
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
+    const input = screen.getByRole("textbox", { name: "Session name" });
+    expect(input).toHaveValue("Release planning");
+    fireEvent.change(input, { target: { value: "Release launch" } });
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+    expect(mocks.rename).toHaveBeenCalledWith({ id: "conv-2", title: "Release launch" });
+  });
+
+  it("closes Delete and clears branch selection when the conversation id changes", async () => {
+    const view = renderMenu();
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    fireEvent.click(screen.getByTestId("header-delete-branch-checkbox"));
+
+    view.rerender(menuTree({ conversation: SECOND_CONVERSATION }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: "Delete conversation?" })).toBeNull();
+    });
+    expect(mocks.deleteConversation).not.toHaveBeenCalled();
+
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    expect(screen.getByTestId("header-delete-branch-checkbox")).not.toBeChecked();
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(mocks.deleteConversation).toHaveBeenCalledWith({
+      id: "conv-2",
+      deleteBranch: false,
+    });
   });
 
   it("reflects pinned state and preserves the disabled share reason", () => {

--- a/web/src/shell/HeaderConversationMenu.test.tsx
+++ b/web/src/shell/HeaderConversationMenu.test.tsx
@@ -1,0 +1,172 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import type { Conversation } from "@/hooks/useConversations";
+import type * as ConversationsModule from "@/hooks/useConversations";
+import type * as UnseenConversationsModule from "@/hooks/useUnseenConversations";
+import { HeaderConversationMenu } from "./HeaderConversationMenu";
+
+const mocks = vi.hoisted(() => ({
+  isMobile: false,
+  projects: [{ id: "project-1", name: "Sprint 42" }],
+  togglePinned: vi.fn(),
+  rename: vi.fn(),
+  moveToProject: vi.fn(),
+  archive: vi.fn(),
+  deleteConversation: vi.fn(),
+  markUnread: vi.fn(),
+}));
+
+vi.mock("@/hooks/useIsMobileViewport", () => ({
+  useIsMobileViewport: () => mocks.isMobile,
+}));
+
+vi.mock("@/hooks/useConversations", async (importOriginal) => {
+  const actual = await importOriginal<typeof ConversationsModule>();
+  return {
+    ...actual,
+    useProjects: () => ({ data: mocks.projects }),
+    useTogglePinnedConversation: () => ({ mutate: mocks.togglePinned }),
+    useRenameConversation: () => ({ mutate: mocks.rename, isPending: false }),
+    useMoveToProject: () => ({ mutate: mocks.moveToProject }),
+    useArchiveConversation: () => ({ mutate: mocks.archive }),
+    useStopAndDeleteConversation: () => ({
+      mutate: mocks.deleteConversation,
+      isPending: false,
+    }),
+  };
+});
+
+vi.mock("@/hooks/useUnseenConversations", async (importOriginal) => {
+  const actual = await importOriginal<typeof UnseenConversationsModule>();
+  return { ...actual, markConversationUnread: mocks.markUnread };
+});
+
+const CONVERSATION: Conversation = {
+  id: "conv-1",
+  object: "conversation",
+  title: "Quarterly planning",
+  created_at: 1_700_000_000,
+  updated_at: 1_700_000_100,
+  labels: {},
+  permission_level: 3,
+  git_branch: "feature/quarterly-planning",
+};
+
+function renderMenu(overrides: Partial<Parameters<typeof HeaderConversationMenu>[0]> = {}) {
+  return render(
+    <MemoryRouter initialEntries={["/c/conv-1"]}>
+      <HeaderConversationMenu
+        conversation={CONVERSATION}
+        currentProject={null}
+        canShare
+        onShare={() => {}}
+        {...overrides}
+      />
+    </MemoryRouter>,
+  );
+}
+
+function openMenu() {
+  fireEvent.pointerDown(screen.getByRole("button", { name: "Conversation actions" }), {
+    button: 0,
+  });
+}
+
+beforeEach(() => {
+  mocks.isMobile = false;
+  mocks.projects = [{ id: "project-1", name: "Sprint 42" }];
+  vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe("HeaderConversationMenu", () => {
+  it("exposes an accessible trigger and the established action order", () => {
+    renderMenu();
+    const trigger = screen.getByRole("button", { name: "Conversation actions" });
+    expect(trigger).toHaveAttribute("aria-haspopup", "menu");
+
+    openMenu();
+    expect(screen.getAllByRole("menuitem").map((item) => item.textContent?.trim())).toEqual([
+      "Pin",
+      "Share",
+      "Rename",
+      "Mark as unread",
+      "Add to project",
+      "Archive",
+      "Delete",
+    ]);
+  });
+
+  it("opens from the keyboard and focuses the first action", () => {
+    renderMenu();
+    const trigger = screen.getByRole("button", { name: "Conversation actions" });
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    expect(screen.getByRole("menuitem", { name: "Pin" })).toHaveFocus();
+  });
+
+  it("runs pin, mark-unread, and rename actions for the active session", () => {
+    renderMenu();
+
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Pin" }));
+    expect(mocks.togglePinned).toHaveBeenCalledWith({ id: "conv-1", pinned: true });
+
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Mark as unread" }));
+    expect(mocks.markUnread).toHaveBeenCalledWith("conv-1", 1_700_000_100);
+
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
+    const input = screen.getByTestId("header-rename-conversation-input");
+    fireEvent.change(input, { target: { value: "Roadmap planning" } });
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+    expect(mocks.rename).toHaveBeenCalledWith({ id: "conv-1", title: "Roadmap planning" });
+  });
+
+  it("labels project actions for filed and unfiled sessions", () => {
+    const view = renderMenu();
+    openMenu();
+    expect(screen.getByTestId("header-move-to-project")).toHaveTextContent("Add to project");
+
+    view.unmount();
+    renderMenu({ currentProject: "Payments" });
+    openMenu();
+    expect(screen.getByTestId("header-move-to-project")).toHaveTextContent("Move session");
+  });
+
+  it("uses the in-place project picker on mobile and moves to the selected project", () => {
+    mocks.isMobile = true;
+    renderMenu();
+    openMenu();
+
+    const projectAction = screen.getByTestId("header-move-to-project");
+    expect(projectAction).not.toHaveAttribute("aria-haspopup", "menu");
+    fireEvent.click(projectAction);
+
+    expect(screen.getByTestId("header-project-picker-back")).toBeInTheDocument();
+    expect(screen.queryByTestId("header-rename-conversation")).toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Sprint 42" }));
+    expect(mocks.moveToProject).toHaveBeenCalledWith({ id: "conv-1", project: "Sprint 42" });
+  });
+
+  it("reflects pinned state and preserves the disabled share reason", () => {
+    renderMenu({
+      conversation: {
+        ...CONVERSATION,
+        labels: { "omnigent.pinned": "1700000000000" },
+      },
+      shareDisabled: true,
+      shareDisabledReason: "Sharing is unavailable from a local server.",
+    });
+    openMenu();
+
+    expect(screen.getByRole("menuitem", { name: "Unpin" })).toBeInTheDocument();
+    const share = screen.getByRole("menuitem", { name: "Share" });
+    expect(share).toHaveAttribute("data-disabled");
+    expect(share).toHaveAttribute("title", "Sharing is unavailable from a local server.");
+  });
+});

--- a/web/src/shell/HeaderConversationMenu.tsx
+++ b/web/src/shell/HeaderConversationMenu.tsx
@@ -1,0 +1,423 @@
+import { useEffect, useState, type FormEvent, type KeyboardEvent } from "react";
+import {
+  ArchiveIcon,
+  CheckIcon,
+  ChevronLeftIcon,
+  EllipsisVerticalIcon,
+  FolderInputIcon,
+  GitBranchIcon,
+  InfoIcon,
+  MailIcon,
+  PencilIcon,
+  PinIcon,
+  PinOffIcon,
+  SearchIcon,
+  ShareIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  PINNED_LABEL_KEY,
+  type Conversation,
+  useArchiveConversation,
+  useMoveToProject,
+  useProjects,
+  useRenameConversation,
+  useStopAndDeleteConversation,
+  useTogglePinnedConversation,
+} from "@/hooks/useConversations";
+import { markConversationUnread } from "@/hooks/useUnseenConversations";
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
+import { Link, useNavigate } from "@/lib/routing";
+import { showToast } from "@/components/ui/toast";
+import { conversationDisplayLabel } from "./sidebarNav";
+
+interface HeaderConversationMenuProps {
+  conversation: Conversation;
+  currentProject: string | null;
+  canShare: boolean;
+  shareDisabled?: boolean;
+  shareDisabledReason?: string;
+  onShare: () => void;
+  hasAgentInfo?: boolean;
+  onAgentInfo?: () => void;
+}
+
+function ArchivedToast() {
+  return (
+    <span>
+      View archived sessions in{" "}
+      <Link to="/settings/archived" className="font-medium text-primary hover:underline">
+        Settings
+      </Link>
+    </span>
+  );
+}
+
+function showArchivedToast() {
+  showToast(<ArchivedToast />);
+}
+
+function ProjectPicker({
+  currentProject,
+  onSelect,
+}: {
+  currentProject: string | null;
+  onSelect: (project: string) => void;
+}) {
+  const { data: projects = [] } = useProjects();
+  const [search, setSearch] = useState("");
+  const filtered = search
+    ? projects.filter((project) => project.name.toLowerCase().includes(search.toLowerCase()))
+    : projects;
+
+  return (
+    <>
+      <div className="flex items-center gap-2 border-b px-2 py-1.5">
+        <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
+        <input
+          className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          placeholder="Search projects"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          onKeyDown={(event) => event.stopPropagation()}
+        />
+      </div>
+      <div className="max-h-48 overflow-y-auto">
+        {filtered.map((project) => (
+          <DropdownMenuItem
+            key={project.name}
+            className="px-2 py-1"
+            onSelect={() => onSelect(project.name)}
+          >
+            <span className="flex-1 truncate text-left">{project.name}</span>
+            {currentProject === project.name && (
+              <CheckIcon className="size-3.5 shrink-0 text-primary" />
+            )}
+          </DropdownMenuItem>
+        ))}
+        {filtered.length === 0 && (
+          <p className="px-2 py-1.5 text-sm text-muted-foreground">No projects yet.</p>
+        )}
+      </div>
+      {currentProject && (
+        <div className="border-t pt-1">
+          <DropdownMenuItem className="px-2 py-1" onSelect={() => onSelect("")}>
+            Remove from{" "}
+            <span className="rounded bg-muted px-1 py-0.5 font-mono text-[0.95em]">
+              {currentProject}
+            </span>
+          </DropdownMenuItem>
+        </div>
+      )}
+    </>
+  );
+}
+
+export function HeaderConversationMenu({
+  conversation,
+  currentProject,
+  canShare,
+  shareDisabled = false,
+  shareDisabledReason,
+  onShare,
+  hasAgentInfo = false,
+  onAgentInfo,
+}: HeaderConversationMenuProps) {
+  const navigate = useNavigate();
+  const isMobile = useIsMobileViewport();
+  const togglePinned = useTogglePinnedConversation();
+  const rename = useRenameConversation();
+  const moveToProject = useMoveToProject();
+  const archive = useArchiveConversation();
+  const deleteConversation = useStopAndDeleteConversation();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [projectPickerOpen, setProjectPickerOpen] = useState(false);
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [renameTitle, setRenameTitle] = useState(conversation.title ?? "");
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteBranch, setDeleteBranch] = useState(false);
+  const isPinned = conversation.labels?.[PINNED_LABEL_KEY] != null;
+  const label = conversationDisplayLabel(conversation);
+  const gitBranch = conversation.git_branch ?? null;
+
+  useEffect(() => {
+    if (!renameOpen) setRenameTitle(conversation.title ?? "");
+  }, [conversation.title, renameOpen]);
+
+  const closeMenu = () => {
+    setMenuOpen(false);
+    setProjectPickerOpen(false);
+  };
+
+  const handleProjectSelect = (project: string) => {
+    closeMenu();
+    moveToProject.mutate({ id: conversation.id, project });
+  };
+
+  const submitRename = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const title = renameTitle.trim();
+    if (title && title !== (conversation.title ?? "")) {
+      rename.mutate({ id: conversation.id, title });
+    }
+    setRenameOpen(false);
+  };
+
+  const confirmDelete = () => {
+    setDeleteOpen(false);
+    setDeleteBranch(false);
+    navigate("/", { replace: true });
+    deleteConversation.mutate({
+      id: conversation.id,
+      deleteBranch: gitBranch !== null && deleteBranch,
+    });
+  };
+
+  const archiveConversation = () => {
+    closeMenu();
+    archive.mutate(
+      { id: conversation.id, archived: true },
+      {
+        onSuccess: () => {
+          navigate("/", { replace: true });
+          showArchivedToast();
+        },
+      },
+    );
+  };
+
+  const mainItems = (
+    <>
+      <DropdownMenuItem
+        data-testid="header-pin-conversation"
+        onSelect={() => togglePinned.mutate({ id: conversation.id, pinned: !isPinned })}
+      >
+        {isPinned ? <PinOffIcon className="size-3.5" /> : <PinIcon className="size-3.5" />}
+        {isPinned ? "Unpin" : "Pin"}
+      </DropdownMenuItem>
+      {canShare && (
+        <DropdownMenuItem
+          data-testid="header-share-conversation"
+          disabled={shareDisabled}
+          title={shareDisabledReason}
+          onSelect={shareDisabled ? undefined : onShare}
+        >
+          <ShareIcon className="size-3.5" />
+          Share
+        </DropdownMenuItem>
+      )}
+      {hasAgentInfo && onAgentInfo && (
+        <DropdownMenuItem data-testid="header-agent-info" onSelect={onAgentInfo}>
+          <InfoIcon className="size-3.5" />
+          Agent info
+        </DropdownMenuItem>
+      )}
+      <DropdownMenuItem
+        data-testid="header-rename-conversation"
+        onSelect={() => setRenameOpen(true)}
+      >
+        <PencilIcon className="size-3.5" />
+        Rename
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        data-testid="header-mark-unread-conversation"
+        onSelect={() => markConversationUnread(conversation.id, conversation.updated_at)}
+      >
+        <MailIcon className="size-3.5" />
+        Mark as unread
+      </DropdownMenuItem>
+      {isMobile ? (
+        <DropdownMenuItem
+          data-testid="header-move-to-project"
+          className="whitespace-nowrap"
+          onSelect={(event) => {
+            event.preventDefault();
+            setProjectPickerOpen(true);
+          }}
+        >
+          <FolderInputIcon className="size-3.5" />
+          {currentProject ? "Move session" : "Add to project"}
+        </DropdownMenuItem>
+      ) : (
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger
+            data-testid="header-move-to-project"
+            className="whitespace-nowrap"
+          >
+            <FolderInputIcon className="size-3.5" />
+            {currentProject ? "Move session" : "Add to project"}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="min-w-56">
+            <ProjectPicker currentProject={currentProject} onSelect={handleProjectSelect} />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      )}
+      <DropdownMenuSeparator />
+      <DropdownMenuItem data-testid="header-archive-conversation" onSelect={archiveConversation}>
+        <ArchiveIcon className="size-3.5" />
+        Archive
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        data-testid="header-delete-conversation"
+        variant="destructive"
+        onSelect={() => setDeleteOpen(true)}
+      >
+        <Trash2Icon className="size-3.5" />
+        Delete
+      </DropdownMenuItem>
+    </>
+  );
+
+  return (
+    <>
+      <DropdownMenu
+        open={menuOpen}
+        onOpenChange={(open) => {
+          setMenuOpen(open);
+          if (!open) setProjectPickerOpen(false);
+        }}
+      >
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Conversation actions"
+            data-testid="header-conversation-actions"
+            className="shrink-0 border-none text-muted-foreground hover:text-foreground"
+          >
+            <EllipsisVerticalIcon className="size-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="min-w-56">
+          {isMobile && projectPickerOpen ? (
+            <>
+              <DropdownMenuItem
+                data-testid="header-project-picker-back"
+                onSelect={(event) => {
+                  event.preventDefault();
+                  setProjectPickerOpen(false);
+                }}
+              >
+                <ChevronLeftIcon className="size-3.5" />
+                Back
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <ProjectPicker currentProject={currentProject} onSelect={handleProjectSelect} />
+            </>
+          ) : (
+            mainItems
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <DialogContent>
+          <form onSubmit={submitRename}>
+            <DialogHeader>
+              <DialogTitle>Rename session</DialogTitle>
+              <DialogDescription>Choose a short name that is easy to find later.</DialogDescription>
+            </DialogHeader>
+            <input
+              autoFocus
+              data-testid="header-rename-conversation-input"
+              value={renameTitle}
+              onChange={(event) => setRenameTitle(event.target.value)}
+              onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
+                if (event.key === "Escape") setRenameOpen(false);
+              }}
+              className="mt-4 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50"
+            />
+            <DialogFooter className="mt-4 border-t-0 bg-transparent">
+              <Button type="button" variant="ghost" onClick={() => setRenameOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={!renameTitle.trim() || rename.isPending}>
+                Rename
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          setDeleteOpen(open);
+          if (!open) setDeleteBranch(false);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete conversation?</DialogTitle>
+            <DialogDescription>
+              <span className="font-medium break-all">{label}</span> and all of its history will be
+              removed. This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          {gitBranch !== null && (
+            <div className="flex flex-col gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+              <p className="text-sm text-muted-foreground">
+                Optionally clean up the git worktree. These actions are{" "}
+                <span className="font-semibold text-destructive">irreversible</span>.
+              </p>
+              <label className="flex cursor-pointer items-start gap-2 text-ui">
+                <input
+                  type="checkbox"
+                  data-testid="header-delete-branch-checkbox"
+                  checked={deleteBranch}
+                  onChange={(event) => setDeleteBranch(event.target.checked)}
+                  className="mt-0.5 size-4 shrink-0 accent-destructive"
+                />
+                <GitBranchIcon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+                <span className="min-w-0">
+                  Delete local branch{" "}
+                  <code className="break-all rounded bg-muted px-1 py-0.5 text-sm">
+                    {gitBranch}
+                  </code>
+                </span>
+              </label>
+            </div>
+          )}
+          <DialogFooter className="border-t-0 bg-transparent">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setDeleteOpen(false)}
+              disabled={deleteConversation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={confirmDelete}
+              disabled={deleteConversation.isPending}
+            >
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/web/src/shell/HeaderConversationMenu.tsx
+++ b/web/src/shell/HeaderConversationMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FormEvent, type KeyboardEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent, type KeyboardEvent } from "react";
 import {
   ArchiveIcon,
   CheckIcon,
@@ -94,6 +94,7 @@ function ProjectPicker({
       <div className="flex items-center gap-2 border-b px-2 py-1.5">
         <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
         <input
+          aria-label="Search projects"
           className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
           placeholder="Search projects"
           value={search}
@@ -155,6 +156,7 @@ export function HeaderConversationMenu({
   const [renameTitle, setRenameTitle] = useState(conversation.title ?? "");
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteBranch, setDeleteBranch] = useState(false);
+  const previousConversationId = useRef(conversation.id);
   const isPinned = conversation.labels?.[PINNED_LABEL_KEY] != null;
   const label = conversationDisplayLabel(conversation);
   const gitBranch = conversation.git_branch ?? null;
@@ -162,6 +164,17 @@ export function HeaderConversationMenu({
   useEffect(() => {
     if (!renameOpen) setRenameTitle(conversation.title ?? "");
   }, [conversation.title, renameOpen]);
+
+  useEffect(() => {
+    if (previousConversationId.current === conversation.id) return;
+    previousConversationId.current = conversation.id;
+    setMenuOpen(false);
+    setProjectPickerOpen(false);
+    setRenameOpen(false);
+    setRenameTitle(conversation.title ?? "");
+    setDeleteOpen(false);
+    setDeleteBranch(false);
+  }, [conversation.id, conversation.title]);
 
   const closeMenu = () => {
     setMenuOpen(false);
@@ -339,6 +352,7 @@ export function HeaderConversationMenu({
             </DialogHeader>
             <input
               autoFocus
+              aria-label="Session name"
               data-testid="header-rename-conversation-input"
               value={renameTitle}
               onChange={(event) => setRenameTitle(event.target.value)}


### PR DESCRIPTION
## Related issue

Closes [OMNI-3744](https://linear.app/omnigent/issue/OMNI-3744/add-overflow-menu-next-to-session-name-in-chat-header-bar)

## Summary

- Add an accessible overflow trigger immediately beside the chat-header session name so session management actions remain available without returning to the sidebar.
- Reuse the established session actions and dialogs for pinning, renaming, unread state, project assignment, archive, and delete; keep Agent info available on mobile when applicable.
- Preserve title truncation, project breadcrumbs, responsive header geometry, and child-session navigation by limiting the management menu to owner-level top sessions.

**ELI5:** the session title now has the same familiar “more actions” menu as the sidebar, while sub-agent breadcrumbs stay navigation-only.

```text
Top session:  [project / session title] [⋮] -> existing session actions
Sub-agent:    [parent session / child]       -> no management menu
```

## Test Plan

- `npm test -- src/shell/HeaderConversationMenu.test.tsx src/shell/ChatHeader.test.tsx` — 2 files passed, 24 tests passed.
- `npm run type-check` — passed (`tsc -b`).
- `npm run lint` — passed with zero warnings.
- `git diff --check upstream/main...HEAD` — passed.
- Verified in the real three-process development stack through Vite at `http://localhost:5174`:
  - dark theme with expanded sidebar for project and non-project sessions;
  - light theme with collapsed sidebar and a long session title;
  - mobile light-theme owner menu, including Agent info;
  - sub-agent breadcrumb behavior with no overflow trigger;
  - 24px trigger sizing, menu placement, alignment, contrast, and the expected action order.

## Demo

**Dark theme — project session menu**

![Dark project session menu](https://raw.githubusercontent.com/zhengwin/omnigent/omni-3744-demo-assets/demo/desktop-dark-project-menu.png)

**Light theme — long title with collapsed sidebar**

![Light long-title session menu](https://raw.githubusercontent.com/zhengwin/omnigent/omni-3744-demo-assets/demo/desktop-light-long-title-collapsed.png)

**Mobile light theme — owner menu**

![Mobile owner session menu](https://raw.githubusercontent.com/zhengwin/omnigent/omni-3744-demo-assets/demo/mobile-light-owner-menu.png)

**Dark theme — sub-agent breadcrumb remains navigation-only**

![Dark sub-agent breadcrumb](https://raw.githubusercontent.com/zhengwin/omnigent/omni-3744-demo-assets/demo/desktop-dark-sub-agent.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused unit coverage exercises trigger accessibility and keyboard focus, action ordering, pin/unread/rename behavior, project labels and mobile project selection, disabled states, long-title layout, and the absence of a management menu for sub-agents. Manual browser verification covers the responsive and theme-dependent visual states listed in the Test Plan.

## Changelog

Manage the active session from a new overflow menu beside its chat-header title.
