### PR TITLE
docs(benchmarks): stop native_hook_spawn claiming to be the per-chunk MessageDisplay hook

### DIFF
--- a/dev/benchmarks/omnigent/README.md
+++ b/dev/benchmarks/omnigent/README.md
@@ -72,11 +72,22 @@ they still work with no runner or LLM.
 
 | Journey | Operation timed |
 | --- | --- |
-| `native_hook_spawn` | Spawn the per-chunk `MessageDisplay` hook exactly as Claude Code does — isolated interpreter, module entrypoint, JSON payload on stdin |
+| `native_hook_spawn` | Spawn one **Python** command hook — isolated interpreter, module entrypoint, JSON payload on stdin — and time its whole lifetime |
 
 Claude Code **blocks its TUI** on command hooks, so one hook subprocess's
-lifetime is user-visible streaming latency, and the same interpreter+import
-cost fronts every statusline refresh and per-tool-call policy hook. The
+lifetime is user-visible latency. Read this number as *"what a hook costs if it
+is Python"*.
+
+It is **not** the per-chunk streaming cost, and treating it as one leads
+straight to wasted work. The hooks that fire per chunk (`MessageDisplay`) and
+per tool call (`evaluate-policy`) were deliberately moved off the interpreter —
+a `/bin/sh` appender and a `curl` to the runner's relay — and
+`test_message_display_shell_command_round_trips` pins that by asserting
+`"python"` is absent from the installed command. What still pays this number is
+the per-turn set (`SessionStart` / `Stop` / `UserPromptSubmit` / `PreCompact` /
+`Task*`), the `PostToolUse` `TodoWrite`+`TaskUpdate` matchers, and the policy
+hook's Python fallback before the relay is up. So the journey's real job is to
+keep the argument for staying off the interpreter measurable. The
 journey needs no server or runner; registering it here rides hook spawn cost
 on the same nightly/release regression comparison as everything else
 (`omnigent/__init__` re-exports lazily so this stays ~interpreter-sized). The

--- a/dev/benchmarks/omnigent/journeys.py
+++ b/dev/benchmarks/omnigent/journeys.py
@@ -881,12 +881,21 @@ async def _measure_cli_startup(env: BenchEnvironment, _ctx: JourneyContext) -> N
 # ── native hook spawn (no server involved) ───────────────────
 
 # Claude Code blocks its TUI on command hooks, so one hook subprocess's whole
-# lifetime is user-visible latency: the MessageDisplay hook runs once per
-# streamed text chunk, and the same interpreter+import cost fronts every
-# statusline refresh and per-tool-call policy hook. Spawn the per-chunk hook
-# exactly as Claude Code does — isolated interpreter, module entrypoint, JSON
-# payload on stdin — and time the full process lifetime. The import-graph side
-# of this guarantee is pinned by tests/test_claude_native_message_display_hook.
+# lifetime is user-visible latency. This journey times that lifetime for a
+# Python hook — isolated interpreter, module entrypoint, JSON payload on stdin —
+# which is the cost of ANY hook the bridge installs as a `python -m` command.
+#
+# It is NOT the per-chunk streaming path. The hooks that fire per chunk
+# (MessageDisplay) and per tool call (evaluate-policy) were deliberately moved
+# off the interpreter — a /bin/sh appender and a curl to the runner's relay
+# respectively — and tests pin that (`test_message_display_shell_command_round_trips`
+# asserts "python" is absent from the installed command). What still pays this
+# is the per-turn set (SessionStart / Stop / UserPromptSubmit / PreCompact /
+# Task*), the PostToolUse TodoWrite+TaskUpdate matchers, and the policy hook's
+# Python fallback when the relay is not yet up. So read this number as
+# "what a hook costs if it is Python", and as the standing argument for keeping
+# the hot paths off it — not as a per-chunk cost. The import-graph side is
+# pinned by tests/test_claude_native_message_display_hook.py.
 _HOOK_SPAWN_PAYLOAD = json.dumps(
     {
         "hook_event_name": "MessageDisplay",
@@ -905,7 +914,7 @@ async def _setup_hook_spawn(env: BenchEnvironment) -> JourneyContext:
 
 
 async def _measure_hook_spawn(env: BenchEnvironment, ctx: JourneyContext) -> None:
-    """Spawn the MessageDisplay hook once, as Claude Code does, and wait."""
+    """Spawn one Python hook subprocess and wait, as Claude Code would."""
     del env
     proc = await asyncio.create_subprocess_exec(
         sys.executable,
@@ -1082,7 +1091,12 @@ ALL_JOURNEYS: dict[str, Journey] = {
             measure=_measure_hook_spawn,
             setup=_setup_hook_spawn,
             teardown=_teardown_hook_spawn,
-            description="Spawn the per-chunk MessageDisplay hook exactly as Claude Code does.",
+            description=(
+                "Spawn one Python command hook (isolated interpreter, module "
+                "entrypoint) and time its whole lifetime — what any `python -m` "
+                "hook costs Claude's blocked TUI. Not the per-chunk path: that "
+                "one is a /bin/sh appender."
+            ),
         ),
         Journey(
             name="cli_startup",


### PR DESCRIPTION
## Related issue

Closes #

<!-- Docs/benchmark correction found while profiling; no tracking issue. -->

## Summary

`native_hook_spawn`'s comment, docstring, README row and CLI description all say
it spawns *"the per-chunk `MessageDisplay` hook exactly as Claude Code does"*.
That stopped being true when `MessageDisplay` moved to a `/bin/sh` appender and
`evaluate-policy` moved to a `curl` against the runner's relay. Both changes are
pinned by tests — `test_message_display_shell_command_round_trips` asserts
`"python"` is absent from the installed command — so the ~40ms the journey
reports is **not** on any per-chunk or per-tool-call path.

Left as it stands, that number reads as ~40ms of blocked TUI *per streamed
chunk*. Multiply by a 200-chunk message and it looks like ~8s per reply — the
largest single cost in the system and the obvious thing to go fix. I did exactly
that: measured `sh -c 'cat >> file'` at 2.4ms against the hook's 40.6ms,
concluded it was a 17× win, and started building a replacement for an
optimization the repo already had. The stale description is what produced that,
and it will produce it again.

So: say what the journey measures. The lifetime of a hook that *is* Python — which
the per-turn hooks (`SessionStart` / `Stop` / `UserPromptSubmit` / `PreCompact` /
`Task*`), the `PostToolUse` `TodoWrite`+`TaskUpdate` matchers, and the policy
hook's pre-relay fallback still pay — and which is the standing argument for
keeping the hot paths off the interpreter. Naming the tests that pin the hot paths
points the next reader at the evidence instead of at a comment.

No behaviour change: comments, docstring, journey description, and README only.

## Test Plan

Nothing to test — no code path changes. Verified the journey still runs and
reports the same number under the corrected description:

```
uv run --no-sync dev/benchmarks/omnigent/run.py \
  --journeys native_hook_spawn --iterations 10 --runs 1 --warmup 2

native_hook_spawn   P50 40.0 ms   HTTP/op 0.0
```

And confirmed the claim the new text makes, on `main`, before any of my changes
(`git show 3d537bba:omnigent/claude_native_bridge.py`):

```python
message_display_hook = {
    "type": "command",
    "command": (
        "p=$(cat | tr -d '\\r\\n'); "
        f'[ -n "$p" ] && printf \'%s\\n\' "$p" >> {deltas_quoted}; :'
    ),
}
```

`pre-commit` clean on both touched files.

## Demo

N/A — comments and docs only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Docs-only, so there is nothing new to cover. The invariants the new text asserts
are already pinned by existing tests, which it now names:
`test_message_display_shell_command_round_trips` (no `python` in the per-chunk
command, plus a pretty-printed payload round-tripping through the reader) and
`tests/test_claude_native_message_display_hook.py` (the import graph). Manual
verification was running the journey and reading the hook construction at the
commit before my branches.
