### PR TITLE
fix(web): hide native composer scrollbars

### DIFF
--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -284,26 +284,47 @@ def test_composer_hides_native_scrollbar_without_disabling_scroll(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """A capped session draft scrolls internally without painting browser chrome."""
+    """A capped draft and transcript scroll without painting native browser chrome."""
     base_url, session_id = seeded_session
+    for i in range(6):
+        seed_committed_turn(
+            session_id,
+            prompt=f"Question {i}?",
+            reply=f"Paragraph {i}. " + ("filler sentence for height. " * 12),
+            response_id=f"scrollbar_probe_{i}",
+        )
     page.goto(f"{base_url}/c/{session_id}")
 
+    expect(page.locator(_TEXT_SECTION)).to_have_count(6, timeout=30_000)
     composer = page.get_by_label("Message the agent")
     expect(composer).to_be_visible(timeout=30_000)
     composer.fill("\n".join(f"Draft line {i}" for i in range(20)))
 
-    geometry = composer.evaluate(
-        """textarea => ({
-            clientHeight: textarea.clientHeight,
-            scrollHeight: textarea.scrollHeight,
-            scrollbarWidth: getComputedStyle(textarea).scrollbarWidth,
-            webkitScrollbarDisplay:
-                getComputedStyle(textarea, '::-webkit-scrollbar').display,
-        })"""
+    geometry = page.evaluate(
+        """() => {
+            const composer = document.querySelector(
+                'textarea[aria-label="Message the agent"]'
+            );
+            const transcript = document.querySelector('[role="log"] > div');
+            const probe = (element) => ({
+                clientHeight: element.clientHeight,
+                scrollHeight: element.scrollHeight,
+                scrollbarWidth: getComputedStyle(element).scrollbarWidth,
+                webkitScrollbarDisplay:
+                    getComputedStyle(element, '::-webkit-scrollbar').display,
+            });
+            return {
+                composer: probe(composer),
+                transcript: probe(transcript),
+                bodyOverflowY: getComputedStyle(document.body).overflowY,
+            };
+        }"""
     )
-    assert geometry["scrollHeight"] > geometry["clientHeight"], geometry
-    assert geometry["scrollbarWidth"] == "none", geometry
-    assert geometry["webkitScrollbarDisplay"] == "none", geometry
+    for surface in ("composer", "transcript"):
+        assert geometry[surface]["scrollHeight"] > geometry[surface]["clientHeight"], geometry
+        assert geometry[surface]["scrollbarWidth"] == "none", geometry
+        assert geometry[surface]["webkitScrollbarDisplay"] == "none", geometry
+    assert geometry["bodyOverflowY"] == "hidden", geometry
 
     composer.evaluate("textarea => { textarea.scrollTop = textarea.scrollHeight; }")
     assert composer.evaluate("textarea => textarea.scrollTop") > 0

--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -280,6 +280,35 @@ def _append_output_during_composer_reflow(
     )
 
 
+def test_composer_hides_native_scrollbar_without_disabling_scroll(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A capped session draft scrolls internally without painting browser chrome."""
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill("\n".join(f"Draft line {i}" for i in range(20)))
+
+    geometry = composer.evaluate(
+        """textarea => ({
+            clientHeight: textarea.clientHeight,
+            scrollHeight: textarea.scrollHeight,
+            scrollbarWidth: getComputedStyle(textarea).scrollbarWidth,
+            webkitScrollbarDisplay:
+                getComputedStyle(textarea, '::-webkit-scrollbar').display,
+        })"""
+    )
+    assert geometry["scrollHeight"] > geometry["clientHeight"], geometry
+    assert geometry["scrollbarWidth"] == "none", geometry
+    assert geometry["webkitScrollbarDisplay"] == "none", geometry
+
+    composer.evaluate("textarea => { textarea.scrollTop = textarea.scrollHeight; }")
+    assert composer.evaluate("textarea => textarea.scrollTop") > 0
+
+
 def test_composer_growth_reflows_transcript_without_covering_output(
     page: Page,
     seeded_session: tuple[str, str],

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -146,6 +146,16 @@ describe("Composer growth layout", () => {
     expect(ta.style.height).toBe("200px");
     expect(form?.style.marginTop).toBe("");
   });
+
+  it("keeps long drafts scrollable without showing a native scrollbar", () => {
+    render(<Composer {...composerProps()} />);
+
+    expect(textarea()).toHaveClass(
+      "overflow-y-auto",
+      "[scrollbar-width:none]",
+      "[&::-webkit-scrollbar]:hidden",
+    );
+  });
 });
 
 describe("Composer Claude goal control", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5764,7 +5764,7 @@ export function Composer({
             disabled={disabled || isReadOnly || unreachable || hasPendingElicitation}
             data-slash-command={composerIsCommand ? "true" : undefined}
             className={cn(
-              "relative w-full resize-none bg-transparent px-4 pt-3 pb-2 text-ui outline-none placeholder:text-muted-foreground disabled:opacity-60",
+              "relative w-full resize-none overflow-y-auto bg-transparent px-4 pt-3 pb-2 text-ui outline-none [scrollbar-width:none] placeholder:text-muted-foreground disabled:opacity-60 [&::-webkit-scrollbar]:hidden",
               // Hand glyph painting to the overlay while a command is drafted;
               // the caret stays visible via caret-foreground.
               composerIsCommand && "text-transparent caret-foreground",

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -984,9 +984,12 @@ describe("NewChatLandingScreen", () => {
     expect(screen.getByTestId("new-chat-landing-input")).toHaveClass(
       "min-h-[60px]",
       "max-h-[200px]",
+      "overflow-y-auto",
       "px-4",
       "pt-3",
       "pb-2",
+      "[scrollbar-width:none]",
+      "[&::-webkit-scrollbar]:hidden",
     );
     expect(screen.getByTestId("new-chat-landing-actions")).toHaveClass("px-2", "pb-2");
     const footer = screen.getByTestId("new-chat-landing-footer");

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -4373,7 +4373,7 @@ export function NewChatLandingScreen() {
               // inside them): max 200px = the spec's 180px of content.
               // A 60px floor holds two 20px lines plus that padding;
               // useAutoGrowTextarea expands from there to the unchanged cap.
-              className="min-h-[60px] max-h-[200px] w-full resize-none overflow-y-auto bg-transparent px-4 pt-3 pb-2 font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-ui leading-5 text-foreground outline-none placeholder:text-muted-foreground md:select-text"
+              className="min-h-[60px] max-h-[200px] w-full resize-none overflow-y-auto bg-transparent px-4 pt-3 pb-2 font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-ui leading-5 text-foreground outline-none [scrollbar-width:none] placeholder:text-muted-foreground md:select-text [&::-webkit-scrollbar]:hidden"
             />
             {/* Gated on an empty draft so it reads as the placeholder.
                 pointer-events-none lets clicks fall through to focus the


### PR DESCRIPTION
## Related issue

Closes #5372

## Summary

- Permanently hide native textarea scrollbars in both the in-session and new-session composers, including Firefox and WebKit/Chromium styling.
- Keep capped long drafts internally scrollable and add component plus real-browser regression coverage for that invariant.
- Exercise an overflowing transcript and composer together to ensure no native scrollbar escapes outside the composer; the transcript keeps only its intentional custom scrollbar and the document remains overflow-locked.

## Test Plan

- `pnpm --filter web run lint`
- `pnpm --filter web run type-check`
- `pnpm --filter web run build`
- `pnpm --filter web run test` (300 files passed, 1 skipped; 5,946 tests passed)
- `.venv/bin/python -m pytest tests/e2e_ui/chat/test_composer_growth_transcript_stability.py::test_composer_hides_native_scrollbar_without_disabling_scroll -v`
- `.venv/bin/pre-commit run --all-files`

## Demo

The 20-line draft below is capped and scrolled to its bottom (line 9 is the first visible line), but no native scrollbar competes with the transcript scrollbar:

![Capped composer scrolling without a native scrollbar](https://raw.githubusercontent.com/dbczumar/omnigent/assets/composer-scrollbar-demo/docs/images/composer-scrollbar-demo.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified in Chromium with both a long transcript and a capped 20-line draft. Both real scroll surfaces overflow and remain functional, both suppress standard and WebKit native scrollbar chrome, and the document stays overflow-locked rather than becoming a third external scroller.

## Changelog

Chat composers no longer flash a redundant native scrollbar while growing.
