### PR TITLE
fix(pi-native): keep a provider's configured default model verbatim

### DIFF
--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -984,17 +984,12 @@ def _inline_family_pi_provider(
         resolved_model = model or entry.family_default_model(family_name)
         if not resolved_model:
             continue
-        # A session model override can arrive as a Databricks-gateway id
-        # (``databricks-claude-opus-4-7``) — that prefix only routes through the
-        # Databricks AI Gateway (``_databricks_pi_provider``). This family is
-        # vendor-direct (key / inline gateway / local Anthropic|OpenAI endpoint),
-        # so strip the mechanical ``databricks-`` prefix to the bare vendor id
-        # the endpoint can actually route. ``normalize_model_for_provider`` is
-        # prefix-mechanical: it only strips ``databricks-claude-*``/
-        # ``databricks-gpt-*`` and passes non-mechanical ids (e.g.
-        # ``zai-org/GLM-4.7``) and already-bare ids through unchanged. Family
-        # defaults are bare, so the no-override path is unaffected.
-        resolved_model = normalize_model_for_provider(resolved_model, KEY_KIND)
+        # A session override can arrive as a Databricks-gateway id, which only the
+        # gateway routes; strip the mechanical prefix for a vendor-direct endpoint.
+        # A configured family default is exempt — it names an id its own endpoint
+        # serves, so a translating proxy's gateway-shaped default survives verbatim.
+        if model is not None:
+            resolved_model = normalize_model_for_provider(resolved_model, KEY_KIND)
         # Strip bracket suffixes (e.g. "[1m]") — accepted by the direct
         # Anthropic API but rejected by the Databricks AI Gateway.
         resolved_model = re.sub(r"\[.*?\]$", "", resolved_model)

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -1155,7 +1155,7 @@ def test_inline_family_configured_gateway_default_survives_verbatim() -> None:
     assert provider.api == "anthropic-messages"
     assert provider.model == "databricks-claude-opus-4-8"
     cfg = provider.to_models_config()
-    assert cfg["providers"]["omnigent"]["models"] == [{"id": "databricks-claude-opus-4-8"}]
+    assert cfg["providers"]["omnigent"]["models"][0]["id"] == "databricks-claude-opus-4-8"
 
 
 def test_databricks_profile_registers_gpt_provider(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -1129,6 +1129,35 @@ def test_inline_family_passes_non_mechanical_override_through() -> None:
     assert cfg["providers"]["omnigent"]["models"] == [{"id": "zai-org/GLM-4.7"}]
 
 
+def test_inline_family_configured_gateway_default_survives_verbatim() -> None:
+    """A configured ``databricks-`` family default is not rewritten.
+
+    A protocol-translating proxy (a LiteLLM / AI-Gateway-shaped ``/anthropic``
+    passthrough) is addressed by serving-endpoint name, so stripping the prefix
+    the user configured yields an id the endpoint answers ``ENDPOINT_NOT_FOUND``
+    for. Only a session override is normalized for a vendor-direct endpoint.
+    """
+    config = {
+        "providers": {
+            "translating-proxy": {
+                "kind": "gateway",
+                "default": ["pi"],
+                "anthropic": {
+                    "base_url": "http://127.0.0.1:8399/ai-gateway/anthropic",
+                    "api_key": "local",
+                    "models": {"default": "databricks-claude-opus-4-8"},
+                },
+            }
+        }
+    }
+    provider = creds.resolve_pi_native_provider(config_loader=lambda: config)
+    assert provider is not None
+    assert provider.api == "anthropic-messages"
+    assert provider.model == "databricks-claude-opus-4-8"
+    cfg = provider.to_models_config()
+    assert cfg["providers"]["omnigent"]["models"] == [{"id": "databricks-claude-opus-4-8"}]
+
+
 def test_databricks_profile_registers_gpt_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     """A Databricks profile provider includes an OpenAI Completions provider for GPT models.
 


### PR DESCRIPTION
## Related issue

Closes #5258

## Summary

**Problem:** omnigent silently rewrites the model id you put in your own config. For a
`kind: gateway` or `kind: local` provider, `_inline_family_pi_provider` runs `models.default`
through `normalize_model_for_provider` with the kind pinned to `KEY_KIND` — a vendor-direct
kind — which strips the `databricks-` prefix.

**Why it matters:** that breaks the deployment this function's own docstring promises to
support — "keeps protocol-translating proxies working: a LiteLLM `/anthropic` passthrough is
the only configured family and still serves any model" (`omnigent/pi_native_credentials.py:934`).
Such a proxy is addressed by serving-endpoint name, so the rewrite makes the **first request
of the session** fail with `ENDPOINT_NOT_FOUND`, which reads as spawn death rather than a
config rewrite.

**Fix:** decide on **provenance, not kind**. A configured family default is passed through
verbatim; a session override still normalizes, because it can legitimately arrive in gateway
vocabulary from `/model` or a spec's `executor.model`.

```mermaid
flowchart TD
    subgraph B["🚫 Before — both paths rewritten"]
        direction TB
        B1["configured default<br/>databricks-claude-opus-4-8"] --> BS["strip 'databricks-'"]
        B2["session override<br/>databricks-claude-opus-4-8"] --> BS
        BS --> BR["claude-opus-4-8<br/>ENDPOINT_NOT_FOUND"]
    end
    subgraph A["✅ After — provenance decides"]
        direction TB
        A1["configured default"] --> AK["verbatim<br/>databricks-claude-opus-4-8"]
        A2["session override"] --> AS["strip 'databricks-'"]
        AS --> AR["claude-opus-4-8<br/>for a vendor-direct endpoint"]
    end
```

**Why kind can't be the discriminator:** `test_databricks_prefixed_override_normalized_for_inline_openai`
configures `kind: gateway` against `api.openai.com` and correctly asserts the prefix *is*
stripped. Host-sniffing for a Databricks domain fails too — a local translating proxy lives
on loopback.

## Test Plan

- Rebased onto the latest `upstream/main` with no conflicts.
- `pytest tests/test_pi_native_credentials.py` — **87 passed**, including the two existing
  tests that must keep stripping an override.
- `pytest tests/runner/test_app_pi_native_model.py tests/runner/test_app_sessions_native_terminals_autocreate.py`
  — **67 passed** (the other suites touching `resolve_pi_native_provider`).
- `pre-commit run --all-files` — every repository hook passed, including Ruff, Pyrefly, web formatting, oxlint, and TypeScript checks.
- Live: a `kind: gateway` provider whose default names a serving endpoint now reaches
  `models.json` unchanged and the first Pi turn succeeds. Before, the same config 404s.

## Demo

The same provider config and resolver call against `upstream/main` and this PR:

![Before and after Pi default model resolution](https://raw.githubusercontent.com/randypitcherii/omnigent/feature/randypitcherii/5258-pi-default-model-verbatim/docs/demo/pi-default-model-resolution.svg)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added `test_inline_family_configured_gateway_default_survives_verbatim`, asserting a
gateway-shaped family default survives into `models.json`. The two pre-existing override
tests guard the other half of the rule. Manual verification was a live Pi session through a
protocol-translating proxy, confirming the 404 → 200 transition above.

## Changelog

Pi now honours the model id you configure as a provider's default instead of rewriting it, so
gateway-style ids reach translating proxies unchanged.