### PR TITLE
fix(cli): heal a zombie remote host daemon instead of polling it

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2523,32 +2523,44 @@ def _normalize_daemon_target(server_url: str | None) -> str:
     return _LOCAL_DAEMON_MARKER if not server_url else server_url.rstrip("/")
 
 
-def _daemon_host_online(record: _HostDaemonRecord, *, timeout_s: float = 2.0) -> bool:
+_DaemonHostState: TypeAlias = Literal["online", "offline", "unknown"]
+
+
+def _daemon_host_state(
+    record: _HostDaemonRecord,
+    *,
+    timeout_s: float = 2.0,
+) -> _DaemonHostState:
     """
-    Probe whether a daemon's host is currently online on its server.
+    Probe a daemon's host registration, separating offline from unreachable.
 
     A daemon process being alive (PID check) does not mean its WebSocket
     tunnel to the Omnigent server is up: the server only reports the host
     ``online`` while a daemon holds an authenticated tunnel and has
     heartbeated within ``HOST_LIVENESS_TTL_S``. After a server restart,
     an ungraceful daemon death, or a flapping tunnel, the daemon can be a
-    "zombie" — alive but not registered. This probe distinguishes the two
-    so reuse can heal instead of polling a zombie until timeout.
+    "zombie" — alive but not registered.
+
+    ``"unknown"`` is deliberately distinct from ``"offline"``: we could not
+    complete the probe (no host id, unreachable server, a non-200, an
+    unparseable body), which says nothing about the daemon. Only a server that
+    answers and reports a non-online status is evidence the tunnel is really
+    gone — the difference between healing a zombie and killing a healthy
+    daemon over a network blip.
 
     :param record: Daemon record to probe.
     :param timeout_s: Per-request HTTP timeout in seconds, e.g. ``2.0``.
-    :returns: ``True`` only when the server reports the record's host id
-        as ``"online"``; ``False`` if the host id is unknown, the server
-        is unreachable, or the host reports offline.
+    :returns: ``"online"`` / ``"offline"`` when the server answered,
+        ``"unknown"`` when the probe could not be completed.
     """
     from omnigent.claude_native_bridge import url_component
 
     host_id = record.host_id or _load_existing_host_id()
     if host_id is None:
-        return False
+        return "unknown"
     base_url = _daemon_base_url(record)
     if base_url is None:
-        return False
+        return "unknown"
     result = _host_http_json(
         base_url=base_url,
         method="GET",
@@ -2557,8 +2569,21 @@ def _daemon_host_online(record: _HostDaemonRecord, *, timeout_s: float = 2.0) ->
         host_id=host_id,
     )
     if result.status_code != 200 or not isinstance(result.body, dict):
-        return False
-    return result.body.get("status") == "online"
+        return "unknown"
+    return "online" if result.body.get("status") == "online" else "offline"
+
+
+def _daemon_host_online(record: _HostDaemonRecord, *, timeout_s: float = 2.0) -> bool:
+    """
+    Probe whether a daemon's host is currently online on its server.
+
+    :param record: Daemon record to probe.
+    :param timeout_s: Per-request HTTP timeout in seconds, e.g. ``2.0``.
+    :returns: ``True`` only when the server reports the record's host id
+        as ``"online"``; ``False`` if the host id is unknown, the server
+        is unreachable, or the host reports offline.
+    """
+    return _daemon_host_state(record, timeout_s=timeout_s) == "online"
 
 
 def _daemon_registry_dir() -> Path:
@@ -2811,6 +2836,38 @@ def _daemon_tunnel_recovers(
     return False
 
 
+def _daemon_host_definitely_offline(
+    record: _HostDaemonRecord,
+    *,
+    grace_s: float = _DAEMON_RECONNECT_GRACE_S,
+) -> bool:
+    """
+    Return whether the server insists a daemon's host is offline.
+
+    Like :func:`_daemon_tunnel_recovers` this polls for up to *grace_s* to let
+    a daemon mid-reconnect re-register, but it answers the stricter question:
+    did the server actually tell us the host is offline? A probe we could not
+    complete (``"unknown"``) is never evidence — it usually means *we* cannot
+    reach the server, and tearing down a healthy remote daemon over the
+    caller's own network blip would be worse than the zombie we are hunting.
+
+    :param record: Daemon record to probe.
+    :param grace_s: Seconds to keep polling for recovery, e.g. ``5.0``.
+    :returns: ``True`` only if the host never reported online during the grace
+        window and the final answer was a definite ``"offline"``.
+    """
+    state = _daemon_host_state(record)
+    if state == "online":
+        return False
+    deadline = time.monotonic() + grace_s
+    while time.monotonic() < deadline:
+        time.sleep(0.5)
+        state = _daemon_host_state(record)
+        if state == "online":
+            return False
+    return state == "offline"
+
+
 def _daemon_host_identity_changed(record: _HostDaemonRecord) -> bool:
     """
     Return whether a daemon record belongs to a different current host id.
@@ -2908,11 +2965,25 @@ def _reuse_existing_daemon_record(target: str) -> _DaemonReuseDecision:
 
     if target != _LOCAL_DAEMON_MARKER:
         # Remote / explicit ``--server`` mode: the daemon connects to a server
-        # we don't own and can't restart, so the config-signature / heal /
-        # "re-run" semantics below don't apply (auth posture is the remote's
-        # concern; its own reconnect loop covers transient tunnel drops). Keep
-        # the original PID-liveness reuse so a live daemon for the URL is
-        # reused as-is.
+        # we don't own and can't restart, so the config-signature and "re-run"
+        # semantics below don't apply — auth posture is the remote's concern.
+        #
+        # Tunnel health still does. A daemon whose tunnel is gone for good is
+        # a zombie either way: every later command waits out
+        # ``wait_for_host_online`` and fails with "did not come online", which
+        # is what made `omnigent host stop` the standing remedy. Heal it the
+        # way local mode does, with one extra guard — only on a definite
+        # "the server says offline", never on a probe we could not complete,
+        # since the daemon's own reconnect loop handles transient drops and we
+        # must not kill a healthy daemon over our own network blip.
+        age_s = time.time() - existing.started_at
+        if (
+            background
+            and age_s >= _DAEMON_REUSE_MIN_AGE_S
+            and _daemon_host_definitely_offline(existing)
+        ):
+            _terminate_host_unit(existing, reason="host tunnel is offline")
+            return _DaemonReuseDecision(reuse=False, config_changed=False)
         return _DaemonReuseDecision(reuse=True, config_changed=False)
 
     if not background:

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import itertools
 import json
 import re
 import sys
@@ -2327,3 +2328,204 @@ def test_resume_command_defaults_scheme_https(monkeypatch: pytest.MonkeyPatch) -
     assert result.exit_code == 0, result.output
     assert seen == ["https://dbc-x.cloud.databricks.com/omnigent"]
     assert captured["server"] == _expand_marker("https://dbc-x.cloud.databricks.com/omnigent")
+
+
+def _remote_record() -> cli._HostDaemonRecord:
+    """Build a background remote-target daemon record.
+
+    :returns: A ``server``-mode record carrying a log path (background-spawned).
+    """
+    return cli._HostDaemonRecord(
+        pid=4242,
+        target="https://server.example.com",
+        mode="server",
+        server_url="https://server.example.com",
+        log_path="/tmp/daemon.log",
+        started_at=1_000_000,
+        host_id="host_abc",
+        resolved_server_url=None,
+    )
+
+
+def test_daemon_host_state_distinguishes_offline_from_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A completed probe reports offline; an incomplete one reports unknown."""
+    monkeypatch.setattr(
+        cli,
+        "_host_http_json",
+        lambda **_kw: cli._HostHttpResult(status_code=200, body={"status": "offline"}),
+    )
+    assert cli._daemon_host_state(_online_record()) == "offline"
+
+    monkeypatch.setattr(
+        cli,
+        "_host_http_json",
+        lambda **_kw: cli._HostHttpResult(status_code=0, body="ConnectError: refused"),
+    )
+    assert cli._daemon_host_state(_online_record()) == "unknown"
+
+    # A 404 is not evidence either: the row may be missing because we asked
+    # with different credentials than the daemon registered under.
+    monkeypatch.setattr(
+        cli,
+        "_host_http_json",
+        lambda **_kw: cli._HostHttpResult(status_code=404, body={"detail": "host not found"}),
+    )
+    assert cli._daemon_host_state(_online_record()) == "unknown"
+
+
+def test_daemon_host_definitely_offline_only_on_a_server_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreachable server must never read as a definite offline."""
+    monkeypatch.setattr(cli.time, "sleep", lambda _s: None)
+
+    monkeypatch.setattr(cli, "_daemon_host_state", lambda record, **_kw: "offline")
+    assert cli._daemon_host_definitely_offline(_remote_record(), grace_s=0.0) is True
+
+    monkeypatch.setattr(cli, "_daemon_host_state", lambda record, **_kw: "unknown")
+    assert cli._daemon_host_definitely_offline(_remote_record(), grace_s=0.0) is False
+
+    monkeypatch.setattr(cli, "_daemon_host_state", lambda record, **_kw: "online")
+    assert cli._daemon_host_definitely_offline(_remote_record(), grace_s=0.0) is False
+
+
+def test_daemon_host_definitely_offline_waits_for_a_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A daemon that re-registers inside the grace window is not offline."""
+    monkeypatch.setattr(cli.time, "sleep", lambda _s: None)
+    states = iter(["offline", "offline", "online"])
+    monkeypatch.setattr(cli, "_daemon_host_state", lambda record, **_kw: next(states))
+
+    assert cli._daemon_host_definitely_offline(_remote_record(), grace_s=5.0) is False
+
+
+def test_ensure_host_daemon_respawns_zombie_remote_daemon(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A remote daemon the server calls offline is torn down and respawned.
+
+    Without this every later command waits out ``wait_for_host_online`` and
+    fails with "did not come online", leaving ``omnigent host stop`` as the
+    only remedy.
+    """
+    captured: dict[str, object] = {}
+    _patch_daemon_spawn(monkeypatch, tmp_path, captured)
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target="https://server.example.com",
+        mode="server",
+        server_url="https://server.example.com",
+        log_path=str(tmp_path / "daemon.log"),
+        started_at=1_000_000,
+    )
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    # Old enough to be eligible for the tunnel-health check.
+    monkeypatch.setattr(cli.time, "time", lambda: 1_000_100.0)
+    monkeypatch.setattr(cli, "_daemon_host_definitely_offline", lambda record, **_kw: True)
+    torn_down: list[str] = []
+    monkeypatch.setattr(
+        cli, "_terminate_host_unit", lambda record, *, reason: torn_down.append(reason)
+    )
+
+    _ensure_host_daemon("https://server.example.com")
+
+    assert torn_down == ["host tunnel is offline"]
+    assert "args" in captured  # a fresh daemon was spawned
+
+
+def test_ensure_host_daemon_keeps_remote_daemon_when_probe_inconclusive(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An unreachable server must not cost the user a healthy remote daemon.
+
+    The daemon has its own reconnect loop; a blip on the CLI's side is no
+    reason to tear it down.
+    """
+    captured: dict[str, object] = {}
+    _patch_daemon_spawn(monkeypatch, tmp_path, captured)
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target="https://server.example.com",
+        mode="server",
+        server_url="https://server.example.com",
+        log_path=str(tmp_path / "daemon.log"),
+        started_at=1_000_000,
+    )
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli.time, "time", lambda: 1_000_100.0)
+    monkeypatch.setattr(cli.time, "sleep", lambda _s: None)
+    # Advance the monotonic clock so the grace window elapses without waiting.
+    ticks = itertools.count(0.0, 10.0)
+    monkeypatch.setattr(cli.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(cli, "_daemon_host_state", lambda record, **_kw: "unknown")
+    torn_down: list[str] = []
+    monkeypatch.setattr(
+        cli, "_terminate_host_unit", lambda record, *, reason: torn_down.append(reason)
+    )
+
+    _ensure_host_daemon("https://server.example.com")
+
+    assert torn_down == []
+    assert "args" not in captured  # reused, not respawned
+
+
+def test_ensure_host_daemon_keeps_young_remote_daemon(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A just-spawned remote daemon is not judged before it can connect."""
+    captured: dict[str, object] = {}
+    _patch_daemon_spawn(monkeypatch, tmp_path, captured)
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target="https://server.example.com",
+        mode="server",
+        server_url="https://server.example.com",
+        log_path=str(tmp_path / "daemon.log"),
+        started_at=1_000_000,
+    )
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    # Younger than _DAEMON_REUSE_MIN_AGE_S.
+    monkeypatch.setattr(cli.time, "time", lambda: 1_000_001.0)
+
+    def _must_not_probe(record: object, **_kw: object) -> bool:
+        raise AssertionError("a young daemon must not be probed for tunnel health")
+
+    monkeypatch.setattr(cli, "_daemon_host_definitely_offline", _must_not_probe)
+
+    _ensure_host_daemon("https://server.example.com")
+
+    assert "args" not in captured  # reused, not respawned
+
+
+def test_ensure_host_daemon_keeps_foreground_remote_daemon(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A foreground ``omnigent host`` is never silently killed by the heal."""
+    captured: dict[str, object] = {}
+    _patch_daemon_spawn(monkeypatch, tmp_path, captured)
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target="https://server.example.com",
+        mode="server",
+        server_url="https://server.example.com",
+        log_path=None,  # foreground
+        started_at=1_000_000,
+    )
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli.time, "time", lambda: 1_000_100.0)
+
+    def _must_not_probe(record: object, **_kw: object) -> bool:
+        raise AssertionError("a foreground daemon must not be probed for tunnel health")
+
+    monkeypatch.setattr(cli, "_daemon_host_definitely_offline", _must_not_probe)
+
+    _ensure_host_daemon("https://server.example.com")
+
+    assert "args" not in captured  # reused, not respawned


### PR DESCRIPTION
## Related issue

Closes #

<!-- Found while investigating host lifecycle; no issue was filed beforehand. -->

## Summary

Daemon reuse for a `--server` target was PID-liveness only. A daemon process
that is alive but whose tunnel is gone for good was reused as-is, so every later
command waited out `wait_for_host_online` and failed with "did not come online
within 30s". The only way out was `omnigent host stop` — which is precisely how
that became the standing folk remedy for a wedged host.

Local-mode daemons have had a tunnel-health heal for a while. Remote ones were
excluded on the grounds that the remote server owns tunnel health and the
daemon's own reconnect loop covers drops. That reasoning holds for a *transient*
drop; it does not cover a daemon that never re-registers (server restart while
the daemon slept, an ungraceful death mid-handshake, a flap that outlived the
backoff).

The guard that makes this safe: heal only on a definite "the server says
offline". `_daemon_host_online` folded an unreachable server into `False`, so
reusing it here would let a VPN drop or a captive portal kill a perfectly
healthy remote daemon. Split the probe into a tri-state and heal only on
`offline`, never on `unknown`:

| probe outcome | state | heal? |
| --- | --- | --- |
| 200, `status == "online"` | `online` | no |
| 200, any other status | `offline` | **yes** |
| transport error / non-200 / 404 / unparseable / no host id | `unknown` | no |

`_daemon_host_online` stays as a thin wrapper over the new
`_daemon_host_state`, so local mode and the background-registration wait are
byte-for-byte unchanged.

```
                   ┌─ online ──────────────> reuse
GET /v1/hosts/{id} ├─ offline (after grace) ─> terminate + respawn   ← new for remote
                   └─ unknown ─────────────> reuse (never kill on a blip)
```

The existing gates still apply on the remote path: the age gate
(`_DAEMON_REUSE_MIN_AGE_S`) leaves a daemon that is merely still connecting
alone, and only background-spawned daemons are eligible, so a foreground
`omnigent host` is never silently killed. The 5s grace poll gives a daemon
mid-reconnect a chance to come back before we judge it.

**ELI5:** if the server tells us the host is offline, restart it instead of
waiting 30s to fail. If we can't reach the server at all, that's our problem,
not the daemon's — leave it alone.

## Test Plan

- `pytest tests/cli/ tests/host/test_cli_host.py` — 1152 passed.
- Seven new tests, all verified to fail on `main`:
  - `test_daemon_host_state_distinguishes_offline_from_unknown` — offline vs.
    transport error vs. 404.
  - `test_daemon_host_definitely_offline_only_on_a_server_answer` — `unknown`
    never reads as offline.
  - `test_daemon_host_definitely_offline_waits_for_a_reconnect` — a host that
    re-registers inside the grace window is not offline.
  - `test_ensure_host_daemon_respawns_zombie_remote_daemon` — the heal fires and
    a fresh daemon is spawned.
  - `test_ensure_host_daemon_keeps_remote_daemon_when_probe_inconclusive` — an
    unreachable server costs nobody their daemon.
  - `test_ensure_host_daemon_keeps_young_remote_daemon` and
    `..._keeps_foreground_remote_daemon` — both assert the probe is not even
    issued.

Live verification against a real server and daemon, in an isolated
`OMNIGENT_CONFIG_HOME` / `OMNIGENT_DATA_DIR`. A local server is the target, so
`_normalize_daemon_target` yields `http://127.0.0.1:<port>` — not the `local`
marker — and the server-mode branch this PR changes is the one under test.

**Case 1 — genuinely wedged daemon (expect heal).** `SIGSTOP` the daemon so it
stops answering pings; the server declares it dead after the 90s window:

```
host state after registration: online
SIGSTOP 3421850 -- waiting out the 90s server liveness window
host state while wedged: offline (pid alive: True)
--- calling _ensure_host_daemon on the zombie (expect heal) ---
Restarting host daemon for 'http://127.0.0.1:60973' (host tunnel is offline).
took 10.3s; old pid=3421850 new pid=3504333
RESULT heal: PASS
old daemon still alive? False
fresh daemon state: online
```

**Case 2 — unreachable server (expect no teardown).** Stop the server, then ask
again:

```
server /health now: 0 (0 == unreachable)
probe state with server down: unknown
pid before=3504333 after=3504333
RESULT unreachable-is-not-offline: PASS
```

That second case is the one that would regress if `_daemon_host_online`'s
two-state answer were reused here: it returns `False` for an unreachable server,
so the daemon would have been torn down and respawned into the same outage.

The 10.3s in case 1 is the 5s grace poll plus teardown and respawn — paid only
on the broken path, replacing a ~30s `wait_for_host_online` timeout that ended
in a failed command.

## Demo

N/A — no visual surface; the one user-visible string is the
`Restarting host daemon for … (host tunnel is offline).` stderr line, quoted
above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the tri-state probe, the grace-window behavior and all four
branches of the reuse decision; all seven were confirmed to fail on `main`.
Manual verification covered both live cases above end-to-end — a real wedged
daemon (SIGSTOP past the 90s liveness TTL) and a real unreachable server —
since the fix lives in the interaction between the server's freshness gate and
the client's reuse decision.

One trade-off worth a reviewer's eye: this adds one host-status GET to the
remote reuse path. In `_ensure_backend` it runs concurrently with the auth probe
(`GET /v1/me`), which is the longer pole, so wall-clock cost is ~0 there; the
other two callers (`_run_background_host`, the smart-routing arm) are not hot
paths.

## Changelog

A host daemon whose connection to the server is gone now restarts itself on the next command instead of failing with "did not come online".
