### PR TITLE
hermes forwarder: stop retrying deterministic external_session_id PATCH 4xx

### DIFF
--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -69,6 +69,7 @@ from pathlib import Path
 import httpx
 
 from omnigent import hermes_native_status
+from omnigent.host.daemon_launch import error_text
 from omnigent.inner.native_attachments import ATTACHMENT_MARKER_STRIP_PATTERN
 
 _logger = logging.getLogger(__name__)
@@ -1166,8 +1167,28 @@ async def forward_hermes_store_to_session(
                             f"/v1/sessions/{session_id}",
                             json={"external_session_id": hermes_session_id},
                         )
+                        if 400 <= resp.status_code < 500:
+                            _logger.warning(
+                                "hermes forwarder external_session_id PATCH rejected; "
+                                "not retrying: session=%s status=%s reason=%s",
+                                session_id,
+                                resp.status_code,
+                                error_text(resp),
+                            )
+                            # Deterministic 4xx rejections are not transient.
+                            # Latch off to avoid a hot PATCH loop.
+                            _external_id_synced = True
+                            continue
                         resp.raise_for_status()
                         _external_id_synced = True
+                    except httpx.HTTPStatusError as exc:
+                        _logger.debug(
+                            "hermes forwarder failed to PATCH external_session_id; "
+                            "will retry next poll; session=%s status=%s",
+                            session_id,
+                            exc.response.status_code,
+                            exc_info=True,
+                        )
                     except httpx.HTTPError:
                         _logger.debug(
                             "hermes forwarder failed to PATCH external_session_id; "

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4267,6 +4267,41 @@ def create_runner_app(
                 publish_event=_publish_event,
             )
 
+    async def _heal_claude_pane_before_injection(
+        conv_id: str,
+        bridge_dir: Path,
+    ) -> None:
+        """Recreate a dead-but-registered Claude pane before a slash-command injection.
+
+        The model/effort session-change handlers inject into the pane's tmux
+        socket directly, so a terminal record that outlived its tmux backend
+        (crash, external kill, an eviction that skipped ``close()``) fails with
+        ``error connecting to .../tmux.sock`` — the same stale-registry class
+        #2951 healed on the turn path. Reuse that self-heal here, then wait for
+        the resumed TUI to render its input box: the recreate relaunches Claude
+        with ``--resume``, and ``inject_slash_command``'s short advertisement
+        window is well under the TUI's boot time.
+
+        A registered-and-alive pane returns after one ``is_alive()`` probe with
+        no ready-wait, so the healthy path is unchanged — including a pane
+        mid-turn, which never enters the wait loop. The deadline expiring is
+        not an error: the injection proceeds and surfaces its own failure.
+        """
+        from omnigent.claude_native_bridge import claude_pane_ready
+
+        terminal_registry = resource_registry.terminal_registry if resource_registry else None
+        if terminal_registry is None:
+            return
+        instance = terminal_registry.get(conv_id, "claude", "main")
+        if instance is not None and await instance.is_alive():
+            return
+        await _ensure_native_terminal_for_turn(conv_id, "claude-native")
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline:
+            if await asyncio.to_thread(claude_pane_ready, bridge_dir):
+                return
+            await asyncio.sleep(0.5)
+
     async def _handle_claude_native_effort_change(
         conv_id: str,
         effort: str | None,
@@ -4285,6 +4320,7 @@ def create_runner_app(
             session_id=conv_id,
         )
         bridge_dir = bridge_dir_for_bridge_id(bridge_id)
+        await _heal_claude_pane_before_injection(conv_id, bridge_dir)
         command = f"/effort {effort}"
         try:
             # An effort switch invalidates the prompt cache on a session with
@@ -4332,6 +4368,10 @@ def create_runner_app(
             session_id=conv_id,
         )
         bridge_dir = bridge_dir_for_bridge_id(bridge_id)
+        # Heal before read_model_env below: a recreated pane republishes the
+        # bridge dir's model env, so reading it first could pin a stale picker
+        # vocabulary and 503 a model the resumed session actually accepts.
+        await _heal_claude_pane_before_injection(conv_id, bridge_dir)
         selected_model = model.strip()
         claude_config = await _resolve_session_claude_launch_config(conv_id)
         resolved_model = (

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -14,6 +14,7 @@ import json
 import sqlite3
 from pathlib import Path
 
+import httpx
 import pytest
 
 from omnigent import hermes_native_forwarder as f
@@ -543,6 +544,153 @@ async def test_forward_loop_patches_external_session_id_once(tmp_path, monkeypat
     url, body = patch_calls[0]
     assert url == "/v1/sessions/conv_patch"
     assert body["external_session_id"] == "20260620_1"
+
+
+@pytest.mark.asyncio
+async def test_external_session_id_patch_4xx_latches_and_logs(
+    tmp_path,
+    monkeypatch,
+    caplog,
+) -> None:
+    """A deterministic 4xx PATCH rejection logs once and does not retry-loop."""
+    workspace = str(tmp_path)
+    db = tmp_path / "state.db"
+    _seed_db(db, cwd=workspace, started_at=1000.0)
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    patched_calls: list[tuple[str, dict]] = []
+
+    class _Patch4xxClient:
+        async def patch(self, url: str, *, json: dict) -> httpx.Response:
+            patched_calls.append((url, json))
+            req = httpx.Request("PATCH", f"http://test{url}")
+            return httpx.Response(
+                400,
+                request=req,
+                json={"error": {"message": "external_session_id already set"}},
+            )
+
+    class _ClientCM:
+        async def __aenter__(self):
+            return _Patch4xxClient()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    monkeypatch.setattr(
+        "omnigent.cli_auth.open_server_client",
+        lambda *args, **kwargs: _ClientCM(),
+    )
+
+    # Keep loop alive for several polls; if latching is broken we'd see repeated PATCHes.
+    tick = {"n": 0}
+
+    async def _sleep(_s):
+        tick["n"] += 1
+        if tick["n"] >= 4:
+            raise asyncio.CancelledError
+
+    async def _noop_item(_client, *, session_id, item):
+        return None
+
+    monkeypatch.setattr(f.asyncio, "sleep", _sleep)
+    monkeypatch.setattr(f, "_post_conversation_item", _noop_item)
+    monkeypatch.setattr(f, "_persist_hermes_compaction_item", lambda *a, **k: _noop())
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(asyncio.CancelledError):
+            await f.forward_hermes_store_to_session(
+                base_url="http://test",
+                headers={},
+                session_id="conv_4xx",
+                bridge_dir=bridge_dir,
+                agent_name="hermes-native-ui",
+                workspace=workspace,
+                launch_epoch_s=1000.0,
+                db_path=db,
+                poll_interval_s=0.001,
+            )
+
+    assert len(patched_calls) == 1
+    assert any(
+        "PATCH rejected; not retrying" in rec.getMessage() and "status=400" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_external_session_id_patch_5xx_retries(tmp_path, monkeypatch, caplog) -> None:
+    """A 5xx PATCH rejection remains retryable across polls."""
+    workspace = str(tmp_path)
+    db = tmp_path / "state.db"
+    _seed_db(db, cwd=workspace, started_at=1000.0)
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    patched_calls: list[tuple[str, dict]] = []
+
+    class _Patch5xxClient:
+        async def patch(self, url: str, *, json: dict) -> httpx.Response:
+            patched_calls.append((url, json))
+            req = httpx.Request("PATCH", f"http://test{url}")
+            return httpx.Response(
+                503,
+                request=req,
+                json={"error": {"message": "temporary unavailable"}},
+            )
+
+    class _ClientCM:
+        async def __aenter__(self):
+            return _Patch5xxClient()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    monkeypatch.setattr(
+        "omnigent.cli_auth.open_server_client",
+        lambda *args, **kwargs: _ClientCM(),
+    )
+
+    tick = {"n": 0}
+
+    async def _sleep(_s):
+        tick["n"] += 1
+        if tick["n"] >= 4:
+            raise asyncio.CancelledError
+
+    async def _noop_item(_client, *, session_id, item):
+        return None
+
+    monkeypatch.setattr(f.asyncio, "sleep", _sleep)
+    monkeypatch.setattr(f, "_post_conversation_item", _noop_item)
+    monkeypatch.setattr(f, "_persist_hermes_compaction_item", lambda *a, **k: _noop())
+
+    import logging
+
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(asyncio.CancelledError):
+            await f.forward_hermes_store_to_session(
+                base_url="http://test",
+                headers={},
+                session_id="conv_5xx",
+                bridge_dir=bridge_dir,
+                agent_name="hermes-native-ui",
+                workspace=workspace,
+                launch_epoch_s=1000.0,
+                db_path=db,
+                poll_interval_s=0.001,
+            )
+
+    assert len(patched_calls) >= 2
+    assert any(
+        "will retry next poll" in rec.getMessage() and "status=503" in rec.getMessage()
+        for rec in caplog.records
+    )
 
 
 async def test_forward_loop_repins_to_child_after_compaction(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- Fixes a hot-loop in `hermes_native_forwarder` where `PATCH /v1/sessions/{id}` for `external_session_id` retried every poll on deterministic 4xx responses (for example 400), creating repeated `python-httpx` 400 spam.
- Keeps retry behavior for transient failures: transport errors/timeouts and server-side 5xx still retry on subsequent polls.
- Improves diagnostics for rejected PATCH responses by logging status plus parsed server reason via `error_text(resp)` without logging request headers/tokens.
- Adds regression tests that prove 4xx rejections latch and stop retrying, while 5xx remains retryable.

## Test Plan

- `uv run --no-sync ruff check omnigent/hermes_native_forwarder.py tests/test_hermes_native_forwarder.py`
- `uv run --no-sync pyrefly check omnigent/hermes_native_forwarder.py`
- `uv run pytest -q tests/test_hermes_native_forwarder.py -k "external_session_id_patch_4xx_latches_and_logs or external_session_id_patch_5xx_retries or forward_loop_patches_external_session_id_once"`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

- Added focused regression coverage for retry classification in the Hermes PATCH path:
  - 4xx PATCH rejection logs once and does not retry-loop.
  - 5xx PATCH rejection remains retryable across polls.

## Changelog

Hermes native forwarder now treats `external_session_id` PATCH 4xx rejections as terminal and stops retry looping while still retrying transient failures.
