### PR TITLE
perf(web): load Mermaid only when a diagram renders

### DIFF
--- a/web/src/components/ai-elements/lazyMermaidPlugin.test.ts
+++ b/web/src/components/ai-elements/lazyMermaidPlugin.test.ts
@@ -3,11 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Stand in for @streamdown/mermaid so the test can observe *when* the real
 // module is reached. Rendering a diagram for real needs SVG layout APIs
 // (getBBox) that jsdom does not implement.
+const calls: string[] = [];
 const getMermaid = vi.fn((config?: unknown) => ({
-  initialize: vi.fn(),
-  render: vi.fn(async (id: string) => ({
-    svg: `<svg data-id="${id}" data-config="${!!config}" />`,
-  })),
+  initialize: vi.fn(() => calls.push("initialize")),
+  render: vi.fn(async (id: string) => {
+    calls.push("render");
+    return { svg: `<svg data-id="${id}" data-config="${!!config}" />` };
+  }),
 }));
 
 vi.mock("@streamdown/mermaid", () => ({
@@ -22,6 +24,7 @@ describe("lazyMermaidPlugin", () => {
   beforeEach(() => {
     vi.resetModules();
     getMermaid.mockClear();
+    calls.length = 0;
   });
 
   it("exposes the diagram plugin contract synchronously", async () => {
@@ -52,5 +55,17 @@ describe("lazyMermaidPlugin", () => {
     await lazyMermaidPlugin.getMermaid(config).render("diagram-2", "graph TD;\n  C-->D;");
 
     expect(getMermaid).toHaveBeenCalledWith(config);
+  });
+
+  it("applies a config from initialize before rendering", async () => {
+    const { lazyMermaidPlugin } = await import("./lazyMermaidPlugin");
+
+    const instance = lazyMermaidPlugin.getMermaid();
+    instance.initialize({ theme: "forest" });
+    await instance.render("diagram-3", "graph TD;\n  E-->F;");
+
+    // initialize is synchronous on our wrapper, so it must not race the import:
+    // the engine has to see it before the first render.
+    expect(calls).toEqual(["initialize", "render"]);
   });
 });

--- a/web/src/components/ai-elements/lazyMermaidPlugin.test.ts
+++ b/web/src/components/ai-elements/lazyMermaidPlugin.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stand in for @streamdown/mermaid so the test can observe *when* the real
+// module is reached. Rendering a diagram for real needs SVG layout APIs
+// (getBBox) that jsdom does not implement.
+const getMermaid = vi.fn((config?: unknown) => ({
+  initialize: vi.fn(),
+  render: vi.fn(async (id: string) => ({
+    svg: `<svg data-id="${id}" data-config="${!!config}" />`,
+  })),
+}));
+
+vi.mock("@streamdown/mermaid", () => ({
+  mermaid: { name: "mermaid", type: "diagram", language: "mermaid", getMermaid },
+}));
+
+// Guards the shape Streamdown depends on, and that mermaid stays off the
+// module-load path. Streamdown reads `language` synchronously to match a
+// ```mermaid fence, then calls `getMermaid(config).render(...)` from an async
+// path -- so `render` may return a promise, which is what lets the import wait.
+describe("lazyMermaidPlugin", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    getMermaid.mockClear();
+  });
+
+  it("exposes the diagram plugin contract synchronously", async () => {
+    const { lazyMermaidPlugin } = await import("./lazyMermaidPlugin");
+
+    expect(lazyMermaidPlugin.name).toBe("mermaid");
+    expect(lazyMermaidPlugin.type).toBe("diagram");
+    expect(lazyMermaidPlugin.language).toBe("mermaid");
+    // Reading the contract must not reach the engine.
+    expect(getMermaid).not.toHaveBeenCalled();
+  });
+
+  it("does not touch the engine until a diagram renders", async () => {
+    const { lazyMermaidPlugin } = await import("./lazyMermaidPlugin");
+
+    const instance = lazyMermaidPlugin.getMermaid();
+    expect(getMermaid).not.toHaveBeenCalled();
+
+    const { svg } = await instance.render("diagram-1", "graph TD;\n  A-->B;");
+    expect(getMermaid).toHaveBeenCalledTimes(1);
+    expect(svg).toContain('data-id="diagram-1"');
+  });
+
+  it("forwards the config given to getMermaid", async () => {
+    const { lazyMermaidPlugin } = await import("./lazyMermaidPlugin");
+
+    const config = { theme: "dark" } as const;
+    await lazyMermaidPlugin.getMermaid(config).render("diagram-2", "graph TD;\n  C-->D;");
+
+    expect(getMermaid).toHaveBeenCalledWith(config);
+  });
+});

--- a/web/src/components/ai-elements/lazyMermaidPlugin.ts
+++ b/web/src/components/ai-elements/lazyMermaidPlugin.ts
@@ -27,16 +27,25 @@ export const lazyMermaidPlugin: DiagramPlugin = {
   name: "mermaid",
   type: "diagram",
   language: "mermaid",
-  getMermaid: (config?: MermaidConfig): MermaidInstance => ({
-    // Streamdown never calls initialize (it passes config to getMermaid and
-    // renders), but the contract allows it, so forward it once loaded.
-    initialize: (nextConfig: MermaidConfig) => {
-      // oxlint-disable-next-line eslint-plugin-promise(prefer-await-to-then)
-      void loadMermaid().then((plugin) => plugin.getMermaid(config).initialize(nextConfig));
-    },
-    render: async (id: string, source: string) => {
+  getMermaid: (config?: MermaidConfig): MermaidInstance => {
+    let pending: MermaidConfig | undefined;
+    const engine = async () => {
       const plugin = realMermaid ?? (await loadMermaid());
-      return plugin.getMermaid(config).render(id, source);
-    },
-  }),
+      const instance = plugin.getMermaid(config);
+      if (pending) {
+        instance.initialize(pending);
+        pending = undefined;
+      }
+      return instance;
+    };
+    return {
+      // Streamdown passes its config to getMermaid and never calls initialize,
+      // but the contract allows it. Hold the config rather than racing a
+      // floating import, so initialize-then-render keeps that order.
+      initialize: (nextConfig: MermaidConfig) => {
+        pending = nextConfig;
+      },
+      render: async (id: string, source: string) => (await engine()).render(id, source),
+    };
+  },
 };

--- a/web/src/components/ai-elements/lazyMermaidPlugin.ts
+++ b/web/src/components/ai-elements/lazyMermaidPlugin.ts
@@ -1,0 +1,42 @@
+import type { DiagramPlugin, MermaidConfig, MermaidInstance } from "@streamdown/mermaid";
+
+// Streamdown's `mermaid` plugin (@streamdown/mermaid) statically imports
+// mermaid, which drags cytoscape and the hand-drawn renderer into the eager
+// entry graph even when no message ever contains a diagram.
+//
+// This wrapper defers the @streamdown/mermaid import until a diagram actually
+// renders, mirroring `lazyCodePlugin`, so mermaid splits into its own on-demand
+// chunk. Streamdown only ever reaches the instance as
+// `getMermaid(config).render(...)` from an async path, so a promise-returning
+// `render` satisfies the contract; `language` is the one field it needs
+// synchronously, to match the ```mermaid fence.
+
+let realMermaid: DiagramPlugin | null = null;
+let mermaidPromise: Promise<DiagramPlugin> | null = null;
+
+const loadMermaid = (): Promise<DiagramPlugin> => {
+  // oxlint-disable-next-line eslint-plugin-promise(prefer-await-to-then)
+  mermaidPromise ??= import("@streamdown/mermaid").then(({ mermaid }) => {
+    realMermaid = mermaid;
+    return mermaid;
+  });
+  return mermaidPromise;
+};
+
+export const lazyMermaidPlugin: DiagramPlugin = {
+  name: "mermaid",
+  type: "diagram",
+  language: "mermaid",
+  getMermaid: (config?: MermaidConfig): MermaidInstance => ({
+    // Streamdown never calls initialize (it passes config to getMermaid and
+    // renders), but the contract allows it, so forward it once loaded.
+    initialize: (nextConfig: MermaidConfig) => {
+      // oxlint-disable-next-line eslint-plugin-promise(prefer-await-to-then)
+      void loadMermaid().then((plugin) => plugin.getMermaid(config).initialize(nextConfig));
+    },
+    render: async (id: string, source: string) => {
+      const plugin = realMermaid ?? (await loadMermaid());
+      return plugin.getMermaid(config).render(id, source);
+    },
+  }),
+};

--- a/web/src/components/ai-elements/streamdown-security.ts
+++ b/web/src/components/ai-elements/streamdown-security.ts
@@ -1,8 +1,8 @@
 import { cjk } from "@streamdown/cjk";
 import { createMathPlugin } from "@streamdown/math";
-import { mermaid } from "@streamdown/mermaid";
 import { defaultRehypePlugins, type LinkSafetyConfig, type StreamdownProps } from "streamdown";
 import { lazyCodePlugin } from "./lazyCodePlugin";
+import { lazyMermaidPlugin } from "./lazyMermaidPlugin";
 
 type StreamdownRehypePlugins = NonNullable<StreamdownProps["rehypePlugins"]>;
 type StreamdownRehypePlugin = StreamdownRehypePlugins[number];
@@ -28,7 +28,7 @@ export const STREAMDOWN_PLUGINS = {
   // delimiters (`\(…\)`, `\[…\]`), which is what LLMs emit for real math, are
   // rewritten to `$$…$$` by `normalizeExplicitMathDelimiters`.
   math: createMathPlugin({ singleDollarTextMath: false }),
-  mermaid,
+  mermaid: lazyMermaidPlugin,
 };
 export const SECURE_STREAMDOWN_REHYPE_PLUGINS = createStreamdownRehypePlugins(false);
 export const FILE_LINK_STREAMDOWN_REHYPE_PLUGINS = createStreamdownRehypePlugins(true);

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -42,7 +42,7 @@ import remarkEmoji from "remark-emoji";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { rehypeGithubAlerts } from "rehype-github-alerts";
-import { mermaid } from "@streamdown/mermaid";
+import { lazyMermaidPlugin } from "@/components/ai-elements/lazyMermaidPlugin";
 import { Streamdown } from "streamdown";
 import type { Comment } from "@/hooks/useComments";
 import {
@@ -138,7 +138,7 @@ const MARKDOWN_REHYPE_PLUGINS: Options["rehypePlugins"] = [
   [rehypeSanitize, MARKDOWN_SANITIZE_SCHEMA],
 ];
 
-const MERMAID_STREAMDOWN_PLUGINS = { mermaid };
+const MERMAID_STREAMDOWN_PLUGINS = { mermaid: lazyMermaidPlugin };
 
 function MermaidPreview({ source }: { source: string }) {
   return (


### PR DESCRIPTION
## Related issue

Closes #

<!-- Perf / chore: no issue required. -->

## Summary

`@streamdown/mermaid` statically imports mermaid, which drags cytoscape, khroma,
dompurify and the hand-drawn renderer into the eager entry graph even in a
session that never shows a diagram. Both plugin sites imported it eagerly:

- `STREAMDOWN_PLUGINS` in `streamdown-security.ts` — used by every chat message
- `MERMAID_STREAMDOWN_PLUGINS` in `CodeViewer.tsx` — the markdown preview

`lazyMermaidPlugin` defers the import to the first diagram render, mirroring the
`lazyCodePlugin` sitting next to it. The contract allows this cleanly: Streamdown
reads only `language` synchronously — to match a ```mermaid fence — and reaches
the engine as `getMermaid(config).render(...)` from an `async` function, so a
promise-returning `render` is enough. (`initialize` is never called by
Streamdown; it is forwarded anyway to honour the type.)

First-paint payload (`vite build`, gzip of every asset `index.html` loads):

| | eager assets | raw | gzip |
|---|---|---|---|
| before | 51 | 7.18 MB | 1779 kB |
| after | **33** | 6.57 MB | **1630 kB** |

**−149 kB gzip and 18 fewer requests** off first paint.

## Test Plan

```bash
cd web
npx vitest run src/components/ai-elements/lazyMermaidPlugin.test.ts  # 3 passed
npx vitest run          # 296 files, 5897 passed, 3 expected fail, 1 skipped
npx tsc -b              # no errors
```

Verified against the built output — the mermaid chunks (`chunk-ZGVPDNZ5`,
`chunk-Q4XR5HBZ`, `chunk-52WLFC77`, `rough.esm`, khroma/dompurify) are gone from
`index.html`'s modulepreload list, and a headless Chrome load renders
byte-identical DOM with no console errors.

**Please verify by hand** — mermaid can't render under jsdom (it needs
`getBBox`), so the unit test mocks the engine and real rendering is unproven by
CI:

1. `just dev`, open a session, and send a message with a fenced ```mermaid block
   (e.g. `graph TD; A-->B;`) — the diagram must render as SVG.
2. Open a `.md` file containing a mermaid block in the file viewer — the
   `MermaidPreview` must render too (this is the `CodeViewer` call site).
3. Hard-reload with DevTools ▸ Network and confirm the mermaid chunk is fetched
   only when a diagram first appears.

## Demo

N/A — no visual change intended; diagrams render exactly as before, just after a
lazy chunk load. Network-waterfall evidence is in the Test Plan.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`lazyMermaidPlugin.test.ts` mocks `@streamdown/mermaid` to assert the plugin
contract is readable synchronously, that building the instance does **not** reach
the engine, that `render()` does and returns its result, and that the config
passed to `getMermaid` is forwarded. `CodeViewer.test.tsx` continues to cover the
preview call site.

The mock is a real gap: it proves *when* mermaid loads, not that mermaid still
draws. That is why the three browser steps above are listed — they need a human.

## Changelog

The web UI no longer loads the Mermaid diagram engine until a diagram appears.
