### PR TITLE
fix: enforce model catalog freshness at launch

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -63,7 +63,7 @@ from omnigent_client._http import is_loopback_url
 from websockets.exceptions import ConnectionClosed, ConnectionClosedError, WebSocketException
 from websockets.frames import Close
 
-from omnigent import model_catalog
+from omnigent import model_catalog, model_catalog_store
 from omnigent._native_resume_hint import echo_native_resume_hint
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
 from omnigent._startup_profile import StartupProfiler
@@ -413,6 +413,13 @@ def _serves_canonical_anthropic_ids(claude_config: ClaudeNativeUcodeConfig) -> b
         return True
     host = (urlparse(base_url).hostname or "").lower()
     return host == "anthropic.com" or host.endswith(".anthropic.com")
+
+
+def claude_config_serves_canonical_ids(
+    claude_config: ClaudeNativeUcodeConfig | None,
+) -> bool:
+    """Whether a launch config accepts canonical Anthropic model ids."""
+    return claude_config is None or _serves_canonical_anthropic_ids(claude_config)
 
 
 def _claude_family(token: str) -> str | None:
@@ -1187,7 +1194,7 @@ async def claude_model_catalog(
 
 async def claude_launch_catalog(
     claude_config: ClaudeNativeUcodeConfig | None,
-) -> list[dict[str, object]] | None:
+) -> model_catalog_store.CatalogResult:
     """
     The shared catalog for this launch config: read the store, probe on miss.
 
@@ -1196,10 +1203,8 @@ async def claude_launch_catalog(
     the answer for every later consumer.
 
     :param claude_config: The resolved launch config, or ``None``.
-    :returns: Catalog rows, or ``None`` when no catalog could be obtained.
+    :returns: Catalog rows with freshness and any sanitized refresh error.
     """
-    from omnigent import model_catalog_store
-
     fingerprint = claude_catalog_fingerprint(claude_config)
     return await model_catalog_store.ensure_catalog(
         "claude-native", fingerprint, lambda: claude_model_catalog(claude_config)

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -24,7 +24,7 @@ import websockets
 from cachetools import TTLCache
 from websockets.asyncio.client import ClientConnection
 
-from omnigent import model_catalog
+from omnigent import model_catalog, model_catalog_store
 from omnigent.json_types import JsonObject as _JsonObject
 
 if TYPE_CHECKING:
@@ -988,7 +988,9 @@ def codex_catalog_fingerprint(launch: NativeCodexLaunch) -> str:
     )
 
 
-async def codex_launch_catalog(*, codex_path: str | None = None) -> list[_JsonObject] | None:
+async def codex_launch_catalog(
+    *, codex_path: str | None = None
+) -> model_catalog_store.CatalogResult:
     """
     The shared codex catalog for this host's default shape: store, then probe.
 
@@ -997,15 +999,17 @@ async def codex_launch_catalog(*, codex_path: str | None = None) -> list[_JsonOb
     answer for every later consumer.
 
     :param codex_path: Optional Codex executable override.
-    :returns: Catalog rows, or ``None`` when no catalog could be obtained.
+    :returns: Catalog rows with freshness and any sanitized refresh error.
     """
-    from omnigent import model_catalog_store
-
     try:
         launch = await asyncio.to_thread(resolve_native_codex_launch, model=None)
     except Exception:  # noqa: BLE001 — a broken provider config means no catalog
         _logger.warning("codex catalog: launch shape resolution failed", exc_info=True)
-        return None
+        return model_catalog_store.CatalogResult(
+            None,
+            model_catalog_store.CatalogFreshness.MISSING,
+            "launch configuration unavailable",
+        )
     fingerprint = codex_catalog_fingerprint(launch)
 
     async def _probe() -> list[_JsonObject] | None:

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -2312,10 +2312,11 @@ class HostProcess:
         from omnigent.codex_native_app_server import codex_launch_catalog
 
         try:
-            rows = await codex_launch_catalog()
+            catalog = await codex_launch_catalog()
         except Exception:  # noqa: BLE001 — no catalog, never a crash
             _logger.warning("Codex model catalog unavailable", exc_info=True)
             return None
+        rows = catalog.rows
         if rows is None:
             return None
         routable = [row["id"] for row in rows if isinstance(row.get("id"), str) and row["id"]]
@@ -2336,10 +2337,11 @@ class HostProcess:
 
         try:
             config = await asyncio.to_thread(resolve_native_claude_config, spec=None)
-            rows = await claude_launch_catalog(config)
+            catalog = await claude_launch_catalog(config)
         except Exception:  # noqa: BLE001 — no catalog, never a crash
             _logger.warning("Claude model catalog unavailable", exc_info=True)
             return None
+        rows = catalog.rows
         if rows is None:
             return None
         routable = list(config.routable_models) if config is not None else []

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -794,6 +794,7 @@ class ModelOptionsResult:
 
     models: list[dict[str, object]]
     routable_models: list[str]
+    error: str | None = None
 
 
 @dataclass
@@ -2316,11 +2317,22 @@ class HostProcess:
         except Exception:  # noqa: BLE001 — no catalog, never a crash
             _logger.warning("Codex model catalog unavailable", exc_info=True)
             return None
+        if catalog is None:
+            return None
         rows = catalog.rows
         if rows is None:
-            return None
+            return ModelOptionsResult(
+                models=[],
+                routable_models=[],
+                error=catalog.refresh_error or "the codex model probe failed",
+            )
         routable = [row["id"] for row in rows if isinstance(row.get("id"), str) and row["id"]]
-        return ModelOptionsResult(models=rows, routable_models=routable)
+        error = (
+            f"stale model catalog: {catalog.refresh_error or 'refresh failed'}"
+            if catalog.freshness.value == "stale"
+            else None
+        )
+        return ModelOptionsResult(models=rows, routable_models=routable, error=error)
 
     async def _probed_claude_model_options(self) -> ModelOptionsResult | None:
         """
@@ -2341,11 +2353,22 @@ class HostProcess:
         except Exception:  # noqa: BLE001 — no catalog, never a crash
             _logger.warning("Claude model catalog unavailable", exc_info=True)
             return None
+        if catalog is None:
+            return None
         rows = catalog.rows
         if rows is None:
-            return None
+            return ModelOptionsResult(
+                models=[],
+                routable_models=[],
+                error="the claude model probe failed — see the host log",
+            )
         routable = list(config.routable_models) if config is not None else []
-        return ModelOptionsResult(models=rows, routable_models=routable)
+        error = (
+            f"stale model catalog: {catalog.refresh_error or 'refresh failed'}"
+            if catalog.freshness.value == "stale"
+            else None
+        )
+        return ModelOptionsResult(models=rows, routable_models=routable, error=error)
 
     async def _handle_model_options(
         self,
@@ -2371,6 +2394,7 @@ class HostProcess:
                     request_id=frame.request_id,
                     status="ok",
                     models=probed.models,
+                    error=probed.error,
                     routable_models=probed.routable_models,
                 )
             return HostModelOptionsResultFrame(
@@ -2432,6 +2456,7 @@ class HostProcess:
                         request_id=frame.request_id,
                         status="ok",
                         models=probed.models,
+                        error=probed.error,
                         routable_models=probed.routable_models,
                     )
             return HostModelOptionsResultFrame(
@@ -2452,6 +2477,7 @@ class HostProcess:
                 request_id=frame.request_id,
                 status="ok",
                 models=probed.models,
+                error=probed.error,
                 routable_models=probed.routable_models,
             )
         return HostModelOptionsResultFrame(

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -965,8 +965,12 @@ def _redacted_failure_reason(exc: Exception) -> str:
         error_text = str(exc)
         if re.search(r"(?i)(?:--token\b|token\s*=|\b(?:dapi|sk-)[A-Za-z0-9_-]+)", error_text):
             return "provider credentials or network unavailable"
+        # The production remedy wraps the command in markdown backticks (see
+        # omnigent/runtime/credentials/databricks.py), so a whitespace-only
+        # boundary never matches it. Anchor on an identifier boundary instead;
+        # the profile capture stops at the closing backtick on its own.
         match = re.search(
-            r"(?<!\S)databricks auth login --profile ([A-Za-z0-9_.-]+)(?!\S)",
+            r"(?<![A-Za-z0-9_.-])databricks auth login --profile ([A-Za-z0-9_.-]+)",
             error_text,
         )
         if match is not None:

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -34,6 +34,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import subprocess
 import threading
 from dataclasses import dataclass, field, replace
@@ -961,6 +962,18 @@ def _redacted_failure_reason(exc: Exception) -> str:
         # secret-free messages (no credential / no base_url / empty token).
         return str(exc)
     if isinstance(exc, OSError):
+        error_text = str(exc)
+        if re.search(r"(?i)(?:--token\b|token\s*=|\b(?:dapi|sk-)[A-Za-z0-9_-]+)", error_text):
+            return "provider credentials or network unavailable"
+        match = re.search(
+            r"(?<!\S)databricks auth login --profile ([A-Za-z0-9_.-]+)(?!\S)",
+            error_text,
+        )
+        if match is not None:
+            return (
+                "provider credentials expired; run "
+                f"`databricks auth login --profile {match.group(1)}`"
+            )
         return "provider credentials or network unavailable"
     return type(exc).__name__
 

--- a/omnigent/model_catalog_store.py
+++ b/omnigent/model_catalog_store.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import fcntl
 import hashlib
 import json
 import logging
@@ -24,6 +25,8 @@ import os
 import tempfile
 import time
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -45,9 +48,28 @@ def fingerprint_of(*parts: object) -> str:
     return digest.hexdigest()[:16]
 
 
-#: Catalog entries older than this get a background refresh on read (the
-#: readers decide; the store only reports staleness).
+#: Catalog entries older than this are revalidated on read.
 CATALOG_STALE_AFTER_S = 3600.0
+CATALOG_REFRESH_TIMEOUT_S = 10.0
+CATALOG_LOCK_TIMEOUT_S = 2.0
+CATALOG_CLOCK_SKEW_TOLERANCE_S = 5.0
+
+
+class CatalogFreshness(Enum):
+    """Authority state of catalog rows returned by the store."""
+
+    FRESH = "fresh"
+    STALE = "stale"
+    MISSING = "missing"
+
+
+@dataclass(frozen=True)
+class CatalogResult:
+    """Catalog rows together with their launch-authority state."""
+
+    rows: list[dict[str, Any]] | None
+    freshness: CatalogFreshness
+    refresh_error: str | None = None
 
 
 def _data_dir() -> Path:
@@ -95,7 +117,10 @@ def catalog_age_s(harness: str, fingerprint: str) -> float | None:
     """Age of the stored catalog in seconds, or ``None`` on a miss."""
     path = catalog_path(harness, fingerprint)
     try:
-        return max(0.0, time.time() - path.stat().st_mtime)
+        delta = time.time() - path.stat().st_mtime
+        if delta < -CATALOG_CLOCK_SKEW_TOLERANCE_S:
+            return float("inf")
+        return max(0.0, delta)
     except OSError:
         return None
 
@@ -132,14 +157,38 @@ def write_catalog(harness: str, fingerprint: str, rows: list[dict[str, Any]]) ->
 #: In-flight probes, keyed (harness, fingerprint) — the thin single-flight
 #: wrapper the design keeps process-side: concurrent misses join one probe
 #: instead of each spawning CLI processes.
-_inflight: dict[tuple[str, str], asyncio.Task[list[dict[str, Any]] | None]] = {}
+_inflight: dict[tuple[str, str], asyncio.Task[CatalogResult]] = {}
+
+
+def _refresh_failure(exc: Exception) -> str:
+    if isinstance(exc, TimeoutError):
+        return "model catalog refresh timed out"
+    if isinstance(exc, OSError):
+        return "provider credentials or network unavailable"
+    return f"model catalog refresh failed ({type(exc).__name__})"
+
+
+async def _acquire_lock(path: Path) -> Any | None:
+    """Acquire the per-catalog advisory lock without blocking indefinitely."""
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    handle = path.open("a+")
+    deadline = time.monotonic() + CATALOG_LOCK_TIMEOUT_S
+    while True:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return handle
+        except BlockingIOError:
+            if time.monotonic() >= deadline:
+                handle.close()
+                return None
+            await asyncio.sleep(0.05)
 
 
 async def ensure_catalog(
     harness: str,
     fingerprint: str,
     resolve: Callable[[], Awaitable[list[dict[str, Any]] | None]],
-) -> list[dict[str, Any]] | None:
+) -> CatalogResult:
     """Store-first catalog access with a single probe in flight per key.
 
     A hit serves immediately; a miss runs *resolve* once (concurrent
@@ -148,23 +197,58 @@ async def ensure_catalog(
     :param harness: Canonical harness name.
     :param fingerprint: The launch-config fingerprint.
     :param resolve: Probe coroutine factory producing verbatim rows.
-    :returns: Catalog rows, or ``None`` when no catalog could be obtained.
+    :returns: Rows together with freshness and any sanitized refresh error.
     """
     cached = read_catalog(harness, fingerprint)
-    if cached is not None:
-        return cached
+    age = catalog_age_s(harness, fingerprint) if cached is not None else None
+    if cached is not None and age is not None and age <= CATALOG_STALE_AFTER_S:
+        return CatalogResult(cached, CatalogFreshness.FRESH)
     key = (harness, fingerprint)
     task = _inflight.get(key)
     if task is None or task.done():
 
-        async def _run() -> list[dict[str, Any]] | None:
+        async def _run() -> CatalogResult:
+            lock_handle = None
             try:
-                rows = await resolve()
+                lock_path = catalog_path(harness, fingerprint).with_suffix(".lock")
+                lock_handle = await _acquire_lock(lock_path)
+                if lock_handle is None:
+                    return CatalogResult(
+                        cached,
+                        CatalogFreshness.STALE if cached is not None else CatalogFreshness.MISSING,
+                        "model catalog refresh lock timed out",
+                    )
+                # Another process may have refreshed while this process waited.
+                post_lock = read_catalog(harness, fingerprint)
+                post_lock_age = (
+                    catalog_age_s(harness, fingerprint) if post_lock is not None else None
+                )
+                if (
+                    post_lock is not None
+                    and post_lock_age is not None
+                    and post_lock_age <= CATALOG_STALE_AFTER_S
+                ):
+                    return CatalogResult(post_lock, CatalogFreshness.FRESH)
+                rows = await asyncio.wait_for(resolve(), timeout=CATALOG_REFRESH_TIMEOUT_S)
+                if rows:
+                    write_catalog(harness, fingerprint, rows)
+                    return CatalogResult(rows, CatalogFreshness.FRESH)
+                return CatalogResult(
+                    cached,
+                    CatalogFreshness.STALE if cached is not None else CatalogFreshness.MISSING,
+                    "model catalog refresh returned no models",
+                )
+            except Exception as exc:  # noqa: BLE001 — stale rows remain available
+                return CatalogResult(
+                    cached,
+                    CatalogFreshness.STALE if cached is not None else CatalogFreshness.MISSING,
+                    _refresh_failure(exc),
+                )
             finally:
                 _inflight.pop(key, None)
-            if rows:
-                write_catalog(harness, fingerprint, rows)
-            return rows
+                if lock_handle is not None:
+                    fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+                    lock_handle.close()
 
         task = asyncio.create_task(_run(), name=f"model-catalog-{harness}")
         _inflight[key] = task
@@ -192,6 +276,8 @@ def catalog_contains(rows: list[dict[str, Any]], token: str) -> bool:
 
 __all__ = [
     "CATALOG_STALE_AFTER_S",
+    "CatalogFreshness",
+    "CatalogResult",
     "catalog_age_s",
     "catalog_contains",
     "catalog_path",

--- a/omnigent/model_catalog_store.py
+++ b/omnigent/model_catalog_store.py
@@ -231,7 +231,7 @@ async def ensure_catalog(
                 ):
                     return CatalogResult(post_lock, CatalogFreshness.FRESH)
                 rows = await asyncio.wait_for(resolve(), timeout=CATALOG_REFRESH_TIMEOUT_S)
-                if rows:
+                if rows is not None:
                     write_catalog(harness, fingerprint, rows)
                     return CatalogResult(rows, CatalogFreshness.FRESH)
                 return _failed_refresh(cached, "model catalog refresh returned no models")

--- a/omnigent/model_catalog_store.py
+++ b/omnigent/model_catalog_store.py
@@ -214,8 +214,8 @@ async def ensure_catalog(
 
         async def _run() -> CatalogResult:
             lock_handle = None
+            lock_path = catalog_path(harness, fingerprint).with_suffix(".lock")
             try:
-                lock_path = catalog_path(harness, fingerprint).with_suffix(".lock")
                 lock_handle = await _acquire_lock(lock_path)
                 if lock_handle is None:
                     return _failed_refresh(cached, "model catalog refresh lock timed out")
@@ -240,6 +240,13 @@ async def ensure_catalog(
             finally:
                 _inflight.pop(key, None)
                 if lock_handle is not None:
+                    # Drop our lockfile while still holding the lock so a crash
+                    # or normal exit never leaves a stale lockfile behind. A
+                    # racing waiter that already opened the same path may then
+                    # re-probe — benign for a best-effort cache (atomic writes,
+                    # at most a duplicate probe).
+                    with contextlib.suppress(OSError):
+                        lock_path.unlink()
                     fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
                     lock_handle.close()
 

--- a/omnigent/model_catalog_store.py
+++ b/omnigent/model_catalog_store.py
@@ -168,6 +168,11 @@ def _refresh_failure(exc: Exception) -> str:
     return f"model catalog refresh failed ({type(exc).__name__})"
 
 
+def _failed_refresh(cached: list[dict[str, Any]] | None, reason: str) -> CatalogResult:
+    freshness = CatalogFreshness.STALE if cached is not None else CatalogFreshness.MISSING
+    return CatalogResult(cached, freshness, reason)
+
+
 async def _acquire_lock(path: Path) -> Any | None:
     """Acquire the per-catalog advisory lock without blocking indefinitely."""
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -213,11 +218,7 @@ async def ensure_catalog(
                 lock_path = catalog_path(harness, fingerprint).with_suffix(".lock")
                 lock_handle = await _acquire_lock(lock_path)
                 if lock_handle is None:
-                    return CatalogResult(
-                        cached,
-                        CatalogFreshness.STALE if cached is not None else CatalogFreshness.MISSING,
-                        "model catalog refresh lock timed out",
-                    )
+                    return _failed_refresh(cached, "model catalog refresh lock timed out")
                 # Another process may have refreshed while this process waited.
                 post_lock = read_catalog(harness, fingerprint)
                 post_lock_age = (
@@ -233,17 +234,9 @@ async def ensure_catalog(
                 if rows:
                     write_catalog(harness, fingerprint, rows)
                     return CatalogResult(rows, CatalogFreshness.FRESH)
-                return CatalogResult(
-                    cached,
-                    CatalogFreshness.STALE if cached is not None else CatalogFreshness.MISSING,
-                    "model catalog refresh returned no models",
-                )
+                return _failed_refresh(cached, "model catalog refresh returned no models")
             except Exception as exc:  # noqa: BLE001 — stale rows remain available
-                return CatalogResult(
-                    cached,
-                    CatalogFreshness.STALE if cached is not None else CatalogFreshness.MISSING,
-                    _refresh_failure(exc),
-                )
+                return _failed_refresh(cached, _refresh_failure(exc))
             finally:
                 _inflight.pop(key, None)
                 if lock_handle is not None:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -8878,7 +8878,7 @@ def create_runner_app(
             # (ensure_catalog shields it), so a 503 here is genuinely
             # "pending", not "restarted".
             async with asyncio.timeout(_CLAUDE_MODEL_OPTIONS_INLINE_WAIT_S):
-                rows = await claude_launch_catalog(claude_config)
+                catalog = await claude_launch_catalog(claude_config)
         except TimeoutError:
             return JSONResponse(
                 status_code=503,
@@ -8887,6 +8887,7 @@ def create_runner_app(
                     "detail": "the harness model probe is still resolving",
                 },
             )
+        rows = catalog.rows
         if not rows:
             return JSONResponse(
                 status_code=503,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -8887,8 +8887,16 @@ def create_runner_app(
                     "detail": "the harness model probe is still resolving",
                 },
             )
+        if catalog is None:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "claude_native_model_options_failed",
+                    "detail": "the harness model probe failed; retrying",
+                },
+            )
         rows = catalog.rows
-        if not rows:
+        if rows is None:
             return JSONResponse(
                 status_code=503,
                 content={

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -6053,17 +6053,28 @@ async def _load_claude_launch_metadata(
 
 
 def _validate_explicit_codex_launch_model(model: str, catalog: Any) -> None:
-    """Require fresh catalog authority for a persisted Codex model."""
+    """Gate a persisted Codex model against the shared catalog by provenance.
+
+    Two outcomes must stay distinct. When a *fresh* list was obtained and it
+    does not name the pin, the pick genuinely changed since it was made — a
+    legitimate refusal. When validation *could not run* (a stale or missing
+    catalog because the probe failed), refusing would strand a user's explicit
+    pin on a transient probe defect; honor the pin instead and surface the
+    probe's real reason so a dead provider stays visible rather than silent.
+    The stale/missing catalog still never *originates* a model — that
+    implicit-default path stays fresh-gated at the call site.
+    """
     from omnigent.model_catalog_store import CatalogFreshness, catalog_contains
 
     if catalog is None:
         return
     if catalog.freshness is not CatalogFreshness.FRESH:
-        raise click.ClickException(
-            f"the requested model {model!r} could not be validated against a fresh model "
-            f"list ({catalog.refresh_error or 'catalog refresh failed'}). Pick again after "
-            "restoring provider credentials."
+        _logger.warning(
+            "Codex launch honoring explicit model %r without fresh catalog validation: %s",
+            model,
+            catalog.refresh_error or "catalog refresh failed",
         )
+        return
     if catalog.rows is None or not catalog_contains(catalog.rows, model):
         raise click.ClickException(
             f"the requested model {model!r} is not in this host's current model list — it "
@@ -6094,23 +6105,32 @@ def _select_authoritative_claude_launch_model(
         canonical_allowed = resolved.lower().startswith(
             "claude-"
         ) and claude_config_serves_canonical_ids(claude_config)
-        freshly_validated = bool(
-            catalog is not None
-            and catalog.freshness is CatalogFreshness.FRESH
-            and catalog.rows
-            and (
-                claude_catalog_serves_model(catalog.rows, explicit_model, claude_config)
-                or claude_catalog_serves_model(catalog.rows, resolved, claude_config)
-            )
+        fresh_rows = (
+            catalog.rows
+            if catalog is not None and catalog.freshness is CatalogFreshness.FRESH and catalog.rows
+            else None
         )
-        if not freshly_validated and not canonical_allowed:
-            detail = catalog.refresh_error if catalog is not None else "model catalog unavailable"
+        served_by_fresh = fresh_rows is not None and (
+            claude_catalog_serves_model(fresh_rows, explicit_model, claude_config)
+            or claude_catalog_serves_model(fresh_rows, resolved, claude_config)
+        )
+        if served_by_fresh or canonical_allowed:
+            return resolved
+        # Provenance decides, symmetric with the codex path: a fresh list that
+        # omits the pin is a legitimate refusal (the pick changed); a catalog
+        # that could not be validated must not strand the explicit pin on a
+        # probe failure — honor it and surface the probe's real reason.
+        if fresh_rows is not None:
             raise click.ClickException(
-                f"the requested model {explicit_model!r} could not be validated against a "
-                f"fresh model list ({detail}). Pick again from the model menu after restoring "
-                "provider credentials; for Databricks, run "
-                "`databricks auth login --profile <PROFILE>`."
+                f"the requested model {explicit_model!r} is not in this host's current model "
+                "list — it may have changed since the pick. Pick again from the model menu."
             )
+        detail = catalog.refresh_error if catalog is not None else "model catalog unavailable"
+        _logger.warning(
+            "Claude launch honoring explicit model %r without fresh catalog validation: %s",
+            explicit_model,
+            detail,
+        )
         return resolved
     if configured_model:
         return resolve_claude_native_model_selection(configured_model, claude_config)

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3759,11 +3759,11 @@ async def _auto_create_codex_terminal(
     # Resolved before the fork/cold-resume branches below so any rollout
     # synthesis can stamp session_meta.model_provider with the provider
     # this launch actually routes through.
-    default_model = launch_config.model_override or _codex_native_model_from_spec(agent_spec)
+    explicit_model = launch_config.model_override or _codex_native_model_from_spec(agent_spec)
     # Thread the spec so its executor.auth / legacy profile win over
     # machine-level config, parity with the in-process harness (#2744).
     _launch_spec = agent_spec.spec if isinstance(agent_spec, ResolvedSpec) else agent_spec
-    _codex_launch = resolve_native_codex_launch(model=default_model, spec=_launch_spec)
+    _codex_launch = resolve_native_codex_launch(model=explicit_model, spec=_launch_spec)
     _session_meta_provider = codex_session_meta_model_provider(_codex_launch)
     from omnigent.inner.codex_executor import _find_codex_cli
 
@@ -3774,31 +3774,21 @@ async def _auto_create_codex_terminal(
     # the user's shared config can never govern a session (the stale-gpt-5.4
     # 400 class). Profile-backed shapes already resolve their default at
     # materialization time and are left alone.
-    if launch_config.model_override or (
-        _codex_launch.model is None and _codex_launch.profile is None
-    ):
+    if explicit_model or (_codex_launch.model is None and _codex_launch.profile is None):
         from dataclasses import replace as _dataclass_replace
 
         from omnigent.codex_native_app_server import codex_launch_catalog
-        from omnigent.model_catalog_store import CatalogFreshness, catalog_contains, default_row
+        from omnigent.model_catalog_store import CatalogFreshness, default_row
 
         _codex_catalog_result = await codex_launch_catalog(codex_path=_codex_cli_path)
-        _codex_catalog = _codex_catalog_result.rows
-        if (
-            launch_config.model_override
-            and _codex_catalog
-            and _codex_catalog_result.freshness is CatalogFreshness.FRESH
-        ):
-            if not catalog_contains(_codex_catalog, launch_config.model_override):
-                raise click.ClickException(
-                    f"the requested model {launch_config.model_override!r} is not in "
-                    "this host's current model list — it may have changed since the "
-                    "pick. Pick again from the model menu."
-                )
+        _codex_catalog = _codex_catalog_result.rows if _codex_catalog_result is not None else None
+        if explicit_model:
+            _validate_explicit_codex_launch_model(explicit_model, _codex_catalog_result)
         if (
             _codex_launch.model is None
             and _codex_launch.profile is None
             and _codex_catalog
+            and _codex_catalog_result is not None
             and _codex_catalog_result.freshness is CatalogFreshness.FRESH
         ):
             _catalog_default = default_row(_codex_catalog)
@@ -6062,6 +6052,25 @@ async def _load_claude_launch_metadata(
     return metadata
 
 
+def _validate_explicit_codex_launch_model(model: str, catalog: Any) -> None:
+    """Require fresh catalog authority for a persisted Codex model."""
+    from omnigent.model_catalog_store import CatalogFreshness, catalog_contains
+
+    if catalog is None:
+        return
+    if catalog.freshness is not CatalogFreshness.FRESH:
+        raise click.ClickException(
+            f"the requested model {model!r} could not be validated against a fresh model "
+            f"list ({catalog.refresh_error or 'catalog refresh failed'}). Pick again after "
+            "restoring provider credentials."
+        )
+    if catalog.rows is None or not catalog_contains(catalog.rows, model):
+        raise click.ClickException(
+            f"the requested model {model!r} is not in this host's current model list — it "
+            "may have changed since the pick. Pick again from the model menu."
+        )
+
+
 def _select_authoritative_claude_launch_model(
     *,
     explicit_model: str | None,
@@ -6114,6 +6123,12 @@ def _select_authoritative_claude_launch_model(
             "Claude provider configuration and the fresh model list are unavailable. "
             "Restore provider credentials and retry; for Databricks, run "
             "`databricks auth login --profile <PROFILE>`."
+        )
+    if claude_config is not None and catalog is not None:
+        raise click.ClickException(
+            "the configured Claude gateway has no authoritative launch model "
+            f"({catalog.refresh_error or 'model catalog unavailable'}). Restore provider "
+            "credentials and retry."
         )
     return None
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3780,17 +3780,27 @@ async def _auto_create_codex_terminal(
         from dataclasses import replace as _dataclass_replace
 
         from omnigent.codex_native_app_server import codex_launch_catalog
-        from omnigent.model_catalog_store import catalog_contains, default_row
+        from omnigent.model_catalog_store import CatalogFreshness, catalog_contains, default_row
 
-        _codex_catalog = await codex_launch_catalog(codex_path=_codex_cli_path)
-        if launch_config.model_override and _codex_catalog:
+        _codex_catalog_result = await codex_launch_catalog(codex_path=_codex_cli_path)
+        _codex_catalog = _codex_catalog_result.rows
+        if (
+            launch_config.model_override
+            and _codex_catalog
+            and _codex_catalog_result.freshness is CatalogFreshness.FRESH
+        ):
             if not catalog_contains(_codex_catalog, launch_config.model_override):
                 raise click.ClickException(
                     f"the requested model {launch_config.model_override!r} is not in "
                     "this host's current model list — it may have changed since the "
                     "pick. Pick again from the model menu."
                 )
-        if _codex_launch.model is None and _codex_launch.profile is None and _codex_catalog:
+        if (
+            _codex_launch.model is None
+            and _codex_launch.profile is None
+            and _codex_catalog
+            and _codex_catalog_result.freshness is CatalogFreshness.FRESH
+        ):
             _catalog_default = default_row(_codex_catalog)
             _default_id = (
                 str(_catalog_default.get("id") or _catalog_default.get("model") or "") or None
@@ -6052,6 +6062,62 @@ async def _load_claude_launch_metadata(
     return metadata
 
 
+def _select_authoritative_claude_launch_model(
+    *,
+    explicit_model: str | None,
+    configured_model: str | None,
+    claude_config: Any,
+    catalog: Any,
+    implicit_cli_default_allowed: bool = True,
+) -> str | None:
+    """Apply freshness policy without losing the model selection's source."""
+    from omnigent.claude_native import (
+        claude_catalog_serves_model,
+        claude_config_serves_canonical_ids,
+        resolve_claude_native_model_selection,
+    )
+    from omnigent.model_catalog_store import CatalogFreshness, default_row
+
+    if explicit_model:
+        resolved = (
+            resolve_claude_native_model_selection(explicit_model, claude_config) or explicit_model
+        )
+        canonical_allowed = resolved.lower().startswith(
+            "claude-"
+        ) and claude_config_serves_canonical_ids(claude_config)
+        freshly_validated = bool(
+            catalog is not None
+            and catalog.freshness is CatalogFreshness.FRESH
+            and catalog.rows
+            and (
+                claude_catalog_serves_model(catalog.rows, explicit_model, claude_config)
+                or claude_catalog_serves_model(catalog.rows, resolved, claude_config)
+            )
+        )
+        if not freshly_validated and not canonical_allowed:
+            detail = catalog.refresh_error if catalog is not None else "model catalog unavailable"
+            raise click.ClickException(
+                f"the requested model {explicit_model!r} could not be validated against a "
+                f"fresh model list ({detail}). Pick again from the model menu after restoring "
+                "provider credentials; for Databricks, run "
+                "`databricks auth login --profile <PROFILE>`."
+            )
+        return resolved
+    if configured_model:
+        return resolve_claude_native_model_selection(configured_model, claude_config)
+    if catalog is not None and catalog.freshness is CatalogFreshness.FRESH and catalog.rows:
+        row = default_row(catalog.rows)
+        if row is not None:
+            return str(row.get("model") or row.get("id") or "") or None
+    if claude_config is None and not implicit_cli_default_allowed:
+        raise click.ClickException(
+            "Claude provider configuration and the fresh model list are unavailable. "
+            "Restore provider credentials and retry; for Databricks, run "
+            "`databricks auth login --profile <PROFILE>`."
+        )
+    return None
+
+
 async def _auto_create_claude_terminal(
     session_id: str,
     resource_registry: SessionResourceRegistry,
@@ -6450,11 +6516,13 @@ async def _auto_create_claude_terminal(
     # provider selection just like the in-process claude-sdk harness and the
     # CLI path.
     claude_config: ClaudeNativeUcodeConfig | None = None
+    claude_config_resolved = False
     try:
         if resolve_launch_config is not None:
             claude_config = await resolve_launch_config()
         else:
             claude_config = await asyncio.to_thread(resolve_native_claude_config, spec=None)
+        claude_config_resolved = True
     except click.ClickException:
         # An authoritative Databricks response with no Claude models is a
         # configuration failure, not permission to bypass the gateway.
@@ -6475,49 +6543,35 @@ async def _auto_create_claude_terminal(
         from omnigent.server.smart_routing import task_v1_claude_arms
 
         claude_config = claude_config_with_routed_arms_pinned(claude_config, task_v1_claude_arms())
+    spec_model = _claude_native_model_from_spec(agent_spec)
+    explicit_model = session_model_override or spec_model
+    configured_model = claude_config.model if claude_config is not None else None
     launch_model = resolve_claude_native_model_selection(
-        session_model_override
-        or _claude_native_model_from_spec(agent_spec)
-        or (claude_config.model if claude_config is not None else None),
-        claude_config,
+        explicit_model or configured_model, claude_config
     )
     # Explicit launches (model-flows design §4): consult the shared catalog
     # only when it can change the outcome — to validate an explicit request,
     # or to resolve a Default launch that would otherwise pass no ``--model``
     # and leave the model to invisible CLI-private state.
-    if session_model_override or launch_model is None:
-        from omnigent.claude_native import claude_catalog_serves_model, claude_launch_catalog
-        from omnigent.model_catalog_store import default_row
+    if explicit_model or launch_model is None:
+        from omnigent.claude_native import claude_launch_catalog
 
-        launch_catalog: list[dict[str, object]] | None = None
+        launch_catalog_result = None
         try:
-            launch_catalog = await claude_launch_catalog(claude_config)
+            launch_catalog_result = await claude_launch_catalog(claude_config)
         except Exception:  # noqa: BLE001 — no catalog means no validation/default
             _logger.warning(
                 "claude launch catalog unavailable for session=%s", session_id, exc_info=True
             )
-        if session_model_override and launch_catalog:
-            resolved_request = (
-                resolve_claude_native_model_selection(session_model_override, claude_config)
-                or session_model_override
-            )
-            # A pane's ``/model`` persists the exact id it runs; the catalog
-            # may spell that model only by its family alias.
-            if not (
-                claude_catalog_serves_model(launch_catalog, session_model_override, claude_config)
-                or claude_catalog_serves_model(launch_catalog, resolved_request, claude_config)
-            ):
-                raise click.ClickException(
-                    f"the requested model {session_model_override!r} is not in this "
-                    "host's current model list — it may have changed since the pick. "
-                    "Pick again from the model menu."
-                )
-        if launch_model is None and launch_catalog:
-            catalog_default = default_row(launch_catalog)
-            if catalog_default is not None:
-                launch_model = (
-                    str(catalog_default.get("model") or catalog_default.get("id") or "") or None
-                )
+        launch_model = _select_authoritative_claude_launch_model(
+            explicit_model=explicit_model,
+            configured_model=configured_model,
+            claude_config=claude_config,
+            catalog=launch_catalog_result,
+            implicit_cli_default_allowed=claude_config_resolved and claude_config is None,
+        )
+        if launch_model is None and claude_config_resolved and claude_config is None:
+            _logger.info("Claude subscription launch is deferring to the CLI's default model")
     # Give an exact launch model (a Smart Routing pick is resolved before the
     # terminal exists) a spelling of its own in the picker, so a later
     # ``/model`` can return to it instead of stepping onto whatever the family

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -279,6 +279,31 @@ async def test_handle_model_options_codex_probe_failure_is_an_honest_empty(
     _cleanup_host(host)
 
 
+async def test_handle_model_options_labels_stale_codex_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent import codex_native_app_server
+    from omnigent.model_catalog_store import CatalogFreshness, CatalogResult
+
+    async def _stale_catalog(**_kwargs: object) -> CatalogResult:
+        return CatalogResult(
+            [{"id": "removed-model", "model": "removed-model"}],
+            CatalogFreshness.STALE,
+            "provider credentials expired",
+        )
+
+    monkeypatch.setattr(codex_native_app_server, "codex_launch_catalog", _stale_catalog)
+    host = _make_host_process()
+
+    result = await host._handle_model_options(
+        HostModelOptionsFrame(request_id="req_stale", harness="codex-native"),
+    )
+
+    assert result.models == [{"id": "removed-model", "model": "removed-model"}]
+    assert result.error == "stale model catalog: provider credentials expired"
+    _cleanup_host(host)
+
+
 async def test_handle_model_options_rejects_unsupported_harness() -> None:
     """Only launch paths with host-resolved model catalogs are accepted."""
     host = _make_host_process()

--- a/tests/runner/test_app_claude_native_launch_args.py
+++ b/tests/runner/test_app_claude_native_launch_args.py
@@ -14,20 +14,90 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import click
 import pytest
 
 from omnigent.claude_native import (
     ClaudeNativeUcodeConfig,
     build_native_claude_terminal_env,
 )
+from omnigent.model_catalog_store import CatalogFreshness, CatalogResult
 from omnigent.runner.app import _build_claude_native_base_args, _claude_terminal_env_unset
 from omnigent.runner.native.orchestration import (
     _ROUTED_SPAWN_ALLOWED_TOOLS,
     _claude_launch_metadata_from_envelope,
     _load_legacy_claude_launch_metadata,
     _routed_spawn_launch_args,
+    _select_authoritative_claude_launch_model,
 )
 from omnigent.runner.subagent_routing import AUTO_HARNESS_LABEL_KEY
+
+
+def _catalog(freshness: CatalogFreshness) -> CatalogResult:
+    return CatalogResult(
+        [{"id": "fable", "model": "claude-fable-5", "isDefault": True}],
+        freshness,
+        "provider credentials expired" if freshness is CatalogFreshness.STALE else None,
+    )
+
+
+def test_stale_implicit_subscription_default_omits_model() -> None:
+    selected = _select_authoritative_claude_launch_model(
+        explicit_model=None,
+        configured_model=None,
+        claude_config=None,
+        catalog=_catalog(CatalogFreshness.STALE),
+    )
+
+    args = _build_claude_native_base_args(
+        reasoning_effort=None,
+        model_override=selected,
+        terminal_launch_args=None,
+    )
+    assert "--model" not in args
+
+
+def test_stale_unvalidated_explicit_model_fails_without_substitution() -> None:
+    with pytest.raises(click.ClickException, match=r"Pick again.*restoring provider credentials"):
+        _select_authoritative_claude_launch_model(
+            explicit_model="gateway-fable-5",
+            configured_model=None,
+            claude_config=ClaudeNativeUcodeConfig(
+                env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"}
+            ),
+            catalog=_catalog(CatalogFreshness.STALE),
+        )
+
+
+def test_configured_gateway_pin_survives_a_stale_catalog() -> None:
+    config = ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"},
+        model="gateway-opus-5",
+    )
+
+    assert (
+        _select_authoritative_claude_launch_model(
+            explicit_model=None,
+            configured_model=config.model,
+            claude_config=config,
+            catalog=_catalog(CatalogFreshness.STALE),
+        )
+        == "gateway-opus-5"
+    )
+
+
+def test_offline_gateway_without_a_pin_remains_launchable() -> None:
+    assert (
+        _select_authoritative_claude_launch_model(
+            explicit_model=None,
+            configured_model=None,
+            claude_config=ClaudeNativeUcodeConfig(
+                env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"}
+            ),
+            catalog=_catalog(CatalogFreshness.STALE),
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/runner/test_app_claude_native_launch_args.py
+++ b/tests/runner/test_app_claude_native_launch_args.py
@@ -86,8 +86,8 @@ def test_configured_gateway_pin_survives_a_stale_catalog() -> None:
     )
 
 
-def test_offline_gateway_without_a_pin_remains_launchable() -> None:
-    assert (
+def test_unpinned_gateway_with_stale_catalog_fails_actionably() -> None:
+    with pytest.raises(click.ClickException, match="provider credentials expired"):
         _select_authoritative_claude_launch_model(
             explicit_model=None,
             configured_model=None,
@@ -96,8 +96,6 @@ def test_offline_gateway_without_a_pin_remains_launchable() -> None:
             ),
             catalog=_catalog(CatalogFreshness.STALE),
         )
-        is None
-    )
 
 
 @pytest.mark.parametrize(

--- a/tests/runner/test_app_claude_native_launch_args.py
+++ b/tests/runner/test_app_claude_native_launch_args.py
@@ -12,6 +12,7 @@ passed. See designs/NATIVE_RUNNER_SERVER_LAUNCH.md.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import click
@@ -57,15 +58,37 @@ def test_stale_implicit_subscription_default_omits_model() -> None:
     assert "--model" not in args
 
 
-def test_stale_unvalidated_explicit_model_fails_without_substitution() -> None:
-    with pytest.raises(click.ClickException, match=r"Pick again.*restoring provider credentials"):
-        _select_authoritative_claude_launch_model(
+def test_stale_catalog_does_not_strand_an_explicit_claude_pin(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A stale catalog means validation could not run against a fresh list.
+    # Honor the explicit gateway pin rather than stranding the session, but
+    # surface the probe's real reason so a dead provider stays visible.
+    with caplog.at_level(logging.WARNING):
+        selected = _select_authoritative_claude_launch_model(
             explicit_model="gateway-fable-5",
             configured_model=None,
             claude_config=ClaudeNativeUcodeConfig(
                 env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"}
             ),
             catalog=_catalog(CatalogFreshness.STALE),
+        )
+
+    assert selected == "gateway-fable-5"
+    assert "provider credentials expired" in caplog.text
+
+
+def test_fresh_catalog_refuses_an_absent_explicit_claude_model() -> None:
+    # Validation ran against a fresh list and the pin is genuinely absent —
+    # a legitimate refusal, symmetric with the codex path.
+    with pytest.raises(click.ClickException, match="not in this host's current model list"):
+        _select_authoritative_claude_launch_model(
+            explicit_model="gateway-ghost-5",
+            configured_model=None,
+            claude_config=ClaudeNativeUcodeConfig(
+                env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"}
+            ),
+            catalog=_catalog(CatalogFreshness.FRESH),
         )
 
 

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -47,6 +47,7 @@ from omnigent.codex_native_bridge import (
 )
 from omnigent.entities.session_resources import SessionResourceView
 from omnigent.inner.terminal import TerminalInstance
+from omnigent.model_catalog_store import CatalogFreshness, CatalogResult
 from omnigent.runner import create_runner_app
 from omnigent.runner.app import (
     ResolvedSpec,
@@ -3225,9 +3226,9 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         },
     ]
 
-    async def _catalog(config: object) -> list[dict[str, object]]:
+    async def _catalog(config: object) -> CatalogResult:
         del config
-        return catalog
+        return CatalogResult(catalog, CatalogFreshness.FRESH)
 
     monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", _catalog)
 
@@ -3291,7 +3292,7 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         args = captured["spec"].args
         assert args[args.index("--model") + 1] == "claude-opus-4-8"
     else:
-        with pytest.raises(click.ClickException, match="not in this host's current model list"):
+        with pytest.raises(click.ClickException, match="could not be validated"):
             await _auto_create_claude_terminal(
                 session_id,
                 _FakeResourceRegistry(),

--- a/tests/runner/test_codex_native_launch_config.py
+++ b/tests/runner/test_codex_native_launch_config.py
@@ -9,6 +9,7 @@ function with a stub async client returning controlled snapshots.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import click
@@ -20,14 +21,50 @@ from omnigent.runner.app import _codex_native_launch_config
 from omnigent.runner.native.orchestration import _validate_explicit_codex_launch_model
 
 
-def test_stale_catalog_cannot_authorize_an_explicit_codex_model() -> None:
+def test_stale_catalog_does_not_strand_an_explicit_codex_pin(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A stale catalog means validation could not run against a fresh list — not
+    # that the pinned model is gone. Honor the explicit pin instead of refusing.
     catalog = CatalogResult(
         [{"id": "removed-model", "model": "removed-model"}],
         CatalogFreshness.STALE,
         "provider credentials expired",
     )
 
-    with pytest.raises(click.ClickException, match="provider credentials expired"):
+    with caplog.at_level(logging.WARNING):
+        _validate_explicit_codex_launch_model("removed-model", catalog)
+
+    assert "provider credentials expired" in caplog.text
+
+
+def test_missing_catalog_does_not_strand_an_explicit_codex_pin(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # The probe could not run at all (the incident: `codex model discovery exited
+    # early`). A dead probe must not turn a user's explicit pin into a dead session.
+    catalog = CatalogResult(
+        None,
+        CatalogFreshness.MISSING,
+        "model catalog refresh returned no models",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        _validate_explicit_codex_launch_model("gpt-5.6-sol", catalog)
+
+    assert "model catalog refresh returned no models" in caplog.text
+
+
+def test_fresh_catalog_still_refuses_an_absent_explicit_codex_model() -> None:
+    # Validation ran against a fresh list and the model is genuinely absent —
+    # a legitimate refusal that stays closed.
+    catalog = CatalogResult(
+        [{"id": "kept-model", "model": "kept-model"}],
+        CatalogFreshness.FRESH,
+        None,
+    )
+
+    with pytest.raises(click.ClickException, match="not in this host's current model list"):
         _validate_explicit_codex_launch_model("removed-model", catalog)
 
 

--- a/tests/runner/test_codex_native_launch_config.py
+++ b/tests/runner/test_codex_native_launch_config.py
@@ -11,10 +11,24 @@ from __future__ import annotations
 
 from typing import Any
 
+import click
 import httpx
 import pytest
 
+from omnigent.model_catalog_store import CatalogFreshness, CatalogResult
 from omnigent.runner.app import _codex_native_launch_config
+from omnigent.runner.native.orchestration import _validate_explicit_codex_launch_model
+
+
+def test_stale_catalog_cannot_authorize_an_explicit_codex_model() -> None:
+    catalog = CatalogResult(
+        [{"id": "removed-model", "model": "removed-model"}],
+        CatalogFreshness.STALE,
+        "provider credentials expired",
+    )
+
+    with pytest.raises(click.ClickException, match="provider credentials expired"):
+        _validate_explicit_codex_launch_model("removed-model", catalog)
 
 
 class _Resp:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -9548,7 +9548,8 @@ async def test_claude_launch_catalog_reads_the_store_then_probes_once(
     monkeypatch.setattr(claude_native, "claude_model_catalog", _fake_catalog)
     first = await claude_native.claude_launch_catalog(None)
     second = await claude_native.claude_launch_catalog(None)
-    assert first == second == [{"id": "sonnet", "model": "claude-sonnet-5", "isDefault": True}]
+    assert first == second
+    assert first.rows == [{"id": "sonnet", "model": "claude-sonnet-5", "isDefault": True}]
     assert len(calls) == 1, "the second read must come from the store, not a re-probe"
 
 

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -701,7 +701,7 @@ async def test_codex_launch_catalog_reads_the_store_then_probes_once(
     first = await codex_native_app_server.codex_launch_catalog()
     second = await codex_native_app_server.codex_launch_catalog()
     assert first == second
-    assert first == [{"id": "gpt-5.6-terra", "model": "gpt-5.6-terra", "isDefault": True}]
+    assert first.rows == [{"id": "gpt-5.6-terra", "model": "gpt-5.6-terra", "isDefault": True}]
     assert len(calls) == 1, "the second read must come from the store, not a re-probe"
 
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1242,11 +1242,23 @@ def test_databricks_reauth_guidance_survives_failure_redaction() -> None:
     assert model_catalog._redacted_failure_reason(exc) == (
         "provider credentials expired; run `databricks auth login --profile DEFAULT`"
     )
-    secret = "dapi0123456789abcdef"
-    exc = OSError(f"token={secret}; databricks auth login --profile DEFAULT --token {secret}")
+    fake_token = "dapiFAKEFAKEFAKE0000"
+    exc = OSError(
+        f"token={fake_token}; databricks auth login --profile DEFAULT --token {fake_token}"
+    )
     reason = model_catalog._redacted_failure_reason(exc)
     assert reason == "provider credentials or network unavailable"
-    assert secret not in reason
+    assert fake_token not in reason
+
+
+def test_databricks_reauth_guidance_does_not_echo_token_shaped_profile() -> None:
+    fake_profile = "dapiFAKEPROFILE0000"
+    exc = OSError(f"databricks auth login --profile {fake_profile}")
+
+    reason = model_catalog._redacted_failure_reason(exc)
+
+    assert reason == "provider credentials or network unavailable"
+    assert fake_profile not in reason
 
 
 # ── catalog_for_spec (the tool payload) ────────────────────

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1237,7 +1237,17 @@ def test_failed_auth_command_note_never_leaks_the_command(
 
 
 def test_databricks_reauth_guidance_survives_failure_redaction() -> None:
-    exc = OSError("refresh expired; run databricks auth login --profile DEFAULT")
+    # The verbatim production remedy wraps the command in markdown backticks
+    # (omnigent/runtime/credentials/databricks.py); the redaction must extract
+    # the profile-specific guidance from that exact shape, not only from a
+    # synthetic backtick-free string.
+    exc = OSError(
+        "Databricks profile [DEFAULT] in ~/.databrickscfg is a token-less "
+        "SDK-only profile: the databricks-sdk path could not mint a token for "
+        "it. Ensure the `databricks` CLI is installed and on PATH, and that the "
+        "OAuth session is valid (run `databricks auth login --profile DEFAULT`). "
+        "See the cli-*.log for the underlying SDK error."
+    )
 
     assert model_catalog._redacted_failure_reason(exc) == (
         "provider credentials expired; run `databricks auth login --profile DEFAULT`"

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1236,6 +1236,19 @@ def test_failed_auth_command_note_never_leaks_the_command(
     assert secret not in json.dumps(catalog)
 
 
+def test_databricks_reauth_guidance_survives_failure_redaction() -> None:
+    exc = OSError("refresh expired; run databricks auth login --profile DEFAULT")
+
+    assert model_catalog._redacted_failure_reason(exc) == (
+        "provider credentials expired; run `databricks auth login --profile DEFAULT`"
+    )
+    secret = "dapi0123456789abcdef"
+    exc = OSError(f"token={secret}; databricks auth login --profile DEFAULT --token {secret}")
+    reason = model_catalog._redacted_failure_reason(exc)
+    assert reason == "provider credentials or network unavailable"
+    assert secret not in reason
+
+
 # ── catalog_for_spec (the tool payload) ────────────────────
 
 

--- a/tests/test_model_catalog_store.py
+++ b/tests/test_model_catalog_store.py
@@ -177,3 +177,21 @@ async def test_small_future_mtime_is_clamped_fresh() -> None:
     assert result.rows == _ROWS
     assert result.freshness is store.CatalogFreshness.FRESH
     assert calls == 0
+
+
+@pytest.mark.asyncio
+async def test_successful_empty_catalog_is_fresh_and_persisted() -> None:
+    calls = 0
+
+    async def _empty() -> list[dict[str, object]]:
+        nonlocal calls
+        calls += 1
+        return []
+
+    first = await store.ensure_catalog("claude-native", "abc123", _empty)
+    second = await store.ensure_catalog("claude-native", "abc123", _empty)
+
+    assert first.rows == second.rows == []
+    assert first.freshness is second.freshness is store.CatalogFreshness.FRESH
+    assert first.refresh_error is second.refresh_error is None
+    assert calls == 1

--- a/tests/test_model_catalog_store.py
+++ b/tests/test_model_catalog_store.py
@@ -145,6 +145,67 @@ async def test_cross_process_lock_wait_is_bounded(
 
 
 @pytest.mark.asyncio
+async def test_lock_holder_refresh_is_picked_up_without_reprobe() -> None:
+    store.write_catalog("claude-native", "abc123", _ROWS)
+    path = store.catalog_path("claude-native", "abc123")
+    old = time.time() - store.CATALOG_STALE_AFTER_S - 1
+    os.utime(path, (old, old))
+    lock_path = path.with_suffix(".lock")
+    lock_handle = lock_path.open("a+")
+    fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+    called = False
+
+    async def _refresh() -> list[dict[str, object]]:
+        nonlocal called
+        called = True
+        return [{"id": "should-not-run", "model": "should-not-run"}]
+
+    task = asyncio.create_task(store.ensure_catalog("claude-native", "abc123", _refresh))
+    # Let the task block acquiring the lock this test still holds.
+    await asyncio.sleep(0.15)
+    fresh_rows = [{"id": "haiku", "model": "claude-haiku-5", "isDefault": True}]
+    store.write_catalog("claude-native", "abc123", fresh_rows)
+    fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+    lock_handle.close()
+
+    result = await task
+
+    # The refresh another process wrote while we waited is served; the lock
+    # would accomplish nothing if the cache were not re-checked after acquiring it.
+    assert result.freshness is store.CatalogFreshness.FRESH
+    assert result.rows == fresh_rows
+    assert not called
+
+
+@pytest.mark.asyncio
+async def test_successful_probe_leaves_no_lockfile_behind() -> None:
+    path = store.catalog_path("claude-native", "abc123")
+    lock_path = path.with_suffix(".lock")
+
+    async def _refresh() -> list[dict[str, object]]:
+        return _ROWS
+
+    result = await store.ensure_catalog("claude-native", "abc123", _refresh)
+
+    assert result.freshness is store.CatalogFreshness.FRESH
+    assert not lock_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_failed_probe_leaves_no_lockfile_behind() -> None:
+    path = store.catalog_path("claude-native", "abc123")
+    lock_path = path.with_suffix(".lock")
+
+    async def _boom() -> list[dict[str, object]]:
+        raise OSError("offline")
+
+    result = await store.ensure_catalog("claude-native", "abc123", _boom)
+
+    assert result.freshness is store.CatalogFreshness.MISSING
+    assert not lock_path.exists()
+
+
+@pytest.mark.asyncio
 async def test_future_mtime_is_stale_until_revalidated() -> None:
     store.write_catalog("claude-native", "abc123", _ROWS)
     path = store.catalog_path("claude-native", "abc123")

--- a/tests/test_model_catalog_store.py
+++ b/tests/test_model_catalog_store.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import fcntl
+import os
+import time
 from pathlib import Path
 
 import pytest
@@ -60,3 +64,116 @@ def test_catalog_age_reports_and_misses() -> None:
     store.write_catalog("claude-native", "abc123", _ROWS)
     age = store.catalog_age_s("claude-native", "abc123")
     assert age is not None and age >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_stale_catalog_is_returned_with_failed_refresh_marked_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store.write_catalog("claude-native", "abc123", _ROWS)
+    path = store.catalog_path("claude-native", "abc123")
+    old = time.time() - store.CATALOG_STALE_AFTER_S - 1
+    os.utime(path, (old, old))
+
+    async def _offline() -> None:
+        raise OSError("offline")
+
+    result = await store.ensure_catalog("claude-native", "abc123", _offline)
+
+    assert result.rows == _ROWS
+    assert result.freshness is store.CatalogFreshness.STALE
+    assert result.refresh_error == "provider credentials or network unavailable"
+
+
+@pytest.mark.asyncio
+async def test_hanging_stale_refresh_is_bounded_and_single_flight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store.write_catalog("claude-native", "abc123", _ROWS)
+    path = store.catalog_path("claude-native", "abc123")
+    old = time.time() - store.CATALOG_STALE_AFTER_S - 1
+    os.utime(path, (old, old))
+    monkeypatch.setattr(store, "CATALOG_REFRESH_TIMEOUT_S", 0.02)
+    calls = 0
+
+    async def _hang() -> None:
+        nonlocal calls
+        calls += 1
+        await asyncio.Event().wait()
+
+    first, second = await asyncio.gather(
+        store.ensure_catalog("claude-native", "abc123", _hang),
+        store.ensure_catalog("claude-native", "abc123", _hang),
+    )
+
+    assert calls == 1
+    assert first.rows == second.rows == _ROWS
+    assert first.freshness is second.freshness is store.CatalogFreshness.STALE
+    assert first.refresh_error == second.refresh_error == "model catalog refresh timed out"
+
+
+@pytest.mark.asyncio
+async def test_cross_process_lock_wait_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store.write_catalog("claude-native", "abc123", _ROWS)
+    path = store.catalog_path("claude-native", "abc123")
+    old = time.time() - store.CATALOG_STALE_AFTER_S - 1
+    os.utime(path, (old, old))
+    monkeypatch.setattr(store, "CATALOG_LOCK_TIMEOUT_S", 0.02)
+    lock_path = path.with_suffix(".lock")
+    lock_path.touch()
+    lock_handle = lock_path.open("a+")
+    fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    called = False
+
+    async def _refresh() -> list[dict[str, object]]:
+        nonlocal called
+        called = True
+        return []
+
+    try:
+        result = await store.ensure_catalog("claude-native", "abc123", _refresh)
+    finally:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+        lock_handle.close()
+
+    assert result.rows == _ROWS
+    assert result.freshness is store.CatalogFreshness.STALE
+    assert result.refresh_error == "model catalog refresh lock timed out"
+    assert not called
+
+
+@pytest.mark.asyncio
+async def test_future_mtime_is_stale_until_revalidated() -> None:
+    store.write_catalog("claude-native", "abc123", _ROWS)
+    path = store.catalog_path("claude-native", "abc123")
+    future = time.time() + store.CATALOG_CLOCK_SKEW_TOLERANCE_S + 1
+    os.utime(path, (future, future))
+    refreshed = [{"id": "haiku", "model": "claude-haiku-5", "isDefault": True}]
+
+    async def _refresh() -> list[dict[str, object]]:
+        return refreshed
+
+    result = await store.ensure_catalog("claude-native", "abc123", _refresh)
+
+    assert result.rows == refreshed
+    assert result.freshness is store.CatalogFreshness.FRESH
+
+
+@pytest.mark.asyncio
+async def test_small_future_mtime_is_clamped_fresh() -> None:
+    store.write_catalog("claude-native", "abc123", _ROWS)
+    path = store.catalog_path("claude-native", "abc123")
+    os.utime(path, (time.time() + 1, time.time() + 1))
+    calls = 0
+
+    async def _refresh() -> None:
+        nonlocal calls
+        calls += 1
+
+    result = await store.ensure_catalog("claude-native", "abc123", _refresh)
+
+    assert result.rows == _ROWS
+    assert result.freshness is store.CatalogFreshness.FRESH
+    assert calls == 0


### PR DESCRIPTION
## Related issue
Closes #5281 — specifically **root causes 1–2** of that RCA (the model-catalog cache never expires; a stale pin is launched without validation).

The other root causes in #5281 are delivered separately: root cause 3 (the failure reason is discarded on the way out) — #5278; root cause 4 (startup failures misclassified as success) — tracked as #5334.
## Summary

A stale on-disk Claude catalog selected `claude-fable-5` as an implicit default after catalog refresh failed, producing `model_not_found`. This restores the invariant introduced with catalog-only discovery: unverified catalog data may remain visible, but it must not become launch authority.

- Return `CatalogResult(rows, freshness, refresh_error)` so callers can distinguish fresh, stale, and missing catalogs without a second filesystem race.
- Revalidate stale entries with bounded async single-flight, a bounded cross-process advisory lock, and a post-lock cache recheck; stale rows remain available for display and diagnostics.
- Preserve Claude model-selection provenance: stale implicit subscription defaults defer to Claude CLI, explicit picks require fresh validation or a canonical Anthropic spelling, configured gateway pins remain authoritative, and pass-through `--model` remains untouched.
- Preserve sanitized Databricks reauthentication guidance while redacting secret-shaped error payloads.

ELI5: an old menu can still be shown during an outage, but Omnigent no longer orders yesterday's default from it. For a native Claude subscription, Claude chooses its own current default instead.

```text
catalog read
  ├─ fresh ───────────────> display + launch validation/default
  └─ stale/missing
       └─ bounded refresh (in-process single-flight + process lock)
            ├─ success ───> fresh authority
            └─ failure ───> stale display only; source-aware launch policy
```

## Test Plan

- `uv run --frozen --extra all --group test python -m pytest --collect-only -q tests/test_model_catalog_store.py tests/test_model_catalog.py tests/test_claude_native.py tests/test_codex_native_app_server.py tests/runner/test_app_claude_native_launch_args.py tests/runner/test_app_sessions_native_terminals_autocreate.py` — 571 tests collected.
- `uv run --frozen --extra all --group test python -m pytest -q tests/test_model_catalog_store.py tests/test_model_catalog.py tests/test_claude_native.py tests/test_codex_native_app_server.py tests/runner/test_app_claude_native_launch_args.py tests/runner/test_app_sessions_native_terminals_autocreate.py` — 571 passed.
- `uv run --frozen --extra all --group lint --group test pre-commit run --all-files` — all hooks passed (pyrefly invoked with ignore-file handling disabled because this required worktree lives under the repository-ignored `.worktrees/` directory).
- Mutation checks confirmed every new test fails with its corresponding freshness/selection/redaction fix removed, including stale authority, refresh timeout/single-flight, cross-process locking, clock skew, launch provenance, offline launch, and safe reauthentication guidance.

## Demo

Not a UI change. The user-visible effect is that a stale catalog pin no longer
launches silently.

**Before** — a catalog entry written while `claude-fable-5` was servable keeps
pinning it forever (`CATALOG_STALE_AFTER_S` had no production caller). The
launch proceeds, the provider rejects the model, and the operator sees a generic
turn failure with no mention of the catalog.

**After** — freshness is load-bearing at launch: an expired entry is refreshed
rather than trusted, an empty-but-successful catalog is distinguished from a
refresh failure (`rows is None` vs falsy `rows`), and an explicit pin whose
validation could not run fails closed with the reason attached instead of
deferring to CLI-private state.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage exercises fresh/stale/missing behavior, credential success/failure fallbacks, subscription and gateway selection provenance, user pass-through precedence, bounded refresh concurrency, cross-process coordination, clock skew, and credential-message redaction.

## Changelog

Stale model catalogs no longer pin an obsolete implicit model when starting a native Claude session.

