### PR TITLE
perf(repl): reuse the attach snapshot instead of re-fetching the session

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -133,6 +133,9 @@ class _SessionSnapshot(Protocol):
     """
     Minimal snapshot shape returned by ``client.sessions``.
 
+    :param id: Session/conversation id the snapshot describes, e.g.
+        ``"conv_abc123"``. Lets a caller that already holds a snapshot
+        prove it names the session in hand before reusing it.
     :param agent_id: Durable agent id, e.g. ``"ag_abc123"``.
     :param agent_name: Human-readable name of the bound agent,
         e.g. ``"polly"``. Changes when the session is switched
@@ -152,6 +155,9 @@ class _SessionSnapshot(Protocol):
         or ``None`` when no task has completed yet. Used to seed the
         context-ring on resume without waiting for the first response.
     """
+
+    @property
+    def id(self) -> str: ...
 
     @property
     def agent_id(self) -> str: ...
@@ -1665,7 +1671,7 @@ class _SessionsChatReplAdapter:
         self._context_window = session.context_window
         self._last_total_tokens = session.last_total_tokens
 
-    async def _ensure_session(self) -> str:
+    async def _ensure_session(self, *, snapshot: _SessionSnapshot | None = None) -> str:
         """
         Lazily create the session and start the persistent stream.
 
@@ -1677,6 +1683,11 @@ class _SessionsChatReplAdapter:
         Set ``OMNIGENT_SESSIONS_ADAPTER_DEBUG=1`` to trace
         construction + per-event flow on stderr.
 
+        :param snapshot: An already-fetched snapshot of this adapter's
+            session, e.g. the one the resume path just read. Reused in
+            place of ``GET /v1/sessions/{id}`` when it names the same
+            session, which saves a full round trip on every startup
+            attach; ignored otherwise.
         :returns: The durable session id, e.g. ``"conv_abc123"``.
         """
         _dbg = bool(os.environ.get("OMNIGENT_SESSIONS_ADAPTER_DEBUG"))
@@ -1698,7 +1709,10 @@ class _SessionsChatReplAdapter:
                         file=sys.stderr,
                         flush=True,
                     )
-                session = await self._client.sessions.get(self._session_id)
+                if snapshot is not None and snapshot.id == self._session_id:
+                    session = snapshot
+                else:
+                    session = await self._client.sessions.get(self._session_id)
                 self._hydrate_from_session_snapshot(session)
             await self._bind_runner_if_needed()
             if self._stream_task is None:
@@ -5536,16 +5550,20 @@ async def _attach_to_conversation(
     # Fail loud on a bad session id: _list_all_conversation_items
     # silently falls back to the legacy items endpoint (which returns
     # [] for missing conversations), hiding the 404 until first send.
+    snapshot: _SessionSnapshot | None = None
     if hasattr(session, "session_id"):
-        await client.sessions.get(conversation_id)
+        snapshot = await client.sessions.get(conversation_id)
 
     # Eagerly bind THIS REPL's runner and start the SSE pump so
     # turns posted from the web UI / another client stream into the
     # local REPL right away — without this, they only surface after
     # the local user sends a message and triggers the lazy bind.
     # Idempotent: a later ``send()`` short-circuits in ``_ensure_session``.
+    # The probe above already holds the snapshot the adapter would
+    # otherwise re-fetch, so hand it over instead of paying a second
+    # round trip for the same document.
     if isinstance(session, _SessionsChatReplAdapter):
-        await session._ensure_session()
+        await session._ensure_session(snapshot=snapshot)
 
     items = await _list_all_conversation_items(client, conversation_id)
 

--- a/tests/repl/test_attach_snapshot_reuse.py
+++ b/tests/repl/test_attach_snapshot_reuse.py
@@ -1,0 +1,116 @@
+"""Pin the single session fetch on the REPL's startup attach.
+
+``_attach_to_conversation`` reads the session once to fail loud on a bad
+id, then hands the adapter the same snapshot. Before that handoff the
+adapter re-read ``GET /v1/sessions/{id}`` immediately afterwards, so every
+``omnigent run`` — fresh or resumed — paid two round trips for one
+unchanged document. On a hosted server that is ~150-250ms of dead time in
+the last stretch before the REPL paints.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omnigent.repl._repl import _SessionsChatReplAdapter
+
+pytestmark = pytest.mark.asyncio
+
+
+@dataclass
+class _StubSession:
+    """Minimal Session-shaped dataclass for snapshot returns."""
+
+    id: str
+    agent_id: str = "ag_x"
+    runner_id: str | None = None
+    reasoning_effort: str | None = None
+    model_override: str | None = None
+    agent_name: str | None = None
+    llm_model: str | None = None
+    context_window: int | None = None
+    last_total_tokens: int | None = None
+    harness: str | None = None
+
+
+def _build_adapter(session_id: str, snapshot: _StubSession) -> _SessionsChatReplAdapter:
+    """
+    Build an attach-mode adapter whose ``sessions.get`` is observable.
+
+    :param session_id: Existing session the adapter attaches to, e.g.
+        ``"conv_abc123"``.
+    :param snapshot: Session the mocked ``sessions.get`` returns.
+    :returns: An adapter with bind/stream/recovery stubbed out so
+        ``_ensure_session`` runs without HTTP or asyncio plumbing.
+    """
+    client = MagicMock()
+    client.sessions.get = AsyncMock(return_value=snapshot)
+    adapter = _SessionsChatReplAdapter(client=client, agent_name="t", session_id=session_id)
+    adapter._bind_runner_if_needed = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    adapter._recover_runner_if_needed = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    adapter._stream_pump = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    return adapter
+
+
+async def test_matching_snapshot_skips_the_refetch() -> None:
+    """A handed-in snapshot for this session replaces the GET."""
+    snap = _StubSession(id="conv_a", runner_id="runner_1", harness="claude-sdk")
+    adapter = _build_adapter("conv_a", snap)
+
+    assert await adapter._ensure_session(snapshot=snap) == "conv_a"
+
+    adapter._client.sessions.get.assert_not_awaited()  # type: ignore[attr-defined]
+    # The snapshot still hydrates the adapter — skipping the fetch must
+    # not skip the state it carried.
+    assert adapter._bound_runner_id == "runner_1"
+    assert adapter._harness == "claude-sdk"
+
+
+async def test_snapshot_for_another_session_is_ignored() -> None:
+    """A mismatched snapshot must not be trusted for this session."""
+    other = _StubSession(id="conv_other", runner_id="runner_other")
+    mine = _StubSession(id="conv_a", runner_id="runner_mine")
+    adapter = _build_adapter("conv_a", mine)
+
+    await adapter._ensure_session(snapshot=other)
+
+    adapter._client.sessions.get.assert_awaited_once_with("conv_a")  # type: ignore[attr-defined]
+    assert adapter._bound_runner_id == "runner_mine"
+
+
+async def test_no_snapshot_still_fetches() -> None:
+    """Callers that hold no snapshot keep the original fetch."""
+    mine = _StubSession(id="conv_a", runner_id="runner_mine")
+    adapter = _build_adapter("conv_a", mine)
+
+    await adapter._ensure_session()
+
+    adapter._client.sessions.get.assert_awaited_once_with("conv_a")  # type: ignore[attr-defined]
+
+
+async def test_attach_reads_the_session_exactly_once() -> None:
+    """The startup attach makes one ``GET /v1/sessions/{id}``, not two."""
+    from omnigent.repl import _repl
+
+    snap = _StubSession(id="conv_a", runner_id="runner_1")
+    adapter = _build_adapter("conv_a", snap)
+    # Empty conversation: attach returns right after the items fetch, so
+    # the rendering path needs no stubbing.
+    adapter._client.sessions.list_items = AsyncMock(  # type: ignore[attr-defined]
+        return_value=MagicMock(data=[], has_more=False)
+    )
+
+    await _repl._attach_to_conversation(
+        "conv_a",
+        adapter,
+        adapter._client,
+        MagicMock(),
+        MagicMock(),
+        ui_name="t",
+        redraw_screen=False,
+    )
+
+    assert adapter._client.sessions.get.await_count == 1  # type: ignore[attr-defined]


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Profiling `omnigent run` end-to-end (see Test Plan) showed the same session
document being read twice in a row on the way into the REPL, on both the fresh
and the resume path:

```
 4.685  GET /v1/sessions/{id}  200 220.7ms   [repl/_repl.py:_attach_to_conversation]
 4.831  GET /v1/sessions/{id}  200 144.8ms   [repl/_repl.py:_ensure_session]
```

`_attach_to_conversation` reads the session to fail loud on a bad id and throws
the body away; `_ensure_session` then reads the same document again, 150ms
later, to hydrate the adapter.

- Hand the probe's snapshot to `_ensure_session`, which skips its own
  `GET /v1/sessions/{id}` when the snapshot names the session it is attaching
  to.
- A snapshot for any other session is ignored, and callers that hold none keep
  the original fetch — so the fail-loud 404 still precedes
  `_list_all_conversation_items` on every path.
- `_SessionSnapshot` gains the `id` property that check reads.

## Test Plan

Traced every client HTTP request during startup by patching `httpx.Client.send`
/ `AsyncClient.send` via a `sitecustomize.py` on `PYTHONPATH`, then driving the
real CLI through a PTY (`pexpect`) to the `claude · ready` marker. Run against
both a local dev pod and a Databricks-hosted server.

Before, per start (fresh and resume alike), two reads of `/v1/sessions/{id}`
20ms apart locally, 150ms apart hosted. After, one.

New unit tests in `tests/repl/test_attach_snapshot_reuse.py`:

- a matching snapshot skips the fetch and still hydrates runner/harness state
- a snapshot for another session is ignored and the fetch stands
- no snapshot keeps the original fetch
- the startup attach reads the session exactly once (fails with 2 before this
  change — verified by reverting just the call-site line)

```
pytest tests/repl/ tests/cli/test_chat.py -q     # 202 passed
pre-commit run --files omnigent/repl/_repl.py tests/repl/test_attach_snapshot_reuse.py
```

## Demo

N/A — no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the request trace described above: drove the real
`omnigent run --harness claude` through a PTY against a local pod and a hosted
server, fresh and `--resume`, and confirmed the second
`GET /v1/sessions/{id}` disappears while the REPL still resumes and renders
history. Existing `tests/repl/` and `tests/cli/test_chat.py` cover the resume
and adapter paths this touches.

## Changelog

The terminal REPL no longer reads the session twice while attaching, cutting a
round trip off every session start.
