### PR TITLE
fix(subagents): propagate assigned workspace to child runners

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1453,6 +1453,19 @@ def _subagent_file_ids_from_args(args: _JsonObject) -> list[str]:
     return list(raw_ids)
 
 
+def _subagent_workspace_from_args(args: _JsonObject) -> str | None:
+    """Extract the optional create-time workspace from a sub-agent send."""
+    raw_args = args.get("args")
+    if not isinstance(raw_args, dict):
+        return None
+    workspace = raw_args.get("workspace")
+    if workspace is None:
+        return None
+    if not isinstance(workspace, str) or not workspace:
+        raise ValueError("'workspace' must be a non-empty string when provided")
+    return workspace
+
+
 async def _teardown_failed_child(
     server_client: httpx.AsyncClient,
     child_session_id: str,
@@ -1628,6 +1641,47 @@ def _find_subagent_spec(sub_agent_name: str, agent_spec: AgentSpec | None) -> Ag
         if sub_agent.name == sub_agent_name:
             return sub_agent
     return None
+
+
+def _canonical_subagent_workspace(
+    workspace: str,
+    *,
+    sub_agent_name: str,
+    agent_spec: AgentSpec | None,
+) -> str:
+    """Validate a child workspace against its configured filesystem root."""
+    requested = Path(workspace)
+    if not requested.is_absolute():
+        raise ValueError("'workspace' must be an absolute path")
+    try:
+        canonical = requested.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"workspace does not exist or cannot be resolved: {workspace!r}") from exc
+    if not canonical.is_dir():
+        raise ValueError(f"workspace is not a directory: {workspace!r}")
+
+    sub_spec = _find_subagent_spec(sub_agent_name, agent_spec)
+    os_env = getattr(sub_spec, "os_env", None) if sub_spec is not None else None
+    configured_root = getattr(os_env, "cwd", None) if os_env is not None else None
+    if not isinstance(configured_root, str) or not configured_root:
+        raise ValueError(f"sub-agent {sub_agent_name!r} has no configured os_env.cwd boundary")
+    root = Path(configured_root).expanduser()
+    try:
+        canonical_root = root.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(
+            f"sub-agent {sub_agent_name!r} os_env.cwd does not exist: {configured_root!r}"
+        ) from exc
+    if not canonical_root.is_dir():
+        raise ValueError(
+            f"sub-agent {sub_agent_name!r} os_env.cwd is not a directory: {configured_root!r}"
+        )
+    if canonical != canonical_root and not canonical.is_relative_to(canonical_root):
+        raise ValueError(
+            f"workspace {str(canonical)!r} is outside sub-agent {sub_agent_name!r} "
+            f"root {str(canonical_root)!r}"
+        )
+    return str(canonical)
 
 
 def _subagent_harness(sub_agent_name: str, agent_spec: AgentSpec | None) -> str | None:
@@ -1904,6 +1958,11 @@ async def _execute_subagent_tool(
     except (ValueError, TypeError) as exc:
         return f"Error: sys_session_send invalid 'cost_budget': {exc}"
 
+    try:
+        workspace = _subagent_workspace_from_args(args)
+    except ValueError as exc:
+        return f"Error: sys_session_send invalid 'workspace': {exc}"
+
     # By-session-id mode: post to an existing direct child instead of
     # spawning/continuing a named (agent, title) sub-agent.
     target_session_id = args.get("session_id")
@@ -1921,6 +1980,13 @@ async def _execute_subagent_tool(
                 "Error: sys_session_send 'model' applies only when a "
                 "sub-agent session is first created; it cannot change an "
                 "existing session. Re-send without 'model' to continue "
+                f"session {target_session_id!r}."
+            )
+        if workspace is not None:
+            return (
+                "Error: sys_session_send 'workspace' applies only when a "
+                "sub-agent session is first created; it cannot change an "
+                "existing session. Re-send without 'workspace' to continue "
                 f"session {target_session_id!r}."
             )
         if file_ids:
@@ -1974,6 +2040,17 @@ async def _execute_subagent_tool(
     if not _has_subagent(sub_agent_name, agent_spec):
         return f"Error: sub-agent {sub_agent_name!r} not found in agent spec"
 
+    canonical_workspace: str | None = None
+    if workspace is not None:
+        try:
+            canonical_workspace = _canonical_subagent_workspace(
+                workspace,
+                sub_agent_name=sub_agent_name,
+                agent_spec=agent_spec,
+            )
+        except ValueError as exc:
+            return f"Error: sys_session_send invalid 'workspace': {exc}"
+
     dispatch_created_by = await _session_turn_actor(
         server_client=server_client,
         conversation_id=conversation_id,
@@ -2026,6 +2103,14 @@ async def _execute_subagent_tool(
                 f"{child_session_id}. Re-send without 'model' to continue "
                 "it, or sys_session_close it first to spawn a fresh "
                 "session on the requested model."
+            )
+        if canonical_workspace is not None:
+            return (
+                f"Error: sys_session_send 'workspace' applies only when a "
+                f"sub-agent session is first created; {sub_agent_name!r} "
+                f"title {session_name!r} already exists as "
+                f"{child_session_id}. Re-send without 'workspace' to continue "
+                "it, or sys_session_close it first to spawn a fresh session."
             )
         if file_ids:
             return (
@@ -2166,6 +2251,8 @@ async def _execute_subagent_tool(
             "title": f"{sub_agent_name}:{session_name}",
             "sub_agent_name": sub_agent_name,
         }
+        if canonical_workspace is not None:
+            create_body["workspace"] = canonical_workspace
         if harness_override_canonical is not None:
             create_body["harness_override"] = harness_override_canonical
         if model is not None:

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -48,6 +48,7 @@ from omnigent.runner.identity import (
     RUNNER_TUNNEL_TOKEN_HEADER,
 )
 from omnigent.runner.routing import RunnerRouter
+from omnigent.runner.session_init_protocol import build_runner_session_init_payload
 from omnigent.runtime import (
     pending_elicitations,
     user_session_stream,
@@ -193,6 +194,7 @@ from omnigent.stores.conversation_store import (
 from omnigent.stores.file_store import FileStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.project_store import ProjectStore
+from omnigent.version import VERSION
 
 
 def register_core_routes(
@@ -334,11 +336,10 @@ def register_core_routes(
             try:
                 await _rc.post(
                     "/v1/sessions",
-                    json={
-                        "session_id": resp.id,
-                        "agent_id": conv.agent_id,
-                        "sub_agent_name": conv.sub_agent_name,
-                    },
+                    json=build_runner_session_init_payload(
+                        conv,
+                        server_version=VERSION,
+                    ),
                     timeout=10.0,
                 )
             except (httpx.HTTPError, ConnectionError):

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -285,7 +285,8 @@ def _build_sys_session_send_schema(
             "The user-input message to send to the sub-agent. The sub-agent "
             "treats this as the first user turn in its conversation. Pass a "
             "plain string for the normal contract, or pass "
-            "{input, purpose, model, harness, cost_budget} when a spec-level "
+            "{input, purpose, model, workspace, harness, cost_budget} when a "
+            "spec-level "
             "policy requires explicit dispatch metadata, a per-dispatch model "
             "override, an allowlisted harness override, or a per-subagent "
             "cost budget."
@@ -295,7 +296,8 @@ def _build_sys_session_send_schema(
             "The user-input message to send to the sub-agent. The sub-agent "
             "treats this as the first user turn in its conversation. Pass a "
             "plain string for the normal contract, or pass "
-            "{input, purpose, model, cost_budget} when a spec-level policy "
+            "{input, purpose, model, workspace, cost_budget} when a spec-level "
+            "policy "
             "requires explicit dispatch metadata, a per-dispatch model "
             "override, or a per-subagent cost budget."
         )
@@ -352,6 +354,18 @@ def _build_sys_session_send_schema(
                                             "Applies only when this send "
                                             "CREATES the sub-agent session; "
                                             "omitted = the harness default."
+                                        ),
+                                    },
+                                    "workspace": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "description": (
+                                            "Optional absolute workspace for the "
+                                            "sub-agent. The path must exist, be a "
+                                            "directory, and resolve inside the "
+                                            "sub-agent's configured os_env.cwd. "
+                                            "Applies only when this send CREATES "
+                                            "the sub-agent session."
                                         ),
                                     },
                                     "file_ids": {

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -3074,7 +3074,9 @@ async def test_sys_session_send_existing_child_retries_without_rejected_actor(
     assert "created_by" not in event_posts[1]
 
 
-def _spec_with_subagent_harness(harness: str) -> SimpleNamespace:
+def _spec_with_subagent_harness(
+    harness: str, workspace_root: Path | None = None
+) -> SimpleNamespace:
     """
     Build a parent-spec stub declaring one ``worker`` sub-agent.
 
@@ -3091,9 +3093,244 @@ def _spec_with_subagent_harness(harness: str) -> SimpleNamespace:
             SimpleNamespace(
                 name="worker",
                 executor=SimpleNamespace(type="omnigent", config={"harness": harness}),
+                os_env=(
+                    SimpleNamespace(cwd=str(workspace_root))
+                    if workspace_root is not None
+                    else None
+                ),
             )
         ]
     )
+
+
+@pytest.mark.asyncio
+async def test_sys_session_send_workspace_lands_in_child_create_body(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A fresh child create receives the canonical assigned workspace."""
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    worker_root = tmp_path / "workers"
+    workspace = worker_root / "task"
+    workspace.mkdir(parents=True)
+    create_bodies: list[dict[str, Any]] = []
+    monkeypatch.setattr(runner_app, "get_session_agent_id", lambda _sid: "ag_parent")
+    monkeypatch.setattr(runner_app, "register_child_session", lambda *a, **k: None)
+    session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path.endswith("/child_sessions"):
+            return httpx.Response(200, json={"data": []})
+        if request.method == "POST" and request.url.path == "/v1/sessions":
+            create_bodies.append(json.loads(request.content))
+            return httpx.Response(201, json={"id": "conv_child_workspace"})
+        if request.method == "POST" and request.url.path.endswith("/events"):
+            return httpx.Response(202, json={"queued": True})
+        return httpx.Response(404)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler), base_url="http://server"
+    ) as server_client:
+        try:
+            output = await execute_tool(
+                tool_name="sys_session_send",
+                arguments=json.dumps(
+                    {
+                        "agent": "worker",
+                        "title": "task",
+                        "args": {
+                            "input": "do it",
+                            "workspace": str(workspace),
+                        },
+                    }
+                ),
+                server_client=server_client,
+                conversation_id="conv_parent_workspace",
+                agent_spec=_spec_with_subagent_harness("claude-native", worker_root),
+                session_inbox=session_inbox,
+            )
+        finally:
+            runner_app.unregister_subagent_work("conv_child_workspace")
+            runner_app._session_inboxes_ref.pop("conv_parent_workspace", None)
+
+    assert json.loads(output)["status"] == "launching"
+    assert create_bodies == [
+        {
+            "agent_id": "ag_parent",
+            "parent_session_id": "conv_parent_workspace",
+            "title": "worker:task",
+            "sub_agent_name": "worker",
+            "workspace": str(workspace.resolve()),
+        }
+    ]
+
+
+def test_subagent_workspace_resolves_relative_os_env_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A common ``cwd: .`` boundary resolves from the runner's cwd."""
+    from omnigent.runner.tool_dispatch import _canonical_subagent_workspace
+
+    workspace = tmp_path / "task"
+    workspace.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    assert _canonical_subagent_workspace(
+        str(workspace),
+        sub_agent_name="worker",
+        agent_spec=_spec_with_subagent_harness("claude-native", Path(".")),
+    ) == str(workspace.resolve())
+
+
+@pytest.mark.asyncio
+async def test_sys_session_send_rejects_workspace_outside_worker_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A canonical workspace cannot escape the worker's os_env.cwd."""
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    worker_root = tmp_path / "workers"
+    worker_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    monkeypatch.setattr(runner_app, "get_session_agent_id", lambda _sid: "ag_parent")
+    session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    requests_seen = 0
+
+    async def _server_handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal requests_seen
+        requests_seen += 1
+        return httpx.Response(500)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler), base_url="http://server"
+    ) as server_client:
+        try:
+            output = await execute_tool(
+                tool_name="sys_session_send",
+                arguments=json.dumps(
+                    {
+                        "agent": "worker",
+                        "title": "task",
+                        "args": {"input": "do it", "workspace": str(outside)},
+                    }
+                ),
+                server_client=server_client,
+                conversation_id="conv_parent_outside",
+                agent_spec=_spec_with_subagent_harness("claude-native", worker_root),
+                session_inbox=session_inbox,
+            )
+        finally:
+            runner_app._session_inboxes_ref.pop("conv_parent_outside", None)
+
+    assert output.startswith("Error:")
+    assert "outside" in output
+    assert requests_seen == 0
+
+
+@pytest.mark.asyncio
+async def test_sys_session_send_rejects_workspace_in_by_id_mode(tmp_path: Path) -> None:
+    """A create-time workspace cannot alter a child addressed by id."""
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    requests_seen = 0
+    session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def _server_handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal requests_seen
+        requests_seen += 1
+        return httpx.Response(500)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler), base_url="http://server"
+    ) as server_client:
+        try:
+            output = await execute_tool(
+                tool_name="sys_session_send",
+                arguments=json.dumps(
+                    {
+                        "session_id": "conv_existing",
+                        "args": {"input": "continue", "workspace": str(tmp_path)},
+                    }
+                ),
+                server_client=server_client,
+                conversation_id="conv_parent_existing_workspace",
+                session_inbox=session_inbox,
+            )
+        finally:
+            runner_app._session_inboxes_ref.pop("conv_parent_existing_workspace", None)
+
+    assert output.startswith("Error:")
+    assert "workspace" in output
+    assert requests_seen == 0
+
+
+@pytest.mark.asyncio
+async def test_sys_session_send_rejects_workspace_for_existing_named_child(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A create-time workspace cannot alter an existing named child."""
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    worker_root = tmp_path / "workers"
+    worker_root.mkdir()
+    writes_seen = 0
+    monkeypatch.setattr(runner_app, "get_session_agent_id", lambda _sid: "ag_parent")
+    session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal writes_seen
+        if request.method == "GET" and request.url.path.endswith("/child_sessions"):
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "conv_existing_workspace",
+                            "tool": "worker",
+                            "session_name": "task",
+                            "busy": False,
+                        }
+                    ]
+                },
+            )
+        if request.method == "POST":
+            writes_seen += 1
+        return httpx.Response(404)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler), base_url="http://server"
+    ) as server_client:
+        try:
+            output = await execute_tool(
+                tool_name="sys_session_send",
+                arguments=json.dumps(
+                    {
+                        "agent": "worker",
+                        "title": "task",
+                        "args": {"input": "continue", "workspace": str(worker_root)},
+                    }
+                ),
+                server_client=server_client,
+                conversation_id="conv_parent_named_workspace",
+                agent_spec=_spec_with_subagent_harness("claude-native", worker_root),
+                session_inbox=session_inbox,
+            )
+        finally:
+            runner_app._session_inboxes_ref.pop("conv_parent_named_workspace", None)
+
+    assert output.startswith("Error:")
+    assert "conv_existing_workspace" in output
+    assert "sys_session_close" in output
+    assert writes_seen == 0
 
 
 @pytest.mark.asyncio

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -31,6 +31,7 @@ import yaml
 from omnigent.entities import Conversation
 from omnigent.entities.conversation import MessageData, NewConversationItem
 from omnigent.server.routes import sessions as sessions_module
+from omnigent.server.routes.sessions import routes_core as routes_core_module
 from omnigent.server.routes.sessions import routes_events as routes_events_module
 from omnigent.session_lifecycle import CLOSED_LABEL_KEY, CLOSED_LABEL_VALUE
 from omnigent.stores.conversation_store.sqlalchemy_store import (
@@ -1315,6 +1316,57 @@ async def test_native_subagent_yolo_args_derived_from_trusted_spec(
     # The persisted child session carries exactly the YOLO bypass flags;
     # an empty / None value would mean the worker launches prompting.
     assert resp.json()["terminal_launch_args"] == expected_args
+
+
+async def test_live_runner_child_create_receives_persisted_workspace_snapshot(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The eager runner notification carries the child's persisted workspace."""
+    parent = await _create_parent_with_subagents(
+        client,
+        name="orch-child-workspace-snapshot",
+        sub_agents=[{"name": "impl", "harness": "claude-native"}],
+    )
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    assert conv_store.set_runner_id(parent["session_id"], "runner-live-parent")
+
+    notifications: list[dict[str, Any]] = []
+
+    def _runner_handler(request: httpx.Request) -> httpx.Response:
+        notifications.append(json.loads(request.content))
+        return httpx.Response(200, json={"session_init_protocol_version": 2})
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(_runner_handler),
+        base_url="http://runner",
+    )
+
+    async def _runner_live(*_args: Any, **_kwargs: Any) -> httpx.AsyncClient:
+        return fake_runner
+
+    monkeypatch.setattr(routes_core_module, "_get_runner_client", _runner_live)
+    try:
+        resp = await client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": parent["agent_id"],
+                "parent_session_id": parent["session_id"],
+                "title": "impl:assigned",
+                "sub_agent_name": "impl",
+                "workspace": "/assigned/child-worktree",
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 201, resp.text
+    assert len(notifications) == 1
+    envelope = notifications[0]["session_init"]
+    assert envelope["session_id"] == resp.json()["id"]
+    assert envelope["sub_agent_name"] == "impl"
+    assert envelope["snapshot"]["workspace"] == "/assigned/child-worktree"
 
 
 async def test_native_subagent_yolo_args_reject_overlong_spec_value(

--- a/tests/tools/builtins/test_spawn.py
+++ b/tests/tools/builtins/test_spawn.py
@@ -58,6 +58,13 @@ def test_file_ids_present_and_optional() -> None:
     assert branch["additionalProperties"] is False
 
 
+def test_workspace_present_and_optional() -> None:
+    branch = _object_branch()
+    assert branch["properties"]["workspace"]["type"] == "string"
+    assert branch["properties"]["workspace"]["minLength"] == 1
+    assert "workspace" not in branch["required"]
+
+
 def test_description_mentions_file_ids() -> None:
     schema = _schema_with_subagent()
     assert "file_ids" in schema["function"]["description"]
@@ -97,6 +104,10 @@ def test_object_args_without_file_ids_validate() -> None:
     _validate({"input": "go"})
 
 
+def test_object_args_with_workspace_validate() -> None:
+    _validate({"input": "go", "workspace": "/tmp/worktree"})
+
+
 def test_plain_string_args_validate() -> None:
     _validate("just a message")
 
@@ -112,6 +123,12 @@ def test_file_ids_string_rejected() -> None:
 def test_empty_file_ids_rejected() -> None:
     with pytest.raises(jsonschema.ValidationError):
         _validate({"input": "go", "file_ids": []})
+
+
+@pytest.mark.parametrize("workspace", ["", 123, True, []])
+def test_invalid_workspace_rejected(workspace: object) -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        _validate({"input": "go", "workspace": workspace})
 
 
 def test_duplicate_file_ids_allowed() -> None:

--- a/tests/tools/builtins/test_sys_session.py
+++ b/tests/tools/builtins/test_sys_session.py
@@ -192,6 +192,7 @@ def test_send_schema_advertises_plain_string_and_purpose_object_args() -> None:
         "input",
         "purpose",
         "model",
+        "workspace",
         "file_ids",
         "cost_budget",
     }
@@ -202,6 +203,12 @@ def test_send_schema_advertises_plain_string_and_purpose_object_args() -> None:
     assert object_schema["properties"]["model"]["type"] == "string"
     assert "CREATES" in model_desc
     assert "harness default" in model_desc
+    workspace_schema = object_schema["properties"]["workspace"]
+    assert "workspace" not in object_schema["required"]
+    assert workspace_schema["type"] == "string"
+    assert workspace_schema["minLength"] == 1
+    assert "absolute" in workspace_schema["description"]
+    assert "CREATES" in workspace_schema["description"]
 
 
 def _object_branch_props(tool: SysSessionSendTool) -> set[str]:
@@ -220,8 +227,9 @@ def test_send_schema_gates_harness_field_behind_allowlist_opt_in() -> None:
     Per design D.4 the runtime harness override is allowlist-gated: the
     schema exposes ``harness`` only when at least one declared sub-agent
     declares a non-empty ``executor.config.allowed_harnesses``. A sub-agent
-    without that opt-in keeps the base ``{input, purpose, model, file_ids}``
-    args object, so the orchestrator never sees a harness knob it cannot use.
+    without that opt-in keeps the base
+    ``{input, purpose, model, workspace, file_ids, cost_budget}`` args object,
+    so the orchestrator never sees a harness knob it cannot use.
     This mirrors the per-child dispatch guard in tool_dispatch.py — the two
     gates must agree on what "opted in" means.
     """
@@ -233,6 +241,7 @@ def test_send_schema_gates_harness_field_behind_allowlist_opt_in() -> None:
         "input",
         "purpose",
         "model",
+        "workspace",
         "file_ids",
         "cost_budget",
     }
@@ -257,6 +266,7 @@ def test_send_schema_gates_harness_field_behind_allowlist_opt_in() -> None:
         "input",
         "purpose",
         "model",
+        "workspace",
         "file_ids",
         "harness",
         "cost_budget",
@@ -283,6 +293,7 @@ def test_send_schema_gates_harness_field_behind_allowlist_opt_in() -> None:
         "input",
         "purpose",
         "model",
+        "workspace",
         "file_ids",
         "harness",
         "cost_budget",


### PR DESCRIPTION
cat > /tmp/omnigent-workspace-pr.md <<'EOF'
## Related issue

Closes #5376

## Summary

- Add an optional create-time `workspace` to the object form of `sys_session_send`.
- Canonicalize and validate the workspace against the selected sub-agent's configured `os_env.cwd`, rejecting nonexistent paths, non-directories, reuse attempts, traversal, and symlink escapes.
- Persist the workspace on the child session and use the standard session-init snapshot for eager runner initialization so the runner receives the assigned runtime cwd.

ELI5: a child agent assigned to a particular folder now keeps that folder all the way from dispatch through runner startup.

```text
sys_session_send
      |
      v
canonicalize + validate against os_env.cwd
      |
      v
persist child session workspace
      |
      v
standard runner init snapshot
      |
      v
child runtime cwd
