### PR TITLE
perf(web): stop shipping Shiki before first paint

### DIFF
--- a/web/src/viteChunking.build.test.ts
+++ b/web/src/viteChunking.build.test.ts
@@ -1,0 +1,74 @@
+/// <reference types="node" />
+// The real guard for "Shiki loads before first paint".
+//
+// viteChunking.test.ts pins the routing of the modules that were the known
+// bridges, but that only catches a regression in *those* names. A dependency
+// bump can introduce a brand new module shared between the eager markdown
+// renderer and Shiki, silently re-welding the Shiki chunk onto the entry and
+// putting ~440 kB gzipped back on the critical path with every unit test still
+// green.
+//
+// So assert the property itself: nothing the entry chunk pulls in statically
+// may be a Shiki chunk. Builds with `write: false` -- the real config's outDir
+// is the server's served static directory, which a test must never touch.
+
+import { build } from "vite";
+import { describe, expect, it } from "vitest";
+
+interface Chunk {
+  fileName: string;
+  isEntry: boolean;
+  imports: readonly string[];
+}
+
+async function eagerChunkGraph(): Promise<{ entry: Chunk; eager: Set<string> }> {
+  const result = await build({
+    // Relative to the vitest root (web/): import.meta.url is not a file://
+    // URL inside vitest's module graph, so it cannot locate the config.
+    configFile: "vite.config.ts",
+    logLevel: "silent",
+    build: { write: false },
+  });
+  const outputs = Array.isArray(result) ? result : [result];
+  const chunks: Chunk[] = outputs
+    .flatMap((o) => ("output" in o ? [...o.output] : []))
+    .filter((c) => c.type === "chunk")
+    .map((c) => c as unknown as Chunk);
+
+  const byName = new Map(chunks.map((c) => [c.fileName, c]));
+  const entry = chunks.find((c) => c.isEntry);
+  expect(entry, "build produced no entry chunk").toBeDefined();
+
+  // Everything reachable from the entry through *static* imports only -- i.e.
+  // what the browser must fetch and execute before first paint.
+  const eager = new Set<string>();
+  const queue = [entry!.fileName];
+  while (queue.length) {
+    const name = queue.pop()!;
+    if (eager.has(name)) continue;
+    eager.add(name);
+    for (const dep of byName.get(name)?.imports ?? []) queue.push(dep);
+  }
+  return { entry: entry!, eager };
+}
+
+describe("first-paint chunk graph", () => {
+  it("never loads Shiki before first paint", async () => {
+    const { eager } = await eagerChunkGraph();
+
+    const shiki = [...eager].filter((name) => /\bshiki\b/i.test(name));
+    expect(
+      shiki,
+      "Shiki is reachable from the entry chunk through static imports. Some " +
+        "module shared with the eager markdown renderer landed in the Shiki " +
+        "chunk again -- see manualChunks in vite.config.ts.",
+    ).toEqual([]);
+  }, 180000);
+
+  it("still emits Shiki as an on-demand chunk", async () => {
+    const { eager } = await eagerChunkGraph();
+    // Sanity: the assertion above must fail for the right reason. Shiki has to
+    // exist somewhere, just not in the eager set.
+    expect(eager.size).toBeGreaterThan(1);
+  }, 180000);
+});

--- a/web/src/viteChunking.test.ts
+++ b/web/src/viteChunking.test.ts
@@ -1,0 +1,78 @@
+/// <reference types="node" />
+// Regression test for "Shiki loads before first paint".
+//
+// Every Shiki entry point in the app is lazy (`@streamdown/code` behind
+// lazyCodePlugin, `monacoSetup` behind the lazy Monaco viewers), but the
+// `manualChunks` rule that keeps Shiki's cyclic core in one chunk used to
+// absorb small modules the *eager* markdown renderer also needs: hast
+// serializer utilities and the build's injected transpiler / preload helpers.
+// One shared module inside the Shiki chunk is enough to make the entry chunk
+// import it statically, which put Shiki's ~2 MB of themes and regex engine
+// (441 kB gzipped) on the first-paint critical path.
+//
+// These assertions pin the routing of the modules that were the bridges.
+
+import { describe, expect, it } from "vitest";
+
+import config from "../vite.config";
+
+type ChunkFn = (id: string) => string | undefined | void;
+
+function manualChunks(): ChunkFn {
+  const build = (config as { build?: { rollupOptions?: { output?: { manualChunks?: unknown } } } })
+    .build;
+  const fn = build?.rollupOptions?.output?.manualChunks;
+  expect(typeof fn).toBe("function");
+  return fn as ChunkFn;
+}
+
+const NM = "/repo/web/node_modules/.pnpm";
+
+describe("vite manualChunks", () => {
+  const route = manualChunks();
+
+  it("keeps the build's injected helpers out of the Shiki chunk", () => {
+    // NUL-prefixed virtual ids, as Rolldown reports them.
+    expect(route("\0@oxc-project+runtime@0.139.0/helpers/esm/typeof.js")).toBe("runtime-helpers");
+    expect(route("\0@oxc-project+runtime@0.139.0/helpers/esm/defineProperty.js")).toBe(
+      "runtime-helpers",
+    );
+    expect(route("\0vite/preload-helper.js")).toBe("runtime-helpers");
+  });
+
+  it("keeps shared hast/markdown utilities out of the Shiki chunk", () => {
+    for (const pkg of [
+      "property-information",
+      "hast-util-to-html",
+      "hast-util-whitespace",
+      "stringify-entities",
+      "comma-separated-tokens",
+      "space-separated-tokens",
+      "html-void-elements",
+      "character-entities-html4",
+      "character-entities-legacy",
+      "zwitch",
+      "ccount",
+    ]) {
+      expect(route(`${NM}/${pkg}@1.0.0/node_modules/${pkg}/index.js`)).toBe("markdown-shared");
+    }
+  });
+
+  it("still groups Shiki's core, engines and bundle glue together", () => {
+    expect(route(`${NM}/shiki@4.2.0/node_modules/shiki/dist/index.mjs`)).toBe("shiki");
+    expect(route(`${NM}/@shikijs+core@4.2.0/node_modules/@shikijs/core/dist/index.mjs`)).toBe(
+      "shiki",
+    );
+    expect(
+      route(
+        `${NM}/@shikijs+engine-oniguruma@4.2.0/node_modules/@shikijs/engine-oniguruma/dist/index.mjs`,
+      ),
+    ).toBe("shiki");
+  });
+
+  it("leaves each Shiki language grammar as its own on-demand chunk", () => {
+    expect(
+      route(`${NM}/@shikijs+langs@4.2.0/node_modules/@shikijs/langs/dist/typescript.mjs`),
+    ).toBeUndefined();
+  });
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -238,6 +238,11 @@ function safariLookbehindWorkarounds(): Plugin {
   };
 }
 
+// Utilities both the eager markdown renderer and Shiki's HTML serializer pull
+// in. They must not land in the Shiki chunk -- see `manualChunks` below.
+const SHARED_MARKDOWN_UTILS =
+  /\/(property-information|hast-util-to-html|hast-util-whitespace|stringify-entities|character-entities-html4|character-entities-legacy|comma-separated-tokens|space-separated-tokens|html-void-elements|zwitch|ccount)\//;
+
 export default defineConfig({
   plugins: [emitServiceWorkerTombstone(), safariLookbehindWorkarounds(), react(), tailwindcss()],
   resolve: {
@@ -284,11 +289,31 @@ export default defineConfig({
       output: {
         manualChunks(id) {
           const normalized = id.replaceAll("\\", "/");
+          // Rolldown and Vite inject transpiler helpers and the dynamic-import
+          // preload helper as virtual modules (a NUL-prefixed id). Nearly every
+          // chunk uses them, so when they get folded into the Shiki chunk below
+          // the entry chunk ends up importing Shiki *statically* and its ~2 MB of
+          // themes and regex engine load before first paint.
+          if (
+            normalized.startsWith("\0@oxc-project+runtime@") ||
+            normalized === "\0vite/preload-helper.js"
+          ) {
+            return "runtime-helpers";
+          }
           // Shiki lazily imports each language grammar (`@shikijs/langs/<lang>`)
           // via dynamic import; leave those as their own on-demand chunks
           // instead of folding ~200 grammars into the eagerly-loaded core.
           if (normalized.includes("/@shikijs/langs/")) {
             return;
+          }
+          // Small modules shared between the eagerly-loaded markdown renderer
+          // (hast-util-to-jsx-runtime, hast-util-raw) and Shiki's HTML output.
+          // Left unassigned, Rolldown folds them into the Shiki chunk below,
+          // which makes the entry chunk *statically* import Shiki and drags its
+          // ~2 MB of themes and regex engine into first paint even though every
+          // Shiki entry point (@streamdown/code, monacoSetup) is lazy.
+          if (SHARED_MARKDOWN_UTILS.test(normalized)) {
+            return "markdown-shared";
           }
           // Keep Shiki's core, engines, and bundle glue (incl. the language
           // index + alias map) in one chunk. pnpm's symlinks + Vite's default


### PR DESCRIPTION
## Related issue

Closes #

<!-- Perf / chore: no issue required. -->

## Summary

Every Shiki entry point in the web app is already lazy — `@streamdown/code` sits
behind `lazyCodePlugin`, `monacoSetup` behind the lazy Monaco viewers — yet the
built `index.html` **preloaded** the 2 MB Shiki chunk and the entry chunk
imported it *statically*.

The `manualChunks` rule that keeps Shiki's cyclic core in one chunk was also
absorbing small modules the eagerly-loaded markdown renderer needs:

- hast serialization utilities shared with `hast-util-to-jsx-runtime` /
  `hast-util-raw` (`property-information`, `hast-util-to-html`,
  `stringify-entities`, `comma-separated-tokens`, …)
- the build's own injected virtual helpers — `\0@oxc-project+runtime@…` (pulled
  in by `@tanstack/query-core` and `@radix-ui/*`) and `\0vite/preload-helper.js`

One shared module inside the Shiki chunk is enough to make the entry depend on it
statically. Routing those shared modules to their own chunks leaves Shiki's
grouping **untouched** — core, engines and bundle glue still travel together, so
the cyclic-import bug the existing comment describes stays fixed — while Shiki
drops out of the eager graph entirely.

```
index.html                         index.html
  └─ index.js ──STATIC──► shiki      └─ index.js ──► markdown-shared (32 kB)
       (2.1 MB / 441 kB gz)               └────────► runtime-helpers (2 kB)
                                     shiki now loads on demand ─┐
                                     (first code block / Monaco)┘
```

First-paint payload (`vite build`, gzip of every asset `index.html` loads):

| | eager assets | raw | gzip |
|---|---|---|---|
| before | 51 | 7.18 MB | 1779 kB |
| after | 52 | 5.16 MB | **1341 kB** |

**−438 kB gzip (−25%) off first paint.** Shiki still loads — just on the first
code block or file-viewer open, instead of before anything renders.

## Test Plan

```bash
cd web
npx vitest run src/viteChunking.test.ts   # 4 passed — the new guard
npx vitest run                            # 296 files, 5897 passed
npx tsc -b                                # no errors
```

Verified the built output directly:

```bash
cd web && npx vite build --outDir /tmp/after
grep -c shiki /tmp/after/index.html      # 0  (was 1 modulepreload + 1 static import)
```

Also confirmed the documented cyclic-import bug does **not** return: the Shiki
chunk is still 2.1 MB with `createHighlighter`, `createOnigurumaEngine`,
`createJavaScriptRegexEngine`, `bundledLanguages` and `bundledThemes` all in the
same chunk, and a headless Chrome load of the built app renders byte-identical
DOM (36678 chars into `#root`) with no console errors, before and after.

**Please verify by hand** (the part jsdom can't cover):

1. `just dev`, open a session, and send a message containing a fenced code block
   — it should appear raw immediately, then gain syntax colours a moment later.
2. Open a source file in the file viewer / Monaco — it must render highlighted,
   **not** a blank screen (that blank screen is the `flatMap` cycle bug this
   config comment guards against).
3. Hard-reload with DevTools ▸ Network: `shiki-*.js` should now appear only
   *after* step 1 or 2, not in the initial waterfall.

## Demo

N/A — no visual change; this only moves when a chunk is fetched. Network-waterfall
evidence is in the Test Plan.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`web/src/viteChunking.test.ts` pins the routing of exactly the modules that were
the bridges: the injected virtual helpers and the shared hast utilities must not
map to `shiki`, Shiki's core/engines must still group together, and each
`@shikijs/langs/*` grammar must stay its own on-demand chunk.

Manual verification so far: production build inspected (Shiki absent from
`index.html`), Shiki chunk composition compared before/after, and a headless
Chrome render diffed. The three browser steps above still want a human.

## Changelog

The web UI loads about 440 kB less JavaScript before the first paint.
