### PR TITLE
docs(databricks): align required Python version with project standard (3.12+)

### DIFF
--- a/docs/databricks.md
+++ b/docs/databricks.md
@@ -95,7 +95,7 @@ file, not a fork.
    installed and authenticated against your workspace. Either a CLI
    profile (`DATABRICKS_CONFIG_PROFILE=<profile>`) or env-based auth
    (`DATABRICKS_HOST` + `DATABRICKS_CLIENT_ID` + `DATABRICKS_CLIENT_SECRET`).
-3. **Python 3.11+** locally with `uv` installed (the omnigent project
+3. **Python 3.12+** locally with `uv` installed (the omnigent project
    standard).
 4. **Workspace permissions** to:
    - Create or use a Unity Catalog catalog and schema for trace


### PR DESCRIPTION
## Related issue

None (documentation consistency fix; Docs type does not require a linked issue per CONTRIBUTING).

## Summary

The Databricks setup guide (`docs/databricks.md`) listed **"Python 3.11+"** as the required local Python version, calling it "the omnigent project standard". That is incorrect: the project requires `>=3.12` (`.python-version` pins `3.12`, and `pyproject.toml` sets `requires-python = ">=3.12"`).

A user following the guide with exactly Python 3.11 would be unable to install the `omnigent` package. This change aligns the documented version with the actual project standard so the prerequisite is accurate.

## Test Plan

- Verified the contradiction with repo facts: `.python-version` contains `3.12` and `pyproject.toml` has `requires-python = ">=3.12"`.
- Confirmed the edit is the only change (`git diff` shows 1 file, 1 line modified).
- No runtime/test impact — documentation-only change.

## Demo

N/A (non-visual documentation change).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Documentation-only change; no code path or behavior is modified, so automated test coverage is not applicable. The fix is verified by cross-checking against `.python-version` and `pyproject.toml`.
