### PR TITLE
fix(web): contain composer autosize overflow

### DIFF
--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -298,7 +298,44 @@ def test_composer_hides_native_scrollbar_without_disabling_scroll(
     expect(page.locator(_TEXT_SECTION)).to_have_count(6, timeout=30_000)
     composer = page.get_by_label("Message the agent")
     expect(composer).to_be_visible(timeout=30_000)
-    composer.fill("\n".join(f"Draft line {i}" for i in range(20)))
+    transition = page.evaluate(
+        r"""async () => {
+            const composer = document.querySelector(
+                'textarea[aria-label="Message the agent"]'
+            );
+            const valueSetter = Object.getOwnPropertyDescriptor(
+                HTMLTextAreaElement.prototype,
+                'value'
+            ).set;
+            const samples = [];
+            for (let i = 0; i < 20; i += 1) {
+                valueSetter.call(
+                    composer,
+                    Array.from({ length: i + 1 }, (_, line) => `Draft line ${line}`).join('\n')
+                );
+                composer.dispatchEvent(new InputEvent('input', { bubbles: true }));
+                await new Promise((resolve) => requestAnimationFrame(resolve));
+                samples.push({
+                    inputViewportOverflowY:
+                        getComputedStyle(composer.parentElement).overflowY,
+                    rootOverflowY: getComputedStyle(document.documentElement).overflowY,
+                    bodyOverflowY: getComputedStyle(document.body).overflowY,
+                    rootScrollTop: document.scrollingElement.scrollTop,
+                });
+            }
+            return samples;
+        }"""
+    )
+    assert all(
+        sample
+        == {
+            "inputViewportOverflowY": "hidden",
+            "rootOverflowY": "hidden",
+            "bodyOverflowY": "hidden",
+            "rootScrollTop": 0,
+        }
+        for sample in transition
+    ), transition
 
     geometry = page.evaluate(
         """() => {
@@ -316,6 +353,9 @@ def test_composer_hides_native_scrollbar_without_disabling_scroll(
             return {
                 composer: probe(composer),
                 transcript: probe(transcript),
+                inputViewportOverflowY:
+                    getComputedStyle(composer.parentElement).overflowY,
+                rootOverflowY: getComputedStyle(document.documentElement).overflowY,
                 bodyOverflowY: getComputedStyle(document.body).overflowY,
             };
         }"""
@@ -324,6 +364,8 @@ def test_composer_hides_native_scrollbar_without_disabling_scroll(
         assert geometry[surface]["scrollHeight"] > geometry[surface]["clientHeight"], geometry
         assert geometry[surface]["scrollbarWidth"] == "none", geometry
         assert geometry[surface]["webkitScrollbarDisplay"] == "none", geometry
+    assert geometry["inputViewportOverflowY"] == "hidden", geometry
+    assert geometry["rootOverflowY"] == "hidden", geometry
     assert geometry["bodyOverflowY"] == "hidden", geometry
 
     composer.evaluate("textarea => { textarea.scrollTop = textarea.scrollHeight; }")

--- a/web/src/hooks/useAutoGrowTextarea.test.tsx
+++ b/web/src/hooks/useAutoGrowTextarea.test.tsx
@@ -110,19 +110,23 @@ describe("useAutoGrowTextarea", () => {
     // scrollHeight is read while the textarea is collapsed, so it's the one
     // moment that sees the layout the rest of the page would have seen.
     let wrapperHeightWhileCollapsed: string | null = null;
+    let wrapperOverflowWhileCollapsed: string | null = null;
     Object.defineProperty(ta, "scrollHeight", {
       configurable: true,
       get: () => {
         wrapperHeightWhileCollapsed = wrapper.style.height;
+        wrapperOverflowWhileCollapsed = wrapper.style.overflow;
         return 40;
       },
     });
     roCallback?.([], {} as ResizeObserver);
 
     expect(wrapperHeightWhileCollapsed).toBe("100px");
+    expect(wrapperOverflowWhileCollapsed).toBe("hidden");
     // Released again once the real height is on, so the wrapper goes back to
     // tracking its content instead of freezing at the pinned value.
     expect(wrapper.style.height).toBe("");
+    expect(wrapper.style.overflow).toBe("");
     expect(ta.style.height).toBe("40px");
   });
 

--- a/web/src/hooks/useAutoGrowTextarea.ts
+++ b/web/src/hooks/useAutoGrowTextarea.ts
@@ -13,8 +13,8 @@ import { type RefObject, useLayoutEffect, useRef } from "react";
  * transcript's scroll viewport is correspondingly taller, and the browser
  * clamps its ``scrollTop`` against that larger viewport's smaller maximum.
  * The clamp sticks once the composer springs back, so every re-measure shunts
- * the transcript down a line. Pinning the wrapper's height keeps the collapse
- * inside the composer.
+ * the transcript down a line. Pinning and clipping the wrapper keeps the
+ * collapse inside the composer.
  */
 function measureTextarea(
   ta: HTMLTextAreaElement,
@@ -24,8 +24,12 @@ function measureTextarea(
   const wrapper = ta.parentElement;
   const wrapperHeight = wrapper?.getBoundingClientRect().height ?? 0;
   const restoreHeight = wrapper?.style.height ?? "";
+  const restoreOverflow = wrapper?.style.overflow ?? "";
   const pinned = wrapper !== null && wrapperHeight > 0;
-  if (pinned) wrapper.style.height = `${wrapperHeight}px`;
+  if (pinned) {
+    wrapper.style.height = `${wrapperHeight}px`;
+    wrapper.style.overflow = "hidden";
+  }
   try {
     ta.style.height = "auto";
     if (ta.scrollHeight === 0) {
@@ -49,9 +53,11 @@ function measureTextarea(
     );
     onGrowth?.(Math.max(0, height - resting));
   } finally {
-    // Released before the next layout, so the composer resizes in one step
-    // from its old height to its new one.
-    if (pinned) wrapper.style.height = restoreHeight;
+    // Release both guards before the next layout so the composer resizes once.
+    if (pinned) {
+      wrapper.style.height = restoreHeight;
+      wrapper.style.overflow = restoreOverflow;
+    }
   }
 }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -992,6 +992,7 @@ aside[aria-label="Workspace"][data-maximized] {
    * removes it — widening the layout viewport and every fixed-position
    * overlay with it. Scoped via :has so login/register/setup pages (outside
    * the shell) keep default document scrolling. */
+  html:has(.app-shell),
   body:has(.app-shell) {
     overflow: hidden;
   }

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -133,6 +133,18 @@ describe("index.css bg-card glass rule selector", () => {
   });
 });
 
+describe("index.css app-shell viewport lock", () => {
+  const rule = (cssSource.match(/[^{}]+\{[^{}]*\}/g) ?? []).find(
+    (block) => block.includes("body:has(.app-shell)") && /overflow\s*:\s*hidden/.test(block),
+  );
+
+  it("locks both document roots while the fixed app shell is mounted", () => {
+    expect(rule, "the app-shell viewport lock is gone from index.css").toBeDefined();
+    expect(rule).toContain("html:has(.app-shell)");
+    expect(rule).toContain("body:has(.app-shell)");
+  });
+});
+
 /* Regression test for the "table link column collapses to ~2ch" bug.
  *
  * Streamdown styles links with `wrap-anywhere`, which also drops the

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -150,11 +150,13 @@ describe("Composer growth layout", () => {
   it("keeps long drafts scrollable without showing a native scrollbar", () => {
     render(<Composer {...composerProps()} />);
 
-    expect(textarea()).toHaveClass(
+    const ta = textarea();
+    expect(ta).toHaveClass(
       "overflow-y-auto",
       "[scrollbar-width:none]",
       "[&::-webkit-scrollbar]:hidden",
     );
+    expect(ta.parentElement).toHaveClass("overflow-hidden");
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5667,7 +5667,7 @@ export function Composer({
             (text-transparent, caret kept visible) and render an aligned mirror
             behind it. Same box/typography so wrapping matches the textarea
             exactly. Only mounted while the draft is a command. */}
-        <div className="relative">
+        <div className="relative overflow-hidden">
           {composerIsCommand && (
             <div
               ref={backdropRef}

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -991,6 +991,9 @@ describe("NewChatLandingScreen", () => {
       "[scrollbar-width:none]",
       "[&::-webkit-scrollbar]:hidden",
     );
+    expect(screen.getByTestId("new-chat-landing-input").parentElement).toHaveClass(
+      "overflow-hidden",
+    );
     expect(screen.getByTestId("new-chat-landing-actions")).toHaveClass("px-2", "pb-2");
     const footer = screen.getByTestId("new-chat-landing-footer");
     expect(footer).toHaveClass("py-1.5", "pr-4", "pl-2");

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -982,6 +982,7 @@ describe("NewChatLandingScreen", () => {
     renderLanding();
 
     expect(screen.getByTestId("new-chat-landing-input")).toHaveClass(
+      "block",
       "min-h-[60px]",
       "max-h-[200px]",
       "overflow-y-auto",

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -4260,132 +4260,134 @@ export function NewChatLandingScreen() {
                 onAttach={attachMention}
               />
             )}
-            <textarea
-              ref={textareaRef}
-              value={message}
-              onChange={(e) => {
-                setMessage(e.target.value);
-                // A rejected attachment is never added, so there's no chip to
-                // remove and nothing else would ever clear this. Left sticky it
-                // reads as a blocker on a composer the user can actually submit.
-                if (attachmentError !== null) setAttachmentError(null);
-                // Recompute the active "@"-mention from the caret each keystroke
-                // (native terminal agents with a workspace — ``mentionEnabled``).
-                setMention(
-                  mentionEnabled
-                    ? detectMentionAt(
-                        e.target.value,
-                        e.target.selectionStart ?? e.target.value.length,
-                      )
-                    : null,
-                );
-              }}
-              onFocus={() => {
-                // From here the textarea's caret is one the user placed, so
-                // dictation inserts there instead of at the end of the draft.
-                dictation.noteFocus();
-              }}
-              onBlur={() => {
-                // Dismiss the mention menu when focus leaves the textarea; menu
-                // rows preventDefault on mousedown so selecting one doesn't blur.
-                dismissMention();
-              }}
-              onCompositionStart={() => {
-                isComposingRef.current = true;
-              }}
-              onCompositionEnd={() => {
-                isComposingRef.current = false;
-              }}
-              onKeyDown={(e) => {
-                if (isImeCompositionKeyEvent(e, isComposingRef.current)) {
-                  return;
-                }
+            <div className="relative overflow-hidden">
+              <textarea
+                ref={textareaRef}
+                value={message}
+                onChange={(e) => {
+                  setMessage(e.target.value);
+                  // A rejected attachment is never added, so there's no chip to
+                  // remove and nothing else would ever clear this. Left sticky it
+                  // reads as a blocker on a composer the user can actually submit.
+                  if (attachmentError !== null) setAttachmentError(null);
+                  // Recompute the active "@"-mention from the caret each keystroke
+                  // (native terminal agents with a workspace — ``mentionEnabled``).
+                  setMention(
+                    mentionEnabled
+                      ? detectMentionAt(
+                          e.target.value,
+                          e.target.selectionStart ?? e.target.value.length,
+                        )
+                      : null,
+                  );
+                }}
+                onFocus={() => {
+                  // From here the textarea's caret is one the user placed, so
+                  // dictation inserts there instead of at the end of the draft.
+                  dictation.noteFocus();
+                }}
+                onBlur={() => {
+                  // Dismiss the mention menu when focus leaves the textarea; menu
+                  // rows preventDefault on mousedown so selecting one doesn't blur.
+                  dismissMention();
+                }}
+                onCompositionStart={() => {
+                  isComposingRef.current = true;
+                }}
+                onCompositionEnd={() => {
+                  isComposingRef.current = false;
+                }}
+                onKeyDown={(e) => {
+                  if (isImeCompositionKeyEvent(e, isComposingRef.current)) {
+                    return;
+                  }
 
-                // "@"-mention menu navigation (shared useMentionBrowser) —
-                // mutually exclusive with the slash menu (a token can't be both)
-                // and takes priority over submission.
-                if (handleMentionKeyDown(e)) return;
+                  // "@"-mention menu navigation (shared useMentionBrowser) —
+                  // mutually exclusive with the slash menu (a token can't be both)
+                  // and takes priority over submission.
+                  if (handleMentionKeyDown(e)) return;
 
-                // While the skills menu is open, ArrowUp/Down navigate it and
-                // Enter/Tab complete the highlighted item — these take
-                // priority over submission (same UX as the in-session
-                // composer).
-                if (slashMenuOpen && slashMenuMatches.length > 0) {
-                  if (e.key === "ArrowDown") {
-                    e.preventDefault();
-                    setSlashMenuIndex((i) => (i + 1) % slashMenuMatches.length);
-                    return;
+                  // While the skills menu is open, ArrowUp/Down navigate it and
+                  // Enter/Tab complete the highlighted item — these take
+                  // priority over submission (same UX as the in-session
+                  // composer).
+                  if (slashMenuOpen && slashMenuMatches.length > 0) {
+                    if (e.key === "ArrowDown") {
+                      e.preventDefault();
+                      setSlashMenuIndex((i) => (i + 1) % slashMenuMatches.length);
+                      return;
+                    }
+                    if (e.key === "ArrowUp") {
+                      e.preventDefault();
+                      setSlashMenuIndex((i) => (i <= 0 ? slashMenuMatches.length - 1 : i - 1));
+                      return;
+                    }
+                    if (
+                      (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) &&
+                      slashMenuIndex >= 0
+                    ) {
+                      e.preventDefault();
+                      applySlashSelection(slashMenuMatches[slashMenuIndex]!);
+                      return;
+                    }
+                    if (e.key === "Escape") {
+                      e.preventDefault();
+                      // Dismiss the menu by clearing the draft so the user can
+                      // start fresh.
+                      setMessage("");
+                      setSlashMenuIndex(-1);
+                      return;
+                    }
                   }
-                  if (e.key === "ArrowUp") {
+                  // Enter sends; Shift+Enter inserts a newline.
+                  if (e.key === "Enter" && !e.shiftKey) {
                     e.preventDefault();
-                    setSlashMenuIndex((i) => (i <= 0 ? slashMenuMatches.length - 1 : i - 1));
-                    return;
+                    // The mention menu is briefly closed while its listing loads;
+                    // swallow Enter so the in-progress "@dir/" token isn't sent.
+                    if (mentionListingPending) return;
+                    void handleCreate();
                   }
-                  if (
-                    (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) &&
-                    slashMenuIndex >= 0
-                  ) {
+                }}
+                onPaste={(e) => {
+                  // Pasted images/files attach instead of inserting as text,
+                  // mirroring the in-session composer.
+                  const pasted = Array.from(e.clipboardData.items)
+                    .filter((item) => item.kind === "file")
+                    .map((item) => item.getAsFile())
+                    .filter((f): f is File => f !== null);
+                  if (pasted.length > 0) {
                     e.preventDefault();
-                    applySlashSelection(slashMenuMatches[slashMenuIndex]!);
-                    return;
+                    addFiles(pasted);
                   }
-                  if (e.key === "Escape") {
-                    e.preventDefault();
-                    // Dismiss the menu by clearing the draft so the user can
-                    // start fresh.
-                    setMessage("");
-                    setSlashMenuIndex(-1);
-                    return;
-                  }
-                }
-                // Enter sends; Shift+Enter inserts a newline.
-                if (e.key === "Enter" && !e.shiftKey) {
-                  e.preventDefault();
-                  // The mention menu is briefly closed while its listing loads;
-                  // swallow Enter so the in-progress "@dir/" token isn't sent.
-                  if (mentionListingPending) return;
-                  void handleCreate();
-                }
-              }}
-              onPaste={(e) => {
-                // Pasted images/files attach instead of inserting as text,
-                // mirroring the in-session composer.
-                const pasted = Array.from(e.clipboardData.items)
-                  .filter((item) => item.kind === "file")
-                  .map((item) => item.getAsFile())
-                  .filter((f): f is File => f !== null);
-                if (pasted.length > 0) {
-                  e.preventDefault();
-                  addFiles(pasted);
-                }
-              }}
-              // Suppress the native placeholder when the overlay supplies its
-              // own prompt text; aria-label preserves the accessible name.
-              placeholder={pillSkills.length > 0 ? "" : placeholderText}
-              aria-label={placeholderText}
-              rows={1}
-              autoFocus
-              data-testid="new-chat-landing-input"
-              // Compose-pill text spec: SF Pro Text system stack at
-              // 14px/20px. (Note: sub-16px inputs make mobile Safari
-              // auto-zoom on focus — accepted tradeoff per the design.)
-              // Heights are border-box (12px top + 8px bottom padding lives
-              // inside them): max 200px = the spec's 180px of content.
-              // A 60px floor holds two 20px lines plus that padding;
-              // useAutoGrowTextarea expands from there to the unchanged cap.
-              className="min-h-[60px] max-h-[200px] w-full resize-none overflow-y-auto bg-transparent px-4 pt-3 pb-2 font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-ui leading-5 text-foreground outline-none [scrollbar-width:none] placeholder:text-muted-foreground md:select-text [&::-webkit-scrollbar]:hidden"
-            />
-            {/* Gated on an empty draft so it reads as the placeholder.
-                pointer-events-none lets clicks fall through to focus the
-                textarea; the pills themselves opt back in. */}
-            {pillSkills.length > 0 && message.length === 0 && (
-              <div className="pointer-events-none absolute inset-x-4 top-3 flex flex-wrap items-center gap-2">
-                <span className="font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-ui leading-5 text-muted-foreground">
-                  Describe a task, or try a skill
-                </span>
-                <SkillPills skills={pillSkills} onPick={applySkillPill} />
-              </div>
-            )}
+                }}
+                // Suppress the native placeholder when the overlay supplies its
+                // own prompt text; aria-label preserves the accessible name.
+                placeholder={pillSkills.length > 0 ? "" : placeholderText}
+                aria-label={placeholderText}
+                rows={1}
+                autoFocus
+                data-testid="new-chat-landing-input"
+                // Compose-pill text spec: SF Pro Text system stack at
+                // 14px/20px. (Note: sub-16px inputs make mobile Safari
+                // auto-zoom on focus — accepted tradeoff per the design.)
+                // Heights are border-box (12px top + 8px bottom padding lives
+                // inside them): max 200px = the spec's 180px of content.
+                // A 60px floor holds two 20px lines plus that padding;
+                // useAutoGrowTextarea expands from there to the unchanged cap.
+                className="min-h-[60px] max-h-[200px] w-full resize-none overflow-y-auto bg-transparent px-4 pt-3 pb-2 font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-ui leading-5 text-foreground outline-none [scrollbar-width:none] placeholder:text-muted-foreground md:select-text [&::-webkit-scrollbar]:hidden"
+              />
+              {/* Gated on an empty draft so it reads as the placeholder.
+                  pointer-events-none lets clicks fall through to focus the
+                  textarea; the pills themselves opt back in. */}
+              {pillSkills.length > 0 && message.length === 0 && (
+                <div className="pointer-events-none absolute inset-x-4 top-3 flex flex-wrap items-center gap-2">
+                  <span className="font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-ui leading-5 text-muted-foreground">
+                    Describe a task, or try a skill
+                  </span>
+                  <SkillPills skills={pillSkills} onPick={applySkillPill} />
+                </div>
+              )}
+            </div>
             {/* Hidden file input for the attach button. */}
             <input
               ref={fileInputRef}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -4374,7 +4374,7 @@ export function NewChatLandingScreen() {
                 // inside them): max 200px = the spec's 180px of content.
                 // A 60px floor holds two 20px lines plus that padding;
                 // useAutoGrowTextarea expands from there to the unchanged cap.
-                className="min-h-[60px] max-h-[200px] w-full resize-none overflow-y-auto bg-transparent px-4 pt-3 pb-2 font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-ui leading-5 text-foreground outline-none [scrollbar-width:none] placeholder:text-muted-foreground md:select-text [&::-webkit-scrollbar]:hidden"
+                className="block min-h-[60px] max-h-[200px] w-full resize-none overflow-y-auto bg-transparent px-4 pt-3 pb-2 font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-ui leading-5 text-foreground outline-none [scrollbar-width:none] placeholder:text-muted-foreground md:select-text [&::-webkit-scrollbar]:hidden"
               />
               {/* Gated on an empty draft so it reads as the placeholder.
                   pointer-events-none lets clicks fall through to focus the


### PR DESCRIPTION
## Related issue

Closes #5372 (follow-up to #5374).

## Summary

- Contain the textarea's temporary auto-size collapse inside dedicated clipped wrappers in both the session and landing composers.
- Lock both document roots (`html` and `body`) while the fixed app shell is mounted, preventing the outer browser scrollbar from flashing above the composer.
- Add frame-by-frame browser coverage while a draft rapidly grows through 20 lines, plus component and CSS regressions.

**ELI5:** Auto-sizing briefly shrinks the input so it can measure the text. That one-frame shrink could expose either the input's parent or the page itself as a scroll surface. The measurement now happens behind a clipped wrapper, while the fixed app page is explicitly prevented from scrolling.

```text
value changes → pin + clip input wrapper → measure textarea → restore wrapper → resize once
                                             document html + body stay locked
```

## Test Plan

- `pnpm --filter web run lint`
- `pnpm --filter web run type-check`
- `pnpm --filter web run build`
- `pnpm --filter web run test` (300 files passed, 1 skipped; 5,947 tests passed)
- `.venv/bin/python -m pytest tests/e2e_ui/chat/test_composer_growth_transcript_stability.py::test_composer_hides_native_scrollbar_without_disabling_scroll -v`
- `.venv/bin/pre-commit run` on all changed files

## Demo

The composer remains internally scrollable after reaching its cap, without native scrollbar chrome. The updated Playwright regression additionally samples every animation frame during growth to cover the transient flash.

![Capped composer scrolling without a native scrollbar](https://raw.githubusercontent.com/dbczumar/omnigent/assets/composer-scrollbar-demo/docs/images/composer-scrollbar-demo.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The browser regression drives the controlled textarea one line at a time, waits one animation frame between updates, and asserts throughout that the input wrapper plus both document roots cannot paint native scrollbars.

## Changelog

Chat composers no longer flash a native scrollbar inside or above the input while growing.
