### PR TITLE
perf(web): load xterm on demand

### DIFF
--- a/web/src/components/blocks/LazyTerminalView.tsx
+++ b/web/src/components/blocks/LazyTerminalView.tsx
@@ -1,0 +1,47 @@
+// Lazy boundary in front of `TerminalView`.
+//
+// `TerminalView` pulls in xterm.js and its fit / web-links / WebGL addons —
+// together the single largest dependency in the app. Every mount site renders
+// it only once a terminal is actually on screen, so importing it eagerly meant
+// every page load paid for a terminal most sessions never open. Behind
+// `React.lazy` the chunk is fetched on the first terminal render instead.
+//
+// Import this rather than `./TerminalView` from anything that renders a
+// terminal; a static import anywhere on the eager graph pulls xterm back into
+// the entry chunk.
+
+import { lazy, Suspense, type ComponentProps } from "react";
+import { Loader2Icon } from "lucide-react";
+import type { TerminalView as TerminalViewImpl } from "./TerminalView";
+
+const TerminalViewChunk = lazy(() =>
+  import("./TerminalView").then((m) => ({ default: m.TerminalView })),
+);
+
+export type TerminalViewProps = ComponentProps<typeof TerminalViewImpl>;
+
+/**
+ * `TerminalView`, loaded on demand.
+ *
+ * The fallback mirrors the terminal's own "Connecting…" overlay, so a cold
+ * chunk load reads as part of the connect it precedes rather than as a
+ * separate loading state.
+ */
+export function LazyTerminalView(props: TerminalViewProps) {
+  return (
+    <Suspense
+      fallback={
+        <div className="relative flex min-h-0 flex-1 flex-col">
+          <div className="absolute inset-0 flex items-center justify-center bg-background/85 text-ui text-foreground">
+            <span className="flex items-center gap-2">
+              <Loader2Icon className="size-4 animate-spin" />
+              Connecting…
+            </span>
+          </div>
+        </div>
+      }
+    >
+      <TerminalViewChunk {...props} />
+    </Suspense>
+  );
+}

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -1036,7 +1036,7 @@ describe("Right-rail terminals card", () => {
 });
 
 describe("Chat-mode terminal panel layout", () => {
-  it("hosts an open shell as a rail tab (not the full-width push panel) and keeps chat visible", () => {
+  it("hosts an open shell as a rail tab (not the full-width push panel) and keeps chat visible", async () => {
     // A shell opens as a tab inside the workspace rail — its xterm surfaces in
     // the rail's content slot, the full-width push panel stays closed, and chat
     // is not hidden. Seed a restored (open + selected) shell tab so it's live on
@@ -1059,8 +1059,9 @@ describe("Chat-mode terminal panel layout", () => {
 
     renderShell("/c/conv_abc");
 
-    // The shell tab's xterm is mounted in the rail...
-    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_main");
+    // The shell tab's xterm is mounted in the rail... (`findBy` — it sits
+    // behind a lazy chunk boundary.)
+    expect(await screen.findByTestId("terminal-view-stub")).toHaveTextContent("terminal_main");
     // ...while the push panel stays closed and chat stays visible. The
     // md:hidden gate lives on the chat+workspace group (main's parent).
     const chatGroup = () => screen.getByRole("main").parentElement as HTMLElement;

--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -127,11 +127,12 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("MainTerminalView — terminal-first SDK sessions", () => {
-  it("renders the REPL chrome-free: shells and the + stay out of the pill view", () => {
+  it("renders the REPL chrome-free: shells and the + stay out of the pill view", async () => {
     renderView({ terminals: [REPL_TERMINAL, BASH_SHELL] });
 
-    // The agent's terminal fills the pane.
-    expect(screen.getByTestId("terminal-view")).toHaveAttribute(
+    // The agent's terminal fills the pane. `findBy` — it sits behind a lazy
+    // chunk boundary.
+    expect(await screen.findByTestId("terminal-view")).toHaveAttribute(
       "data-terminal-id",
       "terminal_tui_main",
     );

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -15,7 +15,7 @@
 
 import { TerminalIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { TerminalView } from "@/components/blocks/TerminalView";
+import { LazyTerminalView } from "@/components/blocks/LazyTerminalView";
 import { AGENT_TERMINAL_IDS, terminalTabKey, useTerminals } from "@/hooks/useTerminals";
 import { useTerminalFirst } from "./TerminalFirstContext";
 import { TerminalStatusBadge } from "./terminalStatus";
@@ -191,7 +191,7 @@ export function MainTerminalView({
                   key={`${conversationId}:${activeTerminal.id}`}
                   className="flex h-full flex-col"
                 >
-                  <TerminalView
+                  <LazyTerminalView
                     sessionId={conversationId}
                     terminalId={activeTerminal.id}
                     readOnly={readOnly}

--- a/web/src/shell/TerminalsPanel.test.tsx
+++ b/web/src/shell/TerminalsPanel.test.tsx
@@ -117,7 +117,7 @@ describe("TerminalsPanel navigation", () => {
     expect(screen.queryByTestId("terminal-view")).toBeNull();
   });
 
-  it("shows terminal view after clicking a row, deferred until expanded", () => {
+  it("shows terminal view after clicking a row, deferred until expanded", async () => {
     renderPanel();
 
     fireEvent.click(screen.getByRole("button", { name: /worker/i }));
@@ -128,7 +128,9 @@ describe("TerminalsPanel navigation", () => {
     // TerminalView deferred until 180 ms settle.
     expect(screen.queryByTestId("terminal-view")).toBeNull();
 
-    act(() => {
+    // Async `act` so the settle timer fires *and* the lazy terminal chunk's
+    // import promise resolves before asserting.
+    await act(async () => {
       vi.advanceTimersByTime(180);
     });
 

--- a/web/src/shell/TerminalsPanel.tsx
+++ b/web/src/shell/TerminalsPanel.tsx
@@ -26,7 +26,7 @@
 import { TerminalIcon, XIcon } from "lucide-react";
 import type { CSSProperties } from "react";
 import { useEffect, useRef, useState } from "react";
-import { TerminalView } from "@/components/blocks/TerminalView";
+import { LazyTerminalView } from "@/components/blocks/LazyTerminalView";
 import { Button } from "@/components/ui/button";
 import { useResizablePanel } from "@/hooks/useResizablePanel";
 import { useIOSNativeKeyboardInset } from "@/hooks/useIOSNativeKeyboardInset";
@@ -239,7 +239,7 @@ export function TerminalsPanel({
             // across same-shape sessions (e.g. `terminal_claude_main`), so id
             // alone reuses the xterm mount and shows stale scrollback.
             <div key={`${conversationId}:${activeTerminal.id}`} className="flex h-full flex-col">
-              <TerminalView
+              <LazyTerminalView
                 sessionId={conversationId}
                 terminalId={activeTerminal.id}
                 readOnly={readOnly}

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -329,7 +329,7 @@ describe("WorkspacePanel shell tabs", () => {
     expect(shellTab).not.toHaveClass("h-[32px]");
   });
 
-  it("surfaces the active shell's xterm in the content slot", () => {
+  it("surfaces the active shell's xterm in the content slot", async () => {
     useTerminalsMock.mockReturnValue({ terminals: [term], isLoading: false, error: null });
     renderWorkspace({
       openTerminals: [termKey],
@@ -338,7 +338,8 @@ describe("WorkspacePanel shell tabs", () => {
 
     // The selected shell tab owns the single content slot — its terminal id is
     // attached, and neither the files scope view nor a file viewer mounts.
-    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_zsh_s1");
+    // `findBy` — the terminal sits behind a lazy chunk boundary.
+    expect(await screen.findByTestId("terminal-view-stub")).toHaveTextContent("terminal_zsh_s1");
     expect(screen.queryByTestId("files-panel-stub")).toBeNull();
     expect(screen.queryByTestId("file-viewer-stub")).toBeNull();
   });

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { TerminalView } from "@/components/blocks/TerminalView";
+import { LazyTerminalView } from "@/components/blocks/LazyTerminalView";
 import { BrowserPane } from "@/components/BrowserPane/BrowserPane";
 import { useSessionAgent } from "@/hooks/useAgents";
 import type { SessionLiveness } from "@/hooks/useSessionLiveness";
@@ -507,7 +507,7 @@ function RailTerminalView({
   }
   return (
     <div key={terminal.id} className="flex h-full min-h-0 flex-col">
-      <TerminalView
+      <LazyTerminalView
         sessionId={conversationId}
         terminalId={terminal.id}
         readOnly={readOnly}


### PR DESCRIPTION
## Related issue

Closes #

## Summary

xterm.js plus its fit / web-links / WebGL addons are the **largest dependency in
the app** — ~461 KB of source between them. They reached the eagerly-loaded
entry chunk through an entirely static chain:

```
AppShell  →  TerminalsPanel  →  TerminalView  →  TerminalSession  →  @xterm/*
```

So every page load downloaded and parsed a terminal emulator, including the many
sessions that never open one.

All three mount sites (`TerminalsPanel`, `WorkspacePanel`, `MainTerminalView`)
already render `TerminalView` **only once a terminal is actually on screen** —
`TerminalsPanel` even defers it until its open animation settles. That makes a
lazy boundary free: nothing fetches the chunk until a terminal renders.

- New `src/components/blocks/LazyTerminalView.tsx` wraps `TerminalView` in
  `React.lazy` + `Suspense`. The fallback mirrors the terminal's own
  "Connecting…" overlay, so a cold chunk load reads as part of the connect it
  precedes rather than as a separate loading state.
- The three mount sites import it instead of `TerminalView`. Nothing else
  imports `TerminalView` at runtime, and the two `TerminalSession` importers are
  `import type` only, so no other path pulls xterm back in.

Entry chunk `assets/index-*.js`:

| | minified | gzip |
|---|---|---|
| before | 3,833.26 kB | 971.59 kB |
| after | 3,353.62 kB | 844.44 kB |
| **delta** | **−479.64 kB** | **−127.15 kB (−13%)** |

xterm now ships as its own 476.68 kB chunk fetched on first terminal render, and
`xterm.css` leaves the critical path with it as a separate 3.93 kB stylesheet.

## Test Plan

- `npx vitest run` — full web suite: **5,897 passed, 0 failed** across 1,389
  suites.
- `npx vitest run src/shell/TerminalsPanel src/shell/WorkspacePanel src/shell/MainTerminalView src/components/blocks/TerminalView src/shell/AppShell`
  — 187/187 pass.
- `npx tsc -b`, `oxlint --deny-warnings`, `prettier --check` all clean.
- `npx vite build` before/after on the same base commit for the numbers above,
  confirming the new `TerminalView-*.js` chunk and that the entry chunk no
  longer contains `@xterm/*`.
- Manually: opened a session, opened the Shells rail tab and a terminal, and
  confirmed in the Network panel that `TerminalView-*.js` is requested only at
  that point — not on load — and that the terminal attaches, echoes input,
  resizes, and reconnects as before.

Four tests asserted the terminal's presence synchronously and now await it,
which is what a Suspense boundary requires (`findByTestId`, or an async `act`
in the one suite driving fake timers).

## Demo

No visual change in the steady state. The one new frame is the Suspense
fallback during a cold chunk fetch, which renders the same "Connecting…" spinner
the terminal already showed while dialing — so the transition looks identical to
today's, just with the spinner appearing a few hundred ms earlier in the
sequence.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing terminal suites already cover every mount site and the
deferred-mount behaviour; they were updated only to await the new async
boundary, and their passing is what proves the boundary is transparent. Two
things tests can't assert were checked by hand: the bundle placement (before /
after `vite build` plus a check that the entry chunk no longer contains
`@xterm/*`), and that the chunk is fetched on first terminal render rather than
on load, verified in the Network panel.

## Changelog

The web UI no longer downloads xterm.js until a terminal is opened, cutting 127 KB (gzipped) from the initial page load.
