### PR TITLE
Analytics: interaction phase events

### DIFF
--- a/web/src/lib/analytics.test.tsx
+++ b/web/src/lib/analytics.test.tsx
@@ -4,7 +4,12 @@ import { MemoryRouter, useNavigate } from "react-router-dom";
 import type { ReactNode } from "react";
 
 import { setOmnigentHostConfig, type OmnigentAnalyticsEvent } from "@/lib/host";
-import { emitOmnigentAnalytics, useOmnigentAnalytics, useOmnigentPageView } from "@/lib/analytics";
+import {
+  emitOmnigentAnalytics,
+  emitInteractionPhase,
+  useOmnigentAnalytics,
+  useOmnigentPageView,
+} from "@/lib/analytics";
 
 afterEach(() => {
   // Reset the module-singleton host config between tests. The empty-config
@@ -42,7 +47,70 @@ describe("emitOmnigentAnalytics", () => {
   });
 });
 
+describe("emitInteractionPhase", () => {
+  it("is a no-op when no host sink is configured", () => {
+    expect(() =>
+      emitInteractionPhase({
+        interactionId: "run_1",
+        interactionKind: "agent_run",
+        phase: "start",
+      }),
+    ).not.toThrow();
+  });
+
+  it("forwards a start phase, then a complete phase carrying status and duration", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+
+    emitInteractionPhase({ interactionId: "run_1", interactionKind: "agent_run", phase: "start" });
+    expect(analytics).toHaveBeenLastCalledWith({
+      type: "interaction_phase",
+      interactionId: "run_1",
+      interactionKind: "agent_run",
+      phase: "start",
+    });
+
+    emitInteractionPhase({
+      interactionId: "run_1",
+      interactionKind: "agent_run",
+      phase: "complete",
+      status: "success",
+      durationMs: 1234,
+    });
+    expect(analytics).toHaveBeenLastCalledWith({
+      type: "interaction_phase",
+      interactionId: "run_1",
+      interactionKind: "agent_run",
+      phase: "complete",
+      status: "success",
+      durationMs: 1234,
+    });
+  });
+});
+
 describe("useOmnigentAnalytics", () => {
+  it("forwards trackInteraction to the host sink", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    const { result } = renderHook(() => useOmnigentAnalytics());
+
+    result.current.trackInteraction({
+      interactionId: "call_1",
+      interactionKind: "tool_call",
+      phase: "complete",
+      name: "shell",
+      durationMs: 42,
+    });
+    expect(analytics).toHaveBeenCalledExactlyOnceWith({
+      type: "interaction_phase",
+      interactionId: "call_1",
+      interactionKind: "tool_call",
+      phase: "complete",
+      name: "shell",
+      durationMs: 42,
+    });
+  });
+
   it("redacts field values by default and forwards only when declared PII-free", () => {
     const analytics = vi.fn();
     setOmnigentHostConfig({ analytics });

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -24,9 +24,11 @@ import { useLocation } from "@/lib/routing";
 // them here so this module stays the single import surface for analytics.
 export {
   emitOmnigentAnalytics,
+  emitInteractionPhase,
   useOmnigentAnalytics,
   type OmnigentAnalytics,
   type TrackValueChangeOptions,
+  type InteractionPhaseArgs,
 } from "@/lib/analyticsEmit";
 import { emitOmnigentAnalytics } from "@/lib/analyticsEmit";
 

--- a/web/src/lib/analyticsEmit.ts
+++ b/web/src/lib/analyticsEmit.ts
@@ -16,6 +16,8 @@ import {
   getOmnigentAnalytics,
   type OmnigentAnalyticsEvent,
   type OmnigentComponentKind,
+  type OmnigentInteractionKind,
+  type OmnigentInteractionStatus,
 } from "@/lib/host";
 
 /**
@@ -30,6 +32,29 @@ export function emitOmnigentAnalytics(event: OmnigentAnalyticsEvent): void {
   } catch {
     // ignore
   }
+}
+
+export interface InteractionPhaseArgs {
+  /** Correlates the `start` and `complete` of one interaction. */
+  interactionId: string;
+  interactionKind: OmnigentInteractionKind;
+  phase: "start" | "complete";
+  /** Set on `complete`. */
+  status?: OmnigentInteractionStatus;
+  /** Optional bounded, non-PII label (e.g. a tool name). Never user content. */
+  name?: string;
+  /** Elapsed time, set on `complete` when known. */
+  durationMs?: number;
+}
+
+/**
+ * Emit an interaction-phase event (agent run / tool call / approval, start or
+ * completion). A routing-free free function so non-React call sites — the event
+ * reducer in `lib/blockStream.ts`, store thunks in `store/chatStore.ts` — can
+ * report outcomes. No-op when no host sink is configured.
+ */
+export function emitInteractionPhase(args: InteractionPhaseArgs): void {
+  emitOmnigentAnalytics({ type: "interaction_phase", ...args });
 }
 
 export interface TrackValueChangeOptions {
@@ -49,6 +74,8 @@ export interface OmnigentAnalytics {
     value?: string | number | boolean,
     options?: TrackValueChangeOptions,
   ) => void;
+  /** Report an interaction-phase event (agent run / tool call / approval). */
+  trackInteraction: (args: InteractionPhaseArgs) => void;
 }
 
 /**
@@ -70,6 +97,7 @@ export function useOmnigentAnalytics(): OmnigentAnalytics {
           // it carries no PII.
           value: options?.valueHasNoPii ? value : undefined,
         }),
+      trackInteraction: (args) => emitInteractionPhase(args),
     }),
     [],
   );

--- a/web/src/lib/host.ts
+++ b/web/src/lib/host.ts
@@ -33,12 +33,26 @@ export type OmnigentComponentKind =
   "button" | "link" | "input" | "textarea" | "checkbox" | "toggle" | "select" | "tabs";
 
 /**
+ * A multi-phase interaction whose *outcome* matters — not just that a control was
+ * clicked. Host-agnostic; the host maps each onto its own taxonomy.
+ *   - `agent_run`  — one user prompt → model run.
+ *   - `tool_call`  — a single tool / skill / MCP invocation within a run.
+ *   - `approval`   — a human-in-the-loop permission decision.
+ */
+export type OmnigentInteractionKind = "agent_run" | "tool_call" | "approval";
+
+/** Terminal outcome of an interaction, set on the `complete` phase. */
+export type OmnigentInteractionStatus = "success" | "failure" | "cancelled" | "timed_out";
+
+/**
  * A product-analytics event forwarded to the host. Each carries a stable,
  * caller-chosen `componentId` / `pageId` so the host can attribute the action.
  *
  * PII: `value` on a value-change is only ever set when the emitting call site
  * explicitly declares the value PII-free (see `useOmnigentAnalytics` in
- * `lib/analytics.ts`). Free-form field text is never forwarded.
+ * `lib/analytics.ts`). Free-form field text is never forwarded. Likewise
+ * `interaction_phase.name` must be a bounded, non-PII label (e.g. a tool name
+ * from a fixed set), never user content.
  */
 export type OmnigentAnalyticsEvent =
   | { type: "click"; componentId: string; componentKind?: OmnigentComponentKind }
@@ -48,7 +62,21 @@ export type OmnigentAnalyticsEvent =
       componentKind?: OmnigentComponentKind;
       value?: string | number | boolean;
     }
-  | { type: "page_view"; pageId: string };
+  | { type: "page_view"; pageId: string }
+  | {
+      /**
+       * Start or end of an interaction whose outcome matters (agent run, tool
+       * call, approval). `interactionId` correlates the `start` and `complete`
+       * of one interaction; `status` and `durationMs` are set on `complete`.
+       */
+      type: "interaction_phase";
+      interactionId: string;
+      interactionKind: OmnigentInteractionKind;
+      phase: "start" | "complete";
+      status?: OmnigentInteractionStatus;
+      name?: string;
+      durationMs?: number;
+    };
 
 export interface OmnigentHostConfig {
   /**

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -36,6 +36,11 @@ import { INITIAL_WINDOW_ITEMS, SESSION_HISTORY_PAGE_SIZE } from "@/lib/sessionsA
 import { SSE_STALL_TIMEOUT_MS } from "@/lib/sse";
 import { getCurrentAuthorId } from "@/lib/identity";
 import { PRESENCE_IDLE_AFTER_MS } from "@/lib/presenceIdle";
+import {
+  setOmnigentHostConfig,
+  type OmnigentAnalyticsEvent,
+  type OmnigentInteractionKind,
+} from "@/lib/host";
 import type {
   SessionCreatedEvent,
   SessionInputConsumedEvent,
@@ -11490,5 +11495,202 @@ describe("chatStore — origin-wide stream slots", () => {
     await useChatStore.getState().switchTo("conv_c");
     expect(useChatStore.getState().streamBudgetExceeded).toBe(true);
     expect(useChatStore.getState().streamBudgetBannerDismissed).toBe(false);
+  });
+});
+
+describe("chatStore — interaction_phase analytics", () => {
+  const setState = useChatStore.setState as unknown as Parameters<typeof pumpStreamEvents>[3];
+  const getState = useChatStore.getState as unknown as Parameters<typeof pumpStreamEvents>[4];
+  // Commit synchronously so each pushed frame lands without waiting a frame.
+  const immediate: FrameScheduler = { schedule: (cb) => cb(), cancel: () => {} };
+
+  type InteractionPhaseEvent = Extract<OmnigentAnalyticsEvent, { type: "interaction_phase" }>;
+  let events: OmnigentAnalyticsEvent[];
+
+  beforeEach(() => {
+    events = [];
+    setOmnigentHostConfig({ analytics: (e) => events.push(e) });
+  });
+  afterEach(() => {
+    // Drop the sink so no other suite's pump emits leak here. No fetcher is set
+    // in this file, so the empty-config guard lets this reset through.
+    setOmnigentHostConfig({});
+  });
+
+  const phases = (kind: OmnigentInteractionKind): InteractionPhaseEvent[] =>
+    events.filter(
+      (e): e is InteractionPhaseEvent =>
+        e.type === "interaction_phase" && e.interactionKind === kind,
+    );
+
+  it("emits agent_run start on response.created and complete+duration on response.completed", async () => {
+    useChatStore.setState({ conversationId: "conv_ip_run", blocks: [] });
+    const sink = pushableStream();
+    const controller = new AbortController();
+    void pumpStreamEvents("conv_ip_run", sink.stream, controller, setState, getState, immediate);
+
+    sink.push(sse("response.created", { id: "resp_ip_run", status: "in_progress", output: [] }));
+    await tick();
+    sink.push(sse("response.completed", { id: "resp_ip_run", status: "completed", output: [] }));
+    await tick();
+
+    const runs = phases("agent_run");
+    expect(runs).toHaveLength(2);
+    expect(runs[0]).toEqual({
+      type: "interaction_phase",
+      interactionId: "resp_ip_run",
+      interactionKind: "agent_run",
+      phase: "start",
+    });
+    expect(runs[1]).toMatchObject({
+      interactionId: "resp_ip_run",
+      interactionKind: "agent_run",
+      phase: "complete",
+      status: "success",
+    });
+    expect(typeof runs[1]!.durationMs).toBe("number");
+
+    controller.abort();
+  });
+
+  it("emits agent_run start only once for a re-delivered response.created", async () => {
+    // SSE re-delivery on reconnect must not double-count a run: the id-keyed
+    // start map guards the second `response.created`.
+    useChatStore.setState({ conversationId: "conv_ip_dup", blocks: [] });
+    const sink = pushableStream();
+    const controller = new AbortController();
+    void pumpStreamEvents("conv_ip_dup", sink.stream, controller, setState, getState, immediate);
+
+    sink.push(sse("response.created", { id: "resp_ip_dup", status: "in_progress", output: [] }));
+    await tick();
+    sink.push(sse("response.created", { id: "resp_ip_dup", status: "in_progress", output: [] }));
+    await tick();
+
+    const starts = phases("agent_run").filter((e) => e.phase === "start");
+    expect(starts).toHaveLength(1);
+
+    controller.abort();
+  });
+
+  it("maps run terminal status (completed→success, failed→failure, incomplete→cancelled)", async () => {
+    async function runToTerminal(
+      id: string,
+      terminalType: string,
+      terminalData: Record<string, unknown>,
+    ): Promise<void> {
+      useChatStore.setState({ conversationId: id, blocks: [] });
+      const sink = pushableStream();
+      const controller = new AbortController();
+      void pumpStreamEvents(id, sink.stream, controller, setState, getState, immediate);
+      sink.push(sse("response.created", { id, status: "in_progress", output: [] }));
+      await tick();
+      sink.push(sse(terminalType, { id, ...terminalData }));
+      await tick();
+      controller.abort();
+    }
+
+    await runToTerminal("resp_ip_ok", "response.completed", { status: "completed", output: [] });
+    await runToTerminal("resp_ip_fail", "response.failed", { status: "failed", output: [] });
+    await runToTerminal("resp_ip_inc", "response.incomplete", {
+      status: "incomplete",
+      output: [],
+      reason: "max_iterations",
+    });
+
+    const completes = phases("agent_run").filter((e) => e.phase === "complete");
+    expect(completes.map((e) => e.status)).toEqual(["success", "failure", "cancelled"]);
+  });
+
+  it("emits tool_call start (with name) and complete (with name + duration)", async () => {
+    useChatStore.setState({ conversationId: "conv_ip_tool", blocks: [] });
+    const sink = pushableStream();
+    const controller = new AbortController();
+    void pumpStreamEvents("conv_ip_tool", sink.stream, controller, setState, getState, immediate);
+
+    sink.push(sse("response.created", { id: "resp_ip_tool", status: "in_progress", output: [] }));
+    sink.push(
+      sse("response.output_item.done", {
+        item: {
+          id: "fc_ip_1",
+          type: "function_call",
+          response_id: "resp_ip_tool",
+          call_id: "call_ip_1",
+          name: "shell",
+          arguments: "{}",
+          status: "in_progress",
+        },
+      }),
+    );
+    sink.push(
+      sse("response.output_item.done", {
+        item: {
+          id: "fco_ip_1",
+          type: "function_call_output",
+          response_id: "resp_ip_tool",
+          call_id: "call_ip_1",
+          status: "completed",
+          output: "done",
+        },
+      }),
+    );
+    await tick();
+
+    const tools = phases("tool_call");
+    expect(tools).toHaveLength(2);
+    expect(tools[0]).toEqual({
+      type: "interaction_phase",
+      interactionId: "call_ip_1",
+      interactionKind: "tool_call",
+      phase: "start",
+      name: "shell",
+    });
+    expect(tools[1]).toMatchObject({
+      interactionId: "call_ip_1",
+      interactionKind: "tool_call",
+      phase: "complete",
+      name: "shell",
+    });
+    expect(typeof tools[1]!.durationMs).toBe("number");
+
+    controller.abort();
+  });
+
+  it("emits an approval complete with the mapped status for each verdict", async () => {
+    useChatStore.setState({
+      conversationId: "conv_ip_appr",
+      blocks: [
+        elicitationBlock("elic_ok"),
+        elicitationBlock("elic_no"),
+        elicitationBlock("elic_x"),
+      ],
+    });
+
+    await useChatStore.getState().submitApproval("elic_ok", "accept");
+    await useChatStore.getState().submitApproval("elic_no", "decline");
+    await useChatStore.getState().submitApproval("elic_x", "cancel");
+
+    expect(phases("approval")).toEqual([
+      {
+        type: "interaction_phase",
+        interactionId: "elic_ok",
+        interactionKind: "approval",
+        phase: "complete",
+        status: "success",
+      },
+      {
+        type: "interaction_phase",
+        interactionId: "elic_no",
+        interactionKind: "approval",
+        phase: "complete",
+        status: "failure",
+      },
+      {
+        type: "interaction_phase",
+        interactionId: "elic_x",
+        interactionKind: "approval",
+        phase: "complete",
+        status: "cancelled",
+      },
+    ]);
   });
 });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -4753,7 +4753,8 @@ export async function pumpStreamEvents(
             interactionId: endedId,
             interactionKind: "agent_run",
             phase: "complete",
-            status: active?.state === "cancelled" ? "cancelled" : mapRunStatus(String(block.status)),
+            status:
+              active?.state === "cancelled" ? "cancelled" : mapRunStatus(String(block.status)),
             durationMs: Date.now() - runStart,
           });
         }

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -113,7 +113,10 @@ import { supportsEffortControl } from "@/lib/sessionCapabilities";
 import { claudePermissionModeFromSession } from "@/lib/claudePermissionMode";
 import { codexPlanModeFromSession } from "@/lib/codexPlanMode";
 import { getCurrentAuthorId } from "@/lib/identity";
-import { getOmnigentHostConfig } from "@/lib/host";
+import { getOmnigentHostConfig, type OmnigentInteractionStatus } from "@/lib/host";
+// Routing-free emit primitive (not "@/lib/analytics", which pulls in useLocation
+// and would form a routing↔store import cycle).
+import { emitInteractionPhase } from "@/lib/analyticsEmit";
 import { getSessionHost } from "@/lib/sessionHost";
 import { isSystemUserContent } from "@/lib/systemMessage";
 import { isNativeWrapper } from "@/lib/nativeCodingAgents";
@@ -2042,6 +2045,14 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
           : b,
       ),
     }));
+    // Human-in-the-loop decision: accept = granted, decline = rejected, cancel =
+    // dismissed without deciding. Fires on the user's action (live only).
+    emitInteractionPhase({
+      interactionId: elicitationId,
+      interactionKind: "approval",
+      phase: "complete",
+      status: action === "accept" ? "success" : action === "decline" ? "failure" : "cancelled",
+    });
     try {
       await approveElicitation(
         targetSessionId,
@@ -4474,6 +4485,30 @@ function revivePendingElicitationBlock(set: Setter, elicitationId: string): void
   });
 }
 
+// Product-analytics interaction tracking (agent runs, tool calls). START stamps
+// a timestamp keyed by the run/tool id; COMPLETE reads-and-deletes it, so each
+// interaction emits start/complete exactly once (guarding SSE re-delivery on
+// reconnect) and carries a duration. Only the LIVE pump below writes these —
+// history hydration goes through `reduceSync`, which never runs this loop, so
+// reopening an old conversation never re-emits.
+const runStartTimes = new Map<string, number>();
+const toolStartTimes = new Map<string, number>();
+
+function mapRunStatus(state: string): OmnigentInteractionStatus {
+  switch (state) {
+    case "completed":
+      return "success";
+    case "failed":
+      return "failure";
+    // "incomplete"/"cancelled" are both a stopped turn from the user's view.
+    case "incomplete":
+    case "cancelled":
+      return "cancelled";
+    default:
+      return "failure";
+  }
+}
+
 export async function pumpStreamEvents(
   id: string,
   body: ReadableStream<Uint8Array>,
@@ -4562,6 +4597,14 @@ export async function pumpStreamEvents(
           activeResponse: { responseId: block.responseId, state: "streaming", error: null },
           status: "streaming",
         });
+        if (block.responseId && !runStartTimes.has(block.responseId)) {
+          runStartTimes.set(block.responseId, Date.now());
+          emitInteractionPhase({
+            interactionId: block.responseId,
+            interactionKind: "agent_run",
+            phase: "start",
+          });
+        }
         continue;
       }
 
@@ -4703,6 +4746,17 @@ export async function pumpStreamEvents(
           const errorMsg = block.response?.error?.message ?? null;
           finalizeActive(set, block.status as ActiveResponse["state"], errorMsg);
         }
+        const runStart = runStartTimes.get(endedId);
+        if (endedId && runStart !== undefined) {
+          runStartTimes.delete(endedId);
+          emitInteractionPhase({
+            interactionId: endedId,
+            interactionKind: "agent_run",
+            phase: "complete",
+            status: active?.state === "cancelled" ? "cancelled" : mapRunStatus(String(block.status)),
+            durationMs: Date.now() - runStart,
+          });
+        }
         // Turn over: drop any provisional preview never finalized by a
         // committed item (e.g. an interrupt where the partial item lands
         // after this event, or a stream drop). Normal messages already
@@ -4725,6 +4779,35 @@ export async function pumpStreamEvents(
           // on reconnect.
         }
         continue;
+      }
+
+      // Tool-call analytics (live only). No reliable success/failure signal on
+      // the result block — tool errors surface as separate error events — so we
+      // report invocation + duration + tool name, not an outcome status.
+      if (block.type === "tool_group") {
+        for (const ex of block.executions) {
+          if (ex.callId && !toolStartTimes.has(ex.callId)) {
+            toolStartTimes.set(ex.callId, Date.now());
+            emitInteractionPhase({
+              interactionId: ex.callId,
+              interactionKind: "tool_call",
+              phase: "start",
+              name: ex.name,
+            });
+          }
+        }
+      } else if (block.type === "tool_result") {
+        const toolStart = toolStartTimes.get(block.callId);
+        if (block.callId && toolStart !== undefined) {
+          toolStartTimes.delete(block.callId);
+          emitInteractionPhase({
+            interactionId: block.callId,
+            interactionKind: "tool_call",
+            phase: "complete",
+            name: block.name,
+            durationMs: Date.now() - toolStart,
+          });
+        }
       }
 
       buffer.push(block);


### PR DESCRIPTION
## Related issue

N/A — internal product-analytics instrumentation (Refactor / chore; no issue required).

## Summary

Adds a new `interaction_phase` product-analytics event so the host can measure the
*outcome* of the interactions that matter — not just that a control was clicked.
Three interaction kinds are tracked, each emitting a `start` and a `complete`
phase correlated by a stable, caller-chosen `interactionId`:

- **`agent_run`** — one user prompt → model run. `start` on the response-created
  event, `complete` on response-ended with a mapped status (`completed`→success,
  `failed`→failure, `incomplete`/`cancelled`→cancelled) and a `durationMs`.
- **`tool_call`** — a single tool / skill / MCP invocation within a run. `start`
  on `tool_group`, `complete` on `tool_result`, carrying the tool `name` and
  `durationMs`. There's no reliable success/failure signal on the result block
  (tool errors surface as separate error events), so no `status` is reported.
- **`approval`** — a human-in-the-loop permission decision. Emits `complete` on
  the user's action (`accept`→success, `decline`→failure, `cancel`→cancelled).

**ELI5:** today we log "the user clicked a button." This adds "…and here's how it
turned out and how long it took" for the three things whose result actually
matters: agent runs, tool calls, and approvals.

New surface:
- `lib/host.ts` — `OmnigentInteractionKind` (`agent_run` | `tool_call` | `approval`)
  and `OmnigentInteractionStatus` (`success` | `failure` | `cancelled` | `timed_out`)
  types, plus the `interaction_phase` variant on `OmnigentAnalyticsEvent`.
- `lib/analyticsEmit.ts` — a routing-free `emitInteractionPhase()` free function
  (so non-React call sites like the store can report outcomes) and a
  `trackInteraction` method on the `useOmnigentAnalytics` hook.
- `lib/analytics.ts` — re-exports the above so it stays the single analytics
  import surface.
- `store/chatStore.ts` — imports the free function directly (not `@/lib/analytics`,
  which pulls in `useLocation` and would form a routing↔store import cycle) and
  wires up the emits.

**Emit safety:** only the *live* SSE pump emits these. Start times are held in
`Map`s keyed by id; `complete` reads-and-deletes, so each interaction emits
start/complete exactly once even if SSE re-delivers on reconnect, and carries a
duration. History hydration goes through `reduceSync`, which never runs this
loop — so reopening an old conversation never re-emits. No PII is forwarded:
`name` is a bounded, non-PII label (e.g. a tool name), never user content.

```mermaid
sequenceDiagram
  participant P as live SSE pump
  participant M as start-time map
  participant H as host analytics sink
  P->>M: response.created → set(id, now)
  P->>H: interaction_phase { agent_run, start }
  Note over P: …streaming…
  P->>M: response.ended → get + delete(id)
  P->>H: interaction_phase { agent_run, complete, status, durationMs }
```

## Test Plan

- Covered by the existing web unit tests (type checking of the new
  `interaction_phase` union variant + args; analytics/store suites). No behaviour
  change to existing click / value-change / page-view events.
- Optional local smoke, with a host analytics sink configured:
  - send a prompt → one `agent_run` `start`, then `complete` with `status` + `durationMs`;
  - trigger a tool call → `tool_call` `start`/`complete` with `name` + `durationMs`;
  - accept / decline / cancel an approval → one `approval` `complete` with the mapped status;
  - reconnect mid-run and reopen an old conversation → confirm no duplicate or replayed events.

## Demo

N/A — non-visual analytics instrumentation; no UI change to show.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Additive, host-agnostic instrumentation on the existing analytics event surface;
existing web unit tests exercise the store SSE pump and the analytics emit path,
and the new event is type-checked into the `OmnigentAnalyticsEvent` union.
