### PR TITLE
perf(web): load the OpenTelemetry SDK on demand

### DIFF
--- a/web/src/lib/telemetry.test.ts
+++ b/web/src/lib/telemetry.test.ts
@@ -59,10 +59,10 @@ describe("initBrowserTelemetry", () => {
     vi.stubEnv("VITE_OTEL_EXPORTER_OTLP_ENDPOINT", "");
     const { initBrowserTelemetry } = await import("./telemetry");
 
-    initBrowserTelemetry();
+    await initBrowserTelemetry();
 
-    // With no collector, nothing is registered — production builds without
-    // a backend pay zero overhead and never patch fetch.
+    // With no collector, nothing is registered and the SDK chunk is never
+    // fetched — builds without a backend never patch fetch.
     expect(m.WebTracerProvider).not.toHaveBeenCalled();
     expect(m.registerInstrumentations).not.toHaveBeenCalled();
   });
@@ -71,7 +71,7 @@ describe("initBrowserTelemetry", () => {
     vi.stubEnv("VITE_OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318");
     const { initBrowserTelemetry } = await import("./telemetry");
 
-    initBrowserTelemetry();
+    await initBrowserTelemetry();
 
     expect(m.WebTracerProvider).toHaveBeenCalledTimes(1);
     expect(m.register).toHaveBeenCalledTimes(1);
@@ -88,8 +88,8 @@ describe("initBrowserTelemetry", () => {
     vi.stubEnv("VITE_OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318");
     const { initBrowserTelemetry } = await import("./telemetry");
 
-    initBrowserTelemetry();
-    initBrowserTelemetry();
+    await initBrowserTelemetry();
+    await initBrowserTelemetry();
 
     expect(m.WebTracerProvider).toHaveBeenCalledTimes(1);
   });
@@ -98,7 +98,7 @@ describe("initBrowserTelemetry", () => {
     vi.stubEnv("VITE_OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318/");
     const { initBrowserTelemetry } = await import("./telemetry");
 
-    initBrowserTelemetry();
+    await initBrowserTelemetry();
 
     expect(m.OTLPTraceExporter).toHaveBeenCalledWith({
       url: "http://localhost:4318/v1/traces",

--- a/web/src/lib/telemetry.ts
+++ b/web/src/lib/telemetry.ts
@@ -9,28 +9,22 @@
 // Opt-in by configuration, mirroring the server: tracing only activates when
 // `VITE_OTEL_EXPORTER_OTLP_ENDPOINT` is set (the base URL of an OTLP/HTTP
 // collector, e.g. `http://localhost:4318`). With no endpoint configured this
-// is a no-op — no provider, no patched fetch, zero overhead — so production
-// builds without a collector are unaffected.
-
-import { ZoneContextManager } from "@opentelemetry/context-zone";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
-import { registerInstrumentations } from "@opentelemetry/instrumentation";
-import { FetchInstrumentation } from "@opentelemetry/instrumentation-fetch";
-import { XMLHttpRequestInstrumentation } from "@opentelemetry/instrumentation-xml-http-request";
-import { resourceFromAttributes } from "@opentelemetry/resources";
-import { BatchSpanProcessor, WebTracerProvider } from "@opentelemetry/sdk-trace-web";
-import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+// is a no-op — and because the SDK sits behind a dynamic import in
+// `telemetryProvider.ts`, an unconfigured build never even downloads it.
 
 let initialized = false;
 
 /**
  * Initialize browser tracing if a collector endpoint is configured.
  *
- * Idempotent and safe to call once at app startup (before any request is
- * made, so fetch/XHR are patched in time). No-op when
- * `VITE_OTEL_EXPORTER_OTLP_ENDPOINT` is unset.
+ * Idempotent and safe to call once at app startup. No-op when
+ * `VITE_OTEL_EXPORTER_OTLP_ENDPOINT` is unset — the endpoint check is
+ * synchronous, so an unconfigured build resolves without loading the SDK.
+ *
+ * @returns Resolves once fetch/XHR are patched. Await it before the first
+ *   request so that request is traced too.
  */
-export function initBrowserTelemetry(): void {
+export async function initBrowserTelemetry(): Promise<void> {
   if (initialized) return;
 
   const endpoint = import.meta.env.VITE_OTEL_EXPORTER_OTLP_ENDPOINT?.trim();
@@ -39,42 +33,6 @@ export function initBrowserTelemetry(): void {
 
   const serviceName = import.meta.env.VITE_OTEL_SERVICE_NAME?.trim() || "omni-web";
 
-  const exporter = new OTLPTraceExporter({
-    // OTLP/HTTP traces are posted to the collector's `/v1/traces` path.
-    url: `${endpoint.replace(/\/$/, "")}/v1/traces`,
-  });
-
-  const provider = new WebTracerProvider({
-    resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: serviceName }),
-    spanProcessors: [new BatchSpanProcessor(exporter)],
-  });
-
-  // ZoneContextManager keeps the active span across async boundaries
-  // (promises, timers) so child spans nest correctly in the browser.
-  provider.register({ contextManager: new ZoneContextManager() });
-
-  // Propagate `traceparent` to same-origin API calls (the default) and,
-  // explicitly, to this app's own origin — scoped so the header is never
-  // attached to unrelated third-party requests (analytics, CDNs).
-  const propagateTraceHeaderCorsUrls = [new RegExp(`^${escapeRegExp(window.location.origin)}`)];
-
-  registerInstrumentations({
-    instrumentations: [
-      new FetchInstrumentation({
-        propagateTraceHeaderCorsUrls,
-        clearTimingResources: true,
-      }),
-      new XMLHttpRequestInstrumentation({ propagateTraceHeaderCorsUrls }),
-    ],
-  });
-}
-
-/**
- * Escape a string for safe use inside a RegExp.
- *
- * @param value Raw string, e.g. an origin like `https://app.example.com`.
- * @returns The string with regex metacharacters escaped.
- */
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const { startTracing } = await import("./telemetryProvider");
+  startTracing(endpoint, serviceName);
 }

--- a/web/src/lib/telemetryProvider.ts
+++ b/web/src/lib/telemetryProvider.ts
@@ -1,0 +1,67 @@
+// The OpenTelemetry provider wiring, split out of `telemetry.ts` so the SDK
+// stays behind a dynamic `import()`.
+//
+// Every `@opentelemetry/*` package lands in this module's chunk — including
+// `@opentelemetry/context-zone`, which pulls in zone.js. zone.js monkeypatches
+// the global async primitives (promises, timers, event listeners) the moment it
+// is evaluated, so importing it eagerly costs both bundle bytes and startup
+// work on every load, tracing configured or not. Loading it here means a build
+// with no collector endpoint never fetches or evaluates any of it.
+
+import { ZoneContextManager } from "@opentelemetry/context-zone";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { registerInstrumentations } from "@opentelemetry/instrumentation";
+import { FetchInstrumentation } from "@opentelemetry/instrumentation-fetch";
+import { XMLHttpRequestInstrumentation } from "@opentelemetry/instrumentation-xml-http-request";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { BatchSpanProcessor, WebTracerProvider } from "@opentelemetry/sdk-trace-web";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+
+/**
+ * Register a web tracer provider and patch fetch/XHR to propagate
+ * `traceparent`.
+ *
+ * @param endpoint Base URL of an OTLP/HTTP collector, e.g.
+ *   `http://localhost:4318`. Any trailing slash is stripped.
+ * @param serviceName `service.name` resource attribute for exported spans.
+ */
+export function startTracing(endpoint: string, serviceName: string): void {
+  const exporter = new OTLPTraceExporter({
+    // OTLP/HTTP traces are posted to the collector's `/v1/traces` path.
+    url: `${endpoint.replace(/\/$/, "")}/v1/traces`,
+  });
+
+  const provider = new WebTracerProvider({
+    resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: serviceName }),
+    spanProcessors: [new BatchSpanProcessor(exporter)],
+  });
+
+  // ZoneContextManager keeps the active span across async boundaries
+  // (promises, timers) so child spans nest correctly in the browser.
+  provider.register({ contextManager: new ZoneContextManager() });
+
+  // Propagate `traceparent` to same-origin API calls (the default) and,
+  // explicitly, to this app's own origin — scoped so the header is never
+  // attached to unrelated third-party requests (analytics, CDNs).
+  const propagateTraceHeaderCorsUrls = [new RegExp(`^${escapeRegExp(window.location.origin)}`)];
+
+  registerInstrumentations({
+    instrumentations: [
+      new FetchInstrumentation({
+        propagateTraceHeaderCorsUrls,
+        clearTimingResources: true,
+      }),
+      new XMLHttpRequestInstrumentation({ propagateTraceHeaderCorsUrls }),
+    ],
+  });
+}
+
+/**
+ * Escape a string for safe use inside a RegExp.
+ *
+ * @param value Raw string, e.g. an origin like `https://app.example.com`.
+ * @returns The string with regex metacharacters escaped.
+ */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -28,10 +28,11 @@ import "katex/dist/katex.min.css";
 import "streamdown/styles.css";
 import "./index.css";
 
-// Start tracing before any request fires so fetch/XHR are patched in time
-// and a trace begins in the browser. No-op unless a collector endpoint is
-// configured (VITE_OTEL_EXPORTER_OTLP_ENDPOINT).
-initBrowserTelemetry();
+// Arm tracing before any request fires so fetch/XHR are patched in time and a
+// trace begins in the browser. No-op unless a collector endpoint is configured
+// (VITE_OTEL_EXPORTER_OTLP_ENDPOINT); the SDK loads on demand, so an
+// unconfigured build never downloads it.
+const telemetryReady = initBrowserTelemetry();
 
 // Single client at module scope — shared across the whole app.
 //
@@ -52,8 +53,10 @@ initChatStore(queryClient);
 
 // Discover the current user identity from the server. Once resolved,
 // all subsequent fetch calls include X-Forwarded-Email so session
-// routes know who's making the request.
-void resolveIdentity();
+// routes know who's making the request. Chained off `telemetryReady` so the
+// probe is traced when tracing is on; `resolveIdentity` memoizes its promise,
+// so this is only a warm-up kick — later callers await the same request.
+void telemetryReady.then(resolveIdentity);
 
 // Mirror the iOS shell's native bar footprints into the inset CSS variables.
 // No-op off the iOS shell (the inset vars stay at their env()-only defaults).


### PR DESCRIPTION
## Related issue

Closes #

## Summary

`src/lib/telemetry.ts` statically imported eight `@opentelemetry/*` packages, so
the whole tracing SDK shipped inside the eagerly-loaded entry chunk of every
build. That included `@opentelemetry/context-zone`, which pulls in **zone.js** —
and zone.js monkeypatches the global async primitives (promises, timers, event
listeners) the moment it is evaluated, so the cost was not just bytes but
startup work on every single page load.

Tracing is opt-in on `VITE_OTEL_EXPORTER_OTLP_ENDPOINT`, which is unset in
ordinary production builds, so that work was pure waste there. The module's own
comment claimed builds without a collector were *"no provider, no patched
fetch, zero overhead […] production builds without a collector are
unaffected"* — true at runtime, never true for the bundle.

- Move the provider wiring into a new `src/lib/telemetryProvider.ts` and reach
  it through a dynamic `import()` behind the existing endpoint check. The check
  stays synchronous, so an unconfigured build never fetches or evaluates any of
  it — zone.js included.
- `initBrowserTelemetry()` now returns a promise. `main.tsx` chains the identity
  probe off it so that first request is still traced when tracing *is* on.
  `resolveIdentity` memoizes its promise, so the module-scope call is only a
  warm-up kick and later callers await the same request.

Measured on `vite build`, entry chunk `assets/index-*.js`:

| | minified | gzip |
|---|---|---|
| before | 3,833.26 kB | 971.59 kB |
| after | 3,798.11 kB | 959.85 kB |
| **delta** | **−35.15 kB** | **−11.74 kB** |

The bytes are the smaller half of the win; not evaluating zone.js at boot is
the point. Confirmed via source-map analysis that `zone.js` and every
`@opentelemetry/*` module are gone from the entry chunk.

## Test Plan

- `npx vitest run src/lib/telemetry.test.ts` — 4/4 pass. The suite already
  mocked every OTel package; it now awaits the async entry point.
- `npx vite build` before/after on the same base commit for the numbers above.
- Source-map analysis of `assets/index-*.js.map` confirms `zone.js` no longer
  appears among the entry chunk's modules.
- Verified tracing still works end to end with an endpoint configured:
  `VITE_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 pnpm dev`, then
  confirmed requests carry a `traceparent` header and the SDK chunk is fetched
  on demand. With the variable unset, no OTel chunk is requested at all.

## Demo

N/A — no visual change; this is a startup/bundle change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing `telemetry.test.ts` covers both branches (endpoint set /
unset), idempotency, and URL normalisation; it was updated only for the async
signature. What automated tests can't assert is the bundle placement, so that
was verified manually: a before/after `vite build` for the byte delta, and
source-map inspection to confirm `zone.js` and `@opentelemetry/*` left the
entry chunk. Tracing-on behaviour was checked by hand against a local
collector endpoint, since the suite mocks the SDK.

## Changelog

The web UI no longer downloads or evaluates the OpenTelemetry SDK when tracing is not configured, trimming startup work on every page load.
