### PR TITLE
fix(runner): send an MCP server the answer the person actually gave

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7296,7 +7296,15 @@ def create_runner_app(
         if body_type == "approval":
             _data = body.get("data") or body
             _elicit_action = _data.get("action", "")
-            pending_approvals.resolve(_data.get("elicitation_id", ""), _elicit_action == "accept")
+            # ``content`` is the person's answer when the prompt asked for
+            # more than consent (an MCP ``requestedSchema``). Dropping it here
+            # is what used to make the awaiting caller invent one.
+            _elicit_content = _data.get("content")
+            pending_approvals.resolve(
+                _data.get("elicitation_id", ""),
+                _elicit_action == "accept",
+                _elicit_content if isinstance(_elicit_content, dict) else None,
+            )
             if _session_harness_name(conversation_id) == "claude-native":
                 await _apply_claude_native_plan_verdict(conversation_id, _data)
             if _elicit_action == "decline":

--- a/omnigent/runner/mcp_manager.py
+++ b/omnigent/runner/mcp_manager.py
@@ -23,6 +23,63 @@ from omnigent.tools.mcp import McpServerConnection
 _logger = logging.getLogger(__name__)
 
 
+def _schema_asks_for_fields(params: ElicitRequestParams) -> bool:
+    """
+    Whether the server's ``requestedSchema`` declares any property.
+
+    A schema with no properties is a bare consent prompt, where an accept
+    carrying no content is exactly right.
+
+    :param params: The elicitation params from the MCP server.
+    :returns: ``True`` when at least one property was requested.
+    """
+    schema = getattr(params, "requestedSchema", None)
+    if not isinstance(schema, dict):
+        return False
+    properties = schema.get("properties")
+    return isinstance(properties, dict) and bool(properties)
+
+
+def _validated_content(
+    content: dict[str, str | int | float | bool | list[str] | None] | None,
+    params: ElicitRequestParams,
+) -> dict[str, str | int | float | bool | list[str] | None] | None:
+    """
+    Keep answered content only when it fits what the server asked for.
+
+    The resolve payload reaches here from a browser, so it is checked rather
+    than trusted: values must be the primitives MCP allows, keys must be ones
+    the schema named, and an enum must be answered with one of its own
+    members. Anything else is discarded so the caller falls back instead of
+    forwarding a body the server's own schema rejects — or one that would
+    fail ``ElicitResult`` validation inside this callback.
+
+    :param content: The content the person's verdict carried, or ``None``.
+    :param params: The elicitation params from the MCP server.
+    :returns: The content when it conforms, otherwise ``None``.
+    """
+    if not content:
+        return None
+    schema = getattr(params, "requestedSchema", None)
+    properties = schema.get("properties") if isinstance(schema, dict) else None
+    if not isinstance(properties, dict):
+        return None
+    for key, value in content.items():
+        prop = properties.get(key)
+        if not isinstance(prop, dict):
+            return None
+        if isinstance(value, list) and not all(isinstance(v, str) for v in value):
+            return None
+        if not isinstance(value, str | int | float | bool | list) and value is not None:
+            return None
+        allowed = prop.get("enum")
+        if isinstance(allowed, list) and allowed:
+            chosen = value if isinstance(value, list) else [value]
+            if any(v not in allowed for v in chosen):
+                return None
+    return content
+
+
 def _build_accept_content(
     params: ElicitRequestParams,
 ) -> dict[str, str | int | float | bool | list[str] | None] | None:
@@ -308,24 +365,39 @@ class RunnerMcpManager:
                 return ElicitResult(action="decline")
 
             # Park until the user approves or declines (or timeout).
-            # ``pending_approvals`` resolves a bool (accept/decline)
-            # — it does not carry the user's form data. Content is
-            # auto-filled from the requestedSchema below.
             # No-op publish_event: ``response.elicitation_resolved``
             # won't fire on timeout/cancellation, so the Omnigent server's
             # sidebar badge may stay stale. Same pattern as
             # proxy_mcp_manager. A future enhancement could POST
             # the resolved event back to the Omnigent server here.
-            approved = await pending_approvals.wait_for_user_approval(
+            verdict = await pending_approvals.wait_for_user_verdict(
                 elicitation_id=elicitation_id,
                 conversation_id=session_id,
                 publish_event=lambda _s, _e: None,
             )
 
-            if not approved:
+            if not verdict.approved:
                 return ElicitResult(action="decline")
 
-            content = _build_accept_content(params)
+            # The person's own answer wins. The schema auto-fill is the
+            # fallback for a surface that collected no fields — a bare
+            # approve/reject card, or the REPL — where a consent-shaped
+            # schema (a boolean, a lone enum, an explicit default) has only
+            # one sensible value anyway.
+            content = _validated_content(verdict.content, params)
+            if content is None:
+                content = _build_accept_content(params)
+            if content is None and _schema_asks_for_fields(params):
+                # The server asked for something nobody supplied, and the
+                # schema gives nothing to fall back on. An accept without the
+                # fields it declared is a malformed answer; declining is the
+                # outcome the server already knows how to handle.
+                _logger.info(
+                    "MCP elicitation %s accepted with no content for a schema "
+                    "that requires fields — declining instead",
+                    elicitation_id,
+                )
+                return ElicitResult(action="decline")
             return ElicitResult(action="accept", content=content)
 
         return _elicit

--- a/omnigent/runner/pending_approvals.py
+++ b/omnigent/runner/pending_approvals.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
+from dataclasses import dataclass
 
 # Default wait budget for a UI verdict, in seconds. Held at one day
 # (86400s) — matching the deciding policy's default ``ask_timeout``: an ASK
@@ -41,11 +42,35 @@ from collections.abc import Callable
 # that want a fast fail-closed should pass a finite ``timeout_seconds``.
 _DEFAULT_WAIT_SECONDS: float = 86400.0
 
-# Module-global registry: elicitation_id → asyncio.Future[bool].
-# True = approved, False = declined/timed-out. Future is owned by the
-# caller that registered it — this module is just the routing table
-# the session-event handler reads to set the result.
-_pending: dict[str, asyncio.Future[bool]] = {}
+#: Content values MCP allows in an ``ElicitResult`` — the same union the
+#: server validates a resolve payload against.
+ElicitContent = dict[str, str | int | float | bool | list[str] | None]
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """What the user decided, and whatever their form carried.
+
+    ``content`` exists because an elicitation can ask for more than consent:
+    an MCP server's ``requestedSchema`` names fields, and the answer to
+    "which environment?" is the field, not the accept. Carrying it here is
+    what lets the awaiting caller return the person's answer instead of
+    guessing one.
+
+    :param approved: ``True`` on accept, ``False`` on decline or timeout.
+    :param content: The resolver's ``content`` map, or ``None`` when the
+        verdict carried none (a bare approve/reject card, a decline, or a
+        timeout).
+    """
+
+    approved: bool
+    content: ElicitContent | None = None
+
+
+# Module-global registry: elicitation_id → asyncio.Future[Verdict].
+# Future is owned by the caller that registered it — this module is just
+# the routing table the session-event handler reads to set the result.
+_pending: dict[str, asyncio.Future[Verdict]] = {}
 
 # Per-session count of outstanding ASK verdicts (a session may have more
 # than one parked at once — e.g. parallel tool calls that each tripped a
@@ -80,7 +105,7 @@ def has_any_pending() -> bool:
     return any(not fut.done() for fut in _pending.values())
 
 
-def register(elicitation_id: str) -> asyncio.Future[bool]:
+def register(elicitation_id: str) -> asyncio.Future[Verdict]:
     """
     Create and store a Future for an outstanding ASK verdict.
 
@@ -93,7 +118,7 @@ def register(elicitation_id: str) -> asyncio.Future[bool]:
     :returns: The newly created Future. Caller awaits with
         :func:`asyncio.wait_for` to bound the wait.
     """
-    fut: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+    fut: asyncio.Future[Verdict] = asyncio.get_running_loop().create_future()
     _pending[elicitation_id] = fut
     return fut
 
@@ -111,7 +136,11 @@ def cleanup(elicitation_id: str) -> None:
     _pending.pop(elicitation_id, None)
 
 
-def resolve(elicitation_id: str, approved: bool) -> bool:
+def resolve(
+    elicitation_id: str,
+    approved: bool,
+    content: ElicitContent | None = None,
+) -> bool:
     """
     Set the verdict on a registered Future.
 
@@ -123,6 +152,9 @@ def resolve(elicitation_id: str, approved: bool) -> bool:
     :param elicitation_id: Correlation id from the approval event.
     :param approved: ``True`` on ``action == "accept"``, ``False``
         on decline or other terminal actions.
+    :param content: The ``content`` map the resolver sent, when the
+        prompt asked for more than consent. ``None`` for a bare
+        approve/reject.
     :returns: ``True`` if the Future was unresolved and was set;
         ``False`` if no Future was registered or it was already
         completed (e.g. timed out before the verdict arrived).
@@ -130,17 +162,19 @@ def resolve(elicitation_id: str, approved: bool) -> bool:
     fut = _pending.get(elicitation_id)
     if fut is None or fut.done():
         return False
-    fut.set_result(approved)
+    # A refusal is not an answer, so nothing the form collected travels with
+    # it. Normalising here means no consumer has to remember to drop it.
+    fut.set_result(Verdict(approved=approved, content=content if approved else None))
     return True
 
 
-async def wait_for_user_approval(
+async def wait_for_user_verdict(
     *,
     elicitation_id: str,
     conversation_id: str,
     publish_event: Callable[[str, dict[str, object]], None],
     timeout_seconds: float | None = None,
-) -> bool:
+) -> Verdict:
     """
     Park on a registered Future until the user delivers a verdict.
 
@@ -168,7 +202,8 @@ async def wait_for_user_approval(
         treating the prompt as refused, e.g. the spec-resolved
         ``ask_timeout`` from the server's pending verdict. ``None``
         falls back to :data:`_DEFAULT_WAIT_SECONDS`.
-    :returns: ``True`` on accept, ``False`` on decline / timeout.
+    :returns: The user's :class:`Verdict`. Declines and timeouts
+        carry ``approved=False`` and no content.
     """
     effective_timeout = _DEFAULT_WAIT_SECONDS if timeout_seconds is None else timeout_seconds
     fut = register(elicitation_id)
@@ -177,9 +212,9 @@ async def wait_for_user_approval(
     # exit path (verdict, timeout, cancellation) so the flag never leaks.
     _session_pending[conversation_id] = _session_pending.get(conversation_id, 0) + 1
     try:
-        approved = await asyncio.wait_for(fut, timeout=effective_timeout)
+        verdict = await asyncio.wait_for(fut, timeout=effective_timeout)
     except asyncio.TimeoutError:
-        approved = False
+        verdict = Verdict(approved=False)
     finally:
         cleanup(elicitation_id)
         _remaining = _session_pending.get(conversation_id, 0) - 1
@@ -199,7 +234,35 @@ async def wait_for_user_approval(
                 "elicitation_id": elicitation_id,
             },
         )
-    return approved
+    return verdict
+
+
+async def wait_for_user_approval(
+    *,
+    elicitation_id: str,
+    conversation_id: str,
+    publish_event: Callable[[str, dict[str, object]], None],
+    timeout_seconds: float | None = None,
+) -> bool:
+    """
+    Park on a verdict and report only whether it was an accept.
+
+    The consent-only view of :func:`wait_for_user_verdict`, for gates that
+    ask nothing beyond yes or no.
+
+    :param elicitation_id: Correlation id, e.g. ``"elicit_abc123"``.
+    :param conversation_id: Session the prompt was published on.
+    :param publish_event: Runner ``_publish_event``-shaped callable.
+    :param timeout_seconds: Wait budget; ``None`` uses the module default.
+    :returns: ``True`` on accept, ``False`` on decline / timeout.
+    """
+    verdict = await wait_for_user_verdict(
+        elicitation_id=elicitation_id,
+        conversation_id=conversation_id,
+        publish_event=publish_event,
+        timeout_seconds=timeout_seconds,
+    )
+    return verdict.approved
 
 
 def reset_for_tests() -> None:

--- a/omnigent/runner/proxy_mcp_manager.py
+++ b/omnigent/runner/proxy_mcp_manager.py
@@ -58,6 +58,25 @@ def _response_json_object(response: httpx.Response) -> _JsonObject:
     return result
 
 
+def _input_response(verdict: pending_approvals.Verdict) -> _JsonObject:
+    """
+    Build the MRTR ``inputResponses`` entry for one resolved elicitation.
+
+    Carries the person's ``content`` when the prompt collected fields, so a
+    server that asked "which environment?" is told which one rather than
+    only that someone said yes.
+
+    :param verdict: The resolved verdict for this elicitation.
+    :returns: The wire object for this elicitation id.
+    """
+    if not verdict.approved:
+        return {"action": "decline"}
+    response: _JsonObject = {"action": "accept"}
+    if verdict.content is not None:
+        response["content"] = cast(object, verdict.content)
+    return response
+
+
 def _json_object_list(value: object) -> list[_JsonObject]:
     """Return only object entries from a JSON array."""
     if not isinstance(value, list):
@@ -330,7 +349,7 @@ class ProxyMcpManager:
                     if self._publish_event is not None
                     else (lambda _s, _e: None)
                 )
-                approved = await pending_approvals.wait_for_user_approval(
+                verdict = await pending_approvals.wait_for_user_verdict(
                     elicitation_id=elicitation_id,
                     conversation_id=self._session_id,
                     publish_event=publisher,
@@ -345,7 +364,7 @@ class ProxyMcpManager:
                         "arguments": arguments,
                         "requestState": request_state,
                         "inputResponses": {
-                            elicitation_id: {"action": "accept" if approved else "decline"}
+                            elicitation_id: _input_response(verdict),
                         },
                     },
                 }

--- a/tests/runner/test_mcp_elicitation_content.py
+++ b/tests/runner/test_mcp_elicitation_content.py
@@ -1,0 +1,310 @@
+"""An MCP server gets the answer the person gave, not one the schema implies.
+
+``elicitation/create`` is how an MCP server asks for something it cannot
+decide alone — "which environment?", "what should I name the branch?". The
+server declares the shape in ``requestedSchema`` and expects that shape back
+in ``ElicitResult.content``.
+
+The web UI already collects those answers: a schema with an ``answer`` enum
+renders option buttons that post ``{"answer": "<label>"}``. What the runner
+did with them is what these tests pin — the verdict registry carried a bare
+bool, so the answer was dropped on arrival and the accept was filled in from
+the schema instead. A person choosing "prod" from three options had "dev"
+sent on their behalf, because auto-fill takes the first enum value.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+from mcp.types import ElicitRequestFormParams
+
+from omnigent.runner import pending_approvals
+from omnigent.runner.mcp_manager import RunnerMcpManager
+from omnigent.tools._elicitation_schema import build_accept_content_from_schema
+
+ELICIT_ID = "elicit_env_choice"
+SESSION = "conv_mcp_elicit"
+
+#: What an MCP server asking a real question sends.
+ENV_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"answer": {"type": "string", "enum": ["dev", "staging", "prod"]}},
+}
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> object:
+    """The verdict registry is process-global; keep this module's ids out."""
+    pending_approvals.reset_for_tests()
+    yield
+    pending_approvals.reset_for_tests()
+
+
+async def _park_then(
+    resolve: Any,
+) -> pending_approvals.Verdict:
+    """Park on a verdict and deliver *resolve* once the Future is registered."""
+
+    async def _deliver() -> None:
+        for _ in range(200):
+            if ELICIT_ID in pending_approvals._pending:
+                break
+            await asyncio.sleep(0.001)
+        resolve()
+
+    waiter = asyncio.ensure_future(
+        pending_approvals.wait_for_user_verdict(
+            elicitation_id=ELICIT_ID,
+            conversation_id=SESSION,
+            publish_event=lambda _s, _e: None,
+            timeout_seconds=5.0,
+        )
+    )
+    await _deliver()
+    return await waiter
+
+
+async def test_the_chosen_option_reaches_the_waiting_caller() -> None:
+    """The whole point: "prod" was chosen, so "prod" is what comes back.
+
+    Without this the caller only learned that *someone* accepted, and had to
+    invent the field the server asked for.
+    """
+    verdict = await _park_then(
+        lambda: pending_approvals.resolve(ELICIT_ID, True, {"answer": "prod"})
+    )
+
+    assert verdict.approved is True
+    assert verdict.content == {"answer": "prod"}
+
+
+async def test_auto_fill_would_have_sent_a_different_answer() -> None:
+    """Names the damage, so a revert reads as a behaviour change.
+
+    The schema fallback picks the first enum value. That is a reasonable
+    guess for a surface that collected nothing, and the wrong answer whenever
+    a person actually chose.
+    """
+    auto_filled = build_accept_content_from_schema(ENV_SCHEMA)
+
+    assert auto_filled == {"answer": "dev"}
+
+    verdict = await _park_then(
+        lambda: pending_approvals.resolve(ELICIT_ID, True, {"answer": "prod"})
+    )
+
+    assert verdict.content != auto_filled
+
+
+async def test_a_bare_approval_carries_no_content() -> None:
+    """A yes/no card collects no fields, and must not invent any.
+
+    ``None`` is the signal that lets the MCP caller fall back to the schema
+    auto-fill rather than sending an empty map the server's schema rejects.
+    """
+    verdict = await _park_then(lambda: pending_approvals.resolve(ELICIT_ID, True))
+
+    assert verdict.approved is True
+    assert verdict.content is None
+
+
+async def test_a_decline_is_a_decline_whatever_was_typed() -> None:
+    """The registry reports the verdict faithfully; refusal is the caller's job.
+
+    ``_elicit`` returns a bare ``ElicitResult(action="decline")`` on a false
+    verdict, so anything typed before the refusal never reaches the server —
+    pinned end-to-end in ``test_a_declined_elicitation_sends_no_content``.
+    """
+    verdict = await _park_then(
+        lambda: pending_approvals.resolve(ELICIT_ID, False, {"answer": "prod"})
+    )
+
+    assert verdict.approved is False
+
+
+async def test_a_timeout_is_a_decline_with_no_content() -> None:
+    """Nobody answered, so there is no answer to carry."""
+    verdict = await pending_approvals.wait_for_user_verdict(
+        elicitation_id=ELICIT_ID,
+        conversation_id=SESSION,
+        publish_event=lambda _s, _e: None,
+        timeout_seconds=0.01,
+    )
+
+    assert verdict.approved is False
+    assert verdict.content is None
+
+
+async def test_multi_field_and_free_form_answers_survive() -> None:
+    """MCP allows several properties, and values the schema cannot guess.
+
+    ``build_accept_content_from_schema`` gives up on exactly these (it
+    returns ``None`` for a free-form string), which is why the person's own
+    answer has to be the thing that travels.
+    """
+    typed: dict[str, Any] = {"branch": "release/2.4", "notify": True, "reviewers": ["ana", "kai"]}
+
+    verdict = await _park_then(lambda: pending_approvals.resolve(ELICIT_ID, True, typed))
+
+    free_form = {"type": "object", "properties": {"branch": {"type": "string"}}}
+
+    assert verdict.content == typed
+    assert build_accept_content_from_schema(free_form) is None
+
+
+class _StubServerClient:
+    """Enough of ``httpx.AsyncClient`` for the elicitation callback's POST."""
+
+    async def post(self, url: str, json: Any = None, timeout: float = 30.0) -> Any:
+        class _Resp:
+            @staticmethod
+            def raise_for_status() -> None:
+                return None
+
+            @staticmethod
+            def json() -> dict[str, str]:
+                return {"elicitation_id": ELICIT_ID}
+
+        return _Resp()
+
+
+async def _elicit_with(resolve: Any) -> Any:
+    """Drive the real inline-elicitation callback, delivering *resolve* mid-park."""
+    manager = RunnerMcpManager(server_client=cast(Any, _StubServerClient()))
+    callback = manager._build_elicitation_callback()
+    params = ElicitRequestFormParams(
+        message="Which environment?", requestedSchema=cast(Any, ENV_SCHEMA)
+    )
+
+    task = asyncio.ensure_future(callback(SESSION, params))
+    for _ in range(500):
+        if ELICIT_ID in pending_approvals._pending:
+            break
+        await asyncio.sleep(0.001)
+    resolve()
+    return await task
+
+
+async def test_the_server_receives_the_option_the_person_picked() -> None:
+    """End to end through the real callback: "prod" chosen, "prod" sent.
+
+    This is the behaviour the fix exists for. Before it, the callback
+    discarded the verdict's content and auto-filled ``{"answer": "dev"}``
+    from the schema — the first enum value — so the server acted on an
+    environment nobody selected.
+    """
+    result = await _elicit_with(
+        lambda: pending_approvals.resolve(ELICIT_ID, True, {"answer": "prod"})
+    )
+
+    assert result.action == "accept"
+    assert result.content == {"answer": "prod"}
+
+
+async def test_a_bare_approval_still_falls_back_to_the_schema() -> None:
+    """A yes/no surface collects nothing, so the guess is better than nothing.
+
+    Keeps the REPL and the binary approve card working: the server asked for
+    a field and must get one, even when the surface had no way to ask.
+    """
+    result = await _elicit_with(lambda: pending_approvals.resolve(ELICIT_ID, True))
+
+    assert result.action == "accept"
+    assert result.content == build_accept_content_from_schema(ENV_SCHEMA)
+
+
+async def test_a_declined_elicitation_sends_no_content() -> None:
+    """Refusal is refusal — nothing typed beforehand travels with it."""
+    result = await _elicit_with(
+        lambda: pending_approvals.resolve(ELICIT_ID, False, {"answer": "prod"})
+    )
+
+    assert result.action == "decline"
+    assert result.content is None
+
+
+async def test_the_runner_events_endpoint_carries_the_content() -> None:
+    """The regression boundary, exercised through the real HTTP handler.
+
+    Every other test here calls ``resolve`` directly, which is precisely the
+    line the old handler never reached with content. Posting the approval the
+    way the Omnigent server posts it is what proves the handler forwards it.
+    """
+    import httpx
+
+    from omnigent.runner import create_runner_app
+    from tests.runner.conftest import _FakeProcessManager, _ScriptedHarnessClient
+    from tests.runner.helpers import NullServerClient
+
+    app = create_runner_app(
+        process_manager=cast(Any, _FakeProcessManager(_ScriptedHarnessClient([]))),
+        server_client=cast(Any, NullServerClient()),
+    )
+    parked = pending_approvals.register(ELICIT_ID)
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as client:
+            resp = await client.post(
+                f"/v1/sessions/{SESSION}/events",
+                json={
+                    "type": "approval",
+                    "data": {
+                        "elicitation_id": ELICIT_ID,
+                        "action": "accept",
+                        "content": {"answer": "prod"},
+                    },
+                },
+            )
+            assert resp.status_code in (200, 204)
+        assert parked.done(), "the approval event never reached the registry"
+        assert parked.result() == pending_approvals.Verdict(
+            approved=True, content={"answer": "prod"}
+        )
+    finally:
+        pending_approvals.cleanup(ELICIT_ID)
+
+
+async def test_an_unanswerable_schema_declines_rather_than_inventing() -> None:
+    """A free-form field nobody filled in must not become a bare accept.
+
+    ``build_accept_content_from_schema`` cannot guess a string, so the old
+    fallback produced ``accept`` with no content at all — an answer that
+    violates the very schema the server published. Declining is the outcome
+    the server already has a path for.
+    """
+    manager = RunnerMcpManager(server_client=cast(Any, _StubServerClient()))
+    callback = manager._build_elicitation_callback()
+    params = ElicitRequestFormParams(
+        message="Name the release branch",
+        requestedSchema=cast(
+            Any, {"type": "object", "properties": {"branch": {"type": "string"}}}
+        ),
+    )
+
+    task = asyncio.ensure_future(callback(SESSION, params))
+    for _ in range(500):
+        if ELICIT_ID in pending_approvals._pending:
+            break
+        await asyncio.sleep(0.001)
+    pending_approvals.resolve(ELICIT_ID, True)
+    result = await task
+
+    assert result.action == "decline"
+
+
+async def test_an_answer_outside_the_enum_is_not_forwarded() -> None:
+    """Content arrives from a browser, so it is checked, not trusted.
+
+    A value the schema never offered would make the server act on something
+    it declared impossible; falling back keeps the wire body inside the
+    contract the server published.
+    """
+    result = await _elicit_with(
+        lambda: pending_approvals.resolve(ELICIT_ID, True, {"answer": "production"})
+    )
+
+    assert result.action == "accept"
+    assert result.content == build_accept_content_from_schema(ENV_SCHEMA)

--- a/tests/runner/test_pending_approvals.py
+++ b/tests/runner/test_pending_approvals.py
@@ -67,7 +67,7 @@ async def test_resolve_sets_result_and_returns_true() -> None:
     # between register and resolve.
     assert delivered is True
     assert fut.done()
-    assert fut.result() is True
+    assert fut.result() == pending_approvals.Verdict(approved=True, content=None)
 
 
 @pytest.mark.asyncio
@@ -94,7 +94,7 @@ async def test_resolve_already_done_returns_false() -> None:
     stays idempotent.
     """
     fut = pending_approvals.register("elicit_dup")
-    fut.set_result(True)
+    fut.set_result(pending_approvals.Verdict(approved=True))
     second = pending_approvals.resolve("elicit_dup", False)
     assert second is False
 

--- a/tests/runner/test_runner_idle_active_work.py
+++ b/tests/runner/test_runner_idle_active_work.py
@@ -270,7 +270,7 @@ async def test_parked_approval_blocks_idle_shutdown() -> None:
     assert app.state.has_active_work() is True
 
     async def _release() -> None:
-        fut.set_result(True)
+        fut.set_result(pending_approvals.Verdict(approved=True))
         pending_approvals.cleanup("elicit_idle_pin")
 
     await _assert_monitor_blocked_then_shuts_down(
@@ -288,7 +288,7 @@ async def test_done_approval_future_does_not_pin_runner() -> None:
     """
     app = _scaffold_app()
     fut = pending_approvals.register("elicit_stale")
-    fut.set_result(False)
+    fut.set_result(pending_approvals.Verdict(approved=False))
     assert fut.done()
     assert app.state.has_active_work() is False
 


### PR DESCRIPTION
## Related issue

Closes #5272

## Summary

An MCP server asks a question with `elicitation/create` and declares the shape
it wants back. The approval card renders an enum schema as option buttons, the
person picks one, and the server is told something else.

The answer survives most of the trip. `_resolve_elicitation` forwards it to the
runner verbatim — "``action``, optional ``content``" per its own docstring —
and the runner's `approval` branch read only `action`. It had nowhere to put
the rest: the verdict registry was `dict[str, asyncio.Future[bool]]`. So the
MCP callback got a bare "yes" and filled the answer in from the schema instead:
first enum value, or `"allow"`, or `True`. Its comment said as much.

Pick "prod" out of dev/staging/prod and the server deploys to `dev`, with an
audit trail saying you approved it.

- **Carry a `Verdict`** (`approved` + optional `content`) instead of a bool,
  forward the content the server already sends, and prefer the person's answer
  over the schema guess. Same fix in `proxy_mcp_manager`, whose
  `inputResponses` entry carried only an action.
- **Check the answer before forwarding it.** It arrives from a browser, so
  values must be the primitives MCP allows, keys must be ones the schema
  named, and an enum must be answered with one of its own members. Anything
  else falls back rather than putting a body on the wire that the server's own
  schema rejects — or one that would fail `ElicitResult` validation inside the
  callback.
- **A refusal carries no answer**, normalised at the registry so no consumer
  has to remember to drop it.
- **Fail closed on an unanswerable schema.** A schema naming fields that
  nothing collected and nothing can guess now declines. Previously that was an
  `accept` with no content at all — which is what
  `build_accept_content_from_schema` returns for a free-form string, the case
  its own docstring says should "direct the user to the web UI".

The schema fallback stays for consent-shaped prompts — a boolean, a lone enum,
an explicit default — where a yes/no surface has only one sensible value and
declining would invert the person's actual answer.

`wait_for_user_approval` keeps its boolean signature, so the policy-ASK gates
are untouched; the content-aware callers use `wait_for_user_verdict`.

## Test Plan

`tests/runner/test_mcp_elicitation_content.py` — new, 12 tests. The chosen
option reaching the caller; the same option reaching the server through the
real inline-elicitation callback; the runner's `/v1/sessions/{id}/events`
handler carrying content (the exact line that dropped it, driven over HTTP
rather than by calling `resolve` directly); the consent-shaped fallback still
firing; an unanswerable schema declining; an out-of-enum answer refused;
decline and timeout carrying nothing; multi-field answers surviving. Eleven of
the twelve fail against `upstream/main`; the twelfth is the fallback guard that
must keep passing.

```
pytest tests/runner            1667 passed, 1 skipped, 4 xfailed
pre-commit run --files …       ruff, ruff format, pyrefly, hygiene — all pass
```

Two failures in that area are pre-existing and reproduce with all four changed
files checked out at `upstream/main`:
`test_session_resources.py::test_reset_state_rematerializes_env_from_new_agent_spec`,
and the `tests/tools/test_manager.py` group that reads the developer's own
`~/.claude/skills`.

## Demo

No UI change, so the demo is what the MCP server receives. The probe drives
the real inline-elicitation callback and prints the `ElicitResult`; the left
half checks the four changed files out at `upstream/main`, so both halves run
real code.

![what the server receives](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/mcp-elicitation-content.gif)

On `upstream/main` — the person picked `prod`:

![before](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/mcp-elicit-before.png)

Same probe, same pick, with the fix:

![after](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/mcp-elicit-after.png)

The probe and the `vhs` tape are
[committed with the media](https://github.com/Paldom/omnigent/tree/agent-army/docs/agent-army/media).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The transport is covered through the real handler and the real callback rather
than by re-performing their writes in the test. What that cannot show is an
actual third-party MCP server on the other end, so the manual pass ran the
probe against both versions and compared the `ElicitResult` each would send.

## Notes for review

Two things I found next door and deliberately did not fold in:

- `build_accept_content_from_schema` checks enum and boolean *before* an
  explicit `default`, so a property declaring `default: false` auto-fills as
  `true`. Pre-existing, and only reachable on the fallback path.
- The registry is keyed by `elicitation_id` alone and the runner's handler
  does not check the id belongs to the posting session. That was already true
  when the verdict was a bare bool; now the same weakness would let a chosen
  answer, not just an accept, land on another session's elicitation. Worth
  binding `(conversation_id, elicitation_id)` at register time — happy to do
  it here if you would rather it not wait.

## Changelog

An MCP server that asks a question now receives the answer you picked, instead of the first option in its own schema.
