### PR TITLE
feat(web): add a chat Attach button for a disconnected runner

### DIFF
--- a/tests/e2e/test_host_e2e.py
+++ b/tests/e2e/test_host_e2e.py
@@ -1102,3 +1102,141 @@ def test_host_native_session_round_trips_after_runner_death(
         except subprocess.TimeoutExpired:
             host_proc.kill()
             host_proc.wait()
+
+
+def test_host_retry_session_recovers_killed_runner(
+    live_server: str,
+    http_client: httpx.Client,
+    tmp_path: Path,
+    mock_llm_server_url: str,
+) -> None:
+    """``retry_session`` relaunches a host-bound runner without a user message.
+
+    The customer scenario: a host restart (or a killed runner) drops the runner
+    tunnel while the host stays up. The web UI reads that as ``runner_asleep``
+    and offers an Attach button that POSTs a ``retry_session`` event — no chat
+    message. This exercises the server primitive that button calls end to end
+    against a REAL host + server: with the runner dead and the host live,
+    ``retry_session`` relaunches the runner via the host
+    (``recovery: "runner_relaunched"``), and the recovered runner is usable.
+    """
+    marker_pre = "RETRY_PRE_KILL"
+    marker_post = "RETRY_POST_RECOVER"
+    configure_mock_llm(mock_llm_server_url, [{"text": marker_pre}, {"text": marker_post}])
+
+    daemon = _spawn_host_daemon(
+        tmp_path=tmp_path,
+        live_server=live_server,
+        mock_llm_server_url=mock_llm_server_url,
+    )
+    host_proc = daemon.proc
+    host_id = daemon.host_id
+
+    try:
+        _wait_for_host_online(http_client, host_id, timeout=30.0)
+
+        agent_name = upload_agent(http_client, _write_smoke_agent_yaml(tmp_path))
+        agent_id = lookup_agent_id(http_client, agent_name)
+        session_resp = http_client.post("/v1/sessions", json={"agent_id": agent_id})
+        session_resp.raise_for_status()
+        session_id = session_resp.json()["id"]
+
+        launch_resp = http_client.post(
+            f"/v1/hosts/{host_id}/runners",
+            json={"session_id": session_id, "workspace": str(tmp_path)},
+            timeout=60.0,
+        )
+        assert launch_resp.status_code == 200
+        runner_id = launch_resp.json()["runner_id"]
+
+        deadline = time.monotonic() + 30.0
+        runner_online = False
+        while time.monotonic() < deadline:
+            sr = http_client.get(f"/v1/runners/{runner_id}/status")
+            if sr.status_code == 200 and sr.json().get("online"):
+                runner_online = True
+                break
+            time.sleep(0.5)
+        assert runner_online, f"Runner {runner_id} never came online"
+        http_client.patch(
+            f"/v1/sessions/{session_id}",
+            json={"runner_id": runner_id},
+        ).raise_for_status()
+
+        # Baseline: the host-bound session round-trips before the runner dies.
+        rid_pre = send_user_message_to_session(
+            http_client,
+            session_id=session_id,
+            content=f"Reply with exactly {marker_pre} and nothing else.",
+        )
+        body_pre = poll_session_until_terminal(
+            http_client,
+            session_id=session_id,
+            response_id=rid_pre,
+            timeout=120,
+        )
+        assert body_pre["status"] == "completed"
+        assert marker_pre in final_assistant_text(body_pre)
+
+        # Kill the RUNNER, not the host: the host stays online, so the session
+        # is now runner-down/host-up — the state the web's Attach button targets.
+        runner_pid = _runner_pid_from_daemon_log(daemon.daemon_log)
+        assert runner_pid is not None, (
+            "could not find the launched runner pid in the daemon log:\n"
+            f"{daemon.daemon_log.read_text()}"
+        )
+        os.kill(runner_pid, signal.SIGKILL)
+
+        # Wait until the server observes the runner tunnel gone, so retry_session
+        # exercises the relaunch path rather than the already-connected fast path.
+        deadline = time.monotonic() + 15.0
+        runner_offline = False
+        while time.monotonic() < deadline:
+            sr = http_client.get(f"/v1/runners/{runner_id}/status")
+            if sr.status_code == 200 and not sr.json().get("online"):
+                runner_offline = True
+                break
+            time.sleep(0.5)
+        assert runner_offline, f"Runner {runner_id} still online after SIGKILL"
+
+        # Precondition for host-relaunch: the host itself is still online.
+        hosts = http_client.get("/v1/hosts").json().get("hosts", [])
+        assert any(h["host_id"] == host_id and h["status"] == "online" for h in hosts), (
+            "host should stay online when only the runner is killed"
+        )
+
+        # retry_session: relaunch the runner via the host with NO user message.
+        retry_resp = http_client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={"type": "retry_session", "data": {}},
+            timeout=120.0,
+        )
+        assert retry_resp.status_code in (200, 202), retry_resp.text
+        recovery = retry_resp.json()
+        assert recovery.get("recovered") is True, recovery
+        assert recovery.get("recovery") == "runner_relaunched", recovery
+
+        # The relaunched runner is usable: a follow-up turn round-trips without
+        # a manual reconnect, proving recovery attached the forwarder + runner.
+        rid_post = send_user_message_to_session(
+            http_client,
+            session_id=session_id,
+            content=f"Reply with exactly {marker_post} and nothing else.",
+        )
+        body_post = poll_session_until_terminal(
+            http_client,
+            session_id=session_id,
+            response_id=rid_post,
+            timeout=120,
+        )
+        assert body_post["status"] == "completed"
+        assert marker_post in final_assistant_text(body_post)
+
+    finally:
+        if host_proc.poll() is None:
+            host_proc.send_signal(signal.SIGTERM)
+            try:
+                host_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                host_proc.kill()
+                host_proc.wait()

--- a/tests/e2e_ui/sessions/test_runner_asleep_attach.py
+++ b/tests/e2e_ui/sessions/test_runner_asleep_attach.py
@@ -1,0 +1,176 @@
+"""E2E: a runner_asleep chat session offers a direct Attach button.
+
+When a session's runner is down but its host is still up (``runner_asleep``),
+the runner relaunches on the next message — and the chat now also offers a
+direct **Attach** button that recovers via ``retry_session`` with NO message.
+
+This drives the ``runner_asleep`` liveness row end to end (see
+``web/src/hooks/useSessionLiveness.ts`` row 5: ``runner_online=false`` +
+``host_online=true`` + past the startup grace + no turn in flight) and asserts
+the banner renders, the click fires ``retry_session`` (no user message), and the
+button holds pending afterwards.
+
+The server fixture seeds a real runner-bound ``hello_world`` session; the
+browser's view is patched into the ``runner_asleep`` shape via route
+interception:
+
+- ``GET /v1/sessions/{id}`` (snapshot) → an old ``created_at`` so the session is
+  past the startup grace (a fresh session reads as ``starting`` and masks the
+  runner-down signal).
+- ``GET /health`` → the session reports ``runner_online=false`` +
+  ``host_online=true`` (runner down, host up).
+- ``WS /v1/sessions/updates`` → blocked so a stream push can't revert liveness
+  to the real (online) values.
+- ``POST /v1/sessions/{id}/events`` → the ``retry_session`` control event the
+  Attach button fires is captured and answered with a recovered response.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+from tests.e2e_ui.conftest import fetch_with_retry
+
+# Unix seconds well before now so the session is outside STARTING_GRACE_S — see
+# useSessionLiveness row 2; a fresh runner-never-seen session reads as
+# `starting` and would mask the runner-down signal.
+_OLD_CREATED_AT = 1_700_000_000
+_RECONNECT_PLACEHOLDER = "Send a message to reconnect this session"
+
+
+def _force_runner_asleep(page: Page, session_id: str) -> None:
+    """Patch the browser's view of ``session_id`` into the runner_asleep state.
+
+    :param page: Playwright page before navigation.
+    :param session_id: Session id to patch, e.g. ``"conv_abc123"``.
+    """
+
+    def _patch_snapshot(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+        response = fetch_with_retry(route)
+        payload = response.json()
+        payload["created_at"] = _OLD_CREATED_AT
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    def _patch_list(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != "/v1/sessions":
+            route.continue_()
+            return
+        response = fetch_with_retry(route)
+        payload = response.json()
+        rows = payload.get("data") if isinstance(payload, dict) else None
+        if isinstance(rows, list):
+            payload["data"] = [
+                r for r in rows if not (isinstance(r, dict) and r.get("id") == session_id)
+            ]
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    def _patch_health(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != "/health":
+            route.continue_()
+            return
+        response = fetch_with_retry(route)
+        payload = response.json()
+        # Runner down, host up: the row this Attach button targets.
+        asleep = {"runner_online": False, "host_online": True}
+        if isinstance(payload.get("sessions"), dict):
+            payload["sessions"][session_id] = asleep
+        if isinstance(payload.get("session"), dict):
+            payload["session"] = {**payload["session"], **asleep}
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    # Drop the session from the sidebar list so its liveness resolves off the
+    # patched /health poll (the open-session fallback) rather than the
+    # `/v1/sessions/updates` push, which carries the real runner_online for
+    # sidebar sessions. The snapshot route is registered last so it wins for
+    # `/v1/sessions/{id}`; list/health fall through via continue_().
+    page.route(re.compile(r"/v1/sessions(\?|$)"), _patch_list)
+    page.route(re.compile(r"/health(\?|$)"), _patch_health)
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), _patch_snapshot)
+    page.route_web_socket(re.compile(r"/v1/sessions/updates"), lambda ws: None)
+
+
+def test_runner_asleep_chat_offers_attach_button(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The runner_asleep banner's Attach fires retry_session with no message.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser view is patched to the runner_asleep shape.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+
+    # Capture the retry_session control events the Attach button fires; answer
+    # them as a successful relaunch so the button can settle into pending.
+    retry_calls: list[dict] = []
+
+    def _intercept_events(route: Route) -> None:
+        request = route.request
+        if request.method == "POST" and (
+            urlparse(request.url).path == f"/v1/sessions/{session_id}/events"
+        ):
+            body = request.post_data_json or {}
+            if body.get("type") == "retry_session":
+                retry_calls.append(body)
+                route.fulfill(
+                    status=200,
+                    headers={"content-type": "application/json"},
+                    body=json.dumps({"recovered": True, "recovery": "runner_relaunched"}),
+                )
+                return
+        route.continue_()
+
+    page.route(
+        re.compile(rf"/v1/sessions/{re.escape(session_id)}/events(\?|$)"),
+        _intercept_events,
+    )
+    _force_runner_asleep(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=15_000)
+    # runner_asleep tell: composer stays open with the reconnect placeholder,
+    # NOT the host_offline "Session offline — reconnect" dead-end.
+    expect(composer).to_have_attribute("placeholder", _RECONNECT_PLACEHOLDER, timeout=15_000)
+
+    # The new affordance: a direct Attach banner (owner supplied the action).
+    banner = page.get_by_test_id("runner-asleep-indicator")
+    expect(banner).to_be_visible(timeout=15_000)
+    expect(banner).to_contain_text("Agent disconnected")
+
+    attach = banner.get_by_role("button", name="Attach")
+    expect(attach).to_be_enabled()
+    attach.click()
+
+    # The click recovers in place — retry_session with no user message — and the
+    # button holds pending while liveness is still runner_asleep.
+    expect(banner.get_by_role("button", name=re.compile("Attaching"))).to_be_disabled(
+        timeout=5_000
+    )
+    assert retry_calls, "Attach did not fire a retry_session event"
+    assert retry_calls[0]["type"] == "retry_session"

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatStore } from "@/store/chatStore";
 import type { Bubble } from "@/lib/renderItems";
 import type { SessionLiveness } from "@/hooks/useSessionLiveness";
@@ -112,14 +112,50 @@ describe("ConnectionIndicator", () => {
   it.each<SessionLiveness>([{ kind: "online" }, { kind: "runner_asleep" }, { kind: "unknown" }])(
     "renders nothing for the reachable/sidebar-owned state %o",
     (liveness) => {
-      // WHY: online/asleep/unknown surface their status in the sidebar or keep
-      // the composer open — this band stays empty for them.
+      // WHY: online/unknown surface status in the sidebar; runner_asleep with no
+      // attach action (non-owner) keeps the silent send-to-wake path — this band
+      // stays empty for all three when no onAttach is supplied.
       const { container } = render(
         <ConnectionIndicator liveness={liveness} onShowReconnectHelp={onShowReconnectHelp} />,
       );
       expect(container).toBeEmptyDOMElement();
     },
   );
+
+  it("offers a direct Attach for a runner_asleep session when an owner attach action is supplied", () => {
+    // WHY: the runner is down but the host is up — an owner can relaunch it in
+    // place, so we surface an Attach button instead of only nudging them to send
+    // a message (the customer's downed-agent recovery without a chat message).
+    const onAttach = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ConnectionIndicator
+        liveness={{ kind: "runner_asleep" }}
+        onShowReconnectHelp={onShowReconnectHelp}
+        onAttach={onAttach}
+      />,
+    );
+    const banner = screen.getByTestId("runner-asleep-indicator");
+    expect(banner).toHaveTextContent(/Agent disconnected/);
+    fireEvent.click(screen.getByRole("button", { name: "Attach" }));
+    expect(onAttach).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds the Attach button pending after a click so a recovering banner reads as busy", async () => {
+    // WHY: retry_session returns well before the runner-health poll clears the
+    // banner. Re-enabling the instant it returns flips the label back to "Attach"
+    // over a still-shown banner, which reads as a no-op and invites a re-click —
+    // so the button stays disabled/"Attaching…" until liveness moves off asleep.
+    const onAttach = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ConnectionIndicator
+        liveness={{ kind: "runner_asleep" }}
+        onShowReconnectHelp={onShowReconnectHelp}
+        onAttach={onAttach}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Attach" }));
+    expect(await screen.findByRole("button", { name: /Attaching/ })).toBeDisabled();
+  });
 });
 
 describe("RunnerStartingIndicator", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -29,6 +29,7 @@ import {
   SettingsIcon,
   SquareIcon,
   SquareTerminalIcon,
+  UnplugIcon,
   WifiOffIcon,
   XIcon,
 } from "lucide-react";
@@ -2058,6 +2059,7 @@ function MainAgentSurface({
           <ConnectionIndicator
             liveness={liveness}
             onShowReconnectHelp={onShowReconnectHelp}
+            onAttach={isActive && !entry.readOnly ? handleTerminalResume : undefined}
             surfaceFrontmost={surfaceFrontmost}
           />
         )}
@@ -2316,6 +2318,7 @@ function MainAgentSurface({
           <ConnectionIndicator
             liveness={liveness}
             onShowReconnectHelp={onShowReconnectHelp}
+            onAttach={terminalReadOnly ? undefined : handleTerminalResume}
             surfaceFrontmost={surfaceFrontmost}
           />
         </>
@@ -3160,15 +3163,57 @@ export function SandboxFailedIndicator({ status }: { status: SandboxStatus }) {
 export function ConnectionIndicator({
   liveness,
   onShowReconnectHelp,
+  onAttach,
   surfaceFrontmost = true,
 }: {
   liveness: SessionLiveness;
   onShowReconnectHelp: () => void;
+  /**
+   * Direct attach action for a downed-but-wakeable runner (`runner_asleep`).
+   * Reconnects/relaunches the runner via `retry_session` without sending a
+   * message. Absent for non-owners (who can't relaunch); then the state stays
+   * on the send-a-message path with no banner.
+   */
+  onAttach?: () => void | Promise<void>;
   // Whether the chat/terminal surface is frontmost (not under a drawer). Gates
   // the native iOS bar so it doesn't float over an opened sidebar/panel.
   surfaceFrontmost?: boolean;
 }) {
   const terminalFirst = useTerminalFirst();
+  const [attaching, setAttaching] = useState(false);
+  const [attachError, setAttachError] = useState<string | null>(null);
+  // Safety timer that re-enables Attach if liveness never clears (a genuinely
+  // failed relaunch), so the button doesn't get stuck pending. Longer than the
+  // runner-health poll so a normal recovery unmounts the banner first.
+  const attachSettleTimer = useRef<number | null>(null);
+  const handleAttach = useCallback(async () => {
+    if (!onAttach) return;
+    setAttachError(null);
+    setAttaching(true);
+    try {
+      await onAttach();
+      // Stay pending until the liveness poll confirms the runner is back and
+      // this banner unmounts. Re-enabling the instant retry_session returns
+      // (well before the poll refresh) flips the label back to "Attach" over a
+      // still-shown banner — it reads as a no-op and invites a redundant click.
+      if (attachSettleTimer.current) window.clearTimeout(attachSettleTimer.current);
+      attachSettleTimer.current = window.setTimeout(() => setAttaching(false), 12_000);
+    } catch (error) {
+      setAttachError(error instanceof Error && error.message ? error.message : "Couldn't attach.");
+      setAttaching(false);
+    }
+  }, [onAttach]);
+  // Recovery (or any move off runner_asleep) resets pending/error so a later
+  // disconnect starts clean; the cleanup also clears the timer on unmount.
+  useEffect(() => {
+    if (liveness.kind !== "runner_asleep") {
+      setAttaching(false);
+      setAttachError(null);
+    }
+    return () => {
+      if (attachSettleTimer.current) window.clearTimeout(attachSettleTimer.current);
+    };
+  }, [liveness.kind]);
   const keyboardVisible = useIOSNativeKeyboardVisible(
     terminalFirst?.isTerminalFirst === true,
     terminalFirst?.view === "chat",
@@ -3260,6 +3305,42 @@ export function ConnectionIndicator({
           />
         )}
       </>
+    );
+  }
+
+  // Runner down but the host is up: the runner relaunches on the next message,
+  // but offer a direct Attach so the user recovers without sending one. Only
+  // where the composer is on screen (the terminal-first *terminal* view is
+  // owned by the PTY overlay, which carries its own Resume) and only for owners
+  // (onAttach is undefined otherwise, leaving the silent send-to-wake path).
+  const composerOnScreen = !(terminalFirst?.isTerminalFirst && terminalFirst.view === "terminal");
+  if (liveness.kind === "runner_asleep" && onAttach && composerOnScreen) {
+    return (
+      <div
+        data-testid="runner-asleep-indicator"
+        className={cn(
+          "mx-auto mb-4 flex w-full flex-wrap items-center justify-center gap-x-2 gap-y-1 px-6",
+          CHAT_COLUMN_WIDTH,
+        )}
+      >
+        <span className="flex items-center gap-1.5 text-muted-foreground text-sm">
+          <UnplugIcon className="size-3.5 shrink-0" />
+          Agent disconnected
+        </span>
+        <Button
+          type="button"
+          size="xs"
+          variant="secondary"
+          onClick={handleAttach}
+          disabled={attaching}
+          componentId="diagnostics.session.attach"
+        >
+          {attaching ? "Attaching…" : "Attach"}
+        </Button>
+        {attachError && (
+          <span className="basis-full text-center text-destructive text-sm">{attachError}</span>
+        )}
+      </div>
     );
   }
 


### PR DESCRIPTION
## Related issue

No linked public issue — addresses user-reported behavior: an Omni session whose
runner drops (host restart, `stop`) while its host stays up sits in
`runner_asleep`, and was recoverable only by sending a chat message.

## Summary

When a session's runner is down but its host is still up (`runner_asleep`), the
runner relaunches on the next chat message — but the only affordance was a
placeholder nudging the user to send one. The terminal already offers an
in-place "Resume session" on a closed bridge; the chat had no equivalent.

- Adds an **"Agent disconnected — Attach"** banner to `ConnectionIndicator` for
  the `runner_asleep` state. **Attach** relaunches the runner in place via the
  existing `retry_session` path — **no message sent**.
- **Owner-only**: a non-owner can't relaunch someone else's runner, so the
  button is withheld (`onAttach` undefined) and the silent send-to-wake path
  stays. Shown only where the composer is on screen (the terminal-first
  *terminal* view keeps its own Resume overlay, so the banner never doubles up).
- Holds **pending** after a click until liveness moves off `runner_asleep` and
  the banner unmounts (12s safety timer > the runner-health poll), so a
  recovering banner reads as busy instead of inviting a redundant click; errors
  surface and re-enable immediately.

Scoped to the chat side on purpose: the terminal pane's resume affordance
already exists upstream and is left untouched.

## Test Plan

- **web unit (vitest)** — `ChatPage.indicators` + `ConnectionIndicator` pass,
  including new cases for the `runner_asleep` Attach button (renders for an owner
  attach action, calls it on click, holds pending after click) alongside the
  existing "no banner without `onAttach`" gate. `tsc -b`,
  `oxlint --deny-warnings`, `prettier --check` clean; `pre-commit` on the changed
  files passes.
- **Real host + server e2e** (`tests/e2e/test_host_e2e.py`):
  `test_host_retry_session_recovers_killed_runner` — spawns a real host daemon +
  server + mock LLM, launches a host-bound runner, does a baseline round-trip,
  SIGKILLs the runner while the host stays online (the `runner_asleep` state this
  button targets), POSTs `retry_session` with no message and asserts
  `recovery: "runner_relaunched"`, then a follow-up turn round-trips. Passes
  (~23s).
- **Manual** — live host + real Claude Code TUI (`claude-native`, Opus 4.8 via
  the Databricks AI gateway): killed the runner, saw the chat "Agent
  disconnected" + Attach banner, clicked it, and the runner relaunched with no
  message (`recovery: "runner_relaunched"`) — session recovered (light + dark
  below).

## Demo

Chat session — runner down, host up (`runner_asleep`):

![Agent disconnected — chat](https://github.com/marktai/omnigent/releases/download/pr5392-demo/chat-dark-full.png?v=native)

<sub>Light variant: [chat](https://github.com/marktai/omnigent/releases/download/pr5392-demo/chat-light-full.png?v=native)</sub>

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Vitest covers the new banner end to end at the component level: it renders for an
owner-supplied attach action, calls the action on click, and holds pending after
the click; the existing gate confirms no banner renders without `onAttach`
(non-owner send-to-wake path). A new real-host e2e
(`test_host_retry_session_recovers_killed_runner`) proves the server primitive
the button calls — with the runner dead and the host live, `retry_session`
relaunches the runner and the session recovers with no user message. Also
manually verified the live UI against a real host + Claude Code TUI.

## Changelog

A disconnected agent (runner down, host up) now shows an "Attach" button in the chat to reconnect without sending a message

This pull request and its description were written by Isaac.
