### PR TITLE
fix(web): let a person answer an MCP elicitation that asks for fields

### DIFF
--- a/tests/e2e_ui/approvals/test_elicitation_schema_form.py
+++ b/tests/e2e_ui/approvals/test_elicitation_schema_form.py
@@ -12,11 +12,10 @@ posts one, the SPA renders the card, and the test drives the controls. Unlike
 endpoint returns the elicitation id immediately rather than parking, which is
 how the runner's own callback uses it.
 
-The binary counterpart is ``test_approval_card.py`` (a policy ASK, which sends
-an empty schema and must keep its Approve / Reject), and the keyboard half of
-the story is ``test_approve_hotkey.py``: a prompt asking for fields must not be
-acceptable from the keyboard, since a keystroke would send the server none of
-what it asked for.
+The binary counterpart is ``test_approval_card.py``, which drives a real
+consent prompt, and the keyboard half of the story is ``test_approve_hotkey.py``:
+a prompt asking for fields must not be acceptable from the keyboard, since a
+keystroke would send the server none of what it asked for.
 """
 
 from __future__ import annotations
@@ -39,6 +38,9 @@ _RENDER_TIMEOUT_MS = 15_000
 # Loading the conversation is slower than rendering a card in it, and slower
 # again when the whole directory runs at once, so it gets its own budget.
 _LOAD_TIMEOUT_MS = 60_000
+# A wrong accept has to travel keydown -> handler -> POST -> server state, so
+# too short a window here reads as "nothing happened" on a loaded shard.
+_NON_EVENT_MS = 5_000
 # The composer's placeholder changes while a prompt is pending; its accessible
 # name does not, which is what makes it usable as a "transcript is up" signal.
 _COMPOSER = "Message the agent"
@@ -58,9 +60,26 @@ _SCHEMA = {
 
 def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
     """Return the session snapshot's pending elicitation events."""
-    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=30.0)
     resp.raise_for_status()
     return resp.json().get("pending_elicitations") or []
+
+
+def _parked(base_url: str, session_id: str, elicitation_id: str) -> bool:
+    """Whether the server still holds *elicitation_id* unanswered.
+
+    Named rather than counted, so a renamed snapshot key cannot make "drained"
+    pass by returning nothing.
+    """
+    return any(
+        e.get("elicitation_id") == elicitation_id or e.get("id") == elicitation_id
+        for e in _pending_elicitations(base_url, session_id)
+    )
+
+
+def _wait_for_parked(base_url: str, session_id: str, elicitation_id: str) -> None:
+    """Block until the prompt is in the snapshot the SPA is about to read."""
+    _wait_for(lambda: _parked(base_url, session_id, elicitation_id))
 
 
 def _wait_for(predicate, *, timeout_s: float = 30.0, interval_s: float = 0.5) -> None:
@@ -113,8 +132,8 @@ def test_a_schema_that_names_fields_renders_a_form_and_submits(
     base_url, session_id = seeded_session
     _log.info("seeded session ready: base_url=%s session_id=%s", base_url, session_id)
 
-    _raise_elicitation(base_url, session_id, _SCHEMA)
-    page.wait_for_timeout(500)
+    eid = _raise_elicitation(base_url, session_id, _SCHEMA)
+    _wait_for_parked(base_url, session_id, eid)
     _open_session(page, base_url, session_id)
 
     card = (
@@ -142,7 +161,10 @@ def test_a_schema_that_names_fields_renders_a_form_and_submits(
     submit = form.locator(_SUBMIT)
     expect(submit).to_be_disabled()
 
+    # Every required property, not just one of them: answering `branch` alone
+    # still leaves the server short of what it asked for.
     branch.fill("release/2.4")
+    expect(submit).to_be_disabled()
     channel.select_option("stable")
     expect(submit).to_be_enabled()
 
@@ -150,7 +172,7 @@ def test_a_schema_that_names_fields_renders_a_form_and_submits(
 
     responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first
     expect(responded).to_be_visible(timeout=_RENDER_TIMEOUT_MS)
-    _wait_for(lambda: not _pending_elicitations(base_url, session_id))
+    _wait_for(lambda: not _parked(base_url, session_id, eid))
 
 
 @pytest.mark.timeout(180)
@@ -160,19 +182,27 @@ def test_a_consent_prompt_keeps_its_buttons(
 ) -> None:
     """A schema naming no fields is a yes/no question, and stays one.
 
-    A policy ASK sends ``requestedSchema: {}``. Rendering a form with no fields
-    for it would replace a working control with an unusable one.
+    A policy ASK carries no properties. Rendering an empty form for it would
+    replace a working control with an unusable one. This one passes against the
+    pre-change UI as well — it guards the path this change must not touch,
+    rather than proving the change.
     """
     base_url, session_id = seeded_session
 
-    _raise_elicitation(base_url, session_id, {"type": "object"})
-    page.wait_for_timeout(500)
+    eid = _raise_elicitation(base_url, session_id, {"type": "object"})
+    _wait_for_parked(base_url, session_id, eid)
     _open_session(page, base_url, session_id)
 
     card = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first
     expect(card).to_be_visible(timeout=_RENDER_TIMEOUT_MS)
     expect(card.locator(_FORM)).to_have_count(0)
     expect(card.get_by_role("button", name="Approve")).to_be_visible()
+    reject = card.get_by_role("button", name="Reject")
+    expect(reject).to_be_visible()
+
+    # Answer it rather than leaving it parked for whatever runs next.
+    reject.click()
+    _wait_for(lambda: not _parked(base_url, session_id, eid))
 
 
 @pytest.mark.timeout(180)
@@ -185,11 +215,16 @@ def test_the_keyboard_cannot_accept_a_prompt_that_asks_for_fields(
     The hotkey accepts a pending prompt with no content. That is right for a
     yes/no gate and wrong here: the server asked for values, and accepting from
     the keyboard would send it none of them.
+
+    No wait proves a keystroke did nothing, so the same test goes on to answer
+    the form. Reaching ``responded`` that way is the control: the page was live
+    and taking input all along, so the earlier stillness was the guard working
+    rather than a keystroke that never landed.
     """
     base_url, session_id = seeded_session
 
-    _raise_elicitation(base_url, session_id, _SCHEMA)
-    page.wait_for_timeout(500)
+    eid = _raise_elicitation(base_url, session_id, _SCHEMA)
+    _wait_for_parked(base_url, session_id, eid)
     _open_session(page, base_url, session_id)
 
     card = (
@@ -198,10 +233,21 @@ def test_the_keyboard_cannot_accept_a_prompt_that_asks_for_fields(
         .first
     )
     expect(card).to_be_visible(timeout=_RENDER_TIMEOUT_MS)
+    form = card.locator(_FORM)
 
     page.keyboard.press("Control+Enter")
-    page.wait_for_timeout(1500)
+    page.wait_for_timeout(_NON_EVENT_MS)
 
-    # Still pending, on the card and on the server.
+    # Still pending, on the card and on the server, and still refusing a submit
+    # it has no values for.
     expect(card).to_be_visible()
-    assert _pending_elicitations(base_url, session_id), "the keystroke accepted it"
+    expect(form.locator(_SUBMIT)).to_be_disabled()
+    assert _parked(base_url, session_id, eid), "the keystroke accepted it"
+
+    form.locator(f'{_FIELD.format("branch")} input[type="text"]').fill("release/2.4")
+    form.locator(f"{_FIELD.format('channel')} select").select_option("stable")
+    form.locator(_SUBMIT).click()
+    expect(page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first).to_be_visible(
+        timeout=_RENDER_TIMEOUT_MS
+    )
+    _wait_for(lambda: not _parked(base_url, session_id, eid))

--- a/tests/e2e_ui/approvals/test_elicitation_schema_form.py
+++ b/tests/e2e_ui/approvals/test_elicitation_schema_form.py
@@ -1,0 +1,207 @@
+r"""E2E: an MCP elicitation that asks for fields renders a form you can answer.
+
+``elicitation/create`` lets an MCP server declare what it needs back in
+``requestedSchema``. The approval card could collect one shape of that — a lone
+``answer`` enum, rendered as option buttons — and everything else fell through
+to Approve / Reject, so a server asking for a branch name and a release channel
+showed two buttons and no way to say either.
+
+An ``mcp_elicitation`` event is posted the way the runner's inline callback
+posts one, the SPA renders the card, and the test drives the controls. Unlike
+``test_ask_user_question.py`` this needs no background thread: the event
+endpoint returns the elicitation id immediately rather than parking, which is
+how the runner's own callback uses it.
+
+The binary counterpart is ``test_approval_card.py`` (a policy ASK, which sends
+an empty schema and must keep its Approve / Reject), and the keyboard half of
+the story is ``test_approve_hotkey.py``: a prompt asking for fields must not be
+acceptable from the keyboard, since a keystroke would send the server none of
+what it asked for.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_log = logging.getLogger(__name__)
+
+_APPROVAL_CARD = '[data-testid="approval-card"]'
+_FORM = '[data-testid="elicitation-schema-form"]'
+_FIELD = '[data-testid="elicit-field-{}"]'
+_SUBMIT = '[data-testid="elicitation-schema-submit"]'
+
+_RENDER_TIMEOUT_MS = 15_000
+# Loading the conversation is slower than rendering a card in it, and slower
+# again when the whole directory runs at once, so it gets its own budget.
+_LOAD_TIMEOUT_MS = 60_000
+# The composer's placeholder changes while a prompt is pending; its accessible
+# name does not, which is what makes it usable as a "transcript is up" signal.
+_COMPOSER = "Message the agent"
+
+# What a server sends when it needs values rather than consent: a required
+# free-form string, a required enum, and a boolean carrying a default.
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "branch": {"type": "string", "title": "Release branch"},
+        "channel": {"type": "string", "enum": ["beta", "stable"]},
+        "notify": {"type": "boolean", "title": "Notify the channel", "default": True},
+    },
+    "required": ["branch", "channel"],
+}
+
+
+def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
+    """Return the session snapshot's pending elicitation events."""
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+    resp.raise_for_status()
+    return resp.json().get("pending_elicitations") or []
+
+
+def _wait_for(predicate, *, timeout_s: float = 30.0, interval_s: float = 0.5) -> None:
+    """Poll *predicate* until truthy or the deadline passes."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise AssertionError("condition not met within timeout")
+
+
+def _open_session(page: Page, base_url: str, session_id: str) -> None:
+    """Open the session and wait until the transcript has actually loaded."""
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_role("textbox", name=_COMPOSER)).to_be_visible(timeout=_LOAD_TIMEOUT_MS)
+
+
+def _raise_elicitation(base_url: str, session_id: str, schema: dict) -> str:
+    """Post an ``mcp_elicitation`` event and return its elicitation id.
+
+    Mirrors ``RunnerMcpManager._build_elicitation_callback``: it POSTs the
+    message and schema, and the server answers with the id it parked under.
+
+    :param base_url: Server base URL.
+    :param session_id: Session to raise the prompt on.
+    :param schema: The MCP ``requestedSchema``.
+    :returns: The server-minted elicitation id.
+    """
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={
+            "type": "mcp_elicitation",
+            "data": {"message": "Which release should I cut?", "requestedSchema": schema},
+        },
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    elicitation_id = resp.json().get("elicitation_id")
+    assert isinstance(elicitation_id, str) and elicitation_id, resp.text
+    return elicitation_id
+
+
+@pytest.mark.timeout(180)
+def test_a_schema_that_names_fields_renders_a_form_and_submits(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """One control per property, gated on the required ones, then answered."""
+    base_url, session_id = seeded_session
+    _log.info("seeded session ready: base_url=%s session_id=%s", base_url, session_id)
+
+    _raise_elicitation(base_url, session_id, _SCHEMA)
+    page.wait_for_timeout(500)
+    _open_session(page, base_url, session_id)
+
+    card = (
+        page.locator(f'{_APPROVAL_CARD}[data-state="pending"]')
+        .filter(has=page.locator(_FORM))
+        .first
+    )
+    expect(card).to_be_visible(timeout=_RENDER_TIMEOUT_MS)
+    form = card.locator(_FORM)
+
+    # One control per declared property, of the type the schema asked for, and
+    # labelled by ``title`` where the server sent one.
+    expect(form.locator(_FIELD.format("branch"))).to_contain_text("Release branch")
+    branch = form.locator(f'{_FIELD.format("branch")} input[type="text"]')
+    channel = form.locator(f"{_FIELD.format('channel')} select")
+    notify = form.locator(f'{_FIELD.format("notify")} input[type="checkbox"]')
+    expect(branch).to_be_visible()
+    expect(channel).to_be_visible()
+    expect(notify).to_be_visible()
+    # ``default: true`` prefills, so the person is not asked to restate it.
+    expect(notify).to_be_checked()
+
+    # The whole point of the gate: the server declared two required fields, so
+    # an accept cannot be sent before they are answered.
+    submit = form.locator(_SUBMIT)
+    expect(submit).to_be_disabled()
+
+    branch.fill("release/2.4")
+    channel.select_option("stable")
+    expect(submit).to_be_enabled()
+
+    submit.click()
+
+    responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first
+    expect(responded).to_be_visible(timeout=_RENDER_TIMEOUT_MS)
+    _wait_for(lambda: not _pending_elicitations(base_url, session_id))
+
+
+@pytest.mark.timeout(180)
+def test_a_consent_prompt_keeps_its_buttons(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A schema naming no fields is a yes/no question, and stays one.
+
+    A policy ASK sends ``requestedSchema: {}``. Rendering a form with no fields
+    for it would replace a working control with an unusable one.
+    """
+    base_url, session_id = seeded_session
+
+    _raise_elicitation(base_url, session_id, {"type": "object"})
+    page.wait_for_timeout(500)
+    _open_session(page, base_url, session_id)
+
+    card = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first
+    expect(card).to_be_visible(timeout=_RENDER_TIMEOUT_MS)
+    expect(card.locator(_FORM)).to_have_count(0)
+    expect(card.get_by_role("button", name="Approve")).to_be_visible()
+
+
+@pytest.mark.timeout(180)
+def test_the_keyboard_cannot_accept_a_prompt_that_asks_for_fields(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Cmd/Ctrl+Enter must not walk around the disabled Submit.
+
+    The hotkey accepts a pending prompt with no content. That is right for a
+    yes/no gate and wrong here: the server asked for values, and accepting from
+    the keyboard would send it none of them.
+    """
+    base_url, session_id = seeded_session
+
+    _raise_elicitation(base_url, session_id, _SCHEMA)
+    page.wait_for_timeout(500)
+    _open_session(page, base_url, session_id)
+
+    card = (
+        page.locator(f'{_APPROVAL_CARD}[data-state="pending"]')
+        .filter(has=page.locator(_FORM))
+        .first
+    )
+    expect(card).to_be_visible(timeout=_RENDER_TIMEOUT_MS)
+
+    page.keyboard.press("Control+Enter")
+    page.wait_for_timeout(1500)
+
+    # Still pending, on the card and on the server.
+    expect(card).to_be_visible()
+    assert _pending_elicitations(base_url, session_id), "the keystroke accepted it"

--- a/web/src/components/blocks/ApprovalCard.tsx
+++ b/web/src/components/blocks/ApprovalCard.tsx
@@ -55,6 +55,11 @@ import type { RenderItem } from "@/lib/renderItems";
 import type { RememberScope } from "@/lib/types";
 import { useChatStore } from "@/store/chatStore";
 import { AskUserQuestionForm, type AskUserQuestionAnswers } from "./AskUserQuestionForm";
+import {
+  type ElicitationAnswers,
+  ElicitationSchemaForm,
+  schemaFields,
+} from "./ElicitationSchemaForm";
 import { ExitPlanModeReview } from "./ExitPlanModeReview";
 
 /**
@@ -69,6 +74,10 @@ import { ExitPlanModeReview } from "./ExitPlanModeReview";
 function extractOptionLabels(schema: Record<string, unknown>): string[] {
   const properties = schema.properties;
   if (!properties || typeof properties !== "object") return [];
+  // Only when ``answer`` is the whole question. A schema pairing it with, say,
+  // a required ``reason`` renders as buttons that submit the answer and drop
+  // the reason the server said it needed; that shape belongs to the form.
+  if (Object.keys(properties as Record<string, unknown>).length !== 1) return [];
   const answer = (properties as Record<string, unknown>).answer;
   if (!answer || typeof answer !== "object") return [];
   const enumValues = (answer as Record<string, unknown>).enum;
@@ -188,6 +197,9 @@ export function ApprovalCard({
   const submitOption = (label: string) => {
     submit(elicitationId, "accept", { answer: label });
   };
+  const submitSchemaAnswers = (content: ElicitationAnswers) => {
+    submit(elicitationId, "accept", content);
+  };
   const submitAnswers = (answers: AskUserQuestionAnswers) => {
     // ``content`` is MCP's ``ElicitResult.content``: a flat
     // ``{[field]: scalar | string[]}`` map, where each AskUserQuestion
@@ -239,6 +251,12 @@ export function ApprovalCard({
   const optionLabels = askPayload === null ? extractOptionLabels(requestedSchema) : [];
   const isAskUserQuestion = askPayload !== null;
   const isMultiChoice = optionLabels.length > 0;
+  // Any other schema that names fields: a free-form string, several
+  // properties, an enum under a name other than ``answer``. These used to
+  // fall through to Approve / Reject, which cannot answer them.
+  const schemaFormFields =
+    askPayload === null && !isMultiChoice ? schemaFields(requestedSchema) : [];
+  const isSchemaForm = schemaFormFields.length > 0;
   const isCodexCommandApproval = codexCommand !== null && codexCommand !== undefined;
   // External URL: the elicitation points to a third-party page (OAuth,
   // external MCP server, etc.) — show a link. Our own /approve/...
@@ -271,7 +289,7 @@ export function ApprovalCard({
   // approvals get a dedicated command render below, so showing the
   // transport JSON would expose unrelated ids and duplicate details.
   const formattedPreview =
-    isAskUserQuestion || isExitPlanMode || isMultiChoice || isCodexCommandApproval
+    isAskUserQuestion || isExitPlanMode || isMultiChoice || isSchemaForm || isCodexCommandApproval
       ? ""
       : formatPreview(contentPreview);
   const execPolicyAmendment =
@@ -559,6 +577,12 @@ export function ApprovalCard({
                   </a>
                 </Button>
               </div>
+            ) : isSchemaForm ? (
+              <ElicitationSchemaForm
+                fields={schemaFormFields}
+                onSubmit={submitSchemaAnswers}
+                onReject={() => submitBinary("decline")}
+              />
             ) : isMultiChoice ? (
               <div className="flex flex-wrap gap-2 pt-1" data-testid="approval-card-options">
                 {optionLabels.map((optLabel) => (

--- a/web/src/components/blocks/ElicitationSchemaForm.test.ts
+++ b/web/src/components/blocks/ElicitationSchemaForm.test.ts
@@ -1,0 +1,229 @@
+// An MCP server's ``requestedSchema`` is answerable, not just approvable.
+//
+// The card had one schema shape it could collect — a lone ``answer`` enum,
+// rendered as option buttons. Everything else fell through to Approve /
+// Reject, so a server asking for a branch name got a yes carrying none of
+// the fields it declared. These pin the reading of the schema and the shape
+// of what goes back on the wire.
+
+import { describe, expect, it } from "vitest";
+import {
+  type ElicitationDraft,
+  enumLabel,
+  isComplete,
+  type SchemaField,
+  schemaFields,
+  toContent,
+} from "./ElicitationSchemaForm";
+
+const RELEASE_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    branch: { type: "string", title: "Release branch" },
+    notify: { type: "boolean", default: true },
+    channel: { type: "string", enum: ["beta", "stable"] },
+    holdback: { type: "integer" },
+  },
+  required: ["branch", "channel"],
+};
+
+describe("schemaFields", () => {
+  it("reads every property in the order the server wrote them", () => {
+    expect(schemaFields(RELEASE_SCHEMA).map((f) => f.name)).toEqual([
+      "branch",
+      "notify",
+      "channel",
+      "holdback",
+    ]);
+  });
+
+  it("marks the required ones", () => {
+    const required = schemaFields(RELEASE_SCHEMA)
+      .filter((f) => f.required)
+      .map((f) => f.name);
+    expect(required).toEqual(["branch", "channel"]);
+  });
+
+  it("owns nothing when there is no schema at all", () => {
+    // ``requestedSchema`` is optional on the wire; an absent one must not
+    // throw where it is read, which includes the approve hotkey's guard.
+    expect(schemaFields(undefined)).toEqual([]);
+    expect(schemaFields(null)).toEqual([]);
+  });
+
+  it("owns nothing when the schema names no properties", () => {
+    // A bare consent prompt. Approve / Reject is the right control, and a
+    // form with no fields would be a worse one.
+    expect(schemaFields({ type: "object" })).toEqual([]);
+    expect(schemaFields({})).toEqual([]);
+  });
+
+  it("skips a property that is not an object", () => {
+    // Malformed input from an outside server must not crash the card.
+    const fields = schemaFields({ properties: { ok: { type: "string" }, bad: "nope" } });
+    expect(fields.map((f) => f.name)).toEqual(["ok"]);
+  });
+});
+
+describe("isComplete", () => {
+  const fields: SchemaField[] = schemaFields(RELEASE_SCHEMA);
+
+  it("blocks submit while a required field is blank", () => {
+    // The server declared it; sending an accept without it is the bug this
+    // whole form exists to stop.
+    expect(isComplete(fields, { branch: "release/2.4", channel: "" })).toBe(false);
+  });
+
+  it("ignores blank optional fields", () => {
+    expect(isComplete(fields, { branch: "release/2.4", channel: "beta" })).toBe(true);
+  });
+
+  it("treats false as an answered boolean", () => {
+    // "No" is an answer to "should I notify?" — not an empty field.
+    const boolOnly = schemaFields({
+      properties: { force: { type: "boolean" } },
+      required: ["force"],
+    });
+    expect(isComplete(boolOnly, { force: false })).toBe(true);
+  });
+
+  it("rejects whitespace as an answer", () => {
+    expect(isComplete(fields, { branch: "   ", channel: "beta" })).toBe(false);
+  });
+});
+
+describe("toContent", () => {
+  const fields: SchemaField[] = schemaFields(RELEASE_SCHEMA);
+
+  it("sends the values the person entered", () => {
+    const answers: ElicitationDraft = {
+      branch: "release/2.4",
+      notify: true,
+      channel: "stable",
+      holdback: "10",
+    };
+    expect(toContent(fields, answers)).toEqual({
+      branch: "release/2.4",
+      notify: true,
+      channel: "stable",
+      holdback: 10,
+    });
+  });
+
+  it("coerces a number field so the server gets a number", () => {
+    // The input element hands back a string; the schema asked for an integer.
+    expect(toContent(fields, { branch: "b", channel: "beta", holdback: "3" }).holdback).toBe(3);
+  });
+
+  it("omits an untouched optional field", () => {
+    // Sending "" would read as answered-with-nothing rather than unanswered.
+    const content = toContent(fields, { branch: "b", channel: "beta", holdback: "" });
+    expect("holdback" in content).toBe(false);
+  });
+
+  it("keeps a false boolean", () => {
+    const content = toContent(fields, { branch: "b", channel: "beta", notify: false });
+    expect(content.notify).toBe(false);
+  });
+});
+
+describe("values the server must never receive", () => {
+  const numeric: SchemaField[] = schemaFields({
+    properties: { holdback: { type: "integer" }, ratio: { type: "number" } },
+    required: ["holdback"],
+  });
+
+  it("refuses a number that JSON would write as null", () => {
+    // `Number("1e999")` is Infinity, and JSON.stringify turns that into null —
+    // the server declared a number and would receive a null inside an accept.
+    expect(isComplete(numeric, { holdback: "1e999" })).toBe(false);
+    expect("holdback" in toContent(numeric, { holdback: "1e999" })).toBe(false);
+  });
+
+  it("refuses a fraction in an integer field", () => {
+    expect(isComplete(numeric, { holdback: "3.5" })).toBe(false);
+  });
+
+  it("accepts a fraction in a number field", () => {
+    expect(toContent(numeric, { holdback: "1", ratio: "0.25" }).ratio).toBe(0.25);
+  });
+
+  it("omits an unparseable numeric entry rather than sending text", () => {
+    // Reachable through a non-conforming string `default` on a numeric
+    // property. An accept carrying a type-invalid value is worse than one
+    // carrying nothing: the server has already taken the accept path.
+    expect("ratio" in toContent(numeric, { holdback: "1", ratio: "soon" })).toBe(false);
+  });
+});
+
+describe("an untouched optional boolean", () => {
+  const fields: SchemaField[] = schemaFields({ properties: { notify: { type: "boolean" } } });
+
+  it("is not answered on the person's behalf", () => {
+    // false and unanswered are different instructions: one turns something
+    // off, the other leaves the server's own decision alone.
+    const draft: ElicitationDraft = Object.fromEntries(fields.map((f) => [f.name, undefined]));
+    expect("notify" in toContent(fields, draft)).toBe(false);
+  });
+
+  it("is sent once it is actually set to false", () => {
+    expect(toContent(fields, { notify: false }).notify).toBe(false);
+  });
+
+  it("keeps a declared default", () => {
+    const withDefault = schemaFields({
+      properties: { notify: { type: "boolean", default: true } },
+    });
+    expect(toContent(withDefault, { notify: true }).notify).toBe(true);
+  });
+});
+
+describe("enumNames", () => {
+  const prop = { enum: ["c1", "c2"], enumNames: ["Beta channel", "Stable channel"] };
+
+  it("shows the label the server supplied", () => {
+    expect(enumLabel(prop, 0, "c1")).toBe("Beta channel");
+  });
+
+  it("falls back to the value when no label was given", () => {
+    expect(enumLabel({ enum: ["c1"] }, 0, "c1")).toBe("c1");
+    expect(enumLabel(prop, 5, "c9")).toBe("c9");
+  });
+});
+
+describe("shapes the form must not claim", () => {
+  it("leaves the ACP approval scopes on the option buttons", () => {
+    // What `_executor_adapter._permission_card` emits for an ACP agent's own
+    // approval scopes: `answer` alone, which the card renders as one button
+    // per option. The form must not take that over — a list of scopes is a
+    // pick-one, and a select would be a worse control than the buttons.
+    const acpScopes = {
+      type: "object",
+      properties: {
+        answer: {
+          type: "string",
+          enum: ["Allow", "Yes, allow `ls` commands (this session)", "Reject"],
+        },
+      },
+      required: ["answer"],
+    };
+
+    // The card computes fields only when the option-button branch declines the
+    // schema, and that branch owns any schema whose sole property is `answer`.
+    expect(Object.keys(acpScopes.properties)).toEqual(["answer"]);
+    expect(schemaFields(acpScopes).map((f) => f.name)).toEqual(["answer"]);
+  });
+
+  it("does claim `answer` once the server also asks for something else", () => {
+    // Buttons here would submit the answer and silently drop the reason the
+    // server declared required.
+    const withReason = {
+      properties: {
+        answer: { type: "string", enum: ["yes", "no"] },
+        reason: { type: "string" },
+      },
+      required: ["answer", "reason"],
+    };
+    expect(schemaFields(withReason).map((f) => f.name)).toEqual(["answer", "reason"]);
+  });
+});

--- a/web/src/components/blocks/ElicitationSchemaForm.tsx
+++ b/web/src/components/blocks/ElicitationSchemaForm.tsx
@@ -1,0 +1,307 @@
+// Form for an MCP elicitation's ``requestedSchema``.
+//
+// ``elicitation/create`` is how an MCP server asks for something it cannot
+// decide alone, and the shape it wants back is declared in the request:
+// a flat object of primitive properties, per MCP's elicitation spec. The
+// card rendered a bare Approve / Reject for all of them, so a server asking
+// "which branch?" or "name the release" got a yes with no fields — the
+// answer it declared it needed was unanswerable.
+//
+// Each property becomes one control, chosen by what the schema says:
+//   - ``enum``            → a select, with the offered values
+//   - ``type: boolean``   → a checkbox
+//   - ``type: number`` /
+//     ``integer``         → a number input
+//   - anything else       → a text input
+//
+// ``default`` prefills. ``title`` labels the field and ``description``
+// explains it, both per the spec's presentation hints, falling back to the
+// property name. Submit is gated on every ``required`` property having a
+// value, so a server that declared a field cannot be sent an accept without
+// it.
+
+import { CheckIcon, XIcon } from "lucide-react";
+import { useId, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+/** One value MCP allows in an ``ElicitResult.content`` map. */
+export type ElicitValue = string | number | boolean;
+
+/** The answers gathered from the form, keyed by property name. */
+export type ElicitationAnswers = Record<string, ElicitValue>;
+
+/** Form state, where a field may not have been answered yet. */
+export type ElicitationDraft = Record<string, ElicitValue | undefined>;
+
+/** A single property of a ``requestedSchema``, as far as this form reads it. */
+interface SchemaProperty {
+  type?: string;
+  enum?: unknown[];
+  enumNames?: unknown[];
+  default?: unknown;
+  title?: string;
+  description?: string;
+}
+
+/** A property paired with the name it is keyed under. */
+export interface SchemaField {
+  name: string;
+  prop: SchemaProperty;
+  required: boolean;
+}
+
+/**
+ * Read a ``requestedSchema`` into an ordered field list.
+ *
+ * Returns an empty array for a schema with no properties at all — a bare
+ * consent prompt, where Approve / Reject is the right control. Property order
+ * follows the schema's own key order, which is the order the server wrote
+ * them in.
+ *
+ * A lone ``answer`` enum *does* come back as one field. Excluding it is the
+ * caller's job: the card checks the option-button branch first, and the
+ * approve hotkey wants that shape counted so it stops firing a bare accept at
+ * a question that needs a choice.
+ */
+export function schemaFields(schema: Record<string, unknown> | null | undefined): SchemaField[] {
+  // The schema comes from an outside server and is optional on the wire, so
+  // an absent one is ordinary rather than exceptional.
+  const properties = schema?.properties;
+  if (!properties || typeof properties !== "object") return [];
+  const entries = Object.entries(properties as Record<string, unknown>);
+  if (entries.length === 0) return [];
+  const requiredRaw = schema.required;
+  const required = new Set(
+    Array.isArray(requiredRaw) ? requiredRaw.filter((r): r is string => typeof r === "string") : [],
+  );
+  return entries
+    .filter(([, prop]) => prop !== null && typeof prop === "object")
+    .map(([name, prop]) => ({
+      name,
+      prop: prop as SchemaProperty,
+      required: required.has(name),
+    }));
+}
+
+/**
+ * The value a field starts at: its ``default``, or unset.
+ *
+ * A boolean with no default starts ``undefined`` rather than ``false``. They
+ * are not the same answer — ``false`` tells the server to turn something off,
+ * and an untouched checkbox has told it nothing.
+ */
+function initialValue(field: SchemaField): ElicitValue | undefined {
+  const { prop } = field;
+  if (prop.default !== undefined && isElicitValue(prop.default)) return prop.default;
+  if (prop.type === "boolean") return undefined;
+  return "";
+}
+
+/**
+ * A schema-supplied string, or ``""`` when the server sent something else.
+ *
+ * ``title`` and ``description`` are typed as strings but arrive from an
+ * outside server; handing React a non-string here crashes the whole card.
+ */
+function asText(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/** True when a value is one of the primitives MCP allows in ``content``. */
+function isElicitValue(value: unknown): value is ElicitValue {
+  return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+}
+
+/** The enum members of a property, as strings, or an empty array. */
+function enumValues(prop: SchemaProperty): string[] {
+  if (!Array.isArray(prop.enum)) return [];
+  return prop.enum
+    .filter((v): v is string => typeof v === "string" || typeof v === "number")
+    .map(String);
+}
+
+/**
+ * The label to show for an enum member.
+ *
+ * The spec lets a server send ``enumNames`` alongside ``enum`` — display text
+ * for values that are ids. Showing the id when a name was supplied puts the
+ * server's internal spelling in front of a person.
+ */
+export function enumLabel(prop: SchemaProperty, index: number, value: string): string {
+  const names = prop.enumNames;
+  if (!Array.isArray(names)) return value;
+  const name = names[index];
+  return typeof name === "string" && name.length > 0 ? name : value;
+}
+
+/**
+ * Whether every required field has an answer.
+ *
+ * A boolean is always answered — false is a real answer to "should I force
+ * push?" — so only text-shaped fields can be blank.
+ */
+export function isComplete(fields: SchemaField[], answers: ElicitationDraft): boolean {
+  return fields.every((field) => {
+    const value = answers[field.name];
+    if (typeof value === "boolean") return true;
+    const blank = value === undefined || String(value).trim().length === 0;
+    // An optional field may be left alone, but not filled in wrongly: dropping
+    // what someone typed while reporting success is the worse of the two.
+    if (blank) return !field.required;
+    return numberOrNull(field, value) !== null;
+  });
+}
+
+/**
+ * A numeric field's value as a finite number, or ``null`` when it is not one.
+ *
+ * ``Number("1e999")`` is ``Infinity``, which ``JSON.stringify`` writes as
+ * ``null`` — the server would receive a null where it declared a number. A
+ * non-integer in an ``integer`` field is type-invalid in the same way, and an
+ * accept carrying either is worse than a decline: the server has already
+ * committed to the accept path by the time it hits the error.
+ */
+function numberOrNull(field: SchemaField, value: ElicitValue): number | null {
+  const { type } = field.prop;
+  if (type !== "number" && type !== "integer") return 0;
+  const parsed = Number(String(value));
+  if (!Number.isFinite(parsed)) return null;
+  if (type === "integer" && !Number.isInteger(parsed)) return null;
+  return parsed;
+}
+
+/**
+ * Drop blank optional fields and coerce numbers before submitting.
+ *
+ * An untouched optional text field would otherwise send ``""``, which reads
+ * to the server as "answered, with nothing" rather than "not answered".
+ */
+export function toContent(fields: SchemaField[], answers: ElicitationDraft): ElicitationAnswers {
+  const content: ElicitationAnswers = {};
+  for (const field of fields) {
+    const value = answers[field.name];
+    if (value === undefined) continue;
+    if (typeof value === "boolean") {
+      content[field.name] = value;
+      continue;
+    }
+    const text = String(value);
+    if (text.trim().length === 0) continue;
+    const numeric = field.prop.type === "number" || field.prop.type === "integer";
+    if (numeric) {
+      const parsed = numberOrNull(field, value);
+      // Unparseable in a numeric field: omit rather than send the server a
+      // value its own schema rejects.
+      if (parsed !== null) content[field.name] = parsed;
+      continue;
+    }
+    content[field.name] = text;
+  }
+  return content;
+}
+
+interface ElicitationSchemaFormProps {
+  fields: SchemaField[];
+  onSubmit: (content: ElicitationAnswers) => void;
+  onReject: () => void;
+}
+
+/**
+ * Render one control per schema property and gather the answers.
+ *
+ * :param fields: Parsed properties, from :func:`schemaFields`.
+ * :param onSubmit: Receives the ``ElicitResult.content`` map.
+ * :param onReject: Called when the person declines instead.
+ */
+export function ElicitationSchemaForm({ fields, onSubmit, onReject }: ElicitationSchemaFormProps) {
+  const [answers, setAnswers] = useState<ElicitationDraft>(() =>
+    Object.fromEntries(fields.map((field) => [field.name, initialValue(field)])),
+  );
+  const set = (name: string, value: ElicitValue) =>
+    setAnswers((prev) => ({ ...prev, [name]: value }));
+  // Two pending cards can both ask for "branch"; a bare field name would give
+  // them the same DOM id and point every label at the first card's input.
+  const scope = useId();
+  const complete = isComplete(fields, answers);
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="elicitation-schema-form">
+      {fields.map((field) => {
+        const { name, prop, required } = field;
+        const label = asText(prop.title) || name;
+        const description = asText(prop.description);
+        const options = enumValues(prop);
+        const value = answers[name];
+        const controlId = `${scope}-${name}`;
+        const describedBy = asText(prop.description) ? `${controlId}-description` : undefined;
+        return (
+          <div key={name} className="flex flex-col gap-1" data-testid={`elicit-field-${name}`}>
+            <label htmlFor={controlId} className="text-ui text-foreground">
+              {label}
+              {required && <span className="ml-1 text-muted-foreground">*</span>}
+            </label>
+            {description && (
+              <span id={describedBy} className="text-sm text-muted-foreground">
+                {description}
+              </span>
+            )}
+            {options.length > 0 ? (
+              <select
+                id={controlId}
+                className="rounded border bg-background px-2 py-1 text-ui text-foreground"
+                required={required}
+                aria-required={required}
+                aria-describedby={describedBy}
+                value={String(value ?? "")}
+                onChange={(e) => set(name, e.target.value)}
+              >
+                <option value="">Choose…</option>
+                {options.map((option, index) => (
+                  <option key={option} value={option}>
+                    {enumLabel(prop, index, option)}
+                  </option>
+                ))}
+              </select>
+            ) : prop.type === "boolean" ? (
+              <input
+                id={controlId}
+                type="checkbox"
+                className="size-4 self-start"
+                aria-required={required}
+                aria-describedby={describedBy}
+                checked={value === true}
+                onChange={(e) => set(name, e.target.checked)}
+              />
+            ) : (
+              <Input
+                id={controlId}
+                type={prop.type === "number" || prop.type === "integer" ? "number" : "text"}
+                required={required}
+                aria-required={required}
+                aria-describedby={describedBy}
+                value={String(value ?? "")}
+                onChange={(e) => set(name, e.target.value)}
+              />
+            )}
+          </div>
+        );
+      })}
+      <div className="flex flex-wrap gap-2 pt-1">
+        <Button
+          size="sm"
+          disabled={!complete}
+          data-testid="elicitation-schema-submit"
+          onClick={() => onSubmit(toContent(fields, answers))}
+        >
+          <CheckIcon className="mr-1 size-3.5" />
+          Submit
+        </Button>
+        <Button size="sm" variant="outline" onClick={onReject}>
+          <XIcon className="mr-1 size-3.5" />
+          Reject
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/useApproveHotkey.test.tsx
+++ b/web/src/hooks/useApproveHotkey.test.tsx
@@ -36,6 +36,41 @@ afterEach(() => {
 describe("useApproveHotkey", () => {
   const pending = { type: "elicitation", elicitationId: "e1", status: "pending" };
 
+  const FIELD_SCHEMA = {
+    type: "object",
+    properties: { branch: { type: "string" } },
+    required: ["branch"],
+  };
+
+  it("does not accept a prompt that asks for fields", () => {
+    // The card disables Submit until the required fields are answered. A
+    // keystroke that accepts anyway walks around that gate and sends the
+    // server none of what it asked for.
+    blocks = [{ ...pending, requestedSchema: FIELD_SCHEMA }];
+    renderHook(() => useApproveHotkey());
+    press();
+    expect(submitApproval).not.toHaveBeenCalled();
+  });
+
+  it("does not reach past a form to accept an older binary prompt", () => {
+    // The newest prompt is the one on screen. Accepting an older one while
+    // someone fills in a form approves something they cannot see.
+    blocks = [
+      { type: "elicitation", elicitationId: "old", status: "pending" },
+      { ...pending, elicitationId: "form", requestedSchema: FIELD_SCHEMA },
+    ];
+    renderHook(() => useApproveHotkey());
+    press();
+    expect(submitApproval).not.toHaveBeenCalled();
+  });
+
+  it("still accepts a bare consent prompt that names no fields", () => {
+    blocks = [{ ...pending, requestedSchema: { type: "object" } }];
+    renderHook(() => useApproveHotkey());
+    press();
+    expect(submitApproval).toHaveBeenCalledWith("e1", "accept");
+  });
+
   it("Cmd+Enter accepts the pending approval", () => {
     blocks = [pending];
     renderHook(() => useApproveHotkey());

--- a/web/src/hooks/useApproveHotkey.ts
+++ b/web/src/hooks/useApproveHotkey.ts
@@ -11,10 +11,13 @@
 // Only plain accept/decline prompts (command, edit, plan, codex command) are
 // accepted. AskUserQuestion elicitations are skipped: they require choosing a
 // specific option, so a blanket "accept" carries no answer and the user must
-// pick on the card itself.
+// pick on the card itself. An elicitation whose `requestedSchema` names
+// fields is skipped for exactly that reason — the server asked for values,
+// and accepting from the keyboard would send it none of them.
 
 import { useEffect } from "react";
 
+import { schemaFields } from "@/components/blocks/ElicitationSchemaForm";
 import type { ElicitationBlock } from "@/lib/blocks";
 import { useChatStore } from "@/store/chatStore";
 
@@ -28,13 +31,17 @@ export function useApproveHotkey(): void {
       const { blocks, submitApproval } = useChatStore.getState();
       // Newest-first: accept the most recent still-pending prompt that takes a
       // plain verdict. Skip AskUserQuestion (needs an explicit choice).
-      const pending = [...blocks]
+      // The newest pending prompt is the one on screen. Searching past it for
+      // an older binary one would accept something the person cannot see while
+      // they are filling in a form.
+      const newest = [...blocks]
         .reverse()
-        .find(
-          (b): b is ElicitationBlock =>
-            b.type === "elicitation" && b.status === "pending" && !b.askUserQuestion,
-        );
-      if (!pending) return;
+        .find((b): b is ElicitationBlock => b.type === "elicitation" && b.status === "pending");
+      if (!newest) return;
+      const takesAPlainVerdict =
+        !newest.askUserQuestion && schemaFields(newest.requestedSchema).length === 0;
+      if (!takesAPlainVerdict) return;
+      const pending = newest;
 
       // Intercept before the composer's Enter-to-send handler runs.
       e.preventDefault();


### PR DESCRIPTION
## Related issue

Closes #5312

## Summary

An MCP server declares what it needs back in `requestedSchema`. The approval
card could collect exactly one shape of that — a lone `answer` enum, rendered
as option buttons — and everything else fell through to Approve / Reject. A
server asking for a branch name and a release channel showed two buttons and no
way to say either.

This renders one control per property: an enum becomes a select, a boolean a
checkbox, a number a number input, anything else a text field. `default`
prefills, `title` and `description` label and explain, `enumNames` supplies
display text when the server sent it, and Submit stays disabled until every
`required` property is answered.

The new branch sits **below** the existing ones, so nothing that renders today
changes: ExitPlanMode, Claude's `AskUserQuestion`, and the option buttons are
untouched. A policy ASK sends `requestedSchema: {}` and keeps Approve / Reject.
An ACP agent's own approval scopes (#5053) arrive as a lone `answer` enum and
stay on the buttons — pinned by a test, since that landed recently.

Three things are kept off the wire:

- **An untouched optional boolean is not sent.** `false` turns something off; an
  unanswered checkbox has said nothing.
- **A number that would serialise as `null`** — `1e999` is `Infinity` — **or a
  fraction in an `integer`, is refused.** An accept carrying a value the schema
  rejects is worse than a decline: the server has already committed by the time
  it hits the error.
- **A filled-in optional field is validated too**, so nothing typed is dropped
  while the UI reports success.

Two related fixes fell out:

- The option-button branch now claims a schema only when `answer` is its whole
  question. Paired with a required `reason`, it used to render two buttons that
  submitted the answer and silently dropped the reason.
- **The approve hotkey judges the newest pending prompt** and skips it when its
  schema names fields — the reason it already skipped `AskUserQuestion`: the
  server asked for values and a keystroke would send none of them. It no longer
  reaches past a form to accept an older binary prompt either. As a side effect
  it now also skips a lone-`answer`-enum card, which it previously accepted with
  no choice at all.

## Depends on #5273

**This is the UI half.** #5273 is the runner half, and without it the collected
answers do not reach the MCP server: `mcp_manager`'s inline callback parks on a
verdict that carries a bool, then fills `content` in from the schema. So on
`main` today, whatever is typed here is replaced by the schema's first enum
value or its defaults.

Safe to merge in either order — without #5273, submitting this form produces
the same wire result as clicking Approve does today, so there is no regression —
but the feature is inert until #5273 lands. Merging #5273 first, or together,
is the order that makes this do anything.

## Test Plan

`ElicitationSchemaForm.test.ts` — new, 24 tests: reading the schema, required
marking, the shapes the form must *not* claim (empty schema, ACP scopes),
malformed properties, submit gating, number refusal (`1e999`, fractions in
integers), untouched optional booleans, and `enumNames`.

`useApproveHotkey.test.tsx` — three added: a field-bearing prompt is not
accepted, the hotkey does not reach past a form to an older binary prompt, and a
bare consent prompt still is.

`tests/e2e_ui/approvals/test_elicitation_schema_form.py` — new, 3 Playwright
cases against a live server: a schema naming fields renders one control per
property with submit gated on the required ones, a schema naming none keeps
Approve / Reject, and the hotkey does not accept a prompt that asks for fields.

Each e2e case fails against the pre-change UI for its own reason — checked by
restoring the three files from `upstream/main` rather than trusting the suite:

| Reverted | Result |
| --- | --- |
| all three files | form cases fail (no form renders) |
| `useApproveHotkey.ts` only | hotkey case fails (a keystroke accepts it) |
| nothing | 3 passed |

```
vitest run src              5918 passed, 3 expected fail, 1 skipped
pytest tests/e2e_ui/approvals    18 passed, 2 failed
tsc --noEmit                clean
pre-commit (web hooks)      prettier, oxlint, tsc — clean
```

Three failures in `src/shell/NewChatDialog.test.tsx` are pre-existing and
reproduce identically with this branch stashed. Both e2e failures are also
unrelated to this branch: `test_cursor_native_approval` fails the same way with
these three files restored from `upstream/main` (it drives a real `cursor-agent`
turn), and `test_elicitation_floats_to_bottom` passes on its own — it times out
waiting for `Loading conversation…` only when the whole directory runs at once.
The new cases wait on the composer rather than the card for that reason.

## Demo

A real browser against a PostgreSQL-backed server, with an `mcp_elicitation`
event carrying the schema above.

Before — the server asked for three fields and the card offers two buttons:

![before](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/elicit-form-before.png)

After — one control per property, `notify` prefilled from its `default`, and
Submit disabled while the required fields are blank:

![after](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/elicit-form-after.png)

Filled in, Submit enabled:

![filled](https://raw.githubusercontent.com/Paldom/omnigent/agent-army/docs/agent-army/media/elicit-form-filled.png)

The Playwright driver is
[committed with the screenshots](https://github.com/Paldom/omnigent/tree/agent-army/docs/agent-army/media).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The schema reading and the wire shape are unit-tested; the browser rendering,
the submit gate, and the hotkey guard are covered by the new e2e_ui cases. The
manual pass drove the same flow by hand against a Postgres-backed server for
the screenshots above. All of it verifies rendering and gating — not content
arrival at an MCP server, which needs #5273.

## Notes for review

Scope, stated rather than implied:

- **The supported subset is MCP's flat primitives** — string, number/integer,
  boolean, string enum — which is what the four control types cover. Newer
  shapes are rendered as text inputs rather than refused: `oneOf`/`const`
  single-selects, and **`items.enum` arrays, where a text answer is
  type-invalid on the wire (a string where an array is expected)**. Happy to
  fail closed on those instead if you would rather; I chose text because the
  current behaviour for them is an accept carrying no fields at all, which is
  strictly less useful.
- **`minLength` / `maxLength` / `minimum` / `maximum` / `format` are not
  enforced.** Client-side validation is UX rather than a boundary — any client
  can POST any `content` — so the server needs to validate regardless.
- **`enumNames` is used by the form but not by the older option-button branch**,
  which still shows raw enum values. Left alone to keep this diff to the gap it
  describes.

## Changelog

An MCP elicitation that asks for fields now shows a form you can answer, instead of only Approve and Reject.
