### PR TITLE
feat(web): group typography settings with a searchable font picker

### DIFF
--- a/tests/e2e_ui/sessions/test_archived_search.py
+++ b/tests/e2e_ui/sessions/test_archived_search.py
@@ -1,0 +1,123 @@
+"""Browser e2e for the Archived settings view's search box.
+
+Settings → Archived (``/settings/archived``) offers a search box that narrows
+the archived list server-side (``GET /v1/sessions?search_query=``). The server
+matches a session when ``LOWER(title)`` or any of its items' ``search_text``
+contains the query as a substring, so distinctive seeded titles are enough to
+drive it. Typing is debounced, so the request trails the keystrokes; Playwright's
+retrying assertions absorb that delay.
+
+Search composes with the **Project** picker (both feed the same query), and a
+query that matches nothing shows a search-specific empty state rather than the
+plain "No archived sessions." copy.
+
+These drive the real chain the ``SettingsPage`` unit tests mock out: seed
+archived sessions over the REST API, load the view, and assert the filtered
+list, the no-match empty state, and the restore-on-clear against the live
+server. All seeded titles and project names carry a uuid suffix so the
+assertions are immune to other tests' sessions on the shared server.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.sessions.test_archived_project_filter import (
+    _delete_sessions,
+    _seed_archived_session,
+)
+
+# The search Input carries no testid; its aria-label is the stable handle.
+_SEARCH_LABEL = "Search archived sessions"
+
+
+def test_archived_search_narrows_and_clears(page: Page, live_server: str) -> None:
+    """Typing narrows the archived list to matching titles; clearing restores it.
+
+    Seeds three archived sessions whose titles share a uuid prefix, two of them
+    additionally sharing a ``keep`` marker. Searching the marker leaves exactly
+    those two, a query that matches nothing shows the search empty state, and
+    clearing the box brings all three back.
+    """
+    uniq = uuid.uuid4().hex[:6]
+    titles = {
+        "keep_one": f"e2e-archsearch-{uniq}-keep-one",
+        "keep_two": f"e2e-archsearch-{uniq}-keep-two",
+        "other": f"e2e-archsearch-{uniq}-other",
+    }
+    session_ids: list[str] = []
+    try:
+        for title in titles.values():
+            session_ids.append(_seed_archived_session(live_server, title=title, project=None))
+
+        page.goto(f"{live_server}/settings/archived")
+        rows = page.get_by_test_id("archived-row")
+        search = page.get_by_label(_SEARCH_LABEL)
+
+        # Unfiltered: all three rows are present (newest by updated_at, so they
+        # sort onto the first page even on a shared server).
+        for title in titles.values():
+            expect(rows.filter(has_text=title)).to_have_count(1)
+
+        # → the "keep" marker: exactly the two matching rows survive. The uuid
+        # makes the query unique server-wide, so the total count is exact.
+        search.fill(f"{uniq}-keep")
+        expect(rows).to_have_count(2)
+        expect(rows.filter(has_text=titles["keep_one"])).to_have_count(1)
+        expect(rows.filter(has_text=titles["keep_two"])).to_have_count(1)
+        expect(rows.filter(has_text=titles["other"])).to_have_count(0)
+
+        # → a query nothing can match: the search-specific empty state, not the
+        # plain "no archived sessions" copy.
+        search.fill(f"nomatch-{uuid.uuid4().hex}")
+        expect(rows).to_have_count(0)
+        expect(page.get_by_text("No archived sessions match.")).to_be_visible()
+
+        # Clearing restores the unfiltered list.
+        search.fill("")
+        for title in titles.values():
+            expect(rows.filter(has_text=title)).to_have_count(1)
+    finally:
+        _delete_sessions(live_server, session_ids)
+
+
+def test_archived_search_composes_with_the_project_filter(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Search narrows within the picked project instead of escaping it.
+
+    Seeds two archived sessions in one project and one in another, all sharing a
+    ``keep`` marker in their titles. Filtering to the first project and then
+    searching the marker must leave only that project's rows — the other
+    project's matching row stays hidden.
+    """
+    uniq = uuid.uuid4().hex[:6]
+    proj_a = f"E2E Search Alpha {uniq}"
+    proj_b = f"E2E Search Beta {uniq}"
+    titles = {
+        "a1": f"e2e-archsearchproj-{uniq}-keep-a1",
+        "a2": f"e2e-archsearchproj-{uniq}-keep-a2",
+        "b1": f"e2e-archsearchproj-{uniq}-keep-b1",
+    }
+    session_ids: list[str] = []
+    try:
+        session_ids.append(_seed_archived_session(live_server, title=titles["a1"], project=proj_a))
+        session_ids.append(_seed_archived_session(live_server, title=titles["a2"], project=proj_a))
+        session_ids.append(_seed_archived_session(live_server, title=titles["b1"], project=proj_b))
+
+        page.goto(f"{live_server}/settings/archived")
+        rows = page.get_by_test_id("archived-row")
+
+        page.get_by_test_id("archived-project-filter").click()
+        page.get_by_test_id(f"archived-project-option-{proj_a}").click()
+        expect(rows).to_have_count(2)
+
+        # The marker matches all three sessions, but only project A's are listed.
+        page.get_by_label(_SEARCH_LABEL).fill(f"{uniq}-keep")
+        expect(rows).to_have_count(2)
+        expect(rows.filter(has_text=titles["b1"])).to_have_count(0)
+    finally:
+        _delete_sessions(live_server, session_ids)

--- a/tests/e2e_ui/sessions/test_ui_font_family.py
+++ b/tests/e2e_ui/sessions/test_ui_font_family.py
@@ -1,11 +1,12 @@
-"""E2E: the Settings → Appearance font-family field re-fonts the UI and persists.
+"""E2E: the Settings → Appearance font-family picker re-fonts the UI and persists.
 
 The font-family control lives on the Settings page (``pages/SettingsPage.tsx``,
-``UiFontFamilyControl``): a free-text input (Cursor-style) plus a ``Reset``
-button under a ``role="group"`` labelled "Font family". Typing a name writes the
-choice to ``localStorage["omnigent:ui-font-family"]`` and applies it as the
-``--ui-font-family`` custom property on ``<html>`` (see
-``lib/uiFontPreferences.ts``). A blank field is "System default": the property is
+``UiFontFamilyControl``): a searchable combobox plus a ``Reset`` button under a
+``role="group"`` labelled "Font family". The combobox lists a few common families
+and offers whatever the user types as its own entry, so an unlisted font is still
+reachable. Choosing a name writes it to ``localStorage["omnigent:ui-font-family"]``
+and applies it as the ``--ui-font-family`` custom property on ``<html>`` (see
+``lib/uiFontPreferences.ts``). The "System" entry is the default: the property is
 removed and the ``html`` rule falls back to ``var(--font-sans)``.
 
 Because the whole rem-based UI inherits its font from the root ``html`` rule
@@ -21,6 +22,8 @@ from __future__ import annotations
 from playwright.sync_api import Page, expect
 
 STORAGE_KEY = "omnigent:ui-font-family"
+# Substring match: the real placeholder ends in a non-ASCII ellipsis.
+SEARCH_PLACEHOLDER = "Search or type a font"
 
 
 def _ui_font_family(page: Page) -> str:
@@ -42,36 +45,45 @@ def _open_appearance(page: Page, base_url: str) -> None:
     expect(page.get_by_role("group", name="Font family", exact=True)).to_be_visible(timeout=30_000)
 
 
-def test_ui_font_family_applies_and_persists(page: Page, seeded_session: tuple[str, str]) -> None:
-    """Typing a family updates the applied property + value live and survives reload.
+def _pick_typed_family(page: Page, family: str) -> None:
+    """Open the combobox, type ``family``, and take the "use what I typed" entry."""
+    page.get_by_test_id("ui-font-family-combobox").click()
+    page.get_by_placeholder(SEARCH_PLACEHOLDER).fill(family)
+    page.get_by_test_id("ui-font-family-combobox-use-typed").click()
 
-    A fresh context has no stored preference → empty field, no ``--ui-font-family``
-    override (the UI uses the system stack). Typing a name applies the property and
-    persists the choice; a page reload restores it (no reset, no flash to default).
+
+def test_ui_font_family_applies_and_persists(page: Page, seeded_session: tuple[str, str]) -> None:
+    """Choosing a family updates the applied property + trigger and survives reload.
+
+    A fresh context has no stored preference → the combobox reads "System" and no
+    ``--ui-font-family`` override is applied (the UI uses the system stack).
+    Choosing a name applies the property and persists the choice; a page reload
+    restores it (no reset, no flash to default).
     """
     base_url, _session_id = seeded_session
     _open_appearance(page, base_url)
 
-    value = page.get_by_test_id("ui-font-family-input")
+    trigger = page.get_by_test_id("ui-font-family-combobox")
 
-    # Fresh context → empty field, nothing stored, no override applied.
-    expect(value).to_have_value("")
+    # Fresh context → default entry selected, nothing stored, no override applied.
+    expect(trigger).to_have_text("System")
     assert _stored_family(page) is None, "expected no persisted family on a fresh load"
     assert _ui_font_family(page) == "", "fresh load should apply no family override"
 
-    # → "Georgia": the field, the applied property, and storage all move together.
-    # The applied value leads with the chosen family and appends the system stack
-    # (so an uninstalled/partial name degrades to the default sans, not serif), so
-    # the resolved custom property starts with — rather than equals — "Georgia".
-    value.fill("Georgia")
-    expect(value).to_have_value("Georgia")
-    assert _stored_family(page) == '"Georgia"', "the typed family was not persisted"
-    assert _ui_font_family(page).startswith("Georgia"), "root family did not track the typed name"
+    # → "Georgia": unlisted, so it arrives through the typed entry. The trigger,
+    # the applied property, and storage all move together. The applied value leads
+    # with the chosen family and appends the system stack (so an uninstalled or
+    # partial name degrades to the default sans, not serif), so the resolved
+    # custom property starts with — rather than equals — "Georgia".
+    _pick_typed_family(page, "Georgia")
+    expect(trigger).to_have_text("Georgia")
+    assert _stored_family(page) == '"Georgia"', "the chosen family was not persisted"
+    assert _ui_font_family(page).startswith("Georgia"), "root family did not track the choice"
 
     # The choice survives a full reload (persisted + re-applied before paint).
     page.reload()
     expect(page.get_by_role("group", name="Font family", exact=True)).to_be_visible(timeout=30_000)
-    expect(page.get_by_test_id("ui-font-family-input")).to_have_value("Georgia")
+    expect(page.get_by_test_id("ui-font-family-combobox")).to_have_text("Georgia")
     assert _ui_font_family(page).startswith("Georgia"), "family was not restored after reload"
 
 
@@ -86,16 +98,17 @@ def test_ui_font_family_reset_restores_system_default(
     page.evaluate(f"() => window.localStorage.setItem('{STORAGE_KEY}', '\"Georgia\"')")
     _open_appearance(page, base_url)
 
-    value = page.get_by_test_id("ui-font-family-input")
+    trigger = page.get_by_test_id("ui-font-family-combobox")
     reset = page.get_by_test_id("ui-font-family-reset")
 
     # The seeded family renders and is applied to the root (leading the appended
     # system-stack fallback, so the resolved value starts with "Georgia").
-    expect(value).to_have_value("Georgia")
+    expect(trigger).to_have_text("Georgia")
     assert _ui_font_family(page).startswith("Georgia")
 
-    # → Reset: the field clears, the override is removed, and the key is cleared.
+    # → Reset: the trigger returns to "System", the override is removed, and the
+    # key is cleared.
     reset.click()
-    expect(value).to_have_value("")
+    expect(trigger).to_have_text("System")
     assert _ui_font_family(page) == "", "the family override was not removed on reset"
     assert _stored_family(page) is None, "reset did not clear the persisted family"

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -209,6 +209,20 @@ function renderPage(path = "/settings") {
   );
 }
 
+async function chooseFont(comboboxTestId: string, label: string) {
+  fireEvent.click(screen.getByTestId(comboboxTestId));
+  fireEvent.click(await screen.findByTestId(`${comboboxTestId}-option-${label}`));
+}
+
+/** Pick an off-list font by typing its name into the search box. */
+async function typeFont(comboboxTestId: string, family: string) {
+  fireEvent.click(screen.getByTestId(comboboxTestId));
+  fireEvent.change(await screen.findByPlaceholderText(/search or type a font/i), {
+    target: { value: family },
+  });
+  fireEvent.click(await screen.findByTestId(`${comboboxTestId}-use-typed`));
+}
+
 beforeEach(() => {
   mocks.setTheme.mockReset();
   mocks.archiveMutate.mockReset();
@@ -494,20 +508,17 @@ describe("SettingsPage", () => {
     expect(screen.getByTestId("ui-font-size-inc")).not.toBeDisabled();
   });
 
-  it("shows the empty font family default and applies + persists a typed name", () => {
+  it("selects and persists an interface font from the combobox", async () => {
     localStorage.clear();
     document.documentElement.style.removeProperty("--ui-font-family");
     renderPage("/settings/appearance");
-    const input = screen.getByTestId("ui-font-family-input") as HTMLInputElement;
-    // No stored preference → empty input, System-default placeholder, no override.
-    expect(input.value).toBe("");
-    expect(input.placeholder).toBe("System default");
+    const combobox = screen.getByTestId("ui-font-family-combobox");
+    expect(combobox).toHaveTextContent("System");
     expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("");
-    // Reset has nothing to do at the default.
     expect(screen.getByTestId("ui-font-family-reset")).toBeDisabled();
 
-    fireEvent.change(input, { target: { value: "Inter" } });
-    expect(input.value).toBe("Inter");
+    await chooseFont("ui-font-family-combobox", "Inter");
+    expect(combobox).toHaveTextContent("Inter");
     // The choice is persisted so it survives a refresh...
     expect(localStorage.getItem("omnigent:ui-font-family")).toBe(JSON.stringify("Inter"));
     // ...and applied live to the document root, with the system stack appended
@@ -521,18 +532,16 @@ describe("SettingsPage", () => {
   it("reset restores the system default font family", () => {
     localStorage.setItem("omnigent:ui-font-family", JSON.stringify("Georgia"));
     renderPage("/settings/appearance");
-    const input = screen.getByTestId("ui-font-family-input") as HTMLInputElement;
-    // The control reflects the stored preference on mount.
-    expect(input.value).toBe("Georgia");
+    expect(screen.getByTestId("ui-font-family-combobox")).toHaveTextContent("Georgia");
 
     fireEvent.click(screen.getByTestId("ui-font-family-reset"));
-    // Reset clears the field, the applied property, and the stored key.
-    expect(input.value).toBe("");
+    // Reset clears the selection, the applied property, and the stored key.
+    expect(screen.getByTestId("ui-font-family-combobox")).toHaveTextContent("System");
     expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("");
     expect(localStorage.getItem("omnigent:ui-font-family")).toBeNull();
   });
 
-  it("resets every appearance preference back to product defaults", () => {
+  it("resets every appearance preference back to product defaults", async () => {
     localStorage.clear();
     renderPage("/settings/appearance");
 
@@ -548,14 +557,10 @@ describe("SettingsPage", () => {
     fireEvent.click(screen.getByTestId("hide-unconfigured-harnesses-toggle"));
     fireEvent.click(screen.getByTestId("ui-font-size-inc"));
     fireEvent.click(screen.getByTestId("ui-font-size-inc"));
-    fireEvent.change(screen.getByTestId("ui-font-family-input") as HTMLInputElement, {
-      target: { value: "Inter" },
-    });
+    await chooseFont("ui-font-family-combobox", "Inter");
     fireEvent.click(screen.getByTestId("code-font-size-inc"));
     fireEvent.click(screen.getByTestId("code-font-size-inc"));
-    fireEvent.change(screen.getByTestId("code-font-family-input") as HTMLInputElement, {
-      target: { value: "Fira Code" },
-    });
+    await chooseFont("code-font-family-combobox", "Fira Code");
     fireEvent.click(screen.getByTestId("heavier-code-text-toggle"));
 
     // Sanity: the non-default choices were persisted.
@@ -575,9 +580,9 @@ describe("SettingsPage", () => {
 
     // Fonts are back to their defaults.
     expect((screen.getByTestId("ui-font-size-input") as HTMLInputElement).value).toBe("13");
-    expect((screen.getByTestId("ui-font-family-input") as HTMLInputElement).value).toBe("");
+    expect(screen.getByTestId("ui-font-family-combobox")).toHaveTextContent("System");
     expect((screen.getByTestId("code-font-size-input") as HTMLInputElement).value).toBe("13");
-    expect((screen.getByTestId("code-font-family-input") as HTMLInputElement).value).toBe("");
+    expect(screen.getByTestId("code-font-family-combobox")).toHaveTextContent("Editor default");
     expect(document.documentElement.style.getPropertyValue("--desktop-ui-font-size")).toBe("13px");
     expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("");
     expect(localStorage.getItem("omnigent:ui-font-size")).toBeNull();
@@ -703,33 +708,43 @@ describe("SettingsPage", () => {
     expect(localStorage.getItem("omnigent:code-font-size")).toBe("10");
   });
 
-  it("shows the empty code font family default and applies + persists a typed name", () => {
+  it("applies an off-list code font typed into the search box", async () => {
     localStorage.clear();
     renderPage("/settings/appearance");
-    const input = screen.getByTestId("code-font-family-input") as HTMLInputElement;
-    // No stored preference → empty input, editor-default placeholder.
-    expect(input.value).toBe("");
-    expect(input.placeholder).toBe("Editor default");
-    // Reset has nothing to do at the default.
+    expect(screen.getByTestId("code-font-family-combobox")).toHaveTextContent("Editor default");
     expect(screen.getByTestId("code-font-family-reset")).toBeDisabled();
 
-    fireEvent.change(input, { target: { value: "Fira Code" } });
-    expect(input.value).toBe("Fira Code");
+    await typeFont("code-font-family-combobox", "Recursive Mono");
+    expect(screen.getByTestId("code-font-family-combobox")).toHaveTextContent("Recursive Mono");
+    expect(screen.queryByTestId("code-font-family-input")).toBeNull();
     // The choice is persisted under the code-font family key so it survives a refresh.
-    expect(localStorage.getItem("omnigent:code-font-family")).toBe(JSON.stringify("Fira Code"));
+    expect(localStorage.getItem("omnigent:code-font-family")).toBe(
+      JSON.stringify("Recursive Mono"),
+    );
     expect(screen.getByTestId("code-font-family-reset")).not.toBeDisabled();
+  });
+
+  it("offers a curated font by name instead of re-adding it as a typed entry", async () => {
+    localStorage.clear();
+    renderPage("/settings/appearance");
+    fireEvent.click(screen.getByTestId("code-font-family-combobox"));
+    fireEvent.change(await screen.findByPlaceholderText(/search or type a font/i), {
+      target: { value: "menlo" },
+    });
+    expect(screen.queryByTestId("code-font-family-combobox-use-typed")).toBeNull();
+    fireEvent.click(screen.getByTestId("code-font-family-combobox-option-Menlo"));
+    expect(localStorage.getItem("omnigent:code-font-family")).toBe(JSON.stringify("Menlo"));
   });
 
   it("reset restores the default code font family", () => {
     localStorage.setItem("omnigent:code-font-family", JSON.stringify("JetBrains Mono"));
     renderPage("/settings/appearance");
-    const input = screen.getByTestId("code-font-family-input") as HTMLInputElement;
     // The control reflects the stored preference on mount.
-    expect(input.value).toBe("JetBrains Mono");
+    expect(screen.getByTestId("code-font-family-combobox")).toHaveTextContent("JetBrains Mono");
 
     fireEvent.click(screen.getByTestId("code-font-family-reset"));
     // Reset clears the field and the stored key.
-    expect(input.value).toBe("");
+    expect(screen.getByTestId("code-font-family-combobox")).toHaveTextContent("Editor default");
     expect(localStorage.getItem("omnigent:code-font-family")).toBeNull();
   });
 
@@ -753,6 +768,64 @@ describe("SettingsPage", () => {
     localStorage.setItem("omnigent:code-font-weight", "100");
     renderPage("/settings/appearance");
     expect(screen.getByTestId("heavier-code-text-toggle")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("tracks the heavier code weight in the preview", () => {
+    localStorage.clear();
+    renderPage("/settings/appearance");
+    const preview = screen.getByTestId("code-font-preview");
+    expect(preview).toHaveStyle({ fontWeight: "400" });
+
+    fireEvent.click(screen.getByTestId("heavier-code-text-toggle"));
+    expect(preview).toHaveStyle({ fontWeight: "500" });
+  });
+
+  it("updates the code preview through the curated font selection path", async () => {
+    renderPage("/settings/appearance");
+    await chooseFont("code-font-family-combobox", "Fira Code");
+
+    const preview = screen.getByTestId("code-font-preview");
+    expect(preview).toHaveStyle({ fontFamily: "Fira Code, var(--font-mono)" });
+    expect(localStorage.getItem("omnigent:code-font-family")).toBe(JSON.stringify("Fira Code"));
+  });
+
+  it("advertises the appearance controls as clickable on hover", () => {
+    renderPage("/settings/appearance");
+    // Bare <button>s, so they don't inherit the shared Button's cursor.
+    expect(screen.getByTestId("ui-font-size-inc")).toHaveClass("cursor-pointer");
+    expect(screen.getByTestId("code-font-size-dec")).toHaveClass("cursor-pointer");
+    expect(screen.getByTestId("ui-font-family-combobox")).toHaveClass("cursor-pointer");
+  });
+
+  it("marks the typography groups up as headings, not as another option row", () => {
+    renderPage("/settings/appearance");
+    for (const name of [/^Interface$/, /^Editor & terminal$/]) {
+      expect(screen.getByRole("heading", { level: 3, name })).toBeInTheDocument();
+    }
+  });
+
+  it("updates the code preview for a font typed into the search box", async () => {
+    localStorage.clear();
+    renderPage("/settings/appearance");
+    await typeFont("code-font-family-combobox", "Recursive Mono");
+
+    expect(screen.getByTestId("code-font-preview")).toHaveStyle({
+      fontFamily: "Recursive Mono, var(--font-mono)",
+    });
+  });
+
+  it("renders the preview with the persisted code font and size", () => {
+    localStorage.setItem("omnigent:code-font-family", JSON.stringify("JetBrains Mono"));
+    localStorage.setItem("omnigent:code-font-size", "17");
+    renderPage("/settings/appearance");
+
+    const preview = screen.getByTestId("code-font-preview");
+    expect(preview).toHaveStyle({
+      fontFamily: "JetBrains Mono, var(--font-mono)",
+      fontSize: "17px",
+    });
+    // Preflight styles `code` itself, so styling only the <pre> has no effect.
+    expect(preview.tagName).toBe("CODE");
   });
 
   it("defaults bare /settings to Account when a login session exists, else Appearance", async () => {

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -4,7 +4,7 @@
 // Archived sessions list (which moved here out of the sidebar).
 
 import type { ReactNode } from "react";
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -37,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   projectNames: [] as string[],
   hasNextPage: false,
   fetchNextPage: vi.fn(),
+  useConversationsCalls: vi.fn(),
 }));
 
 vi.mock("next-themes", () => ({
@@ -63,24 +64,30 @@ vi.mock("@/hooks/useConversations", async () => {
   // A stateful mock that emulates useInfiniteQuery pagination: it tracks how
   // many pages are "loaded" and reveals the next on fetchNextPage, so a click
   // on "Load more" re-renders with more rows (as the real hook would).
-  const { useState } = await import("react");
+  const { useEffect, useState } = await import("react");
   return {
     PROJECT_LABEL_KEY: "omni_project",
     // The Archived view drives the visible list from this hook; filter on the
     // fourth (`project`) arg so the mock mirrors the server-side ?project=
     // scoping.
     useConversations: (
-      _searchQuery?: string,
+      searchQuery = "",
       _includeArchived?: boolean,
       _options?: unknown,
       project?: string,
     ) => {
+      mocks.useConversationsCalls(searchQuery, _includeArchived, _options, project);
       // `mocks.pages` (array of per-page row arrays) drives multi-page tests;
       // otherwise serve a single page of `mocks.conversations`.
       const source = mocks.pages ?? [mocks.conversations];
       const [shown, setShown] = useState(1);
+      useEffect(() => setShown(1), [searchQuery, project]);
       const pages = source.slice(0, shown).map((rows) => ({
-        data: project ? rows.filter((c) => c.labels?.["omni_project"] === project) : rows,
+        data: rows.filter((c) => {
+          const matchesProject = !project || c.labels?.["omni_project"] === project;
+          const haystack = `${c.title ?? ""} ${c.search_snippet ?? ""}`.toLowerCase();
+          return matchesProject && (!searchQuery || haystack.includes(searchQuery.toLowerCase()));
+        }),
       }));
       return {
         data: { pages },
@@ -209,6 +216,7 @@ beforeEach(() => {
   mocks.bulkArchiveMutate.mockReset();
   mocks.bulkDeleteMutate.mockReset();
   mocks.fetchNextPage.mockReset();
+  mocks.useConversationsCalls.mockReset();
   mocks.theme = "system";
   mocks.accountsEnabled = true;
   mocks.loginUrl = "/login";
@@ -921,6 +929,84 @@ describe("SettingsPage", () => {
     });
     // Unarchiving opens the restored session (the mock mutate runs onSuccess).
     expect(screen.getByTestId("location").textContent).toBe("/c/conv_archived");
+  });
+
+  it("debounces archived-session search before querying", () => {
+    vi.useFakeTimers();
+    try {
+      renderPage("/settings/archived");
+      fireEvent.change(screen.getByRole("searchbox", { name: "Search archived sessions" }), {
+        target: { value: "needle" },
+      });
+
+      expect(mocks.useConversationsCalls).not.toHaveBeenCalledWith(
+        "needle",
+        true,
+        undefined,
+        undefined,
+      );
+      act(() => vi.advanceTimersByTime(299));
+      expect(mocks.useConversationsCalls).not.toHaveBeenCalledWith(
+        "needle",
+        true,
+        undefined,
+        undefined,
+      );
+      act(() => vi.advanceTimersByTime(1));
+      expect(mocks.useConversationsCalls).toHaveBeenCalledWith(
+        "needle",
+        true,
+        undefined,
+        undefined,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("combines archived project filtering with search", () => {
+    vi.useFakeTimers();
+    try {
+      mocks.projectNames = ["Alpha", "Beta"];
+      mocks.conversations = [
+        conv("a1", { archived: true, title: "Release notes", labels: { omni_project: "Alpha" } }),
+        conv("a2", { archived: true, title: "Planning", labels: { omni_project: "Alpha" } }),
+        conv("b1", { archived: true, title: "Release notes", labels: { omni_project: "Beta" } }),
+      ];
+      renderPage("/settings/archived");
+
+      fireEvent.change(screen.getByTestId("archived-project-filter"), {
+        target: { value: "project:Alpha" },
+      });
+      fireEvent.change(screen.getByRole("searchbox", { name: "Search archived sessions" }), {
+        target: { value: "release" },
+      });
+      act(() => vi.advanceTimersByTime(300));
+
+      expect(mocks.useConversationsCalls).toHaveBeenCalledWith("release", true, undefined, "Alpha");
+      const rows = screen.getAllByTestId("archived-row");
+      expect(rows).toHaveLength(1);
+      expect(within(rows[0]).getByText("Release notes")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows a search-specific empty state for archived sessions", () => {
+    vi.useFakeTimers();
+    try {
+      mocks.conversations = [conv("old", { archived: true, title: "Old chat" })];
+      renderPage("/settings/archived");
+
+      fireEvent.change(screen.getByRole("searchbox", { name: "Search archived sessions" }), {
+        target: { value: "missing" },
+      });
+      act(() => vi.advanceTimersByTime(300));
+
+      expect(screen.getByText("No archived sessions match.")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("deletes an archived session after confirming, with no row-click navigation", () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -52,6 +52,7 @@ import {
   PanelRightCloseIcon,
   PanelRightIcon,
   PlusIcon,
+  SearchIcon,
   SunIcon,
   SquareCheckIcon,
   SquareIcon,
@@ -1896,6 +1897,13 @@ function ImportSection() {
 function ArchivedSection() {
   // `undefined` = all projects; a name scopes the list to that project.
   const [project, setProject] = useState<string | undefined>(undefined);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setDebouncedSearch(search.trim()), 300);
+    return () => window.clearTimeout(timeout);
+  }, [search]);
 
   // Picker options: every project that has an archived session. Sourced from a
   // dedicated hook that pages through ALL archived sessions server-side —
@@ -1920,8 +1928,7 @@ function ArchivedSection() {
     }
   }, [project, projectNames, namesQuery.isSuccess, namesQuery.isFetching]);
 
-  // The visible list, filtered server-side via ?project= when one is picked.
-  const listQuery = useConversations("", true, undefined, project);
+  const listQuery = useConversations(debouncedSearch, true, undefined, project);
   const archived = useMemo(
     () => (listQuery.data?.pages ?? []).flatMap((p) => p.data).filter((c) => c.archived === true),
     [listQuery.data],
@@ -1988,7 +1995,21 @@ function ArchivedSection() {
       title="Archived sessions"
       description="Sessions you've archived. Restore one to the sidebar, or delete it for good."
     >
-      <div className="mb-4 flex items-center gap-2">
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <div className="relative min-w-56 flex-1">
+          <SearchIcon
+            aria-hidden
+            className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <Input
+            type="search"
+            aria-label="Search archived sessions"
+            placeholder="Search archived sessions"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            className="pl-9"
+          />
+        </div>
         {items.length > 0 && (
           <>
             <label htmlFor="archived-project-filter" className="text-ui text-muted-foreground">
@@ -2050,7 +2071,11 @@ function ArchivedSection() {
         // Definitive empty only when there are no archived rows AND no further
         // pages to fetch.
         <p className="text-ui text-muted-foreground">
-          {project ? "No archived sessions in this project." : "No archived sessions."}
+          {debouncedSearch
+            ? "No archived sessions match."
+            : project
+              ? "No archived sessions in this project."
+              : "No archived sessions."}
         </p>
       ) : (
         <>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -41,6 +41,8 @@ import {
 import {
   ArchiveRestoreIcon,
   AlertTriangleIcon,
+  ChevronDownIcon,
+  CodeIcon,
   KeyRoundIcon,
   Loader2Icon,
   LaptopMinimalIcon,
@@ -58,6 +60,7 @@ import {
   SquareIcon,
   TerminalIcon,
   Trash2Icon,
+  TypeIcon,
   UserCogIcon,
   XIcon,
 } from "lucide-react";
@@ -71,7 +74,16 @@ import {
   PaletteSwatchPreview,
 } from "@/components/theme/AppearancePreviews";
 import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
 import {
   Select,
@@ -144,6 +156,7 @@ import {
   writeCodeFontFamily,
   writeCodeFontSizePx,
   writeCodeFontWeight,
+  type CodeFontWeight,
 } from "@/lib/codeFontPreferences";
 import {
   readTerminalThemeMode,
@@ -838,19 +851,7 @@ function AppearanceSection() {
 
         <HideUnconfiguredHarnessesControl />
 
-        <UiFontSizeControl />
-
-        <UiFontFamilyControl />
-
-        {/* Code font (Monaco + xterm) sits as its own rows — labelled in full
-            ("Code font size" / "Code font family" / "Code font weight") rather than under a shared
-            heading — so each control reads unambiguously next to the UI-font rows
-            above and it's clear these don't scale the surrounding chrome. */}
-        <UiCodeFontSizeControl />
-
-        <UiCodeFontFamilyControl />
-
-        <UiCodeFontWeightControl />
+        <TypographyControl />
       </div>
 
       <div className="mt-8 flex items-center justify-end">
@@ -982,6 +983,70 @@ function DefaultBaseBranchControl() {
   );
 }
 
+function TypographyControl() {
+  const [codeSize, setCodeSize] = useState(() => readCodeFontSizePx());
+  const [codeFamily, setCodeFamily] = useState(() => readCodeFontFamily());
+  const [codeWeight, setCodeWeight] = useState(() => readCodeFontWeight());
+  const labelId = useId();
+
+  return (
+    <ThemeSubsection
+      labelId={labelId}
+      title="Typography"
+      helper="Choose fonts for the app chrome and coding surfaces."
+    >
+      <div className="flex flex-col gap-3">
+        <TypographyGroup
+          icon={TypeIcon}
+          title="Interface"
+          hint="Affects menus, settings, sidebars, and conversation text."
+        >
+          <UiFontSizeControl />
+          <UiFontFamilyControl />
+        </TypographyGroup>
+
+        <TypographyGroup
+          icon={CodeIcon}
+          title="Editor & terminal"
+          hint="Affects source code, diffs, and terminal output."
+        >
+          <UiCodeFontSizeControl onValueChange={setCodeSize} />
+          <UiCodeFontFamilyControl onValueChange={setCodeFamily} />
+          <UiCodeFontWeightControl onValueChange={setCodeWeight} />
+          <CodeFontPreview size={codeSize} family={codeFamily} weight={codeWeight} />
+        </TypographyGroup>
+      </div>
+    </ThemeSubsection>
+  );
+}
+
+function TypographyGroup({
+  icon: Icon,
+  title,
+  hint,
+  children,
+}: {
+  icon: typeof TypeIcon;
+  title: string;
+  hint: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border bg-card/55 shadow-xs">
+      <div className="flex items-center gap-2.5 border-b border-border/70 px-4 py-3">
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+          <Icon className="size-4" />
+        </span>
+        <div className="min-w-0">
+          <h3 className="text-ui font-semibold">{title}</h3>
+          <p className="text-sm text-muted-foreground">{hint}</p>
+        </div>
+      </div>
+      <div className="flex flex-col gap-5 p-4">{children}</div>
+    </div>
+  );
+}
+
 /**
  * Desktop UI font size stepper. Maps one of the supported discrete px values
  * into typography tokens via --desktop-ui-font-size (see
@@ -1032,8 +1097,8 @@ function UiFontSizeControl() {
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
-      <div className="flex flex-col">
-        <span className="text-ui font-medium">Interface font size</span>
+      <div className="flex flex-col gap-0.5">
+        <span className="text-ui font-medium">Size</span>
         <span className="text-sm text-muted-foreground">
           Set text across the desktop interface. Icons and spacing stay fixed.
         </span>
@@ -1089,14 +1154,129 @@ function UiFontSizeControl() {
   );
 }
 
-/**
- * UI font family picker. Free-text (Cursor-style): type any font installed on
- * this device; blank means "System default", which falls back to the existing
- * --font-sans stack. Applies live and persists on every change via the
- * --ui-font-family variable (see lib/uiFontPreferences.ts). Like the size
- * control it stays visible when embedded — a per-device readability pref that
- * doesn't conflict with host theming.
- */
+const UI_FONT_OPTIONS = [
+  { label: "System", value: "" },
+  { label: "Inter", value: "Inter" },
+  { label: "Helvetica Neue", value: "Helvetica Neue" },
+  { label: "Arial", value: "Arial" },
+  { label: "Verdana", value: "Verdana" },
+] as const;
+
+/** "Editor default" is the shared mono stack, whose first face is Geist Mono. */
+const CODE_FONT_OPTIONS = [
+  { label: "Editor default", value: "" },
+  { label: "Menlo", value: "Menlo" },
+  { label: "Monaco", value: "Monaco" },
+  { label: "SF Mono", value: "SF Mono" },
+  { label: "Courier New", value: "Courier New" },
+  { label: "Consolas", value: "Consolas" },
+  { label: "JetBrains Mono", value: "JetBrains Mono" },
+  { label: "Fira Code", value: "Fira Code" },
+] as const;
+
+function FontFamilyCombobox({
+  ariaLabel,
+  testId,
+  value,
+  defaultLabel,
+  options,
+  fallback,
+  onChange,
+}: {
+  ariaLabel: string;
+  testId: string;
+  value: string;
+  defaultLabel: string;
+  options: readonly { label: string; value: string }[];
+  /** Stack appended behind each option so a missing face still renders. */
+  fallback: string;
+  onChange: (value: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const choose = (next: string) => {
+    onChange(next);
+    setQuery("");
+    setOpen(false);
+  };
+
+  const preview = (family: string) =>
+    family ? { fontFamily: `${family}, ${fallback}` } : undefined;
+
+  const typed = query.trim();
+  const typedIsNew =
+    typed !== "" && !options.some((option) => option.label.toLowerCase() === typed.toLowerCase());
+
+  const selectedLabel =
+    options.find((option) => option.value === value)?.label || value.trim() || defaultLabel;
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setQuery("");
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-label={ariaLabel}
+          aria-expanded={open}
+          data-testid={testId}
+          className="h-9 w-56 cursor-pointer justify-between font-normal"
+        >
+          <span className="truncate" style={preview(value)}>
+            {selectedLabel}
+          </span>
+          <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-64 p-0">
+        <Command>
+          <CommandInput
+            placeholder="Search or type a font name…"
+            value={query}
+            onValueChange={setQuery}
+          />
+          <CommandList>
+            <CommandEmpty>No fonts found.</CommandEmpty>
+            <CommandGroup>
+              {typedIsNew && (
+                <CommandItem
+                  value={typed}
+                  data-testid={`${testId}-use-typed`}
+                  onSelect={() => choose(typed)}
+                >
+                  <span className="truncate" style={preview(typed)}>
+                    Use “{typed}”
+                  </span>
+                </CommandItem>
+              )}
+              {options.map((option) => (
+                <CommandItem
+                  key={option.label}
+                  value={option.label}
+                  data-checked={option.value === value}
+                  data-testid={`${testId}-option-${option.label}`}
+                  onSelect={() => choose(option.value)}
+                >
+                  <span className="truncate" style={preview(option.value)}>
+                    {option.label}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 function UiFontFamilyControl() {
   const [family, setFamily] = useState(() => readUiFontFamily());
 
@@ -1113,10 +1293,10 @@ function UiFontFamilyControl() {
       {/* Take the remaining width (and let the longer description wrap within
           this column) so the input stays inline instead of dropping to its own
           row — matches the font-size row's alignment. */}
-      <div className="flex min-w-0 flex-1 flex-col">
-        <span className="text-ui font-medium">Font family</span>
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="text-ui font-medium">Family</span>
         <span className="text-sm text-muted-foreground">
-          Use any font installed on this device. Leave blank for the system default.
+          Use any font installed on this device.
         </span>
       </div>
       {/* Reset sits left of the input so the input is the rightmost element and
@@ -1135,17 +1315,14 @@ function UiFontFamilyControl() {
         >
           Reset
         </Button>
-        <Input
-          type="text"
-          aria-label="UI font family"
-          data-testid="ui-font-family-input"
-          placeholder="System default"
-          spellCheck={false}
-          autoCapitalize="off"
-          autoCorrect="off"
-          className="h-9 w-56"
+        <FontFamilyCombobox
+          ariaLabel="UI font family"
+          testId="ui-font-family-combobox"
+          defaultLabel="System"
+          options={UI_FONT_OPTIONS}
+          fallback="var(--font-sans)"
           value={family}
-          onChange={(e) => update(e.target.value)}
+          onChange={update}
         />
       </div>
     </div>
@@ -1159,7 +1336,7 @@ function UiFontFamilyControl() {
  * lib/codeFontPreferences.ts). Same free-editing draft/commit + blur-clamp
  * behavior as UiFontSizeControl; only the bounds and storage differ.
  */
-function UiCodeFontSizeControl() {
+function UiCodeFontSizeControl({ onValueChange }: { onValueChange?: (value: number) => void }) {
   // `px` is the committed value; `draft` is the raw text in the box, kept
   // separate so a transient out-of-range/empty mid-edit state isn't clamped or
   // persisted on every keystroke. We only commit while typing when the draft is
@@ -1167,25 +1344,33 @@ function UiCodeFontSizeControl() {
   const [px, setPx] = useState(() => readCodeFontSizePx());
   const [draft, setDraft] = useState(() => String(px));
 
-  const commit = useCallback((next: number) => {
-    const clamped = clampCodeFontSizePx(next);
-    setPx(clamped);
-    setDraft(String(clamped));
-    writeCodeFontSizePx(clamped);
-  }, []);
+  const commit = useCallback(
+    (next: number) => {
+      const clamped = clampCodeFontSizePx(next);
+      setPx(clamped);
+      setDraft(String(clamped));
+      writeCodeFontSizePx(clamped);
+      onValueChange?.(clamped);
+    },
+    [onValueChange],
+  );
 
-  const onDraftChange = useCallback((text: string) => {
-    setDraft(text);
-    // Apply live only once the field holds a valid, in-range whole number;
-    // leave partial/out-of-range/empty drafts untouched until blur.
-    if (/^\d+$/.test(text)) {
-      const value = Number(text);
-      if (value >= CODE_FONT_SIZE_MIN && value <= CODE_FONT_SIZE_MAX) {
-        setPx(value);
-        writeCodeFontSizePx(value);
+  const onDraftChange = useCallback(
+    (text: string) => {
+      setDraft(text);
+      // Apply live only once the field holds a valid, in-range whole number;
+      // leave partial/out-of-range/empty drafts untouched until blur.
+      if (/^\d+$/.test(text)) {
+        const value = Number(text);
+        if (value >= CODE_FONT_SIZE_MIN && value <= CODE_FONT_SIZE_MAX) {
+          setPx(value);
+          writeCodeFontSizePx(value);
+          onValueChange?.(value);
+        }
       }
-    }
-  }, []);
+    },
+    [onValueChange],
+  );
 
   // Clamp and re-sync the text to the committed value. An empty or invalid
   // draft reverts to the last committed size rather than a bogus one.
@@ -1199,8 +1384,8 @@ function UiCodeFontSizeControl() {
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
-      <div className="flex flex-col">
-        <span className="text-ui font-medium">Code font size</span>
+      <div className="flex flex-col gap-0.5">
+        <span className="text-ui font-medium">Size</span>
         <span className="text-sm text-muted-foreground">
           Size of code in the editor and terminal.
         </span>
@@ -1256,28 +1441,26 @@ function UiCodeFontSizeControl() {
   );
 }
 
-/**
- * Code font family picker. Free-text (Cursor-style): type any monospace font
- * installed on this device; blank means the editor/terminal default (the shared
- * mono stack). Applies live and persists on every change via the code-font
- * pub/sub (see lib/codeFontPreferences.ts). Mirrors UiFontFamilyControl.
- */
-function UiCodeFontFamilyControl() {
+function UiCodeFontFamilyControl({ onValueChange }: { onValueChange?: (value: string) => void }) {
   const [family, setFamily] = useState(() => readCodeFontFamily());
 
-  const update = useCallback((next: string) => {
-    setFamily(next);
-    writeCodeFontFamily(next);
-  }, []);
+  const update = useCallback(
+    (next: string) => {
+      setFamily(next);
+      writeCodeFontFamily(next);
+      onValueChange?.(next);
+    },
+    [onValueChange],
+  );
 
   const isDefault = family.trim() === CODE_FONT_FAMILY_DEFAULT;
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
-      <div className="flex min-w-0 flex-1 flex-col">
-        <span className="text-ui font-medium">Code font family</span>
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="text-ui font-medium">Family</span>
         <span className="text-sm text-muted-foreground">
-          Font for the code editor and terminal. Leave blank for the default.
+          Font for the code editor and terminal.
         </span>
       </div>
       {/* Reset sits left of the input so the input's right edge lines up flush
@@ -1296,17 +1479,14 @@ function UiCodeFontFamilyControl() {
         >
           Reset
         </Button>
-        <Input
-          type="text"
-          aria-label="Code font family"
-          data-testid="code-font-family-input"
-          placeholder="Editor default"
-          spellCheck={false}
-          autoCapitalize="off"
-          autoCorrect="off"
-          className="h-9 w-56"
+        <FontFamilyCombobox
+          ariaLabel="Code font family"
+          testId="code-font-family-combobox"
+          defaultLabel="Editor default"
+          options={CODE_FONT_OPTIONS}
+          fallback="var(--font-mono)"
           value={family}
-          onChange={(e) => update(e.target.value)}
+          onChange={update}
         />
       </div>
     </div>
@@ -1314,12 +1494,18 @@ function UiCodeFontFamilyControl() {
 }
 
 /** Font weight preset shared by Monaco and xterm code surfaces. */
-function UiCodeFontWeightControl() {
+function UiCodeFontWeightControl({
+  onValueChange,
+}: {
+  onValueChange?: (value: CodeFontWeight) => void;
+}) {
   const [heavier, setHeavier] = useState(() => readCodeFontWeight() === CODE_FONT_WEIGHT_HEAVIER);
 
   const toggle = (enabled: boolean) => {
+    const weight = enabled ? CODE_FONT_WEIGHT_HEAVIER : CODE_FONT_WEIGHT_NORMAL;
     setHeavier(enabled);
-    writeCodeFontWeight(enabled ? CODE_FONT_WEIGHT_HEAVIER : CODE_FONT_WEIGHT_NORMAL);
+    writeCodeFontWeight(weight);
+    onValueChange?.(weight);
   };
 
   return (
@@ -1338,6 +1524,35 @@ function UiCodeFontWeightControl() {
         className="shrink-0"
         componentId="settings.appearance.heavier_code_text"
       />
+    </div>
+  );
+}
+
+function CodeFontPreview({
+  size,
+  family,
+  weight,
+}: {
+  size: number;
+  family: string;
+  weight: CodeFontWeight;
+}) {
+  return (
+    <div className="min-w-0 self-stretch rounded-lg border bg-muted/35 p-3">
+      <div className="mb-2 text-sm font-medium text-muted-foreground">Preview</div>
+      <pre className="overflow-x-auto whitespace-pre rounded-md bg-background/80 p-3 leading-relaxed">
+        {/* Styled here, not on <pre>: preflight sets font-family on `code`. */}
+        <code
+          data-testid="code-font-preview"
+          style={{
+            fontFamily: family ? `${family}, var(--font-mono)` : "var(--font-mono)",
+            fontSize: `${size}px`,
+            fontWeight: weight,
+          }}
+        >{`const greet = (name) => {
+  return \`Hello, \${name}!\`;
+};`}</code>
+      </pre>
     </div>
   );
 }
@@ -1370,7 +1585,7 @@ function StepperButton({
         onClick();
       }}
       className={cn(
-        "flex w-9 items-center justify-center text-muted-foreground transition-colors",
+        "flex w-9 cursor-pointer items-center justify-center text-muted-foreground transition-colors",
         "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50",
         "disabled:pointer-events-none disabled:opacity-40",
       )}
@@ -1928,6 +2143,8 @@ function ArchivedSection() {
     }
   }, [project, projectNames, namesQuery.isSuccess, namesQuery.isFetching]);
 
+  // The visible list, filtered server-side via ?project= when one is picked.
+  // Search and project are both in the query key, so either change re-pages.
   const listQuery = useConversations(debouncedSearch, true, undefined, project);
   const archived = useMemo(
     () => (listQuery.data?.pages ?? []).flatMap((p) => p.data).filter((c) => c.archived === true),


### PR DESCRIPTION
## Related issue

Closes #5473

## Summary

Appearance typography is two cards (Interface, Editor and terminal) with searchable font pickers and a live code preview.

The `Heavier code font` toggle that landed on `main` while this was open now sits in the editor card and drives the preview too, so the sample tracks every code font setting rather than only size and family.

Depends on #5340.

## Test Plan

- `pnpm test src/pages/SettingsPage.test.tsx`
- `uv run pytest tests/e2e_ui/sessions/test_ui_font_family.py`
- Open Settings > Appearance.
- Change interface and editor fonts. Preview should update.
- Type a custom font name in the picker.
- Toggle `Heavier code font`. Preview should get heavier.
- Confirm Reset to defaults still works.

## Demo

**Before:**
<img width="1526" height="954" alt="image" src="https://github.com/user-attachments/assets/daf56f43-78fa-46a3-ae25-904c8129775e" />


**After:**

https://github.com/user-attachments/assets/c187b1fa-c3e0-4986-b321-a1b68bbbe9c8

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover combobox selection, typed fonts, preview font on the `code` element, heading structure, and the weight toggle reaching the preview. `tests/e2e_ui/sessions/test_ui_font_family.py` was rewritten to drive the combobox instead of the removed free text input, covering selection, persistence across reload, and reset to the system default.

## Changelog

Grouped typography settings with a font picker and code preview