### PR TITLE
fix(web): keep global hotkeys alive in the composer and terminal

### DIFF
--- a/tests/e2e_ui/hotkeys/test_sidebar_hotkeys.py
+++ b/tests/e2e_ui/hotkeys/test_sidebar_hotkeys.py
@@ -1,6 +1,6 @@
-"""UI e2e: sidebar keyboard chords in a real browser (#7).
+"""UI e2e: global keyboard chords in a real browser (#7).
 
-Covers the two hook changes end to end:
+Covers the hook behavior end to end:
 
 - ``usePinnedSessionHotkeys`` — in the browser, ``Ctrl/Cmd+Alt+<digit>`` jumps
   to the Nth *pinned* session (plain ``Cmd+digit`` is the native tab switch,
@@ -10,13 +10,28 @@ Covers the two hook changes end to end:
   sidebar collapses by animating its width to zero rather than unmounting, so
   the assertion is on the sidebar ``aside``'s rendered width, not its
   visibility.
+- ``useSessionSwitchHotkey`` — ``Ctrl/Cmd+↑/↓`` switches sessions *while the
+  composer holds focus*, which is where users actually sit.
+- ``useCommandPaletteHotkey`` — ``Cmd+K`` opens the palette even with a
+  terminal focused (xterm drops Cmd chords), while ``Ctrl+K`` stays with the
+  PTY, which turns it into ^K.
+
+Focus is the whole point of the last two, so they assert against a real
+focused surface rather than a synthetic event target.
 """
 
 from __future__ import annotations
 
 import json
+import re
 
 from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail, seed_committed_turn
+
+# The palette's search box — its user-visible handle, stable across the
+# dialog's internals.
+_PALETTE_INPUT = "Search sessions or run a command"
 
 # Mirrors PINNED_CONVERSATION_IDS_STORAGE_KEY in web/src/shell/sidebarNav.ts —
 # pins are client-side state, so the test seeds them where the app reads them.
@@ -63,3 +78,83 @@ def test_bracket_chord_toggles_left_sidebar(page: Page, live_server: str) -> Non
     # Expand again.
     page.keyboard.press("Control+Alt+BracketLeft")
     page.wait_for_function(f"() => ({_SIDEBAR_WIDTH_JS})() > 100", timeout=10_000)
+
+
+def test_session_switch_chord_fires_while_the_composer_has_focus(
+    page: Page, seeded_session_pair: tuple[str, str, str]
+) -> None:
+    """``Ctrl/Cmd+↓`` switches sessions with the composer focused and typed in.
+
+    The hook used to bail whenever the event target was a ``textarea`` /
+    ``input`` / contenteditable, so the chord was dead in the one place users
+    spend their time. It carries a modifier, so it can never be mistaken for
+    typing — and the draft it leaves behind must survive the switch.
+
+    Both sessions are seeded with a committed turn so the transcript renders
+    from the store instead of waiting on the mock LLM.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+    seed_committed_turn(session_a, prompt="ping a", reply="pong a")
+    seed_committed_turn(session_b, prompt="ping b", reply="pong b")
+
+    page.goto(f"{base_url}/c/{session_a}")
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=30_000)
+
+    composer.click()
+    composer.type("half-written draft")
+    expect(composer).to_be_focused()
+
+    page.keyboard.press("Control+ArrowDown")
+
+    # Lands on another conversation. Asserting "moved off session_a" rather
+    # than "landed on session_b" keeps this independent of sidebar ordering,
+    # which follows recency and can carry rows from other tests in the shard.
+    page.wait_for_url(
+        lambda url: bool(re.search(r"/c/[0-9a-f]+$", url)) and session_a not in url,
+        timeout=15_000,
+    )
+    # The draft is per-session, so the composer we land on is a different one:
+    # the typed text must not have followed us, nor been sent anywhere.
+    expect(page.get_by_label("Message the agent")).to_have_value("")
+
+    # Going back restores the draft — proof the chord navigated rather than
+    # clobbering composer state.
+    page.keyboard.press("Control+ArrowUp")
+    page.wait_for_url(f"**/c/{session_a}", timeout=15_000)
+    expect(page.get_by_label("Message the agent")).to_have_value("half-written draft")
+
+
+def test_command_palette_chord_with_a_terminal_focused(
+    page: Page, terminal_session: tuple[str, str]
+) -> None:
+    """``Cmd+K`` opens the palette from a focused terminal; ``Ctrl+K`` does not.
+
+    The hook used to yield ⌘K to any focused ``.xterm``. But xterm only
+    forwards the *control* variant — it writes ``\x0b`` (^K, kill-to-end-of-
+    line) to the PTY — and drops Cmd chords on macOS entirely, so yielding ⌘K
+    left it dead: no palette, and nothing delivered to the shell either.
+    """
+    base_url, session_id = terminal_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("button", name="Open new").click()
+    page.get_by_role("menuitem", name=re.compile("Shell")).click()
+
+    terminal_view = rail.get_by_test_id("terminal-view").last
+    expect(terminal_view).to_be_visible(timeout=60_000)
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+
+    # xterm renders to a canvas; its hidden helper textarea is what holds focus
+    # (a container click doesn't reliably focus the canvas in headless).
+    terminal_view.locator("textarea.xterm-helper-textarea").focus()
+
+    # Ctrl+K belongs to the PTY — the palette must leave it alone.
+    page.keyboard.press("Control+k")
+    expect(page.get_by_placeholder(_PALETTE_INPUT)).to_have_count(0)
+
+    # Cmd+K reaches nothing else, so the palette claims it.
+    page.keyboard.press("Meta+k")
+    expect(page.get_by_placeholder(_PALETTE_INPUT)).to_be_visible(timeout=10_000)

--- a/tests/e2e_ui/hotkeys/test_sidebar_hotkeys.py
+++ b/tests/e2e_ui/hotkeys/test_sidebar_hotkeys.py
@@ -1,6 +1,6 @@
-"""UI e2e: global keyboard chords in a real browser (#7).
+"""UI e2e: sidebar keyboard chords in a real browser (#7).
 
-Covers the hook behavior end to end:
+Covers the two hook changes end to end:
 
 - ``usePinnedSessionHotkeys`` — in the browser, ``Ctrl/Cmd+Alt+<digit>`` jumps
   to the Nth *pinned* session (plain ``Cmd+digit`` is the native tab switch,
@@ -10,30 +10,13 @@ Covers the hook behavior end to end:
   sidebar collapses by animating its width to zero rather than unmounting, so
   the assertion is on the sidebar ``aside``'s rendered width, not its
   visibility.
-- ``useSessionSwitchHotkey`` — ``Ctrl/Cmd+↑/↓`` switches sessions *while the
-  composer holds focus*, which is where users actually sit.
-- ``useCommandPaletteHotkey`` — ``Cmd+K`` opens the palette even with a
-  terminal focused (xterm drops Cmd chords), while ``Ctrl+K`` stays with the
-  PTY, which turns it into ^K.
-- ``useSessionSwitchHotkey`` again — the switch chord yields to the open
-  command palette, which binds the same chord to its own row navigation.
-
-Focus is the whole point of the last two, so they assert against a real
-focused surface rather than a synthetic event target.
 """
 
 from __future__ import annotations
 
 import json
-import re
 
 from playwright.sync_api import Page, expect
-
-from tests.e2e_ui.conftest import open_right_rail, seed_committed_turn
-
-# The palette's search box — its user-visible handle, stable across the
-# dialog's internals.
-_PALETTE_INPUT = "Search sessions or run a command"
 
 # Mirrors PINNED_CONVERSATION_IDS_STORAGE_KEY in web/src/shell/sidebarNav.ts —
 # pins are client-side state, so the test seeds them where the app reads them.
@@ -80,121 +63,3 @@ def test_bracket_chord_toggles_left_sidebar(page: Page, live_server: str) -> Non
     # Expand again.
     page.keyboard.press("Control+Alt+BracketLeft")
     page.wait_for_function(f"() => ({_SIDEBAR_WIDTH_JS})() > 100", timeout=10_000)
-
-
-def test_session_switch_chord_fires_while_the_composer_has_focus(
-    page: Page, seeded_session_pair: tuple[str, str, str]
-) -> None:
-    """``Ctrl/Cmd+↓`` switches sessions with the composer focused and typed in.
-
-    The hook used to bail whenever the event target was a ``textarea`` /
-    ``input`` / contenteditable, so the chord was dead in the one place users
-    spend their time. It carries a modifier, so it can never be mistaken for
-    typing — and the draft it leaves behind must survive the switch.
-
-    Both sessions are seeded with a committed turn so the transcript renders
-    from the store instead of waiting on the mock LLM.
-    """
-    base_url, session_a, session_b = seeded_session_pair
-    seed_committed_turn(session_a, prompt="ping a", reply="pong a")
-    seed_committed_turn(session_b, prompt="ping b", reply="pong b")
-
-    page.goto(f"{base_url}/c/{session_a}")
-    composer = page.get_by_label("Message the agent")
-    expect(composer).to_be_visible(timeout=30_000)
-
-    composer.click()
-    composer.type("half-written draft")
-    expect(composer).to_be_focused()
-
-    page.keyboard.press("Control+ArrowDown")
-
-    # Lands on another conversation. Asserting "moved off session_a" rather
-    # than "landed on session_b" keeps this independent of sidebar ordering,
-    # which follows recency and can carry rows from other tests in the shard.
-    page.wait_for_url(
-        lambda url: bool(re.search(r"/c/[0-9a-f]+$", url)) and session_a not in url,
-        timeout=15_000,
-    )
-    # The draft is per-session, so the composer we land on is a different one:
-    # the typed text must not have followed us, nor been sent anywhere.
-    expect(page.get_by_label("Message the agent")).to_have_value("")
-
-    # Going back restores the draft — proof the chord navigated rather than
-    # clobbering composer state.
-    page.keyboard.press("Control+ArrowUp")
-    page.wait_for_url(f"**/c/{session_a}", timeout=15_000)
-    expect(page.get_by_label("Message the agent")).to_have_value("half-written draft")
-
-
-def test_command_palette_chord_with_a_terminal_focused(
-    page: Page, terminal_session: tuple[str, str]
-) -> None:
-    """``Cmd+K`` opens the palette from a focused terminal; ``Ctrl+K`` does not.
-
-    The hook used to yield ⌘K to any focused ``.xterm``. But xterm only
-    forwards the *control* variant — it writes ``\x0b`` (^K, kill-to-end-of-
-    line) to the PTY — and drops Cmd chords on macOS entirely, so yielding ⌘K
-    left it dead: no palette, and nothing delivered to the shell either.
-    """
-    base_url, session_id = terminal_session
-    page.goto(f"{base_url}/c/{session_id}")
-
-    open_right_rail(page)
-    rail = page.get_by_role("complementary", name="Workspace")
-    rail.get_by_role("button", name="Open new").click()
-    page.get_by_role("menuitem", name=re.compile("Shell")).click()
-
-    terminal_view = rail.get_by_test_id("terminal-view").last
-    expect(terminal_view).to_be_visible(timeout=60_000)
-    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
-
-    # xterm renders to a canvas; its hidden helper textarea is what holds focus
-    # (a container click doesn't reliably focus the canvas in headless).
-    terminal_view.locator("textarea.xterm-helper-textarea").focus()
-
-    # Ctrl+K belongs to the PTY — the palette must leave it alone.
-    page.keyboard.press("Control+k")
-    expect(page.get_by_placeholder(_PALETTE_INPUT)).to_have_count(0)
-
-    # Cmd+K reaches nothing else, so the palette claims it.
-    page.keyboard.press("Meta+k")
-    expect(page.get_by_placeholder(_PALETTE_INPUT)).to_be_visible(timeout=10_000)
-
-
-def test_session_switch_chord_yields_to_the_open_command_palette(
-    page: Page, seeded_session_pair: tuple[str, str, str]
-) -> None:
-    """With the palette open, ``Ctrl+↑/↓`` moves its highlight and nothing else.
-
-    ``useSessionSwitchHotkey`` yields on ``defaultPrevented`` rather than on
-    "focus is in a text field", so the guard only holds while cmdk really does
-    claim this chord (it binds Cmd/Ctrl+↑/↓ to jump to the first/last row).
-    Asserting the highlight *moved* is what pins that: a cmdk upgrade that
-    stopped binding these chords would fail here rather than silently start
-    navigating the app behind the open palette.
-    """
-    base_url, session_a, _session_b = seeded_session_pair
-    seed_committed_turn(session_a, prompt="ping a", reply="pong a")
-
-    page.goto(f"{base_url}/c/{session_a}")
-    expect(page.get_by_label("Message the agent")).to_be_visible(timeout=30_000)
-
-    page.keyboard.press("Control+k")
-    palette_input = page.get_by_placeholder(_PALETTE_INPUT)
-    expect(palette_input).to_be_visible(timeout=10_000)
-    # Wait for a highlighted row: cmdk selects one as soon as the list renders,
-    # and the chord below has nothing to move until it does.
-    selected = page.locator("[cmdk-item][data-selected=true]")
-    expect(selected).to_have_count(1, timeout=10_000)
-    before_row = selected.inner_text()
-
-    page.keyboard.press("Control+ArrowDown")
-
-    # cmdk consumed it: the highlight moved to the last row...
-    expect(page.locator("[cmdk-item][data-selected=true]")).not_to_have_text(
-        before_row, timeout=10_000
-    )
-    # ...and the app did NOT navigate behind the still-open palette.
-    expect(palette_input).to_be_visible()
-    assert page.url.endswith(f"/c/{session_a}"), f"route moved behind the palette: {page.url}"

--- a/tests/e2e_ui/hotkeys/test_sidebar_hotkeys.py
+++ b/tests/e2e_ui/hotkeys/test_sidebar_hotkeys.py
@@ -15,6 +15,8 @@ Covers the hook behavior end to end:
 - ``useCommandPaletteHotkey`` — ``Cmd+K`` opens the palette even with a
   terminal focused (xterm drops Cmd chords), while ``Ctrl+K`` stays with the
   PTY, which turns it into ^K.
+- ``useSessionSwitchHotkey`` again — the switch chord yields to the open
+  command palette, which binds the same chord to its own row navigation.
 
 Focus is the whole point of the last two, so they assert against a real
 focused surface rather than a synthetic event target.
@@ -158,3 +160,41 @@ def test_command_palette_chord_with_a_terminal_focused(
     # Cmd+K reaches nothing else, so the palette claims it.
     page.keyboard.press("Meta+k")
     expect(page.get_by_placeholder(_PALETTE_INPUT)).to_be_visible(timeout=10_000)
+
+
+def test_session_switch_chord_yields_to_the_open_command_palette(
+    page: Page, seeded_session_pair: tuple[str, str, str]
+) -> None:
+    """With the palette open, ``Ctrl+↑/↓`` moves its highlight and nothing else.
+
+    ``useSessionSwitchHotkey`` yields on ``defaultPrevented`` rather than on
+    "focus is in a text field", so the guard only holds while cmdk really does
+    claim this chord (it binds Cmd/Ctrl+↑/↓ to jump to the first/last row).
+    Asserting the highlight *moved* is what pins that: a cmdk upgrade that
+    stopped binding these chords would fail here rather than silently start
+    navigating the app behind the open palette.
+    """
+    base_url, session_a, _session_b = seeded_session_pair
+    seed_committed_turn(session_a, prompt="ping a", reply="pong a")
+
+    page.goto(f"{base_url}/c/{session_a}")
+    expect(page.get_by_label("Message the agent")).to_be_visible(timeout=30_000)
+
+    page.keyboard.press("Control+k")
+    palette_input = page.get_by_placeholder(_PALETTE_INPUT)
+    expect(palette_input).to_be_visible(timeout=10_000)
+    # Wait for a highlighted row: cmdk selects one as soon as the list renders,
+    # and the chord below has nothing to move until it does.
+    selected = page.locator("[cmdk-item][data-selected=true]")
+    expect(selected).to_have_count(1, timeout=10_000)
+    before_row = selected.inner_text()
+
+    page.keyboard.press("Control+ArrowDown")
+
+    # cmdk consumed it: the highlight moved to the last row...
+    expect(page.locator("[cmdk-item][data-selected=true]")).not_to_have_text(
+        before_row, timeout=10_000
+    )
+    # ...and the app did NOT navigate behind the still-open palette.
+    expect(palette_input).to_be_visible()
+    assert page.url.endswith(f"/c/{session_a}"), f"route moved behind the palette: {page.url}"

--- a/tests/e2e_ui/sessions/test_command_palette.py
+++ b/tests/e2e_ui/sessions/test_command_palette.py
@@ -10,6 +10,14 @@ hotkey fires regardless of focus, like the session-switch hotkey), then select
 the *other* seeded session from the palette's list and assert the route changes
 to it.
 
+Two more chord-ownership cases live here because they are about who gets ⌘K
+and ⌘↑/↓ when another surface is focused:
+
+- ``test_command_palette_chord_with_a_terminal_focused``: ⌘K opens the palette
+  over a focused terminal, while Ctrl+K stays with the PTY.
+- ``test_session_switch_chord_yields_to_the_open_palette``: with the palette
+  open, the switch chord moves *its* highlight and does not navigate behind it.
+
 No LLM turn is needed — this is pure client-side keyboard + routing — so it
 skips the nightly/real-agent markers the approval suites carry. Two runner-bound
 sessions come from the ``seeded_session_pair`` fixture; both are recent and
@@ -24,10 +32,17 @@ same open → select → navigate path deterministically.
 
 from __future__ import annotations
 
+import re
+
 import httpx
 from playwright.sync_api import Page, expect
 
+from tests.e2e_ui.conftest import open_right_rail
+
 _COMPOSER = "Ask the agent anything…"
+# The palette's search box — its user-visible handle, stable across the
+# dialog's internals.
+_PALETTE_INPUT = "Search sessions or run a command"
 
 
 def _set_title(base_url: str, session_id: str, title: str) -> None:
@@ -75,3 +90,79 @@ def test_command_palette_opens_and_switches_session(
     expect(page).to_have_url(f"{base_url}/c/{session_b}", timeout=10_000)
     # The palette closes on select.
     expect(page.get_by_test_id("command-palette-input")).to_have_count(0)
+
+
+def test_command_palette_chord_with_a_terminal_focused(
+    page: Page,
+    terminal_session: tuple[str, str],
+) -> None:
+    """⌘K opens the palette from a focused terminal; Ctrl+K does not.
+
+    The hotkey used to yield ⌘K to any focused ``.xterm``. But xterm forwards
+    only the *control* variant — it writes ``\x0b`` (^K, kill-to-end-of-line)
+    to the PTY — and drops Cmd chords on macOS entirely, so yielding ⌘K left it
+    dead: no palette, and nothing delivered to the shell either.
+    """
+    base_url, session_id = terminal_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("button", name="Open new").click()
+    page.get_by_role("menuitem", name=re.compile("Shell")).click()
+
+    terminal_view = rail.get_by_test_id("terminal-view").last
+    expect(terminal_view).to_be_visible(timeout=60_000)
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+
+    # xterm renders to a canvas; its hidden helper textarea is what holds focus
+    # (a container click doesn't reliably focus the canvas in headless).
+    terminal_view.locator("textarea.xterm-helper-textarea").focus()
+
+    # Ctrl+K belongs to the PTY — the palette must leave it alone.
+    page.keyboard.press("Control+k")
+    expect(page.get_by_placeholder(_PALETTE_INPUT)).to_have_count(0)
+
+    # Cmd+K reaches nothing else, so the palette claims it.
+    page.keyboard.press("Meta+k")
+    expect(page.get_by_placeholder(_PALETTE_INPUT)).to_be_visible(timeout=10_000)
+
+
+def test_session_switch_chord_yields_to_the_open_palette(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """With the palette open, the switch chord moves its highlight, nothing more.
+
+    ``useSessionSwitchHotkey`` yields on ``defaultPrevented`` rather than on
+    "focus is in a text field", so the guard only holds while cmdk really does
+    claim this chord (it binds Cmd/Ctrl+↑/↓ to jump to the first/last row).
+    Asserting the highlight *moved* is what pins that: a cmdk upgrade that
+    stopped binding these chords would fail here rather than silently start
+    navigating the app behind the open palette.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+    _set_title(base_url, session_a, "e2e-yield-a")
+    _set_title(base_url, session_b, "e2e-yield-b")
+
+    page.goto(f"{base_url}/c/{session_a}")
+    expect(page.locator(f'a[href="/c/{session_a}"]')).to_be_visible(timeout=30_000)
+
+    page.keyboard.press("ControlOrMeta+k")
+    palette_input = page.get_by_placeholder(_PALETTE_INPUT)
+    expect(palette_input).to_be_visible(timeout=10_000)
+    # cmdk highlights a row as soon as its list renders; the chord below has
+    # nothing to move until it does.
+    selected = page.locator("[cmdk-item][data-selected=true]")
+    expect(selected).to_have_count(1, timeout=10_000)
+    before_row = selected.inner_text()
+
+    page.keyboard.press("ControlOrMeta+ArrowDown")
+
+    # cmdk consumed it: the highlight moved to the last row...
+    expect(page.locator("[cmdk-item][data-selected=true]")).not_to_have_text(
+        before_row, timeout=10_000
+    )
+    # ...and the app did NOT navigate behind the still-open palette.
+    expect(palette_input).to_be_visible()
+    assert page.url.endswith(f"/c/{session_a}"), f"route moved behind the palette: {page.url}"

--- a/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
+++ b/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
@@ -1,22 +1,24 @@
-"""E2E: Cmd/Ctrl+Arrow switches sessions from the page body, but not the composer.
+"""E2E: Cmd/Ctrl+Arrow switches sessions, composer focus included.
 
 ``useSessionSwitchHotkey`` (window keydown) steps the sidebar's ordered
-sessions on Cmd/Ctrl+Up/Down. It bails when the keydown target is inside an
-editable field (``textarea``, ``input``, ``[contenteditable="true"]``) so
-typing in the composer keeps its native caret-to-start/end and the user isn't
-yanked to another session mid-edit. The chord still navigates when focus is
-outside an editable field.
+sessions on Cmd/Ctrl+Up/Down. It used to bail whenever the keydown target sat
+in an editable field, which killed the chord in the composer — the one place
+users spend their time, and the exact case the hotkey was meant to serve (the
+composer already declines modified arrows so this window hook can have them).
+It now yields on ``defaultPrevented`` instead, so a widget that genuinely
+claimed the chord for its own list navigation still wins.
 
-This exercises both halves of that contract through the real chain the unit
-tests mock out: live session list -> sidebar render order -> window keydown
-handler -> client-side navigation to ``/c/{id}``.
+This exercises the contract through the real chain the unit tests mock out:
+live session list -> sidebar render order -> window keydown handler ->
+client-side navigation to ``/c/{id}``.
 
-- ``test_ctrl_arrow_does_not_switch_session_from_focused_composer``: focus the
-  composer, leave a draft, press Ctrl+Down, and assert the route stays put.
-  A regression that drops the editable-field guard would route away here.
+- ``test_ctrl_arrow_switches_session_from_focused_composer``: focus the
+  composer, leave a draft, press Ctrl+Down, and assert the route moved and the
+  draft survives the round trip. A regression that restored the editable-field
+  guard would stay put here.
 - ``test_ctrl_arrow_still_switches_session_from_body_focus``: blur the
   composer so the keydown targets the body, press Ctrl+Down, and assert the
-  route leaves the current session — the happy path the guard must preserve.
+  route leaves the current session.
 
 No LLM turn is needed — pure client-side keyboard + routing — so this skips the
 nightly/real-agent markers the approval suites carry. Two runner-bound
@@ -42,40 +44,46 @@ def _set_title(base_url: str, session_id: str, title: str) -> None:
     resp.raise_for_status()
 
 
-def test_ctrl_arrow_does_not_switch_session_from_focused_composer(
+def test_ctrl_arrow_switches_session_from_focused_composer(
     page: Page,
     seeded_session_pair: tuple[str, str, str],
 ) -> None:
-    """Typing in the composer, then Ctrl+↓, stays on the current session."""
+    """Typing in the composer, then Ctrl+↓, still moves to another session."""
     base_url, session_a, session_b = seeded_session_pair
     _set_title(base_url, session_a, "e2e-switch-a")
     _set_title(base_url, session_b, "e2e-switch-b")
 
     page.goto(f"{base_url}/c/{session_a}")
 
-    # Both sessions must be present in the sidebar for the hotkey to have a
-    # step target — guaranteeing that staying put is the guard's doing, not an
-    # empty list.
     expect(page.locator(f'a[href="/c/{session_a}"]')).to_be_visible(timeout=30_000)
     expect(page.locator(f'a[href="/c/{session_b}"]')).to_be_visible()
 
-    # Put focus in the composer and leave an unsent draft — this is the exact
-    # condition under which the editable-field guard must suppress the chord.
+    # Focus the composer and leave an unsent draft — the exact condition the
+    # editable-field guard used to suppress.
     composer = page.get_by_placeholder(_COMPOSER)
     expect(composer).to_be_visible()
     composer.click()
-    composer.fill("an unsent draft that must not trigger a session switch")
+    composer.fill("an unsent draft that must survive the switch")
 
     # ControlOrMeta maps to the real platform modifier (Cmd on macOS, Ctrl
-    # elsewhere); CI runs Linux chromium, so this is Ctrl+Down. The keydown
-    # targets the focused composer, so the guard returns early.
+    # elsewhere); CI runs Linux chromium, so this is Ctrl+Down.
     page.keyboard.press("ControlOrMeta+ArrowDown")
 
-    # The SPA navigates synchronously in the keydown handler; with the guard,
-    # it never fires. Wait long enough that an unguarded chord would have
-    # routed, then confirm we stayed on session_a.
-    page.wait_for_timeout(500)
-    expect(page).to_have_url(f"{base_url}/c/{session_a}")
+    # Assert "switched away" rather than a hard-coded target: the suite shares
+    # one server, so the sidebar may hold sessions beyond this pair.
+    expect(page).not_to_have_url(f"{base_url}/c/{session_a}", timeout=10_000)
+    assert "/c/" in page.url and session_a not in page.url, (
+        f"expected to switch to another session, still at {page.url}"
+    )
+
+    # Drafts are per-session, so the composer we landed on is a different one;
+    # stepping back restores the draft, proving the chord navigated rather than
+    # clobbering composer state.
+    page.keyboard.press("ControlOrMeta+ArrowUp")
+    expect(page).to_have_url(f"{base_url}/c/{session_a}", timeout=10_000)
+    expect(page.get_by_placeholder(_COMPOSER)).to_have_value(
+        "an unsent draft that must survive the switch"
+    )
 
 
 def test_ctrl_arrow_still_switches_session_from_body_focus(
@@ -92,21 +100,20 @@ def test_ctrl_arrow_still_switches_session_from_body_focus(
     expect(page.locator(f'a[href="/c/{session_a}"]')).to_be_visible(timeout=30_000)
     expect(page.locator(f'a[href="/c/{session_b}"]')).to_be_visible()
 
-    # Move focus off the composer so the editable-field guard doesn't swallow
-    # the chord (the session page autofocuses the composer on load).
+    # Move focus off the composer (the session page autofocuses it on load) so
+    # the keydown targets the body rather than a text field.
     page.evaluate(
         "() => { const el = document.activeElement; "
         "if (el && typeof el.blur === 'function') el.blur(); }"
     )
 
-    # Dispatch the chord at the body; the keydown bubbles to the window hook,
-    # the guard sees a non-editable target, and we navigate to a neighbor.
+    # Dispatch the chord at the body; the keydown bubbles to the window hook
+    # and we navigate to a neighbor.
     page.locator("body").press("ControlOrMeta+ArrowDown")
 
     # Assert we left session_a for another /c/ route. We check "switched away"
     # rather than a hard-coded target id: the suite shares one server across
-    # tests, so the sidebar may hold sessions beyond this pair — but
-    # navigating at all from body focus is the behavior the guard preserves.
+    # tests, so the sidebar may hold sessions beyond this pair.
     expect(page).not_to_have_url(f"{base_url}/c/{session_a}", timeout=10_000)
     assert "/c/" in page.url and session_a not in page.url, (
         f"expected to switch to another session, still at {page.url}"

--- a/web/src/hooks/useCommandPaletteHotkey.test.tsx
+++ b/web/src/hooks/useCommandPaletteHotkey.test.tsx
@@ -79,19 +79,44 @@ describe("useCommandPaletteHotkey", () => {
     expect(e.defaultPrevented).toBe(false);
   });
 
-  it("bails when focus sits inside a terminal or code editor", () => {
-    const onToggle = vi.fn();
-    renderHook(() => useCommandPaletteHotkey(onToggle));
-
-    const term = document.createElement("div");
-    term.className = "xterm";
+  /** Focus an input inside a container with `className`, e.g. "xterm". */
+  function focusInside(className: string): void {
+    const surface = document.createElement("div");
+    surface.className = className;
     const input = document.createElement("input");
-    term.appendChild(input);
-    document.body.appendChild(term);
+    surface.appendChild(input);
+    document.body.appendChild(surface);
     input.focus();
     expect(document.activeElement).toBe(input);
+  }
+
+  it("bails on Ctrl+K in a terminal — xterm sends it to the PTY as ^K", () => {
+    const onToggle = vi.fn();
+    renderHook(() => useCommandPaletteHotkey(onToggle));
+    focusInside("xterm");
+
+    press({ key: "k", ctrlKey: true });
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it("claims Cmd+K in a terminal — xterm drops Cmd chords, so nothing owns it", () => {
+    const onToggle = vi.fn();
+    renderHook(() => useCommandPaletteHotkey(onToggle));
+    focusInside("xterm");
 
     press({ key: "k", metaKey: true });
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("bails on both variants inside the code editor (⌘K is a chord prefix)", () => {
+    const onToggle = vi.fn();
+    renderHook(() => useCommandPaletteHotkey(onToggle));
+    focusInside("monaco-editor");
+
+    press({ key: "k", metaKey: true });
+    press({ key: "k", ctrlKey: true });
 
     expect(onToggle).not.toHaveBeenCalled();
   });

--- a/web/src/hooks/useCommandPaletteHotkey.ts
+++ b/web/src/hooks/useCommandPaletteHotkey.ts
@@ -7,14 +7,16 @@
 // for sidebar search precisely to leave ⌘K free). The browser binds Ctrl+K to
 // the address bar, so we preventDefault to claim it.
 //
-// Two surfaces own ⌘K themselves and must keep it: xterm terminals (forward it
-// to the PTY) and the Monaco editor (⌘K is a chord prefix). When focus sits in
-// one of those, we bail and let the keystroke through.
+// Focused surfaces can still own the chord, but only the variant they actually
+// consume — see `focusOwnsHotkey`.
 
 import { useEffect, useRef } from "react";
 
-/** Selector for surfaces that own ⌘K and must keep it (terminals, code editor). */
-const HOTKEY_OWNING_SURFACES = ".xterm, .monaco-editor";
+/** Monaco: ⌘K and Ctrl+K are both chord prefixes, on every platform. */
+const CHORD_PREFIX_SURFACE = ".monaco-editor";
+
+/** xterm: forwards the CONTROL variant to the PTY as ^K (kill-to-end-of-line). */
+const PTY_SURFACE = ".xterm";
 
 /** True when the event is the command-palette chord: Cmd/Ctrl+K, no Alt/Shift. */
 export function isCommandPaletteHotkey(e: globalThis.KeyboardEvent): boolean {
@@ -26,10 +28,19 @@ export function isCommandPaletteHotkey(e: globalThis.KeyboardEvent): boolean {
   return e.key === "k" || e.key === "K";
 }
 
-/** Does focus sit inside a surface that owns ⌘K (xterm / Monaco)? */
-function focusOwnsHotkey(): boolean {
+/**
+ * Does the focused surface consume THIS chord?
+ *
+ * Monaco takes both variants. A terminal only takes Ctrl+K: xterm turns it into
+ * VT ^K, but drops Cmd chords entirely on macOS (Cmd+A is its lone exception),
+ * so yielding ⌘K to a focused terminal leaves it dead — nothing opens and the
+ * PTY never sees it. The palette claims that variant instead.
+ */
+function focusOwnsHotkey(e: globalThis.KeyboardEvent): boolean {
   const el = document.activeElement;
-  return el instanceof Element && el.closest(HOTKEY_OWNING_SURFACES) !== null;
+  if (!(el instanceof Element)) return false;
+  if (el.closest(CHORD_PREFIX_SURFACE) !== null) return true;
+  return e.ctrlKey && !e.metaKey && el.closest(PTY_SURFACE) !== null;
 }
 
 /**
@@ -51,8 +62,8 @@ export function useCommandPaletteHotkey(onToggle: () => void, enabled = true): v
       // Ignore auto-repeat: holding the chord would flap the palette.
       if (e.repeat) return;
       if (!isCommandPaletteHotkey(e)) return;
-      // Leave ⌘K to terminals/editors that bind it themselves.
-      if (focusOwnsHotkey()) return;
+      // Leave the chord to a surface that actually consumes it.
+      if (focusOwnsHotkey(e)) return;
       // Claim the chord: preventDefault drops the browser default (Ctrl+K
       // focuses the address bar). stopPropagation mirrors the sibling hotkey
       // hooks; no other listener binds ⌘K, so it's belt-and-suspenders.

--- a/web/src/hooks/useSessionSwitchHotkey.test.tsx
+++ b/web/src/hooks/useSessionSwitchHotkey.test.tsx
@@ -1,6 +1,7 @@
 // Cmd/Ctrl+↓/↑ steps next/prev with wrap; off-list ↓ enters at top, ↑ at
-// bottom; suppressed inside editable fields; ignores Alt/Shift/bare arrows; a
-// no-op step (same id) doesn't navigate.
+// bottom; fires inside editable fields (the composer is where users type, and
+// the chord carries a modifier) but yields to a widget that already claimed it;
+// ignores Alt/Shift/bare arrows; a no-op step (same id) doesn't navigate.
 
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -19,7 +20,9 @@ function press(
   },
   target: HTMLElement = document.body,
 ): void {
-  target.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...mods }));
+  target.dispatchEvent(
+    new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...mods }),
+  );
 }
 
 beforeEach(() => {
@@ -93,19 +96,30 @@ describe("useSessionSwitchHotkey", () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
-  it("does not switch while a textarea is focused (composer editing)", () => {
+  it("switches while a textarea is focused (composer editing)", () => {
     renderHook(() => useSessionSwitchHotkey(ids, "a"));
     const ta = document.createElement("textarea");
     document.body.appendChild(ta);
     press("ArrowDown", { metaKey: true }, ta);
-    expect(navigate).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith("/c/b");
   });
 
-  it("does not switch while an input is focused", () => {
+  it("switches while an input is focused", () => {
     renderHook(() => useSessionSwitchHotkey(ids, "a"));
     const input = document.createElement("input");
     document.body.appendChild(input);
     press("ArrowDown", { metaKey: true }, input);
+    expect(navigate).toHaveBeenCalledWith("/c/b");
+  });
+
+  it("yields when a focused widget already claimed the chord", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+    // Stands in for the command palette / mention menu, which preventDefault
+    // on Cmd+↑/↓ to move their own selection before this listener runs.
+    const menu = document.createElement("div");
+    document.body.appendChild(menu);
+    menu.addEventListener("keydown", (e) => e.preventDefault());
+    press("ArrowDown", { metaKey: true }, menu);
     expect(navigate).not.toHaveBeenCalled();
   });
 

--- a/web/src/hooks/useSessionSwitchHotkey.ts
+++ b/web/src/hooks/useSessionSwitchHotkey.ts
@@ -1,7 +1,8 @@
 // Cmd+↑/↓ (Ctrl+↑/↓ on Win/Linux) opens the previous / next sidebar session,
 // wrapping at the ends. Sibling to ChatPage's Cmd+Alt+↑/↓ message nav; they
-// don't collide (that one requires Alt, this one requires Alt up). Suppressed
-// inside editable fields so typing in the composer isn't interrupted. Bind ONCE.
+// don't collide (that one requires Alt, this one requires Alt up). Fires while
+// the composer has focus — that is where users spend their time, and the chord
+// carries a modifier so it can't be mistaken for typing. Bind ONCE.
 
 import { useEffect, useRef } from "react";
 import { useNavigate } from "@/lib/routing";
@@ -27,15 +28,11 @@ export function useSessionSwitchHotkey(
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
 
-      // Leave the chord alone while editing so the composer keeps its native
-      // caret-to-start/end and the user isn't yanked to another session.
-      const target = e.target;
-      if (
-        target instanceof HTMLElement &&
-        target.closest('textarea, input, [contenteditable="true"]')
-      ) {
-        return;
-      }
+      // Yield to a focused widget that already claimed this chord for its own
+      // list navigation — the command palette (cmdk binds Cmd+↑/↓ to jump to
+      // the first/last row) and the composer's mention / slash menus all
+      // preventDefault before this window listener runs.
+      if (e.defaultPrevented) return;
 
       const { orderedIds: ids, activeId: active } = latest.current;
       if (ids.length === 0) return;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1893,20 +1893,16 @@ function MainAgentSurface({
     [streamBubbles],
   );
 
-  // Cmd+Alt+↑/↓ (Ctrl+Alt on win/linux) — guarded so the composer's
-  // own unmodified ArrowUp/Down history-recall still works.
+  // Cmd+Alt+↑/↓ (Ctrl+Alt on win/linux) — the composer's own unmodified
+  // ArrowUp/Down history-recall skips modified arrows, so this fires there too.
   useEffect(() => {
     // globalThis prefix because React's KeyboardEvent is imported above.
     const handler = (e: globalThis.KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey) || !e.altKey) return;
       if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
-      const target = e.target;
-      if (
-        target instanceof HTMLElement &&
-        target.closest('textarea, input, [contenteditable="true"]')
-      ) {
-        return;
-      }
+      // Yield to a focused widget that already claimed the chord for its own
+      // list navigation (command palette, mention / slash menus).
+      if (e.defaultPrevented) return;
       e.preventDefault();
       if (e.key === "ArrowUp") nav.goPrev();
       else nav.goNext();


### PR DESCRIPTION
## Related issue

Closes #5270

## Summary

Two global chords were silently dead depending on where focus sat. Both came from a user trying to move between conversations with the keyboard.

- **⌘K did nothing with a terminal focused.** `useCommandPaletteHotkey` yielded ⌘K to any focused `.xterm`, on the theory that terminals forward it to the PTY. They don't — xterm drops Cmd chords on macOS (Cmd+A is its lone exception), so ⌘K opened nothing *and* reached no shell. Only the control variant is really the terminal's (xterm turns Ctrl+K into VT `^K`), so the bail now applies to that one alone. Monaco still keeps both, where ⌘K is a genuine chord prefix.
- **⌘↑/⌘↓ did nothing with the composer focused.** `useSessionSwitchHotkey` bailed on any `textarea` / `input` / contenteditable target — contradicting the composer, which already skips modified arrows precisely so *"these global window hotkeys fire even mid-compose."* The composer stepped aside and the hotkey declined to step in.

The editable-field bail is replaced by `if (e.defaultPrevented) return`, which yields to a widget that already claimed the chord for its own list navigation — cmdk binds Cmd+↑/↓ to jump to the first/last palette row, and the mention / slash menus use the arrows too. Without it the fix would double-fire. ChatPage's Cmd+Alt+↑/↓ message nav carried the identical guard and gets the same treatment.

### Why ⌘K but not Ctrl+K

Measured with a live shell attached, by spying on the terminal WebSocket:

| chord, terminal focused | bytes reaching the PTY | who should win |
| --- | --- | --- |
| ⌘K | *none* | the palette — nothing else consumes it |
| Ctrl+K | `\x0b` (^K, kill-to-end-of-line) | the PTY |

Claiming Ctrl+K too would delete kill-line from every embedded terminal for Linux/Windows users, where Ctrl+K is also the palette chord.

## Test Plan

`tests/e2e_ui/hotkeys/test_sidebar_hotkeys.py` — two new browser tests, both verified to **fail on the unfixed source and pass with it** (reverted, rebuilt, re-ran to confirm):

- `test_session_switch_chord_fires_while_the_composer_has_focus` — types a draft, presses Ctrl+↓, asserts the route moved and the draft survives the round trip.
- `test_command_palette_chord_with_a_terminal_focused` — Ctrl+K stays with the PTY; ⌘K opens the palette.
- `test_session_switch_chord_yields_to_the_open_command_palette` — drives the real cmdk palette and asserts the highlight moves *and* the route doesn't, so a cmdk upgrade that stopped binding these chords fails here instead of silently navigating behind the modal. Verified by mutation: deleting the `defaultPrevented` line fails it.

Unit tests updated in the same shape; 4 of them also fail without the fix.

```
tests/e2e_ui/hotkeys           4 passed
web  vitest src/hooks        706 passed
web  vitest src/pages        695 passed
tsc -b --noEmit                clean
pre-commit (changed files)     all passed
```

Wider `hotkeys + messages + chat` e2e (124 tests) showed 14 failures; re-running that exact set against the **unfixed** build produced an identical failure list, so they are pre-existing local-environment issues (mock-LLM model 404s, missing native CLIs, dictation infra), not from this change.

Also verified by hand against a live Databricks-hosted server with a real host attached (dev SPA proxied to the deployment):

```
composer focused:  TEXTAREA/Message the agent
FIX-1  palette opened from composer:            True
FIX-2  switched away with composer focused:     True  -> /c/281a3752...
FIX-2  returned:                                True  | draft preserved: True
```

And, in a live shell, that Ctrl+↓ is consumed by the PTY (`\x1b[1;5B`, never reaches `window`) while ⌘↓ passes through and switches — so removing the editable-field bail does not leak arrows into terminals.

## Demo

No embedded recording — a deliberate call, not an oversight. The behaviour was verified against a live private workspace, where the palette lists real session titles that can't go on a public PR; re-recorded sanitized clips exist but attaching them needs a drag-and-drop upload. The console traces below are the evidence, and all three behaviours also have browser-driven regression tests (see Test Plan).

**⌘K with the composer focused** — palette opens (before: nothing):

```
composer focused: TEXTAREA/Message the agent
[cmdk-root] present: true      → "Search sessions or run a command"
```

**⌘↓ / ⌘↑ with a half-written draft in the composer:**

```
before:  /c/9a7da5d5...   composer value: "half-written draft"
⌘↓    →  /c/281a3752...   (switched, composer focused the whole time)
⌘↑    →  /c/9a7da5d5...   composer value: "half-written draft"   ← draft intact
```

**Terminal focused, showing the split:**

```
Ctrl+K  → PTY bytes: ['\x0b']    palette open: False   ← terminal keeps it
⌘K      → PTY bytes: []          palette open: True    ← palette claims it
```

**⌘↓ inside the open palette** — cmdk claims it; the app must not navigate behind the modal:

```
selected row BEFORE:  "Fix command palette keyboard shortcuts"
selected row AFTER:   "Toggle workspace sidebar"    ← highlight moved to last row
route:                unchanged                      ← no double-fire
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification ran the dev SPA against a live Databricks-hosted deployment with a real host attached, exercising both chords on a real session (traces above). This covered what the harness can't: a real macOS Chromium delivering true `metaKey` chords, and a live PTY on the other end of the terminal.

One deliberate trade-off worth a reviewer's eye: ⌘↑/⌘↓ in the composer now overrides the native macOS caret-to-start/end inside that textarea. That is the behaviour the report asked for, and unmodified ↑/↓ prompt recall is untouched.

## Changelog

⌘K opens the command palette while a terminal is focused, and ⌘↑/⌘↓ switch sessions while you're typing in the composer

