### PR TITLE
fix(server): wake an asleep runner for /compact on native sessions

### DIFF
--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -741,6 +741,8 @@ def register_events_routes(
 
             :param wake_conv: The session row (may have a stale binding).
             :returns: ``(conversation, runner_client_or_None)``.
+            :raises OmnigentError: ``WRONG_REPLICA`` when the host tunnel is
+                absent here but the host is live on another replica.
             """
             _app_state = request.app.state
             if wake_conv.host_id is not None and await _maybe_wake_stale_resumable_managed_sandbox(
@@ -758,6 +760,25 @@ def register_events_routes(
             if _client is None and wake_conv.host_id is not None:
                 _host_reg = getattr(_app_state, "host_registry", None)
                 _tunnel_reg = getattr(_app_state, "tunnel_registry", None)
+                # Wrong-replica routing miss, checked before we try to launch:
+                # the runner tunnel registers on the same replica as its host,
+                # so an absent tunnel here while the host is live elsewhere
+                # means the key routed to the wrong replica. Signal it (same as
+                # the message path) so the client re-addresses without the key,
+                # rather than getting a false "reconnect" 503 for a session that
+                # is actually wakeable on another replica.
+                _host_store = getattr(_app_state, "host_store", None)
+                if (
+                    _host_reg is not None
+                    and _host_store is not None
+                    and _host_reg.get(wake_conv.host_id) is None
+                ):
+                    _elsewhere = await asyncio.to_thread(_host_store.get_host, wake_conv.host_id)
+                    if _elsewhere is not None and host_is_live(_elsewhere):
+                        raise OmnigentError(
+                            "session runner is on another replica; retry",
+                            code=ErrorCode.WRONG_REPLICA,
+                        )
                 _relaunched_runner_id: str | None = None
                 _host_conn = _host_reg.get(wake_conv.host_id) if _host_reg is not None else None
                 if _host_conn is not None:
@@ -800,6 +821,12 @@ def register_events_routes(
                 wake_conv = _refreshed
             # Bring the terminal + transcript forwarder up before the control
             # is injected, mirroring the message-dispatch relaunch path.
+            # suppress_recovery_turn=True: unlike the message path (which
+            # suppresses because the server already persisted a pending message
+            # the runner's history load would otherwise start a recovery turn
+            # for), /compact persists nothing — so there is no pending item to
+            # trigger recovery. Suppression is a harmless no-op here; kept for
+            # parity so a wake never spuriously starts a turn.
             await _ensure_runner_session_initialized(
                 session_id,
                 wake_conv,
@@ -1022,10 +1049,17 @@ def register_events_routes(
             if runner_result is None and _is_native_terminal_session(conv):
                 conv, woke_client = await _wake_bound_runner_for_control(conv)
                 if woke_client is not None:
+                    # Same TUI-inject budget as the initial forward: a
+                    # just-relaunched runner is the slow case (cold pane, just
+                    # advertised), and the claude-native injector's worst case
+                    # (~16s) exceeds the 5s default — a timeout there returns
+                    # None and would wrongly fall through to the "reconnect"
+                    # 503 while Claude Code is actually compacting.
                     runner_result = await _forward_session_change_to_runner(
                         session_id,
                         runner_router,
                         {"type": _COMPACT_TYPE},
+                        timeout_s=_TUI_INJECT_FORWARD_TIMEOUT_S,
                     )
                     if runner_result is not None and runner_result.status_code == 200:
                         return {"queued": False}

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -724,6 +724,98 @@ def register_events_routes(
             # ``function_call`` as an unknown inbound event type).
             return {"verdict": "allow"}
 
+        async def _wake_bound_runner_for_control(
+            wake_conv: Any,
+        ) -> tuple[Any, httpx.AsyncClient | None]:
+            """
+            Relaunch a disconnected-but-wakeable runner for a control event.
+
+            A native-terminal /compact must run in the vendor TUI, so when no
+            runner is bound we wake it the same way the message-dispatch path
+            does (resume a managed sandbox / relaunch the runner on its still-
+            online host), wait for the tunnel to connect, then re-run the
+            session-init handshake and relay so the forwarded control reaches
+            a live harness. Returns the (possibly re-read) conversation row and
+            the resolved runner client, or ``(conv, None)`` when the session
+            can't be woken (e.g. the host is offline).
+
+            :param wake_conv: The session row (may have a stale binding).
+            :returns: ``(conversation, runner_client_or_None)``.
+            """
+            _app_state = request.app.state
+            if wake_conv.host_id is not None and await _maybe_wake_stale_resumable_managed_sandbox(
+                session_id=session_id,
+                conv=wake_conv,
+                app_state=_app_state,
+                conversation_store=conversation_store,
+            ):
+                _refreshed = await asyncio.to_thread(
+                    conversation_store.get_conversation, session_id
+                )
+                if _refreshed is not None:
+                    wake_conv = _refreshed
+            _client = await _get_runner_client(session_id, runner_router)
+            if _client is None and wake_conv.host_id is not None:
+                _host_reg = getattr(_app_state, "host_registry", None)
+                _tunnel_reg = getattr(_app_state, "tunnel_registry", None)
+                _relaunched_runner_id: str | None = None
+                _host_conn = _host_reg.get(wake_conv.host_id) if _host_reg is not None else None
+                if _host_conn is not None:
+                    _attempt = await _launch_runner_on_host(
+                        wake_conv,
+                        conversation_store,
+                        _host_reg,
+                        _host_conn,
+                    )
+                    # A structured refusal (harness not configured / workspace
+                    # missing) leaves no runner to compact against — treat as
+                    # unwakeable; the caller surfaces the reconnect error.
+                    if _attempt.error_code is None:
+                        _relaunched_runner_id = _attempt.runner_id
+                elif await _maybe_relaunch_managed_sandbox(
+                    session_id=session_id,
+                    conv=wake_conv,
+                    app_state=_app_state,
+                    conversation_store=conversation_store,
+                ):
+                    _refreshed = await asyncio.to_thread(
+                        conversation_store.get_conversation, session_id
+                    )
+                    if _refreshed is not None:
+                        wake_conv = _refreshed
+                    _client = await _get_runner_client(session_id, runner_router)
+                if _client is None:
+                    _client = await _wait_for_runner_client(
+                        session_id,
+                        runner_router,
+                        _tunnel_reg,
+                        runner_id=_relaunched_runner_id,
+                        timeout_s=_HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S,
+                        runner_exit_reports=runner_exit_reports,
+                    )
+            if _client is None:
+                return wake_conv, None
+            _refreshed = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+            if _refreshed is not None:
+                wake_conv = _refreshed
+            # Bring the terminal + transcript forwarder up before the control
+            # is injected, mirroring the message-dispatch relaunch path.
+            await _ensure_runner_session_initialized(
+                session_id,
+                wake_conv,
+                _client,
+                conversation_store,
+                initializer=getattr(_app_state, "runner_session_initializer", None),
+                suppress_recovery_turn=True,
+            )
+            await _ensure_runner_relay_ready(
+                session_id,
+                wake_conv.runner_id,
+                _client,
+                conversation_store,
+            )
+            return wake_conv, _client
+
         if body.type == _INTERRUPT_TYPE:
             _publish_interrupted(session_id)
             # Fence the cancelled turn (see _interrupt_fenced_sessions).
@@ -918,6 +1010,40 @@ def register_events_routes(
                 raise OmnigentError(
                     f"Compaction failed: runner returned {runner_result.status_code}",
                     code=ErrorCode.INTERNAL_ERROR,
+                )
+            # ``runner_result is None`` means no runner was reachable. For a
+            # native-terminal session /compact MUST run in the vendor TUI —
+            # falling through to server-side in-process compaction is wrong
+            # (it wouldn't compact the terminal's own context) and errors for
+            # a harness that declares no LLM model. A disconnected-but-wakeable
+            # session (runner_asleep / host_asleep) should wake and compact
+            # just like sending a message does, so relaunch the runner the same
+            # way the message-dispatch path does, then retry the forward once.
+            if runner_result is None and _is_native_terminal_session(conv):
+                conv, woke_client = await _wake_bound_runner_for_control(conv)
+                if woke_client is not None:
+                    runner_result = await _forward_session_change_to_runner(
+                        session_id,
+                        runner_router,
+                        {"type": _COMPACT_TYPE},
+                    )
+                    if runner_result is not None and runner_result.status_code == 200:
+                        return {"queued": False}
+                    if runner_result is not None and runner_result.status_code != 204:
+                        raise OmnigentError(
+                            f"Compaction failed: runner returned {runner_result.status_code}",
+                            code=ErrorCode.INTERNAL_ERROR,
+                        )
+                # Native session that couldn't be woken (host offline) — the
+                # runner is the only thing that can compact it, so surface a
+                # clear "reconnect first" error rather than falling through to
+                # in-process compaction (which fails with a confusing
+                # no-LLM-model message).
+                raise OmnigentError(
+                    "Can't compact this session while its runner is offline. "
+                    "Reconnect the session (send a message to wake it), then "
+                    "run /compact again.",
+                    code=ErrorCode.RUNNER_UNAVAILABLE,
                 )
             await _run_compact_locked(
                 session_id,

--- a/tests/e2e_ui/sessions/test_compact_offline_native_reconnect.py
+++ b/tests/e2e_ui/sessions/test_compact_offline_native_reconnect.py
@@ -1,0 +1,127 @@
+"""E2E: /compact on a disconnected native session shows the reconnect hint.
+
+A native-terminal (claude-native) session compacts only in its vendor TUI, so
+when its runner is offline the server can't run server-side compaction. Rather
+than the old confusing "agent declares no LLM model" error, ``/compact`` now
+surfaces an actionable message telling the user to reconnect (send a message to
+wake the runner) first. This drives that client contract end to end: on a
+native-wrapper session, typing ``/compact`` and submitting posts the compact
+control, and the composer renders the server's reconnect error inline.
+
+The e2e harness binds a real *online* ``openai-agents`` runner, not a native
+one with a sleeping sandbox, so the server-side auto-wake path itself is covered
+by ``tests/server/integration/test_sessions_compact.py``. Here the browser's
+view is patched into a native-wrapper session and the compact ``POST`` is
+intercepted to return the exact 503 envelope the server change produces, so the
+test exercises the real client ``/compact`` → error-render path.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+# Must match the OmnigentError raised in the compact branch of
+# omnigent/server/routes/sessions/routes_events.py.
+_RECONNECT_ERROR = (
+    "Can't compact this session while its runner is offline. "
+    "Reconnect the session (send a message to wake it), then run /compact again."
+)
+_WRAPPER_LABEL_KEY = "omnigent.wrapper"
+_CLAUDE_NATIVE_WRAPPER = "claude-code-native-ui"
+
+
+def _force_native_wrapper_and_stub_compact(page: Page, session_id: str) -> None:
+    """Patch the browser's view into a native-wrapper session + stub /compact.
+
+    Two route patches, registered before navigation:
+
+    - ``GET /v1/sessions/{id}`` (snapshot) → stamp the claude-native wrapper
+      label so ``isNativeWrapper`` is true and the composer treats ``/compact``
+      as a supported native command (``showCompact``).
+    - ``POST /v1/sessions/{id}/events`` for a ``compact`` body → return the
+      server's 503 reconnect error envelope so the composer renders it inline.
+
+    :param page: Playwright page before navigation.
+    :param session_id: Session id to patch, e.g. ``"conv_abc123"``.
+    """
+
+    def _patch_snapshot(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        labels = dict(payload.get("labels") or {})
+        labels[_WRAPPER_LABEL_KEY] = _CLAUDE_NATIVE_WRAPPER
+        payload["labels"] = labels
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    def _patch_events(route: Route) -> None:
+        request = route.request
+        path = urlparse(request.url).path
+        if request.method != "POST" or path != f"/v1/sessions/{session_id}/events":
+            route.continue_()
+            return
+        # Only the compact control gets the offline-runner error; let other
+        # events (e.g. messages) pass through to the real server.
+        body: dict[str, object] | None = None
+        try:
+            body = json.loads(request.post_data or "")
+        except (json.JSONDecodeError, TypeError):
+            body = None
+        if not (isinstance(body, dict) and body.get("type") == "compact"):
+            route.continue_()
+            return
+        route.fulfill(
+            status=503,
+            headers={"content-type": "application/json"},
+            body=json.dumps(
+                {"error": {"code": "runner_unavailable", "message": _RECONNECT_ERROR}}
+            ),
+        )
+
+    page.route(re.compile(r"/v1/sessions/[^/]+/events$"), _patch_events)
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), _patch_snapshot)
+
+
+def test_compact_offline_native_session_shows_reconnect_error(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Typing ``/compact`` on an offline native session shows the reconnect hint.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser view is patched to a native-wrapper session and the
+        compact POST is stubbed to the server's 503 reconnect error.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _force_native_wrapper_and_stub_compact(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=15_000)
+
+    # Type /compact and press Enter. With the slash-command suggestions menu
+    # open and "/compact" highlighted, Enter completes the menu selection,
+    # which runs the builtin immediately (it takes no argument) → the compact
+    # control POST.
+    composer.click()
+    composer.fill("/compact")
+    composer.press("Enter")
+
+    # The composer renders the server's reconnect error inline, NOT the old
+    # "agent declares no LLM model" message.
+    error = page.get_by_text(_RECONNECT_ERROR, exact=False)
+    expect(error).to_be_visible(timeout=15_000)

--- a/tests/server/integration/test_sessions_compact.py
+++ b/tests/server/integration/test_sessions_compact.py
@@ -439,6 +439,55 @@ async def test_compact_errors_when_runner_injection_fails(
     )
 
 
+async def test_compact_native_session_no_runner_returns_reconnect_error(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A native-terminal /compact with no reachable runner surfaces a clear
+    "reconnect first" error, not the confusing no-LLM-model message.
+
+    A native session compacts only in its vendor TUI, so when no runner is
+    bound (disconnected session) the compact branch must NOT fall through to
+    server-side ``_run_compact_locked`` — which would 400 with the opaque
+    "does not declare an LLM model" text. Instead it should try to wake the
+    runner; an un-host-bound native session can't be woken, so it returns a
+    503 RUNNER_UNAVAILABLE the user can act on.
+    """
+
+    async def _must_not_run(**_: Any) -> CompactionResult:
+        """Fail loudly if AP-side compaction is reached on the native path."""
+        raise AssertionError(
+            "compact_conversation_now must not run for a native-terminal "
+            "session with no runner — the compact branch fell through to "
+            "in-process compaction instead of the reconnect error."
+        )
+
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow.compact_conversation_now",
+        _must_not_run,
+    )
+
+    # No runner bound (no set_runner_client) and no host_id → unwakeable.
+    agent = await create_test_agent(
+        client,
+        name="claude-native-compact",
+        executor={"type": "omnigent", "config": {"harness": "claude-native"}},
+    )
+    sid = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={"type": "compact", "data": {}},
+    )
+
+    # 503 = RUNNER_UNAVAILABLE (reconnect-first). A 400 would mean it fell
+    # through to the no-LLM-model check (the original confusing bug).
+    assert resp.status_code == 503, resp.text
+    assert "Reconnect the session" in resp.text
+    assert "llm.model" not in resp.text
+
+
 # ── external_compaction_status: terminal-observed compaction edge ────────
 #
 # The claude-native forwarder posts external_compaction_status when Claude


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- On a disconnected-but-wakeable native (claude-native) session, typing `/compact` showed a confusing *"agent declares no LLM model for server-side compaction"* error instead of working.
- A native-terminal session compacts only in its vendor TUI, so `/compact` posts a `compact` control event that must reach a live runner. The control branch only forwarded to an *already-bound* runner; finding none (`runner_asleep` / `host_asleep`), it fell through to server-side in-process compaction — which a claude-native agent can't do (no LLM model).
- Sending a normal **message** in that state already auto-wakes the runner (the message-dispatch relaunch path). This teaches `/compact` to do the same: relaunch the runner on its still-online host (or resume a managed sandbox), wait for the tunnel, re-run session-init + relay, then retry the forward. If it genuinely can't be woken (host offline), surface a clear **503** telling the user to reconnect first, instead of the opaque no-LLM-model 400.
- Non-native (SDK) sessions and already-bound-runner cases are untouched — SDK sessions still compact server-side.

**ELI5:** Before, `/compact` on a "sleeping" native session gave a cryptic error because it never woke the agent up — even though just sending a message would have. Now `/compact` wakes it the same way a message does, then compacts. If the agent's host is truly offline, you get a plain "reconnect first" message.

```
/compact on native session, no runner bound
        │
        ▼
forward compact → runner?  ──found──▶ inject into TUI (200) ✅
        │ none
        ▼
native session?  ──no──▶ in-process compaction (SDK path, unchanged)
        │ yes
        ▼
wake runner (relaunch on host / resume sandbox) ──woke──▶ retry forward ✅
        │ can't wake (host offline)
        ▼
503 "Reconnect the session … then run /compact again"  (was: confusing no-LLM-model 400)
```

## Test Plan

- `python -m pytest tests/server/integration/test_sessions_compact.py` — 11 pass, including the new `test_compact_native_session_no_runner_returns_reconnect_error` (asserts the 503 reconnect error and that in-process compaction is **never** reached on the native path).
- `python -m pytest tests/runner/test_app_sessions_native_events_options.py` — 47 pass (compact-forwarding contract unaffected).
- Added an e2e_ui test (`tests/e2e_ui/sessions/test_compact_offline_native_reconnect.py`) driving the client `/compact` → error-render path; it renders the reconnect hint in the composer. (Note: the e2e_ui `live_server` fixture couldn't boot in my local worktree — a dev server was contending for resources — so this test is verified in CI, not locally.)
- `ruff check` / `ruff format` / `pyrefly` clean.

To reproduce the original bug manually: start a claude-native session, let its runner sleep (or stop its host so the composer shows "Send a message to reconnect this session"), then type `/compact`. With this fix: if the host is online the runner relaunches and Claude Code compacts in its terminal; if the host is offline you get the clear reconnect error.

## Demo

N/A — the only UI-visible change is a composer error string; covered by the e2e_ui test.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The server-side auto-wake behavior is covered by the integration test. The e2e_ui test covers the client contract (composer renders the reconnect hint); it relies on CI for execution because the local e2e_ui server fixture couldn't boot in this worktree.

## Changelog

`/compact` on a disconnected native (claude-native) session now wakes the runner and compacts, instead of showing a confusing "no LLM model" error

## Follow-up (not in this PR)

A separate stuck-spinner bug exists: running `/compact` with too little history fires Claude's `PreCompact` hook (raising the web "Compacting conversation…" spinner) but the aborted compaction never emits the `SessionStart(source=compact)` completion, so the spinner hangs forever. Tracked as a follow-up.

This pull request and its description were written by Isaac.
