### PR TITLE
fix(web): keep Terminal view on the agent terminal

### DIFF
--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -35,12 +35,13 @@ independent session.
 
 from __future__ import annotations
 
+import json
 import re
 import time
 from pathlib import Path
 
 import httpx
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Page, Route, expect
 
 from tests.e2e_ui.conftest import open_right_rail
 
@@ -147,6 +148,37 @@ def test_terminal_toggle_stays_disabled_when_only_a_shell_is_open(
 ) -> None:
     """A live rail shell does not enable or populate the agent Terminal view."""
     base_url, session_id = terminal_session
+
+    # Runner-hosted SDK sessions auto-create ``terminal_tui_main`` when the
+    # parity sidecar is available (as it is in CI). Hide that pane from this
+    # browser's terminal snapshot and stream so the test deterministically
+    # models the cache window from the bug: a user shell has landed while the
+    # agent pane has not. The shell itself is still launched and attached
+    # through the real runner below.
+    def _serve_shells_only(route: Route) -> None:
+        response = route.fetch()
+        payload = response.json()
+        rows = payload.get("data", [])
+        shells = [
+            row
+            for row in rows
+            if isinstance(row, dict)
+            and isinstance(row.get("metadata"), dict)
+            and str(row["metadata"].get("session_key", "")).startswith("u-")
+        ]
+        payload["data"] = shells
+        payload["first_id"] = shells[0]["id"] if shells else None
+        payload["last_id"] = shells[-1]["id"] if shells else None
+        payload["has_more"] = False
+        route.fulfill(
+            status=response.status,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    terminal_list = re.compile(rf"/v1/sessions/{re.escape(session_id)}/resources/terminals\?.*")
+    page.route(terminal_list, _serve_shells_only)
+    page.route(f"**/v1/sessions/{session_id}/stream*", lambda route: route.abort())
 
     terminal_first = httpx.patch(
         f"{base_url}/v1/sessions/{session_id}",

--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -39,6 +39,7 @@ import re
 import time
 from pathlib import Path
 
+import httpx
 from playwright.sync_api import Page, expect
 
 from tests.e2e_ui.conftest import open_right_rail
@@ -139,6 +140,36 @@ def test_new_shell_accepts_typed_command(page: Page, terminal_session: tuple[str
     # "terminal session ended". A regression that drops user input or kills
     # the PTY on first keystroke would flip this out of ``connected``.
     expect(terminal_view).to_have_attribute("data-state", "connected")
+
+
+def test_terminal_toggle_stays_disabled_when_only_a_shell_is_open(
+    page: Page, terminal_session: tuple[str, str]
+) -> None:
+    """A live rail shell does not enable or populate the agent Terminal view."""
+    base_url, session_id = terminal_session
+
+    terminal_first = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"labels": {"omnigent.ui": "terminal"}},
+        timeout=10.0,
+    )
+    terminal_first.raise_for_status()
+
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_new_shell(page)
+
+    rail = page.get_by_role("complementary", name="Workspace")
+    shell_view = rail.get_by_test_id("terminal-view").last
+    expect(shell_view).to_have_attribute("data-state", "connected", timeout=60_000)
+
+    # This is the cache window from the bug: the user shell is live while the
+    # session's agent terminal is absent.
+    terminal_button = page.get_by_test_id("view-mode-terminal")
+    expect(terminal_button).to_be_disabled()
+    expect(page.locator('[data-testid="main-terminal-view"][data-visible="true"]')).to_have_count(
+        0
+    )
+    expect(shell_view).to_be_visible()
 
 
 def test_shell_wheel_scroll_reaches_mouse_tracking_program(

--- a/web/src/hooks/useTerminals.test.ts
+++ b/web/src/hooks/useTerminals.test.ts
@@ -14,6 +14,7 @@ import {
   createTerminal,
   deleteTerminal,
   fetchTerminals,
+  findAgentTerminal,
   inventoryTerminals,
   isAgentTerminalKey,
   PENDING_RECONCILE_INTERVAL_MS,
@@ -452,21 +453,17 @@ describe("deleteTerminal", () => {
 });
 
 describe("terminalsReconcileInterval", () => {
-  // The spinner is `terminalPending && !terminalsAvailable`. This decides
-  // when the terminals query re-polls to recover a missed
-  // `session.resource.created` (the dbx-apps stuck-spinner bug) — and,
-  // critically, when it STOPS so there's no steady-state polling.
-  it("polls only while pending AND no terminal is visible yet", () => {
-    expect(terminalsReconcileInterval(true, 0)).toBe(PENDING_RECONCILE_INTERVAL_MS);
+  it("polls only while pending AND no agent terminal is visible yet", () => {
+    expect(terminalsReconcileInterval(true, false)).toBe(PENDING_RECONCILE_INTERVAL_MS);
   });
 
-  it("stops the instant a terminal lands (clears the spinner via AND)", () => {
-    expect(terminalsReconcileInterval(true, 1)).toBe(false);
+  it("stops the instant the agent terminal lands", () => {
+    expect(terminalsReconcileInterval(true, true)).toBe(false);
   });
 
   it("never polls when the runner is not spinning up a terminal", () => {
-    expect(terminalsReconcileInterval(false, 0)).toBe(false);
-    expect(terminalsReconcileInterval(false, 2)).toBe(false);
+    expect(terminalsReconcileInterval(false, false)).toBe(false);
+    expect(terminalsReconcileInterval(false, true)).toBe(false);
   });
 });
 
@@ -491,6 +488,19 @@ describe("useTerminals reconcile poll (stuck-spinner self-heal)", () => {
   }
 
   const emptyList = () => mockResponse({ object: "list", data: [] });
+  const oneShell = () =>
+    mockResponse({
+      object: "list",
+      data: [
+        {
+          id: "terminal_bash_s1",
+          type: "terminal",
+          session_id: "conv_abc",
+          name: "bash:s1",
+          metadata: { terminal_name: "bash", session_key: "s1", running: true },
+        },
+      ],
+    });
   const oneTerminal = () =>
     mockResponse({
       object: "list",
@@ -505,13 +515,11 @@ describe("useTerminals reconcile poll (stuck-spinner self-heal)", () => {
       ],
     });
 
-  it("re-polls while pending until the terminal lands, then stops", async () => {
-    // Mount + first reconcile poll see no terminal; the auto-created
-    // terminal lands on the third fetch — exactly the missed-delta case
-    // a page refresh used to be the only recovery for.
+  it("re-polls while pending until the agent terminal lands, then stops", async () => {
+    // A user shell alone must not satisfy the pending agent-terminal launch.
     fetchMock
       .mockResolvedValueOnce(emptyList())
-      .mockResolvedValueOnce(emptyList())
+      .mockResolvedValueOnce(oneShell())
       .mockResolvedValue(oneTerminal());
 
     const { result } = renderHook(() => useTerminals("conv_abc", { reconcileWhilePending: true }), {
@@ -522,29 +530,21 @@ describe("useTerminals reconcile poll (stuck-spinner self-heal)", () => {
     expect(result.current.terminals).toEqual([]);
     const seedCalls = fetchMock.mock.calls.length;
 
-    // First reconcile poll fires while still empty: the interval scheduled a
-    // refetch, so the fetch count must climb past the seed. (Asserting `>`
-    // rather than an exact `+1` because React Query anchors the next interval
-    // off each fetch's settle time, so the precise count under fake timers is
-    // a scheduling detail; a count still == seedCalls would mean no poll fired
-    // — the bug we're guarding against.)
+    // The first interval starts reconciliation. Its exact settle point is a
+    // React Query scheduling detail, so assert that a refetch was issued.
     await act(async () => void (await vi.advanceTimersByTimeAsync(PENDING_RECONCILE_INTERVAL_MS)));
-    expect(result.current.terminals).toEqual([]);
     expect(fetchMock.mock.calls.length).toBeGreaterThan(seedCalls);
 
-    // Further reconcile polls -> terminal lands. Assert the full mapped row
-    // (not just id) so a broken resource→TerminalInfo mapping can't pass.
+    // A later poll finds the agent terminal and unions it with the cached shell.
     await act(
       async () => void (await vi.advanceTimersByTimeAsync(PENDING_RECONCILE_INTERVAL_MS * 2)),
     );
     expect(result.current.terminals).toEqual([
+      { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
       { id: "terminal_claude_main", name: "claude", session: "main", running: true },
     ]);
 
-    // Polling must stop now that a terminal is visible: the refetchInterval
-    // returns false once terminalCount > 0. Assert ZERO further fetches over
-    // 4 would-be intervals — a higher count would mean the interval was never
-    // disabled and the poll runs forever.
+    // The agent terminal stops the interval; shells alone did not.
     const callsAtLand = fetchMock.mock.calls.length;
     await act(
       async () => void (await vi.advanceTimersByTimeAsync(PENDING_RECONCILE_INTERVAL_MS * 4)),
@@ -890,5 +890,35 @@ describe("isAgentTerminalKey", () => {
 
   it("treats a user shell as not-the-agent-terminal", () => {
     expect(isAgentTerminalKey("terminal:terminal_bash_s1")).toBe(false);
+  });
+});
+
+describe("findAgentTerminal", () => {
+  it("selects the agent pane even when a user shell appears first", () => {
+    const shell: TerminalInfo = {
+      id: "terminal_bash_s1",
+      name: "bash",
+      session: "s1",
+      running: true,
+    };
+    const agent: TerminalInfo = {
+      id: "terminal_codex_main",
+      name: "codex",
+      session: "main",
+      running: true,
+    };
+
+    expect(findAgentTerminal([shell, agent])).toBe(agent);
+  });
+
+  it("does not substitute a user shell when the agent pane is absent", () => {
+    const shell: TerminalInfo = {
+      id: "terminal_bash_s1",
+      name: "bash",
+      session: "s1",
+      running: true,
+    };
+
+    expect(findAgentTerminal([shell])).toBeNull();
   });
 });

--- a/web/src/hooks/useTerminals.ts
+++ b/web/src/hooks/useTerminals.ts
@@ -73,6 +73,18 @@ export function isAgentTerminalKey(terminalKey: string): boolean {
 }
 
 /**
+ * Find the session's agent terminal, excluding user-created shells.
+ *
+ * The Chat/Terminal view toggle must use this selector instead of the first
+ * terminal in the resource list. A user shell can be the only cached row
+ * briefly while the agent terminal is starting or reconciling; treating that
+ * shell as a fallback duplicates it in the main viewport.
+ */
+export function findAgentTerminal(terminals: TerminalInfo[]): TerminalInfo | null {
+  return terminals.find((terminal) => AGENT_TERMINAL_IDS.has(terminal.id)) ?? null;
+}
+
+/**
  * Project the terminal list down to the session's *inventory* — the
  * shells shown as the rail's soft tabs and in the mobile Shells menu
  * entry / drawer.
@@ -100,7 +112,7 @@ interface UseTerminalsResult {
 
 /**
  * How often (ms) to re-poll the authoritative terminals endpoint while
- * the runner reports a terminal is spinning up but none is visible yet.
+ * the runner reports the agent terminal is spinning up but it is not visible.
  * Short enough that the Terminal-pill spinner clears within a couple
  * seconds of the terminal landing; only active during that window, so it
  * adds no steady-state polling.
@@ -111,37 +123,37 @@ export const PENDING_RECONCILE_INTERVAL_MS = 2500;
  * Decide the React Query ``refetchInterval`` for the terminals query.
  *
  * Returns :data:`PENDING_RECONCILE_INTERVAL_MS` only while the runner
- * reports a terminal is spinning up (*reconcileWhilePending*) and none is
- * visible yet; ``false`` (no polling) the instant a terminal lands or
- * pending clears. Reading *terminalCount* keeps the poll self-limiting to
- * the Terminal-pill spinner window — no steady-state polling.
+ * reports the agent terminal is spinning up (*reconcileWhilePending*) and it
+ * is not visible; ``false`` (no polling) the instant the agent terminal lands or
+ * pending clears. A user shell does not satisfy the pending agent-terminal
+ * launch and must not stop reconciliation.
  *
  * :param reconcileWhilePending: Whether the runner reports a terminal
  *     spinning up (``terminalPending``).
- * :param terminalCount: Terminals currently in the query cache.
+ * :param agentTerminalAvailable: Whether the agent terminal is in the cache.
  * :returns: Poll interval in ms, or ``false`` to disable polling.
  */
 export function terminalsReconcileInterval(
   reconcileWhilePending: boolean,
-  terminalCount: number,
+  agentTerminalAvailable: boolean,
 ): number | false {
-  return reconcileWhilePending && terminalCount === 0 ? PENDING_RECONCILE_INTERVAL_MS : false;
+  return reconcileWhilePending && !agentTerminalAvailable ? PENDING_RECONCILE_INTERVAL_MS : false;
 }
 
 interface UseTerminalsOptions {
   /**
-   * When ``true`` (the runner is auto-creating a terminal — see
+   * When ``true`` (the runner is auto-creating the agent terminal — see
    * ``terminalPending``), poll :func:`fetchTerminals` every
-   * :data:`PENDING_RECONCILE_INTERVAL_MS` until a terminal appears.
+   * :data:`PENDING_RECONCILE_INTERVAL_MS` until the agent terminal appears.
    *
    * The query is otherwise fetch-once + live-SSE-delta driven. A single
    * missed ``session.resource.created`` delta (e.g. dropped through the
    * dbx-apps proxy before the SSE subscription opened, with the server's
    * best-effort snapshot-on-connect reconcile also timing out) would
-   * otherwise leave ``terminals`` empty — stranding the Terminal-pill
+   * otherwise leave the agent terminal absent — stranding the Terminal-pill
    * spinner on ``terminalPending && !terminalsAvailable`` until a manual
    * page refresh. This bounded reconcile poll self-heals that exact
-   * window: it stops the instant a terminal lands (or pending clears).
+   * window: it stops the instant the agent terminal lands (or pending clears).
    */
   reconcileWhilePending?: boolean;
 }
@@ -393,11 +405,13 @@ export function useTerminals(
     // initial load without hammering an unreachable runner.
     retry: 1,
     // Self-heal a missed ``session.resource.created`` while a terminal is
-    // spinning up: poll the authoritative endpoint until one appears, then
-    // stop. Reads the query's own cached data for the stop condition so it
-    // never feeds back through the caller.
+    // spinning up: poll the authoritative endpoint until the agent pane
+    // appears, then stop. User shells are unrelated and do not satisfy it.
     refetchInterval: (query) =>
-      terminalsReconcileInterval(reconcileWhilePending, query.state.data?.length ?? 0),
+      terminalsReconcileInterval(
+        reconcileWhilePending,
+        findAgentTerminal(query.state.data ?? []) !== null,
+      ),
   });
   // The poll corrects the SSE-driven list ONLY on runner-liveness edges — it
   // never masks continuously. Two corrections, both keyed off the edge so a

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -251,6 +251,7 @@ function TerminalFirstViewProbe() {
       data-is-terminal-first={ctx.isTerminalFirst ? "true" : "false"}
       data-is-claude-native={ctx.isClaudeNative ? "true" : "false"}
       data-view={ctx.view}
+      data-terminal-view-key={ctx.terminalViewKey ?? "null"}
       data-terminals-available={ctx.terminalsAvailable ? "true" : "false"}
       data-terminal-starting-up={ctx.terminalStartingUp ? "true" : "false"}
     >
@@ -701,7 +702,7 @@ describe("TerminalFirstContext", () => {
       },
     ]);
     useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "claude", session: "main", running: true }],
+      terminals: [{ id: "terminal_claude_main", name: "claude", session: "main", running: true }],
       isLoading: false,
       error: null,
     });
@@ -718,6 +719,65 @@ describe("TerminalFirstContext", () => {
     const regularProbe = screen.getByTestId("view-probe");
     expect(regularProbe).toHaveAttribute("data-is-terminal-first", "false");
     expect(regularProbe).toHaveAttribute("data-is-claude-native", "false");
+  });
+
+  it("targets the agent terminal while a user shell remains open in the workspace rail", () => {
+    writeSessionWorkspaceState("conv_native", {
+      open: true,
+      selectedTerminalKey: "terminal:terminal_bash_s1",
+    });
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null, home: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      {
+        id: "conv_native",
+        permission_level: null,
+        labels: {
+          "omnigent.ui": "terminal",
+          "omnigent.wrapper": "codex-native-ui",
+        },
+      },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
+        { id: "terminal_codex_main", name: "codex", session: "main", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_native");
+
+    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_bash_s1");
+    fireEvent.click(screen.getByTestId("view-mode-terminal"));
+    expect(screen.getByTestId("view-probe")).toHaveAttribute(
+      "data-terminal-view-key",
+      "terminal:terminal_codex_main",
+    );
+    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_bash_s1");
+  });
+
+  it("does not enable Terminal view when only a user shell is cached", () => {
+    mockConversations([
+      {
+        id: "conv_native",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal" },
+      },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_bash_s1", name: "bash", session: "s1", running: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_native");
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminals-available", "false");
+    expect(screen.getByTestId("view-mode-terminal")).toBeDisabled();
   });
 
   it("flags a child (sub-agent) session terminal-first from the snapshot when the sidebar omits it", () => {
@@ -781,7 +841,7 @@ describe("TerminalFirstContext", () => {
       },
     ]);
     useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "claude", session: "main", running: true }],
+      terminals: [{ id: "terminal_claude_main", name: "claude", session: "main", running: true }],
       isLoading: false,
       error: null,
     });
@@ -847,7 +907,7 @@ describe("TerminalFirstContext", () => {
       { id: "conv_native", permission_level: null, labels: { "omnigent.ui": "terminal" } },
     ]);
     useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "claude", session: "main", running: true }],
+      terminals: [{ id: "terminal_claude_main", name: "claude", session: "main", running: true }],
       isLoading: false,
       error: null,
     });
@@ -901,7 +961,7 @@ describe("TerminalFirstContext", () => {
     // the list empties (see the startup-spinner tests above).
     useChatStore.setState({ terminalPending: true, sessionStatus: "running" });
     useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "claude", session: "main", running: true }],
+      terminals: [{ id: "terminal_claude_main", name: "claude", session: "main", running: true }],
       isLoading: false,
       error: null,
     });
@@ -960,7 +1020,7 @@ describe("TerminalFirstContext", () => {
       { id: "conv_other", permission_level: null, labels: {} },
     ]);
     useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "claude", session: "main", running: true }],
+      terminals: [{ id: "terminal_claude_main", name: "claude", session: "main", running: true }],
       isLoading: false,
       error: null,
     });
@@ -1002,7 +1062,7 @@ describe("TerminalFirstContext", () => {
       },
     ]);
     useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "claude", session: "main", running: true }],
+      terminals: [{ id: "terminal_claude_main", name: "claude", session: "main", running: true }],
       isLoading: false,
       error: null,
     });
@@ -1031,7 +1091,7 @@ describe("Right-rail terminals card", () => {
       },
     ]);
     useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "claude", session: "main", running: true }],
+      terminals: [{ id: "terminal_claude_main", name: "claude", session: "main", running: true }],
       isLoading: false,
       error: null,
     });
@@ -1070,7 +1130,7 @@ describe("Right-rail terminals card", () => {
       },
     ]);
     useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "claude", session: "main", running: true }],
+      terminals: [{ id: "terminal_claude_main", name: "claude", session: "main", running: true }],
       isLoading: false,
       error: null,
     });

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -56,7 +56,7 @@ import { useDebugMode } from "@/hooks/useDebugMode";
 import { useBrowserAgentRelay } from "@/hooks/useBrowserAgentRelay";
 import { resyncBrowserSuppression } from "@/hooks/useSuppressBrowserView";
 import {
-  AGENT_TERMINAL_IDS,
+  findAgentTerminal,
   inventoryTerminals,
   isAgentTerminalKey,
   PANEL_NO_TERMINAL_KEY,
@@ -352,6 +352,7 @@ export function AppShell() {
   const { terminals } = useTerminals(conversationId ?? null, {
     reconcileWhilePending: terminalPending,
   });
+  const agentTerminal = useMemo(() => findAgentTerminal(terminals), [terminals]);
 
   const debugMode = useDebugMode();
   const { data: conversationsData } = useConversations("", true);
@@ -1471,22 +1472,21 @@ export function AppShell() {
         setPanelInitialKey(null);
         return;
       }
-      if (terminals.length === 0) {
+      if (agentTerminal === null) {
         if (terminalFirst) setPanelInitialKey(PANEL_NO_TERMINAL_KEY);
         return;
       }
-      // The pill's Terminal view is the AGENT's terminal: target it
-      // explicitly (the SDK REPL or the native vendor pane) so the
-      // pill never lands on a user shell.
-      const agentTerminal = terminals.find((t) => AGENT_TERMINAL_IDS.has(t.id));
-      setPanelInitialKey(terminalTabKey(agentTerminal ?? terminals[0]));
+      // The pill targets only the agent's REPL/vendor pane. A user shell may
+      // be the only cached terminal briefly, but it belongs in the workspace
+      // rail and must never become the main Terminal view.
+      setPanelInitialKey(terminalTabKey(agentTerminal));
     },
-    [terminalFirst, terminals, setPanelInitialKey],
+    [terminalFirst, agentTerminal, setPanelInitialKey],
   );
 
-  // `terminals` is already runner-accurate (useTerminals empties it when the
-  // runner is offline), so a non-empty list means an openable PTY.
-  const terminalsAvailable = terminals.length > 0;
+  // Shells do not make the Terminal-view toggle available: that control owns
+  // only the session's agent REPL/vendor pane.
+  const terminalsAvailable = agentTerminal !== null;
   // Single pill-facing "loading" signal: not yet openable, but coming up —
   // either the runner is launching/relaunching (liveness `starting`, known the
   // instant a message is sent) or it's up and auto-creating the PTY
@@ -1520,10 +1520,13 @@ export function AppShell() {
   // affordance. The PANEL_NO_TERMINAL_KEY sentinel ("") is falsy, so
   // "open with no target" stays a pill view.
   const isShellView = terminalFirst && !!panelInitialKey && !isAgentTerminalKey(panelInitialKey);
+  const terminalViewTargetAvailable = isShellView
+    ? terminals.some((terminal) => terminalTabKey(terminal) === panelInitialKey)
+    : terminalsAvailable;
 
   // A runner stop/disconnect empties the terminal list; if that lands while the
-  // terminal view is open, flip back to chat rather than stranding the user on
-  // "No terminals available" (and chat is where the composer resumes it).
+  // open agent terminal or explicit mobile shell disappears, flip back to chat
+  // rather than stranding the user on an empty surface.
   // Edge-triggered + startingUp-guarded so a cold boot / relaunch isn't yanked.
   const hadTerminalRef = useRef(false);
   useEffect(() => {
@@ -1531,13 +1534,19 @@ export function AppShell() {
       terminalFirst &&
       panelOpen &&
       hadTerminalRef.current &&
-      !terminalsAvailable &&
+      !terminalViewTargetAvailable &&
       !terminalStartingUp
     ) {
       setPanelInitialKey(null);
     }
-    hadTerminalRef.current = terminalsAvailable;
-  }, [terminalFirst, panelOpen, terminalsAvailable, terminalStartingUp, setPanelInitialKey]);
+    hadTerminalRef.current = terminalViewTargetAvailable;
+  }, [
+    terminalFirst,
+    panelOpen,
+    terminalViewTargetAvailable,
+    terminalStartingUp,
+    setPanelInitialKey,
+  ]);
 
   const terminalFirstContextValue = useMemo<TerminalFirstContextValue>(
     () => ({

--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -193,6 +193,13 @@ describe("MainTerminalView — terminal-first SDK sessions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Close shell" }));
     expect(setView).toHaveBeenCalledWith("chat");
   });
+
+  it("never substitutes an open user shell for the agent terminal", () => {
+    renderView({ terminals: [BASH_SHELL] });
+
+    expect(screen.queryByTestId("terminal-view")).toBeNull();
+    expect(screen.getByText("Agent terminal unavailable.")).toBeInTheDocument();
+  });
 });
 
 describe("MainTerminalView — native wrapper sessions", () => {

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -16,7 +16,12 @@
 import { TerminalIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TerminalView } from "@/components/blocks/TerminalView";
-import { AGENT_TERMINAL_IDS, terminalTabKey, useTerminals } from "@/hooks/useTerminals";
+import {
+  AGENT_TERMINAL_IDS,
+  findAgentTerminal,
+  terminalTabKey,
+  useTerminals,
+} from "@/hooks/useTerminals";
 import { useTerminalFirst } from "./TerminalFirstContext";
 import { TerminalStatusBadge } from "./terminalStatus";
 import { useTerminalStatuses } from "./useTerminalStatuses";
@@ -67,10 +72,7 @@ export function MainTerminalView({
   const terminalFirstCtx = useTerminalFirst();
   // The agent's own terminal (SDK REPL / native vendor pane) — the
   // auto-selection target and the pane the pill's Terminal view shows.
-  const agentTerminals = useMemo(
-    () => terminals.filter((t) => AGENT_TERMINAL_IDS.has(t.id)),
-    [terminals],
-  );
+  const agentTerminal = useMemo(() => findAgentTerminal(terminals), [terminals]);
   // Seed from the explicit target so the mount-time validity effect
   // below sees the requested key already in place — a separate
   // set-on-mount effect would race it (both fire in the same commit
@@ -101,8 +103,8 @@ export function MainTerminalView({
   useEffect(() => {
     if (terminals.length === 0) return;
     const stillValid = terminals.some((t) => terminalTabKey(t) === activeKey);
-    if (!stillValid) setActiveKey(terminalTabKey(agentTerminals[0] ?? terminals[0]));
-  }, [terminals, agentTerminals, activeKey]);
+    if (!stillValid) setActiveKey(agentTerminal ? terminalTabKey(agentTerminal) : "");
+  }, [terminals, agentTerminal, activeKey]);
 
   // While hidden, drop a user-shell selection back to the agent terminal.
   // The surface used to unmount on close (forgetting the selection), so
@@ -111,9 +113,8 @@ export function MainTerminalView({
   // the pane the next open will actually show.
   useEffect(() => {
     if (visible || terminals.length === 0) return;
-    const fallback = agentTerminals[0] ?? terminals[0];
-    setActiveKey(terminalTabKey(fallback));
-  }, [visible, terminals, agentTerminals]);
+    setActiveKey(agentTerminal ? terminalTabKey(agentTerminal) : "");
+  }, [visible, terminals, agentTerminal]);
 
   const activeTerminal = terminals.find((t) => terminalTabKey(t) === activeKey) ?? null;
   // A user shell opened from the rail takes over the pane chrome-free:
@@ -154,9 +155,9 @@ export function MainTerminalView({
       className="main-terminal-view flex min-h-0 flex-1 flex-col px-3 pt-14 pb-1.5"
     >
       <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden rounded-lg border border-border bg-card p-3 shadow-sm">
-        {terminals.length === 0 ? (
+        {activeTerminal === null ? (
           <div className="flex flex-1 items-center justify-center text-muted-foreground text-ui">
-            No terminals available.
+            {terminals.length === 0 ? "No terminals available." : "Agent terminal unavailable."}
           </div>
         ) : (
           <>

--- a/web/src/shell/TerminalFirstContext.tsx
+++ b/web/src/shell/TerminalFirstContext.tsx
@@ -60,9 +60,8 @@ export interface TerminalFirstContextValue {
   /** Switch view. `"terminal"` opens the terminal surface. */
   setView: (view: TerminalFirstView) => void;
   /**
-   * True when a terminal exists AND is reachable (the runner is online) —
-   * i.e. there's a PTY the "Terminal" pill can open right now. False on a
-   * stopped/offline runner, which greys the button.
+   * True when the agent terminal exists and is reachable. User shells do not
+   * enable the Terminal-view toggle; they open through the workspace rail.
    */
   terminalsAvailable: boolean;
   /**


### PR DESCRIPTION
## Related issue

N/A — reported directly.

## Summary

- Keep the Chat/Terminal toggle bound to the session's agent terminal instead of falling back to the first cached terminal.
- Continue reconciling while the agent terminal is starting, even if a user-created shell is already cached.
- Preserve explicit shell views opened from the workspace rail or mobile Shells drawer.

ELI5: a user shell and the agent's terminal are two different panes. Clicking **Terminal** now always asks for the agent's pane; an already-open shell can no longer be mistaken for it.

## Test Plan

- `cd web && npm test -- --run src/hooks/useTerminals.test.ts src/shell/AppShell.test.tsx src/shell/MainTerminalView.test.tsx` (161 tests passed)
- `cd web && npm run type-check`
- `.venv/bin/pytest -q tests/e2e_ui/shells/test_new_shell.py::test_terminal_toggle_stays_disabled_when_only_a_shell_is_open` (1 passed)
- `.venv/bin/pre-commit run --all-files`
- Regression coverage verifies that clicking **Terminal** with a rail shell open targets `terminal_codex_main`, and that a shell-only cache leaves the agent Terminal switcher disabled without populating the main viewport.

## Demo

Agent Terminal selected while the user shell remains open in the workspace rail:

![Agent terminal in the main viewport with the user shell still open in the workspace rail](https://raw.githubusercontent.com/dbczumar/omnigent/pr-assets-5385/pr-assets/5385-agent-terminal.png)

Only a user shell is available: the Terminal segment (`>_`) beside Chat stays grayed out and the main viewport remains in Chat.

![Disabled Terminal switcher while only a user shell is open](https://raw.githubusercontent.com/dbczumar/omnigent/pr-assets-5385/pr-assets/5385-shell-only.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Component and hook tests assert exact terminal selection and polling behavior. The Playwright journey opens a real shell in the workspace rail and verifies that the agent Terminal switcher stays disabled when no agent terminal is available.

## Changelog

The Terminal view now always opens the agent terminal instead of an open shell.
