### PR TITLE
Fix Windows theme picker startup

### DIFF
--- a/omnigent/repl/_theme_picker.py
+++ b/omnigent/repl/_theme_picker.py
@@ -192,9 +192,14 @@ def _detect_terminal_background() -> Literal["dark", "light"] | None:
     if not sys.stdin.isatty() or not sys.stdout.isatty():
         return None
 
-    import select
-    import termios
-    import tty
+    try:
+        import select
+        import termios
+        import tty
+    except ModuleNotFoundError:
+        # Windows has no termios or tty support, even when its terminal
+        # streams report that they are TTYs.
+        return None
 
     fd = sys.stdin.fileno()
     try:
@@ -312,8 +317,15 @@ def startup_theme_picker(
         update_user_config(theme=theme.name)
         return theme
 
-    import termios
-    import tty
+    try:
+        import termios
+        import tty
+    except ModuleNotFoundError:
+        # Raw terminal mode is unavailable on Windows. Use the same
+        # persisted fallback as other non-interactive terminals.
+        theme = DARK_THEME if detected == "dark" else LIGHT_THEME
+        update_user_config(theme=theme.name)
+        return theme
 
     fd = sys.stdin.fileno()
     try:

--- a/tests/repl/test_theme_picker.py
+++ b/tests/repl/test_theme_picker.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import io
+import sys
+
 import pytest
 from omnigent_ui_sdk.terminal._theme import DARK_THEME, LIGHT_THEME
 
@@ -197,8 +200,6 @@ def test_startup_picker_non_tty_defaults_to_light(
         lambda: None,
     )
 
-    import io
-
     out = io.StringIO()
     result = startup_theme_picker(out=out)
     assert result is LIGHT_THEME
@@ -219,10 +220,28 @@ def test_startup_picker_non_tty_respects_dark_detection(
         lambda: "dark",
     )
 
-    import io
-
     out = io.StringIO()
     result = startup_theme_picker(out=out)
     assert result is DARK_THEME
     config = (tmp_path / ".omnigent" / "config.yaml").read_text(encoding="utf-8")
     assert "theme: dark" in config
+
+
+def test_startup_picker_falls_back_without_unix_terminal_modules(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Windows-style TTY without termios falls back instead of crashing."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setitem(sys.modules, "termios", None)
+    monkeypatch.setitem(sys.modules, "tty", None)
+
+    result = startup_theme_picker(out=io.StringIO())
+
+    # Both termios import sites were traversed safely. If either guard is
+    # removed, this call raises ModuleNotFoundError before returning a theme.
+    assert result is LIGHT_THEME
+    config = (tmp_path / ".omnigent" / "config.yaml").read_text(encoding="utf-8")
+    assert "theme: light" in config


### PR DESCRIPTION
## Related issue

Closes #5240

## Summary

Guard the startup theme picker's Unix-only terminal imports so Windows TTYs fall back to the detected/default theme instead of crashing.

## Test Plan

- `.venv/bin/python -m pytest tests/repl/test_theme_picker.py -q`
- `.venv/bin/pre-commit run --all-files`
- Negative control: confirmed the regression test fails with `ModuleNotFoundError` when the guards are removed
- PTY smoke test with `termios` and `tty` unavailable; picker returned `light`

## Demo

A native Windows recording is not available in this Linux environment. This real PTY capture simulates Windows' missing terminal modules and shows startup falling back cleanly instead of crashing:

```console
$ env -u DATABRICKS_TOKEN -u ANTHROPIC_API_KEY -u CODEX -u CLAUDE_CODE HOME="$task_tmp" script -qec ".venv/bin/python -c 'import sys; from omnigent.repl._theme_picker import startup_theme_picker; sys.modules[\"termios\"] = None; sys.modules[\"tty\"] = None; print(startup_theme_picker().name)'" /dev/null
light
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified in a real PTY while simulating the absence of Windows-unavailable terminal modules.

## Changelog

The CLI now starts normally on Windows terminals instead of crashing when selecting a startup theme.