### PR TITLE
fix(deploy): use public PyPI URLs for Apps dependencies

### DIFF
--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -407,6 +407,20 @@ def run_uv_lock(src: Path) -> None:
         check=True,
     )
 
+    # Local uv configuration can rewrite the lockfile to the Databricks proxy,
+    # which may advertise artifacts that are unavailable at install time.
+    import runpy
+
+    normalize_text = runpy.run_path(
+        str(_repo_root() / "scripts" / "normalize_uv_lock_registry.py")
+    )["normalize_text"]
+    lockfile = src / "uv.lock"
+    original = lockfile.read_text()
+    normalized = normalize_text(original)
+    if normalized != original:
+        lockfile.write_text(normalized)
+        _log("normalized src/uv.lock to public PyPI URLs")
+
 
 def write_uv_dependency_files(
     src: Path,

--- a/deploy/databricks/src/app.yaml
+++ b/deploy/databricks/src/app.yaml
@@ -6,3 +6,5 @@ env:
     valueFrom: artifact_volume
   - name: OTEL_TRACES_SAMPLER
     value: 'always_on'
+  - name: UV_INDEX_URL
+    value: 'https://pypi.org/simple'

--- a/tests/deploy/test_databricks_pypi.py
+++ b/tests/deploy/test_databricks_pypi.py
@@ -1,0 +1,62 @@
+"""Databricks Apps dependency installation uses canonical public PyPI URLs."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_DEPLOY_PY = _ROOT / "deploy" / "databricks" / "deploy.py"
+
+
+@pytest.fixture(scope="module")
+def deploy_mod() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_databricks_deploy_pypi", _DEPLOY_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_uv_lock_normalizes_proxy_urls(
+    deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "normalize_uv_lock_registry.py").write_text(
+        (_ROOT / "scripts" / "normalize_uv_lock_registry.py").read_text()
+    )
+
+    def fake_run(*args: object, **kwargs: object) -> None:
+        del args
+        cwd = kwargs["cwd"]
+        assert isinstance(cwd, Path)
+        (cwd / "uv.lock").write_text(
+            'source = { registry = "https://pypi-proxy.example/simple/" }\n'
+            'sdist = { url = "https://pypi-proxy.example/packages/abc/pkg.tar.gz", '
+            'hash = "sha256:abc", size = 123 }\n'
+        )
+
+    monkeypatch.setattr(deploy_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(deploy_mod, "_repo_root", lambda: tmp_path)
+
+    deploy_mod.run_uv_lock(src)
+
+    normalized = (src / "uv.lock").read_text()
+    assert 'registry = "https://pypi.org/simple"' in normalized
+    assert "https://files.pythonhosted.org/packages/abc/pkg.tar.gz" in normalized
+    assert "size =" not in normalized
+
+
+def test_app_overrides_workspace_package_proxy() -> None:
+    source = (_ROOT / "deploy" / "databricks" / "src" / "app.yaml").read_text()
+    assert "name: UV_INDEX_URL" in source
+    assert "value: 'https://pypi.org/simple'" in source


### PR DESCRIPTION
## Related issue

Closes #5337

## Summary

Databricks Apps dependency installation can resolve packages from a workspace PyPI proxy that advertises artifacts which return HTTP 404 at install time. The app then remains unavailable even though the same packages are available on public PyPI.

This change:

- sets the app-level `UV_INDEX_URL` to public PyPI, overriding the incomplete workspace repository configuration;
- normalises generated `uv.lock` registry and artifact URLs to `pypi.org` and `files.pythonhosted.org`; and
- keeps the lockfile integrity hashes while removing index-specific size metadata.

ELI5:

```text
before: uv lock -> workspace proxy URL -> advertised Linux wheel -> HTTP 404
 after: uv lock -> canonical public PyPI URL -> dependency installs
```

## Test Plan

- `python -m pytest -q tests/deploy/test_databricks_pypi.py` -> **2 passed**.
- `python -m py_compile deploy/databricks/deploy.py`.
- `bash -n deploy/databricks/build.sh`.
- `git diff --check`.
- Live Databricks Apps verification: direct public PyPI installation succeeded from the Apps runtime, followed by a successful Omnigent startup and `/health` response.

## Demo

N/A — this is a deployment and dependency-resolution fix with no standalone visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test runs the deployment lock-normalisation helper against proxy-style registry and artifact URLs and verifies the app-level override. Manual verification covers the Databricks Apps build installing dependencies from public PyPI and starting successfully.

## Changelog

Databricks Apps deployments now avoid incomplete workspace PyPI proxy artifacts by using canonical public PyPI dependency URLs.
