### PR TITLE
Fix compaction boundaries when forking sessions

### DIFF
--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3659,11 +3659,32 @@ class SqlAlchemyConversationStore(ConversationStore):
                 items_query = items_query.where(SqlConversationItem.position <= cutoff_position)
             source_items = session.execute(items_query).scalars().all()
 
+            # Compaction cursors refer to item IDs. Since every copied item gets
+            # a fresh ID, build the complete mapping before copying any payloads
+            # so compaction records can point at the fork's boundary item.
+            copied_item_ids = {
+                src_item.id: generate_item_id(decode_item_type(src_item.type))
+                for src_item in source_items
+            }
+            decoded_item_data = self._decode_item_data_batch(
+                [src_item.data for src_item in source_items]
+            )
+
             fts_rows: list[tuple[str, str, str]] = []
-            for pos, src_item in enumerate(source_items):
+            for pos, (src_item, decoded_data) in enumerate(
+                zip(source_items, decoded_item_data, strict=True)
+            ):
                 # src_item.type/status are int codes copied verbatim to the new
-                # row; only generate_item_id needs the decoded string type.
-                new_item_id = generate_item_id(decode_item_type(src_item.type))
+                # row. Compaction data is the sole payload containing an item ID.
+                new_item_id = copied_item_ids[src_item.id]
+                copied_data = decoded_data
+                if decode_item_type(src_item.type) == "compaction":
+                    compaction_data = json.loads(decoded_data)
+                    boundary_id = compaction_data.get("last_item_id")
+                    mapped_boundary_id = copied_item_ids.get(boundary_id)
+                    if mapped_boundary_id is not None:
+                        compaction_data["last_item_id"] = mapped_boundary_id
+                        copied_data = json.dumps(compaction_data)
                 new_item = SqlConversationItem(
                     id=new_item_id,
                     conversation_id=new_conv.id,
@@ -3672,7 +3693,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     status=src_item.status,
                     position=pos,
                     type=src_item.type,
-                    data=src_item.data,
+                    data=self._encode_item_data(copied_data),
                     search_text=src_item.search_text,
                     created_by=src_item.created_by,
                 )

--- a/tests/e2e/test_host_claude_native_fork_e2e.py
+++ b/tests/e2e/test_host_claude_native_fork_e2e.py
@@ -630,6 +630,32 @@ def test_compacted_fork_remaps_boundary_and_continues_with_claude(
                 f"resumed compacted fork should answer exactly {marker!r}, got {text!r}"
             )
 
+            # Resuming the compacted transcript must consume its existing
+            # boundary, not run compaction again because older audit items
+            # remain stored on the fork.
+            resumed_items_resp = http_client.get(
+                f"/v1/sessions/{fork_id}/items",
+                params={"limit": 100, "order": "asc"},
+                timeout=30.0,
+            )
+            resumed_items_resp.raise_for_status()
+            resumed_compactions = [
+                item
+                for item in resumed_items_resp.json()["data"]
+                if item.get("type") == "compaction"
+            ]
+            assert len(resumed_compactions) == 1, (
+                "resuming the compacted fork unexpectedly persisted another compaction; "
+                f"got {len(resumed_compactions)}"
+            )
+            resumed_compaction = resumed_compactions[0]
+            assert resumed_compaction["id"] == fork_compaction["id"], (
+                "resume replaced the fork's original compaction record"
+            )
+            assert resumed_compaction.get("last_item_id") == fork_boundary_id, (
+                "resume changed the fork's remapped compaction boundary"
+            )
+
 
 def test_fork_resume_worktree_carries_history(
     live_server: str,

--- a/tests/e2e/test_host_claude_native_fork_e2e.py
+++ b/tests/e2e/test_host_claude_native_fork_e2e.py
@@ -459,6 +459,8 @@ def test_compacted_fork_remaps_boundary_and_continues_with_claude(
 
     with _workspaces_trusted_in_claude_config([workspace]):
         with _host_daemon(tmp_path, live_server):
+            # 1. Launch a real Claude Code session and seed history that must
+            # survive both compaction and the subsequent fork.
             host_id = _online_host_id(http_client, timeout=30.0)
             agent_id = _claude_native_agent_id(http_client)
             source_id = _create_native_session(
@@ -480,9 +482,8 @@ def test_compacted_fork_remaps_boundary_and_continues_with_claude(
             )
             _wait_for_external_session_id(http_client, session_id=source_id, timeout=60.0)
 
-            # Claude refuses /compact for a one-turn transcript even when
-            # startup instructions consume a substantial part of the context
-            # window. Commit a second real turn so compaction is eligible.
+            # 2. Complete the second real turn Claude requires before it will
+            # accept /compact, even with substantial startup instructions.
             second_ack = f"SECOND_ACK_{uuid.uuid4().hex[:6].upper()}"
             _send_user_message(
                 http_client,
@@ -496,23 +497,62 @@ def test_compacted_fork_remaps_boundary_and_continues_with_claude(
                 timeout=180.0,
             )
 
+            # 3. Invoke Claude Code's real /compact flow and validate the
+            # source cursor before forking through the public session API.
             compact = http_client.post(
                 f"/v1/sessions/{source_id}/events",
                 json={"type": "compact", "data": {}},
                 timeout=30.0,
             )
-            assert compact.status_code == 202, compact.text
+            assert compact.status_code == 202, (
+                f"compact request returned {compact.status_code}: {compact.text}"
+            )
+            assert compact.json() == {"queued": False}, (
+                f"compact request returned an unexpected acknowledgement: {compact.json()!r}"
+            )
             source_compaction = _wait_for_compaction_item(
                 http_client,
                 session_id=source_id,
                 timeout=180.0,
             )
+            source_summary = source_compaction.get("summary")
+            assert isinstance(source_summary, str) and source_summary.strip(), (
+                f"source compaction did not persist a non-empty summary: {source_compaction!r}"
+            )
+            source_boundary_id = source_compaction.get("last_item_id")
+            assert isinstance(source_boundary_id, str) and source_boundary_id, (
+                f"source compaction did not persist a string boundary: {source_compaction!r}"
+            )
 
+            source_items_resp = http_client.get(
+                f"/v1/sessions/{source_id}/items",
+                params={"limit": 100, "order": "asc"},
+                timeout=30.0,
+            )
+            source_items_resp.raise_for_status()
+            source_items = source_items_resp.json()["data"]
+            source_ids = {item["id"] for item in source_items}
+            assert len(source_ids) == len(source_items), "source item IDs must be unique"
+            assert source_boundary_id in source_ids, (
+                f"source compaction boundary {source_boundary_id!r} does not reference a "
+                f"source item; source IDs: {sorted(source_ids)!r}"
+            )
+            source_compactions = [
+                item for item in source_items if item.get("type") == "compaction"
+            ]
+            assert len(source_compactions) == 1, (
+                f"expected exactly one source compaction, got {len(source_compactions)}"
+            )
+
+            # 4. Fork the compacted session and prove every item received a
+            # fresh ID while type/response ordering and the cursor position
+            # were preserved exactly.
             fork_id = _fork_session(
                 http_client,
                 source_id=source_id,
                 title=f"compacted clone of {source_id}",
             )
+            assert fork_id != source_id, "fork endpoint returned the source session ID"
             fork_items_resp = http_client.get(
                 f"/v1/sessions/{fork_id}/items",
                 params={"limit": 100, "order": "asc"},
@@ -520,11 +560,51 @@ def test_compacted_fork_remaps_boundary_and_continues_with_claude(
             )
             fork_items_resp.raise_for_status()
             fork_items = fork_items_resp.json()["data"]
-            fork_compaction = next(item for item in fork_items if item.get("type") == "compaction")
-            fork_boundary_id = fork_compaction["last_item_id"]
-            assert fork_boundary_id != source_compaction["last_item_id"]
-            assert fork_boundary_id in {item["id"] for item in fork_items}
+            fork_ids = {item["id"] for item in fork_items}
+            assert len(fork_ids) == len(fork_items), "fork item IDs must be unique"
+            assert len(fork_items) == len(source_items), (
+                f"fork copied {len(fork_items)} items from a {len(source_items)}-item source"
+            )
+            assert source_ids.isdisjoint(fork_ids), (
+                f"fork reused source item IDs: {sorted(source_ids & fork_ids)!r}"
+            )
 
+            source_shape = [(item.get("type"), item.get("response_id")) for item in source_items]
+            fork_shape = [(item.get("type"), item.get("response_id")) for item in fork_items]
+            assert fork_shape == source_shape, (
+                "fork changed ordered item types/response IDs: "
+                f"source={source_shape!r}, fork={fork_shape!r}"
+            )
+
+            fork_compactions = [item for item in fork_items if item.get("type") == "compaction"]
+            assert len(fork_compactions) == 1, (
+                f"expected exactly one fork compaction, got {len(fork_compactions)}"
+            )
+            fork_compaction = fork_compactions[0]
+            assert fork_compaction.get("summary") == source_summary, (
+                "fork did not preserve the source compaction summary"
+            )
+            fork_boundary_id = fork_compaction.get("last_item_id")
+            assert isinstance(fork_boundary_id, str) and fork_boundary_id, (
+                f"fork compaction did not persist a string boundary: {fork_compaction!r}"
+            )
+            source_boundary_position = next(
+                index
+                for index, item in enumerate(source_items)
+                if item["id"] == source_boundary_id
+            )
+            expected_fork_boundary_id = fork_items[source_boundary_position]["id"]
+            assert fork_boundary_id == expected_fork_boundary_id, (
+                "fork compaction cursor did not map to the clone of the source boundary: "
+                f"expected {expected_fork_boundary_id!r} at position "
+                f"{source_boundary_position}, got {fork_boundary_id!r}"
+            )
+            assert fork_boundary_id != source_boundary_id, (
+                "fork compaction cursor still references the source item ID"
+            )
+
+            # 5. Resume the cloned real-Claude transcript and demand exact
+            # recall, proving the remapped compacted session remains usable.
             _launch_runner(
                 http_client,
                 host_id=host_id,
@@ -546,7 +626,9 @@ def test_compacted_fork_remaps_boundary_and_continues_with_claude(
                 marker=marker,
                 timeout=180.0,
             )
-            assert marker in text
+            assert text.strip() == marker, (
+                f"resumed compacted fork should answer exactly {marker!r}, got {text!r}"
+            )
 
 
 def test_fork_resume_worktree_carries_history(

--- a/tests/e2e/test_host_claude_native_fork_e2e.py
+++ b/tests/e2e/test_host_claude_native_fork_e2e.py
@@ -203,6 +203,41 @@ def _wait_for_external_session_id(client: httpx.Client, *, session_id: str, time
     )
 
 
+def _wait_for_compaction_item(
+    client: httpx.Client,
+    *,
+    session_id: str,
+    timeout: float,
+) -> dict[str, object]:
+    """Wait until Claude Code's real ``/compact`` persists its boundary.
+
+    :param client: HTTP client pointed at the test server.
+    :param session_id: Source session being compacted.
+    :param timeout: Maximum seconds to wait for the transcript forwarder.
+    :returns: The flattened compaction item from ``GET /items``.
+    :raises AssertionError: If no compaction item appears in time.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp = client.get(
+            f"/v1/sessions/{session_id}/items",
+            params={"limit": 100, "order": "desc"},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        compaction = next(
+            (item for item in resp.json().get("data", []) if item.get("type") == "compaction"),
+            None,
+        )
+        if compaction is not None:
+            return dict(compaction)
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(
+        f"Claude Code /compact did not persist a compaction item for "
+        f"{session_id} within {timeout}s"
+    )
+
+
 def _fork_session(
     client: httpx.Client, *, source_id: str, title: str, agent_id: str | None = None
 ) -> str:
@@ -403,6 +438,115 @@ def test_fork_resume_same_dir_carries_history(
                 resume_workspace=workspace,
                 git=None,
             )
+
+
+def test_compacted_fork_remaps_boundary_and_continues_with_claude(
+    live_server: str,
+    http_client: httpx.Client,
+    tmp_path: Path,
+) -> None:
+    """A real Claude Code compaction remains valid after fork and resume.
+
+    Runs an actual Claude turn, invokes ``/compact`` in its live TUI,
+    waits for the hook/transcript forwarder to persist the boundary, and
+    forks through the public session API. The fork must remap the boundary
+    to one of its fresh item IDs, then its cloned Claude session must resume
+    and recall the pre-compaction marker.
+    """
+    workspace = tmp_path / "compacted-fork-workspace"
+    workspace.mkdir()
+    marker = f"COMPACT_FORK_{uuid.uuid4().hex[:6].upper()}"
+
+    with _workspaces_trusted_in_claude_config([workspace]):
+        with _host_daemon(tmp_path, live_server):
+            host_id = _online_host_id(http_client, timeout=30.0)
+            agent_id = _claude_native_agent_id(http_client)
+            source_id = _create_native_session(
+                http_client,
+                agent_id=agent_id,
+                host_id=host_id,
+                workspace=workspace,
+            )
+            _send_user_message(
+                http_client,
+                session_id=source_id,
+                text=f"Remember {marker}. Reply with exactly ACK.",
+            )
+            _poll_for_assistant_marker(
+                http_client,
+                session_id=source_id,
+                marker="ACK",
+                timeout=180.0,
+            )
+            _wait_for_external_session_id(http_client, session_id=source_id, timeout=60.0)
+
+            # Claude refuses /compact for a one-turn transcript even when
+            # startup instructions consume a substantial part of the context
+            # window. Commit a second real turn so compaction is eligible.
+            second_ack = f"SECOND_ACK_{uuid.uuid4().hex[:6].upper()}"
+            _send_user_message(
+                http_client,
+                session_id=source_id,
+                text=f"Reply with exactly {second_ack}.",
+            )
+            _poll_for_assistant_marker(
+                http_client,
+                session_id=source_id,
+                marker=second_ack,
+                timeout=180.0,
+            )
+
+            compact = http_client.post(
+                f"/v1/sessions/{source_id}/events",
+                json={"type": "compact", "data": {}},
+                timeout=30.0,
+            )
+            assert compact.status_code == 202, compact.text
+            source_compaction = _wait_for_compaction_item(
+                http_client,
+                session_id=source_id,
+                timeout=180.0,
+            )
+
+            fork_id = _fork_session(
+                http_client,
+                source_id=source_id,
+                title=f"compacted clone of {source_id}",
+            )
+            fork_items_resp = http_client.get(
+                f"/v1/sessions/{fork_id}/items",
+                params={"limit": 100, "order": "asc"},
+                timeout=30.0,
+            )
+            fork_items_resp.raise_for_status()
+            fork_items = fork_items_resp.json()["data"]
+            fork_compaction = next(item for item in fork_items if item.get("type") == "compaction")
+            fork_boundary_id = fork_compaction["last_item_id"]
+            assert fork_boundary_id != source_compaction["last_item_id"]
+            assert fork_boundary_id in {item["id"] for item in fork_items}
+
+            _launch_runner(
+                http_client,
+                host_id=host_id,
+                session_id=fork_id,
+                workspace=workspace,
+                git=None,
+            )
+            _send_user_message(
+                http_client,
+                session_id=fork_id,
+                text=(
+                    "What marker did I ask you to remember before compaction? "
+                    "Reply with exactly that marker."
+                ),
+            )
+            text = _poll_for_assistant_marker(
+                http_client,
+                session_id=fork_id,
+                marker=marker,
+                timeout=180.0,
+            )
+            assert marker in text
 
 
 def test_fork_resume_worktree_carries_history(

--- a/tests/e2e/test_sessions_fork_e2e.py
+++ b/tests/e2e/test_sessions_fork_e2e.py
@@ -265,7 +265,10 @@ def test_full_fork_replays_whole_history(
     )
 
 
+# Compaction-cursor remapping is server-side behavior introduced in v0.11.
+# A new runner paired with an old server must skip this new-server contract.
 @pytest.mark.compat_smoke
+@pytest.mark.min_server_version("0.11.0")
 def test_fork_preserves_compacted_context_boundary(
     http_client: httpx.Client,
     live_runner_id: str,

--- a/tests/e2e/test_sessions_fork_e2e.py
+++ b/tests/e2e/test_sessions_fork_e2e.py
@@ -265,6 +265,61 @@ def test_full_fork_replays_whole_history(
     )
 
 
+@pytest.mark.compat_smoke
+def test_fork_preserves_compacted_context_boundary(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    mock_llm_server_url: str,
+) -> None:
+    """Forking a compacted session remaps its cursor and remains executable."""
+    reset_mock_llm(mock_llm_server_url)
+    agent_name, model = _register_mock_fork_agent(
+        http_client, mock_llm_server_url, prefix="compacted"
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "OK"}, {"text": "OK"}, {"text": "context preserved"}],
+        key=model,
+    )
+    source_id = _seed_two_codeword_turns(
+        http_client, agent_name=agent_name, runner_id=live_runner_id
+    )
+    source = http_client.get(f"/v1/sessions/{source_id}").json()
+    boundary = next(
+        item
+        for item in source["items"]
+        if item.get("type") == "message" and (item.get("data") or {}).get("role") == "assistant"
+    )
+    compact = http_client.post(
+        f"/v1/sessions/{source_id}/events",
+        json={
+            "type": "compaction",
+            "data": {
+                "summary": f"The user mentioned {_CODEWORD_1}.",
+                "last_item_id": boundary["id"],
+                "token_count": 12,
+            },
+        },
+    )
+    assert compact.status_code == 202, compact.text
+
+    fork = _fork_session(http_client, source_id, runner_id=live_runner_id)
+    fork_items = fork["items"]
+    fork_compaction = next(item for item in fork_items if item.get("type") == "compaction")
+    fork_ids = {item["id"] for item in fork_items}
+    fork_boundary_id = fork_compaction["data"]["last_item_id"]
+    assert fork_boundary_id in fork_ids
+    assert fork_boundary_id != boundary["id"]
+
+    response_id = send_user_message_to_session(
+        http_client,
+        session_id=fork["id"],
+        content="Confirm that the compacted fork can continue.",
+    )
+    body = poll_session_until_terminal(http_client, session_id=fork["id"], response_id=response_id)
+    assert body["status"] == "completed", body.get("error")
+
+
 # Truncating a fork at a mid-conversation cutoff (dropping the post-cutoff turn)
 # is server-side behavior that shipped after v0.2.0 — a v0.2.0 server keeps the
 # post-cutoff turn, so main's test (unchanged) fails against it (server-behavior

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -7,6 +7,7 @@ from sqlalchemy import event, text
 
 from omnigent.db.utils import get_or_create_engine
 from omnigent.entities import (
+    CompactionData,
     ErrorData,
     FunctionCallData,
     FunctionCallOutputData,
@@ -3469,6 +3470,54 @@ def test_fork_conversation_copies_items(
         assert fork_item.response_id == src_item.response_id
         # Data content is identical.
         assert fork_item.data == src_item.data
+
+
+def test_fork_remaps_compaction_boundary_to_copied_item(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A fork's compaction cursor must not keep an item ID from its source."""
+    source = conversation_store.create_conversation()
+    [boundary] = conversation_store.append(
+        source.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_001",
+                data=MessageData(role="user", content=[{"type": "input_text", "text": "old"}]),
+            )
+        ],
+    )
+    conversation_store.append(
+        source.id,
+        [
+            NewConversationItem(
+                type="compaction",
+                response_id="compact_001",
+                data=CompactionData(
+                    summary="The user said old.",
+                    last_item_id=boundary.id,
+                    token_count=6,
+                ),
+            )
+        ],
+    )
+    conversation_store.append(
+        source.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_002",
+                data=MessageData(role="user", content=[{"type": "input_text", "text": "recent"}]),
+            )
+        ],
+    )
+
+    fork = conversation_store.fork_conversation(source.id)
+    fork_items = conversation_store.list_items(fork.id).data
+    fork_compaction = next(item for item in fork_items if item.type == "compaction")
+    assert isinstance(fork_compaction.data, CompactionData)
+    assert fork_compaction.data.last_item_id != boundary.id
+    assert fork_compaction.data.last_item_id == fork_items[0].id
 
 
 def test_fork_of_sub_agent_is_top_level(


### PR DESCRIPTION
## Related issue

N/A — reported directly and reproduced locally.

## Summary

- Remap each copied compaction cursor from its source item ID to the corresponding fresh item ID in the fork.
- Decode and re-encode copied item payloads through the store hooks, preserving encrypted/compressed store compatibility.
- Add deterministic unit/mock coverage plus a real Claude Code terminal journey that turns twice, compacts, forks, launches the clone, and recalls pre-compaction context.

ELI5: a fork gives every history item a new ID, but its bookmark still pointed to the old conversation. This updates the bookmark to the matching item in the fork.

```text
source boundary ID ──fork ID map──> cloned boundary ID
        │                                  │
compaction cursor                    remapped cursor
```

## Test Plan

- `uv run --no-sync pytest tests/stores/test_conversation_store.py -q` — 186 passed, 1 skipped.
- `uv run --no-sync pytest tests/stores/test_conversation_store.py::test_fork_remaps_compaction_boundary_to_copied_item tests/e2e/test_sessions_fork_e2e.py::test_fork_preserves_compacted_context_boundary -q --no-header` — 2 passed.
- `OMNIGENT_E2E_CLAUDE_NATIVE=1 uv run --no-sync pytest tests/e2e/test_host_claude_native_fork_e2e.py::test_compacted_fork_remaps_boundary_and_continues_with_claude --llm-api-key=mock-key -v --tb=short` — passed on this branch with real Claude Code 2.1.241 in 51.81s.
- The identical live test in a detached `upstream/main` worktree failed in 48.08s: the fork's `last_item_id` exactly equaled the source's stale boundary ID.
- Scoped Ruff check and format check passed for all changed files.

## Demo

N/A — non-visual storage/runtime fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The deterministic e2e posts a compaction event through the HTTP API. The opt-in live e2e launches the actual Claude Code terminal harness, completes two real model turns, invokes `/compact`, waits for the hook/transcript forwarder to persist the boundary, forks via the public API, verifies the remapped cursor, launches the cloned Claude session, and recalls a marker from before compaction.

## Changelog

Forked sessions now preserve compacted context without replaying their full archived history.
