### PR TITLE
perf: defer FastAPI imports from terminal bridge

### DIFF
--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -43,7 +43,7 @@ import time
 import weakref
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 # fcntl/pty/termios are POSIX-only. This module drives tmux PTY ``attach``
 # sessions, a feature that is disabled on Windows (see the terminal
@@ -54,7 +54,8 @@ if sys.platform != "win32":
     import pty
     import termios
 
-from fastapi import WebSocket, WebSocketDisconnect
+if TYPE_CHECKING:
+    from fastapi import WebSocket
 
 _logger = logging.getLogger(__name__)
 
@@ -448,6 +449,8 @@ async def _forward_pty_to_ws(
         control frames; PTY mode has only this sender and leaves it unset.
     :returns: None on EOF or websocket disconnect.
     """
+    from fastapi import WebSocketDisconnect
+
     pending = bytearray()
     eof_seen = False
     while True:
@@ -561,6 +564,8 @@ async def bridge_tmux_pty_to_websocket(
         pane output could otherwise bypass ``set-clipboard external``. ``None``
         omits the capability frame for low-level test compatibility.
     """
+    from fastapi import WebSocketDisconnect
+
     # Attaching is itself a client interaction: tmux resizes the window to
     # the new client, which reflows the pane. Stamp it before the bridge
     # starts so that reflow is discounted.

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -22,6 +22,7 @@ import signal
 import stat
 import struct
 import subprocess
+import sys
 import termios
 import tty
 from pathlib import Path
@@ -40,6 +41,36 @@ from omnigent.terminals.ws_bridge import (
 )
 
 _HAS_TMUX = shutil.which("tmux") is not None
+
+
+def test_importing_claude_native_does_not_pull_in_fastapi() -> None:
+    """Importing the CLI module keeps the FastAPI server stack lazy.
+
+    ``claude_native`` imports terminal constants from ``ws_bridge`` on every
+    launch. The bridge must therefore avoid loading FastAPI until it is used
+    to serve a WebSocket.
+
+    :returns: None.
+    """
+    probe = (
+        "import sys\n"
+        "import omnigent.claude_native\n"
+        "assert 'fastapi' not in sys.modules, "
+        "'fastapi loaded via claude_native import'\n"
+    )
+    child_env = {**os.environ, "PYTHONPATH": os.pathsep.join(p for p in sys.path if p)}
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        env=child_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, (
+        f"claude_native import pulled in the FastAPI stack. stderr:\n{result.stderr}"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Keep FastAPI off the omnigent claude startup import path by making WebSocket type-only and loading WebSocketDisconnect only when the bridge runs.
- Add a subprocess regression test that verifies importing omnigent.claude_native does not load fastapi.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

- .venv/bin/pytest -q tests/terminals/test_ws_bridge.py (41 passed)
- .venv/bin/pre-commit run --files omnigent/terminals/ws_bridge.py tests/terminals/test_ws_bridge.py
- A fresh interpreter importing omnigent.claude_native reports fastapi loaded: False.

Fixes OMNI-2909.