### PR TITLE
fix(runner): tolerate transient tmux probe failures

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -386,6 +386,10 @@ def _tmux_status_option_commands() -> list[list[str]]:
 # tests can lower them instead of waiting the full threshold per assertion.
 _IDLE_THRESHOLD_SECONDS = 10.0
 _IDLE_POLL_INTERVAL_SECONDS = 1.0
+# A tmux client can fail transiently while the server and pane remain healthy
+# (for example when the host briefly cannot fork another client). Require
+# repeated capture + session-probe failures before publishing terminal exit.
+_IDLE_EXIT_FAILURE_THRESHOLD = 3
 
 # When a web client interacts with the terminal (attach/detach, focus
 # in/out, mouse, keystroke, resize — all stamped via
@@ -1407,10 +1411,14 @@ class TerminalInstance:
         await self._stop_idle_watcher()
         self._stop_idle_watcher_thread()
 
-        if self.running:
+        # The watcher and is_alive() both set ``running=False`` when they
+        # observe a failure. A private socket can still belong to a live tmux
+        # server (or a remain-on-exit pane), so cleanup must not trust that
+        # advisory flag before issuing kill-server.
+        if self.running or self.socket_path.exists():
             with contextlib.suppress(RuntimeError):
                 await self._tmux("kill-server")
-            self.running = False
+        self.running = False
 
         if self.os_env is not None:
             self.os_env.close()
@@ -1498,6 +1506,7 @@ class TerminalInstance:
                 return False
             return True
 
+        consecutive_capture_failures = 0
         while self.running:
             await asyncio.sleep(_IDLE_POLL_INTERVAL_SECONDS)
             if not self.running:
@@ -1510,13 +1519,31 @@ class TerminalInstance:
                     "-p",
                     "-e",
                 )
-            except RuntimeError:
-                # tmux server likely gone.
+            except RuntimeError as exc:
+                logger.warning(
+                    "tmux capture-pane probe failed for terminal %s:%s: %s",
+                    self.name,
+                    self.session_key,
+                    exc,
+                )
+                if await self._tmux_session_exists_async():
+                    consecutive_capture_failures = 0
+                    continue
+                consecutive_capture_failures += 1
+                if consecutive_capture_failures < _IDLE_EXIT_FAILURE_THRESHOLD:
+                    continue
+                logger.error(
+                    "tmux unavailable after %d consecutive probes for terminal %s:%s",
+                    consecutive_capture_failures,
+                    self.name,
+                    self.session_key,
+                )
                 self.running = False
                 if on_exit is not None:
                     await _fire(on_exit, "exit")
                 return
 
+            consecutive_capture_failures = 0
             self._remember_pane_snapshot(snapshot)
             if await self._pane_is_dead_async():
                 # remain-on-exit kept the server alive after the inner CLI
@@ -1646,8 +1673,8 @@ class TerminalInstance:
         Runs on the daemon thread spawned by
         :meth:`start_idle_watcher_thread`. Stops cleanly when
         ``stop_event`` is set or when ``self.running`` flips to
-        ``False`` (close path), and exits silently if ``tmux
-        capture-pane`` fails (server likely gone).
+        ``False`` (close path). A failed ``capture-pane`` is confirmed with
+        ``has-session`` and must repeat before the watcher reports exit.
 
         :param stop_event: Event the close path sets to signal
             shutdown. Doubles as the poll-interval sleep via
@@ -1671,6 +1698,7 @@ class TerminalInstance:
         """
         detector = _IdleDetector(idle_threshold_s=idle_threshold_s)
         interval = poll_interval_s if poll_interval_s is not None else _IDLE_POLL_INTERVAL_SECONDS
+        consecutive_capture_failures = 0
         while self.running:
             # ``Event.wait`` doubles as the poll-interval sleep, so
             # ``stop_event.set()`` from :meth:`close` returns within
@@ -1681,10 +1709,23 @@ class TerminalInstance:
                 return
             snapshot = self._capture_pane_for_idle_or_none()
             if snapshot is None:
+                if self._tmux_session_exists_sync():
+                    consecutive_capture_failures = 0
+                    continue
+                consecutive_capture_failures += 1
+                if consecutive_capture_failures < _IDLE_EXIT_FAILURE_THRESHOLD:
+                    continue
+                logger.error(
+                    "tmux unavailable after %d consecutive probes for terminal %s:%s",
+                    consecutive_capture_failures,
+                    self.name,
+                    self.session_key,
+                )
                 self.running = False
                 if on_exit is not None:
                     self._fire_watch_callback(on_exit, "exit")
                 return
+            consecutive_capture_failures = 0
             self._remember_pane_snapshot(snapshot)
             if self._pane_is_dead():
                 # The inner CLI exited but remain-on-exit kept the server, so
@@ -1736,14 +1777,27 @@ class TerminalInstance:
         Capture the pane for an idle tick, or signal "tmux gone".
 
         :returns: Pane bytes from ``tmux capture-pane -p -e``, or
-            ``None`` when the tmux subprocess raised — the
-            threaded loop reads ``None`` as "stop watching, the
-            server is no longer there".
+            ``None`` when the tmux subprocess raised. The threaded loop
+            confirms and counts this failure before treating it as exit.
         """
         try:
             return self._tmux_output_sync("capture-pane", "-t", self.tmux_target, "-p", "-e")
-        except RuntimeError:
+        except RuntimeError as exc:
+            logger.warning(
+                "tmux capture-pane probe failed for terminal %s:%s: %s",
+                self.name,
+                self.session_key,
+                exc,
+            )
             return None
+
+    def _tmux_session_exists_sync(self) -> bool:
+        """Confirm that this instance's tmux session still exists."""
+        try:
+            self._tmux_output_sync("has-session", "-t", self.tmux_target)
+        except RuntimeError:
+            return False
+        return True
 
     def _pane_is_dead(self) -> bool:
         """
@@ -1905,29 +1959,49 @@ class TerminalInstance:
         self._remember_exit_status(out)
         return out.split()[:1] == ["1"]
 
+    async def _tmux_session_exists_async(self) -> bool:
+        """Async confirmation that this instance's tmux session still exists."""
+        try:
+            await self._tmux_output("has-session", "-t", self.tmux_target)
+        except RuntimeError:
+            return False
+        return True
+
     async def _tmux(self, *args: str) -> None:
         """Run a tmux command against this instance's server."""
-        proc = await asyncio.create_subprocess_exec(
-            *self._tmux_base_cmd(),
-            *args,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.PIPE,
-        )
+        cmd = [*self._tmux_base_cmd(), *args]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except OSError as exc:
+            raise RuntimeError(f"tmux command could not start: {' '.join(cmd)}: {exc}") from exc
         _, stderr = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(f"tmux command failed: {' '.join(args)}: {stderr.decode().strip()}")
+            detail = stderr.decode(errors="replace").strip() or "<no stderr>"
+            raise RuntimeError(
+                f"tmux command failed (rc={proc.returncode}): {' '.join(cmd)}: {detail}"
+            )
 
     async def _tmux_output(self, *args: str) -> str:
         """Run a tmux command and return stdout."""
-        proc = await asyncio.create_subprocess_exec(
-            *self._tmux_base_cmd(),
-            *args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
+        cmd = [*self._tmux_base_cmd(), *args]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except OSError as exc:
+            raise RuntimeError(f"tmux command could not start: {' '.join(cmd)}: {exc}") from exc
         stdout, stderr = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(f"tmux command failed: {' '.join(args)}: {stderr.decode().strip()}")
+            detail = stderr.decode(errors="replace").strip() or "<no stderr>"
+            raise RuntimeError(
+                f"tmux command failed (rc={proc.returncode}): {' '.join(cmd)}: {detail}"
+            )
         return stdout.decode()
 
     def _tmux_output_sync(self, *args: str) -> str:
@@ -1945,10 +2019,15 @@ class TerminalInstance:
         :raises RuntimeError: When the tmux subprocess exits
             non-zero (typically because the server has gone away).
         """
-        proc = subprocess.run([*self._tmux_base_cmd(), *args], capture_output=True, check=False)
+        cmd = [*self._tmux_base_cmd(), *args]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, check=False)
+        except OSError as exc:
+            raise RuntimeError(f"tmux command could not start: {' '.join(cmd)}: {exc}") from exc
         if proc.returncode != 0:
+            detail = proc.stderr.decode(errors="replace").strip() or "<no stderr>"
             raise RuntimeError(
-                f"tmux command failed: {' '.join(args)}: {proc.stderr.decode().strip()}"
+                f"tmux command failed (rc={proc.returncode}): {' '.join(cmd)}: {detail}"
             )
         return proc.stdout.decode()
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2453,17 +2453,19 @@ def create_runner_app(
                 "session_id": event.session_id,
             },
         )
-        # A codex TUI pane that exits on its own (crash / OOM / host recycle)
-        # never runs the DELETE-session cleanup, so its per-session app-server
-        # + forwarder would linger with no TUI. Tear them down here; no-op for
-        # any session without a registered codex app-server.
+        # Auxiliary terminals do not own the session control plane. In
+        # particular, losing Codex's streamable TUI must not cancel an active
+        # app-server turn; the native-terminal ensure path can recreate it.
+        if event.lifecycle != TerminalLifecycle.REQUIRED:
+            return
+
+        # A required terminal exit ends the session. Tear down any registered
+        # Codex app-server alongside it; this is a no-op for other harnesses.
         _teardown_task = asyncio.create_task(
             _native_runtime.teardown_codex_native_app_server(event.session_id)
         )
         _teardown_task.add_done_callback(_background_tasks.discard)
         _background_tasks.add(_teardown_task)
-        if event.lifecycle != TerminalLifecycle.REQUIRED:
-            return
 
         if event.terminal_name in ("qwen", "antigravity") and event.session_key == "main":
             _publish_event(event.session_id, {"type": "session.status", "status": "idle"})
@@ -7960,9 +7962,6 @@ def create_runner_app(
             # same dead instance we just probed.
             current = terminal_registry.get(conv_id, terminal_name, "main")
             if current is instance:
-                # is_alive() set instance.running=False as a side effect;
-                # restore it so close() issues tmux kill-server.
-                instance.running = True
                 try:
                     await terminal_registry.close(conv_id, terminal_name, "main")
                 except asyncio.CancelledError:

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -200,21 +200,17 @@ async def teardown_codex_native_app_server(session_id: str) -> None:
     """
     Tear down a host-spawned codex-native session's app-server subprocess.
 
-    Only the ``DELETE /v1/sessions`` teardown runs the full native cleanup;
-    the codex TUI pane can also disappear on its own — the idle pane reaper
-    closes the tmux pane after the idle window, and an unexpected TUI exit
-    (crash / OOM / host recycle) evicts it — neither of which cancels the
-    forwarder. Left alone, the per-session ``codex app-server`` (and its
-    forwarder) survives with no TUI, so long-lived multi-session runners
-    (e.g. Polly, which dispatches every ``codex`` sub-agent this way)
-    accumulate orphaned ``codex`` processes.
+    ``DELETE /v1/sessions``, runner shutdown, and the idle pane reaper use
+    this helper for full native cleanup. An unexpected auxiliary-TUI exit
+    deliberately leaves the app-server running so an active response is not
+    cancelled; the next native-terminal ensure can recreate the TUI.
 
     Cancelling the forwarder closes the app-server via the forwarder's own
     ``finally`` (see :func:`_codex_discover_thread_and_forward`); the pop
     below is the belt-and-suspenders close for the discovery-failed case
     where no forwarder ever adopted the server. No-op for a session that
     has no registered codex app-server, so this is safe to call from the
-    shared pane-teardown paths regardless of harness.
+    required-session teardown paths regardless of harness.
 
     :param session_id: Session/conversation id, e.g. ``"conv_abc123"``.
     :returns: None.

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import shutil
 import subprocess
 import sys
@@ -130,6 +131,7 @@ def test_threaded_idle_watcher_reports_terminal_exit(tmp_path: Path) -> None:
     exited = threading.Event()
 
     instance._capture_pane_for_idle_or_none = lambda: None  # type: ignore[method-assign]
+    instance._tmux_session_exists_sync = lambda: False  # type: ignore[method-assign]
 
     instance.start_idle_watcher_thread(
         on_exit=exited.set,
@@ -154,9 +156,10 @@ def test_threaded_idle_watcher_keeps_last_pane_text_on_exit(tmp_path: Path) -> N
         running=True,
     )
     exited = threading.Event()
-    snapshots = iter(["\x1b[31mstartup failed\x1b[0m\ntry config", None])
+    snapshots = iter(["\x1b[31mstartup failed\x1b[0m\ntry config", None, None, None])
 
     instance._capture_pane_for_idle_or_none = lambda: next(snapshots)  # type: ignore[method-assign]
+    instance._tmux_session_exists_sync = lambda: False  # type: ignore[method-assign]
 
     instance.start_idle_watcher_thread(
         on_exit=exited.set,
@@ -165,6 +168,140 @@ def test_threaded_idle_watcher_keeps_last_pane_text_on_exit(tmp_path: Path) -> N
 
     assert exited.wait(timeout=1.0)
     assert instance.last_pane_text() == "startup failed\ntry config"
+
+
+def test_threaded_idle_watcher_resets_transient_capture_failures(tmp_path: Path) -> None:
+    """Successful pane captures reset the consecutive-failure threshold."""
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    captures = iter([None, None, "recovered once", None, None, "recovered twice"])
+    exited = threading.Event()
+    recovered_twice = threading.Event()
+    successful_ticks = 0
+
+    def _capture() -> str | None:
+        return next(captures, "steady")
+
+    def _on_tick() -> None:
+        nonlocal successful_ticks
+        successful_ticks += 1
+        if successful_ticks >= 2:
+            recovered_twice.set()
+
+    instance._capture_pane_for_idle_or_none = _capture  # type: ignore[method-assign]
+    instance._tmux_session_exists_sync = lambda: False  # type: ignore[method-assign]
+    instance._pane_is_dead = lambda: False  # type: ignore[method-assign]
+
+    instance.start_idle_watcher_thread(
+        on_exit=exited.set,
+        on_tick=_on_tick,
+        poll_interval_s=0.01,
+    )
+
+    assert recovered_twice.wait(timeout=1.0)
+    instance._stop_idle_watcher_thread()
+    assert not exited.is_set()
+    assert instance.running is True
+
+
+def test_threaded_idle_watcher_uses_session_probe_to_confirm_capture_failure(
+    tmp_path: Path,
+) -> None:
+    """A live has-session probe prevents a failed capture from becoming exit."""
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    exited = threading.Event()
+    confirmed = threading.Event()
+    confirmations = 0
+
+    def _confirm() -> bool:
+        nonlocal confirmations
+        confirmations += 1
+        if confirmations >= 4:
+            confirmed.set()
+        return True
+
+    instance._capture_pane_for_idle_or_none = lambda: None  # type: ignore[method-assign]
+    instance._tmux_session_exists_sync = _confirm  # type: ignore[method-assign]
+
+    instance.start_idle_watcher_thread(on_exit=exited.set, poll_interval_s=0.01)
+
+    assert confirmed.wait(timeout=1.0)
+    instance._stop_idle_watcher_thread()
+    assert not exited.is_set()
+    assert instance.running is True
+
+
+@pytest.mark.asyncio
+async def test_close_kills_tmux_when_socket_exists_after_running_cleared(tmp_path: Path) -> None:
+    """Cleanup kills a surviving tmux server even after a watcher marked it dead."""
+    private_dir = tmp_path / "terminal"
+    private_dir.mkdir()
+    socket_path = private_dir / "tmux.sock"
+    socket_path.touch()
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=socket_path,
+        private_dir=private_dir,
+        running=False,
+    )
+    commands: list[tuple[str, ...]] = []
+
+    async def _tmux(*args: str) -> None:
+        commands.append(args)
+
+    instance._tmux = _tmux  # type: ignore[method-assign]
+
+    await instance.close()
+
+    assert commands == [("kill-server",)]
+    assert not private_dir.exists()
+
+
+def test_capture_probe_logs_command_return_code_and_stderr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Watcher probe errors retain the evidence needed to diagnose tmux failures."""
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+
+    monkeypatch.setattr(
+        terminal_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=17,
+            stdout=b"",
+            stderr=b"fork failed: resource temporarily unavailable",
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING, logger=terminal_mod.__name__):
+        snapshot = instance._capture_pane_for_idle_or_none()
+
+    assert snapshot is None
+    message = caplog.text
+    assert "rc=17" in message
+    assert str(instance.socket_path) in message
+    assert "capture-pane -t main -p -e" in message
+    assert "fork failed: resource temporarily unavailable" in message
 
 
 def test_threaded_idle_watcher_fires_on_tick_each_poll(tmp_path: Path) -> None:

--- a/tests/runner/test_app_sessions_native_events_lifecycle.py
+++ b/tests/runner/test_app_sessions_native_events_lifecycle.py
@@ -2921,6 +2921,58 @@ async def test_required_terminal_exit_while_idle_does_not_fail_session(tmp_path:
     assert pm.released == [conv_id]
 
 
+@pytest.mark.asyncio
+async def test_auxiliary_codex_tui_exit_preserves_app_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Losing the streamable TUI does not cancel Codex's active control plane."""
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.app import _session_event_queues_ref
+    from omnigent.runner.resource_registry import TerminalExitEvent, TerminalLifecycle
+
+    conv_id = uuid.uuid4().hex
+    teardown_calls: list[str] = []
+
+    async def _record_teardown(session_id: str) -> None:
+        teardown_calls.append(session_id)
+
+    monkeypatch.setattr(
+        runner_app._native_runtime,
+        "teardown_codex_native_app_server",
+        _record_teardown,
+    )
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    publish_exit = app.state.session_resource_registry._terminal_exit_publisher
+    assert callable(publish_exit)
+
+    try:
+        publish_exit(
+            TerminalExitEvent(
+                session_id=conv_id,
+                terminal_id="terminal_codex_main",
+                terminal_name="codex",
+                session_key="main",
+                lifecycle=TerminalLifecycle.AUXILIARY,
+            )
+        )
+        await asyncio.sleep(0)
+        events = _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
+    finally:
+        _session_event_queues_ref.pop(conv_id, None)
+
+    assert teardown_calls == []
+    assert {
+        "type": "session.resource.deleted",
+        "resource_id": "terminal_codex_main",
+        "resource_type": "terminal",
+        "session_id": conv_id,
+    } in events
+    assert not [event for event in events if event.get("type") == "session.status"]
+
+
 @pytest.mark.parametrize("terminal_name", ["qwen", "antigravity"])
 @pytest.mark.asyncio
 async def test_required_terminal_clean_quit_publishes_idle_not_failed(

--- a/tests/runner/test_app_sessions_native_terminal_routing.py
+++ b/tests/runner/test_app_sessions_native_terminal_routing.py
@@ -1037,17 +1037,15 @@ async def test_ensure_terminal_route_recreates_dead_registered_pane(
 
 
 @pytest.mark.asyncio
-async def test_dead_registered_pane_close_restores_running_for_kill_server(
+async def test_dead_registered_pane_close_does_not_restore_running(
     tmp_path: Path,
 ) -> None:
-    """``running`` must be restored before ``close()`` so kill-server runs.
+    """A dead-pane close no longer mutates the advisory ``running`` flag.
 
     ``is_alive()`` sets ``instance.running = False`` as a side effect when
-    the pane is dead. ``TerminalInstance.close()`` checks ``self.running``
-    before issuing ``tmux kill-server``. The self-heal path in
-    ``_ensure_native_terminal_for_turn`` must restore ``running = True``
-    after detecting a dead pane so the subsequent ``close()`` properly
-    kills the remain-on-exit tmux server instead of leaving it orphaned.
+    the pane is dead. ``TerminalInstance.close()`` now uses the private socket
+    to decide whether to issue ``tmux kill-server``, so the self-heal path does
+    not need to falsify this liveness state before closing the stale entry.
 
     This test exercises the contract directly on ``TerminalRegistry.close``
     with a tracking ``close()`` stub that captures ``running`` at call time.
@@ -1087,18 +1085,12 @@ async def test_dead_registered_pane_close_restores_running_for_kill_server(
     assert alive is False
     assert dead_instance.running is False, "is_alive() should set running=False"
 
-    # This is what _ensure_native_terminal_for_turn does: restore running
-    # before calling registry.close() so close() issues kill-server.
-    dead_instance.running = True
     await registry.close(sid, "claude", "main")
 
     assert len(running_at_close) == 1, (
         f"Expected close() to be called once; got {len(running_at_close)} calls"
     )
-    assert running_at_close[0] is True, (
-        "running must be True when close() is called so tmux kill-server runs; "
-        "was False — is_alive() side-effect was not restored"
-    )
+    assert running_at_close[0] is False
     assert registry.get(sid, "claude", "main") is None, (
         "Stale entry must be removed from the registry"
     )

--- a/tests/runner/test_app_sessions_native_wake_forwarders.py
+++ b/tests/runner/test_app_sessions_native_wake_forwarders.py
@@ -386,11 +386,10 @@ async def test_teardown_codex_native_app_server_cancels_forwarder_and_closes_ser
     """
     Codex pane teardown cancels the forwarder and closes the app-server.
 
-    The idle pane reaper and an unexpected TUI exit both close only the tmux
-    pane; without this helper the per-session ``codex app-server`` (and its
-    forwarder) survives with no TUI, orphaning a ``codex`` process for the
-    runner's lifetime. Teardown must both cancel the registered forwarder and
-    close the registered app-server so neither leaks.
+    The idle pane reaper closes only the tmux pane; without this helper the
+    per-session ``codex app-server`` (and its forwarder) survives with no TUI,
+    orphaning a ``codex`` process for the runner's lifetime. Teardown must both
+    cancel the registered forwarder and close the registered app-server.
     """
     session_id = "c0d3f00d0000000000000000deadbeef"
     run = _ForwarderRun()
@@ -433,10 +432,9 @@ async def test_teardown_codex_native_app_server_noop_without_registered_server()
     """
     Teardown is a no-op for a session with no registered codex app-server.
 
-    The shared pane-teardown paths (reaper, terminal-exit publisher) fire for
-    every native harness, so calling this for a non-codex session — or a codex
-    session whose server is already gone — must not touch that session's
-    forwarder or raise.
+    Shared required-session and idle-reaper cleanup can fire for every native
+    harness, so calling this for a non-codex session — or a codex session whose
+    server is already gone — must not touch that session's forwarder or raise.
     """
     session_id = "1111111122222222aaaaaaaabbbbbbbb"
     run = _ForwarderRun()

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -1809,6 +1809,7 @@ def test_install_crash_logging_is_idempotent() -> None:
 @pytest.mark.asyncio
 async def test_runner_shutdown_closes_terminal_registry(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """The --server local runner shuts down terminal-owned resources.
 
@@ -1818,6 +1819,7 @@ async def test_runner_shutdown_closes_terminal_registry(
     startup/shutdown hooks directly and verifies shutdown includes the
     TerminalRegistry, not just harness subprocesses and MCPs.
     """
+    import omnigent.inner.terminal as terminal_mod
     import omnigent.runner._entry as entry_mod
 
     process_managers: list[_FakeProcessManager] = []
@@ -1866,6 +1868,10 @@ async def test_runner_shutdown_closes_terminal_registry(
         return client
 
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://runner.test")
+    # create_app() performs its production orphan sweep during construction.
+    # Keep this lifecycle unit test away from terminals owned by other local
+    # runners and test sessions.
+    monkeypatch.setattr(terminal_mod, "_terminals_tmp_root", lambda: tmp_path)
     monkeypatch.setattr(
         "omnigent.runtime.harnesses.process_manager.HarnessProcessManager",
         _FakeProcessManager,


### PR DESCRIPTION
## Related issue

N/A — diagnosed from an unresponsive codex-native session.

## Summary

- Require repeated `capture-pane` and `has-session` failures before declaring a terminal dead, and log the tmux command, return code, and stderr.
- Kill a surviving private tmux server during cleanup even when a watcher already cleared the advisory `running` flag.
- Keep an auxiliary Codex TUI failure from cancelling the app-server control plane, and isolate the runner lifecycle unit test from host terminal state.

ELI5: one missed terminal heartbeat used to be treated as certain death. That removed the terminal and shut down Codex mid-response. We now double-check the heartbeat, tolerate transient misses, and keep the agent control plane alive if only its display disappears.

```text
capture-pane fails
  ├─ has-session succeeds ─────────> keep watching
  └─ both fail three times ────────> confirmed terminal exit

auxiliary Codex TUI exits ─────────> remove TUI resource, preserve app-server
```

## Test Plan

- `pre-commit run --files <all modified files>`
- `pytest -q tests/inner/test_terminal.py` — 46 passed
- Focused terminal/lifecycle regression suite — 49 passed
- Broader affected runner suite — 211 passed; two unrelated SDK-dispatch cases were blocked by the developer machine's `codex-databricks` provider configuration.

## Demo

N/A — non-visual runner lifecycle fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression coverage exercises transient probe recovery, successful confirmation, cleanup after `running` is cleared, retained probe diagnostics, auxiliary Codex app-server preservation, and unit-test orphan-sweep isolation.

## Changelog

Terminal sessions no longer freeze after a transient tmux probe failure.
