### PR TITLE
fix(web): close the "Open new" tab menu on shell launch

### DIFF
--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useSessionAgent } from "@/hooks/useAgents";
@@ -438,6 +438,9 @@ describe('WorkspacePanel "+" new-tab menu', () => {
     // Launches the first declared shell and opens the created terminal's tab.
     expect(mutate).toHaveBeenCalledWith("zsh", expect.any(Object));
     expect(openTerminalTab).toHaveBeenCalledWith("terminal:terminal_zsh_s1");
+
+    // The menu closes on its own after the launch.
+    await waitFor(() => expect(screen.queryByRole("menuitem", { name: /shell/i })).toBeNull());
   });
 
   it("launches the default shell directly when several are declared (type selection is optional)", async () => {
@@ -466,6 +469,14 @@ describe('WorkspacePanel "+" new-tab menu', () => {
     // Launches the default (first-declared) shell without a further pick.
     expect(mutate).toHaveBeenCalledWith("zsh", expect.any(Object));
     expect(openTerminalTab).toHaveBeenCalledWith("terminal:terminal_zsh_s1");
+
+    // The menu closes on its own — the submenu trigger's preventDefault would
+    // otherwise leave it stuck open, needing a second click to dismiss.
+    await waitFor(() => expect(screen.queryByRole("menuitem", { name: /shell/i })).toBeNull());
+
+    // Focus is not restored to the "+" trigger on close — that focus return is
+    // what re-opened its tooltip for a frame (the visible flash after launch).
+    expect(screen.getByRole("button", { name: "Open new" })).not.toHaveFocus();
   });
 
   it("remembers the picked shell type as the new default (persisted + check-marked)", async () => {

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -143,6 +143,11 @@ function NewTabMenu({
   // Remembered shell type, persisted across remounts/reloads. Seeded from
   // localStorage so the "+" in either strip spot agrees on the current pick.
   const [preferred, setPreferred] = useState<string | null>(() => readPreferredShell());
+  // Controlled so a launch can force the menu closed. The submenu "Shell"
+  // trigger preventDefaults its click (to launch the default without toggling
+  // the submenu), which also suppresses Radix's auto-close — leaving the menu
+  // stuck open until a second click. Closing here fixes that.
+  const [menuOpen, setMenuOpen] = useState(false);
   // Shell access mirrors NewTerminalButton's gate: the agent's spec must
   // declare a non-empty ``terminals:`` block.
   const declaredTerminals = agent?.terminals ?? [];
@@ -157,6 +162,7 @@ function NewTabMenu({
     preferred !== null && declaredTerminals.includes(preferred) ? preferred : declaredTerminals[0];
 
   const launchShell = (name: string) => {
+    setMenuOpen(false);
     // Signal the create is starting so the shell gets focused the moment its
     // tab lands in the list — not only when this POST resolves. On a waking
     // (runner-asleep) session the POST can lag the tab's arrival by seconds;
@@ -205,7 +211,7 @@ function NewTabMenu({
   );
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
       <WorkspaceTabTooltip label="Open new" className={triggerClassName}>
         <DropdownMenuTrigger asChild>
           <button
@@ -221,7 +227,14 @@ function NewTabMenu({
       {/* min-w-44 floors the content wide enough for the longest item label
           ("Reconnecting…" + spinner, and the sub-trigger's chevron) — the
           default min-w-32 tracks the 32px "+" trigger and clips it. */}
-      <DropdownMenuContent align="start" className="min-w-44">
+      <DropdownMenuContent
+        align="start"
+        className="min-w-44"
+        // On close, Radix restores focus to the "+" trigger, which re-opens its
+        // tooltip for a frame before blur dismisses it — a visible flash after a
+        // shell launch. Suppress the focus restore to keep the tooltip closed.
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
         {/* Hide the native browser view while this menu is open so it doesn't
             paint over the dropdown (#3980). Only this rail menu needs it. */}
         <SuppressBrowserView />


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- Launching a shell from the tab-strip **+** ("Open new") menu left the dropdown open when the agent declared **multiple** terminals. The "Shell" submenu trigger `preventDefault`s its click (so a plain click launches the remembered default instead of merely toggling the submenu), which also suppresses Radix's auto-close — so the menu stayed open until a second click.
- Made the `DropdownMenu` controlled and close it explicitly on every launch path (single item, submenu default, specific type pick).
- Also suppressed the on-close focus restore to the "+" trigger (`onCloseAutoFocus`), which was re-opening its tooltip for a frame — the brief tooltip flash seen right after a launch.

## Test Plan

- `cd web && npm test` — `WorkspacePanel.test.tsx` passes (39 tests). Added assertions that the menu closes after launch (single- and multi-shell) and that focus is not restored to the "+" trigger on close.
- `cd web && npm run build` — clean.
- Manual: opened a session with multiple declared terminals, clicked **+** → **Shell**. Menu closes immediately, shell opens, and the "Open new" tooltip no longer flashes on the "+" afterward.

## Demo

N/A — behavioral fix (menu no longer lingers / tooltip no longer flashes); verified manually in the running app.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests assert menu closes on launch and focus isn't restored to the trigger. Manually verified in the running app that the dropdown dismisses on the first click and the tooltip no longer flashes.

## Changelog

The workspace "Open new" (+) menu now closes immediately when you launch a shell

This pull request and its description were written by Isaac.