### PR TITLE
fix(host): cycle a superseded daemon, and read tunnel health locally

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -632,6 +632,10 @@ _DAEMON_RECONNECT_GRACE_S = 5.0
 # a freshly-spawned daemon (possibly from a concurrent invocation) still
 # bringing its tunnel up. Avoids racing/thrashing sibling invocations.
 _DAEMON_REUSE_MIN_AGE_S = 6.0
+# A tunnel stamp older than this is treated as absent. Several times the
+# daemon's refresh interval, so an event loop that is merely busy does not
+# read as a dropped tunnel.
+_TUNNEL_HEARTBEAT_STALE_S = 60.0
 
 # How long uvicorn waits for active connections (WebSocket, SSE) after
 # SIGTERM before force-closing them.  SSE streams signal themselves via
@@ -2403,6 +2407,12 @@ class _HostDaemonRecord:
         ``None`` for legacy records written before config-signature
         tracking existed; a ``None`` signature is never treated as a
         config mismatch (we can't know what it was started with).
+    :param pkg_version: Installed ``omnigent`` version the daemon process
+        was started from, e.g. ``"0.4.12"``. Stamped separately from
+        *config_sig* because it is a property of this machine's code, not
+        of the server's config, so it can be checked in server mode too.
+        ``None`` for legacy records and source checkouts with no
+        registered distribution; never treated as a mismatch.
     """
 
     pid: int
@@ -2414,6 +2424,7 @@ class _HostDaemonRecord:
     host_id: str | None = None
     resolved_server_url: str | None = None
     config_sig: str | None = None
+    pkg_version: str | None = None
 
 
 @dataclass(frozen=True)
@@ -2586,6 +2597,82 @@ def _daemon_host_online(record: _HostDaemonRecord, *, timeout_s: float = 2.0) ->
     return _daemon_host_state(record, timeout_s=timeout_s) == "online"
 
 
+def _installed_omnigent_version() -> str | None:
+    """
+    Return the installed ``omnigent`` distribution version.
+
+    :returns: Version string, e.g. ``"0.4.12"``, or ``None`` when running
+        from a source tree with no registered distribution (nothing to key
+        upgrade drift on).
+    """
+    import importlib.metadata
+
+    try:
+        return importlib.metadata.version("omnigent")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _daemon_build_changed(record: _HostDaemonRecord) -> bool:
+    """
+    Return whether a daemon is running code from a superseded install.
+
+    A daemon holds its code in memory and forks runners from a zygote that
+    imported that same code, so after an in-place upgrade (``omni upgrade``,
+    a refreshed ``isaac`` wheel) the old daemon keeps minting runners on
+    pre-upgrade code while the CLI speaks the new protocol. Mixed-version
+    runners then fail in confusing ways that a daemon restart resolves.
+
+    Unlike the config signature this is a property of the local install
+    rather than of the server's config, so it is checked in server mode too.
+
+    :param record: Daemon record being considered for reuse.
+    :returns: ``True`` when both versions are known and differ.
+    """
+    if record.pkg_version is None:
+        return False
+    current = _installed_omnigent_version()
+    return current is not None and current != record.pkg_version
+
+
+def _daemon_heartbeat_path(target: str) -> Path:
+    """
+    Return the tunnel-health stamp path for a daemon target.
+
+    Sits beside the target's registry record so both are removed together.
+
+    :param target: Normalized daemon target, e.g. ``"local"``.
+    :returns: Stamp path, e.g.
+        ``Path("~/.omnigent/daemons/abc.tunnel")``.
+    """
+    return _daemon_record_path(target).with_suffix(".tunnel")
+
+
+def _daemon_tunnel_heartbeat_fresh(record: _HostDaemonRecord) -> bool:
+    """
+    Return whether a daemon recently stamped its tunnel as up.
+
+    The daemon refreshes this file while its tunnel is registered and deletes
+    it on disconnect, so a fresh stamp answers "is the tunnel up?" from the
+    local filesystem — no round trip to the server on the common path where
+    everything is fine.
+
+    Treated as *not* fresh when the file is missing or stale, which is also
+    what a foreground host and any daemon from a build that predates the
+    stamp look like. Those fall through to the server probe, so a missing
+    stamp costs correctness nothing.
+
+    :param record: Daemon record to check.
+    :returns: ``True`` when the stamp was refreshed within
+        :data:`_TUNNEL_HEARTBEAT_STALE_S`.
+    """
+    try:
+        age_s = time.time() - _daemon_heartbeat_path(record.target).stat().st_mtime
+    except OSError:
+        return False
+    return 0 <= age_s < _TUNNEL_HEARTBEAT_STALE_S
+
+
 def _daemon_registry_dir() -> Path:
     """
     Return the directory containing per-target daemon registry records.
@@ -2640,6 +2727,7 @@ def _record_from_json(raw: _HostJsonObject) -> _HostDaemonRecord | None:
     host_id = raw.get("host_id")
     resolved_server_url = raw.get("resolved_server_url")
     config_sig = raw.get("config_sig")
+    pkg_version = raw.get("pkg_version")
     return _HostDaemonRecord(
         pid=pid,
         target=target,
@@ -2654,6 +2742,7 @@ def _record_from_json(raw: _HostJsonObject) -> _HostDaemonRecord | None:
             else None
         ),
         config_sig=config_sig if isinstance(config_sig, str) and config_sig else None,
+        pkg_version=pkg_version if isinstance(pkg_version, str) and pkg_version else None,
     )
 
 
@@ -2699,6 +2788,10 @@ def _delete_daemon_record(record: _HostDaemonRecord) -> None:
     """
     with contextlib.suppress(OSError):
         _daemon_record_path(record.target).unlink()
+    # The tunnel stamp belongs to this daemon; leaving it behind would
+    # outlive the record it describes.
+    with contextlib.suppress(OSError):
+        _daemon_heartbeat_path(record.target).unlink(missing_ok=True)
     legacy = _read_host_pid_file()
     if legacy is not None and legacy[1] == record.target:
         with contextlib.suppress(OSError):
@@ -2948,6 +3041,15 @@ def _reuse_existing_daemon_record(target: str) -> _DaemonReuseDecision:
     never silently killed — we don't tear down an interactive process or
     one whose config we can't verify.
 
+    Both local and remote daemons get the tunnel-health heal, but they judge
+    "offline" differently: a local daemon's server is on loopback, so an
+    unreachable probe is proof enough, while a remote daemon is torn down
+    only when its server explicitly reports the host as not connected
+    (see :func:`_daemon_host_definitely_offline`). Config-signature drift
+    applies to local mode alone — the remote's auth posture is not ours —
+    while upgrade drift applies to both, since the daemon process runs this
+    machine's code even when its server does not.
+
     :param target: Normalized daemon target, e.g. ``"local"``.
     :returns: A :class:`_DaemonReuseDecision`.
     """
@@ -2967,19 +3069,27 @@ def _reuse_existing_daemon_record(target: str) -> _DaemonReuseDecision:
         # Remote / explicit ``--server`` mode: the daemon connects to a server
         # we don't own and can't restart, so the config-signature and "re-run"
         # semantics below don't apply — auth posture is the remote's concern.
+        # Our own install still is: a daemon and its zygote hold superseded
+        # code after an in-place upgrade, and local mode only catches that
+        # because the version rides in its config signature.
+        if background and _daemon_build_changed(existing):
+            _terminate_host_unit(existing, reason="omnigent was upgraded")
+            return _DaemonReuseDecision(reuse=False, config_changed=False)
         #
         # Tunnel health still does. A daemon whose tunnel is gone for good is
         # a zombie either way: every later command waits out
         # ``wait_for_host_online`` and fails with "did not come online", which
         # is what made `omnigent host stop` the standing remedy. Heal it the
-        # way local mode does, with one extra guard — only on a definite
-        # "the server says offline", never on a probe we could not complete,
-        # since the daemon's own reconnect loop handles transient drops and we
-        # must not kill a healthy daemon over our own network blip.
+        # way local mode does, with two guards — a fresh stamp settles health
+        # locally, and only a definite "the server says offline" (never a probe
+        # we could not complete) justifies a teardown, since the daemon's own
+        # reconnect loop handles transient drops and we must not kill a healthy
+        # daemon over our own network blip.
         age_s = time.time() - existing.started_at
         if (
             background
             and age_s >= _DAEMON_REUSE_MIN_AGE_S
+            and not _daemon_tunnel_heartbeat_fresh(existing)
             and _daemon_host_definitely_offline(existing)
         ):
             _terminate_host_unit(existing, reason="host tunnel is offline")
@@ -3089,6 +3199,7 @@ def _persist_spawned_daemon(
             started_at=int(time.time()),
             host_id=_load_existing_host_id(),
             config_sig=config_sig,
+            pkg_version=_installed_omnigent_version(),
         )
     )
     _HOST_PID_PATH.write_text(f"{spawned.pid}\n{target}\n")
@@ -3241,10 +3352,11 @@ def _ensure_host_daemon(server_url: str | None) -> bool:
     _HOST_PID_PATH.parent.mkdir(parents=True, exist_ok=True)
     mode_args = ["--local"] if not server_url else ["--server", server_url]
     args = [sys.executable, "-m", "omnigent.host._daemon_entry", *mode_args]
-    spawned = _spawn_host_daemon_process(
-        args=args,
-        env=_build_host_daemon_env(server_url=server_url),
-    )
+    from omnigent.host.connect import TUNNEL_HEARTBEAT_ENV_VAR
+
+    daemon_env = _build_host_daemon_env(server_url=server_url)
+    daemon_env[TUNNEL_HEARTBEAT_ENV_VAR] = str(_daemon_heartbeat_path(target))
+    spawned = _spawn_host_daemon_process(args=args, env=daemon_env)
     if spawned is None:
         return False
     _persist_spawned_daemon(

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -353,6 +353,15 @@ _AUTH_REJECT_ESCALATE_ATTEMPTS = 30
 # endpoint that accepts and never speaks is functionally down.
 _SILENT_CONNECT_ESCALATE_ATTEMPTS = 10
 
+# Set by the CLI when it spawns a background daemon: a file whose mtime the
+# daemon refreshes while its tunnel is registered, and removes when it drops.
+# Lets the next CLI invocation read tunnel health off the local filesystem
+# instead of paying a round trip to the server on every launch. Advisory —
+# absent (a foreground host, or a daemon from an older build) simply means the
+# CLI falls back to asking the server.
+TUNNEL_HEARTBEAT_ENV_VAR = "OMNIGENT_HOST_TUNNEL_HEARTBEAT_FILE"
+_TUNNEL_HEARTBEAT_INTERVAL_S = 15.0
+
 # Capability discovery is advisory and must not delay the host channel forever.
 _HOST_CAPABILITY_INIT_TIMEOUT_S = 15.0
 
@@ -627,6 +636,41 @@ class HostConnectError(Exception):
     The message is the full, user-facing explanation including the
     suggested fix; it is printed verbatim by :func:`run_host_process`.
     """
+
+
+def _tunnel_heartbeat_path() -> Path | None:
+    """Return the tunnel-health stamp path the CLI assigned, if any.
+
+    :returns: Path from :data:`TUNNEL_HEARTBEAT_ENV_VAR`, or ``None`` when
+        unset (a foreground host, or a daemon spawned by an older CLI).
+    """
+    value = os.environ.get(TUNNEL_HEARTBEAT_ENV_VAR)
+    return Path(value) if value else None
+
+
+def _touch_tunnel_heartbeat() -> None:
+    """Stamp the tunnel-health file with the current time."""
+    path = _tunnel_heartbeat_path()
+    if path is None:
+        return
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+    except OSError as exc:
+        _logger.debug("Could not stamp tunnel heartbeat %s: %s", path, exc)
+
+
+def _clear_tunnel_heartbeat() -> None:
+    """Remove the tunnel-health stamp when the tunnel is no longer up.
+
+    Deleting it (rather than letting it age out) makes a dropped tunnel
+    visible to the next CLI invocation immediately.
+    """
+    path = _tunnel_heartbeat_path()
+    if path is None:
+        return
+    with contextlib.suppress(OSError):
+        path.unlink(missing_ok=True)
 
 
 def _build_runner_env(
@@ -3158,6 +3202,11 @@ class HostProcess:
         prewarm_task = asyncio.create_task(
             self._prewarm_model_options(), name="host-model-options-prewarm"
         )
+        # Bracketed by this registered connection, so the stamp means "the
+        # tunnel was up as of then" — not merely "the process is alive".
+        heartbeat_task = asyncio.create_task(
+            self._tunnel_heartbeat_loop(), name="host-tunnel-heartbeat"
+        )
         try:
             while True:
                 raw = await ws.recv()
@@ -3178,12 +3227,27 @@ class HostProcess:
                     # _runner_lifecycle_lock in _dispatch_host_frame.
                     self._start_frame_task(ws, raw)
         finally:
+            heartbeat_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await heartbeat_task
+            _clear_tunnel_heartbeat()
             prewarm_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await prewarm_task
             readiness_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await readiness_task
+
+    async def _tunnel_heartbeat_loop(self) -> None:
+        """Refresh the tunnel-health stamp while this connection is registered.
+
+        Runs off the receive loop (a slow home directory must not delay
+        ``ws.recv()``). Errors are swallowed: the stamp is advisory, and a CLI
+        that finds it missing or stale just asks the server instead.
+        """
+        while True:
+            await asyncio.to_thread(_touch_tunnel_heartbeat)
+            await asyncio.sleep(_TUNNEL_HEARTBEAT_INTERVAL_S)
 
     async def _harness_readiness_loop(
         self,

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1003,3 +1003,344 @@ def test_start_hosts_on_explicit_server(
             "https://example.databricksapps.com",
         ]
     ]
+
+
+# ── remote daemon tunnel heal ──────────────────────────────────────
+
+
+_REMOTE_TARGET = "https://example.databricksapps.com"
+_REMOTE_HOST_ID = "host_remote_abc"
+
+
+def _remote_daemon_record(
+    tmp_path: Path,
+    *,
+    pid: int = 5150,
+    age_s: int = 600,
+    background: bool = True,
+) -> object:
+    """
+    Build a server-mode daemon record for reuse tests.
+
+    :param tmp_path: Test-scoped directory hosting the fake daemon log.
+    :param pid: Record pid, e.g. ``5150``.
+    :param age_s: Seconds since the daemon started, e.g. ``600``.
+    :param background: Whether the record carries a ``log_path`` (a daemon
+        this CLI spawned) rather than a foreground ``omnigent host``.
+    :returns: The daemon record.
+    """
+    from omnigent.cli import _HostDaemonRecord
+
+    return _HostDaemonRecord(
+        pid=pid,
+        target=_REMOTE_TARGET,
+        mode="server",
+        server_url=_REMOTE_TARGET,
+        log_path=str(tmp_path / "remote.log") if background else None,
+        started_at=int(time.time()) - age_s,
+        host_id=_REMOTE_HOST_ID,
+        config_sig="deadbeefdeadbeef",
+    )
+
+
+def _patch_remote_reuse(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    pid: int = 5150,
+) -> list[str]:
+    """
+    Isolate ``_reuse_existing_daemon_record`` for a server-mode record.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Test-scoped directory used as the config home.
+    :param pid: Pid treated as alive, e.g. ``5150``.
+    :returns: List that records teardown reasons.
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr("omnigent.cli._HOST_PID_PATH", tmp_path / "host.pid")
+    monkeypatch.setattr("omnigent.cli._pid_alive", lambda checked: checked == pid)
+    # The tmp config home has no identity file; match the record's id so the
+    # identity-drift check isn't what tears the daemon down.
+    monkeypatch.setattr("omnigent.cli._load_existing_host_id", lambda: _REMOTE_HOST_ID)
+    reasons: list[str] = []
+    monkeypatch.setattr(
+        "omnigent.cli._terminate_host_unit",
+        lambda record, *, reason: reasons.append(reason),
+    )
+    return reasons
+
+
+def _probe_result(status_code: int, body: object) -> object:
+    """
+    Build a canned management-HTTP result.
+
+    :param status_code: HTTP status, e.g. ``200`` (``0`` = transport failure).
+    :param body: Decoded body, e.g. ``{"status": "online"}``.
+    :returns: The result object.
+    """
+    from omnigent.cli import _HostHttpResult
+
+    return _HostHttpResult(status_code=status_code, body=body)
+
+
+def test_upgraded_install_restarts_remote_daemon(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A daemon from a superseded install is cycled onto the new code.
+
+    Server-mode records skip the config-signature check that carries the
+    version in local mode, so without a build stamp an in-place upgrade
+    (a refreshed ``isaac`` wheel) leaves the old daemon forking pre-upgrade
+    runners until the user stops it by hand.
+    """
+    from omnigent.cli import _HostDaemonRecord, _reuse_existing_daemon_record, _write_daemon_record
+
+    reasons = _patch_remote_reuse(monkeypatch, tmp_path)
+    record = _remote_daemon_record(tmp_path)
+    assert isinstance(record, _HostDaemonRecord)
+    _write_daemon_record(replace(record, pkg_version="0.4.11"))
+    monkeypatch.setattr("omnigent.cli._installed_omnigent_version", lambda: "0.4.12")
+    monkeypatch.setattr(
+        "omnigent.cli._daemon_host_definitely_offline",
+        lambda record: pytest.fail("upgrade drift must be caught before the tunnel probe"),
+    )
+
+    decision = _reuse_existing_daemon_record(_REMOTE_TARGET)
+
+    assert decision.reuse is False
+    assert reasons == ["omnigent was upgraded"]
+
+
+def test_matching_build_keeps_remote_daemon(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unchanged install is not a reason to cycle a healthy daemon."""
+    from omnigent.cli import _HostDaemonRecord, _reuse_existing_daemon_record, _write_daemon_record
+
+    reasons = _patch_remote_reuse(monkeypatch, tmp_path)
+    record = _remote_daemon_record(tmp_path)
+    assert isinstance(record, _HostDaemonRecord)
+    _write_daemon_record(replace(record, pkg_version="0.4.12"))
+    monkeypatch.setattr("omnigent.cli._installed_omnigent_version", lambda: "0.4.12")
+    monkeypatch.setattr(
+        "omnigent.cli._host_http_json",
+        lambda **kwargs: _probe_result(200, {"status": "online"}),
+    )
+
+    decision = _reuse_existing_daemon_record(_REMOTE_TARGET)
+
+    assert decision.reuse is True
+    assert reasons == []
+
+
+@pytest.mark.parametrize(
+    ("stamped", "installed"),
+    [
+        # Legacy record written before build stamping: we cannot know what it
+        # started with, so it is never torn down on this signal.
+        (None, "0.4.12"),
+        # Source checkout with no registered distribution: nothing to key on.
+        ("0.4.11", None),
+    ],
+)
+def test_unknown_build_is_never_a_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stamped: str | None,
+    installed: str | None,
+) -> None:
+    """
+    Build drift needs both versions known.
+
+    Guessing in either direction would cycle daemons on every launch for
+    contributors running from a source tree.
+    """
+    from omnigent.cli import _daemon_build_changed, _HostDaemonRecord
+
+    _patch_remote_reuse(monkeypatch, tmp_path)
+    monkeypatch.setattr("omnigent.cli._installed_omnigent_version", lambda: installed)
+    record = _remote_daemon_record(tmp_path)
+    assert isinstance(record, _HostDaemonRecord)
+
+    assert _daemon_build_changed(replace(record, pkg_version=stamped)) is False
+
+
+def test_daemon_record_round_trips_the_build_stamp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The build stamp survives the registry JSON round trip.
+
+    The reuse check reads it back from disk on a later invocation, so a field
+    that is written but not parsed would silently disable the upgrade heal.
+    """
+    from omnigent.cli import (
+        _find_daemon_record,
+        _HostDaemonRecord,
+        _write_daemon_record,
+    )
+
+    _patch_remote_reuse(monkeypatch, tmp_path)
+    record = _remote_daemon_record(tmp_path)
+    assert isinstance(record, _HostDaemonRecord)
+    _write_daemon_record(replace(record, pkg_version="0.4.12"))
+
+    reloaded = _find_daemon_record(_REMOTE_TARGET)
+
+    assert reloaded is not None
+    assert reloaded.pkg_version == "0.4.12"
+
+
+def test_fresh_tunnel_stamp_reuses_without_asking_the_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A recent stamp settles tunnel health locally.
+
+    The point of the stamp is that the common case — everything is fine —
+    costs no round trip to the server on every launch.
+    """
+    from omnigent.cli import (
+        _daemon_heartbeat_path,
+        _reuse_existing_daemon_record,
+        _write_daemon_record,
+    )
+
+    reasons = _patch_remote_reuse(monkeypatch, tmp_path)
+    _write_daemon_record(_remote_daemon_record(tmp_path))
+    stamp = _daemon_heartbeat_path(_REMOTE_TARGET)
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    stamp.touch()
+
+    def _fail_probe(**kwargs: object) -> object:
+        raise AssertionError("a fresh stamp must not trigger a server probe")
+
+    monkeypatch.setattr("omnigent.cli._host_http_json", _fail_probe)
+
+    decision = _reuse_existing_daemon_record(_REMOTE_TARGET)
+
+    assert decision.reuse is True
+    assert reasons == []
+
+
+def test_stale_tunnel_stamp_falls_back_to_the_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A stale stamp is not proof of a dead tunnel on its own.
+
+    Only the server can distinguish a wedged daemon from one whose stamp
+    aged out because the network — not the daemon — is broken.
+    """
+    from omnigent.cli import (
+        _daemon_heartbeat_path,
+        _reuse_existing_daemon_record,
+        _write_daemon_record,
+    )
+
+    reasons = _patch_remote_reuse(monkeypatch, tmp_path)
+    _write_daemon_record(_remote_daemon_record(tmp_path))
+    stamp = _daemon_heartbeat_path(_REMOTE_TARGET)
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    stamp.touch()
+    stale = time.time() - 3600
+    os.utime(stamp, (stale, stale))
+    probed: list[str] = []
+
+    def _probe(**kwargs: object) -> object:
+        probed.append(str(kwargs.get("path")))
+        return _probe_result(200, {"status": "online"})
+
+    monkeypatch.setattr("omnigent.cli._host_http_json", _probe)
+
+    decision = _reuse_existing_daemon_record(_REMOTE_TARGET)
+
+    assert decision.reuse is True, "the server said online — keep the daemon"
+    assert probed, "a stale stamp must be confirmed against the server"
+    assert reasons == [], "a stale stamp alone must not tear the daemon down"
+
+
+def test_missing_tunnel_stamp_falls_back_to_the_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    No stamp means "unknown", not "offline".
+
+    Foreground hosts and daemons from builds that predate the stamp never
+    write one, so its absence must not by itself condemn a daemon.
+    """
+    from omnigent.cli import _reuse_existing_daemon_record, _write_daemon_record
+
+    reasons = _patch_remote_reuse(monkeypatch, tmp_path)
+    _write_daemon_record(_remote_daemon_record(tmp_path))
+    monkeypatch.setattr(
+        "omnigent.cli._host_http_json",
+        lambda **kwargs: _probe_result(200, {"status": "online"}),
+    )
+
+    decision = _reuse_existing_daemon_record(_REMOTE_TARGET)
+
+    assert decision.reuse is True
+    assert reasons == []
+
+
+def test_deleting_a_daemon_record_removes_its_tunnel_stamp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stamp must not outlive the record it describes."""
+    from omnigent.cli import (
+        _daemon_heartbeat_path,
+        _delete_daemon_record,
+        _write_daemon_record,
+    )
+
+    _patch_remote_reuse(monkeypatch, tmp_path)
+    record = _remote_daemon_record(tmp_path)
+    _write_daemon_record(record)
+    stamp = _daemon_heartbeat_path(_REMOTE_TARGET)
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    stamp.touch()
+
+    _delete_daemon_record(record)
+
+    assert not stamp.exists()
+
+
+def test_spawned_daemon_is_told_where_to_stamp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The daemon learns its stamp path from the environment.
+
+    Passing it (rather than recomputing it daemon-side) keeps one owner for
+    the registry layout and makes the stamp honor a patched data dir.
+    """
+    from omnigent.cli import _daemon_heartbeat_path, _ensure_host_daemon, _SpawnedDaemonProcess
+    from omnigent.host.connect import TUNNEL_HEARTBEAT_ENV_VAR
+
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr("omnigent.cli._HOST_PID_PATH", tmp_path / "host.pid")
+    monkeypatch.setattr("omnigent.cli._pid_alive", lambda checked: False)
+    monkeypatch.setattr("omnigent.cli._load_existing_host_id", lambda: _REMOTE_HOST_ID)
+    captured: list[dict[str, str]] = []
+
+    def _fake_spawn(*, args: list[str], env: dict[str, str]) -> _SpawnedDaemonProcess:
+        captured.append(env)
+        return _SpawnedDaemonProcess(pid=4242, log_path=str(tmp_path / "host.log"))
+
+    monkeypatch.setattr("omnigent.cli._spawn_host_daemon_process", _fake_spawn)
+
+    _ensure_host_daemon(_REMOTE_TARGET)
+
+    assert captured, "the daemon must be spawned"
+    assert captured[0][TUNNEL_HEARTBEAT_ENV_VAR] == str(_daemon_heartbeat_path(_REMOTE_TARGET))

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -4746,3 +4746,104 @@ def test_post_connect_auth_rejection_escalates_without_going_fatal(
     assert "omnigent login http://localhost:8000" in escalated
     assert "no longer a transient network blip" in escalated
     assert host._auth_retry_streak == _AUTH_REJECT_ESCALATE_ATTEMPTS
+
+
+class _HoldOpenTunnel:
+    """Tunnel that stays connected until released, then disconnects.
+
+    Lets a test observe work the host does *while* registered — the fake
+    tunnels that disconnect immediately give the heartbeat task no chance to
+    run before ``_serve_frames`` unwinds.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the frame log and the release signal."""
+        self.sent: list[str] = []
+        self.release = asyncio.Event()
+
+    async def send(self, data: str) -> None:
+        """Record an outbound frame.
+
+        :param data: Encoded frame text.
+        """
+        self.sent.append(data)
+
+    async def recv(self) -> str:
+        """Block until released, then simulate a disconnect."""
+        await self.release.wait()
+        raise ConnectionError("test disconnect")
+
+
+async def test_tunnel_stamp_tracks_the_registered_connection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The host stamps its tunnel while registered and clears it on drop.
+
+    The stamp is what lets the next CLI invocation read tunnel health off the
+    filesystem instead of asking the server, so it must mean "the tunnel is
+    up" — present while serving, gone the moment the connection dies.
+    """
+    from omnigent.host.connect import TUNNEL_HEARTBEAT_ENV_VAR
+
+    stamp = tmp_path / "daemons" / "abc.tunnel"
+    monkeypatch.setenv(TUNNEL_HEARTBEAT_ENV_VAR, str(stamp))
+    host = _make_host_process()
+    tunnel = _HoldOpenTunnel()
+
+    serve = asyncio.create_task(host._serve_frames(tunnel))  # type: ignore[arg-type]
+    try:
+        for _ in range(200):
+            if stamp.exists():
+                break
+            await asyncio.sleep(0.01)
+        assert stamp.exists(), "a registered tunnel must be stamped"
+    finally:
+        tunnel.release.set()
+        with contextlib.suppress(ConnectionError):
+            await serve
+        _cleanup_host(host)
+
+    assert not stamp.exists(), "a dropped tunnel must clear its stamp"
+
+
+async def test_tunnel_stamp_is_optional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host with no stamp path assigned serves normally.
+
+    Foreground ``omnigent host`` runs get no stamp path, and the daemon must
+    not treat that as an error.
+    """
+    from omnigent.host.connect import TUNNEL_HEARTBEAT_ENV_VAR
+
+    monkeypatch.delenv(TUNNEL_HEARTBEAT_ENV_VAR, raising=False)
+    host = _make_host_process()
+    tunnel = _FakeTunnel()
+
+    with pytest.raises(ConnectionError, match="test disconnect"):
+        await host._serve_frames(tunnel)  # type: ignore[arg-type]
+    _cleanup_host(host)
+
+
+async def test_unwritable_stamp_path_is_not_fatal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stamp the daemon cannot write is swallowed, not raised.
+
+    The stamp is advisory — a read-only state dir must degrade to the server
+    probe, never take the tunnel down.
+    """
+    from omnigent.host.connect import (
+        TUNNEL_HEARTBEAT_ENV_VAR,
+        _clear_tunnel_heartbeat,
+        _touch_tunnel_heartbeat,
+    )
+
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("")
+    monkeypatch.setenv(TUNNEL_HEARTBEAT_ENV_VAR, str(blocker / "nested" / "abc.tunnel"))
+
+    _touch_tunnel_heartbeat()
+    _clear_tunnel_heartbeat()


### PR DESCRIPTION
## Related issue

No tracked issue. Split out of a PR that duplicated #5256's remote-daemon heal —
this keeps only the parts that heal leaves on the table.

**Stacked on #5256** (`fix/heal-zombie-remote-host-daemon`) and should merge
after it; the diff shown against `main` will include that PR's commit.

## Summary

Two gaps the remote-daemon heal in #5256 does not cover.

**Upgrade drift.** A daemon holds its code in memory and forks runners from a
zygote that imported the same code, so after an in-place upgrade (`omni
upgrade`, a refreshed `isaac` wheel) the old daemon keeps minting pre-upgrade
runners while the CLI speaks the new protocol — the *other* state people escape
with `omnigent host stop`. Local mode already catches this because the package
version rides in its config signature; server-mode records skip that check
entirely. So stamp the version on the record in its own field — deliberately not
the config signature, which also encodes the *server's* auth posture and is not
ours to police in server mode.

**A local tunnel-health signal.** `_daemon_host_definitely_offline` is
authoritative but costs a round trip on every launch — measured **91–100 ms**
against a real workspace. The daemon already knows whether its tunnel is up, so
let it say so: it touches `daemons/<digest>.tunnel` every 15 s while its tunnel
is registered (bracketed inside `_serve_frames`) and removes it on disconnect. A
stamp under 60 s old settles reuse locally in **~1 ms, no probe**.

A pure heartbeat would *not* be safe on its own — a real network outage also
stops it, which is exactly the VPN-blip teardown #5256 guards against. So a
missing or stale stamp means only "unknown", never "offline", and still falls
through to that probe:

```
PID alive? ──no──▶ spawn fresh
   │yes
   ▼
build stamp == installed version? ──no──▶ restart ("omnigent was upgraded")
   │yes
   ▼
tunnel stamp < 60s old? ──yes──▶ REUSE            (0 probes, ~1ms)
   │no  ("unknown", never "offline")
   ▼
_daemon_host_definitely_offline()  ← #5256's tri-state probe
   ├─ definite offline ──▶ restart
   └─ online / unknown ──▶ REUSE
```

The CLI passes the stamp path via `OMNIGENT_HOST_TUNNEL_HEARTBEAT_FILE` rather
than having the daemon recompute it, so the registry layout keeps one owner and
a patched data dir works.

**Rollout is safe.** A foreground host, or a daemon from a build predating the
stamp, writes none — so it always takes #5256's probe path, i.e. that PR's
behavior unchanged.

## Test Plan

Measured against a real daemon-side writer plus a real HTTP server standing in
for the Omnigent server:

| state | reuse | server probes | cost |
|---|---|---|---|
| tunnel up (stamp fresh) | yes | **0** | ~1 ms |
| tunnel dropped, server confirms offline | **restarts** | 11 | grace window |
| stamp stale, server says online | yes | 1 | one probe |
| server unreachable (VPN down) | yes | 1 | one probe |
| install upgraded | **restarts** | 0 | — |

- Verified on a live 7-hour server-mode daemon: it predates the stamp, correctly
  falls back to the probe, and is reused with nothing killed. Its legacy record
  also has no version stamp, and correctly reports no build drift.
- Probe latency measured against a real workspace: min 91 ms / median 93 ms —
  the cost the stamp removes.
- `pytest tests/host/ tests/cli/` → 1527 passed. `pre-commit` clean.

Manual reproduction:

```bash
# Upgrade drift
python - <<'PY'
import json, pathlib
p = next(pathlib.Path.home().glob(".omnigent/daemons/*.json"))
d = json.loads(p.read_text()); d["pkg_version"] = "0.0.1-old"
p.write_text(json.dumps(d, indent=2))
PY
# launch → "Restarting host daemon for '<url>' (omnigent was upgraded)."

# Watch the stamp track the tunnel, then break it and watch it vanish (~15s)
watch -n 2 'ls -l --time-style=+%H:%M:%S ~/.omnigent/daemons/*.tunnel'
sudo iptables -A OUTPUT -d <workspace-ip> -j DROP
# ...stamp disappears; the launch still must NOT tear the daemon down (#5256's guard)
sudo iptables -D OUTPUT -d <workspace-ip> -j DROP
```

## Demo

N/A — no UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Nine new tests. Upgrade drift: teardown on a changed version, reuse on a
matching one, both unknown-version directions (a legacy record and a source
checkout are never a mismatch), and the record JSON round trip — a field written
but not parsed would silently disable the heal. Tunnel stamp: a fresh stamp
skips the probe entirely (asserted by making the probe raise), stale and missing
stamps fall through to #5256's probe, the stamp is deleted with its record, and
the spawn passes the path in the environment. Daemon side
(`tests/host/test_connect.py`): the stamp appears while a connection is
registered and is removed when it drops, an unassigned path is a no-op, and an
unwritable path is swallowed rather than taking the tunnel down.

Deliberately *not* re-tested here: the offline/unknown probe matrix, teardown,
inconclusive-probe, young-daemon and foreground-daemon cases, all covered by
#5256's own tests. Seven tests duplicating them were dropped during the split.

## Changelog

A host daemon left over from a previous version now restarts itself instead of
launching sessions on stale code, and the health check that guards this costs no
network round trip when everything is fine.
This pull request and its description were written by Isaac.
