### PR TITLE
fix(db): reject databases from newer builds

### DIFF
--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -398,10 +398,16 @@ def _run_migrations(engine: Engine, db_uri: str) -> None:
     :param db_uri: Database connection string forwarded to
         Alembic's ``sqlalchemy.url`` config option, e.g.
         ``"sqlite:///mydb.db"``.
+    :raises RuntimeError: If the database revision is newer than
+        the revisions known to this build.
     """
     from alembic import command
 
     from omnigent.db.db_models import ConversationBase, OmnigentBase
+
+    current = _get_current_db_revision(engine)
+    head = _get_head_db_revision(db_uri)
+    _verify_db_revision_is_supported(db_uri, current, head)
 
     _logger.info("Running database migrations...")
     config = _build_alembic_config(db_uri)
@@ -476,11 +482,34 @@ def _get_head_db_revision(db_uri: str) -> str:
     return head
 
 
+def _verify_db_revision_is_supported(
+    db_uri: str,
+    current: str | None,
+    head: str,
+) -> None:
+    """Reject a database revision that is unknown to this build."""
+    if current is None or current == head:
+        return
+
+    from alembic.script import ScriptDirectory
+    from alembic.util import CommandError
+
+    script = ScriptDirectory.from_config(_build_alembic_config(db_uri))
+    try:
+        script.get_revision(current)
+    except CommandError as exc:
+        raise RuntimeError(
+            "Omnigent database schema is newer than this version of Omnigent "
+            f"(found revision {current!r}, latest supported revision {head!r}). "
+            "Upgrade Omnigent before using this database."
+        ) from exc
+
+
 def _initialize_or_verify_schema(engine: Engine, db_uri: str) -> None:
     """
     Bring a fresh or stale database to head before the server starts.
 
-    Three cases:
+    Four cases:
 
     - **Fresh DB** (no ``alembic_version`` table) — run migrations to
       head. This covers brand-new SQLite files and freshly created
@@ -491,6 +520,8 @@ def _initialize_or_verify_schema(engine: Engine, db_uri: str) -> None:
       If the migration fails, re-raise with context so the server
       still terminates with an actionable error instead of continuing
       against an incompatible schema.
+    - **Newer than this build** — stop without attempting a migration
+      and tell the operator to upgrade Omnigent.
 
     :param engine: SQLAlchemy engine bound to the target database.
     :param db_uri: Database URL, used both for Alembic config and in
@@ -500,6 +531,7 @@ def _initialize_or_verify_schema(engine: Engine, db_uri: str) -> None:
     """
     head = _get_head_db_revision(db_uri)
     current = _get_current_db_revision(engine)
+    _verify_db_revision_is_supported(db_uri, current, head)
 
     if current is None:
         _run_migrations(engine, db_uri)

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -20,6 +20,7 @@ from omnigent.db.utils import (
     _initialize_or_verify_schema,
     _install_lakebase_token_refresh,
     _resolve_lakebase_token_provider,
+    _run_migrations,
     _shared_read_sessions,
     build_search_snippet,
     builtin_agent_id,
@@ -329,6 +330,24 @@ def _make_db_at_revision(db_path: Path, revision: str) -> str:
     return uri
 
 
+def _make_db_at_unknown_revision(db_path: Path, revision: str) -> str:
+    """Build a SQLite database stamped beyond this build's migration map."""
+    uri = f"sqlite:///{db_path}"
+    engine = create_engine(uri)
+    try:
+        with engine.begin() as conn:
+            conn.exec_driver_sql(
+                "CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL PRIMARY KEY)"
+            )
+            conn.exec_driver_sql(
+                "INSERT INTO alembic_version (version_num) VALUES (?)",
+                (revision,),
+            )
+    finally:
+        engine.dispose()
+    return uri
+
+
 def test_initialize_or_verify_schema_initializes_fresh_db(
     tmp_path: Path,
 ) -> None:
@@ -460,6 +479,63 @@ def test_initialize_or_verify_schema_reports_manual_retry_when_auto_migration_fa
         f"Error message must include the database URL so the "
         f"command is copy-pastable. Got: {msg!r}"
     )
+
+
+def test_initialize_or_verify_schema_reports_database_from_newer_build(
+    tmp_path: Path,
+) -> None:
+    """An unknown DB revision means this build is too old, not that the DB is stale."""
+    future_revision = "deadbeef1234"
+    uri = _make_db_at_unknown_revision(tmp_path / "newer.db", future_revision)
+    head = _get_head_db_revision(uri)
+
+    engine = create_engine(uri)
+    try:
+        with pytest.raises(RuntimeError, match="newer") as exc_info:
+            _initialize_or_verify_schema(engine, uri)
+    finally:
+        engine.dispose()
+
+    msg = str(exc_info.value)
+    assert future_revision in msg
+    assert head in msg
+    assert "out of date" not in msg.lower()
+    assert "db-upgrade" not in msg
+
+
+def test_initialize_or_verify_schema_does_not_migrate_database_from_newer_build(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup must leave a database from a newer build untouched."""
+    uri = _make_db_at_unknown_revision(tmp_path / "newer.db", "deadbeef1234")
+    run_migrations = MagicMock()
+    monkeypatch.setattr("omnigent.db.utils._run_migrations", run_migrations)
+
+    engine = create_engine(uri)
+    try:
+        with pytest.raises(RuntimeError, match="newer"):
+            _initialize_or_verify_schema(engine, uri)
+    finally:
+        engine.dispose()
+
+    run_migrations.assert_not_called()
+
+
+def test_run_migrations_reports_database_from_newer_build(tmp_path: Path) -> None:
+    """The manual db-upgrade path must replace Alembic's CommandError."""
+    future_revision = "deadbeef1234"
+    uri = _make_db_at_unknown_revision(tmp_path / "newer.db", future_revision)
+
+    engine = create_engine(uri)
+    try:
+        with pytest.raises(RuntimeError, match="newer") as exc_info:
+            _run_migrations(engine, uri)
+        assert _get_current_db_revision(engine) == future_revision
+    finally:
+        engine.dispose()
+
+    assert "Can't locate revision" not in str(exc_info.value)
 
 
 # ── slash_command persistence path ────────────────────


### PR DESCRIPTION
## Related issue

Closes #4963

## Summary

Validate a database's stamped Alembic revision before attempting a migration. If the revision is unknown to the installed build, both server startup and `omnigent debug db-upgrade` now stop with an actionable message to upgrade Omnigent instead of misreporting a stale schema or crashing.

ELI5:

```text
database state
├── no revision     → initialize
├── known revision  → keep the existing no-op or upgrade behavior
└── unknown revision → stop and upgrade Omnigent; leave the DB untouched
```

## Test Plan

- `uv run pytest tests/db/test_utils.py -q` — 44 passed
- `uv run pytest tests/db -m 'not databricks' -q` — 374 passed, 4 deselected
- `uv run pre-commit run --files omnigent/db/utils.py tests/db/test_utils.py` — all hooks passed

## Demo

N/A — non-visual database compatibility fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression tests stamp a real SQLite database with a revision absent from this build and verify that startup and manual migration both report the newer database, preserve its revision, and never attempt an upgrade.

## Changelog

Older Omnigent clients now explain when a database was migrated by a newer version instead of recommending an impossible schema upgrade.
