### PR TITLE
perf(chat): skip the accounts first-run probe when already signed in

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -1467,8 +1467,9 @@ def _await_accounts_first_run_setup(
     loopback token, which we detect and return on.
 
     No-op when the server is not in accounts mode, when this CLI already holds
-    a token for *base_url*, or when an admin already exists (the server mints
-    our token at boot in that case).
+    a credential for *base_url* (a stored token or a Databricks login pointer),
+    or when an admin already exists (the server mints our token at boot in that
+    case).
 
     :param base_url: Resolved local Omnigent server URL, e.g.
         ``"http://127.0.0.1:6767"``.
@@ -1480,8 +1481,17 @@ def _await_accounts_first_run_setup(
     """
     from omnigent import cli_auth
 
-    # Already authenticated to this server — nothing to wait for.
-    if cli_auth.load_token(base_url) is not None:
+    # Already authenticated to this server — nothing to wait for. A stored
+    # Databricks pointer record counts: it is only written after a successful
+    # login against this server, which a fresh accounts server awaiting its
+    # first admin can never have granted. Without this arm every remote start
+    # paid a TCP+TLS handshake and a round trip for the /v1/info probe below,
+    # which answers 401 there anyway (it is deliberately unauthenticated, so a
+    # needs-setup server can answer it before anyone holds a credential).
+    if (
+        cli_auth.load_token(base_url) is not None
+        or cli_auth.load_databricks_workspace_host(base_url) is not None
+    ):
         return
     try:
         info = httpx.get(f"{base_url}/v1/info", timeout=5.0).json()

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -3164,6 +3164,7 @@ def test_await_accounts_setup_noop_when_token_present(
 ) -> None:
     """A CLI that already holds a token for the server does not probe/wait."""
     monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: "existing-token")
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_workspace_host", lambda _url: None)
 
     def _must_not_probe(*_a: object, **_k: object) -> object:
         raise AssertionError("must not call /v1/info when a token already exists")
@@ -3173,11 +3174,38 @@ def test_await_accounts_setup_noop_when_token_present(
     chat_module._await_accounts_first_run_setup("http://127.0.0.1:8000")
 
 
+def test_await_accounts_setup_noop_when_databricks_login_stored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stored Databricks login for the server skips the probe entirely.
+
+    The pointer record is written only after a successful login against
+    this server, which a fresh accounts server awaiting its first admin
+    cannot have granted. Probing anyway cost every remote start a TCP+TLS
+    handshake and a round trip for a request that answers 401 there.
+    """
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr(
+        "omnigent.cli_auth.load_databricks_workspace_host",
+        lambda _url: "https://example.cloud.databricks.com",
+    )
+
+    def _must_not_probe(*_a: object, **_k: object) -> object:
+        raise AssertionError("must not call /v1/info when a Databricks login is stored")
+
+    monkeypatch.setattr("omnigent.chat.httpx.get", _must_not_probe)
+
+    chat_module._await_accounts_first_run_setup(
+        "https://example.cloud.databricks.com/api/2.0/omnigent"
+    )
+
+
 def test_await_accounts_setup_noop_for_header_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When the server is not in accounts mode there is no admin to wait for."""
     monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_workspace_host", lambda _url: None)
     monkeypatch.setattr(
         "omnigent.chat.httpx.get",
         lambda _url, timeout=5.0: _info_response(
@@ -3211,6 +3239,7 @@ def test_await_accounts_setup_waits_then_continues(
         return None if calls["n"] <= 2 else "minted-token"
 
     monkeypatch.setattr("omnigent.cli_auth.load_token", _load)
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_workspace_host", lambda _url: None)
     monkeypatch.setattr(
         "omnigent.chat.httpx.get",
         lambda _url, timeout=5.0: _info_response({"accounts_enabled": True, "needs_setup": True}),
@@ -3227,6 +3256,7 @@ def test_await_accounts_setup_times_out(
 ) -> None:
     """If the admin is never created, the wait fails loud (no hang/traceback)."""
     monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_workspace_host", lambda _url: None)
     monkeypatch.setattr(
         "omnigent.chat.httpx.get",
         lambda _url, timeout=5.0: _info_response({"accounts_enabled": True, "needs_setup": True}),


### PR DESCRIPTION
## Related issue

Closes #

## Summary

The accounts first-run wait probes `GET /v1/info` **unauthenticated** — on
purpose, since a server awaiting its first admin has to answer before anyone
holds a credential. But it ran whenever no *bearer* was cached on disk, which
includes every Databricks-fronted server: those store a login pointer record
(`auth_type: databricks`, workspace host, org id) rather than a token. So on
every remote start the probe fired, answered 401, and the result was discarded:

```
-0.077  ---- TLS handshake #1
 0.000  GET /v1/me     200  86.0ms  [cli.py:_ensure_databricks_server_auth]
 0.081  ---- TLS handshake #2
 0.094  GET /v1/info   401  18.4ms  [chat.py:_await_accounts_first_run_setup]   ← always 401
```

It runs on its own throwaway client, so the cost is a TCP+TLS handshake plus a
round trip, before anything else begins.

- Treat a stored Databricks pointer record as "already signed in", the same as
  a stored token.
- The record is written only after a successful login against that server,
  which a fresh accounts server awaiting its first admin cannot have granted —
  so no genuine first-run wait is skipped.
- The unauthenticated probe itself is left alone; it is still the right shape
  for the case it exists for (a self-hosted accounts server with no admin yet,
  which answers 200 with `needs_setup: true`).

## Test Plan

Traced every client HTTP request during startup by patching `httpx.Client.send`
/ `AsyncClient.send` via a `sitecustomize.py` on `PYTHONPATH`, plus counting TLS
handshakes by wrapping `ssl.SSLContext.wrap_socket` / `wrap_bio`, then driving
the real CLI through a PTY (`pexpect`) to the `claude · ready` marker.

Against a Databricks-hosted server, `--resume`: **14 → 13 requests, 7 → 6 TLS
handshakes**, and the 401 is gone. Confirmed the probe's 401 first-hand:

```
$ curl -s -o /dev/null -w '%{http_code}\n' "$SERVER/v1/info"          # 401
$ curl -s -H "Authorization: Bearer $TOK" "$SERVER/v1/info" | jq .accounts_enabled   # false
```

Tests: new `test_await_accounts_setup_noop_when_databricks_login_stored` in
`tests/cli/test_chat.py`. The four existing `_await_accounts_first_run_setup`
tests now pin `load_databricks_workspace_host` explicitly so they cannot read
developer state.

```
pytest tests/cli/test_chat.py -q     # 126 passed
pre-commit run --files omnigent/chat.py tests/cli/test_chat.py
```

## Demo

N/A — no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the request trace described above against a
Databricks-hosted server, plus the two `curl` probes confirming `/v1/info`
answers 401 unauthenticated and `accounts_enabled: false` authenticated — so
the skipped request could never have changed the outcome. Local-mode starts are
unaffected (they store a token, already covered by the existing early return).
The four existing accounts-wait tests cover the header-mode, wait-then-continue,
and timeout branches.

## Changelog

Connecting to a Databricks-hosted server no longer makes a doomed
unauthenticated probe first, cutting a round trip and a TLS handshake off startup.
