### PR TITLE
fix(runner): reap a stale codex app-server before launching a new one

### DIFF
--- a/omnigent/codex_native_process_registry.py
+++ b/omnigent/codex_native_process_registry.py
@@ -8,6 +8,7 @@ import logging
 import os
 import signal
 import subprocess
+import time
 import uuid
 from collections.abc import Generator
 from dataclasses import asdict, dataclass
@@ -419,3 +420,80 @@ def _kill_tmux_session(tmux_session_name: str) -> None:
             stderr=subprocess.DEVNULL,
             timeout=2.0,
         )
+
+
+def reap_codex_native_processes_for_state_dir(
+    state_dir: Path,
+    *,
+    grace_s: float = 1.5,
+) -> int:
+    """
+    Kill any live Codex app-server still bound to *state_dir*'s session.
+
+    A runner that dies without finishing graceful shutdown (host restart,
+    hard exit) strands its app-server: the process runs in its own
+    session, survives, and keeps holding the codex thread's writer lock —
+    so every later ``thread/resume`` for the session is refused with
+    "already has an active writer". Launch time is when that matters, so
+    the launch path calls this first. Identity is the session state dir
+    baked into the app-server command line (its ``-c`` config overrides
+    name the bridge dir), which — unlike the argv0 crash tag — survives
+    the npm shim's ``exec``. Matches are killed by process group, taking
+    their bridge/hook children with them.
+
+    :param state_dir: The session's codex-native state dir, e.g.
+        ``~/.omnigent/codex-native/<sha256(session)[:32]>``.
+    :param grace_s: Seconds to wait after SIGTERM before escalating the
+        survivors to SIGKILL, e.g. ``1.5``.
+    :returns: Number of matched processes signalled.
+    """
+    if os.name != "posix":
+        return 0
+    needle = str(state_dir)
+    try:
+        listing = subprocess.run(
+            ["ps", "-axww", "-o", "pid=,pgid=,command="],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        ).stdout
+    except (OSError, subprocess.TimeoutExpired):
+        return 0
+    own_pgid = os.getpgid(0)
+    victims: dict[int, int] = {}
+    for line in listing.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) != 3:
+            continue
+        pid_text, pgid_text, command = parts
+        try:
+            pid, pgid = int(pid_text), int(pgid_text)
+        except ValueError:
+            continue
+        # "app-server" scopes the match to the codex app-server itself (the
+        # session's bridge MCP child also carries the state dir, but it is a
+        # member of the app-server's process group and dies with it).
+        if needle not in command or "app-server" not in command:
+            continue
+        if pid == os.getpid() or pgid <= 0 or pgid == own_pgid:
+            continue
+        victims[pid] = pgid
+    if not victims:
+        return 0
+    for pgid in sorted(set(victims.values())):
+        with contextlib.suppress(OSError):
+            os.killpg(pgid, signal.SIGTERM)
+    deadline = time.monotonic() + grace_s
+    while time.monotonic() < deadline and any(_pid_alive(pid) for pid in victims):
+        time.sleep(0.05)
+    for pid, pgid in victims.items():
+        if _pid_alive(pid):
+            with contextlib.suppress(OSError):
+                os.killpg(pgid, signal.SIGKILL)
+    _logger.warning(
+        "reaped %d stale codex app-server process(es) for state dir %s",
+        len(victims),
+        state_dir.name,
+    )
+    return len(victims)

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3803,6 +3803,15 @@ async def _auto_create_codex_terminal(
     # not the one registered below — and so it can't mirror alongside the new one.
     await _cancel_auto_forwarder_task(session_id)
     clear_bridge_state(bridge_dir)
+    # A previous runner's app-server for THIS session can outlive a hard runner
+    # exit (it runs in its own process session) while still holding the codex
+    # thread's writer lock, which makes the ``thread/resume`` below fail with
+    # "already has an active writer". Reap it before starting a replacement.
+    from omnigent.codex_native_process_registry import (
+        reap_codex_native_processes_for_state_dir,
+    )
+
+    await asyncio.to_thread(reap_codex_native_processes_for_state_dir, bridge_dir)
 
     # Forked clone with no native thread of its own yet: clone the SOURCE's
     # local Codex rollout into the clone's OWN CODEX_HOME under a thread id
@@ -4099,11 +4108,20 @@ async def _auto_create_codex_terminal(
     else:
         from omnigent.codex_native_bridge import CodexNativeBridgeState, write_bridge_state
 
-        await preload_codex_thread_for_resume(
-            codex_ws_url,
-            launch_config.external_session_id,
-            terminal_launch_args=launch_config.terminal_launch_args,
-        )
+        try:
+            await preload_codex_thread_for_resume(
+                codex_ws_url,
+                launch_config.external_session_id,
+                terminal_launch_args=launch_config.terminal_launch_args,
+            )
+        except Exception:
+            # The app-server started above must not outlive a refused resume:
+            # without this close, every retry stacked another live codex
+            # process (and only the newest stayed tracked for teardown).
+            with contextlib.suppress(Exception):
+                await app_server.close()
+            _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+            raise
         write_bridge_state(
             bridge_dir,
             CodexNativeBridgeState(

--- a/tests/runner/test_app_sessions_native_wake_forwarders.py
+++ b/tests/runner/test_app_sessions_native_wake_forwarders.py
@@ -1031,3 +1031,163 @@ async def test_forwarder_task_exit_paths_are_logged(
     finally:
         for sid in (cancelled_id, died_id, returned_id):
             runner_app_mod._AUTO_FORWARDER_TASKS.pop(sid, None)
+
+
+async def test_auto_create_codex_terminal_refused_resume_closes_app_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A refused ``thread/resume`` must not leak the app-server it started.
+
+    The stale-writer incident shape: a leftover process holds the codex
+    thread's writer lock, ``thread/resume`` fails, and each retry stacked
+    another live app-server — only the newest stayed tracked for teardown.
+    The failure path must close the app-server and drop the session's
+    tracking entry so a retry starts clean.
+
+    :param tmp_path: Temporary directory for isolated bridge state.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    import omnigent.codex_native_app_server as codex_app_mod
+
+    session_id = "b7d2c1e0aa114b52b7c2f1d3e4a5b6c7"
+    thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936c"
+    monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+
+    class _SnapshotServerClient:
+        """Server client whose snapshot carries a persisted resume thread."""
+
+        async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+            """
+            Return the session snapshot / items consumed by the helper.
+
+            :param url: Request path, e.g. ``"/v1/sessions/conv_..."``.
+            :param kwargs: Request keyword arguments (ignored).
+            :returns: HTTP 200 response carrying launch config or items.
+            """
+            del kwargs
+            if url == f"/v1/sessions/{session_id}/items":
+                return httpx.Response(
+                    200,
+                    json={"data": [], "has_more": False},
+                    request=httpx.Request("GET", url),
+                )
+            return httpx.Response(
+                200,
+                json={"external_session_id": thread_id},
+                request=httpx.Request("GET", url),
+            )
+
+    closed: list[str] = []
+
+    class _FakeCodexAppServer:
+        """Minimal app-server recording whether it was closed."""
+
+        codex_path = "/opt/codex/bin/codex"
+        codex_cli_version: tuple[int, int, int] | None = None
+
+        def __init__(self) -> None:
+            """:returns: None."""
+            self.env = {"OPENAI_API_KEY": "sk-test"}
+            self.codex_home = tmp_path / "unconfigured-codex-home"
+            self.listen_url: str | None = None
+            self.config_overrides: list[str] = []
+
+        async def start(self) -> None:
+            """:returns: None."""
+
+        async def close(self) -> None:
+            """Record the teardown the failure path owes."""
+            closed.append("closed")
+
+    def _fake_build_codex_native_server(**kwargs: Any) -> _FakeCodexAppServer:
+        """
+        Build a fake app-server bound to the requested CODEX_HOME.
+
+        :param kwargs: Keyword arguments passed by the runner helper.
+        :returns: Fresh fake app-server.
+        """
+        app_server = _FakeCodexAppServer()
+        app_server.codex_home = kwargs["codex_home"]
+        return app_server
+
+    class _IdleClient:
+        """Event client that must never connect before the resume succeeds."""
+
+        def __init__(self, *, ws_url: str, client_name: str) -> None:
+            """
+            :param ws_url: App-server WebSocket URL.
+            :param client_name: JSON-RPC client name.
+            """
+            self.ws_url = ws_url
+            self.client_name = client_name
+
+        async def connect(self) -> None:
+            """Fail if the refused resume still wires the listener."""
+            raise AssertionError("refused resume must not connect the event client")
+
+        async def close(self) -> None:
+            """:returns: None."""
+
+    async def _refusing_preload(
+        transport: str,
+        loaded_thread_id: str,
+        *,
+        terminal_launch_args: list[str] | None = None,
+    ) -> None:
+        """
+        Refuse the resume the way a stale writer-lock holder does.
+
+        :param transport: App-server transport URL (ignored).
+        :param loaded_thread_id: Thread id passed to ``thread/resume``.
+        :raises RuntimeError: Always, mirroring the app-server error.
+        """
+        del transport, terminal_launch_args
+        raise RuntimeError(f"thread {loaded_thread_id} already has an active writer")
+
+    class _UnreachableResourceRegistry:
+        """Terminal launcher the failing path must never reach."""
+
+        async def launch_auxiliary_terminal(self, **kwargs: Any) -> SessionResourceView:
+            """Fail if a terminal is launched despite the refused resume."""
+            del kwargs
+            raise AssertionError("refused resume must not launch the TUI")
+
+    monkeypatch.setattr(
+        codex_app_mod,
+        "build_codex_native_server",
+        _fake_build_codex_native_server,
+    )
+    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _IdleClient)
+    monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _refusing_preload)
+
+    agent_spec = AgentSpec(
+        spec_version=1,
+        name="codex",
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "codex-native", "model": "gpt-5-default"},
+        ),
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="active writer"):
+            await runner_app_mod._auto_create_codex_terminal(
+                session_id,
+                _UnreachableResourceRegistry(),  # type: ignore[arg-type]
+                lambda _sid, _evt: None,
+                agent_spec=agent_spec,
+                server_client=_SnapshotServerClient(),  # type: ignore[arg-type]
+            )
+        assert closed == ["closed"], "refused resume left the app-server running"
+        assert session_id not in runner_app_mod._AUTO_CODEX_APP_SERVERS, (
+            "failed create left its app-server tracked; the next attempt would "
+            "overwrite (and leak) it"
+        )
+    finally:
+        runner_app_mod._AUTO_CODEX_APP_SERVERS.pop(session_id, None)

--- a/tests/test_codex_native_process_registry.py
+++ b/tests/test_codex_native_process_registry.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import signal
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -245,3 +248,41 @@ def test_registry_lock_serializes_read_modify_write(tmp_path: Path) -> None:
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         finally:
             registry.os.close(fd)
+
+
+def test_reap_state_dir_kills_matching_app_server_and_spares_others(tmp_path: Path) -> None:
+    """
+    Reaping by state dir kills only processes carrying dir + "app-server".
+
+    The stale-holder incident shape: an app-server from a dead runner still
+    runs with the session state dir in its command line. A process carrying
+    the dir WITHOUT the "app-server" marker (e.g. the pytest process's own
+    tree) must survive.
+    """
+    state_dir = tmp_path / "deadbeefdeadbeefdeadbeefdeadbeef"
+    sleeper = "import time; time.sleep(300)"
+    victim = subprocess.Popen(
+        [sys.executable, "-c", sleeper, str(state_dir), "app-server"],
+        start_new_session=True,
+    )
+    bystander = subprocess.Popen(
+        [sys.executable, "-c", sleeper, str(state_dir)],
+        start_new_session=True,
+    )
+    try:
+        reaped = registry.reap_codex_native_processes_for_state_dir(state_dir, grace_s=1.0)
+        assert reaped == 1, f"expected exactly the victim to match, got {reaped}"
+        # SIGTERM (or the SIGKILL escalation) must actually end the process.
+        victim.wait(timeout=5.0)
+        assert bystander.poll() is None, "process without the app-server marker was killed"
+    finally:
+        for proc in (victim, bystander):
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            with contextlib.suppress(Exception):
+                proc.wait(timeout=5.0)
+
+
+def test_reap_state_dir_without_matches_is_a_noop(tmp_path: Path) -> None:
+    """A state dir no live process references reaps nothing."""
+    assert registry.reap_codex_native_processes_for_state_dir(tmp_path / "no-match") == 0


### PR DESCRIPTION
## Related issue

Closes #5286

## Summary

- A runner that dies without finishing graceful shutdown (host restart, hard exit) strands its codex app-server, which keeps holding the codex thread's writer lock — so every later `thread/resume` for the session fails with **"already has an active writer"** and the session is stuck on "Native Codex terminal failed to start". The crash registry can't reap the orphan because its argv0 tag doesn't survive the npm shim's `exec` (verified: the tag appears in no live app-server's cmdline).
- Fix is self-healing at launch, the only moment an orphan matters: `reap_codex_native_processes_for_state_dir()` kills (SIGTERM → SIGKILL, by process group) any live app-server whose command line names this session's codex-native state dir — an identity the shim can't strip — before a replacement starts.
- The resume branch now closes the app-server it started when `thread/resume` is refused, instead of leaking one live codex process per retry (only the newest was tracked for teardown).

ELI5: if the previous attendant died without handing back the key to this session's Codex notebook, the new attendant used to just fail at the locked drawer, forever. Now it recognizes the old attendant's ghost, dismisses it (which releases the key), and opens the drawer.

```
runner A (dies hard) ──spawned──> app-server A  ── holds thread writer lock
runner B: launch codex terminal
  BEFORE: start app-server B → thread/resume → "already has an active writer" → fail (+ leak B)
  AFTER:  reap by state-dir cmdline match (kills A) → start B → thread/resume → OK
```

## Test Plan

- `pytest tests/test_codex_native_process_registry.py tests/runner/test_app_sessions_native_wake_forwarders.py` — 33 passed. New: the reaper kills a real process carrying the state dir + "app-server" in its argv and spares one without the marker; a no-match dir is a no-op; a refused `thread/resume` driven through the real `_auto_create_codex_terminal` closes the app-server and leaves no tracking entry. The existing recreate test now also runs the reap call in its path.
- **Verified on the live incident**: a dry run (killpg stubbed) against the stuck session's state dir matched exactly the 4 known stale app-server process groups (8 pids) and nothing else; the real run reaped all 8, `lsof` confirmed the thread's writer lock was released, and the session became resumable.
- `pre-commit` green (ruff, pyrefly, hooks).

## Demo

N/A — runner-side process lifecycle; no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was against the real production incident on the affected machine: dry-run target list asserted exact (no false positives), then the real reap freed the writer lock and unblocked the session. The orphan-creation path itself (host restart killing a runner mid-flush) isn't reproducible in CI; the unit tests pin the reaper's matching/kill semantics with real processes and the close-on-failure contract through the real launch helper.

## Changelog

A Codex session no longer gets stuck on "Native Codex terminal failed to start" after a host restart leaves a stale Codex process holding the session's thread.
