### PR TITLE
fix: accept preallocation response failures

### DIFF
--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1139,11 +1139,11 @@ class FailedResponseObject(BaseModel):
     :param incomplete_details: Incomplete-response details, or ``None``.
     """
 
-    id: str | None = None
+    id: str | None = Field(default=None, exclude_if=lambda value: value is None)
     object: str = "response"
     status: str
-    model: str | None = None
-    created_at: int | None = None
+    model: str | None = Field(default=None, exclude_if=lambda value: value is None)
+    created_at: int | None = Field(default=None, exclude_if=lambda value: value is None)
     completed_at: int | None = None
     output: list[dict[str, Any]] = Field(default_factory=list)
     background: bool = False

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -3941,7 +3941,7 @@ class FailedEvent(_SSEEventBase):
     """
 
     type: Literal["response.failed"]
-    response: FailedResponseObject
+    response: ResponseObject | FailedResponseObject
 
 
 class CancelledEvent(_SSEEventBase):

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1109,6 +1109,54 @@ class ResponseObject(BaseModel):
     incomplete_details: IncompleteDetails | None = None
 
 
+class FailedResponseObject(BaseModel):
+    """Response payload for failures raised before response allocation.
+
+    Transport and setup failures can terminate a turn before the harness has
+    assigned the metadata required by :class:`ResponseObject`. The remaining
+    fields mirror that model so fully allocated failures retain their complete
+    wire representation.
+
+    :param id: Unique response identifier, e.g. ``"resp_abc123"``, or
+        ``None`` when allocation did not complete.
+    :param object: Fixed resource type, always ``"response"``.
+    :param status: Lifecycle status, normally ``"failed"``.
+    :param model: Agent name that produced the response, e.g.
+        ``"research-agent"``, or ``None`` when resolution did not complete.
+    :param created_at: Unix epoch timestamp of creation, or ``None`` when the
+        response failed before creation.
+    :param completed_at: Unix epoch timestamp of completion, or ``None``.
+    :param output: Heterogeneous serialized output items accumulated before
+        failure.
+    :param background: Whether the response was created as a background task.
+    :param store: Whether the response is persisted.
+    :param usage: Token usage statistics, or ``None`` when unavailable.
+    :param previous_response_id: ID of the prior response, or ``None``.
+    :param conversation: Reference to the owning conversation, or ``None``.
+    :param instructions: Per-request instructions override, or ``None``.
+    :param reasoning: Reasoning configuration, or ``None``.
+    :param error: Error details describing the failure, or ``None``.
+    :param incomplete_details: Incomplete-response details, or ``None``.
+    """
+
+    id: str | None = None
+    object: str = "response"
+    status: str
+    model: str | None = None
+    created_at: int | None = None
+    completed_at: int | None = None
+    output: list[dict[str, Any]] = Field(default_factory=list)
+    background: bool = False
+    store: bool = True
+    usage: Usage | None = None
+    previous_response_id: str | None = None
+    conversation: ConversationRef | None = None
+    instructions: str | None = None
+    reasoning: dict[str, str] | None = None
+    error: ErrorDetail | None = None
+    incomplete_details: IncompleteDetails | None = None
+
+
 class ToolResult(BaseModel):
     """
     A single tool result submitted by the client via PATCH.
@@ -3883,17 +3931,17 @@ class FailedEvent(_SSEEventBase):
     """
     Terminal event for a turn that ended with an error.
 
-    Carries the final
-    :class:`omnigent.server.schemas.ResponseObject` whose
-    ``error`` field describes the failure.
+    Carries a :class:`omnigent.server.schemas.FailedResponseObject`
+    whose ``error`` field describes the failure. Response metadata may
+    be absent when the failure occurs before response allocation.
 
     :param type: Always ``"response.failed"``.
-    :param response: The final response object with
-        ``status="failed"`` and ``error`` populated.
+    :param response: The failure response object with ``status="failed"``
+        and ``error`` populated.
     """
 
     type: Literal["response.failed"]
-    response: ResponseObject
+    response: FailedResponseObject
 
 
 class CancelledEvent(_SSEEventBase):

--- a/openapi.json
+++ b/openapi.json
@@ -1806,8 +1806,16 @@
         "description": "Terminal event for a turn that ended with an error.\n\nCarries a `omnigent.server.schemas.FailedResponseObject`\nwhose `error` field describes the failure. Response metadata may\nbe absent when the failure occurs before response allocation.",
         "properties": {
           "response": {
-            "$ref": "#/components/schemas/FailedResponseObject",
-            "description": "The failure response object with `status=\"failed\"` and `error` populated."
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ResponseObject"
+              },
+              {
+                "$ref": "#/components/schemas/FailedResponseObject"
+              }
+            ],
+            "description": "The failure response object with `status=\"failed\"` and `error` populated.",
+            "title": "Response"
           },
           "sequence_number": {
             "anyOf": [

--- a/openapi.json
+++ b/openapi.json
@@ -1803,11 +1803,11 @@
         "type": "object"
       },
       "FailedEvent": {
-        "description": "Terminal event for a turn that ended with an error.\n\nCarries the final\n`omnigent.server.schemas.ResponseObject` whose\n`error` field describes the failure.",
+        "description": "Terminal event for a turn that ended with an error.\n\nCarries a `omnigent.server.schemas.FailedResponseObject`\nwhose `error` field describes the failure. Response metadata may\nbe absent when the failure occurs before response allocation.",
         "properties": {
           "response": {
-            "$ref": "#/components/schemas/ResponseObject",
-            "description": "The final response object with `status=\"failed\"` and `error` populated."
+            "$ref": "#/components/schemas/FailedResponseObject",
+            "description": "The failure response object with `status=\"failed\"` and `error` populated."
           },
           "sequence_number": {
             "anyOf": [
@@ -1833,6 +1833,190 @@
           "response"
         ],
         "title": "FailedEvent",
+        "type": "object"
+      },
+      "FailedResponseObject": {
+        "description": "Response payload for failures raised before response allocation.\n\nTransport and setup failures can terminate a turn before the harness has\nassigned the metadata required by `ResponseObject`. The remaining\nfields mirror that model so fully allocated failures retain their complete\nwire representation.",
+        "properties": {
+          "background": {
+            "default": false,
+            "description": "Whether the response was created as a background task.",
+            "title": "Background",
+            "type": "boolean"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unix epoch timestamp of completion, or `None`.",
+            "title": "Completed At"
+          },
+          "conversation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConversationRef"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Reference to the owning conversation, or `None`."
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unix epoch timestamp of creation, or `None` when the response failed before creation.",
+            "title": "Created At"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ErrorDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Error details describing the failure, or `None`."
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unique response identifier, e.g. `\"resp_abc123\"`, or `None` when allocation did not complete.",
+            "title": "Id"
+          },
+          "incomplete_details": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IncompleteDetails"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Incomplete-response details, or `None`."
+          },
+          "instructions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Per-request instructions override, or `None`.",
+            "title": "Instructions"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Agent name that produced the response, e.g. `\"research-agent\"`, or `None` when resolution did not complete.",
+            "title": "Model"
+          },
+          "object": {
+            "default": "response",
+            "description": "Fixed resource type, always `\"response\"`.",
+            "title": "Object",
+            "type": "string"
+          },
+          "output": {
+            "description": "Heterogeneous serialized output items accumulated before failure.",
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Output",
+            "type": "array"
+          },
+          "previous_response_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the prior response, or `None`.",
+            "title": "Previous Response Id"
+          },
+          "reasoning": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Reasoning configuration, or `None`.",
+            "title": "Reasoning"
+          },
+          "status": {
+            "description": "Lifecycle status, normally `\"failed\"`.",
+            "title": "Status",
+            "type": "string"
+          },
+          "store": {
+            "default": true,
+            "description": "Whether the response is persisted.",
+            "title": "Store",
+            "type": "boolean"
+          },
+          "usage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Usage"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Token usage statistics, or `None` when unavailable."
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "FailedResponseObject",
         "type": "object"
       },
       "FunctionCallData": {

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -28,6 +28,7 @@ from omnigent.server.schemas import (
     ElicitationRequestEvent,
     ElicitationRequestParams,
     FailedEvent,
+    FailedResponseObject,
     HeartbeatEvent,
     IncompleteEvent,
     InProgressEvent,
@@ -249,10 +250,10 @@ def test_response_envelope_event_carries_real_response_object(
     without a second parse step.
     """
     response = sample_response_object.model_copy(update={"status": status_value})
-    event = event_class(type=type_literal, response=response)
+    event = event_class(type=type_literal, response=response.model_dump())
     # response field must be a real ResponseObject, not a dict — so
     # downstream consumers see typed field access.
-    assert isinstance(event.response, ResponseObject)
+    assert isinstance(event.response, (ResponseObject, FailedResponseObject))
     assert event.response.status == status_value
     # model_dump produces the canonical wire shape with response nested.
     dumped = event.model_dump(exclude_none=True)
@@ -371,9 +372,60 @@ def test_response_stream_event_dispatches_envelope_events(
     )
     # response field round-trips back to a ResponseObject — proves
     # the union didn't downgrade it to a dict.
-    assert isinstance(parsed.response, ResponseObject)
+    assert isinstance(parsed.response, (ResponseObject, FailedResponseObject))
     assert parsed.response.id == "resp_abc123"
     assert parsed.response.status == status_value
+
+
+def test_response_failed_accepts_preallocation_failure_payload() -> None:
+    """Transport failures may occur before response metadata is allocated."""
+    adapter: TypeAdapter[ServerStreamEvent] = TypeAdapter(ServerStreamEvent)
+
+    parsed = adapter.validate_python(
+        {
+            "type": "response.failed",
+            "response": {
+                "status": "failed",
+                "error": {
+                    "code": "connection_error",
+                    "message": "Harness stream connection error",
+                    "type": "RemoteProtocolError",
+                },
+            },
+        }
+    )
+
+    assert isinstance(parsed, FailedEvent)
+    assert type(parsed.response) is FailedResponseObject
+    assert parsed.response.id is None
+    assert parsed.response.model is None
+    assert parsed.response.created_at is None
+    assert parsed.response.error is not None
+    assert parsed.response.error.code == "connection_error"
+
+
+@pytest.mark.parametrize(
+    "event_type,status",
+    [
+        ("response.created", "queued"),
+        ("response.queued", "queued"),
+        ("response.in_progress", "in_progress"),
+        ("response.completed", "completed"),
+        ("response.cancelled", "cancelled"),
+        ("response.incomplete", "incomplete"),
+    ],
+)
+def test_nonfailed_response_events_reject_missing_metadata(event_type: str, status: str) -> None:
+    """Only pre-allocation failure events may omit response metadata."""
+    adapter: TypeAdapter[ServerStreamEvent] = TypeAdapter(ServerStreamEvent)
+
+    with pytest.raises(ValidationError):
+        adapter.validate_python(
+            {
+                "type": event_type,
+                "response": {"status": status},
+            }
+        )
 
 
 def test_response_stream_event_rejects_unknown_type() -> None:

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -402,6 +402,9 @@ def test_response_failed_accepts_preallocation_failure_payload() -> None:
     assert parsed.response.created_at is None
     assert parsed.response.error is not None
     assert parsed.response.error.code == "connection_error"
+    assert "id" not in parsed.response.model_dump()
+    assert "model" not in parsed.response.model_dump()
+    assert "created_at" not in parsed.response.model_dump()
 
 
 @pytest.mark.parametrize(

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -407,6 +407,21 @@ def test_response_failed_accepts_preallocation_failure_payload() -> None:
     assert "created_at" not in parsed.response.model_dump()
 
 
+def test_response_failed_accepts_allocated_response_model() -> None:
+    """Harnesses may construct a failed event from a strict response model."""
+    response = ResponseObject(
+        id="resp_abc123",
+        status="failed",
+        model="test-agent",
+        created_at=1,
+        error={"code": "model_not_found", "message": "model not found"},
+    )
+
+    event = FailedEvent(type="response.failed", response=response)
+
+    assert event.response is response
+
+
 @pytest.mark.parametrize(
     "event_type,status",
     [


### PR DESCRIPTION
## Related issue

OMNI-4769

## Summary

- Add a dedicated typed payload for `response.failed` events emitted before response metadata is allocated.
- Keep `id`, `model`, and `created_at` required for every non-failed response lifecycle event.
- Regenerate the OpenAPI schema.

## Test Plan

- `.venv/bin/python -m pytest tests/server/test_schemas.py tests/server/test_openapi_drift.py -q` (85 passed)
- Focused Ruff hooks passed.
- Pyrefly reports no errors in the changed schema; the full local check is blocked by missing optional dependency imports.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Validated the exact metadata-free `response.failed` payload through `TypeAdapter(ServerStreamEvent)` and confirmed all other lifecycle variants reject the same missing metadata.

## Changelog

Failure events now parse correctly when a connection drops before response metadata is allocated.