### PR TITLE
fix(web): gate boot queries on the identity probe

### DIFF
--- a/web/src/lib/bootCapabilities.test.ts
+++ b/web/src/lib/bootCapabilities.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ServerInfo } from "./capabilities";
-import { createBootServerInfo, SERVER_INFO_OFFLINE_FALLBACK } from "./bootCapabilities";
+import {
+  createBootServerInfo,
+  SERVER_INFO_OFFLINE_FALLBACK,
+  withBootTimeout,
+} from "./bootCapabilities";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -37,5 +41,36 @@ describe("createBootServerInfo", () => {
     probe.resolve(branded);
 
     await expect(boot.settled).resolves.toEqual(branded);
+  });
+});
+
+// Shared by the /v1/info and /v1/me boot gates in main.tsx: both must be
+// awaited before first render, and neither may deadlock first paint.
+describe("withBootTimeout", () => {
+  it("resolves with the probe when it beats the timeout", async () => {
+    await expect(withBootTimeout(Promise.resolve("alice"), null, 1500)).resolves.toBe("alice");
+  });
+
+  it("falls back when the probe hangs past the timeout", async () => {
+    vi.useFakeTimers();
+    const hung = new Promise<string | null>(() => {});
+    const result = vi.fn();
+    void withBootTimeout(hung, null, 1500).then(result);
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(result).toHaveBeenCalledWith(null);
+  });
+
+  it("clears the timer once the probe settles", async () => {
+    vi.useFakeTimers();
+    const probe = deferred<string | null>();
+    const settled = withBootTimeout(probe.promise, null, 1500);
+    probe.resolve("alice");
+    await expect(settled).resolves.toBe("alice");
+
+    // A live timer here would keep the fallback armed (and hold the event
+    // loop open) long after boot resolved.
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/web/src/lib/bootCapabilities.ts
+++ b/web/src/lib/bootCapabilities.ts
@@ -21,17 +21,31 @@ export const SERVER_INFO_OFFLINE_FALLBACK: ServerInfo = {
   branding: null,
 };
 
-export function createBootServerInfo(
-  settled: Promise<ServerInfo>,
-  timeoutMs = 1500,
-): { initial: Promise<ServerInfo>; settled: Promise<ServerInfo> } {
+/**
+ * Race a boot probe against a timeout so first paint never waits on a
+ * stalled server: whichever settles first wins, and `fallback` stands in
+ * when the probe is too slow. The timer is cleared once the probe settles
+ * so a fast boot doesn't leave a pending handle behind (which would hold
+ * the event loop open in tests).
+ */
+export function withBootTimeout<T>(settled: Promise<T>, fallback: T, timeoutMs = 1500): Promise<T> {
   let timeout: ReturnType<typeof setTimeout>;
-  const fallback = new Promise<ServerInfo>((resolve) => {
-    timeout = setTimeout(() => resolve(SERVER_INFO_OFFLINE_FALLBACK), timeoutMs);
+  const timer = new Promise<T>((resolve) => {
+    timeout = setTimeout(() => resolve(fallback), timeoutMs);
   });
   void settled.then(
     () => clearTimeout(timeout),
     () => clearTimeout(timeout),
   );
-  return { initial: Promise.race([settled, fallback]), settled };
+  return Promise.race([settled, timer]);
+}
+
+export function createBootServerInfo(
+  settled: Promise<ServerInfo>,
+  timeoutMs = 1500,
+): { initial: Promise<ServerInfo>; settled: Promise<ServerInfo> } {
+  return {
+    initial: withBootTimeout(settled, SERVER_INFO_OFFLINE_FALLBACK, timeoutMs),
+    settled,
+  };
 }

--- a/web/src/lib/identity.test.ts
+++ b/web/src/lib/identity.test.ts
@@ -339,3 +339,108 @@ describe("getCurrentAuthorId", () => {
     expect(getCurrentAuthorId()).toBeNull();
   });
 });
+
+// The login redirect is a once-per-document side effect. An unauthenticated
+// page load produces a BURST of 401s (the shell mounts ~8 ungated queries) and
+// every one reaches the redirect branch in `authenticatedFetch`. Re-assigning
+// `location.href` per failure piled up navigations to a page the browser was
+// already headed to; these tests pin it at exactly one.
+describe("login redirect", () => {
+  const ORIGIN = "https://app.example.com";
+  let hrefWrites: string[];
+  let originalLocation: Location;
+
+  function stubLocation(pathname: string, search: string) {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        origin: ORIGIN,
+        pathname,
+        search,
+        set href(value: string) {
+          hrefWrites.push(value);
+        },
+        get href() {
+          return hrefWrites[hrefWrites.length - 1] ?? `${ORIGIN}${pathname}`;
+        },
+      },
+    });
+  }
+
+  beforeEach(() => {
+    // The slice-key tests above `vi.doMock("./host")` with a truthy `fetcher`,
+    // and doMock registrations outlive `vi.resetModules()`. Left in place, the
+    // embedded-host guard short-circuits the entire 401 redirect branch and
+    // these tests pass no matter what the code does. Same for ./sessionHost,
+    // and for the workspace env stub that turns on slice-key routing.
+    vi.doUnmock("./host");
+    vi.doUnmock("./sessionHost");
+    vi.unstubAllEnvs();
+
+    hrefWrites = [];
+    originalLocation = window.location;
+    stubLocation("/", "");
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("redirects once for a whole burst of 401s", async () => {
+    // /v1/me 401s with a login page (accounts / OIDC), then eight queries land
+    // 401 behind it — the shape of a real logged-out page load.
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({ user_id: null, login_url: "/login" }, { ok: false, status: 401 }),
+    );
+    const { resolveIdentity, authenticatedFetch, isLoginRedirectPending } =
+      await import("./identity");
+
+    await resolveIdentity();
+    await Promise.all(
+      Array.from({ length: 8 }, () => authenticatedFetch("/v1/sessions?limit=100")),
+    );
+
+    expect(hrefWrites).toEqual(["/login?return_to=%2F"]);
+    expect(isLoginRedirectPending()).toBe(true);
+  });
+
+  it("preserves the originating path in return_to", async () => {
+    stubLocation("/c/abc", "?tab=diff");
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({ user_id: null, login_url: "/auth/login" }, { ok: false, status: 401 }),
+    );
+    const { resolveIdentity } = await import("./identity");
+
+    await resolveIdentity();
+
+    expect(hrefWrites).toEqual(["/auth/login?return_to=%2Fc%2Fabc%3Ftab%3Ddiff"]);
+  });
+
+  it("never redirects in header mode, where there is no login page", async () => {
+    // login_url null → the proxy owns identity, so a stray 401 must surface to
+    // the caller instead of bouncing the user to a phantom form.
+    fetchMock.mockResolvedValue(mockJsonResponse({ user_id: null }, { ok: false, status: 401 }));
+    const { resolveIdentity, authenticatedFetch, isLoginRedirectPending } =
+      await import("./identity");
+
+    await resolveIdentity();
+    const res = await authenticatedFetch("/v1/hosts");
+
+    expect(hrefWrites).toEqual([]);
+    expect(isLoginRedirectPending()).toBe(false);
+    expect(res.status).toBe(401);
+  });
+
+  it("reports no pending redirect for an authenticated load", async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ user_id: "alice" }));
+    const { resolveIdentity, isLoginRedirectPending } = await import("./identity");
+
+    await resolveIdentity();
+
+    expect(isLoginRedirectPending()).toBe(false);
+    expect(hrefWrites).toEqual([]);
+  });
+});

--- a/web/src/lib/identity.ts
+++ b/web/src/lib/identity.ts
@@ -246,6 +246,41 @@ let identityPromise: Promise<string | null> | null = null;
 // Hardcoding "/login" here previously sent OIDC users to an accounts
 // password form that had no connection to their IdP.
 let serverLoginUrl: string | null = null;
+// Set the moment we hand the browser to the login page. Assigning
+// `location.href` starts a navigation but does NOT stop this document:
+// requests already in flight keep landing, and every 401 among them used
+// to re-assign the same URL, so one logged-out page load queued ~28
+// navigations. Boot also reads this to skip mounting the app when the
+// session is already on its way out (see `isLoginRedirectPending`).
+let loginRedirectPending = false;
+
+/**
+ * Hand the browser to `loginUrl`, at most once per document.
+ *
+ * :param loginUrl: Login path from the capabilities probe or `/v1/me`.
+ * :returns: True if this call started the navigation, False if one was
+ *     already under way.
+ */
+function redirectToLogin(loginUrl: string): boolean {
+  if (loginRedirectPending) return false;
+  loginRedirectPending = true;
+  const returnTo = encodeURIComponent(window.location.pathname + window.location.search);
+  window.location.href = `${loginUrl}?return_to=${returnTo}`;
+  return true;
+}
+
+/**
+ * Whether a login redirect is under way.
+ *
+ * The navigation is asynchronous, so this document keeps running until
+ * the login page commits. Boot checks this before mounting React —
+ * otherwise the app renders and fans its queries out against a session
+ * we already know is invalid, and each one 401s behind the pending
+ * navigation. Always false in header mode, which has no login page.
+ */
+export function isLoginRedirectPending(): boolean {
+  return loginRedirectPending;
+}
 
 /**
  * Whether the current page IS the login or register page, so we
@@ -290,10 +325,7 @@ export async function resolveIdentity(): Promise<string | null> {
           if (data.login_url) {
             serverLoginUrl = data.login_url;
             if (!isOnLoginPath()) {
-              const returnTo = encodeURIComponent(
-                window.location.pathname + window.location.search,
-              );
-              window.location.href = `${data.login_url}?return_to=${returnTo}`;
+              redirectToLogin(data.login_url);
               return null;
             }
           }
@@ -504,10 +536,11 @@ export async function authenticatedFetch(
     // the default for a bare local server, so we surface the 401 to
     // the caller instead. (serverLoginUrl from the /v1/me probe is a
     // fallback for the brief window before capabilities resolves.)
+    // Once-only (see redirectToLogin): a burst of 401s from one page load
+    // all reach here, and re-assigning the same URL per failure just piles
+    // up navigations to a page we're already going to.
     const loginUrl = getCachedServerInfo()?.login_url ?? serverLoginUrl;
-    if (loginUrl) {
-      window.location.href = `${loginUrl}?return_to=${encodeURIComponent(window.location.pathname + window.location.search)}`;
-    }
+    if (loginUrl) redirectToLogin(loginUrl);
   }
   return res;
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -11,8 +11,8 @@ import { QueueFlushProvider } from "./hooks/QueueFlushProvider";
 import { SessionUpdatesProvider } from "./hooks/SessionUpdatesProvider";
 import { resolveServerInfo, type ServerInfo } from "./lib/capabilities";
 import { CapabilitiesProvider } from "./lib/CapabilitiesContext";
-import { createBootServerInfo } from "./lib/bootCapabilities";
-import { resolveIdentity } from "./lib/identity";
+import { createBootServerInfo, withBootTimeout } from "./lib/bootCapabilities";
+import { isLoginRedirectPending, resolveIdentity } from "./lib/identity";
 import { initNativeInsets } from "./lib/nativeInsets";
 import { initBrowserTelemetry } from "./lib/telemetry";
 import {
@@ -53,7 +53,16 @@ initChatStore(queryClient);
 // Discover the current user identity from the server. Once resolved,
 // all subsequent fetch calls include X-Forwarded-Email so session
 // routes know who's making the request.
-void resolveIdentity();
+//
+// Started here but AWAITED at the render gate below, alongside the
+// /v1/info probe. The app's shell mounts ~8 queries (hosts, agents,
+// conversations, projects, harnesses) with no auth gating of their own,
+// so rendering before this settles fans them all out at once — logged
+// out, every one 401s in parallel and the login redirect races the
+// burst. Kicked off at module scope so it runs CONCURRENTLY with
+// `resolveServerInfo()`; the gate waits on the slower of the two rather
+// than chaining a second round-trip onto first paint.
+const bootIdentity = resolveIdentity();
 
 // Mirror the iOS shell's native bar footprints into the inset CSS variables.
 // No-op off the iOS shell (the inset vars stay at their env()-only defaults).
@@ -85,6 +94,11 @@ applyThemePalette(readThemePalette());
 // safety timeout (1.5s) so users on a flaky network still get
 // something on screen.
 const bootServerInfo = createBootServerInfo(resolveServerInfo());
+
+// Same 1.5s safety net for the identity probe: a hung /v1/me must not
+// deadlock first paint. On timeout we render anyway and the app degrades
+// exactly as it did before this gate existed.
+const bootIdentityGate = withBootTimeout<string | null>(bootIdentity, null);
 
 function RootApp({ initialInfo }: { initialInfo: ServerInfo }) {
   const [info, setInfo] = useState(initialInfo);
@@ -133,7 +147,13 @@ function RootApp({ initialInfo }: { initialInfo: ServerInfo }) {
   );
 }
 
-void bootServerInfo.initial.then((initialInfo) => {
+void Promise.all([bootServerInfo.initial, bootIdentityGate]).then(([initialInfo]) => {
+  // `/v1/me` came back 401 with a login page and we're already on our way
+  // there. Mounting now would start a navigation race we lose either way:
+  // the shell's queries fire against a session we know is invalid, 401,
+  // and get torn down mid-flight when the login page commits. Header mode
+  // never lands here (no login page), so a proxy-less deploy still renders.
+  if (isLoginRedirectPending()) return;
   createRoot(document.getElementById("root")!).render(
     <StrictMode>
       <RootApp initialInfo={initialInfo} />


### PR DESCRIPTION
## Related issue

Closes #4896

## Summary

A page load with no valid session fanned out ~10 API requests before auth state was known, and every one 401'd. `resolveIdentity()` ran unawaited at `main.tsx` module scope while the app shell mounted eight ungated queries alongside it, so the login redirect *raced* the burst instead of preventing it.

Two changes:

- **Await the identity probe at the render gate**, next to the `/v1/info` probe that already gates first paint — and skip mounting when a login redirect is already under way. The second half is load-bearing: assigning `location.href` starts a navigation but does **not** stop the current document, so awaiting alone would have moved the burst later rather than removing it.
- **Fire the login redirect once per document instead of once per 401.** Both redirect sites now route through `redirectToLogin()`, and the flag it sets is what the boot gate reads. Previously "we are on our way to the login page" existed only as a side effect on `window.location`, which can't be read back reliably.

Result, accounts / OIDC, measured in a real browser (details below): the initial document drops from **11 requests to 2** (`/v1/me` + `/v1/info`, both pre-existing pre-render probes), and redirect assignments from 9 to 1.

### ELI5

The app used to knock on nine doors at once before checking whether it had a key. All nine said "no". Now it checks for the key first, and if there isn't one it walks straight to the front desk without knocking.

### Boot sequence

```mermaid
sequenceDiagram
  participant M as main.tsx
  participant S as server
  Note over M,S: before
  M->>S: GET /v1/me
  M->>M: render() immediately
  M->>S: hosts x2, agents, sessions x4, harnesses, projects
  S-->>M: 401 x9
  S-->>M: 401 (/v1/me) → location.href = /login
  Note over M: 8 more href writes as the burst lands

  Note over M,S: after
  M->>S: GET /v1/me
  S-->>M: 401 {login_url}
  M->>M: redirectToLogin() → one href write
  M->>M: gate sees pending redirect → no render
```

### Notes on scope

- **Header mode is unaffected.** `login_url` is `null`, so no redirect fires, `isLoginRedirectPending()` stays false, and the app renders exactly as before — a proxy-less deploy still boots.
- **No added latency to first paint.** `resolveIdentity()` still starts at module scope, so it races `resolveServerInfo()` rather than chaining a second round-trip. It gets the same 1.5s timeout fallback, so a hung `/v1/me` can't deadlock rendering. `createBootServerInfo`'s timeout race was extracted as a generic `withBootTimeout<T>` to share it; behavior is unchanged.
- **The `/login` page still fans out.** `RunnerHealthProvider` mounts above `<App />`, so `useConversations` fires on the login route too — 4 requests in my measurements (1 + 3 retries), which is why the end-to-end logged-out total goes 17 → 8 rather than to 2. That's the layering violation the issue notes under "Related observations" (and which `App.tsx:102-107` documents as something to avoid); out of scope here, happy to follow up.
- **The retry tail is still there.** The client default `retry: 3` and the bare `throw new Error(\`${res.status} …\`)` in each fetcher are untouched, so a header-mode deploy whose proxy isn't injecting the identity header still emits the full burst *with* retries — there's no login page to redirect to, so the app must render. Fixing that needs a typed error carrying `.status` (one already exists: `ApiError` in `lib/sessionsApi.ts`) plus a global retry predicate. Left out to keep this reviewable; happy to follow up.
- `embed.tsx` keeps its bare `void resolveIdentity()`. Embedded auth is owned by the host shell and has different semantics, so I didn't change its boot gate.

## Test Plan

`web/`, all green:

- `vitest run` — 295 files, **5901 passed**, 3 expected-fail, 1 skipped
- `tsc -b` — clean
- `oxlint --deny-warnings --report-unused-disable-directives .` — clean
- `prettier --check` on the touched files — clean

New unit tests in `identity.test.ts` (`describe("login redirect")`): one redirect across a burst of nine 401s, `return_to` preserved from the originating path, no redirect in header mode, and no pending redirect on an authenticated load. `bootCapabilities.test.ts` covers `withBootTimeout` — probe wins, timeout wins, and the timer is cleared once the probe settles.

**Verified the burst test actually fails without the fix** (9 href writes vs the expected 1), not just that it passes with it.

⚠️ **One thing reviewers should know:** my first version of that test passed against deliberately broken code. The slice-key tests earlier in `identity.test.ts` call `vi.doMock("./host", …)` with a truthy `fetcher`, and `doMock` registrations survive `vi.resetModules()` — so every later dynamic import saw an embedded-host config, which short-circuits the whole 401 redirect branch before it can do anything. The test was asserting on a path it never reached. Fixed with `vi.doUnmock("./host")` / `vi.doUnmock("./sessionHost")` / `vi.unstubAllEnvs()` in the block's `beforeEach`. **Any test appended to the tail of that file inherits the same leak** — the mocks aren't scoped to the describe block that installs them.

### Verified end-to-end in a real browser

The render gate is module-scope side effects in `main.tsx`, which nothing imports, so it isn't unit-testable. I measured it instead against a live accounts-mode server (sqlite, `OMNIGENT_AUTH_PROVIDER=accounts`), driving headless Chrome over CDP and counting `Network.requestWillBeSent` per document:

| code | added latency | requests on `/` | on `/login` |
| --- | --- | --- | --- |
| pre-fix | 100 ms | **11** | 6 |
| fixed | 100 ms | **2** | 6 |
| pre-fix | 0 ms (plain localhost) | 2 | 8 |
| fixed | 0 ms (plain localhost) | 2 | 8 |

The 11 are exactly the ones the issue lists (`/v1/me`, `/v1/info`, `/v1/hosts` ×2, `/v1/agents`, `/v1/sessions` ×4, `/v1/harnesses`, `/v1/sessions/projects`); the 2 are `/v1/me` + `/v1/info`, both pre-existing pre-render probes. A `console.log` probe at the gate confirmed the mechanism directly: on `/` it logged *"gate BLOCKED render (login redirect pending)"*, on `/login` it rendered normally.

⚠️ **The bug does not reproduce on plain localhost** — bottom two rows. With ~1 ms RTT the login navigation commits before the app's first render, so the burst never gets to fire and pre-fix and fixed look identical. Reproducing it needs realistic latency (I used CDP `Network.emulateNetworkConditions` at 100 ms; devtools throttling does the same). **Reviewers testing without throttling will see no difference and may conclude the fix does nothing.** Also warm vite's dep-optimizer first — the very first load after `vite` starts is slow enough that the redirect wins there too.

**First paint is unaffected**, measured not assumed: module-scope → gate resolved was 102.3 ms pre-fix vs 102.4 ms fixed, because `/v1/me` rides concurrently with the `/v1/info` probe that already gated render.

**Authenticated load unchanged:** with a valid `ap_session` cookie the gate passes through, all 11 requests fire and succeed, and the app renders (probe logged *"render() returned"*).

### Manual reproduction

Against a multi-user (accounts or OIDC) server, with devtools Network open, **Preserve log** on, filter `/v1/`, throttling set to anything with latency (e.g. Fast 3G):

1. Clear cookies for the origin, reload `/`.
2. Count requests on the first document, before the `/login` navigation.

Expect 2 (`/v1/me`, `/v1/info`); before this change, 11. Then log in and reload — the full set fires and succeeds, no perceptible first-paint change. Worth also booting a **single-user local server** (`login_url: null`) to confirm it renders with no redirect; that's the path that would break if the gate were too aggressive.

## Demo

N/A — no visual change. The observable difference is request count in the network panel; steps above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the once-only redirect and the boot timeout helper directly. The render gate itself can't be unit-tested — `main.tsx` is an entrypoint with module-scope side effects and no importers — so it's covered by the browser measurement above: logged-out initial document drops from 11 requests to 2 under realistic latency, first paint unchanged (102.3 → 102.4 ms), authenticated load still renders with all requests succeeding. Note the bug is invisible on un-throttled localhost — see the warning there.

`pre-commit` couldn't bootstrap its hook environments in my sandbox (no PyPI access), so I ran the hooks that apply to these files directly instead: `web-prettier`, `web-oxlint` (full `web/` scope, as the hook does), and `web-tsc`.

## Changelog

A logged-out page load now makes only its identity and capability checks instead of 11 requests that mostly fail with 401
