### PR TITLE
perf(web): build the chat's Intl formatters once, not per call

### DIFF
--- a/web/src/lib/dateFormat.test.ts
+++ b/web/src/lib/dateFormat.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { formatMonthDay, formatMonthDayYear, formatTime, isSameLocalDay } from "./dateFormat";
+
+// The cached formatters must stay output-identical to the per-call
+// `toLocale*String(undefined, opts)` they replaced — that equivalence is the
+// whole basis for caching them.
+describe("cached formatters match toLocale*String", () => {
+  const dates = [
+    new Date("2024-01-05T00:07:00"),
+    new Date("2024-07-04T13:45:00"),
+    new Date("2023-12-31T23:59:00"),
+  ];
+
+  it.each(dates)("formatTime(%s)", (date) => {
+    expect(formatTime(date)).toBe(
+      date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" }),
+    );
+  });
+
+  it.each(dates)("formatMonthDay(%s)", (date) => {
+    expect(formatMonthDay(date)).toBe(
+      date.toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+    );
+  });
+
+  it.each(dates)("formatMonthDayYear(%s)", (date) => {
+    expect(formatMonthDayYear(date)).toBe(
+      date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" }),
+    );
+  });
+});
+
+describe("isSameLocalDay", () => {
+  it("matches two instants on the same local day", () => {
+    expect(isSameLocalDay(new Date("2024-03-04T00:00:00"), new Date("2024-03-04T23:59:59"))).toBe(
+      true,
+    );
+  });
+
+  it("separates adjacent local days", () => {
+    expect(isSameLocalDay(new Date("2024-03-04T23:59:59"), new Date("2024-03-05T00:00:00"))).toBe(
+      false,
+    );
+  });
+
+  it("separates the same day-of-month in different months and years", () => {
+    expect(isSameLocalDay(new Date("2024-03-04T12:00:00"), new Date("2024-04-04T12:00:00"))).toBe(
+      false,
+    );
+    expect(isSameLocalDay(new Date("2023-03-04T12:00:00"), new Date("2024-03-04T12:00:00"))).toBe(
+      false,
+    );
+  });
+
+  it("agrees with the toDateString comparison it replaced", () => {
+    const a = new Date("2024-03-04T08:00:00");
+    const b = new Date("2024-03-04T20:00:00");
+    const c = new Date("2024-03-05T08:00:00");
+    expect(isSameLocalDay(a, b)).toBe(a.toDateString() === b.toDateString());
+    expect(isSameLocalDay(a, c)).toBe(a.toDateString() === c.toDateString());
+  });
+});

--- a/web/src/lib/dateFormat.ts
+++ b/web/src/lib/dateFormat.ts
@@ -1,0 +1,47 @@
+// Cached `Intl` formatters for the date/time labels the chat renders in bulk.
+//
+// `date.toLocaleTimeString(undefined, opts)` builds a fresh
+// `Intl.DateTimeFormat` on every call, and constructing one is roughly 30x the
+// cost of formatting with an existing instance (~46us vs ~1.5us). The message
+// list formats a timestamp per bubble and re-formats them all whenever the list
+// re-renders, so the constructor cost dominated the label.
+//
+// Caching at module scope is safe: a browser cannot change its locale without a
+// reload, and `undefined` locales resolves once to the same default either way.
+
+/** `9:41 AM` */
+const timeFormat = new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" });
+
+/** `Mar 4` */
+const monthDayFormat = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" });
+
+/** `Mar 4, 2024` */
+const monthDayYearFormat = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+/** Clock time, e.g. `9:41 AM`. */
+export function formatTime(date: Date): string {
+  return timeFormat.format(date);
+}
+
+/** Day within the current year, e.g. `Mar 4`. */
+export function formatMonthDay(date: Date): string {
+  return monthDayFormat.format(date);
+}
+
+/** Day in an earlier year, e.g. `Mar 4, 2024`. */
+export function formatMonthDayYear(date: Date): string {
+  return monthDayYearFormat.format(date);
+}
+
+/** True when both instants fall on the same local calendar day. */
+export function isSameLocalDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}

--- a/web/src/lib/formatCost.ts
+++ b/web/src/lib/formatCost.ts
@@ -6,13 +6,18 @@ export function formatSessionCostUsd(costUsd: number): string {
   return `$${costUsd.toFixed(2)}`;
 }
 
+// Built once, not per call: constructing an `Intl.NumberFormat` costs far more
+// than formatting with an existing one, and the usage tables format a count per
+// row.
+const compactTokenFormat = new Intl.NumberFormat(undefined, {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
 /**
  * Compact token-count formatter, e.g. ``842`` -> ``"842"``,
  * ``12_400`` -> ``"12.4K"``, ``1_530_000`` -> ``"1.5M"``.
  */
 export function formatTokenCount(tokens: number): string {
-  return new Intl.NumberFormat(undefined, {
-    notation: "compact",
-    maximumFractionDigits: 1,
-  }).format(tokens);
+  return compactTokenFormat.format(tokens);
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -68,6 +68,12 @@ import { Button } from "@/components/ui/button";
 import { BrandLogo } from "@/components/BrandLogo";
 import { useAppName } from "@/lib/branding";
 import { StreamBudgetBanner } from "@/components/StreamBudgetBanner";
+import {
+  formatMonthDay,
+  formatMonthDayYear,
+  formatTime,
+  isSameLocalDay,
+} from "@/lib/dateFormat";
 import { cn } from "@/lib/utils";
 import { QueuedMessagesStrip } from "@/pages/QueuedMessagesStrip";
 import { TranscriptScrollbar } from "@/pages/TranscriptScrollbar";
@@ -3584,19 +3590,10 @@ function formatBubbleTimestamp(epochSeconds: number | undefined): string | null 
   if (epochSeconds === undefined || epochSeconds === 0) return null;
   const d = new Date(epochSeconds * 1000);
   const now = new Date();
-  const time = d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
-  if (
-    d.getFullYear() === now.getFullYear() &&
-    d.getMonth() === now.getMonth() &&
-    d.getDate() === now.getDate()
-  ) {
-    return time;
-  }
-  const date = d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-  if (d.getFullYear() !== now.getFullYear()) {
-    return `${d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}, ${time}`;
-  }
-  return `${date}, ${time}`;
+  const time = formatTime(d);
+  if (isSameLocalDay(d, now)) return time;
+  if (d.getFullYear() !== now.getFullYear()) return `${formatMonthDayYear(d)}, ${time}`;
+  return `${formatMonthDay(d)}, ${time}`;
 }
 
 export const BubbleView = memo(

--- a/web/src/shell/CommentsPanel.tsx
+++ b/web/src/shell/CommentsPanel.tsx
@@ -3,6 +3,7 @@ import { CheckIcon, Link2Icon, WandSparklesIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useResizableCommentsPanel } from "@/hooks/useResizableCommentsPanel";
+import { formatMonthDay, formatTime, isSameLocalDay } from "@/lib/dateFormat";
 import { getCurrentAuthorId } from "@/lib/identity";
 import { cn } from "@/lib/utils";
 import type { Comment } from "@/hooks/useComments";
@@ -18,12 +19,12 @@ function avatarStyle(name: string): { backgroundColor: string; color: string } {
 function formatCommentTime(createdAt: number): string {
   const date = new Date(createdAt * 1000);
   const now = new Date();
-  const time = date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
-  if (date.toDateString() === now.toDateString()) return `${time} Today`;
+  const time = formatTime(date);
+  if (isSameLocalDay(date, now)) return `${time} Today`;
   const yesterday = new Date(now);
   yesterday.setDate(now.getDate() - 1);
-  if (date.toDateString() === yesterday.toDateString()) return `${time} Yesterday`;
-  return `${date.toLocaleDateString(undefined, { month: "short", day: "numeric" })} ${time}`;
+  if (isSameLocalDay(date, yesterday)) return `${time} Yesterday`;
+  return `${formatMonthDay(date)} ${time}`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

Closes #

## Summary

`date.toLocaleTimeString(undefined, opts)` builds a **fresh
`Intl.DateTimeFormat` on every call** — one of the more expensive things you can
do in a render path. Measured on this Node build: ~46us per call versus ~1.5us
to format with an already-constructed instance, a ~30x difference.

`formatBubbleTimestamp` (`ChatPage.tsx`) ran up to three of those per message
bubble, and the message list re-formats every visible bubble whenever it
re-renders. A 50-bubble list therefore spent **~4.4 ms on timestamps alone**,
per render.

- New `src/lib/dateFormat.ts` holds the three formatter shapes the chat uses,
  constructed once at module scope, plus the `isSameLocalDay` helper that
  replaces the inline `getFullYear()/getMonth()/getDate()` triple and
  `toDateString()` string comparison.
- `ChatPage.tsx` and `shell/CommentsPanel.tsx` both use it — the comments panel
  had the identical per-call construction.
- `formatTokenCount` (`lib/formatCost.ts`) gets the same treatment for
  `Intl.NumberFormat`, since the usage tables format a count per row.

Caching at module scope is safe: a browser cannot change its locale without a
reload, so `undefined` locales resolves to the same default every time.

Simulating a 50-bubble list re-render:

| | per render |
|---|---|
| before (construct per call) | 4.37 ms |
| after (cached) | 0.18 ms |

No visible change — the rendered strings are byte-identical.

## Test Plan

- New `src/lib/dateFormat.test.ts` (13 assertions) pins each cached formatter
  against the exact `toLocale*String(undefined, opts)` call it replaced across
  several dates, and pins `isSameLocalDay` against the `toDateString()`
  comparison it replaced — that equivalence is the whole basis for caching.
- `npx vitest run src/pages/ChatPage` — 489/489 pass across 89 suites.
- `npx vitest run src/shell/CommentsPanel src/components/usage src/pages/UsagePage src/components/AgentInfo` — 74/74 pass.
- `npx tsc -b` — no errors.
- Benchmarked the before/after loop above for the numbers, asserting identical
  output for every sample date first.

## Demo

N/A — output strings are unchanged; this is purely the cost of producing them.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new suite covers the risk that matters here — that a cached formatter
renders exactly what the per-call version did — and the existing ChatPage /
comments / usage suites cover the call sites.

## Changelog

Chat message timestamps are formatted from cached Intl formatters, cutting per-render work in long conversations.
