### PR TITLE
perf(web): load the file viewer on demand

### DIFF
--- a/tests/e2e_ui/files/test_file_viewer_lazy_chunk.py
+++ b/tests/e2e_ui/files/test_file_viewer_lazy_chunk.py
@@ -1,0 +1,126 @@
+"""E2E: the FileViewer's JS is fetched on first file open, not on page load.
+
+``FileViewer`` owns the app's only reachable path to the TipTap / ProseMirror
+rich-text stack, so both mount sites (AppShell's mobile push panel and
+WorkspacePanel's rail slot) render it through ``LazyFileViewer``. This test pins
+the property that boundary exists for: booting a session must not download the
+viewer, and clicking a file must still open it.
+
+Without the boundary the viewer sits in the eagerly-loaded entry chunk — the
+"not requested on load" assertion would then hold vacuously, so the test also
+requires the chunk to arrive *after* the click.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, Request, expect
+
+# ---------------------------------------------------------------------------
+# Test constants
+# ---------------------------------------------------------------------------
+
+_MARKDOWN_FILE_PATH = "lazy_notes.md"
+
+_MARKDOWN_CONTENT = """\
+# Lazy Notes
+
+Opened on demand.
+"""
+
+# The viewer's own chunk, in either serving mode: a production build emits
+# ``assets/FileViewer-<hash>.js``, the dev server serves
+# ``/src/shell/FileViewer.tsx``. The leading slash keeps ``LazyFileViewer`` —
+# statically imported, so part of the entry graph — from matching.
+_FILE_VIEWER_CHUNK_RE = re.compile(r"/FileViewer[-.]")
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def seeded_lazy_markdown_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str, str]]:
+    """Seed one markdown file and yield (base_url, session_id, path).
+
+    :param seeded_session: Runner-bound (base_url, session_id) pair.
+    :returns: ``(base_url, session_id, file_path)`` for the test body.
+    """
+    base_url, session_id = seeded_session
+    file_url = (
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_MARKDOWN_FILE_PATH}"
+    )
+    resp = httpx.put(
+        file_url,
+        json={"content": _MARKDOWN_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    yield (base_url, session_id, _MARKDOWN_FILE_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_file_viewer_chunk_loads_only_when_a_file_is_opened(
+    page: Page,
+    seeded_lazy_markdown_session: tuple[str, str, str],
+) -> None:
+    """The viewer's chunk is absent from page load and arrives on first open."""
+    base_url, session_id, _file_path = seeded_lazy_markdown_session
+
+    scripts: list[str] = []
+    viewer_chunks: list[str] = []
+
+    def _record(request: Request) -> None:
+        if request.resource_type != "script":
+            return
+        scripts.append(request.url)
+        if _FILE_VIEWER_CHUNK_RE.search(request.url):
+            viewer_chunks.append(request.url)
+
+    page.on("request", _record)
+
+    page.goto(f"{base_url}/c/{session_id}?view=explore")
+
+    # The seeded file rendering in the list means the shell and the rail have
+    # both booted — anything eager has had its chance to request the chunk.
+    file_button = page.get_by_role(
+        "button", name=re.compile(rf"^{re.escape(_MARKDOWN_FILE_PATH)}\b")
+    )
+    expect(file_button).to_be_visible(timeout=30_000)
+
+    # Guard against a vacuous pass: with no script request seen at all, the
+    # assertion below would hold no matter where the viewer lives.
+    assert scripts, "no script requests observed — the recorder never saw the page's JS"
+    assert not viewer_chunks, (
+        f"the FileViewer chunk was fetched before any file was opened: {viewer_chunks}"
+    )
+
+    file_button.click()
+
+    # Two FileViewer instances mount with the same test id (AppShell's
+    # md:hidden push panel and WorkspacePanel's rail slot); match the visible
+    # one rather than relying on DOM order.
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible(timeout=30_000)
+    editor = file_viewer.locator("[contenteditable='true']")
+    expect(editor).to_be_visible(timeout=30_000)
+    expect(editor.locator("h1")).to_contain_text("Lazy Notes")
+
+    # Resolving the lazy import is what fetched it: a statically imported
+    # viewer would already be in the entry chunk and this would stay empty.
+    assert viewer_chunks, (
+        "opening a file did not fetch a separate FileViewer chunk — the viewer "
+        "is back in the eagerly-loaded entry chunk"
+    )

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -81,7 +81,7 @@ import { useResizableInlinePanel } from "@/hooks/useResizableInlinePanel";
 import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { ChatHeader } from "./ChatHeader";
 import { ExecutionLogsPanel } from "./ExecutionLogsPanel";
-import { FileViewer } from "./FileViewer";
+import { LazyFileViewer } from "./LazyFileViewer";
 import { FileViewerContext } from "./FileViewerContext";
 import { FilesPanelDrawer } from "./FilesPanelDrawer";
 import type { ChangedSort } from "./FlatFileList";
@@ -1874,7 +1874,7 @@ export function AppShell() {
               {/* Mobile-only push panel — on desktop the viewer lives inside the inline aside. */}
               {conversationId && selectedFilePath !== null && (
                 <div className="md:hidden">
-                  <FileViewer
+                  <LazyFileViewer
                     open
                     conversationId={conversationId}
                     path={selectedFilePath}

--- a/web/src/shell/LazyFileViewer.test.tsx
+++ b/web/src/shell/LazyFileViewer.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Stub the real viewer: this suite is about the boundary in front of it, not
+// the TipTap / ProseMirror stack it pulls in.
+vi.mock("./FileViewer", () => ({
+  FileViewer: ({ path, frameless }: { path: string; frameless?: boolean }) => (
+    <div data-testid="file-viewer-stub" data-frameless={frameless ? "true" : "false"}>
+      {path}
+    </div>
+  ),
+}));
+
+import { LazyFileViewer } from "./LazyFileViewer";
+
+describe("LazyFileViewer", () => {
+  it("shows the loading fallback until the viewer chunk resolves", async () => {
+    render(<LazyFileViewer open conversationId="session-1" path="design.md" onClose={() => {}} />);
+
+    // First paint happens before the dynamic import settles.
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(screen.queryByTestId("file-viewer-stub")).not.toBeInTheDocument();
+
+    expect(await screen.findByTestId("file-viewer-stub")).toBeInTheDocument();
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+  });
+
+  it("forwards its props to the loaded viewer", async () => {
+    const onClose = vi.fn();
+    render(
+      <LazyFileViewer
+        open
+        frameless
+        conversationId="session-1"
+        path="src/deep/nested.ts"
+        onClose={onClose}
+      />,
+    );
+
+    const stub = await screen.findByTestId("file-viewer-stub");
+    expect(stub).toHaveTextContent("src/deep/nested.ts");
+    expect(stub).toHaveAttribute("data-frameless", "true");
+  });
+});

--- a/web/src/shell/LazyFileViewer.tsx
+++ b/web/src/shell/LazyFileViewer.tsx
@@ -1,27 +1,13 @@
-// Lazy boundary in front of `FileViewer`.
-//
-// The viewer owns the app's only reachable path to the TipTap / ProseMirror
-// rich-text stack (via `MarkdownRichTextViewer`'s editable markdown mode) —
-// ~940 KB of source, plus linkify and the rest of `CodeViewer`. Importing it
-// statically from AppShell put all of that in the eagerly-loaded entry chunk,
-// so every page load paid for an editor that only appears once someone opens a
-// file.
-//
-// Both mount sites already gate on a selected file, so nothing fetches this
-// until the viewer is genuinely on screen. `CodeViewer` keeps its own inner lazy
-// boundaries for Monaco / PDF / 3D on top of this one.
-
 import { lazy, Suspense, type ComponentProps } from "react";
 import type { FileViewer as FileViewerImpl } from "./FileViewer";
 
+// `FileViewer` is the only reachable path to the TipTap / ProseMirror rich-text
+// stack, so it stays out of the entry chunk until a file is actually opened.
 const FileViewerChunk = lazy(() => import("./FileViewer").then((m) => ({ default: m.FileViewer })));
 
 export type FileViewerProps = ComponentProps<typeof FileViewerImpl>;
 
-/**
- * `FileViewer`, loaded on demand. The fallback matches the "Loading…" panel
- * `CodeViewer` already shows behind its own lazy boundaries.
- */
+/** `FileViewer`, loaded on demand behind the same "Loading…" panel `CodeViewer` uses. */
 export function LazyFileViewer(props: FileViewerProps) {
   return (
     <Suspense

--- a/web/src/shell/LazyFileViewer.tsx
+++ b/web/src/shell/LazyFileViewer.tsx
@@ -1,0 +1,37 @@
+// Lazy boundary in front of `FileViewer`.
+//
+// The viewer owns the app's only reachable path to the TipTap / ProseMirror
+// rich-text stack (via `MarkdownRichTextViewer`'s editable markdown mode) —
+// ~940 KB of source, plus linkify and the rest of `CodeViewer`. Importing it
+// statically from AppShell put all of that in the eagerly-loaded entry chunk,
+// so every page load paid for an editor that only appears once someone opens a
+// file.
+//
+// Both mount sites already gate on a selected file, so nothing fetches this
+// until the viewer is genuinely on screen. `CodeViewer` keeps its own inner lazy
+// boundaries for Monaco / PDF / 3D on top of this one.
+
+import { lazy, Suspense, type ComponentProps } from "react";
+import type { FileViewer as FileViewerImpl } from "./FileViewer";
+
+const FileViewerChunk = lazy(() => import("./FileViewer").then((m) => ({ default: m.FileViewer })));
+
+export type FileViewerProps = ComponentProps<typeof FileViewerImpl>;
+
+/**
+ * `FileViewer`, loaded on demand. The fallback matches the "Loading…" panel
+ * `CodeViewer` already shows behind its own lazy boundaries.
+ */
+export function LazyFileViewer(props: FileViewerProps) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center p-8 text-muted-foreground text-ui">
+          Loading…
+        </div>
+      }
+    >
+      <FileViewerChunk {...props} />
+    </Suspense>
+  );
+}

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -34,7 +34,7 @@ import type { SessionLiveness } from "@/hooks/useSessionLiveness";
 import { terminalTabKey, useCreateTerminal, useTerminals } from "@/hooks/useTerminals";
 import { SuppressBrowserView } from "@/hooks/useSuppressBrowserView";
 import { FilesPanel } from "./FilesPanel";
-import { FileViewer } from "./FileViewer";
+import { LazyFileViewer } from "./LazyFileViewer";
 import type { ChangedSort } from "./FlatFileList";
 import { SubagentsPanel } from "./SubagentsPanel";
 import { useTerminalStatuses } from "./useTerminalStatuses";
@@ -907,7 +907,7 @@ export function WorkspacePanel({
             readOnly={!isOwnerLevel(permissionLevel)}
           />
         ) : selectedFilePath !== null ? (
-          <FileViewer
+          <LazyFileViewer
             frameless
             open
             conversationId={conversationId}


### PR DESCRIPTION
## Related issue

Closes #

## Summary

`FileViewer` turns out to be the app's **only reachable path to the TipTap /
ProseMirror rich-text stack** — `MarkdownRichTextViewer`'s editable markdown mode
pulls in ~940 KB of source across `@tiptap/*` and `prosemirror-*`, plus
`linkifyjs`, `react-markdown`, `anser`, and the rest of `CodeViewer`. AppShell
imported it statically, so every page load downloaded and parsed a **markdown
editor** that only appears once someone opens a file.

Both mount sites already gate on `selectedFilePath !== null` (AppShell's mobile
push panel, WorkspacePanel's rail slot), so a lazy boundary costs nothing —
nothing fetches the chunk until the viewer is genuinely on screen.

- New `src/shell/LazyFileViewer.tsx` wraps `FileViewer` in `React.lazy` +
  `Suspense`, reusing the same `"Loading…"` fallback `CodeViewer` already shows
  behind its own Monaco / PDF / 3D boundaries.
- Both sites import it instead of `FileViewer`. Nothing else imports
  `FileViewer` at runtime.

Entry chunk `assets/index-*.js`:

| | minified | gzip |
|---|---|---|
| before | 3,833.30 kB | 971.63 kB |
| after | 1,961.01 kB | 568.85 kB |
| **delta** | **−1,872.29 kB** | **−402.78 kB (−41%)** |

Source-map diff of what left the entry chunk (KB of source):

```
 -364.6  src/shell (FileViewer, CodeViewer, MarkdownRichTextViewer, comments)
 -241.7  prosemirror-view          -221.8  @tiptap/core
 -122.0  prosemirror-model          -89.8  prosemirror-tables
  -82.4  prosemirror-transform      -61.3  linkifyjs
  -52.3  @radix-ui/react-select     -43.5  @tiptap/markdown
  -35.4  prosemirror-state          -35.1  @tiptap/react
  -34.6  @tiptap/extension-list     -33.7  prosemirror-commands
  … 17 more @tiptap/prosemirror/radix modules
```

One note for reviewers: **parse5 (270 KB) and mermaid (146 KB) stay in the entry
chunk on purpose.** I first assumed they came in via `CodeViewer`'s `rehype-raw`
and would leave with it; the lockfile says otherwise — they are `streamdown`
dependencies, and streamdown renders every chat message, so they are genuinely
critical path. Getting those out is a separate problem.

## Test Plan

New tests, both of which pin the boundary rather than restate the refactor:

- `tests/e2e_ui/files/test_file_viewer_lazy_chunk.py` — drives a real session,
  waits for the seeded file to render in the rail (so anything eager has had its
  chance), and asserts no `FileViewer-*.js` script request has happened yet;
  then clicks the file and asserts the chunk arrives *and* the viewer renders the
  markdown as before.
- `web/src/shell/LazyFileViewer.test.tsx` — the `Suspense` fallback and prop
  forwarding, where jsdom lets the deferred import be observed directly.

Both fail for the right reason. Swapping `LazyFileViewer.tsx` for a static
`export { FileViewer as LazyFileViewer }` re-export puts the viewer back in a
3,833.26 kB entry chunk with no separate `FileViewer-*.js`, and:

```
E  AssertionError: opening a file did not fetch a separate FileViewer chunk —
E  the viewer is back in the eagerly-loaded entry chunk
1 failed in 7.39s

×  shows the loading fallback until the viewer chunk resolves
   TestingLibraryElementError: Unable to find an element with the text: Loading…
```

The e2e test also guards the vacuous-pass case: it requires *some* script request
to have been observed, so it cannot silently pass if the recorder sees no JS at
all. The chunk regex (`/FileViewer[-.]`) matches both serving modes — the
production `assets/FileViewer-<hash>.js` and the dev server's
`/src/shell/FileViewer.tsx` — and excludes `LazyFileViewer`, which is statically
imported and so part of the entry graph.

Wider runs, all on this branch:

- `npx vitest run` — **5,896 passed, 3 expected-fail (pre-existing `it.fails`
  xfails in `AddAgentDialog` / `FileViewer` / `PermissionsModal.safety`), 1
  skipped**, 0 unexpected failures. No existing test needed changing: every
  FileViewer assertion already awaited something.
- `pytest tests/e2e_ui/files` — **36 passed, 1 failed** against a freshly built
  SPA. The failure is `test_right_panel_terminals_and_file_viewer`, which times
  out waiting for a `zsh · main` terminal after the turn errors with "Something
  went wrong setting up the turn on the host" — it never reaches the viewer.
  Pre-existing, not this branch: it fails identically at the same line on a
  clean `origin/main` worktree in the same environment.
- `npx tsc -b`, `oxlint --deny-warnings`, `prettier --check` all clean.
- `npx vite build` before/after on the same base commit for the numbers above.
- Manually: opened a session, clicked a file from the chat and from the Changes
  rail, and confirmed the viewer opens, renders markdown, switches to the
  rich-text editor, and closes as before — with `FileViewer-*.js` requested in
  the Network panel only at that first click, not on load.

## Demo

No steady-state visual change. A cold chunk fetch briefly shows the same
`"Loading…"` panel the viewer already displays while fetching file content, in
the same slot.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The two properties worth testing are split by what each layer can actually see.
The e2e test owns chunk placement, because only a real browser against a real
build can say when `FileViewer-*.js` is fetched; the vitest test owns the
`Suspense` fallback, because only jsdom can hold the import unresolved long
enough to assert on it deterministically. The pre-existing `FileViewer` /
`AppShell` / `WorkspacePanel` suites still pass unchanged, which is the separate
signal that the boundary is transparent to everything downstream.

## Changelog

The web UI no longer downloads the markdown editor until a file is opened, cutting the initial page load by 41%.
