### PR TITLE
fix(examples): add agy bypassPermissions and codex max reasoning effort to polly

### DIFF
--- a/examples/polly/agents/agy/config.yaml
+++ b/examples/polly/agents/agy/config.yaml
@@ -4,14 +4,16 @@ description: Google Antigravity CLI coding sub-agent — implements, cross-vendo
 
 # Native Google Antigravity (`agy`) TUI/CLI harness: drives the `agy` binary
 # in its own terminal the human can open in the UI's Subagents panel and TAKE
-# OVER. Antigravity's in-terminal approval prompt still fires for dangerous
-# commands and is mirrored to the web UI, so risky actions surface as approval
-# cards rather than being auto-bypassed. agy is Gemini-native (own Google
+# OVER. Runs with permission_mode: bypassPermissions so headless dispatches do
+# not stall on terminal approval prompts. agy is Gemini-native (own Google
 # account auth via ~/.gemini) and does not run Claude/GPT-family models.
 executor:
   type: omnigent
   config:
     harness: antigravity-native
+    # Headless workers can't answer approval prompts in the terminal, so run agy
+    # with full bypass (translates to --dangerously-skip-permissions).
+    permission_mode: bypassPermissions
 
 prompt: |
   You are agy, Google Antigravity's CLI coding sub-agent, dispatched by the

--- a/examples/polly/agents/codex/config.yaml
+++ b/examples/polly/agents/codex/config.yaml
@@ -10,6 +10,8 @@ executor:
     # with full bypass. The server translates this into
     # ``--dangerously-bypass-approvals-and-sandbox`` (native sub-agents only).
     yolo: true
+  extra:
+    reasoning_effort: max
 
 prompt: |
   You are Codex, a coding sub-agent dispatched by the polly


### PR DESCRIPTION
### Summary

This PR updates the bundled Polly orchestrator sub-agent configurations for `agy` and `codex`:

1. **`agy` (Antigravity sub-agent)**:
   - Sets `permission_mode: bypassPermissions`.
   - **Why**: Native headless sub-agents in Polly run in their own worktrees without direct human terminal intervention. Without `bypassPermissions`, `agy` defaults to `toolPermission=request-review` on tool execution, prompting for interactive terminal approval cards and stalling background dispatches.

2. **`codex` (Codex sub-agent)**:
   - Adds `extra.reasoning_effort: max`.
   - **Why**: Allows the Codex sub-agent to utilize deep reasoning (`max`) during implementation and review tasks, natively aligning with `CODEX_NATIVE_EFFORTS` where `max` is supported for model execution.

### Verification
- Tested with test suite: `pytest tests/test_reasoning_effort.py tests/runtime/test_reasoning_effort_validation.py` (all 47 tests passed).
- Verified sub-agent YAML configs match Omnigent spec conventions.