### PR TITLE
fix(test): persist collaboration_mode on GET in the codex-native mock

### DIFF
--- a/tests/e2e_ui/chat/test_codex_model_metadata.py
+++ b/tests/e2e_ui/chat/test_codex_model_metadata.py
@@ -38,6 +38,19 @@ def _patch_session_as_codex_native(page: Page, session_id: str) -> list[dict]:
             response = route.fetch()
             payload = response.json()
             headers = {**response.headers, **headers}
+            # A real server persists the collaboration_mode a prior PATCH set, so
+            # a session rebind/refetch after toggling Plan mode still reports it.
+            # The seeded hello_world session carries no such label, so carry the
+            # last mode this mock recorded forward — otherwise a rebind (e.g. a
+            # stream re-bind) re-derives Plan mode as off and the toggle snaps
+            # back to "Enter Plan mode" mid-test.
+            prior_labels = (latest_payload or {}).get("labels", {})
+            prior_mode = prior_labels.get("omnigent.codex_native.collaboration_mode")
+            if prior_mode is not None:
+                payload["labels"] = {
+                    **payload.get("labels", {}),
+                    "omnigent.codex_native.collaboration_mode": prior_mode,
+                }
         elif request.method == "PATCH":
             request_body = json.loads(request.post_data or "{}")
             patch_bodies.append(request_body)


### PR DESCRIPTION
## Problem

`tests/e2e_ui/chat/test_codex_model_metadata.py::test_codex_native_plan_mode_toggle_uses_codex_session_patch` has been failing on recent runs across unrelated PRs:

```
expect(codex-plan-mode-toggle).to_have_attribute("aria-pressed", "true") → "false"
34 × locator resolved to <button ... aria-pressed="false" aria-label="Enter Plan mode" ...>
```

The click **does** fire the PATCH with `collaboration_mode=plan` (the `patch_bodies[-1] == {"collaboration_mode": "plan"}` assert passes just above), but the toggle's pressed state never updates — it stays "Enter Plan mode" for the full 15s.

## Root cause (test-only)

The sidebar derives `codexPlanMode` from the session snapshot's `omnigent.codex_native.collaboration_mode` label (`codexPlanModeFromSession`). A post-toggle stream re-bind (`sessionBindingPatch`) re-reads that label from a session **GET**.

The mock's **GET** branch rebuilt the payload from the real `hello_world` session — which carries no such label — and overlaid only `omnigent.wrapper`. So a re-bind after the toggle re-derived Plan mode as **off** and snapped the button back to "Enter Plan mode". (The **PATCH** branch set the label, which is why the optimistic/reconcile path briefly worked before the re-bind clobbered it.)

This is a mock-fidelity gap, not a product bug: a real server **persists** the `collaboration_mode` a PATCH set, so a subsequent GET reports it and the toggle stays pressed.

## Fix

The GET branch now carries the last `collaboration_mode` this mock recorded forward onto its responses, mirroring a persisting server. Test-only; no product code changes.

## Validation

I traced the full path (`ChatPage` toggle → `setCodexPlanMode` → `updateSession`/`sessionFromWire` → `codexPlanModeFromSession`, and the `sessionBindingPatch` re-bind that reads the GET) to confirm the mechanism. I was **not** able to run the Playwright e2e locally (it needs a built SPA, a live server, a mock-LLM server, the chromium binary, and the codex-native harness), so CI on this PR is the validation.

Co-authored-by: Isaac