### PR TITLE
perf(web): stop polling /health in a hidden tab

### DIFF
--- a/web/src/hooks/useRunnerHealth.test.tsx
+++ b/web/src/hooks/useRunnerHealth.test.tsx
@@ -118,3 +118,89 @@ describe("useRunnerHealth", () => {
     expect(result.current.size).toBe(0);
   });
 });
+
+// A hidden tab renders no liveness badges, so the poll has nothing to keep
+// fresh. Every other poller in the app is a react-query `refetchInterval`,
+// which already stands down when the window loses focus; this hand-rolled
+// loop is the one that didn't.
+describe("useRunnerHealth — hidden tab", () => {
+  // Hoisted so `renderHook` re-renders keep the same array identity, matching
+  // how RunnerHealthProvider passes its memoized `fallbackSet`. An inline
+  // literal would re-fire the effect on every state update the poll causes.
+  const SESSIONS: RunnerHealthInput[] = [{ id: "conv_a", runner_id: null }];
+
+  function setHidden(hidden: boolean) {
+    Object.defineProperty(document, "hidden", { value: hidden, configurable: true });
+    document.dispatchEvent(new Event("visibilitychange"));
+  }
+
+  afterEach(() => {
+    Object.defineProperty(document, "hidden", { value: false, configurable: true });
+  });
+
+  it("skips the request entirely while the tab is hidden", async () => {
+    Object.defineProperty(document, "hidden", { value: true, configurable: true });
+    renderHook(() => useRunnerHealth(SESSIONS));
+
+    // Give the effect and any microtasks a chance to fire a request.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("polls immediately on returning to the tab, without waiting out the tick", async () => {
+    Object.defineProperty(document, "hidden", { value: true, configurable: true });
+    fetchMock.mockResolvedValue(mockHealth({ conv_a: { runner_online: true } }));
+    const { result } = renderHook(() => useRunnerHealth(SESSIONS));
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Becoming visible must not wait out the 10s tick the hidden branch
+    // scheduled — otherwise liveness reads stale right when the user looks.
+    setHidden(false);
+    await waitFor(() => expect(result.current.get("conv_a")?.runner_online).toBe(true));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a single poll chain across repeated visibility flips", async () => {
+    fetchMock.mockResolvedValue(mockHealth({ conv_a: { runner_online: true } }));
+    const { result } = renderHook(() => useRunnerHealth(SESSIONS));
+    await waitFor(() => expect(result.current.size).toBe(1));
+
+    const before = fetchMock.mock.calls.length;
+
+    // Each return to the tab retires the previous chain rather than adding
+    // one, so N flips must not leave N timers polling in parallel.
+    for (let i = 0; i < 3; i++) {
+      setHidden(true);
+      setHidden(false);
+    }
+
+    // Exactly one poll per wake-up, and it stays there once things settle —
+    // a duplicated chain would keep climbing past this.
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(before + 3));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(before + 3);
+  });
+
+  it("stops listening for visibility changes after unmount", async () => {
+    fetchMock.mockResolvedValue(mockHealth({ conv_a: { runner_online: true } }));
+    const { result, unmount } = renderHook(() => useRunnerHealth(SESSIONS));
+    await waitFor(() => expect(result.current.size).toBe(1));
+    const callsAtUnmount = fetchMock.mock.calls.length;
+
+    unmount();
+    setHidden(true);
+    setHidden(false);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(callsAtUnmount);
+  });
+});

--- a/web/src/hooks/useRunnerHealth.ts
+++ b/web/src/hooks/useRunnerHealth.ts
@@ -87,16 +87,28 @@ export function useRunnerHealth(
     // /health when it's already returning 5xx.
     let nextDelayMs = POLL_INTERVAL_MS;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    // Retires the running chain when returning to the tab starts a fresh one,
+    // so an in-flight poll can't leave a second timer behind.
+    let generation = 0;
 
-    async function poll() {
+    async function poll(gen: number) {
+      if (cancelled || gen !== generation) return;
+      // A hidden tab shows no liveness badges, so the request buys nothing —
+      // skip it and re-check on the next tick. This is not a failure, so the
+      // error backoff is left alone. Returning to the tab polls immediately
+      // (see below), so nothing is stale by the time it's visible again.
+      if (typeof document !== "undefined" && document.hidden) {
+        timer = setTimeout(() => void poll(gen), POLL_INTERVAL_MS);
+        return;
+      }
       let success = false;
       try {
         const param = ids.join(",");
         const resp = await authenticatedFetch(`/health?session_ids=${encodeURIComponent(param)}`);
-        if (cancelled) return;
+        if (cancelled || gen !== generation) return;
         if (resp.ok) {
           const body = (await resp.json()) as BatchHealthResponse;
-          if (cancelled) return;
+          if (cancelled || gen !== generation) return;
           if (body.sessions) {
             const next = new Map<string, SessionLiveness>();
             for (const id of ids) {
@@ -116,18 +128,35 @@ export function useRunnerHealth(
       } catch {
         // Network error — leave current state unchanged.
       }
-      if (cancelled) return;
+      if (cancelled || gen !== generation) return;
       if (success) {
         nextDelayMs = POLL_INTERVAL_MS;
       } else {
         nextDelayMs = Math.min(nextDelayMs * 2, POLL_MAX_INTERVAL_MS);
       }
-      timer = setTimeout(() => void poll(), nextDelayMs);
+      timer = setTimeout(() => void poll(gen), nextDelayMs);
     }
 
-    void poll();
+    // Back on screen: poll now rather than waiting out the tick the hidden
+    // branch scheduled, so liveness is current the moment it's visible. Also
+    // clears any accumulated backoff — a fresh look deserves a fresh attempt.
+    function onVisibilityChange() {
+      if (cancelled || document.hidden) return;
+      if (timer !== null) clearTimeout(timer);
+      generation += 1;
+      nextDelayMs = POLL_INTERVAL_MS;
+      void poll(generation);
+    }
+
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisibilityChange);
+    }
+    void poll(generation);
     return () => {
       cancelled = true;
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+      }
       if (timer !== null) clearTimeout(timer);
     };
   }, [sessions]);


### PR DESCRIPTION
## Related issue

Closes #

## Summary

`useRunnerHealth` is a hand-rolled self-rescheduling `setTimeout` loop, so it
kept issuing `GET /health` **every 10 seconds for as long as a tab stayed
open** — backgrounded or not. A hidden tab renders no liveness badges, so every
one of those requests bought nothing: 6 requests/minute, 360/hour, per open tab.

The notable part is that this is an *inconsistency*, not a policy choice. Every
other poller in the app is a react-query `refetchInterval`
(`useConversations`, `useHosts`, `useTerminals`, `useScheduledTasks`), and
react-query only fires those while the window is focused —
`refetchIntervalInBackground` defaults to `false` and nothing here overrides it
(`queryObserver.js`: `if (this.options.refetchIntervalInBackground || focusManager.isFocused())`).
This loop was the lone exception. The change brings it in line rather than
introducing new behaviour.

- While `document.hidden`, skip the request and re-check on the next tick. This
  is not a failure, so the error backoff is deliberately left untouched.
- On `visibilitychange` back to visible, **poll immediately** instead of waiting
  out the tick the hidden branch scheduled — so liveness is current the moment
  the user looks, rather than up to 10s stale. Accumulated backoff is dropped
  too: a fresh look deserves a fresh attempt.
- A generation counter retires the previous chain on wake-up, so an in-flight
  poll can't leave a second timer behind and turn N tab-flips into N parallel
  loops.

## Test Plan

- Four new tests in `src/hooks/useRunnerHealth.test.tsx`:
  - no request at all while hidden,
  - returning to the tab polls immediately (not after the tick),
  - repeated hide/show flips keep **exactly one** poll chain — the count settles
    at one poll per wake-up instead of climbing, which is what catches the
    duplicate-timer bug the generation counter exists to prevent,
  - unmount removes the `visibilitychange` listener.
- `npx vitest run src/hooks/useRunnerHealth` — 9/9 pass.
- `npx vitest run` — full web suite: **5,901 passed, 0 failed**.
- `npx tsc -b`, `oxlint --deny-warnings`, `prettier --check` all clean.
- Manually: opened a session, switched to another tab and watched the Network
  panel go quiet, then switched back and saw a single `/health` fire
  immediately with the host/runner badges correct.

### One thing I found but did not change

While testing I hit a **pre-existing** latent footgun worth flagging: this
effect keys on the `sessions` array *identity*, and its own `setStatusMap` causes
a re-render. If a caller passes a fresh array literal each render, the effect
re-fires in a loop — I measured ~2,000 `/health` calls in 100 ms on unmodified
`origin/main`. The only real caller (`RunnerHealthProvider`'s `fallbackSet`) is
`useMemo`'d, so this is latent rather than live, and it is out of scope here. My
new tests hoist their `sessions` array to match the real caller's contract.
Happy to file it separately.

## Demo

N/A — no visual change. The observable difference is an idle Network panel while
the tab is backgrounded.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new tests cover both halves of the contract — that a hidden tab is silent,
and that returning to it is *not* stale — plus the duplicate-chain regression the
generation counter guards. The five existing tests cover the polling and
payload-normalisation behaviour and pass unchanged. Manual verification covered
the real browser `visibilitychange` path, since jsdom only simulates it.

## Changelog

Backgrounded tabs no longer poll the server for session liveness, and refresh immediately when you return to them.
