### PR TITLE
fix(codex): apply configured retry policy

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -918,6 +918,8 @@ def _populate_codex_home_config(
 def materialize_codex_provider_config(
     codex_home: Path,
     config_overrides: Iterable[str],
+    *,
+    retry_policy: RetryPolicy | None = None,
 ) -> list[str]:
     """Move generated provider definitions into a private Codex config.
 
@@ -928,6 +930,8 @@ def materialize_codex_provider_config(
 
     :param codex_home: Private session ``CODEX_HOME`` directory.
     :param config_overrides: Pending Codex config override strings.
+    :param retry_policy: Omnigent retry policy to apply through Codex's native
+        provider settings. ``None`` uses :class:`RetryPolicy` defaults.
     :returns: Overrides safe to retain in subprocess arguments.
     """
     codex_home.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -941,9 +945,9 @@ def materialize_codex_provider_config(
             provider_overrides.append(override)
         else:
             argv_overrides.append(override)
-    if not provider_overrides:
-        if config_path.is_file() and not config_path.is_symlink():
-            os.chmod(config_path, 0o600)
+    if not provider_overrides and not config_path.is_file():
+        return argv_overrides
+    if not provider_overrides and config_path.is_symlink():
         return argv_overrides
 
     import tomlkit
@@ -951,6 +955,10 @@ def materialize_codex_provider_config(
     existing = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
     document = tomlkit.parse(existing) if existing else tomlkit.document()
     providers = document.get("model_providers")
+    if providers is None and not provider_overrides:
+        if config_path.is_file() and not config_path.is_symlink():
+            os.chmod(config_path, 0o600)
+        return argv_overrides
     if providers is None:
         document["model_providers"] = tomlkit.table()
         providers = document["model_providers"]
@@ -964,6 +972,21 @@ def materialize_codex_provider_config(
             raise ValueError("Codex provider override must define model_providers")
         for provider_name, provider_config in generated.items():
             providers[provider_name] = provider_config
+
+    policy = retry_policy if retry_policy is not None else RetryPolicy()
+    for provider_name, provider_config in list(providers.items()):
+        if not isinstance(provider_config, MutableMapping):
+            continue
+        if not isinstance(provider_config, tomlkit.items.Table):
+            provider_table = tomlkit.table()
+            for key, value in provider_config.items():
+                provider_table[key] = value
+            providers[provider_name] = provider_table
+            provider_config = provider_table
+        provider_config["request_max_retries"] = policy.max_retries
+        provider_config["stream_max_retries"] = policy.max_retries
+        if policy.timeout_per_request_s is not None:
+            provider_config["stream_idle_timeout_ms"] = int(policy.timeout_per_request_s * 1000)
 
     fd, tmp_name = tempfile.mkstemp(prefix="config.toml.", dir=str(codex_home))
     try:
@@ -2195,6 +2218,7 @@ class _CodexAppServerSession:
         env: dict[str, str],
         tool_executor: CodexToolExecutor | None,
         codex_config_overrides: list[str] | None = None,
+        retry_policy: RetryPolicy | None = None,
         disable_native_tools: bool = False,
         bundle_dir: Path | None = None,
         skills_filter: str | list[str] = "all",
@@ -2204,6 +2228,7 @@ class _CodexAppServerSession:
         self._env = env
         self._tool_executor = tool_executor
         self._codex_config_overrides = list(codex_config_overrides or [])
+        self._retry_policy = retry_policy if retry_policy is not None else RetryPolicy()
         self._disable_native_tools = disable_native_tools
         self._bundle_dir = bundle_dir
         self._skills_filter = skills_filter
@@ -2313,6 +2338,7 @@ class _CodexAppServerSession:
         self._codex_config_overrides = materialize_codex_provider_config(
             self._codex_home_dir,
             self._codex_config_overrides,
+            retry_policy=self._retry_policy,
         )
         if router_bridge_dir is not None:
             write_codex_router_hooks_file(
@@ -3212,6 +3238,7 @@ class _AppSessionFactory(Protocol):
         env: dict[str, str],
         tool_executor: CodexToolExecutor | None,
         codex_config_overrides: list[str] | None,
+        retry_policy: RetryPolicy,
         disable_native_tools: bool,
         bundle_dir: Path | None,
         skills_filter: str | list[str],
@@ -3225,6 +3252,7 @@ def _default_app_session_factory(
     env: dict[str, str],
     tool_executor: CodexToolExecutor | None,
     codex_config_overrides: list[str] | None,
+    retry_policy: RetryPolicy,
     disable_native_tools: bool,
     bundle_dir: Path | None,
     skills_filter: str | list[str],
@@ -3235,6 +3263,7 @@ def _default_app_session_factory(
         env=env,
         tool_executor=tool_executor,
         codex_config_overrides=codex_config_overrides,
+        retry_policy=retry_policy,
         disable_native_tools=disable_native_tools,
         bundle_dir=bundle_dir,
         skills_filter=skills_filter,
@@ -3555,6 +3584,7 @@ class CodexExecutor(Executor):
             env=self._env,
             tool_executor=self._tool_executor,
             codex_config_overrides=self._codex_config_overrides,
+            retry_policy=self._retry_policy,
             disable_native_tools=self._disable_native_tools,
             bundle_dir=self._bundle_dir,
             skills_filter=self._skills_filter,

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -977,12 +977,12 @@ def materialize_codex_provider_config(
     for provider_name, provider_config in list(providers.items()):
         if not isinstance(provider_config, MutableMapping):
             continue
-        if not isinstance(provider_config, tomlkit.items.Table):
-            provider_table = tomlkit.table()
+        if isinstance(provider_config, tomlkit.items.InlineTable):
+            inline_provider = tomlkit.inline_table()
             for key, value in provider_config.items():
-                provider_table[key] = value
-            providers[provider_name] = provider_table
-            provider_config = provider_table
+                inline_provider[key] = value
+            providers[provider_name] = inline_provider
+            provider_config = inline_provider
         provider_config["request_max_retries"] = policy.max_retries
         provider_config["stream_max_retries"] = policy.max_retries
         if policy.timeout_per_request_s is not None:

--- a/tests/codex_parity/test_codex_executor_parity.py
+++ b/tests/codex_parity/test_codex_executor_parity.py
@@ -14,6 +14,7 @@ from omnigent.inner.executor import (
     ToolCallStatus,
     TurnComplete,
 )
+from omnigent.spec.types import RetryPolicy
 from tests.codex_parity.helpers import (
     assert_completed as _assert_completed,
 )
@@ -256,13 +257,14 @@ async def test_real_codex_ignores_retry_progress_until_terminal_failure(
     # error. CodexExecutor must keep waiting until Codex has exhausted retries.
     monkeypatch.setenv("CODEX_HOME", str(tmp_path / "source-codex-home"))
     (tmp_path / "source-codex-home").mkdir()
+    max_attempts = RetryPolicy().max_retries + 1
     sidecar = codex_responses_sidecar(
         [
             [
                 ev_response_created("resp-failed"),
                 ev_failed("resp-failed", "boom from mock model"),
             ]
-            for _ in range(6)
+            for _ in range(max_attempts)
         ]
     )
     executor = _executor(resolved_codex_bin, sidecar.base_url, tmp_path / "workspace")
@@ -276,7 +278,7 @@ async def test_real_codex_ignores_retry_progress_until_terminal_failure(
     assert len(errors) == 1
     assert "boom from mock model" in errors[0].message
     assert errors[0].retryable is True
-    assert len(sidecar.requests(min_count=6)) == 6
+    assert len(sidecar.requests(min_count=max_attempts)) == max_attempts
 
 
 @pytest.mark.asyncio

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -3095,6 +3095,60 @@ def test_populate_codex_home_config_does_not_overwrite_existing(tmp_path: Path) 
     assert not (target / "auth.json").is_symlink()
 
 
+def test_materialize_codex_provider_config_applies_default_retry_policy(tmp_path: Path) -> None:
+    """Private Codex providers receive Omnigent's retry budget.
+
+    Codex does not honor the speculative ``OPENAI_MAX_RETRIES`` environment
+    variable. Its native provider settings must be written into the private
+    config so a sustained retryable response does not exhaust Codex's smaller
+    built-in default first.
+    """
+    import tomllib
+
+    from omnigent.inner.codex_executor import materialize_codex_provider_config
+    from omnigent.spec.types import RetryPolicy
+
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text(
+        '[model_providers.gateway]\nname = "Gateway"\nbase_url = "https://example.test"\n'
+    )
+
+    materialize_codex_provider_config(codex_home, [])
+
+    config = tomllib.loads((codex_home / "config.toml").read_text())
+    provider = config["model_providers"]["gateway"]
+    assert provider["request_max_retries"] == RetryPolicy().max_retries
+    assert provider["stream_max_retries"] == RetryPolicy().max_retries
+    assert provider["stream_idle_timeout_ms"] == 120_000
+
+
+def test_materialize_codex_provider_config_applies_custom_retry_policy(tmp_path: Path) -> None:
+    """Agent-specific retry values override Codex provider defaults."""
+    import tomllib
+
+    from omnigent.inner.codex_executor import materialize_codex_provider_config
+    from omnigent.spec.types import RetryPolicy
+
+    codex_home = tmp_path / "codex-home"
+    retry_policy = RetryPolicy(max_retries=13, timeout_per_request_s=300)
+
+    materialize_codex_provider_config(
+        codex_home,
+        [
+            'model_providers.generated={name="Generated",'
+            'base_url="https://example.test",wire_api="responses"}'
+        ],
+        retry_policy=retry_policy,
+    )
+
+    config = tomllib.loads((codex_home / "config.toml").read_text())
+    provider = config["model_providers"]["generated"]
+    assert provider["request_max_retries"] == 13
+    assert provider["stream_max_retries"] == 13
+    assert provider["stream_idle_timeout_ms"] == 300_000
+
+
 # ---------------------------------------------------------------------------
 # _clean_codex_env tests
 # ---------------------------------------------------------------------------

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -3095,7 +3095,18 @@ def test_populate_codex_home_config_does_not_overwrite_existing(tmp_path: Path) 
     assert not (target / "auth.json").is_symlink()
 
 
-def test_materialize_codex_provider_config_applies_default_retry_policy(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "provider_config",
+    [
+        '[model_providers.gateway]\nname = "Gateway"\nbase_url = "https://example.test"\n',
+        'model_providers = { gateway = { name = "Gateway", '
+        'base_url = "https://example.test" } }\n',
+    ],
+    ids=["table", "inline-table"],
+)
+def test_materialize_codex_provider_config_applies_default_retry_policy(
+    tmp_path: Path, provider_config: str
+) -> None:
     """Private Codex providers receive Omnigent's retry budget.
 
     Codex does not honor the speculative ``OPENAI_MAX_RETRIES`` environment
@@ -3110,9 +3121,7 @@ def test_materialize_codex_provider_config_applies_default_retry_policy(tmp_path
 
     codex_home = tmp_path / "codex-home"
     codex_home.mkdir()
-    (codex_home / "config.toml").write_text(
-        '[model_providers.gateway]\nname = "Gateway"\nbase_url = "https://example.test"\n'
-    )
+    (codex_home / "config.toml").write_text(provider_config)
 
     materialize_codex_provider_config(codex_home, [])
 


### PR DESCRIPTION
## Related issue

Closes #5354

## Summary

Codex's built-in provider retries can expire before Omnigent's configured retry policy. This writes the active retry count and request timeout into every session-private Codex provider, covering existing and generated provider tables.

## Test Plan

- `.venv/bin/python -m pytest tests/inner/test_codex_executor.py -k 'materialize_codex_provider_config_applies' -q` — 2 passed.
- Rebased onto current `upstream/main`; the full GitHub check suite is running on the refreshed commit.

## Demo

![Before and after Codex provider configuration showing Omnigent retry policy materialized](https://raw.githubusercontent.com/randypitcherii/omnigent/pr-demo-assets/pr-demo/demo-5378-review-evidence.png)

The image shows the exact default and custom policy values asserted by the focused tests.

## ELI5

Omnigent already knew how long to keep retrying, but Codex could stop earlier. The private Codex configuration now receives the same retry budget.

```text
Omnigent RetryPolicy -> private Codex provider config -> Codex request + stream retries
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests assert default and custom retry policies for both existing and generated provider tables.

## Changelog

Codex sessions now honor Omnigent's configured retry count and request timeout.
