### PR TITLE
fix(host): run the clean shutdown path on SIGTERM

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import re
+import signal
 import subprocess
 import sys
 from collections.abc import Callable, Iterator, Mapping
@@ -930,6 +931,11 @@ class HostProcess:
         # detected resume; read+cleared in run()'s reconnect handler to force a
         # prompt reconnect (skip the backoff).
         self._woke_from_suspend = False
+        # Set by a shutdown signal (see _request_shutdown): the flag stops
+        # run()'s loop reconnecting, the event cuts short a backoff sleep so a
+        # SIGTERM mid-backoff doesn't wait it out.
+        self._shutdown_requested = False
+        self._shutdown_event: asyncio.Event | None = None
 
     def _tracked_runner_pids(self) -> set[int]:
         """PIDs of runners this host spawned and still tracks directly.
@@ -2691,7 +2697,9 @@ class HostProcess:
 
         Connects to the server, sends hello, and enters the
         receive loop. Reconnects with exponential backoff on
-        disconnect. Ctrl-C / SIGTERM exit cleanly.
+        disconnect. Ctrl-C / SIGTERM exit cleanly — see
+        :meth:`_install_shutdown_signal_handlers` for why SIGTERM needs
+        a handler to get there.
 
         :returns: None. Runs until the process is terminated.
         :raises HostConnectError: On a permanent failure — auth /
@@ -2702,6 +2710,11 @@ class HostProcess:
         # them once during daemon initialization. They are advisory: a broken
         # harness is reported as unknown and must not prevent registration.
         await self._initialize_capabilities()
+
+        # Route SIGTERM into the same clean shutdown Ctrl-C takes, so the
+        # cleanup in this method's finally block runs for a backgrounded
+        # daemon too.
+        self._install_shutdown_signal_handlers()
 
         # Reap orphaned harness/tool grandchildren that reparent here when a
         # runner dies (this host is PID 1 in a container, or a subreaper
@@ -2730,6 +2743,8 @@ class HostProcess:
         backoff = _RECONNECT_BASE_S
         try:
             while True:
+                if self._shutdown_requested:
+                    break
                 try:
                     await self._connect_and_serve()
                     backoff = _RECONNECT_BASE_S
@@ -2741,6 +2756,11 @@ class HostProcess:
                     # ``run_host_process`` can fail loud.
                     raise
                 except Exception as exc:
+                    if self._shutdown_requested:
+                        # We aborted this tunnel ourselves (see
+                        # _request_shutdown) — don't classify it as a
+                        # disconnect or announce a reconnect we won't make.
+                        break
                     if not isinstance(exc, InvalidURI):
                         # Any non-redirect failure (5xx bounce, network
                         # blip, mid-serve drop) breaks a login-redirect
@@ -2857,7 +2877,9 @@ class HostProcess:
                         if woke
                         else (" (recycle — prompt reconnect)" if recycle else ""),
                     )
-                    await asyncio.sleep(wait_s)
+                    await self._sleep_before_reconnect(wait_s)
+                    if self._shutdown_requested:
+                        break
                     import random
 
                     if recycle:
@@ -2903,6 +2925,78 @@ class HostProcess:
                 with contextlib.suppress(Exception):
                     self._zygote.stop()
                 self._zygote = None
+
+    def _install_shutdown_signal_handlers(self) -> None:
+        """Route SIGTERM into the clean shutdown path Ctrl-C already takes.
+
+        SIGINT arrives as ``KeyboardInterrupt``, which :meth:`run` catches on
+        its way into the cleanup that terminates tracked runners, drains
+        orphans and stops the zygote. SIGTERM has no such default: Python
+        exits where it stands, so a backgrounded daemon — the only kind
+        ``omnigent host stop`` can signal — never ran that cleanup. Its
+        runners were left to notice the dead parent themselves and hard-exit
+        after their 2s grace, skipping their own graceful drain.
+
+        Best-effort: a platform with no ``add_signal_handler`` (Windows) keeps
+        the previous behavior rather than failing daemon startup.
+
+        SIGINT is deliberately left alone: it already reaches the cleanup as
+        ``KeyboardInterrupt``, and ``omnigent host`` relies on that exception
+        to exit with the interrupt's status rather than a clean 0.
+
+        :returns: None.
+        """
+        loop = asyncio.get_running_loop()
+        self._shutdown_event = asyncio.Event()
+        with contextlib.suppress(NotImplementedError, RuntimeError, ValueError):
+            loop.add_signal_handler(signal.SIGTERM, self._request_shutdown, signal.SIGTERM)
+
+    def _request_shutdown(self, sig: signal.Signals) -> None:
+        """Unwind :meth:`run` into its cleanup after a shutdown signal.
+
+        Force-drops the live tunnel the same way :meth:`_on_resume_from_suspend`
+        does, so ``_serve_frames``' ``recv`` raises at once, and wakes any
+        reconnect backoff. :meth:`run`'s loop then sees the flag and breaks
+        instead of reconnecting, reaching the cleanup in its ``finally``.
+
+        Deliberately does not cancel ``run()``'s own task: that cleanup awaits
+        the reaper and watcher tasks, which a pending cancellation would cut
+        short. Runs synchronously on the event loop, so reading ``self._ws``
+        is atomic w.r.t. ``_serve_frames``.
+
+        With no live tunnel (a shutdown that lands mid-handshake) there is
+        nothing to abort; the loop breaks once the handshake settles, bounded
+        by its own connect timeout.
+
+        :param sig: The signal received, e.g. ``signal.SIGTERM``.
+        :returns: None.
+        """
+        if self._shutdown_requested:
+            # A second signal means the operator is impatient; the sender's own
+            # SIGKILL escalation is the backstop, so just note it.
+            _logger.info("Received %s again; shutdown already in progress", sig.name)
+            return
+        self._shutdown_requested = True
+        _logger.info("Received %s; shutting down host", sig.name)
+        if self._shutdown_event is not None:
+            self._shutdown_event.set()
+        ws = self._ws
+        transport = getattr(ws, "transport", None) if ws is not None else None
+        if transport is not None:
+            with contextlib.suppress(Exception):
+                transport.abort()
+
+    async def _sleep_before_reconnect(self, wait_s: float) -> None:
+        """Wait out the reconnect backoff, returning early on shutdown.
+
+        :param wait_s: Backoff to wait, in seconds, e.g. ``0.5``.
+        :returns: None.
+        """
+        if self._shutdown_event is None:
+            await asyncio.sleep(wait_s)
+            return
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(self._shutdown_event.wait(), timeout=wait_s)
 
     def _on_resume_from_suspend(self, gap_s: float) -> None:
         """Force-drop the tunnel after a detected wake from system suspend.

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -6,6 +6,8 @@ import asyncio
 import contextlib
 import errno
 import logging
+import os
+import signal
 import subprocess
 import threading
 import time
@@ -18,6 +20,7 @@ from websockets.datastructures import Headers
 from websockets.exceptions import ConnectionClosedError, InvalidStatus, InvalidURI
 from websockets.http11 import Response
 
+from omnigent._platform import IS_POSIX
 from omnigent.host import HOST_FATAL_EXIT_CODE
 from omnigent.host.connect import (
     HostConnectError,
@@ -4746,3 +4749,69 @@ def test_post_connect_auth_rejection_escalates_without_going_fatal(
     assert "omnigent login http://localhost:8000" in escalated
     assert "no longer a transient network blip" in escalated
     assert host._auth_retry_streak == _AUTH_REJECT_ESCALATE_ATTEMPTS
+
+
+@pytest.mark.skipif(not IS_POSIX, reason="SIGTERM handling is POSIX-only")
+async def test_sigterm_runs_the_clean_shutdown_path(tmp_path: Path) -> None:
+    """Regression: SIGTERM must reach run()'s cleanup, not kill the daemon.
+
+    ``omnigent host stop`` signals a backgrounded daemon with SIGTERM. Without
+    a handler Python exits where it stands, so the cleanup that terminates
+    tracked runners never ran and they were left to their own parent-death
+    watchdog.
+    """
+    host = _make_host_process()
+    host._zygote = None
+    serving = asyncio.Event()
+    aborted = asyncio.Event()
+    # run() force-drops the live tunnel on a shutdown signal, so stand in a
+    # connection whose transport records the abort.
+    host._ws = SimpleNamespace(  # type: ignore[assignment]
+        transport=SimpleNamespace(abort=aborted.set)
+    )
+
+    async def _hang() -> None:
+        serving.set()
+        await aborted.wait()
+        raise ConnectionClosedError(None, None)
+
+    async def _noop() -> None:
+        return None
+
+    proc = subprocess.Popen(
+        ["sleep", "60"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    host._runners["runner_sigterm"] = _RunnerHandle(proc=proc, log_path=tmp_path / "runner.log")
+
+    with (
+        patch.object(host, "_connect_and_serve", _hang),
+        patch.object(host, "_initialize_capabilities", _noop),
+        patch.object(host, "_orphan_reaper_loop", _noop),
+        patch("omnigent.host.connect.watch_for_resume", lambda _cb: _noop()),
+    ):
+        run_task = asyncio.create_task(host.run())
+        await asyncio.wait_for(serving.wait(), timeout=5.0)
+        # The handler is installed by now; sending the real signal proves the
+        # wiring rather than just the helper it calls.
+        assert host._shutdown_event is not None
+        os.kill(os.getpid(), signal.SIGTERM)
+        await asyncio.wait_for(run_task, timeout=10.0)
+
+    assert proc.poll() is not None, "SIGTERM must terminate tracked runners"
+    assert host._runners == {}
+
+
+@pytest.mark.skipif(not IS_POSIX, reason="SIGTERM handling is POSIX-only")
+async def test_shutdown_signal_cuts_short_the_reconnect_backoff(tmp_path: Path) -> None:
+    """A SIGTERM during reconnect backoff must not wait out the sleep."""
+    host = _make_host_process()
+    host._shutdown_event = asyncio.Event()
+
+    host._request_shutdown(signal.SIGTERM)
+
+    start = time.monotonic()
+    await host._sleep_before_reconnect(30.0)
+    assert time.monotonic() - start < 5.0, "backoff should return early on shutdown"
+    assert host._shutdown_requested is True


### PR DESCRIPTION
## Related issue

Closes #

<!-- Found while investigating host lifecycle; no issue was filed beforehand. -->

## Summary

`omnigent host stop` signals a backgrounded daemon with plain
`os.kill(pid, SIGTERM)`, and the daemon installed no handler for it. Python's
default disposition kills the process where it stands, so everything in
`run()`'s `finally` was skipped: tracked runners were never terminated, the
final orphan drain never ran, and the zygote's control socket was closed by
process death instead of `stop()`.

The runners did still go away — but by the fallback chain, not by design: the
daemon dies, the zygote sees EOF on its control socket and exits, each forked
runner notices `getppid()` changed and hard-exits after a 2s grace. That skips
the runner's own graceful drain. Only the foreground `omnigent host` reached the
clean path, via Ctrl-C's `KeyboardInterrupt` — despite `run()`'s docstring
promising "Ctrl-C / SIGTERM exit cleanly".

**ELI5:** the daemon had a tidy-up routine on the way out, and the one command
that stops it took a door it had never wired up.

```
before:  SIGTERM ──> process dies ──> (no cleanup)
                                       runners notice dead parent, hard-exit after 2s

after:   SIGTERM ──> handler ──> abort tunnel ──> loop breaks ──> finally:
                                                                  cancel reaper/watchers
                                                                  terminate runners (5s, then kill)
                                                                  drain orphans
                                                                  stop zygote
```

Rather than wrap the connect/serve await in a cancellable task — which routes a
`KeyboardInterrupt` raised inside a task out to the event loop and changes Ctrl-C
semantics — the handler force-drops the live tunnel exactly the way the existing
resume-from-suspend watcher does, so `_serve_frames`' `recv` raises at once. A
flag makes the reconnect loop break instead of announcing a reconnect it will not
make, and a shutdown event cuts short an in-flight backoff sleep so a SIGTERM
landing mid-backoff doesn't wait it out.

SIGINT is deliberately left alone: it already reaches the cleanup as
`KeyboardInterrupt`, and `omnigent host` relies on that exception rather than a
clean 0 exit.

## Test Plan

- `pytest tests/host/` — 392 passed, including the existing tests that stop
  `run()` by raising `KeyboardInterrupt` from `_connect_and_serve` (an earlier
  task-wrapping approach broke those; this one does not).
- Two new tests, both verified to fail on `main`:
  - `test_sigterm_runs_the_clean_shutdown_path` sends a real `SIGTERM` to the
    test process and asserts the tracked runner is terminated and `_runners`
    cleared. It asserts the handler is installed before signalling, so on
    unfixed code it fails on that assertion rather than killing pytest.
  - `test_shutdown_signal_cuts_short_the_reconnect_backoff` asserts a 30s
    backoff returns immediately once shutdown is requested.

Live verification on a real daemon (isolated `OMNIGENT_CONFIG_HOME` /
`OMNIGENT_DATA_DIR`, local server standing in as the target). The daemon is
spawned as a direct child so its exit status is observable, which is the
sharpest signal here:

| observation | `main` (72b4469d) | this branch |
| --- | --- | --- |
| exit after SIGTERM | `rc=-15` — killed *by* the signal, 0.02s | `rc=0` — handled and unwound, 0.97s |
| `Received SIGTERM; shutting down host` in the host log | no | yes |
| `finally` cleanup ran (`_cleanup_runners`, orphan drain, `zygote.stop()`) | no | yes |
| zygote gone afterwards | yes | yes |

Two honest notes on that table:

- **The zygote dies either way.** On `main` it exits on its own via
  control-socket EOF (confirmed: no surviving children at +1.5s, +5s and +10s).
  The fix changes *how* — an explicit `stop()` after the runners are terminated,
  rather than the zygote noticing its parent vanished. An earlier run of mine
  showed a survivor at +1.5s and I initially read that as a zygote leak; on
  re-run with cmdlines captured it was a transient `claude -p /model` capability
  probe, not the zygote. No leak claim here.
- **Runner termination is covered by the unit test, not by this live run.** A
  real tracked runner needs a server-driven session launch (harness + provider
  config), so the live check exercises the signal path and the cleanup entry,
  while `test_sigterm_runs_the_clean_shutdown_path` covers the runner half with
  a real `sleep 60` subprocess as the tracked runner.

The 0.97s spent unwinding is comfortably inside `_HOST_DAEMON_STOP_GRACE_S = 5.0`,
so `omnigent host stop` still returns without escalating to SIGKILL.

## Demo

N/A — no visual surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the signal wiring, the runner-termination half (real
subprocess) and the backoff wake-up; both were confirmed to fail on `main`.
Manual verification covered the live daemon: exit status, the shutdown log line,
and child lifetimes on both `main` and this branch — results in the table above,
including one initial misreading I corrected.

## Changelog

`omnigent host stop` now shuts a host daemon's runners down gracefully instead of leaving them to notice their dead parent.
