### PR TITLE
fix(auth): stop reporting Databricks pointer records as expired logins

### DIFF
--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -265,6 +265,13 @@ def load_token(server_url: str, *, min_remaining_seconds: float = 0.0) -> str | 
     if entry is None:
         return None
 
+    # A tokenless record — a Databricks pointer, which deliberately stores no
+    # bearer — is not a session that can lapse. Declining it is the normal
+    # path, so return before the expiry check rather than reporting it as
+    # expired at epoch 0 and telling the user to re-run `omnigent login`.
+    if not isinstance(entry.get("token"), str):
+        return None
+
     expires_at = entry.get("expires_at", 0)
     if isinstance(expires_at, (int, float)) and expires_at < time.time():
         _warn_expired_once(server_url, expires_at, has_refresh="refresh_token" in entry)

--- a/tests/cli/test_cli_auth.py
+++ b/tests/cli/test_cli_auth.py
@@ -456,6 +456,37 @@ def test_load_token_returns_none_for_databricks_record(token_dir) -> None:
     assert load_token("https://myapp-123.aws.databricksapps.com") is None
 
 
+def test_databricks_record_is_not_reported_as_an_expired_session(
+    token_dir,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Declining a tokenless pointer record must not warn about expiry.
+
+    The record holds no ``expires_at``, so an epoch-0 default made every
+    command claim the session "expired on 1970-01-01" and tell the user to
+    re-run ``omnigent login`` — pointing at auth while the real fault lay
+    elsewhere. Databricks auth is minted from the CLI OAuth cache instead,
+    so there is nothing to re-authenticate.
+    """
+    import logging
+
+    from omnigent import cli_auth
+    from omnigent.cli_auth import load_token, store_databricks_auth
+
+    store_databricks_auth(
+        server_url="https://myapp-123.aws.databricksapps.com",
+        workspace_host="https://example.databricks.com",
+    )
+    # The warning fires at most once per process per server.
+    cli_auth._warned_expired_servers.clear()
+
+    with caplog.at_level(logging.DEBUG, logger="omnigent.cli_auth"):
+        assert load_token("https://myapp-123.aws.databricksapps.com") is None
+
+    assert "expired" not in caplog.text.lower()
+    assert "1970" not in caplog.text
+
+
 def test_load_databricks_host_returns_none_for_jwt_record(token_dir) -> None:
     """A session-JWT record is not a Databricks pointer record.
 


### PR DESCRIPTION
## Related issue

No tracked issue — found while investigating why a failed remote launch pointed
operators at the wrong cause. Split out of a larger PR as an unrelated bug.

## Summary

`load_token` defaulted a missing `expires_at` to `0` and checked expiry **before**
checking for a token. A Databricks Apps pointer record deliberately stores
neither — as this module's own docstring says, it "deliberately store[s] NO
token", because Databricks OAuth tokens last ~1 hour and are minted on demand
from the CLI's OAuth cache.

So every command that consulted a Databricks-fronted server logged:

> `Stored login session for … expired on 1970-01-01 00:00:00 UTC and holds no refresh material. Run 'omnigent login …' to re-authenticate.`

Nothing was wrong with the credential, and re-running `omnigent login` fixes
nothing. The warning exists precisely so "an operator's first actionable signal
must name the cause and the remedy" — here it named the wrong one, on every
launch, for everyone using Databricks auth.

The fix returns quietly for a tokenless record: a record with no token is not a
session that can lapse. `stored_token_status` and `_refresh_locked` already
guarded on the token first; only `load_token` did not.

## Test Plan

- The new test was confirmed to **fail** on the pre-fix code, with the
  `expired on 1970-01-01 …` warning captured in the log, and to pass after.
- Verified against a real `~/.omnigent/auth_tokens.json` holding a Databricks
  pointer record (keys: `auth_type`, `org_id`, `user_id`, `workspace_host` — no
  token, no expiry): the warning is gone and the return value is unchanged
  (`None`, status `absent`).
- `pytest tests/cli/test_cli_auth.py` → 32 passed. `pre-commit` clean.

To see it yourself: run any `omnigent` command against a Databricks Apps server
with `--log-level DEBUG`; before this change every invocation carries the 1970
expiry warning, after it none do. A genuinely expired JWT session still warns.

## Demo

N/A — the change is the absence of a misleading log line.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

One new test asserting a pointer record is declined without any expiry
narration, verified to fail before the fix. An existing test already covered the
return value (`load_token` must miss on a Databricks record), which is why the
bug survived — it was only ever the *warning* that was wrong. Manual
verification used the real token file on a machine authenticated to a Databricks
workspace, which the unit tests cannot reproduce.

## Changelog

Commands against a Databricks-hosted server no longer claim your login expired
in 1970 and tell you to re-authenticate when nothing is wrong.
This pull request and its description were written by Isaac.
