### PR TITLE
perf(host): let the launch helper own the online wait, skipping a re-poll

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -1591,7 +1591,6 @@ async def _prepare_chat_session_via_daemon(
         launch_or_reuse_daemon_runner,
         open_daemon_client,
         wait_for_host_online,
-        wait_for_runner_online,
     )
     from omnigent.native_terminal import bind_session_runner
 
@@ -1642,20 +1641,21 @@ async def _prepare_chat_session_via_daemon(
             # Record the session's host so its turn/resource/stream traffic reaches
             # the replica holding the host's runner tunnel.
             set_session_host(session_id, host_id)
+            # ``wait_online_timeout_s`` folds in the online wait, so a resume
+            # into a live session does not re-ask the status endpoint what the
+            # reuse check just answered.
             runner_id = await launch_or_reuse_daemon_runner(
                 client,
                 host_id=host_id,
                 session_id=session_id,
                 workspace=workspace,
                 fresh=fresh_session,
-            )
-            await wait_for_runner_online(
-                client, runner_id, timeout_s=_DAEMON_CHAT_RUNNER_ONLINE_TIMEOUT_S
+                wait_online_timeout_s=_DAEMON_CHAT_RUNNER_ONLINE_TIMEOUT_S,
             )
             # launch_or_reuse_daemon_runner's atomic-bind / online-reuse paths
             # don't pass through replace_runner_id, so re-bind via PATCH to
             # clear the ``omnigent.stopped`` marker on resumed sessions. Must run
-            # AFTER wait_for_runner_online — a freshly launched runner isn't
+            # AFTER the runner is online — a freshly launched runner isn't
             # registered until then, and replace_runner_id 400s on an unregistered id.
             await bind_session_runner(client, session_id, runner_id)
     except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ProxyError) as exc:

--- a/omnigent/host/daemon_launch.py
+++ b/omnigent/host/daemon_launch.py
@@ -239,6 +239,7 @@ async def launch_or_reuse_daemon_runner(
     session_id: str,
     workspace: str,
     fresh: bool = False,
+    wait_online_timeout_s: float | None = None,
 ) -> str:
     """
     Ensure the session is bound to a daemon-spawned runner; return its id.
@@ -247,6 +248,12 @@ async def launch_or_reuse_daemon_runner(
     (resume into a live session). Otherwise clears any stale binding and
     asks the server to launch a fresh runner on the host via
     ``POST /v1/hosts/{host_id}/runners`` (which atomically binds it).
+
+    Pass *wait_online_timeout_s* to have the returned runner be online.
+    That folds in the wait every caller already runs next, and lets the
+    reuse path skip it: reuse already proved the tunnel is registered
+    moments earlier, from the same registry the wait polls, so the wait's
+    first request only asks the question again.
 
     :param client: HTTP client pointed at the Omnigent server.
     :param host_id: This machine's host id, e.g. ``"host_abc123"``.
@@ -258,8 +265,14 @@ async def launch_or_reuse_daemon_runner(
         Safe to set when the session was just created in this same startup
         sequence — a brand-new session can't have a runner bound yet, so
         the read would always return empty and only add latency (~2-3s).
-    :returns: The bound runner id, e.g. ``"runner_abc123"``.
-    :raises click.ClickException: If the launch request fails.
+    :param wait_online_timeout_s: Max seconds to wait for a freshly
+        launched runner's tunnel, e.g. ``60.0``. ``None`` (the default)
+        returns as soon as the launch is accepted and leaves the wait to
+        the caller — the historical contract.
+    :returns: The bound runner id, e.g. ``"runner_abc123"``. Online
+        already when *wait_online_timeout_s* was passed.
+    :raises click.ClickException: If the launch request fails, or if a
+        freshly launched runner does not come online in time.
     """
     if fresh:
         existing = None
@@ -268,6 +281,9 @@ async def launch_or_reuse_daemon_runner(
         existing = _json_body(snap).get("runner_id") if snap.status_code == 200 else None
     if isinstance(existing, str) and existing:
         if await runner_is_online(client, existing):
+            # Online per the tunnel registry as of a moment ago, which is
+            # exactly what wait_for_runner_online polls — so callers that
+            # asked us to guarantee online need no further request.
             return existing
         # Stale binding (offline runner): clear it so the launch
         # endpoint's atomic ``UPDATE ... WHERE runner_id IS NULL`` can
@@ -304,6 +320,10 @@ async def launch_or_reuse_daemon_runner(
     runner_id = resp.json().get("runner_id")
     if not isinstance(runner_id, str) or not runner_id:
         raise click.ClickException("Host launch response did not include a runner_id.")
+    if wait_online_timeout_s is not None:
+        # A just-launched runner is still booting ("launching"), so this one
+        # genuinely has to poll.
+        await wait_for_runner_online(client, runner_id, timeout_s=wait_online_timeout_s)
     return runner_id
 
 

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -15,6 +15,7 @@ from omnigent_client import QueryResult
 
 import omnigent.chat as chat_module
 from omnigent.chat import (
+    _DAEMON_CHAT_RUNNER_ONLINE_TIMEOUT_S,
     _SERVER_READY_BACKOFF_POLL_SECONDS,
     _SERVER_READY_FAST_POLL_WINDOW_SECONDS,
     _SERVER_READY_INITIAL_POLL_SECONDS,
@@ -1296,9 +1297,18 @@ def _patch_daemon_launch(monkeypatch: pytest.MonkeyPatch, captured: dict[str, ob
         return None
 
     async def _fake_launch(
-        client: object, *, host_id: str, session_id: str, workspace: str, fresh: bool = False
+        client: object,
+        *,
+        host_id: str,
+        session_id: str,
+        workspace: str,
+        fresh: bool = False,
+        wait_online_timeout_s: float | None = None,
     ) -> str:
         captured["launch"] = {"host_id": host_id, "session_id": session_id, "workspace": workspace}
+        # The chat path asks the helper to guarantee the runner is online
+        # rather than re-polling the status endpoint itself.
+        captured["launch_wait_online_timeout_s"] = wait_online_timeout_s
         return "runner_daemon"
 
     async def _no_runner_wait(client: object, runner_id: str, *, timeout_s: float) -> None:
@@ -1343,6 +1353,10 @@ def test_prepare_chat_session_via_daemon_creates_fresh_and_launches(
         "session_id": "conv_created",
         "workspace": "/tmp/proj",
     }
+    # The helper owns the online wait, so the chat path must pass its budget —
+    # otherwise the returned runner isn't guaranteed registered and the
+    # bind PATCH below would 400 on an unregistered runner id.
+    assert captured["launch_wait_online_timeout_s"] == _DAEMON_CHAT_RUNNER_ONLINE_TIMEOUT_S
 
 
 def test_prepare_chat_session_via_daemon_resume_skips_create(

--- a/tests/test_claude_native_daemon.py
+++ b/tests/test_claude_native_daemon.py
@@ -179,6 +179,145 @@ async def test_launch_or_reuse_daemon_runner_fresh_skips_session_get() -> None:
     assert gets == []
 
 
+async def test_wait_online_reuse_asks_status_once() -> None:
+    """
+    Guaranteeing online costs no extra request on the reuse path.
+
+    The reuse check and the online wait poll the same
+    ``GET /v1/runners/{id}/status``, milliseconds apart, so asking twice was
+    a wasted round trip on every resume into a live session.
+    """
+    status_probes: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Serve a live-runner snapshot and count status probes."""
+        path = request.url.path
+        if request.method == "GET" and path == "/v1/sessions/conv_a":
+            return httpx.Response(200, json={"runner_id": "runner_live"})
+        if request.method == "GET" and path == "/v1/runners/runner_live/status":
+            status_probes.append(path)
+            return httpx.Response(200, json={"runner_id": "runner_live", "online": True})
+        return httpx.Response(404, json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://e.com"
+    ) as client:
+        runner_id = await daemon_launch.launch_or_reuse_daemon_runner(
+            client,
+            host_id="host_1",
+            session_id="conv_a",
+            workspace="/w",
+            wait_online_timeout_s=60.0,
+        )
+
+    assert runner_id == "runner_live"
+    assert len(status_probes) == 1
+
+
+async def test_wait_online_launch_path_waits_for_the_tunnel() -> None:
+    """A freshly launched runner is polled until its tunnel registers."""
+    polls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Report the new runner offline once, then online."""
+        path = request.url.path
+        if request.method == "GET" and path == "/v1/sessions/conv_a":
+            return httpx.Response(200, json={})
+        if request.method == "POST" and path == "/v1/hosts/host_1/runners":
+            return httpx.Response(200, json={"runner_id": "runner_new", "status": "launching"})
+        if request.method == "GET" and path == "/v1/runners/runner_new/status":
+            polls["n"] += 1
+            return httpx.Response(200, json={"runner_id": "runner_new", "online": polls["n"] > 1})
+        return httpx.Response(404, json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://e.com"
+    ) as client:
+        runner_id = await daemon_launch.launch_or_reuse_daemon_runner(
+            client,
+            host_id="host_1",
+            session_id="conv_a",
+            workspace="/w",
+            wait_online_timeout_s=60.0,
+        )
+
+    assert runner_id == "runner_new"
+    assert polls["n"] >= 2  # returned only once the tunnel was up
+
+
+async def test_wait_online_relaunches_a_runner_the_registry_calls_dead() -> None:
+    """
+    A runner the status endpoint reports offline is relaunched, not reused.
+
+    ``GET /v1/sessions/{id}``'s ``runner_online`` is a superset of this:
+    it also reads ``True`` from a fresh ``runner_last_seen`` stamp for up to
+    ``RUNNER_LIVENESS_TTL_S`` after an ungraceful death (see
+    ``test_health_derives_runner_online_from_fresh_row_stamp``). Deciding
+    reuse from the snapshot would strand a resume on a dead runner until the
+    online wait timed out, so the reuse check stays on the registry.
+    """
+    events: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Snapshot claims the runner is live; the registry says otherwise."""
+        path = request.url.path
+        if request.method == "GET" and path == "/v1/sessions/conv_a":
+            # Exactly the post-crash divergence: a stale-but-fresh stamp.
+            return httpx.Response(200, json={"runner_id": "runner_dead", "runner_online": True})
+        if request.method == "GET" and path == "/v1/runners/runner_dead/status":
+            return httpx.Response(200, json={"runner_id": "runner_dead", "online": False})
+        if request.method == "PATCH" and path == "/v1/sessions/conv_a":
+            events.append("clear")
+            return httpx.Response(200, json={})
+        if request.method == "POST" and path == "/v1/hosts/host_1/runners":
+            events.append("launch")
+            return httpx.Response(200, json={"runner_id": "runner_fresh"})
+        if request.method == "GET" and path == "/v1/runners/runner_fresh/status":
+            return httpx.Response(200, json={"runner_id": "runner_fresh", "online": True})
+        return httpx.Response(404, json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://e.com"
+    ) as client:
+        runner_id = await daemon_launch.launch_or_reuse_daemon_runner(
+            client,
+            host_id="host_1",
+            session_id="conv_a",
+            workspace="/w",
+            wait_online_timeout_s=60.0,
+        )
+
+    assert runner_id == "runner_fresh"
+    assert events == ["clear", "launch"]
+
+
+async def test_default_still_returns_before_the_runner_is_online() -> None:
+    """Without the new argument the historical contract is unchanged."""
+    polls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Serve the launch and record any status poll."""
+        path = request.url.path
+        if request.method == "GET" and path == "/v1/sessions/conv_a":
+            return httpx.Response(200, json={})
+        if request.method == "POST" and path == "/v1/hosts/host_1/runners":
+            return httpx.Response(200, json={"runner_id": "runner_new"})
+        if request.method == "GET" and path.endswith("/status"):
+            polls.append(path)
+            return httpx.Response(200, json={"runner_id": "runner_new", "online": False})
+        return httpx.Response(404, json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://e.com"
+    ) as client:
+        runner_id = await daemon_launch.launch_or_reuse_daemon_runner(
+            client, host_id="host_1", session_id="conv_a", workspace="/w"
+        )
+
+    assert runner_id == "runner_new"
+    assert polls == []  # the caller still owns the wait
+
+
 async def test_create_claude_session_persists_terminal_launch_args() -> None:
     """
     The daemon-flow create persists pass-through args and omits the


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Every caller of `launch_or_reuse_daemon_runner` follows it with
`wait_for_runner_online`. On the **reuse** path that wait's first request asks
the question the reuse check just answered — both poll
`GET /v1/runners/{id}/status`, milliseconds apart:

```
 0.611  GET /v1/sessions/{id}        200 200.1ms  [launch_or_reuse_daemon_runner]
 0.689  GET /v1/runners/{id}/status  200  77.5ms  [runner_is_online]        ← reuse check
 0.761  GET /v1/runners/{id}/status  200  72.0ms  [wait_for_runner_online]  ← same answer
```

So every resume into a live session paid two round trips for one fact.

- Add an opt-in `wait_online_timeout_s`. When passed, the returned runner is
  online: the reuse path returns straight away (the tunnel registry already
  proved it up), and the launch path — where the runner genuinely is still
  booting — waits internally.
- Omitting the argument keeps the historical contract **exactly**, so the other
  twelve callers (every native harness) are untouched and can adopt it
  separately. A test pins that default.
- `chat.py` adopts it and drops its own `wait_for_runner_online` call.

### Deliberately not taken

The tempting version of this is to read liveness from the session snapshot's
`runner_online`, which the same function already fetched — one *fewer* request
still. That is **wrong**, and I nearly shipped it. `runner_online` is a
**superset** of the status endpoint:

```python
# server/app.py — _bulk_session_liveness._runner_up
if tunnel_registry.get(conn.runner_id) is not None:
    return True
# Another replica may hold the tunnel: fresh runner_last_seen stamp
return runner_seen_is_fresh(conn.runner_last_seen, now=liveness_now)
```

The second disjunct has no counterpart in `GET /v1/runners/{id}/status`, which
is registry-only. `tests/server/test_app.py::test_health_derives_runner_online_from_fresh_row_stamp`
pins exactly that: *"fresh reads online, past the TTL reads offline (the
self-correcting path for an ungraceful host/replica death)"*, with
`RUNNER_LIVENESS_TTL_S = 90`.

So for up to 90s after an ungraceful runner death the snapshot still says
`runner_online: true` while the registry says false. Deciding reuse from it
would return the dead runner, and the caller's online wait — polling the
registry-only endpoint — would time out after 60s instead of clearing the
binding and relaunching in ~2s. `test_wait_online_relaunches_a_runner_the_registry_calls_dead`
reproduces that divergence and fails against the snapshot-trusting version.

## Test Plan

Traced every client HTTP request during startup by patching `httpx.Client.send`
/ `AsyncClient.send` via a `sitecustomize.py` on `PYTHONPATH`, then driving the
real CLI through a PTY (`pexpect`) to the `claude · ready` marker.

`--resume` into a live session: 15 → 14 requests, with exactly one
`GET /v1/runners/{id}/status` (the reuse check) and no follow-up poll.

New tests in `tests/test_claude_native_daemon.py`:

- reuse + `wait_online_timeout_s` asks the status endpoint exactly once
- launch + `wait_online_timeout_s` polls until the tunnel registers
- a runner the **registry** calls dead is relaunched even when the snapshot
  claims `runner_online: true` (the regression guard above)
- omitting the argument still returns before the runner is online — the
  historical contract

```
pytest tests/host/ tests/test_claude_native_daemon.py tests/test_qwen_native.py tests/test_cursor_native.py -q
```

The three existing reuse-online / launch-when-unbound / clear-stale-binding
tests pass unchanged, which is the point: they exercise the default path.

One pre-existing failure,
`tests/host/test_frames.py::test_encode_injects_traceparent_under_active_span`,
also fails on a clean `main` in this environment (missing optional OTel extra).

## Demo

N/A — no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the request trace described above: `--resume` into a
live session against a local pod, confirming the second status poll is gone and
the runner is reused rather than respawned (no `POST /v1/hosts/{id}/runners` in
the trace), plus a fresh start confirming the launch path still waits for the
tunnel before the bind PATCH. The regression guard was validated by reverting to
the snapshot-trusting implementation and watching that one test fail.

## Changelog

Resuming a session no longer double-checks whether its runner is online,
cutting a round trip off every resume.
