### PR TITLE
perf(web): look pinned ids up in a Set in the sidebar row loop

### DIFF
--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -2537,6 +2537,10 @@ function ConversationSection({
 }) {
   // An untitled section is always open — there's no header to collapse it.
   const isCollapsed = title != null && collapsed;
+  // Set, not the raw array: the row loop below asks per row, so `.includes`
+  // made the pinned check O(rows x pinned) on every sidebar render. Matches
+  // what `ProjectFolder` and the section builder already do with this prop.
+  const pinnedSet = useMemo(() => new Set(pinnedConversationIds), [pinnedConversationIds]);
   return (
     <section className="group/section relative">
       {title && (
@@ -2590,7 +2594,7 @@ function ConversationSection({
                 <ConversationRow
                   key={conv.id}
                   conversation={conv}
-                  isPinned={pinnedConversationIds.includes(conv.id)}
+                  isPinned={pinnedSet.has(conv.id)}
                   onClick={onRowClick}
                   onTogglePinned={onTogglePinned}
                   selectionMode={selectionMode}


### PR DESCRIPTION
## Related issue

Closes #

## Summary

`ConversationSection` asked `pinnedConversationIds.includes(conv.id)` **once per
row** inside its render loop, making the pinned check O(rows × pinned) on every
sidebar render.

Build the `Set` once with `useMemo` and use `.has()`. This is the pattern the
file already uses for this exact prop in `ProjectFolder` (line 1132) and in the
section builder (line 1420) — `ConversationSection` was simply the one place it
was missed.

**Honest sizing:** this is a micro-fix. With a few hundred loaded sessions and a
handful of pins it is fractions of a millisecond per render — I am not going to
claim it is more than that. It is worth landing for consistency with the
file's other three call sites as much as for the cycles saved, and it scales
correctly if either list grows.

## Test Plan

- `npx vitest run src/shell/Sidebar` — 238/238 pass. The suite already covers
  pinning, unpinning, pinned ordering, and the pinned-outside-the-loaded-window
  case, so it exercises the changed lookup directly.
- `npx vitest run` — full web suite: **5,897 passed, 0 failed**.
- `npx tsc -b`, `oxlint --deny-warnings`, `prettier --check` all clean.
- Manually: pinned and unpinned sessions from the row kebab and confirmed rows
  move between the Pinned section and the flat list, that the pin icon state is
  right in both, and that a session pinned inside a project moves out to the
  flat Pinned section as before.

## Demo

N/A — no visual or behavioural change; identical results from a faster lookup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

No new tests: the change swaps one lookup for an equivalent one with no new
branches, and the existing Sidebar suite already asserts pinned-row placement
and icon state, which is exactly what would break if the lookup were wrong.
Verified pin/unpin by hand on top of that.
