### PR TITLE
fix(server): don't fail mid-turn sessions when the server itself shuts down

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4203,7 +4203,11 @@ def server(
             import asyncio as _asyncio
 
             from omnigent.runtime import session_stream as _session_stream
+            from omnigent.server import shutdown_state as _shutdown_state
 
+            # The runner tunnels close next; their disconnect handlers must
+            # read that loss as ours, not as the runners dying.
+            _shutdown_state.mark_server_shutting_down()
             _session_stream.shutdown_all()
             # Yield to the event loop so generators can consume _DONE,
             # flush their final "data: [DONE]\n\n" chunk, and exit before

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -43,7 +43,7 @@ from omnigent.runtime import (
 )
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
-from omnigent.server import session_live_state
+from omnigent.server import session_live_state, shutdown_state
 from omnigent.server.auth import AuthProvider, SharingMode
 from omnigent.server.background_session_titles import (
     BackgroundSessionTitleCoordinator,
@@ -2383,6 +2383,11 @@ def create_app(
         :func:`_mark_runner_sessions_offline`, which fails only the
         interrupted turns and stamps the disconnect cause.
 
+        A server that is itself shutting down skips the marking too: it
+        closed the tunnel, and the runner cannot re-register with a
+        process that stopped listening — the replacement server re-adopts
+        it on reconnect (:mod:`omnigent.server.shutdown_state`).
+
         :param runner_id: The disconnected runner's id.
         """
         from omnigent.server.routes.sessions import (
@@ -2392,6 +2397,12 @@ def create_app(
         from omnigent.server.schemas import ErrorDetail
 
         await asyncio.sleep(RUNNER_DISCONNECT_GRACE_S)
+        if shutdown_state.server_shutting_down():
+            _logger.info(
+                "Runner %s dropped because this server is shutting down; skipping offline-marking",
+                runner_id,
+            )
+            return
         if tunnel_registry.get(runner_id) is not None:
             _logger.info(
                 "Runner %s reconnected within the disconnect grace; skipping offline-marking",

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -90,7 +90,7 @@ from omnigent.runtime.policies.builder import (
 )
 from omnigent.runtime.policies.engine import PolicyEngine
 from omnigent.runtime.workflow import _find_spec_by_name
-from omnigent.server import session_live_state
+from omnigent.server import session_live_state, shutdown_state
 from omnigent.server._elicitation_registry import (
     _harness_elicitation_owners,
     _harness_elicitation_registry,
@@ -5677,8 +5677,11 @@ async def _relay_runner_stream(
     lost stream retries inside that window instead of failing the
     session. An intentional Stop exits quietly at once.
 
-    Past the grace the runner is genuinely gone, and only a session it
-    caught mid-turn (:func:`_runner_drop_interrupted_turn`) gets the
+    Past the grace the runner is genuinely gone — unless this server is the
+    one shutting down (:func:`omnigent.server.shutdown_state.server_shutting_down`):
+    it closed the tunnel itself, so the loss says nothing about the runner
+    and no session is failed. Otherwise only a session it caught mid-turn
+    (:func:`_runner_drop_interrupted_turn`) gets the
     ``failed`` status and durable ``runner_disconnected`` labels — the same
     rule :func:`_mark_runner_sessions_offline_impl` applies to the runner's
     other sessions. An idle session had no work to interrupt, so it stays
@@ -5737,6 +5740,15 @@ async def _relay_runner_stream(
                     session_id,
                     None,
                     conversation_store,
+                )
+            elif shutdown_state.server_shutting_down():
+                # This server closed the tunnel on its way down; the runner is
+                # reachable, just not by a process that stopped listening. The
+                # replacement server re-adopts it on reconnect.
+                _logger.info(
+                    "Relay: transport lost during server shutdown for session=%s; "
+                    "not failing the turn",
+                    session_id,
                 )
             elif not await _runner_drop_interrupted_turn(session_id, conversation_store):
                 # The runner went away while this session sat idle (host

--- a/omnigent/server/routes/runner_tunnel.py
+++ b/omnigent/server/routes/runner_tunnel.py
@@ -35,7 +35,7 @@ from omnigent.runner.transports.ws_tunnel.frames import (
     encode_frame,
 )
 from omnigent.runner.transports.ws_tunnel.registry import RunnerSession, TunnelRegistry
-from omnigent.server import session_live_state
+from omnigent.server import session_live_state, shutdown_state
 from omnigent.server.auth import RESERVED_USER_LOCAL, AuthProvider
 from omnigent.server.host_registry import RunnerExitReports
 from omnigent.server.routes._auth_helpers import require_user
@@ -538,6 +538,7 @@ def create_runner_tunnel_router(
                         )
                         continue
                     if isinstance(task_error, WebSocketDisconnect):
+                        shutdown_state.note_tunnel_close_code(getattr(task_error, "code", None))
                         _logger.warning(
                             "Tunnel helper task disconnected for runner %s: %s "
                             "(code=%s, reason=%r)",
@@ -578,6 +579,7 @@ def create_runner_tunnel_router(
                         )
 
         except WebSocketDisconnect as exc:
+            shutdown_state.note_tunnel_close_code(getattr(exc, "code", None))
             _logger.warning(
                 "Runner %s websocket disconnected (code=%s, reason=%r)",
                 runner_id,

--- a/omnigent/server/shutdown_state.py
+++ b/omnigent/server/shutdown_state.py
@@ -19,11 +19,14 @@ Two sources set the signal:
   code through :func:`note_tunnel_close_code`, which covers entrypoints that
   run a bare ``uvicorn.run(app)`` (the Databricks Apps wrapper).
 
-The signal is time-bounded rather than latched for the life of the process:
-a server that really is shutting down is gone within its platform's
+The mark is process-wide: while it is fresh, disconnect reconciliation is
+suppressed for every runner, so a genuine runner death inside that window
+surfaces through liveness (the offline dot) rather than a ``failed`` card.
+That is why it is time-bounded rather than latched for the life of the
+process: a server that really is shutting down is gone within its platform's
 termination grace (seconds), so the window never limits it, while a spurious
-mark (a client that closed with 1012) cannot permanently disable disconnect
-reconciliation.
+mark (a client that closed with 1012, which runners never send — they close
+with 1001) costs at most :data:`SHUTDOWN_WINDOW_S` of suppression.
 """
 
 from __future__ import annotations

--- a/omnigent/server/shutdown_state.py
+++ b/omnigent/server/shutdown_state.py
@@ -1,0 +1,87 @@
+"""
+Process-wide "this server is shutting down" signal.
+
+A server going down closes every runner tunnel itself, and the runners
+cannot reconnect to a process that stopped listening. The disconnect
+reconciliation paths — the per-runner grace timer in ``omnigent.server.app``
+and the relay give-up in the sessions orchestration — would otherwise read
+that self-inflicted loss as "the runner is gone" and fail every mid-turn
+session, which is what a rolling deploy did.
+
+Two sources set the signal:
+
+* Explicit: an entrypoint that owns the uvicorn ``Server`` (``omnigent
+  server``) calls :func:`mark_server_shutting_down` from its ``shutdown()``
+  override, before the tunnels close.
+* In-band: uvicorn closes WebSockets with close code 1012 ("service
+  restart") only while shutting down, so a runner-tunnel disconnect carrying
+  that code proves the close was ours. The tunnel route reports every close
+  code through :func:`note_tunnel_close_code`, which covers entrypoints that
+  run a bare ``uvicorn.run(app)`` (the Databricks Apps wrapper).
+
+The signal is time-bounded rather than latched for the life of the process:
+a server that really is shutting down is gone within its platform's
+termination grace (seconds), so the window never limits it, while a spurious
+mark (a client that closed with 1012) cannot permanently disable disconnect
+reconciliation.
+"""
+
+from __future__ import annotations
+
+import time
+
+# uvicorn's shutdown close code (RFC 6455 "service restart"); a server is
+# the only peer that sends it.
+SERVER_INITIATED_CLOSE_CODES: frozenset[int] = frozenset({1012})
+
+# How long a mark counts as "still shutting down". Platform termination
+# graces are far shorter (Databricks Apps: 15s; Kubernetes default: 30s),
+# and the reconciliation deadlines this suppresses fire ~10s after the drop.
+SHUTDOWN_WINDOW_S: float = 60.0
+
+_marked_at: float | None = None
+
+
+def mark_server_shutting_down() -> None:
+    """
+    Record that this server process is shutting down now.
+    """
+    global _marked_at
+    _marked_at = time.monotonic()
+
+
+def note_tunnel_close_code(code: int | None) -> bool:
+    """
+    Record a runner-tunnel close code; mark shutdown when the server sent it.
+
+    :param code: WebSocket close code observed on a runner tunnel, or
+        ``None`` when unknown.
+    :returns: ``True`` when the code identifies a server-initiated close and
+        the shutdown mark was set.
+    """
+    if code in SERVER_INITIATED_CLOSE_CODES:
+        mark_server_shutting_down()
+        return True
+    return False
+
+
+def server_shutting_down(now: float | None = None) -> bool:
+    """
+    Return whether a shutdown mark was set within :data:`SHUTDOWN_WINDOW_S`.
+
+    :param now: Monotonic clock reading to measure against; defaults to
+        :func:`time.monotonic`.
+    :returns: ``True`` while the mark is fresh.
+    """
+    if _marked_at is None:
+        return False
+    current = time.monotonic() if now is None else now
+    return current - _marked_at < SHUTDOWN_WINDOW_S
+
+
+def reset_for_tests() -> None:
+    """
+    Clear the shutdown mark (test isolation).
+    """
+    global _marked_at
+    _marked_at = None

--- a/tests/e2e_ui/chat/test_failure_error_card.py
+++ b/tests/e2e_ui/chat/test_failure_error_card.py
@@ -79,6 +79,86 @@ def _seed_error_item(session_id: str, *, code: str, message: str) -> None:
     )
 
 
+def _seed_disconnect_failure(session_id: str, *, code: str, message: str) -> None:
+    """Seed a session as ``failed`` with a persisted ``last_task_error``.
+
+    Reproduces the durable shape a runner disconnect leaves behind: the
+    snapshot reads ``status="failed"`` from ``live_status`` and synthesizes
+    the error card from the ``last_task_error`` labels (no committed error
+    item, exactly as the relay's ``_publish_status`` + label persistence
+    does). A later live status edge is what should clear it.
+
+    :param session_id: Session to mark, e.g. ``"conv_abc123"``.
+    :param code: Failure classifier, e.g. ``"runner_disconnected"``.
+    :param message: Human-readable failure message stored alongside the code.
+    :raises RuntimeError: If the server under test isn't one we spawned.
+    """
+    from omnigent.server.routes._sessions.common import (
+        _LAST_TASK_ERROR_CODE_LABEL_KEY,
+        _LAST_TASK_ERROR_MESSAGE_LABEL_KEY,
+    )
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+
+    database_uri = _server_state.get("database_uri")
+    if not database_uri:
+        raise RuntimeError(
+            "seeding a disconnect failure needs the spawned server's database; "
+            "it is unavailable when running against --ui-base-url."
+        )
+    store = SqlAlchemyConversationStore(str(database_uri))
+    store.set_labels(
+        session_id,
+        {
+            _LAST_TASK_ERROR_CODE_LABEL_KEY: code,
+            _LAST_TASK_ERROR_MESSAGE_LABEL_KEY: message,
+        },
+    )
+    store.set_session_live_status(session_id, "failed")
+
+
+def test_runner_disconnect_card_clears_when_the_runner_reports_a_live_status(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A ``runner_disconnected`` card disappears once the runner is live again.
+
+    A server that closed a runner tunnel on its way down (a deploy) lit a
+    "connection to the host dropped" card; the runner never died and its
+    next status edge on reconnect proves it is reachable. The card is an
+    observation, not a turn result, so a live (non-``failed``) status edge
+    must remove it — and the server clears the persisted ``last_task_error``
+    on the same ``running`` edge, so it does not come back on refetch.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the local server.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _seed_disconnect_failure(
+        session_id,
+        code="runner_disconnected",
+        message="Runner disconnected unexpectedly.",
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # The durable failure synthesizes the disconnect card on hydration.
+    pill = page.get_by_test_id("error-pill")
+    expect(pill).to_contain_text("The connection to the host dropped unexpectedly", timeout=15_000)
+
+    # The runner reconnects and reports a live turn: the card must clear,
+    # and stay cleared after the snapshot refetch the edge triggers (the
+    # server drops the last_task_error labels on the same running edge).
+    _publish_native_status(base_url, session_id, "running", response_id="codex_turn_recover")
+    expect(pill).to_have_count(0, timeout=15_000)
+    # Give the invalidation-driven snapshot refetch time to land; it must
+    # not resurrect the card from stale labels.
+    page.wait_for_timeout(1_000)
+    expect(pill).to_have_count(0)
+
+
 def test_unclassified_failure_renders_english_headline_not_raw_code(
     page: Page,
     seeded_session: tuple[str, str],

--- a/tests/e2e_ui/chat/test_failure_error_card.py
+++ b/tests/e2e_ui/chat/test_failure_error_card.py
@@ -79,45 +79,6 @@ def _seed_error_item(session_id: str, *, code: str, message: str) -> None:
     )
 
 
-def _seed_disconnect_failure(session_id: str, *, code: str, message: str) -> None:
-    """Seed a session as ``failed`` with a persisted ``last_task_error``.
-
-    Reproduces the durable shape a runner disconnect leaves behind: the
-    snapshot reads ``status="failed"`` from ``live_status`` and synthesizes
-    the error card from the ``last_task_error`` labels (no committed error
-    item, exactly as the relay's ``_publish_status`` + label persistence
-    does). A later live status edge is what should clear it.
-
-    :param session_id: Session to mark, e.g. ``"conv_abc123"``.
-    :param code: Failure classifier, e.g. ``"runner_disconnected"``.
-    :param message: Human-readable failure message stored alongside the code.
-    :raises RuntimeError: If the server under test isn't one we spawned.
-    """
-    from omnigent.server.routes._sessions.common import (
-        _LAST_TASK_ERROR_CODE_LABEL_KEY,
-        _LAST_TASK_ERROR_MESSAGE_LABEL_KEY,
-    )
-    from omnigent.stores.conversation_store.sqlalchemy_store import (
-        SqlAlchemyConversationStore,
-    )
-
-    database_uri = _server_state.get("database_uri")
-    if not database_uri:
-        raise RuntimeError(
-            "seeding a disconnect failure needs the spawned server's database; "
-            "it is unavailable when running against --ui-base-url."
-        )
-    store = SqlAlchemyConversationStore(str(database_uri))
-    store.set_labels(
-        session_id,
-        {
-            _LAST_TASK_ERROR_CODE_LABEL_KEY: code,
-            _LAST_TASK_ERROR_MESSAGE_LABEL_KEY: message,
-        },
-    )
-    store.set_session_live_status(session_id, "failed")
-
-
 def test_runner_disconnect_card_clears_when_the_runner_reports_a_live_status(
     page: Page,
     seeded_session: tuple[str, str],
@@ -125,38 +86,46 @@ def test_runner_disconnect_card_clears_when_the_runner_reports_a_live_status(
     """A ``runner_disconnected`` card disappears once the runner is live again.
 
     A server that closed a runner tunnel on its way down (a deploy) lit a
-    "connection to the host dropped" card; the runner never died and its
-    next status edge on reconnect proves it is reachable. The card is an
+    "connection to the host dropped" card; the runner never died, and its
+    next status edge on reconnect proves it is reachable. That card is an
     observation, not a turn result, so a live (non-``failed``) status edge
-    must remove it — and the server clears the persisted ``last_task_error``
-    on the same ``running`` edge, so it does not come back on refetch.
+    must remove it — the fix in the ``session_status`` handler. Other
+    failure cards (e.g. ``required_terminal_exited``) must NOT be cleared by
+    a status edge, so a control card is seeded alongside and asserted to
+    survive.
 
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)`` from the local server.
     :returns: None.
     """
     base_url, session_id = seeded_session
-    _seed_disconnect_failure(
+    _seed_error_item(
         session_id,
         code="runner_disconnected",
         message="Runner disconnected unexpectedly.",
     )
+    _seed_error_item(
+        session_id,
+        code="required_terminal_exited",
+        message="Required terminal exited unexpectedly; the runtime is no longer available.",
+    )
 
     page.goto(f"{base_url}/c/{session_id}")
 
-    # The durable failure synthesizes the disconnect card on hydration.
-    pill = page.get_by_test_id("error-pill")
-    expect(pill).to_contain_text("The connection to the host dropped unexpectedly", timeout=15_000)
+    pills = page.get_by_test_id("error-pill")
+    expect(pills).to_have_count(2, timeout=15_000)
+    disconnect_pill = page.get_by_test_id("error-pill").filter(
+        has_text="The connection to the host dropped unexpectedly"
+    )
+    expect(disconnect_pill).to_have_count(1)
 
-    # The runner reconnects and reports a live turn: the card must clear,
-    # and stay cleared after the snapshot refetch the edge triggers (the
-    # server drops the last_task_error labels on the same running edge).
+    # The runner reconnects and reports a live turn. The disconnect card
+    # clears; the genuine terminal-exit failure card stays.
     _publish_native_status(base_url, session_id, "running", response_id="codex_turn_recover")
-    expect(pill).to_have_count(0, timeout=15_000)
-    # Give the invalidation-driven snapshot refetch time to land; it must
-    # not resurrect the card from stale labels.
-    page.wait_for_timeout(1_000)
-    expect(pill).to_have_count(0)
+    expect(disconnect_pill).to_have_count(0, timeout=15_000)
+    surviving = page.get_by_test_id("error-pill")
+    expect(surviving).to_have_count(1)
+    expect(surviving).to_contain_text("The agent's terminal exited unexpectedly")
 
 
 def test_unclassified_failure_renders_english_headline_not_raw_code(

--- a/tests/server/integration/test_sessions_tunnel_three_layer.py
+++ b/tests/server/integration/test_sessions_tunnel_three_layer.py
@@ -1330,33 +1330,16 @@ async def test_on_runner_connect_preserves_genuine_failure_on_reconnect(
         sessions_module._session_status_cache.pop(session_id, None)
 
 
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("_isolated_session_status_cache")
-async def test_runner_disconnect_grace_defers_failed_marking(
-    tunnel_three_layer_stack: _TunnelStack,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A tunnel drop marks sessions failed only after the reconnect grace.
+def _stub_connect_hook_for_pumpless_ws(ap_app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep ``_on_runner_connect`` from hanging on a test-owned, pump-less WS.
 
-    Drives a real WS disconnect for a dedicated runner whose session is
-    seeded mid-turn (``running`` — offline reconciliation only fails
-    interrupted turns) and asserts (a) the session is NOT failed inside
-    the grace, (b) it IS failed once the grace expires with the runner
-    still gone, and (c) a reconnect inside the grace suppresses the
-    marking entirely.
+    The connect hook fires on every hello for a bound session: it POSTs the
+    session init through the tunnel and spawns an SSE relay. Stub the router
+    resolver with a client that answers 200 and the relay spawn with a no-op.
     """
     from omnigent.runner.routing import RoutedRunner
-    from omnigent.runtime import get_conversation_store
     from omnigent.server.routes import sessions as sessions_module
 
-    ap_client = tunnel_three_layer_stack.ap_client
-    ap_app = tunnel_three_layer_stack.ap_app
-
-    grace = 0.4
-    monkeypatch.setattr("omnigent.server.routes.sessions.RUNNER_DISCONNECT_GRACE_S", grace)
-
-    # The connect hook fires on every hello for the bound session; stub
-    # the resolver + relay spawn so it cannot hang on this pump-less WS.
     class _StubResponse:
         status_code = 200
 
@@ -1380,6 +1363,32 @@ async def test_runner_disconnect_grace_defers_failed_marking(
         return None
 
     monkeypatch.setattr(sessions_module, "_ensure_runner_relay", _stub_ensure)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_isolated_session_status_cache")
+async def test_runner_disconnect_grace_defers_failed_marking(
+    tunnel_three_layer_stack: _TunnelStack,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tunnel drop marks sessions failed only after the reconnect grace.
+
+    Drives a real WS disconnect for a dedicated runner whose session is
+    seeded mid-turn (``running`` — offline reconciliation only fails
+    interrupted turns) and asserts (a) the session is NOT failed inside
+    the grace, (b) it IS failed once the grace expires with the runner
+    still gone, and (c) a reconnect inside the grace suppresses the
+    marking entirely.
+    """
+    from omnigent.runtime import get_conversation_store
+    from omnigent.server.routes import sessions as sessions_module
+
+    ap_client = tunnel_three_layer_stack.ap_client
+    ap_app = tunnel_three_layer_stack.ap_app
+
+    grace = 0.4
+    monkeypatch.setattr("omnigent.server.routes.sessions.RUNNER_DISCONNECT_GRACE_S", grace)
+    _stub_connect_hook_for_pumpless_ws(ap_app, monkeypatch)
 
     create_resp = await ap_client.post(
         "/v1/sessions",
@@ -1445,6 +1454,67 @@ async def test_runner_disconnect_grace_defers_failed_marking(
                 )
             with contextlib.suppress(asyncio.TimeoutError, Exception):
                 await reconnect_communicator.wait(timeout=2.0)
+        sessions_module._session_status_cache.pop(session_id, None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_isolated_session_status_cache")
+async def test_server_initiated_close_never_fails_the_turn(
+    tunnel_three_layer_stack: _TunnelStack,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tunnel THIS server closed (code 1012) leaves the mid-turn session alone.
+
+    A deploy shuts the server down: uvicorn closes every runner tunnel with
+    close code 1012 and stops listening, so no runner can re-register inside
+    the grace even though all of them are alive. The grace timer must read
+    that close as the server's own shutdown and skip the offline-marking —
+    no ``failed`` status, no ``runner_disconnected`` labels.
+    """
+    from omnigent.runtime import get_conversation_store
+    from omnigent.server import shutdown_state
+    from omnigent.server.routes import sessions as sessions_module
+
+    ap_client = tunnel_three_layer_stack.ap_client
+    ap_app = tunnel_three_layer_stack.ap_app
+
+    grace = 0.4
+    monkeypatch.setattr("omnigent.server.routes.sessions.RUNNER_DISCONNECT_GRACE_S", grace)
+    _stub_connect_hook_for_pumpless_ws(ap_app, monkeypatch)
+
+    create_resp = await ap_client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={
+            "bundle": (
+                "agent.tar.gz",
+                _build_harness_agent_bundle(),
+                "application/gzip",
+            ),
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    session_id = create_resp.json()["session_id"]
+    runner_id = "runner-server-close"
+    store = get_conversation_store()
+    store.replace_runner_id(session_id, runner_id)
+
+    communicator = await _connect_runner_tunnel(ap_app, runner_id)
+    await _send_hello_and_wait(communicator, ap_app, runner_id, harnesses=[_TEST_HARNESS_NAME])
+    sessions_module._session_status_cache[session_id] = "running"
+    try:
+        await communicator.send_input({"type": "websocket.disconnect", "code": 1012})
+        await communicator.wait(timeout=2.0)
+        assert shutdown_state.server_shutting_down(), "a 1012 close did not mark server shutdown"
+
+        # Well past the grace: the timer has fired and must have skipped the marking.
+        await asyncio.sleep(grace * 3)
+        assert sessions_module._session_status_cache.get(session_id) == "running"
+        conv = store.get_conversation(session_id)
+        assert conv is not None
+        assert sessions_module._last_task_error_from_labels(conv.labels) is None
+    finally:
+        shutdown_state.reset_for_tests()
         sessions_module._session_status_cache.pop(session_id, None)
 
 

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -1265,3 +1265,57 @@ async def test_mark_runner_sessions_offline_only_fails_interrupted_turns(
         sessions_module._intentional_stop_sessions.discard(session_id)
         sessions_module._session_status_cache.pop(session_id, None)
         session_stream.close(session_id)
+
+
+@pytest.mark.asyncio
+async def test_relay_does_not_fail_turn_during_server_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A stream drop while THIS server is shutting down leaves the turn alone.
+
+    Shutdown closes the runner tunnels, which drops every relay stream; the
+    runner itself is alive and reconnects to the replacement server. The
+    give-up path must publish no ``failed`` status and persist no
+    ``runner_disconnected`` labels for that self-inflicted loss.
+    """
+    from omnigent.runtime import session_stream
+    from omnigent.server import shutdown_state
+    from omnigent.server.routes import sessions as sessions_module
+
+    monkeypatch.setattr(
+        "omnigent.server.routes._sessions.orchestration.RUNNER_DISCONNECT_GRACE_S",
+        0.0,
+    )
+    sessions_module._runner_relay_tasks.clear()
+    gate = asyncio.Event()
+    fake_runner = _TunnelCloseRunnerClient(gate)
+    store = _RecordingLabelStore(live_status="running")
+    session_id = "5b1e2d7c9a4f4e0b8c3d2a1f6e7d8c9b"
+    sessions_module._session_status_cache[session_id] = "running"
+    shutdown_state.mark_server_shutting_down()
+
+    try:
+        handle = await sessions_module._ensure_runner_relay_ready(
+            session_id,
+            "runner_server_shutdown",
+            fake_runner,  # type: ignore[arg-type]
+            conversation_store=store,  # type: ignore[arg-type]
+        )
+        assert handle is not None
+        gate.set()
+        await asyncio.wait_for(handle.task, timeout=2.0)
+
+        assert session_id not in store.labels, "shutdown-time drop persisted failure labels"
+        assert sessions_module._session_status_cache.get(session_id) == "running"
+    finally:
+        shutdown_state.reset_for_tests()
+        gate.set()
+        handle = sessions_module._runner_relay_tasks.get(session_id)
+        if handle is not None and not handle.task.done():
+            handle.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(handle.task, timeout=1.0)
+        sessions_module._runner_relay_tasks.clear()
+        sessions_module._session_status_cache.pop(session_id, None)
+        session_stream.close(session_id)

--- a/tests/server/test_shutdown_state.py
+++ b/tests/server/test_shutdown_state.py
@@ -1,0 +1,39 @@
+"""Tests for the process-wide server-shutdown signal."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+
+import pytest
+
+from omnigent.server import shutdown_state
+
+
+@pytest.fixture(autouse=True)
+def _reset_shutdown_state() -> Iterator[None]:
+    shutdown_state.reset_for_tests()
+    yield
+    shutdown_state.reset_for_tests()
+
+
+def test_unmarked_process_is_not_shutting_down() -> None:
+    assert shutdown_state.server_shutting_down() is False
+
+
+def test_explicit_mark_is_fresh_within_the_window_then_expires() -> None:
+    shutdown_state.mark_server_shutting_down()
+    assert shutdown_state.server_shutting_down() is True
+    expired = time.monotonic() + shutdown_state.SHUTDOWN_WINDOW_S
+    assert shutdown_state.server_shutting_down(now=expired) is False
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [(1012, True), (1000, False), (1001, False), (1006, False), (None, False)],
+)
+def test_only_a_server_initiated_close_code_marks_shutdown(
+    code: int | None, expected: bool
+) -> None:
+    assert shutdown_state.note_tunnel_close_code(code) is expected
+    assert shutdown_state.server_shutting_down() is expected

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -2762,6 +2762,53 @@ describe("chatStore — send while streaming (queueing)", () => {
     expect(useChatStore.getState().activeResponse?.state).toBe("failed");
   });
 
+  it("drops a runner_disconnected error card once the runner reports a live status", () => {
+    // A deploy-time tunnel drop lights a "connection to the host dropped"
+    // card; the runner's next status edge proves it is reachable again, so
+    // the stale card must go instead of sitting beside a live turn.
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      sessionStatus: "running",
+      blocks: [],
+    });
+    handleSessionEvent({
+      type: "session_status",
+      conversationId: "conv_abc",
+      status: "failed",
+      error: { code: "runner_disconnected", message: "Runner disconnected unexpectedly." },
+    });
+    expect(useChatStore.getState().blocks.filter((b) => b.type === "error")).toHaveLength(1);
+
+    handleSessionEvent({
+      type: "session_status",
+      conversationId: "conv_abc",
+      status: "running",
+    });
+    expect(useChatStore.getState().blocks.filter((b) => b.type === "error")).toHaveLength(0);
+  });
+
+  it("keeps a genuine failure card across a later live status edge", () => {
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      sessionStatus: "running",
+      blocks: [],
+    });
+    handleSessionEvent({
+      type: "session_status",
+      conversationId: "conv_abc",
+      status: "failed",
+      error: { code: "executor_error", message: "boom" },
+    });
+    handleSessionEvent({
+      type: "session_status",
+      conversationId: "conv_abc",
+      status: "running",
+    });
+    const errorBlocks = useChatStore.getState().blocks.filter((b) => b.type === "error");
+    expect(errorBlocks).toHaveLength(1);
+    expect(errorBlocks[0]).toMatchObject({ code: "executor_error", message: "boom" });
+  });
+
   it("preserves a cancelled turn across a bare idle edge", () => {
     // The user's interrupt verdict must survive the trailing idle the
     // teardown publishes.

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -5419,6 +5419,16 @@ export function handleSessionEvent(event: StreamEvent, streamConversationId?: st
             } satisfies ErrorBlock,
           ];
         }
+        // A `runner_disconnected` card is an observation ("can't reach the
+        // runner"), not a turn result: any live status edge from the runner
+        // proves it is reachable again, so the stale card goes.
+        if (event.status !== "failed") {
+          const current = patch.blocks ?? s.blocks;
+          const reachable = current.filter(
+            (b) => !(b.type === "error" && b.code === "runner_disconnected"),
+          );
+          if (reachable.length !== current.length) patch.blocks = reachable;
+        }
         return patch;
       });
       // Refetch the snapshot at turn START too: the runner persists


### PR DESCRIPTION
## Related issue

Closes #5268

## Summary

- A server going down closes every runner tunnel with close code 1012 and stops listening, so runners can't re-register inside the 10 s disconnect grace even though they're alive. Both reconciliation paths — the per-runner grace timer in `app.py` and the relay give-up in `orchestration.py` — then failed every in-flight turn with "Runner disconnected unexpectedly" on every rolling deploy (3–14 sessions per deploy of the `omnigents` app), while the runner kept working.
- New `omnigent/server/shutdown_state.py` records the server's own shutdown: explicitly from the CLI server's `shutdown()` override, and in-band from a 1012 close observed on a runner tunnel (uvicorn only sends 1012 while shutting down, so this also covers entrypoints that run a bare `uvicorn.run(app)`, like the Databricks Apps wrapper). Both reconciliation paths skip the failed-marking while it's set; runner invalidation and liveness clearing are unchanged. The mark is time-bounded (60 s) so a spurious client close can't disable reconciliation for good.
- Web: a `runner_disconnected` error card is dropped on the next live status edge from the runner; other failure cards are untouched.

ELI5: during a deploy the server hung up on every runner and then blamed the runners for the dropped call. Now it remembers that it was the one who hung up.

```
old server                               runner (alive the whole time)
  | SIGTERM → closes tunnels (1012) ------>| can't reconnect: nothing is listening
  | 10 s grace expires                     |
  |   BEFORE: publish failed / runner_disconnected
  |   AFTER:  "this is my own shutdown" → skip
new server                                |
  |<------ runner reconnects, re-adopted --|
```

## Test Plan

- `pytest tests/server/test_shutdown_state.py tests/server/routes/test_sessions_runner_relay.py tests/server/integration/test_sessions_tunnel_three_layer.py` — new: a 1012 close on a mid-turn session goes through the real tunnel route and grace timer and never produces `failed`/labels; the relay give-up during shutdown persists nothing; close-code/window unit tests. The existing grace, idle-spared and crash-report tests are unchanged and pass.
- `cd web && pnpm exec vitest run src/store/chatStore.test.ts` — card dropped on a later `running` edge; a genuine `executor_error` card survives.
- `pre-commit run --files …` green (ruff, pyrefly, prettier, oxlint, tsc).
- Root cause confirmed against the app's exported server logs (`Shutting down` → relay give-up at +10 s → failed) and the runner/host logs on the host machine: the runner process and its Claude session survived the whole window.

## Demo

N/A — no new visuals; the only UI effect is a stale error card disappearing once the session is live again.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The deploy itself can't be driven in CI; the integration test drives the same close code (1012) through the real tunnel route and the grace timer, which is the exact path a deploy takes.

## Changelog

A server restart or redeploy no longer marks in-progress sessions as "Runner disconnected unexpectedly", and the stale card clears once the runner is back.
