### PR TITLE
perf(client-sdk): resolve the public barrel's exports lazily

### DIFF
--- a/sdks/python-client/omnigent_client/__init__.py
+++ b/sdks/python-client/omnigent_client/__init__.py
@@ -26,55 +26,171 @@ Or consume semantic blocks via :class:`BlockStream`::
         ...
 """
 
-from ._blocks import (
-    AnyBlock,
-    BlockContext,
-    CompactionBlock,
-    ErrorBlock,
-    FileBlock,
-    NativeToolBlock,
-    ReasoningBlock,
-    ReasoningChunk,
-    ReasoningStartBlock,
-    ResponseEndBlock,
-    ResponseStartBlock,
-    RetryBlock,
-    StreamBlock,
-    TextChunk,
-    TextDone,
-    ToolExecution,
-    ToolGroup,
-    ToolResultBlock,
-)
-from ._child_status import (
-    TERMINAL_TASK_STATUSES,
-    child_session_busy,
-    child_summary_busy,
-)
-from ._client import OmnigentClient
-from ._errors import OmnigentError, ToolCallDenied
-from ._events import MCP_ELICITATION_METHOD, ElicitationRequest
-from ._query import QueryResult, QueryStream
-from ._server import LocalServer
-from ._session import Session
-from ._sessions import RegisteredAgent, SessionsNamespace
-from ._sessions_chat import SessionsChat, SessionToolCallInfo, ToolCallable
-from ._stream import BlockStream, format_tool_args_brief
-from ._tool_handler import (
-    ElicitationRequestCtx,
-    StreamHooks,
-    ToolCallInfo,
-    ToolHandler,
-)
-from ._transforms import (
-    merge_text_across_iterations,
-    only_agent,
-    pipe,
-    skip_blocks,
-    skip_intermediate_ends,
-)
-from ._types import File
-from .tools import ToolMetadata, ToolState, tool
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ._blocks import (
+        AnyBlock,
+        BlockContext,
+        CompactionBlock,
+        ErrorBlock,
+        FileBlock,
+        NativeToolBlock,
+        ReasoningBlock,
+        ReasoningChunk,
+        ReasoningStartBlock,
+        ResponseEndBlock,
+        ResponseStartBlock,
+        RetryBlock,
+        StreamBlock,
+        TextChunk,
+        TextDone,
+        ToolExecution,
+        ToolGroup,
+        ToolResultBlock,
+    )
+    from ._child_status import (
+        TERMINAL_TASK_STATUSES,
+        child_session_busy,
+        child_summary_busy,
+    )
+    from ._client import OmnigentClient
+    from ._errors import OmnigentError, ToolCallDenied
+    from ._events import MCP_ELICITATION_METHOD, ElicitationRequest
+    from ._query import QueryResult, QueryStream
+    from ._server import LocalServer
+    from ._session import Session
+    from ._sessions import RegisteredAgent, SessionsNamespace
+    from ._sessions_chat import SessionsChat, SessionToolCallInfo, ToolCallable
+    from ._stream import BlockStream, format_tool_args_brief
+    from ._tool_handler import (
+        ElicitationRequestCtx,
+        StreamHooks,
+        ToolCallInfo,
+        ToolHandler,
+    )
+    from ._transforms import (
+        merge_text_across_iterations,
+        only_agent,
+        pipe,
+        skip_blocks,
+        skip_intermediate_ends,
+    )
+    from ._types import File
+    from .tools import ToolMetadata, ToolState, tool
+
+# Submodule -> the public names it provides. Resolved on first attribute
+# access so that importing one submodule (e.g. ``_http`` for a URL
+# helper) no longer builds the whole client: ``_sessions`` and ``_sse``
+# reach into ``omnigent.server.schemas``, whose Pydantic models cost
+# ~290ms to construct.
+_EXPORTS: dict[str, tuple[str, ...]] = {
+    "_blocks": (
+        "AnyBlock",
+        "BlockContext",
+        "CompactionBlock",
+        "ErrorBlock",
+        "FileBlock",
+        "NativeToolBlock",
+        "ReasoningBlock",
+        "ReasoningChunk",
+        "ReasoningStartBlock",
+        "ResponseEndBlock",
+        "ResponseStartBlock",
+        "RetryBlock",
+        "StreamBlock",
+        "TextChunk",
+        "TextDone",
+        "ToolExecution",
+        "ToolGroup",
+        "ToolResultBlock",
+    ),
+    "_child_status": (
+        "TERMINAL_TASK_STATUSES",
+        "child_session_busy",
+        "child_summary_busy",
+    ),
+    "_client": ("OmnigentClient",),
+    "_errors": (
+        "OmnigentError",
+        "ToolCallDenied",
+    ),
+    "_events": (
+        "ElicitationRequest",
+        "MCP_ELICITATION_METHOD",
+    ),
+    "_query": (
+        "QueryResult",
+        "QueryStream",
+    ),
+    "_server": ("LocalServer",),
+    "_session": ("Session",),
+    "_sessions": (
+        "RegisteredAgent",
+        "SessionsNamespace",
+    ),
+    "_sessions_chat": (
+        "SessionToolCallInfo",
+        "SessionsChat",
+        "ToolCallable",
+    ),
+    "_stream": (
+        "BlockStream",
+        "format_tool_args_brief",
+    ),
+    "_tool_handler": (
+        "ElicitationRequestCtx",
+        "StreamHooks",
+        "ToolCallInfo",
+        "ToolHandler",
+    ),
+    "_transforms": (
+        "merge_text_across_iterations",
+        "only_agent",
+        "pipe",
+        "skip_blocks",
+        "skip_intermediate_ends",
+    ),
+    "_types": ("File",),
+    "tools": (
+        "ToolMetadata",
+        "ToolState",
+        "tool",
+    ),
+}
+
+_NAME_TO_MODULE: dict[str, str] = {
+    name: module for module, names in _EXPORTS.items() for name in names
+}
+
+
+def __getattr__(name: str) -> object:
+    """
+    Import the submodule backing *name* on first access (PEP 562).
+
+    :param name: A public attribute from :data:`__all__`, e.g.
+        ``"OmnigentClient"``.
+    :returns: The requested object.
+    :raises AttributeError: If *name* is not exported.
+    """
+    module = _NAME_TO_MODULE.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    value = getattr(import_module(f".{module}", __name__), name)
+    globals()[name] = value  # cache so later reads skip __getattr__
+    return value
+
+
+def __dir__() -> list[str]:
+    """
+    List the module's public names without importing them.
+
+    :returns: Sorted :data:`__all__`.
+    """
+    return sorted(__all__)
+
 
 __all__ = [
     "MCP_ELICITATION_METHOD",

--- a/tests/frontends/sdk/test_client_lazy_exports.py
+++ b/tests/frontends/sdk/test_client_lazy_exports.py
@@ -1,0 +1,91 @@
+"""Guard: the client SDK's public barrel resolves its exports lazily.
+
+``omnigent_client/__init__.py`` re-exports 50 names from 15 submodules.
+Two of those submodules (``_sessions``, ``_sse``) import
+:mod:`omnigent.server.schemas`, whose Pydantic models cost ~290ms to
+build. Because importing any submodule first executes the package
+``__init__``, an eager barrel made ``from omnigent_client._http import
+is_loopback_url`` — a URL helper used on the CLI launch path — pay for
+the entire client plus the server's schemas.
+
+These tests pin both halves of the contract: the lazy barrel exposes
+exactly what the eager one did, and importing a light submodule stays
+light.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+import omnigent_client
+
+# Importing this submodule must not drag in the heavy graph below it.
+_LIGHT_SUBMODULE = "omnigent_client._http"
+_MUST_NOT_LOAD = (
+    "fastapi",
+    "omnigent.server.schemas",
+    "omnigent_client._client",
+    "omnigent_client._sessions",
+    "omnigent_client._sse",
+    "pydantic",
+)
+
+
+def _import_in_fresh_interpreter(statement: str, report: str) -> str:
+    """
+    Run *statement* in a clean interpreter and echo *report*.
+
+    A subprocess is used rather than :mod:`importlib` so the assertion
+    sees a pristine ``sys.modules`` — an earlier test in the same
+    session may already have imported the heavy graph.
+
+    :param statement: Code to execute first, e.g. ``"import x"``.
+    :param report: Expression whose ``print`` output is returned.
+    :returns: The subprocess's stripped stdout.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", f"{statement}\nimport sys\nprint({report})"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout.strip()
+
+
+def test_importing_a_light_submodule_does_not_load_the_server_schemas() -> None:
+    """The CLI's URL-helper import must not build the whole client."""
+    loaded = _import_in_fresh_interpreter(
+        f"from {_LIGHT_SUBMODULE} import is_loopback_url",
+        f"sorted(m for m in {_MUST_NOT_LOAD!r} if m in sys.modules)",
+    )
+    assert loaded == "[]", f"{_LIGHT_SUBMODULE} pulled in heavy modules: {loaded}"
+
+
+def test_every_exported_name_resolves() -> None:
+    """``__getattr__`` must cover all of ``__all__`` — no dead exports."""
+    unresolvable = [name for name in omnigent_client.__all__ if not hasattr(omnigent_client, name)]
+    assert unresolvable == []
+
+
+def test_export_table_matches_all() -> None:
+    """The submodule table and ``__all__`` must not drift apart."""
+    mapped = {name for names in omnigent_client._EXPORTS.values() for name in names}
+    assert mapped == set(omnigent_client.__all__)
+    # A one-name group written without its trailing comma would be a
+    # plain string here, and would iterate as characters.
+    non_tuples = [mod for mod, names in omnigent_client._EXPORTS.items() if not isinstance(names, tuple)]
+    assert non_tuples == []
+
+
+def test_dir_lists_the_public_surface() -> None:
+    """``dir()`` stays useful without importing every submodule."""
+    assert dir(omnigent_client) == sorted(omnigent_client.__all__)
+
+
+def test_unknown_attribute_still_raises() -> None:
+    """A typo must not silently return ``None``."""
+    with pytest.raises(AttributeError, match="no attribute 'NoSuchExport'"):
+        omnigent_client.NoSuchExport  # noqa: B018


### PR DESCRIPTION
## Related issue

Closes #

<!-- Refactor / chore: no issue required. -->

## Summary

`omnigent_client/__init__.py` eagerly re-exported 50 names from 15 submodules.
Two of them — `_sessions` and `_sse` — import `omnigent.server.schemas`, and
building that module's Pydantic discriminated unions costs ~290ms. Because
importing *any* submodule first executes the package `__init__`, the CLI's
`from omnigent_client._http import is_loopback_url` (a loopback URL check in
`claude_native.py`) paid for the entire client **and** the server's schema layer
before launching a harness:

```
from omnigent_client._http import is_loopback_url   # wanted: one URL helper
  -> omnigent_client/__init__.py:54  from ._client import OmnigentClient
     -> _client.py:17               from ._sessions import SessionsNamespace
        -> _sessions.py:34          from omnigent.server.schemas import ServerStreamEvent   # ~290ms
```

- Resolve the re-exports through a PEP 562 `__getattr__`. The submodule table is
  **generated from the previous eager import block**, so the public surface is
  unchanged: `from omnigent_client import OmnigentClient` and
  `from omnigent_client import *` still yield the same 50 names, `dir()` lists
  them without importing anything, and an unknown name still raises
  `AttributeError`.
- Resolved values are cached in `globals()`, so only the first read pays the
  lookup.
- The eager block is kept under `TYPE_CHECKING`, so pyrefly and IDEs resolve the
  names exactly as before.

**ELI5:** the client's front door imported every room in the house. Now it opens
only the room you asked for — and the CLI, which just wanted a doorknob, no
longer boots the server's schema layer.

## Test Plan

Best of 5 runs, warm bytecode cache:

| | before | after |
|---|---|---|
| `import omnigent.claude_native` | 0.72s | **0.60s** (-120ms) |
| modules loaded by `import omnigent_client._http` | ~500 | **80** |

`omnigent.server.schemas`, `fastapi`, and `pydantic` are no longer in
`sys.modules` after importing `omnigent_client._http`.

```bash
python -c "import sys; from omnigent_client._http import is_loopback_url; \
  print('server.schemas', 'omnigent.server.schemas' in sys.modules, len(sys.modules))"

pytest tests/frontends/sdk/test_client_lazy_exports.py   # 5 passed (new)
pytest tests/frontends                                   # 581 passed
pytest tests/repl tests/deploy tests/cli                 # 1601 passed
```

The new guard was verified to **fail** against the old eager barrel, so the
boundary cannot silently regress:

```
AssertionError: omnigent_client._http pulled in heavy modules:
  ['omnigent.server.schemas', 'omnigent_client._client',
   'omnigent_client._sessions', 'omnigent_client._sse', 'pydantic']
```

## Demo

N/A — no user-visible surface change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`tests/frontends/sdk/test_client_lazy_exports.py` pins both halves of the
contract: the lazy barrel exports exactly what the eager one did (name set,
`__all__`/table agreement, `dir()`, `AttributeError` on typos), and importing a
light submodule stays light. The export table is asserted to contain only
tuples — a one-name group written without its trailing comma would be a plain
string and would iterate as characters, which is the one way this
transformation can go subtly wrong.

Manual verification: `from omnigent_client import *` yields the same 50 names as
before, and the timing/`sys.modules` measurements above.
