### PR TITLE
feat(web): expand product-analytics component IDs across the app

### DIFF
--- a/web/src/components/HarnessConfigControls.tsx
+++ b/web/src/components/HarnessConfigControls.tsx
@@ -89,6 +89,7 @@ export function RoutingModelSelect({
   defaultLabel = "Default",
   activeModelId,
   contentClassName,
+  componentId,
   children,
 }: {
   value: string;
@@ -100,10 +101,14 @@ export function RoutingModelSelect({
   defaultLabel?: string;
   activeModelId?: string | null;
   contentClassName?: string;
+  // Opt-in analytics id. Model values are a bounded catalog + the "smart"/
+  // "default" sentinels, so the value is reported (valueHasNoPii) for pattern
+  // analysis of model choice.
+  componentId?: string;
   children?: ReactNode;
 }) {
   return (
-    <Select value={value} onValueChange={onValueChange}>
+    <Select value={value} onValueChange={onValueChange} componentId={componentId} valueHasNoPii>
       <SelectTrigger className="w-full" data-testid={testId} aria-label={ariaLabel}>
         <SelectValue />
       </SelectTrigger>
@@ -199,6 +204,7 @@ export function DescribedSelect({
   testId,
   ariaLabel,
   disabled,
+  componentId,
 }: {
   value: string;
   onValueChange: (value: string) => void;
@@ -206,6 +212,9 @@ export function DescribedSelect({
   testId: string;
   ariaLabel: string;
   disabled?: boolean;
+  // Opt-in analytics id. Options are a fixed enum (permission / approval modes),
+  // so the selected value is reported (valueHasNoPii).
+  componentId?: string;
 }) {
   const [previewed, setPreviewed] = useState<string | null>(null);
   const detail = options.find((o) => o.value === (previewed ?? value))?.description;
@@ -213,6 +222,8 @@ export function DescribedSelect({
     <Select
       value={value}
       onValueChange={onValueChange}
+      componentId={componentId}
+      valueHasNoPii
       disabled={disabled}
       // Reset the preview when the list closes so the next open starts on the
       // selected option's blurb.

--- a/web/src/components/HarnessConfigControls.tsx
+++ b/web/src/components/HarnessConfigControls.tsx
@@ -108,6 +108,7 @@ export function RoutingModelSelect({
   children?: ReactNode;
 }) {
   return (
+    // valueHasNoPii assumes a bounded catalog; drop it if reused for typed values.
     <Select value={value} onValueChange={onValueChange} componentId={componentId} valueHasNoPii>
       <SelectTrigger className="w-full" data-testid={testId} aria-label={ariaLabel}>
         <SelectValue />
@@ -223,6 +224,7 @@ export function DescribedSelect({
       value={value}
       onValueChange={onValueChange}
       componentId={componentId}
+      // valueHasNoPii assumes fixed option enums; drop it if reused for free text.
       valueHasNoPii
       disabled={disabled}
       // Reset the preview when the list closes so the next open starts on the

--- a/web/src/components/PermissionsModal.tsx
+++ b/web/src/components/PermissionsModal.tsx
@@ -179,6 +179,7 @@ export function PermissionsModal({ sessionId, open, onOpenChange }: PermissionsM
               checked={isPublic}
               onCheckedChange={handlePublicToggle}
               disabled={grant.isPending || revoke.isPending}
+              componentId="diagnostics.permissions.public_toggle"
             />
           </div>
         )}
@@ -231,7 +232,12 @@ export function PermissionsModal({ sessionId, open, onOpenChange }: PermissionsM
             <label htmlFor="perm-level" className="text-sm font-medium text-muted-foreground">
               Level
             </label>
-            <Select value={newLevel} onValueChange={setNewLevel}>
+            <Select
+              value={newLevel}
+              onValueChange={setNewLevel}
+              componentId="diagnostics.permissions.grant_level"
+              valueHasNoPii
+            >
               <SelectTrigger className="mt-1 w-24">
                 <SelectValue />
               </SelectTrigger>
@@ -242,7 +248,13 @@ export function PermissionsModal({ sessionId, open, onOpenChange }: PermissionsM
               </SelectContent>
             </Select>
           </div>
-          <Button type="submit" size="sm" loading={grant.isPending} disabled={!newUserId.trim()}>
+          <Button
+            type="submit"
+            size="sm"
+            loading={grant.isPending}
+            disabled={!newUserId.trim()}
+            componentId="diagnostics.permissions.grant"
+          >
             <UserPlusIcon className="mr-1 size-3.5" />
             Grant
           </Button>
@@ -499,7 +511,13 @@ function CopyLinkButton({ sessionId }: { sessionId: string }) {
   }, [sessionId, rebasePath]);
 
   return (
-    <Button variant="ghost" size="sm" onClick={handleCopy} className="gap-1.5 text-primary">
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={handleCopy}
+      className="gap-1.5 text-primary"
+      componentId="diagnostics.permissions.copy_link"
+    >
       {copied ? <CheckIcon className="size-3.5" /> : <LinkIcon className="size-3.5" />}
       {copied ? "Copied!" : "Copy link"}
     </Button>
@@ -623,6 +641,7 @@ function GrantRow({
           onClick={() => onRevoke(permission.user_id)}
           disabled={busy}
           className="shrink-0 text-muted-foreground hover:text-destructive"
+          componentId="diagnostics.permissions.revoke"
         >
           <Trash2Icon className="size-3.5" />
           <span className="sr-only">Revoke</span>

--- a/web/src/components/blocks/ApprovalCard.tsx
+++ b/web/src/components/blocks/ApprovalCard.tsx
@@ -297,12 +297,17 @@ export function ApprovalCard({
     : undefined;
   const binaryButtons = (
     <div className="flex flex-wrap gap-2 pt-1">
-      <Button size="sm" onClick={() => submitBinary("accept")}>
+      <Button size="sm" onClick={() => submitBinary("accept")} componentId="approval.approve">
         <CheckIcon className="mr-1 size-3.5" />
         Approve
       </Button>
       {allowAllEdits && (
-        <Button size="sm" variant="outline" onClick={submitAllowAllEdits}>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={submitAllowAllEdits}
+          componentId="approval.approve_allow_edits"
+        >
           <CheckIcon className="mr-1 size-3.5" />
           Accept & allow all edits
         </Button>
@@ -314,12 +319,18 @@ export function ApprovalCard({
           onClick={submitRemember}
           title={rememberTitle}
           data-testid="approval-card-remember"
+          componentId="approval.approve_remember"
         >
           <CheckIcon className="mr-1 size-3.5" />
           Approve &amp; don't ask again for {rememberTarget}
         </Button>
       )}
-      <Button size="sm" variant="outline" onClick={() => submitBinary("decline")}>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => submitBinary("decline")}
+        componentId="approval.reject"
+      >
         <XIcon className="mr-1 size-3.5" />
         Reject
       </Button>
@@ -327,7 +338,11 @@ export function ApprovalCard({
   );
   const codexCommandButtons = (
     <div className="flex flex-wrap items-center gap-2 pt-1" data-testid="codex-command-actions">
-      <Button size="sm" onClick={() => submitBinary("accept")}>
+      <Button
+        size="sm"
+        onClick={() => submitBinary("accept")}
+        componentId="approval.approve_command"
+      >
         <CheckIcon className="mr-1 size-3.5" />
         Approve
       </Button>
@@ -336,6 +351,7 @@ export function ApprovalCard({
           size="sm"
           variant="outline"
           onClick={() => submitExecPolicyAmendment(execPolicyAmendment)}
+          componentId="approval.approve_command_remember"
         >
           <CheckIcon className="mr-1 size-3.5" />
           Approve and remember

--- a/web/src/components/blocks/AskUserQuestionForm.tsx
+++ b/web/src/components/blocks/AskUserQuestionForm.tsx
@@ -348,6 +348,7 @@ export function AskUserQuestionForm({ questions, onSubmit, onReject }: AskUserQu
           onClick={() => setCurrentIndex((i) => i - 1)}
           disabled={isFirst}
           data-testid="ask-user-question-prev"
+          componentId="question.prev"
         >
           <ChevronLeftIcon className="mr-1 size-3.5" />
           Prev
@@ -358,6 +359,7 @@ export function AskUserQuestionForm({ questions, onSubmit, onReject }: AskUserQu
             variant="outline"
             onClick={() => setCurrentIndex((i) => i + 1)}
             data-testid="ask-user-question-next"
+            componentId="question.next"
           >
             Next
             <ChevronRightIcon className="ml-1 size-3.5" />
@@ -369,12 +371,19 @@ export function AskUserQuestionForm({ questions, onSubmit, onReject }: AskUserQu
             onClick={handleSubmit}
             disabled={!allAnswered}
             data-testid="ask-user-question-submit"
+            componentId="question.submit"
           >
             <CheckIcon className="mr-1 size-3.5" />
             Submit
           </Button>
         )}
-        <Button size="sm" variant="outline" onClick={onReject} className="ml-auto">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onReject}
+          className="ml-auto"
+          componentId="question.cancel"
+        >
           <XIcon className="mr-1 size-3.5" />
           Cancel
         </Button>

--- a/web/src/components/blocks/ExitPlanModeReview.tsx
+++ b/web/src/components/blocks/ExitPlanModeReview.tsx
@@ -63,9 +63,10 @@ export function ExitPlanModeReview({
             value={feedback}
             onChange={(e) => setFeedback(e.target.value)}
             className="min-h-20 text-ui"
+            componentId="plan.feedback"
           />
           <div className="flex flex-wrap gap-2">
-            <Button size="sm" onClick={() => onReject(feedback)}>
+            <Button size="sm" onClick={() => onReject(feedback)} componentId="plan.reject">
               <XIcon className="mr-1 size-3.5" />
               Reject plan
             </Button>
@@ -76,11 +77,11 @@ export function ExitPlanModeReview({
         </div>
       ) : (
         <div className="flex flex-wrap gap-2 pt-1">
-          <Button size="sm" onClick={onAcceptAuto}>
+          <Button size="sm" onClick={onAcceptAuto} componentId="plan.accept_auto">
             <ZapIcon className="mr-1 size-3.5" />
             Yes, and use auto mode
           </Button>
-          <Button size="sm" variant="outline" onClick={onAccept}>
+          <Button size="sm" variant="outline" onClick={onAccept} componentId="plan.accept_manual">
             <CheckIcon className="mr-1 size-3.5" />
             Yes, manually approve edits
           </Button>

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -393,6 +393,7 @@ export function ErrorBanner({
                     copiedTarget === "message" ? "Error message copied" : "Copy error message"
                   }
                   onClick={() => void copy("message", messageText)}
+                  componentId="diagnostics.status.copy"
                 >
                   {copiedTarget === "message" ? (
                     <CheckIcon className="size-3.5" aria-hidden="true" />
@@ -432,7 +433,11 @@ export function ErrorBanner({
                   </button>
                 </CollapsibleTrigger>
                 <CollapsibleContent id={diagnosticsId} className="min-w-0 px-[12px] pb-[12px]">
-                  <Tabs value={activeDiagnostics} onValueChange={setActiveDiagnostics}>
+                  <Tabs
+                    value={activeDiagnostics}
+                    onValueChange={setActiveDiagnostics}
+                    componentId="diagnostics.status.tabs"
+                  >
                     {diagnostics.length > 1 ? (
                       <TabsList
                         variant="line"
@@ -470,6 +475,7 @@ export function ErrorBanner({
                                 : `Copy ${item.label.toLowerCase()}`
                             }
                             onClick={() => void copy(item.id, item.content)}
+                            componentId="diagnostics.status.diagnostic_copy"
                           >
                             {copiedTarget === item.id ? (
                               <CheckIcon aria-hidden="true" />

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -218,6 +218,7 @@ export function TerminalView({
             size="xs"
             variant="secondary"
             onClick={() => void copyAndRefocus().then(copied, failed)}
+            componentId="diagnostics.terminal.copy"
           >
             Copy
           </Button>
@@ -611,6 +612,7 @@ function StatusOverlay({
               onClick={onResume}
               disabled={resumePending}
               className="border-zinc-500/50 bg-zinc-100 text-zinc-950 hover:bg-white"
+              componentId="diagnostics.terminal.resume"
             >
               {resumePending ? "Resuming…" : "Resume session"}
             </Button>

--- a/web/src/components/blocks/ToolCard.tsx
+++ b/web/src/components/blocks/ToolCard.tsx
@@ -449,6 +449,7 @@ function OutputSection({ output }: { output: string }) {
             size="xs"
             type="button"
             variant="outline"
+            componentId="diagnostics.tool.toggle_expanded"
           >
             {isExpanded ? (
               <Minimize2Icon className="size-3" />
@@ -544,6 +545,7 @@ function CopyTextButton({ text, label }: CopyTextButtonProps) {
           size="icon-xs"
           type="button"
           variant="ghost"
+          componentId="diagnostics.tool.copy"
         >
           <Icon className="size-3.5" />
         </Button>

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
@@ -367,6 +367,7 @@ export function CreateScheduledTaskDialog({
               rows={3}
               placeholder="What should the agent do each run?"
               data-testid="task-prompt-input"
+              componentId="tasks.scheduled.prompt"
               // No native resize grip — match the clean styling of the other fields.
               className="resize-none text-ui"
               onChange={(e) => setPrompt(e.target.value)}
@@ -484,6 +485,7 @@ export function CreateScheduledTaskDialog({
             <Label htmlFor="task-host">Host (optional)</Label>
             <Select
               value={hostId === "" ? UNSET_HOST : hostId}
+              componentId="tasks.scheduled.host"
               onValueChange={(v) => {
                 if (preservePinnedHost && v === UNSET_HOST) return;
                 const next = v === UNSET_HOST ? "" : v;
@@ -554,7 +556,11 @@ export function CreateScheduledTaskDialog({
         </div>
 
         <DialogFooter className="mx-0 mb-0 shrink-0 rounded-none border-t-0 bg-transparent px-6 py-4 sm:justify-end">
-          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            componentId="tasks.scheduled.cancel"
+          >
             Cancel
           </Button>
           <Button
@@ -562,6 +568,7 @@ export function CreateScheduledTaskDialog({
             loading={mutationPending}
             disabled={!canSubmit}
             data-testid="create-scheduled-task-submit"
+            componentId="tasks.scheduled.save"
           >
             {isEdit ? "Save changes" : "Create task"}
           </Button>

--- a/web/src/components/scheduled/ModelEffortFields.tsx
+++ b/web/src/components/scheduled/ModelEffortFields.tsx
@@ -85,6 +85,8 @@ export function ModelEffortFields({
           <Label htmlFor="task-model">Model</Label>
           <Select
             value={model === "" ? MODEL_SELECT_DEFAULT : model}
+            componentId="tasks.scheduled.model"
+            valueHasNoPii
             onValueChange={(v) => onModelChange(v === MODEL_SELECT_DEFAULT ? "" : v)}
             onOpenChange={onSelectOpenChange}
           >
@@ -110,6 +112,8 @@ export function ModelEffortFields({
           <Label htmlFor="task-effort">Effort</Label>
           <Select
             value={effort === "" ? EFFORT_SELECT_NONE : effort}
+            componentId="tasks.scheduled.effort"
+            valueHasNoPii
             onValueChange={(v) => onEffortChange(v === EFFORT_SELECT_NONE ? "" : v)}
             onOpenChange={onSelectOpenChange}
           >
@@ -136,6 +140,8 @@ export function ModelEffortFields({
         <Label htmlFor="task-permission">Permission mode</Label>
         <Select
           value={permissionMode === "" ? PERMISSION_SELECT_DEFAULT : permissionMode}
+          componentId="tasks.scheduled.permission_mode"
+          valueHasNoPii
           onValueChange={(v) => onPermissionModeChange(v === PERMISSION_SELECT_DEFAULT ? "" : v)}
           onOpenChange={onSelectOpenChange}
         >

--- a/web/src/components/scheduled/ScheduleFields.tsx
+++ b/web/src/components/scheduled/ScheduleFields.tsx
@@ -195,6 +195,8 @@ export function ScheduleFields({
           <Label htmlFor="schedule-preset">Frequency</Label>
           <Select
             value={model.preset}
+            componentId="tasks.scheduled.schedule_frequency"
+            valueHasNoPii
             onValueChange={(value) => onChange({ ...model, preset: value as SchedulePreset })}
             onOpenChange={onSelectOpenChange}
           >

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { describeSchedule, formatNextRunAt } from "@/lib/scheduleText";
+import { useOmnigentAnalytics } from "@/lib/analytics";
 import type { ScheduledTask } from "@/lib/scheduledTasksApi";
 
 export function ScheduledTaskRow({
@@ -56,6 +57,7 @@ export function ScheduledTaskRow({
   busy: boolean;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const { trackClick } = useOmnigentAnalytics();
   const paused = task.state === "paused";
   // Subtitle: the schedule summary, plus the SERVER's next-run time when armed
   // (active tasks only — a paused task has null nextRunAt). We only format the
@@ -131,15 +133,33 @@ export function ScheduledTaskRow({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem onSelect={() => onRunNow(task)} data-testid="task-run-now">
+          <DropdownMenuItem
+            onSelect={() => {
+              trackClick("tasks.scheduled.run_now", "button");
+              onRunNow(task);
+            }}
+            data-testid="task-run-now"
+          >
             <ZapIcon className="size-4" />
             Run now
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => onEdit(task)} data-testid="task-edit">
+          <DropdownMenuItem
+            onSelect={() => {
+              trackClick("tasks.scheduled.edit", "button");
+              onEdit(task);
+            }}
+            data-testid="task-edit"
+          >
             <PencilIcon className="size-4" />
             Edit
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => onPauseToggle(task)} data-testid="task-pause-toggle">
+          <DropdownMenuItem
+            onSelect={() => {
+              trackClick("tasks.scheduled.pause_resume", "button");
+              onPauseToggle(task);
+            }}
+            data-testid="task-pause-toggle"
+          >
             {paused ? (
               <>
                 <PlayIcon className="size-4" />
@@ -154,7 +174,10 @@ export function ScheduledTaskRow({
           </DropdownMenuItem>
           <DropdownMenuItem
             variant="destructive"
-            onSelect={() => onDelete(task)}
+            onSelect={() => {
+              trackClick("tasks.scheduled.delete", "button");
+              onDelete(task);
+            }}
             data-testid="task-delete"
           >
             <Trash2Icon className="size-4" />

--- a/web/src/components/ui/select.test.tsx
+++ b/web/src/components/ui/select.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./select";
+import { setOmnigentHostConfig } from "@/lib/host";
+
+afterEach(() => {
+  cleanup();
+  setOmnigentHostConfig({});
+});
+
+function renderSelect(props: {
+  componentId?: string;
+  valueHasNoPii?: boolean;
+  onValueChange?: (v: string) => void;
+}) {
+  return render(
+    <Select {...props}>
+      <SelectTrigger aria-label="Effort">
+        <SelectValue placeholder="Pick" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="low">Low</SelectItem>
+        <SelectItem value="high">High</SelectItem>
+      </SelectContent>
+    </Select>,
+  );
+}
+
+function pickHigh() {
+  fireEvent.click(screen.getByRole("combobox"));
+  fireEvent.click(screen.getByRole("option", { name: "High" }));
+}
+
+describe("Select analytics (componentId)", () => {
+  it("forwards the value when the call site declares it PII-free", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    const onValueChange = vi.fn();
+    renderSelect({ componentId: "chat.composer.effort", valueHasNoPii: true, onValueChange });
+    pickHigh();
+    expect(analytics).toHaveBeenLastCalledWith({
+      type: "value_change",
+      componentId: "chat.composer.effort",
+      componentKind: "select",
+      value: "high",
+    });
+    expect(onValueChange).toHaveBeenLastCalledWith("high");
+  });
+
+  it("redacts the value by default (no valueHasNoPii)", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    renderSelect({ componentId: "chat.composer.effort" });
+    pickHigh();
+    expect(analytics).toHaveBeenLastCalledWith({
+      type: "value_change",
+      componentId: "chat.composer.effort",
+      componentKind: "select",
+      value: undefined,
+    });
+  });
+
+  it("emits nothing when componentId is absent", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    renderSelect({});
+    pickHigh();
+    expect(analytics).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -27,9 +27,7 @@ function Select({
         onValueChange?.(value);
       }
     : onValueChange;
-  return (
-    <SelectPrimitive.Root data-slot="select" onValueChange={handleValueChange} {...props} />
-  );
+  return <SelectPrimitive.Root data-slot="select" onValueChange={handleValueChange} {...props} />;
 }
 
 function SelectGroup({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -5,10 +5,31 @@ import * as SelectPrimitive from "radix-ui/select";
 
 import { getEmbedRoot } from "@/lib/host";
 import { cn } from "@/lib/utils";
+import { useOmnigentAnalytics } from "@/lib/analytics";
 import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react";
 
-function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />;
+function Select({
+  componentId,
+  valueHasNoPii,
+  onValueChange,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root> & {
+  // Opt-in analytics id. When set, a selection reports to the host sink (see
+  // `lib/analytics.ts`). The value is redacted by default; set `valueHasNoPii`
+  // ONLY when the option set is bounded/enumerable (never for a free-text value).
+  componentId?: string;
+  valueHasNoPii?: boolean;
+}) {
+  const { trackValueChange } = useOmnigentAnalytics();
+  const handleValueChange = componentId
+    ? (value: string) => {
+        trackValueChange(componentId, "select", value, { valueHasNoPii });
+        onValueChange?.(value);
+      }
+    : onValueChange;
+  return (
+    <SelectPrimitive.Root data-slot="select" onValueChange={handleValueChange} {...props} />
+  );
 }
 
 function SelectGroup({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {

--- a/web/src/components/ui/switch.test.tsx
+++ b/web/src/components/ui/switch.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Switch } from "./switch";
+import { setOmnigentHostConfig } from "@/lib/host";
+
+afterEach(() => {
+  cleanup();
+  setOmnigentHostConfig({});
+});
+
+describe("Switch analytics (componentId)", () => {
+  it("reports the new checked state and still calls the caller's onCheckedChange", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    const onCheckedChange = vi.fn();
+    render(
+      <Switch
+        componentId="settings.translucent_sidebar"
+        onCheckedChange={onCheckedChange}
+        aria-label="Toggle"
+      />,
+    );
+    fireEvent.click(screen.getByRole("switch"));
+    // Boolean carries no PII, so the value is forwarded.
+    expect(analytics).toHaveBeenCalledExactlyOnceWith({
+      type: "value_change",
+      componentId: "settings.translucent_sidebar",
+      componentKind: "toggle",
+      value: true,
+    });
+    expect(onCheckedChange).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it("emits nothing when componentId is absent", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    render(<Switch aria-label="Toggle" />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(analytics).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -2,18 +2,33 @@ import * as React from "react";
 import * as SwitchPrimitive from "radix-ui/switch";
 
 import { cn } from "@/lib/utils";
+import { useOmnigentAnalytics } from "@/lib/analytics";
 
 function Switch({
   className,
   size = "default",
+  componentId,
+  onCheckedChange,
   ...props
 }: React.ComponentProps<typeof SwitchPrimitive.Root> & {
   size?: "sm" | "default";
+  // Opt-in analytics id. When set, a toggle reports the new checked state to the
+  // host sink (see `lib/analytics.ts`). A boolean carries no PII, so it's sent.
+  componentId?: string;
 }) {
+  const { trackValueChange } = useOmnigentAnalytics();
+  const handleCheckedChange = componentId
+    ? (checked: boolean) => {
+        trackValueChange(componentId, "toggle", checked, { valueHasNoPii: true });
+        onCheckedChange?.(checked);
+      }
+    : onCheckedChange;
   return (
     <SwitchPrimitive.Root
       data-slot="switch"
       data-size={size}
+      data-component-id={componentId}
+      onCheckedChange={handleCheckedChange}
       className={cn(
         "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className,

--- a/web/src/components/ui/tabs.test.tsx
+++ b/web/src/components/ui/tabs.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
+import { setOmnigentHostConfig } from "@/lib/host";
+
+afterEach(() => {
+  cleanup();
+  setOmnigentHostConfig({});
+});
+
+function renderTabs(props: { componentId?: string; onValueChange?: (v: string) => void }) {
+  return render(
+    <Tabs defaultValue="local" {...props}>
+      <TabsList>
+        <TabsTrigger value="local">Local</TabsTrigger>
+        <TabsTrigger value="lakebox">Lakebox</TabsTrigger>
+      </TabsList>
+      <TabsContent value="local">local</TabsContent>
+      <TabsContent value="lakebox">lakebox</TabsContent>
+    </Tabs>,
+  );
+}
+
+describe("Tabs analytics (componentId)", () => {
+  it("reports the selected tab value and still calls the caller's onValueChange", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    const onValueChange = vi.fn();
+    renderTabs({ componentId: "new_chat.host_tabs", onValueChange });
+    // Radix Tabs (automatic activation) selects on focus; jsdom's synthetic
+    // click doesn't move focus, so drive both.
+    const tab = screen.getByRole("tab", { name: "Lakebox" });
+    fireEvent.focus(tab);
+    fireEvent.click(tab);
+    // Tab values are a bounded set, so the value is forwarded.
+    expect(analytics).toHaveBeenCalledExactlyOnceWith({
+      type: "value_change",
+      componentId: "new_chat.host_tabs",
+      componentKind: "tabs",
+      value: "lakebox",
+    });
+    expect(onValueChange).toHaveBeenCalledExactlyOnceWith("lakebox");
+  });
+
+  it("emits nothing when componentId is absent", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    renderTabs({});
+    const tab = screen.getByRole("tab", { name: "Lakebox" });
+    fireEvent.focus(tab);
+    fireEvent.click(tab);
+    expect(analytics).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -3,16 +3,32 @@ import { cva, type VariantProps } from "class-variance-authority";
 import * as TabsPrimitive from "radix-ui/tabs";
 
 import { cn } from "@/lib/utils";
+import { useOmnigentAnalytics } from "@/lib/analytics";
 
 function Tabs({
   className,
   orientation = "horizontal",
+  componentId,
+  onValueChange,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+}: React.ComponentProps<typeof TabsPrimitive.Root> & {
+  // Opt-in analytics id on the tab group. When set, switching tabs reports the
+  // selected value to the host sink (see `lib/analytics.ts`) — instrumenting the
+  // root covers every trigger. Tab values are a bounded set, so the value is sent.
+  componentId?: string;
+}) {
+  const { trackValueChange } = useOmnigentAnalytics();
+  const handleValueChange = componentId
+    ? (value: string) => {
+        trackValueChange(componentId, "tabs", value, { valueHasNoPii: true });
+        onValueChange?.(value);
+      }
+    : onValueChange;
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
       data-orientation={orientation}
+      onValueChange={handleValueChange}
       className={cn("group/tabs flex gap-2 data-horizontal:flex-col", className)}
       {...props}
     />

--- a/web/src/components/ui/textarea.test.tsx
+++ b/web/src/components/ui/textarea.test.tsx
@@ -1,0 +1,36 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Textarea } from "./textarea";
+import { setOmnigentHostConfig } from "@/lib/host";
+
+afterEach(() => {
+  cleanup();
+  setOmnigentHostConfig({});
+});
+
+describe("Textarea analytics (componentId)", () => {
+  it("reports a value-change with the value redacted and still calls onChange", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    const onChange = vi.fn();
+    render(<Textarea componentId="plan.feedback" onChange={onChange} aria-label="Feedback" />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "some private text" } });
+    // Textarea text is PII: only that the field changed is reported, never the value.
+    expect(analytics).toHaveBeenCalledExactlyOnceWith({
+      type: "value_change",
+      componentId: "plan.feedback",
+      componentKind: "textarea",
+      value: undefined,
+    });
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it("emits nothing when componentId is absent", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    render(<Textarea aria-label="Feedback" />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "x" } });
+    expect(analytics).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/ui/textarea.tsx
+++ b/web/src/components/ui/textarea.tsx
@@ -1,11 +1,31 @@
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
+import { useOmnigentAnalytics } from "@/lib/analytics";
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+function Textarea({
+  className,
+  componentId,
+  onChange,
+  ...props
+}: React.ComponentProps<"textarea"> & {
+  // Opt-in analytics id. When set, a value-change is reported to the host sink
+  // (see `lib/analytics.ts`). The value itself is redacted by default (textarea
+  // text is treated as PII); only that the field changed is sent.
+  componentId?: string;
+}) {
+  const { trackValueChange } = useOmnigentAnalytics();
+  const handleChange = componentId
+    ? (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        trackValueChange(componentId, "textarea");
+        onChange?.(e);
+      }
+    : onChange;
   return (
     <textarea
       data-slot="textarea"
+      data-component-id={componentId}
+      onChange={handleChange}
       className={cn(
         "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-ui transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-ui dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className,

--- a/web/src/lib/analytics.test.tsx
+++ b/web/src/lib/analytics.test.tsx
@@ -29,6 +29,17 @@ describe("emitOmnigentAnalytics", () => {
     emitOmnigentAnalytics(event);
     expect(analytics).toHaveBeenCalledExactlyOnceWith(event);
   });
+
+  it("swallows a throwing host sink so it can't break the primary action", () => {
+    // The wrappers emit BEFORE running the caller's handler, so a sink that
+    // throws must not propagate up and suppress the user's action.
+    setOmnigentHostConfig({
+      analytics: () => {
+        throw new Error("host sink blew up");
+      },
+    });
+    expect(() => emitOmnigentAnalytics({ type: "click", componentId: "x" })).not.toThrow();
+  });
 });
 
 describe("useOmnigentAnalytics", () => {

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -16,64 +16,19 @@
  * even then free-form strings should be avoided — prefer enumerable values.
  */
 
-import { useEffect, useMemo, useRef } from "react";
-import {
-  getOmnigentAnalytics,
-  type OmnigentAnalyticsEvent,
-  type OmnigentComponentKind,
-} from "@/lib/host";
+import { useEffect, useRef } from "react";
 import { useLocation } from "@/lib/routing";
 
-/**
- * Emit one analytics event to the host sink. No-op when no host is configured.
- * Safe to call from anywhere (event handlers, effects) — it is not a hook.
- */
-export function emitOmnigentAnalytics(event: OmnigentAnalyticsEvent): void {
-  getOmnigentAnalytics()?.(event);
-}
-
-export interface TrackValueChangeOptions {
-  /**
-   * Set true ONLY when the value is known non-PII (e.g. a selection from a
-   * fixed set, a boolean toggle, a count). When false/omitted the value is
-   * dropped and only the fact that the field changed is reported.
-   */
-  valueHasNoPii?: boolean;
-}
-
-export interface OmnigentAnalytics {
-  trackClick: (componentId: string, componentKind?: OmnigentComponentKind) => void;
-  trackValueChange: (
-    componentId: string,
-    componentKind?: OmnigentComponentKind,
-    value?: string | number | boolean,
-    options?: TrackValueChangeOptions,
-  ) => void;
-}
-
-/**
- * Stable analytics callbacks for use in components. The returned object is
- * referentially stable for the lifetime of the component (the sink is read
- * lazily inside each call), so it's safe in effect/callback deps.
- */
-export function useOmnigentAnalytics(): OmnigentAnalytics {
-  return useMemo<OmnigentAnalytics>(
-    () => ({
-      trackClick: (componentId, componentKind) =>
-        emitOmnigentAnalytics({ type: "click", componentId, componentKind }),
-      trackValueChange: (componentId, componentKind, value, options) =>
-        emitOmnigentAnalytics({
-          type: "value_change",
-          componentId,
-          componentKind,
-          // Redact by default: only forward the value when the caller vouches
-          // it carries no PII.
-          value: options?.valueHasNoPii ? value : undefined,
-        }),
-    }),
-    [],
-  );
-}
+// The routing-free emit primitives live in `lib/analyticsEmit.ts` (so
+// `lib/routing.tsx` can emit without a routing↔analytics import cycle). Re-export
+// them here so this module stays the single import surface for analytics.
+export {
+  emitOmnigentAnalytics,
+  useOmnigentAnalytics,
+  type OmnigentAnalytics,
+  type TrackValueChangeOptions,
+} from "@/lib/analyticsEmit";
+import { emitOmnigentAnalytics } from "@/lib/analyticsEmit";
 
 /**
  * Report a page view for the given stable `pageId`. Each page calls this at the

--- a/web/src/lib/analyticsEmit.ts
+++ b/web/src/lib/analyticsEmit.ts
@@ -23,7 +23,13 @@ import {
  * Safe to call from anywhere (event handlers, effects) — it is not a hook.
  */
 export function emitOmnigentAnalytics(event: OmnigentAnalyticsEvent): void {
-  getOmnigentAnalytics()?.(event);
+  // Wrappers emit before the caller's handler runs, so a throwing sink must not
+  // suppress the user's action.
+  try {
+    getOmnigentAnalytics()?.(event);
+  } catch {
+    // ignore
+  }
 }
 
 export interface TrackValueChangeOptions {

--- a/web/src/lib/analyticsEmit.ts
+++ b/web/src/lib/analyticsEmit.ts
@@ -1,0 +1,70 @@
+/**
+ * Routing-free analytics emit primitives.
+ *
+ * Split out from `lib/analytics.ts` so modules that only need to *emit* an event
+ * (e.g. `lib/routing.tsx`'s Link) can import these without pulling in
+ * `useOmnigentPageView`, which imports `useLocation` from `lib/routing` — that
+ * would form a routing↔analytics import cycle. The page-view hook stays in
+ * `lib/analytics.ts`; both are re-exported there so existing call sites are
+ * unchanged.
+ *
+ * See `lib/analytics.ts` for the IoC rationale and PII policy.
+ */
+
+import { useMemo } from "react";
+import {
+  getOmnigentAnalytics,
+  type OmnigentAnalyticsEvent,
+  type OmnigentComponentKind,
+} from "@/lib/host";
+
+/**
+ * Emit one analytics event to the host sink. No-op when no host is configured.
+ * Safe to call from anywhere (event handlers, effects) — it is not a hook.
+ */
+export function emitOmnigentAnalytics(event: OmnigentAnalyticsEvent): void {
+  getOmnigentAnalytics()?.(event);
+}
+
+export interface TrackValueChangeOptions {
+  /**
+   * Set true ONLY when the value is known non-PII (e.g. a selection from a
+   * fixed set, a boolean toggle, a count). When false/omitted the value is
+   * dropped and only the fact that the field changed is reported.
+   */
+  valueHasNoPii?: boolean;
+}
+
+export interface OmnigentAnalytics {
+  trackClick: (componentId: string, componentKind?: OmnigentComponentKind) => void;
+  trackValueChange: (
+    componentId: string,
+    componentKind?: OmnigentComponentKind,
+    value?: string | number | boolean,
+    options?: TrackValueChangeOptions,
+  ) => void;
+}
+
+/**
+ * Stable analytics callbacks for use in components. The returned object is
+ * referentially stable for the lifetime of the component (the sink is read
+ * lazily inside each call), so it's safe in effect/callback deps.
+ */
+export function useOmnigentAnalytics(): OmnigentAnalytics {
+  return useMemo<OmnigentAnalytics>(
+    () => ({
+      trackClick: (componentId, componentKind) =>
+        emitOmnigentAnalytics({ type: "click", componentId, componentKind }),
+      trackValueChange: (componentId, componentKind, value, options) =>
+        emitOmnigentAnalytics({
+          type: "value_change",
+          componentId,
+          componentKind,
+          // Redact by default: only forward the value when the caller vouches
+          // it carries no PII.
+          value: options?.valueHasNoPii ? value : undefined,
+        }),
+    }),
+    [],
+  );
+}

--- a/web/src/lib/host.ts
+++ b/web/src/lib/host.ts
@@ -30,7 +30,7 @@ export interface UserSuggestion {
  * telemetry taxonomy uses. Omitted when the element doesn't fit any of these.
  */
 export type OmnigentComponentKind =
-  "button" | "link" | "input" | "textarea" | "checkbox" | "toggle" | "select";
+  "button" | "link" | "input" | "textarea" | "checkbox" | "toggle" | "select" | "tabs";
 
 /**
  * A product-analytics event forwarded to the host. Each carries a stable,

--- a/web/src/lib/routing.test.tsx
+++ b/web/src/lib/routing.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, type To } from "react-router-dom";
-import { describe, expect, it } from "vitest";
-import { basenamedRouting, reactRouterRouting } from "./routing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { basenamedRouting, Link as RoutingLink, reactRouterRouting } from "./routing";
+import { setOmnigentHostConfig } from "@/lib/host";
 
 // `basenamedRouting` is the embed seam: it rebases web's absolute
 // navigation targets under the host mount path so links land under
@@ -90,5 +91,51 @@ describe("rebasePath primitive", () => {
     // `/mounting` merely shares the `/mount` text prefix; it's a different path
     // and must be rebased under the mount, not treated as already-under.
     expect(basenamedRouting("/mount").rebasePath("/mounting")).toBe("/mount/mounting");
+  });
+});
+
+describe("Link analytics (componentId)", () => {
+  afterEach(() => {
+    cleanup();
+    setOmnigentHostConfig({});
+  });
+
+  function renderLink(props: { componentId?: string; onClick?: () => void }) {
+    return render(
+      <MemoryRouter>
+        <RoutingLink to="/tasks" {...props}>
+          Tasks
+        </RoutingLink>
+      </MemoryRouter>,
+    );
+  }
+
+  it("reports a click to the host sink and still calls the caller's onClick", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    const onClick = vi.fn();
+    renderLink({ componentId: "sidebar.tasks", onClick });
+    fireEvent.click(screen.getByRole("link", { name: "Tasks" }));
+    expect(analytics).toHaveBeenCalledExactlyOnceWith({
+      type: "click",
+      componentId: "sidebar.tasks",
+      componentKind: "link",
+    });
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("does not leak componentId onto the rendered <a>", () => {
+    setOmnigentHostConfig({ analytics: vi.fn() });
+    renderLink({ componentId: "sidebar.tasks" });
+    // React would warn on an unknown DOM attribute; also assert it isn't present.
+    expect(screen.getByRole("link", { name: "Tasks" })).not.toHaveAttribute("componentId");
+  });
+
+  it("emits nothing when componentId is absent", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    renderLink({});
+    fireEvent.click(screen.getByRole("link", { name: "Tasks" }));
+    expect(analytics).not.toHaveBeenCalled();
   });
 });

--- a/web/src/lib/routing.tsx
+++ b/web/src/lib/routing.tsx
@@ -24,6 +24,7 @@
 import {
   type ComponentPropsWithoutRef,
   type ComponentType,
+  type MouseEvent,
   type ReactNode,
   type RefAttributes,
   createContext,
@@ -40,6 +41,7 @@ import {
   useParams as useRRParams,
   useSearchParams as useRRSearchParams,
 } from "react-router-dom";
+import { useOmnigentAnalytics } from "@/lib/analyticsEmit";
 
 /**
  * The routing contract web depends on. Types are taken verbatim from
@@ -70,14 +72,22 @@ export interface RoutingApi {
   rebasePath: (path: string) => string;
 }
 
-// Standalone Link: react-router-dom's Link, minus the host-only `componentId`
-// (standalone has no analytics sink; passing it to a real <a> would warn on an
-// unknown DOM attribute).
+// Standalone Link: react-router-dom's Link that reports a click to the host
+// analytics sink when a `componentId` is given (see `lib/analytics.ts`). The id
+// is consumed here and never spread onto the real <a>, so it can't warn as an
+// unknown DOM attribute. When no host sink is configured the emit is a no-op.
 const StandaloneLink = forwardRef<HTMLAnchorElement, OmnigentLinkProps>(function StandaloneLink(
-  { componentId: _componentId, ...props },
+  { componentId, onClick, ...props },
   ref,
 ) {
-  return <RRLink ref={ref} {...props} />;
+  const { trackClick } = useOmnigentAnalytics();
+  const handleClick = componentId
+    ? (e: MouseEvent<HTMLAnchorElement>) => {
+        trackClick(componentId, "link");
+        onClick?.(e);
+      }
+    : onClick;
+  return <RRLink ref={ref} {...props} onClick={handleClick} />;
 });
 
 /** Default implementation: plain react-router-dom. */

--- a/web/src/pages/ApprovePage.tsx
+++ b/web/src/pages/ApprovePage.tsx
@@ -165,11 +165,16 @@ export function ApprovePage() {
               </pre>
             )}
             <div className="flex flex-wrap gap-2 pt-1">
-              <Button size="sm" onClick={() => void submit("accept")}>
+              <Button size="sm" onClick={() => void submit("accept")} componentId="approve.approve">
                 <CheckIcon className="mr-1 size-3.5" />
                 Approve
               </Button>
-              <Button size="sm" variant="outline" onClick={() => void submit("decline")}>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => void submit("decline")}
+                componentId="approve.reject"
+              >
                 <XIcon className="mr-1 size-3.5" />
                 Reject
               </Button>

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2990,6 +2990,7 @@ export function JumpToTopButton({
         disabled={jumping}
         onClick={() => void jumpToTop()}
         aria-label="Jump to the first message"
+        componentId="chat.nav.jump_to_top"
         // When hidden (opacity-0 / pointer-events-none) keep the button out of
         // the tab order and the accessibility tree so it can't take focus or be
         // announced while invisible.
@@ -3866,7 +3867,12 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
             )}
             {text && (
               <MessageActions>
-                <MessageAction tooltip="Copy" size="icon-xxs" onClick={handleCopy}>
+                <MessageAction
+                  tooltip="Copy"
+                  size="icon-xxs"
+                  onClick={handleCopy}
+                  componentId="chat.message.copy_user"
+                >
                   {isCopied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
                 </MessageAction>
               </MessageActions>
@@ -3992,7 +3998,12 @@ function AssistantBubble({
           <div className="flex items-center gap-3 py-1 opacity-40 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100">
             {markdownText && (
               <MessageActions>
-                <MessageAction tooltip="Copy" size="icon-xxs" onClick={handleCopy}>
+                <MessageAction
+                  tooltip="Copy"
+                  size="icon-xxs"
+                  onClick={handleCopy}
+                  componentId="chat.message.copy_assistant"
+                >
                   {isCopied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
                 </MessageAction>
                 {/* Fork from this response: clone the session with history
@@ -4005,6 +4016,7 @@ function AssistantBubble({
                     size="icon-xxs"
                     data-testid="fork-from-response"
                     onClick={() => forkDialog.openForkDialog({ upToResponseId: bubble.responseId })}
+                    componentId="chat.message.fork"
                   >
                     <GitForkIcon size={14} />
                   </MessageAction>
@@ -5737,6 +5749,7 @@ export function Composer({
               disabled={disabled || isReadOnly || hasPendingElicitation}
               onClick={() => fileInputRef.current?.click()}
               title="Attach files"
+              componentId="chat.composer.attach_files"
             >
               <PaperclipIcon className="size-4" data-icon-size="16" />
               <span className="sr-only">Attach files</span>
@@ -5787,6 +5800,7 @@ export function Composer({
                     data-testid="codex-plan-mode-toggle"
                     data-active={codexPlanMode ? "true" : undefined}
                     onClick={() => void toggleCodexPlanMode()}
+                    componentId="chat.composer.toggle_plan_mode"
                   >
                     {planModeBusy ? (
                       <Loader2Icon className="size-3.5 animate-spin" />
@@ -6548,6 +6562,7 @@ function SessionConfigModal({
                     : undefined
                 }
                 activeModelId={draftModelId}
+                componentId="chat.composer.model"
               />
             </ConfigRow>
           )}
@@ -6560,6 +6575,8 @@ function SessionConfigModal({
                 value={draftRoutingOn ? "" : (draftEffort ?? EFFORT_SELECT_NONE)}
                 onValueChange={(v) => setDraftEffort(v === EFFORT_SELECT_NONE ? null : v)}
                 disabled={draftRoutingOn}
+                componentId="chat.composer.effort"
+                valueHasNoPii
               >
                 <SelectTrigger
                   className="w-full"
@@ -6594,7 +6611,12 @@ function SessionConfigModal({
               footer in some pane states, and a guess would misreport it. */}
           {showClaudePermissionMode && claudePermissionMode !== "" && (
             <ConfigRow label="Permissions" description="How much Claude asks before acting">
-              <Select value={draftPermissionMode} onValueChange={setDraftPermissionMode}>
+              <Select
+                value={draftPermissionMode}
+                onValueChange={setDraftPermissionMode}
+                componentId="chat.composer.permission_mode"
+                valueHasNoPii
+              >
                 <SelectTrigger
                   className="w-full"
                   data-testid="composer-config-permission-mode"
@@ -6632,6 +6654,8 @@ function SessionConfigModal({
               <Select
                 value={subagentRoutingValue}
                 onValueChange={(v) => setPickedSubagentRouting(v === "on" ? "on" : "off")}
+                componentId="chat.composer.subagent_routing"
+                valueHasNoPii
               >
                 <SelectTrigger
                   className="w-full"

--- a/web/src/pages/InboxPage.tsx
+++ b/web/src/pages/InboxPage.tsx
@@ -53,6 +53,7 @@ import { useConversations } from "@/hooks/useConversations";
 import { collectInboxItems, type InboxItem, type InboxSource } from "@/lib/inbox";
 import { relativeTime } from "@/lib/relativeTime";
 import { Link } from "@/lib/routing";
+import { useOmnigentAnalytics } from "@/lib/analytics";
 import { approve, getSession } from "@/lib/sessionsApi";
 import { userColor, userInitials } from "@/lib/userBadge";
 import { cn } from "@/lib/utils";
@@ -66,6 +67,7 @@ type RespondedMap = Record<
 
 export function InboxPage() {
   const queryClient = useQueryClient();
+  const { trackClick } = useOmnigentAnalytics();
   const conversationsQuery = useConversations("", false, { reconcileWhileConnected: true });
   const [responded, setResponded] = useState<RespondedMap>({});
   // Manual expand/collapse toggles keyed by elicitation id. Anything
@@ -217,6 +219,7 @@ export function InboxPage() {
               failedSnapshots.forEach((q) => void q.refetch());
               commentInbox.retryFailed();
             }}
+            componentId="inbox.retry"
           >
             Retry
           </Button>
@@ -269,9 +272,10 @@ export function InboxPage() {
                 <button
                   type="button"
                   aria-expanded={expanded}
-                  onClick={() =>
-                    setExpandedOverrides((prev) => ({ ...prev, [elicitationId]: !expanded }))
-                  }
+                  onClick={() => {
+                    trackClick("inbox.approval.toggle_expanded", "button");
+                    setExpandedOverrides((prev) => ({ ...prev, [elicitationId]: !expanded }));
+                  }}
                   className="flex min-w-0 flex-1 items-center gap-2 text-left"
                 >
                   <ChevronDownIcon
@@ -300,7 +304,7 @@ export function InboxPage() {
                     {relativeTime(item.row.updated_at * 1000)}
                   </span>
                   <Button asChild variant="ghost" size="sm" className="text-sm">
-                    <Link to={`/c/${item.row.id}`}>
+                    <Link to={`/c/${item.row.id}`} componentId="inbox.approval.open_session">
                       Open session
                       <ArrowRightIcon className="ml-1 size-3.5" />
                     </Link>
@@ -369,6 +373,7 @@ export function InboxPage() {
                           is what clears this inbox item. */}
                       <Link
                         to={`/c/${item.row.id}?file=${encodeURIComponent(comment.path)}&comment=${encodeURIComponent(comment.id)}`}
+                        componentId="inbox.comment.open_file"
                       >
                         Open file
                         <ArrowRightIcon className="ml-1 size-3.5" />

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -192,7 +192,12 @@ export function LoginPage() {
             </div>
           )}
 
-          <Button type="submit" className="w-full" disabled={submitting || password.length === 0}>
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={submitting || password.length === 0}
+            componentId="login.sign_in"
+          >
             {submitting ? "Signing in…" : "Sign in"}
           </Button>
         </form>

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -555,6 +555,7 @@ export function PoliciesPage() {
                             })
                           }
                           aria-label={`Toggle ${p.name}`}
+                          componentId="settings.policies.toggle_enabled"
                         />
                         <Button
                           variant="ghost"

--- a/web/src/pages/RegisterPage.tsx
+++ b/web/src/pages/RegisterPage.tsx
@@ -164,6 +164,7 @@ export function RegisterPage() {
               disabled={
                 submitting || password.length < MIN_PASSWORD_LENGTH || username.length === 0
               }
+              componentId="register.create_account"
             >
               {submitting ? "Creating…" : "Create account"}
             </Button>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -82,7 +82,7 @@ import { KeyboardShortcutsList } from "@/components/KeyboardShortcutsDialog";
 import { changePassword, logout } from "@/lib/accountsApi";
 import { getCurrentIsAdmin, resolveIdentity } from "@/lib/identity";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
-import { useOmnigentPageView } from "@/lib/analytics";
+import { useOmnigentAnalytics, useOmnigentPageView } from "@/lib/analytics";
 import {
   type Conversation,
   useArchiveConversation,
@@ -398,6 +398,7 @@ function CardRadioGroup<T extends string>({
   labelledBy,
   value,
   onSelect,
+  componentId,
   items,
   className,
   cardClassName,
@@ -405,10 +406,21 @@ function CardRadioGroup<T extends string>({
   labelledBy: string;
   value: T;
   onSelect: (value: T) => void;
+  // Opt-in analytics id for the whole picker. When set, a selection reports the
+  // chosen value to the host sink (see `lib/analytics.ts`). Card values are a
+  // bounded set, so the value is sent. Covers both the click and arrow-key paths.
+  componentId?: string;
   items: readonly CardRadioOption<T>[];
   className?: string;
   cardClassName?: string;
 }) {
+  const { trackValueChange } = useOmnigentAnalytics();
+  const select = componentId
+    ? (next: T) => {
+        trackValueChange(componentId, "select", next, { valueHasNoPii: true });
+        onSelect(next);
+      }
+    : onSelect;
   // Keep a handle on each card so arrow-key navigation can move focus as it
   // moves selection (selection-follows-focus, per the radiogroup pattern).
   const refs = useRef(new Map<T, HTMLButtonElement | null>());
@@ -429,7 +441,7 @@ function CardRadioGroup<T extends string>({
             tabIndex={selected ? 0 : -1}
             title={item.title}
             data-testid={item.testId}
-            onClick={() => onSelect(item.value)}
+            onClick={() => select(item.value)}
             onKeyDown={(event) => {
               const forward = event.key === "ArrowRight" || event.key === "ArrowDown";
               const backward = event.key === "ArrowLeft" || event.key === "ArrowUp";
@@ -437,7 +449,7 @@ function CardRadioGroup<T extends string>({
               event.preventDefault();
               const nextIndex = (index + (forward ? 1 : -1) + items.length) % items.length;
               const next = items[nextIndex].value;
-              onSelect(next);
+              select(next);
               refs.current.get(next)?.focus();
             }}
             className={themeCardClass(selected, cardClassName)}
@@ -491,6 +503,7 @@ function ModeControl() {
         labelledBy={labelId}
         value={mode}
         onSelect={(next) => setTheme(next)}
+        componentId="settings.appearance.theme_mode"
         className="grid grid-cols-3 gap-3"
         cardClassName="gap-2 p-2"
         items={themeCards.map((card) => ({
@@ -526,6 +539,7 @@ function TerminalThemeControl() {
         labelledBy={labelId}
         value={mode}
         onSelect={choose}
+        componentId="settings.appearance.terminal_theme"
         className="grid grid-cols-3 gap-3"
         cardClassName="items-center gap-2 p-4"
         items={terminalThemeCards.map((card) => ({
@@ -560,6 +574,7 @@ function WorkspacePanelDefaultControl() {
         labelledBy={labelId}
         value={value}
         onSelect={choose}
+        componentId="settings.appearance.workspace_panel"
         className="grid grid-cols-2 gap-3"
         cardClassName="items-center gap-2 p-4"
         items={workspacePanelCards.map((card) => ({
@@ -653,6 +668,8 @@ function ColorThemeControl() {
             onValueChange={(next) => {
               if (isThemeSelection(next)) choose(next);
             }}
+            componentId="settings.appearance.color_theme"
+            valueHasNoPii
           >
             <SelectTrigger
               aria-labelledby={labelId}
@@ -736,6 +753,7 @@ function ColorThemeControl() {
               checked={editableTheme.translucentSidebar}
               onCheckedChange={(translucentSidebar) => updateCustomTheme({ translucentSidebar })}
               data-testid="custom-theme-translucent-sidebar"
+              componentId="settings.appearance.translucent_sidebar"
             />
           </div>
         </div>
@@ -818,6 +836,7 @@ function HideUnconfiguredHarnessesControl() {
         onCheckedChange={toggle}
         data-testid="hide-unconfigured-harnesses-toggle"
         className="mt-0.5 shrink-0"
+        componentId="settings.appearance.hide_unconfigured_harnesses"
       />
     </div>
   );
@@ -930,7 +949,12 @@ function AppearanceSection() {
       <div className="flex items-center justify-end">
         <Dialog open={isResetDialogOpen} onOpenChange={setIsResetDialogOpen}>
           <DialogTrigger asChild>
-            <Button variant="outline" size="sm" data-testid="reset-appearance-button">
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="reset-appearance-button"
+              componentId="settings.appearance.open_reset_dialog"
+            >
               Reset to defaults
             </Button>
           </DialogTrigger>
@@ -952,6 +976,7 @@ function AppearanceSection() {
                 size="sm"
                 onClick={confirmResetAppearance}
                 data-testid="reset-appearance-confirm"
+                componentId="settings.appearance.reset"
               >
                 Reset
               </Button>
@@ -1007,6 +1032,7 @@ function DefaultBaseBranchControl() {
         className="h-9 w-56 shrink-0"
         value={branch}
         onChange={(e) => update(e.target.value)}
+        componentId="settings.git.default_branch"
       />
     </div>
   );
@@ -1083,6 +1109,7 @@ function UiFontSizeControl() {
           testId="ui-font-size-dec"
           disabled={atMin}
           onClick={() => commit(px - UI_FONT_SIZE_STEP)}
+          componentId="settings.appearance.ui_font_decrease"
         >
           <MinusIcon className="ui-icon" />
         </StepperButton>
@@ -1109,6 +1136,7 @@ function UiFontSizeControl() {
           testId="ui-font-size-inc"
           disabled={atMax}
           onClick={() => commit(px + UI_FONT_SIZE_STEP)}
+          componentId="settings.appearance.ui_font_increase"
         >
           <PlusIcon className="ui-icon" />
         </StepperButton>
@@ -1159,6 +1187,7 @@ function UiFontFamilyControl() {
           disabled={isDefault}
           className={cn("h-9", isDefault && "invisible")}
           onClick={() => update(UI_FONT_FAMILY_DEFAULT)}
+          componentId="settings.appearance.ui_font_family_reset"
         >
           Reset
         </Button>
@@ -1247,6 +1276,7 @@ function UiCodeFontSizeControl() {
           testId="code-font-size-dec"
           disabled={atMin}
           onClick={() => commit(px - CODE_FONT_SIZE_STEP)}
+          componentId="settings.appearance.code_font_decrease"
         >
           <MinusIcon className="ui-icon" />
         </StepperButton>
@@ -1273,6 +1303,7 @@ function UiCodeFontSizeControl() {
           testId="code-font-size-inc"
           disabled={atMax}
           onClick={() => commit(px + CODE_FONT_SIZE_STEP)}
+          componentId="settings.appearance.code_font_increase"
         >
           <PlusIcon className="ui-icon" />
         </StepperButton>
@@ -1317,6 +1348,7 @@ function UiCodeFontFamilyControl() {
           disabled={isDefault}
           className={cn("h-9", isDefault && "invisible")}
           onClick={() => update(CODE_FONT_FAMILY_DEFAULT)}
+          componentId="settings.appearance.code_font_family_reset"
         >
           Reset
         </Button>
@@ -1343,21 +1375,27 @@ function StepperButton({
   testId,
   disabled,
   onClick,
+  componentId,
   children,
 }: {
   label: string;
   testId: string;
   disabled: boolean;
   onClick: () => void;
+  componentId?: string;
   children: ReactNode;
 }) {
+  const { trackClick } = useOmnigentAnalytics();
   return (
     <button
       type="button"
       aria-label={label}
       data-testid={testId}
       disabled={disabled}
-      onClick={onClick}
+      onClick={() => {
+        if (componentId) trackClick(componentId, "button");
+        onClick();
+      }}
       className={cn(
         "flex w-9 items-center justify-center text-muted-foreground transition-colors",
         "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50",
@@ -1571,6 +1609,8 @@ function UpdatesSection() {
               value={config.mode}
               onValueChange={(value) => void persistConfig({ mode: value as UpdateMode })}
               disabled={saving}
+              componentId="settings.updates.mode"
+              valueHasNoPii
             >
               <SelectTrigger className="w-full max-w-md" data-testid="update-mode-select">
                 <SelectValue />
@@ -1597,11 +1637,16 @@ function UpdatesSection() {
               onCheckedChange={(checked) => void persistConfig({ autoInstall: checked })}
               disabled={saving}
               aria-label="Install downloaded updates on next quit"
+              componentId="settings.updates.auto_install"
             />
           </div>
 
           <div className="flex flex-wrap items-center gap-3">
-            <Button onClick={() => void onCheck()} loading={checking}>
+            <Button
+              onClick={() => void onCheck()}
+              loading={checking}
+              componentId="settings.updates.check_now"
+            >
               Check for updates now
             </Button>
             {saving && <span className="text-sm text-muted-foreground">Saving…</span>}
@@ -1727,6 +1772,7 @@ function AccountSection() {
                 resetPwForm();
                 setPwOpen(true);
               }}
+              componentId="settings.account.change_password"
             >
               <KeyRoundIcon className="size-4" /> Change password
             </Button>
@@ -1735,6 +1781,7 @@ function AccountSection() {
             variant="ghost"
             className="w-full justify-start gap-2"
             onClick={() => void onSignOut()}
+            componentId="settings.account.sign_out"
           >
             <LogOutIcon className="size-4" /> Sign out
           </Button>
@@ -1807,6 +1854,7 @@ function AccountSection() {
                   disabled={
                     pwBusy || oldPw.length === 0 || newPw.length === 0 || confirmPw.length === 0
                   }
+                  componentId="settings.account.update_password"
                 >
                   {pwBusy ? "Changing…" : "Change password"}
                 </Button>

--- a/web/src/pages/SharingPage.tsx
+++ b/web/src/pages/SharingPage.tsx
@@ -181,6 +181,7 @@ export function SharingPage() {
                 onCheckedChange={togglePublic}
                 disabled={!publicEditable || setMode.isPending}
                 aria-label="Public access"
+                componentId="settings.sharing.public_access"
               />
             </div>
             {error && <p className="mt-3 text-ui text-destructive">{error}</p>}

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -15,6 +15,7 @@ import { ClockIcon, Loader2Icon, SearchIcon, TriangleAlertIcon } from "lucide-re
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useOmnigentAnalytics } from "@/lib/analytics";
 import { CreateScheduledTaskDialog } from "@/components/scheduled/CreateScheduledTaskDialog";
 import { ScheduledTaskRow } from "@/components/scheduled/ScheduledTaskRow";
 import {
@@ -42,6 +43,7 @@ const FILTER_TABS: { value: FilterTab; label: string }[] = [
 
 export function TasksPage() {
   const { data: tasks, isLoading, isError, refetch } = useScheduledTasks();
+  const { trackClick } = useOmnigentAnalytics();
   // A single shared, slowly-ticking clock for the whole list. Passing it down to
   // each row (rather than each row owning a timer) keeps the relative next-run
   // labels fresh with ONE interval regardless of how many rows are on screen.
@@ -155,7 +157,12 @@ export function TasksPage() {
             Run agent sessions on a recurring schedule. Tasks fire on a connected host.
           </p>
         </div>
-        <Button data-testid="new-task-button" className="shrink-0" onClick={openManual}>
+        <Button
+          data-testid="new-task-button"
+          className="shrink-0"
+          onClick={openManual}
+          componentId="tasks.new"
+        >
           New task
         </Button>
       </div>
@@ -183,7 +190,10 @@ export function TasksPage() {
                 type="button"
                 aria-pressed={filter === tab.value}
                 data-testid={`tasks-filter-${tab.value}`}
-                onClick={() => setFilter(tab.value)}
+                onClick={() => {
+                  trackClick(`tasks.filter_${tab.value}`, "button");
+                  setFilter(tab.value);
+                }}
                 className={cn(
                   "rounded-md px-3 py-1 text-ui font-medium transition-colors",
                   filter === tab.value
@@ -206,7 +216,12 @@ export function TasksPage() {
         >
           <TriangleAlertIcon className="size-4 shrink-0 text-destructive" />
           <span className="flex-1">Couldn’t load automations.</span>
-          <Button variant="outline" size="sm" onClick={() => void refetch()}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void refetch()}
+            componentId="tasks.retry"
+          >
             Retry
           </Button>
         </div>

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { CalendarIcon, Loader2Icon, TriangleAlertIcon } from "lucide-react";
+import { useOmnigentAnalytics } from "@/lib/analytics";
 import { PageScroll } from "@/components/PageScroll";
 import { CostTimelineChart } from "@/components/usage/CostTimelineChart";
 import { UsageBreakdownCharts } from "@/components/usage/UsageBreakdownCharts";
@@ -73,6 +74,7 @@ function filterSessions(
 
 export function UsagePage() {
   const { data, isLoading, isError, refetch } = useUsageReport();
+  const { trackClick } = useOmnigentAnalytics();
 
   const [rangeKey, setRangeKey] = useState<RangeKey>("30d");
   const [customStart, setCustomStart] = useState(() => daysAgoIso(30));
@@ -113,7 +115,10 @@ export function UsagePage() {
                     ? "bg-primary text-primary-foreground"
                     : "bg-muted text-muted-foreground hover:bg-muted/80",
                 )}
-                onClick={() => setRangeKey(key)}
+                onClick={() => {
+                  trackClick(`usage.range_${key}`, "button");
+                  setRangeKey(key);
+                }}
               >
                 {label}
               </button>
@@ -161,7 +166,14 @@ export function UsagePage() {
           <div className="flex h-64 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
             <TriangleAlertIcon className="h-5 w-5" />
             <p>Failed to load usage data</p>
-            <button type="button" className="text-primary underline" onClick={() => refetch()}>
+            <button
+              type="button"
+              className="text-primary underline"
+              onClick={() => {
+                trackClick("usage.retry", "button");
+                void refetch();
+              }}
+            >
               Retry
             </button>
           </div>

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -28,6 +28,7 @@ import { PresenceAvatars } from "@/components/PresenceAvatars";
 import type { Agent } from "@/hooks/useAgents";
 import type { Conversation } from "@/hooks/useConversations";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
+import { useOmnigentAnalytics } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import { TAB_BADGE_BASE } from "./railTabs";
 import { ViewModeToggle } from "./ViewModeToggle";
@@ -205,6 +206,7 @@ export function ChatHeader({
   // hover affordance — on mobile the toggle just opens the full-screen overlay,
   // so a tap's synthetic pointerenter must not trigger it.
   const isMobile = useIsMobileViewport();
+  const { trackClick } = useOmnigentAnalytics();
   const peekTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cancelPeek = useCallback(() => {
     if (peekTimer.current) {
@@ -259,6 +261,7 @@ export function ChatHeader({
                 // md:size-6 override replaces the variant's md:size-8.
                 size="icon"
                 aria-label="Open sidebar"
+                componentId="chat.header.open_sidebar"
                 onClick={() => {
                   cancelPeek();
                   onOpenSidebar(false);
@@ -351,7 +354,14 @@ export function ChatHeader({
             <DropdownMenuContent align="end" className="min-w-44">
               {canShare && (
                 <DropdownMenuItem
-                  onSelect={shareDisabled ? undefined : onShare}
+                  onSelect={
+                    shareDisabled
+                      ? undefined
+                      : () => {
+                          trackClick("chat.header.mobile_share", "button");
+                          onShare();
+                        }
+                  }
                   disabled={shareDisabled}
                   data-testid="mobile-share-session"
                   title={shareDisabledReason}
@@ -363,7 +373,10 @@ export function ChatHeader({
               )}
               {hasAgentInfo && (
                 <DropdownMenuItem
-                  onSelect={onAgentInfo}
+                  onSelect={() => {
+                    trackClick("chat.header.mobile_agent_info", "button");
+                    onAgentInfo();
+                  }}
                   data-testid="mobile-agent-info"
                   className="gap-2.5 px-2.5 py-2 text-ui"
                 >
@@ -407,6 +420,7 @@ export function ChatHeader({
             type="button"
             aria-label="Share session"
             onClick={onShare}
+            componentId="chat.header.share"
             // share-button-glassy (index.css) paints the pink gradient,
             // shadow, and white text in both light and dark mode.
             className="share-button-glassy hidden h-6 gap-1 rounded-[6px] px-2 text-ui font-normal text-white md:inline-flex"
@@ -426,6 +440,7 @@ export function ChatHeader({
                 size="icon-xs"
                 aria-label={rightPanelOpen ? "Collapse right panel" : "Expand right panel"}
                 onClick={onToggleRightPanel}
+                componentId="chat.header.toggle_right_panel"
                 className="hidden md:inline-flex text-muted-foreground hover:text-foreground border-none"
               >
                 {rightPanelOpen ? (

--- a/web/src/shell/CreateAgentDialog.tsx
+++ b/web/src/shell/CreateAgentDialog.tsx
@@ -235,7 +235,12 @@ export function CreateAgentDialog({
             <label className="text-sm font-medium text-muted-foreground">
               Harness <span className="text-destructive">*</span>
             </label>
-            <Select value={harness} onValueChange={setHarness}>
+            <Select
+              value={harness}
+              onValueChange={setHarness}
+              componentId="create_agent.harness"
+              valueHasNoPii
+            >
               <SelectTrigger data-testid="create-agent-harness" className="w-full">
                 <SelectValue />
               </SelectTrigger>
@@ -281,6 +286,7 @@ export function CreateAgentDialog({
               onChange={(e) => setInstructions(e.target.value)}
               placeholder="You are a helpful assistant that..."
               className="min-h-[120px]"
+              componentId="create_agent.instructions"
             />
           </div>
 
@@ -350,6 +356,8 @@ function MCPServerRow({
         <Select
           value={entry.transport}
           onValueChange={(v: "http" | "stdio") => onChange({ transport: v })}
+          componentId="create_agent.mcp_transport"
+          valueHasNoPii
         >
           <SelectTrigger data-testid="create-agent-mcp-transport" className="w-24">
             <SelectValue />

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -554,6 +554,7 @@ export function ForkSessionForm({
               <>
                 <Select
                   value={selectedHostId ?? ""}
+                  componentId="fork_session.host"
                   onValueChange={(v) => {
                     setSelectedHostId(v);
                     // Workspace and the worktree branch are host-specific:
@@ -614,7 +615,11 @@ export function ForkSessionForm({
           <label htmlFor="fork-session-agent" className="text-sm font-medium text-muted-foreground">
             Agent
           </label>
-          <Select value={agentChoice} onValueChange={setAgentChoice}>
+          <Select
+            value={agentChoice}
+            onValueChange={setAgentChoice}
+            componentId="fork_session.agent"
+          >
             <SelectTrigger
               id="fork-session-agent"
               data-testid="fork-session-agent-select"

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -149,6 +149,7 @@ import {
   sortAgentsForDisplay,
 } from "@/lib/agentGrouping";
 import { cn } from "@/lib/utils";
+import { useOmnigentAnalytics } from "@/lib/analytics";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
 import {
   isFullySupportedNativeCodingAgent,
@@ -506,7 +507,7 @@ export function ConnectHostInstructions({
     <div className="flex flex-col gap-4 rounded-lg border border-dashed border-border p-4">
       {label && <p className="text-sm text-muted-foreground">{label}</p>}
       {databricksFeatures ? (
-        <Tabs defaultValue="local">
+        <Tabs defaultValue="local" componentId="new_chat.host_tabs">
           <TabsList className="w-full">
             <TabsTrigger value="local" className="text-sm">
               Local machine
@@ -766,6 +767,7 @@ function HarnessSetupNotice({
   featureEnabled: boolean;
   onSetup: () => void;
 }) {
+  const { trackClick } = useOmnigentAnalytics();
   return (
     <p
       // pl-2 lines the icon up with the chips tray directly above (which has
@@ -785,7 +787,10 @@ function HarnessSetupNotice({
             type="button"
             data-testid="new-chat-landing-harness-setup"
             className="inline-flex h-5 shrink-0 items-center rounded-md border border-amber-300 px-2 text-sm font-medium text-amber-700 hover:bg-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-amber-500/40 dark:text-amber-400 dark:hover:bg-amber-500/20"
-            onClick={onSetup}
+            onClick={() => {
+              trackClick("new_chat.setup", "button");
+              onSetup();
+            }}
           >
             Set up {agentName}
           </button>
@@ -1764,6 +1769,7 @@ function HarnessConfigModal({
                   models={claudeModelSelectOptions}
                   defaultLabel={defaultModelLabel(claudeModelOptions)}
                   contentClassName="[&_[data-slot=select-item]]:pl-2.5"
+                  componentId="new_chat.config.model"
                 >
                   {claudeModelsLoading && (
                     <div className="px-2.5 py-1 text-sm text-muted-foreground">Loading models…</div>
@@ -1815,6 +1821,7 @@ function HarnessConfigModal({
                   options={CLAUDE_NATIVE_PERMISSION_MODES}
                   testId="new-chat-landing-config-permission"
                   ariaLabel="Permissions"
+                  componentId="new_chat.config.permission"
                 />
               </ConfigRow>
             </>
@@ -1835,6 +1842,7 @@ function HarnessConfigModal({
                   models={codexModelSelectOptions}
                   defaultLabel={defaultModelLabel(codexModelOptions)}
                   contentClassName="[&_[data-slot=select-item]]:pl-2.5"
+                  componentId="new_chat.config.model"
                 >
                   {codexModelsLoading && (
                     <div className="px-2.5 py-1 text-sm text-muted-foreground">Loading models…</div>
@@ -1868,6 +1876,7 @@ function HarnessConfigModal({
                   }
                   testId="new-chat-landing-config-approval"
                   ariaLabel="Approval"
+                  componentId="new_chat.config.approval"
                 />
               </ConfigRow>
             </>
@@ -1881,6 +1890,7 @@ function HarnessConfigModal({
                 options={CURSOR_NATIVE_EXEC_MODES}
                 testId="new-chat-landing-config-cursor-mode"
                 ariaLabel="Mode"
+                componentId="new_chat.config.cursor_mode"
               />
             </ConfigRow>
           )}
@@ -1894,6 +1904,7 @@ function HarnessConfigModal({
                   options={AGY_NATIVE_SKIP_MODES}
                   testId="new-chat-landing-config-agy-skip"
                   ariaLabel="Permissions"
+                  componentId="new_chat.config.permission"
                 />
               </ConfigRow>
               {/* Persistent danger banner while the bypass is selected. agy has
@@ -1920,7 +1931,12 @@ function HarnessConfigModal({
           read it back or switch away without cancelling. */}
           {!hasPermission && !hasApproval && !hasCursor && !hasAgySkip && brainDefault && (
             <ConfigRow label="Agent Harness" description="Underlying coding harness">
-              <Select value={draftHarness ?? brainDefault} onValueChange={setDraftHarness}>
+              <Select
+                value={draftHarness ?? brainDefault}
+                onValueChange={setDraftHarness}
+                componentId="new_chat.config.harness"
+                valueHasNoPii
+              >
                 <SelectTrigger
                   className="w-full cursor-pointer"
                   data-testid="new-chat-landing-config-harness"
@@ -1996,7 +2012,13 @@ function HarnessConfigModal({
           >
             Cancel
           </Button>
-          <Button type="button" onClick={save} data-testid="new-chat-landing-config-save" size="lg">
+          <Button
+            type="button"
+            onClick={save}
+            data-testid="new-chat-landing-config-save"
+            size="lg"
+            componentId="new_chat.save_config"
+          >
             Save
           </Button>
         </DialogFooter>
@@ -4464,6 +4486,7 @@ export function NewChatLandingScreen() {
                   onClick={() => fileInputRef.current?.click()}
                   title="Attach files"
                   data-testid="new-chat-landing-attach"
+                  componentId="new_chat.attach_files"
                 >
                   <PaperclipIcon className="size-4" data-icon-size="16" />
                   <span className="sr-only">Attach files</span>
@@ -4531,6 +4554,7 @@ export function NewChatLandingScreen() {
                               disabled={creating}
                               onClick={() => setConfigOpen(true)}
                               data-testid="new-chat-landing-config-gear"
+                              componentId="new_chat.open_config"
                             >
                               <SettingsIcon className="size-4" data-icon-size="16" />
                               <span className="sr-only">
@@ -4619,6 +4643,7 @@ export function NewChatLandingScreen() {
                           aria-busy={creating}
                           data-testid="new-chat-landing-submit"
                           className="size-8 rounded-lg bg-foreground disabled:bg-muted disabled:text-muted-foreground transition-opacity hover:opacity-80 disabled:opacity-100 "
+                          componentId="new_chat.start_session"
                         >
                           {creating ? (
                             <Loader2Icon className="size-4 animate-spin" />

--- a/web/src/shell/ReconnectSessionDialog.tsx
+++ b/web/src/shell/ReconnectSessionDialog.tsx
@@ -177,6 +177,7 @@ export function ReconnectSessionDialog({
           <Tabs
             defaultValue={showCommand ? "reconnect" : "clone"}
             className="flex min-h-0 flex-1 flex-col gap-4"
+            componentId="reconnect.tabs"
           >
             <TabsList className="w-full">
               <TabsTrigger value="reconnect" data-testid="reconnect-session-tab-reconnect">

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -155,6 +155,7 @@ import {
   useUnseenTick,
 } from "@/hooks/useUnseenConversations";
 import { cn } from "@/lib/utils";
+import { useOmnigentAnalytics } from "@/lib/analytics";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
@@ -800,6 +801,7 @@ export function Sidebar({
               to="/"
               onClick={onNavClick}
               data-testid="sidebar-brand"
+              componentId="sidebar.home"
               className="sidebar-brand rounded-none transition-opacity duration-200 ease-[var(--ease-otto)] hover:opacity-70"
             >
               {branding.app_name ? (
@@ -854,6 +856,7 @@ export function Sidebar({
               (the button stays visible on both tabs). */}
               <Link
                 to="/"
+                componentId="sidebar.new_chat"
                 onClick={(e) => {
                   switchTab("mine");
                   onNavClick(e);
@@ -885,7 +888,7 @@ export function Sidebar({
               variant="ghost"
               data-testid="scheduled-tasks-nav"
             >
-              <Link to="/tasks" onClick={onNavClick}>
+              <Link to="/tasks" onClick={onNavClick} componentId="sidebar.tasks">
                 <ClockIcon
                   className={cn(
                     "ui-icon",
@@ -908,7 +911,7 @@ export function Sidebar({
               )}
               data-testid="inbox-button"
             >
-              <Link to="/inbox" onClick={onNavClick}>
+              <Link to="/inbox" onClick={onNavClick} componentId="sidebar.inbox">
                 <InboxIcon
                   className={cn(
                     "ui-icon",
@@ -950,7 +953,7 @@ export function Sidebar({
                 )}
                 data-testid="usage-nav"
               >
-                <Link to="/usage" onClick={onNavClick}>
+                <Link to="/usage" onClick={onNavClick} componentId="sidebar.usage">
                   <WalletIcon
                     className={cn(
                       "ui-icon",
@@ -2722,6 +2725,7 @@ function ConversationMenuItems({
   // to the side. `view` swaps between the main actions and that sub-view;
   // desktop always renders the native side-flyout submenu regardless.
   const isMobile = useIsMobileViewport();
+  const { trackClick } = useOmnigentAnalytics();
   const [view, setView] = useState<"main" | "projects">("main");
 
   // The project pick / create / remove flow — shared verbatim by the desktop
@@ -2815,7 +2819,13 @@ function ConversationMenuItems({
           </Tooltip>
         ))}
       {isOwner ? (
-        <C.Item data-testid="rename-conversation" onSelect={() => setIsEditing(true)}>
+        <C.Item
+          data-testid="rename-conversation"
+          onSelect={() => {
+            trackClick("sidebar.conversation.rename", "button");
+            setIsEditing(true);
+          }}
+        >
           <PencilIcon className="size-3.5" />
           Rename
         </C.Item>
@@ -3734,6 +3744,7 @@ function ConversationRow({
               variant="destructive"
               onClick={confirmDelete}
               disabled={del.isPending}
+              componentId="sidebar.conversation.delete"
             >
               Delete
             </Button>
@@ -3769,6 +3780,7 @@ function ConversationRow({
               data-testid="confirm-leave-conversation"
               onClick={confirmLeave}
               disabled={leave.isPending}
+              componentId="sidebar.conversation.leave"
             >
               Leave
             </Button>
@@ -3816,6 +3828,7 @@ function ConversationRow({
                 stopSession.mutate(conversation.id, { onSuccess: () => setStopOpen(false) })
               }
               loading={stopSession.isPending}
+              componentId="sidebar.conversation.stop"
             >
               Stop session
             </Button>
@@ -4245,6 +4258,7 @@ function ProjectFolderMenu({
                 data-testid="rename-project-confirm"
                 loading={renameProject.isPending || updateConfig.isPending}
                 disabled={renameValue.trim() === ""}
+                componentId="sidebar.project.rename"
               >
                 Confirm
               </Button>

--- a/web/src/shell/SwitchAgentDialog.tsx
+++ b/web/src/shell/SwitchAgentDialog.tsx
@@ -156,7 +156,11 @@ export function SwitchAgentDialog({
           >
             Agent
           </label>
-          <Select value={agentChoice || undefined} onValueChange={setAgentChoice}>
+          <Select
+            value={agentChoice || undefined}
+            onValueChange={setAgentChoice}
+            componentId="switch_agent.agent"
+          >
             <SelectTrigger
               id="switch-agent-select"
               data-testid="switch-agent-select"

--- a/web/src/shell/SwitchHostDialog.tsx
+++ b/web/src/shell/SwitchHostDialog.tsx
@@ -224,7 +224,11 @@ export function SwitchHostDialog({
           <>
             <div className="flex flex-col gap-2">
               <span className="text-xs font-medium text-muted-foreground">Host</span>
-              <Select value={selectedHostId ?? ""} onValueChange={(v) => setSelectedHostId(v)}>
+              <Select
+                value={selectedHostId ?? ""}
+                onValueChange={(v) => setSelectedHostId(v)}
+                componentId="switch_host.host"
+              >
                 <SelectTrigger className="w-full text-xs" data-testid="switch-host-select">
                   <SelectValue placeholder="Select a host" />
                 </SelectTrigger>

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -763,6 +763,7 @@ export function WorkspacePanel({
               : rightRailTab
           }
           onValueChange={(v) => onRightRailTabChange(v as RightRailTab)}
+          componentId="chat.right_rail.tabs"
         >
           <TabsList variant="pill" className="gap-1">
             {showFilesPanel && (

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -261,6 +261,7 @@ export function SettingsSidebarBody({
                     to={`/settings/${item.id}`}
                     onClick={onNavClick}
                     data-testid={`settings-nav-${item.id}`}
+                    componentId={`settings.nav.${item.id}`}
                     aria-current={selected ? "page" : undefined}
                   >
                     <Icon


### PR DESCRIPTION
## Related issue

<!-- Refactor / chore + Feature enablement; no single issue. -->

N/A

## Summary

Commit a4248e34 (#3569) introduced an opt-in, host-injected product-analytics
seam (`click` / `value_change` / `page_view` events keyed by a stable
`componentId`, forwarded to `OmnigentHostConfig.analytics`; a no-op standalone).
That PR wired only ~4 example call sites. This PR expands coverage so an
embedding host can build **funnels and pattern analysis**.

- **Framework enablers.** Add `"tabs"` to `OmnigentComponentKind`. Fix
  `StandaloneLink` (it accepted `componentId` in its type but dropped it without
  emitting) — it now reports `trackClick(id, "link")` and never leaks the prop to
  the DOM `<a>`. Give the `Tabs` / `Switch` / `Select` / `Textarea` primitives an
  optional `componentId` that wraps their native event; `Select` also takes
  `valueHasNoPii`. Instrumenting the `Tabs` / `Select` root covers every
  trigger/item for free. Thread `componentId` through the shared
  `CardRadioGroup` (SettingsPage) and `RoutingModelSelect` / `DescribedSelect`
  (HarnessConfigControls) so appearance pickers and config-dialog selects emit.
- **Call-site coverage (~75 IDs).** auth (`login.sign_in`,
  `register.create_account`, `approve.*`), chat composer/message/header
  (`chat.composer.*`, `chat.message.*`, `chat.header.*`, `chat.right_rail.tabs`),
  approvals (`approval.*`, `question.*`, `plan.*`), tasks (`tasks.*`,
  `tasks.scheduled.*`), settings (`settings.appearance.*`, `settings.account.*`,
  `settings.nav.*`, sharing/policies toggles), sidebar (`sidebar.*`), inbox,
  usage, diagnostics (`diagnostics.*`), and new-chat (`new_chat.*`).
- **PII.** `valueHasNoPii` is set only for bounded enums (theme, effort,
  permission/approval mode, model catalog, tab values, grant level, harness /
  transport). Free-text fields, host ids, agent/branch names, and credential
  textareas stay redacted (value dropped, only the fact-of-change reported).
- **Cycle fix.** Extract the routing-free emit helpers into `lib/analyticsEmit.ts`
  to break the `routing` ↔ `analytics` import cycle the Link wiring introduced;
  `lib/analytics.ts` re-exports them so no other call site changed.

## Test Plan

- `cd web && npx tsc -b` — clean.
- `cd web && npm run lint` (oxlint `--deny-warnings`) — clean.
- `cd web && npx vitest run` — 5909 pass; the only failures are 3 pre-existing
  `NewChatDialog.test.tsx` host-picker flakes (fail identically on `main`).
- New focused per-primitive tests (`tabs` / `switch` / `select` / `textarea`,
  and Link analytics appended to `routing.test.tsx` — existing routing coverage
  preserved) each assert the emitted event shape, that the caller's handler still
  runs, and no-op when `componentId` is absent; the `select` test asserts value
  present-with-`valueHasNoPii` vs redacted-without.
- **Live** (chrome-devtools against the dev server): installed a capturing sink
  through the host seam, confirmed the standalone no-op contract
  (`getOmnigentAnalytics()` is `undefined` until a host wires it), then exercised
  each surface and read back the events — sidebar/settings-nav links
  (`link` + page_view), tasks filters/search (search value redacted), config
  selects (`select` with bounded value), appearance radios (`select`), the
  translucent-sidebar switch (`toggle` + boolean), right-rail tabs (`tabs` with
  value), and chat header / message actions (`button`). No `componentId` leaked to
  any DOM `<a>` and no React attribute warnings.

## Demo

<!-- Live-driven verification; representative captured events: -->

```
{ type: "click",        componentId: "sidebar.tasks",                      componentKind: "link"   }
{ type: "page_view",    pageId:      "tasks" }
{ type: "value_change", componentId: "tasks.search",                       componentKind: "input",  value: undefined }   // redacted
{ type: "value_change", componentId: "new_chat.config.permission",         componentKind: "select", value: "auto" }
{ type: "value_change", componentId: "settings.appearance.translucent_sidebar", componentKind: "toggle", value: true }
{ type: "value_change", componentId: "chat.right_rail.tabs",               componentKind: "tabs",   value: "files" }
{ type: "click",        componentId: "chat.message.fork",                  componentKind: "button" }
```

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the framework layer (each newly-instrumented primitive + the
StandaloneLink fix), asserting event shape, handler pass-through, PII redaction,
and no-op-without-id. The ~75 call-site additions are pass-a-prop changes
verified live with chrome-devtools against the running app (each surface emits
the expected `componentId` / `componentKind` with correct redaction; no DOM
attribute leak, no console warnings) rather than a test per call site.

## Changelog

<!-- No user-facing behavior change: analytics is inert standalone. Omit. -->
