### PR TITLE
perf(web): load the QR encoder on demand

### DIFF
--- a/web/src/components/PermissionsModal.tsx
+++ b/web/src/components/PermissionsModal.tsx
@@ -9,6 +9,8 @@
 import {
   type FormEvent,
   type KeyboardEvent,
+  lazy,
+  Suspense,
   useCallback,
   useEffect,
   useId,
@@ -16,7 +18,6 @@ import {
   useState,
 } from "react";
 import { CheckIcon, LinkIcon, QrCodeIcon, Trash2Icon, UserPlusIcon } from "lucide-react";
-import { QRCodeSVG } from "qrcode.react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -514,6 +515,11 @@ function CopyLinkButton({ sessionId }: { sessionId: string }) {
  * (a dark-on-dark QR won't read). Error correction is bumped to M for
  * resilience against partial occlusion.
  */
+// `qrcode.react` is only ever rendered inside the mobile-handoff dialog below,
+// which Radix does not mount until it opens. Loading it lazily keeps the encoder
+// out of the entry chunk that every page load fetches.
+const QRCodeSVG = lazy(() => import("qrcode.react").then((m) => ({ default: m.QRCodeSVG })));
+
 function QrCodeDialog({
   sessionId,
   open,
@@ -540,16 +546,20 @@ function QrCodeDialog({
         </DialogHeader>
         <div className="flex justify-center">
           <div className="rounded-lg bg-white p-3">
-            <QRCodeSVG
-              value={deepLink}
-              size={200}
-              level="M"
-              // White tile + explicit module colors keep the code scannable in dark
-              // mode; the padding also serves as the QR quiet zone.
-              bgColor="#ffffff"
-              fgColor="#000000"
-              aria-label="QR code to open this session in the Omnigent app"
-            />
+            {/* Fixed 200px box matches the rendered code, so the dialog keeps
+                its size while the encoder chunk loads. */}
+            <Suspense fallback={<div className="size-[200px]" />}>
+              <QRCodeSVG
+                value={deepLink}
+                size={200}
+                level="M"
+                // White tile + explicit module colors keep the code scannable in dark
+                // mode; the padding also serves as the QR quiet zone.
+                bgColor="#ffffff"
+                fgColor="#000000"
+                aria-label="QR code to open this session in the Omnigent app"
+              />
+            </Suspense>
           </div>
         </div>
         <DialogFooter>


### PR DESCRIPTION
## Related issue

Closes #

## Summary

`qrcode.react` was a static import in `PermissionsModal`, so the QR encoder
shipped inside the entry chunk that **every** page load fetches — for a code
that only ever renders inside the nested "Open in mobile app" dialog.

Radix does not mount a closed dialog's content, so a `React.lazy` boundary
around the encoder never fetches until someone actually opens that dialog.

- `QRCodeSVG` becomes a lazy component; the static import is gone.
- The `Suspense` fallback reserves the code's 200px box so the dialog keeps its
  size while the chunk lands rather than snapping wider.

Entry chunk `assets/index-*.js`:

| | minified | gzip |
|---|---|---|
| before | 3,833.30 kB | 971.63 kB |
| after | 3,817.27 kB | 965.51 kB |
| **delta** | **−16.03 kB** | **−6.12 kB** |

`qrcode` now ships as a 16.17 kB (6.01 kB gzip) on-demand chunk. This is the
smallest of the bundle changes — worth it because it is nearly free, not because
it moves the needle on its own.

## Test Plan

- `npx vitest run src/components/PermissionsModal` — 27/27 pass, unchanged. The
  suite already mocked `qrcode.react` and already used
  `await screen.findByTestId("share-qr-code")`, so its assertions cover the code
  rendering through the new async boundary without modification.
- `npx tsc -b`, `oxlint --deny-warnings`, `prettier --check` all clean.
- `npx vite build` before/after on the same base commit for the numbers above,
  and confirmed the encoder moved into its own chunk.
- Manually: opened Share → "Open in mobile app", confirmed the QR renders and
  scans, and that its chunk appears in the Network panel only on that click.

## Demo

No steady-state visual change. On a cold chunk load the dialog shows its
white tile with the code appearing a moment later, at the same size — the
fallback holds the layout.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing PermissionsModal suite already asserts the QR code renders with the
right deep link and that it is absent until the dialog opens — passing unchanged
is what shows the lazy boundary is transparent. Bundle placement and the
on-demand fetch aren't things tests can assert, so both were checked by hand
(before/after `vite build`, and the Network panel).

## Changelog

The web UI no longer downloads the QR encoder unless the mobile-handoff dialog is opened.
