### PR TITLE
perf(runtime): stop pulling the server router into every client import

### DIFF
--- a/omnigent/runtime/caps.py
+++ b/omnigent/runtime/caps.py
@@ -13,13 +13,6 @@ if TYPE_CHECKING:
     from omnigent.spec.types import LLMConfig, PolicySpec
 
 
-def _default_routing_settings() -> RoutingSettings:
-    """Build the default :class:`RoutingSettings` (imported lazily)."""
-    from omnigent.server.smart_routing import RoutingSettings
-
-    return RoutingSettings()
-
-
 @dataclass
 class RuntimeCaps:
     """
@@ -108,6 +101,9 @@ class RuntimeCaps:
     routing_backends: RoutingBackends | None = None
     # Routing knobs parsed from the ``routing:`` block of the server --config
     # YAML (router name, extraction model, scenario menus, subagent fail mode).
-    # Always present so consumers read one value object instead of re-parsing
-    # config; the defaults describe an unconfigured deployment.
-    routing_settings: RoutingSettings = field(default_factory=_default_routing_settings)
+    # ``None`` describes an unconfigured deployment: read it through
+    # ``smart_routing.routing_settings(caps)``, which substitutes the defaults.
+    # Not defaulted to a ``RoutingSettings()`` because building one drags
+    # omnigent.server.smart_routing into every CLI client that imports the
+    # runtime.
+    routing_settings: RoutingSettings | None = None


### PR DESCRIPTION
## Related issue

Closes #

<!-- Refactor / chore: no issue required. -->

## Summary

`RuntimeCaps.routing_settings` defaulted to
`field(default_factory=_default_routing_settings)`, and that factory imports
`omnigent.server.smart_routing`. Because `runtime/_globals.py` builds a
module-level `RuntimeCaps()`, the factory ran on **every**
`import omnigent.runtime` — so any CLI client that touched the runtime paid for
the server's routing stack before doing any work:

```
import omnigent.runtime
  -> runtime/_globals.py:39   _caps: RuntimeCaps = RuntimeCaps()
     -> runtime/caps.py:18    from omnigent.server.smart_routing import RoutingSettings
        -> omnigent.model_fallbacks -> onboarding.provider_config -> spec.parser
```

- Default the field to `None` instead. Every read already goes through
  `smart_routing.routing_settings(caps)`, which substitutes `RoutingSettings()`
  for anything that is not a `RoutingSettings` — so an unconfigured deployment
  resolves the same defaults, just at first use instead of at import.
- Nothing reads `caps.routing_settings` directly (verified across `omnigent/`
  and `tests/`; the only other mention is a docstring reference), so the
  accessor is the single choke point.
- Drops the now-unused `_default_routing_settings` factory.

**ELI5:** a client asking "what are my runtime limits?" was accidentally booting
the server's model-routing machinery to fill in a default nobody had configured.
Now that default is filled in when something actually reads it.

## Test Plan

`import omnigent.runtime`, best of 7 runs, warm bytecode cache:

| | before | after |
|---|---|---|
| `import omnigent.runtime` | 0.23s | **0.04s** (-190ms, -83%) |

`omnigent.server.smart_routing` no longer appears in `sys.modules` after
`import omnigent.runtime` (was present before).

```bash
# timing
python -c 'import omnigent.runtime'

# the removed edge
python -c "import sys, omnigent.runtime; \
  print('smart_routing' , 'omnigent.server.smart_routing' in sys.modules)"

# suites covering caps + every routing read path
pytest tests/runtime/test_caps.py tests/server/test_smart_routing.py \
       tests/server/test_routing_oss_fallback.py tests/server/test_subagent_routing.py \
       tests/test_reasoning_effort.py        # 356 passed
pytest tests/server/integration/test_routing_integration.py   # 71 passed
```

## Demo

N/A — no user-visible surface change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The behavioural contract — "an unconfigured deployment sees `RoutingSettings()`
defaults" — is already covered by the 427 tests above, which exercise both the
configured and unconfigured branches of `routing_settings(caps)`. Manual
verification was the import-graph assertion (`smart_routing` absent from
`sys.modules`) and the timing measurement, neither of which the existing suites
assert.

The import-cost guard is deliberately left out of this PR: the same
`sys.modules` assertion belongs with the other client/server boundary guards,
and adding it here would conflict with the sibling perf PRs that introduce them.
