### PR TITLE
feat(logging): user_id attribution + more session_id coverage + drop self-probe

### DIFF
--- a/omnigent/claude_native_status_file.py
+++ b/omnigent/claude_native_status_file.py
@@ -306,10 +306,15 @@ class SessionStatusPoller:
         pane_pid_getter: Callable[[], int | None],
         session_id_getter: Callable[[], str | None],
         config_dir: Path | None = None,
+        omnigent_session_id: str | None = None,
     ) -> None:
         self._on_status = on_status
         self._pane_pid_getter = pane_pid_getter
+        # Claude's own session uuid, resolved lazily from the bridge.
         self._session_id_getter = session_id_getter
+        # The Omnigent conversation id this poller watches — for debug-log
+        # attribution only (distinct from Claude's session uuid above).
+        self._omnigent_session_id = omnigent_session_id
         self._config_dir = config_dir
         self._path: Path | None = None
         self._attempts = 0
@@ -361,6 +366,7 @@ class SessionStatusPoller:
                 path,
                 self._attempts,
                 pane_pid,
+                extra={"session_id": self._omnigent_session_id},
             )
             self._path = path
             return
@@ -370,6 +376,7 @@ class SessionStatusPoller:
                 "(pane_pid=%s); session status falls back to the pane watcher",
                 self._attempts,
                 pane_pid,
+                extra={"session_id": self._omnigent_session_id},
             )
             self._exhausted = True
 
@@ -381,7 +388,11 @@ class SessionStatusPoller:
         the file owns the session's status while it is readable, a dead pane
         must retire it or that final value would pin the session forever.
         """
-        _logger.info("claude status file retired: path=%s", self._path)
+        _logger.info(
+            "claude status file retired: path=%s",
+            self._path,
+            extra={"session_id": self._omnigent_session_id},
+        )
         self._exhausted = True
 
     def resync(self) -> None:
@@ -398,7 +409,11 @@ class SessionStatusPoller:
         Keeps the resolved path and the attempt count — this re-asserts a
         working poller, it does not restart resolution.
         """
-        _logger.info("claude status file resync: path=%s", self._path)
+        _logger.info(
+            "claude status file resync: path=%s",
+            self._path,
+            extra={"session_id": self._omnigent_session_id},
+        )
         self._last_mtime = None
         self._last_edge = None
 

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -28,6 +28,8 @@ import time
 import traceback
 import urllib.parse
 import uuid
+from collections.abc import Iterator
+from contextvars import ContextVar
 from dataclasses import dataclass
 
 import httpx
@@ -47,6 +49,13 @@ ENDPOINT_ENV_VAR = "OMNIGENT_DEBUG_LOG_ENDPOINT"
 # so this is the primary session, not the only one — pass it explicitly at
 # runner-level log callsites that have no per-request session id in scope.
 PRIMARY_SESSION_ID_ENV_VAR = "OMNIGENT_RUNNER_PRIMARY_SESSION_ID"
+
+# Authenticated user id (email) attribution. The multi-tenant server sets a
+# request-scoped ContextVar per request; the single-user runner/host set the
+# env var once at startup (a process constant — an env var, not a ContextVar,
+# because a ContextVar set at startup is invisible to run_in_executor threads).
+USER_ID_ENV_VAR = "OMNIGENT_USER_ID"
+_user_id_var: ContextVar[str | None] = ContextVar("omnigent_debug_user_id", default=None)
 
 # Batching / delivery defaults.
 _BATCH_MAX_RECORDS = 100
@@ -191,11 +200,39 @@ def runner_primary_session_id() -> str | None:
     return os.environ.get(PRIMARY_SESSION_ID_ENV_VAR) or None
 
 
+def set_current_user_id(user_id: str | None) -> None:
+    """Bind the current request's authenticated user (server middleware / WS boundary)."""
+    _user_id_var.set(user_id or None)
+
+
+@contextlib.contextmanager
+def current_user_id_scope(user_id: str | None) -> Iterator[None]:
+    """Bind ``user_id`` for the duration of the block, restoring the prior value on exit."""
+    token = _user_id_var.set(user_id or None)
+    try:
+        yield
+    finally:
+        _user_id_var.reset(token)
+
+
+def current_user_id() -> str | None:
+    """Best-available user attribution the sink stamps when a record has no explicit user_id.
+
+    Request-scoped ContextVar first (multi-tenant server, per request), then the
+    process-constant ``OMNIGENT_USER_ID`` env (single-user runner/host). Both
+    empty -> ``None``. On the runner/host this is the process **owner** (session/
+    host owner), which in a shared session can differ from the per-turn initiator
+    the server records -- inherent to a per-process attribution column.
+    """
+    return _user_id_var.get() or os.environ.get(USER_ID_ENV_VAR) or None
+
+
 def debug_event(
     event_name: str,
     *,
     session_id: str | None = None,
     turn_id: str | None = None,
+    user_id: str | None = None,
     **attributes: object,
 ) -> dict[str, object]:
     """Build a logging ``extra=`` payload naming a semantic event.
@@ -208,16 +245,20 @@ def debug_event(
             "tool_call_dispatched", session_id=session_id,
             tool_call_id=tc.id, model=model))
 
-    The correlation columns are populated only from what the callsite passes --
-    the sink reads them off the record, with no ambient fallback. Freeform
-    ``_logger.debug("…")`` calls need no ``extra``; they ship with null
-    correlation columns and an empty attributes map.
+    ``session_id``/``turn_id`` are populated only from what the callsite passes;
+    ``user_id`` additionally has an ambient fallback the sink applies when the
+    record carries none (a request-scoped ContextVar on the server, the
+    ``OMNIGENT_USER_ID`` env on the runner/host). Freeform ``_logger.debug("…")``
+    calls need no ``extra``; they ship with null correlation columns and an empty
+    attributes map.
     """
     extra: dict[str, object] = {"event_name": event_name, "attributes": dict(attributes)}
     if session_id is not None:
         extra["session_id"] = session_id
     if turn_id is not None:
         extra["turn_id"] = turn_id
+    if user_id is not None:
+        extra["user_id"] = user_id
     return extra
 
 
@@ -257,7 +298,7 @@ def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
         "stack_trace": _stack_trace(record),
         "attributes": _attributes(record),
         "log_id": uuid.uuid4().hex,
-        "user_id": getattr(record, "user_id", None),
+        "user_id": getattr(record, "user_id", None) or current_user_id(),
     }
 
 

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -63,10 +63,6 @@ _FLUSH_INTERVAL_S = 2.0
 _QUEUE_MAX_RECORDS = 10_000
 _TOKEN_REFRESH_SKEW_S = 300.0
 _HTTP_TIMEOUT_S = 10.0
-# Delay before the one-shot startup self-probe fires. Long enough to land after
-# the process's startup-time logging reconfiguration (uvicorn's dictConfig,
-# which closes all handlers, runs a second or two into serving).
-_PROBE_DELAY_S = 10.0
 # Logger-name prefixes the sink drops as noise: httpx/httpcore emit an
 # "HTTP Request: …" line per call — high-volume plumbing the debug view doesn't
 # want (and the sink's own uploads go through httpx).
@@ -415,33 +411,6 @@ class ZerobusLogHandler(logging.Handler):
         self._delivered_any = False
         self._start_worker()
         atexit.register(self.close)
-        # One-shot startup self-probe. Deliberately NOT cancelled on close() —
-        # uvicorn's dictConfig close()s this handler a beat into startup, and the
-        # probe firing *after* that is exactly what re-arms the worker and proves
-        # end-to-end delivery on an otherwise-idle process.
-        self._probe_timer = threading.Timer(_PROBE_DELAY_S, self._probe)
-        self._probe_timer.daemon = True
-        self._probe_timer.start()
-
-    def _probe(self) -> None:
-        """Emit one startup self-probe, after logging reconfiguration.
-
-        Fires ~10s after arm — past uvicorn's startup ``dictConfig()`` — so every
-        boot leaves a health line in the local log (``alive``/``delivered``/queue
-        depth) and, via the normal emit path, a delivered ``sink_online`` row.
-        The emit revives the worker if ``dictConfig`` (or a fork) stopped it, so
-        the sink is guaranteed live even when no session traffic has flowed yet.
-        Best-effort; never raises.
-        """
-        with contextlib.suppress(Exception):  # a probe must never break anything
-            _logger.info(
-                "debug-log sink: self-probe source=%s alive=%s delivered=%s qsize=%d",
-                self._source,
-                self._thread.is_alive(),
-                self._delivered_any,
-                self._queue.qsize(),
-                extra=debug_event("sink_online"),
-            )
 
     def _start_worker(self) -> None:
         """Create the queue/client and launch the uploader thread.

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -27,7 +27,7 @@ import websockets.asyncio.client
 from websockets.exceptions import ConnectionClosed, InvalidStatus, InvalidURI
 
 from omnigent._platform import IS_POSIX, WINDOWS_ENV_PASSTHROUGH
-from omnigent.debug_logging import PRIMARY_SESSION_ID_ENV_VAR
+from omnigent.debug_logging import PRIMARY_SESSION_ID_ENV_VAR, USER_ID_ENV_VAR
 from omnigent.env_credentials import env_names_with_omnigent_prefix
 from omnigent.gateway_inference import gateway_inference_map
 from omnigent.harness_aliases import canonicalize_harness, is_claude_sdk_harness_name
@@ -856,6 +856,11 @@ class HostProcess:
         # to retry credential discovery.
         self._auth_token_factory: Callable[[], str | None] | None = None
         self._auth_token_factory_resolved = False
+        # This host's owning user, resolved once after the first accepted tunnel
+        # upgrade (GET /v1/me). Injected into every runner it spawns and published
+        # to OMNIGENT_USER_ID so host/runner debug-log rows carry it. None until
+        # resolved, or on a single-user server / managed host where it is absent.
+        self._owner_user_id: str | None = None
         # Set on the first accepted WS upgrade. Distinguishes a host that
         # never authenticated (login redirects / 401 / 403 turn fatal) from a
         # live host hit by a transient failure — a server restart or a dropped
@@ -1429,6 +1434,11 @@ class HostProcess:
         # pass it so runner-level log records can be attributed to that session.
         if frame.session_id:
             env[PRIMARY_SESSION_ID_ENV_VAR] = frame.session_id
+        # The runner is 1:1 with this host's owner (cross-owner co-location is
+        # rejected server-side), so hand it our resolved owner for user_id
+        # attribution of runner-level log records.
+        if self._owner_user_id:
+            env[USER_ID_ENV_VAR] = self._owner_user_id
 
         # Embed the session id so operators can find all logs for a session
         # with `omnigent debug logs --session <id>`. Cap at 32 chars to keep
@@ -3024,6 +3034,7 @@ class HostProcess:
         self._auth_retry_streak = 0
         self._refused_streak = 0
         self._conn_upgrade_accepted = True
+        await self._ensure_owner_user_id()
         try:
             await self._serve_frames(ws)
         finally:
@@ -3036,6 +3047,32 @@ class HostProcess:
             # ``async with`` this replaced; the manual enter is only so the
             # upgrade-time exception can be classified above.
             await ws_cm.__aexit__(*sys.exc_info())
+
+    async def _ensure_owner_user_id(self) -> None:
+        """Resolve this host's owning user once and publish it for attribution.
+
+        Best-effort ``GET /v1/me`` (the same call the CLI resume picker uses),
+        run after the tunnel upgrade is accepted so credentials are known to
+        work. On success, store it on the handler (injected into every runner
+        this host spawns) and in ``OMNIGENT_USER_ID`` (so the host's own
+        debug-log rows carry it). A single-user server / managed host answers no
+        owner, and any failure is swallowed -- attribution must never disrupt the
+        host, and those rows simply ship ``user_id = NULL``.
+        """
+        if self._owner_user_id is not None:
+            return
+        try:
+            from omnigent.resume_dispatch import _resolve_current_user_id
+
+            headers = self._build_connect_headers()
+            owner = await asyncio.to_thread(
+                _resolve_current_user_id, base_url=self._server_url, headers=headers
+            )
+        except Exception:  # noqa: BLE001 — attribution is best-effort
+            return
+        if owner:
+            self._owner_user_id = owner
+            os.environ[USER_ID_ENV_VAR] = owner
 
     def _build_connect_headers(self) -> dict[str, str]:
         """Build the WebSocket upgrade headers for the tunnel connection.

--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -212,9 +212,16 @@ class ClaudeNativeExecutor(Executor):
         try:
             kill_session(self._bridge_dir, timeout_s=1.0)
         except TmuxSessionNotAdvertised:
-            _logger.debug("claude-native: timed-out session already disappeared")
+            _logger.debug(
+                "claude-native: timed-out session already disappeared",
+                extra={"session_id": self._request_session_id},
+            )
         except RuntimeError as exc:
-            _logger.warning("claude-native: failed to reap timed-out session", exc_info=True)
+            _logger.warning(
+                "claude-native: failed to reap timed-out session",
+                exc_info=True,
+                extra={"session_id": self._request_session_id},
+            )
             return describe_exception(exc)
         return None
 
@@ -238,12 +245,16 @@ class ClaudeNativeExecutor(Executor):
             should be typed.
         """
         if wanted_model is None:
-            _logger.info("claude-native: turn carries no routed model; not typing /model")
+            _logger.info(
+                "claude-native: turn carries no routed model; not typing /model",
+                extra={"session_id": self._request_session_id},
+            )
             return None
         if not self._should_switch_model(wanted_model):
             _logger.info(
                 "claude-native: skipping /model — pane is already on %s",
                 wanted_model,
+                extra={"session_id": self._request_session_id},
             )
             return None
         env = read_model_env(self._bridge_dir) or None
@@ -254,6 +265,7 @@ class ClaudeNativeExecutor(Executor):
                 "session accepts (pins=%s); sending the turn on the current model",
                 wanted_model,
                 sorted(env or ()),
+                extra={"session_id": self._request_session_id},
             )
             return None
         if (
@@ -266,12 +278,14 @@ class ClaudeNativeExecutor(Executor):
                 "claude-native: skipping /model — %r resolves to %r, already applied",
                 wanted_model,
                 wanted_arg,
+                extra={"session_id": self._request_session_id},
             )
             return None
         _logger.info(
             "claude-native: typing /model %s for routed model %s",
             wanted_arg,
             wanted_model,
+            extra={"session_id": self._request_session_id},
         )
         return wanted_arg
 

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -1401,6 +1401,7 @@ class SessionResourceRegistry:
             on_status=on_status,
             pane_pid_getter=instance.pane_pid_sync,
             session_id_getter=_session_id_getter,
+            omnigent_session_id=session_id,
         )
 
     async def _handle_terminal_exit(

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -27,6 +27,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from omnigent._platform import resolve_repo_symlink
 from omnigent.db.db_models import InvalidUuidError
+from omnigent.debug_logging import set_current_user_id
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_plugins import (
     NativeHarnessProvider,
@@ -1486,6 +1487,18 @@ def create_app(
         set_request_session_id_for_access_log(
             session_match.group(1) if session_match else None,
         )
+        # Bind the request's authenticated user so debug-log records emitted
+        # while handling it are attributed. Request-scoped: each request runs in
+        # its own task/context, so concurrent users never see each other's id.
+        # Best-effort — attribution must never fail a request. The raw identity
+        # (incl. the "local" single-user sentinel) is kept; it is a meaningful
+        # queryable value in the debug table.
+        try:
+            set_current_user_id(
+                auth_provider.get_user_id(request) if auth_provider is not None else None
+            )
+        except Exception:  # noqa: BLE001 — attribution is best-effort
+            set_current_user_id(None)
 
         failed = False
         status_code: int | None = None

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -26,6 +26,7 @@ from collections.abc import Awaitable, Callable
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from omnigent.db.db_models import InvalidUuidError, uuid_to_bytes
+from omnigent.debug_logging import set_current_user_id
 from omnigent.host.frames import (
     HostConnectionErrorFrame,
     HostCreateDirResultFrame,
@@ -191,6 +192,12 @@ def create_host_tunnel_router(
             # deployment; RESERVED_USER_LOCAL is the accepted local owner
             # (consistent with get_user_id returning None on the HTTP side).
             tunnel_owner = RESERVED_USER_LOCAL
+
+        # Attribute debug-log records emitted while servicing this host's tunnel
+        # to its owner. This WebSocket handler runs in its own task, so the set
+        # is scoped to this connection (child loop tasks inherit it) and cannot
+        # bleed across concurrent host connections.
+        set_current_user_id(tunnel_owner)
 
         # Reject a cross-owner takeover before accept(). ``host_id`` is
         # UNIQUE, so a peer authenticated as one user dialing in on a

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -31,6 +31,8 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
         dl.CLIENT_SECRET_ENV_VAR,
         dl.WORKSPACE_URL_ENV_VAR,
         dl.ENDPOINT_ENV_VAR,
+        dl.USER_ID_ENV_VAR,
+        dl.PRIMARY_SESSION_ID_ENV_VAR,
     ):
         monkeypatch.delenv(name, raising=False)
 
@@ -160,6 +162,64 @@ def test_debug_event_includes_explicit_correlation() -> None:
         "session_id": "conv_1",
         "turn_id": "turn_1",
     }
+
+
+def test_debug_event_includes_explicit_user_id() -> None:
+    assert dl.debug_event("evt", user_id="u@x") == {
+        "event_name": "evt",
+        "attributes": {},
+        "user_id": "u@x",
+    }
+    assert "user_id" not in dl.debug_event("evt")
+
+
+def test_record_to_row_prefers_explicit_user_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An explicit record.user_id wins over both ambient fallbacks.
+    monkeypatch.setenv(dl.USER_ID_ENV_VAR, "env@x")
+    record = logging.LogRecord("omnigent", logging.INFO, __file__, 1, "hi", (), None)
+    record.user_id = "explicit@x"
+    with dl.current_user_id_scope("ctx@x"):
+        row = dl.record_to_row(record, source="server")
+    assert row["user_id"] == "explicit@x"
+
+
+def test_record_to_row_falls_back_to_context_var() -> None:
+    # No explicit user_id -> the request-scoped ContextVar (server), and only
+    # inside the scope.
+    record = logging.LogRecord("omnigent", logging.INFO, __file__, 1, "hi", (), None)
+    with dl.current_user_id_scope("ctx@x"):
+        assert dl.record_to_row(record, source="server")["user_id"] == "ctx@x"
+    assert dl.record_to_row(record, source="server")["user_id"] is None
+
+
+def test_record_to_row_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No explicit user_id and no ContextVar -> the process-constant env (runner/host).
+    monkeypatch.setenv(dl.USER_ID_ENV_VAR, "env@x")
+    record = logging.LogRecord("omnigent.runner", logging.INFO, __file__, 1, "hi", (), None)
+    assert dl.record_to_row(record, source="runner")["user_id"] == "env@x"
+
+
+def test_current_user_id_priority(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert dl.current_user_id() is None
+    monkeypatch.setenv(dl.USER_ID_ENV_VAR, "env@x")
+    assert dl.current_user_id() == "env@x"
+    with dl.current_user_id_scope("ctx@x"):
+        assert dl.current_user_id() == "ctx@x"  # ContextVar beats env
+    assert dl.current_user_id() == "env@x"
+    # Empty values normalize to None and don't mask the lower-priority source.
+    with dl.current_user_id_scope(""):
+        assert dl.current_user_id() == "env@x"
+    monkeypatch.setenv(dl.USER_ID_ENV_VAR, "")
+    assert dl.current_user_id() is None
+
+
+def test_current_user_id_scope_resets() -> None:
+    with dl.current_user_id_scope("outer@x"):
+        assert dl.current_user_id() == "outer@x"
+        with dl.current_user_id_scope("inner@x"):
+            assert dl.current_user_id() == "inner@x"
+        assert dl.current_user_id() == "outer@x"
+    assert dl.current_user_id() is None
 
 
 def test_emit_revives_closed_uploader(_configured_env: None) -> None:

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -257,23 +257,6 @@ def test_ignored_loggers_are_dropped() -> None:
     assert not dl._is_ignored_logger("runner.native")
 
 
-def test_startup_probe_emits_sink_online(
-    _configured_env: None, caplog: pytest.LogCaptureFixture
-) -> None:
-    # The startup probe emits a `sink_online` record so every boot has a
-    # definitive health signal (and revives the worker even when idle).
-    config = dl.config_from_env()
-    assert config is not None
-    sink = dl.ZerobusLogHandler(config, "server")
-    try:
-        with caplog.at_level(logging.INFO, logger="omnigent.debug_logging"):
-            sink._probe()
-        assert any(getattr(r, "event_name", None) == "sink_online" for r in caplog.records)
-    finally:
-        sink._probe_timer.cancel()
-        sink.close()
-
-
 def test_attach_is_noop_when_disabled() -> None:
     target = logging.getLogger("test.debug_logging.disabled")
     target.handlers.clear()
@@ -302,7 +285,6 @@ def test_close_tears_down_captured_worker_not_a_concurrent_revive(
     config = dl.config_from_env()
     assert config is not None
     sink = dl.ZerobusLogHandler(config, "server")
-    sink._probe_timer.cancel()
     old_client = sink._client
     old_thread = sink._thread
     orig_join = old_thread.join


### PR DESCRIPTION
## Related issue

Tracked in Linear **OMNI-4198** (Omnigent Debuggability). No GitHub issue. Builds on #5331.

## Summary

Debug-log sink follow-ups, in three commits:

**1. Thread `user_id` (authenticated user email)** into the sink's rows — the column shipped
in #5331 but was always NULL. The mechanism **splits by surface** because the server is
multi-tenant per process while the runner/host are single-user:

- **Sink** (`debug_logging.py`): a layered `current_user_id()` accessor —
  request-scoped `ContextVar` (server) → `OMNIGENT_USER_ID` env (runner/host) → `None`.
  `record_to_row` stamps it as a fallback when a record carries no explicit `user_id`;
  `debug_event` gains an optional `user_id` kwarg. Lives here, **not** `telemetry.py`, whose
  helpers no-op when telemetry is off (the sink's usual mode).
- **Server** (`app.py`): the `_record_server_metrics` HTTP middleware binds the request's
  authenticated user in the ContextVar. Safe under concurrency — each request runs in its own
  asyncio task/context, so users never clobber each other; worst case is a NULL, never a wrong
  user. Best-effort; never fails a request. Keeps the raw `"local"` sentinel.
- **Host-tunnel WS** (`host_tunnel.py`): the WS handler bypasses HTTP middleware, so it binds
  `tunnel_owner` for its own connection task.
- **Host** (`connect.py`): resolves its owning user once after the tunnel upgrade (best-effort
  `GET /v1/me`), publishes `OMNIGENT_USER_ID`, and injects it into every runner it spawns —
  valid because the runner is 1:1 with the host owner (cross-owner co-location is rejected
  server-side); no runner code change.

Why env (not a ContextVar) for runner/host: a ContextVar set at startup is invisible to
`run_in_executor` threads. Collaboration note (documented in the accessor docstring):
runner/host `user_id` is the process **owner**, which in a shared session can differ from the
per-turn initiator the server records — inherent to a per-process attribution column.

**2. Wire `session_id` in two more runner-side modules** (`inner/claude_native_executor.py`,
`claude_native_status_file.py`): the executor's log calls use the `self._request_session_id`
it already holds; `SessionStatusPoller` gains an `omnigent_session_id` field (distinct from its
Claude-session-uuid getter — different identifier namespaces) threaded from its construction
site in `runner/resource_registry.py`.

**3. Drop the debug-sink startup self-probe** — a delivery-proving aid from the debugging phase
that now just emitted a noisy `self-probe …` line + a `sink_online` row every boot. Safe:
`emit()`'s self-heal already revives the uploader on the next record after dictConfig/fork.

## Test Plan

- `pytest tests/test_debug_logging.py` → **23 passed** (user_id: explicit-wins, ContextVar
  fallback scoped, env fallback, priority ordering, scope reset, `debug_event` kwarg; probe test
  removed with the probe).
- `pytest tests/test_claude_native_status_file.py tests/inner/test_claude_native_executor.py`
  → **46 passed** (the new `SessionStatusPoller` kwarg is defaulted; existing behavior intact).
- `ruff` + `pyrefly` clean on all touched modules.
- **Manual E2E to run on an internal build** (sink on, telemetry off): create a host-bound
  session as `alice`, run a turn, query the table for that `session_id`:
  - `server`/`runner`/`host` rows all show `user_id='alice'`;
  - `SELECT DISTINCT source, user_id` → no cross-tenant bleed; a `bob`-initiated turn into
    `alice`'s session shows server=`bob`, runner=`alice`;
  - the claude-native executor / status-file log rows now carry `session_id`;
  - no more `self-probe` rows/lines.

## Demo

N/A — backend logging change, no UI.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the `user_id` accessor and all three fallback layers, and existing suites cover
the two `session_id`-wired modules (the added `SessionStatusPoller` kwarg is defaulted). The
per-surface set-points (server middleware, WS `tunnel_owner` bind, host `/v1/me` resolution +
runner env injection) are thin glue validated by `pyrefly`/compile and the documented manual E2E
above; I did not stand up a full server+host+runner deployment to run that E2E, so it is listed
as the reviewer/author verification step rather than checked as completed.

This pull request and its description were written by Isaac.
