### PR TITLE
fix(web): reconnect the embedded terminal on code-less and proxy closes

### DIFF
--- a/tests/e2e_ui/shells/test_terminal_bridge_reconnect.py
+++ b/tests/e2e_ui/shells/test_terminal_bridge_reconnect.py
@@ -1,0 +1,101 @@
+"""E2E: the embedded terminal reconnects after a code-less bridge close.
+
+A server redeploy behind the Databricks Apps ingress tears the terminal
+attach WebSocket down without a clean app close code reaching the browser,
+which reports ``1005`` ("no status"). The client must treat that transport
+drop like the ``1006`` it already handled — show a "Reconnecting…" overlay
+and re-attach — instead of dead-ending on "Bridge closed: code 1005"
+(``isUnexpectedTerminalClose`` in
+``web/src/components/blocks/TerminalSession.ts``; the retry budget in
+``TerminalView.tsx``).
+
+The attach WebSocket is proxied through ``page.route_web_socket`` so the test
+holds a handle to the live connection; once the terminal is connected, the
+test closes that connection with ``1011`` (server internal error) and the
+next dial is proxied straight back to the real bridge — so the terminal
+recovers on its own. 1011 stands in for the whole newly-reconnectable set
+(1005/1011/1014): it is a real on-the-wire code the browser reports verbatim,
+whereas the reported ``1005`` is a reserved sentinel a proxy synthesizes that
+Playwright cannot reproduce end to end (its classification is pinned by the
+``TerminalSession`` unit test). Before the fix every one of these was
+classified deliberate and the terminal dead-ended; the
+``data-state="connected"`` assertion AFTER the drop is what that regression
+would fail. Closing from the test body (not the route handler) avoids the
+sync-API deadlock of a blocking call inside the handler.
+"""
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Page, WebSocketRoute, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+_ATTACH_WS = re.compile(r"/resources/terminals/.*/attach")
+
+
+def _open_new_shell(page: Page) -> None:
+    """Create a shell via the Workspace rail's "+" → Shell menu."""
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("button", name="Open new").click()
+    page.get_by_role("menuitem", name=re.compile("Shell")).click()
+
+
+def test_embedded_terminal_reconnects_after_transport_close(
+    page: Page, terminal_session: tuple[str, str]
+) -> None:
+    """A transport-level attach close (1011) recovers instead of dead-ending.
+
+    Proxy the attach WebSocket, let the terminal connect, then close that
+    connection with ``1011`` — a newly-reconnectable transport code (same
+    class as the reported ``1005`` a redeploy behind the ingress produces).
+    The overlay must read "Reconnecting…" (never the dead-end "Bridge
+    closed"), and the proxied retry must re-attach the terminal back to
+    ``connected``.
+
+    :param page: Playwright page fixture.
+    :param terminal_session: ``(base_url, session_id)`` with the terminal agent.
+    :returns: None.
+    """
+    base_url, session_id = terminal_session
+    live: dict[str, object] = {"ws": None, "dials": 0}
+
+    def _handle(ws: WebSocketRoute) -> None:
+        live["dials"] = int(live["dials"]) + 1
+        live["ws"] = ws
+        # Transparent proxy to the real terminal bridge (binary frames pass
+        # through unchanged); the test drives the drop from outside.
+        server = ws.connect_to_server()
+        ws.on_message(lambda message: server.send(message))
+        server.on_message(lambda message: ws.send(message))
+
+    page.route_web_socket(_ATTACH_WS, _handle)
+
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_new_shell(page)
+
+    rail = page.get_by_role("complementary", name="Workspace")
+    terminal_view = rail.get_by_test_id("terminal-view").last
+    expect(terminal_view).to_be_visible(timeout=60_000)
+    # The live terminal attaches through the proxy.
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=30_000)
+    dials_before = int(live["dials"])
+
+    # Simulate the redeploy: drop the attach socket with a server-error code
+    # from the test body (a blocking close inside the route handler deadlocks
+    # the sync API). 1011 is a real on-the-wire code in the newly-reconnectable
+    # set — the browser reports it verbatim, unlike the reserved 1005/1006
+    # sentinels a proxy synthesizes (covered by the TerminalSession unit test).
+    assert isinstance(live["ws"], WebSocketRoute)
+    live["ws"].close(code=1011)
+
+    # Recovery is presented AS recovery, and the dead-end message never shows.
+    # Before the fix, a 1005 close was terminal and this overlay never appeared.
+    expect(page.get_by_test_id("terminal-reconnecting")).to_be_visible(timeout=20_000)
+    expect(page.get_by_text(re.compile("Bridge closed"))).to_have_count(0)
+
+    # The proxied retry re-attaches the terminal on its own — no manual refresh.
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=60_000)
+    assert int(live["dials"]) > dials_before, "terminal did not re-dial after the code-less drop"

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -286,6 +286,13 @@ describe("isUnexpectedTerminalClose", () => {
     expect(isUnexpectedTerminalClose(1006)).toBe(true);
     expect(isUnexpectedTerminalClose(1012)).toBe(true);
     expect(isUnexpectedTerminalClose(1013)).toBe(true);
+    // 1005 "no status" is the browser's other no-clean-close sentinel
+    // (mirror of 1006); a server redeploy behind an ingress surfaces as
+    // 1005. 1011/1014 are the proxy's server-error / bad-gateway codes
+    // while the backend restarts.
+    expect(isUnexpectedTerminalClose(1005)).toBe(true);
+    expect(isUnexpectedTerminalClose(1011)).toBe(true);
+    expect(isUnexpectedTerminalClose(1014)).toBe(true);
   });
 
   it("treats deliberate closes (normal, policy, app 4xxx) as terminal", () => {

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -134,12 +134,19 @@ export type ConnectionState =
  * Transport-shaped closes happen *to* the connection rather than
  * being decided by either end's terminal logic:
  *
- * - 1006: abnormal closure, no close frame. The classic background-tab
- *   case — the tab freezes, buffered output stalls the socket, the
- *   server's keepalive ping times out, and the browser discovers a
- *   dead TCP connection on thaw.
+ * - 1005 / 1006: the browser's own "closed without a clean app code"
+ *   sentinels — 1005 is "no status code" (a Close frame with an empty
+ *   payload, e.g. a fronting proxy collapsing the close of a backend
+ *   that went away), 1006 is "no close frame at all" (a dead TCP
+ *   connection discovered on tab thaw). Neither is a code any endpoint
+ *   sets deliberately, so both are always a transport drop. A server
+ *   redeploy behind an ingress surfaces as 1005 here.
  * - 1001: "going away" — a server or proxy restarting.
  * - 1012 / 1013: service restart / try again later.
+ * - 1011 / 1014: server internal error / bad gateway — the fronting
+ *   proxy (e.g. Databricks Apps) emits these while the backend is
+ *   mid-restart. The app's OWN internal error is the explicit 4500, so
+ *   a raw 1011/1014 is infrastructure, not a deliberate terminal end.
  *
  * Pure helper — exported for direct unit testing.
  *
@@ -149,7 +156,15 @@ export type ConnectionState =
  *     reconnect attempt is appropriate.
  */
 export function isUnexpectedTerminalClose(code: number): boolean {
-  return code === 1001 || code === 1006 || code === 1012 || code === 1013;
+  return (
+    code === 1001 ||
+    code === 1005 ||
+    code === 1006 ||
+    code === 1011 ||
+    code === 1012 ||
+    code === 1013 ||
+    code === 1014
+  );
 }
 
 /** Listener for `ConnectionState` transitions. */

--- a/web/src/components/blocks/TerminalView.test.tsx
+++ b/web/src/components/blocks/TerminalView.test.tsx
@@ -456,6 +456,23 @@ describe("automatic reconnect", () => {
     expect(terminalSessionMock.instances[0].dispose).toHaveBeenCalled();
   });
 
+  it("re-dials after a code-less close (1005) — the redeploy-behind-ingress case", async () => {
+    // A server redeploy behind a fronting proxy tears the attach socket
+    // down without a clean app code reaching the browser, which reports
+    // 1005 ("no status"). It must recover exactly like 1006, not dead-end
+    // on "Bridge closed: code 1005".
+    await renderAndAttach();
+
+    closeNewest(1005);
+
+    expect(screen.getByTestId("terminal-reconnecting")).toBeInTheDocument();
+    expect(screen.queryByText(/Bridge closed/)).toBeNull();
+
+    await elapse(RECONNECT_BACKOFF_MS[0]);
+    expect(terminalSessionMock.instances).toHaveLength(2);
+    expect(terminalSessionMock.instances[0].dispose).toHaveBeenCalled();
+  });
+
   it("does not re-dial after a deliberate server close (4405 terminal-detached)", async () => {
     await renderAndAttach();
 

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -39,9 +39,16 @@ import {
  * when the schedule is exhausted the closed overlay stays up and the
  * user falls back to a manual refresh / resume.
  *
+ * The cumulative budget must outlast a server redeploy so a terminal
+ * watched through one recovers on its own instead of dead-ending a few
+ * seconds before the backend returns. A Databricks Apps redeploy takes
+ * the ingress ~20-25s to route to the new instance, so the tail reaches
+ * 15s for a ~30.5s total — comfortably past that window. (A backgrounded
+ * tab also re-dials with a fresh budget on the visibilitychange reveal.)
+ *
  * Exported for direct unit testing (fake timers advance through it).
  */
-export const RECONNECT_BACKOFF_MS = [500, 1000, 2000, 4000, 8000] as const;
+export const RECONNECT_BACKOFF_MS = [500, 1000, 2000, 4000, 8000, 15000] as const;
 
 /**
  * A connection that stayed open at least this long before dropping is

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -39,16 +39,26 @@ import {
  * when the schedule is exhausted the closed overlay stays up and the
  * user falls back to a manual refresh / resume.
  *
- * The cumulative budget must outlast a server redeploy so a terminal
- * watched through one recovers on its own instead of dead-ending a few
- * seconds before the backend returns. A Databricks Apps redeploy takes
- * the ingress ~20-25s to route to the new instance, so the tail reaches
- * 15s for a ~30.5s total — comfortably past that window. (A backgrounded
- * tab also re-dials with a fresh budget on the visibilitychange reveal.)
+ * The cumulative budget must outlast a server outage so a terminal
+ * watched through one recovers on its own instead of dead-ending while
+ * the backend is still coming back. The fast ramp covers the common
+ * case — a Databricks Apps redeploy reroutes the ingress in ~20-25s —
+ * and the schedule then holds at 30s for several minutes so a slow
+ * redeploy, a stuck rollout, or a longer infra blip still self-heals
+ * rather than stranding the user on a manual refresh. ~5 min total.
+ * (A backgrounded tab also re-dials with a fresh budget on the
+ * visibilitychange reveal, so this budget is really about a foreground
+ * terminal the user is actively watching.)
  *
  * Exported for direct unit testing (fake timers advance through it).
  */
-export const RECONNECT_BACKOFF_MS = [500, 1000, 2000, 4000, 8000, 15000] as const;
+export const RECONNECT_BACKOFF_MS = [
+  // Fast ramp: recover promptly from the common ~20-25s redeploy.
+  500, 1000, 2000, 4000, 8000, 15000,
+  // Then hold at 30s for the rest of a ~5-minute budget, so a longer
+  // outage still auto-recovers at a calm cadence instead of dead-ending.
+  30000, 30000, 30000, 30000, 30000, 30000, 30000, 30000, 30000,
+] as const;
 
 /**
  * A connection that stayed open at least this long before dropping is


### PR DESCRIPTION
## Related issue

Closes #5276

## Summary

- The embedded terminal dead-ended on **"Bridge closed: code 1005"** across a server redeploy even though the runner/host stayed up. `isUnexpectedTerminalClose` only reconnected on 1001/1006/1012/1013; a redeploy behind the Databricks Apps ingress closes the browser↔server attach socket without a clean app code, so the browser reports **1005** ("no status") — the mirror of the 1006 already handled — and the client skipped the re-dial.
- Classify **1005** (code-less close), **1011** (internal error) and **1014** (bad gateway) as transport-shaped. Deliberate closes still carry explicit codes (1000/1008/4400/4404/4405/4500), so this can't resurrect a terminal the server intentionally ended.
- Extend the reconnect backoff tail to 15s (~30.5s total) so a terminal watched through a redeploy outlasts the ~20-25s ingress reroute instead of exhausting the budget a few seconds early.

ELI5: the terminal knew how to auto-reconnect when the connection dropped one way (1006), but a redeploy drops it a slightly different way (1005) that it didn't recognize, so it gave up. Now it recognizes that shape too — and waits long enough for the server to come back.

## Test Plan

- `cd web && pnpm exec vitest run src/components/blocks/TerminalSession.test.ts src/components/blocks/TerminalView.test.tsx src/shell/terminalStatus.test.tsx` — 86 pass. New: `isUnexpectedTerminalClose` returns true for 1005/1011/1014; a view-level test drives a 1005 close and asserts the "Reconnecting…" overlay + a fresh re-dial (not the dead-end). The data-driven budget-exhaustion / stability-reset tests still pass against the longer schedule.
- `pnpm exec tsc --noEmit` and `oxlint` clean; `pre-commit` green.
- Root cause reproduced from the live incident: during the deploy of #5269 the runner/host showed no errors (the shutdown-mark fix worked), but the embedded terminal showed "Bridge closed: code 1005"; the browser CloseEvent code was 1005 while the app's deliberate closes use explicit 4xxx codes.

## Demo

- **Before (screenshot in #5276):** the terminal shows a static "Bridge closed: code 1005" over a frozen buffer after a redeploy, requiring a manual refresh.
- **After:** it shows "Reconnecting…" and re-attaches once the backend is back (tmux repaints the full screen on re-attach, so nothing visible is lost).

A recorded after-clip would need a live server redeploy, which this workflow can't stage. The overlay transition is instead demonstrated deterministically by the new Playwright test `tests/e2e_ui/shells/test_terminal_bridge_reconnect.py::test_embedded_terminal_reconnects_after_transport_close`: it proxies the attach WebSocket, drops it mid-session with a transport-level code, and asserts the `terminal-reconnecting` overlay appears (never "Bridge closed") and the terminal returns to `data-state="connected"` — i.e. the exact recovery a reviewer would otherwise film.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified against the live redeploy that surfaced the bug (browser CloseEvent code 1005, terminal frozen). The unit + view tests lock in the classification and the reconnect-vs-dead-end overlay behavior; a real server redeploy can't be driven in CI, but the view test drives the exact 1005 close the redeploy produces.

## Changelog

The in-app terminal now reconnects itself after a server restart or redeploy instead of dead-ending on "Bridge closed".

