### PR TITLE
feat(logging): ship process debug logs to a Delta table via a ZeroBus sink

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -2038,6 +2038,7 @@ def _fetch_external_session_id_for_redirect(
             "failed to fetch external Claude session id for redirect; session=%s",
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
         return None
     external_session_id = payload.get("external_session_id") if isinstance(payload, dict) else None

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -1046,12 +1046,14 @@ async def forward_claude_transcript_to_session(
                     session_id,
                     bridge_dir,
                     exc_info=True,
+                    extra={"session_id": session_id},
                 )
             except Exception:
                 _logger.exception(
                     "Claude transcript forwarder loop failed; session=%s bridge_dir=%s",
                     session_id,
                     bridge_dir,
+                    extra={"session_id": session_id},
                 )
             await asyncio.sleep(poll_interval_s)
 
@@ -1379,6 +1381,7 @@ async def _forward_available_subagents(
                     subagent_id,
                     decision.attempts,
                     _http_status_for_log(exc),
+                    extra={"session_id": parent_session_id},
                 )
                 # Dead-letter the dropped payload for recovery (#1120; replay #1579).
                 append_dead_letter(
@@ -1423,6 +1426,7 @@ async def _forward_available_subagents(
                 decision.delay_s,
                 _http_status_for_log(exc),
                 exc_info=True,
+                extra={"session_id": parent_session_id},
             )
             continue
         start_retry_tracker.clear(retry_key)
@@ -1917,6 +1921,7 @@ async def _forward_session_cost(
             _http_status_for_log(exc),
             delay,
             exc_info=True,
+            extra={"session_id": session_id},
         )
         return
     dedupe.cost_retry_failures = 0
@@ -2037,6 +2042,7 @@ async def supervise_forwarder(
                 "session=%s bridge_dir=%s",
                 session_id,
                 bridge_dir,
+                extra={"session_id": session_id},
             )
         except asyncio.CancelledError:
             raise
@@ -2055,6 +2061,7 @@ async def supervise_forwarder(
                 session_id,
                 bridge_dir,
                 exc_info=crash_exc,
+                extra={"session_id": session_id},
             )
         await _supervisor_sleep(backoff_s)
         backoff_s = min(backoff_s * 2.0, _SUPERVISOR_MAX_BACKOFF_S)
@@ -2123,6 +2130,7 @@ async def _maybe_rotate_session_on_clear(
             "Claude /clear rotation failed; consuming the clear hook to avoid a "
             "re-rotation loop. old_session=%s",
             session_id,
+            extra={"session_id": session_id},
         )
     await _write_hook_state_async(bridge_dir, durable)
     reset_transcript_forward_state(bridge_dir, reset_hooks=False)
@@ -2250,6 +2258,7 @@ async def _create_clear_replacement_session(
             new_session_id,
             clear_resp.status_code,
             clear_resp.text,
+            extra={"session_id": old_session_id},
         )
     return new_session_id
 
@@ -2313,6 +2322,7 @@ async def _maybe_rotate_session_on_fork(
             "Claude /fork rotation failed; consuming the fork hook to avoid a "
             "re-rotation loop. old_session=%s",
             session_id,
+            extra={"session_id": session_id},
         )
     await _write_hook_state_async(bridge_dir, durable)
     await _seed_fork_transcript_forward_state(
@@ -2384,6 +2394,7 @@ async def _create_fork_replacement_session(
             new_session_id,
             clear_resp.status_code,
             clear_resp.text,
+            extra={"session_id": old_session_id},
         )
     return new_session_id
 
@@ -2514,12 +2525,14 @@ async def _maybe_mirror_external_session_id(
                 exc.response.status_code,
                 session_id,
                 claude_sid,
+                extra={"session_id": session_id},
             )
             return True
         _logger.warning(
             "Transient Omnigent error PATCHing external_session_id (%s); session=%s — will retry",
             exc.response.status_code,
             session_id,
+            extra={"session_id": session_id},
         )
         return False
     except httpx.HTTPError:
@@ -2527,6 +2540,7 @@ async def _maybe_mirror_external_session_id(
             "Transient transport error PATCHing external_session_id; session=%s — will retry",
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
         return False
     return True
@@ -2712,6 +2726,7 @@ async def _forward_available_status_events(
                 record.event_name,
                 status,
                 record.transcript_path,
+                extra={"session_id": session_id},
             )
             durable = next_durable
             await _write_hook_state_async(bridge_dir, durable)
@@ -2738,6 +2753,7 @@ async def _forward_available_status_events(
                         record.event_cursor,
                         compaction_status,
                         exc_info=True,
+                        extra={"session_id": session_id},
                     )
                 if compaction_status == "in_progress":
                     # ``PreCompact`` mints a durable pending token that the
@@ -2833,6 +2849,7 @@ async def _forward_available_status_events(
                                         seq,
                                         decision.attempts,
                                         _http_status_for_log(exc),
+                                        extra={"session_id": session_id},
                                     )
                                     # Fall through to advance the cursor.
                                 else:
@@ -2848,6 +2865,7 @@ async def _forward_available_status_events(
                                         decision.delay_s,
                                         _http_status_for_log(exc),
                                         exc_info=True,
+                                        extra={"session_id": session_id},
                                     )
                                     return durable
                         except Exception:  # noqa: BLE001
@@ -2924,6 +2942,7 @@ async def _forward_available_status_events(
                         session_id,
                         record.event_cursor,
                         exc_info=True,
+                        extra={"session_id": session_id},
                     )
             durable = next_durable
             await _write_hook_state_async(bridge_dir, durable)
@@ -2960,6 +2979,7 @@ async def _forward_available_status_events(
                     status,
                     decision.attempts,
                     _http_status_for_log(exc),
+                    extra={"session_id": session_id},
                 )
                 if status != "failed":
                     await _post_forwarder_failed_status(
@@ -2985,6 +3005,7 @@ async def _forward_available_status_events(
                 decision.delay_s,
                 _http_status_for_log(exc),
                 exc_info=True,
+                extra={"session_id": session_id},
             )
             return durable
         retry_tracker.clear(retry_key)
@@ -3206,6 +3227,7 @@ async def _handle_compact_summary_item(
                 session_id,
                 bridge_dir,
                 _compaction_skip_stats.precompact_miss,
+                extra={"session_id": session_id},
             )
         else:
             _compaction_skip_stats.expected_skip += 1
@@ -3215,6 +3237,7 @@ async def _handle_compact_summary_item(
                 session_id,
                 bridge_dir,
                 _compaction_skip_stats.expected_skip,
+                extra={"session_id": session_id},
             )
         await _note_transcript_summary_without_token(bridge_dir)
         return True
@@ -3254,6 +3277,7 @@ async def _handle_compact_summary_item(
             decision.delay_s,
             _http_status_for_log(exc),
             exc_info=True,
+            extra={"session_id": session_id},
         )
         return False
     except Exception:  # noqa: BLE001
@@ -3409,6 +3433,7 @@ async def _forward_available_items(
                     item.item_type,
                     decision.attempts,
                     _http_status_for_log(exc),
+                    extra={"session_id": session_id},
                 )
                 # Dead-letter the dropped item for recovery (#1120; replay #1579).
                 append_dead_letter(
@@ -3463,6 +3488,7 @@ async def _forward_available_items(
                     item.item_type,
                     _http_status_for_log(exc),
                     exc_info=True,
+                    extra={"session_id": session_id},
                 )
                 retry_tracker.clear(retry_key)
                 seen.add(item.source_id)
@@ -3492,6 +3518,7 @@ async def _forward_available_items(
                 decision.delay_s,
                 _http_status_for_log(exc),
                 exc_info=True,
+                extra={"session_id": session_id},
             )
             return updated
         retry_tracker.clear(retry_key)
@@ -3591,6 +3618,7 @@ async def _forward_available_items(
                 bridge_dir,
                 _http_status_for_log(exc),
                 exc_info=True,
+                extra={"session_id": session_id},
             )
     # Report the transcript's model verbatim. This transcript-derived
     # observation only fires when a turn produces a fresh
@@ -3714,6 +3742,7 @@ def _validated_hook_state(
             session_id,
             bridge_dir,
             state.byte_offset,
+            extra={"session_id": session_id},
         )
     elif state.cursor_fingerprint is None:
         _logger.warning(
@@ -3722,6 +3751,7 @@ def _validated_hook_state(
             session_id,
             bridge_dir,
             state.byte_offset,
+            extra={"session_id": session_id},
         )
     elif current_fingerprint == state.cursor_fingerprint:
         return state
@@ -3732,6 +3762,7 @@ def _validated_hook_state(
             session_id,
             bridge_dir,
             state.byte_offset,
+            extra={"session_id": session_id},
         )
     return HookForwardState(
         event_cursor=0,
@@ -3806,6 +3837,7 @@ def _validated_transcript_state(
             bridge_dir,
             state.transcript_path,
             state.byte_offset,
+            extra={"session_id": session_id},
         )
     elif state.cursor_fingerprint is None:
         if state.byte_offset == 0 and state.line_cursor == 0:
@@ -3830,6 +3862,7 @@ def _validated_transcript_state(
             bridge_dir,
             state.transcript_path,
             state.byte_offset,
+            extra={"session_id": session_id},
         )
     elif current_fingerprint == state.cursor_fingerprint:
         return state
@@ -3841,6 +3874,7 @@ def _validated_transcript_state(
             bridge_dir,
             state.transcript_path,
             state.byte_offset,
+            extra={"session_id": session_id},
         )
     end_offset = _transcript_end_offset(state.transcript_path)
     return TranscriptForwardState(
@@ -3908,6 +3942,7 @@ async def _post_clear_supersession(
             old_session_id,
             new_session_id,
             exc_info=True,
+            extra={"session_id": old_session_id},
         )
     notice = (
         "This conversation was ended by `/clear`. "
@@ -3936,6 +3971,7 @@ async def _post_clear_supersession(
             old_session_id,
             new_session_id,
             exc_info=True,
+            extra={"session_id": old_session_id},
         )
     try:
         event_resp = await client.post(
@@ -3952,6 +3988,7 @@ async def _post_clear_supersession(
             old_session_id,
             new_session_id,
             exc_info=True,
+            extra={"session_id": old_session_id},
         )
 
 
@@ -4097,6 +4134,7 @@ async def _forward_available_deltas(
                 delta.message_id,
                 delta.index,
                 _http_status_for_log(exc),
+                extra={"session_id": session_id},
             )
     updated = DeltaForwardState(byte_offset=result.byte_offset)
     await _write_delta_forward_state_async(bridge_dir, updated)
@@ -4268,6 +4306,7 @@ async def _forward_permission_mode_from_pane(
             session_id,
             mode,
             exc_info=True,
+            extra={"session_id": session_id},
         )
         return
     dedupe.posted_permission_mode = mode
@@ -4377,6 +4416,7 @@ async def _post_title_change_if_new(
             "list may show a stale title until the next poll",
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
 
 
@@ -4429,6 +4469,7 @@ async def _post_model_change_if_new(
             "cost-budget gate may lag until the next poll",
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
 
 
@@ -4667,6 +4708,7 @@ async def _maybe_sync_effort_from_slash_command(
             level,
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
 
 
@@ -4708,6 +4750,7 @@ async def _post_forwarder_failed_status(
             bridge_dir,
             reason,
             exc_info=True,
+            extra={"session_id": session_id},
         )
 
 

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -42,6 +42,12 @@ CLIENT_SECRET_ENV_VAR = "OMNIGENT_DEBUG_LOG_CLIENT_SECRET"
 WORKSPACE_URL_ENV_VAR = "OMNIGENT_DEBUG_LOG_WORKSPACE_URL"
 ENDPOINT_ENV_VAR = "OMNIGENT_DEBUG_LOG_ENDPOINT"
 
+# The host spawns a runner for one *primary* session and names the runner's log
+# file after it. Subagent child sessions co-locate in the same runner process,
+# so this is the primary session, not the only one — pass it explicitly at
+# runner-level log callsites that have no per-request session id in scope.
+PRIMARY_SESSION_ID_ENV_VAR = "OMNIGENT_RUNNER_PRIMARY_SESSION_ID"
+
 # Batching / delivery defaults.
 _BATCH_MAX_RECORDS = 100
 _FLUSH_INTERVAL_S = 2.0
@@ -170,6 +176,19 @@ def config_from_env() -> DebugLogConfig | None:
         table=table,
         workspace_id=workspace_id,
     )
+
+
+def runner_primary_session_id() -> str | None:
+    """Return the runner's primary (spawn-time) session id, or ``None``.
+
+    The host sets ``OMNIGENT_RUNNER_PRIMARY_SESSION_ID`` when it spawns a runner
+    for a session. It is the best-available attribution for runner-level log
+    callsites that have no per-request session id in scope (tunnel lifecycle,
+    startup, infra). Prefer an explicit per-request session id wherever one is
+    available -- a subagent turn runs in the same runner process, so this
+    primary id would otherwise mis-attribute it to the parent.
+    """
+    return os.environ.get(PRIMARY_SESSION_ID_ENV_VAR) or None
 
 
 def debug_event(

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -1,0 +1,559 @@
+"""Client-side debug-log sink that ships process logs to a Databricks table.
+
+Every Omnigent Python entrypoint (server / runner / host / harness) writes its
+logs to a local file via :mod:`omnigent.process_logging`. This module adds an
+extra logging handler that also forwards each record, as JSON, to a Databricks
+Delta table through the ZeroBus REST ingest endpoint, so a whole session's logs
+can be queried in one place (see the Omnigent Debuggability Plan, OMNI-4198).
+
+The sink is enabled only when the ``OMNIGENT_DEBUG_LOG_*`` environment variables
+are present -- the internal ``omni`` config CLI sets them for internal users, so
+the feature is off by default for OSS users and customers. Uploading is
+best-effort and fully non-blocking: records are queued and flushed by a daemon
+thread, and any failure (auth, network, overflow) drops rows rather than
+disrupting the process.
+"""
+
+from __future__ import annotations
+
+import atexit
+import contextlib
+import json
+import logging
+import os
+import queue
+import socket
+import threading
+import time
+import traceback
+import urllib.parse
+import uuid
+from dataclasses import dataclass
+
+import httpx
+
+from omnigent.version import VERSION
+
+# ── environment contract ────────────────────────────────────────────────────
+# The insert endpoint carries the table (in its path) and the workspace id (in
+# its host), so only four values are needed. See config_from_env.
+CLIENT_ID_ENV_VAR = "OMNIGENT_DEBUG_LOG_CLIENT_ID"
+CLIENT_SECRET_ENV_VAR = "OMNIGENT_DEBUG_LOG_CLIENT_SECRET"
+WORKSPACE_URL_ENV_VAR = "OMNIGENT_DEBUG_LOG_WORKSPACE_URL"
+ENDPOINT_ENV_VAR = "OMNIGENT_DEBUG_LOG_ENDPOINT"
+
+# Batching / delivery defaults.
+_BATCH_MAX_RECORDS = 100
+_FLUSH_INTERVAL_S = 2.0
+_QUEUE_MAX_RECORDS = 10_000
+_TOKEN_REFRESH_SKEW_S = 300.0
+_HTTP_TIMEOUT_S = 10.0
+# Delay before the one-shot startup self-probe fires. Long enough to land after
+# the process's startup-time logging reconfiguration (uvicorn's dictConfig,
+# which closes all handlers, runs a second or two into serving).
+_PROBE_DELAY_S = 10.0
+# Logger-name prefixes the sink drops as noise: httpx/httpcore emit an
+# "HTTP Request: …" line per call — high-volume plumbing the debug view doesn't
+# want (and the sink's own uploads go through httpx).
+_IGNORED_LOGGER_PREFIXES = ("httpx", "httpcore")
+
+_HOSTNAME = socket.gethostname()
+
+_logger = logging.getLogger(__name__)
+
+# Diagnostics are throttled per category so a persistently broken endpoint
+# surfaces the reason without flooding the local logs on every flush.
+_DIAG_THROTTLE_S = 60.0
+_diag_last: dict[str, float] = {}
+_diag_lock = threading.Lock()
+
+
+def _diag(key: str, msg: str, *args: object) -> None:
+    """Log a throttled sink diagnostic (at most once per category per minute).
+
+    Called from the uploader thread, so these lines reach the local file log and
+    stderr but are never re-ingested by the sink itself (``emit`` skips its own
+    thread). The first occurrence of each ``key`` logs immediately.
+    """
+    now = time.time()
+    with _diag_lock:
+        if now - _diag_last.get(key, 0.0) < _DIAG_THROTTLE_S:
+            return
+        _diag_last[key] = now
+    _logger.warning("debug-log sink: " + msg, *args)
+
+
+def _body_snippet(response: httpx.Response, limit: int = 300) -> str:
+    """Return a short single-line preview of a response body for diagnostics."""
+    try:
+        text = " ".join(response.text.split())
+    except Exception:  # noqa: BLE001 — diagnostics must never raise
+        return "<unreadable body>"
+    return text[:limit]
+
+
+def _is_ignored_logger(name: str) -> bool:
+    """Return whether a logger's records are dropped by the sink as noise."""
+    return name.startswith(_IGNORED_LOGGER_PREFIXES)
+
+
+@dataclass(frozen=True)
+class DebugLogConfig:
+    """Resolved configuration for the debug-log sink."""
+
+    client_id: str
+    client_secret: str
+    workspace_url: str  # OIDC token-mint host, e.g. https://dbc-….cloud.databricks.com
+    insert_url: str  # full ZeroBus …/tables/<table>/insert URL
+    table: str  # catalog.schema.table, parsed from insert_url
+    workspace_id: str  # numeric id, parsed from insert_url host
+
+
+def _parse_insert_url(insert_url: str) -> tuple[str, str] | None:
+    """Extract ``(table, workspace_id)`` from a ZeroBus insert URL.
+
+    The URL shape is a fixed API contract:
+    ``https://<workspace-id>.zerobus.<region>…/zerobus/v1/tables/<table>/insert``
+    -- the table is the path segment after ``/tables/`` and the workspace id is
+    the first DNS label of the host. Returns ``None`` if the URL is malformed.
+    """
+    try:
+        parsed = urllib.parse.urlparse(insert_url)
+        host = parsed.hostname or ""
+        workspace_id = host.split(".", 1)[0]
+        marker = "/tables/"
+        start = parsed.path.find(marker)
+        if start < 0:
+            return None
+        table = parsed.path[start + len(marker) :].split("/", 1)[0]
+        if not table or not workspace_id:
+            return None
+        return table, workspace_id
+    except ValueError:
+        return None
+
+
+def config_from_env() -> DebugLogConfig | None:
+    """Build the sink config from the environment, or ``None`` when disabled.
+
+    All four variables must be set for the sink to run. When none are set it
+    stays silently off (the default for OSS/customers); a *partial* or malformed
+    set logs one warning naming the problem, then disables — that partial case
+    almost always means someone tried to enable it and slipped.
+    """
+    client_id = os.environ.get(CLIENT_ID_ENV_VAR)
+    client_secret = os.environ.get(CLIENT_SECRET_ENV_VAR)
+    workspace_url = os.environ.get(WORKSPACE_URL_ENV_VAR)
+    insert_url = os.environ.get(ENDPOINT_ENV_VAR)
+    if not (client_id and client_secret and workspace_url and insert_url):
+        present = {
+            CLIENT_ID_ENV_VAR: client_id,
+            CLIENT_SECRET_ENV_VAR: client_secret,
+            WORKSPACE_URL_ENV_VAR: workspace_url,
+            ENDPOINT_ENV_VAR: insert_url,
+        }
+        missing = [name for name, value in present.items() if not value]
+        # A partial set almost always means someone tried to enable it and slipped.
+        if len(missing) < len(present):
+            _logger.warning("debug-log sink disabled: missing env var(s): %s", ", ".join(missing))
+        return None
+    parsed = _parse_insert_url(insert_url)
+    if parsed is None:
+        _logger.warning("debug-log sink disabled: could not parse %s", ENDPOINT_ENV_VAR)
+        return None
+    table, workspace_id = parsed
+    return DebugLogConfig(
+        client_id=client_id,
+        client_secret=client_secret,
+        workspace_url=workspace_url.rstrip("/"),
+        insert_url=insert_url,
+        table=table,
+        workspace_id=workspace_id,
+    )
+
+
+def debug_event(
+    event_name: str,
+    *,
+    session_id: str | None = None,
+    turn_id: str | None = None,
+    **attributes: object,
+) -> dict[str, object]:
+    """Build a logging ``extra=`` payload naming a semantic event.
+
+    Use at lifecycle callsites so the row carries an ``event_name`` and a
+    string-valued attributes map, and pass ``session_id`` (and ``turn_id`` once
+    it is wired) explicitly so the row is correlated to its session, e.g.::
+
+        _logger.info("dispatching tool", extra=debug_event(
+            "tool_call_dispatched", session_id=session_id,
+            tool_call_id=tc.id, model=model))
+
+    The correlation columns are populated only from what the callsite passes --
+    the sink reads them off the record, with no ambient fallback. Freeform
+    ``_logger.debug("…")`` calls need no ``extra``; they ship with null
+    correlation columns and an empty attributes map.
+    """
+    extra: dict[str, object] = {"event_name": event_name, "attributes": dict(attributes)}
+    if session_id is not None:
+        extra["session_id"] = session_id
+    if turn_id is not None:
+        extra["turn_id"] = turn_id
+    return extra
+
+
+def _stack_trace(record: logging.LogRecord) -> str | None:
+    if record.exc_info:
+        return "".join(traceback.format_exception(*record.exc_info))
+    return record.exc_text or None
+
+
+def _attributes(record: logging.LogRecord) -> dict[str, str]:
+    raw = getattr(record, "attributes", None)
+    if not isinstance(raw, dict):
+        return {}
+    # The target column is MAP<STRING,STRING>; coerce values and drop nulls.
+    return {str(k): str(v) for k, v in raw.items() if v is not None}
+
+
+def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
+    """Serialize a log record into one debug-logs table row.
+
+    ``client_time`` is epoch microseconds and ``attributes`` a plain object --
+    the two shapes the ZeroBus JSON path requires for the ``TIMESTAMP`` and
+    ``MAP<STRING,STRING>`` columns respectively.
+    """
+    return {
+        "session_id": getattr(record, "session_id", None),
+        "turn_id": getattr(record, "turn_id", None),
+        "source": source,
+        "event_name": getattr(record, "event_name", None),
+        "level": record.levelname,
+        "message": record.getMessage(),
+        "client_time": int(record.created * 1_000_000),
+        "hostname": _HOSTNAME,
+        "logger_name": record.name,
+        "func_name": record.funcName,
+        "app_version": VERSION,
+        "stack_trace": _stack_trace(record),
+        "attributes": _attributes(record),
+        "log_id": uuid.uuid4().hex,
+        "user_id": getattr(record, "user_id", None),
+    }
+
+
+class _TokenSource:
+    """Mints and caches a ZeroBus-audience OAuth token from the SP creds.
+
+    The token must be minted for the ``zerobusDirectWriteApi`` resource via the
+    ``client_credentials`` grant -- a plain workspace token is rejected -- so we
+    do the OIDC exchange by hand rather than through the SDK.
+    """
+
+    def __init__(self, config: DebugLogConfig, client: httpx.Client) -> None:
+        self._config = config
+        self._client = client
+        self._lock = threading.Lock()
+        self._token: str | None = None
+        self._expires_at = 0.0
+
+    def token(self) -> str | None:
+        with self._lock:
+            if self._token and time.time() < self._expires_at - _TOKEN_REFRESH_SKEW_S:
+                return self._token
+            minted = self._mint()
+            if minted is None:
+                return None
+            self._token, self._expires_at = minted
+            return self._token
+
+    def invalidate(self) -> None:
+        with self._lock:
+            self._token = None
+            self._expires_at = 0.0
+
+    def _authorization_details(self) -> str:
+        parts = self._config.table.split(".")
+        catalog = parts[0]
+        schema = ".".join(parts[:2])
+        return json.dumps(
+            [
+                {
+                    "type": "unity_catalog_privileges",
+                    "privileges": ["USE CATALOG"],
+                    "object_type": "CATALOG",
+                    "object_full_path": catalog,
+                },
+                {
+                    "type": "unity_catalog_privileges",
+                    "privileges": ["USE SCHEMA"],
+                    "object_type": "SCHEMA",
+                    "object_full_path": schema,
+                },
+                {
+                    "type": "unity_catalog_privileges",
+                    "privileges": ["SELECT", "MODIFY"],
+                    "object_type": "TABLE",
+                    "object_full_path": self._config.table,
+                },
+            ]
+        )
+
+    def _mint(self) -> tuple[str, float] | None:
+        resource = f"api://databricks/workspaces/{self._config.workspace_id}/zerobusDirectWriteApi"
+        try:
+            response = self._client.post(
+                f"{self._config.workspace_url}/oidc/v1/token",
+                auth=(self._config.client_id, self._config.client_secret),
+                data={
+                    "grant_type": "client_credentials",
+                    "scope": "all-apis",
+                    "resource": resource,
+                    "authorization_details": self._authorization_details(),
+                },
+                timeout=_HTTP_TIMEOUT_S,
+            )
+        except httpx.HTTPError as exc:
+            _diag(
+                "token_transport",
+                "token mint request to %s failed: %s",
+                self._config.workspace_url,
+                exc,
+            )
+            return None
+        if response.status_code != 200:
+            # The body carries the OAuth error (invalid_client, unauthorized
+            # authorization_details, …) — the actionable part.
+            _diag(
+                "token_status",
+                "token mint failed: status=%s body=%s",
+                response.status_code,
+                _body_snippet(response),
+            )
+            return None
+        try:
+            body = response.json()
+        except ValueError:
+            _diag("token_decode", "token mint returned a non-JSON body")
+            return None
+        token = body.get("access_token")
+        if not token:
+            _diag("token_missing", "token mint response had no access_token")
+            return None
+        expires_in = float(body.get("expires_in", 3600))
+        return token, time.time() + expires_in
+
+
+class ZerobusLogHandler(logging.Handler):
+    """Non-blocking logging handler that batches records to a ZeroBus table."""
+
+    def __init__(self, config: DebugLogConfig, source: str) -> None:
+        super().__init__()
+        self._config = config
+        self._source = source
+        self._closed = False
+        self._delivered_any = False
+        self._start_worker()
+        atexit.register(self.close)
+        # One-shot startup self-probe. Deliberately NOT cancelled on close() —
+        # uvicorn's dictConfig close()s this handler a beat into startup, and the
+        # probe firing *after* that is exactly what re-arms the worker and proves
+        # end-to-end delivery on an otherwise-idle process.
+        self._probe_timer = threading.Timer(_PROBE_DELAY_S, self._probe)
+        self._probe_timer.daemon = True
+        self._probe_timer.start()
+
+    def _probe(self) -> None:
+        """Emit one startup self-probe, after logging reconfiguration.
+
+        Fires ~10s after arm — past uvicorn's startup ``dictConfig()`` — so every
+        boot leaves a health line in the local log (``alive``/``delivered``/queue
+        depth) and, via the normal emit path, a delivered ``sink_online`` row.
+        The emit revives the worker if ``dictConfig`` (or a fork) stopped it, so
+        the sink is guaranteed live even when no session traffic has flowed yet.
+        Best-effort; never raises.
+        """
+        with contextlib.suppress(Exception):  # a probe must never break anything
+            _logger.info(
+                "debug-log sink: self-probe source=%s alive=%s delivered=%s qsize=%d",
+                self._source,
+                self._thread.is_alive(),
+                self._delivered_any,
+                self._queue.qsize(),
+                extra=debug_event("sink_online"),
+            )
+
+    def _start_worker(self) -> None:
+        """Create the queue/client and launch the uploader thread.
+
+        Re-invoked by :meth:`emit` when the thread has stopped — after a
+        ``logging.config.dictConfig()`` (uvicorn) or an ``os.fork()`` (the
+        runner ``_zygote``), which leave the handler attached but kill the
+        thread. Fresh queue/client/thread let delivery resume; the inherited
+        ones (whose locks are in an indeterminate post-fork state) are dropped.
+        """
+        self._queue: queue.Queue[dict[str, object]] = queue.Queue(maxsize=_QUEUE_MAX_RECORDS)
+        self._client = httpx.Client(timeout=_HTTP_TIMEOUT_S)
+        self._tokens = _TokenSource(self._config, self._client)
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, name="omnigent-debug-log", daemon=True)
+        self._thread.start()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def emit(self, record: logging.LogRecord) -> None:
+        # Skip records the uploader itself emits (e.g. httpx), or a failing POST
+        # would feed its own error logs back into the queue.
+        if threading.current_thread() is self._thread:
+            return
+        # Drop chatty HTTP-client internals (httpx/httpcore) as noise.
+        if _is_ignored_logger(record.name):
+            return
+        # logging.config.dictConfig() (uvicorn applies one at startup) calls
+        # logging.shutdown() on every handler — which close()s this one and stops
+        # its uploader thread while leaving it attached to root; os.fork() (the
+        # runner _zygote) likewise kills the thread. Receiving a record means the
+        # handler is still live, so revive the worker (fresh queue/client/thread)
+        # and delivery resumes on the next line. A real shutdown emits nothing
+        # afterward, so this never fights atexit. emit() is serialized by the
+        # Handler lock, so the restart happens once.
+        if self._closed or not self._thread.is_alive():
+            try:
+                self._closed = False
+                self._start_worker()
+            except Exception:  # noqa: BLE001 — never break logging over the sink
+                return
+        try:
+            row = record_to_row(record, self._source)
+        except Exception:  # noqa: BLE001 — a logging handler must never raise into the app
+            return
+        try:
+            self._queue.put_nowait(row)
+        except queue.Full:
+            # Shed the oldest row to keep the newest under sustained overflow.
+            try:
+                self._queue.get_nowait()
+                self._queue.put_nowait(row)
+            except queue.Empty:
+                pass
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            batch = self._collect_batch(self._FLUSH_WAIT)
+            if batch:
+                self._post(batch)
+        # Drain whatever is left on shutdown.
+        remaining = self._collect_batch(0.0)
+        if remaining:
+            self._post(remaining)
+
+    _FLUSH_WAIT = _FLUSH_INTERVAL_S
+
+    def _collect_batch(self, wait: float) -> list[dict[str, object]]:
+        batch: list[dict[str, object]] = []
+        try:
+            batch.append(self._queue.get(timeout=wait) if wait else self._queue.get_nowait())
+        except queue.Empty:
+            return batch
+        while len(batch) < _BATCH_MAX_RECORDS:
+            try:
+                batch.append(self._queue.get_nowait())
+            except queue.Empty:
+                break
+        return batch
+
+    def _post(self, batch: list[dict[str, object]]) -> None:
+        payload = json.dumps(batch)
+        for attempt in range(3):
+            token = self._tokens.token()
+            if not token:
+                # Mint failed — _mint already logged why; note the data loss.
+                _diag("no_token", "no auth token (mint failing); dropping %d row(s)", len(batch))
+                return
+            try:
+                response = self._client.post(
+                    self._config.insert_url,
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Content-Type": "application/json",
+                    },
+                    content=payload,
+                    timeout=_HTTP_TIMEOUT_S,
+                )
+            except httpx.HTTPError as exc:
+                _diag(
+                    "post_transport", "insert POST to %s failed: %s", self._config.insert_url, exc
+                )
+                time.sleep(min(0.5 * 2**attempt, 3.0))
+                continue
+            if response.status_code == 200:
+                if not self._delivered_any:
+                    self._delivered_any = True
+                    _logger.info(
+                        "debug-log sink: first batch delivered to %s (%d row(s))",
+                        self._config.table,
+                        len(batch),
+                    )
+                return
+            if response.status_code in (401, 403):
+                # Wrong/expired token audience shows up here (not at mint).
+                _diag(
+                    "post_auth",
+                    "insert rejected: status=%s body=%s",
+                    response.status_code,
+                    _body_snippet(response),
+                )
+                self._tokens.invalidate()  # stale/rotated token — refresh and retry
+                continue
+            _diag(
+                "post_status",
+                "insert failed: status=%s body=%s",
+                response.status_code,
+                _body_snippet(response),
+            )
+            time.sleep(min(0.5 * 2**attempt, 3.0))
+        _diag("post_dropped", "dropped %d row(s) after 3 failed insert attempts", len(batch))
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._stop.set()
+        self._thread.join(timeout=5.0)
+        try:
+            self._client.close()
+        finally:
+            super().close()
+
+
+# Process-wide sink; recreated only if a prior instance was closed (e.g. a
+# logging reconfigure closed the root handlers out from under us).
+_active_sink: ZerobusLogHandler | None = None
+_sink_lock = threading.Lock()
+
+
+def attach_debug_log_sink(loggers: list[logging.Logger], *, source: str, level: int) -> None:
+    """Attach the shared debug-log sink to *loggers* when configured.
+
+    A no-op unless the ``OMNIGENT_DEBUG_LOG_*`` variables are set. Reuses one
+    handler per process; ``Logger.addHandler`` is idempotent for a given
+    instance, so repeated calls do not double-ship.
+    """
+    global _active_sink
+    config = config_from_env()
+    if config is None:
+        return
+    with _sink_lock:
+        if _active_sink is None or _active_sink.closed:
+            _active_sink = ZerobusLogHandler(config, source)
+            _logger.info(
+                "debug-log sink enabled: source=%s table=%s endpoint=%s",
+                source,
+                config.table,
+                config.insert_url,
+            )
+        _active_sink.setLevel(level)
+        for target in loggers:
+            target.addHandler(_active_sink)

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -456,6 +456,9 @@ class ZerobusLogHandler(logging.Handler):
                 self._queue.get_nowait()
                 self._queue.put_nowait(row)
             except queue.Empty:
+                # The uploader drained the queue between our full put and this
+                # get — there is room now and this one row is dropped, which is
+                # acceptable for a best-effort sink shedding under overflow.
                 pass
 
     def _run(self) -> None:
@@ -538,11 +541,16 @@ class ZerobusLogHandler(logging.Handler):
     def close(self) -> None:
         if self._closed:
             return
+        # Capture the worker we are tearing down first. A concurrent emit()
+        # (which runs under the handler lock) can revive the sink during the
+        # join below — reassigning self._stop/_thread/_client to fresh ones — so
+        # stop and close the captured locals, never the revived worker.
+        stop, thread, client = self._stop, self._thread, self._client
         self._closed = True
-        self._stop.set()
-        self._thread.join(timeout=5.0)
+        stop.set()
+        thread.join(timeout=5.0)
         try:
-            self._client.close()
+            client.close()
         finally:
             super().close()
 
@@ -566,7 +574,14 @@ def attach_debug_log_sink(loggers: list[logging.Logger], *, source: str, level: 
         return
     with _sink_lock:
         if _active_sink is None or _active_sink.closed:
-            _active_sink = ZerobusLogHandler(config, source)
+            try:
+                _active_sink = ZerobusLogHandler(config, source)
+            except Exception:  # noqa: BLE001 — the sink must never break logging setup
+                # Honor the module's best-effort contract: handler construction
+                # (httpx client, uploader thread, probe timer) failing must not
+                # take down configure_process_logging() and thus process startup.
+                _logger.warning("debug-log sink disabled: handler init failed", exc_info=True)
+                return
             _logger.info(
                 "debug-log sink enabled: source=%s table=%s endpoint=%s",
                 source,

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -27,6 +27,7 @@ import websockets.asyncio.client
 from websockets.exceptions import ConnectionClosed, InvalidStatus, InvalidURI
 
 from omnigent._platform import IS_POSIX, WINDOWS_ENV_PASSTHROUGH
+from omnigent.debug_logging import PRIMARY_SESSION_ID_ENV_VAR
 from omnigent.env_credentials import env_names_with_omnigent_prefix
 from omnigent.gateway_inference import gateway_inference_map
 from omnigent.harness_aliases import canonicalize_harness, is_claude_sdk_harness_name
@@ -1424,6 +1425,10 @@ class HostProcess:
             host_id=self._identity.host_id,
             harness=frame.harness,
         )
+        # The runner serves one primary session (plus any co-located subagents);
+        # pass it so runner-level log records can be attributed to that session.
+        if frame.session_id:
+            env[PRIMARY_SESSION_ID_ENV_VAR] = frame.session_id
 
         # Embed the session id so operators can find all logs for a session
         # with `omnigent debug logs --session <id>`. Cap at 32 chars to keep

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -447,6 +447,16 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         "OMNIGENT_LOG_LEVEL",
         "OMNIGENT_LOG_TO_STDERR",
         LOG_TTY_FD_ENV_VAR,
+        # Debug-log sink config + creds (OMNI-4198). The runner uploads its OWN
+        # process logs to the debug-logs table, so it needs these — including the
+        # service-principal secret. That is the one deliberate exception to the
+        # "no secrets" rule: it is the app's SP creds for log upload (not a user
+        # secret), and the runner is a trusted child. Without them the runner's
+        # sink never arms and runner logs never reach the table.
+        "OMNIGENT_DEBUG_LOG_CLIENT_ID",
+        "OMNIGENT_DEBUG_LOG_CLIENT_SECRET",
+        "OMNIGENT_DEBUG_LOG_WORKSPACE_URL",
+        "OMNIGENT_DEBUG_LOG_ENDPOINT",
         # Secret-store backend selector. The CLI's `configure harnesses` stores
         # pasted API keys via the file backend when this is set (headless /
         # locked-keyring hosts), writing `keychain:<name>` refs. The runner

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -413,6 +413,15 @@ def configure_process_logging(
             for handler in handlers:
                 _add_handler_once(logger, handler)
 
+    # Mirror the file handler's reach with the optional debug-log upload sink,
+    # so it captures the same records this process writes to disk.
+    from omnigent.debug_logging import attach_debug_log_sink
+
+    sink_targets = (
+        [logging.getLogger()] if root else [logging.getLogger(name) for name in logger_names]
+    )
+    attach_debug_log_sink(sink_targets, source=destination, level=resolved_level)
+
     logging.captureWarnings(True)
     return path
 

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -25,6 +25,7 @@ import httpx
 from fastapi import FastAPI
 
 from omnigent._platform import IS_WINDOWS
+from omnigent.debug_logging import runner_primary_session_id
 from omnigent.inner import _proc
 from omnigent.runner.transports.ws_tunnel.serve import RUNNER_TUNNEL_REJECTION_PREFIX
 from omnigent.version import VERSION
@@ -245,6 +246,7 @@ async def _run_inactivity_monitor(
             _logger.info(
                 "runner idle timeout reached after %.1fs with no active work; shutting down",
                 elapsed_s,
+                extra={"session_id": runner_primary_session_id()},
             )
             request_shutdown()
             return
@@ -434,7 +436,8 @@ class _InitialAuthTokenFactory:
                 self._no_credential_logged = True
                 _logger.error(
                     "host bootstrap bearer expired and no SDK/OIDC credential is available "
-                    "to renew it; run `databricks auth login` to re-authenticate"
+                    "to renew it; run `databricks auth login` to re-authenticate",
+                    extra={"session_id": runner_primary_session_id()},
                 )
             return token
 
@@ -451,7 +454,10 @@ class _InitialAuthTokenFactory:
             if self._initial_token is None:
                 return False
             self._initial_token = None
-            _logger.info("host bootstrap bearer rejected; resolving runner-local auth")
+            _logger.info(
+                "host bootstrap bearer rejected; resolving runner-local auth",
+                extra={"session_id": runner_primary_session_id()},
+            )
             return True
 
 
@@ -530,7 +536,10 @@ def _make_auth_token_factory(
         else ""
     )
     if initial_token and resolved_server_url:
-        _logger.info("using host-provided bearer for runner bootstrap")
+        _logger.info(
+            "using host-provided bearer for runner bootstrap",
+            extra={"session_id": runner_primary_session_id()},
+        )
         return _InitialAuthTokenFactory(initial_token, resolved_server_url)
 
     from omnigent.inner.databricks_executor import (
@@ -1035,6 +1044,7 @@ def _run_parent_death_killer(
         "runner exiting: parent process died and graceful shutdown did not "
         "complete within %.1fs; forcing hard exit",
         grace_s,
+        extra={"session_id": runner_primary_session_id()},
     )
     # os._exit skips buffer flushing, so flush logs first for diagnosability.
     with contextlib.suppress(Exception):
@@ -1319,6 +1329,7 @@ def create_app(
         _logger.info(
             "Reaped %d orphaned terminal tmux server(s) from prior runs",
             _reaped_terminals,
+            extra={"session_id": runner_primary_session_id()},
         )
 
     # Reuse the tunnel binding token for runner-side request auth.
@@ -1356,9 +1367,14 @@ def create_app(
                     "runner MCP prewarm registered for %s (servers=%d)",
                     prewarm_path,
                     len(prewarm_spec.mcp_servers or []),
+                    extra={"session_id": runner_primary_session_id()},
                 )
             except Exception:
-                _logger.exception("runner MCP prewarm failed for %s", prewarm_path)
+                _logger.exception(
+                    "runner MCP prewarm failed for %s",
+                    prewarm_path,
+                    extra={"session_id": runner_primary_session_id()},
+                )
         # Native-pane idle reaper (#1349): reclaims idle native CLI panes.
         _pane_reaper = getattr(app.state, "native_pane_reaper", None)
         if _pane_reaper is not None:
@@ -1461,7 +1477,11 @@ async def _run_tunnel_from_env() -> None:
 
         telemetry.init("omni-runner")
     except Exception:  # noqa: BLE001 — best-effort; tracing failure must not crash the runner
-        _logger.debug("telemetry init failed in runner", exc_info=True)
+        _logger.debug(
+            "telemetry init failed in runner",
+            exc_info=True,
+            extra={"session_id": runner_primary_session_id()},
+        )
 
     # Reuse the tunnel's token factory for the app's httpx client so the
     # runner resolves Databricks auth once at boot, not twice.
@@ -1476,6 +1496,30 @@ async def _run_tunnel_from_env() -> None:
     stop_event = asyncio.Event()
     loop = asyncio.get_running_loop()
     last_activity_at = loop.time()
+
+    # asyncio funnels unretrieved task exceptions and callback errors through
+    # the loop's exception handler. Those are not our own _logger callsites
+    # (e.g. a discarded ``ws.recv()`` task on a normal tunnel close), so this is
+    # the one place we can attribute them to the runner's session and keep them
+    # out of asyncio's default, untagged "Task exception was never retrieved".
+    from websockets.exceptions import ConnectionClosedOK
+
+    def _handle_loop_exception(
+        loop: asyncio.AbstractEventLoop,  # noqa: ARG001 — signature mandated by asyncio
+        context: dict[str, object],
+    ) -> None:
+        exc = context.get("exception")
+        message = context.get("message") or "unhandled asyncio exception"
+        extra = {"session_id": runner_primary_session_id()}
+        if isinstance(exc, asyncio.CancelledError | ConnectionClosedOK):
+            # Benign teardown — keep it quiet but still attributed.
+            _logger.debug("asyncio: %s", message, exc_info=exc, extra=extra)
+        elif isinstance(exc, BaseException):
+            _logger.error("asyncio: %s", message, exc_info=exc, extra=extra)
+        else:
+            _logger.error("asyncio: %s (context=%r)", message, context, extra=extra)
+
+    loop.set_exception_handler(_handle_loop_exception)
 
     def _mark_activity() -> None:
         """Record real runner work for the inactivity watchdog.
@@ -1559,7 +1603,11 @@ async def _run_tunnel_from_env() -> None:
                     )
                 )
         except Exception:  # noqa: BLE001 — optimization only; never block the tunnel
-            _logger.warning("direct-attach listener setup failed", exc_info=True)
+            _logger.warning(
+                "direct-attach listener setup failed",
+                exc_info=True,
+                extra={"session_id": runner_primary_session_id()},
+            )
             direct_attach_listener = None
     tunnel_task = asyncio.create_task(
         serve_tunnel(
@@ -1662,7 +1710,11 @@ async def _run_tunnel_from_env() -> None:
         # A crash unwinding through here is attributed by sys.excepthook with
         # its traceback, so only record the reason for an orderly shutdown.
         if sys.exc_info()[0] is None:
-            _logger.info("runner exiting: %s", exit_reason or "shutdown requested")
+            _logger.info(
+                "runner exiting: %s",
+                exit_reason or "shutdown requested",
+                extra={"session_id": runner_primary_session_id()},
+            )
         for task in wait_tasks:
             task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -1737,6 +1789,7 @@ def _install_signal_handlers(
                 "Signal handler registration failed; continuing without "
                 "graceful-shutdown signal handling",
                 exc_info=True,
+                extra={"session_id": runner_primary_session_id()},
             )
 
     for sig in (signal.SIGINT, signal.SIGTERM):
@@ -1786,6 +1839,7 @@ def _install_crash_logging() -> None:
                 exc_type.__name__,
                 exc,
                 exc_info=(exc_type, exc, traceback),
+                extra={"session_id": runner_primary_session_id()},
             )
         previous_hook(exc_type, exc, traceback)
 
@@ -1840,7 +1894,7 @@ def main() -> None:
             raise
         # A fatal server rejection is an expected, actionable exit — log the
         # reason but keep stderr to the concise message (no traceback).
-        _logger.error("runner exiting: %s", exc)
+        _logger.error("runner exiting: %s", exc, extra={"session_id": runner_primary_session_id()})
         print(f"error: {exc}", file=sys.stderr)
         raise SystemExit(1) from None
 

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1138,6 +1138,7 @@ async def _resolve_agent_spec_from_server(
         _logger.info(
             "spec_resolver: GET %s returned 404 for missing agent",
             path,
+            extra={"session_id": session_id},
         )
         return None
     if resp.status_code != 200:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -44,6 +44,7 @@ from fastapi import FastAPI, HTTPException, Query, Request, WebSocket
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
+from omnigent.debug_logging import runner_primary_session_id
 from omnigent.entities.session_resources import (
     DEFAULT_ENVIRONMENT_ID,
     SessionResourceView,
@@ -290,6 +291,7 @@ def _version_supports_waiting_status(server_version: str) -> bool:
         _logger.warning(
             "server version %r is not PEP 440; treating waiting status support as unknown",
             server_version,
+            extra={"session_id": runner_primary_session_id()},
         )
         return False
 
@@ -313,9 +315,17 @@ async def _get_server_version(server_client: httpx.AsyncClient) -> str | None:
         resp = await server_client.get("/api/version")
         resp.raise_for_status()
         _server_version = resp.json()["version"]
-        _logger.info("resolved server version: %s", _server_version)
+        _logger.info(
+            "resolved server version: %s",
+            _server_version,
+            extra={"session_id": runner_primary_session_id()},
+        )
     except Exception as exc:  # noqa: BLE001 — degrade gracefully; never 500 an old server
-        _logger.warning("could not probe server /api/version (%s); treating as unknown", exc)
+        _logger.warning(
+            "could not probe server /api/version (%s); treating as unknown",
+            exc,
+            extra={"session_id": runner_primary_session_id()},
+        )
     return _server_version
 
 
@@ -342,7 +352,13 @@ def _client_safe_error_detail(exc: BaseException, *, context: str) -> str:
         ``"Request failed on the runner; see the runner log for details:
         ~/.omnigent/logs/runner/runner-conv_ab12.log"``.
     """
-    _logger.warning("%s failed: %s", context, exc, exc_info=exc)
+    _logger.warning(
+        "%s failed: %s",
+        context,
+        exc,
+        exc_info=exc,
+        extra={"session_id": runner_primary_session_id()},
+    )
     log_reference = process_log_reference("runner")
     return f"Request failed on the runner; see the runner log for details: {log_reference}"
 
@@ -1571,6 +1587,7 @@ async def _deliver_subagent_wake_post(
                     "Sub-agent wake POST attribution rejected for parent=%s; "
                     "retrying without actor",
                     parent_id,
+                    extra={"session_id": runner_primary_session_id()},
                 )
                 attribution_created_by = None
                 continue
@@ -1583,6 +1600,7 @@ async def _deliver_subagent_wake_post(
                 parent_id,
                 retryable,
                 exc,
+                extra={"session_id": runner_primary_session_id()},
             )
             if last_attempt or not retryable:
                 return False
@@ -3772,12 +3790,14 @@ def create_runner_app(
                 "_convert_raw_items_to_input: skipped %d items with types: %s",
                 len(_skipped_types),
                 _skipped_types,
+                extra={"session_id": runner_primary_session_id()},
             )
         _logger.info(
             "_convert_raw_items_to_input: %d raw items → %d converted (compaction_idx=%s)",
             len(items),
             len(result),
             compaction_idx,
+            extra={"session_id": runner_primary_session_id()},
         )
         return result
 
@@ -4314,7 +4334,11 @@ def create_runner_app(
                 model_catalog_store.write_catalog, "codex-native", fingerprint, shaped
             )
         except Exception:  # noqa: BLE001 — write-back is best-effort
-            _logger.debug("codex model-catalog write-back skipped", exc_info=True)
+            _logger.debug(
+                "codex model-catalog write-back skipped",
+                exc_info=True,
+                extra={"session_id": runner_primary_session_id()},
+            )
 
     async def _handle_pi_native_model_change(
         conv_id: str,
@@ -5707,6 +5731,7 @@ def create_runner_app(
                 parent_id,
                 child_id,
                 _WAKE_POST_MAX_ATTEMPTS,
+                extra={"session_id": runner_primary_session_id()},
             )
 
     def _schedule_subagent_wake(entry: _SubagentWorkEntry, *, is_rewake: bool = False) -> None:
@@ -9628,6 +9653,7 @@ def create_runner_app(
                 "/v1/summarize: failed to resolve provider %r",
                 provider_name,
                 exc_info=True,
+                extra={"session_id": runner_primary_session_id()},
             )
             return None
 
@@ -9647,6 +9673,7 @@ def create_runner_app(
                 profile,
                 context,
                 exc_info=True,
+                extra={"session_id": runner_primary_session_id()},
             )
             return None
         return {
@@ -9764,7 +9791,11 @@ def create_runner_app(
             try:
                 resource_registry.resync_session_statuses()
             except Exception:  # noqa: BLE001 — best-effort; never block catch-up.
-                _logger.warning("Session status resync failed after reconnect", exc_info=True)
+                _logger.warning(
+                    "Session status resync failed after reconnect",
+                    exc_info=True,
+                    extra={"session_id": runner_primary_session_id()},
+                )
         for session_id in list(_session_histories):
             if _is_native_harness(session_id):
                 continue

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2407,6 +2407,7 @@ def create_runner_app(
                     "Failed to release harness subprocess after required terminal exit: "
                     "session=%s",
                     session_id,
+                    extra={"session_id": session_id},
                 )
 
         task = asyncio.create_task(
@@ -3008,6 +3009,7 @@ def create_runner_app(
                             "Claude terminal stale after agent switch; tearing it down to "
                             "rebuild from current items: session=%s",
                             session_id,
+                            extra={"session_id": session_id},
                         )
                     # The inline arm ran the transfer check whenever the terminal was
                     # (or just became, via rebuild) absent. Return force_recreate and
@@ -3026,6 +3028,7 @@ def create_runner_app(
                             "terminal_inbound=%s",
                             session_id,
                             inbound,
+                            extra={"session_id": session_id},
                         )
                     return PreLaunchResult(force_recreate=wants_rebuild, skip=inbound)
 
@@ -3041,6 +3044,7 @@ def create_runner_app(
                             "Claude terminal spec resolution failed; continuing without "
                             "bundle skills: session=%s",
                             session_id,
+                            extra={"session_id": session_id},
                         )
                     if spec is not None:
                         entry = _session_spec_cache.get(session_id)
@@ -3056,6 +3060,7 @@ def create_runner_app(
                         bundle_dir,
                         agent_name,
                         skills_filter,
+                        extra={"session_id": session_id},
                     )
                     _ensure_orchestrator_skills_in_bundle(bundle_dir, spec)
                     return dataclasses.replace(
@@ -3090,6 +3095,7 @@ def create_runner_app(
                             "terminal_inbound=%s",
                             session_id,
                             inbound,
+                            extra={"session_id": session_id},
                         )
                         if inbound:
                             return PreLaunchResult(skip=True)
@@ -3143,6 +3149,7 @@ def create_runner_app(
                             "terminal_inbound=%s",
                             session_id,
                             inbound,
+                            extra={"session_id": session_id},
                         )
                         if inbound:
                             return PreLaunchResult(skip=True)
@@ -3189,7 +3196,11 @@ def create_runner_app(
                             session_id, session_labels=init_context.labels
                         )
                     except Exception:
-                        _logger.exception("Failed to pre-start comment relay for %s", session_id)
+                        _logger.exception(
+                            "Failed to pre-start comment relay for %s",
+                            session_id,
+                            extra={"session_id": session_id},
+                        )
 
                 _relay_task = asyncio.create_task(
                     _start_claude_relay_early(),
@@ -3572,6 +3583,7 @@ def create_runner_app(
                     "Last-item seed returned %d for session=%s",
                     resp.status_code,
                     session_id,
+                    extra={"session_id": session_id},
                 )
                 return
             page_items = resp.json().get("data", [])
@@ -3580,6 +3592,7 @@ def create_runner_app(
                 "Last-item seed failed for session=%s",
                 session_id,
                 exc_info=True,
+                extra={"session_id": session_id},
             )
             return
         last_id = page_items[0].get("id") if page_items else None
@@ -3610,6 +3623,7 @@ def create_runner_app(
                         "History load returned %d for session=%s",
                         resp.status_code,
                         session_id,
+                        extra={"session_id": session_id},
                     )
                     break
             except httpx.HTTPError:
@@ -3617,6 +3631,7 @@ def create_runner_app(
                     "History load failed for session=%s",
                     session_id,
                     exc_info=True,
+                    extra={"session_id": session_id},
                 )
                 break
             page = resp.json()
@@ -4131,6 +4146,7 @@ def create_runner_app(
                 state.thread_id,
                 sorted(settings),
                 exc_info=True,
+                extra={"session_id": conv_id},
             )
             return JSONResponse(
                 status_code=503,
@@ -4308,6 +4324,7 @@ def create_runner_app(
                 "Pi-native model change failed for session=%s",
                 conv_id,
                 exc_info=True,
+                extra={"session_id": conv_id},
             )
             return JSONResponse(
                 status_code=503,
@@ -4467,13 +4484,17 @@ def create_runner_app(
                 )
             except Exception:  # noqa: BLE001 — best-effort; the report reconciles
                 _logger.debug(
-                    "late model-dialog watch errored for session=%s", conv_id, exc_info=True
+                    "late model-dialog watch errored for session=%s",
+                    conv_id,
+                    exc_info=True,
+                    extra={"session_id": conv_id},
                 )
                 return
             await asyncio.sleep(_CLAUDE_MODEL_LATE_DIALOG_POLL_S)
         _logger.info(
             "late model-dialog watch for session=%s ended without a confirmed switch",
             conv_id,
+            extra={"session_id": conv_id},
         )
 
     async def _handle_claude_native_model_change(
@@ -4518,6 +4539,7 @@ def create_runner_app(
                 resolved_model,
                 conv_id,
                 sorted(env or ()),
+                extra={"session_id": conv_id},
             )
             return JSONResponse(
                 status_code=503,
@@ -4587,6 +4609,7 @@ def create_runner_app(
                     "no statusLine snapshot in %s",
                     conv_id,
                     bridge_dir,
+                    extra={"session_id": conv_id},
                 )
                 return Response(status_code=204)
             # The confirm dialog can render well after the injection's own
@@ -4614,6 +4637,7 @@ def create_runner_app(
                 "claude-native model change for session=%s is queued behind an active "
                 "turn; watching for the late confirm dialog",
                 conv_id,
+                extra={"session_id": conv_id},
             )
             return Response(status_code=204)
         return JSONResponse(
@@ -4837,7 +4861,12 @@ def create_runner_app(
         try:
             return await asyncio.to_thread(list_opencode_cli_model_options, env=cli_env)
         except Exception as exc:  # noqa: BLE001 - fall back to the server catalog.
-            _logger.debug("OpenCode CLI model list failed for %s: %r", conv_id, exc)
+            _logger.debug(
+                "OpenCode CLI model list failed for %s: %r",
+                conv_id,
+                exc,
+                extra={"session_id": conv_id},
+            )
 
         client = OpenCodeClient(
             base_url=state.server_base_url,
@@ -4928,6 +4957,7 @@ def create_runner_app(
                 "Pi-native compact failed for session=%s",
                 conv_id,
                 exc_info=True,
+                extra={"session_id": conv_id},
             )
             return JSONResponse(
                 status_code=503,
@@ -5383,7 +5413,11 @@ def create_runner_app(
                 timeout=3.0,
             )
         except NoLiveHarnessError:
-            _logger.debug("Interrupt forward skipped for %s: no live harness", conv_id)
+            _logger.debug(
+                "Interrupt forward skipped for %s: no live harness",
+                conv_id,
+                extra={"session_id": conv_id},
+            )
         except Exception:  # noqa: BLE001 — best-effort: harness may have exited
             _logger.warning(
                 "Interrupt forward to harness failed for %s",
@@ -5451,7 +5485,12 @@ def create_runner_app(
                 _live_response_id.get(conv_id),
             )
             return
-        _logger.warning("resyncing turn state for %s: %s", conv_id, reason)
+        _logger.warning(
+            "resyncing turn state for %s: %s",
+            conv_id,
+            reason,
+            extra={"session_id": conv_id},
+        )
         _desynced_sessions.add(conv_id)
         # Capture entry epoch; an advance during teardown means a replacement ran.
         _entry_epoch = _turn_bind_epoch.get(conv_id, 0)
@@ -5852,6 +5891,7 @@ def create_runner_app(
                 "Failed to start comment relay for session=%s",
                 session_id,
                 exc_info=True,
+                extra={"session_id": session_id},
             )
             return
         superseded = _session_comment_relays.get(session_id)
@@ -5876,6 +5916,7 @@ def create_runner_app(
                 _logger.debug(
                     "tools-changed notification skipped for session=%s (bridge server not ready)",
                     session_id,
+                    extra={"session_id": session_id},
                 )
 
         if await_notify:
@@ -6082,6 +6123,7 @@ def create_runner_app(
                 "_run_turn_bg: conv=%s received model_override=%s (forwarding to harness)",
                 conv,
                 _model_override,
+                extra={"session_id": conv},
             )
         if _session_histories[conv]:
             harness_body["content"] = _session_histories[conv]
@@ -6106,6 +6148,7 @@ def create_runner_app(
             conv,
             len(_content),
             _content_summary[:20],
+            extra={"session_id": conv},
         )
 
         if instructions:
@@ -6391,7 +6434,11 @@ def create_runner_app(
                     reraise=True,
                 )
             except Exception as exc:
-                _logger.exception("opencode-native cold-boot ensure failed for %s", conv_id)
+                _logger.exception(
+                    "opencode-native cold-boot ensure failed for %s",
+                    conv_id,
+                    extra={"session_id": conv_id},
+                )
                 return JSONResponse(
                     status_code=503,
                     content={
@@ -6900,6 +6947,7 @@ def create_runner_app(
             if isinstance(body, dict)
             else "N/A",
             body.get("model_override") if isinstance(body, dict) else None,
+            extra={"session_id": conversation_id},
         )
         if body_type == "message" or body_type is None:
             if not isinstance(body, dict):
@@ -6950,6 +6998,7 @@ def create_runner_app(
                         conversation_id,
                         _native,
                         _awaiting_approval,
+                        extra={"session_id": conversation_id},
                     )
                     _session_message_buffers.setdefault(
                         conversation_id,
@@ -6970,6 +7019,7 @@ def create_runner_app(
                                     conversation_id,
                                     _injection_resp.status_code,
                                     _response_body_preview(_injection_resp),
+                                    extra={"session_id": conversation_id},
                                 )
                             else:
                                 _logger.debug(
@@ -6977,6 +7027,7 @@ def create_runner_app(
                                     "conv=%s status=%s",
                                     conversation_id,
                                     _injection_resp.status_code,
+                                    extra={"session_id": conversation_id},
                                 )
                         except (httpx.HTTPError, RuntimeError, asyncio.TimeoutError):
                             _logger.debug(
@@ -7013,6 +7064,7 @@ def create_runner_app(
                 _logger.info(
                     "post_session_events: starting background turn conv=%s",
                     conversation_id,
+                    extra={"session_id": conversation_id},
                 )
 
                 _publish_turn_status(conversation_id, "running")
@@ -7835,6 +7887,7 @@ def create_runner_app(
                 "native pane registered but dead for conv=%s harness=%s; closing stale entry",
                 conv_id,
                 harness_name,
+                extra={"session_id": conv_id},
             )
             # Re-check the registry before closing: a concurrent ensure/recreate
             # path may have already replaced this entry with a live pane between
@@ -7854,16 +7907,19 @@ def create_runner_app(
                         "failed to close stale native pane for conv=%s; proceeding to re-create",
                         conv_id,
                         exc_info=True,
+                        extra={"session_id": conv_id},
                     )
             else:
                 _logger.info(
                     "stale entry already replaced for conv=%s; skipping close",
                     conv_id,
+                    extra={"session_id": conv_id},
                 )
         _logger.info(
             "native pane missing for conv=%s harness=%s; re-ensuring before turn (#1349)",
             conv_id,
             harness_name,
+            extra={"session_id": conv_id},
         )
         try:
             resp = await create_session_terminal(
@@ -7880,7 +7936,11 @@ def create_runner_app(
                 ),
             )
         except Exception:
-            _logger.exception("native pane self-heal failed for conv=%s", conv_id)
+            _logger.exception(
+                "native pane self-heal failed for conv=%s",
+                conv_id,
+                extra={"session_id": conv_id},
+            )
             return
         status = getattr(resp, "status_code", 200)
         if status >= 400:
@@ -7889,6 +7949,7 @@ def create_runner_app(
                 status,
                 conv_id,
                 terminal_name,
+                extra={"session_id": conv_id},
             )
 
     @app.get("/v1/sessions/{session_id}/resources/terminals/{terminal_id}")
@@ -8707,7 +8768,9 @@ def create_runner_app(
             catalog = await asyncio.to_thread(catalog_for_spec, spec)
         except Exception:
             _logger.exception(
-                "get_session_models: catalog_for_spec failed for session=%s", session_id
+                "get_session_models: catalog_for_spec failed for session=%s",
+                session_id,
+                extra={"session_id": session_id},
             )
             return JSONResponse(status_code=200, content={"workers": {}})
         return JSONResponse(status_code=200, content={"workers": catalog})
@@ -8730,7 +8793,12 @@ def create_runner_app(
                     },
                 )
             except Exception as exc:  # noqa: BLE001 - picker failures are retryable.
-                _logger.warning("OpenCode-native model list failed for %s: %s", session_id, exc)
+                _logger.warning(
+                    "OpenCode-native model list failed for %s: %s",
+                    session_id,
+                    exc,
+                    extra={"session_id": session_id},
+                )
                 return JSONResponse(
                     status_code=503,
                     content={
@@ -8758,6 +8826,7 @@ def create_runner_app(
                 "Codex-native model/list failed for session=%s",
                 session_id,
                 exc_info=True,
+                extra={"session_id": session_id},
             )
             return JSONResponse(
                 status_code=503,
@@ -8780,6 +8849,7 @@ def create_runner_app(
                 "Kiro-native model discovery failed for session=%s",
                 session_id,
                 exc_info=True,
+                extra={"session_id": session_id},
             )
             return JSONResponse(
                 status_code=503,
@@ -8803,6 +8873,7 @@ def create_runner_app(
                 "Cursor-native model discovery failed for session=%s",
                 session_id,
                 exc_info=True,
+                extra={"session_id": session_id},
             )
             return JSONResponse(
                 status_code=503,
@@ -8844,6 +8915,7 @@ def create_runner_app(
                 "Claude-native model options unavailable for session=%s: %s",
                 session_id,
                 exc.message,
+                extra={"session_id": session_id},
             )
             return JSONResponse(
                 status_code=424,
@@ -8857,6 +8929,7 @@ def create_runner_app(
                 "Claude-native model discovery failed for session=%s",
                 session_id,
                 exc_info=True,
+                extra={"session_id": session_id},
             )
             return JSONResponse(
                 status_code=503,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -558,6 +558,7 @@ async def _evaluate_policy_via_omnigent(
                 ap_resp.status_code,
                 evaluation_id,
                 _default_action,
+                extra={"session_id": conversation_id},
             )
     except Exception:  # noqa: BLE001 — fail-open (LLM phases) / fail-closed (tool phases)
         _logger.warning(
@@ -565,6 +566,7 @@ async def _evaluate_policy_via_omnigent(
             evaluation_id,
             _default_action,
             exc_info=True,
+            extra={"session_id": conversation_id},
         )
 
     # Post the verdict back to the harness as a policy_verdict event.
@@ -593,6 +595,7 @@ async def _evaluate_policy_via_omnigent(
                 evaluation_id,
                 _attempt + 1,
                 exc,
+                extra={"session_id": conversation_id},
             )
             continue
         except Exception:  # noqa: BLE001 — non-transport: no retry, but still signal
@@ -600,6 +603,7 @@ async def _evaluate_policy_via_omnigent(
                 "Failed to deliver policy verdict %s to harness (unexpected error)",
                 evaluation_id,
                 exc_info=True,
+                extra={"session_id": conversation_id},
             )
             break
         if 200 <= resp.status_code < 300:
@@ -609,6 +613,7 @@ async def _evaluate_policy_via_omnigent(
             evaluation_id,
             resp.status_code,
             _attempt + 1,
+            extra={"session_id": conversation_id},
         )
 
     _logger.error(
@@ -616,6 +621,7 @@ async def _evaluate_policy_via_omnigent(
         "non-2xx / unexpected) after retry; signaling desync for %s",
         evaluation_id,
         conversation_id,
+        extra={"session_id": conversation_id},
     )
     if on_delivery_failure is not None:
         await on_delivery_failure(conversation_id)
@@ -3808,6 +3814,7 @@ def create_runner_app(
                 "Skipping harness compaction persist for %s: no "
                 "server-side last_item_id available",
                 conv,
+                extra={"session_id": conv},
             )
             return
 
@@ -3835,6 +3842,7 @@ def create_runner_app(
                 "Failed to persist harness compaction item for %s",
                 conv,
                 exc_info=True,
+                extra={"session_id": conv},
             )
 
         if compacted_messages:
@@ -3964,6 +3972,7 @@ def create_runner_app(
                     conv_id,
                     item_type,
                     exc_info=True,
+                    extra={"session_id": conv_id},
                 )
 
     async def _recover_sub_agent_name(conv_id: str) -> str | None:
@@ -4193,6 +4202,7 @@ def create_runner_app(
                     "Codex-native plan-mode update could not fetch session snapshot for %s",
                     conv_id,
                     exc_info=True,
+                    extra={"session_id": conv_id},
                 )
 
         if model is None:
@@ -4218,6 +4228,7 @@ def create_runner_app(
             _logger.warning(
                 "Codex-native plan-mode update skipped for %s: current model is unknown",
                 conv_id,
+                extra={"session_id": conv_id},
             )
             return JSONResponse(
                 status_code=503,
@@ -4356,6 +4367,7 @@ def create_runner_app(
                     terminal_id,
                     conv_id,
                     exc_info=True,
+                    extra={"session_id": conv_id},
                 )
             _publish_terminal_deleted_event(
                 conversation_id=conv_id,
@@ -4697,7 +4709,11 @@ def create_runner_app(
                 timeout_s=1.0,
             )
         except Exception:  # noqa: BLE001 — best-effort; TUI can still answer
-            _logger.debug("claude-native plan verdict not applied", exc_info=True)
+            _logger.debug(
+                "claude-native plan verdict not applied",
+                exc_info=True,
+                extra={"session_id": conv_id},
+            )
 
     async def _handle_cursor_native_model_change(
         conv_id: str,
@@ -5277,6 +5293,7 @@ def create_runner_app(
                 conv_id,
                 owner_response_id,
                 _live_response_id.get(conv_id),
+                extra={"session_id": conv_id},
             )
             return
 
@@ -5423,6 +5440,7 @@ def create_runner_app(
                 "Interrupt forward to harness failed for %s",
                 conv_id,
                 exc_info=True,
+                extra={"session_id": conv_id},
             )
 
     async def _cancel_inprocess_turn(conv_id: str) -> None:
@@ -5483,6 +5501,7 @@ def create_runner_app(
                 conv_id,
                 owner_response_id,
                 _live_response_id.get(conv_id),
+                extra={"session_id": conv_id},
             )
             return
         _logger.warning(
@@ -5952,6 +5971,7 @@ def create_runner_app(
                 conv,
                 exc,
                 exc_info=True,
+                extra={"session_id": conv},
             )
             _on_proxy_stream_end(conv, error={"message": f"turn setup failed: {exc}"})
             raise
@@ -5961,6 +5981,7 @@ def create_runner_app(
                 conv,
                 exc,
                 exc_info=True,
+                extra={"session_id": conv},
             )
             _on_proxy_stream_end(conv, error={"message": f"turn setup failed: {exc}"})
         finally:
@@ -5996,6 +6017,7 @@ def create_runner_app(
                 conv,
                 _prior_agent_id,
                 _dispatched_agent_id,
+                extra={"session_id": conv},
             )
             _session_spec_cache.pop(conv, None)
             _session_harness_overrides.pop(conv, None)
@@ -6029,6 +6051,7 @@ def create_runner_app(
                         "Spec resolution failed for %s",
                         conv,
                         exc_info=True,
+                        extra={"session_id": conv},
                     )
             else:
                 try:
@@ -6039,6 +6062,7 @@ def create_runner_app(
                         "On-demand agent resolution failed for %s",
                         conv,
                         exc_info=True,
+                        extra={"session_id": conv},
                     )
 
         # The resolver branches above write straight into the cache, so the
@@ -6176,6 +6200,7 @@ def create_runner_app(
                         "ToolManager schema build failed for %s",
                         conv,
                         exc_info=True,
+                        extra={"session_id": conv},
                     )
             _session_tool_schemas[conv] = all_tools
 
@@ -6209,6 +6234,7 @@ def create_runner_app(
                         "MCP schema resolution failed for %s",
                         conv,
                         exc_info=True,
+                        extra={"session_id": conv},
                     )
 
         _spec_tools = _session_tool_schemas.get(conv) or []
@@ -6313,6 +6339,7 @@ def create_runner_app(
                 "turn bg error for %s: %s",
                 conv,
                 err_detail,
+                extra={"session_id": conv},
             )
             _on_proxy_stream_end(
                 conv,
@@ -6483,6 +6510,7 @@ def create_runner_app(
                         conv_id,
                         exc,
                         exc_info=True,
+                        extra={"session_id": conv_id},
                     )
                     _eager_spec_error = (
                         type(exc).__name__,
@@ -6500,9 +6528,16 @@ def create_runner_app(
                     _mcp_schemas = _mcp.schemas
                     _mcp_tool_names = _mcp.tool_names
                     for _srv, _err in _mcp.failures.items():
-                        _logger.warning("runner MCP %r unavailable for this turn: %s", _srv, _err)
+                        _logger.warning(
+                            "runner MCP %r unavailable for this turn: %s",
+                            _srv,
+                            _err,
+                            extra={"session_id": conv_id},
+                        )
                 except Exception:
-                    _logger.exception("runner mcp_manager.schemas_for failed")
+                    _logger.exception(
+                        "runner mcp_manager.schemas_for failed", extra={"session_id": conv_id}
+                    )
 
         async def _resolve_turn_spec_lazy() -> tuple[object | None, tuple[str, str] | None]:
             nonlocal _turn_spec, _turn_spec_entry, _turn_spec_resolved
@@ -6529,6 +6564,7 @@ def create_runner_app(
                     conv_id,
                     exc,
                     exc_info=True,
+                    extra={"session_id": conv_id},
                 )
                 return None, (
                     type(exc).__name__,
@@ -6894,6 +6930,7 @@ def create_runner_app(
                     conv_id,
                     exc,
                     exc_info=True,
+                    extra={"session_id": conv_id},
                 )
                 _error = {
                     "code": "connection_error",
@@ -7035,6 +7072,7 @@ def create_runner_app(
                                 "LLM will see message on next turn",
                                 conversation_id,
                                 exc_info=True,
+                                extra={"session_id": conversation_id},
                             )
                     return JSONResponse(
                         status_code=202,
@@ -10213,6 +10251,7 @@ def _build_spawn_env_from_spec(
             env.get(f"{prefix}_GATEWAY_BASE_URL"),
             env.get(f"{prefix}_DATABRICKS_PROFILE"),
             env.get(_HARNESS_MODEL_ENV_KEY.get(harness, f"{prefix}_MODEL")),
+            extra={"session_id": session_id},
         )
     return env
 

--- a/omnigent/runner/background_titles/claude_native.py
+++ b/omnigent/runner/background_titles/claude_native.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 
+from omnigent.debug_logging import runner_primary_session_id
 from omnigent.runner.background_titles.service import (
     BACKGROUND_TITLE_INFERENCE_TIMEOUT_SECONDS,
     BACKGROUND_TITLE_INSTRUCTIONS,
@@ -33,6 +34,7 @@ async def generate_background_title(context: BackgroundTitleContext) -> str | No
             "background Claude Code title could not resolve provider config; "
             "falling back to Claude Code's native login",
             exc_info=True,
+            extra={"session_id": runner_primary_session_id()},
         )
         claude_config = None
     effective_model = (
@@ -89,6 +91,7 @@ async def generate_background_title(context: BackgroundTitleContext) -> str | No
             "background Claude Code title failed returncode=%s detail=%s",
             process.returncode,
             detail[-1000:],
+            extra={"session_id": runner_primary_session_id()},
         )
         return None
     return stdout.decode(errors="replace").strip()

--- a/omnigent/runner/background_titles/codex_native.py
+++ b/omnigent/runner/background_titles/codex_native.py
@@ -8,6 +8,7 @@ import logging
 import tempfile
 from pathlib import Path
 
+from omnigent.debug_logging import runner_primary_session_id
 from omnigent.runner.background_titles.service import (
     BACKGROUND_TITLE_INFERENCE_TIMEOUT_SECONDS,
     BACKGROUND_TITLE_INSTRUCTIONS,
@@ -119,6 +120,7 @@ async def generate_background_title(context: BackgroundTitleContext) -> str | No
                 "background native Codex title failed returncode=%s detail=%s",
                 process.returncode,
                 detail[-1000:],
+                extra={"session_id": runner_primary_session_id()},
             )
             return None
         if not output_path.is_file():

--- a/omnigent/runner/background_titles/sdk.py
+++ b/omnigent/runner/background_titles/sdk.py
@@ -7,6 +7,7 @@ import json
 import logging
 import uuid
 
+from omnigent.debug_logging import runner_primary_session_id
 from omnigent.runner.background_titles.service import (
     BACKGROUND_TITLE_INFERENCE_TIMEOUT_SECONDS,
     BACKGROUND_TITLE_INSTRUCTIONS,
@@ -119,6 +120,7 @@ async def generate_background_title(context: BackgroundTitleContext) -> str | No
                             "background title harness failed process=%s detail=%s",
                             process_key,
                             detail,
+                            extra={"session_id": runner_primary_session_id()},
                         )
                         raise BackgroundTitleHarnessError(detail)
                     elif event_type == "response.completed":

--- a/omnigent/runner/direct_attach.py
+++ b/omnigent/runner/direct_attach.py
@@ -45,6 +45,8 @@ import uvicorn
 from fastapi import FastAPI, Query, WebSocket
 from starlette import status
 
+from omnigent.debug_logging import runner_primary_session_id
+
 _logger = logging.getLogger(__name__)
 
 # Bind loopback by literal IPv4 address, matching the URL the server
@@ -200,7 +202,11 @@ async def _await_quietly(task: asyncio.Task[None]) -> None:
     if not task.done() or task.cancelled():
         return
     if (exc := task.exception()) is not None:
-        _logger.warning("direct-attach listener exited with an error", exc_info=exc)
+        _logger.warning(
+            "direct-attach listener exited with an error",
+            exc_info=exc,
+            extra={"session_id": runner_primary_session_id()},
+        )
 
 
 class DirectAttachListener:
@@ -242,7 +248,10 @@ async def start_direct_attach_listener(app: FastAPI) -> DirectAttachListener | N
     deadline = asyncio.get_running_loop().time() + _STARTUP_TIMEOUT_S
     while not server.started:
         if task.done() or asyncio.get_running_loop().time() >= deadline:
-            _logger.warning("direct-attach listener failed to start; relay-only")
+            _logger.warning(
+                "direct-attach listener failed to start; relay-only",
+                extra={"session_id": runner_primary_session_id()},
+            )
             task.cancel()
             await _await_quietly(task)
             return None
@@ -251,8 +260,16 @@ async def start_direct_attach_listener(app: FastAPI) -> DirectAttachListener | N
         sockets = server.servers[0].sockets
         port = int(sockets[0].getsockname()[1])
     except (IndexError, AttributeError, OSError):
-        _logger.warning("direct-attach listener has no bound socket; relay-only")
+        _logger.warning(
+            "direct-attach listener has no bound socket; relay-only",
+            extra={"session_id": runner_primary_session_id()},
+        )
         await DirectAttachListener(server, task, 0).stop()
         return None
-    _logger.info("direct-attach listener on %s:%d", DIRECT_ATTACH_BIND_HOST, port)
+    _logger.info(
+        "direct-attach listener on %s:%d",
+        DIRECT_ATTACH_BIND_HOST,
+        port,
+        extra={"session_id": runner_primary_session_id()},
+    )
     return DirectAttachListener(server, task, port)

--- a/omnigent/runner/mcp_manager.py
+++ b/omnigent/runner/mcp_manager.py
@@ -15,6 +15,7 @@ import httpx
 from mcp.types import ElicitRequestParams, ElicitResult
 from mcp.types import Tool as McpToolDef
 
+from omnigent.debug_logging import runner_primary_session_id
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.spec.types import AgentSpec, MCPServerConfig, RetryPolicy
 from omnigent.tools.base import is_valid_tool_name
@@ -186,6 +187,7 @@ def _mcp_tool_schema(
             "(must match [a-zA-Z0-9_-]{1,256}) — skipping",
             bare_name,
             server_name,
+            extra={"session_id": runner_primary_session_id()},
         )
         return None
     # Namespace: ``{server_name}__{bare_name}`` so two servers with a tool
@@ -370,7 +372,10 @@ class RunnerMcpManager:
                 try:
                     await asyncio.gather(*connect_tasks.values())
                 except Exception:
-                    _logger.exception("runner mcp connect task raised; surfacing partial results")
+                    _logger.exception(
+                        "runner mcp connect task raised; surfacing partial results",
+                        extra={"session_id": runner_primary_session_id()},
+                    )
 
             schemas: list[_JsonObject] = []
             tool_names: set[str] = set()
@@ -613,6 +618,7 @@ class RunnerMcpManager:
                     "error closing MCP %r (%s) during shutdown",
                     server.config.name,
                     server.server_hash,
+                    extra={"session_id": runner_primary_session_id()},
                 )
 
         if self._evict_tasks:
@@ -660,6 +666,7 @@ class RunnerMcpManager:
                 "runner mcp pool evicting spec %s (over capacity %d)",
                 victim,
                 _POOL_SPEC_CAPACITY,
+                extra={"session_id": runner_primary_session_id()},
             )
             self._release_spec_entry(victim, entry)
 
@@ -675,7 +682,12 @@ class RunnerMcpManager:
         try:
             await conn.close()
         except Exception:
-            _logger.exception("error closing MCP %r for %s", name, owner)
+            _logger.exception(
+                "error closing MCP %r for %s",
+                name,
+                owner,
+                extra={"session_id": runner_primary_session_id()},
+            )
 
     def _schedule_close(self, conn: McpServerConnection, owner: str, name: str) -> None:
         task = asyncio.create_task(
@@ -751,6 +763,7 @@ class RunnerMcpManager:
                         server.server_hash,
                         server.config.name,
                         server.error,
+                        extra={"session_id": runner_primary_session_id()},
                     )
                     return
 
@@ -770,6 +783,7 @@ class RunnerMcpManager:
                     server.server_hash,
                     server.config.name,
                     len(tools),
+                    extra={"session_id": runner_primary_session_id()},
                 )
         finally:
             cleanup_conn: McpServerConnection | None = None

--- a/omnigent/runner/mcp_manager.py
+++ b/omnigent/runner/mcp_manager.py
@@ -269,6 +269,7 @@ class RunnerMcpManager:
             if server_client is None:
                 _logger.warning(
                     "MCP elicitation callback: no Omnigent server client available — declining",
+                    extra={"session_id": session_id},
                 )
                 return ElicitResult(action="decline")
 
@@ -296,6 +297,7 @@ class RunnerMcpManager:
                 _logger.warning(
                     "MCP elicitation callback: Omnigent server POST failed (%s) — declining",
                     exc,
+                    extra={"session_id": session_id},
                 )
                 return ElicitResult(action="decline")
 
@@ -304,6 +306,7 @@ class RunnerMcpManager:
                 _logger.warning(
                     "MCP elicitation callback: Omnigent server returned no "
                     "elicitation_id — declining",
+                    extra={"session_id": session_id},
                 )
                 return ElicitResult(action="decline")
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -283,6 +283,7 @@ def _register_auto_forwarder_task(session_id: str, task: asyncio.Task[object]) -
                 "Transcript forwarder task %s cancelled; session=%s",
                 done_task.get_name(),
                 session_id,
+                extra={"session_id": session_id},
             )
         elif (exc := done_task.exception()) is not None:
             _logger.error(
@@ -291,12 +292,14 @@ def _register_auto_forwarder_task(session_id: str, task: asyncio.Task[object]) -
                 done_task.get_name(),
                 session_id,
                 exc_info=exc,
+                extra={"session_id": session_id},
             )
         else:
             _logger.warning(
                 "Transcript forwarder task %s returned; session mirroring has stopped; session=%s",
                 done_task.get_name(),
                 session_id,
+                extra={"session_id": session_id},
             )
 
     task.add_done_callback(_evict)
@@ -399,6 +402,7 @@ def _log_terminal_lookup_miss(
         session_id,
         terminal_id,
         reason,
+        extra={"session_id": session_id},
     )
 
 
@@ -656,6 +660,7 @@ def _recover_pending_turn_replay(
             "turn-routing replay recovery could not start for session=%s",
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
 
 
@@ -1479,7 +1484,11 @@ async def _auto_create_opencode_terminal(
         _AUTO_OPENCODE_SERVERS.pop(session_id, None)
         raise
 
-    _logger.info("Auto-created opencode terminal + forwarder for session %s", session_id)
+    _logger.info(
+        "Auto-created opencode terminal + forwarder for session %s",
+        session_id,
+        extra={"session_id": session_id},
+    )
     return terminal_view
 
 
@@ -1963,6 +1972,7 @@ async def _resolve_pi_resume_session(
                 "Could not synthesize Pi resume session for %s; launching fresh",
                 session_id,
                 exc_info=True,
+                extra={"session_id": session_id},
             )
         # Only launch with ``--session <id>`` when a session file actually
         # exists/was written. ``ensure_local_pi_resume_session`` returns
@@ -1976,6 +1986,7 @@ async def _resolve_pi_resume_session(
             _logger.info(
                 "Pi cold-resume produced no local session file for %s; launching fresh",
                 session_id,
+                extra={"session_id": session_id},
             )
             return None
         return launch_config.external_session_id
@@ -2003,12 +2014,14 @@ async def _resolve_pi_resume_session(
                 "Could not build Pi session from items for forked clone %s; launching fresh",
                 session_id,
                 exc_info=True,
+                extra={"session_id": session_id},
             )
         _logger.info(
             "Pi terminal fork-rebuild decision: session=%s minted=%s built=%s",
             session_id,
             minted,
             str(built) if built is not None else None,
+            extra={"session_id": session_id},
         )
         if built is not None:
             # Record the minted id so Omnigent reflects the clone's own Pi
@@ -2027,6 +2040,7 @@ async def _resolve_pi_resume_session(
                     "relying on extension capture",
                     session_id,
                     exc_info=True,
+                    extra={"session_id": session_id},
                 )
             return minted
 
@@ -2364,6 +2378,7 @@ async def _auto_create_cursor_terminal(
             "chat id; ignoring it for resume (session=%s).",
             resume_chat_id,
             session_id,
+            extra={"session_id": session_id},
         )
         resume_chat_id = None
     # On cold resume, pre-seed the bridge state with the known store path and
@@ -2397,6 +2412,7 @@ async def _auto_create_cursor_terminal(
                 "starting a fresh chat (session=%s).",
                 resume_chat_id,
                 session_id,
+                extra={"session_id": session_id},
             )
             resume_chat_id = None
     # A fork bound to cursor carries history as a text preamble: cursor's
@@ -2418,6 +2434,7 @@ async def _auto_create_cursor_terminal(
                 "cursor-native: could not build fork history preamble (session=%s).",
                 session_id,
                 exc_info=True,
+                extra={"session_id": session_id},
             )
     write_mcp_config(Path(workspace), bridge_dir)
     # Register the cursor ``stop`` hook that captures per-turn token usage into
@@ -2864,12 +2881,14 @@ async def _auto_create_hermes_terminal(
                         launch_config.fork_source_external_id,
                         _target_session_id,
                         session_id,
+                        extra={"session_id": session_id},
                     )
                 except Exception:  # noqa: BLE001
                     _logger.warning(
                         "Failed to clone hermes session for fork; launching fresh; session=%s",
                         session_id,
                         exc_info=True,
+                        extra={"session_id": session_id},
                     )
                     # Remove broken state.db so Hermes starts fresh.
                     if _target_db.exists():
@@ -3162,6 +3181,7 @@ async def _persist_qwen_external_session_id(
             "AP rejected qwen external_session_id PATCH (%s); session=%s",
             resp.status_code,
             session_id,
+            extra={"session_id": session_id},
         )
 
 
@@ -3237,6 +3257,7 @@ async def _build_qwen_fork_recording(
         qwen_session_id,
         recording,
         len(records),
+        extra={"session_id": session_id},
     )
     return qwen_session_id
 
@@ -3848,6 +3869,7 @@ async def _auto_create_codex_terminal(
             target_thread_id,
             clone_workspace,
             str(cloned_rollout) if cloned_rollout is not None else None,
+            extra={"session_id": session_id},
         )
         if cloned_rollout is not None:
             # Resume our OWN clone via the existing resume path below.
@@ -3921,6 +3943,7 @@ async def _auto_create_codex_terminal(
             target_thread_id,
             clone_workspace,
             str(built_rollout) if built_rollout is not None else None,
+            extra={"session_id": session_id},
         )
         if built_rollout is not None:
             launch_config = dataclasses.replace(
@@ -4379,6 +4402,7 @@ async def _codex_discover_thread_and_forward(
                     _ext_resp.status_code,
                     session_id,
                     thread_id,
+                    extra={"session_id": session_id},
                 )
         except httpx.HTTPError:
             _logger.warning(
@@ -4726,6 +4750,7 @@ async def _auto_create_antigravity_terminal(
         resume,
         bridge_dir,
         len(argv) - 1,
+        extra={"session_id": session_id},
     )
 
     # Resolve every fallible input BEFORE registering the terminal resource, so a
@@ -6025,6 +6050,7 @@ async def _load_legacy_claude_launch_metadata(
         metadata.model_override is not None,
         len(metadata.terminal_launch_args or []),
         metadata.external_session_id is not None,
+        extra={"session_id": session_id},
     )
     return metadata
 
@@ -6048,6 +6074,7 @@ async def _load_claude_launch_metadata(
         metadata.model_override is not None,
         len(metadata.terminal_launch_args or []),
         metadata.external_session_id is not None,
+        extra={"session_id": session_id},
     )
     return metadata
 
@@ -6139,6 +6166,7 @@ async def _auto_create_claude_terminal(
         bundle_dir,
         agent_name,
         skills_filter,
+        extra={"session_id": session_id},
     )
     # Pick the bridge id this session's dir is keyed on. Normally session_id,
     # and we (re)assert the label = session_id so a STALE label from a rotation
@@ -6207,6 +6235,7 @@ async def _auto_create_claude_terminal(
         "Claude terminal bridge prepared: session=%s bridge_dir=%s",
         session_id,
         bridge_dir,
+        extra={"session_id": session_id},
     )
     # Pre-accept Claude's first-run trust + onboarding TUI prompts for this
     # workspace. They have no PermissionRequest hook, so on a host-spawned
@@ -6271,6 +6300,7 @@ async def _auto_create_claude_terminal(
             "using local bridge hint: session=%s local_claude_sid=%s",
             session_id,
             _pre_wipe_claude_sid,
+            extra={"session_id": session_id},
         )
 
     # Cold resume: when this session wraps a prior Claude session,
@@ -6343,6 +6373,7 @@ async def _auto_create_claude_terminal(
             our_uuid,
             _clone_workspace,
             str(_cloned) if _cloned is not None else None,
+            extra={"session_id": session_id},
         )
         if _cloned is not None:
             # Resume our OWN clone (plain --resume, no --fork-session).
@@ -6407,6 +6438,7 @@ async def _auto_create_claude_terminal(
             our_uuid,
             _clone_workspace,
             str(_built) if _built is not None else None,
+            extra={"session_id": session_id},
         )
         if _built is not None:
             resume_external_session_id = our_uuid
@@ -6434,6 +6466,7 @@ async def _auto_create_claude_terminal(
         session_external_id is not None,
         fork_source_external_id is not None,
         resume_external_session_id is not None,
+        extra={"session_id": session_id},
     )
 
     # Derive the ucode (Databricks gateway) launch config from the
@@ -6494,7 +6527,10 @@ async def _auto_create_claude_terminal(
             launch_catalog = await claude_launch_catalog(claude_config)
         except Exception:  # noqa: BLE001 — no catalog means no validation/default
             _logger.warning(
-                "claude launch catalog unavailable for session=%s", session_id, exc_info=True
+                "claude launch catalog unavailable for session=%s",
+                session_id,
+                exc_info=True,
+                extra={"session_id": session_id},
             )
         if session_model_override and launch_catalog:
             resolved_request = (
@@ -6550,6 +6586,7 @@ async def _auto_create_claude_terminal(
         bool(claude_config.api_key_helper) if claude_config is not None else False,
         bool(claude_config.model) if claude_config is not None else False,
         launch_model,
+        extra={"session_id": session_id},
     )
     base_claude_args = _build_claude_native_base_args(
         reasoning_effort=session_effort,
@@ -6676,6 +6713,7 @@ async def _auto_create_claude_terminal(
         sorted(env_spec.env),
         workspace,
         env_spec.scrollback,
+        extra={"session_id": session_id},
     )
     try:
         terminal_view = await resource_registry.launch_required_terminal(
@@ -6693,6 +6731,7 @@ async def _auto_create_claude_terminal(
             "Claude terminal tmux launch failed: session=%s elapsed_ms=%.0f",
             session_id,
             (time.monotonic() - started_at) * 1000,
+            extra={"session_id": session_id},
         )
         raise
     # Surface the terminal on the live SSE stream so an already-connected
@@ -6717,6 +6756,7 @@ async def _auto_create_claude_terminal(
         terminal_metadata.get("tmux_socket"),
         terminal_metadata.get("tmux_target"),
         (time.monotonic() - started_at) * 1000,
+        extra={"session_id": session_id},
     )
 
     publish_event(
@@ -6742,6 +6782,7 @@ async def _auto_create_claude_terminal(
         "Claude terminal tmux target published: session=%s bridge_id=%s",
         session_id,
         bridge_id,
+        extra={"session_id": session_id},
     )
 
     # Start the transcript forwarder so Claude's responses flow
@@ -7525,6 +7566,7 @@ async def _ensure_native_terminal(
                     agent.display_name,
                     ctx.session_id,
                     terminal_id,
+                    extra={"session_id": ctx.session_id},
                 )
                 return respond(existing)
             _logger.info(
@@ -7558,6 +7600,7 @@ async def _ensure_native_terminal(
                 "%s terminal ensure failed for session=%s",
                 agent.display_name,
                 ctx.session_id,
+                extra={"session_id": ctx.session_id},
             )
             return _native_terminal_start_error_response(exc, agent.display_name)
         return respond(view)
@@ -7801,6 +7844,7 @@ async def _session_labels_for_runner_spawn(
             "Timed out resolving session labels; session=%s error=%s",
             session_id,
             type(exc).__name__,
+            extra={"session_id": session_id},
         )
         return {}
     except httpx.HTTPError as exc:
@@ -7808,6 +7852,7 @@ async def _session_labels_for_runner_spawn(
             "Failed to resolve session labels; session=%s error=%s",
             session_id,
             type(exc).__name__,
+            extra={"session_id": session_id},
         )
         return {}
     if resp.status_code != 200:
@@ -7815,6 +7860,7 @@ async def _session_labels_for_runner_spawn(
             "Failed to resolve session labels; session=%s status=%s",
             session_id,
             resp.status_code,
+            extra={"session_id": session_id},
         )
         return {}
     try:
@@ -7829,6 +7875,7 @@ async def _session_labels_for_runner_spawn(
             "Session labels response was not valid JSON; session=%s status=%s",
             session_id,
             resp.status_code,
+            extra={"session_id": session_id},
         )
         return {}
     if not isinstance(labels, dict):

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -43,6 +43,7 @@ import httpx
 from fastapi.responses import JSONResponse, Response
 
 from omnigent._platform import IS_WINDOWS
+from omnigent.debug_logging import runner_primary_session_id
 from omnigent.entities.session_resources import (
     SessionResourceView,
     session_resource_view_to_dict,
@@ -5381,6 +5382,7 @@ def _cursor_native_model_from_spec(agent_spec: AgentSpec | ResolvedSpec | None) 
             "cursor-native: pinned model %r is not a cursor-agent model id; "
             "launching cursor-agent on its configured default instead.",
             model,
+            extra={"session_id": runner_primary_session_id()},
         )
         return None
     return model
@@ -5716,6 +5718,7 @@ def _measured_prefix_bytes(transcript_path: Path) -> int | None:
             "forwarder will seed from the live transcript end; transcript=%s",
             transcript_path,
             exc_info=True,
+            extra={"session_id": runner_primary_session_id()},
         )
         return None
 
@@ -5732,7 +5735,13 @@ def _native_terminal_start_error_payload(exc: BaseException, runtime_name: str) 
         the runner's log file; the raw cause is logged there for operators,
         not surfaced to the caller.
     """
-    _logger.warning("Native %s terminal start failed: %s", runtime_name, exc, exc_info=exc)
+    _logger.warning(
+        "Native %s terminal start failed: %s",
+        runtime_name,
+        exc,
+        exc_info=exc,
+        extra={"session_id": runner_primary_session_id()},
+    )
     if IS_WINDOWS:
         # Native terminals are tmux/PTY-based and disabled on Windows by design.
         # Give the client an actionable message instead of a log pointer.
@@ -5871,6 +5880,7 @@ def _ensure_orchestrator_skills_in_bundle(
         _logger.debug(
             "Orchestrator skill source %s is not a directory; skipping injection",
             source,
+            extra={"session_id": runner_primary_session_id()},
         )
         return
     try:
@@ -5882,6 +5892,7 @@ def _ensure_orchestrator_skills_in_bundle(
             skill_name,
             bundle_dir,
             exc_info=True,
+            extra={"session_id": runner_primary_session_id()},
         )
 
 
@@ -7988,6 +7999,7 @@ def _resolve_sub_agent_spec_entry(parent_entry: Any, sub_agent_name: str) -> Res
             "Sub-agent %r not found under spec %r; no workdir resolved",
             sub_agent_name,
             getattr(parent_spec, "name", None),
+            extra={"session_id": runner_primary_session_id()},
         )
         return None
     return ResolvedSpec(

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -1597,6 +1597,7 @@ def _build_opencode_policy_evaluator(
                 "OpenCode policy evaluate POST failed for %s; failing closed",
                 conversation_id,
                 exc_info=True,
+                extra={"session_id": conversation_id},
             )
             return {"decision": "deny"}
         if resp.status_code != 200 or not resp.content:
@@ -1604,12 +1605,16 @@ def _build_opencode_policy_evaluator(
                 "OpenCode policy evaluate returned %s for %s; failing closed",
                 resp.status_code,
                 conversation_id,
+                extra={"session_id": conversation_id},
             )
             return {"decision": "deny"}
         try:
             result = resp.json()
         except ValueError:
-            _logger.warning("OpenCode policy evaluate returned non-JSON; failing closed")
+            _logger.warning(
+                "OpenCode policy evaluate returned non-JSON; failing closed",
+                extra={"session_id": conversation_id},
+            )
             return {"decision": "deny"}
         action = result.get("result") if isinstance(result, Mapping) else None
         return {"decision": _OPENCODE_POLICY_ACTION_TO_DECISION.get(str(action), "ask")}
@@ -6500,6 +6505,7 @@ async def _auto_create_claude_terminal(
             "`omnigent setup --no-internal-beta` "
             "and that the secret resolves in this process.",
             exc_info=True,
+            extra={"session_id": session_id},
         )
     # A routed session's turn-1 ``/model`` can only reach ids this launch env
     # spells, so point the family aliases at the router's frozen arms before the

--- a/omnigent/runner/policy.py
+++ b/omnigent/runner/policy.py
@@ -41,6 +41,7 @@ import logging
 from dataclasses import dataclass, replace
 from typing import Literal
 
+from omnigent.debug_logging import runner_primary_session_id
 from omnigent.policies import FunctionPolicy, resolve_function_policy
 from omnigent.policies.types import EvaluationContext, PolicyResult
 from omnigent.spec.types import (
@@ -173,7 +174,9 @@ class RunnerToolPolicyGate:
                 policy = resolve_function_policy(ps)
             except Exception as exc:  # noqa: BLE001 - all resolution failures deny
                 diagnostic = _resolve_failure_diagnostic(ps, exc)
-                _logger.error("runner %s", diagnostic)
+                _logger.error(
+                    "runner %s", diagnostic, extra={"session_id": runner_primary_session_id()}
+                )
                 policy = _unresolved_policy_sentinel(ps, exc)
                 phases = frozenset([Phase.TOOL_CALL, Phase.TOOL_RESULT])
             out.append(_GatedPolicy(name=ps.name, policy=policy, phases=phases))
@@ -304,6 +307,7 @@ class RunnerToolPolicyGate:
                     "runner policy %r raised on %s; treating as DENY",
                     gated.name,
                     phase.value,
+                    extra={"session_id": runner_primary_session_id()},
                 )
                 return PolicyVerdict(
                     action="deny",

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Literal
 
 from cachetools import TTLCache
 
+from omnigent.debug_logging import runner_primary_session_id
 from omnigent.entities.pagination import PagedList
 from omnigent.entities.session_resources import (
     DEFAULT_ENVIRONMENT_ID,
@@ -209,7 +210,10 @@ def _terminal_exit_diagnostics(
         try:
             raw_last_output = read_last_output()
         except Exception:
-            _logger.exception("Failed to read terminal pane diagnostics")
+            _logger.exception(
+                "Failed to read terminal pane diagnostics",
+                extra={"session_id": runner_primary_session_id()},
+            )
         else:
             if isinstance(raw_last_output, str):
                 last_output = _trim_terminal_exit_output(raw_last_output)
@@ -220,7 +224,10 @@ def _terminal_exit_diagnostics(
         try:
             raw_exit_status = read_exit_status()
         except Exception:
-            _logger.exception("Failed to read terminal exit status")
+            _logger.exception(
+                "Failed to read terminal exit status",
+                extra={"session_id": runner_primary_session_id()},
+            )
         else:
             if isinstance(raw_exit_status, int):
                 exit_status = raw_exit_status
@@ -527,6 +534,7 @@ class SessionResourceRegistry:
                 len(sessions),
                 len(pollers),
                 sessions,
+                extra={"session_id": runner_primary_session_id()},
             )
 
     def note_session_turn_started(self, session_id: str) -> None:

--- a/omnigent/runner/subagent_routing.py
+++ b/omnigent/runner/subagent_routing.py
@@ -1176,7 +1176,7 @@ def _handler_factory(
             self.wfile.write(raw)
 
         def log_message(self, format: str, *args: Any) -> None:
-            _logger.debug("subagent-router: " + format, *args)
+            _logger.debug("subagent-router: " + format, *args, extra={"session_id": session_id})
 
     return _Handler
 
@@ -1356,7 +1356,7 @@ def ensure_session_router(
     # Nothing from the rendezvous is logged — neither the URL nor the paths
     # and ids that reach it — so a log file can never carry the bearer token
     # or the identifiers that address it. The advertisement on disk names both.
-    _logger.info("subagent router started")
+    _logger.info("subagent router started", extra={"session_id": session_id})
     return router
 
 

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -51,6 +51,7 @@ from omnigent._wrapper_labels import (
     CLAUDE_NATIVE_WRAPPER_VALUE,
     CODEX_NATIVE_WRAPPER_VALUE,
 )
+from omnigent.debug_logging import runner_primary_session_id
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.model_override import (
     harness_supports_model_override,
@@ -594,7 +595,10 @@ def build_native_relay_tool_schemas(spec: AgentSpec | None) -> list[_JsonObject]
         finally:
             _os_env.close()
     except Exception:  # noqa: BLE001 — OS env setup is best-effort for schema only
-        _logger.debug("Could not create OSEnvironment for native relay OS tool schemas")
+        _logger.debug(
+            "Could not create OSEnvironment for native relay OS tool schemas",
+            extra={"session_id": runner_primary_session_id()},
+        )
 
     return schemas
 
@@ -1804,6 +1808,7 @@ def _normalize_subagent_model(
             sub_agent_name,
             harness,
             provider.kind,
+            extra={"session_id": runner_primary_session_id()},
         )
     return normalized
 
@@ -6903,6 +6908,7 @@ def _apply_subagent_policy_verdict(
             _logger.warning(
                 "Sub-agent inbox TOOL_RESULT policy data must be str; got %s",
                 type(transformed).__name__,
+                extra={"session_id": runner_primary_session_id()},
             )
         return _SubagentInboxEvaluation(
             {
@@ -6913,6 +6919,7 @@ def _apply_subagent_policy_verdict(
     _logger.warning(
         "Sub-agent inbox TOOL_RESULT policy evaluation returned unknown result=%r",
         result,
+        extra={"session_id": runner_primary_session_id()},
     )
     return _SubagentInboxEvaluation(
         _subagent_policy_failure_payload(payload),

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -946,7 +946,11 @@ async def _execute_local_python_tool(
         )
         return await asyncio.to_thread(manager.call_tool, tool_name, args, ctx)
     except Exception as exc:
-        _logger.exception("runner local Python tool dispatch failed for %s", tool_name)
+        _logger.exception(
+            "runner local Python tool dispatch failed for %s",
+            tool_name,
+            extra={"session_id": conversation_id},
+        )
         return f"Error: {type(exc).__name__}: {exc}"
     finally:
         manager.shutdown()
@@ -3411,6 +3415,7 @@ async def _timer_loop(
                     timer_id,
                     conversation_id,
                     exc_info=True,
+                    extra={"session_id": conversation_id},
                 )
             if not repeat:
                 break
@@ -4975,6 +4980,7 @@ async def _collect_sub_agents(
                 "sys_session_list sibling enrichment failed for parent %s",
                 parent_id,
                 exc_info=True,
+                extra={"session_id": conversation_id},
             )
     return result
 
@@ -5841,6 +5847,7 @@ async def dispatch_tool_locally(
             tool_name,
             call_id,
             exc,
+            extra={"session_id": conversation_id},
         )
 
     return output
@@ -6074,7 +6081,11 @@ async def _execute_os_env_tool(
         else:
             return f"Error: {tool_name} not implemented"
     except Exception as exc:
-        _logger.exception("runner OSEnvironment dispatch failed for %s", tool_name)
+        _logger.exception(
+            "runner OSEnvironment dispatch failed for %s",
+            tool_name,
+            extra={"session_id": conversation_id},
+        )
         return json.dumps({"error": str(exc)})
     finally:
         if os_env is not None:
@@ -6516,6 +6527,7 @@ async def _publish_terminal_created_event(
                 conversation_id,
                 terminal_name,
                 session_key,
+                extra={"session_id": conversation_id},
             )
             return
         resource = session_resource_view_to_dict(view)
@@ -6841,6 +6853,7 @@ async def _post_subagent_policy_verdict(
             "Sub-agent inbox TOOL_RESULT policy evaluation failed for parent=%s child=%s",
             conversation_id,
             _subagent_child_id(payload),
+            extra={"session_id": conversation_id},
         )
         return None
     if resp.status_code >= 400:
@@ -6850,6 +6863,7 @@ async def _post_subagent_policy_verdict(
             conversation_id,
             resp.status_code,
             resp.text,
+            extra={"session_id": conversation_id},
         )
         return None
     try:
@@ -6858,6 +6872,7 @@ async def _post_subagent_policy_verdict(
         _logger.warning(
             "Sub-agent inbox TOOL_RESULT policy evaluation returned non-JSON for parent=%s",
             conversation_id,
+            extra={"session_id": conversation_id},
         )
         return None
 
@@ -7007,6 +7022,7 @@ async def _drain_inbox(
                     "malformed terminal-idle inbox item ignored: %s",
                     exc,
                     exc_info=True,
+                    extra={"session_id": conversation_id},
                 )
                 items.append(f"[System: malformed terminal_idle inbox item ignored — {exc}]")
             continue
@@ -7075,12 +7091,14 @@ async def _evaluate_async_tool_call_policy(
             "async PHASE_TOOL_CALL policy evaluate returned %d for %s; denying",
             resp.status_code,
             evaluation_id,
+            extra={"session_id": conversation_id},
         )
     except Exception:  # noqa: BLE001
         _logger.warning(
             "async PHASE_TOOL_CALL policy evaluate failed for %s; denying",
             evaluation_id,
             exc_info=True,
+            extra={"session_id": conversation_id},
         )
     return False
 

--- a/omnigent/runner/transports/ws_tunnel/registry.py
+++ b/omnigent/runner/transports/ws_tunnel/registry.py
@@ -40,6 +40,7 @@ from dataclasses import dataclass, field
 from functools import partial
 from typing import Protocol
 
+from omnigent.debug_logging import runner_primary_session_id
 from omnigent.runner.transports.ws_tunnel.frames import (
     Frame,
     HelloFrame,
@@ -329,9 +330,14 @@ class TunnelRegistry:
                     "Deregistering runner %s; aborting %d in-flight request(s)",
                     runner_id,
                     in_flight_count,
+                    extra={"session_id": runner_primary_session_id()},
                 )
             else:
-                _logger.info("Deregistering runner %s; no in-flight requests", runner_id)
+                _logger.info(
+                    "Deregistering runner %s; no in-flight requests",
+                    runner_id,
+                    extra={"session_id": runner_primary_session_id()},
+                )
             self._abort_session_inflight(
                 removed,
                 ConnectionError("tunnel closed before request completed"),
@@ -416,6 +422,7 @@ class TunnelRegistry:
                 overflow_reason,
                 runner_id,
                 timeout_s,
+                extra={"session_id": runner_primary_session_id()},
             )
             await asyncio.sleep(timeout_s)
             return self.get(runner_id)
@@ -661,6 +668,7 @@ class TunnelRegistry:
                     _logger.warning(
                         "ws-channel %s: dropping frame with malformed base64",
                         frame.ch_id,
+                        extra={"session_id": runner_primary_session_id()},
                     )
                     return False
                 item = ("data", decoded)
@@ -669,6 +677,7 @@ class TunnelRegistry:
                     "ws-channel %s: dropping frame with unknown encoding %r",
                     frame.ch_id,
                     frame.encoding,
+                    extra={"session_id": runner_primary_session_id()},
                 )
                 return False
 
@@ -851,6 +860,7 @@ def _resolve_connect_waiter(
             "Dropping runner-connect wakeup for closed waiter loop (runner_id=%s)",
             session.runner_id,
             exc_info=True,
+            extra={"session_id": runner_primary_session_id()},
         )
 
 
@@ -909,6 +919,7 @@ def _call_soon_threadsafe(state: RequestState, callback: Callable[[], None]) -> 
             "Dropping tunnel response wakeup for closed request loop (runner_id=%s)",
             state.session.runner_id,
             exc_info=True,
+            extra={"session_id": runner_primary_session_id()},
         )
         return False
     return True
@@ -938,6 +949,7 @@ def _call_channel_soon_threadsafe(
             "Dropping ws-channel wakeup for closed loop (runner_id=%s)",
             state.session.runner_id,
             exc_info=True,
+            extra={"session_id": runner_primary_session_id()},
         )
         return False
     return True

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -26,6 +26,7 @@ from urllib.parse import quote, urlsplit, urlunsplit
 from starlette.types import ASGIApp, Message, Scope
 from websockets.exceptions import ConnectionClosedOK, InvalidURI, WebSocketException
 
+from omnigent.debug_logging import runner_primary_session_id
 from omnigent.runner.identity import (
     OMNIGENT_INTERNAL_WS_ORIGIN,
     RUNNER_SLICE_KEY_ENV_VAR,
@@ -374,7 +375,10 @@ async def serve_tunnel(
             try:
                 await on_reconnect()
             except Exception:
-                _logger.exception("on_reconnect callback failed")
+                _logger.exception(
+                    "on_reconnect callback failed",
+                    extra={"session_id": runner_primary_session_id()},
+                )
         retry_reason = "connection closed cleanly"
         recycle = False
         try:
@@ -471,9 +475,14 @@ async def serve_tunnel(
                             "HTTP %d after a successful upgrade; retrying — "
                             "check VPN/network connectivity",
                             http_status,
+                            extra={"session_id": runner_primary_session_id()},
                         )
                     else:
-                        _logger.info("HTTP %d; invalidated auth token, retrying", http_status)
+                        _logger.info(
+                            "HTTP %d; invalidated auth token, retrying",
+                            http_status,
+                            extra={"session_id": runner_primary_session_id()},
+                        )
                         delay_s = _INITIAL_RECONNECT_DELAY_S
                 else:
                     close_code = _websocket_close_code(exc)
@@ -519,6 +528,7 @@ async def serve_tunnel(
             retry_reason,
             jittered,
             delay_s,
+            extra={"session_id": runner_primary_session_id()},
         )
         await asyncio.sleep(jittered)
         # Match the host tunnel (connect.py): escalate the backoff only on
@@ -568,6 +578,7 @@ async def _refresh_auth_token(
         _logger.warning(
             "auth token refresh failed; falling back to previous token",
             exc_info=True,
+            extra={"session_id": runner_primary_session_id()},
         )
     return current_token
 
@@ -599,6 +610,7 @@ async def _handle_refreshable_auth_failure(
                 _logger.info(
                     "auth token refreshed after HTTP %d; retrying",
                     http_status,
+                    extra={"session_id": runner_primary_session_id()},
                 )
                 return fresh
         except (ValueError, OSError, ImportError):
@@ -606,6 +618,7 @@ async def _handle_refreshable_auth_failure(
                 "auth token refresh failed after HTTP %d",
                 http_status,
                 exc_info=True,
+                extra={"session_id": runner_primary_session_id()},
             )
     raise RuntimeError(
         f"{RUNNER_TUNNEL_REJECTION_PREFIX}(HTTP {http_status}); check remote server authentication"
@@ -766,7 +779,12 @@ async def _serve_tunnel_once(
             direct_attach_port=direct_attach_port,
             direct_attach_token=direct_attach_token,
         )
-        _logger.info("runner %s connected to %s", runner_id, tunnel_url)
+        _logger.info(
+            "runner %s connected to %s",
+            runner_id,
+            tunnel_url,
+            extra={"session_id": runner_primary_session_id()},
+        )
 
         def _on_resume_from_suspend(gap_s: float) -> None:
             # Wake from system suspend: this socket is now half-open (the server
@@ -781,6 +799,7 @@ async def _serve_tunnel_once(
                 "runner %s resumed from suspend (~%.0fs); dropping tunnel to reconnect",
                 runner_id,
                 gap_s,
+                extra={"session_id": runner_primary_session_id()},
             )
             if on_resume_note is not None:
                 on_resume_note()
@@ -843,6 +862,7 @@ async def _serve_tunnel_once(
                                     "during graceful shutdown of runner %s",
                                     runner_id,
                                     exc_info=True,
+                                    extra={"session_id": runner_primary_session_id()},
                                 )
                             await _graceful_drain(
                                 dispatch_tasks,
@@ -912,7 +932,10 @@ async def _graceful_drain(
             on_graceful_shutdown()
         except Exception:
             # A drain-hook error must not abort shutdown.
-            _logger.exception("on_graceful_shutdown callback failed")
+            _logger.exception(
+                "on_graceful_shutdown callback failed",
+                extra={"session_id": runner_primary_session_id()},
+            )
     if dispatch_tasks:
         # Wait for the streams to drain the sentinel and emit their end frames.
         # Bounded: a stream that never finishes must not wedge shutdown — the
@@ -926,6 +949,7 @@ async def _graceful_drain(
                 "graceful shutdown: %d dispatch task(s) did not drain in %.1fs; closing anyway",
                 len(pending),
                 _GRACEFUL_SHUTDOWN_DRAIN_TIMEOUT_S,
+                extra={"session_id": runner_primary_session_id()},
             )
 
 
@@ -1009,7 +1033,11 @@ async def _handle_tunnel_frame(
         text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
         frame = decode_frame(text)
     except ValueError as exc:
-        _logger.warning("runner received malformed tunnel frame; dropping: %s", exc)
+        _logger.warning(
+            "runner received malformed tunnel frame; dropping: %s",
+            exc,
+            extra={"session_id": runner_primary_session_id()},
+        )
         return
     if isinstance(frame, PingFrame):
         await send_text(encode_frame(PongFrame(ts=frame.ts)))
@@ -1043,7 +1071,11 @@ async def _handle_tunnel_frame(
             on_activity()
         active_channel = ws_channels.get(frame.ch_id)
         if active_channel is None:
-            _logger.debug("runner: dropping ws.frame for unknown ch_id %r", frame.ch_id)
+            _logger.debug(
+                "runner: dropping ws.frame for unknown ch_id %r",
+                frame.ch_id,
+                extra={"session_id": runner_primary_session_id()},
+            )
             return
         if frame.encoding == "utf-8":
             active_channel.inbound.put_nowait(("text", frame.data))
@@ -1054,11 +1086,16 @@ async def _handle_tunnel_frame(
                 _logger.warning(
                     "runner: dropping ws.frame with malformed base64 on ch_id %r",
                     frame.ch_id,
+                    extra={"session_id": runner_primary_session_id()},
                 )
                 return
             active_channel.inbound.put_nowait(("bytes", decoded))
         else:
-            _logger.warning("runner: dropping ws.frame with unknown encoding %r", frame.encoding)
+            _logger.warning(
+                "runner: dropping ws.frame with unknown encoding %r",
+                frame.encoding,
+                extra={"session_id": runner_primary_session_id()},
+            )
     elif isinstance(frame, WSCloseFrame):
         if on_activity is not None:
             on_activity()
@@ -1211,7 +1248,12 @@ async def _dispatch_ws_via_asgi(
             )
         raise
     except Exception as exc:  # noqa: BLE001 -- log + surface as close
-        _logger.warning("runner ws-attach dispatch %s failed: %r", channel.ch_id, exc)
+        _logger.warning(
+            "runner ws-attach dispatch %s failed: %r",
+            channel.ch_id,
+            exc,
+            extra={"session_id": runner_primary_session_id()},
+        )
         with contextlib.suppress(Exception):
             await channel.send_text(
                 encode_frame(
@@ -1245,7 +1287,12 @@ def _forget_ws_channel(
             return
         exc = task.exception()
         if exc is not None:
-            _logger.warning("runner ws-attach dispatch %s failed: %r", ch_id, exc)
+            _logger.warning(
+                "runner ws-attach dispatch %s failed: %r",
+                ch_id,
+                exc,
+                extra={"session_id": runner_primary_session_id()},
+            )
 
     return _callback
 
@@ -1274,7 +1321,12 @@ def _forget_dispatch_task(
             return
         exc = task.exception()
         if exc is not None:
-            _logger.warning("runner tunnel dispatch %s failed: %s", req_id, exc)
+            _logger.warning(
+                "runner tunnel dispatch %s failed: %s",
+                req_id,
+                exc,
+                extra={"session_id": runner_primary_session_id()},
+            )
 
     return _callback
 

--- a/omnigent/runner/turn_routing.py
+++ b/omnigent/runner/turn_routing.py
@@ -876,7 +876,7 @@ def _handler_factory(
             self.wfile.write(raw)
 
         def log_message(self, format: str, *args: Any) -> None:
-            _logger.debug("turn-router: " + format, *args)
+            _logger.debug("turn-router: " + format, *args, extra={"session_id": session_id})
 
     return _Handler
 
@@ -1633,7 +1633,7 @@ def ensure_session_turn_router(
     # Nothing from the rendezvous is logged — neither the URL nor the paths
     # and ids that reach it — so a log file can never carry the bearer token
     # or the identifiers that address it. The advertisement on disk names both.
-    _logger.info("turn router started")
+    _logger.info("turn router started", extra={"session_id": session_id})
     return router
 
 

--- a/omnigent/runner/uc_function.py
+++ b/omnigent/runner/uc_function.py
@@ -36,6 +36,8 @@ import re
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
+from omnigent.debug_logging import runner_primary_session_id
+
 if TYPE_CHECKING:
     from databricks.sdk import WorkspaceClient
 
@@ -192,6 +194,7 @@ async def execute_uc_function(
         "Executing UC function %s on warehouse %s",
         catalog_path,
         warehouse_id,
+        extra={"session_id": runner_primary_session_id()},
     )
 
     # Statement execution is a blocking HTTP call — run in a thread
@@ -231,11 +234,20 @@ async def execute_uc_function(
     # Extract result data.
     result = response.result
     if result is None or result.data_array is None:
-        _logger.debug("UC function %s returned no result data", catalog_path)
+        _logger.debug(
+            "UC function %s returned no result data",
+            catalog_path,
+            extra={"session_id": runner_primary_session_id()},
+        )
         return json.dumps(None)
 
     data = result.data_array
-    _logger.debug("UC function %s result: %s", catalog_path, data)
+    _logger.debug(
+        "UC function %s result: %s",
+        catalog_path,
+        data,
+        extra={"session_id": runner_primary_session_id()},
+    )
     # Single-row, single-column result (common for scalar functions).
     if len(data) == 1 and len(data[0]) == 1:
         return data[0][0] if data[0][0] is not None else json.dumps(None)

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -24,6 +24,7 @@ from fastapi.responses import Response
 from pydantic import ValidationError
 
 from omnigent.db.utils import generate_agent_id, generate_task_id
+from omnigent.debug_logging import debug_event
 from omnigent.entities import (
     Agent,
     CommentsFingerprint,
@@ -3562,7 +3563,11 @@ async def _run_managed_wake(
         # Fire-and-forget task — settle the tracker (else a waiting message
         # POST hangs to its timeout) and never escape as an unhandled-task
         # traceback. A failed wake leaves the sandbox intact for a retry.
-        _logger.exception("Managed host wake crashed for session %s", session_id)
+        _logger.exception(
+            "Managed host wake crashed for session %s",
+            session_id,
+            extra={"session_id": session_id},
+        )
         tracker.fail(session_id, "internal error during managed host wake")
         _publish_sandbox_status(session_id, "failed", "internal error during managed host wake")
 
@@ -3767,6 +3772,7 @@ async def _ensure_native_terminal_ready(
             display_name,
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
         return _NativeTerminalEnsureOutcome(
             error=_native_terminal_ensure_transport_error(exc, display_name=display_name),
@@ -3782,6 +3788,7 @@ async def _ensure_native_terminal_ready(
         session_id,
         resp.status_code,
         resp.text[:500],
+        extra={"session_id": session_id},
     )
     return _NativeTerminalEnsureOutcome(
         error=_native_terminal_failure_from_runner_response(resp, display_name=display_name),
@@ -4091,7 +4098,7 @@ async def _forward_native_terminal_message(
     :raises HTTPException: 502 when the runner or harness rejects
         the injection request.
     """
-    display_name, _, _ = _native_terminal_runtime(conv)
+    display_name, _, harness = _native_terminal_runtime(conv)
     event = _build_native_terminal_message_event(conv, body, model_override=model_override)
     _logger.info(
         "%s terminal message forward starting: session=%s block_types=%s model_override=%s",
@@ -4101,6 +4108,7 @@ async def _forward_native_terminal_message(
         if isinstance(event.get("content"), list)
         else type(event.get("content")).__name__,
         event.get("model_override"),
+        extra={"session_id": session_id},
     )
     if (
         file_store is not None
@@ -4123,6 +4131,7 @@ async def _forward_native_terminal_message(
                 "File reference resolution failed for native session=%s",
                 session_id,
                 exc_info=True,
+                extra={"session_id": session_id},
             )
     try:
         resp = await runner_client.post(
@@ -4136,6 +4145,7 @@ async def _forward_native_terminal_message(
             session_id,
             resp.status_code,
             resp.text[:500],
+            extra={"session_id": session_id},
         )
     except (httpx.HTTPError, ConnectionError) as exc:
         # WSTunnelTransport raises bare ConnectionError on tunnel close;
@@ -4146,6 +4156,7 @@ async def _forward_native_terminal_message(
             display_name,
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
         raise HTTPException(
             status_code=502,
@@ -4158,6 +4169,7 @@ async def _forward_native_terminal_message(
             session_id,
             resp.status_code,
             resp.text,
+            extra={"session_id": session_id},
         )
         raise HTTPException(
             status_code=502,
@@ -4170,11 +4182,26 @@ async def _forward_native_terminal_message(
             display_name,
             session_id,
             failure,
+            extra={"session_id": session_id},
         )
         raise HTTPException(
             status_code=502,
             detail=f"{display_name} terminal message delivery failed: {failure}",
         )
+    # Native-terminal counterpart to the SDK path's turn_dispatched (same event
+    # name so a session reads uniformly across harnesses); the message was
+    # injected into the live terminal rather than dispatched as a discrete turn.
+    _logger.info(
+        "%s terminal message dispatched for session=%s",
+        display_name,
+        session_id,
+        extra=debug_event(
+            "turn_dispatched",
+            session_id=session_id,
+            agent=conv.agent_id or "",
+            harness=harness,
+        ),
+    )
 
 
 async def _persist_session_event(
@@ -4276,6 +4303,7 @@ async def _refresh_stale_native_model_options(
         session_id,
         time.monotonic() - started,
         session_id in _model_options_stale,
+        extra={"session_id": session_id},
     )
 
 
@@ -4380,6 +4408,7 @@ def _routed_turn_model_spelling(
             model,
             session_id,
             sorted(env.values()),
+            extra={"session_id": session_id},
         )
     return spelling
 
@@ -4689,6 +4718,7 @@ async def _forward_event_to_runner(
                     "Resolved %d file_id block(s) for session=%s before forwarding",
                     len(_unresolved),
                     session_id,
+                    extra={"session_id": session_id},
                 )
             except (ValueError, KeyError):
                 _logger.warning(
@@ -4697,6 +4727,7 @@ async def _forward_event_to_runner(
                     "runner will attempt fallback resolution)",
                     session_id,
                     exc_info=True,
+                    extra={"session_id": session_id},
                 )
 
     # Flatten SessionEventInput {type, data} into the runner's
@@ -4824,6 +4855,7 @@ async def _forward_event_to_runner(
                     "auto-harness: failed to persist resolved harness for session=%s",
                     session_id,
                     exc_info=True,
+                    extra={"session_id": session_id},
                 )
             # Defer card emission until after input.consumed (see below).
             if _auto_model is not None and _auto_verdict is not None:
@@ -4972,6 +5004,7 @@ async def _forward_event_to_runner(
                         "smart_routing: failed to persist harness/model for child session=%s",
                         session_id,
                         exc_info=True,
+                        extra={"session_id": session_id},
                     )
                 if _routed_model is None and _route_err is not None:
                     # ``route_session_harness`` already fails open, so the spawn
@@ -5035,6 +5068,7 @@ async def _forward_event_to_runner(
                                 "for session=%s; turn still uses routed model",
                                 session_id,
                                 exc_info=True,
+                                extra={"session_id": session_id},
                             )
     # ────────────────────────────────────────────────────────────────
     if effective_runner_override is not None:
@@ -5077,6 +5111,12 @@ async def _forward_event_to_runner(
                 session_id,
                 _forward_resp.status_code,
                 _reject_detail,
+                extra=debug_event(
+                    "turn_dispatch_rejected",
+                    session_id=session_id,
+                    status=_forward_resp.status_code,
+                    detail=_reject_detail,
+                ),
             )
             _reject_error = ErrorDetail(code="runner_rejected_event", message=_reject_detail)
             # Persist before publishing: a client that reloads on the ``failed``
@@ -5092,6 +5132,16 @@ async def _forward_event_to_runner(
         # Publish input.consumed AFTER the forward succeeds —
         # the runner has the message and will start the turn.
         _publish_input_consumed(session_id, persisted_items[0])
+        _logger.info(
+            "turn dispatched to runner for session=%s",
+            session_id,
+            extra=debug_event(
+                "turn_dispatched",
+                session_id=session_id,
+                agent=agent_name or conv.agent_id or "",
+                harness=_effective_harness or "",
+            ),
+        )
         # Emit the routing_decision chip AFTER input.consumed so the
         # live SSE stream delivers the user bubble before the chip —
         # matching the store order (user message was persisted first).
@@ -5183,6 +5233,7 @@ async def _forward_event_to_runner(
         _logger.exception(
             "Forward to runner failed for session=%s",
             session_id,
+            extra={"session_id": session_id},
         )
         _publish_status(session_id, "idle")
         raise OmnigentError(
@@ -5221,6 +5272,7 @@ async def _stamp_routing_decision_label(
             "smart_routing: failed to label routing decision for session=%s",
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
 
 
@@ -5261,6 +5313,7 @@ async def _record_create_route_prompt(
             "smart_routing: failed to record the create-time prompt for session=%s",
             conv.id,
             exc_info=True,
+            extra={"session_id": conv.id},
         )
         return conv
     conv.labels[CREATE_ROUTE_PROMPT_LABEL_KEY] = fingerprint
@@ -5514,6 +5567,7 @@ async def _dispatch_session_event_to_runner_impl(
                             "smart_routing: persist failed for native session=%s",
                             session_id,
                             exc_info=True,
+                            extra={"session_id": session_id},
                         )
         # ────────────────────────────────────────────────────────────
         # Forward the message, carrying any routed model in-band. The
@@ -5656,6 +5710,7 @@ async def _runner_drop_interrupted_turn(
             "Relay: live-status read failed for session=%s; reporting the drop",
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
         return True
     if conv is None:
@@ -5715,6 +5770,7 @@ async def _relay_runner_stream(
                     "Relay: runner transport lost for session=%s; retrying for %.1fs",
                     session_id,
                     deadline - now,
+                    extra={"session_id": session_id},
                 )
                 await asyncio.sleep(_RELAY_RETRY_INTERVAL_S)
                 continue
@@ -5722,6 +5778,7 @@ async def _relay_runner_stream(
                 "Relay: runner transport lost for session=%s",
                 session_id,
                 exc_info=True,
+                extra={"session_id": session_id},
             )
             if lost.intentional:
                 # User clicked Stop: the Stop handler brought this runner's
@@ -5751,6 +5808,7 @@ async def _relay_runner_stream(
                 _logger.info(
                     "Relay: runner gone for idle session=%s; no failure to report",
                     session_id,
+                    extra={"session_id": session_id},
                 )
             else:
                 # Publish a failed status so the client's SSE stream sees a
@@ -5820,7 +5878,11 @@ async def _relay_runner_stream_once(
     # web UI's block stream clears its pending-tool state on the
     # response_id transition and the tool card spinner never resolves.
     tool_call_response_ids: dict[str, str] = {}
-    _logger.info("Relay: connecting to runner GET /stream for session=%s", session_id)
+    _logger.info(
+        "Relay: connecting to runner GET /stream for session=%s",
+        session_id,
+        extra={"session_id": session_id},
+    )
 
     # Read timeout: 3x the runner's session-stream heartbeat interval
     # (15s). Between turns the runner emits ``session.heartbeat`` every
@@ -5836,7 +5898,11 @@ async def _relay_runner_stream_once(
             f"/v1/sessions/{session_id}/stream",
             timeout=_relay_timeout,
         ) as resp:
-            _logger.info("Relay: connected to runner GET /stream for session=%s", session_id)
+            _logger.info(
+                "Relay: connected to runner GET /stream for session=%s",
+                session_id,
+                extra=debug_event("runner_stream_connected", session_id=session_id),
+            )
             buffer = ""
             async for chunk in resp.aiter_text():
                 buffer += chunk
@@ -6131,6 +6197,7 @@ async def _relay_runner_stream_once(
                                 "Relay: routing_decision persist failed for session=%s; "
                                 "publishing the live chip without a durable id",
                                 session_id,
+                                extra={"session_id": session_id},
                             )
                             _persisted_id = None
                         session_stream.publish(
@@ -6253,7 +6320,11 @@ async def _relay_runner_stream_once(
     except asyncio.CancelledError:
         raise
     finally:
-        _logger.info("Relay: task exiting for session=%s", session_id)
+        _logger.info(
+            "Relay: task exiting for session=%s",
+            session_id,
+            extra={"session_id": session_id},
+        )
         # Drop any in-flight assistant-text entry so a relay that exits
         # WITHOUT a terminal turn event (runner death / tunnel drop
         # mid-turn, or a rebind cancellation) can't strand it forever.
@@ -6306,23 +6377,35 @@ def _ensure_runner_relay(
             session_id,
             runner_client is not None,
             runner_id,
+            extra={"session_id": session_id},
         )
         return None
     existing = _runner_relay_tasks.get(session_id)
     if existing is not None:
         if existing.runner_id == runner_id and not existing.task.done():
-            _logger.info("Relay: reusing existing for session=%s runner=%s", session_id, runner_id)
+            _logger.info(
+                "Relay: reusing existing for session=%s runner=%s",
+                session_id,
+                runner_id,
+                extra={"session_id": session_id},
+            )
             return existing  # same runner, healthy task
         _logger.info(
             "Relay: replacing stale for session=%s (old_runner=%s done=%s)",
             session_id,
             existing.runner_id,
             existing.task.done(),
+            extra={"session_id": session_id},
         )
         if not existing.task.done():
             existing.task.cancel()  # stale binding; replace
     else:
-        _logger.info("Relay: creating new for session=%s runner=%s", session_id, runner_id)
+        _logger.info(
+            "Relay: creating new for session=%s runner=%s",
+            session_id,
+            runner_id,
+            extra={"session_id": session_id},
+        )
     ready = asyncio.Event()
     # Runtime callers always supply a store. ``None`` is retained for
     # heartbeat-only relay readiness tests that never emit persistable frames.
@@ -7050,7 +7133,11 @@ async def _session_routing_host(
         return await asyncio.to_thread(host_store.get_host, conv.host_id)
     except Exception:  # noqa: BLE001 — an unreadable host row is just unknown
         _logger.debug(
-            "routing: could not read host %r for session=%s", conv.host_id, conv.id, exc_info=True
+            "routing: could not read host %r for session=%s",
+            conv.host_id,
+            conv.id,
+            exc_info=True,
+            extra={"session_id": conv.id},
         )
         return None
 
@@ -8508,6 +8595,7 @@ async def _handle_mcp_tools_call(
         session_id,
         namespaced_name,
         is_retry,
+        extra={"session_id": session_id},
     )
 
     if not namespaced_name:
@@ -8568,6 +8656,7 @@ async def _handle_mcp_tools_call(
             namespaced_name,
             retry_result.action,
             retry_result.reason,
+            extra={"session_id": session_id},
         )
 
         if retry_result.action == PolicyAction.DENY:
@@ -8637,6 +8726,7 @@ async def _handle_mcp_tools_call(
             namespaced_name,
             call_result.action,
             call_result.reason,
+            extra={"session_id": session_id},
         )
 
         if call_result.action == PolicyAction.DENY:
@@ -8831,6 +8921,7 @@ async def _handle_mcp_tools_call(
         session_id,
         namespaced_name,
         len(output),
+        extra={"session_id": session_id},
     )
 
     # ── TOOL_RESULT policy ───────────────────────────────────────────
@@ -8852,6 +8943,7 @@ async def _handle_mcp_tools_call(
         namespaced_name,
         result_policy.action,
         result_policy.reason,
+        extra={"session_id": session_id},
     )
 
     if result_policy.action == PolicyAction.DENY:
@@ -9104,6 +9196,7 @@ async def _get_session_snapshot(
             _logger.debug(
                 "No runner bound for session=%s on snapshot build",
                 session_id,
+                extra={"session_id": session_id},
             )
     if runner_client is None:
         runner_client = get_runner_client()

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -230,3 +230,55 @@ def test_runner_primary_session_id(monkeypatch: pytest.MonkeyPatch) -> None:
     assert dl.runner_primary_session_id() == "conv_primary"
     monkeypatch.setenv(dl.PRIMARY_SESSION_ID_ENV_VAR, "")
     assert dl.runner_primary_session_id() is None
+
+
+def test_close_tears_down_captured_worker_not_a_concurrent_revive(
+    _configured_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A concurrent emit() can revive the sink (fresh client/thread) during
+    # close()'s join. close() must tear down the worker it captured at entry,
+    # never the revived one — otherwise it closes a live client out from under
+    # the new uploader thread.
+    config = dl.config_from_env()
+    assert config is not None
+    sink = dl.ZerobusLogHandler(config, "server")
+    sink._probe_timer.cancel()
+    old_client = sink._client
+    old_thread = sink._thread
+    orig_join = old_thread.join
+
+    def _join_then_revive(timeout: float | None = None) -> None:
+        orig_join(timeout)
+        sink._closed = False
+        sink._start_worker()  # stand in for a concurrent emit() revive
+
+    monkeypatch.setattr(old_thread, "join", _join_then_revive)
+    try:
+        sink.close()
+        assert old_client.is_closed  # the captured worker is torn down
+        assert sink._client is not old_client  # the revived worker survives
+        assert not sink._client.is_closed
+        assert sink._thread is not old_thread
+        assert sink._thread.is_alive()
+    finally:
+        sink._closed = False
+        sink.close()
+
+
+def test_attach_suppresses_handler_init_failure(
+    _configured_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Handler construction (httpx client, uploader thread, probe timer) failing
+    # must not break configure_process_logging(), per the module's best-effort
+    # contract — attach swallows it and stays disabled.
+    monkeypatch.setattr(dl, "_active_sink", None)
+
+    def _boom(config: dl.DebugLogConfig, source: str) -> dl.ZerobusLogHandler:
+        raise RuntimeError("handler init failed")
+
+    monkeypatch.setattr(dl, "ZerobusLogHandler", _boom)
+    target = logging.getLogger("test.debug_logging.initfail")
+    target.handlers.clear()
+    dl.attach_debug_log_sink([target], source="server", level=logging.INFO)
+    assert target.handlers == []
+    assert dl._active_sink is None

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -1,0 +1,221 @@
+"""Tests for the client-side debug-log sink."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from omnigent import debug_logging as dl
+
+_INSERT_URL = (
+    "https://3272836215725701.zerobus.us-west-2.cloud.databricks.com"
+    "/zerobus/v1/tables/omnigents.omnigent_daniel.omnigent_debug_logs/insert"
+)
+_TABLE = "omnigents.omnigent_daniel.omnigent_debug_logs"
+
+
+@pytest.fixture
+def _configured_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(dl.CLIENT_ID_ENV_VAR, "cid")
+    monkeypatch.setenv(dl.CLIENT_SECRET_ENV_VAR, "secret")
+    monkeypatch.setenv(dl.WORKSPACE_URL_ENV_VAR, "https://ws.cloud.databricks.com/")
+    monkeypatch.setenv(dl.ENDPOINT_ENV_VAR, _INSERT_URL)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        dl.CLIENT_ID_ENV_VAR,
+        dl.CLIENT_SECRET_ENV_VAR,
+        dl.WORKSPACE_URL_ENV_VAR,
+        dl.ENDPOINT_ENV_VAR,
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_disabled_without_env() -> None:
+    assert dl.config_from_env() is None
+
+
+def test_config_parses_table_and_workspace_id(_configured_env: None) -> None:
+    config = dl.config_from_env()
+    assert config is not None
+    assert config.table == _TABLE
+    assert config.workspace_id == "3272836215725701"
+    # Trailing slash on the workspace URL is trimmed so token minting can append.
+    assert config.workspace_url == "https://ws.cloud.databricks.com"
+
+
+def test_malformed_endpoint_disables(
+    monkeypatch: pytest.MonkeyPatch, _configured_env: None
+) -> None:
+    monkeypatch.setenv(dl.ENDPOINT_ENV_VAR, "https://host.example.com/no-tables-segment")
+    assert dl.config_from_env() is None
+
+
+def test_authorization_details_splits_catalog_schema_table(_configured_env: None) -> None:
+    config = dl.config_from_env()
+    assert config is not None
+    source = dl._TokenSource(config, client=None)  # type: ignore[arg-type]
+    by_type = {
+        entry["object_type"]: entry["object_full_path"]
+        for entry in json.loads(source._authorization_details())
+    }
+    assert by_type == {
+        "CATALOG": "omnigents",
+        "SCHEMA": "omnigents.omnigent_daniel",
+        "TABLE": _TABLE,
+    }
+
+
+def test_record_to_row_shape_and_coercions() -> None:
+    record = logging.LogRecord(
+        "omnigent.runner", logging.INFO, __file__, 10, "hello %s", ("world",), None, func="do_it"
+    )
+    record.event_name = "turn_started"
+    record.attributes = {"model": "claude-opus-4-8", "count": 3, "skip": None}
+
+    row = dl.record_to_row(record, source="runner")
+
+    assert row["message"] == "hello world"
+    assert row["source"] == "runner"
+    assert row["event_name"] == "turn_started"
+    assert row["app_version"] == dl.VERSION
+    # TIMESTAMP column wants epoch microseconds as an integer, not an ISO string.
+    assert isinstance(row["client_time"], int)
+    assert row["client_time"] == int(record.created * 1_000_000)
+    # MAP<STRING,STRING>: values coerced to str, null values dropped.
+    assert row["attributes"] == {"model": "claude-opus-4-8", "count": "3"}
+    assert set(row) == {
+        "session_id",
+        "turn_id",
+        "source",
+        "event_name",
+        "level",
+        "message",
+        "client_time",
+        "hostname",
+        "logger_name",
+        "func_name",
+        "app_version",
+        "stack_trace",
+        "attributes",
+        "log_id",
+        "user_id",
+    }
+
+
+def test_record_to_row_reads_session_id_from_extra() -> None:
+    # session_id is passed explicitly at the callsite via extra= and read off
+    # the record; there is no ambient contextvar fallback.
+    record = logging.LogRecord(
+        "omnigent.runner", logging.INFO, __file__, 1, "hi", (), None, func="f"
+    )
+    record.session_id = "conv_row"
+    row = dl.record_to_row(record, source="runner")
+    assert row["session_id"] == "conv_row"
+
+
+def test_record_to_row_null_correlation_without_extra() -> None:
+    record = logging.LogRecord("omnigent", logging.INFO, __file__, 1, "hi", (), None)
+    row = dl.record_to_row(record, source="server")
+    assert row["session_id"] is None
+    assert row["turn_id"] is None
+
+
+def test_record_to_row_without_event_or_attributes() -> None:
+    record = logging.LogRecord("omnigent", logging.DEBUG, __file__, 1, "freeform", (), None)
+    row = dl.record_to_row(record, source="host")
+    assert row["event_name"] is None
+    assert row["attributes"] == {}
+
+
+def test_record_to_row_captures_stack_trace() -> None:
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        import sys
+
+        record = logging.LogRecord(
+            "omnigent", logging.ERROR, __file__, 1, "failed", (), sys.exc_info()
+        )
+    row = dl.record_to_row(record, source="server")
+    assert "ValueError: boom" in (row["stack_trace"] or "")
+
+
+def test_debug_event_builds_extra() -> None:
+    assert dl.debug_event("evt", a=1, b="x") == {
+        "event_name": "evt",
+        "attributes": {"a": 1, "b": "x"},
+    }
+
+
+def test_debug_event_includes_explicit_correlation() -> None:
+    extra = dl.debug_event("evt", session_id="conv_1", turn_id="turn_1", a=1)
+    assert extra == {
+        "event_name": "evt",
+        "attributes": {"a": 1},
+        "session_id": "conv_1",
+        "turn_id": "turn_1",
+    }
+
+
+def test_emit_revives_closed_uploader(_configured_env: None) -> None:
+    # dictConfig() (uvicorn) calls logging.shutdown() → close() on the handler,
+    # and os.fork() (the zygote) kills the thread — both leave it attached to
+    # root. A subsequent emit must revive it so records keep getting delivered
+    # instead of queuing forever.
+    config = dl.config_from_env()
+    assert config is not None
+    sink = dl.ZerobusLogHandler(config, "server")
+    try:
+        first_thread = sink._thread
+        assert first_thread.is_alive()
+        # Simulate dictConfig's close() of the handler.
+        sink.close()
+        assert sink._closed
+        assert not first_thread.is_alive()
+        # A subsequent record revives the worker (fresh thread) and enqueues.
+        record = logging.LogRecord("omnigent.x", logging.INFO, __file__, 1, "hi", (), None)
+        sink.emit(record)
+        assert not sink._closed
+        assert sink._thread is not first_thread
+        assert sink._thread.is_alive()
+    finally:
+        sink.close()
+
+
+def test_ignored_loggers_are_dropped() -> None:
+    # httpx/httpcore records are chatty HTTP-client noise and must be dropped;
+    # everything else is kept.
+    assert dl._is_ignored_logger("httpx")
+    assert dl._is_ignored_logger("httpx._client")
+    assert dl._is_ignored_logger("httpcore.connection")
+    assert not dl._is_ignored_logger("omnigent.server.routes.sessions")
+    assert not dl._is_ignored_logger("runner.native")
+
+
+def test_startup_probe_emits_sink_online(
+    _configured_env: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    # The startup probe emits a `sink_online` record so every boot has a
+    # definitive health signal (and revives the worker even when idle).
+    config = dl.config_from_env()
+    assert config is not None
+    sink = dl.ZerobusLogHandler(config, "server")
+    try:
+        with caplog.at_level(logging.INFO, logger="omnigent.debug_logging"):
+            sink._probe()
+        assert any(getattr(r, "event_name", None) == "sink_online" for r in caplog.records)
+    finally:
+        sink._probe_timer.cancel()
+        sink.close()
+
+
+def test_attach_is_noop_when_disabled() -> None:
+    target = logging.getLogger("test.debug_logging.disabled")
+    target.handlers.clear()
+    dl.attach_debug_log_sink([target], source="runner", level=logging.INFO)
+    assert not any(isinstance(h, dl.ZerobusLogHandler) for h in target.handlers)

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -219,3 +219,14 @@ def test_attach_is_noop_when_disabled() -> None:
     target.handlers.clear()
     dl.attach_debug_log_sink([target], source="runner", level=logging.INFO)
     assert not any(isinstance(h, dl.ZerobusLogHandler) for h in target.handlers)
+
+
+def test_runner_primary_session_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The host sets this when it spawns a runner for a session; runner-level
+    # callsites read it as the best-available attribution. Unset/empty is None.
+    monkeypatch.delenv(dl.PRIMARY_SESSION_ID_ENV_VAR, raising=False)
+    assert dl.runner_primary_session_id() is None
+    monkeypatch.setenv(dl.PRIMARY_SESSION_ID_ENV_VAR, "conv_primary")
+    assert dl.runner_primary_session_id() == "conv_primary"
+    monkeypatch.setenv(dl.PRIMARY_SESSION_ID_ENV_VAR, "")
+    assert dl.runner_primary_session_id() is None


### PR DESCRIPTION
## Related issue

Tracked in Linear **OMNI-4198** (Omnigent Debuggability). No GitHub issue to close.

## Summary

Adds an **opt-in, non-blocking logging sink** that streams Omnigent process logs
(server / runner / host / harness) into a Delta table, so a whole session's logs
can be queried in one place instead of being stitched together from per-pod files.

- **The sink** (`omnigent/debug_logging.py`): env-driven config, a `record_to_row()`
  serializer, an SP-minted ZeroBus token source, and a bounded-queue daemon uploader
  with batching + retry/backoff. It self-heals in `emit()` so it survives
  `logging.config.dictConfig()` (uvicorn startup) and `os.fork()` (the runner zygote)
  killing the worker thread. Chatty `httpx`/`httpcore` records are filtered out.
- **Wiring** (`process_logging.py`): the sink attaches to the same loggers as the
  on-disk file handler, so every entrypoint gets it from one place. It stays **off
  unless the `OMNIGENT_DEBUG_LOG_*` env vars are set** — OSS/customer behavior is
  unchanged. `host/connect.py` passes those four vars through the runner env
  allowlist (the one deliberate secret exception: SP creds for log upload to a
  trusted child process).
- **Explicit `session_id`**: passed via `extra=` at every log callsite where the
  conversation id is in scope — **177 sites** across `claude_native`,
  `claude_native_forwarder`, `runner/app`, `runner/native/orchestration`, and
  `server/.../orchestration`. Deterministic, no contextvars.

**ELI5:** every log line a session emits gets a copy shipped to a table in the
background, tagged with which conversation it belongs to — so we can ask "show me
everything that happened in session X" without hunting through pod log files.

```mermaid
flowchart LR
  A[_logger.info with extra session_id] --> B[root logger]
  B --> C[on-disk file handler]
  B --> D[ZerobusLogHandler]
  D --> E[bounded queue]
  E --> F[daemon uploader thread, batches with retry]
  F --> G[ZeroBus REST insert]
  G --> H[Delta table omnigent_debug_logs]
```

`turn_id` and `user_id` columns are reserved in the table but **deferred** — always
NULL for now.

## Test Plan

- `pytest tests/test_debug_logging.py` → **15 passed** (config parsing,
  `record_to_row` coercions, uploader self-heal after `close()`, startup probe,
  httpx/httpcore noise filter, session_id-from-`extra`).
- `ruff format` + `ruff check` clean on all touched files.
- `pyrefly check` clean on all 8 touched modules (0 errors).
- **End-to-end**: with `OMNIGENT_DEBUG_LOG_*` set against the ai-oss workspace,
  verified token mint (200) → ZeroBus insert (200) → rows landing in
  `omnigents.omnigent_daniel.omnigent_debug_logs`, including a boot-time
  `sink_online` probe row and real server/runner log rows carrying `session_id`.

## Demo

N/A — backend logging change, no UI.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the sink's pure logic (serialization, config parsing, self-heal,
noise filter). The network path (SP token mint → ZeroBus REST insert) depends on
live Databricks creds, so it was verified manually end-to-end: config → token (200)
→ insert (200) against the ai-oss workspace, confirming rows (the startup
`sink_online` probe plus session-tagged server/runner logs) appear in the target
table. The `session_id` wiring was verified with a paren-balanced audit of every
`_logger.*` call: **0** session-bearing callsites remain unwired across the five
in-scope modules.

This pull request and its description were written by Isaac.
