### PR TITLE
perf(sandbox): import httpx only when a sandbox probe runs

### DIFF
--- a/omnigent/onboarding/sandboxes/bootstrap.py
+++ b/omnigent/onboarding/sandboxes/bootstrap.py
@@ -41,10 +41,11 @@ from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 
 import click
-import httpx
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+    import httpx
 
     from omnigent.onboarding.sandboxes.base import RemoteProcess, SandboxLauncher
 
@@ -333,6 +334,8 @@ def _probe_server(server_url: str) -> httpx.Response | None:
         unreachable — the caller treats that as "shape unknown" and
         lets the in-sandbox login surface the real connectivity error.
     """
+    import httpx
+
     try:
         return httpx.get(f"{server_url}/v1/me", timeout=10.0)
     except httpx.HTTPError:
@@ -375,6 +378,8 @@ def _workspace_org_id(workspace_host: str) -> str | None:
     :returns: The id, e.g. ``"4168070633950167"``, or ``None`` when
         the header is absent or the workspace is unreachable.
     """
+    import httpx
+
     try:
         response = httpx.get(f"{workspace_host}/login.html", timeout=10.0)
     except httpx.HTTPError:

--- a/tests/cli/test_startup_import_graph.py
+++ b/tests/cli/test_startup_import_graph.py
@@ -1,0 +1,46 @@
+"""Guard: the CLI startup import graph stays free of avoidable weight.
+
+Every `omnigent` invocation pays for `omnigent.cli`'s module graph before
+Click dispatches, so a heavy import on that path is a tax on `--version`,
+`--help`, and tab-completion alike. `httpx` costs ~40ms to import and is
+reached only by two sandbox-bootstrap probe helpers that run when a user
+actually provisions a remote sandbox.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+# Reached only from `_probe_server` / `_workspace_org_id`, both of which
+# import it at call time.
+_MUST_NOT_LOAD = ("httpx",)
+
+
+def test_cli_import_does_not_load_httpx() -> None:
+    """Importing the CLI must not build an HTTP client stack."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from omnigent.cli import main\nimport sys\n"
+            f"print(sorted(m for m in {_MUST_NOT_LOAD!r} if m in sys.modules))",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert proc.stdout.strip() == "[]", f"omnigent.cli pulled in: {proc.stdout.strip()}"
+
+
+def test_sandbox_probes_still_reach_httpx() -> None:
+    """The deferred import must actually resolve when a probe runs.
+
+    An unreachable host exercises the ``except httpx.HTTPError`` branch,
+    which is where a missing module-level import would surface as a
+    ``NameError`` rather than a clean ``None``.
+    """
+    from omnigent.onboarding.sandboxes.bootstrap import _probe_server, _workspace_org_id
+
+    assert _probe_server("http://127.0.0.1:1") is None
+    assert _workspace_org_id("http://127.0.0.1:1") is None


### PR DESCRIPTION
## Related issue

Closes #

<!-- Refactor / chore: no issue required. -->

## Summary

`onboarding/sandboxes/bootstrap.py` imported `httpx` at module scope, and
`omnigent.cli` reaches that module while registering the `sandbox` command
group. So **every** `omnigent` invocation — `--version`, `--help`,
tab-completion — built httpx's client stack (~40ms, and it drags in `ssl`,
`urllib.request`, and httpx's own Click-based `_main`):

```
from omnigent.cli import main
  -> cli.py:50            from omnigent.cli_sandbox import sandbox
     -> onboarding.sandboxes -> bootstrap.py:44   import httpx      # ~40ms
```

Only two helpers use it — `_probe_server` and `_workspace_org_id`, both
unauthenticated GETs that run when a user provisions a remote sandbox.

- Move the import into those two functions.
- Keep the `httpx.Response` return annotation resolving via `TYPE_CHECKING`
  (the module already has `from __future__ import annotations`).

**ELI5:** every `omnigent --version` was loading an HTTP client for two network
probes that only run when you spin up a remote sandbox.

## Test Plan

Best of 5 runs, warm bytecode cache:

| | before | after |
|---|---|---|
| `from omnigent.cli import main` | 0.32s | **0.28s** (-35ms) |

`httpx` is no longer in `sys.modules` after importing the CLI.

```bash
python -c "import sys; from omnigent.cli import main; print('httpx', 'httpx' in sys.modules)"

pytest tests/cli/test_startup_import_graph.py       # 2 passed (new)
pytest tests/cli tests/sandbox tests/onboarding     # 2244 passed
```

Both probes were exercised end-to-end against a live local HTTP server and an
unreachable host, confirming the deferred import resolves on both branches:

```
_probe_server(unreachable)  -> None
_workspace_org_id(unreach)  -> None
_probe_server(live)         -> httpx.Response 200
_workspace_org_id(live)     -> 4168070633950167
```

## Demo

N/A — no user-visible surface change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`tests/cli/test_startup_import_graph.py` covers both halves: the CLI graph stays
httpx-free, and the probes still resolve the deferred import. The second test
deliberately hits an unreachable host so it runs the `except httpx.HTTPError`
branch — that is where a missed import surfaces as a `NameError` instead of the
documented `None`, and it is the one way this change could break silently.

Manual verification was the live-server run above (the existing suites mock
transport, so they would not catch a genuinely missing module-level import) plus
the timing measurement.
