### PR TITLE
fix(web): surface chat errors as pills, not raw red text

### DIFF
--- a/tests/e2e_ui/chat/test_failure_error_card.py
+++ b/tests/e2e_ui/chat/test_failure_error_card.py
@@ -191,6 +191,42 @@ def test_live_native_failure_status_surfaces_each_turn(
     expect(second_pill.get_by_test_id("error-message-content")).to_contain_text(message)
 
 
+def test_failed_turn_surfaces_error_as_pill_not_raw_text(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A failed turn shows its error through the pill, never a bare red "Error:".
+
+    A native ``failed`` status leaves the assistant bubble at
+    ``lifecycle == "failed"`` with a null free-form ``error`` — the message
+    rides on the error pill. The bubble must not paint a separate raw
+    ``Error:`` line beneath it (the empty-content red text a dropped host
+    connection used to show); the failure reads through the pill alone.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the local server.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_role("textbox", name="Message the agent")).to_be_visible(timeout=15_000)
+
+    _publish_native_status(base_url, session_id, "running", response_id="codex_turn_fail")
+    _publish_native_status(
+        base_url,
+        session_id,
+        "failed",
+        response_id="codex_turn_fail",
+        output="You've hit your usage limit.",
+    )
+
+    # The failure surfaces as the standard error pill...
+    expect(page.get_by_test_id("error-pill")).to_have_count(1, timeout=15_000)
+    # ...and never as a bare, raw-red "Error:" line beneath the bubble.
+    expect(page.get_by_text("Error:", exact=True)).to_have_count(0)
+
+
 def test_persisted_failure_expands_retries_and_dismisses_locally(
     page: Page,
     seeded_session: tuple[str, str],

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useChatStore } from "@/store/chatStore";
 import type { Bubble } from "@/lib/renderItems";
@@ -24,18 +24,21 @@ afterEach(() => {
 });
 
 describe("SandboxFailedIndicator", () => {
-  it("renders the recorded failure reason so a dead launch explains itself", () => {
-    // WHY: a silently dead chat is the bug this band exists to prevent — the
-    // reason must reach the DOM.
+  it("surfaces the recorded failure reason in the pill so a dead launch explains itself", () => {
+    // WHY: a silently dead chat is the bug this pill exists to prevent — the
+    // reason must reach the DOM, reachable in the pill's expandable body.
     render(<SandboxFailedIndicator status={{ stage: "failed", error: "out of quota" }} />);
-    expect(screen.getByText(/Sandbox launch failed: out of quota/)).toBeInTheDocument();
+    expect(screen.getByTestId("error-headline")).toHaveTextContent("Sandbox launch failed");
+    fireEvent.click(screen.getByTestId("error-pill"));
+    expect(screen.getByTestId("error-message-content")).toHaveTextContent("out of quota");
   });
 
-  it("omits the colon suffix when no error detail is recorded", () => {
-    // WHY: a missing error must not render a dangling "failed: " — the
-    // ternary guards the suffix.
+  it("shows just the failure headline with no dangling colon when no reason is recorded", () => {
+    // WHY: a missing reason must not render a dangling "failed: " — the pill
+    // shows only the headline.
     render(<SandboxFailedIndicator status={{ stage: "failed", error: null }} />);
-    expect(screen.getByText("Sandbox launch failed")).toBeInTheDocument();
+    expect(screen.getByTestId("error-headline")).toHaveTextContent("Sandbox launch failed");
+    expect(screen.queryByText(/Sandbox launch failed:/)).not.toBeInTheDocument();
   });
 });
 
@@ -270,11 +273,25 @@ describe("BubbleView dispatch", () => {
     expect(screen.getByTestId("assistant-interrupted-indicator")).toHaveTextContent("Interrupted");
   });
 
-  it("renders the error text for a failed assistant turn", () => {
-    // WHY: the failed branch must surface the error so a dead turn explains
-    // itself instead of vanishing.
+  it("surfaces a failed turn's error as a destructive pill, never raw text", () => {
+    // WHY: a failed send/stream must render through the same error pill an error
+    // block uses — never bare red "Error:" text — and the message stays
+    // reachable in the pill's expandable body so a dead turn still explains itself.
     render(<BubbleView bubble={{ ...assistantText("", "failed"), error: "rate limited" }} />);
-    expect(screen.getByText(/Error: rate limited/)).toBeInTheDocument();
+    const pill = screen.getByTestId("error-pill");
+    expect(pill).toBeInTheDocument();
+    expect(screen.queryByText(/^Error:/)).not.toBeInTheDocument();
+    fireEvent.click(pill);
+    expect(screen.getByTestId("error-message-content")).toHaveTextContent("rate limited");
+  });
+
+  it("adds no error pill for a failed turn whose message rides on its block", () => {
+    // WHY: a dropped-host turn ends "failed" but carries its explanation as an
+    // error block inside the bubble, leaving `error` null — the bubble must add
+    // no second pill (and never a bare "Error:") of its own.
+    render(<BubbleView bubble={{ ...assistantText("", "failed"), error: null }} />);
+    expect(screen.queryByTestId("error-pill")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Error:/)).not.toBeInTheDocument();
   });
 
   const toolItem = (callId: string): AssistantBubble["items"][number] => ({

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -57,7 +57,11 @@ import {
   FilePathAwareMessageResponse,
   rendersOnlyWorkedFold,
 } from "@/components/blocks/BlockRenderer";
-import { CompactionMarker, RoutingDecisionCard } from "@/components/blocks/StatusBlocks";
+import {
+  CompactionMarker,
+  ErrorBanner,
+  RoutingDecisionCard,
+} from "@/components/blocks/StatusBlocks";
 import { SystemMessageView } from "@/components/blocks/SystemMessage";
 import { isSystemUserContent, parseSystemMessage } from "@/lib/systemMessage";
 import { Button } from "@/components/ui/button";
@@ -3171,13 +3175,9 @@ export function SandboxFailedIndicator({ status }: { status: SandboxStatus }) {
     <div
       data-testid="sandbox-failed-indicator"
       role="status"
-      className={cn(
-        "mx-auto mb-4 flex w-full items-center justify-center gap-2 px-6 py-1.5 text-destructive text-sm",
-        CHAT_COLUMN_WIDTH,
-      )}
+      className={cn("mx-auto w-full", CHAT_COLUMN_WIDTH)}
     >
-      <AlertTriangleIcon className="size-3.5 shrink-0" aria-hidden />
-      <span>Sandbox launch failed{status.error ? `: ${status.error}` : ""}</span>
+      <ErrorBanner message={status.error ?? ""} source="" code="" title="Sandbox launch failed" />
     </div>
   );
 }
@@ -3244,22 +3244,29 @@ export function ConnectionIndicator({
       return null;
     }
     return (
-      <button
-        type="button"
-        data-testid="disconnected-indicator"
-        onClick={onShowReconnectHelp}
-        className={cn(
-          "mx-auto mb-4 flex w-full items-center justify-center gap-2 px-6 py-1.5 text-sm text-destructive underline-offset-2 hover:underline",
-          CHAT_COLUMN_WIDTH,
-        )}
-      >
-        <WifiOffIcon className="size-3.5 shrink-0" />
-        <span>
-          {liveness.kind === "host_offline"
-            ? "Host is offline — click to reconnect"
-            : "Agent disconnected — click to reconnect"}
-        </span>
-      </button>
+      <div className={cn("mx-auto mb-4 flex w-full justify-center px-6", CHAT_COLUMN_WIDTH)}>
+        {/* Reconnect affordance styled as the destructive error pill (never
+            raw red text). Keeps its own click → reconnect dialog rather than
+            the ErrorBanner's async Retry, since some states need the picker. */}
+        <button
+          type="button"
+          data-testid="disconnected-indicator"
+          onClick={onShowReconnectHelp}
+          className="flex items-center gap-2 rounded-[12px] px-4 py-2 text-sm text-destructive transition-[filter] hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          style={{
+            background:
+              "color-mix(in srgb, var(--destructive) 4%, var(--app-shell-bg, var(--background)))",
+            border: "1px solid color-mix(in srgb, var(--destructive) 32%, transparent)",
+          }}
+        >
+          <WifiOffIcon className="size-3.5 shrink-0" />
+          <span>
+            {liveness.kind === "host_offline"
+              ? "Host is offline — click to reconnect"
+              : "Agent disconnected — click to reconnect"}
+          </span>
+        </button>
+      </div>
     );
   }
 
@@ -4016,8 +4023,12 @@ function AssistantBubble({
         )}
       </Message>
 
-      {bubble.lifecycle === "failed" && (
-        <p className="text-destructive text-sm">Error: {bubble.error}</p>
+      {/* Surface a turn-level failure (a failed send or stream) as the same
+          destructive pill an error block renders — never raw red text. A
+          dropped host connection already carries its own error pill inside the
+          bubble and leaves `bubble.error` null, so this stays hidden there. */}
+      {bubble.lifecycle === "failed" && bubble.error && (
+        <ErrorBanner message={bubble.error} source="" code="" />
       )}
     </>
   );


### PR DESCRIPTION
## Related issue

Closes #5284

## Summary

Errors in the web chat viewport are now surfaced through the standard error
"pill" (`ErrorBanner`) instead of raw red `text-destructive` text.

- **Turn-level failures** (`bubble.error` from a failed send/stream) render as an
  `ErrorBanner` pill, guarded on the message being non-empty. This kills the bare,
  contentless `Error:` line that appeared on a dropped host connection — that turn
  ends `failed` with a null `bubble.error`, and its explanation already rides on
  the separate `runner_disconnected` pill inside the bubble.
- **`SandboxFailedIndicator`** ("Sandbox launch failed: …") now renders as an
  `ErrorBanner` pill (headline + reason in the expandable body).
- The **disconnected / reconnect band** ("Host is offline — click to reconnect")
  is restyled as a pill-styled button. It keeps its own click → reconnect dialog
  (some states need the directory picker, so the pill's async Retry doesn't fit).

## Test Plan

- `web`: `npx vitest run src/pages/ChatPage.indicators.test.tsx` — 26 passing,
  including new/updated cases that assert the pill (`error-pill`,
  `error-headline`, `error-message-content`) renders and that no raw `Error:`
  text is emitted. Confirmed the new `bubble.error` guard test fails without the fix.
- `npx tsc -b`, `npx oxlint`, `npx prettier --check` — all clean on the changed files.

## Demo

No media attached (kept out of `docs/images/`). The change is presentational —
before: a bare red `Error:` (and other raw red-text bands) in the transcript;
after: the same destructive pill used elsewhere. Covered by component tests that
render the real component tree; live visual confirmation recommended on a failed
turn / launch failure / offline session.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Changelog

Chat errors now show as the standard error pill instead of raw red text.
