### PR TITLE
fix(host): stop narrating launch routing on every readiness probe

### DIFF
--- a/omnigent/gateway_inference.py
+++ b/omnigent/gateway_inference.py
@@ -9,11 +9,73 @@ report the answer alongside harness readiness on every registration.
 
 from __future__ import annotations
 
+import contextlib
 import logging
-from collections.abc import Iterable, Mapping
+import threading
+from collections.abc import Iterable, Iterator, Mapping
 from typing import Final
 
 _logger = logging.getLogger(__name__)
+
+# Loggers of the launch resolvers these checks call. The resolvers narrate the
+# routing they picked at INFO, which is what an operator wants when a session
+# actually launches — and pure noise when the host is only asking a question.
+_RESOLVER_LOGGERS: Final[tuple[str, ...]] = (
+    "omnigent.claude_native",
+    "omnigent.codex_native_app_server",
+)
+
+# Set only on the thread running an introspection check. Host launches run as
+# tasks on the daemon's event loop while these checks run in a worker thread
+# (``asyncio.to_thread``), so keying suppression to the thread keeps a real
+# concurrent launch's routing line intact.
+_introspecting = threading.local()
+
+
+def _suppress_resolver_narration(record: logging.LogRecord) -> bool:
+    """Drop a resolver's routing narration on an introspecting thread.
+
+    :param record: The candidate log record.
+    :returns: ``False`` to drop the record, ``True`` to keep it.
+    """
+    del record
+    return not getattr(_introspecting, "active", False)
+
+
+_filters_installed = False
+_filters_lock = threading.Lock()
+
+
+def _install_resolver_filters() -> None:
+    """Attach the narration filter to the resolver loggers once."""
+    global _filters_installed
+    if _filters_installed:
+        return
+    with _filters_lock:
+        if _filters_installed:
+            return
+        for name in _RESOLVER_LOGGERS:
+            logging.getLogger(name).addFilter(_suppress_resolver_narration)
+        _filters_installed = True
+
+
+@contextlib.contextmanager
+def _quiet_resolver_narration() -> Iterator[None]:
+    """Silence resolver routing narration for this thread's duration.
+
+    These checks resolve a launch purely to inspect where it would route. On a
+    long-lived host daemon the readiness loop repeats that every minute, which
+    otherwise buries the host's own lifecycle lines under thousands of
+    identical routing lines.
+    """
+    _install_resolver_filters()
+    previous = getattr(_introspecting, "active", False)
+    _introspecting.active = True
+    try:
+        yield
+    finally:
+        _introspecting.active = previous
+
 
 # Every spelling the Claude family travels under on the wire.
 CLAUDE_GATEWAY_HARNESSES: Final[tuple[str, ...]] = ("claude-native", "native-claude")
@@ -52,7 +114,8 @@ def claude_gateway_inference_backed() -> bool:
     )
     from omnigent.databricks_ai_gateway import is_databricks_ai_gateway_url
 
-    config = resolve_native_claude_config(spec=None, refresh_models=False)
+    with _quiet_resolver_narration():
+        config = resolve_native_claude_config(spec=None, refresh_models=False)
     if config is not None:
         base_url = config.env.get("ANTHROPIC_BASE_URL")
         if base_url and config.api_key_helper and is_databricks_ai_gateway_url(base_url):
@@ -81,7 +144,8 @@ def codex_gateway_inference_backed() -> bool:
     )
     from omnigent.databricks_ai_gateway import is_databricks_ai_gateway_url
 
-    base_url = native_codex_launch_base_url(resolve_native_codex_launch(model=None))
+    with _quiet_resolver_narration():
+        base_url = native_codex_launch_base_url(resolve_native_codex_launch(model=None))
     if not base_url:
         return False
     if not is_databricks_ai_gateway_url(base_url):

--- a/tests/test_gateway_inference.py
+++ b/tests/test_gateway_inference.py
@@ -569,3 +569,124 @@ def test_gateway_url_accepts_databricks_owned_hosts(gateway_url: str) -> None:
 )
 def test_gateway_url_rejects_lookalike_hosts(gateway_url: str) -> None:
     assert is_databricks_ai_gateway_url(gateway_url) is False
+
+
+def test_introspection_does_not_narrate_launch_routing(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Resolving a launch to inspect it must not log as if it launched.
+
+    A long-lived host daemon re-runs these checks every minute, so narrating
+    each one buried the host's own lifecycle lines under thousands of
+    identical routing lines — 98% of one 7-hour daemon log.
+    """
+    import logging
+
+    resolver = logging.getLogger("omnigent.claude_native")
+
+    def _resolve_and_narrate(**kwargs: Any) -> ClaudeNativeUcodeConfig:
+        # Stand in for the real resolver, which narrates the routing it picked.
+        resolver.info("native-claude routing: provider 'gw' (base_url=%s)", _GATEWAY_ANTHROPIC_URL)
+        return ClaudeNativeUcodeConfig(
+            env={"ANTHROPIC_BASE_URL": _GATEWAY_ANTHROPIC_URL},
+            api_key_helper="databricks auth token --profile dev",
+        )
+
+    monkeypatch.setattr(claude_native, "resolve_native_claude_config", _resolve_and_narrate)
+
+    with caplog.at_level(logging.INFO):
+        assert claude_gateway_inference_backed() is True
+
+    routing = [r.getMessage() for r in caplog.records if "routing" in r.getMessage()]
+    assert routing == [], f"introspection must not narrate routing, got {routing}"
+
+
+def test_a_real_launch_still_narrates_its_routing(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The filter must not become a blanket mute on the resolver's logger.
+
+    The routing line is exactly what an operator wants when a session really
+    launches; only the repeated introspection is noise.
+    """
+    import logging
+
+    resolver = logging.getLogger("omnigent.claude_native")
+    _stub_claude(
+        monkeypatch,
+        ClaudeNativeUcodeConfig(
+            env={"ANTHROPIC_BASE_URL": _GATEWAY_ANTHROPIC_URL},
+            api_key_helper="databricks auth token --profile dev",
+        ),
+    )
+
+    with caplog.at_level(logging.INFO):
+        # Install the filter via one introspection pass, then log as a launch would.
+        assert claude_gateway_inference_backed() is True
+        resolver.info("native-claude routing: provider 'gw' (real launch)")
+
+    routing = [r.getMessage() for r in caplog.records if "routing" in r.getMessage()]
+    assert routing == ["native-claude routing: provider 'gw' (real launch)"]
+
+
+def test_narration_survives_a_launch_on_another_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Suppression is scoped to the introspecting thread.
+
+    Host launches run as tasks on the daemon's event loop while these checks
+    run in a worker thread, so a process-wide mute would swallow the routing
+    line of a session that really did launch.
+    """
+    import logging
+    import threading
+
+    records: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record.getMessage())
+
+    resolver = logging.getLogger("omnigent.claude_native")
+    handler = _Capture()
+    resolver.addHandler(handler)
+    resolver.setLevel(logging.INFO)
+    started = threading.Event()
+
+    def _concurrent_launch() -> None:
+        started.wait(timeout=5)
+        resolver.info("native-claude routing: concurrent launch")
+
+    try:
+        with gateway_inference._quiet_resolver_narration():
+            thread = threading.Thread(target=_concurrent_launch)
+            thread.start()
+            started.set()
+            thread.join(timeout=5)
+            resolver.info("native-claude routing: suppressed on this thread")
+    finally:
+        resolver.removeHandler(handler)
+
+    assert records == ["native-claude routing: concurrent launch"]
+
+
+def test_nested_introspection_restores_narration(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Leaving a nested check does not un-suppress its caller."""
+    import logging
+
+    resolver = logging.getLogger("omnigent.claude_native")
+
+    with caplog.at_level(logging.INFO):
+        with gateway_inference._quiet_resolver_narration():
+            with gateway_inference._quiet_resolver_narration():
+                pass
+            resolver.info("native-claude routing: still inside")
+        resolver.info("native-claude routing: after")
+
+    messages = [r.getMessage() for r in caplog.records if "routing" in r.getMessage()]
+    assert messages == ["native-claude routing: after"]


### PR DESCRIPTION
## Related issue

No tracked issue — found while diagnosing why a failed remote launch was hard
to investigate (companion to #5291). Happy to file one if maintainers prefer.

## Summary

The gateway-inference checks resolve a launch purely to **inspect** where it
would route — the module docstring is explicit that it does "no process launch,
no network round-trip". But the resolvers they call narrate their routing at
`INFO`, and the host daemon's readiness loop re-runs the checks every 60s. So a
pure query logged as though a session had started, once a minute, forever.

Measured on a 7-hour server-mode daemon log:

| source | lines | share |
|---|---|---|
| `codex_native_app_server` routing (INFO) | 3,470 | 65.0% |
| `claude_native` routing (INFO) | 1,747 | 32.7% |
| **`host.connect` — actual lifecycle signal** | **58** | **1.1%** |
| total | 5,340 | |

97.7% noise. The single `Connecting to wss://…` line that mattered for
diagnosing a wedged tunnel was buried under thousands of identical routing
lines.

Suppress the narration for the duration of the check.

### Why thread-scoped, not logger-scoped

The obvious fix — mute the resolver's logger, or drop it to `DEBUG` — is wrong
here. Host launches run as tasks on the daemon's event loop while these checks
run in a worker thread (`asyncio.to_thread`), so a process-wide mute would
swallow the routing line of a session that **really did** launch. That line is
exactly what an operator wants in the one case it appears legitimately.

Keying suppression to the introspecting thread keeps the two cases apart:

```
daemon event loop ──▶ launch session ──▶ resolver logs routing   ✅ kept
                 └──▶ to_thread ──▶ gateway check ──▶ resolver   ❌ dropped
```

Suppression is installed inside the two family checks rather than at the
`gateway_inference_map` fan-out, so any future direct caller of
`claude_gateway_inference_backed` / `codex_gateway_inference_backed` gets the
same treatment — they are introspection by definition.

## Test Plan

- Verified on the real code path: three consecutive `gateway_inference_map()`
  calls now emit **0** routing lines (was ~7 per call).
- Verified the safety property directly: a routing line logged from another
  thread *during* an introspection pass is still emitted, and nesting restores
  the previous state on exit.
- Both new assertions were confirmed to **fail** with the suppression reverted
  (the first draft of this test was vacuous because the stub replaced the
  resolver before it could log — rewritten so the stub narrates like the real
  resolver does).
- `pytest tests/test_gateway_inference.py tests/host/ tests/cli/` → 1562 passed.
- `pre-commit` clean.

Real-world effect: that same 7-hour daemon log would go from 5,340 lines to
~123, with the `host.connect` lifecycle lines no longer buried.

## Demo

N/A — log-volume change, no UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Three new tests: introspection emits no routing narration (with a stub that
narrates the way the real resolver does), a real launch's routing line still
survives after the filter is installed, and suppression is scoped to the
introspecting thread rather than the logger. Manual verification covered the
real `gateway_inference_map()` path and the cross-thread case, which the unit
tests then pin.

## Changelog

Host daemon logs are no longer flooded with a routing line every minute, so the
host's own lifecycle events are actually findable when a session fails to start.
This pull request and its description were written by Isaac.
