### PR TITLE
fix(native): don't pin stale catalog defaults; surface failed-turn detail

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -1206,6 +1206,20 @@ async def claude_launch_catalog(
     )
 
 
+def claude_launch_catalog_is_stale(claude_config: ClaudeNativeUcodeConfig | None) -> bool:
+    """
+    Whether this config's stored catalog is past the freshness TTL.
+
+    :param claude_config: The resolved launch config, or ``None``.
+    :returns: ``True`` when the store holds only a stale entry.
+    """
+    from omnigent import model_catalog_store
+
+    return model_catalog_store.catalog_is_stale(
+        "claude-native", claude_catalog_fingerprint(claude_config)
+    )
+
+
 def build_native_claude_terminal_env(
     claude_config: ClaudeNativeUcodeConfig | None,
 ) -> dict[str, str]:

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1018,6 +1018,22 @@ async def codex_launch_catalog(*, codex_path: str | None = None) -> list[_JsonOb
     return await model_catalog_store.ensure_catalog("codex-native", fingerprint, _probe)
 
 
+async def codex_launch_catalog_is_stale() -> bool:
+    """
+    Whether the default launch shape's stored catalog is past the TTL.
+
+    :returns: ``True`` when the store holds only a stale entry; ``False``
+        when it is fresh, absent, or the launch shape cannot resolve.
+    """
+    from omnigent import model_catalog_store
+
+    try:
+        launch = await asyncio.to_thread(resolve_native_codex_launch, model=None)
+    except Exception:  # noqa: BLE001 — a broken provider config means no catalog
+        return False
+    return model_catalog_store.catalog_is_stale("codex-native", codex_catalog_fingerprint(launch))
+
+
 def _build_native_codex_app_server_argv(
     *,
     tagged_argv0: str,

--- a/omnigent/model_catalog_store.py
+++ b/omnigent/model_catalog_store.py
@@ -45,8 +45,8 @@ def fingerprint_of(*parts: object) -> str:
     return digest.hexdigest()[:16]
 
 
-#: Catalog entries older than this get a background refresh on read (the
-#: readers decide; the store only reports staleness).
+#: Catalog entries older than this get a background refresh on read, and
+#: launch paths stop treating their ``isDefault`` row as launch authority.
 CATALOG_STALE_AFTER_S = 3600.0
 
 
@@ -100,6 +100,20 @@ def catalog_age_s(harness: str, fingerprint: str) -> float | None:
         return None
 
 
+def catalog_is_stale(harness: str, fingerprint: str) -> bool:
+    """
+    Whether the stored catalog is older than :data:`CATALOG_STALE_AFTER_S`.
+
+    :param harness: Canonical harness name.
+    :param fingerprint: The launch-config fingerprint.
+    :returns: ``True`` for an entry past the TTL. ``False`` for a fresh
+        entry — and for no entry at all, since rows served without a file
+        can only have come from a probe that just ran.
+    """
+    age = catalog_age_s(harness, fingerprint)
+    return age is not None and age > CATALOG_STALE_AFTER_S
+
+
 def write_catalog(harness: str, fingerprint: str, rows: list[dict[str, Any]]) -> None:
     """Persist catalog rows atomically (best-effort; failures only log).
 
@@ -143,7 +157,10 @@ async def ensure_catalog(
     """Store-first catalog access with a single probe in flight per key.
 
     A hit serves immediately; a miss runs *resolve* once (concurrent
-    callers join it), persists a non-empty answer, and returns it.
+    callers join it), persists a non-empty answer, and returns it. A hit
+    older than :data:`CATALOG_STALE_AFTER_S` still serves immediately but
+    kicks *resolve* in the background so the store converges — the probe's
+    own internal budgets bound it, so nothing here waits on it.
 
     :param harness: Canonical harness name.
     :param fingerprint: The launch-config fingerprint.
@@ -152,6 +169,8 @@ async def ensure_catalog(
     """
     cached = read_catalog(harness, fingerprint)
     if cached is not None:
+        if catalog_is_stale(harness, fingerprint):
+            _refresh_in_background(harness, fingerprint, resolve)
         return cached
     key = (harness, fingerprint)
     task = _inflight.get(key)
@@ -169,6 +188,41 @@ async def ensure_catalog(
         task = asyncio.create_task(_run(), name=f"model-catalog-{harness}")
         _inflight[key] = task
     return await asyncio.shield(task)
+
+
+def _refresh_in_background(
+    harness: str,
+    fingerprint: str,
+    resolve: Callable[[], Awaitable[list[dict[str, Any]] | None]],
+) -> None:
+    """
+    Re-probe a stale catalog off the caller's path, single-flight per key.
+
+    The stale rows keep serving; a successful probe rewrites the store so
+    the next read is fresh. Failures only log — staleness is not an outage.
+
+    :param harness: Canonical harness name.
+    :param fingerprint: The launch-config fingerprint.
+    :param resolve: Probe coroutine factory producing verbatim rows.
+    """
+    key = (harness, fingerprint)
+    task = _inflight.get(key)
+    if task is not None and not task.done():
+        return
+
+    async def _run() -> list[dict[str, Any]] | None:
+        try:
+            rows = await resolve()
+            if rows:
+                write_catalog(harness, fingerprint, rows)
+            return rows
+        except Exception:  # noqa: BLE001 — stale rows keep serving
+            _logger.warning("background %s catalog refresh failed", harness, exc_info=True)
+            return None
+        finally:
+            _inflight.pop(key, None)
+
+    _inflight[key] = asyncio.create_task(_run(), name=f"model-catalog-refresh-{harness}")
 
 
 def default_row(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
@@ -194,6 +248,7 @@ __all__ = [
     "CATALOG_STALE_AFTER_S",
     "catalog_age_s",
     "catalog_contains",
+    "catalog_is_stale",
     "catalog_path",
     "default_row",
     "ensure_catalog",

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3779,9 +3779,15 @@ async def _auto_create_codex_terminal(
     ):
         from dataclasses import replace as _dataclass_replace
 
-        from omnigent.codex_native_app_server import codex_launch_catalog
+        from omnigent.codex_native_app_server import (
+            codex_launch_catalog,
+            codex_launch_catalog_is_stale,
+        )
         from omnigent.model_catalog_store import catalog_contains, default_row
 
+        # Read staleness BEFORE the fetch — the fetch kicks the background
+        # re-probe, which could land between the two reads.
+        _codex_catalog_was_stale = await codex_launch_catalog_is_stale()
         _codex_catalog = await codex_launch_catalog(codex_path=_codex_cli_path)
         if launch_config.model_override and _codex_catalog:
             if not catalog_contains(_codex_catalog, launch_config.model_override):
@@ -3791,14 +3797,23 @@ async def _auto_create_codex_terminal(
                     "pick. Pick again from the model menu."
                 )
         if _codex_launch.model is None and _codex_launch.profile is None and _codex_catalog:
-            _catalog_default = default_row(_codex_catalog)
-            _default_id = (
-                str(_catalog_default.get("id") or _catalog_default.get("model") or "") or None
-                if _catalog_default is not None
-                else None
-            )
-            if _default_id:
-                _codex_launch = _dataclass_replace(_codex_launch, model=_default_id)
+            # Same staleness rule as the claude branch: never convert a stale
+            # entry's default into an explicit model pin.
+            if _codex_catalog_was_stale:
+                _logger.info(
+                    "codex catalog for session=%s is stale; deferring the Default "
+                    "launch to codex's own default model",
+                    session_id,
+                )
+            else:
+                _catalog_default = default_row(_codex_catalog)
+                _default_id = (
+                    str(_catalog_default.get("id") or _catalog_default.get("model") or "") or None
+                    if _catalog_default is not None
+                    else None
+                )
+                if _default_id:
+                    _codex_launch = _dataclass_replace(_codex_launch, model=_default_id)
     # Cancel any surviving forwarder first so its teardown closes the OLD app-server,
     # not the one registered below — and so it can't mirror alongside the new one.
     await _cancel_auto_forwarder_task(session_id)
@@ -6486,11 +6501,20 @@ async def _auto_create_claude_terminal(
     # or to resolve a Default launch that would otherwise pass no ``--model``
     # and leave the model to invisible CLI-private state.
     if session_model_override or launch_model is None:
-        from omnigent.claude_native import claude_catalog_serves_model, claude_launch_catalog
+        from omnigent.claude_native import (
+            claude_catalog_serves_model,
+            claude_launch_catalog,
+            claude_launch_catalog_is_stale,
+        )
         from omnigent.model_catalog_store import default_row
 
         launch_catalog: list[dict[str, object]] | None = None
+        launch_catalog_was_stale = False
         try:
+            # Read staleness BEFORE the fetch: the fetch itself kicks the
+            # background re-probe, which could land between the two reads and
+            # make a same-launch check call yesterday's rows fresh.
+            launch_catalog_was_stale = claude_launch_catalog_is_stale(claude_config)
             launch_catalog = await claude_launch_catalog(claude_config)
         except Exception:  # noqa: BLE001 — no catalog means no validation/default
             _logger.warning(
@@ -6513,11 +6537,25 @@ async def _auto_create_claude_terminal(
                     "Pick again from the model menu."
                 )
         if launch_model is None and launch_catalog:
-            catalog_default = default_row(launch_catalog)
-            if catalog_default is not None:
-                launch_model = (
-                    str(catalog_default.get("model") or catalog_default.get("id") or "") or None
+            # A stale entry's default is yesterday's answer: pinning it as
+            # ``--model`` turns a provider-side retirement or entitlement
+            # change into a hard launch failure. Launch bare instead — the
+            # CLI's own default is servable by construction, and the
+            # harness's ``reported_model`` records what it actually ran —
+            # while the store's background re-probe converges the catalog.
+            if launch_catalog_was_stale:
+                _logger.info(
+                    "claude catalog for session=%s is stale; deferring the Default "
+                    "launch to the CLI's own default model",
+                    session_id,
                 )
+            else:
+                catalog_default = default_row(launch_catalog)
+                if catalog_default is not None:
+                    launch_model = (
+                        str(catalog_default.get("model") or catalog_default.get("id") or "")
+                        or None
+                    )
     # Give an exact launch model (a Smart Routing pick is resolved before the
     # terminal exists) a spelling of its own in the picker, so a later
     # ``/model`` can return to it instead of stepping onto whatever the family

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2194,30 +2194,41 @@ async def _persist_skipped_kiro_pending_input(
     _publish_external_conversation_item(session_id, persisted_items[1])
 
 
-async def _enrich_idle_status_with_subagent_output(
+async def _enrich_terminal_status_with_subagent_output(
     data: dict[str, Any],
     status: str,
     session_id: str,
     conversation_store: ConversationStore,
 ) -> dict[str, Any]:
     """
-    Attach a native sub-agent's durable assistant text to an idle status edge.
+    Attach a native session's durable assistant text to a terminal status edge.
 
-    Shared by both native sub-agent delivery paths (the codex
-    ``external_session_status`` POST handler and the claude-native relay
-    forward) so the parent inbox result carries the child's output. Native
-    harnesses mirror transcript items to the store, not runner memory, so the
-    text is read here and forwarded with the idle edge.
+    Shared by both native delivery paths (the codex ``external_session_status``
+    POST handler and the claude-native relay forward) so the parent inbox
+    result carries the child's output. Native harnesses mirror transcript items
+    to the store, not runner memory, so the text is read here and forwarded
+    with the terminal edge.
+
+    A ``failed`` edge is filled only when the forwarder attached no detail of
+    its own. On a failed turn the latest assistant message is the harness's own
+    error report (e.g. Claude's "There's an issue with the selected model
+    (…)"), which otherwise reaches only the child's transcript while the
+    parent inbox falls back to the generic "Error: native sub-agent turn
+    failed" and the session's ``last_task_error`` stays empty.
 
     :param data: The ``external_session_status`` ``data`` to enrich, e.g.
         ``{"status": "idle"}``.
-    :param status: Status edge; only ``"idle"`` is enriched.
+    :param status: Status edge; only the terminal ``"idle"`` / ``"failed"``
+        edges are enriched.
     :param session_id: Sub-agent session id, e.g. ``"conv_child123"``.
     :param conversation_store: Store read for the child's assistant text.
-    :returns: ``data`` with ``"output"`` added when an idle edge has a
+    :returns: ``data`` with ``"output"`` added when a terminal edge has a
         persisted assistant message; otherwise unchanged.
     """
-    if status != "idle":
+    if status not in ("idle", "failed"):
+        return data
+    existing = data.get("output")
+    if status == "failed" and isinstance(existing, str) and existing.strip():
         return data
     output = await asyncio.to_thread(
         _latest_assistant_text_from_store,
@@ -9337,7 +9348,7 @@ __all__ = [
     "_detached_stop_tasks",
     "_dispatch_session_event_to_runner",
     "_drive_terminal_resolved_elicitation",
-    "_enrich_idle_status_with_subagent_output",
+    "_enrich_terminal_status_with_subagent_output",
     "_ensure_native_terminal_ready",
     "_ensure_runner_relay",
     "_ensure_runner_relay_ready",

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -610,7 +610,7 @@ from omnigent.server.routes._sessions.orchestration import (
     _create_session_from_bundle as _create_session_from_bundle,
     _create_session_from_existing_agent as _create_session_from_existing_agent,
     _drive_terminal_resolved_elicitation as _drive_terminal_resolved_elicitation,
-    _enrich_idle_status_with_subagent_output as _enrich_idle_status_with_subagent_output,
+    _enrich_terminal_status_with_subagent_output as _enrich_terminal_status_with_subagent_output,
     _ensure_native_terminal_ready as _ensure_native_terminal_ready,
     _ensure_runner_relay as _ensure_runner_relay,
     _ensure_runner_session_initialized as _ensure_runner_session_initialized,

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -174,7 +174,7 @@ from omnigent.server.routes._sessions.orchestration import (
     _best_effort_stop,
     _child_session_summaries_from_conversations,
     _dispatch_session_event_to_runner,
-    _enrich_idle_status_with_subagent_output,
+    _enrich_terminal_status_with_subagent_output,
     _ensure_native_terminal_ready,
     _ensure_runner_relay_ready,
     _ensure_runner_session_initialized,
@@ -1011,26 +1011,6 @@ def register_events_routes(
                     "external_session_status data.response_id must be a string",
                     code=ErrorCode.INVALID_INPUT,
                 )
-            # Surface the failure reason a native forwarder carries so a
-            # top-level session sees it on its own status edge and persisted
-            # last_task_error, not only the sub-agent parent-inbox path.
-            output = body.data.get("output")
-            status_error: ErrorDetail | None = None
-            if status == "failed" and isinstance(output, str) and output.strip():
-                status_error = ErrorDetail(
-                    code=(
-                        "codex_reauth_required"
-                        if body.data.get("reauth_required") is True
-                        else "codex_turn_error"
-                    ),
-                    message=output.strip(),
-                )
-            if status_error is not None:
-                await _persist_session_status_error_labels(
-                    session_id, status_error, conversation_store
-                )
-            elif status == "running":
-                await _persist_session_status_error_labels(session_id, None, conversation_store)
             # ``None`` (field absent) = no information; leave the sticky
             # tally untouched (the PTY-activity ``idle`` carries none). An
             # explicit ``0`` from a ``Stop`` hook is authoritative and clears
@@ -1060,6 +1040,39 @@ def register_events_routes(
             if effective_status != status:
                 status = effective_status
                 body.data["status"] = status
+            # Terminal edges carry the harness's own persisted text: the
+            # child's result on ``idle``, and on ``failed`` — when the
+            # forwarder attached no detail — its error report (claude-native's
+            # StopFailure edge posts none). Enriched before the reason is
+            # derived so the pill, ``last_task_error``, and the parent inbox
+            # all see the same detail.
+            data = await _enrich_terminal_status_with_subagent_output(
+                body.data, status, session_id, conversation_store
+            )
+            # Surface the failure reason a native forwarder carries so a
+            # top-level session sees it on its own status edge and persisted
+            # last_task_error, not only the sub-agent parent-inbox path.
+            output = data.get("output")
+            status_error: ErrorDetail | None = None
+            if status == "failed" and isinstance(output, str) and output.strip():
+                status_error = ErrorDetail(
+                    code=(
+                        "codex_reauth_required"
+                        if data.get("reauth_required") is True
+                        # The store-enriched detail keeps a harness-neutral
+                        # code; a forwarder-sent detail keeps codex's.
+                        else (
+                            "codex_turn_error" if body.data.get("output") else "native_turn_error"
+                        )
+                    ),
+                    message=output.strip(),
+                )
+            if status_error is not None:
+                await _persist_session_status_error_labels(
+                    session_id, status_error, conversation_store
+                )
+            elif status == "running":
+                await _persist_session_status_error_labels(session_id, None, conversation_store)
             _publish_status(
                 session_id,
                 status,
@@ -1069,9 +1082,7 @@ def register_events_routes(
                 blocked_on=blocked_on,
             )
             forward_body = body.model_dump()
-            forward_body["data"] = await _enrich_idle_status_with_subagent_output(
-                forward_body["data"], status, session_id, conversation_store
-            )
+            forward_body["data"] = data
             runner_result = await _forward_session_change_to_runner(
                 session_id,
                 runner_router,

--- a/tests/e2e/omnigent/test_model_flows_live.py
+++ b/tests/e2e/omnigent/test_model_flows_live.py
@@ -16,6 +16,8 @@ Rows are numbered after the design's §10.1 table.
 
 from __future__ import annotations
 
+import json
+import os
 import re
 import time
 from collections.abc import Callable, Iterator
@@ -25,6 +27,7 @@ from typing import Any
 import httpx
 import pytest
 
+from omnigent.claude_native import claude_catalog_fingerprint
 from omnigent.native_coding_agents import CLAUDE_NATIVE_AGENT_NAME, CODEX_NATIVE_AGENT_NAME
 from tests.e2e.omnigent._model_flows_rig import (
     ModelFlowsRig,
@@ -723,3 +726,89 @@ def test_row18_cold_resume_honors_the_persisted_model_override(
             f"the resumed pane footer {footer!r} does not name the {family} family "
             f"of {override!r} (session {session_id})"
         )
+
+
+# ---------------------------------------------------------------------------
+# Stale catalog: a Default launch must not run yesterday's default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(600)
+def test_row19_stale_catalog_default_launch_defers_to_the_cli_default(
+    rig: ModelFlowsRig,
+    shaped_host: Callable[[str], str],
+    tmp_path: Path,
+) -> None:
+    """
+    A month-old catalog default must not govern a Default launch.
+
+    The store never re-probes on its own, so its ``isDefault`` row can
+    outlive the model it names (a retirement or an entitlement change).
+    Pinning it as ``--model`` then hard-fails every Default session on the
+    host with a provider ``model_not_found`` — sticky, because nothing
+    invalidates the entry. The launch must instead defer to the CLI's own
+    always-servable default and let the background re-probe converge the
+    store. Seeded with Claude Code's real 2024 default, retired upstream
+    today — exactly what a catalog written back then would hold.
+    """
+    require_clis("claude")
+    host_id = shaped_host("claude-subscription")
+    # Let the boot probe finish first, so it cannot overwrite the seed.
+    wait_for(
+        lambda: host_model_options(rig.base_url, host_id, "claude-native").get("models") or None,
+        timeout=180.0,
+        what="the boot-warmed claude catalog",
+    )
+    retired = "claude-3-5-sonnet-20241022"
+    fingerprint = claude_catalog_fingerprint(None)
+    path = rig.data_dir / "cache" / "model-catalogs" / f"claude-native-{fingerprint}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    month_ago = time.time() - 30 * 86400
+    path.write_text(
+        json.dumps(
+            {
+                "harness": "claude-native",
+                "fingerprint": fingerprint,
+                "written_at": month_ago,
+                "models": [
+                    {"id": "opus", "model": "claude-opus-5", "displayName": "Opus 5"},
+                    {
+                        "id": retired,
+                        "model": retired,
+                        "displayName": "Claude 3.5 Sonnet",
+                        "isDefault": True,
+                    },
+                ],
+            }
+        )
+    )
+    os.utime(path, (month_ago, month_ago))
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "README.md").write_text("# stale catalog workspace\n")
+    pane = PaneWatcher()
+    pane.arm()
+    session_id = rest_create_session(
+        rig.base_url,
+        agent_name=CLAUDE_NATIVE_AGENT_NAME,
+        host_id=host_id,
+        workspace=workspace,
+        terminal_launch_args=bypass_args("claude-native"),
+    )
+    rest_post_user_message(rig.base_url, session_id, "Reply with exactly: ok. Nothing else.")
+
+    def _settled() -> dict[str, Any] | None:
+        snapshot = session_snapshot(rig.base_url, session_id)
+        assert snapshot.get("status") != "failed", (
+            f"the stale catalog default still governed the launch: "
+            f"{snapshot.get('last_task_error') or snapshot.get('error')} "
+            f"(session {session_id})"
+        )
+        return snapshot if assistant_message_count(snapshot) >= 1 else None
+
+    snapshot = wait_for(_settled, timeout=240.0, what="the Default session's first reply")
+    reported = str(snapshot.get("llm_model") or "")
+    assert not reported.startswith(retired), (
+        f"the launch still ran the stale pin {retired!r} (session {session_id})"
+    )

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -14,7 +14,7 @@ import httpx
 import pytest
 from fastapi import FastAPI
 
-from omnigent import claude_native
+from omnigent import claude_native, codex_native_app_server
 from omnigent.process_logging import PROCESS_LOG_FILE_ENV_VAR
 from omnigent.runner import create_runner_app
 from omnigent.runner.mcp_manager import McpSchemasResult
@@ -26,6 +26,7 @@ from tests.runner.helpers import NullServerClient
 # attribute back to this. (An assignment, not an alias import, so lint
 # autofixes can't strip it as unused.)
 REAL_CLAUDE_LAUNCH_CATALOG = claude_native.claude_launch_catalog
+REAL_CODEX_LAUNCH_CATALOG = codex_native_app_server.codex_launch_catalog
 
 # Project root: two parents up from this conftest (tests/runner/ → repo root).
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -3302,3 +3302,126 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         assert "spec" not in captured, "a refused launch must not start a terminal"
 
     await fake_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("freshness", ["fresh", "stale"])
+async def test_auto_create_claude_terminal_default_pin_requires_a_fresh_catalog(
+    freshness: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A Default launch pins the stored default only while the entry is fresh.
+
+    The store never forgets an entry, so its ``isDefault`` row can outlive
+    the model it names (a retirement or an entitlement change); pinning it
+    as ``--model`` then hard-fails every Default launch on the host. A
+    stale entry defers to the CLI's own default — no ``--model`` at all —
+    while the store re-probes in the background.
+    """
+    import os
+    import time
+
+    from omnigent import model_catalog_store
+    from omnigent.claude_native import claude_catalog_fingerprint
+    from tests.runner.conftest import REAL_CLAUDE_LAUNCH_CATALOG
+
+    monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
+
+    async def _no_op_forwarder(**kwargs: Any) -> None:
+        del kwargs
+
+    monkeypatch.setattr(
+        "omnigent.claude_native_forwarder.supervise_forwarder",
+        _no_op_forwarder,
+    )
+    # The real store-backed resolver, against the conftest-isolated store
+    # dir; the background re-probe is stubbed so no real CLI ever runs.
+    monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", REAL_CLAUDE_LAUNCH_CATALOG)
+    refreshed = [{"id": "sonnet", "model": "claude-sonnet-5", "isDefault": True}]
+
+    async def _fake_probe_catalog(config: object) -> list[dict[str, object]]:
+        del config
+        return refreshed
+
+    monkeypatch.setattr("omnigent.claude_native.claude_model_catalog", _fake_probe_catalog)
+    fingerprint = claude_catalog_fingerprint(None)
+    model_catalog_store.write_catalog(
+        "claude-native",
+        fingerprint,
+        [
+            {"id": "opus", "model": "claude-opus-5", "displayName": "Opus 5"},
+            {
+                "id": "claude-3-5-sonnet-20241022",
+                "model": "claude-3-5-sonnet-20241022",
+                "displayName": "Claude 3.5 Sonnet",
+                "isDefault": True,
+            },
+        ],
+    )
+    if freshness == "stale":
+        path = model_catalog_store.catalog_path("claude-native", fingerprint)
+        old = time.time() - (model_catalog_store.CATALOG_STALE_AFTER_S + 60)
+        os.utime(path, (old, old))
+
+    captured: dict[str, Any] = {}
+
+    class _FakeResourceRegistry:
+        """Captures the launched terminal spec."""
+
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self,
+            *,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            resource_role: str | None = None,
+            parent_os_env: Any = None,
+        ) -> SessionResourceView:
+            """Record the spec and return a terminal resource view."""
+            del terminal_name, session_key
+            captured["spec"] = spec
+            return SessionResourceView(
+                id="terminal_claude_main",
+                type="terminal",
+                session_id=session_id,
+                name="claude:main",
+                metadata={"terminal_name": "claude", "session_key": "main", "running": True},
+            )
+
+    def _handle_request(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"labels": {}})
+
+    fake_client = httpx.AsyncClient(
+        base_url="http://test-server",
+        transport=httpx.MockTransport(_handle_request),
+    )
+
+    async def _resolve() -> None:
+        return None
+
+    await _auto_create_claude_terminal(
+        "9b1d2c3e4f5a6b7c8d9e0f1a2b3c4d5e",
+        _FakeResourceRegistry(),
+        lambda _sid, _evt: None,
+        server_client=fake_client,
+        resolve_launch_config=_resolve,
+    )
+    args = captured["spec"].args
+    if freshness == "fresh":
+        assert args[args.index("--model") + 1] == "claude-3-5-sonnet-20241022"
+    else:
+        assert "--model" not in args, f"a stale default was still pinned: {args}"
+        task = model_catalog_store._inflight.get(("claude-native", fingerprint))
+        if task is not None:
+            await task
+        # The background re-probe healed the store for the next launch.
+        assert model_catalog_store.read_catalog("claude-native", fingerprint) == refreshed
+
+    await fake_client.aclose()

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -3235,3 +3235,252 @@ async def test_cold_start_agy_conversation_accepts_a_locally_owned_cascade(
     assert result is not None
     state = bridge_mod.read_bridge_state(bridge_dir)
     assert state is not None and state.conversation_id == result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("freshness", ["fresh", "stale"])
+async def test_auto_create_codex_terminal_default_pin_requires_a_fresh_catalog(
+    freshness: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A Default codex launch pins the stored default only while it is fresh.
+
+    Mirrors the claude rule: the store never forgets an entry, so a stale
+    ``isDefault`` row can name a model the account no longer serves, and
+    pinning it hard-fails the launch. A fresh entry resolves the Default
+    launch; a stale one defers to codex's own account default (no model
+    pin) while the store re-probes in the background.
+    """
+    import os
+    import time
+
+    import omnigent.codex_native_app_server as codex_app_mod
+    from omnigent import model_catalog_store
+    from omnigent.runner import app as runner_app_mod
+    from tests.runner.conftest import REAL_CODEX_LAUNCH_CATALOG
+
+    session_id = "83acdbadf84d4149b2a7d7441b6966aa"
+    thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936c"
+    monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+
+    # A bare subscription default shape, with the real store-backed catalog
+    # serving the seeded rows; the re-probe is stubbed off the real CLI.
+    monkeypatch.setattr(
+        codex_app_mod,
+        "resolve_native_codex_launch",
+        lambda *, model, spec=None: codex_app_mod.NativeCodexLaunch(
+            config_overrides=[], model=model, profile=None
+        ),
+    )
+    monkeypatch.setattr(codex_app_mod, "codex_launch_catalog", REAL_CODEX_LAUNCH_CATALOG)
+    refreshed = [{"id": "gpt-5.6-terra", "model": "gpt-5.6-terra", "isDefault": True}]
+
+    async def _fake_probe(*, codex_path: str | None = None) -> list[dict[str, object]]:
+        """
+        Stand in for the real codex probe on the background refresh path.
+
+        :param codex_path: Ignored executable override.
+        :returns: The refreshed catalog rows.
+        """
+        del codex_path
+        return refreshed
+
+    monkeypatch.setattr(codex_app_mod, "probe_codex_model_options", _fake_probe)
+    fingerprint = codex_app_mod.codex_catalog_fingerprint(
+        codex_app_mod.resolve_native_codex_launch(model=None)
+    )
+    model_catalog_store.write_catalog(
+        "codex-native",
+        fingerprint,
+        [{"id": "gpt-5.4-yesterday", "model": "gpt-5.4-yesterday", "isDefault": True}],
+    )
+    if freshness == "stale":
+        path = model_catalog_store.catalog_path("codex-native", fingerprint)
+        old = time.time() - (model_catalog_store.CATALOG_STALE_AFTER_S + 60)
+        os.utime(path, (old, old))
+
+    class _SnapshotServerClient:
+        """Server client returning a Default-launch resume snapshot."""
+
+        async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+            """
+            Return the session snapshot / item history the helper reads.
+
+            :param url: Request path.
+            :param kwargs: Request keyword arguments.
+            :returns: HTTP 200 response.
+            """
+            del kwargs
+            if url == f"/v1/sessions/{session_id}/items":
+                return httpx.Response(
+                    200,
+                    json={
+                        "data": [
+                            {
+                                "id": "b1649a5cbfec3f92bec12275c14f4b60",
+                                "response_id": "codex_turn_1",
+                                "type": "message",
+                                "role": "user",
+                                "content": [{"type": "input_text", "text": "remember this"}],
+                            }
+                        ],
+                        "has_more": False,
+                    },
+                    request=httpx.Request("GET", url),
+                )
+            return httpx.Response(
+                200,
+                json={"external_session_id": thread_id},
+                request=httpx.Request("GET", url),
+            )
+
+    class _FakeCodexAppServer:
+        """Minimal app-server object used by ``codex_terminal_env``."""
+
+        codex_path = "/opt/codex/bin/codex"
+        codex_cli_version: tuple[int, int, int] | None = (0, 145, 0)
+
+        def __init__(self) -> None:
+            """Initialize the fake app-server state."""
+            self.env = {"OPENAI_API_KEY": "sk-test"}
+            self.codex_home = tmp_path / "unconfigured-codex-home"
+            self.listen_url: str | None = None
+            self.started = False
+            self.config_overrides: list[str] = []
+
+        async def start(self) -> None:
+            """Mark the fake app-server started."""
+            self.started = True
+
+        async def close(self) -> None:
+            """No-op close."""
+
+    app_server = _FakeCodexAppServer()
+    build_calls: list[dict[str, Any]] = []
+
+    def _fake_build_codex_native_server(**kwargs: Any) -> _FakeCodexAppServer:
+        """
+        Capture app-server construction.
+
+        :param kwargs: Keyword arguments passed by the runner helper.
+        :returns: Fake app-server.
+        """
+        build_calls.append(kwargs)
+        app_server.codex_home = kwargs["codex_home"]
+        return app_server
+
+    class _UnexpectedDiscoveryClient:
+        """App-server client that must not connect on a known-thread resume."""
+
+        def __init__(self, *, ws_url: str, client_name: str) -> None:
+            """
+            :param ws_url: App-server WebSocket URL.
+            :param client_name: JSON-RPC client name.
+            """
+            self.ws_url = ws_url
+            self.client_name = client_name
+
+        async def connect(self) -> None:
+            """Fail if the resume path tries to discover a fresh thread."""
+            raise AssertionError("resume path must not connect discovery client")
+
+        async def close(self) -> None:
+            """No-op close."""
+
+    async def _fake_preload_thread(
+        transport: str,
+        loaded_thread_id: str,
+        *,
+        terminal_launch_args: list[str] | None = None,
+    ) -> None:
+        """
+        Accept preloading of the known Codex thread.
+
+        :param transport: App-server transport URL.
+        :param loaded_thread_id: Thread id passed to ``thread/resume``.
+        :param terminal_launch_args: Pass-through args, unused.
+        """
+        del transport, loaded_thread_id, terminal_launch_args
+
+    async def _fake_forward_known_thread(**kwargs: Any) -> None:
+        """
+        Accept the known-thread forwarder invocation.
+
+        :param kwargs: Forwarder keyword arguments.
+        """
+        del kwargs
+
+    class _FakeResourceRegistry:
+        """Resource registry that accepts the terminal launch."""
+
+        async def launch_auxiliary_terminal(
+            self,
+            *,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            resource_role: str | None = None,
+            parent_os_env: Any = None,
+        ) -> SessionResourceView:
+            """
+            Accept the terminal launch request.
+
+            :param session_id: Session id being launched.
+            :param terminal_name: Terminal name.
+            :param session_key: Terminal session key.
+            :param spec: Terminal launch spec.
+            :param resource_role: Private runner resource marker.
+            :param parent_os_env: Inherited os env, unused.
+            :returns: Terminal resource view.
+            """
+            del terminal_name, session_key, spec, resource_role, parent_os_env
+            return SessionResourceView(
+                id="terminal_codex_main",
+                type="terminal",
+                session_id=session_id,
+                name="Codex",
+            )
+
+    monkeypatch.setattr(
+        codex_app_mod, "build_codex_native_server", _fake_build_codex_native_server
+    )
+    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _UnexpectedDiscoveryClient)
+    monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _fake_preload_thread)
+    monkeypatch.setattr(runner_app_mod, "_codex_forward_known_thread", _fake_forward_known_thread)
+
+    agent_spec = AgentSpec(
+        spec_version=1,
+        name="codex",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "codex-native"}),
+    )
+    try:
+        await _auto_create_codex_terminal(
+            session_id,
+            _FakeResourceRegistry(),  # type: ignore[arg-type]
+            lambda _sid, _evt: None,
+            agent_spec=agent_spec,
+            server_client=_SnapshotServerClient(),  # type: ignore[arg-type]
+        )
+        await asyncio.sleep(0)
+    finally:
+        runner_app_mod._AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+
+    assert build_calls, "the app-server was never built"
+    if freshness == "fresh":
+        assert build_calls[0]["model"] == "gpt-5.4-yesterday"
+    else:
+        assert build_calls[0]["model"] is None, (
+            f"a stale default was still pinned: {build_calls[0]['model']!r}"
+        )
+        task = model_catalog_store._inflight.get(("codex-native", fingerprint))
+        if task is not None:
+            await task
+        # The background re-probe healed the store for the next launch.
+        assert model_catalog_store.read_catalog("codex-native", fingerprint) == refreshed

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -3794,6 +3794,148 @@ async def test_post_external_session_status_idle_forwards_persisted_assistant_ou
     ]
 
 
+async def test_post_external_session_status_failed_forwards_persisted_assistant_output(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A ``failed`` edge with no wire ``output`` carries the persisted error text.
+
+    claude-native's ``StopFailure`` edge posts no ``output``, but the
+    harness's own explanation (its last assistant message, e.g. "There's an
+    issue with the selected model (…)") is already persisted. The handler
+    must attach it so the parent inbox shows it instead of the generic
+    "Error: native sub-agent turn failed", and surface it as the session's
+    typed error under the harness-neutral ``native_turn_error`` code.
+    """
+    from omnigent.server.routes import sessions as sessions_module
+
+    detail = (
+        "There's an issue with the selected model (claude-3-5-sonnet-20241022). "
+        "It may not exist or you may not have access to it."
+    )
+    forwarded: list[dict[str, Any]] = []
+    published: list[tuple[str, dict[str, Any]]] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """
+        Capture forwarded runner events.
+
+        :param request: Request sent to the fake runner.
+        :returns: Accepted response.
+        """
+        forwarded.append({"path": request.url.path, "body": json.loads(request.content)})
+        return httpx.Response(204)
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://runner",
+    )
+
+    async def _fake_get_runner_client(
+        session_id: str,
+        runner_router: object,
+    ) -> httpx.AsyncClient:
+        """
+        Resolve the session to the fake runner client.
+
+        :param session_id: Session id being routed.
+        :param runner_router: Real app runner router, unused here.
+        :returns: The fake runner client.
+        """
+        del session_id, runner_router
+        return fake_runner
+
+    monkeypatch.setattr(sessions_module, "_get_runner_client", _fake_get_runner_client)
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda session_id, event: published.append((session_id, event)),
+    )
+    try:
+        agent = await create_test_agent(client, sub_agents=[{"name": "worker"}])
+        parent = await _create_session(client, agent["id"])
+        child_resp = await client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent["id"],
+                "parent_session_id": parent["id"],
+                "sub_agent_name": "worker",
+                "title": "worker:native",
+            },
+        )
+        assert child_resp.status_code == 201, child_resp.text
+        child = child_resp.json()
+
+        item_resp = await client.post(
+            f"/v1/sessions/{child['id']}/events",
+            json={
+                "type": "external_conversation_item",
+                "data": {
+                    "item_type": "message",
+                    "response_id": "resp_native_failed",
+                    "source_id": "src_native_failed",
+                    "item_data": {
+                        "role": "assistant",
+                        "agent": "claude-native-ui",
+                        "content": [{"type": "output_text", "text": detail}],
+                    },
+                },
+            },
+        )
+        assert item_resp.status_code == 202, item_resp.text
+
+        forwarded.clear()
+        status_resp = await client.post(
+            f"/v1/sessions/{child['id']}/events",
+            json={"type": "external_session_status", "data": {"status": "failed"}},
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert status_resp.status_code == 202, status_resp.text
+    assert forwarded, "the failed edge was never forwarded to the runner"
+    assert forwarded[0]["body"]["data"] == {"status": "failed", "output": detail}
+    failed_events = [ev for _sid, ev in published if ev.get("status") == "failed"]
+    assert failed_events, f"no failed status was published: {published}"
+    error = failed_events[0]["error"]
+    assert error is not None
+    assert error["code"] == "native_turn_error"
+    assert "selected model" in error["message"]
+
+
+async def test_post_external_session_status_failed_keeps_wire_output_and_codex_code(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A forwarder-sent ``output`` stays verbatim under codex's error code.
+
+    The store-side enrichment must never clobber a detail the forwarder
+    attached itself, and a wire-carried detail keeps the ``codex_turn_error``
+    code existing clients already see.
+    """
+    published: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda session_id, event: published.append((session_id, event)),
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={
+            "type": "external_session_status",
+            "data": {"status": "failed", "output": "You've hit your usage limit."},
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    error = published[0][1]["error"]
+    assert error is not None
+    assert error["code"] == "codex_turn_error"
+    assert error["message"] == "You've hit your usage limit."
+
+
 async def test_post_external_session_status_propagates_runner_delivery_failure(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -705,6 +705,54 @@ async def test_codex_launch_catalog_reads_the_store_then_probes_once(
     assert len(calls) == 1, "the second read must come from the store, not a re-probe"
 
 
+async def test_codex_launch_catalog_is_stale_reads_the_default_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Stale only when the default shape's stored entry is past the TTL.
+    """
+    from omnigent import codex_native_app_server, model_catalog_store
+
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "resolve_native_codex_launch",
+        lambda *, model, spec=None: codex_native_app_server.NativeCodexLaunch(
+            config_overrides=[], model=model, profile=None
+        ),
+    )
+    fingerprint = codex_native_app_server.codex_catalog_fingerprint(
+        codex_native_app_server.resolve_native_codex_launch(model=None)
+    )
+    assert await codex_native_app_server.codex_launch_catalog_is_stale() is False
+    model_catalog_store.write_catalog(
+        "codex-native", fingerprint, [{"id": "gpt-5.6-terra", "isDefault": True}]
+    )
+    assert await codex_native_app_server.codex_launch_catalog_is_stale() is False
+    path = model_catalog_store.catalog_path("codex-native", fingerprint)
+    old = path.stat().st_mtime - (model_catalog_store.CATALOG_STALE_AFTER_S + 60)
+    import os
+
+    os.utime(path, (old, old))
+    assert await codex_native_app_server.codex_launch_catalog_is_stale() is True
+
+
+async def test_codex_launch_catalog_is_stale_unresolvable_launch_is_not_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A broken provider config means no catalog to distrust — never a crash.
+    """
+    from omnigent import codex_native_app_server
+
+    def _boom(*, model: object, spec: object = None) -> object:
+        raise RuntimeError("broken provider config")
+
+    monkeypatch.setattr(codex_native_app_server, "resolve_native_codex_launch", _boom)
+    assert await codex_native_app_server.codex_launch_catalog_is_stale() is False
+
+
 def _test_app_server(
     tmp_path: Path,
     codex_home: Path,

--- a/tests/test_model_catalog_store.py
+++ b/tests/test_model_catalog_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import time
 from pathlib import Path
 
 import pytest
@@ -60,3 +62,73 @@ def test_catalog_age_reports_and_misses() -> None:
     store.write_catalog("claude-native", "abc123", _ROWS)
     age = store.catalog_age_s("claude-native", "abc123")
     assert age is not None and age >= 0.0
+
+
+def _age_entry(harness: str, fingerprint: str, age_s: float) -> None:
+    """
+    Backdate a stored catalog file's mtime by *age_s* seconds.
+    """
+    path = store.catalog_path(harness, fingerprint)
+    old = time.time() - age_s
+    os.utime(path, (old, old))
+
+
+def test_catalog_is_stale_truth_table() -> None:
+    assert store.catalog_is_stale("claude-native", "abc123") is False
+    store.write_catalog("claude-native", "abc123", _ROWS)
+    assert store.catalog_is_stale("claude-native", "abc123") is False
+    _age_entry("claude-native", "abc123", store.CATALOG_STALE_AFTER_S + 60)
+    assert store.catalog_is_stale("claude-native", "abc123") is True
+
+
+async def test_ensure_catalog_fresh_hit_never_probes() -> None:
+    store.write_catalog("claude-native", "abc123", _ROWS)
+    probes: list[int] = []
+
+    async def _probe() -> list[dict[str, object]]:
+        probes.append(1)
+        return [{"id": "new"}]
+
+    assert await store.ensure_catalog("claude-native", "abc123", _probe) == _ROWS
+    assert probes == []
+
+
+async def test_ensure_catalog_stale_hit_serves_now_and_refreshes_in_background() -> None:
+    """
+    A stale entry still answers instantly; the re-probe converges the store.
+    """
+    store.write_catalog("claude-native", "abc123", _ROWS)
+    _age_entry("claude-native", "abc123", store.CATALOG_STALE_AFTER_S + 60)
+    refreshed = [{"id": "sonnet", "model": "claude-sonnet-6", "isDefault": True}]
+    probes: list[int] = []
+
+    async def _probe() -> list[dict[str, object]]:
+        probes.append(1)
+        return refreshed
+
+    assert await store.ensure_catalog("claude-native", "abc123", _probe) == _ROWS
+    task = store._inflight.get(("claude-native", "abc123"))
+    assert task is not None, "a stale hit must kick a background refresh"
+    await task
+    assert probes == [1]
+    assert store.read_catalog("claude-native", "abc123") == refreshed
+    assert store.catalog_is_stale("claude-native", "abc123") is False
+    # The refreshed entry is fresh again: the next read is a plain hit.
+    assert await store.ensure_catalog("claude-native", "abc123", _probe) == refreshed
+    assert probes == [1]
+
+
+async def test_ensure_catalog_stale_refresh_failure_keeps_serving() -> None:
+    store.write_catalog("claude-native", "abc123", _ROWS)
+    _age_entry("claude-native", "abc123", store.CATALOG_STALE_AFTER_S + 60)
+
+    async def _probe() -> list[dict[str, object]]:
+        raise OSError("provider unreachable")
+
+    assert await store.ensure_catalog("claude-native", "abc123", _probe) == _ROWS
+    task = store._inflight.get(("claude-native", "abc123"))
+    assert task is not None
+    await task
+    # The stale rows keep serving; nothing crashed and nothing was clobbered.
+    assert store.read_catalog("claude-native", "abc123") == _ROWS
+    assert await store.ensure_catalog("claude-native", "abc123", _probe) == _ROWS


### PR DESCRIPTION
## Related issue

Part of #5281 — fixes the stale-catalog launch failure (root causes 1–2) and the discarded failure reason (root cause 3). The submit-verification race (#5280's target) and the credential-lapse "completed / produced no output" classification are separate follow-ups, deliberately out of scope here.

> Overlaps with #5279 / #5278: same two outcomes, landed at a much smaller blast radius — the store keeps its existing call signature (stale rows still serve; the re-probe is background-only, bounded by the probe's own internal budgets rather than a new wait cap), explicit user picks keep today's fail-open validation semantics (no new fail-closed path on staleness), and the failure detail is read from the text the store **already persists** instead of re-deriving it from `hooks.jsonl` behind a new sanitizer.

## Summary

**Bug 1 — a never-refreshed catalog default governs Default launches.** The shared model-catalog store (`~/.omnigent/cache/model-catalogs/`) never re-probed an entry — `CATALOG_STALE_AFTER_S` had no production caller — and both native launch paths convert the stored `isDefault` row into an explicit `--model`/model pin. Once the stored default outlives the model it names (a retirement or an entitlement change), **every Default claude/codex session on the host hard-fails with a provider `model_not_found`**, stickily: nothing invalidates the entry, host restarts serve it verbatim, and only deleting the cache file heals it. Live-reproduced end to end by seeding a month-old catalog whose default is `claude-3-5-sonnet-20241022` — Claude Code's real 2024 default, retired upstream today.

**Bug 2 — the failure reason is discarded on the way out.** Claude's own explanation ("There's an issue with the selected model (…)") is persisted as the child's last assistant message and journaled in `hooks.jsonl`, but the claude-native `StopFailure` edge posts no `output` — so the parent inbox falls back to the literal `Error: native sub-agent turn failed`, and the session's `error` / `last_task_error` stay `null` (no error pill; verified in the same live repro).

**Fix (small, at existing seams):**

- `model_catalog_store.ensure_catalog` still serves a hit instantly, but a hit older than `CATALOG_STALE_AFTER_S` (1h) now kicks the resolve **in the background** (single-flight per key, no new wait cap — the probes bound themselves) and rewrites the store on success. New `catalog_is_stale()` helper.
- Both native launch paths (`_auto_create_claude_terminal`, `_auto_create_codex_terminal`) pin the catalog default **only while the entry is fresh**. A stale entry defers the Default launch to the CLI's own — always-servable — default (no `--model` / no pin), and `reported_model` records what it actually ran. Staleness is read **before** the fetch so the fetch's own background re-probe can't race the decision. Explicit user picks are untouched: they keep today's validation semantics and never fail closed on staleness.
- `_enrich_idle_status_with_subagent_output` → `_enrich_terminal_status_with_subagent_output`: `failed` edges are now enriched too (only when the forwarder attached no detail of its own), and the enrichment runs **before** the failure reason is derived — so the parent inbox, the persisted `last_task_error`, and the web's error pill all carry the harness's own text. Store-enriched details use the harness-neutral `native_turn_error` code; forwarder-sent codex details keep `codex_turn_error` / `codex_reauth_required` byte-identically.

**ELI5:** the menu on the fridge never got reprinted, and we kept ordering yesterday's special by name even after the kitchen retired it — then threw away the waiter's explanation. Now an old menu means "chef's choice" (which always exists) while a new menu prints in the background, and the waiter's explanation is passed along verbatim.

```text
Default launch                                failed turn (StopFailure)
  ├─ catalog fresh ──► pin isDefault row        ├─ forwarder sent output ──► kept verbatim (codex codes)
  └─ catalog stale ──► NO pin (CLI default)     └─ no output ──► child's persisted assistant text
        └─ background re-probe rewrites store         └─► parent inbox + last_task_error + error pill
```

## Test Plan

Every new test was mutation-checked (red with the fix stashed, green restored):

- **E2E (real server + host + real `claude`, opt-in suite):** new `test_row19_stale_catalog_default_launch_defers_to_the_cli_default` in the live model-flows suite — waits for the boot probe, overwrites the store with the month-old retired-default catalog, creates a Default web session via REST. **Red on unfixed source** (session `failed`, `last_task_error=null` — the exact #5281 symptom); **green with the fix, test unmodified** (runner log: `claude catalog … is stale; deferring the Default launch`, `launch_model=None`, real reply on the CLI default).
- **Unit — store** (`tests/test_model_catalog_store.py`): fresh hit never probes; stale hit serves instantly and background-refreshes (probe called once, store rewritten, entry fresh after); refresh failure keeps serving stale; `catalog_is_stale` truth table.
- **Unit — launch gates** through the real auto-create paths: `test_auto_create_claude_terminal_default_pin_requires_a_fresh_catalog[fresh|stale]` (fresh pins `--model <stored default>`; stale passes no `--model` and the background re-probe heals the store) and the codex twin `test_auto_create_codex_terminal_default_pin_requires_a_fresh_catalog[fresh|stale]` (fresh pins the app-server model; stale builds with `model=None`).
- **Route** (`tests/server/integration/test_sessions_endpoints.py`): a `failed` edge with no wire `output` forwards the child's persisted assistant text to the runner and publishes `native_turn_error` with that message; a forwarder-sent `output` stays verbatim under `codex_turn_error`. Existing idle-forward, reauth, and status tests unchanged and green.
- Full neighboring suites run locally (store, codex app-server, claude_native, both terminals suites, wake-forwarders, subagent inbox delivery, sessions endpoints/child-sessions, subagent status-forward recovery) — results in the checklist below.
- `pre-commit` hooks green on all changed files (ruff format/check, pyrefly, hardcoded-models, etc.).

Run the live row yourself (needs a logged-in `claude`, `tmux`):

```bash
OMNIGENT_E2E_MODEL_FLOWS=1 .venv/bin/python -m pytest \
  tests/e2e/omnigent/test_model_flows_live.py -k row19 -v
```

Or by hand: write a `models` entry with an unservable `isDefault` row into `~/.omnigent/cache/model-catalogs/claude-native-<fp>.json`, backdate its mtime by >1h, start a Default claude-native session — before this change it fails with `model_not_found` and no visible reason; after, it runs on the CLI's default and the file is re-probed in the background.

## Demo

N/A (backend launch + status-forward paths; see the Test Plan's red→green live run).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The e2e row is opt-in (`OMNIGENT_E2E_MODEL_FLOWS=1`, like the rest of the live model-flows suite — it launches real CLIs), so CI exercises the unit + route tests; the live row was run locally red→green on this change. Manual verification = the full live reproduction of #5281 that motivated the fix (real server + host + claude, seeded stale store, failing Default sessions before / working after).

## Changelog

A stale model catalog no longer pins yesterday's default when starting a native Claude/Codex session (the CLI's own default is used while the catalog refreshes in the background), and failed native turns now surface the harness's own error text (e.g. `model_not_found: There's an issue with the selected model …`) to the parent session, the session error, and the web instead of a generic "turn failed".
