### PR TITLE
fix(deploy): handle empty Databricks feature configuration

### DIFF
--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -743,6 +743,10 @@ def _ensure_compute_size(
 
 def _bundle_vars(args: argparse.Namespace) -> list[str]:
     """CLI args to pass to `databricks bundle` as --var pairs."""
+    # The Apps API rejects an environment entry with an empty source. A single
+    # space is trimmed by the feature parser and therefore preserves the
+    # documented "no features" behavior while providing a valid value source.
+    features = args.features if args.features.strip() else " "
     return [
         "--var",
         f"app_name={args.app_name}",
@@ -755,7 +759,7 @@ def _bundle_vars(args: argparse.Namespace) -> list[str]:
         "--var",
         f"otel_table_schema={args.otel_table_schema}",
         "--var",
-        f"features={args.features}",
+        f"features={features}",
     ]
 
 

--- a/tests/deploy/test_databricks_empty_features.py
+++ b/tests/deploy/test_databricks_empty_features.py
@@ -1,0 +1,49 @@
+"""Empty Databricks Apps feature configuration remains deployable."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from argparse import Namespace
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_DEPLOY_PY = _ROOT / "deploy" / "databricks" / "deploy.py"
+
+
+@pytest.fixture(scope="module")
+def deploy_mod() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_databricks_deploy_features", _DEPLOY_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("features", "expected"),
+    [
+        ("", " "),
+        ("   ", " "),
+        ("usage_page,harness_install", "usage_page,harness_install"),
+    ],
+)
+def test_bundle_vars_provide_a_valid_empty_feature_source(
+    deploy_mod: ModuleType, features: str, expected: str
+) -> None:
+    args = Namespace(
+        app_name="omnigent",
+        lakebase_branch="projects/omnigent/branches/production",
+        lakebase_database="projects/omnigent/branches/production/databases/databricks-postgres",
+        volume_name="main.omnigent.artifacts",
+        otel_table_schema="main.omnigent_logs",
+        features=features,
+    )
+
+    values = deploy_mod._bundle_vars(args)
+
+    assert values[-2:] == ["--var", f"features={expected}"]


### PR DESCRIPTION
## Related issue

Closes #5342

## Summary

The Databricks Apps bundle always emits `OMNIGENT_FEATURES`. When the documented default is empty, the Apps API rejects the generated environment entry because it has no usable value source.

This change converts an empty or whitespace-only feature value to a single space while preserving non-empty values. The feature parser already trims whitespace, so the application still starts with no release features enabled.

ELI5:

```text
before: features="" -> empty Apps env source -> deployment rejected
after:  features=" " -> valid env source -> parser trims it -> no features
```

## Test Plan

- `python -m pytest -q tests/deploy/test_databricks_empty_features.py` -> **3 passed**.
- `python -m py_compile deploy/databricks/deploy.py`.
- `bash -n deploy/databricks/build.sh`.
- `git diff --check`.
- The parameterised test covers empty, whitespace-only, and populated feature values.

## Demo

N/A — this is a deployment-configuration fix with no standalone visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused tests exercise the exact bundle argument list sent to Databricks and verify that populated feature lists remain unchanged.

## Changelog

Databricks Apps deployments now work when no release features are enabled.
