### PR TITLE
feat(web): search archived sessions from settings

### DIFF
--- a/tests/e2e_ui/sessions/test_archived_search.py
+++ b/tests/e2e_ui/sessions/test_archived_search.py
@@ -1,0 +1,123 @@
+"""Browser e2e for the Archived settings view's search box.
+
+Settings → Archived (``/settings/archived``) offers a search box that narrows
+the archived list server-side (``GET /v1/sessions?search_query=``). The server
+matches a session when ``LOWER(title)`` or any of its items' ``search_text``
+contains the query as a substring, so distinctive seeded titles are enough to
+drive it. Typing is debounced, so the request trails the keystrokes; Playwright's
+retrying assertions absorb that delay.
+
+Search composes with the **Project** picker (both feed the same query), and a
+query that matches nothing shows a search-specific empty state rather than the
+plain "No archived sessions." copy.
+
+These drive the real chain the ``SettingsPage`` unit tests mock out: seed
+archived sessions over the REST API, load the view, and assert the filtered
+list, the no-match empty state, and the restore-on-clear against the live
+server. All seeded titles and project names carry a uuid suffix so the
+assertions are immune to other tests' sessions on the shared server.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.sessions.test_archived_project_filter import (
+    _delete_sessions,
+    _seed_archived_session,
+)
+
+# The search Input carries no testid; its aria-label is the stable handle.
+_SEARCH_LABEL = "Search archived sessions"
+
+
+def test_archived_search_narrows_and_clears(page: Page, live_server: str) -> None:
+    """Typing narrows the archived list to matching titles; clearing restores it.
+
+    Seeds three archived sessions whose titles share a uuid prefix, two of them
+    additionally sharing a ``keep`` marker. Searching the marker leaves exactly
+    those two, a query that matches nothing shows the search empty state, and
+    clearing the box brings all three back.
+    """
+    uniq = uuid.uuid4().hex[:6]
+    titles = {
+        "keep_one": f"e2e-archsearch-{uniq}-keep-one",
+        "keep_two": f"e2e-archsearch-{uniq}-keep-two",
+        "other": f"e2e-archsearch-{uniq}-other",
+    }
+    session_ids: list[str] = []
+    try:
+        for title in titles.values():
+            session_ids.append(_seed_archived_session(live_server, title=title, project=None))
+
+        page.goto(f"{live_server}/settings/archived")
+        rows = page.get_by_test_id("archived-row")
+        search = page.get_by_label(_SEARCH_LABEL)
+
+        # Unfiltered: all three rows are present (newest by updated_at, so they
+        # sort onto the first page even on a shared server).
+        for title in titles.values():
+            expect(rows.filter(has_text=title)).to_have_count(1)
+
+        # → the "keep" marker: exactly the two matching rows survive. The uuid
+        # makes the query unique server-wide, so the total count is exact.
+        search.fill(f"{uniq}-keep")
+        expect(rows).to_have_count(2)
+        expect(rows.filter(has_text=titles["keep_one"])).to_have_count(1)
+        expect(rows.filter(has_text=titles["keep_two"])).to_have_count(1)
+        expect(rows.filter(has_text=titles["other"])).to_have_count(0)
+
+        # → a query nothing can match: the search-specific empty state, not the
+        # plain "no archived sessions" copy.
+        search.fill(f"nomatch-{uuid.uuid4().hex}")
+        expect(rows).to_have_count(0)
+        expect(page.get_by_text("No archived sessions match.")).to_be_visible()
+
+        # Clearing restores the unfiltered list.
+        search.fill("")
+        for title in titles.values():
+            expect(rows.filter(has_text=title)).to_have_count(1)
+    finally:
+        _delete_sessions(live_server, session_ids)
+
+
+def test_archived_search_composes_with_the_project_filter(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Search narrows within the picked project instead of escaping it.
+
+    Seeds two archived sessions in one project and one in another, all sharing a
+    ``keep`` marker in their titles. Filtering to the first project and then
+    searching the marker must leave only that project's rows — the other
+    project's matching row stays hidden.
+    """
+    uniq = uuid.uuid4().hex[:6]
+    proj_a = f"E2E Search Alpha {uniq}"
+    proj_b = f"E2E Search Beta {uniq}"
+    titles = {
+        "a1": f"e2e-archsearchproj-{uniq}-keep-a1",
+        "a2": f"e2e-archsearchproj-{uniq}-keep-a2",
+        "b1": f"e2e-archsearchproj-{uniq}-keep-b1",
+    }
+    session_ids: list[str] = []
+    try:
+        session_ids.append(_seed_archived_session(live_server, title=titles["a1"], project=proj_a))
+        session_ids.append(_seed_archived_session(live_server, title=titles["a2"], project=proj_a))
+        session_ids.append(_seed_archived_session(live_server, title=titles["b1"], project=proj_b))
+
+        page.goto(f"{live_server}/settings/archived")
+        rows = page.get_by_test_id("archived-row")
+
+        page.get_by_test_id("archived-project-filter").click()
+        page.get_by_test_id(f"archived-project-option-{proj_a}").click()
+        expect(rows).to_have_count(2)
+
+        # The marker matches all three sessions, but only project A's are listed.
+        page.get_by_label(_SEARCH_LABEL).fill(f"{uniq}-keep")
+        expect(rows).to_have_count(2)
+        expect(rows.filter(has_text=titles["b1"])).to_have_count(0)
+    finally:
+        _delete_sessions(live_server, session_ids)

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -4,7 +4,7 @@
 // Archived sessions list (which moved here out of the sidebar).
 
 import type { ReactNode } from "react";
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -37,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   projectNames: [] as string[],
   hasNextPage: false,
   fetchNextPage: vi.fn(),
+  useConversationsCalls: vi.fn(),
 }));
 
 vi.mock("next-themes", () => ({
@@ -63,24 +64,30 @@ vi.mock("@/hooks/useConversations", async () => {
   // A stateful mock that emulates useInfiniteQuery pagination: it tracks how
   // many pages are "loaded" and reveals the next on fetchNextPage, so a click
   // on "Load more" re-renders with more rows (as the real hook would).
-  const { useState } = await import("react");
+  const { useEffect, useState } = await import("react");
   return {
     PROJECT_LABEL_KEY: "omni_project",
     // The Archived view drives the visible list from this hook; filter on the
     // fourth (`project`) arg so the mock mirrors the server-side ?project=
     // scoping.
     useConversations: (
-      _searchQuery?: string,
+      searchQuery = "",
       _includeArchived?: boolean,
       _options?: unknown,
       project?: string,
     ) => {
+      mocks.useConversationsCalls(searchQuery, _includeArchived, _options, project);
       // `mocks.pages` (array of per-page row arrays) drives multi-page tests;
       // otherwise serve a single page of `mocks.conversations`.
       const source = mocks.pages ?? [mocks.conversations];
       const [shown, setShown] = useState(1);
+      useEffect(() => setShown(1), [searchQuery, project]);
       const pages = source.slice(0, shown).map((rows) => ({
-        data: project ? rows.filter((c) => c.labels?.["omni_project"] === project) : rows,
+        data: rows.filter((c) => {
+          const matchesProject = !project || c.labels?.["omni_project"] === project;
+          const haystack = `${c.title ?? ""} ${c.search_snippet ?? ""}`.toLowerCase();
+          return matchesProject && (!searchQuery || haystack.includes(searchQuery.toLowerCase()));
+        }),
       }));
       return {
         data: { pages },
@@ -209,6 +216,7 @@ beforeEach(() => {
   mocks.bulkArchiveMutate.mockReset();
   mocks.bulkDeleteMutate.mockReset();
   mocks.fetchNextPage.mockReset();
+  mocks.useConversationsCalls.mockReset();
   mocks.theme = "system";
   mocks.accountsEnabled = true;
   mocks.loginUrl = "/login";
@@ -921,6 +929,84 @@ describe("SettingsPage", () => {
     });
     // Unarchiving opens the restored session (the mock mutate runs onSuccess).
     expect(screen.getByTestId("location").textContent).toBe("/c/conv_archived");
+  });
+
+  it("debounces archived-session search before querying", () => {
+    vi.useFakeTimers();
+    try {
+      renderPage("/settings/archived");
+      fireEvent.change(screen.getByRole("searchbox", { name: "Search archived sessions" }), {
+        target: { value: "needle" },
+      });
+
+      expect(mocks.useConversationsCalls).not.toHaveBeenCalledWith(
+        "needle",
+        true,
+        undefined,
+        undefined,
+      );
+      act(() => vi.advanceTimersByTime(299));
+      expect(mocks.useConversationsCalls).not.toHaveBeenCalledWith(
+        "needle",
+        true,
+        undefined,
+        undefined,
+      );
+      act(() => vi.advanceTimersByTime(1));
+      expect(mocks.useConversationsCalls).toHaveBeenCalledWith(
+        "needle",
+        true,
+        undefined,
+        undefined,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("combines archived project filtering with search", () => {
+    vi.useFakeTimers();
+    try {
+      mocks.projectNames = ["Alpha", "Beta"];
+      mocks.conversations = [
+        conv("a1", { archived: true, title: "Release notes", labels: { omni_project: "Alpha" } }),
+        conv("a2", { archived: true, title: "Planning", labels: { omni_project: "Alpha" } }),
+        conv("b1", { archived: true, title: "Release notes", labels: { omni_project: "Beta" } }),
+      ];
+      renderPage("/settings/archived");
+
+      fireEvent.change(screen.getByTestId("archived-project-filter"), {
+        target: { value: "project:Alpha" },
+      });
+      fireEvent.change(screen.getByRole("searchbox", { name: "Search archived sessions" }), {
+        target: { value: "release" },
+      });
+      act(() => vi.advanceTimersByTime(300));
+
+      expect(mocks.useConversationsCalls).toHaveBeenCalledWith("release", true, undefined, "Alpha");
+      const rows = screen.getAllByTestId("archived-row");
+      expect(rows).toHaveLength(1);
+      expect(within(rows[0]).getByText("Release notes")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows a search-specific empty state for archived sessions", () => {
+    vi.useFakeTimers();
+    try {
+      mocks.conversations = [conv("old", { archived: true, title: "Old chat" })];
+      renderPage("/settings/archived");
+
+      fireEvent.change(screen.getByRole("searchbox", { name: "Search archived sessions" }), {
+        target: { value: "missing" },
+      });
+      act(() => vi.advanceTimersByTime(300));
+
+      expect(screen.getByText("No archived sessions match.")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("deletes an archived session after confirming, with no row-click navigation", () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -52,6 +52,7 @@ import {
   PanelRightCloseIcon,
   PanelRightIcon,
   PlusIcon,
+  SearchIcon,
   SunIcon,
   SquareCheckIcon,
   SquareIcon,
@@ -1896,6 +1897,13 @@ function ImportSection() {
 function ArchivedSection() {
   // `undefined` = all projects; a name scopes the list to that project.
   const [project, setProject] = useState<string | undefined>(undefined);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setDebouncedSearch(search.trim()), 300);
+    return () => window.clearTimeout(timeout);
+  }, [search]);
 
   // Picker options: every project that has an archived session. Sourced from a
   // dedicated hook that pages through ALL archived sessions server-side —
@@ -1920,8 +1928,7 @@ function ArchivedSection() {
     }
   }, [project, projectNames, namesQuery.isSuccess, namesQuery.isFetching]);
 
-  // The visible list, filtered server-side via ?project= when one is picked.
-  const listQuery = useConversations("", true, undefined, project);
+  const listQuery = useConversations(debouncedSearch, true, undefined, project);
   const archived = useMemo(
     () => (listQuery.data?.pages ?? []).flatMap((p) => p.data).filter((c) => c.archived === true),
     [listQuery.data],
@@ -1988,7 +1995,21 @@ function ArchivedSection() {
       title="Archived sessions"
       description="Sessions you've archived. Restore one to the sidebar, or delete it for good."
     >
-      <div className="mb-4 flex items-center gap-2">
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <div className="relative min-w-56 flex-1">
+          <SearchIcon
+            aria-hidden
+            className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <Input
+            type="search"
+            aria-label="Search archived sessions"
+            placeholder="Search archived sessions"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            className="pl-9"
+          />
+        </div>
         {items.length > 0 && (
           <>
             <label htmlFor="archived-project-filter" className="text-ui text-muted-foreground">
@@ -2050,7 +2071,11 @@ function ArchivedSection() {
         // Definitive empty only when there are no archived rows AND no further
         // pages to fetch.
         <p className="text-ui text-muted-foreground">
-          {project ? "No archived sessions in this project." : "No archived sessions."}
+          {debouncedSearch
+            ? "No archived sessions match."
+            : project
+              ? "No archived sessions in this project."
+              : "No archived sessions."}
         </p>
       ) : (
         <>


### PR DESCRIPTION
## Related issue

Closes #5472

## Summary

Adds a search box on Settings > Archived. Input is debounced 300ms and sent as `search_query`. Project filter still works with search. Empty state when nothing matches.

## Test Plan

- `pnpm test src/pages/SettingsPage.test.tsx`
- `uv run pytest tests/e2e_ui/sessions/test_archived_search.py`
- Open Settings > Archived.
- Type a title. List updates after a short pause.
- Type something that matches nothing. Confirm empty state.
- Pick a project and search. Results match both.

## Demo

https://github.com/user-attachments/assets/92b7414e-fe2c-4ece-916d-893d25984415

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover debounce, search plus project filter, and the empty state. `tests/e2e_ui/sessions/test_archived_search.py` drives the same flow against a live server: seeded archived sessions, narrowing by title, the no match empty state, restoring on clear, and search scoped to a picked project.

## Changelog

Search archived sessions from Settings