### PR TITLE
perf(web): scan blocks once per update for the pending-elicitation flag

### DIFF
--- a/web/src/lib/blocks.test.ts
+++ b/web/src/lib/blocks.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { hasPendingElicitation, type AnyBlock, type BlockContext } from "./blocks";
+
+function ctx(): BlockContext {
+  return { agent: "test", depth: 0, turn: 0, timestamp: 0, responseId: "resp_1", itemId: null };
+}
+
+function elicitation(status: "pending" | "answered"): AnyBlock {
+  return {
+    type: "elicitation",
+    ctx: ctx(),
+    elicitationId: "elic_1",
+    message: "Continue?",
+    phase: "request",
+    policyName: "session_cost_budget",
+    contentPreview: "{}",
+    requestedSchema: {},
+    status,
+    response: null,
+  };
+}
+
+function text(): AnyBlock {
+  return { type: "text_done", ctx: ctx(), fullText: "hi", hasCodeBlocks: false };
+}
+
+describe("hasPendingElicitation", () => {
+  it("is false for an empty list", () => {
+    expect(hasPendingElicitation([])).toBe(false);
+  });
+
+  it("is false when no elicitation is pending", () => {
+    expect(hasPendingElicitation([text(), elicitation("answered")])).toBe(false);
+  });
+
+  it("is true when any elicitation is pending", () => {
+    expect(hasPendingElicitation([text(), elicitation("pending"), text()])).toBe(true);
+  });
+
+  // The result is cached against the array instance, so a new array must be
+  // scanned afresh — the store replaces `blocks` on every change, which is what
+  // makes the cache correct rather than stale.
+  it("re-evaluates for a different array instance", () => {
+    const before: AnyBlock[] = [elicitation("pending")];
+    expect(hasPendingElicitation(before)).toBe(true);
+    const after: AnyBlock[] = [elicitation("answered")];
+    expect(hasPendingElicitation(after)).toBe(false);
+  });
+
+  it("returns the same answer for repeated calls on one instance", () => {
+    const blocks: AnyBlock[] = [text(), elicitation("pending")];
+    expect(hasPendingElicitation(blocks)).toBe(true);
+    expect(hasPendingElicitation(blocks)).toBe(true);
+  });
+
+  it("scans each array instance only once", () => {
+    // A getter on the sole element counts how many times the predicate reads
+    // it: once for the first call, never again for the same instance.
+    let reads = 0;
+    const block = elicitation("answered");
+    const spied = {
+      get type() {
+        reads++;
+        return block.type;
+      },
+      status: block.status,
+    } as unknown as AnyBlock;
+    const blocks: AnyBlock[] = [spied];
+
+    hasPendingElicitation(blocks);
+    expect(reads).toBe(1);
+    hasPendingElicitation(blocks);
+    hasPendingElicitation(blocks);
+    expect(reads).toBe(1);
+  });
+});

--- a/web/src/lib/blocks.ts
+++ b/web/src/lib/blocks.ts
@@ -553,3 +553,33 @@ export const ELICITATION_RESPONSE_PREFIX = "elicit_";
 export function answeredElicitationItemId(callItemId: string): string {
   return `${callItemId}:answer`;
 }
+
+// Memoized per `blocks` array identity.
+//
+// Zustand runs every subscriber's selector on every store update, and the
+// message list mounts one `AssistantBubble` per bubble — each of which needs
+// this flag. A plain `blocks.some(...)` selector therefore cost O(bubbles x
+// blocks) on every streaming token, since the common (no-pending) case scans
+// the whole array before returning false.
+//
+// The store replaces the `blocks` array identity whenever it changes, so a
+// WeakMap keyed on that array makes the first caller pay the scan and every
+// other caller in the same update O(1). Entries die with the array they key.
+const pendingElicitationByBlocks = new WeakMap<readonly AnyBlock[], boolean>();
+
+/**
+ * Whether any block is an elicitation still awaiting the user's verdict.
+ *
+ * A pending elicitation means the turn is parked on user input: the shimmer is
+ * suppressed and the "worked for" fold stays expanded.
+ *
+ * @param blocks The store's block list. Must be treated as immutable — the
+ *   result is cached against this exact array instance.
+ */
+export function hasPendingElicitation(blocks: readonly AnyBlock[]): boolean {
+  const cached = pendingElicitationByBlocks.get(blocks);
+  if (cached !== undefined) return cached;
+  const result = blocks.some((b) => b.type === "elicitation" && b.status === "pending");
+  pendingElicitationByBlocks.set(blocks, result);
+  return result;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -96,7 +96,10 @@ import { useAutoGrowTextarea } from "@/hooks/useAutoGrowTextarea";
 import { useDictationInsert } from "@/hooks/useDictationInsert";
 import { useIOSNativeKeyboardVisible } from "@/hooks/useIOSNativeKeyboardInset";
 import type { MessageContentBlock } from "@/lib/blocks";
-import { ELICITATION_RESPONSE_PREFIX } from "@/lib/blocks";
+import {
+  ELICITATION_RESPONSE_PREFIX,
+  hasPendingElicitation as blocksHavePendingElicitation,
+} from "@/lib/blocks";
 import {
   derivePermissionLevel,
   isOwnerLevel,
@@ -1024,12 +1027,10 @@ export function ChatPage() {
   // (host offline, or not host-bound with the runner down).
   const [reconnectDialogOpen, setReconnectDialogOpen] = useState(false);
 
-  // Pending elicitation = parked on user input — suppress shimmer. Must
-  // sit before the early-return guards below (Rules of Hooks).
-  const hasPendingElicitation = useMemo(
-    () => blocks.some((b) => b.type === "elicitation" && b.status === "pending"),
-    [blocks],
-  );
+  // Pending elicitation = parked on user input — suppress shimmer. The helper
+  // memoizes on the `blocks` identity, so this shares one scan with every
+  // AssistantBubble asking the same question on the same update.
+  const hasPendingElicitation = blocksHavePendingElicitation(blocks);
 
   // Single-session snapshot (shared cache with chatStore.bindStream).
   // Must be declared BEFORE the early-return guards below — otherwise
@@ -3896,9 +3897,7 @@ function AssistantBubble({
   // A pending elicitation means the turn is parked awaiting the user —
   // still in flight even when its lifecycle or the session status reads
   // settled (e.g. a reload while parked). Feeds the fold suppression.
-  const hasPendingElicitation = useChatStore((s) =>
-    s.blocks.some((b) => b.type === "elicitation" && b.status === "pending"),
-  );
+  const hasPendingElicitation = useChatStore((s) => blocksHavePendingElicitation(s.blocks));
   // Getter computes the markdown lazily at click time — the hook must run
   // before the early return below (rules of hooks), but `markdownText` is
   // derived after it.


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Zustand runs **every** subscriber's selector on **every** store update. The
message list mounts one `AssistantBubble` per bubble, and each one subscribed
with its own scan:

```ts
const hasPendingElicitation = useChatStore((s) =>
  s.blocks.some((b) => b.type === "elicitation" && b.status === "pending"),
);
```

`.some()` short-circuits on a match — but the common case is *nothing pending*,
so it walks the whole array before returning `false`. That made the flag cost
**O(bubbles × blocks) on every streaming token**. ChatPage separately computed
the byte-identical predicate in its own `useMemo`, so that was one more full scan
on top.

(Worth noting what this is *not*: the selector returns a boolean, so zustand's
`Object.is` check already prevented spurious re-renders. The waste was pure
selector CPU during streaming, not wasted renders.)

- Move the predicate into `lib/blocks.ts` behind a `WeakMap` keyed on the
  `blocks` array instance. The store replaces that array whenever it changes, so
  the first caller in an update pays the scan and every other caller is O(1) —
  and a *changed* array is always rescanned, which is exactly what keeps the
  cache from going stale.
- ChatPage's own copy calls the same helper, so it shares that single scan
  instead of adding a second.

Entries are keyed weakly, so they are collected with the array they key — no
growth over a long session.

60 bubbles × 600 blocks:

| | per streaming token |
|---|---|
| before | 101 µs |
| after | 8 µs |

## Test Plan

- New `src/lib/blocks.test.ts` (6 assertions) covers the predicate itself plus
  the two properties the cache depends on: a *different* array instance is
  re-evaluated (so a flipped status is never stale), and one instance is scanned
  only once — asserted with a counting getter on the block, not just by timing.
- `npx vitest run src/pages/ChatPage src/lib/renderItems src/lib/blocks src/components/blocks` — 984/984 pass.
- `npx vitest run` — full web suite: **5,903 passed, 0 failed**.
- `npx tsc -b`, `oxlint --deny-warnings`, `prettier --check` all clean.
- Benchmarked the before/after loop above, subtracting the shared
  array-construction cost so only the scans are compared.

## Demo

N/A — no behavioural or visual change; the flag's value is identical, only the
cost of computing it changes.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new suite targets the one real risk in a memoized predicate — a stale answer
after the underlying data changes — by asserting that a new array instance is
always rescanned. The existing ChatPage suites cover the two call sites and the
behaviour that depends on the flag (shimmer suppression, fold expansion).

## Changelog

Long conversations spend less CPU per streaming token, so the chat stays responsive as history grows.
