### PR TITLE
fix(claude): extend submit verification budget

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -170,7 +170,12 @@ _PASTE_COMMIT_TIMEOUT_S = 5.0
 # After the submit Enter, how long to keep checking that the draft
 # actually left the input box (re-sending Enter while it hasn't) before
 # failing loud. OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S overrides it.
-_SUBMIT_VERIFY_TIMEOUT_S = float(os.environ.get("OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S", "30"))
+_SUBMIT_VERIFY_TIMEOUT_ENV = "OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S"
+try:
+    _SUBMIT_VERIFY_TIMEOUT_S = float(os.environ.get(_SUBMIT_VERIFY_TIMEOUT_ENV, "30"))
+except ValueError:
+    _logger.warning("Ignoring invalid %s; using 30s", _SUBMIT_VERIFY_TIMEOUT_ENV)
+    _SUBMIT_VERIFY_TIMEOUT_S = 30.0
 # Minimum spacing between repeated submit Enters during verification.
 # Long enough for the TUI to clear the box after a successful submit
 # (so a slow-but-successful first Enter isn't double-tapped), short

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -4124,7 +4124,7 @@ def _verify_draft_submitted(
     last_enter = time.monotonic()
     while time.monotonic() < deadline:
         time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-        # Retry only while the draft guard confirms Enter cannot reach a new surface.
+        # Best-effort: re-check the draft before each Enter to narrow the capture-to-send race.
         if not _draft_in_input_box(_capture_pane(socket_path, tmux_target), needle):
             return
         if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -32,6 +32,7 @@ import contextlib
 import hashlib
 import json
 import logging
+import math
 import os
 import queue
 import re
@@ -171,11 +172,24 @@ _PASTE_COMMIT_TIMEOUT_S = 5.0
 # actually left the input box (re-sending Enter while it hasn't) before
 # failing loud. OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S overrides it.
 _SUBMIT_VERIFY_TIMEOUT_ENV = "OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S"
+_SUBMIT_VERIFY_TIMEOUT_DEFAULT_S = 30.0
+_submit_verify_timeout_raw = os.environ.get(_SUBMIT_VERIFY_TIMEOUT_ENV)
 try:
-    _SUBMIT_VERIFY_TIMEOUT_S = float(os.environ.get(_SUBMIT_VERIFY_TIMEOUT_ENV, "30"))
+    _SUBMIT_VERIFY_TIMEOUT_S = (
+        float(_submit_verify_timeout_raw)
+        if _submit_verify_timeout_raw is not None
+        else _SUBMIT_VERIFY_TIMEOUT_DEFAULT_S
+    )
 except ValueError:
-    _logger.warning("Ignoring invalid %s; using 30s", _SUBMIT_VERIFY_TIMEOUT_ENV)
-    _SUBMIT_VERIFY_TIMEOUT_S = 30.0
+    _SUBMIT_VERIFY_TIMEOUT_S = math.nan
+if not math.isfinite(_SUBMIT_VERIFY_TIMEOUT_S) or _SUBMIT_VERIFY_TIMEOUT_S <= 0:
+    _logger.warning(
+        "Ignoring invalid %s=%r; using %gs",
+        _SUBMIT_VERIFY_TIMEOUT_ENV,
+        _submit_verify_timeout_raw,
+        _SUBMIT_VERIFY_TIMEOUT_DEFAULT_S,
+    )
+    _SUBMIT_VERIFY_TIMEOUT_S = _SUBMIT_VERIFY_TIMEOUT_DEFAULT_S
 # Minimum spacing between repeated submit Enters during verification.
 # Long enough for the TUI to clear the box after a successful submit
 # (so a slow-but-successful first Enter isn't double-tapped), short
@@ -3178,7 +3192,7 @@ def inject_user_message(
         failure_message=(
             "Claude Code hasn't accepted the message yet — your text is still in the "
             "sub-agent's input box. Open the Subagents panel and press Enter to send it. "
-            f"Waited {_SUBMIT_VERIFY_TIMEOUT_S}s."
+            f"Waited {_SUBMIT_VERIFY_TIMEOUT_S:g}s."
         ),
     )
 
@@ -3388,7 +3402,7 @@ def inject_slash_command(
             failure_message=(
                 "Claude Code hasn't accepted the slash command yet — it is still in the "
                 "sub-agent's input box. Open the Subagents panel and press Enter to send it."
-                f" Waited {_SUBMIT_VERIFY_TIMEOUT_S}s."
+                f" Waited {_SUBMIT_VERIFY_TIMEOUT_S:g}s."
             ),
         )
     if dialog_hint is not None:
@@ -4110,6 +4124,7 @@ def _verify_draft_submitted(
     last_enter = time.monotonic()
     while time.monotonic() < deadline:
         time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
+        # Retry only while the draft guard confirms Enter cannot reach a new surface.
         if not _draft_in_input_box(_capture_pane(socket_path, tmux_target), needle):
             return
         if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -168,9 +168,9 @@ _PASTE_SETTLE_S = 0.1  # let the TUI commit a paste before the separate submit E
 # the handoff deterministic where the old fixed sleep raced it.
 _PASTE_COMMIT_TIMEOUT_S = 5.0
 # After the submit Enter, how long to keep checking that the draft
-# actually left the input box (re-sending Enter while it hasn't)
-# before failing loud.
-_SUBMIT_VERIFY_TIMEOUT_S = 10.0
+# actually left the input box (re-sending Enter while it hasn't) before
+# failing loud. OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S overrides it.
+_SUBMIT_VERIFY_TIMEOUT_S = float(os.environ.get("OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S", "30"))
 # Minimum spacing between repeated submit Enters during verification.
 # Long enough for the TUI to clear the box after a successful submit
 # (so a slow-but-successful first Enter isn't double-tapped), short
@@ -3164,24 +3164,17 @@ def inject_user_message(
         # verification would trivially "pass". Submit blind as before.
         return
     # Verify the submit took: a successful Enter clears the input box.
-    # If the draft is still sitting there the Enter was swallowed into
-    # the paste burst as a newline — re-send it (the retry lands well
-    # after the burst, so it submits). Each Enter only fires while the
-    # draft is verifiably still present, so a retry can never hit an
-    # empty prompt or a permission dialog of the started turn.
-    deadline = time.monotonic() + _SUBMIT_VERIFY_TIMEOUT_S
-    last_enter = time.monotonic()
-    while time.monotonic() < deadline:
-        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-        pane = _capture_pane(info["socket_path"], info["tmux_target"])
-        if not _draft_in_input_box(pane, needle):
-            return
-        if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:
-            _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
-            last_enter = time.monotonic()
-    raise RuntimeError(
-        f"Claude Code did not accept the submitted message within {_SUBMIT_VERIFY_TIMEOUT_S}s "
-        "(the draft is still in the input box). The message was not delivered."
+    # A draft still sitting there means the Enter was swallowed into the
+    # paste burst as a newline, so it is re-sent until the box clears.
+    _verify_draft_submitted(
+        info["socket_path"],
+        info["tmux_target"],
+        needle,
+        failure_message=(
+            "Claude Code hasn't accepted the message yet — your text is still in the "
+            "sub-agent's input box. Open the Subagents panel and press Enter to send it. "
+            f"Waited {_SUBMIT_VERIFY_TIMEOUT_S}s."
+        ),
     )
 
 
@@ -3381,28 +3374,18 @@ def inject_slash_command(
     time.sleep(_PASTE_SETTLE_S)
     _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
     if draft_seen:
-        # Re-send only while the command verifiably still sits in the box —
-        # a one-poll-stale retry can at worst hit the empty composer (no-op)
-        # or our own confirm dialog (the intended answer), never a foreign
-        # surface. The command leaving the box is the submit signal; the
-        # dialog replacing the composer counts, since submission pops it.
-        deadline = time.monotonic() + _SUBMIT_VERIFY_TIMEOUT_S
-        last_enter = time.monotonic()
-        submitted = False
-        while time.monotonic() < deadline:
-            time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-            if not _draft_in_input_box(_capture_pane(socket_path, tmux_target), needle):
-                submitted = True
-                break
-            if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:
-                _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
-                last_enter = time.monotonic()
-        if not submitted:
-            raise RuntimeError(
-                f"Claude Code did not accept the slash command within "
-                f"{_SUBMIT_VERIFY_TIMEOUT_S}s (the command is still in the "
-                "input box). The command was not delivered."
-            )
+        # The command leaving the box is the submit signal; the dialog
+        # replacing the composer counts, since submission pops it.
+        _verify_draft_submitted(
+            socket_path,
+            tmux_target,
+            needle,
+            failure_message=(
+                "Claude Code hasn't accepted the slash command yet — it is still in the "
+                "sub-agent's input box. Open the Subagents panel and press Enter to send it."
+                f" Waited {_SUBMIT_VERIFY_TIMEOUT_S}s."
+            ),
+        )
     if dialog_hint is not None:
         _confirm_tui_dialog(socket_path, tmux_target, hint=dialog_hint)
 
@@ -4108,6 +4091,26 @@ def _draft_in_input_box(pane: str, needle: str) -> bool:
     if _PASTED_PLACEHOLDER_PREFIX in tail:
         return True
     return bool(needle) and needle in tail
+
+
+def _verify_draft_submitted(
+    socket_path: str,
+    tmux_target: str,
+    needle: str,
+    *,
+    failure_message: str,
+) -> None:
+    """Re-send Enter while the draft verifiably remains in the input box."""
+    deadline = time.monotonic() + _SUBMIT_VERIFY_TIMEOUT_S
+    last_enter = time.monotonic()
+    while time.monotonic() < deadline:
+        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
+        if not _draft_in_input_box(_capture_pane(socket_path, tmux_target), needle):
+            return
+        if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:
+            _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
+            last_enter = time.monotonic()
+    raise RuntimeError(failure_message)
 
 
 def _format_terminal_failure_tail(pane: str) -> str:

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -13,7 +13,7 @@ import sys
 import tempfile
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from types import SimpleNamespace
@@ -3693,36 +3693,6 @@ def test_inject_user_message_raises_when_draft_never_submits(
         r"Waited 0\.2s\.",
     ):
         inject_user_message(bridge_dir, content="fix the flaky test")
-
-
-def test_inject_user_message_submit_verify_honors_the_budget_override(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The verify loop keeps re-sending Enter for the configured budget.
-
-    The draft never clears here, so the loop re-sends Enter once per
-    retry interval until the budget expires: a wider budget must draw
-    strictly more retries before failing. A loop that ignored the
-    override would give up at the same point in both runs.
-    """
-
-    def _enters_for_budget(budget_s: float) -> list[list[str]]:
-        monkeypatch.setattr(claude_native_bridge, "_SUBMIT_VERIFY_TIMEOUT_S", budget_s)
-        sends = _fake_tmux(monkeypatch, [_draft_pane("fix the flaky test")])
-        with pytest.raises(RuntimeError, match=r"hasn't accepted the message"):
-            claude_native_bridge.inject_user_message(
-                _picker_bridge_dir(tmp_path / f"b{budget_s}"),
-                content="fix the flaky test",
-            )
-        return [args for args in sends if args[-1] == "Enter"]
-
-    tight = _enters_for_budget(2.0)
-    generous = _enters_for_budget(6.0)
-    assert len(tight) < len(generous), (
-        f"a wider budget must retry the swallowed Enter more times; "
-        f"got {len(tight)} vs {len(generous)} Enter(s)"
-    )
 
 
 def test_inject_interrupt_sends_escape_keystroke(
@@ -8094,25 +8064,25 @@ def test_a_slash_command_draft_that_never_renders_submits_blind(
     )
 
 
-def test_a_slash_command_submit_verify_honors_the_budget_override(
+@pytest.mark.parametrize(
+    ("inject", "argument", "draft"),
+    [
+        (claude_native_bridge.inject_user_message, "content", "fix the flaky test"),
+        (claude_native_bridge.inject_slash_command, "command", "/effort high"),
+    ],
+)
+def test_submit_verify_honors_the_budget_override(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    inject: Callable[..., None],
+    argument: str,
+    draft: str,
 ) -> None:
-    """The command-path verify loop also retries for the configured budget.
-
-    Same budget, second call site: the stuck command must keep drawing
-    retries for as long as the override says before failing, so both
-    injection paths widen together when an operator raises it.
-    """
-
     def _enters_for_budget(budget_s: float) -> list[list[str]]:
         monkeypatch.setattr(claude_native_bridge, "_SUBMIT_VERIFY_TIMEOUT_S", budget_s)
-        sends = _fake_tmux(monkeypatch, [_draft_pane("/effort high")])
-        with pytest.raises(RuntimeError, match=r"hasn't accepted the slash command"):
-            claude_native_bridge.inject_slash_command(
-                _picker_bridge_dir(tmp_path / f"b{budget_s}"),
-                command="/effort high",
-            )
+        sends = _fake_tmux(monkeypatch, [_composer_pane(draft)])
+        with pytest.raises(RuntimeError, match=r"hasn't accepted"):
+            inject(_picker_bridge_dir(tmp_path / f"b{budget_s}"), **{argument: draft})
         return [args for args in sends if args[-1] == "Enter"]
 
     tight = _enters_for_budget(2.0)
@@ -8121,6 +8091,24 @@ def test_a_slash_command_submit_verify_honors_the_budget_override(
         f"a wider budget must retry the swallowed Enter more times; "
         f"got {len(tight)} vs {len(generous)} Enter(s)"
     )
+
+
+def test_invalid_submit_verify_budget_uses_default() -> None:
+    env = os.environ | {"OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S": "invalid"}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import omnigent.claude_native_bridge as bridge; "
+            "print(bridge._SUBMIT_VERIFY_TIMEOUT_S)",
+        ],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "30.0"
 
 
 def test_an_effort_switch_with_a_swallowed_confirm_leaves_the_pane_usable(

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -3686,8 +3686,43 @@ def test_inject_user_message_raises_when_draft_never_submits(
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    with pytest.raises(RuntimeError, match="message was not delivered"):
+    with pytest.raises(
+        RuntimeError,
+        match=r"Claude Code hasn't accepted the message yet — your text is still in the "
+        r"sub-agent's input box\. Open the Subagents panel and press Enter to send it\. "
+        r"Waited 0\.2s\.",
+    ):
         inject_user_message(bridge_dir, content="fix the flaky test")
+
+
+def test_inject_user_message_submit_verify_honors_the_budget_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The verify loop keeps re-sending Enter for the configured budget.
+
+    The draft never clears here, so the loop re-sends Enter once per
+    retry interval until the budget expires: a wider budget must draw
+    strictly more retries before failing. A loop that ignored the
+    override would give up at the same point in both runs.
+    """
+
+    def _enters_for_budget(budget_s: float) -> list[list[str]]:
+        monkeypatch.setattr(claude_native_bridge, "_SUBMIT_VERIFY_TIMEOUT_S", budget_s)
+        sends = _fake_tmux(monkeypatch, [_draft_pane("fix the flaky test")])
+        with pytest.raises(RuntimeError, match=r"hasn't accepted the message"):
+            claude_native_bridge.inject_user_message(
+                _picker_bridge_dir(tmp_path / f"b{budget_s}"),
+                content="fix the flaky test",
+            )
+        return [args for args in sends if args[-1] == "Enter"]
+
+    tight = _enters_for_budget(2.0)
+    generous = _enters_for_budget(6.0)
+    assert len(tight) < len(generous), (
+        f"a wider budget must retry the swallowed Enter more times; "
+        f"got {len(tight)} vs {len(generous)} Enter(s)"
+    )
 
 
 def test_inject_interrupt_sends_escape_keystroke(
@@ -8022,9 +8057,15 @@ def test_a_slash_command_stuck_in_the_composer_fails_loud(
     the authoritative fallback — an honest failure, not a silent divergence.
     """
     bridge_dir = _picker_bridge_dir(tmp_path)
+    monkeypatch.setattr(claude_native_bridge, "_SUBMIT_VERIFY_TIMEOUT_S", 0.2)
     _fake_tmux(monkeypatch, [_composer_pane("/effort high")])
 
-    with pytest.raises(RuntimeError, match="was not delivered"):
+    with pytest.raises(
+        RuntimeError,
+        match=r"Claude Code hasn't accepted the slash command yet — it is still in the "
+        r"sub-agent's input box\. Open the Subagents panel and press Enter to send it\. "
+        r"Waited 0\.2s\.",
+    ):
         claude_native_bridge.inject_slash_command(bridge_dir, command="/effort high")
 
 
@@ -8050,6 +8091,35 @@ def test_a_slash_command_draft_that_never_renders_submits_blind(
     tails = [args[-1] for args in sends]
     assert tails == ["C-u", "/effort high", "Enter"], (
         f"An unverifiable draft must submit blind exactly once; got {tails}."
+    )
+
+
+def test_a_slash_command_submit_verify_honors_the_budget_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The command-path verify loop also retries for the configured budget.
+
+    Same budget, second call site: the stuck command must keep drawing
+    retries for as long as the override says before failing, so both
+    injection paths widen together when an operator raises it.
+    """
+
+    def _enters_for_budget(budget_s: float) -> list[list[str]]:
+        monkeypatch.setattr(claude_native_bridge, "_SUBMIT_VERIFY_TIMEOUT_S", budget_s)
+        sends = _fake_tmux(monkeypatch, [_draft_pane("/effort high")])
+        with pytest.raises(RuntimeError, match=r"hasn't accepted the slash command"):
+            claude_native_bridge.inject_slash_command(
+                _picker_bridge_dir(tmp_path / f"b{budget_s}"),
+                command="/effort high",
+            )
+        return [args for args in sends if args[-1] == "Enter"]
+
+    tight = _enters_for_budget(2.0)
+    generous = _enters_for_budget(6.0)
+    assert len(tight) < len(generous), (
+        f"a wider budget must retry the swallowed Enter more times; "
+        f"got {len(tight)} vs {len(generous)} Enter(s)"
     )
 
 

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -3655,8 +3655,9 @@ def test_inject_user_message_raises_when_draft_never_submits(
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
     monkeypatch.setattr("omnigent.claude_native_bridge._SUBMIT_RETRY_INTERVAL_S", 0.02)
-    monkeypatch.setattr("omnigent.claude_native_bridge._SUBMIT_VERIFY_TIMEOUT_S", 0.2)
+    monkeypatch.setattr("omnigent.claude_native_bridge._SUBMIT_VERIFY_TIMEOUT_S", 30.0)
     monkeypatch.setattr("omnigent.claude_native_bridge._PASTE_SETTLE_S", 0.0)
+    monkeypatch.setattr("omnigent.claude_native_bridge.time", _VirtualClock())
     bridge_dir = tmp_path / "bridge"
     write_tmux_target(
         bridge_dir,
@@ -3690,7 +3691,7 @@ def test_inject_user_message_raises_when_draft_never_submits(
         RuntimeError,
         match=r"Claude Code hasn't accepted the message yet — your text is still in the "
         r"sub-agent's input box\. Open the Subagents panel and press Enter to send it\. "
-        r"Waited 0\.2s\.",
+        r"Waited 30s\.",
     ):
         inject_user_message(bridge_dir, content="fix the flaky test")
 
@@ -8027,14 +8028,14 @@ def test_a_slash_command_stuck_in_the_composer_fails_loud(
     the authoritative fallback — an honest failure, not a silent divergence.
     """
     bridge_dir = _picker_bridge_dir(tmp_path)
-    monkeypatch.setattr(claude_native_bridge, "_SUBMIT_VERIFY_TIMEOUT_S", 0.2)
+    monkeypatch.setattr(claude_native_bridge, "_SUBMIT_VERIFY_TIMEOUT_S", 30.0)
     _fake_tmux(monkeypatch, [_composer_pane("/effort high")])
 
     with pytest.raises(
         RuntimeError,
         match=r"Claude Code hasn't accepted the slash command yet — it is still in the "
         r"sub-agent's input box\. Open the Subagents panel and press Enter to send it\. "
-        r"Waited 0\.2s\.",
+        r"Waited 30s\.",
     ):
         claude_native_bridge.inject_slash_command(bridge_dir, command="/effort high")
 
@@ -8093,8 +8094,33 @@ def test_submit_verify_honors_the_budget_override(
     )
 
 
-def test_invalid_submit_verify_budget_uses_default() -> None:
-    env = os.environ | {"OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S": "invalid"}
+@pytest.mark.parametrize(("value", "expected"), [(None, "30.0"), ("45", "45.0")])
+def test_submit_verify_budget_reads_environment(value: str | None, expected: str) -> None:
+    env = os.environ.copy()
+    if value is None:
+        env.pop("OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S", None)
+    else:
+        env["OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S"] = value
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import omnigent.claude_native_bridge as bridge; "
+            "print(bridge._SUBMIT_VERIFY_TIMEOUT_S)",
+        ],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.stdout.strip() == expected
+
+
+@pytest.mark.parametrize("value", ["inf", "nan", "0", "-5", "invalid"])
+def test_invalid_submit_verify_budget_warns_and_uses_default(value: str) -> None:
+    variable = "OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S"
+    env = os.environ | {variable: value}
     result = subprocess.run(
         [
             sys.executable,
@@ -8109,6 +8135,8 @@ def test_invalid_submit_verify_budget_uses_default() -> None:
     )
 
     assert result.stdout.strip() == "30.0"
+    assert f"{variable}={value!r}" in result.stderr
+    assert "using 30s" in result.stderr
 
 
 def test_an_effort_switch_with_a_swallowed_confirm_leaves_the_pane_usable(


### PR DESCRIPTION
## Related issue

Part of #5281
## Summary

A claude-native turn could report failure while the user's draft remained intact in the live Claude composer; pressing Enter manually sent it successfully. Claude Code can fold an Enter into a paste burst on a loaded host, and the previous 10-second submit-verification budget could expire before the TUI drained.

- Raise the default verification budget to 30 seconds and allow `OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S` to override it.
- Share the same retry verifier across user-message and slash-command submission.
- Explain that the draft is recoverable in the Subagents panel instead of claiming it was lost.

ELI5: Omnigent now waits longer for Claude to finish receiving pasted text. If Claude still has not sent it, the error tells you where the text remains and how to send it manually.

```text
paste draft -> Enter folded into paste -> retry while draft remains -> submitted
                                                    |
                                                    +-> timeout: keep pane and explain manual Enter recovery
```

## Test Plan

- `uv run --frozen --group test python -m pytest --collect-only -q tests/test_claude_native_bridge.py tests/inner/test_claude_native_executor.py` (285 collected)
- `uv run --frozen --group test python -m pytest tests/test_claude_native_bridge.py tests/inner/test_claude_native_executor.py` (285 passed)
- `uv run --frozen ruff format --check omnigent/claude_native_bridge.py tests/test_claude_native_bridge.py`
- `uv run --frozen ruff check omnigent/claude_native_bridge.py tests/test_claude_native_bridge.py`
- Mutation-tested both new budget tests by temporarily making the shared verifier ignore the override; each failed with equal retry counts before the implementation was restored.
- Confirmed `OMNIGENT_CLAUDE_SUBMIT_VERIFY_TIMEOUT_S=45` loads a 45-second budget.

## Demo

Not a UI change. The user-visible effect is the one the reporter hit by hand:
"I had to manually submit the prompt after Claude finally started up."

**Before** — Claude coalesces a rapid stdin burst into a paste, folding the
submitting Enter into a newline. The prompt sits in the composer, the turn never
runs, and reaping only fires on `ClaudePromptTimeout` — so the pane is preserved
and the session waits indefinitely for a human to press Enter.

**After** — the submit budget is extended and verified, so a
captured-but-unsent prompt is detected and surfaced instead of stalling.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Both submit-verification call sites have override-sensitive tests, and the executor regression suite confirms unrelated runtime errors still preserve the live pane for human takeover.

## Changelog

Claude-native submissions now wait longer on loaded machines and explain how to send a draft manually if it remains in the sub-agent composer.

