### PR TITLE
fix(windows): keep drive-letter workspace paths in the folder picker

### DIFF
--- a/omnigent/server/routes/_workspace_validation.py
+++ b/omnigent/server/routes/_workspace_validation.py
@@ -44,8 +44,38 @@ _WINDOWS_ABS_PATH_RE = re.compile(r"^[A-Za-z]:[/\\]")
 
 
 def _is_windows_absolute_path(path: str) -> bool:
-    """Return True for Windows drive-letter absolute paths (``C:\\…`` / ``C:/…``)."""
+    """Return True for Windows drive-letter absolute paths (``C:\\...`` / ``C:/...``)."""
     return bool(_WINDOWS_ABS_PATH_RE.match(path))
+
+
+def _is_unc_path(path: str) -> bool:
+    """Return True for UNC paths (backslash-share or ``//server/share``)."""
+    return path.startswith(("\\\\", "//"))
+
+
+def restore_host_filesystem_url_path(path: str) -> str:
+    """Re-add the leading slash FastAPI's ``:path`` converter strips.
+
+    FastAPI captures ``/v1/hosts/{id}/filesystem/{path:path}`` without
+    the URL's leading slash, so POSIX ``/Users/me/proj`` arrives as
+    ``Users/me/proj`` and must be restored. Windows drive-letter and
+    UNC paths are already absolute in the capture (``C:/Users/me``).
+    Prefixing ``/`` would produce ``/C:/Users/me``, which is not a
+    directory on the host and is why the workspace picker falls
+    through to the drive root.
+
+    Tilde-prefixed paths (``~/foo``) are forwarded unchanged; the
+    host expands ``~``.
+
+    :param path: Path captured from the URL, e.g. ``Users/me``,
+        ``C:/Users/me/work``, or ``~/projects``.
+    :returns: Path to forward to ``host.list_dir``.
+    """
+    if path.startswith("~") or _is_windows_absolute_path(path) or _is_unc_path(path):
+        return path
+    if not path.startswith("/"):
+        return "/" + path
+    return path
 
 
 # How long to wait for a host.stat round-trip before giving up. Stat
@@ -176,16 +206,24 @@ def _is_subpath_of(canonical_workspace: str, canonical_boundary: str) -> bool:
     :returns: ``True`` when the workspace is the boundary or
         nested under it.
     """
-    if canonical_workspace == canonical_boundary:
+    # host.stat realpath on Windows uses backslashes. Only then treat
+    # ``\`` as a separator and ignore drive-letter case. On POSIX a
+    # backslash is a legal filename character, so ``/allowed\escape``
+    # must not look like a child of ``/allowed``.
+    if _is_windows_absolute_path(canonical_workspace) or _is_windows_absolute_path(
+        canonical_boundary
+    ):
+        workspace = canonical_workspace.replace("\\", "/").lower()
+        boundary = canonical_boundary.replace("\\", "/").lower()
+    else:
+        workspace = canonical_workspace
+        boundary = canonical_boundary
+    if workspace == boundary:
         return True
     # Add a trailing separator so ``/a/foo`` is not treated as a
-    # subpath of ``/a/fo`` (prefix collision). ``/`` is the only
-    # separator the host stat returns since ``canonical_path`` is
-    # always absolute.
-    boundary_with_sep = (
-        canonical_boundary if canonical_boundary.endswith("/") else canonical_boundary + "/"
-    )
-    return canonical_workspace.startswith(boundary_with_sep)
+    # subpath of ``/a/fo`` (prefix collision).
+    boundary_with_sep = boundary if boundary.endswith("/") else boundary + "/"
+    return workspace.startswith(boundary_with_sep)
 
 
 async def validate_workspace(

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -51,6 +51,10 @@ from omnigent.server.feature_flags import Feature, FeatureFlags, resolve_feature
 from omnigent.server.host_registry import HostConnection, HostRegistry
 from omnigent.server.routes._auth_helpers import require_user
 from omnigent.server.routes._host_launch import resolve_host_launch
+from omnigent.server.routes._workspace_validation import (
+    _is_windows_absolute_path,
+    restore_host_filesystem_url_path,
+)
 from omnigent.server.schemas import SessionGitOptions
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.host_store import Host, HostStore, host_is_live
@@ -1077,10 +1081,10 @@ def create_hosts_router(
             504 (timeout), 502 (host I/O).
         """
         # FastAPI's :path converter strips the leading slash from
-        # the URL match. Re-add it unless the path is tilde-prefixed
-        # (~/foo stays tilde-prefixed; /Users/x becomes Users/x → /Users/x).
-        if not path.startswith("~"):
-            path = "/" + path
+        # the URL match. Re-add it for POSIX paths; leave tilde,
+        # Windows drive-letter, and UNC paths alone (prefixing /
+        # would turn C:/Users/me into /C:/Users/me).
+        path = restore_host_filesystem_url_path(path)
         return await _list_host_filesystem(
             request=request,
             host_id=host_id,
@@ -1219,7 +1223,10 @@ def create_hosts_router(
             )
         # Absolute or tilde-prefixed only — the host needs a path it can
         # resolve on its own; a relative path has no stable meaning here.
-        if not path.startswith(("/", "~")):
+        if not (
+            path.startswith(("/", "~", "\\\\"))
+            or _is_windows_absolute_path(path)
+        ):
             raise HTTPException(
                 status_code=400,
                 detail="path must be absolute or tilde-prefixed",

--- a/tests/server/integration/test_hosts_create_directory.py
+++ b/tests/server/integration/test_hosts_create_directory.py
@@ -301,3 +301,23 @@ async def test_create_directory_unknown_host_returns_404(
         )
 
     assert resp.status_code == 404
+
+
+async def test_create_directory_windows_drive_path_accepted(
+    mkdir_setup: tuple[
+        FastAPI,
+        HostRegistry,
+        ApplicationCommunicator,
+        dict[str, dict[str, Any]],
+        asyncio.Task[None],
+    ],
+) -> None:
+    """A Windows drive path is absolute and must not 400 as relative."""
+    app, _reg, _comm, _replies, _drain = mkdir_setup
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            f"/v1/hosts/{_HOST_ID}/directories",
+            json={"path": r"C:\Users\alice\work\fresh"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["path"] == r"C:\Users\alice\work\fresh"

--- a/tests/server/integration/test_hosts_filesystem.py
+++ b/tests/server/integration/test_hosts_filesystem.py
@@ -700,3 +700,40 @@ async def test_list_filesystem_limit_above_max_rejected(
         )
     # FastAPI returns 422 for failed Query validation.
     assert resp.status_code == 422
+
+
+async def test_list_filesystem_windows_drive_path_is_not_posixified(
+    fs_setup: tuple[
+        FastAPI,
+        HostRegistry,
+        ApplicationCommunicator,
+        dict[str, dict[str, Any]],
+        asyncio.Task[None],
+    ],
+) -> None:
+    """Windows drive paths must reach the host without a leading slash.
+
+    FastAPI strips the URL leading slash; the handler used to always
+    prepend ``/``, turning ``C:/Users/me/work`` into ``/C:/Users/me/work``
+    which does not exist. The picker then fell through to the drive root.
+    """
+    from omnigent.host.frames import HostListDirEntry
+
+    app, _reg, _comm, replies, _drain = fs_setup
+    replies["C:/Users/alice/work"] = {
+        "entries": [
+            HostListDirEntry(
+                name="src",
+                path=r"C:\Users\alice\work\src",
+                type="directory",
+                bytes=None,
+                modified_at=1779980000,
+            ),
+        ],
+        "has_more": False,
+    }
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/v1/hosts/{_HOST_ID}/filesystem/C:/Users/alice/work")
+    assert resp.status_code == 200, resp.text
+    names = [entry["name"] for entry in resp.json()["data"]]
+    assert names == ["src"]

--- a/tests/server/routes/test_workspace_validation_helpers.py
+++ b/tests/server/routes/test_workspace_validation_helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from omnigent.server.routes._workspace_validation import (
     _is_relative_cwd,
     _is_subpath_of,
+    restore_host_filesystem_url_path,
 )
 
 
@@ -58,3 +59,41 @@ class TestIsSubpathOf:
 
     def test_trailing_slash_boundary(self) -> None:
         assert _is_subpath_of("/a/b/c", "/a/b/") is True
+
+    def test_windows_backslash_child(self) -> None:
+        assert _is_subpath_of("C:\\a\\b", "C:\\a") is True
+
+    def test_windows_drive_case_insensitive(self) -> None:
+        assert _is_subpath_of("C:\\Users\\me\\work", "c:\\Users\\me") is True
+
+    def test_windows_prefix_collision(self) -> None:
+        assert _is_subpath_of("C:\\a\\foo", "C:\\a\\fo") is False
+
+    def test_posix_backslash_is_not_a_separator(self) -> None:
+        """A POSIX filename may contain a backslash; it is not a separator."""
+        assert _is_subpath_of("/allowed\\escape/project", "/allowed") is False
+
+    def test_windows_mixed_separators(self) -> None:
+        assert _is_subpath_of("C:\\Users\\alice\\work", "C:/Users/alice") is True
+
+
+class TestRestoreHostFilesystemUrlPath:
+    """FastAPI :path capture restoration for POSIX vs Windows paths."""
+
+    def test_posix_stripped_slash_is_restored(self) -> None:
+        assert restore_host_filesystem_url_path("Users/corey/proj") == "/Users/corey/proj"
+
+    def test_posix_already_absolute(self) -> None:
+        assert restore_host_filesystem_url_path("/Users/corey/proj") == "/Users/corey/proj"
+
+    def test_tilde_is_unchanged(self) -> None:
+        assert restore_host_filesystem_url_path("~/proj") == "~/proj"
+
+    def test_windows_drive_forward_slash_is_not_prefixed(self) -> None:
+        assert restore_host_filesystem_url_path("C:/Users/alice/work") == "C:/Users/alice/work"
+
+    def test_windows_drive_backslash_is_not_prefixed(self) -> None:
+        assert restore_host_filesystem_url_path(r"C:\Users\alice\work") == r"C:\Users\alice\work"
+
+    def test_unc_is_not_prefixed(self) -> None:
+        assert restore_host_filesystem_url_path("//server/share/proj") == "//server/share/proj"

--- a/web/src/hooks/useHostFilesystem.test.ts
+++ b/web/src/hooks/useHostFilesystem.test.ts
@@ -70,6 +70,15 @@ describe("buildHostFilesystemUrl", () => {
     // slash we'd hit the no-path route which forwards ~ instead.
     expect(buildHostFilesystemUrl("host_abc", "/")).toBe("/v1/hosts/host_abc/filesystem/");
   });
+
+  it("encodes a Windows drive path without prefixing a slash", () => {
+    expect(buildHostFilesystemUrl("host_abc", "C:\\Users\\alice\\work")).toBe(
+      "/v1/hosts/host_abc/filesystem/C%3A/Users/alice/work",
+    );
+    expect(buildHostFilesystemUrl("host_abc", "C:/Users/alice/work")).toBe(
+      "/v1/hosts/host_abc/filesystem/C%3A/Users/alice/work",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/src/hooks/useHostFilesystem.ts
+++ b/web/src/hooks/useHostFilesystem.ts
@@ -55,11 +55,26 @@ export function buildHostFilesystemUrl(hostId: string, absolutePath: string): st
   if (absolutePath === "") {
     return base;
   }
+  if (absolutePath === "/") {
+    // Browsing exactly "/" must hit /filesystem/ (with trailing
+    // slash) to match the {path:path} route. Without the trailing
+    // slash we'd hit the no-path route which forwards ~ instead.
+    return `${base}/`;
+  }
+  // Windows drive and UNC paths are already absolute. Encode each
+  // segment after normalizing backslashes so FastAPI captures
+  // ``C:/Users/me`` (not ``/C:/Users/me``).
+  if (/^[A-Za-z]:[\\/]/.test(absolutePath) || absolutePath.startsWith("\\\\")) {
+    const normalized = absolutePath.replace(/\\/g, "/");
+    const encoded = normalized
+      .split("/")
+      .map((segment) => encodeURIComponent(segment))
+      .join("/");
+    return `${base}/${encoded}`;
+  }
   // Strip the single leading slash; the route handler re-adds it.
   const stripped = absolutePath.startsWith("/") ? absolutePath.slice(1) : absolutePath;
   if (stripped === "") {
-    // The user navigated to "/" exactly. Keep a trailing slash so
-    // the route still matches /filesystem/{path:path}.
     return `${base}/`;
   }
   const encoded = stripped

--- a/web/src/shell/WorkspacePicker.test.tsx
+++ b/web/src/shell/WorkspacePicker.test.tsx
@@ -13,6 +13,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   basename,
+  isHostAbsolutePath,
+  isNavigablePath,
   joinPath,
   listingFilter,
   normalizeTypedPath,
@@ -81,6 +83,22 @@ describe("parentOf", () => {
     // climb correctly; without the strip the parent would
     // wrongly include the trailing-empty segment.
     expect(parentOf("/Users/corey/")).toBe("/Users");
+  });
+
+  it("climbs Windows drive paths without falling through to POSIX root", () => {
+    // Host listings on Windows return backslash paths. lastIndexOf("/")
+    // is -1 on those, which previously made parentOf return "/" and
+    // sent the picker to the drive root.
+    expect(parentOf("C:\\Users\\alice\\work")).toBe("C:\\Users\\alice");
+    expect(parentOf("C:\\Users\\alice")).toBe("C:\\Users");
+    expect(parentOf("C:\\Users")).toBe("C:\\");
+    expect(parentOf("C:\\")).toBeNull();
+    expect(parentOf("C:/Users/alice/work")).toBe("C:/Users/alice");
+    expect(parentOf("C:/Users")).toBe("C:/");
+  });
+
+  it("does not treat a backslash as a separator on POSIX paths", () => {
+    expect(parentOf("/tmp/a\\b")).toBe("/tmp");
   });
 });
 
@@ -163,6 +181,12 @@ describe("normalizeTypedPath", () => {
     // resolve. Out of scope for v1 — fall through to "invalid".
     expect(normalizeTypedPath("~root/foo", "/Users/corey")).toBeNull();
   });
+
+  it("accepts a Windows drive path as already absolute", () => {
+    expect(normalizeTypedPath("C:\\Users\\alice\\work")).toBe("C:\\Users\\alice\\work");
+    expect(normalizeTypedPath("C:/Users/alice/work")).toBe("C:/Users/alice/work");
+    expect(normalizeTypedPath("  C:/Users/alice/work/  ")).toBe("C:/Users/alice/work");
+  });
 });
 
 describe("basename", () => {
@@ -189,6 +213,15 @@ describe("basename", () => {
     // produce an empty basename.
     expect(basename("/Users/corey/")).toBe("corey");
   });
+
+  it("returns the last segment of a Windows drive path", () => {
+    expect(basename("C:\\Users\\alice\\work")).toBe("work");
+    expect(basename("C:/Users/alice/work")).toBe("work");
+  });
+
+  it("keeps a POSIX backslash inside the basename", () => {
+    expect(basename("/tmp/a\\b")).toBe("a\\b");
+  });
 });
 
 // listingFilter decides whether (and how) the path-bar text narrows the
@@ -197,6 +230,27 @@ describe("basename", () => {
 // root) and the cases that must NOT — blank, exactly the current path, or a
 // path into a different directory (which is navigation, not a filter). A
 // false positive here would hide entries while the user is navigating away.
+describe("isNavigablePath", () => {
+  it("accepts POSIX absolute, home, and Windows drive paths", () => {
+    expect(isNavigablePath("/Users/me/work")).toBe(true);
+    expect(isNavigablePath("~/work")).toBe(true);
+    expect(isNavigablePath("~")).toBe(true);
+    expect(isNavigablePath("C:\\Users\\alice\\work")).toBe(true);
+    expect(isNavigablePath("C:/Users/alice/work")).toBe(true);
+    expect(isNavigablePath("work")).toBe(false);
+    expect(isNavigablePath("C:relative")).toBe(false);
+  });
+});
+
+describe("isHostAbsolutePath", () => {
+  it("rejects relative and tilde paths", () => {
+    expect(isHostAbsolutePath("/tmp")).toBe(true);
+    expect(isHostAbsolutePath("C:\\Users\\alice")).toBe(true);
+    expect(isHostAbsolutePath("~/work")).toBe(false);
+    expect(isHostAbsolutePath("")).toBe(false);
+  });
+});
+
 describe("listingFilter", () => {
   it.each<[string, string, string | null, string | null]>([
     // [pathInput, currentAbsolute, home, expected]
@@ -218,6 +272,9 @@ describe("listingFilter", () => {
     ["~/pro", "/Users/me", "/Users/me", "pro"],
     // At the root, "/sr" is a fragment of "/" → filters.
     ["/sr", "/", null, "sr"],
+    ["C:\\Users\\me\\pro", "C:\\Users\\me", null, "pro"],
+    ["C:\\Users\\me", "C:\\Users\\me", null, null],
+    ["C:/Users/Alice/pro", "c:\\users\\alice", null, "pro"],
   ])("listingFilter(%j, %j, %j) → %j", (input, current, home, expected) => {
     expect(listingFilter(input, current, home)).toBe(expected);
   });
@@ -279,6 +336,33 @@ describe("WorkspacePicker path bar", () => {
     const input = screen.getByTestId("workspace-picker-path-input") as HTMLInputElement;
     fireEvent.click(screen.getByTestId("workspace-picker-entry-projects"));
     expect(input.value).toBe("/Users/serena.ruan/projects");
+  });
+
+  it("does not treat a Windows home listing as the POSIX root", () => {
+    // Home view (path "") lists entries whose paths are C:\Users\...\name.
+    // Deriving the current dir via lastIndexOf("/") used to yield "/", so
+    // onNavigate fired with the drive root and Select could not pick work/.
+    useHostFilesystemMock.mockReturnValue(
+      result({
+        data: {
+          entries: [
+            dir("work", "C:\\Users\\alice\\work"),
+            dir("Documents", "C:\\Users\\alice\\Documents"),
+          ],
+          truncated: false,
+        },
+        isLoading: false,
+        isPlaceholderData: false,
+      }),
+    );
+    const onNavigate = vi.fn();
+    const onSelect = vi.fn();
+    render(<WorkspacePicker hostId="host_1" onNavigate={onNavigate} onSelect={onSelect} />);
+    expect(onNavigate).toHaveBeenCalledWith("C:\\Users\\alice");
+    fireEvent.click(screen.getByTestId("workspace-picker-select"));
+    expect(onSelect).toHaveBeenCalledWith("C:\\Users\\alice");
+    fireEvent.click(screen.getByTestId("workspace-picker-entry-work"));
+    expect(onNavigate).toHaveBeenCalledWith("C:\\Users\\alice\\work");
   });
 
   it("resolves a tilde start path to an absolute one for selection", () => {
@@ -464,6 +548,11 @@ describe("joinPath", () => {
 
   it("trims surrounding whitespace from the child name", () => {
     expect(joinPath("/Users/me", "  foo  ")).toBe("/Users/me/foo");
+  });
+
+  it("joins a Windows drive path with a backslash", () => {
+    expect(joinPath("C:\\Users\\alice", "work")).toBe("C:\\Users\\alice\\work");
+    expect(joinPath("C:\\", "Users")).toBe("C:\\Users");
   });
 });
 

--- a/web/src/shell/WorkspacePicker.tsx
+++ b/web/src/shell/WorkspacePicker.tsx
@@ -18,14 +18,46 @@ import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCreateHostDirectory, useHostFilesystem } from "@/hooks/useHostFilesystem";
 
+/** True for Windows drive-letter paths such as `C:/Users/me` or `C:\\Users\\me`. */
+export function isWindowsDrivePath(path: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(path);
+}
+
+function sameHostDirectory(a: string, b: string): boolean {
+  if (isWindowsDrivePath(a) && isWindowsDrivePath(b)) {
+    return a.replace(/\\/g, "/").toLowerCase() === b.replace(/\\/g, "/").toLowerCase();
+  }
+  return a === b;
+}
+
+/**
+ * True when the path is already an absolute host path: POSIX ``/…``
+ * or a Windows drive path (``C:\…`` / ``C:/…``).
+ */
+export function isHostAbsolutePath(path: string): boolean {
+  return path.startsWith("/") || isWindowsDrivePath(path);
+}
+
+function lastSeparatorIndex(path: string): number {
+  if (isWindowsDrivePath(path)) {
+    return Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  }
+  return path.lastIndexOf("/");
+}
+
+function separatorOf(path: string): "/" | "\\" {
+  return path.includes("\\") && !path.slice(path.indexOf(":") + 1).includes("/") ? "\\" : "/";
+}
+
 /**
  * Join a directory path and a new child name into an absolute path.
  *
  * Handles the filesystem root (``"/"`` + ``"foo"`` → ``"/foo"`` rather
  * than ``"//foo"``) and trims a trailing slash off the parent so a
- * typed ``"/Users/me/"`` still produces ``"/Users/me/foo"``. The child
- * name is trimmed; surrounding/duplicate slashes in it are left to the
- * host to resolve.
+ * typed ``"/Users/me/"`` still produces ``"/Users/me/foo"``. Windows
+ * drive roots (``C:\``) join with a backslash. The child name is
+ * trimmed; surrounding/duplicate slashes in it are left to the host
+ * to resolve.
  *
  * @param dir Absolute parent directory, e.g. ``"/Users/me"`` or ``"/"``.
  * @param name New child name, e.g. ``"new-app"``.
@@ -36,8 +68,15 @@ export function joinPath(dir: string, name: string): string {
   if (dir === "/") {
     return `/${trimmedName}`;
   }
-  const base = dir.endsWith("/") ? dir.slice(0, -1) : dir;
-  return `${base}/${trimmedName}`;
+  if (/^[A-Za-z]:[\\/]?$/.test(dir)) {
+    const sep = dir.includes("\\") || dir.endsWith("\\") ? "\\" : "/";
+    const root = dir.length === 2 ? `${dir}${sep}` : dir.endsWith(sep) ? dir : `${dir}${sep}`;
+    return `${root}${trimmedName}`;
+  }
+  const sep = separatorOf(dir);
+  const base =
+    dir.endsWith("/") || (isWindowsDrivePath(dir) && dir.endsWith("\\")) ? dir.slice(0, -1) : dir;
+  return `${base}${sep}${trimmedName}`;
 }
 
 /**
@@ -45,7 +84,7 @@ export function joinPath(dir: string, name: string): string {
  *
  * Returns ``null`` when the input is empty (host's home view —
  * has no parent in the picker's UX) or already at the root
- * ``"/"``. Otherwise drops the last segment.
+ * ``"/"`` / ``C:\``. Otherwise drops the last segment.
  *
  * @param absolutePath Absolute path or empty string.
  * @returns Parent path, or ``null`` if there is no further parent.
@@ -54,9 +93,25 @@ export function parentOf(absolutePath: string): string | null {
   if (absolutePath === "" || absolutePath === "/") {
     return null;
   }
-  const stripped = absolutePath.endsWith("/") ? absolutePath.slice(0, -1) : absolutePath;
-  const idx = stripped.lastIndexOf("/");
-  if (idx <= 0) {
+  if (/^[A-Za-z]:[\\/]?$/.test(absolutePath)) {
+    return null;
+  }
+  const stripped =
+    absolutePath.endsWith("/") || (isWindowsDrivePath(absolutePath) && absolutePath.endsWith("\\"))
+      ? absolutePath.slice(0, -1)
+      : absolutePath;
+  if (/^[A-Za-z]:$/.test(stripped)) {
+    return null;
+  }
+  const idx = lastSeparatorIndex(stripped);
+  if (idx < 0) {
+    return null;
+  }
+  // ``C:\Users`` → ``C:\`` (keep the drive root, never POSIX ``/``).
+  if (isWindowsDrivePath(stripped) && idx === 2) {
+    return stripped.slice(0, 3);
+  }
+  if (idx === 0) {
     return "/";
   }
   return stripped.slice(0, idx);
@@ -67,17 +122,10 @@ export function parentOf(absolutePath: string): string | null {
  *
  * Trims whitespace, expands a leading ``~`` against the resolved
  * home directory, collapses runs of slashes, and drops a trailing
- * slash (except on the root ``"/"``). Returns ``null`` for empty
- * or invalid inputs (which the caller treats as "ignore — keep
- * the current path"). The picker never turns a typed path into
- * the empty string; "go home" is its own gesture (clicking the
- * Home breadcrumb).
- *
- * Tilde-only (``"~"``) and ``"~/foo"`` are expanded to
- * ``home`` and ``home + "/foo"`` respectively. If ``home`` is
- * ``null`` (we haven't resolved it yet from the first listing),
- * tilde input is rejected so the user isn't sent to the wrong
- * place. Bare ``~user`` form is not supported.
+ * slash (except on the root ``"/"`` / ``C:\``). Returns ``null`` for
+ * empty or invalid inputs (which the caller treats as "ignore —
+ * keep the current path"). Windows drive-letter paths are accepted
+ * as already-absolute.
  *
  * @param input Whatever the user typed, e.g.
  *   ``"  /Users//corey/  "`` or ``"~/projects"``.
@@ -93,27 +141,28 @@ export function normalizeTypedPath(input: string, home: string | null = null): s
   }
   let absolute: string;
   if (trimmed === "~") {
-    // Bare tilde — go home if we know where that is.
     if (home === null) return null;
     absolute = home;
-  } else if (trimmed.startsWith("~/")) {
-    // ~/foo → <home>/foo. Reject when home isn't resolved yet.
+  } else if (trimmed.startsWith("~/") || (home !== null && trimmed.startsWith("~\\"))) {
     if (home === null) return null;
-    absolute = `${home}/${trimmed.slice(2)}`;
-  } else if (trimmed.startsWith("/")) {
+    absolute = joinPath(home, trimmed.slice(2));
+  } else if (isHostAbsolutePath(trimmed)) {
     absolute = trimmed;
   } else {
-    // Relative paths and ~user forms are not supported — the host
-    // endpoint requires absolute paths.
     return null;
   }
-  // Collapse runs of slashes ("//" → "/") so a typo doesn't
-  // produce a path the host can't list.
+  if (isWindowsDrivePath(absolute) || absolute.startsWith("\\\\")) {
+    const sep = separatorOf(absolute);
+    const collapsed = absolute.replace(/[\\/]+/g, sep);
+    if (/^[A-Za-z]:[\\/]$/.test(collapsed)) {
+      return collapsed;
+    }
+    return collapsed.endsWith(sep) ? collapsed.slice(0, -1) : collapsed;
+  }
   const collapsed = absolute.replace(/\/+/g, "/");
   if (collapsed === "/") {
     return "/";
   }
-  // Drop trailing slash so parent calc stays stable.
   return collapsed.endsWith("/") ? collapsed.slice(0, -1) : collapsed;
 }
 
@@ -133,8 +182,18 @@ export function basename(absolutePath: string): string {
   if (absolutePath === "/") {
     return "/";
   }
-  const parts = absolutePath.split("/").filter((p) => p.length > 0);
-  return parts[parts.length - 1] ?? absolutePath;
+  if (/^[A-Za-z]:[\\/]?$/.test(absolutePath)) {
+    return absolutePath.length >= 3 ? absolutePath.slice(0, 3) : `${absolutePath}\\`;
+  }
+  const stripped =
+    absolutePath.endsWith("/") || (isWindowsDrivePath(absolutePath) && absolutePath.endsWith("\\"))
+      ? absolutePath.slice(0, -1)
+      : absolutePath;
+  const sepIdx = lastSeparatorIndex(stripped);
+  if (sepIdx < 0) {
+    return stripped;
+  }
+  return stripped.slice(sepIdx + 1);
 }
 
 /**
@@ -148,25 +207,14 @@ export function basename(absolutePath: string): string {
  */
 export function isNavigablePath(path: string): boolean {
   const trimmed = path.trim();
-  return trimmed.startsWith("/") || trimmed === "~" || trimmed.startsWith("~/");
+  return (
+    isHostAbsolutePath(trimmed) ||
+    trimmed === "~" ||
+    trimmed.startsWith("~/") ||
+    trimmed.startsWith("~\\")
+  );
 }
 
-/**
- * Live filter for the listing, derived from the path-bar text.
- *
- * Returns the fragment to match the current directory's entries against
- * (case-insensitive prefix), or ``null`` when the text isn't filtering the
- * current directory — it's blank, it's exactly the current path, or it's a
- * path into a *different* directory the user is navigating to (Enter jumps
- * there). Mirrors shell tab-completion: a bare fragment (``"pro"``) or a
- * trailing segment under the current dir (``"/Users/me/pro"``) narrows the
- * list; anything else leaves it whole.
- *
- * @param pathInput Raw path-bar text, e.g. ``"pro"`` or ``"/Users/me/pro"``.
- * @param currentAbsolute Absolute path of the directory currently shown.
- * @param home Resolved home dir (for ``~`` expansion), or ``null``.
- * @returns The fragment to filter by, or ``null`` for no filter.
- */
 export function listingFilter(
   pathInput: string,
   currentAbsolute: string,
@@ -174,7 +222,7 @@ export function listingFilter(
 ): string | null {
   const trimmed = pathInput.trim();
   if (trimmed === "") return null;
-  const slash = trimmed.lastIndexOf("/");
+  const slash = lastSeparatorIndex(trimmed);
   if (slash === -1) {
     // Bare fragment, no directory part → filter the current dir by it.
     return trimmed;
@@ -183,8 +231,11 @@ export function listingFilter(
   if (partial === "") return null; // "<dir>/" — nothing typed past the slash.
   // A fragment only filters when its directory part IS the current directory;
   // otherwise the user is typing a path elsewhere (navigation, not a filter).
-  const dirText = trimmed.slice(0, slash) || "/";
-  return normalizeTypedPath(dirText, home) === currentAbsolute ? partial : null;
+  const dirText =
+    trimmed.slice(0, slash) || (isWindowsDrivePath(trimmed) ? trimmed.slice(0, 3) : "/");
+  const normalizedDir = normalizeTypedPath(dirText, home);
+  if (normalizedDir === null) return null;
+  return sameHostDirectory(normalizedDir, currentAbsolute) ? partial : null;
 }
 
 /**
@@ -388,13 +439,9 @@ export function WorkspacePicker({
     if (resolvedHome !== null || homeIsPlaceholder || !homeData || homeData.entries.length === 0) {
       return;
     }
-    const first = homeData.entries[0];
-    // first.path is "/Users/corey/x" → parent is "/Users/corey".
-    const idx = first.path.lastIndexOf("/");
-    if (idx > 0) {
-      setResolvedHome(first.path.slice(0, idx));
-    } else if (idx === 0) {
-      setResolvedHome("/");
+    const parent = parentOf(homeData.entries[0].path);
+    if (parent !== null) {
+      setResolvedHome(parent);
     }
   }, [resolvedHome, homeData, homeIsPlaceholder]);
 
@@ -411,13 +458,13 @@ export function WorkspacePicker({
   // as-is; "" (home) or a "~"-relative path uses the absolute the host
   // resolved it to, falling back to the raw path until the listing
   // arrives (so the breadcrumb stays put rather than flashing empty).
-  const currentAbsolute = path.startsWith("/") ? path : (listedAbsolute ?? path);
+  const currentAbsolute = isHostAbsolutePath(path) ? path : (listedAbsolute ?? path);
 
   // Other live agents working in the directory currently shown. Only a
   // resolved absolute path can match a stored workspace; the home view ("")
   // and unresolved paths report no conflict.
   const occupiedCount =
-    occupancyForPath && currentAbsolute.startsWith("/") ? occupancyForPath(currentAbsolute) : 0;
+    occupancyForPath && isHostAbsolutePath(currentAbsolute) ? occupancyForPath(currentAbsolute) : 0;
 
   // Mirror navigation into the path input so it reflects where the
   // listing came from (the user can still overwrite it). Skip while
@@ -434,7 +481,7 @@ export function WorkspacePicker({
   const onNavigateRef = useRef(onNavigate);
   onNavigateRef.current = onNavigate;
   useEffect(() => {
-    if (currentAbsolute.startsWith("/")) {
+    if (isHostAbsolutePath(currentAbsolute)) {
       onNavigateRef.current?.(currentAbsolute);
     }
   }, [currentAbsolute]);
@@ -499,7 +546,7 @@ export function WorkspacePicker({
   // listing has loaded, otherwise creating the first folder in an empty
   // home would be impossible. Stays null while loading so the button is
   // disabled until we know what home resolves to.
-  const createBaseDir = currentAbsolute.startsWith("/")
+  const createBaseDir = isHostAbsolutePath(currentAbsolute)
     ? currentAbsolute
     : path === "" && !isLoading && !isPlaceholderData
       ? "~"


### PR DESCRIPTION
## Related issue

Closes #5368

## Summary

On native Windows the workspace folder picker cannot open a directory under the user profile. Host listings return drive-letter paths such as `C:\Users\alice\work`; the UI treated those as relative (parent became `/`), and `GET /v1/hosts/{id}/filesystem/{path}` prefixed `/` onto drive-letter captures, so `C:/Users/alice/work` became `/C:/Users/alice/work` and 404'd. The picker then sat at the drive root.

This change:

- Restores FastAPI `:path` captures without adding `/` for Windows drive (and UNC) paths.
- Accepts drive-letter paths when creating a directory from the picker.
- Makes picker helpers (`parentOf`, `joinPath`, `normalizeTypedPath`, `isNavigablePath`, URL builder) understand `C:\` / `C:/`.
- Compares Windows workspace boundaries with a normalized separator, without treating a POSIX `\` as a path separator.

```mermaid
flowchart LR
  click["Click home child C:\\Users\\alice\\work"] --> url["GET .../filesystem/C:/Users/alice/work"]
  url --> restore["restore_host_filesystem_url_path"]
  restore --> host["host.list_dir C:/Users/alice/work"]
  host --> picker["picker currentAbsolute stays on that folder"]
```

## Test Plan

- `pytest tests/server/routes/test_workspace_validation_helpers.py` plus the Windows filesystem/create-directory integration cases — 27 passed
- `pnpm exec vitest run src/shell/WorkspacePicker.test.tsx src/hooks/useHostFilesystem.test.ts` — 83 passed
- Fixtures use fictional paths only (`C:\Users\alice\...`). They do not require a real directory on the developer machine.
- Manual: on Windows 11, open the New Chat workspace picker, click a folder under home, confirm the path stays a `C:\Users\...` child and a session can start there.

## Demo

N/A as a file attachment from CLI. Before: home-child click → invalid path → current directory `/` (`C:\`). After: the picker stays on the selected folder.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Helpers (`parentOf`, `joinPath`, `normalizeTypedPath`, `isNavigablePath`, URL builder, `restore_host_filesystem_url_path`, `_is_subpath_of`) are covered by unit tests, including Windows drive-letter cases, mixed separators, and a POSIX filename that contains `\`. Integration tests pin that `GET .../filesystem/C:/Users/alice/work` is forwarded without a leading `/` and that `POST .../directories` accepts a `C:\...` path. UNC browse is left out of this PR (session-create still only accepts `/` or drive-letter workspaces).

## Changelog

Windows users can select a folder under their home directory as a workspace; the picker no longer rejects `C:\Users\...` paths and drops to the drive root.
