### PR TITLE
feat(scheduled): support setting permission mode on automations

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1390,6 +1390,10 @@ class SqlScheduledTask(OmnigentBase):
         ``"claude-opus-4-7"``. ``None`` means use the agent default.
     :param reasoning_effort: Per-task reasoning-effort hint, e.g. ``"high"``.
         ``None`` means use the agent default.
+    :param permission_mode: Per-task permission mode for native coding harnesses
+        that support one (Claude Code), e.g. ``"acceptEdits"``. The fire path
+        turns it into the runner's ``--permission-mode`` launch arg. ``None``
+        means use the agent default.
     :param workspace: Absolute path on disk where a fired session's runner
         should start (the source repo / working dir). ``None`` when unset.
     :param base_branch: Git base ref a firing branches FROM when it creates a
@@ -1455,6 +1459,10 @@ class SqlScheduledTask(OmnigentBase):
     # mirror the matching conversations.* override columns.
     model_override: Mapped[str | None] = mapped_column(String(128), nullable=True)
     reasoning_effort: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    # Per-task permission mode for native coding harnesses that carry one
+    # (Claude Code). The fire path converts it to the runner's
+    # ``--permission-mode`` launch arg. NULL = use the agent default.
+    permission_mode: Mapped[str | None] = mapped_column(String(32), nullable=True)
     # Per-firing cost budget in USD. When set, the fire path attaches a
     # cost_budget policy to each spawned session. NULL = no per-firing cap.
     max_cost_usd: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/omnigent/db/migrations/versions/e5d9bc8ac650_add_scheduled_tasks_permission_mode.py
+++ b/omnigent/db/migrations/versions/e5d9bc8ac650_add_scheduled_tasks_permission_mode.py
@@ -1,0 +1,37 @@
+"""add permission_mode column to scheduled_tasks
+
+Revision ID: e5d9bc8ac650
+Revises: za1b2c3d4e5f
+Create Date: 2026-08-24 00:00:00.000000
+
+Adds an optional ``permission_mode`` (VARCHAR(32), nullable) column to
+``scheduled_tasks``. When set, the fire path turns it into the runner's
+``--permission-mode`` terminal launch arg for native coding harnesses that
+support one (Claude Code). NULL = use the agent's configured default.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e5d9bc8ac650"
+down_revision: str | None = "za1b2c3d4e5f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add permission_mode to scheduled_tasks."""
+    op.add_column(
+        "scheduled_tasks",
+        sa.Column("permission_mode", sa.String(length=32), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove permission_mode from scheduled_tasks."""
+    with op.batch_alter_table("scheduled_tasks") as batch_op:
+        batch_op.drop_column("permission_mode")

--- a/omnigent/entities/scheduled_task.py
+++ b/omnigent/entities/scheduled_task.py
@@ -45,6 +45,11 @@ class ScheduledTask:
         ``"claude-opus-4-7"``. ``None`` means use the agent default.
     :param reasoning_effort: Per-task reasoning-effort hint, e.g. ``"high"``.
         ``None`` means use the agent default.
+    :param permission_mode: Per-task permission mode for native coding harnesses
+        that support one (currently Claude Code), e.g. ``"acceptEdits"`` or
+        ``"bypassPermissions"``. The fire path turns it into the runner's
+        ``["--permission-mode", <value>]`` terminal launch args. ``None`` means
+        use the agent's configured default.
     :param max_cost_usd: Optional per-firing cost budget in USD. When set, the
         fire path attaches a ``cost_budget`` policy to each spawned session that
         blocks all models once cumulative spend reaches this limit. ``None``
@@ -79,6 +84,7 @@ class ScheduledTask:
     workspace_id: int = 0
     model_override: str | None = None
     reasoning_effort: str | None = None
+    permission_mode: str | None = None
     max_cost_usd: float | None = None
     workspace: str | None = None
     base_branch: str | None = None

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -3714,6 +3714,7 @@ _SCHEDULED_TASK_CREATE_FIELDS = (
     "timezone",
     "model_override",
     "reasoning_effort",
+    "permission_mode",
     "workspace",
     "host_id",
 )
@@ -3725,6 +3726,7 @@ _SCHEDULED_TASK_UPDATE_FIELDS = (
     "timezone",
     "model_override",
     "reasoning_effort",
+    "permission_mode",
     "workspace",
     "host_id",
     "state",

--- a/omnigent/server/routes/_session_create_validation.py
+++ b/omnigent/server/routes/_session_create_validation.py
@@ -55,10 +55,13 @@ async def validate_permission_mode_agent_support(
     cursor agent could persist a mode the fire path would inject as an unknown
     ``--permission-mode`` flag, breaking the launch.
 
-    A ``None`` mode is always allowed (nothing to gate). When the harness cannot
-    be resolved (no bundle / cache), this is a no-op — the value has already
-    passed the vocabulary allowlist, and the fire path only injects the flag for
-    a Claude launch.
+    This is an early, friendly 4xx at persist time. A ``None`` mode is always
+    allowed (nothing to gate). When the harness cannot be resolved (no bundle /
+    cache / a load error), this is a no-op rather than a rejection: the value has
+    already passed the vocabulary allowlist, and the fire path's launch-arg
+    derivation is itself harness-gated fail-safe (it injects ``--permission-mode``
+    ONLY for a confirmed ``claude-native`` agent, omitting it otherwise), so a
+    non-Claude mode can never actually reach the launch args regardless.
     """
     if permission_mode is None or agent is None:
         return

--- a/omnigent/server/routes/_session_create_validation.py
+++ b/omnigent/server/routes/_session_create_validation.py
@@ -34,6 +34,58 @@ CLAUDE_NATIVE_LAUNCH_PERMISSION_MODES: frozenset[str] = frozenset(
 )
 
 
+# The only harness that accepts a ``--permission-mode`` launch arg — the same
+# ``permissionMode`` capability the web dialog gates its permission control on.
+# Other native CLIs (codex / cursor / …) use different flags, so injecting
+# ``--permission-mode`` there would be an unknown flag that breaks the launch.
+_PERMISSION_MODE_HARNESS = "claude-native"
+
+
+async def validate_permission_mode_agent_support(
+    *,
+    permission_mode: str | None,
+    agent: Any,
+    agent_cache: AgentCache | None,
+) -> None:
+    """Reject a ``permission_mode`` on an agent whose harness has no such flag.
+
+    Mirrors the web dialog's capability gate on the server so the REST endpoint
+    and agent tools enforce the same rule the UI does: only a ``claude-native``
+    agent may carry a ``permission_mode``. Without this, a task on a codex /
+    cursor agent could persist a mode the fire path would inject as an unknown
+    ``--permission-mode`` flag, breaking the launch.
+
+    A ``None`` mode is always allowed (nothing to gate). When the harness cannot
+    be resolved (no bundle / cache), this is a no-op — the value has already
+    passed the vocabulary allowlist, and the fire path only injects the flag for
+    a Claude launch.
+    """
+    if permission_mode is None or agent is None:
+        return
+    if agent_cache is None or getattr(agent, "bundle_location", None) is None:
+        return
+    from omnigent.harness_aliases import canonicalize_harness
+
+    try:
+        loaded = await asyncio.to_thread(agent_cache.load, agent.id, agent.bundle_location)
+        executor = getattr(loaded.spec, "executor", None)
+        raw_harness = None
+        if executor is not None:
+            raw_harness = executor.config.get("harness") or executor.type
+        harness = canonicalize_harness(raw_harness) or raw_harness
+    except Exception:
+        # A spec that won't load fails elsewhere (workspace validation / fire);
+        # don't turn an unrelated load error into a permission_mode rejection.
+        _logger.exception("Failed to load agent spec for permission_mode gating")
+        return
+    if harness != _PERMISSION_MODE_HARNESS:
+        raise OmnigentError(
+            f"permission_mode is only supported for {_PERMISSION_MODE_HARNESS} agents, "
+            f"not {harness!r}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+
+
 def validate_session_permission_mode(permission_mode: str | None) -> str | None:
     """Validate a persisted per-task permission mode shared by schedules.
 

--- a/omnigent/server/routes/_session_create_validation.py
+++ b/omnigent/server/routes/_session_create_validation.py
@@ -24,6 +24,36 @@ from omnigent.stores.host_store import host_is_live
 _logger = logging.getLogger(__name__)
 
 
+# Claude Code's ``--permission-mode`` launch vocabulary — every value the CLI
+# accepts at start, not just the shift+tab-switchable subset. ``dontAsk`` and
+# ``bypassPermissions`` are launch-only (rejected on a running-session PATCH),
+# but a scheduled task launches a fresh session each fire, so all of them are
+# valid here. Mirrors the frontend's ``CLAUDE_NATIVE_PERMISSION_MODES``.
+CLAUDE_NATIVE_LAUNCH_PERMISSION_MODES: frozenset[str] = frozenset(
+    {"default", "auto", "acceptEdits", "plan", "dontAsk", "bypassPermissions"}
+)
+
+
+def validate_session_permission_mode(permission_mode: str | None) -> str | None:
+    """Validate a persisted per-task permission mode shared by schedules.
+
+    A scheduled task fires a fresh native session each run, so the whole launch
+    vocabulary is allowed (including the launch-only ``dontAsk`` /
+    ``bypassPermissions``). The value reaches the native CLI as the
+    ``--permission-mode`` argv element the fire path derives, so reject anything
+    outside the known set before a row persists it.
+    """
+    if permission_mode is None:
+        return None
+    if permission_mode not in CLAUDE_NATIVE_LAUNCH_PERMISSION_MODES:
+        raise OmnigentError(
+            f"invalid permission_mode: {permission_mode!r} (expected one of "
+            f"{sorted(CLAUDE_NATIVE_LAUNCH_PERMISSION_MODES)})",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    return permission_mode
+
+
 def validate_session_model_metadata(
     *,
     model_override: str | None,

--- a/omnigent/server/routes/scheduled_tasks.py
+++ b/omnigent/server/routes/scheduled_tasks.py
@@ -31,6 +31,7 @@ from omnigent.server.routes._session_create_validation import (
     validate_existing_host_workspace,
     validate_session_agent,
     validate_session_model_metadata,
+    validate_session_permission_mode,
 )
 from omnigent.server.scheduled.rrule import RRuleValidationError, validate_rrule
 from omnigent.server.scheduled.run_reconciler import force_fail_stale_runs
@@ -52,6 +53,9 @@ class CreateScheduledTaskRequest(BaseModel):
     timezone: str = "UTC"
     model_override: str | None = None
     reasoning_effort: str | None = None
+    # Native-harness permission mode (Claude Code), e.g. "acceptEdits". The fire
+    # path derives the runner's --permission-mode launch arg from it.
+    permission_mode: str | None = None
     max_cost_usd: float | None = Field(default=None, gt=0)
     # Optional: no PINNED host/workspace. When both are unset the fire path
     # resolves the owner's online host at fire time and defaults the workspace to
@@ -75,6 +79,7 @@ class UpdateScheduledTaskRequest(BaseModel):
     timezone: str | None = None
     model_override: str | None = None
     reasoning_effort: str | None = None
+    permission_mode: str | None = None
     max_cost_usd: float | None = Field(default=None, gt=0)  # null clears the cap
     workspace: str | None = Field(default=None, min_length=1)
     host_id: str | None = Field(default=None, min_length=1)
@@ -123,6 +128,7 @@ def _to_response(
         "created_at": task.created_at,
         "model_override": task.model_override,
         "reasoning_effort": task.reasoning_effort,
+        "permission_mode": task.permission_mode,
         "max_cost_usd": task.max_cost_usd,
         "workspace": task.workspace,
         "host_id": task.host_id,
@@ -304,6 +310,7 @@ def create_scheduled_tasks_router(
             model_override=body.model_override,
             reasoning_effort=body.reasoning_effort,
         )
+        permission_mode = validate_session_permission_mode(body.permission_mode)
         task = store.create(
             scheduled_task_id=uuid.uuid4().hex,
             name=body.name,
@@ -314,6 +321,7 @@ def create_scheduled_tasks_router(
             timezone=body.timezone,
             model_override=model_override,
             reasoning_effort=reasoning_effort,
+            permission_mode=permission_mode,
             max_cost_usd=body.max_cost_usd,
             workspace=workspace,
             host_id=body.host_id,
@@ -486,6 +494,8 @@ def create_scheduled_tasks_router(
                 fields["model_override"] = model_override
             if "reasoning_effort" in fields:
                 fields["reasoning_effort"] = reasoning_effort
+        if "permission_mode" in fields:
+            fields["permission_mode"] = validate_session_permission_mode(fields["permission_mode"])
         if {"workspace", "host_id"}.intersection(fields):
             workspace, _, _ = await _validate_launch_inputs(
                 request,

--- a/omnigent/server/routes/scheduled_tasks.py
+++ b/omnigent/server/routes/scheduled_tasks.py
@@ -29,6 +29,7 @@ from omnigent.server.routes._auth_helpers import require_user
 from omnigent.server.routes._host_launch import resolve_host_owner
 from omnigent.server.routes._session_create_validation import (
     validate_existing_host_workspace,
+    validate_permission_mode_agent_support,
     validate_session_agent,
     validate_session_model_metadata,
     validate_session_permission_mode,
@@ -217,6 +218,7 @@ def create_scheduled_tasks_router(
         workspace: str | None,
         model_override: str | None,
         reasoning_effort: str | None,
+        permission_mode: str | None,
     ) -> tuple[str | None, str | None, str | None]:
         """Validate inputs that scheduled tasks persist into future sessions.
 
@@ -239,6 +241,14 @@ def create_scheduled_tasks_router(
         validated_model, validated_effort = validate_session_model_metadata(
             model_override=model_override,
             reasoning_effort=reasoning_effort,
+        )
+        # Gate permission_mode on the resolved agent's harness (Claude Code
+        # only), mirroring the web dialog's capability gate. A non-Claude agent
+        # carrying a mode would break the fire (unknown --permission-mode flag).
+        await validate_permission_mode_agent_support(
+            permission_mode=permission_mode,
+            agent=agent,
+            agent_cache=agent_cache,
         )
         if workspace is None:
             # No pinned workspace: the fire path defaults it to the launch host's
@@ -301,6 +311,7 @@ def create_scheduled_tasks_router(
         owner = _owner(request)
         _validate_rrule_or_400(body.rrule)
         _validate_timezone_or_400(body.timezone)
+        permission_mode = validate_session_permission_mode(body.permission_mode)
         workspace, model_override, reasoning_effort = await _validate_launch_inputs(
             request,
             owner=owner,
@@ -309,8 +320,8 @@ def create_scheduled_tasks_router(
             workspace=body.workspace,
             model_override=body.model_override,
             reasoning_effort=body.reasoning_effort,
+            permission_mode=permission_mode,
         )
-        permission_mode = validate_session_permission_mode(body.permission_mode)
         task = store.create(
             scheduled_task_id=uuid.uuid4().hex,
             name=body.name,
@@ -495,7 +506,23 @@ def create_scheduled_tasks_router(
             if "reasoning_effort" in fields:
                 fields["reasoning_effort"] = reasoning_effort
         if "permission_mode" in fields:
-            fields["permission_mode"] = validate_session_permission_mode(fields["permission_mode"])
+            new_mode = validate_session_permission_mode(fields["permission_mode"])
+            fields["permission_mode"] = new_mode
+            # Gate a newly-SET mode on the (immutable) agent's harness. Clearing
+            # to null needs no gate — the fire path injects nothing for null.
+            if new_mode is not None:
+                agent = await validate_session_agent(
+                    user_id=owner_id,
+                    agent_id=existing.agent_id,
+                    agent_store=agent_store,
+                    permission_store=permission_store,
+                    conversation_store=conversation_store,
+                )
+                await validate_permission_mode_agent_support(
+                    permission_mode=new_mode,
+                    agent=agent,
+                    agent_cache=agent_cache,
+                )
         if {"workspace", "host_id"}.intersection(fields):
             workspace, _, _ = await _validate_launch_inputs(
                 request,
@@ -505,6 +532,7 @@ def create_scheduled_tasks_router(
                 workspace=fields.get("workspace", existing.workspace),
                 model_override=fields.get("model_override", existing.model_override),
                 reasoning_effort=fields.get("reasoning_effort", existing.reasoning_effort),
+                permission_mode=None,
             )
             if "workspace" in fields:
                 fields["workspace"] = workspace

--- a/omnigent/server/scheduled/fire.py
+++ b/omnigent/server/scheduled/fire.py
@@ -60,6 +60,7 @@ from omnigent.server.routes._session_create_validation import (
     validate_existing_host_workspace,
     validate_session_agent,
     validate_session_model_metadata,
+    validate_session_permission_mode,
 )
 from omnigent.server.schemas import SessionEventInput
 
@@ -586,6 +587,19 @@ async def _resolve_default_workspace(deps: FireDeps, host_id: str) -> str:
     return canonical
 
 
+def _permission_mode_launch_args(permission_mode: str | None) -> list[str] | None:
+    """Derive the native-terminal ``--permission-mode`` args for a task.
+
+    Mirrors how the interactive New Chat dialog builds ``terminal_launch_args``:
+    a set permission mode becomes ``["--permission-mode", <value>]``, which the
+    runner appends to a native coding CLI's argv (Claude Code). ``None`` (agent
+    default) sets nothing, so the fire uses the agent's configured mode.
+    """
+    if permission_mode is None:
+        return None
+    return ["--permission-mode", permission_mode]
+
+
 async def _create_session(deps: FireDeps, task: ScheduledTask) -> Conversation:
     """Create a conversation bound to the task's agent, carrying the stored spec."""
     # Connected-host, existing-workspace runs create the conversation directly.
@@ -597,6 +611,7 @@ async def _create_session(deps: FireDeps, task: ScheduledTask) -> Conversation:
         title=task.name,
         host_id=task.host_id,
         workspace=task.workspace,
+        terminal_launch_args=_permission_mode_launch_args(task.permission_mode),
     )
     if task.model_override is not None or task.reasoning_effort is not None:
         updated: Conversation | None = await asyncio.to_thread(
@@ -728,6 +743,7 @@ async def _validate_fire_session_inputs(
             model_override=task.model_override,
             reasoning_effort=task.reasoning_effort,
         )
+        validate_session_permission_mode(task.permission_mode)
         if validate_workspace:
             if task.host_id is None or task.workspace is None:
                 return (

--- a/omnigent/server/scheduled/fire.py
+++ b/omnigent/server/scheduled/fire.py
@@ -587,17 +587,47 @@ async def _resolve_default_workspace(deps: FireDeps, host_id: str) -> str:
     return canonical
 
 
-def _permission_mode_launch_args(permission_mode: str | None) -> list[str] | None:
+_PERMISSION_MODE_HARNESS = "claude-native"
+
+
+async def _permission_mode_launch_args(deps: FireDeps, task: ScheduledTask) -> list[str] | None:
     """Derive the native-terminal ``--permission-mode`` args for a task.
 
     Mirrors how the interactive New Chat dialog builds ``terminal_launch_args``:
     a set permission mode becomes ``["--permission-mode", <value>]``, which the
-    runner appends to a native coding CLI's argv (Claude Code). ``None`` (agent
-    default) sets nothing, so the fire uses the agent's configured mode.
+    runner appends to Claude Code's argv. ``None`` (agent default) sets nothing.
+
+    Fail-safe on harness: only Claude Code accepts ``--permission-mode``, so the
+    flag is injected ONLY when the task's agent is confirmed ``claude-native``.
+    If the harness can't be resolved (no cache / bundle / a load error), the flag
+    is omitted rather than injected — a session that just uses the agent's own
+    default is strictly safer than one launched with an unknown flag. This makes
+    the Claude-only guarantee hold regardless of whether the create/update/fire
+    capability gates ran, so a mis-stamped non-Claude row can never break a fire.
     """
-    if permission_mode is None:
+    if task.permission_mode is None:
         return None
-    return ["--permission-mode", permission_mode]
+    if deps.agent_cache is None:
+        return None
+    from omnigent.harness_aliases import canonicalize_harness
+
+    try:
+        agent = await asyncio.to_thread(deps.agent_store.get, task.agent_id)
+        if agent is None or getattr(agent, "bundle_location", None) is None:
+            return None
+        loaded = await asyncio.to_thread(deps.agent_cache.load, agent.id, agent.bundle_location)
+        executor = getattr(loaded.spec, "executor", None)
+        raw_harness = (executor.config.get("harness") or executor.type) if executor else None
+        harness = canonicalize_harness(raw_harness) or raw_harness
+    except Exception:
+        _logger.exception(
+            "scheduled fire: could not resolve harness for task %s; omitting --permission-mode",
+            task.id,
+        )
+        return None
+    if harness != _PERMISSION_MODE_HARNESS:
+        return None
+    return ["--permission-mode", task.permission_mode]
 
 
 async def _create_session(deps: FireDeps, task: ScheduledTask) -> Conversation:
@@ -611,7 +641,7 @@ async def _create_session(deps: FireDeps, task: ScheduledTask) -> Conversation:
         title=task.name,
         host_id=task.host_id,
         workspace=task.workspace,
-        terminal_launch_args=_permission_mode_launch_args(task.permission_mode),
+        terminal_launch_args=await _permission_mode_launch_args(deps, task),
     )
     if task.model_override is not None or task.reasoning_effort is not None:
         updated: Conversation | None = await asyncio.to_thread(
@@ -744,6 +774,10 @@ async def _validate_fire_session_inputs(
             reasoning_effort=task.reasoning_effort,
         )
         validate_session_permission_mode(task.permission_mode)
+        # NB: the harness gate for permission_mode is enforced fail-safe in
+        # _permission_mode_launch_args (the flag is injected only for a confirmed
+        # claude-native agent), so a mis-stamped non-Claude row degrades to "no
+        # flag" rather than failing the whole fire here.
         if validate_workspace:
             if task.host_id is None or task.workspace is None:
                 return (

--- a/omnigent/stores/scheduled_task_store/__init__.py
+++ b/omnigent/stores/scheduled_task_store/__init__.py
@@ -50,6 +50,7 @@ class ScheduledTaskStore(ABC):
         *,
         model_override: str | None = None,
         reasoning_effort: str | None = None,
+        permission_mode: str | None = None,
         max_cost_usd: float | None = None,
         workspace: str | None = None,
         host_id: str | None = None,
@@ -69,6 +70,8 @@ class ScheduledTaskStore(ABC):
         :param timezone: IANA timezone the trigger is evaluated in.
         :param model_override: Optional LLM model override.
         :param reasoning_effort: Optional reasoning-effort hint.
+        :param permission_mode: Optional native-harness permission mode
+            (Claude Code), e.g. ``"acceptEdits"``.
         :param max_cost_usd: Optional per-firing cost budget in USD.
         :param workspace: Runner start path (source repo / working dir).
         :param host_id: The connected host to pin the run to.
@@ -133,6 +136,7 @@ class ScheduledTaskStore(ABC):
         timezone: str | None = None,
         model_override: str | None = None,
         reasoning_effort: str | None = None,
+        permission_mode: str | None = None,
         max_cost_usd: float | None = _UNSET,
         workspace: str | None = None,
         host_id: str | None = _UNSET,

--- a/omnigent/stores/scheduled_task_store/__init__.py
+++ b/omnigent/stores/scheduled_task_store/__init__.py
@@ -134,9 +134,9 @@ class ScheduledTaskStore(ABC):
         prompt: str | None = None,
         rrule: str | None = None,
         timezone: str | None = None,
-        model_override: str | None = None,
-        reasoning_effort: str | None = None,
-        permission_mode: str | None = None,
+        model_override: str | None = _UNSET,
+        reasoning_effort: str | None = _UNSET,
+        permission_mode: str | None = _UNSET,
         max_cost_usd: float | None = _UNSET,
         workspace: str | None = None,
         host_id: str | None = _UNSET,
@@ -147,11 +147,14 @@ class ScheduledTaskStore(ABC):
         """
         Update mutable fields of a task.
 
-        Most parameters use ``None`` to mean "leave unchanged". For ``host_id``
-        and ``last_run_conversation_id``, the sentinel default means "not
-        provided / leave unchanged"; passing ``None`` explicitly sets the column
-        to NULL (e.g. to clear a host binding or to null out the last-run
-        conversation after it is deleted).
+        Most parameters use ``None`` to mean "leave unchanged". For the per-task
+        overrides (``model_override``, ``reasoning_effort``,
+        ``permission_mode``), ``host_id``, ``max_cost_usd``, and
+        ``last_run_conversation_id``, the sentinel default means "not provided /
+        leave unchanged"; passing ``None`` explicitly sets the column to NULL —
+        so resetting an override to the agent default actually clears it (e.g.
+        turning a set ``bypassPermissions`` back off), and clearing a host
+        binding or nulling out a deleted last-run conversation.
 
         Passing ``rrule`` updates the recurring trigger; ``None``
         leaves it unchanged.

--- a/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
+++ b/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
@@ -53,6 +53,7 @@ def _to_entity(row: SqlScheduledTask) -> ScheduledTask:
         rrule=row.rrule,
         model_override=row.model_override,
         reasoning_effort=row.reasoning_effort,
+        permission_mode=row.permission_mode,
         max_cost_usd=row.max_cost_usd,
         workspace=row.workspace,
         base_branch=row.base_branch,
@@ -128,6 +129,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         *,
         model_override: str | None = None,
         reasoning_effort: str | None = None,
+        permission_mode: str | None = None,
         max_cost_usd: float | None = None,
         workspace: str | None = None,
         host_id: str | None = None,
@@ -144,6 +146,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
             timezone=timezone,
             model_override=model_override,
             reasoning_effort=reasoning_effort,
+            permission_mode=permission_mode,
             max_cost_usd=max_cost_usd,
             workspace=workspace,
             base_branch=None,
@@ -249,6 +252,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         timezone: str | None = None,
         model_override: str | None = None,
         reasoning_effort: str | None = None,
+        permission_mode: str | None = None,
         max_cost_usd: float | None = _UNSET,
         workspace: str | None = None,
         host_id: str | None = _UNSET,
@@ -286,6 +290,9 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
                 changed = True
             if reasoning_effort is not None and row.reasoning_effort != reasoning_effort:
                 row.reasoning_effort = reasoning_effort
+                changed = True
+            if permission_mode is not None and row.permission_mode != permission_mode:
+                row.permission_mode = permission_mode
                 changed = True
             if max_cost_usd is not _UNSET and row.max_cost_usd != max_cost_usd:
                 row.max_cost_usd = max_cost_usd

--- a/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
+++ b/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
@@ -250,9 +250,9 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         prompt: str | None = None,
         rrule: str | None = None,
         timezone: str | None = None,
-        model_override: str | None = None,
-        reasoning_effort: str | None = None,
-        permission_mode: str | None = None,
+        model_override: str | None = _UNSET,
+        reasoning_effort: str | None = _UNSET,
+        permission_mode: str | None = _UNSET,
         max_cost_usd: float | None = _UNSET,
         workspace: str | None = None,
         host_id: str | None = _UNSET,
@@ -262,11 +262,14 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
     ) -> ScheduledTask | None:
         """Update mutable fields.
 
-        ``None`` leaves most fields unchanged. For ``host_id``,
-        ``max_cost_usd``, and ``last_run_conversation_id``, the sentinel
-        default means "not provided / leave unchanged"; passing ``None``
-        explicitly sets the column to NULL. Passing ``rrule`` updates the
-        recurring trigger; ``None`` leaves it unchanged.
+        ``None`` leaves most fields unchanged. For the per-task overrides
+        (``model_override``, ``reasoning_effort``, ``permission_mode``),
+        ``host_id``, ``max_cost_usd``, and ``last_run_conversation_id``, the
+        sentinel default means "not provided / leave unchanged"; passing
+        ``None`` explicitly sets the column to NULL — so resetting an override
+        to the agent default actually clears it (a set ``bypassPermissions``
+        can be turned back off). Passing ``rrule`` updates the recurring
+        trigger; ``None`` leaves it unchanged.
         """
         with self._session("update_task") as session:
             row = session.get(SqlScheduledTask, (current_workspace_id(), scheduled_task_id))
@@ -285,13 +288,13 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
             if timezone is not None and row.timezone != timezone:
                 row.timezone = timezone
                 changed = True
-            if model_override is not None and row.model_override != model_override:
+            if model_override is not _UNSET and row.model_override != model_override:
                 row.model_override = model_override
                 changed = True
-            if reasoning_effort is not None and row.reasoning_effort != reasoning_effort:
+            if reasoning_effort is not _UNSET and row.reasoning_effort != reasoning_effort:
                 row.reasoning_effort = reasoning_effort
                 changed = True
-            if permission_mode is not None and row.permission_mode != permission_mode:
+            if permission_mode is not _UNSET and row.permission_mode != permission_mode:
                 row.permission_mode = permission_mode
                 changed = True
             if max_cost_usd is not _UNSET and row.max_cost_usd != max_cost_usd:

--- a/omnigent/tools/builtins/scheduled_tasks.py
+++ b/omnigent/tools/builtins/scheduled_tasks.py
@@ -93,6 +93,17 @@ class SysScheduledTaskCreateTool(Tool):
                             "type": "string",
                             "description": "Optional per-run reasoning-effort hint, e.g. 'high'.",
                         },
+                        "permission_mode": {
+                            "type": "string",
+                            "description": (
+                                "Optional permission mode for native coding agents that "
+                                "support one (Claude Code): 'default', 'auto', "
+                                "'acceptEdits', 'plan', 'dontAsk', or 'bypassPermissions'. "
+                                "Runs are unattended, so a prompting mode ('default'/'plan') "
+                                "stalls waiting for approval — prefer an auto-running mode. "
+                                "Omit for the agent default."
+                            ),
+                        },
                         "max_cost_usd": {
                             "type": "number",
                             "description": (
@@ -195,6 +206,14 @@ class SysScheduledTaskUpdateTool(Tool):
                         "reasoning_effort": {
                             "type": "string",
                             "description": "New reasoning-effort hint.",
+                        },
+                        "permission_mode": {
+                            "type": "string",
+                            "description": (
+                                "New permission mode for native coding agents (Claude "
+                                "Code): 'default', 'auto', 'acceptEdits', 'plan', "
+                                "'dontAsk', or 'bypassPermissions'."
+                            ),
                         },
                         "max_cost_usd": {
                             "type": "number",

--- a/tests/db/test_migration_scheduled_tasks.py
+++ b/tests/db/test_migration_scheduled_tasks.py
@@ -60,6 +60,7 @@ def test_scheduled_tasks_columns(db_engine: Engine) -> None:
         "agent_id",
         "model_override",
         "reasoning_effort",
+        "permission_mode",
         "max_cost_usd",
         "workspace",
         "base_branch",

--- a/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
+++ b/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
@@ -58,14 +58,16 @@ def _create_task(
     workspace: str | None = None,
     model_override: str | None = None,
     reasoning_effort: str | None = None,
+    permission_mode: str | None = None,
 ) -> str:
     """Seed one scheduled task via ``POST /v1/scheduled-tasks``.
 
-    ``model_override`` / ``reasoning_effort`` are optional so a test can seed a
-    task carrying the model/effort overrides the create/edit dialog persists —
-    used by the edit-prefill test, where the dialog must read them back onto the
-    ``task-model-trigger`` / ``task-effort-trigger`` controls. Left ``None`` they
-    are omitted from the body (the row persists null, the agent's own defaults).
+    ``model_override`` / ``reasoning_effort`` / ``permission_mode`` are optional
+    so a test can seed a task carrying the overrides the create/edit dialog
+    persists — used by the edit-prefill tests, where the dialog must read them
+    back onto the ``task-model-trigger`` / ``task-effort-trigger`` /
+    ``task-permission-trigger`` controls. Left ``None`` they are omitted from the
+    body (the row persists null, the agent's own defaults).
 
     :returns: The created task id.
     """
@@ -84,6 +86,8 @@ def _create_task(
         body["model_override"] = model_override
     if reasoning_effort is not None:
         body["reasoning_effort"] = reasoning_effort
+    if permission_mode is not None:
+        body["permission_mode"] = permission_mode
     resp = httpx.post(
         f"{base_url}/v1/scheduled-tasks",
         json=body,
@@ -462,10 +466,13 @@ def test_scheduled_task_model_effort_controls_visible_for_capable_agent(
     expect(page.get_by_test_id("task-model-effort-row")).to_be_visible(timeout=30_000)
     model_trigger = page.get_by_test_id("task-model-trigger")
     effort_trigger = page.get_by_test_id("task-effort-trigger")
+    permission_trigger = page.get_by_test_id("task-permission-trigger")
     expect(model_trigger).to_be_visible()
     expect(effort_trigger).to_be_visible()
+    expect(permission_trigger).to_be_visible()
     expect(model_trigger).to_have_text("Default")
     expect(effort_trigger).to_have_text("Default")
+    expect(permission_trigger).to_have_text("Default")
 
 
 def test_scheduled_task_model_effort_controls_hidden_for_incapable_agent(
@@ -496,9 +503,10 @@ def test_scheduled_task_model_effort_controls_hidden_for_incapable_agent(
 
     dialog = page.get_by_test_id("create-scheduled-task-dialog")
     expect(dialog).to_be_visible(timeout=30_000)
-    # Capability gate off → the row is never rendered, and the "uses defaults"
-    # helper hint stands in for it.
+    # Capability gate off → the row is never rendered (nor the permission
+    # control), and the "uses defaults" helper hint stands in for it.
     expect(page.get_by_test_id("task-model-effort-row")).to_be_hidden()
+    expect(page.get_by_test_id("task-permission-control")).to_be_hidden()
     expect(dialog.get_by_text("Uses this agent")).to_be_visible()
 
 
@@ -594,3 +602,99 @@ def test_scheduled_task_edit_prefills_model_and_effort(
     expect(page.get_by_test_id("task-model-effort-row")).to_be_visible()
     expect(page.get_by_test_id("task-model-trigger")).to_have_text("Opus")
     expect(page.get_by_test_id("task-effort-trigger")).to_have_text("High")
+
+
+# ── Permission-mode selector ───────────────────────────────────────────────
+#
+# The dialog renders a Permission-mode select alongside Model/Effort, gated on
+# the same ``permissionMode`` capability (Claude Code). Because an automation
+# fires a fresh session each run, the whole launch vocabulary is offered —
+# including the launch-only ``dontAsk`` / ``bypassPermissions``. Left on
+# "Default" the field is omitted (agent default); a concrete pick persists
+# ``permission_mode``, which the fire path turns into the runner's
+# ``--permission-mode`` launch arg. Like the sibling tests these are LLM-free:
+# they exercise only the dialog, REST, and the rendered row.
+
+
+def test_scheduled_task_create_persists_permission_mode(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Picking a Permission mode on create persists it via the API.
+
+    Opens the create dialog on Claude Code, picks "Accept edits" through the
+    ``task-permission-trigger`` select, submits, then reads the created row back
+    from ``GET /v1/scheduled-tasks`` and asserts its ``permission_mode`` is the
+    persisted pick (``"acceptEdits"`` — the wire value behind the "Accept edits"
+    label).
+    """
+    page.goto(f"{live_server}/tasks")
+    _open_create_dialog(page)
+
+    page.get_by_test_id("task-name-input").fill("Permission create")
+    page.get_by_test_id("task-prompt-input").fill("Summarize the day.")
+    _pick_select_option(page, "task-permission-trigger", "Accept edits")
+    expect(page.get_by_test_id("task-permission-trigger")).to_have_text("Accept edits")
+    page.get_by_test_id("create-scheduled-task-submit").click()
+
+    expect(_row_by_name(page, "Permission create")).to_be_visible(timeout=30_000)
+    tasks = httpx.get(f"{live_server}/v1/scheduled-tasks", timeout=10.0).json()["scheduled_tasks"]
+    created = next(t for t in tasks if t["name"] == "Permission create")
+    assert created["permission_mode"] == "acceptEdits", created
+
+
+def test_scheduled_task_create_default_omits_permission_mode(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Leaving the Permission control on 'Default' persists a null mode.
+
+    A create that never touches the permission control must omit the field so
+    the row inherits the agent's configured mode. Confirms the "Default"
+    sentinel maps to a null override, not the literal sentinel string.
+    """
+    page.goto(f"{live_server}/tasks")
+    _open_create_dialog(page)
+
+    page.get_by_test_id("task-name-input").fill("Default permission")
+    page.get_by_test_id("task-prompt-input").fill("Summarize the day.")
+    # Permission control left on its default "Default" sentinel — no pick.
+    page.get_by_test_id("create-scheduled-task-submit").click()
+
+    expect(_row_by_name(page, "Default permission")).to_be_visible(timeout=30_000)
+    tasks = httpx.get(f"{live_server}/v1/scheduled-tasks", timeout=10.0).json()["scheduled_tasks"]
+    created = next(t for t in tasks if t["name"] == "Default permission")
+    assert created["permission_mode"] is None, created
+
+
+def test_scheduled_task_edit_prefills_permission_mode(
+    page: Page,
+    live_server: str,
+) -> None:
+    """The edit dialog prefills the Permission control from the loaded task.
+
+    Seeds a Claude Code task carrying ``permission_mode="bypassPermissions"`` (a
+    launch-only mode, valid for automations), opens its Edit dialog, and asserts
+    ``task-permission-trigger`` renders the stored pick ("Bypass permissions"),
+    not the "Default" sentinel.
+    """
+    claude_agent_id = _builtin_agent_id(live_server, "claude-native-ui")
+    _create_task(
+        live_server,
+        claude_agent_id,
+        "Permission prefill",
+        "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+        permission_mode="bypassPermissions",
+    )
+
+    page.goto(f"{live_server}/tasks")
+    row = _row_by_name(page, "Permission prefill")
+    expect(row).to_be_visible(timeout=30_000)
+    row.hover()
+    row.get_by_test_id("task-row-menu").click()
+    page.get_by_test_id("task-edit").click()
+
+    dialog = page.get_by_test_id("create-scheduled-task-dialog")
+    expect(dialog).to_be_visible(timeout=30_000)
+    expect(page.get_by_test_id("task-permission-control")).to_be_visible()
+    expect(page.get_by_test_id("task-permission-trigger")).to_have_text("Bypass permissions")

--- a/tests/server/integration/test_scheduled_tasks_routes.py
+++ b/tests/server/integration/test_scheduled_tasks_routes.py
@@ -423,6 +423,88 @@ async def test_update_changes_fields_and_validates_rrule(
     assert deleted_state.status_code == 422, deleted_state.text
 
 
+async def test_create_rejects_permission_mode_for_non_claude_agent(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """A valid mode on a non-Claude agent is rejected (server capability gate).
+
+    The web dialog only shows the permission control for Claude Code; the server
+    enforces the same gate so a codex/cursor/etc. task can't persist a mode the
+    fire path would inject as an unknown ``--permission-mode`` flag. The value
+    itself is a valid Claude mode — the rejection is purely about the agent's
+    harness.
+    """
+    from omnigent.native_coding_agents import CODEX_NATIVE_AGENT_NAME
+
+    _make_user(db_uri)
+    resp = await auth_client.post(
+        "/v1/scheduled-tasks",
+        json=_create_body(
+            agent_id=builtin_agent_id(CODEX_NATIVE_AGENT_NAME),
+            permission_mode="acceptEdits",
+        ),
+        headers=_headers(),
+    )
+    assert resp.status_code == 400, resp.text
+    assert "permission_mode" in resp.text
+
+
+async def test_update_clears_permission_mode_with_explicit_null(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """PATCH ``permission_mode: null`` clears a previously-set mode end-to-end.
+
+    The edit dialog resets the control to Default by sending an explicit null,
+    so a task launched with ``bypassPermissions`` must actually revert to the
+    agent default (not silently keep the dangerous mode). Asserts the PERSISTED
+    value via a read-back, not just the response.
+    """
+    _make_user(db_uri)
+    created = (
+        await auth_client.post(
+            "/v1/scheduled-tasks",
+            json=_create_body(permission_mode="bypassPermissions"),
+            headers=_headers(),
+        )
+    ).json()
+    task_id = created["id"]
+    assert created["permission_mode"] == "bypassPermissions"
+
+    patched = await auth_client.patch(
+        f"/v1/scheduled-tasks/{task_id}",
+        json={"permission_mode": None},
+        headers=_headers(),
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["permission_mode"] is None
+
+    got = await auth_client.get(f"/v1/scheduled-tasks/{task_id}", headers=_headers())
+    assert got.json()["permission_mode"] is None
+
+
+async def test_update_omitting_permission_mode_leaves_it_unchanged(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """A PATCH that omits ``permission_mode`` must not clear a set mode."""
+    _make_user(db_uri)
+    created = (
+        await auth_client.post(
+            "/v1/scheduled-tasks",
+            json=_create_body(permission_mode="acceptEdits"),
+            headers=_headers(),
+        )
+    ).json()
+    task_id = created["id"]
+
+    patched = await auth_client.patch(
+        f"/v1/scheduled-tasks/{task_id}",
+        json={"name": "renamed"},
+        headers=_headers(),
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["permission_mode"] == "acceptEdits"
+
+
 async def test_update_rejects_invalid_model_override(
     auth_client: httpx.AsyncClient, db_uri: str
 ) -> None:

--- a/tests/server/integration/test_scheduled_tasks_routes.py
+++ b/tests/server/integration/test_scheduled_tasks_routes.py
@@ -239,6 +239,39 @@ async def test_create_rejects_invalid_reasoning_effort(
     assert resp.status_code == 400, resp.text
 
 
+async def test_create_persists_permission_mode(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """A valid permission mode round-trips on create and read."""
+    _make_user(db_uri)
+    resp = await auth_client.post(
+        "/v1/scheduled-tasks",
+        json=_create_body(permission_mode="acceptEdits"),
+        headers=_headers(),
+    )
+    assert resp.status_code == 200, resp.text
+    created = resp.json()
+    assert created["permission_mode"] == "acceptEdits"
+    task_id = created["id"]
+
+    got = await auth_client.get(f"/v1/scheduled-tasks/{task_id}", headers=_headers())
+    assert got.status_code == 200
+    assert got.json()["permission_mode"] == "acceptEdits"
+
+
+@pytest.mark.parametrize("permission_mode", ["yolo", "--danger", "Auto"])
+async def test_create_rejects_invalid_permission_mode(
+    auth_client: httpx.AsyncClient, db_uri: str, permission_mode: str
+) -> None:
+    _make_user(db_uri)
+    resp = await auth_client.post(
+        "/v1/scheduled-tasks",
+        json=_create_body(permission_mode=permission_mode),
+        headers=_headers(),
+    )
+    assert resp.status_code == 400, resp.text
+
+
 async def test_create_rejects_relative_workspace(
     auth_client: httpx.AsyncClient, db_uri: str
 ) -> None:

--- a/tests/server/scheduled/test_fire.py
+++ b/tests/server/scheduled/test_fire.py
@@ -57,6 +57,35 @@ class FakeAgentStore:
         return self.agents.get(agent_id)
 
 
+class _FakeExecutor:
+    def __init__(self, harness: str) -> None:
+        # Mirrors AgentSpec.executor: a canonical harness in ``config['harness']``
+        # (falls back to ``type``). The permission-mode injection reads this to
+        # confirm a claude-native agent before adding ``--permission-mode``.
+        self.type = harness
+        self.config = {"harness": harness}
+
+
+class _FakeSpec:
+    def __init__(self, harness: str) -> None:
+        self.executor = _FakeExecutor(harness)
+
+
+class _FakeLoadedAgent:
+    def __init__(self, harness: str) -> None:
+        self.spec = _FakeSpec(harness)
+
+
+class FakeAgentCache:
+    """Resolves an agent id to a spec with a fixed harness (for launch gating)."""
+
+    def __init__(self, harness: str = "claude-native") -> None:
+        self._harness = harness
+
+    def load(self, agent_id: str, bundle_location: str, **_: Any) -> _FakeLoadedAgent:
+        return _FakeLoadedAgent(self._harness)
+
+
 class FakeScheduledTaskStore:
     """Records update/create_run calls and serves get() from a dict."""
 
@@ -370,9 +399,22 @@ async def test_active_creates_session_grant_and_run() -> None:
     assert any("last_run_conversation_id" in u for u in store.updates)
 
 
+def _claude_agent_deps(
+    store: FakeScheduledTaskStore, conv_store: FakeConversationStore, *, harness: str
+) -> FireDeps:
+    """Deps whose agent ``ag_1`` resolves to *harness* (for launch-arg gating)."""
+    return _deps(
+        store,
+        permission_store=FakePermissionStore(),
+        conversation_store=conv_store,
+        agent_store=FakeAgentStore({"ag_1": _FakeAgent("ag_1", bundle_location="ag_1/hash")}),
+        agent_cache=FakeAgentCache(harness=harness),
+    )
+
+
 @pytest.mark.asyncio
 async def test_permission_mode_becomes_terminal_launch_args() -> None:
-    """A task's permission_mode fires as the runner's --permission-mode args."""
+    """A Claude task's permission_mode fires as the runner's --permission-mode args."""
     conv_store = FakeConversationStore()
     store = FakeScheduledTaskStore(rows={"task_1": _task(permission_mode="acceptEdits")})
 
@@ -380,7 +422,7 @@ async def test_permission_mode_becomes_terminal_launch_args() -> None:
         return None
 
     on_fire = build_on_fire(
-        _deps(store, permission_store=FakePermissionStore(), conversation_store=conv_store),
+        _claude_agent_deps(store, conv_store, harness="claude-native"),
         launch_dispatch=_launch,
     )
     await on_fire(0, "task_1")
@@ -400,7 +442,32 @@ async def test_unset_permission_mode_sends_no_launch_args() -> None:
         return None
 
     on_fire = build_on_fire(
-        _deps(store, permission_store=FakePermissionStore(), conversation_store=conv_store),
+        _claude_agent_deps(store, conv_store, harness="claude-native"),
+        launch_dispatch=_launch,
+    )
+    await on_fire(0, "task_1")
+    await _drain()
+
+    assert len(conv_store.created) == 1
+    assert conv_store.created[0]["terminal_launch_args"] is None
+
+
+@pytest.mark.asyncio
+async def test_permission_mode_omitted_for_non_claude_agent() -> None:
+    """A mis-stamped non-Claude row degrades to no --permission-mode flag.
+
+    The injection is harness-gated fail-safe: even if a permission_mode somehow
+    persisted on a codex/cursor task, the fire must NOT inject the unknown flag
+    (which would break the launch) — it launches with the agent's own default.
+    """
+    conv_store = FakeConversationStore()
+    store = FakeScheduledTaskStore(rows={"task_1": _task(permission_mode="bypassPermissions")})
+
+    async def _launch(conv: Any, task: Any) -> None:
+        return None
+
+    on_fire = build_on_fire(
+        _claude_agent_deps(store, conv_store, harness="codex-native"),
         launch_dispatch=_launch,
     )
     await on_fire(0, "task_1")

--- a/tests/server/scheduled/test_fire.py
+++ b/tests/server/scheduled/test_fire.py
@@ -371,6 +371,46 @@ async def test_active_creates_session_grant_and_run() -> None:
 
 
 @pytest.mark.asyncio
+async def test_permission_mode_becomes_terminal_launch_args() -> None:
+    """A task's permission_mode fires as the runner's --permission-mode args."""
+    conv_store = FakeConversationStore()
+    store = FakeScheduledTaskStore(rows={"task_1": _task(permission_mode="acceptEdits")})
+
+    async def _launch(conv: Any, task: Any) -> None:
+        return None
+
+    on_fire = build_on_fire(
+        _deps(store, permission_store=FakePermissionStore(), conversation_store=conv_store),
+        launch_dispatch=_launch,
+    )
+    await on_fire(0, "task_1")
+    await _drain()
+
+    assert len(conv_store.created) == 1
+    assert conv_store.created[0]["terminal_launch_args"] == ["--permission-mode", "acceptEdits"]
+
+
+@pytest.mark.asyncio
+async def test_unset_permission_mode_sends_no_launch_args() -> None:
+    """No permission_mode → no terminal_launch_args (agent default applies)."""
+    conv_store = FakeConversationStore()
+    store = FakeScheduledTaskStore(rows={"task_1": _task()})
+
+    async def _launch(conv: Any, task: Any) -> None:
+        return None
+
+    on_fire = build_on_fire(
+        _deps(store, permission_store=FakePermissionStore(), conversation_store=conv_store),
+        launch_dispatch=_launch,
+    )
+    await on_fire(0, "task_1")
+    await _drain()
+
+    assert len(conv_store.created) == 1
+    assert conv_store.created[0]["terminal_launch_args"] is None
+
+
+@pytest.mark.asyncio
 async def test_fire_runs_under_task_workspace_scope() -> None:
     perm = FakePermissionStore()
     conv_store = FakeConversationStore()

--- a/tests/stores/test_scheduled_task_store.py
+++ b/tests/stores/test_scheduled_task_store.py
@@ -635,6 +635,65 @@ def test_update_host_id_can_be_cleared_to_null(store: SqlAlchemyScheduledTaskSto
     assert fetched.host_id is None
 
 
+def test_update_overrides_can_be_cleared_to_null(store: SqlAlchemyScheduledTaskStore) -> None:
+    """Passing ``None`` for an override clears it to NULL (set→agent default).
+
+    Covers the security-relevant case: a task launched with
+    ``permission_mode="bypassPermissions"`` must be resettable to the agent
+    default through the same edit-then-save path the dialog uses (control reset
+    to Default → the API sends an explicit ``null``). Same for model/effort.
+    """
+    store.create(
+        scheduled_task_id=_uid("st_clear_ovr"),
+        name="n",
+        prompt="p",
+        rrule="FREQ=MINUTELY",
+        user_id="u",
+        agent_id=_uid("ag"),
+        timezone="UTC",
+        model_override="opus",
+        reasoning_effort="high",
+        permission_mode="bypassPermissions",
+    )
+    updated = store.update(
+        _uid("st_clear_ovr"),
+        model_override=None,
+        reasoning_effort=None,
+        permission_mode=None,
+    )
+    assert updated is not None
+    assert updated.model_override is None
+    assert updated.reasoning_effort is None
+    assert updated.permission_mode is None
+    fetched = store.get(_uid("st_clear_ovr"))
+    assert fetched is not None
+    assert fetched.permission_mode is None
+
+
+def test_update_omitting_overrides_leaves_them_unchanged(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """Omitting the override params does NOT clear them (sentinel = unchanged)."""
+    store.create(
+        scheduled_task_id=_uid("st_keep_ovr"),
+        name="n",
+        prompt="p",
+        rrule="FREQ=MINUTELY",
+        user_id="u",
+        agent_id=_uid("ag"),
+        timezone="UTC",
+        model_override="opus",
+        reasoning_effort="high",
+        permission_mode="acceptEdits",
+    )
+    # Update name only — the overrides must be untouched.
+    updated = store.update(_uid("st_keep_ovr"), name="renamed")
+    assert updated is not None
+    assert updated.model_override == "opus"
+    assert updated.reasoning_effort == "high"
+    assert updated.permission_mode == "acceptEdits"
+
+
 def test_update_last_run_conversation_id_can_be_cleared_to_null(
     store: SqlAlchemyScheduledTaskStore,
 ) -> None:

--- a/tests/stores/test_scheduled_task_store.py
+++ b/tests/stores/test_scheduled_task_store.py
@@ -52,6 +52,7 @@ def test_create_returns_scheduled_task_with_all_fields(
         timezone="America/Los_Angeles",
         model_override="claude-opus-4-7",
         reasoning_effort="high",
+        permission_mode="acceptEdits",
         workspace="/home/alice/repo",
         host_id=_uid("host_abc123"),
     )
@@ -65,6 +66,7 @@ def test_create_returns_scheduled_task_with_all_fields(
     assert task.timezone == "America/Los_Angeles"
     assert task.model_override == "claude-opus-4-7"
     assert task.reasoning_effort == "high"
+    assert task.permission_mode == "acceptEdits"
     assert task.workspace == "/home/alice/repo"
     assert task.base_branch is None
     assert task.execution_target == "connected_host"
@@ -89,6 +91,7 @@ def test_create_minimal_defaults(store: SqlAlchemyScheduledTaskStore) -> None:
     )
     assert task.model_override is None
     assert task.reasoning_effort is None
+    assert task.permission_mode is None
     assert task.workspace is None
     assert task.base_branch is None
     assert task.execution_target == "connected_host"

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -186,6 +186,7 @@ function scheduledTask(overrides: Partial<ScheduledTasksApiModule.ScheduledTask>
     updatedAt: 2,
     modelOverride: null,
     reasoningEffort: null,
+    permissionMode: null,
     workspace: null,
     hostId: null,
     state: "active",
@@ -685,15 +686,19 @@ describe("CreateScheduledTaskDialog model + effort controls", () => {
     // Pick an effort.
     fireEvent.keyDown(screen.getByTestId("task-effort-trigger"), { key: "Enter" });
     fireEvent.click(await screen.findByRole("option", { name: "High" }));
+    // Pick a permission mode.
+    fireEvent.keyDown(screen.getByTestId("task-permission-trigger"), { key: "Enter" });
+    fireEvent.click(await screen.findByRole("option", { name: "Accept edits" }));
 
     fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
     await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
     const arg = mutateAsync.mock.calls[0][0];
     expect(arg.modelOverride).toBe("opus");
     expect(arg.reasoningEffort).toBe("high");
+    expect(arg.permissionMode).toBe("acceptEdits");
   });
 
-  it("omits model + effort on create when both are left at Default", async () => {
+  it("omits model + effort + permission on create when left at Default", async () => {
     renderDialog();
     fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "N" } });
     fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
@@ -702,9 +707,10 @@ describe("CreateScheduledTaskDialog model + effort controls", () => {
     const arg = mutateAsync.mock.calls[0][0];
     expect(arg).not.toHaveProperty("modelOverride");
     expect(arg).not.toHaveProperty("reasoningEffort");
+    expect(arg).not.toHaveProperty("permissionMode");
   });
 
-  it("prefills model + effort in edit mode from the loaded task", async () => {
+  it("prefills model + effort + permission in edit mode from the loaded task", async () => {
     render(
       <CreateScheduledTaskDialog
         open
@@ -713,15 +719,17 @@ describe("CreateScheduledTaskDialog model + effort controls", () => {
           agentId: "ag_claude_native",
           modelOverride: "sonnet",
           reasoningEffort: "medium",
+          permissionMode: "acceptEdits",
         })}
       />,
     );
     // Prefilled selections surface as the trigger's shown value.
     expect(screen.getByTestId("task-model-trigger")).toHaveTextContent("Sonnet");
     expect(screen.getByTestId("task-effort-trigger")).toHaveTextContent("Medium");
+    expect(screen.getByTestId("task-permission-trigger")).toHaveTextContent("Accept edits");
   });
 
-  it("threads model + effort through update on edit, nulling a cleared override", async () => {
+  it("threads model + effort + permission through update on edit, nulling a cleared override", async () => {
     render(
       <CreateScheduledTaskDialog
         open
@@ -730,19 +738,21 @@ describe("CreateScheduledTaskDialog model + effort controls", () => {
           agentId: "ag_claude_native",
           modelOverride: "opus",
           reasoningEffort: "high",
+          permissionMode: "plan",
         })}
       />,
     );
-    // Reset the model back to Default; leave effort at "high".
+    // Reset the model back to Default; leave effort + permission untouched.
     fireEvent.keyDown(screen.getByTestId("task-model-trigger"), { key: "Enter" });
     fireEvent.click(await screen.findByRole("option", { name: "Default" }));
 
     fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
     await waitFor(() => expect(updateMutateAsync).toHaveBeenCalledTimes(1));
     const { input } = updateMutateAsync.mock.calls[0][0];
-    // Cleared model → null; untouched effort → the prefilled value.
+    // Cleared model → null; untouched effort + permission → the prefilled values.
     expect(input.modelOverride).toBeNull();
     expect(input.reasoningEffort).toBe("high");
+    expect(input.permissionMode).toBe("plan");
   });
 });
 

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
@@ -86,12 +86,15 @@ export function CreateScheduledTaskDialog({
   // below), reusing lightweight scheduled-local pickers rather than the
   // interactive dialog's 26-prop HarnessConfigModal (bound to smart-routing /
   // cost-control / per-turn model loading — disproportionate for a saved task).
-  // "" = unselected → `model_override` / `reasoning_effort` are omitted so the
-  // fire path uses the agent's configured defaults. Permission/approval/cursor
-  // mode is intentionally NOT offered here.
+  // "" = unselected → `model_override` / `reasoning_effort` / `permission_mode`
+  // are omitted so the fire path uses the agent's configured defaults. Permission
+  // mode is offered for native coding agents that support it (Claude Code); each
+  // fire launches a fresh session, so the whole launch vocabulary is valid —
+  // including the launch-only `dontAsk` / `bypassPermissions`.
   const [pickedAgentId, setPickedAgentId] = useState<string | null>(null);
   const [pickedModel, setPickedModel] = useState<string>("");
   const [pickedEffort, setPickedEffort] = useState<string>("");
+  const [pickedPermission, setPickedPermission] = useState<string>("");
 
   const agentList = useMemo(
     () => sortAgentsForDisplay((agents ?? []).filter((a) => !HIDDEN_PICKER_AGENTS.has(a.name))),
@@ -188,9 +191,10 @@ export function CreateScheduledTaskDialog({
         setName(editingTask.name);
         setPrompt(editingTask.prompt);
         setPickedAgentId(editingTask.agentId);
-        // Prefill the model/effort controls from the loaded task; null → "".
+        // Prefill the model/effort/permission controls from the loaded task; null → "".
         setPickedModel(editingTask.modelOverride ?? "");
         setPickedEffort(editingTask.reasoningEffort ?? "");
+        setPickedPermission(editingTask.permissionMode ?? "");
         setSchedule(parsedSchedule ?? DEFAULT_SCHEDULE_MODEL);
         setScheduleUnsupported(parsedSchedule === null);
         setHostId(editingTask.hostId ?? "");
@@ -201,6 +205,7 @@ export function CreateScheduledTaskDialog({
         setPickedAgentId(null);
         setPickedModel("");
         setPickedEffort("");
+        setPickedPermission("");
         setSchedule(DEFAULT_SCHEDULE_MODEL);
         setScheduleUnsupported(false);
         setHostId("");
@@ -247,6 +252,7 @@ export function CreateScheduledTaskDialog({
     setPickedAgentId(null);
     setPickedModel("");
     setPickedEffort("");
+    setPickedPermission("");
     setSchedule(DEFAULT_SCHEDULE_MODEL);
     setHostId("");
     setWorkspace("");
@@ -279,6 +285,7 @@ export function CreateScheduledTaskDialog({
           ? {
               modelOverride: pickedModel === "" ? null : pickedModel,
               reasoningEffort: pickedEffort === "" ? null : pickedEffort,
+              permissionMode: pickedPermission === "" ? null : pickedPermission,
             }
           : {};
         await updateMutation.mutateAsync({
@@ -295,6 +302,9 @@ export function CreateScheduledTaskDialog({
           // the create uses the agent's configured defaults.
           ...(showModelEffort && pickedModel !== "" ? { modelOverride: pickedModel } : {}),
           ...(showModelEffort && pickedEffort !== "" ? { reasoningEffort: pickedEffort } : {}),
+          ...(showModelEffort && pickedPermission !== ""
+            ? { permissionMode: pickedPermission }
+            : {}),
         });
       }
       handleOpenChange(false);
@@ -427,21 +437,25 @@ export function CreateScheduledTaskDialog({
             )}
           </div>
 
-          {/* Model + reasoning effort — only for native coding agents that
-              carry the model/effort surface (Claude Code). Unselected controls
-              fall back to the agent's configured defaults. */}
+          {/* Model + reasoning effort + permission mode — only for native
+              coding agents that carry the model/effort surface (Claude Code).
+              Unselected controls fall back to the agent's configured defaults. */}
           {showModelEffort && (
             <div data-testid="task-model-effort-field">
               <ModelEffortFields
                 model={pickedModel}
                 effort={pickedEffort}
+                permissionMode={pickedPermission}
                 hostId={hostId}
                 onModelChange={setPickedModel}
                 onEffortChange={setPickedEffort}
+                onPermissionModeChange={setPickedPermission}
                 onSelectOpenChange={handleSelectOpenChange}
               />
               <p className="mt-1.5 text-sm text-muted-foreground">
-                Leave on Default to use the agent&apos;s configured model and effort.
+                Leave on Default to use the agent&apos;s configured model, effort, and permission
+                mode. Automations run unattended, so a prompting mode (Manual or Plan) will wait for
+                approval that never comes.
               </p>
             </div>
           )}

--- a/web/src/components/scheduled/ModelEffortFields.tsx
+++ b/web/src/components/scheduled/ModelEffortFields.tsx
@@ -1,4 +1,5 @@
-// Model + reasoning-effort sub-form for the scheduled-task dialog.
+// Model + reasoning-effort + permission-mode sub-form for the scheduled-task
+// dialog.
 //
 // A deliberately lightweight, scheduled-dialog-local picker rather than the
 // interactive NewChatDialog's 26-prop HarnessConfigModal (which is bound to
@@ -30,24 +31,35 @@ import {
   MODEL_SELECT_DEFAULT,
 } from "@/components/HarnessConfigControls";
 import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
+import { CLAUDE_NATIVE_PERMISSION_MODES } from "@/lib/claudePermissionMode";
 import { useHostModelOptions } from "@/hooks/useHosts";
+
+/** Sentinel Select value for "no permission override" (use the agent default).
+ * Distinct from Claude's real `default` (Manual) mode so leaving the control
+ * alone keeps the agent's configured mode rather than forcing Manual. */
+const PERMISSION_SELECT_DEFAULT = "__agent_default__";
 
 export function ModelEffortFields({
   model,
   effort,
+  permissionMode,
   hostId,
   onModelChange,
   onEffortChange,
+  onPermissionModeChange,
   onSelectOpenChange,
 }: {
   /** Selected model id/alias, or "" = agent default (nothing overridden). */
   model: string;
   /** Selected reasoning effort, or "" = agent default. */
   effort: string;
+  /** Selected permission mode, or "" = agent default (nothing overridden). */
+  permissionMode: string;
   /** Pinned host id, or "" when unset (task resolves a host at fire time). */
   hostId: string;
   onModelChange: (model: string) => void;
   onEffortChange: (effort: string) => void;
+  onPermissionModeChange: (mode: string) => void;
   /** Forwarded to each Select's onOpenChange so the parent Dialog can keep an
    * open dropdown from dismissing the whole modal. */
   onSelectOpenChange?: (open: boolean) => void;
@@ -67,40 +79,71 @@ export function ModelEffortFields({
       : CLAUDE_NATIVE_MODELS.map((m) => ({ id: m.id, label: m.label }));
 
   return (
-    <div className="grid gap-3 sm:grid-cols-2 sm:gap-6" data-testid="task-model-effort-row">
-      <div className="flex w-full min-w-0 flex-col gap-1.5" data-testid="task-model-control">
-        <Label htmlFor="task-model">Model</Label>
-        <Select
-          value={model === "" ? MODEL_SELECT_DEFAULT : model}
-          onValueChange={(v) => onModelChange(v === MODEL_SELECT_DEFAULT ? "" : v)}
-          onOpenChange={onSelectOpenChange}
-        >
-          <SelectTrigger id="task-model" data-testid="task-model-trigger" className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent
-            position="popper"
-            align="start"
-            className="w-(--radix-select-trigger-width)"
+    <div className="flex flex-col gap-3 sm:gap-4">
+      <div className="grid gap-3 sm:grid-cols-2 sm:gap-6" data-testid="task-model-effort-row">
+        <div className="flex w-full min-w-0 flex-col gap-1.5" data-testid="task-model-control">
+          <Label htmlFor="task-model">Model</Label>
+          <Select
+            value={model === "" ? MODEL_SELECT_DEFAULT : model}
+            onValueChange={(v) => onModelChange(v === MODEL_SELECT_DEFAULT ? "" : v)}
+            onOpenChange={onSelectOpenChange}
           >
-            <SelectItem value={MODEL_SELECT_DEFAULT}>Default</SelectItem>
-            {modelOptions.map((m) => (
-              <SelectItem key={m.id} value={m.id}>
-                {m.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+            <SelectTrigger id="task-model" data-testid="task-model-trigger" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent
+              position="popper"
+              align="start"
+              className="w-(--radix-select-trigger-width)"
+            >
+              <SelectItem value={MODEL_SELECT_DEFAULT}>Default</SelectItem>
+              {modelOptions.map((m) => (
+                <SelectItem key={m.id} value={m.id}>
+                  {m.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex w-full min-w-0 flex-col gap-1.5" data-testid="task-effort-control">
+          <Label htmlFor="task-effort">Effort</Label>
+          <Select
+            value={effort === "" ? EFFORT_SELECT_NONE : effort}
+            onValueChange={(v) => onEffortChange(v === EFFORT_SELECT_NONE ? "" : v)}
+            onOpenChange={onSelectOpenChange}
+          >
+            <SelectTrigger id="task-effort" data-testid="task-effort-trigger" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent
+              position="popper"
+              align="start"
+              className="w-(--radix-select-trigger-width)"
+            >
+              <SelectItem value={EFFORT_SELECT_NONE}>Default</SelectItem>
+              {CLAUDE_NATIVE_EFFORTS.map((e) => (
+                <SelectItem key={e.value} value={e.value}>
+                  {e.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </div>
 
-      <div className="flex w-full min-w-0 flex-col gap-1.5" data-testid="task-effort-control">
-        <Label htmlFor="task-effort">Effort</Label>
+      <div className="flex w-full min-w-0 flex-col gap-1.5" data-testid="task-permission-control">
+        <Label htmlFor="task-permission">Permission mode</Label>
         <Select
-          value={effort === "" ? EFFORT_SELECT_NONE : effort}
-          onValueChange={(v) => onEffortChange(v === EFFORT_SELECT_NONE ? "" : v)}
+          value={permissionMode === "" ? PERMISSION_SELECT_DEFAULT : permissionMode}
+          onValueChange={(v) => onPermissionModeChange(v === PERMISSION_SELECT_DEFAULT ? "" : v)}
           onOpenChange={onSelectOpenChange}
         >
-          <SelectTrigger id="task-effort" data-testid="task-effort-trigger" className="w-full">
+          <SelectTrigger
+            id="task-permission"
+            data-testid="task-permission-trigger"
+            className="w-full"
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent
@@ -108,10 +151,10 @@ export function ModelEffortFields({
             align="start"
             className="w-(--radix-select-trigger-width)"
           >
-            <SelectItem value={EFFORT_SELECT_NONE}>Default</SelectItem>
-            {CLAUDE_NATIVE_EFFORTS.map((e) => (
-              <SelectItem key={e.value} value={e.value}>
-                {e.label}
+            <SelectItem value={PERMISSION_SELECT_DEFAULT}>Default</SelectItem>
+            {CLAUDE_NATIVE_PERMISSION_MODES.map((m) => (
+              <SelectItem key={m.value} value={m.value}>
+                {m.label}
               </SelectItem>
             ))}
           </SelectContent>

--- a/web/src/components/scheduled/ScheduledTaskRow.test.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.test.tsx
@@ -23,6 +23,7 @@ function task(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     updatedAt: 2,
     modelOverride: null,
     reasoningEffort: null,
+    permissionMode: null,
     workspace: null,
     hostId: null,
     state: "active",

--- a/web/src/hooks/useScheduledTasks.test.tsx
+++ b/web/src/hooks/useScheduledTasks.test.tsx
@@ -37,6 +37,7 @@ const TASK: api.ScheduledTask = {
   updatedAt: 2,
   modelOverride: null,
   reasoningEffort: null,
+  permissionMode: null,
   workspace: null,
   hostId: null,
   state: "active",

--- a/web/src/lib/scheduledTasksApi.ts
+++ b/web/src/lib/scheduledTasksApi.ts
@@ -38,6 +38,12 @@ export interface ScheduledTask {
   updatedAt: number;
   modelOverride: string | null;
   reasoningEffort: string | null;
+  /**
+   * Native-harness permission mode (Claude Code), e.g. `acceptEdits`, or `null`
+   * to use the agent's configured default. The server derives the runner's
+   * `--permission-mode` launch arg from it at fire time.
+   */
+  permissionMode: string | null;
   /** Pinned absolute workspace, or `null` (server defaults to the host home). */
   workspace: string | null;
   /** Pinned host, or `null` (server resolves the connected host at fire time). */
@@ -84,6 +90,8 @@ export interface CreateScheduledTaskInput {
   timezone?: string;
   modelOverride?: string | null;
   reasoningEffort?: string | null;
+  /** Native-harness permission mode (Claude Code); omit for the agent default. */
+  permissionMode?: string | null;
   /** Optional pinned workspace; only valid together with `hostId`. */
   workspace?: string | null;
   /** Optional pinned host. */
@@ -102,6 +110,7 @@ export interface UpdateScheduledTaskInput {
   timezone?: string;
   modelOverride?: string | null;
   reasoningEffort?: string | null;
+  permissionMode?: string | null;
   workspace?: string;
   hostId?: string;
   state?: ScheduledTaskState;
@@ -120,6 +129,7 @@ interface ScheduledTaskWire {
   updated_at: number;
   model_override: string | null;
   reasoning_effort: string | null;
+  permission_mode: string | null;
   workspace: string | null;
   host_id: string | null;
   state: ScheduledTaskState;
@@ -194,6 +204,7 @@ function taskFromWire(wire: ScheduledTaskWire): ScheduledTask {
     updatedAt: wire.updated_at,
     modelOverride: wire.model_override,
     reasoningEffort: wire.reasoning_effort,
+    permissionMode: wire.permission_mode,
     workspace: wire.workspace,
     hostId: wire.host_id,
     state: wire.state,
@@ -253,6 +264,7 @@ export async function createScheduledTask(input: CreateScheduledTaskInput): Prom
   if (input.timezone !== undefined) body.timezone = input.timezone;
   if (input.modelOverride != null) body.model_override = input.modelOverride;
   if (input.reasoningEffort != null) body.reasoning_effort = input.reasoningEffort;
+  if (input.permissionMode != null) body.permission_mode = input.permissionMode;
   if (input.workspace != null) body.workspace = input.workspace;
   if (input.hostId != null) body.host_id = input.hostId;
   const res = await authenticatedFetch("/v1/scheduled-tasks", {
@@ -279,6 +291,7 @@ export async function updateScheduledTask(
   if (input.timezone !== undefined) body.timezone = input.timezone;
   if (input.modelOverride !== undefined) body.model_override = input.modelOverride;
   if (input.reasoningEffort !== undefined) body.reasoning_effort = input.reasoningEffort;
+  if (input.permissionMode !== undefined) body.permission_mode = input.permissionMode;
   if (input.workspace !== undefined) body.workspace = input.workspace;
   if (input.hostId !== undefined) body.host_id = input.hostId;
   if (input.state !== undefined) body.state = input.state;

--- a/web/src/pages/TasksPage.test.tsx
+++ b/web/src/pages/TasksPage.test.tsx
@@ -60,6 +60,7 @@ function task(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     updatedAt: 2,
     modelOverride: null,
     reasoningEffort: null,
+    permissionMode: null,
     workspace: null,
     hostId: null,
     state: "active",


### PR DESCRIPTION
## Related issue

N/A — small feature extension of the existing automations (scheduled tasks) config surface.

## Summary

- Automation (scheduled) tasks can now set a **permission mode** for native coding harnesses that support one (Claude Code), alongside the existing per-task model and reasoning-effort overrides.
- Stored as a new nullable `permission_mode` column on `scheduled_tasks`; the fire path turns it into the runner's `["--permission-mode", <mode>]` terminal launch args — the exact mechanism the interactive New Chat flow already uses. Leaving it on **Default** omits the field so the agent's configured mode applies.
- Because each firing launches a fresh session, the full launch vocabulary is offered — including the launch-only `dontAsk` / `bypassPermissions` modes (which are rejected on a *running*-session switch but valid at launch).

Threaded end-to-end: DB column + migration → entity → store → REST create/update/response validation → fire-path launch args → `sys_scheduled_task_create/update` agent tools + runner dispatch → create/edit dialog select (gated on the same `permissionMode` capability as Model/Effort).

## Test Plan

- **Unit / integration (Python):** store round-trip (`permission_mode` create + read), migration column-set, route create-persist + reject-invalid (`yolo` / `--danger` / `Auto`), and fire-path assertions that a set mode becomes `["--permission-mode", <mode>]` while unset sends `None`. All pass.
- **Web (vitest / tsc / oxlint / prettier):** 74 scheduled-dialog tests pass, including new create-persist, default-omit, and edit-prefill assertions for the permission select. Type-check + lint clean.
- **E2E (`tests/e2e_ui/scheduled`):** ran live against a spawned server — 3 new permission-mode tests (create persists, default omits, edit prefills) + 2 updated visibility tests, all green.

## Demo

https://github.com/user-attachments — _permission-mode dropdown in the New/Edit automation dialog (screenshot to be attached)._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — automated unit, integration, and e2e coverage added at each layer (store, routes, fire path, dialog, live e2e).

## Changelog

Automations can now set a Claude Code permission mode (e.g. Accept edits, Bypass permissions) per task.

This pull request and its description were written by Isaac.
