### PR TITLE
feat(runner): log claude-native watched file paths to the runner log

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -3095,6 +3095,17 @@ async def _ensure_state_for_transcript(
         cursor_fingerprint=_jsonl_cursor_fingerprint(transcript_path, byte_offset),
     )
     await _write_forward_state_async(bridge_dir, state)
+    # First time this forwarder locks onto a transcript file (fresh session, or a
+    # new transcript after /clear or fork) — surface the path in the runner log,
+    # where the host terminal's ``log:`` line already points, so it is easy to
+    # find and tail. Mirrors the status watcher's "claude status file resolved"
+    # line; the two together name both files a claude-native session watches.
+    _logger.info(
+        "claude transcript file resolved: path=%s session=%s",
+        transcript_path,
+        session_id,
+        extra={"session_id": session_id},
+    )
     return state
 
 

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -8414,3 +8414,67 @@ async def test_forward_loop_deadline_unsticks_a_stalled_iteration(
     assert stall_warnings, "the deadline trip must be loudly logged, never silent"
     # The warning's traceback names the stalled await for next-time forensics.
     assert stall_warnings[0].exc_info is not None
+
+
+async def test_ensure_state_logs_transcript_path_on_fresh_adoption(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The forwarder logs the transcript path the first time it adopts one.
+
+    This is how the transcript file surfaces in the runner log — the file the
+    host terminal's ``log:`` line points at — alongside the status watcher's
+    "claude status file resolved" line, so a user can find both files a
+    claude-native session watches.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type": "user"}\n', encoding="utf-8")
+
+    with caplog.at_level(logging.INFO, logger="omnigent.claude_native_forwarder"):
+        state = await forwarder._ensure_state_for_transcript(
+            bridge_dir=bridge_dir,
+            state=None,
+            transcript_path=transcript,
+            start_at_end=False,
+            session_id="conv_abc",
+        )
+
+    assert state.transcript_path == transcript
+    resolved = [
+        r.getMessage() for r in caplog.records if "transcript file resolved" in r.getMessage()
+    ]
+    assert len(resolved) == 1
+    assert str(transcript) in resolved[0]
+    assert "conv_abc" in resolved[0]
+
+
+async def test_ensure_state_does_not_relog_unchanged_transcript(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Re-adopting the same transcript on later polls logs the path only once."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type": "user"}\n', encoding="utf-8")
+
+    with caplog.at_level(logging.INFO, logger="omnigent.claude_native_forwarder"):
+        state = await forwarder._ensure_state_for_transcript(
+            bridge_dir=bridge_dir,
+            state=None,
+            transcript_path=transcript,
+            start_at_end=False,
+            session_id="conv_abc",
+        )
+        # Second call carries the state back in — the steady-state poll, which
+        # must early-return without re-logging the (unchanged) transcript path.
+        await forwarder._ensure_state_for_transcript(
+            bridge_dir=bridge_dir,
+            state=state,
+            transcript_path=transcript,
+            start_at_end=False,
+            session_id="conv_abc",
+        )
+
+    resolved = [r for r in caplog.records if "transcript file resolved" in r.getMessage()]
+    assert len(resolved) == 1


### PR DESCRIPTION
## Related issue

N/A — internal enhancement (no tracked issue).

## Summary

When a claude-native session starts under the host daemon, the host prints the `↑ Runner started / log / session` block the instant it spawns the runner — **before Claude boots**. So the two files the runner then watches — Claude's **transcript JSONL** and its **`sessions/<pid>.json`** status file — are never surfaced anywhere, even though they're the files you most often want to tail.

The two subsystems that watch these files **already resolve the paths** as part of their normal work, so the fix is just to log them right there — both land in the runner log, the file the host terminal's `log:` line already points at:

- **Status file** — the status watcher already logs it today: `claude_native_status_file.py` emits `claude status file resolved: path=…` when it locks on. No change needed.
- **Transcript** — the forwarder resolves the path but never logged it. This adds one line in `_ensure_state_for_transcript`, emitted once when the forwarder first adopts a transcript (and again on a new transcript after `/clear` or fork): `claude transcript file resolved: path=… session=…`.

So tailing the runner log now shows both:

```
  ↑ Runner started: runner_token_… (pid=81096)
    log: ~/.omnigent/logs/runner/runner-…-20260824-162708.log
    session: cb75258350e74d4fa57e468c5da6c5cd

# …a few seconds later, inside that runner log:
claude transcript file resolved: path=/…/.claude/projects/<slug>/<uuid>.jsonl session=cb75258…
claude status file resolved: path=/…/.claude/sessions/81142.json attempts=3 pane_pid=81142
```

No sidecar, no host-side polling, no separate resolver task — the paths are logged by the code that already knows them, at the moment it starts watching.

Changed files:
- `omnigent/claude_native_forwarder.py` — one `_logger.info` in `_ensure_state_for_transcript`.
- `tests/test_claude_native_forwarder.py` — two tests.

## Test Plan

```bash
python -m pytest tests/test_claude_native_forwarder.py
```

New tests: the transcript path is logged once when the forwarder first adopts a transcript (naming the path + session id), and is **not** re-logged on subsequent steady-state polls of the same transcript. Full file: 148 passed. `ruff format` / `ruff check` clean; `pyrefly` 0 errors on the changed file.

Manual verification: see Coverage notes.

## Demo

N/A — non-visual change (log lines in the runner log).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual: started the host daemon, launched a claude-native session, and confirmed the runner log gains both a `claude transcript file resolved: path=… session=…` line (from the forwarder) and the existing `claude status file resolved: path=…` line (from the status watcher) a few seconds after startup, with paths that resolve to the live transcript JSONL and `sessions/<pid>.json`.

## Changelog

The runner log now names the transcript and status-file paths a claude-native session watches, so they're easy to find and tail.

---

This pull request and its description were written by Isaac.
