### PR TITLE
feat(server): support host_type=managed on the multipart session-create

### DIFF
--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -211,6 +211,109 @@ def register_core_routes(
 ) -> None:
     """Register the core session routes on router."""
 
+    async def _schedule_managed_launch(
+        request: Request,
+        *,
+        session_id: str,
+        agent_id: str | None,
+        user_id: str | None,
+        sandbox_provider: str | None,
+        workspace: str | None,
+    ) -> None:
+        """
+        Provision a managed sandbox host for a just-created session.
+
+        Shared by both create paths: the JSON path (an existing
+        ``agent_id``) and the multipart bundle path (a freshly-created
+        session-scoped ``agent_id``). Validates that managed hosts are
+        configured and the provider is offered, records the repository
+        workspace for relaunch, seeds the launch-progress indicator, and
+        schedules the background ``_run_managed_launch`` — returning
+        immediately, since provisioning takes tens of seconds and must
+        not block the create POST. Config problems and malformed repo
+        workspaces fail the POST synchronously (4xx).
+
+        :param request: The create request (for ``app.state`` lookups).
+        :param session_id: The newly-created session id to bind the host
+            to, e.g. ``"conv_abc123"``.
+        :param agent_id: The session's bound agent id (built-in for the
+            JSON path, session-scoped for the bundle path); the managed
+            runner fetches its spec over the tunnel either way.
+        :param user_id: Authenticated caller, or ``None`` on an
+            auth-disabled server (registers under the reserved local
+            owner).
+        :param sandbox_provider: Provider to provision, or ``None`` for
+            the server's first configured provider.
+        :param workspace: Managed workspace — a git repository URL
+            (optionally ``#<branch>``) cloned into the sandbox, or
+            ``None`` for an empty sandbox.
+        :raises OmnigentError: If managed hosts aren't configured or the
+            provider isn't offered.
+        """
+        sandbox_config = getattr(request.app.state, "sandbox_config", None)
+        host_store_for_managed = getattr(request.app.state, "host_store", None)
+        managed_launches = getattr(request.app.state, "managed_launches", None)
+        if sandbox_config is None or host_store_for_managed is None or managed_launches is None:
+            raise OmnigentError(
+                "managed hosts are not configured on this server — add a "
+                "'sandbox:' section to the server config",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        from omnigent.server.auth import RESERVED_USER_LOCAL
+        from omnigent.server.managed_hosts import (
+            MANAGED_REPO_LABEL_KEY,
+            parse_repo_workspace,
+        )
+
+        # Reject an unconfigured provider on the POST rather than in the
+        # background launch.
+        if sandbox_provider is not None and sandbox_config.for_provider(sandbox_provider) is None:
+            offered = ", ".join(sandbox_config.launchable_providers()) or "none"
+            raise OmnigentError(
+                f"sandbox provider '{sandbox_provider}' is not configured "
+                f"on this server — available: {offered}",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        # A managed workspace is a repository URL (schema-validated) the
+        # launch clones inside the sandbox; parse it now so a malformed
+        # URL is a synchronous 4xx, not a background failure.
+        repo = parse_repo_workspace(workspace) if workspace is not None else None
+        if workspace is not None:
+            # The session row's workspace is overwritten with the CLONED
+            # path at bind time; record the raw request value so a
+            # sandbox relaunch can re-clone the same repository.
+            await asyncio.to_thread(
+                conversation_store.set_labels,
+                session_id,
+                {MANAGED_REPO_LABEL_KEY: workspace},
+            )
+        managed_launches.begin(session_id)
+        # Seed the launch-progress indicator before the background task
+        # starts, so the first GET snapshot (the Web UI navigates to the
+        # session page immediately after this 201) already carries the
+        # "provisioning" stage.
+        _publish_sandbox_status(session_id, "provisioning")
+        launch_task = asyncio.create_task(
+            _run_managed_launch(
+                session_id=session_id,
+                # On auth-disabled servers user_id is None; the sandbox
+                # host registers under the reserved local owner.
+                owner=user_id if user_id is not None else RESERVED_USER_LOCAL,
+                sandbox_config=sandbox_config,
+                repo=repo,
+                tracker=managed_launches,
+                conversation_store=conversation_store,
+                host_store=host_store_for_managed,
+                host_registry=getattr(request.app.state, "host_registry", None),
+                tunnel_registry=getattr(request.app.state, "tunnel_registry", None),
+                provider=sandbox_provider,
+                agent_store=agent_store,
+                agent_id=agent_id,
+            )
+        )
+        _managed_launch_tasks.add(launch_task)
+        launch_task.add_done_callback(_managed_launch_tasks.discard)
+
     @router.post(
         "/sessions",
         status_code=201,
@@ -365,79 +468,14 @@ def register_core_routes(
         # synchronously.
         launch_host_id = body.host_id
         if body.host_type == "managed" and resp.runner_id is None:
-            sandbox_config = getattr(request.app.state, "sandbox_config", None)
-            host_store_for_managed = getattr(request.app.state, "host_store", None)
-            managed_launches = getattr(request.app.state, "managed_launches", None)
-            if (
-                sandbox_config is None
-                or host_store_for_managed is None
-                or managed_launches is None
-            ):
-                raise OmnigentError(
-                    "managed hosts are not configured on this server — add a "
-                    "'sandbox:' section to the server config",
-                    code=ErrorCode.INVALID_INPUT,
-                )
-            from omnigent.server.auth import RESERVED_USER_LOCAL
-            from omnigent.server.managed_hosts import (
-                MANAGED_REPO_LABEL_KEY,
-                parse_repo_workspace,
+            await _schedule_managed_launch(
+                request,
+                session_id=resp.id,
+                agent_id=conv.agent_id if conv is not None else None,
+                user_id=user_id,
+                sandbox_provider=body.sandbox_provider,
+                workspace=body.workspace,
             )
-
-            # Like the repo parse below: reject an unconfigured provider on
-            # the POST rather than in the background launch.
-            if (
-                body.sandbox_provider is not None
-                and sandbox_config.for_provider(body.sandbox_provider) is None
-            ):
-                offered = ", ".join(sandbox_config.launchable_providers()) or "none"
-                raise OmnigentError(
-                    f"sandbox provider '{body.sandbox_provider}' is not configured "
-                    f"on this server — available: {offered}",
-                    code=ErrorCode.INVALID_INPUT,
-                )
-            # A managed workspace is a repository URL (schema-
-            # validated) the launch clones inside the sandbox; parse
-            # it now so a malformed URL is a synchronous 4xx, not a
-            # background failure.
-            repo = parse_repo_workspace(body.workspace) if body.workspace is not None else None
-            if body.workspace is not None:
-                # The session row's workspace is overwritten with the
-                # CLONED path at bind time; record the raw request
-                # value so a sandbox relaunch can re-clone the same
-                # repository into the new generation.
-                await asyncio.to_thread(
-                    conversation_store.set_labels,
-                    resp.id,
-                    {MANAGED_REPO_LABEL_KEY: body.workspace},
-                )
-            managed_launches.begin(resp.id)
-            # Seed the launch-progress indicator before the background
-            # task starts, so the first GET snapshot (the Web UI
-            # navigates to the session page immediately after this
-            # 201) already carries the "provisioning" stage.
-            _publish_sandbox_status(resp.id, "provisioning")
-            launch_task = asyncio.create_task(
-                _run_managed_launch(
-                    session_id=resp.id,
-                    # On auth-disabled servers user_id is None; the
-                    # sandbox host registers under the reserved local
-                    # owner, same as a directly-connected host would.
-                    owner=user_id if user_id is not None else RESERVED_USER_LOCAL,
-                    sandbox_config=sandbox_config,
-                    repo=repo,
-                    tracker=managed_launches,
-                    conversation_store=conversation_store,
-                    host_store=host_store_for_managed,
-                    host_registry=getattr(request.app.state, "host_registry", None),
-                    tunnel_registry=getattr(request.app.state, "tunnel_registry", None),
-                    provider=body.sandbox_provider,
-                    agent_store=agent_store,
-                    agent_id=conv.agent_id if conv is not None else None,
-                )
-            )
-            _managed_launch_tasks.add(launch_task)
-            launch_task.add_done_callback(_managed_launch_tasks.discard)
 
         # Host launch: if a host is targeted (caller-supplied or
         # managed) and no runner is bound yet, authorize (caller must
@@ -608,6 +646,21 @@ def register_core_routes(
                 result.session_id,
                 result.agent_id,
                 runner_router,
+            )
+        # Managed bundle create: provision a sandbox host for the
+        # just-uploaded session-scoped agent (same background launch as
+        # the JSON path). The managed runner fetches the uploaded bundle
+        # over its tunnel like any session-scoped agent, so no separate
+        # bundle delivery is needed. A sub-agent child (inherited runner)
+        # is never itself managed — it co-locates on the parent's runner.
+        if parsed_metadata.host_type == "managed" and inherited_runner_id is None:
+            await _schedule_managed_launch(
+                request,
+                session_id=result.session_id,
+                agent_id=result.agent_id,
+                user_id=user_id,
+                sandbox_provider=parsed_metadata.sandbox_provider,
+                workspace=parsed_metadata.workspace,
             )
         return result
 

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -355,16 +355,7 @@ def register_core_routes(
         user_id = _require_user(request, auth_provider)
         content_type = request.headers.get("content-type", "").split(";", 1)[0].lower()
         if content_type == "multipart/form-data":
-            result = await _create_bundled_session_from_multipart(request, user_id)
-            if permission_store is not None and user_id is not None:
-                await asyncio.to_thread(permission_store.ensure_user, user_id)
-                await asyncio.to_thread(
-                    permission_store.grant, user_id, result.session_id, LEVEL_OWNER
-                )
-            # Push the new session to this user's other open tabs so it
-            # enters the sidebar without a list poll (WS /sessions/updates).
-            _announce_session_added(user_id, result.session_id)
-            return result
+            return await _create_bundled_session_from_multipart(request, user_id)
 
         try:
             payload = await request.json()
@@ -647,6 +638,17 @@ def register_core_routes(
                 result.agent_id,
                 runner_router,
             )
+        # Grant the creator ownership BEFORE scheduling the managed
+        # launch, mirroring the JSON path: a managed-guard failure
+        # (misconfigured server, unconfigured provider) must not leave
+        # the just-persisted session unowned and thus invisible to the
+        # caller. Push to the caller's other open tabs, too.
+        if permission_store is not None and user_id is not None:
+            await asyncio.to_thread(permission_store.ensure_user, user_id)
+            await asyncio.to_thread(
+                permission_store.grant, user_id, result.session_id, LEVEL_OWNER
+            )
+        _announce_session_added(user_id, result.session_id)
         # Managed bundle create: provision a sandbox host for the
         # just-uploaded session-scoped agent (same background launch as
         # the JSON path). The managed runner fetches the uploaded bundle

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1512,6 +1512,16 @@ class SessionCreateMetadata(BaseModel):
         inherits the parent's runner binding for co-location. The
         caller must have READ access to the parent. ``None``
         creates a top-level session.
+    :param host_type: How the session's host is obtained — ``"external"``
+        (the default: the caller manages the runner, e.g. a local
+        ``omnigent run``) or ``"managed"`` (the server provisions a
+        sandbox host). The uploaded bundle's session-scoped agent runs
+        on the provisioned sandbox; its spec is fetched by the managed
+        runner over its tunnel, same as any session-scoped agent.
+    :param sandbox_provider: Which configured sandbox provider to
+        provision on ``host_type: "managed"`` (one of the server's
+        ``sandbox_providers``); ``None`` takes the server's first. Only
+        valid with ``host_type: "managed"``.
     """
 
     title: str | None = None
@@ -1521,8 +1531,62 @@ class SessionCreateMetadata(BaseModel):
     workspace: str | None = None
     terminal_launch_args: list[str] | None = None
     parent_session_id: str | None = None
+    host_type: Literal["external", "managed"] = "external"
+    sandbox_provider: str | None = None
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _check_managed_bundle_fields(self) -> SessionCreateMetadata:
+        """
+        Enforce the multipart per-``host_type`` contract.
+
+        Mirrors :meth:`SessionCreateRequest._check_managed_host_fields`
+        for the bundle-upload path: a managed session's host is
+        server-provisioned, so a caller-supplied ``host_id`` contradicts
+        it, and a managed ``workspace`` (when given) must be a git
+        repository URL (optionally ``#<branch>``) the server clones into
+        the sandbox — a filesystem path points at nothing in a sandbox
+        that doesn't exist yet. ``sandbox_provider`` only applies to a
+        managed host. A repository-URL workspace on an external host is
+        rejected symmetrically.
+
+        :returns: The validated instance.
+        :raises ValueError: On ``"managed"`` + ``host_id``, a managed
+            workspace that isn't a valid repository URL, ``sandbox_provider``
+            without ``"managed"``, or an external repository-URL workspace.
+        """
+        # Lazy import: schemas is imported nearly everywhere, so pulling
+        # the FastAPI/click-importing managed-hosts module in at module
+        # scope would risk import cycles.
+        from omnigent.server.managed_hosts import is_repo_workspace, parse_repo_workspace
+
+        if self.host_type == "managed":
+            if self.host_id is not None:
+                raise ValueError(
+                    "host_type 'managed' lets the server provision the host; "
+                    "host_id must not be set"
+                )
+            if self.workspace is not None:
+                try:
+                    parse_repo_workspace(self.workspace)
+                except ValueError as exc:
+                    raise ValueError(
+                        "host_type 'managed' takes a git repository URL "
+                        f"(optionally '#<branch>') as workspace: {exc}"
+                    ) from exc
+            return self
+        if self.sandbox_provider is not None:
+            raise ValueError(
+                "sandbox_provider only applies to host_type 'managed' — "
+                "external hosts are not server-provisioned"
+            )
+        if self.workspace is not None and is_repo_workspace(self.workspace):
+            raise ValueError(
+                "a repository-URL workspace requires host_type 'managed' — "
+                "external hosts take an absolute path on the host"
+            )
+        return self
 
 
 class CreatedSessionResponse(BaseModel):

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -370,6 +370,8 @@ class SessionsNamespace:
         labels: dict[str, str] | None = None,
         reasoning_effort: str | None = None,
         workspace: str | None = None,
+        host_type: str = "external",
+        sandbox_provider: str | None = None,
     ) -> Session:
         """
         Create a new session from an uploaded agent bundle.
@@ -389,11 +391,18 @@ class SessionsNamespace:
             starts with no labels.
         :param reasoning_effort: Optional per-session reasoning
             effort, e.g. ``"high"``. ``None`` uses the agent default.
-        :param workspace: Optional absolute starting cwd to record on
-            the session, e.g. ``"/Users/corey/projects/myapp"``.
-            CLI-launched sessions populate this with ``os.getcwd()``
-            so the Web UI can show "running locally in <workspace>";
-            sessions with no recorded workspace pass ``None``.
+        :param workspace: Optional starting workspace. For an external
+            host (the default), an absolute cwd to record on the session,
+            e.g. ``"/Users/corey/projects/myapp"`` — CLI-launched sessions
+            populate this with ``os.getcwd()``. For ``host_type="managed"``,
+            a git repository URL (optionally ``#<branch>``) the server
+            clones into the sandbox. ``None`` records no workspace.
+        :param host_type: ``"external"`` (default) uploads the bundle and
+            runs it on a caller-managed runner; ``"managed"`` uploads the
+            bundle and has the server provision a sandbox host to run it.
+        :param sandbox_provider: With ``host_type="managed"``, which
+            configured sandbox provider to provision (e.g. ``"lakebox"``);
+            ``None`` takes the server's first. Ignored for external hosts.
         :returns: The newly created :class:`Session` snapshot.
         :raises OmnigentError: If the server returns a non-2xx
             status.
@@ -407,6 +416,10 @@ class SessionsNamespace:
             metadata["reasoning_effort"] = reasoning_effort
         if workspace is not None:
             metadata["workspace"] = workspace
+        if host_type != "external":
+            metadata["host_type"] = host_type
+        if sandbox_provider is not None:
+            metadata["sandbox_provider"] = sandbox_provider
         resp = await self._http.post(
             f"{self._base}/v1/sessions",
             data={"metadata": json.dumps(metadata)},

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -48,6 +49,7 @@ from omnigent.stores.host_store import HostStore
 from tests.server.helpers import (
     FakeSandboxLauncher,
     HostStartInvocation,
+    build_agent_bundle,
     create_test_agent,
     install_fake_modal_launcher,
 )
@@ -557,6 +559,88 @@ async def test_managed_session_create_with_repo_workspace_binds_cloned_dir(
     assert snapshot.status_code == 200, snapshot.text
     assert snapshot.json()["workspace"] == "/root/workspace/myrepo"
     del tunnels
+
+
+async def test_managed_multipart_bundle_create_end_to_end(
+    managed_session_env: ManagedSessionEnv,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Multipart ``POST /v1/sessions`` with ``host_type="managed"`` uploads
+    a bundle AND provisions a sandbox in one call — the gap this feature
+    closes. The freshly-created session-scoped agent is what the managed
+    runner runs on the sandbox, so the same background launch as the JSON
+    path binds the session to a sandbox host with a runner. Also confirms
+    the caller owns the session (grant happens BEFORE the managed launch
+    is scheduled, so a launch failure can't orphan an unowned row).
+    """
+    env = managed_session_env
+    monkeypatch.setattr("omnigent.server.managed_hosts.MANAGED_HOST_ONLINE_TIMEOUT_S", 10)
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S", 0.2
+    )
+    loop = asyncio.get_running_loop()
+    host_futures: list[asyncio.Future[ApplicationCommunicator]] = []
+
+    def _start_fake_sandbox_host(invocation: HostStartInvocation) -> None:
+        """Spawn the fake sandbox host when the launcher 'starts' it."""
+        future = asyncio.run_coroutine_threadsafe(
+            _fake_sandbox_host(
+                env.app, invocation.host_id, invocation.host_name, invocation.token
+            ),
+            loop,
+        )
+        host_futures.append(asyncio.wrap_future(future, loop=loop))
+
+    fake = FakeSandboxLauncher(on_host_start=_start_fake_sandbox_host)
+    install_fake_modal_launcher(monkeypatch, fake)
+
+    bundle = build_agent_bundle(name="managed-multipart-e2e-agent")
+    resp = await env.client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({"host_type": "managed"})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = resp.json()["session_id"]
+
+    # The uploaded bundle's session-scoped agent is what runs on the
+    # provisioned sandbox — the background launch binds the session the
+    # same way the JSON path does.
+    conv = await _wait_for_managed_binding(env, session_id)
+    tunnels = [await future for future in host_futures]
+    assert len(tunnels) == 1
+    assert conv.host_id is not None
+    assert conv.workspace == "/root/workspace"
+    assert conv.runner_id is not None
+    assert conv.runner_id.startswith("runner_token_")
+
+    host = env.host_store.get_host(conv.host_id)
+    assert host is not None
+    assert host.user_id == RESERVED_USER_LOCAL
+    assert host.status == "online"
+    assert host.sandbox_provider == "modal"
+    assert host.sandbox_id == "sb-fake-1"
+    del tunnels
+
+
+async def test_managed_multipart_bundle_create_rejects_path_workspace(
+    managed_session_env: ManagedSessionEnv,
+) -> None:
+    """
+    A multipart managed create with a filesystem-path workspace is
+    rejected at metadata validation — a managed workspace is a git
+    repository URL, mirroring the JSON path's contract — before any
+    sandbox provisioning is scheduled.
+    """
+    bundle = build_agent_bundle(name="managed-multipart-badws-agent")
+    resp = await managed_session_env.client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({"host_type": "managed", "workspace": "/tmp/w"})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+    )
+    assert resp.status_code >= 400, resp.text
+    assert "git repository URL" in resp.text
 
 
 async def test_managed_session_create_validator_errors_serialize_as_422(

--- a/tests/server/integration/test_sessions_content_type_csrf.py
+++ b/tests/server/integration/test_sessions_content_type_csrf.py
@@ -349,3 +349,47 @@ async def test_create_session_accepts_multipart_bundled_create(
     # The bundled-create response carries the new session id → multipart
     # routed to the bundled-create branch, not rejected at the gate.
     assert "session_id" in resp.json()
+
+
+async def test_multipart_managed_create_reaches_managed_launch(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    Multipart ``host_type: "managed"`` routes to the managed-launch path.
+
+    The default test app has no ``sandbox_config``, so a managed multipart
+    create must fail with the "managed hosts are not configured" error —
+    which proves the handler took the new managed branch (and reached
+    ``_schedule_managed_launch``) rather than silently creating an external
+    session. On a server WITH a ``sandbox:`` config this same request would
+    provision a sandbox for the uploaded session-scoped agent.
+    """
+    bundle = build_agent_bundle(name="managed-multipart-agent")
+    resp = await client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({"host_type": "managed", "sandbox_provider": "lakebox"})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+    )
+    # Reached the managed branch → the not-configured guard fires.
+    assert resp.status_code >= 400, resp.text
+    assert "managed hosts are not configured" in resp.text
+
+
+async def test_multipart_managed_rejects_path_workspace(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    Multipart ``host_type: "managed"`` + a filesystem-path workspace is
+    rejected at metadata validation (a managed workspace is a git repository
+    URL), before any bundle/session work — mirrors the JSON path's contract.
+    The multipart metadata parser surfaces the schema ValueError as a 400
+    invalid_input (the JSON path returns 422; both name the URL requirement).
+    """
+    bundle = build_agent_bundle(name="managed-badws-agent")
+    resp = await client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({"host_type": "managed", "workspace": "/tmp/w"})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+    )
+    assert resp.status_code >= 400, resp.text
+    assert "git repository URL" in resp.text

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -769,6 +769,92 @@ def test_session_create_external_rejects_repo_url_workspace() -> None:
         )
 
 
+def test_session_metadata_host_type_defaults_external() -> None:
+    """
+    Multipart ``SessionCreateMetadata.host_type`` defaults to
+    ``"external"`` — every existing bundle-upload client that omits the
+    field keeps its current external-host behaviour (backcompat).
+    """
+    from omnigent.server.schemas import SessionCreateMetadata
+
+    assert SessionCreateMetadata().host_type == "external"
+
+
+def test_session_metadata_managed_rejects_host_id() -> None:
+    """
+    Multipart ``host_type="managed"`` + a caller-supplied ``host_id`` is
+    a contradiction (the server provisions the host) — mirrors the JSON
+    path's contract.
+    """
+    from omnigent.server.schemas import SessionCreateMetadata
+
+    with pytest.raises(ValidationError, match="host_id must not be set"):
+        SessionCreateMetadata(host_type="managed", host_id="host_abc")
+
+
+def test_session_metadata_managed_rejects_path_workspace() -> None:
+    """
+    Multipart ``host_type="managed"`` + a PATH workspace 422s — a
+    managed workspace is a repository URL cloned into the sandbox.
+    """
+    from omnigent.server.schemas import SessionCreateMetadata
+
+    with pytest.raises(ValidationError, match="takes a git repository URL"):
+        SessionCreateMetadata(host_type="managed", workspace="/tmp/w")
+
+
+@pytest.mark.parametrize(
+    "workspace",
+    [
+        "https://github.com/org/repo",
+        "https://github.com/org/repo.git#release-1.2",
+        "git@github.com:org/repo.git",
+    ],
+)
+def test_session_metadata_managed_accepts_repo_url_workspace(workspace: str) -> None:
+    """
+    Multipart ``host_type="managed"`` accepts the ``<repo>[#<branch>]``
+    workspace forms verbatim for the launch path to clone.
+    """
+    from omnigent.server.schemas import SessionCreateMetadata
+
+    meta = SessionCreateMetadata(host_type="managed", workspace=workspace)
+    assert meta.workspace == workspace
+
+
+def test_session_metadata_managed_accepts_sandbox_provider() -> None:
+    """
+    ``sandbox_provider`` is accepted with ``host_type="managed"`` (chooses
+    which configured provider the server provisions).
+    """
+    from omnigent.server.schemas import SessionCreateMetadata
+
+    meta = SessionCreateMetadata(host_type="managed", sandbox_provider="lakebox")
+    assert meta.sandbox_provider == "lakebox"
+
+
+def test_session_metadata_external_rejects_sandbox_provider() -> None:
+    """
+    ``sandbox_provider`` without ``host_type="managed"`` 422s — external
+    hosts are not server-provisioned.
+    """
+    from omnigent.server.schemas import SessionCreateMetadata
+
+    with pytest.raises(ValidationError, match="sandbox_provider only applies"):
+        SessionCreateMetadata(sandbox_provider="lakebox")
+
+
+def test_session_metadata_external_rejects_repo_url_workspace() -> None:
+    """
+    A repository-URL workspace on an external multipart create 422s —
+    there, ``workspace`` is an absolute path on the host.
+    """
+    from omnigent.server.schemas import SessionCreateMetadata
+
+    with pytest.raises(ValidationError, match="requires host_type 'managed'"):
+        SessionCreateMetadata(workspace="https://github.com/org/repo")
+
+
 @pytest.mark.parametrize("status", ["idle", "running", "waiting", "failed"])
 def test_session_response_status_accepts_canonical_set(status: str) -> None:
     """


### PR DESCRIPTION
## Related issue

N/A — server capability change. Lets a client upload an agent bundle AND run it
on a server-provisioned managed sandbox in one call (previously impossible).

## Summary

Today only the JSON `POST /v1/sessions` (referencing an existing `agent_id`) can
request `host_type: "managed"`; the **multipart** bundle-upload path was
external-host only. So there was no way to *upload* an agent and run it managed —
you had to pre-seed a built-in. This closes that gap.

- **schemas:** add `host_type` / `sandbox_provider` to `SessionCreateMetadata`
  with a validator mirroring `SessionCreateRequest`'s managed-host contract
  (managed rejects `host_id` and path workspaces; `sandbox_provider` only with
  managed; external rejects repo-URL workspaces). Defaults to `external` →
  backcompat for every existing bundle-upload client.
- **routes_core:** extract the JSON path's managed-launch block into a shared
  nested `_schedule_managed_launch` helper and call it from the multipart handler
  with the freshly-created **session-scoped** `agent_id`. The managed runner
  fetches the uploaded bundle over its tunnel like any session-scoped agent, so
  **no new bundle-delivery plumbing** is needed.
- **client SDK:** `sessions.create()` gains `host_type` / `sandbox_provider`
  kwargs.

ELI5: you couldn't upload an agent AND ask for a managed sandbox in one request —
upload-create was always external-host. Now the metadata part accepts
`host_type: "managed"`, so CI (or the repro-agent) can upload a bundle and run it
on a Databricks Sandbox without seeding a built-in first.

## Test Plan

- `tests/server/test_schemas.py` — 9 validator tests for the new
  `SessionCreateMetadata` fields (default external; managed rejects host_id / path
  workspace; accepts repo-URL workspace + sandbox_provider; external rejects
  sandbox_provider / repo-URL workspace).
- `tests/server/integration/test_sessions_content_type_csrf.py` — a managed
  multipart create reaches the managed-launch path (fails "managed hosts are not
  configured" on the no-sandbox test app, proving the branch fires rather than
  silently creating an external session); a path workspace is rejected.
- `pre-commit run` (ruff format + check + pyrefly) passes; `scripts/dump_openapi.py
  --check` reports no drift.

## Demo

N/A — server/API change, no UI.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Schema validator + handler-branch behavior are covered by the unit + integration
tests above. The full managed end-to-end (real sandbox provision) needs a
Databricks-Sandbox-enabled deployment and is out of scope for CI here.

## Changelog

Multipart `POST /v1/sessions` now accepts `host_type: "managed"` (with `sandbox_provider`), so an uploaded agent bundle can run on a server-provisioned sandbox in one call