### PR TITLE
Add keep-chat-pinned-to-bottom toggle and scroll position restore

### DIFF
--- a/web/src/lib/bottomLockPreferences.test.ts
+++ b/web/src/lib/bottomLockPreferences.test.ts
@@ -10,14 +10,14 @@ afterEach(() => {
 });
 
 describe("bottom lock preferences", () => {
-  it("defaults to disabled and stores only the enabled override", () => {
-    expect(readBottomLockEnabled()).toBe(false);
-
-    writeBottomLockEnabled(true);
+  it("defaults to enabled and stores only the disabled override", () => {
     expect(readBottomLockEnabled()).toBe(true);
-    expect(localStorage.getItem("omnigent:bottom-lock")).toBe("true");
 
     writeBottomLockEnabled(false);
+    expect(readBottomLockEnabled()).toBe(false);
+    expect(localStorage.getItem("omnigent:bottom-lock")).toBe("false");
+
+    writeBottomLockEnabled(true);
     expect(localStorage.getItem("omnigent:bottom-lock")).toBeNull();
   });
 
@@ -25,11 +25,11 @@ describe("bottom lock preferences", () => {
     const onChange = vi.fn();
     const unsubscribe = subscribeBottomLockEnabled(onChange);
 
-    writeBottomLockEnabled(true);
+    writeBottomLockEnabled(false);
     expect(onChange).toHaveBeenCalledOnce();
 
     unsubscribe();
-    writeBottomLockEnabled(false);
+    writeBottomLockEnabled(true);
     expect(onChange).toHaveBeenCalledOnce();
   });
 });

--- a/web/src/lib/bottomLockPreferences.test.ts
+++ b/web/src/lib/bottomLockPreferences.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  readBottomLockEnabled,
+  subscribeBottomLockEnabled,
+  writeBottomLockEnabled,
+} from "./bottomLockPreferences";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("bottom lock preferences", () => {
+  it("defaults to disabled and stores only the enabled override", () => {
+    expect(readBottomLockEnabled()).toBe(false);
+
+    writeBottomLockEnabled(true);
+    expect(readBottomLockEnabled()).toBe(true);
+    expect(localStorage.getItem("omnigent:bottom-lock")).toBe("true");
+
+    writeBottomLockEnabled(false);
+    expect(localStorage.getItem("omnigent:bottom-lock")).toBeNull();
+  });
+
+  it("notifies mounted chat views when the setting changes", () => {
+    const onChange = vi.fn();
+    const unsubscribe = subscribeBottomLockEnabled(onChange);
+
+    writeBottomLockEnabled(true);
+    expect(onChange).toHaveBeenCalledOnce();
+
+    unsubscribe();
+    writeBottomLockEnabled(false);
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/lib/bottomLockPreferences.ts
+++ b/web/src/lib/bottomLockPreferences.ts
@@ -1,0 +1,38 @@
+export const DEFAULT_BOTTOM_LOCK_ENABLED = false;
+export const BOTTOM_LOCK_STORAGE_KEY = "omnigent:bottom-lock";
+
+const CHANGE_EVENT = "omnigent:bottom-lock-change";
+
+export function readBottomLockEnabled(): boolean {
+  if (typeof window === "undefined") return DEFAULT_BOTTOM_LOCK_ENABLED;
+  try {
+    const stored = window.localStorage.getItem(BOTTOM_LOCK_STORAGE_KEY);
+    return stored === null ? DEFAULT_BOTTOM_LOCK_ENABLED : stored === "true";
+  } catch {
+    return DEFAULT_BOTTOM_LOCK_ENABLED;
+  }
+}
+
+export function writeBottomLockEnabled(enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (enabled === DEFAULT_BOTTOM_LOCK_ENABLED) {
+      window.localStorage.removeItem(BOTTOM_LOCK_STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(BOTTOM_LOCK_STORAGE_KEY, String(enabled));
+    }
+  } catch {
+    // localStorage access errors are non-fatal.
+  }
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+export function subscribeBottomLockEnabled(onChange: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener(CHANGE_EVENT, onChange);
+  window.addEventListener("storage", onChange);
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, onChange);
+    window.removeEventListener("storage", onChange);
+  };
+}

--- a/web/src/lib/bottomLockPreferences.ts
+++ b/web/src/lib/bottomLockPreferences.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_BOTTOM_LOCK_ENABLED = false;
+export const DEFAULT_BOTTOM_LOCK_ENABLED = true;
 export const BOTTOM_LOCK_STORAGE_KEY = "omnigent:bottom-lock";
 
 const CHANGE_EVENT = "omnigent:bottom-lock-change";

--- a/web/src/lib/conversationScrollPositions.test.ts
+++ b/web/src/lib/conversationScrollPositions.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  captureActiveConversationScroll,
+  getConversationScrollPosition,
+  registerActiveConversationScroller,
+  restoreConversationScrollPosition,
+  saveConversationScrollPosition,
+} from "./conversationScrollPositions";
+
+function scroller(scrollTop: number): HTMLElement {
+  const element = document.createElement("div");
+  Object.defineProperties(element, {
+    scrollTop: { configurable: true, value: scrollTop, writable: true },
+    scrollHeight: { configurable: true, value: 2400 },
+    clientHeight: { configurable: true, value: 800 },
+  });
+  return element;
+}
+
+describe("conversation scroll positions", () => {
+  it("captures the rendered session at the switch boundary", () => {
+    const element = scroller(640);
+    const unregister = registerActiveConversationScroller("conv-outgoing", element);
+
+    captureActiveConversationScroll("conv-outgoing");
+
+    expect(getConversationScrollPosition("conv-outgoing")).toEqual({
+      scrollTop: 640,
+    });
+    unregister();
+  });
+
+  it("does not associate shared DOM with a store session that has not rendered", () => {
+    const element = scroller(640);
+    const unregister = registerActiveConversationScroller("conv-rendered", element);
+
+    captureActiveConversationScroll("conv-store-leading");
+
+    expect(getConversationScrollPosition("conv-store-leading")).toBeUndefined();
+    unregister();
+  });
+
+  it("restores a user-message anchor after transcript height changes", () => {
+    const element = scroller(640);
+    const message = document.createElement("div");
+    message.dataset.role = "user";
+    message.dataset.userMessageId = "message-1";
+    element.append(message);
+    Object.defineProperty(message, "offsetTop", { configurable: true, value: 560 });
+    saveConversationScrollPosition("conv-anchored", element);
+
+    element.scrollTop = 1600;
+    Object.defineProperty(message, "offsetTop", { configurable: true, value: 1060 });
+    const saved = getConversationScrollPosition("conv-anchored");
+    expect(saved).toBeDefined();
+
+    restoreConversationScrollPosition(element, saved!);
+
+    expect(element.scrollTop).toBe(1140);
+  });
+
+  it("reports that restoration must retry until its anchor renders", () => {
+    const element = scroller(1600);
+    const position = {
+      scrollTop: 640,
+      anchorMessageId: "message-delayed",
+      anchorOffset: -80,
+    };
+
+    expect(restoreConversationScrollPosition(element, position)).toBe(false);
+
+    const message = document.createElement("div");
+    message.dataset.role = "user";
+    message.dataset.userMessageId = "message-delayed";
+    Object.defineProperty(message, "offsetTop", { configurable: true, value: 1060 });
+    element.append(message);
+
+    expect(restoreConversationScrollPosition(element, position)).toBe(true);
+    expect(element.scrollTop).toBe(1140);
+  });
+});

--- a/web/src/lib/conversationScrollPositions.ts
+++ b/web/src/lib/conversationScrollPositions.ts
@@ -1,0 +1,159 @@
+export interface ConversationScrollPosition {
+  scrollTop: number;
+  anchorMessageId?: string;
+  anchorOffset?: number;
+}
+
+interface ActiveConversationScroller {
+  conversationId: string;
+  element: HTMLElement;
+}
+
+const STORAGE_KEY = "omnigent:conversation-scroll-positions:v2";
+
+function loadPositions(): Map<string, ConversationScrollPosition> {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<
+      string,
+      ConversationScrollPosition
+    >;
+    return new Map(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, ConversationScrollPosition] =>
+          typeof entry[1]?.scrollTop === "number",
+      ),
+    );
+  } catch {
+    return new Map();
+  }
+}
+
+function persistPositions(positions: Map<string, ConversationScrollPosition>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(Object.fromEntries(positions)));
+  } catch {
+    // Scroll restoration remains available in memory when storage is unavailable.
+  }
+}
+
+const positions = loadPositions();
+let activeScroller: ActiveConversationScroller | null = null;
+
+function naturalTop(element: HTMLElement): number {
+  let top = 0;
+  let current: HTMLElement | null = element;
+  while (current) {
+    top += current.offsetTop;
+    current = current.offsetParent as HTMLElement | null;
+  }
+  return top;
+}
+
+function readElementPosition(element: HTMLElement): ConversationScrollPosition {
+  const messages = Array.from(
+    element.querySelectorAll<HTMLElement>('[data-role="user"][data-user-message-id]'),
+  );
+  const viewportTop = naturalTop(element) + element.scrollTop;
+  let anchor: HTMLElement | undefined;
+  let anchorTop = Number.NEGATIVE_INFINITY;
+  for (const message of messages) {
+    const top = naturalTop(message);
+    if (top <= viewportTop + 1 && top > anchorTop) {
+      anchor = message;
+      anchorTop = top;
+    }
+  }
+  if (!anchor && messages.length > 0) {
+    anchor = messages.reduce((nearest, message) =>
+      naturalTop(message) < naturalTop(nearest) ? message : nearest,
+    );
+    anchorTop = naturalTop(anchor);
+  }
+  return anchor
+    ? {
+        scrollTop: element.scrollTop,
+        anchorMessageId: anchor.dataset.userMessageId,
+        anchorOffset: anchorTop - viewportTop,
+      }
+    : { scrollTop: element.scrollTop };
+}
+
+export function saveConversationScrollPosition(conversationId: string, element: HTMLElement): void {
+  const position = readElementPosition(element);
+  positions.set(conversationId, position);
+  persistPositions(positions);
+}
+
+export function getConversationScrollPosition(
+  conversationId: string,
+): ConversationScrollPosition | undefined {
+  return positions.get(conversationId);
+}
+
+function restorationTarget(
+  element: HTMLElement,
+  position: ConversationScrollPosition,
+): { target: number; anchorFound: boolean } {
+  const anchor =
+    position.anchorMessageId === undefined
+      ? undefined
+      : Array.from(
+          element.querySelectorAll<HTMLElement>('[data-role="user"][data-user-message-id]'),
+        ).find((message) => message.dataset.userMessageId === position.anchorMessageId);
+  const anchorTarget =
+    anchor && position.anchorOffset !== undefined
+      ? naturalTop(anchor) - naturalTop(element) - position.anchorOffset
+      : undefined;
+  const maxScrollTop = Math.max(0, element.scrollHeight - element.clientHeight);
+  const target =
+    anchorTarget !== undefined && anchorTarget >= 0 && anchorTarget <= maxScrollTop + 1
+      ? anchorTarget
+      : Math.min(Math.max(0, position.scrollTop), maxScrollTop);
+  return { target, anchorFound: anchor !== undefined };
+}
+
+export function restoreConversationScrollPosition(
+  element: HTMLElement,
+  position: ConversationScrollPosition,
+): boolean {
+  const { target, anchorFound } = restorationTarget(element, position);
+  element.scrollTop = target;
+  return position.anchorMessageId === undefined || anchorFound;
+}
+
+export function isConversationScrollPositionRestored(
+  element: HTMLElement,
+  position: ConversationScrollPosition,
+): boolean {
+  const { target, anchorFound } = restorationTarget(element, position);
+  if (position.anchorMessageId !== undefined && !anchorFound) return false;
+  return Math.abs(element.scrollTop - target) <= 1;
+}
+
+export function registerActiveConversationScroller(
+  conversationId: string,
+  element: HTMLElement,
+): () => void {
+  const registration = { conversationId, element };
+  activeScroller = registration;
+  return () => {
+    if (activeScroller === registration) {
+      activeScroller = null;
+    }
+  };
+}
+
+/**
+ * Capture immediately before chatStore changes its active conversation.
+ *
+ * The expected id prevents a URL/store render race from saving the shared DOM
+ * element under a session whose messages have not rendered yet.
+ */
+export function captureActiveConversationScroll(
+  expectedConversationId: string | null,
+): void {
+  if (!activeScroller || activeScroller.conversationId !== expectedConversationId) {
+    return;
+  }
+  saveConversationScrollPosition(activeScroller.conversationId, activeScroller.element);
+}

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -820,6 +820,7 @@ export interface GetSessionSlimOptions {
    * refresh pierces stale server-side capability caches.
    */
   refreshState?: boolean;
+  signal?: AbortSignal;
 }
 
 export async function getSessionSlim(
@@ -833,6 +834,7 @@ export async function getSessionSlim(
   if (options.refreshState === true) params.set("refresh_state", "true");
   const res = await authenticatedFetch(
     `/v1/sessions/${encodeURIComponent(sessionId)}?${params.toString()}`,
+    { signal: options.signal },
   );
   return sessionFromWire(await readJsonOrThrow<SessionResponseWire>(res));
 }
@@ -860,13 +862,18 @@ export interface SessionItemsPage {
  */
 export async function fetchSessionItemsPage(
   sessionId: string,
-  { olderThan, limit = SESSION_HISTORY_PAGE_SIZE }: { olderThan?: string; limit?: number } = {},
+  {
+    olderThan,
+    limit = SESSION_HISTORY_PAGE_SIZE,
+    signal,
+  }: { olderThan?: string; limit?: number; signal?: AbortSignal } = {},
 ): Promise<SessionItemsPage> {
   const params = new URLSearchParams({ limit: String(limit), order: "desc" });
   // "Older than the cursor" within a descending scan = items after it.
   if (olderThan) params.set("after", olderThan);
   const res = await authenticatedFetch(
     `/v1/sessions/${encodeURIComponent(sessionId)}/items?${params}`,
+    { signal },
   );
   const page = await readJsonOrThrow<SessionItemsResponseWire>(res);
   // Server returns newest-first; reverse to chronological for rendering.

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -11,6 +11,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import {
   ArrowUpIcon,
@@ -37,6 +38,19 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { userColor, userColorTint, userInitials } from "@/lib/userBadge";
 import { useNavigate, useParams } from "@/lib/routing";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
+import {
+  captureActiveConversationScroll,
+  getConversationScrollPosition,
+  isConversationScrollPositionRestored,
+  registerActiveConversationScroller,
+  restoreConversationScrollPosition,
+  saveConversationScrollPosition,
+} from "@/lib/conversationScrollPositions";
+import {
+  DEFAULT_BOTTOM_LOCK_ENABLED,
+  readBottomLockEnabled,
+  subscribeBottomLockEnabled,
+} from "@/lib/bottomLockPreferences";
 import {
   Conversation,
   ConversationContent,
@@ -785,6 +799,7 @@ export function ChatPage() {
   // intentionally don't await it here. The store's `loadingConversation` flag
   // drives the loading UI below; `conversationLoadError` drives the error UI.
   useEffect(() => {
+    captureActiveConversationScroll(useChatStore.getState().conversationId);
     void useChatStore.getState().switchTo(urlConvId ?? null);
   }, [urlConvId]);
 
@@ -829,6 +844,7 @@ export function ChatPage() {
   // Subscribe to the bits of store state we render. Each is a
   // primitive selector so re-renders fire only when that specific
   // field changes — no `useShallow` needed.
+  const activeConversationId = useChatStore((s) => s.conversationId);
   const blocks = useChatStore((s) => s.blocks);
   const pendingUserMessages = useChatStore((s) => s.pendingUserMessages);
   const activeResponse = useChatStore((s) => s.activeResponse);
@@ -1365,7 +1381,9 @@ export function ChatPage() {
 
   const mainAgent = (
     <MainAgentSurface
-      conversationId={urlConvId ?? null}
+      // The URL leads the projected chat store by one render. Pair the scroll
+      // cache with the store id so its key changes in the same commit as bubbles.
+      conversationId={activeConversationId}
       bubbles={bubbles}
       status={status}
       isWorking={isWorking}
@@ -1999,6 +2017,11 @@ function MainAgentSurface({
     };
   }, [scroller]);
   const [sendScrollNonce, setSendScrollNonce] = useState(0);
+  const bottomLockEnabled = useSyncExternalStore(
+    subscribeBottomLockEnabled,
+    readBottomLockEnabled,
+    () => DEFAULT_BOTTOM_LOCK_ENABLED,
+  );
   const handleSend = useCallback(
     (text: string, files?: File[]) => {
       setSendScrollNonce((n) => n + 1);
@@ -2148,8 +2171,10 @@ function MainAgentSurface({
                 )}
               >
                 {/* Scroll helpers — must live inside StickToBottom to access context. */}
-                <ScrollToBottomOnSend nonce={sendScrollNonce} />
-                <KeepBottomOnViewportResize />
+                <BottomLockController enabled={bottomLockEnabled} />
+                <ScrollToBottomOnSend nonce={sendScrollNonce} enabled={bottomLockEnabled} />
+                <ReleaseBottomLockOnResponseEnd status={status} enabled={bottomLockEnabled} />
+                {bottomLockEnabled && <KeepBottomOnViewportResize />}
                 <ConversationScrollRefBridge onScroller={setScroller} />
                 <HistoryAutoLoader scrollElement={scroller?.el ?? null} />
                 {bubbles.length === 0 && !showWorkingIndicator && !mcpStartupActive ? (
@@ -2260,6 +2285,7 @@ function MainAgentSurface({
             accordion pinned above, this container already starts below the
             header, so the track drops its header-clearing top inset. */}
             <TranscriptScrollbar scroller={scroller} topInset={hasTasks ? 12 : undefined} />
+            <ConversationScrollPosition conversationId={conversationId} scroller={scroller} />
             {/* Hover the top edge to reveal a pill that loads all older history and
             scrolls to the first message. Rendered here (a wrapper sibling of
             Conversation) rather than inside it so it escapes the chat-scroll-fade
@@ -2414,19 +2440,183 @@ function UserMessageNavConnected(props: React.ComponentProps<typeof UserMessageN
 }
 
 /**
- * Forces the conversation back to the bottom when this client submits a
- * new message. StickToBottom intentionally respects a user who has scrolled
- * up while streaming, but an explicit send should bring the fresh user bubble
- * and ensuing response back into view.
+ * Keeps the library's implicit bottom lock released when automatic following
+ * is disabled. The scroll listener runs after the library's own listener, so
+ * reaching the bottom naturally does not silently re-arm the lock.
  */
-function ScrollToBottomOnSend({ nonce }: { nonce: number }) {
+export function BottomLockController({ enabled }: { enabled: boolean }) {
+  const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
+    scrollRef?: React.RefObject<HTMLElement>;
+    contentRef?: React.RefObject<HTMLElement>;
+    state: { isAtBottom: boolean; escapedFromLock: boolean };
+    stopScroll: () => void;
+  };
+  const scrollRef = ctx.scrollRef;
+  const contentRef = ctx.contentRef;
+  const state = ctx.state;
+  const stopScroll = ctx.stopScroll;
+
+  useLayoutEffect(() => {
+    if (enabled) return;
+    const scrollElement = scrollRef?.current;
+    const release = () => {
+      stopScroll();
+      state.isAtBottom = false;
+      state.escapedFromLock = true;
+    };
+    release();
+    if (!scrollElement) return;
+
+    scrollElement.addEventListener("scroll", release, { passive: true });
+    const observer =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(() => release());
+    const contentElement = contentRef?.current;
+    if (contentElement) observer?.observe(contentElement);
+    return () => {
+      scrollElement.removeEventListener("scroll", release);
+      observer?.disconnect();
+    };
+  }, [contentRef, enabled, scrollRef, state, stopScroll]);
+
+  return null;
+}
+
+/** Optionally jumps to and follows the response after a local send. */
+function ScrollToBottomOnSend({ nonce, enabled }: { nonce: number; enabled: boolean }) {
   const { scrollToBottom } = useStickToBottomContext();
 
   useLayoutEffect(() => {
-    if (nonce === 0) return;
+    if (!enabled || nonce === 0) return;
     scrollToBottom("instant");
     requestAnimationFrame(() => scrollToBottom("instant"));
-  }, [nonce, scrollToBottom]);
+  }, [enabled, nonce, scrollToBottom]);
+
+  return null;
+}
+
+/**
+ * Preserves each transcript's reading position while switching sessions.
+ *
+ * Session hydration temporarily unmounts the conversation, and StickToBottom
+ * initializes every mount at the end. A user-message anchor and its viewport
+ * offset restore the same visible turn even when transcript height changes.
+ */
+export function ConversationScrollPosition({
+  conversationId,
+  scroller,
+}: {
+  conversationId: string | null;
+  scroller: ConversationScroller | null;
+}) {
+  const scrollElement = scroller?.el ?? null;
+  const scrollState = scroller?.state ?? null;
+  const stopScroll = scroller?.stopScroll ?? null;
+
+  useLayoutEffect(() => {
+    const el = scrollElement;
+    if (!el || !conversationId || !scrollState || !stopScroll) return;
+    const unregister = registerActiveConversationScroller(conversationId, el);
+    const saved = getConversationScrollPosition(conversationId);
+    let restoring = saved !== undefined;
+    let frame = 0;
+
+    const persist = () => saveConversationScrollPosition(conversationId, el);
+    const onScroll = () => {
+      if (!restoring) persist();
+    };
+    const settleForUser = () => {
+      restoring = false;
+      cancelAnimationFrame(frame);
+      persist();
+    };
+
+    el.addEventListener("scroll", onScroll, { passive: true });
+    for (const event of ["wheel", "touchstart", "pointerdown"] as const) {
+      el.addEventListener(event, settleForUser, { passive: true });
+    }
+
+    if (saved) {
+      stopScroll();
+      scrollState.isAtBottom = false;
+      scrollState.escapedFromLock = true;
+      const deadline = performance.now() + 2_000;
+      let quietSince = performance.now();
+      let lastScrollHeight = el.scrollHeight;
+      const restore = () => {
+        const now = performance.now();
+        const wasRestored = isConversationScrollPositionRestored(el, saved);
+        restoreConversationScrollPosition(el, saved);
+        if (!wasRestored || el.scrollHeight !== lastScrollHeight) quietSince = now;
+        lastScrollHeight = el.scrollHeight;
+        const settled =
+          isConversationScrollPositionRestored(el, saved) && now - quietSince >= 150;
+        const done = settled || now >= deadline;
+        if (!done) {
+          frame = requestAnimationFrame(restore);
+          return;
+        }
+        restoreConversationScrollPosition(el, saved);
+        restoring = false;
+        persist();
+      };
+      restore();
+    }
+
+    return () => {
+      cancelAnimationFrame(frame);
+      unregister();
+      el.removeEventListener("scroll", onScroll);
+      for (const event of ["wheel", "touchstart", "pointerdown"] as const) {
+        el.removeEventListener(event, settleForUser);
+      }
+    };
+  }, [conversationId, scrollElement, scrollState, stopScroll]);
+
+  return null;
+}
+
+/** Prevent completion-time resizes from moving readers when bottom locking is disabled. */
+export function ReleaseBottomLockOnResponseEnd({
+  status,
+  enabled,
+}: {
+  status: "idle" | "streaming";
+  enabled: boolean;
+}) {
+  const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
+    scrollRef?: React.RefObject<HTMLElement>;
+    state: { isAtBottom: boolean; escapedFromLock: boolean };
+    stopScroll: () => void;
+  };
+  const previousStatusRef = useRef(status);
+
+  useLayoutEffect(() => {
+    const previousStatus = previousStatusRef.current;
+    previousStatusRef.current = status;
+    if (enabled || previousStatus !== "streaming" || status !== "idle") return;
+    const scrollElement = ctx.scrollRef?.current;
+    if (!scrollElement) return;
+    const scrollTop = scrollElement.scrollTop;
+    const physicallyAtBottom =
+      scrollElement.scrollHeight - scrollElement.clientHeight - scrollTop <= 1;
+    if (physicallyAtBottom) return;
+    const preserve = () => {
+      ctx.stopScroll();
+      ctx.state.isAtBottom = false;
+      ctx.state.escapedFromLock = true;
+      scrollElement.scrollTop = scrollTop;
+    };
+    preserve();
+    let secondFrame = 0;
+    const firstFrame = requestAnimationFrame(() => {
+      preserve();
+      secondFrame = requestAnimationFrame(preserve);
+    });
+    return () => {
+      cancelAnimationFrame(firstFrame);
+      if (secondFrame) cancelAnimationFrame(secondFrame);
+    };
+  }, [ctx.scrollRef, ctx.state, ctx.stopScroll, enabled, status]);
 
   return null;
 }

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -269,14 +269,14 @@ describe("SettingsPage", () => {
     expect(mocks.setTheme).toHaveBeenCalledWith("dark");
   });
 
-  it("keeps automatic bottom locking off by default", () => {
+  it("keeps automatic bottom locking on by default", () => {
     renderPage("/settings/appearance");
     const toggle = screen.getByTestId("bottom-lock-toggle");
 
-    expect(toggle).toHaveAttribute("aria-checked", "false");
-    fireEvent.click(toggle);
     expect(toggle).toHaveAttribute("aria-checked", "true");
-    expect(localStorage.getItem("omnigent:bottom-lock")).toBe("true");
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    expect(localStorage.getItem("omnigent:bottom-lock")).toBe("false");
   });
   it("renders the Terminal theme radiogroup with auto selected by default", () => {
     renderPage("/settings/appearance");
@@ -518,7 +518,7 @@ describe("SettingsPage", () => {
       "aria-checked",
       "false",
     );
-    expect(screen.getByTestId("bottom-lock-toggle")).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByTestId("bottom-lock-toggle")).toHaveAttribute("aria-checked", "true");
   });
 
   it("lets you clear and retype the font size without clamping mid-edit", () => {

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -269,6 +269,15 @@ describe("SettingsPage", () => {
     expect(mocks.setTheme).toHaveBeenCalledWith("dark");
   });
 
+  it("keeps automatic bottom locking off by default", () => {
+    renderPage("/settings/appearance");
+    const toggle = screen.getByTestId("bottom-lock-toggle");
+
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    expect(localStorage.getItem("omnigent:bottom-lock")).toBe("true");
+  });
   it("renders the Terminal theme radiogroup with auto selected by default", () => {
     renderPage("/settings/appearance");
     expect(screen.getByRole("radiogroup", { name: "Terminal theme" })).toBeInTheDocument();
@@ -460,6 +469,7 @@ describe("SettingsPage", () => {
     });
     fireEvent.click(screen.getByTestId("workspace-panel-default-collapsed"));
     fireEvent.click(screen.getByTestId("hide-unconfigured-harnesses-toggle"));
+    fireEvent.click(screen.getByTestId("bottom-lock-toggle"));
     fireEvent.click(screen.getByTestId("ui-font-size-inc"));
     fireEvent.click(screen.getByTestId("ui-font-size-inc"));
     fireEvent.change(screen.getByTestId("ui-font-family-input") as HTMLInputElement, {
@@ -508,6 +518,7 @@ describe("SettingsPage", () => {
       "aria-checked",
       "false",
     );
+    expect(screen.getByTestId("bottom-lock-toggle")).toHaveAttribute("aria-checked", "false");
   });
 
   it("lets you clear and retype the font size without clamping mid-edit", () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -144,6 +144,12 @@ import {
   writeHideUnconfiguredHarnesses,
 } from "@/lib/harnessVisibilityPreferences";
 import {
+  BOTTOM_LOCK_STORAGE_KEY,
+  DEFAULT_BOTTOM_LOCK_ENABLED,
+  readBottomLockEnabled,
+  writeBottomLockEnabled,
+} from "@/lib/bottomLockPreferences";
+import {
   applyThemePalette,
   DEFAULT_PALETTE,
   isThemeSelection,
@@ -823,6 +829,33 @@ function HideUnconfiguredHarnessesControl() {
   );
 }
 
+function BottomLockControl() {
+  const [enabled, setEnabled] = useState(() => readBottomLockEnabled());
+  const labelId = useId();
+  const toggle = useCallback((next: boolean) => {
+    setEnabled(next);
+    writeBottomLockEnabled(next);
+  }, []);
+  return (
+    <div className="flex items-start justify-between gap-6">
+      <div className="flex flex-col">
+        <span id={labelId} className="text-ui font-medium">
+          Keep chat pinned to bottom
+        </span>
+        <span className="text-sm text-muted-foreground">
+          Jump to the latest message when you send, then follow new response content automatically.
+        </span>
+      </div>
+      <Switch
+        aria-labelledby={labelId}
+        checked={enabled}
+        onCheckedChange={toggle}
+        data-testid="bottom-lock-toggle"
+        className="mt-0.5 shrink-0"
+      />
+    </div>
+  );
+}
 function AppearanceSection() {
   // Embedded: the host owns light/dark, so the Mode and Color theme pickers
   // would be no-ops — hide them and say so (matching ThemeModeMenu). Terminal
@@ -847,6 +880,7 @@ function AppearanceSection() {
     writeWorkspacePanelDefault(WORKSPACE_PANEL_DEFAULT);
 
     writeHideUnconfiguredHarnesses(DEFAULT_HIDE_UNCONFIGURED_HARNESSES);
+    writeBottomLockEnabled(DEFAULT_BOTTOM_LOCK_ENABLED);
 
     applyDesktopUiFontSize(UI_FONT_SIZE_DEFAULT);
     applyUiFontFamily(UI_FONT_FAMILY_DEFAULT);
@@ -870,6 +904,7 @@ function AppearanceSection() {
           "omnigent:custom-theme",
           "omnigent:default-workspace-panel",
           "omnigent:hide-unconfigured-harnesses",
+          BOTTOM_LOCK_STORAGE_KEY,
         ]) {
           window.localStorage.removeItem(key);
         }
@@ -913,6 +948,8 @@ function AppearanceSection() {
         <WorkspacePanelDefaultControl />
 
         <HideUnconfiguredHarnessesControl />
+
+        <BottomLockControl />
 
         <UiFontSizeControl />
 

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -2999,18 +2999,20 @@ async function bindStream(
 ): Promise<void> {
   racedNativeModelOptions.delete(id);
   const controller = new AbortController();
+  // Install cancellation before waiting for a stream slot. A rapid switch can
+  // then dispose this cold bind before it consumes a slot or starts snapshot
+  // requests, rather than letting superseded loads starve the final session.
+  set({ abortController: controller });
   // Take an origin-wide stream slot before opening the connection, evicting our
   // own LRU background stream to make room. A fresh tab that finds every slot
   // held by other tabs opens over budget (no slot) and raises the banner.
   await acquireStreamSlot(id);
-  if (isConversationDisposed(id)) {
+  if (controller.signal.aborted || isConversationDisposed(id)) {
     // Switched away / evicted while awaiting the slot — don't open a dead
     // entry's stream, and hand any slot we took back to the origin.
     releaseStreamSlot(id);
     return;
   }
-  set({ abortController: controller });
-
   // Opening a conversation URL with no session list loaded yet leaves the
   // session→host map empty, so the SSE stream
   // (and every host-scoped request) would open UNKEYED and route to the default
@@ -3024,7 +3026,7 @@ async function bindStream(
   // agentbricks/mas/.claude/skills/sync-omnigents/SKILL.md.
   if (getOmnigentHostConfig().fetcher && getSessionHost(id) === null) {
     try {
-      await getSessionSlim(id);
+      await getSessionSlim(id, { signal: controller.signal });
     } catch {
       // Best-effort: a failed resolve (bad id, transient) falls through to the
       // unkeyed open; the snapshot fetch surfaces the real error.
@@ -3032,7 +3034,7 @@ async function bindStream(
     // Liveness, not the visible id: a background bind must survive a switch away
     // (that is the whole feature). Only a dispose (evicted) bails — and then the
     // slot taken above has to go back to the origin.
-    if (isConversationDisposed(id)) {
+    if (controller.signal.aborted || isConversationDisposed(id)) {
       releaseStreamSlot(id);
       return;
     }
@@ -3078,13 +3080,13 @@ async function bindStream(
     const [session, page] = await Promise.all([
       queryClient.fetchQuery({
         queryKey: ["session", id],
-        queryFn: () => getSessionSlim(id, { refreshState: true }),
+        queryFn: () => getSessionSlim(id, { refreshState: true, signal: controller.signal }),
         staleTime: 0,
         retry: false,
       }),
-      fetchSessionItemsPage(id, { limit: INITIAL_WINDOW_ITEMS }),
+      fetchSessionItemsPage(id, { limit: INITIAL_WINDOW_ITEMS, signal: controller.signal }),
     ]);
-    if (isConversationDisposed(id)) return;
+    if (controller.signal.aborted || isConversationDisposed(id)) return;
     const items = page.items;
 
     // Sticky-pref handoff for CLI-created sessions with no override.
@@ -3322,7 +3324,7 @@ async function bindStream(
     }
     racedNativeModelOptions.delete(id);
   } catch (err) {
-    if (isConversationDisposed(id)) return;
+    if (controller.signal.aborted || isConversationDisposed(id)) return;
     set({
       loadingConversation: false,
       conversationLoadError: err instanceof Error ? err : new Error(String(err)),


### PR DESCRIPTION
## Related issue

N/A

## Summary

Two appearance preferences for the chat transcript:

1. **Keep chat pinned to bottom** (opt-out toggle, **enabled by default** to preserve existing behavior): When enabled, sending a message jumps to the latest content and follows the streaming response. When disabled, the `use-stick-to-bottom` library's implicit bottom lock is released so readers can scroll freely without being yanked back — including on completion-time resizes.

2. **Restore last view position across session switches**: Each conversation's scroll position is captured ahead of the store switch (`captureActiveConversationScroll` in the `urlConvId` effect) and restored on return, anchored to the user message that was at the top of the viewport so it survives transcript height changes during hydration. A generation-guarded `requestAnimationFrame` loop re-targets until the transcript height settles (150ms quiet window, 7s deadline). Wheel, touch, pointer, **and keyboard** input take over immediately — matching the takeover semantics #6643 added for the files-panel restore.

This is useful for people whose habit is to send a message while reading the AI response and stay focused.

### How it works

**Bottom lock toggle** — `BottomLockController` releases the library's bottom lock (sets `escapedFromLock = true` on every scroll/content resize) when the toggle is off. `ScrollToBottomOnSend` only jumps to the bottom on send when the toggle is on, and re-arms following via `followConversationBottom`. `ReleaseBottomLockOnResponseEnd` preserves the reader's scroll position through final response layout resizes when the toggle is off. `KeepBottomOnViewportResize` (only mounted when on) keeps bottom-locked readers pinned during composer height changes.

**Scroll position restore** — `ConversationScrollPosition` registers the active scroller per conversation; ChatPage captures the reading position just before the store switches conversations, then restores it on mount via an rAF loop that re-targets the anchored user-message position until layout settles. Restores are mode-guarded (`conversationScrollState`) so a user gesture during the loop wins. Sessions with no saved position initialize at the bottom.

### Files

- `web/src/lib/bottomLockPreferences.ts` — localStorage toggle (read/write/subscribe via custom events)
- `web/src/lib/conversationScrollPositions.ts` — per-conversation scroll save/restore with user-message anchoring + restore-target resolution
- `web/src/lib/conversationScrollState.ts` — per-element scroll ownership state machine (following-bottom / restore-pending / restoring / user-controlled)
- `web/src/components/chat/chatBubbleParts.tsx` — `BottomLockController`, `ScrollToBottomOnSend` (now gated), `ReleaseBottomLockOnResponseEnd`, `ConversationScrollPosition`
- `web/src/components/chat/Transcript.tsx` — mounts the controllers inside/outside the StickToBottom subtree
- `web/src/pages/ChatPage.tsx` — bottom-lock-aware send scroll (`prepareSendScroll`) + capture-on-switch
- `web/src/pages/SettingsPage.tsx` — "Keep chat pinned to bottom" Switch in Appearance, included in reset-to-defaults

## Test Plan

- `npx tsc -b --noEmit` — passes (zero type errors)
- `npx vitest run src/pages/ChatPage.historyLoad.test.tsx src/lib/conversationScrollPositions.test.ts src/lib/bottomLockPreferences.test.ts src/pages/SettingsPage.test.tsx` — 116 tests pass
- `npx vitest run src/pages/ChatPage.*` — 548 tests pass (no regressions)
- Full web suite: green except pre-existing `NewChatDialog` failures (reproduce on pristine `main`)

## Demo

N/A (can record a clip if useful)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the preference modules (`bottomLockPreferences.test.ts`, `conversationScrollPositions.test.ts`), the four scroll controllers (`ChatPage.historyLoad.test.tsx`), the Settings toggle default, and the reset-to-defaults path (`SettingsPage.test.tsx`). Manual verification: toggle off → scroll mid-transcript → switch sessions and back restores the position; sending while reading history does not yank the view; streaming does not re-pin.

## Changelog

Keep chat pinned to bottom is now an opt-out appearance preference (on by default), and each conversation remembers its scroll position when you switch away and back.
