### PR TITLE
fix(server): authorize session-scoped agents on single-user servers

### DIFF
--- a/omnigent/server/routes/_session_create_validation.py
+++ b/omnigent/server/routes/_session_create_validation.py
@@ -16,7 +16,7 @@ from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.model_override import validate_model_override
 from omnigent.reasoning_effort import EFFORT_VALUES, validate_effort
 from omnigent.runtime.agent_cache import AgentCache
-from omnigent.server.auth import LEVEL_READ
+from omnigent.server.auth import LEVEL_READ, RESERVED_USER_LOCAL, local_single_user_enabled
 from omnigent.server.routes._auth_helpers import require_access
 from omnigent.stores import AgentStore, ConversationStore, PermissionStore
 from omnigent.stores.host_store import host_is_live
@@ -84,8 +84,17 @@ async def validate_session_agent(
     # at least READ access to that owning session — otherwise they can execute
     # another user's private agent by guessing the raw agent id.
     if agent.session_id is not None:
+        # Single-user servers persist the local owner as NULL (scheduled tasks
+        # store user_id=None), but session grants are keyed by the "local"
+        # sentinel — the same identity POST /v1/sessions checks. Resolve None to
+        # it here so a session-scoped agent authorizes, instead of tripping the
+        # require_access unauthenticated guard. Multi-user servers leave None as
+        # None, which still correctly 401s.
+        access_user = user_id
+        if access_user is None and local_single_user_enabled():
+            access_user = RESERVED_USER_LOCAL
         await require_access(
-            user_id,
+            access_user,
             agent.session_id,
             LEVEL_READ,
             permission_store,

--- a/tests/server/routes/test_session_create_validation.py
+++ b/tests/server/routes/test_session_create_validation.py
@@ -1,0 +1,148 @@
+"""Tests for the shared session-create validation helper.
+
+Focused on :func:`validate_session_agent`'s owning-session authorization for
+session-scoped agents. The interactive ``POST /v1/sessions`` route and the
+scheduled-task create/fire paths all funnel through here, so a single-user
+server (which persists the local owner as ``None``) must authorize a
+session-scoped agent the same way the interactive route does with the ``local``
+sentinel — rather than tripping the ``require_access`` unauthenticated guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.auth import RESERVED_USER_LOCAL
+from omnigent.server.routes._session_create_validation import validate_session_agent
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.permission_store.sqlalchemy_store import (
+    SqlAlchemyPermissionStore,
+)
+
+
+@pytest.fixture()
+def agent_store(db_uri: str) -> SqlAlchemyAgentStore:
+    return SqlAlchemyAgentStore(db_uri)
+
+
+@pytest.fixture()
+def conv_store(db_uri: str) -> SqlAlchemyConversationStore:
+    return SqlAlchemyConversationStore(db_uri)
+
+
+@pytest.fixture()
+def perm_store(db_uri: str) -> SqlAlchemyPermissionStore:
+    return SqlAlchemyPermissionStore(db_uri)
+
+
+def _mint_session_agent(
+    conv_store: SqlAlchemyConversationStore,
+    *,
+    agent_id: str = "a0000000000000000000000000000010",
+) -> str:
+    """Mint a session-scoped agent and return its id."""
+    created = conv_store.create_session_with_agent(
+        agent_id=agent_id,
+        agent_name="claude-native-ui (fork ag_x)",
+        agent_bundle_location="ag_x/bundle",
+        agent_description=None,
+        title="session-scoped claude",
+    )
+    return created.agent.id
+
+
+@pytest.mark.asyncio
+async def test_single_user_none_authorizes_session_scoped_agent(
+    agent_store: SqlAlchemyAgentStore,
+    conv_store: SqlAlchemyConversationStore,
+    perm_store: SqlAlchemyPermissionStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Single-user ``None`` owner reaches a ``local``-owned session's agent.
+
+    The scheduled-task path persists the local owner as ``None``; grants are
+    keyed by the ``local`` sentinel. On a single-user server that ``None`` must
+    resolve to ``local`` so the owning-session READ check passes, instead of the
+    old 401.
+    """
+    monkeypatch.setattr(
+        "omnigent.server.routes._session_create_validation.local_single_user_enabled",
+        lambda: True,
+    )
+    agent_id = _mint_session_agent(conv_store)
+    # The mint's spawn-tree root is owned by the local sentinel, exactly as a
+    # single-user server records it.
+    agent = agent_store.get(agent_id)
+    assert agent is not None and agent.session_id is not None
+    perm_store.ensure_user(RESERVED_USER_LOCAL)
+    perm_store.grant(RESERVED_USER_LOCAL, agent.session_id, 4)
+
+    result = await validate_session_agent(
+        user_id=None,
+        agent_id=agent_id,
+        agent_store=agent_store,
+        permission_store=perm_store,
+        conversation_store=conv_store,
+    )
+    assert result.id == agent_id
+
+
+@pytest.mark.asyncio
+async def test_multi_user_none_still_unauthorized_for_session_scoped_agent(
+    agent_store: SqlAlchemyAgentStore,
+    conv_store: SqlAlchemyConversationStore,
+    perm_store: SqlAlchemyPermissionStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A multi-user server keeps 401ing an unauthenticated session-scoped bind.
+
+    Off the single-user path, ``None`` means "no identity" and the fail-closed
+    guard must still reject — the local fallback must not leak into multi-user.
+    """
+    monkeypatch.setattr(
+        "omnigent.server.routes._session_create_validation.local_single_user_enabled",
+        lambda: False,
+    )
+    agent_id = _mint_session_agent(conv_store)
+
+    with pytest.raises(OmnigentError) as excinfo:
+        await validate_session_agent(
+            user_id=None,
+            agent_id=agent_id,
+            agent_store=agent_store,
+            permission_store=perm_store,
+            conversation_store=conv_store,
+        )
+    assert excinfo.value.code == ErrorCode.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_template_agent_skips_owning_session_check(
+    agent_store: SqlAlchemyAgentStore,
+    conv_store: SqlAlchemyConversationStore,
+    perm_store: SqlAlchemyPermissionStore,
+) -> None:
+    """A template agent (no owning session) needs no access check.
+
+    This is the ``builtin``/template path a correctly-seeded harness resolves
+    to; it authorizes regardless of ``user_id``.
+    """
+    created = agent_store.create(
+        "a0000000000000000000000000000011",
+        "claude-native-ui",
+        "ag_tmpl/bundle",
+    )
+    assert created.session_id is None
+
+    result = await validate_session_agent(
+        user_id=None,
+        agent_id=created.id,
+        agent_store=agent_store,
+        permission_store=perm_store,
+        conversation_store=conv_store,
+    )
+    assert result.id == created.id


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- Creating a scheduled task (or firing one) with a **session-scoped agent** returned **401 Unauthorized** on a single-user (loopback) server.
- On a single-user server the local owner is persisted as `None` (scheduled tasks store `user_id=NULL`), but session grants are keyed by the `"local"` sentinel. The shared `validate_session_agent` therefore called `require_access(user_id=None, ...)`, whose fail-closed guard raises `UNAUTHORIZED` on `None` — even though the interactive `POST /v1/sessions` route passes `"local"` for the same identity and succeeds.
- Fix: in `validate_session_agent`, resolve `None → RESERVED_USER_LOCAL` for the owning-session READ check when the server is single-user (`local_single_user_enabled()`), matching the interactive route. Genuine multi-user servers leave `None` as `None`, so unauthenticated binds still correctly 401 (fail-closed preserved). One change covers both the create and fire paths, which both funnel through `validate_session_agent`.

## Test Plan

- New unit tests in `tests/server/routes/test_session_create_validation.py` (real SQLite-backed stores, no mocks):
  - single-user `None` authorizes a `local`-owned session-scoped agent (the regression);
  - multi-user `None` still 401s a session-scoped bind (fail-closed preserved);
  - template agents skip the owning-session check.
- `uv run pytest tests/server/routes/test_session_create_validation.py` → 3 passed.
- Ran related suites — `tests/server/integration/test_scheduled_tasks_routes.py`, `tests/server/routes/test_auth_helpers.py`, `tests/stores/test_agent_store.py` → 79 passed, no regressions.
- Reproduced live before the fix: `POST /v1/scheduled-tasks` with a session-scoped `claude-native-ui` agent returned 401 directly against a loopback server; the same request with a template agent returned 200.

## Demo

N/A — non-visual backend change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: against a local loopback server, a scheduled-task create with a session-scoped agent returned 401 before the fix and 200 after; a create with a template agent was unaffected (200 in both). Automated coverage added at the `validate_session_agent` chokepoint that both the create and fire paths share.

## Changelog

Creating an automation/scheduled task with a session-bound agent no longer fails with a 401 on local single-user servers.

This pull request and its description were written by Isaac.
