### PR TITLE
fix(cli): inherit the CLI-selected workspace on login without ?o=

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10947,6 +10947,51 @@ def _host_with_org(workspace_host: str, org_id: str | None) -> str:
     )
 
 
+def _databricks_default_workspace_id(workspace_host: str) -> str | None:
+    """Return the workspace id the Databricks CLI recorded for *workspace_host*.
+
+    Thin, mockable wrapper over
+    :func:`omnigent.inner.databricks_executor.databrickscfg_workspace_id_for_host`.
+    An account-fronting login carries no ``?o=`` selector, yet the CLI resolves a
+    workspace during login and records its id; the account token routes to it
+    once that id is replayed as ``?o=``. Inheriting it lets the login succeed
+    without the user restating a workspace the CLI already chose.
+
+    :param workspace_host: The workspace host, e.g.
+        ``"https://example.databricks.com"``.
+    :returns: The recorded workspace id, or ``None`` when none is recorded.
+    """
+    from omnigent.inner.databricks_executor import databrickscfg_workspace_id_for_host
+
+    return databrickscfg_workspace_id_for_host(workspace_host)
+
+
+def _databricks_host_needs_org_selector(workspace_host: str) -> bool:
+    """Whether *workspace_host* fronts many workspaces and needs a ``?o=`` selector.
+
+    Reads the host's unauthenticated ``/.well-known/databricks-config`` discovery
+    document. A host acting as an account (many workspaces under one hostname)
+    reports an ``account_id`` but no ``workspace_id``; a single workspace reports
+    its own ``workspace_id``. Such a login carries no ``?o=<workspace-id>``
+    selector, so we gate the inherit-the-CLI-selected-workspace path on this,
+    leaving genuine single-workspace mounts untouched.
+
+    :param workspace_host: The workspace host, e.g.
+        ``"https://example.databricks.com"``.
+    :returns: ``True`` only when the metadata positively identifies an
+        account-acting host. Any fetch/parse failure — or inconclusive
+        metadata (older regional hosts report neither id) — returns ``False``
+        so a discovery outage never changes an otherwise-valid login.
+    """
+    try:
+        from databricks.sdk.oauth import get_host_metadata
+
+        meta = get_host_metadata(workspace_host)
+    except Exception:  # noqa: BLE001 - any discovery failure means "can't tell"; never block login on it
+        return False
+    return not meta.workspace_id and bool(meta.account_id)
+
+
 def _databricks_login(server: str, workspace_host: str, org_id: str | None = None) -> None:
     """Log in to a Databricks-fronted Omnigent server.
 
@@ -10989,11 +11034,33 @@ def _databricks_login(server: str, workspace_host: str, org_id: str | None = Non
             f"{DATABRICKS_EXTRA_INSTALL_HINT}"
         )
 
+    from omnigent.cli_auth import is_workspace_hosted_url
+
+    # An account-fronting workspace mount serves many workspaces under one host,
+    # so the login URL carries no ?o= selector — but the Databricks CLI still
+    # resolves a workspace during login. Recognize that shape (from discovery
+    # metadata) so the resolved workspace can be inherited below instead of
+    # failing on the bare account host, which answers 503/403.
+    account_host_without_selector = (
+        org_id is None
+        and is_workspace_hosted_url(server)
+        and _databricks_host_needs_org_selector(workspace_host)
+    )
+
     token = _databricks_workspace_token(workspace_host)
     fresh_login_done = False
     if token is None:
         token = _login_and_mint_workspace_token(workspace_host, org_id)
         fresh_login_done = True
+
+    # Inherit the workspace the CLI selected: the browser login (or a prior one)
+    # auto-selected a workspace and recorded its id in the profile; replaying it
+    # as ?o= routes the account token to that workspace. Without it the login
+    # would fail on an account host it could have completed unattended.
+    if account_host_without_selector:
+        org_id = _databricks_default_workspace_id(workspace_host)
+        if org_id:
+            click.echo(f"Routing to workspace {org_id}, selected during the Databricks login.")
 
     # Verify the workspace token actually gets through the edge to THIS
     # server (the user may lack access to it), and learn our identity

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -696,6 +696,40 @@ def _databrickscfg_profiles_for_host(host: str) -> list[str]:
     return matches
 
 
+def databrickscfg_workspace_id_for_host(host: str) -> str | None:
+    """Return the ``workspace_id`` the Databricks CLI recorded for *host*.
+
+    ``databricks auth login --host <host>`` resolves a workspace during login
+    (auto-selecting the only accessible one, or the one the user picks) and
+    writes its id into the matching ``~/.databrickscfg`` profile. On an
+    account-fronting host — one hostname over many workspaces — that recorded id
+    is the only trace of which workspace the login chose, and an account token
+    routes to it once the id is replayed as the ``?o=`` selector.
+
+    :param host: Workspace host to match, e.g.
+        ``"https://example.databricks.com"``.
+    :returns: The recorded workspace id, or ``None`` when the file is
+        missing/unparseable or no matching profile carries one.
+    """
+    import configparser
+    from pathlib import Path
+
+    cfg_path = Path(os.environ.get("DATABRICKS_CONFIG_FILE") or (Path.home() / ".databrickscfg"))
+    if not cfg_path.exists():
+        return None
+    config = configparser.ConfigParser()
+    try:
+        config.read(cfg_path)
+    except configparser.Error:
+        return None
+    for section in _databrickscfg_profiles_for_host(host):
+        values = config.defaults() if section == "DEFAULT" else config[section]
+        workspace_id = values.get("workspace_id")
+        if workspace_id:
+            return workspace_id
+    return None
+
+
 def _get_openai_client(profile: str | None = None) -> OpenAI:
     """Lazily import and construct the OpenAI client.
 

--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -108,6 +108,8 @@ def _patch_login_env(
     fake_httpx: _FakeHttpx,
     sdk_installed: bool = True,
     cached_tokens: list[str | None] | None = None,
+    host_needs_selector: bool = False,
+    default_workspace_id: str | None = None,
 ) -> list[str]:
     """Patch the login command's collaborators for a scripted run.
 
@@ -118,6 +120,12 @@ def _patch_login_env(
         results, e.g. ``[None, "tok"]`` for "no cached grant, then a
         token after ``databricks auth login`` runs". Defaults to a
         cached token on first try.
+    :param host_needs_selector: What ``_databricks_host_needs_org_selector``
+        reports for the discovery-metadata check. Defaults to ``False`` so tests
+        never touch the real ``/.well-known/databricks-config`` endpoint.
+    :param default_workspace_id: What ``_databricks_default_workspace_id``
+        returns — the workspace the CLI recorded for the host. Defaults to
+        ``None`` so tests never read the developer's real ``~/.databrickscfg``.
     :returns: A list capturing each ``subprocess.run`` argv (the
         ``databricks auth login`` invocations).
     """
@@ -127,6 +135,13 @@ def _patch_login_env(
     # keeps each login test's scripted response sequence aligned with the
     # login body's own requests.
     monkeypatch.setattr(cli_mod, "_workspace_api_server_url", lambda server: server)
+    # Discovery-metadata + cfg reads are offline by default; account-host tests opt in.
+    monkeypatch.setattr(
+        cli_mod, "_databricks_host_needs_org_selector", lambda workspace_host: host_needs_selector
+    )
+    monkeypatch.setattr(
+        cli_mod, "_databricks_default_workspace_id", lambda workspace_host: default_workspace_id
+    )
     monkeypatch.setattr(
         "omnigent.onboarding.databricks_config.databricks_sdk_installed",
         lambda: sdk_installed,
@@ -217,6 +232,132 @@ def test_login_workspace_hosted_401_uses_url_host(
     assert result.exit_code == 0, result.output
     # Keyed by the full server URL (with the /api/2.0/omnigent path) and
     # pointing at the workspace host without the path.
+    assert load_databricks_workspace_host(_WORKSPACE_API_URL) == _WORKSPACE
+
+
+def test_login_account_host_inherits_cli_selected_workspace(
+    monkeypatch: pytest.MonkeyPatch, token_dir: Path
+) -> None:
+    """An account-acting host without ?o= inherits the workspace the CLI recorded.
+
+    Discovery metadata identifies ``isaac.databricks.com`` as account-acting (an
+    ``account_id`` but no ``workspace_id``). The ``databricks auth login`` flow
+    still resolves a workspace and records its id in the profile; the login reads
+    it back and routes the account token to it (``params o=…``), succeeding
+    unattended — and records the inherited id for later commands.
+    """
+    from omnigent.cli_auth import load_databricks_org_id, load_databricks_workspace_host
+
+    fake = _FakeHttpx(
+        responses=[
+            _response(
+                401,
+                headers={"www-authenticate": 'Bearer realm="DatabricksRealm"'},
+                body={"error_code": 401, "message": "Credential was not sent"},
+            ),
+            # Verify carrying the inherited selector: the workspace accepts it.
+            _response(200, body={"user_id": "alice@example.com"}),
+        ]
+    )
+    _patch_login_env(
+        monkeypatch,
+        fake_httpx=fake,
+        host_needs_selector=True,
+        default_workspace_id="1965859176160743",
+    )
+
+    result = CliRunner().invoke(cli_group, ["login", _WORKSPACE_API_URL])
+
+    assert result.exit_code == 0, result.output
+    # The inherited workspace routed the verify probe and was recorded.
+    assert fake.requests[-1]["params"] == {"o": "1965859176160743"}
+    assert "1965859176160743" in result.output
+    assert load_databricks_org_id(_WORKSPACE_API_URL) == "1965859176160743"
+    assert load_databricks_workspace_host(_WORKSPACE_API_URL) == _WORKSPACE
+
+
+@pytest.mark.parametrize(
+    ("account_id", "workspace_id", "expected"),
+    [
+        ("acc-1", None, True),  # account-acting host fronting many workspaces
+        ("acc-1", "1965859176160743", False),  # single workspace names its own id
+        (None, None, False),  # older regional host: inconclusive, don't block
+    ],
+)
+def test_databricks_host_needs_org_selector_reads_discovery_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    account_id: str | None,
+    workspace_id: str | None,
+    expected: bool,
+) -> None:
+    """Account-acting hosts (account id, no workspace id) need a ?o= selector.
+
+    The signal is the unauthenticated ``/.well-known/databricks-config``
+    document: a workspace id means a single workspace, its absence (with an
+    account id) means the host fronts many.
+    """
+    from types import SimpleNamespace
+
+    import databricks.sdk.oauth as sdk_oauth
+
+    monkeypatch.setattr(
+        sdk_oauth,
+        "get_host_metadata",
+        lambda host: SimpleNamespace(account_id=account_id, workspace_id=workspace_id),
+    )
+    assert cli_mod._databricks_host_needs_org_selector("https://host.example") is expected
+
+
+def test_databricks_host_needs_org_selector_swallows_discovery_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A discovery fetch failure never blocks login (returns False)."""
+    import databricks.sdk.oauth as sdk_oauth
+
+    def _boom(host: str) -> object:
+        raise ValueError("no route to host")
+
+    monkeypatch.setattr(sdk_oauth, "get_host_metadata", _boom)
+    assert cli_mod._databricks_host_needs_org_selector("https://host.example") is False
+
+
+def test_login_workspace_hosted_with_selector_binds_and_succeeds(
+    monkeypatch: pytest.MonkeyPatch, token_dir: Path
+) -> None:
+    """A workspace mount login carrying ?o=<id> threads the selector and succeeds.
+
+    The selector rides both the browser login (``--host …?o=<id>``, which
+    binds the grant to the workspace) and the verify probe (``params o=<id>``,
+    which routes to it), and is recorded for later commands.
+    """
+    from omnigent.cli_auth import load_databricks_org_id, load_databricks_workspace_host
+
+    fake = _FakeHttpx(
+        responses=[
+            _response(
+                401,
+                headers={"www-authenticate": 'Bearer realm="DatabricksRealm"'},
+                body={"error_code": 401, "message": "Credential was not sent"},
+            ),
+            _response(200, body={"user_id": "alice@example.com"}),
+        ]
+    )
+    login_calls = _patch_login_env(monkeypatch, fake_httpx=fake, cached_tokens=[None, "tok-fresh"])
+    # Mirror production normalization, which drops the ?o= query when expanding
+    # to the API mount (the selector travels separately). The default stub is
+    # identity, which would leave the query on the record key.
+    monkeypatch.setattr(cli_mod, "_workspace_api_server_url", lambda server: server.split("?")[0])
+
+    result = CliRunner().invoke(cli_group, ["login", f"{_WORKSPACE_API_URL}?o=1965859176160743"])
+
+    assert result.exit_code == 0, result.output
+    # Selector bound at login (--host …?o=…) and routed at verify (params o=…).
+    assert login_calls == [
+        f"auth login --host {_WORKSPACE}/?o=1965859176160743 --profile {_PROFILE}"
+    ]
+    assert fake.requests[-1]["params"] == {"o": "1965859176160743"}
+    # Recorded (keyed by the query-less mount) for later request routing.
+    assert load_databricks_org_id(_WORKSPACE_API_URL) == "1965859176160743"
     assert load_databricks_workspace_host(_WORKSPACE_API_URL) == _WORKSPACE
 
 

--- a/tests/inner/test_databricks_executor.py
+++ b/tests/inner/test_databricks_executor.py
@@ -714,6 +714,7 @@ from omnigent.inner.databricks_executor import (  # noqa: E402
     _read_databrickscfg,
     _read_databrickscfg_file_fallback,
     _read_databrickscfg_host,
+    databrickscfg_workspace_id_for_host,
 )
 
 _AUTH_ENV_VARS: tuple[str, ...] = (
@@ -1874,3 +1875,43 @@ def test_stream_ended_without_finish_reason_with_content_completes() -> None:
         assert turn_events[0].response == "partial"
 
     _run(_t())
+
+
+def test_databrickscfg_workspace_id_for_host_reads_matching_profile(
+    tmp_path: _Path, monkeypatch: pytest.MonkeyPatch, clean_databricks_env: None
+) -> None:
+    """The workspace id is read from the ~/.databrickscfg profile matching the host.
+
+    ``databricks auth login`` records the resolved workspace id per profile;
+    matching is scheme-insensitive and trailing-slash tolerant, so a bare-host
+    cfg entry matches an ``https://`` query.
+    """
+    cfg = tmp_path / "databrickscfg"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            [acme]
+            host = https://acme.databricks.com
+            workspace_id = 1965859176160743
+            auth_type = databricks-cli
+
+            [no-ws]
+            host = https://plain.databricks.com
+            auth_type = databricks-cli
+            """
+        ).lstrip()
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+
+    assert databrickscfg_workspace_id_for_host("https://acme.databricks.com") == "1965859176160743"
+    # A profile without the field, and an unknown host, both resolve to None.
+    assert databrickscfg_workspace_id_for_host("https://plain.databricks.com") is None
+    assert databrickscfg_workspace_id_for_host("https://other.databricks.com") is None
+
+
+def test_databrickscfg_workspace_id_for_host_missing_file_returns_none(
+    tmp_path: _Path, monkeypatch: pytest.MonkeyPatch, clean_databricks_env: None
+) -> None:
+    """A missing ~/.databrickscfg never raises — it resolves to None."""
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(tmp_path / "absent"))
+    assert databrickscfg_workspace_id_for_host("https://acme.databricks.com") is None


### PR DESCRIPTION
## Related issue

No tracked issue — small bug fix to a confusing CLI login flow. Happy to file one if maintainers prefer.

Closes #

## Summary

Logging in to a Databricks account-fronting workspace mount (`https://<host>/api/2.0/omnigent` — one hostname over many workspaces) without a `?o=<workspace-id>` selector failed with an opaque HTTP 403/503 and the misleading *"check that your user has access to this app"*.

The Databricks CLI already resolves a workspace during login (auto-selecting the only accessible one, or the one the user picks) and records its id in the matching `~/.databrickscfg` profile — and an account token routes to that workspace once the id is replayed as `?o=`. So instead of failing, **inherit** it:

1. **Detect an account-acting host** from its unauthenticated `/.well-known/databricks-config` discovery document (via the SDK's `get_host_metadata`): such a host reports an `account_id` but **no `workspace_id`** (a single workspace reports its own).
2. **Inherit the recorded workspace** from `~/.databrickscfg` and route the account token to it, so the login completes unattended.

Single-workspace mounts report their own `workspace_id` and are left untouched; a discovery outage never changes an otherwise-valid login. The `?o=` selector already flows everywhere once stored — it's persisted as `org_id` in `auth_tokens.json` and replayed as the `X-Databricks-Org-Id` routing header by the one `databricks_request_headers` builder every request path uses — so no per-call-site plumbing was needed.

No hostname pattern matching. Verified against live endpoints: `isaac.databricks.com` → `account_id` set, `workspace_id: None`; a single-workspace host → `workspace_id` set (left alone); account token + request-time `?o=` from the profile → HTTP 200.

Before (had to re-run manually with `?o=`):
```
Error: https://isaac.databricks.com accepted the login, but
https://isaac.databricks.com/api/2.0/omnigent rejected the token (HTTP 403).
Check that your user has access to this app.
```
After (`omnigent login https://isaac.databricks.com/api/2.0/omnigent`, no `?o=`):
```
https://isaac.databricks.com/api/2.0/omnigent authenticates via the Databricks workspace https://isaac.databricks.com.
Routing to workspace 1965859176160743, selected during the Databricks login.
Logged in as ****@databricks.com. Commands targeting https://isaac.databricks.com/api/2.0/omnigent now mint workspace tokens automatically.
```

## Test Plan

- `uv run pytest tests/cli/test_login_databricks.py tests/inner/test_databricks_executor.py` — passing, including new cases:
  - account-acting host without `?o=` inherits the CLI-recorded workspace, routes the verify probe with it (`params o=…`), and records it;
  - `?o=<id>` in the URL still threads onto `--host …?o=…` and the verify probe;
  - parametrized unit tests for the discovery-metadata classifier and its failure-swallowing;
  - `databrickscfg_workspace_id_for_host` reads the matching profile / tolerates a missing file.
- Live end-to-end: `omnigent login https://isaac.databricks.com/api/2.0/omnigent` (no `?o=`) inherits the workspace and logs in (output above).
- `uv run ruff check` / `uv run ruff format --check` — clean. `pyrefly check` — 0 errors.

## Demo

N/A (CLI login-flow / output change; before/after shown in Summary).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the happy path end-to-end against a real account-fronting host (`isaac.databricks.com`): `omnigent login <mount>` with no `?o=` inherits the CLI-selected workspace and logs in. The interactive `databricks auth login` browser flow and multi-workspace picker are exercised by the CLI itself and are mocked in unit tests.

## Changelog

`omnigent login` to a Databricks account-fronting workspace mount without `?o=` now inherits the workspace the Databricks CLI already selected, instead of failing with an opaque 403.
