### PR TITLE
fix(web): remember the workspace panel's collapsed state across sessions

### DIFF
--- a/tests/e2e_ui/sessions/test_workspace_panel_default.py
+++ b/tests/e2e_ui/sessions/test_workspace_panel_default.py
@@ -10,9 +10,13 @@ AppShell applies that preference only when a session has no saved
 that chat's own open-state wins on restore — so changing Appearance later
 does not rewrite existing layouts.
 
-This covers the pair the feature exists for: a brand-new session starts
-collapsed after picking Collapsed, and a session the user already toggled
-keeps its saved open-state even when the Appearance default is Collapsed.
+Collapsing or expanding the rail from the header writes the same key, so the
+state the rail was last left in carries into the next chat.
+
+This covers what the feature exists for: a brand-new session starts collapsed
+after picking Collapsed, a session the user already toggled keeps its saved
+open-state even when the Appearance default is Collapsed, and a collapse
+sticks across a reload and into a never-visited session until it is reopened.
 No LLM turn is needed.
 """
 
@@ -153,3 +157,39 @@ def test_saved_session_open_state_wins_over_appearance_default(
     _wait_session_ready(page)
     expect(page.get_by_role("complementary", name="Workspace")).to_have_count(0)
     expect(page.get_by_role("button", name="Expand right panel")).to_be_visible()
+
+
+def test_collapsing_the_rail_sticks_across_reload_and_new_sessions(
+    page: Page, seeded_session_pair: tuple[str, str, str]
+) -> None:
+    """A collapsed rail stays collapsed on reload and in the next chat opened.
+
+    Collapsing in session A must not be undone by a reload, and must carry into
+    session B — a chat with no saved open-state of its own — instead of
+    springing back to the open product default. Reopening in B flips the
+    remembered state back, so the next fresh chat starts open again.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+
+    page.goto(f"{base_url}/c/{session_a}")
+    _wait_session_ready(page)
+    expect(page.get_by_role("complementary", name="Workspace")).to_be_visible(timeout=30_000)
+    page.get_by_role("button", name="Collapse right panel").click()
+    expect(page.get_by_role("complementary", name="Workspace")).to_have_count(0)
+    assert _stored_default(page) == "collapsed", "collapsing did not record the rail state"
+
+    # A reload of the same chat keeps it collapsed.
+    page.reload()
+    _wait_session_ready(page)
+    expect(page.get_by_role("complementary", name="Workspace")).to_have_count(0)
+
+    # Session B has never been opened in this browser: it follows the
+    # remembered collapse rather than the open default.
+    page.goto(f"{base_url}/c/{session_b}")
+    _wait_session_ready(page)
+    expect(page.get_by_role("complementary", name="Workspace")).to_have_count(0)
+
+    # Reopening it there flips the remembered state back.
+    page.get_by_role("button", name="Expand right panel").click()
+    expect(page.get_by_role("complementary", name="Workspace")).to_be_visible()
+    assert _stored_default(page) is None, "reopening the rail did not clear the collapsed state"

--- a/web/src/lib/workspacePanelPreferences.test.ts
+++ b/web/src/lib/workspacePanelPreferences.test.ts
@@ -4,6 +4,7 @@ import {
   readDefaultWorkspacePanelOpen,
   readWorkspacePanelDefault,
   WORKSPACE_PANEL_DEFAULT,
+  writeDefaultWorkspacePanelOpen,
   writeWorkspacePanelDefault,
 } from "./workspacePanelPreferences";
 
@@ -16,6 +17,16 @@ afterEach(() => {
 describe("workspacePanelPreferences — read/write", () => {
   it("returns open when nothing is stored", () => {
     expect(readWorkspacePanelDefault()).toBe(WORKSPACE_PANEL_DEFAULT);
+    expect(readDefaultWorkspacePanelOpen()).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("records the rail's visibility from the collapse/expand toggle", () => {
+    writeDefaultWorkspacePanelOpen(false);
+    expect(readDefaultWorkspacePanelOpen()).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("collapsed");
+
+    writeDefaultWorkspacePanelOpen(true);
     expect(readDefaultWorkspacePanelOpen()).toBe(true);
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
   });

--- a/web/src/lib/workspacePanelPreferences.ts
+++ b/web/src/lib/workspacePanelPreferences.ts
@@ -1,9 +1,13 @@
 // Persisted, app-global preference for whether a brand-new chat's right
 // Workspace rail (Files / Agents / Shells) starts open or collapsed.
 //
+// Set from Appearance settings, and re-written whenever the user collapses or
+// expands the rail — so the state the rail was last left in carries into the
+// next chat instead of springing back open.
+//
 // This only seeds sessions that have no saved per-chat `open` state. Once a
 // user toggles the rail in a session, that session's own
-// `SessionWorkspaceState.open` wins on restore. Set from Appearance settings.
+// `SessionWorkspaceState.open` wins on restore.
 
 const STORAGE_KEY = "omnigent:default-workspace-panel";
 
@@ -76,4 +80,14 @@ export function writeWorkspacePanelDefault(value: WorkspacePanelDefault): void {
  */
 export function readDefaultWorkspacePanelOpen(): boolean {
   return readWorkspacePanelDefault() === "open";
+}
+
+/**
+ * Record the rail's visibility as the app-global default.
+ *
+ * Called from AppShell's collapse/expand toggle so the state the user left the
+ * rail in becomes the starting state for chats they haven't opened yet.
+ */
+export function writeDefaultWorkspacePanelOpen(open: boolean): void {
+  writeWorkspacePanelDefault(open ? "open" : "collapsed");
 }

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -554,7 +554,7 @@ function WorkspacePanelDefaultControl() {
     <ThemeSubsection
       labelId={labelId}
       title="Workspace panel"
-      helper="Whether new chats open with the Files / Agents / Shells panel visible. Existing chats keep their last layout."
+      helper="Whether new chats open with the Files / Agents / Shells panel visible. Collapsing or expanding the panel updates this. Existing chats keep their last layout."
     >
       <CardRadioGroup<WorkspacePanelDefault>
         labelledBy={labelId}

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -2052,6 +2052,37 @@ describe("Right workspace card visibility", () => {
     expect(screen.getByRole("button", { name: "Expand right panel" })).toBeInTheDocument();
   });
 
+  it("carries the last collapse into sessions with no saved open-state", () => {
+    // Collapsing the rail is remembered app-wide, so the next chat the user
+    // opens starts collapsed instead of springing back to the open default —
+    // and reopening it restores the open start for the chat after that.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: false, root: null, home: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      { id: "conv_sticky_a", permission_level: null },
+      { id: "conv_sticky_b", permission_level: null },
+      { id: "conv_sticky_c", permission_level: null },
+    ]);
+
+    const first = renderShell("/c/conv_sticky_a");
+    fireEvent.click(screen.getByRole("button", { name: "Collapse right panel" }));
+    first.unmount();
+
+    // conv_sticky_b was never visited: no saved open-state of its own, so it
+    // follows the remembered collapse.
+    const second = renderShell("/c/conv_sticky_b");
+    expect(screen.queryByRole("complementary", { name: "Workspace" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Expand right panel" }));
+    second.unmount();
+
+    // Reopening flips the remembered state back for the next fresh session.
+    renderShell("/c/conv_sticky_c");
+    expect(screen.getByRole("complementary", { name: "Workspace" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Collapse right panel" })).toBeInTheDocument();
+  });
+
   it("restores the selected rail tab per session", () => {
     // Seed conv_tabmem open on the Agents tab; on mount the rail restores that
     // tab as selected rather than falling back to Files.

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -29,7 +29,10 @@ import {
   type DesignModeElement,
 } from "@/lib/designModePrompt";
 import { readSessionWorkspaceState, writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
-import { readDefaultWorkspacePanelOpen } from "@/lib/workspacePanelPreferences";
+import {
+  readDefaultWorkspacePanelOpen,
+  writeDefaultWorkspacePanelOpen,
+} from "@/lib/workspacePanelPreferences";
 import {
   Dialog,
   DialogContent,
@@ -1011,6 +1014,10 @@ export function AppShell() {
   const toggleRightPanel = () => {
     const next = !rightPanelOpen;
     if (conversationId) writeSessionWorkspaceState(conversationId, { open: next });
+    // Remember the choice app-wide as well, so a collapsed rail stays collapsed
+    // in the next chat the user opens (and on reload) until they reopen it.
+    // Sessions with their own saved open-state still win over this.
+    writeDefaultWorkspacePanelOpen(next);
     if (next) {
       if (selectedFilePath) {
         // Reopening lands back on the file remembered in per-session

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1013,11 +1013,16 @@ export function AppShell() {
   // advertises a panel that isn't shown.
   const toggleRightPanel = () => {
     const next = !rightPanelOpen;
-    if (conversationId) writeSessionWorkspaceState(conversationId, { open: next });
-    // Remember the choice app-wide as well, so a collapsed rail stays collapsed
-    // in the next chat the user opens (and on reload) until they reopen it.
-    // Sessions with their own saved open-state still win over this.
-    writeDefaultWorkspacePanelOpen(next);
+    if (conversationId) {
+      writeSessionWorkspaceState(conversationId, { open: next });
+      // Remember the choice app-wide as well, so a collapsed rail stays
+      // collapsed in the next chat the user opens (and on reload) until they
+      // reopen it. Sessions with their own saved open-state still win over
+      // this. Guarded on a conversation like the per-session write: off a
+      // session route the rail can't render, so the hotkey's flip is inert and
+      // must not rewrite the remembered state.
+      writeDefaultWorkspacePanelOpen(next);
+    }
     if (next) {
       if (selectedFilePath) {
         // Reopening lands back on the file remembered in per-session


### PR DESCRIPTION
## Related issue

N/A

## Summary

Collapsing the right Workspace panel (Files / Agents / Shells) only stuck for
the chat you collapsed it in. Open any other session — or a brand-new one — and
the rail sprang back open, because a session with no saved open-state fell back
to the app-global "Workspace panel" default, which nothing but Settings ever
wrote.

- The header's collapse/expand toggle (and its `⌘⌥]` hotkey) now records the
  rail's visibility in that same app-global default, so a collapse survives a
  reload and carries into the next chat you open until you reopen the rail.
- Chats that have their own saved open-state still win over it, and
  Settings → Appearance → Workspace panel still sets it explicitly (its helper
  copy now says the toggle updates it too).

```
before:  collapse in chat A  →  open chat B  →  rail springs back open
after:   collapse in chat A  →  open chat B  →  rail stays collapsed
                                              →  reopen in B  →  next fresh chat opens with it
```

## Test Plan

- `pnpm --filter web exec vitest run src/lib/workspacePanelPreferences.test.ts src/shell/AppShell.test.tsx src/pages/SettingsPage.test.tsx src/shell/ChatHeader.test.tsx src/lib/sessionWorkspaceState.test.ts src/shell/WorkspacePanel.test.tsx` → 210 passed.
- `pytest tests/e2e_ui/sessions/test_workspace_panel_default.py --ui-skip-build` → 4 passed (3 pre-existing + the new one).
- Verified the new coverage fails without the fix: reverting `AppShell.tsx` +
  `workspacePanelPreferences.ts` (and rebuilding the SPA) makes both the new
  vitest case and the new E2E test fail, then pass again with the fix restored.
- `pre-commit run --files …` on every touched file → all hooks pass.

## Demo

Behaviour is covered end-to-end by
`tests/e2e_ui/sessions/test_workspace_panel_default.py::test_collapsing_the_rail_sticks_across_reload_and_new_sessions`,
which drives the real UI: collapse the rail in session A → reload (still
collapsed) → open never-visited session B (still collapsed) → expand there (the
remembered state flips back). To see it by hand: collapse the Workspace panel in
any chat, reload the page, then open a different chat — the panel stays
collapsed until you expand it again.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the fail-on-main / pass-on-branch A/B described in the
Test Plan: the new vitest case and the new Playwright test were both run against
a reverted working tree (with the SPA rebuilt, since the E2E tests serve the
built bundle) to confirm they fail without the change.

## Changelog

The Workspace panel stays collapsed across reloads and new chats until you reopen it
