### PR TITLE
Gate runner-offline resource retries on liveness

### DIFF
--- a/web/src/hooks/useWorkspaceChangedFiles.test.tsx
+++ b/web/src/hooks/useWorkspaceChangedFiles.test.tsx
@@ -11,9 +11,14 @@ vi.mock("@/hooks/RunnerHealthProvider", () => ({
 vi.mock("@/store/chatStore", () => ({
   useChatStore: vi.fn(),
 }));
+vi.mock("@/hooks/useSession", () => ({
+  useSession: vi.fn(),
+}));
 
 import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { useSession } from "@/hooks/useSession";
 import { useChatStore } from "@/store/chatStore";
+import type { Session } from "@/lib/types";
 import {
   type WorkspaceEnvironment,
   MAX_RUNNER_OFFLINE_RETRIES,
@@ -36,8 +41,26 @@ import {
 
 const onlineMock = vi.mocked(useSessionRunnerOnline);
 const hostOnlineMock = vi.mocked(useSessionHostOnline);
+const sessionMock = vi.mocked(useSession);
 const chatStoreMock = vi.mocked(useChatStore);
 const fetchMock = vi.fn();
+
+function stubSession(opts: { hostId?: string | null; createdAtSecondsAgo?: number } | null) {
+  if (opts === null) {
+    sessionMock.mockReturnValue({ session: null, isLoading: false, error: null });
+    return;
+  }
+  const createdAt = Math.floor(Date.now() / 1000) - (opts.createdAtSecondsAgo ?? 0);
+  sessionMock.mockReturnValue({
+    session: {
+      hostId: opts.hostId ?? "host_1",
+      permissionLevel: null,
+      createdAt,
+    } as Session,
+    isLoading: false,
+    error: null,
+  });
+}
 
 type StubStatus = "idle" | "running" | "waiting" | "failed";
 
@@ -199,6 +222,8 @@ beforeEach(() => {
   // assume sessionActive is false (initial fetch from `enabled`, no
   // polling). The trailing-invalidate test overrides per-call.
   stubChatStore();
+  hostOnlineMock.mockReturnValue(null);
+  stubSession(null);
 });
 
 afterEach(() => {
@@ -760,6 +785,16 @@ describe("isRunnerUnavailable503", () => {
     } as unknown as Response;
     expect(await isRunnerUnavailable503(res)).toBe(false);
   });
+
+  it("does not consume a non-503 response body", async () => {
+    const json = vi.fn(async () => {
+      throw new Error("body must not be read");
+    });
+    const res = { ok: true, status: 200, statusText: "OK", json } as unknown as Response;
+
+    expect(await isRunnerUnavailable503(res)).toBe(false);
+    expect(json).not.toHaveBeenCalled();
+  });
 });
 
 describe("looksLikeWorkspaceFilePath", () => {
@@ -964,6 +999,22 @@ describe("useWorkspaceFileExists", () => {
     expect(results.at(-1)).toBe(false);
   });
 
+  it("reports false without retrying when the runner is offline", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: { code: "runner_unavailable" } }, 503));
+    const results: boolean[] = [];
+    render(
+      <Wrap>
+        <FileExistsProbe id="conv_1" path="projects/out/foo.md" onResult={(r) => results.push(r)} />
+      </Wrap>,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    await flushMicrotasks();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(results).not.toContain(true);
+    expect(results.at(-1)).toBe(false);
+  });
+
   it("checks a trusted root-level basename against the workspace root listing", async () => {
     // A path resolved from an absolute/"~" form can be a bare basename
     // ("foo.md", no slash) that looksLikeWorkspaceFilePath rejects. With
@@ -1056,6 +1107,86 @@ describe("runnerOfflineRetryDelay", () => {
     expect(runnerOfflineRetryDelay(3)).toBe(8000);
     expect(runnerOfflineRetryDelay(4)).toBe(15_000);
     expect(runnerOfflineRetryDelay(10)).toBe(15_000);
+  });
+});
+
+describe("runner-offline retry liveness gate", () => {
+  function renderEnvironment(id: string) {
+    const qc = new QueryClient({ defaultOptions: { queries: { staleTime: 0 } } });
+    return render(
+      <QueryClientProvider client={qc}>
+        <EnvironmentProbe id={id} />
+      </QueryClientProvider>,
+    );
+  }
+
+  it("does not retry a 503 from a stale-online runner", async () => {
+    vi.useFakeTimers();
+    onlineMock.mockReturnValue(true);
+    fetchMock.mockResolvedValue(jsonResponse({ error: { code: "runner_unavailable" } }, 503));
+
+    renderEnvironment("conv_stuck");
+    await vi.advanceTimersByTimeAsync(130_000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a 503 for an old session with unknown liveness", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-23T00:00:00Z"));
+    onlineMock.mockReturnValue(undefined);
+    stubSession({ createdAtSecondsAgo: 3600 });
+    fetchMock.mockResolvedValue(jsonResponse({ error: { code: "runner_unavailable" } }, 503));
+
+    renderEnvironment("conv_old");
+    await vi.advanceTimersByTimeAsync(130_000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries while a fresh session is cold-booting", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-23T00:00:00Z"));
+    onlineMock.mockReturnValue(undefined);
+    stubSession({ createdAtSecondsAgo: 1 });
+    fetchMock.mockResolvedValue(jsonResponse({ error: { code: "runner_unavailable" } }, 503));
+
+    renderEnvironment("conv_fresh");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_200);
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("retries while the session snapshot is loading", async () => {
+    vi.useFakeTimers();
+    onlineMock.mockReturnValue(undefined);
+    sessionMock.mockReturnValue({ session: null, isLoading: true, error: null });
+    fetchMock.mockResolvedValue(jsonResponse({ error: { code: "runner_unavailable" } }, 503));
+
+    renderEnvironment("conv_loading");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_200);
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("retries while an active turn relaunches an offline runner", async () => {
+    vi.useFakeTimers();
+    onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(true);
+    stubSession({ createdAtSecondsAgo: 3600 });
+    stubChatStore("conv_relaunch", "running");
+    fetchMock.mockResolvedValue(jsonResponse({ error: { code: "runner_unavailable" } }, 503));
+
+    renderEnvironment("conv_relaunch");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_200);
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 });
 

--- a/web/src/hooks/useWorkspaceChangedFiles.ts
+++ b/web/src/hooks/useWorkspaceChangedFiles.ts
@@ -17,6 +17,8 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { useSession } from "@/hooks/useSession";
+import { livenessRowFromSession, useSessionLiveness } from "@/hooks/useSessionLiveness";
 import { authenticatedFetch } from "@/lib/identity";
 import { isTempConvId } from "@/lib/tempConversationId";
 import { useChatStore } from "@/store/chatStore";
@@ -147,13 +149,9 @@ export class PathUnreachableError extends Error {
 
 // ── Runner-boot retry policy ──────────────────────────────────────────────────
 //
-// A freshly-bound session whose runner is still booting/connecting its WS
-// tunnel answers 503 (``runner_unavailable``) until it comes up. The previous
-// budget — 3 retries at a flat 1.5s (~4.5s) — gave up before a cold runner
-// finished, so the Working-folder panel flashed "Failed to load: 503". These
-// queries instead retry the runner-offline case with capped exponential
-// backoff for ~2 minutes, long enough to outlast a cold boot; the reconnect
-// hint only shows once that budget is exhausted (a genuinely offline runner).
+// A runner that is still connecting answers 503 (``runner_unavailable``).
+// Retry only while session liveness says that connection is imminent; a 503
+// from a stale or dead runner will not clear because of a background GET.
 
 /**
  * Max retry attempts for a still-connecting runner. With the backoff schedule
@@ -176,16 +174,20 @@ export function shouldRetryRunnerOffline(failureCount: number, error: Error): bo
 }
 
 /**
- * Whether a 503 response is the app's `runner_unavailable` error rather
- * than a generic infrastructure 503.
- *
- * A 503 is NOT always the bound runner being offline: the Databricks Apps
- * front door / gateway returns 503 while the app restarts or cold-starts.
- * Only the app-level error carries `{"error": {"code": "runner_unavailable"}}`,
- * so match on that — a bare/HTML 503 falls through to the normal
- * error+retry path instead of the (misleading) "agent is asleep" hint.
+ * Whether retrying a runner-offline response can plausibly succeed.
  */
+function useRunnerRecovering(conversationId: string | undefined): boolean {
+  const { session, isLoading } = useSession(conversationId);
+  const turnActive = useSessionActive(conversationId);
+  const liveness = useSessionLiveness(conversationId, livenessRowFromSession(session), {
+    turnActive,
+  });
+  return isLoading || liveness.kind === "starting";
+}
+
+/** Whether `res` is the app's runner-offline 503 response. */
 export async function isRunnerUnavailable503(res: Response): Promise<boolean> {
+  if (res.status !== 503) return false;
   try {
     const body = (await res.json()) as { error?: { code?: string } };
     return body?.error?.code === "runner_unavailable";
@@ -265,6 +267,7 @@ export function useWorkspaceChangedFiles(
 ) {
   const queryEnabled = options.enabled ?? true;
   const serveable = useWorkspaceServeable(conversationId);
+  const recovering = useRunnerRecovering(conversationId);
   const environmentQuery = useWorkspaceEnvironment(conversationId, {
     enabled: queryEnabled,
   });
@@ -278,11 +281,7 @@ export function useWorkspaceChangedFiles(
       !!conversationId &&
       serveable !== false &&
       environmentQuery.data?.available === true,
-    // Capped-backoff retry of the runner-offline case (see
-    // shouldRetryRunnerOffline). Whether the eventual error reads as
-    // "asleep" vs the plain empty state is decided by the session's
-    // `failed` status, not by retries.
-    retry: shouldRetryRunnerOffline,
+    retry: (failureCount, error) => recovering && shouldRetryRunnerOffline(failureCount, error),
     retryDelay: runnerOfflineRetryDelay,
     // No polling: the SSE ``session.changed_files.invalidated`` event
     // (runner-emitted after file-mutating tools, throttled) drives
@@ -406,6 +405,7 @@ export function useWorkspaceAllFiles(
 ) {
   const queryEnabled = options.enabled ?? true;
   const serveable = useWorkspaceServeable(conversationId);
+  const recovering = useRunnerRecovering(conversationId);
   const environmentQuery = useWorkspaceEnvironment(conversationId, {
     enabled: queryEnabled,
   });
@@ -419,10 +419,7 @@ export function useWorkspaceAllFiles(
       !!conversationId &&
       serveable !== false &&
       environmentQuery.data?.available === true,
-    // Capped-backoff retry of the runner-offline case (see
-    // shouldRetryRunnerOffline). The asleep-vs-empty decision is made by
-    // the session's `failed` status downstream, not by retries.
-    retry: shouldRetryRunnerOffline,
+    retry: (failureCount, error) => recovering && shouldRetryRunnerOffline(failureCount, error),
     retryDelay: runnerOfflineRetryDelay,
     // Keep the tree warm on revisits: within staleTime a return to a
     // previously-loaded conversation/location paints its cached tree with no
@@ -537,6 +534,7 @@ async function fetchWorkspaceFileSearch(
   // agent).  Mirror the behaviour of useWorkspaceAllFiles: return empty
   // results rather than surfacing an error.
   if (res.status === 404) return [];
+  if (await isRunnerUnavailable503(res)) return [];
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return mapFilesystemEntries((await res.json()) as FilesystemListResponse, location);
 }
@@ -726,6 +724,7 @@ async function fetchDirEntriesTolerant(
   // 404 = the directory (or the whole OS environment) is absent, so the file
   // can't exist. Degrade to "no entries" rather than surfacing an error.
   if (res.status === 404) return [];
+  if (await isRunnerUnavailable503(res)) return [];
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return mapFilesystemEntries((await res.json()) as FilesystemListResponse);
 }
@@ -854,11 +853,12 @@ export function useWorkspaceEnvironment(
   // that gate on its result) hits `/v1/sessions/temp:*/resources/*`.
   const conversationId = isTempConvId(rawConversationId) ? undefined : rawConversationId;
   const serveable = useWorkspaceServeable(conversationId);
+  const recovering = useRunnerRecovering(conversationId);
   return useQuery({
     queryKey: ["workspace-environment", conversationId],
     queryFn: () => fetchWorkspaceEnvironment(conversationId!),
     enabled: (options.enabled ?? true) && !!conversationId && serveable !== false,
-    retry: shouldRetryRunnerOffline,
+    retry: (failureCount, error) => recovering && shouldRetryRunnerOffline(failureCount, error),
     retryDelay: runnerOfflineRetryDelay,
     staleTime: 60_000,
   });


### PR DESCRIPTION
## Related issue

Closes #5391

## Summary

- Gate the two-minute `runner_unavailable` retry budget on session liveness, so stale or dead runners receive one request instead of a retry storm.
- Preserve retries for initial cold boots, loading races, and active-turn runner relaunches.
- Treat runner-offline responses as empty results in tolerant file-search and inline-path existence reads.

ELI5: retry when the runner is actually starting; otherwise stop after the first failed request.

```text
runner_unavailable 503
  ├─ starting/loading/relaunching → capped backoff retry
  └─ stale or offline            → stop after one request
```

## Test Plan

- `pnpm exec vitest run src/hooks/useWorkspaceChangedFiles.test.tsx` (114 passed)
- `pnpm test -- src/hooks/useWorkspaceChangedFiles.test.tsx` (full suite: 5,953 passed, 3 expected failures, 1 skipped)
- `pnpm type-check`
- `pnpm exec oxlint --deny-warnings --report-unused-disable-directives src/hooks/useWorkspaceChangedFiles.ts src/hooks/useWorkspaceChangedFiles.test.tsx`
- `pnpm exec prettier --check src/hooks/useWorkspaceChangedFiles.ts src/hooks/useWorkspaceChangedFiles.test.tsx`
- `uv run --with pre-commit pre-commit run --files web/src/hooks/useWorkspaceChangedFiles.ts web/src/hooks/useWorkspaceChangedFiles.test.tsx`

## Demo

N/A — this changes background request retry behavior and has no visual UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression tests cover stale-online and old unknown sessions, initial cold boot, snapshot-loading races, active-turn relaunch, tolerant reads, and response-body safety.

## Changelog

Workspace file browsing no longer repeatedly retries when a session's runner is unavailable.