### PR TITLE
perf(chat): skip the native-wrapper probe for a session created this run

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -982,6 +982,7 @@ def _chat_with_server(
     progress: RunnerStartupProgress | None = None,
     attach_only: bool = False,
     attach_harness: str | None = None,
+    resume_created_this_run: bool = False,
 ) -> None:
     """
     Connect to a server URL and run a one-shot query or REPL.
@@ -999,6 +1000,11 @@ def _chat_with_server(
     :param resume_conversation_id: When set, the REPL opens
         attached to this existing conversation on the remote
         server instead of creating a fresh one.
+    :param resume_created_this_run: When ``True``,
+        *resume_conversation_id* names a session this same startup
+        just created, so it cannot be a terminal-native wrapper
+        session and the redirect probe below is skipped. ``False``
+        (the default) is a genuine resume of a pre-existing session.
     :param fork_session_id: When set, fork this session before
         entering the REPL. The REPL opens attached to the fork.
     :param agent_name: Optional already-selected agent name,
@@ -1061,11 +1067,19 @@ def _chat_with_server(
     # into the native wrapper carrying ``--server`` through. Without
     # this, the REPL renders an empty chat on top of a
     # session whose state lives in a tmux terminal it can't see.
-    if resume_conversation_id is not None and _redirect_native_resume_if_needed(
-        base_url=base_url,
-        conversation_id=resume_conversation_id,
-        auto_open_conversation=auto_open_conversation,
-        progress=progress,
+    # A session this startup just created is skipped: the wrapper label is
+    # written by the native launchers, never by the path that got here, so
+    # the probe can only ever answer "no wrapper" — at the cost of a full
+    # round trip in the last stretch before the REPL paints.
+    if (
+        resume_conversation_id is not None
+        and not resume_created_this_run
+        and _redirect_native_resume_if_needed(
+            base_url=base_url,
+            conversation_id=resume_conversation_id,
+            auto_open_conversation=auto_open_conversation,
+            progress=progress,
+        )
     ):
         return
 
@@ -1437,10 +1451,13 @@ class _DaemonChatSession:
         ``"conv_abc123"``.
     :param runner_id: The daemon-spawned runner bound to the session, e.g.
         ``"runner_abc123"``.
+    :param fresh: Whether this startup created the session just now, as
+        opposed to resuming or forking an existing one.
     """
 
     session_id: str
     runner_id: str
+    fresh: bool = False
 
 
 _DAEMON_CHAT_HOST_ONLINE_TIMEOUT_S = 30.0
@@ -1577,7 +1594,8 @@ async def _prepare_chat_session_via_daemon(
         "Launching your agent…") as the host and runner come online, so a
         slow cold start is not silent. ``None`` (the default) runs without
         any progress updates.
-    :returns: The prepared session id + bound runner id.
+    :returns: The prepared session id + bound runner id, and whether the
+        session was created by this call.
     :raises click.ClickException: If the server is unreachable, or session
         create/fork or runner launch fails.
     """
@@ -1663,7 +1681,7 @@ async def _prepare_chat_session_via_daemon(
         # --server URL, or a proxy refusing the tunnel. These three are
         # siblings under TransportError, so each has to be named.
         raise click.ClickException(_unreachable_server_message(base_url)) from exc
-    return _DaemonChatSession(session_id=session_id, runner_id=runner_id)
+    return _DaemonChatSession(session_id=session_id, runner_id=runner_id, fresh=fresh_session)
 
 
 def _chat_via_daemon(
@@ -1815,6 +1833,7 @@ def _chat_via_daemon(
                 skills=all_skills or None,
                 auto_open_conversation=auto_open_conversation,
                 progress=progress,
+                resume_created_this_run=prepared.fresh,
             )
     finally:
         _cleanup_materialized_override_bundle(spec_path)

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -1189,7 +1189,7 @@ def test_chat_via_daemon_hands_daemon_runner_to_chat_with_server(
 
     async def _fake_prepare(**kwargs: object) -> _DaemonChatSession:
         captured["prepare"] = kwargs
-        return _DaemonChatSession(session_id="conv_daemon", runner_id="runner_daemon")
+        return _DaemonChatSession(session_id="conv_daemon", runner_id="runner_daemon", fresh=True)
 
     def _fake_chat_with_server(
         server_url: str,
@@ -1200,6 +1200,7 @@ def test_chat_via_daemon_hands_daemon_runner_to_chat_with_server(
         resume_conversation_id: str | None = None,
         session_bundle: bytes | None = None,
         fork_session_id: str | None = None,
+        resume_created_this_run: bool = False,
         **kwargs: object,
     ) -> None:
         captured["chat"] = {
@@ -1209,6 +1210,7 @@ def test_chat_via_daemon_hands_daemon_runner_to_chat_with_server(
             "resume_conversation_id": resume_conversation_id,
             "session_bundle": session_bundle,
             "fork_session_id": fork_session_id,
+            "resume_created_this_run": resume_created_this_run,
         }
 
     monkeypatch.setattr(chat_module, "_bundle_agent", lambda _p: b"bundle-bytes")
@@ -1235,6 +1237,9 @@ def test_chat_via_daemon_hands_daemon_runner_to_chat_with_server(
     assert chat["resume_conversation_id"] == "conv_daemon"
     assert chat["runner_recover"] is None
     assert chat["fork_session_id"] is None
+    # A session the prep just created is flagged, so _chat_with_server skips
+    # the wrapper-label probe instead of re-reading the snapshot.
+    assert chat["resume_created_this_run"] is True
     # Bundle is still passed so the one-shot path takes its sessions branch.
     assert chat["session_bundle"] == b"bundle-bytes"
     # The prep was asked to create a fresh session (no resume/fork).
@@ -1337,6 +1342,8 @@ def test_prepare_chat_session_via_daemon_creates_fresh_and_launches(
     assert "fork" not in captured
     assert prepared.session_id == "conv_created"
     assert prepared.runner_id == "runner_daemon"
+    # ``fresh`` tells _chat_with_server it may skip the wrapper-label probe.
+    assert prepared.fresh is True
     # The runner is launched bound to the freshly-created session.
     assert captured["launch"] == {
         "host_id": "host_x",
@@ -1368,6 +1375,8 @@ def test_prepare_chat_session_via_daemon_resume_skips_create(
     assert "create" not in captured  # resume must not create a new session
     assert prepared.session_id == "conv_resume"
     assert prepared.runner_id == "runner_daemon"
+    # A pre-existing session may carry a wrapper label, so the probe stands.
+    assert prepared.fresh is False
     launch = captured["launch"]
     assert isinstance(launch, dict)
     assert launch["session_id"] == "conv_resume"

--- a/tests/cli/test_chat_fresh_session_wrapper_probe.py
+++ b/tests/cli/test_chat_fresh_session_wrapper_probe.py
@@ -1,0 +1,68 @@
+"""The native-wrapper redirect probe must not run on a brand-new session.
+
+``omnigent run`` creates the session, then hands it to ``_chat_with_server``
+as the resume target. That made the wrapper-label probe — a full
+``GET /v1/sessions/{id}`` whose only job is to spot a claude-native /
+codex-native session and re-dispatch — fire on every fresh start, where it
+can only ever answer "no wrapper". On a hosted server that read measured
+155-228ms, spent in the last stretch before the REPL paints.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent import chat as chat_module
+
+
+class _StopBeforeRepl(Exception):
+    """Raised from the stubbed agent picker to end the call under test."""
+
+
+@pytest.fixture(name="probe_calls")
+def _probe_calls(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """
+    Record wrapper-redirect probes and stop the flow just after the gate.
+
+    :param monkeypatch: pytest monkeypatch fixture.
+    :returns: List that collects each probed conversation id.
+    """
+    calls: list[str] = []
+
+    def _redirect(*, conversation_id: str, **_kw: object) -> bool:
+        """Record the probe without claiming the resume."""
+        calls.append(conversation_id)
+        return False
+
+    def _pick_agent(_base_url: str) -> str:
+        """Stop the call under test right after the gate."""
+        raise _StopBeforeRepl
+
+    monkeypatch.setattr(chat_module, "_redirect_native_resume_if_needed", _redirect)
+    monkeypatch.setattr(chat_module, "_pick_agent", _pick_agent)
+    return calls
+
+
+def test_session_created_this_run_skips_the_probe(probe_calls: list[str]) -> None:
+    """A session this startup created is never probed for a wrapper label."""
+    with pytest.raises(_StopBeforeRepl):
+        chat_module._chat_with_server(
+            "http://localhost:8000",
+            None,
+            resume_conversation_id="conv_fresh",
+            resume_created_this_run=True,
+        )
+
+    assert probe_calls == []
+
+
+def test_genuine_resume_still_probes(probe_calls: list[str]) -> None:
+    """A pre-existing session keeps the redirect probe."""
+    with pytest.raises(_StopBeforeRepl):
+        chat_module._chat_with_server(
+            "http://localhost:8000",
+            None,
+            resume_conversation_id="conv_old",
+        )
+
+    assert probe_calls == ["conv_old"]


### PR DESCRIPTION
## Related issue

Closes #

## Summary

`omnigent run` creates the session, then hands it to `_chat_with_server` as the
*resume* target. That made the wrapper-label redirect probe fire on every fresh
start:

```
 4.152  PATCH /v1/sessions/{id}   200 1702.3ms  [native_terminal.bind_session_runner]
 4.401  GET   /v1/sessions/{id}   200  227.5ms  [chat.py:_wrapper_label_for_conversation]
```

The probe's only job is to spot a claude-native / codex-native session and
re-dispatch to its TUI. On a session this same process created seconds earlier
the answer is knowable in advance: the `omnigent.wrapper` label is written by
the native launchers, never by the path that just got here.

- Carry a `fresh` flag out of `_prepare_chat_session_via_daemon` and skip the
  probe for a session this startup created.
- A genuine resume or fork still probes, so the claude/codex-native redirect is
  untouched.
- The probe runs on its own throwaway `httpx` client, so a hosted server also
  loses a TCP+TLS handshake — it lands in the last stretch before the REPL
  paints, where the spinner is already on its final label.

## Test Plan

Traced every client HTTP request during startup by patching `httpx.Client.send`
/ `AsyncClient.send` via a `sitecustomize.py` on `PYTHONPATH`, then driving the
real CLI through a PTY (`pexpect`) to the `claude · ready` marker.

Fresh start against a Databricks-hosted server: the
`_wrapper_label_for_conversation` read (228ms) and its TLS handshake are gone.
`--resume` against the same server: the probe still fires, as it must.

Tests:

- new `tests/cli/test_chat_fresh_session_wrapper_probe.py` — a session created
  this run is never probed; a pre-existing one still is
- `tests/cli/test_chat.py` extended: the prep reports `fresh` correctly for
  create vs resume, and `_chat_via_daemon` forwards it to `_chat_with_server`

```
pytest tests/cli/test_chat.py tests/cli/test_cli.py tests/cli/test_chat_fresh_session_wrapper_probe.py -q   # 427 passed
pre-commit run --files omnigent/chat.py tests/cli/test_chat.py tests/cli/test_chat_fresh_session_wrapper_probe.py
```

## Demo

N/A — no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the request trace described above, run four ways —
fresh and `--resume`, against a local dev pod and a Databricks-hosted server —
confirming the probe disappears only on the fresh path and that a `--resume`
into a claude-native session still redirects to the native TUI. The existing
`_redirect_native_resume_if_needed` tests in `tests/cli/test_chat.py` and
`tests/cli/test_cli.py` cover the redirect behaviour itself.

## Changelog

Starting a fresh session no longer re-reads it to check for a terminal-native
redirect that cannot apply, cutting a round trip and a TLS handshake off startup.
