### PR TITLE
fix(tests): deflake sys_terminal interactive REPL test with mock delay

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -389,7 +389,8 @@ def configure_mock_llm(
     :param mock_llm_server_url: Mock server URL or ``None``.
     :param responses: List of response configs. Keys:
         ``text``, ``tool_calls``, ``block``, ``stream``,
-        ``error``, ``status_code``.
+        ``error``, ``status_code``, ``delay`` (seconds to pause
+        before returning this response).
     :param key: Queue key — typically the model name baked into the
         agent spec. Defaults to ``"default"`` (matches any model
         not assigned to a more specific queue).

--- a/tests/integration/test_sys_terminal_round_trip.py
+++ b/tests/integration/test_sys_terminal_round_trip.py
@@ -503,10 +503,11 @@ def test_sys_terminal_send_keys_drives_interactive(
     is the calls are scripted rather than chosen by a real LLM, so this
     does not prove a model would *decide* to drive the REPL with two
     sends — only that the server-side send/Enter/REPL plumbing works
-    when it does. Three reads (extra model round-trips) give the cold
-    ``python3`` interpreter time to boot and evaluate before capture;
-    the old e2e leaned on real-LLM "wait briefly" pauses for the same
-    reason.
+    when it does. Mock ``delay`` pauses before the second send and each
+    read give the cold ``python3`` interpreter real wall-clock time to
+    boot and evaluate before capture; the old e2e leaned on real-LLM
+    "wait briefly" pauses for the same reason, and back-to-back mock
+    responses on a loaded CI runner reintroduced the race the delays fix.
     """
     session_id, model_name = terminal_session
     term = {"terminal": "bash", "session": "pyrepl"}
@@ -527,10 +528,19 @@ def test_sys_terminal_send_keys_drives_interactive(
         [
             _call("sys_terminal_launch", term),
             _call("sys_terminal_send", {**term, "text": "python3", "keys": "Enter"}),
-            _call("sys_terminal_send", {**term, "text": "print(2+2)", "keys": "Enter"}),
-            _call("sys_terminal_read", term),
-            _call("sys_terminal_read", term),
-            _call("sys_terminal_read", term),
+            # Give the cold ``python3`` interpreter real wall-clock time to
+            # finish booting its REPL before the second send lands, and for
+            # each read to land after the REPL has evaluated. The mock owns
+            # these pauses (``delay``) so a loaded CI runner can't fire the
+            # scripted calls back-to-back faster than the subprocess reacts —
+            # the root of the ``'4' missing`` flake.
+            {
+                **_call("sys_terminal_send", {**term, "text": "print(2+2)", "keys": "Enter"}),
+                "delay": 1.5,
+            },
+            {**_call("sys_terminal_read", term), "delay": 1.5},
+            {**_call("sys_terminal_read", term), "delay": 1.0},
+            {**_call("sys_terminal_read", term), "delay": 1.0},
             {"text": "done"},
         ],
         key=model_name,

--- a/tests/server/integration/mock_llm_server.py
+++ b/tests/server/integration/mock_llm_server.py
@@ -45,7 +45,8 @@ Configuration via ``POST /mock/configure``::
                     {"call_id": "c1", "name": "grep", "arguments": "{}"}
                 ]
             },
-            {"error": "rate limit exceeded", "status_code": 429}
+            {"error": "rate limit exceeded", "status_code": 429},
+            {"text": "later", "delay": 1.5}
         ]
     }
 """
@@ -520,6 +521,13 @@ class QueuedResponse:
     :param stream: If True, stream text deltas before completed.
     :param error: If set, return an error response with this message.
     :param status_code: HTTP status code for error responses.
+    :param delay: Seconds to sleep before returning this response.
+        Unlike ``block`` (which waits for an external gate release),
+        this is a fixed wall-clock pause the mock owns — use it to
+        give a server-side side effect (e.g. a cold interactive
+        subprocess booting/evaluating) real time to land before the
+        next scripted tool call fires, without depending on the CI
+        runner being fast enough for a back-to-back agent loop.
     """
 
     text: str = "Mock LLM response"
@@ -529,6 +537,7 @@ class QueuedResponse:
     stream: bool = False
     error: str | None = None
     status_code: int = 500
+    delay: float = 0.0
     _gate: asyncio.Event = field(default_factory=asyncio.Event)
     _pending: asyncio.Event = field(default_factory=asyncio.Event)
 
@@ -761,6 +770,10 @@ async def create_response(
         queue = _state.resolve_queue_for_request(parsed)
         qr = queue.next()
 
+    # Fixed wall-clock pause the mock owns (see QueuedResponse.delay).
+    if qr.delay:
+        await asyncio.sleep(qr.delay)
+
     # Error response
     if qr.error is not None:
         return JSONResponse(
@@ -828,6 +841,10 @@ async def create_message(
         queue = _state.resolve_queue_for_request(parsed)
         qr = queue.next()
 
+    # Fixed wall-clock pause the mock owns (see QueuedResponse.delay).
+    if qr.delay:
+        await asyncio.sleep(qr.delay)
+
     if qr.error is not None:
         return JSONResponse(
             status_code=qr.status_code,
@@ -877,6 +894,10 @@ async def create_chat_completion(
         model = parsed.get("model") if isinstance(parsed, dict) else None
         queue = _state.resolve_queue_for_request(parsed)
         qr = queue.next()
+
+    # Fixed wall-clock pause the mock owns (see QueuedResponse.delay).
+    if qr.delay:
+        await asyncio.sleep(qr.delay)
 
     if qr.error is not None:
         return JSONResponse(
@@ -1001,6 +1022,7 @@ async def configure(request: Request) -> dict[str, object]:
                     stream=entry.get("stream", False),
                     error=entry.get("error"),
                     status_code=entry.get("status_code", 500),
+                    delay=entry.get("delay", 0.0),
                 )
             )
         count = len(queue.responses)


### PR DESCRIPTION
## Related issue

N/A — Test / CI change (deflaking an existing integration test); no issue required.

## Summary

`test_sys_terminal_send_keys_drives_interactive` is flaky on loaded CI
runners. It's a mock-LLM test: the mock serves the scripted sequence
(`launch` → send `python3` → send `print(2+2)` → 3× `read`) back-to-back in
milliseconds, but step 2 starts a **real** `python3` process that needs
wall-clock time to cold-boot its REPL. On a slow runner the reads capture a
pane still showing the typed input with no `>>>` prompt and no `4`, so
`assert "4" in combined` fails. A real model paces its tool calls naturally
(token generation); the mock strips that pacing away, exposing the race.

- Add a `delay` (seconds) field to the mock server's `QueuedResponse`. The
  mock `await asyncio.sleep(delay)` before returning, wired into all three API
  handlers (`/v1/responses`, `/v1/messages`, `/v1/chat/completions`). It's a
  reusable primitive — distinct from `block` (external gate release).
- The test sets `delay` on the second send (REPL boot) and each read (eval +
  capture) so the REPL is ready before it's driven/read.
- No product code changes; the delay-free production `sys_terminal_*` tools
  are untouched.

## Test Plan

- Ran the failing test 5× locally → all pass; also passes with a 4s artificial
  `python3` startup injected.
- Confirmed the `delay` actually fires: the test's `[slow]` timing jumps
  ~1.8s → ~6.8s (= the injected 1.5+1.5+1.0+1.0s).
- `uv run pytest tests/server/integration/test_mock_llm_server.py` → 3 passed.
- `uv run pytest tests/integration/test_sys_terminal_round_trip.py --model mock-model --harness openai-agents` → 3 passed (run twice).
- `pre-commit run` (ruff format + check) passes.

## Demo

N/A — test-only change, no user-visible runtime output.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change deflakes an existing integration test rather than adding new
coverage. Verified manually by running the test repeatedly (including with an
artificial slow `python3` startup) and confirming the mock `delay` takes
effect via the test's reported slow-timing.

This pull request and its description were written by Isaac.