### PR TITLE
fix(runtime): carry the human's verdict in approval resolution notices

### DIFF
--- a/omnigent/runtime/subagent_block_notifier.py
+++ b/omnigent/runtime/subagent_block_notifier.py
@@ -8,9 +8,10 @@ module observes every elicitation at the
 is mirrored into ancestor chats for the human, so for a child session the
 parent *agent* is woken only after an escalation grace passes with the block
 still unanswered (once per block, re-arming when it clears); a delivered wake
-is then paired with a resolution notice when the block clears so the parent is
-never left waiting on a stale notice. Delivery is an injected ``wake_dispatch``
-coroutine (kept free of HTTP/server knowledge) wired up by the Omnigent server
+is then paired with a resolution notice — carrying the human's verdict — when
+the block clears so the parent is never left waiting on a stale notice or
+narrating a guessed verdict into the transcript. Delivery is an injected
+``wake_dispatch`` coroutine (kept free of HTTP/server knowledge) wired up by the Omnigent server
 in ``configure_subagent_block_notifier``. See
 ``designs/SUBAGENT_ELICITATION_VISIBILITY_V2.md``.
 """
@@ -37,6 +38,9 @@ _RESOLVED_TYPE = "response.elicitation_resolved"
 
 # Max length of the elicitation prompt echoed into the parent's notice.
 _REASON_MAX_CHARS = 200
+
+# MCP ElicitResult verdicts a resolution event may carry.
+_VERDICT_ACTIONS = ("accept", "decline", "cancel")
 
 # Bounded in-handler retry for a transient delivery miss (parent runner briefly
 # unroutable during a reconnect/relaunch). Total attempts = 1 + _WAKE_RETRIES.
@@ -129,6 +133,10 @@ class SubagentBlockNotifier:
         # dispatches a wake so a resolve racing the in-flight wake is never
         # missed; observe() sets it on the resolved event.
         self._resolution_signals: dict[str, asyncio.Event] = {}
+        # Verdict captured off the resolved event ("accept"/"decline"/"cancel"),
+        # stored only while a handler waits on the matching signal so entries
+        # never outlive the notice they inform.
+        self._verdicts: dict[str, str] = {}
         # Strong refs so scheduled wake futures aren't GC'd mid-flight; close() cancels them.
         self._inflight: set[concurrent.futures.Future[None]] = set()
 
@@ -157,6 +165,9 @@ class SubagentBlockNotifier:
             with self._lock:
                 self._notified.discard(elicitation_id)
                 signal = self._resolution_signals.get(elicitation_id)
+                action = _resolution_action(event)
+                if signal is not None and action is not None:
+                    self._verdicts[elicitation_id] = action
             if signal is not None:
                 # Event.set is not thread-safe; hop onto the loop. A gone
                 # loop (shutdown) means the waiting handler dies with it.
@@ -293,12 +304,15 @@ class SubagentBlockNotifier:
             if outcome is _WakeOutcome.MOOT:
                 return
             await signal.wait()
+            with self._lock:
+                verdict = self._verdicts.pop(elicitation_id, None)
             await self._deliver_with_retry(
-                parent_id, child, _format_resolution_notice(child), armed_id=None
+                parent_id, child, _format_resolution_notice(child, verdict), armed_id=None
             )
         finally:
             with self._lock:
                 self._resolution_signals.pop(elicitation_id, None)
+                self._verdicts.pop(elicitation_id, None)
 
     async def _deliver_with_retry(
         self,
@@ -392,27 +406,70 @@ def _format_block_notice(child: Conversation, event: dict[str, Any]) -> str:
     )
 
 
-def _format_resolution_notice(child: Conversation) -> str:
+def _format_resolution_notice(child: Conversation, action: str | None) -> str:
     """
     Build the follow-up notice sent after a woken block resolves.
 
     Sent only when a block notice was actually delivered, so the parent
     stops acting on it (offering to relay answers, polling the child)
-    once the human has dealt with the prompt directly.
+    once the human has dealt with the prompt directly. The human's
+    verdict is stated verbatim so the parent agent cannot narrate an
+    approval that did not happen (a decline must never be retold as
+    "approved" into the transcript); when no verdict was recorded
+    (timeout, severed wait, older runner) the notice says so and points
+    at the fail-closed reading.
 
     :param child: The previously blocked child :class:`Conversation`,
         used for its ``<agent>:<title>`` label.
+    :param action: The MCP verdict from the resolution event —
+        ``"accept"``, ``"decline"``, or ``"cancel"`` — or ``None``
+        when the resolution carried no verdict.
     :returns: A one-line ``[System: …]`` notice, e.g. ``"[System:
         sub-agent codex/auth-refactor's pending approval has been
-        resolved and it is continuing. …]"``.
+        resolved (action: decline — NOT approved) and it is
+        continuing. …]"``.
     """
     label = _child_label(child)
     return (
-        f"[System: sub-agent {label}'s pending approval has been resolved and it "
-        "is continuing. No action is needed on the earlier block notice — if you "
-        "are waiting on its output, the result will arrive in your inbox as "
-        "usual.]"
+        f"[System: sub-agent {label}'s pending approval has been resolved "
+        f"{_verdict_clause(action)} and it is continuing. No action is needed "
+        "on the earlier block notice — if you are waiting on its output, the "
+        "result will arrive in your inbox as usual.]"
     )
+
+
+def _verdict_clause(action: str | None) -> str:
+    """
+    Render the human's verdict as an un-misreadable clause.
+
+    Every branch names the gate outcome explicitly so an agent reading
+    the transcript cannot infer "approved" from the bare word
+    "resolved".
+
+    :param action: The MCP verdict, or ``None`` when unrecorded.
+    :returns: A parenthesized clause, e.g. ``"(action: decline — NOT
+        approved)"``.
+    """
+    if action == "accept":
+        return "(action: accept)"
+    if action == "decline" or action == "cancel":
+        return f"(action: {action} — NOT approved)"
+    return "(no human verdict recorded — treat the call as NOT approved)"
+
+
+def _resolution_action(event: dict[str, Any]) -> str | None:
+    """
+    Extract the MCP verdict from a ``response.elicitation_resolved`` event.
+
+    :param event: The resolved event dict; reads ``action``.
+    :returns: ``"accept"``/``"decline"``/``"cancel"``, or ``None``
+        when the event predates verdict carriage or carries a
+        malformed value.
+    """
+    action = event.get("action")
+    if isinstance(action, str) and action in _VERDICT_ACTIONS:
+        return action
+    return None
 
 
 def _child_label(child: Conversation) -> str:

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -1429,6 +1429,7 @@ def _publish_elicitation_resolved_to_ancestors(
     conv_store: ConversationStore,
     session_id: str,
     elicitation_id: str,
+    action: str | None = None,
 ) -> None:
     """
     Mirror an elicitation-resolved event into each ancestor stream.
@@ -1438,9 +1439,11 @@ def _publish_elicitation_resolved_to_ancestors(
         e.g. ``"conv_child123"``.
     :param elicitation_id: Elicitation correlation id, e.g.
         ``"elicit_abc123"``.
+    :param action: Optional MCP verdict carried through to the
+        mirrors; see :func:`_publish_elicitation_resolved`.
     """
     for ancestor_id in _ancestor_session_ids(conv_store, session_id):
-        _publish_elicitation_resolved(ancestor_id, elicitation_id)
+        _publish_elicitation_resolved(ancestor_id, elicitation_id, action=action)
 
 
 def _descendant_sessions(
@@ -2784,7 +2787,14 @@ def _publish_external_output_reasoning_delta(session_id: str, body: SessionEvent
     session_stream.publish(session_id, event.model_dump(exclude_none=True))
 
 
-def _publish_elicitation_resolved(session_id: str, elicitation_id: str) -> None:
+_VALID_ELICITATION_ACTIONS: tuple[str, ...] = ("accept", "decline", "cancel")
+
+
+def _publish_elicitation_resolved(
+    session_id: str,
+    elicitation_id: str,
+    action: str | None = None,
+) -> None:
     """
     Universal "approval done" signal — single publish drives both
     sidebar (via :func:`pending_elicitations.record_publish` decrement)
@@ -2793,14 +2803,20 @@ def _publish_elicitation_resolved(session_id: str, elicitation_id: str) -> None:
 
     :param session_id: Session id, e.g. ``"conv_abc123"``.
     :param elicitation_id: Correlation id, e.g. ``"elicit_abc123"``.
+    :param action: Optional MCP verdict (``"accept"``/``"decline"``/
+        ``"cancel"``) so downstream consumers — notably the
+        sub-agent block notifier's parent resolution notice — can
+        state how the gate was answered instead of leaving agents to
+        guess. Omitted from the payload when unknown or not one of
+        the three MCP actions.
     """
-    session_stream.publish(
-        session_id,
-        {
-            "type": "response.elicitation_resolved",
-            "elicitation_id": elicitation_id,
-        },
-    )
+    payload: dict[str, Any] = {
+        "type": "response.elicitation_resolved",
+        "elicitation_id": elicitation_id,
+    }
+    if action in _VALID_ELICITATION_ACTIONS:
+        payload["action"] = action
+    session_stream.publish(session_id, payload)
 
 
 async def _forward_approval_to_runner(

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -427,6 +427,9 @@ async def _publish_and_wait_for_harness_elicitation(
     # severed wait instead defers the clear so a hook retry can re-park.
     published_request = False
     settled = False
+    # MCP verdict when a real web verdict settles the wait, so the
+    # finally's resolved fan-out carries it (None = severed / terminal).
+    settled_action: str | None = None
     try:
         tombstone = _consume_pre_resolved_harness_elicitation(session_id, elicitation_id)
         if tombstone is not None:
@@ -491,7 +494,9 @@ async def _publish_and_wait_for_harness_elicitation(
         # honoring a verdict that lands in the same tick as a disconnect.
         if future in done and future.exception() is None:
             settled = True
-            return future.result()
+            verdict = future.result()
+            settled_action = getattr(verdict, "action", None)
+            return verdict
         settled = parked.resolved_elsewhere.is_set()
         return None
     finally:
@@ -511,13 +516,14 @@ async def _publish_and_wait_for_harness_elicitation(
                 conversation_store,
             )
         elif published_request:
-            _publish_elicitation_resolved(session_id, elicitation_id)
+            _publish_elicitation_resolved(session_id, elicitation_id, action=settled_action)
             if conversation_store is not None:
                 await asyncio.to_thread(
                     _publish_elicitation_resolved_to_ancestors,
                     conversation_store,
                     session_id,
                     elicitation_id,
+                    settled_action,
                 )
 
 
@@ -1746,14 +1752,17 @@ async def _resolve_elicitation(
     # Fan-out for every other subscribed client (other tabs, REPL
     # TUI). Idempotent vs. the runner's own ``wait_for_user_approval``
     # finally / harness hook finally — those also publish for the id.
+    # The verdict rides along so the parent-side resolution notice
+    # states how the gate was answered instead of a bare "resolved".
     if isinstance(elicitation_id, str) and elicitation_id:
-        _publish_elicitation_resolved(session_id, elicitation_id)
+        _publish_elicitation_resolved(session_id, elicitation_id, action=data.get("action"))
         if conversation_store is not None:
             await asyncio.to_thread(
                 _publish_elicitation_resolved_to_ancestors,
                 conversation_store,
                 session_id,
                 elicitation_id,
+                data.get("action"),
             )
     # Runner-side elicitations (policy approvals, scaffold dispatch)
     # resolve when the canonical approval event reaches the runner.
@@ -6325,6 +6334,7 @@ async def _relay_runner_stream_once(
                                 conversation_store,
                                 session_id,
                                 elicitation_id,
+                                event.get("action"),
                             )
                         continue
                     session_stream.publish(session_id, event)

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -3777,10 +3777,17 @@ class ElicitationResolvedEvent(_SSEEventBase):
     :param elicitation_id: Correlation id of the elicitation
         being cleared, e.g. ``"elicit_abc123"``. Must match the
         id of a prior :class:`ElicitationRequestEvent`.
+    :param action: Optional MCP verdict recorded when the
+        resolution carried a human decision (``"accept"`` /
+        ``"decline"`` / ``"cancel"``). ``None`` for resolutions
+        without a verdict — timeout, severed wait, or a runner
+        that predates verdict carriage — so consumers can say "no
+        verdict was recorded" rather than guessing one.
     """
 
     type: Literal["response.elicitation_resolved"]
     elicitation_id: str
+    action: Literal["accept", "decline", "cancel"] | None = None
 
 
 class PolicyDeniedEvent(_SSEEventBase):

--- a/openapi.json
+++ b/openapi.json
@@ -1622,6 +1622,24 @@
       "ElicitationResolvedEvent": {
         "description": "Signal that a previously-published elicitation is no longer\noutstanding, even though no UI `approval` verdict was\ndelivered through `POST /v1/sessions/{id}/events`.\n\nEmitted by the runner when its own `_pending_approvals`\nFuture is popped without a verdict (the runner's wait timed\nout, the turn was cancelled, the harness exited) so the AP\nserver's `omnigent.runtime.pending_elicitations`\nindex can decrement the sidebar badge in lockstep with the\nunderlying awaiter's lifecycle. Without this signal, the AP\nserver has no way to learn that the prompt is dead and the\nbadge stays stuck.\n\nIdempotent on the consumer side: the Omnigent server's index\ndecrement is a no-op when the id isn't tracked, so the\nrunner can fire-and-forget on every Future cleanup.",
         "properties": {
+          "action": {
+            "anyOf": [
+              {
+                "enum": [
+                  "accept",
+                  "decline",
+                  "cancel"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional MCP verdict recorded when the resolution carried a human decision (`\"accept\"` / `\"decline\"` / `\"cancel\"`). `None` for resolutions without a verdict \u2014 timeout, severed wait, or a runner that predates verdict carriage \u2014 so consumers can say \"no verdict was recorded\" rather than guessing one.",
+            "title": "Action"
+          },
           "elicitation_id": {
             "description": "Correlation id of the elicitation being cleared, e.g. `\"elicit_abc123\"`. Must match the id of a prior `ElicitationRequestEvent`.",
             "title": "Elicitation Id",

--- a/tests/runtime/test_subagent_block_notifier.py
+++ b/tests/runtime/test_subagent_block_notifier.py
@@ -215,12 +215,15 @@ def _request_event(elicitation_id: str, message: str | None = None) -> dict[str,
     return event
 
 
-def _resolved_event(elicitation_id: str) -> dict[str, Any]:
+def _resolved_event(elicitation_id: str, action: str | None = None) -> dict[str, Any]:
     """Build a ``response.elicitation_resolved`` event dict."""
-    return {
+    event: dict[str, Any] = {
         "type": "response.elicitation_resolved",
         "elicitation_id": elicitation_id,
     }
+    if action is not None:
+        event["action"] = action
+    return event
 
 
 async def _wait_for_calls(
@@ -545,6 +548,102 @@ async def test_resolution_notice_follows_delivered_wake(
     assert "result will arrive in your inbox" in resolution.notice
     # Arm released: a later re-block of the same id can wake again.
     assert not elicitation_armed(notifier, "elicit_geo")
+
+
+@pytest.mark.asyncio
+async def test_resolution_notice_states_decline_verdict(
+    conv_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    A declined block's resolution notice names the decline verbatim.
+
+    The fabricated-approval bug: the gate was DECLINED but a bare
+    "resolved" notice let the parent agent narrate "Approved" into the
+    durable transcript. The verdict must ride the notice itself, in
+    words an agent cannot misread.
+    """
+    parent = conv_store.create_conversation(kind="default", title="parent")
+    child = conv_store.create_conversation(
+        kind="sub_agent", title="codex:gate", parent_conversation_id=parent.id
+    )
+    dispatch = _RecordingDispatch()
+    notifier = SubagentBlockNotifier(
+        conversation_store=conv_store,
+        wake_dispatch=dispatch,
+        loop=asyncio.get_event_loop(),
+    )
+
+    notifier.observe(child.id, _request_event("elicit_shell"))
+    await _wait_for_calls(dispatch, expected=1)
+    notifier.observe(child.id, _resolved_event("elicit_shell", action="decline"))
+    await _wait_for_calls(dispatch, expected=2)
+
+    resolution = dispatch.calls[1]
+    assert "(action: decline — NOT approved)" in resolution.notice
+
+
+@pytest.mark.asyncio
+async def test_resolution_notice_states_accept_verdict(
+    conv_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    An accepted block's resolution notice records the acceptance.
+    """
+    parent = conv_store.create_conversation(kind="default", title="parent")
+    child = conv_store.create_conversation(
+        kind="sub_agent", title="codex:ok", parent_conversation_id=parent.id
+    )
+    dispatch = _RecordingDispatch()
+    notifier = SubagentBlockNotifier(
+        conversation_store=conv_store,
+        wake_dispatch=dispatch,
+        loop=asyncio.get_event_loop(),
+    )
+
+    notifier.observe(child.id, _request_event("elicit_ok"))
+    await _wait_for_calls(dispatch, expected=1)
+    notifier.observe(child.id, _resolved_event("elicit_ok", action="accept"))
+    await _wait_for_calls(dispatch, expected=2)
+
+    resolution = dispatch.calls[1]
+    assert "(action: accept)" in resolution.notice
+    assert "NOT approved" not in resolution.notice
+
+
+@pytest.mark.asyncio
+async def test_resolution_notice_without_verdict_says_not_approved(
+    conv_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    A resolution with no recorded verdict cannot be read as approval.
+
+    Timeouts, severed waits, and older runners publish resolved events
+    without ``action``; the notice must state the fail-closed reading
+    instead of leaving the agent to guess — silence here is exactly how
+    the fabricated narration happened. A malformed action value is
+    treated the same way as a missing one.
+    """
+    parent = conv_store.create_conversation(kind="default", title="parent")
+    child = conv_store.create_conversation(
+        kind="sub_agent", title="codex:no-verdict", parent_conversation_id=parent.id
+    )
+    for action in (None, "maybe"):
+        dispatch = _RecordingDispatch()
+        notifier = SubagentBlockNotifier(
+            conversation_store=conv_store,
+            wake_dispatch=dispatch,
+            loop=asyncio.get_event_loop(),
+        )
+        elicitation_id = "elicit_no_verdict" if action is None else "elicit_bad_verdict"
+
+        notifier.observe(child.id, _request_event(elicitation_id))
+        await _wait_for_calls(dispatch, expected=1)
+        notifier.observe(child.id, _resolved_event(elicitation_id, action=action))
+        await _wait_for_calls(dispatch, expected=2)
+
+        resolution = dispatch.calls[1]
+        assert "no human verdict recorded" in resolution.notice
+        assert "NOT approved" in resolution.notice
 
 
 class _ResolveDuringDispatch:

--- a/tests/server/integration/test_sessions_elicitation_resolve_url.py
+++ b/tests/server/integration/test_sessions_elicitation_resolve_url.py
@@ -608,6 +608,7 @@ async def test_child_codex_elicitation_bubbles_to_parent_stream(
         assert resolved_event == {
             "type": "response.elicitation_resolved",
             "elicitation_id": elicitation_id,
+            "action": "accept",
         }
 
         resp = await hook_task
@@ -687,6 +688,7 @@ async def test_child_policy_elicitation_bubbles_to_parent_stream(
         assert resolved_event == {
             "type": "response.elicitation_resolved",
             "elicitation_id": elicitation_id,
+            "action": "accept",
         }
 
         resp = await evaluate
@@ -704,6 +706,103 @@ async def test_child_policy_elicitation_bubbles_to_parent_stream(
             parent_resolved.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await parent_resolved
+        pending_elicitations.reset_for_tests()
+
+
+async def test_decline_verdict_rides_resolved_events_to_parent(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A declined child gate publishes ``action: "decline"`` on the resolve fan-out.
+
+    Regression for the fabricated-approval transcript bug: resolving a
+    parked sub-agent approval with ``action == "decline"`` via the
+    generic approval event (the exact POST a web card sends) must carry
+    the verdict on both the session's and every ancestor's resolved
+    event. A bare "resolved" left parent agents narrating an approval
+    that did not happen.
+    """
+    from omnigent.runtime import pending_elicitations
+
+    _patch_default_policies(monkeypatch, f"{__name__}._ask_for_bash")
+    agent = await create_test_agent(client, "test-child-decline-verdict")
+    parent_id = await _create_session(client, agent["id"])
+    child_id = _create_child_session(db_uri, parent_id=parent_id, agent_id=agent["id"])
+    parent_subscribed = asyncio.Event()
+    parent_drain = asyncio.create_task(
+        _drain_until_elicitation_event(parent_id, subscribed=parent_subscribed)
+    )
+    await parent_subscribed.wait()
+    evaluate = asyncio.create_task(
+        client.post(
+            f"/v1/sessions/{child_id}/policies/evaluate",
+            json=_tool_call_request("Bash", {"command": "date"}),
+        )
+    )
+    child_resolved: asyncio.Task[dict[str, Any]] | None = None
+    parent_resolved: asyncio.Task[dict[str, Any]] | None = None
+
+    try:
+        event = await parent_drain
+        elicitation_id = event.get("elicitation_id")
+        assert isinstance(elicitation_id, str) and elicitation_id
+
+        child_subscribed = asyncio.Event()
+        child_resolved = asyncio.create_task(
+            _drain_until_elicitation_resolved(
+                child_id,
+                elicitation_id,
+                subscribed=child_subscribed,
+            )
+        )
+        await child_subscribed.wait()
+        parent_resolved_subscribed = asyncio.Event()
+        parent_resolved = asyncio.create_task(
+            _drain_until_elicitation_resolved(
+                parent_id,
+                elicitation_id,
+                subscribed=parent_resolved_subscribed,
+            )
+        )
+        await parent_resolved_subscribed.wait()
+
+        # The exact POST shape from the repro: generic approval event,
+        # payload nested under ``data``, action decline.
+        verdict = await client.post(
+            f"/v1/sessions/{child_id}/events",
+            json={
+                "type": "approval",
+                "data": {"elicitation_id": elicitation_id, "action": "decline"},
+            },
+        )
+        assert verdict.status_code == 202, verdict.text
+
+        assert await child_resolved == {
+            "type": "response.elicitation_resolved",
+            "elicitation_id": elicitation_id,
+            "action": "decline",
+        }
+        assert await parent_resolved == {
+            "type": "response.elicitation_resolved",
+            "elicitation_id": elicitation_id,
+            "action": "decline",
+        }
+
+        resp = await evaluate
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["result"] == "POLICY_ACTION_DENY"
+    finally:
+        if not evaluate.done():
+            evaluate.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await evaluate
+        for task in (child_resolved, parent_resolved):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
         pending_elicitations.reset_for_tests()
 
 
@@ -797,6 +896,7 @@ async def test_child_mcp_elicitation_bubbles_to_parent_stream(
         assert resolved_event == {
             "type": "response.elicitation_resolved",
             "elicitation_id": elicitation_id,
+            "action": "accept",
         }
     finally:
         for task in [parent_drain, parent_resolved]:
@@ -872,6 +972,7 @@ async def test_child_claude_ask_user_question_bubbles_to_parent_stream(
         assert resolved_event == {
             "type": "response.elicitation_resolved",
             "elicitation_id": elicitation_id,
+            "action": "accept",
         }
 
         resp = await hook_task

--- a/tests/server/routes/test_subagent_block_wake.py
+++ b/tests/server/routes/test_subagent_block_wake.py
@@ -114,18 +114,6 @@ def _request_event(elicitation_id: str, message: str) -> dict[str, Any]:
     }
 
 
-def _resolved_event(elicitation_id: str) -> dict[str, Any]:
-    """
-    Build a ``response.elicitation_resolved`` event dict.
-
-    :param elicitation_id: Correlation id, e.g. ``"elicit_demo"``.
-    """
-    return {
-        "type": "response.elicitation_resolved",
-        "elicitation_id": elicitation_id,
-    }
-
-
 async def test_record_publish_delivers_wake_message_to_parent(
     conv_store: SqlAlchemyConversationStore,
     monkeypatch: pytest.MonkeyPatch,
@@ -203,8 +191,17 @@ async def test_record_publish_delivers_wake_message_to_parent(
 
         # Resolving the block sends the woken parent a follow-up through
         # the same wiring, so it stops acting on the stale block notice.
+        # The resolved event carries the human's verdict, as the server's
+        # approval-dispatch path now publishes it.
         fired.clear()
-        pending_elicitations.record_publish(child.id, _resolved_event("elicit_demo"))
+        pending_elicitations.record_publish(
+            child.id,
+            {
+                "type": "response.elicitation_resolved",
+                "elicitation_id": "elicit_demo",
+                "action": "decline",
+            },
+        )
         await asyncio.wait_for(fired.wait(), timeout=2.0)
     finally:
         uninstall()
@@ -216,6 +213,9 @@ async def test_record_publish_delivers_wake_message_to_parent(
     assert resolution.session_id == parent.id
     assert "codex/demo" in resolution.text
     assert "has been resolved" in resolution.text
+    # The verdict rides the notice verbatim so the parent agent cannot
+    # narrate an approval that did not happen.
+    assert "(action: decline — NOT approved)" in resolution.text
 
 
 async def test_record_publish_no_wake_when_no_runner_bound(


### PR DESCRIPTION
## Related issue

Closes #5289

## Summary

When a parked sub-agent approval was resolved, the `response.elicitation_resolved` fan-out and the parent-facing `[System: …]` resolution notice both said only "resolved" — never **how**. A woken parent agent had to guess the verdict, and that guess landed in the durable transcript as fact: on a **declined** gate, agents narrated "Approved — polling for the result now." Two reviewers escalated a suspected fail-open security control that had actually held (#5289).

- **Server**: every resolved publish now threads the MCP verdict (`accept` / `decline` / `cancel`) through the payload — the generic approval-event path, the resolve-URL endpoint, the harness-wait settle path, and the runner relay (which also mirrors it to ancestors). Verdict-less resolutions (timeout, severed wait) stay field-less.
- **Notifier**: `SubagentBlockNotifier.observe` captures the verdict off the resolved event while a wake handler is waiting; `_format_resolution_notice` renders it verbatim:
  - `(action: accept)`
  - `(action: decline — NOT approved)` / `(action: cancel — NOT approved)`
  - `(no human verdict recorded — treat the call as NOT approved)` when none was carried
- **Schema/API**: `ElicitationResolvedEvent` gains optional `action`; `openapi.json` regenerated via `scripts/dump_openapi.py`.

```
approval POST {elicitation_id, action:"decline"}
        │
        ▼
_resolve_elicitation_from_payload ──► _publish_elicitation_resolved(..., action="decline")
        │                                      │
        ▼                                      ▼
runner forward                    record_publish → SubagentBlockNotifier.observe
                                           │ signal + verdict stash
                                           ▼
                          _format_resolution_notice(child, "decline")
                                           │
                                           ▼
        "[System: sub-agent codex/task's pending approval has been resolved
         (action: decline — NOT approved) and it is continuing. …]"
```

Out of scope (deliberately, matching the issue): persistence of verdicts (#5144), the `{"queued": false}` response shape, malformed-body 4xx, and ancestor-session discoverability.

## Test Plan

- [x] `uv run --no-sync pytest tests/runtime/test_subagent_block_notifier.py tests/server/routes/test_subagent_block_wake.py tests/server/integration/test_sessions_elicitation_resolve_url.py tests/runtime/test_pending_elicitations.py tests/runner/test_pending_approvals.py tests/server/integration/test_sessions_permission_request_hook.py` — 161 passed.
- New integration test drives the issue's exact repro against the real app: park a child ASK gate via `/policies/evaluate`, POST `{"type":"approval","data":{...,"action":"decline"}}`, and assert both child and parent SSE streams emit `response.elicitation_resolved` with `"action":"decline"` while the evaluate result is `POLICY_ACTION_DENY`.
- Route-level test drives the full production wiring (`configure_subagent_block_notifier` → real `record_publish` chokepoint → dispatch) and asserts the notice delivered to the parent contains `(action: decline — NOT approved)`.
- Unit tests cover accept / decline / cancel / missing / malformed verdict rendering, and that no-verdict resolutions can never read as approval.
- `pre-commit run --all-files` equivalent hooks pass (ruff check/format, pyrefly).

## Demo

The parent conversation after a declined `git push --force` gate on a sub-agent (real server + real web UI; the second notice is what this PR changes — previously it read "…has been resolved and it is continuing" with no verdict):

![Sub-agent approval resolution notice now states the verdict: resolved (action: decline — NOT approved)](https://raw.githubusercontent.com/VinayBhagavath/omnigent/demo-media/pr-5364-demo.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The escalation-grace path (wake delivered only after 120s unanswered) is covered at unit/route level with the grace patched to an instant gate, matching the existing suite convention; a live multi-minute E2E wasn't added since the wiring under test is identical.

## Changelog

Sub-agent approval resolution notices now state the human's verdict (approved / declined / no verdict recorded) so parent agents can't narrate an approval that didn't happen.
