### PR TITLE
fix(web): flatten file-viewer settings into the overflow menu when collapsed

### DIFF
--- a/web/src/shell/FileViewer.test.tsx
+++ b/web/src/shell/FileViewer.test.tsx
@@ -281,6 +281,38 @@ function installContentWidth(width: number): void {
 }
 
 /**
+ * Force the header's inline toolbar into its collapsed "⋯" overflow state.
+ *
+ * useToolbarOverflow bails in jsdom (no ResizeObserver, zero clientWidth, and
+ * empty computed padding → NaN reserve), so the toolbar never collapses on its
+ * own. This stubs a ResizeObserver so the measure effect runs, numeric header
+ * padding so the reserve math resolves, and a tiny-but-positive header width
+ * that sits below the minimum required width (the title reserve alone is 48px),
+ * which flips `collapsed` to true. getComputedStyle is proxied (not replaced)
+ * so Radix's own positioning reads still see real values.
+ */
+function installCollapsedToolbar(): void {
+  class StubResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", StubResizeObserver);
+  const originalGetComputedStyle = window.getComputedStyle.bind(window);
+  vi.spyOn(window, "getComputedStyle").mockImplementation((el, pseudo) => {
+    const real = originalGetComputedStyle(el, pseudo ?? undefined);
+    return new Proxy(real, {
+      get(target, prop) {
+        if (prop === "paddingLeft" || prop === "paddingRight") return "0px";
+        const val = Reflect.get(target, prop);
+        return typeof val === "function" ? val.bind(target) : val;
+      },
+    });
+  });
+  vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(10);
+}
+
+/**
  * Simulate the iOS native shell and its live visual viewport. The keyboard
  * "opens" by shrinking the visual viewport below the layout viewport
  * (window.innerHeight); useIOSNativeKeyboardInset reads the delta. Pass
@@ -1302,6 +1334,62 @@ describe("FileViewer view-settings menu", () => {
     first.unmount();
     render(viewerTree({ open: true, initialSearch: "diff=1" }));
     expect(await screen.findByTestId("diff-viewer")).toHaveAttribute("data-wrap-lines", "true");
+  });
+});
+
+// ── Collapsed toolbar overflow "⋯" menu ─────────────────────────────────────
+//
+// When the header is too narrow for the inline action buttons, they all fold
+// into one "⋯" ("More actions") overflow menu. The settings menu's items
+// (Find, Download, and the diff-only wrap/whitespace toggles) are already
+// independent, so they flatten straight into this overflow rather than nesting
+// a second "⋯" submenu inside it. The mutually-exclusive view-mode picker still
+// collapses to a submenu (its "one selected choice" semantics need it).
+
+describe("FileViewer collapsed-toolbar overflow menu", () => {
+  beforeEach(() => {
+    useCommentsMock.mockReturnValue(makeCommentsQuery([]));
+    installCollapsedToolbar();
+  });
+
+  const openOverflowMenu = () =>
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions" }), { button: 0 });
+
+  it("collapses the inline actions into a single '⋯' overflow menu", () => {
+    render(viewerTree({ open: true }));
+    // The inline buttons are gone; only the single overflow trigger remains.
+    expect(screen.getByRole("button", { name: "More actions" })).toBeInTheDocument();
+  });
+
+  it("flattens the settings items into the overflow menu (no '⋯'-in-'⋯' submenu)", () => {
+    render(viewerTree({ open: true }));
+    openOverflowMenu();
+    // The settings items appear as flat rows in the overflow menu…
+    expect(screen.getByRole("menuitem", { name: "Find in file" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Download file" })).toBeInTheDocument();
+    // …and there is no nested "View settings" submenu trigger wrapping them.
+    expect(screen.queryByRole("menuitem", { name: "View settings" })).toBeNull();
+  });
+
+  it("flattens the diff-only wrap/whitespace toggles too, and they still work", async () => {
+    render(viewerTree({ open: true, initialSearch: "diff=1" }));
+    const diff = await screen.findByTestId("diff-viewer");
+    expect(diff).toHaveAttribute("data-wrap-lines", "false");
+    openOverflowMenu();
+    // Diff toggles are flat rows here, not behind a "View settings" submenu.
+    expect(screen.queryByRole("menuitem", { name: "View settings" })).toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Wrap lines" }));
+    expect(screen.getByTestId("diff-viewer")).toHaveAttribute("data-wrap-lines", "true");
+  });
+
+  it("keeps the mutually-exclusive view-mode picker as a submenu", () => {
+    render(viewerTree({ open: true, path: "notes.md" }));
+    openOverflowMenu();
+    // Markdown's Preview/Edit/Source picker still nests (a submenu trigger),
+    // since it carries a single highlighted "selected choice".
+    expect(screen.getByRole("menuitem", { name: "View mode" })).toBeInTheDocument();
+    // Its choices are not surfaced at the top level of the overflow menu.
+    expect(screen.queryByRole("menuitem", { name: "Preview" })).toBeNull();
   });
 });
 

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -1272,25 +1272,22 @@ function FileViewerBody({
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-auto min-w-40">
                   {toolbarActions.map((action) =>
-                    action.options || action.menu ? (
-                      // Pickers and settings menus collapse to a nested submenu
-                      // of their items. Toggle items (keepOpen) prevent the
-                      // submenu from closing so several can be flipped in a row.
+                    action.options ? (
+                      // A mutually-exclusive picker (e.g. view mode) collapses to
+                      // a nested submenu so its "selected choice" semantics — one
+                      // highlighted option — stay intact.
                       <DropdownMenuSub key={action.key}>
                         <DropdownMenuSubTrigger className="whitespace-nowrap">
                           {action.icon}
                           {action.tooltip ?? action.label}
                         </DropdownMenuSubTrigger>
                         <DropdownMenuSubContent>
-                          {(action.options ?? action.menu ?? []).map((option) => (
+                          {action.options.map((option) => (
                             <DropdownMenuItem
                               key={option.key}
-                              // Settings-menu items lean on the check mark alone;
-                              // the mutually-exclusive picker also highlights the
-                              // active choice.
                               className={cn(
                                 "whitespace-nowrap",
-                                action.options && option.active && "bg-muted dark:bg-muted/50",
+                                option.active && "bg-muted dark:bg-muted/50",
                               )}
                               onSelect={(e) => {
                                 if (option.keepOpen) e.preventDefault();
@@ -1306,6 +1303,26 @@ function FileViewerBody({
                           ))}
                         </DropdownMenuSubContent>
                       </DropdownMenuSub>
+                    ) : action.menu ? (
+                      // The settings menu's items are already independent
+                      // toggles/actions, so flatten them straight into this "⋯"
+                      // overflow rather than nesting a "⋯"-in-"⋯" submenu.
+                      action.menu.map((option) => (
+                        <DropdownMenuItem
+                          key={option.key}
+                          className="whitespace-nowrap"
+                          onSelect={(e) => {
+                            if (option.keepOpen) e.preventDefault();
+                            option.onSelect();
+                          }}
+                        >
+                          {option.icon}
+                          {option.label}
+                          {option.active && !option.noActiveCheck && (
+                            <CheckIcon className="ml-auto size-4" />
+                          )}
+                        </DropdownMenuItem>
+                      ))
                     ) : (
                       <DropdownMenuItem
                         key={action.key}


### PR DESCRIPTION
## Related issue

N/A — small UI fix.

## Summary

- When the file-viewer toolbar is too narrow for its inline action buttons, they collapse into a single overflow (`⋯`) menu. The "View settings" action is *itself* a `⋯`-icon menu, so it was being rendered as a nested submenu inside the overflow — producing a `⋯`-within-`⋯`.
- This flattens the settings menu's items (**Find in file**, **Download file**, and the diff-only **Wrap lines** / **Hide whitespace changes** toggles) directly into the overflow menu, since they're already independent toggles/actions.
- The mutually-exclusive **View mode** picker (Preview/Edit/Source) still collapses to a submenu — its "one selected choice" semantics need the nesting.

## Test Plan

- `cd web && npm test` — added 4 unit tests in `FileViewer.test.tsx` covering the collapsed overflow menu; the two flatten assertions were confirmed to fail against the pre-fix component and pass after.
- `cd web && npm run build` — passes (tsc + vite).
- Manual: open a file in the right-panel viewer, narrow the panel until the toolbar collapses to a single `⋯`, open it, and confirm Find/Download (and, in diff view, Wrap/Hide-whitespace) appear as flat rows with no nested "View settings" entry. A markdown file's View-mode picker still nests as a submenu.

Note: 3 pre-existing failures in `NewChatDialog.test.tsx` are unrelated to this change (confirmed failing on the base commit).

## Demo

Before: collapsed `⋯` overflow menu contained a nested "View settings ›" row opening a second `⋯` submenu.
After: Find in file, Download file (and diff toggles) render as flat rows directly in the overflow menu.

_(Text-only description — behavior is exercised by the new unit tests; the change is a menu-nesting flatten with no new visuals.)_

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added 4 unit tests that force the toolbar into its collapsed overflow state and assert the settings items are flattened (no nested `⋯` submenu) while the view-mode picker still nests. Verified the flatten assertions fail on the pre-fix component. Also manually verified in the running app as described in the Test Plan.

## Changelog

File viewer no longer nests a redundant "⋯" menu inside the "⋯" overflow when the toolbar collapses on a narrow panel

This pull request and its description were written by Isaac.
