### PR TITLE
Serialize Databricks credential refreshes across processes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,13 @@ repos:
         files: \.(py|ya?ml|json|toml|sh)$
         exclude: (^|/)tests/|^openapi\.json$
 
+      - id: no-direct-databricks-auth
+        name: no direct Databricks credential refresh
+        language: system
+        entry: .venv/bin/python dev/lint/lint_no_direct_databricks_auth.py
+        pass_filenames: false
+        files: ^omnigent/.*\.py$
+
       - id: web-prettier
         name: web prettier
         language: system

--- a/designs/CREDENTIAL_HARDENING.md
+++ b/designs/CREDENTIAL_HARDENING.md
@@ -1,0 +1,457 @@
+# Making Databricks credentials bullet-proof in Omnigent
+
+## Summary
+
+Omnigent currently allows several local processes to refresh the same Databricks credentials independently. When those refreshes overlap, Databricks can treat the shared refresh token as reused and invalidate the entire credential family. One collision can therefore break hosts, runners, forwarding, policy checks, Codex, and the web UI at once.
+
+The fix is to make credential refresh a machine-wide shared service:
+
+1. Detect permanently invalid credentials and report one clear error everywhere.
+2. Allow only one process per machine and Databricks profile to refresh credentials.
+3. Publish the resulting short-lived bearer token for the other local processes.
+4. Recover automatically after the user logs in again.
+5. Test the design under heavy concurrency and process crashes.
+
+The plan is self-contained. It includes both the immediate host-to-runner token sharing needed to stop runner refresh collisions and the machine-wide coordination needed to stop collisions between separate hosts and other components.
+
+## Goals
+
+- **G1:** A machine performs at most one Databricks credential refresh at a time for each profile.
+- **G2:** After the user logs in again, everything resumes automatically within about 20 seconds, without restarting sessions.
+- **G3:** Every Omnigent component reports the same clear login remedy when credentials are permanently invalid.
+- **G4:** A crashed refresher does not leave the machine stuck.
+- **G5:** Normal requests are not made slower by this design.
+
+## Non-goals
+
+- Changing Databricks' refresh-token behavior.
+- Synchronizing credentials across different machines.
+- Making requests succeed while the Databricks login is genuinely invalid.
+- Replacing Databricks CLI profiles with a new account system.
+
+## The problem in plain English
+
+Databricks gives a logged-in profile a long-lived refresh token. Omnigent uses it to obtain short-lived bearer tokens for requests.
+
+Today, multiple Omnigent processes can decide to refresh at nearly the same time. They are all using the same refresh-token family. If two refreshes overlap, one process may use a token that another process has just replaced. Databricks can interpret that as unsafe reuse and invalidate the whole family.
+
+After that, retries do not repair anything. They only produce many different-looking errors until the user runs:
+
+```bash
+databricks auth login --profile oss
+```
+
+The system should avoid the collision in the first place, recognize the permanently broken state if it occurs, and recover cleanly after login.
+
+## Evidence and motivation
+
+This is not only a theoretical race. An investigation of Corey Zumar's Omnigent host and runner logs covering August 19–22, 2026 found multiple episodes in which processes sharing the same Databricks profile attempted credential refresh around the same time and the machine subsequently lost working Databricks authentication.
+
+The repeated incident pattern was:
+
+1. Several Omnigent processes were active under the same operating-system user and Databricks profile.
+2. More than one process entered a token-refresh path during the same period.
+3. Databricks then rejected the shared refresh credentials as invalid.
+4. The failure spread beyond the process that refreshed: hosts, runners, forwarding, and policy or model-facing requests began reporting different authentication-related symptoms.
+5. Retrying did not repair the state. A new `databricks auth login` was required.
+6. After login, normal operation returned until a later overlapping-refresh episode reproduced the problem.
+
+The logs exposed the user impact through symptoms rather than one clean root-cause message. Depending on which component failed first, the visible result could look like a disconnected session, a runner that could not resume, failed event forwarding, a policy failure, or an unrelated model/service error. That made each incident slower to recognize and encouraged retries that could not succeed once the refresh-token family was invalid.
+
+### What the evidence proves
+
+The logs directly establish that multiple local processes shared one profile, entered refresh-related paths concurrently, and then experienced machine-wide authentication failure more than once during the August 19–22 window. The timing and Databricks' invalid-refresh response are consistent with refresh-token rotation and reuse detection.
+
+The logs alone cannot prove Databricks' internal decision process or identify which individual refresh invalidated the family. The design therefore does not depend on that narrower claim. Independently of the exact server-side sequence, allowing several processes to mutate one credential source concurrently is unsafe. Serializing refresh, publishing one result, and giving permanent failure one shared state prevents both the observed race and equivalent variants of it.
+
+### Why smaller fixes are insufficient
+
+- Sharing a token only between one host and its runners reduces runner collisions but leaves separate hosts and other components racing each other.
+- Adding retries cannot repair permanently invalid refresh credentials and increases noise.
+- Adding a dead marker improves the error but does not prevent the original collision.
+- Refreshing more aggressively can rotate credentials unnecessarily and increase the collision opportunity.
+
+The machine-wide broker, shared token publication, and dead-state recovery must therefore be implemented together.
+
+## Immediate host-to-runner protection
+
+The first step is to stop runners from refreshing shared Databricks credentials.
+
+The host obtains the bearer token and publishes it to a private local file. Each runner reads that file when it starts and rereads it after Databricks rejects its current bearer token. If the host is in the middle of publishing a replacement, the runner waits briefly for the new file rather than trying to refresh the Databricks profile itself.
+
+This immediately removes the largest synchronized failure mode: many runners all deciding to refresh at once.
+
+The initial implementation may use a token file belonging to one host process. The completed design replaces that with the shared profile-and-workspace file described below, allowing separate hosts and all other local components to coordinate too.
+
+Required safeguards from the beginning:
+
+- Publish at least once per minute and whenever a new token is obtained.
+- Store JSON containing the token, expiry, profile, and workspace—not a bare token.
+- Write atomically with permissions restricted to the current user.
+- Log publication failures at `WARNING`; a silent failure can strand every runner.
+- Validate ownership, permissions, profile, workspace, and expiry before using the file.
+- Never let a runner invoke Databricks profile refresh, even as a fallback.
+
+## Shared files and identity
+
+Credential coordination must use one canonical location for the current operating-system user. It must not follow each session's configurable Omnigent data directory: two sessions with different data directories would otherwise acquire different locks and could refresh the same Databricks credentials concurrently.
+
+Use a platform-specific, machine-local runtime directory for locks, with a private `0700` Omnigent subdirectory. Use a canonical per-user Omnigent state directory for token metadata and dead markers. A test-only override may replace these locations, but production processes must not choose them independently.
+
+State is keyed by both Databricks profile and normalized workspace URL. The filename should contain a safe profile slug plus a stable hash of the normalized workspace URL; the full profile and URL remain inside the JSON for validation. This prevents one workspace from consuming or clearing another workspace's state when both use the same profile name.
+
+Conceptually, the files are:
+
+```text
+<user-state-dir>/auth/databricks/<profile>-<workspace-hash>.json
+<user-state-dir>/auth/databricks/<profile>-<workspace-hash>.dead
+<machine-runtime-dir>/omnigent/auth/databricks/<profile>-<workspace-hash>.lock
+```
+
+The `databricks` directory prevents future credential providers from colliding with Databricks state. Workspace URLs must be normalized consistently—for example, lowercasing the hostname and removing a trailing slash—before hashing or comparison.
+
+All directories and files must be owned by the current user. Secret-bearing files must use mode `0600`; private directories must use `0700`. Open files without following symbolic links, reject unexpected owners or permissive modes, cap file size, and reject malformed or mismatched JSON. Updates must use a temporary file in the same directory, flush it, and atomically replace the destination so readers see either the old complete file or the new complete file, never a half-written file.
+
+The lock directory must be on a local filesystem with verified inter-process locking semantics. Omnigent must refuse to enable shared refresh if it cannot establish a trustworthy lock; it must not silently fall back to independent refreshes. Add platform tests for Linux and macOS and document which runtime-directory fallback is used when the preferred OS directory is unavailable.
+
+## Layer 1: Recognize and contain dead credentials
+
+### Strict error classification
+
+Create one shared classifier for errors that definitively mean the login is no longer usable, such as:
+
+- `invalid_grant`
+- “refresh token is invalid”
+- Other confirmed Databricks responses with the same permanent meaning
+
+Timeouts, connection failures, server errors, and ambiguous messages must not create a dead marker. A bare HTTP `401` is also insufficient: it can mean an expired bearer token, the wrong workspace, or a permanently invalid login. Only an explicit permanent refresh-credential response from the trusted auth path may create the marker. Everything else remains an ordinary temporary or configuration failure.
+
+### Dead marker
+
+When a permanent error is confirmed, atomically write:
+
+```text
+<user-state-dir>/auth/databricks/<profile>-<workspace-hash>.dead
+```
+
+The marker should contain JSON with:
+
+- profile name
+- Databricks workspace URL
+- detection time
+- component that detected it
+- sanitized error category and message
+- exact recovery command
+
+Do not store access or refresh tokens in the marker.
+
+Once the marker exists, components stop repeatedly attempting expensive refreshes and show the same remedy:
+
+```bash
+databricks auth login --profile oss
+```
+
+### Component behavior
+
+| Component | Behavior while the marker exists |
+|---|---|
+| Host | Stops expensive reconnect/refresh attempts. Checks the marker every 5 seconds. |
+| Runner | Does not refresh independently. Waits and checks the marker every 5 seconds. |
+| Forwarder | Pauses sending but retains its cursor so data is not skipped. |
+| Policy hook | Continues to fail closed, but reports that Databricks login expired and gives the login command. |
+| Codex integration | Reports an authentication problem instead of a misleading model or transport error. |
+| Web UI | Shows that host authentication expired and displays the recovery command. |
+| CLI | Fails quickly with the same clear explanation and command. |
+
+### Clearing the marker
+
+The marker is cleared only after Omnigent successfully obtains a real working token for the matching profile and workspace.
+
+It is not cleared merely because:
+
+- enough time passed,
+- a process restarted,
+- the marker is old, or
+- the credential command started successfully but did not return a valid token.
+
+At startup, a component may perform an immediate revalidation if a marker exists. This lets a restart recover promptly after the user has already logged in again.
+
+A marker older than 24 hours should trigger an additional warning and diagnostic event. Age alone must not delete it.
+
+### Recovery probe
+
+While the credential is marked dead, one machine-wide probe is allowed every 15 seconds. The probe runs:
+
+```bash
+databricks auth token --profile oss
+```
+
+It does not explicitly request `--force-refresh` because the probe's job is only to answer: “Does the user's normal Databricks login work again?” After `databricks auth login`, the ordinary token command should return a usable token. Forcing a refresh would rotate credentials even when the current token is already valid, creating unnecessary writes and another opportunity for the same refresh-token collision this plan is designed to prevent.
+
+The command returning a token is not enough by itself. Omnigent must verify that token with a small authentication-only request to the expected workspace. Before implementation, choose and test an endpoint that is available to every supported Databricks identity and does not require optional workspace permissions. Clear the marker only when that endpoint proves the token was accepted; a timeout, `403`, redirect, or ambiguous response is not sufficient. If no universal endpoint exists, add a dedicated server-side validation path rather than guessing from an unrelated API.
+
+If the normal command keeps returning an unusable cached token after a successful login, invalidate only the known bearer-token cache entry under the shared lock and retry the ordinary command once. Do not force refresh repeatedly. If it still fails, preserve the marker and report a distinct “login succeeded but cached token remains unusable” diagnostic.
+
+The probe is protected by the same profile-and-workspace lock used for refreshes. Before probing, the process checks the marker's modification time under the lock; if another process probed within 15 seconds, it does nothing.
+
+On success it validates the returned token and workspace, publishes the token, and deletes the marker. Hosts and runners notice the deletion within 5 seconds and reconnect through their normal path, which usually takes about half a second.
+
+Expected recovery time after login:
+
+- Typical: about 10 seconds.
+- Worst case: about 15 seconds until the probe, 5 seconds until a component notices, and roughly 1 second to reconnect—about 20 seconds total.
+
+The marker prevents a false positive from lasting indefinitely. If a permanent-looking error was incorrectly classified, a successful probe repairs the state within roughly 15 seconds.
+
+### Impact on user-perceived latency
+
+There is no added latency during normal operation. Marker checks and recovery probes run only after a permanent credential failure has been detected; they are not on the normal request path.
+
+While credentials are dead, requests cannot succeed regardless of retry speed. Stopping repeated refresh attempts therefore does not make useful work slower; it replaces noisy failures with one actionable status.
+
+After the user logs in again, the revised design takes at most about 20 seconds to resume and typically about 10 seconds. An earlier proposal combined 60-second checks in a way that could make recovery take nearly two minutes. That design is rejected because the delay would be obvious and frustrating to users.
+
+If 20 seconds still feels too slow, the machine-wide probe can run every 5 seconds. That gives near-immediate recovery but starts one CLI subprocess every 5 seconds per affected machine until login is repaired. The recommended starting point is 15 seconds, backed by a recovery-latency metric.
+
+## Layer 2: Allow only one machine-wide refresher
+
+Create a central credential broker in the Omnigent auth module. It does not need to be a permanently running daemon. Any process can become the refresher by acquiring the profile-and-workspace file lock.
+
+The flow is:
+
+1. A process needs a token.
+2. It reads the published token file.
+3. If that token is still valid, it uses it.
+4. If refresh is needed, it acquires the profile lock.
+5. After acquiring the lock, it rereads the published file because another process may already have refreshed it.
+6. Only if refresh is still needed does it ask Databricks for a new token.
+7. It atomically publishes the new token and releases the lock.
+
+This “check again after locking” step prevents sequential duplicate refreshes: processes that waited for the lock use the result produced by the first process instead of refreshing again.
+
+The broker must also protect against `databricks auth login` running at the same time. Before requesting a token, it records a private fingerprint of the profile's credential source. Before publishing, it reads that source again. If it changed, the broker discards its result and retries the normal token path using the newly logged-in credentials. The fingerprint must never be logged or written to shared diagnostics.
+
+Every CLI or SDK operation has a bounded timeout. A timeout is a temporary failure: the operation is cancelled, the lock is released, and no dead marker is created. The operating system releases the lock automatically if the refresher crashes, allowing another process to take over. Add useful diagnostics for command timeouts and unexpected lock contention.
+
+There is an unavoidable narrow crash window after Databricks rotates a credential but before Omnigent publishes the new bearer token. Recovery must still remain serialized under the lock. Record a metric for “refresh started without publication,” and on takeover first run the ordinary token path to discover any usable result before attempting another refresh.
+
+If refresh succeeds but publishing fails, the broker reports a prominent error and keeps recovery serialized. It must not hand the unpublished token to only one long-lived component, and no consumer may fall back to refreshing independently. The next broker attempt first checks whether the publication problem has cleared and whether the ordinary auth path can provide the same usable token.
+
+Runners must never refresh the Databricks profile themselves. They consume the host or broker's published bearer token.
+
+## Layer 3: Publish expiry with the token
+
+Replace a bare-token file with private JSON resembling:
+
+```json
+{
+  "token": "REDACTED",
+  "exp": 1780000000,
+  "profile": "oss",
+  "workspace_host": "https://example.cloud.databricks.com",
+  "published_at": "2026-08-24T12:00:00Z"
+}
+```
+
+Consumers use `exp` to reread the shared file shortly before expiry rather than waiting for a rejected request. Use a small safety margin for clock differences and network delay.
+
+Readers must treat malformed, mismatched, or expired files as unusable. They must never log the token.
+
+Expiry is only a hint. Databricks can revoke a token before `exp`. After rejection, a consumer rereads the shared file once in case another process already published a replacement. If the token is unchanged, it asks the broker for recovery. It never refreshes directly.
+
+A runner that reconnects or resumes after being disconnected must reread the shared file before its first request. It must not reuse the bearer token retained from its earlier connection.
+
+## Layer 4: Route all Databricks authentication through one module
+
+Create one public Omnigent API for obtaining Databricks credentials and move hosts, runners, forwarding, policy checks, Codex integration, web support, and CLI paths onto it.
+
+Add a repository check that rejects new direct calls to Databricks SDK refresh methods or `databricks auth token` outside the central module and explicitly approved tests. This prevents the same concurrency bug from quietly returning later.
+
+## Layer 5: Prove it under stress
+
+Add an integration or chaos test that starts at least 20 processes against one profile and verifies:
+
+- Exactly one refresh occurs for each token rotation.
+- All consumers receive the same usable bearer token.
+- Killing the process holding the lock allows another process to take over.
+- A permanent error creates one dead marker and stops refresh thrashing.
+- Temporary network errors do not create a dead marker.
+- A successful re-login removes the marker automatically.
+- Hosts recover within about 20 seconds and existing sessions resume in place.
+- The forwarder resumes at the saved cursor without loss or duplication.
+- No secret appears in logs, marker files, or test output.
+- Two sessions with different Omnigent data directories still share one refresh lock.
+- The same profile name on two workspaces receives separate state and locks.
+- Login racing with refresh discards the superseded result.
+- A hung credential command times out and releases the lock without creating a dead marker.
+- Unsafe files—including symlinks, wrong ownership or modes, oversized files, and malformed JSON—are rejected.
+- A token revoked before its stated expiry follows the broker recovery path.
+- A disconnected runner rereads the token before resuming.
+- Publication failure never causes runners or other consumers to refresh independently.
+
+Add metrics and structured logs for:
+
+- refresh attempts, successes, and failures by profile and error category
+- lock wait time and timeout count
+- dead-marker creation and clearing
+- time from successful login probe to host recovery
+- active marker age
+
+The main success metric is approximately one credential refresh per hour per machine and profile, rather than one per process.
+
+## Implementation plan
+
+All of this work can be delivered in one PR. The steps below are an implementation order, not separate rollout phases or deployments. Keeping them as distinct commits may make review easier, but the final behavior should be enabled together.
+
+### Step 1: Build the shared authentication foundation
+
+- Add the central Omnigent authentication module.
+- Define normalized profile-and-workspace identity.
+- Resolve the canonical user-state and machine-runtime directories.
+- Add safe JSON reading, atomic publication, ownership and permission checks, and reliable file locking.
+- Define the shared token, dead-marker, and lock formats.
+
+### Step 2: Implement the broker and dead-state recovery
+
+- Serialize token refresh through the shared lock and recheck the token after acquiring it.
+- Handle login/refresh races, command timeouts, process crashes, and publication failures.
+- Add the strict permanent-error classifier and `.dead` marker.
+- Add the 15-second machine-wide recovery probe and 5-second marker checks.
+- Publish token expiry and identity metadata in the shared format.
+
+### Step 3: Move every consumer to the shared path
+
+- Make hosts obtain and publish credentials through the broker.
+- Make runners read the shared token at startup, before reconnecting, shortly before expiry, and after rejection.
+- Make runners wait briefly for an in-progress publication and remove every path that lets them refresh independently.
+- Move forwarding, policy checks, Codex integration, web support, and CLI authentication to the same module.
+- Remove old direct-refresh and per-host token-file behavior.
+
+### Step 4: Add consistent user-visible recovery
+
+- Show the same expired-login explanation and login command in every component.
+- Add the host status and web banner.
+- Preserve forwarder cursors and existing sessions while authentication is unavailable.
+- Verify that login restores hosts within about 20 seconds and sessions resume in place.
+
+### Step 5: Add prevention, tests, and diagnostics
+
+- Add the repository check that prevents new direct refresh calls outside the central module.
+- Add the 20-process concurrency test, crash takeover test, and all edge-case tests listed above.
+- Add metrics and structured logs for refresh count, lock contention, dead markers, publication failures, and recovery time.
+- Confirm that normal request latency is unchanged and refreshes converge to one per machine, profile, workspace, and token rotation.
+
+## Safety and failure cases
+
+- **Login races with refresh:** Detect the changed credential source, discard the stale result, and retry against the new login.
+- **Refresher crashes:** The operating system releases the file lock; another process checks the ordinary auth path before considering another refresh.
+- **Credential command hangs:** Cancel it at the timeout, release the lock, and treat it as temporary failure.
+- **Token file is half-written:** Atomic replacement prevents readers from observing partial data.
+- **Token file is malicious or unsafe:** Reject symlinks, wrong ownership, weak permissions, oversized content, malformed JSON, and identity mismatches.
+- **Wrong profile or workspace:** Reject the file rather than sending a token to the wrong destination.
+- **Same profile name targets two workspaces:** Separate state and locks by normalized profile-and-workspace identity.
+- **Sessions use different data directories:** They still coordinate through the canonical per-user state and machine-runtime locations.
+- **Runtime filesystem cannot provide reliable locks:** Fail clearly; never fall back to uncoordinated refresh.
+- **Network is temporarily down:** Back off normally; do not mark credentials dead.
+- **Bearer token is revoked before expiry:** Reread once, then ask the broker for recovery.
+- **Runner resumes after disconnection:** Reread the shared token before sending its first request.
+- **Databricks login is permanently invalid:** Create the marker once and stop repeated refresh attempts.
+- **User logs in again:** The next probe validates the credential, clears the marker, and components reconnect.
+- **CLI returns an unusable cached token:** Clear only the known bearer cache under the lock and retry once; preserve the dead marker if validation still fails.
+- **Several processes probe together:** The lock and marker timestamp allow only one probe in each interval.
+- **Refresh succeeds but publication fails:** Keep recovery serialized, report it prominently, and do not allow consumer refresh fallbacks.
+- **Machine clock changes:** Use monotonic time for local retry intervals; use wall-clock timestamps only for diagnostics and token expiry validation.
+- **Process cannot write the shared directory:** Fail clearly instead of silently reverting to independent refreshes.
+
+## Open decisions
+
+1. Select and test the universal authentication-validation endpoint for every supported Databricks identity. This is an implementation prerequisite.
+2. Decide whether the recovery probe should start at 15 seconds or 5 seconds. Fifteen seconds limits subprocess churn and gives a roughly 20-second worst-case recovery.
+3. Choose where the web authentication-expired banner appears and whether it offers a copy button for the login command.
+4. Choose the runner's short wait time for a newly published token before reporting the shared auth failure.
+5. Confirm that 24 hours is the right threshold for escalating a stale-marker warning; it must remain advisory.
+6. Decide whether the separate bug that reports credentials as expired on `1970-01-01` belongs in this work or in its own fix.
+
+## Acceptance criteria
+
+- Twenty concurrent processes cause one refresh, not twenty.
+- No runner can refresh the shared Databricks profile independently.
+- Separate hosts and sessions on the same machine coordinate through the same profile-and-workspace lock even when their Omnigent data directories differ.
+- The implementation refuses unsafe shared refresh when reliable machine-local locking is unavailable.
+- Permanent credential failure produces one clear state and one recovery instruction everywhere.
+- Temporary failures, bearer-token rejection alone, and ambiguous `401` responses never create a dead marker.
+- A successful login clears the state automatically and restores service within about 20 seconds.
+- Existing sessions resume without being recreated or forked.
+- A refresher crash is recovered without manual cleanup.
+- A login racing with refresh cannot publish a token derived from superseded credentials.
+- A reconnecting runner cannot reuse the bearer token retained before disconnection.
+- Normal request latency is unchanged.
+- Tokens are never exposed through logs or insecure file permissions.
+
+## Glossary
+
+- **Access token / bearer token:** A short-lived secret sent with a request to prove identity.
+- **Refresh token:** A longer-lived secret used to obtain a new bearer token.
+- **Rotation:** Replacing a refresh token with a new one when it is used.
+- **Reuse detection:** A security rule that may invalidate a token family if an already-replaced refresh token is used again.
+- **Token family:** The chain of refresh tokens descended from one login.
+- **Profile:** A named Databricks CLI login, such as `oss`.
+- **Databricks workspace host:** The Databricks server URL associated with a profile.
+- **Omnigent host:** The local Omnigent process connecting sessions to the server; not the Databricks workspace host.
+- **Runner:** The process executing a model or agent session.
+- **Forwarder:** A process that sends locally produced records or events to the server.
+- **Policy hook:** A check that approves or rejects an action before it runs.
+- **Fail closed:** Reject an action when a required safety check cannot be completed.
+- **Bridge:** The connection layer joining local processes and the remote Omnigent service.
+- **SDK:** A software library used to call Databricks APIs.
+- **`--force-refresh`:** A CLI option that asks for fresh credentials even if cached credentials may still work.
+- **Apps edge / login redirect:** The outer Databricks Apps layer that may redirect unauthenticated requests to login.
+- **Marker file:** A small shared file recording that credentials are known to be invalid.
+- **Probe:** A rate-limited attempt to determine whether login now works.
+- **Broker / refresher:** The shared code path allowed to obtain and publish a new token.
+- **Lock / `flock`:** An operating-system mechanism allowing only one local process into a critical section at a time.
+- **Atomic write:** Writing a complete temporary file and replacing the old file in one operation so readers never see partial content.
+- **Data directory:** A session's configured directory for general Omnigent state. Credential coordination deliberately does not depend on this directory.
+- **User state directory:** The one canonical location where all Omnigent processes for an operating-system user share credential metadata.
+- **Machine runtime directory:** A private, machine-local location for short-lived locks. Unlike a network-mounted home directory, it must provide reliable local process locking.
+- **Credential fingerprint:** A private comparison value used only to detect whether login credentials changed during an operation; it is never logged or published.
+- **JWT / `exp`:** A common token format and its expiry-time field.
+- **Fail fast:** Stop promptly with a clear error when retrying cannot help.
+- **Thrashing:** Repeating expensive work that cannot currently succeed.
+- **Backoff:** Increasing the delay between repeated attempts after temporary failures.
+- **Thundering herd:** Many processes attempting the same work simultaneously.
+
+## Implementation addendums
+
+This section records intentional differences discovered during the required implementation audits. Unintended differences must be fixed in code instead of being documented here.
+
+### Step 1 audit: shared authentication foundation
+
+- **Opaque tokens have no `exp` value.** JWT bearer tokens publish their real `exp` claim. Opaque personal-access tokens cannot be decoded and therefore publish `exp: null`; treating them as if they had an invented expiry could cause needless refreshes or premature failure. They remain cached until Databricks rejects them, at which point the normal rejection and broker-recovery path applies. Consumers must accept `null` only for opaque tokens.
+- **Production coordination ignores session data-directory overrides.** The implementation uses one canonical per-user state directory and one machine-local runtime directory. Separate overrides exist only for isolated tests; production sessions cannot select independent lock locations.
+- **Windows ownership checks use platform capabilities.** POSIX validates numeric file ownership and modes. Windows lacks `getuid`, so the implementation relies on a per-user runtime path plus the platform's file access controls and still rejects links, non-regular files, malformed content, and unsafe state shape. Windows-specific access-control verification remains part of the platform test requirement.
+
+### Step 2 audit: broker and dead-state recovery
+
+- **Recovery validation uses the workspace status API.** Before a `.dead` marker is removed, the broker calls `GET /api/2.0/workspace/get-status?path=/` with the candidate bearer. This is a small, read-only workspace request and proves that the intended workspace accepts the token; merely receiving a token from the CLI is not enough.
+- **The first recovery probe remains an ordinary token lookup.** It does not force a refresh. If the workspace rejects that returned token, the broker performs one forced OAuth refresh under the same lock and validates the replacement. This handles a token revoked before its advertised expiry without rotating healthy credentials during every probe.
+- **OAuth login races receive a second ordinary lookup.** File metadata detects config-file changes, but macOS Keychain and other credential managers can change without touching a visible file. After the first OAuth-U2M lookup, the broker therefore performs one cheap cached lookup and uses the newer result if they differ. This adds negligible cost only to the approximately hourly refresh path, not normal requests.
+- **Timeouts follow the credential mechanism.** OAuth-U2M runs in a child process with a 20-second timeout, so a hung CLI can be killed. SDK-backed network credential types are capped through the SDK's HTTP timeout. A timeout is temporary and never creates a `.dead` marker.
+- **Probe throttling uses the machine's monotonic clock.** The marker retains wall-clock timestamps for diagnostics, but the 15-second gate uses monotonic time so a manual or automatic wall-clock correction cannot suppress probes or cause a burst. A negative elapsed value, such as after reboot, is treated as stale and allows a new probe.
+
+### Step 3 audit: consumer migration
+
+- **Harness helpers invoke the Python broker.** Generated Claude and Codex token commands no longer call `databricks auth token` or `--force-refresh` themselves. The old recorded-command fallback is accepted as an API argument for compatibility but is deliberately not executed, because it would bypass machine-wide serialization.
+- **Runners use the same broker rather than a separate refresh path.** A runner still starts with the bearer handed to it by its host. If Databricks rejects that bearer, the runner invalidates the shared publication and retries once through the broker. The process that wins the broker lock may be a host, runner, or harness helper; ownership is not pinned to the host process, but refresh is still single-file, machine-wide, and serialized. This is intentional: it avoids adding a host-runner control channel while preserving the safety property that only one refresh can occur.
+- **Test state is isolated per test.** The test suite points broker state and locks at a private temporary directory for every test. This prevents tests from reading or changing a developer's real credential publication and prevents one test's token from hiding another test's authentication call.
+
+### Step 4 audit: user-visible recovery
+
+- **The browser cannot reliably receive a special host-auth status.** A dead Databricks credential is rejected by the Databricks Apps edge before the host's WebSocket reaches the Omnigent server. The server therefore sees an offline host, but it cannot distinguish “login expired” from sleep, network loss, or a stopped process. Sending that distinction would require a second control channel or heartbeat, which this design explicitly avoids. The implementation keeps the existing offline host badge in the web UI and gives the exact `databricks auth login` command in host, runner, harness, and CLI errors and logs. It does not claim a browser-only “login expired” diagnosis that the server cannot prove.
+- **Sessions remain in place during authentication loss.** No session, forwarder cursor, runner record, or local workspace is deleted when the marker is present. Components retry through the shared broker; a successful 15-second probe removes the marker and the existing host and runner reconnect paths resume the same sessions.
+
+### Step 5 audit: prevention, tests, and diagnostics
+
+- **The repository guardrail is syntax-based.** Pre-commit parses every production Python file and rejects any `.authenticate()` call outside `databricks_auth_broker.py`. This catches direct SDK refreshes without false positives from comments or documentation. The broker is the only allowlisted implementation boundary.
+- **Concurrency and crash behavior use real processes.** The test suite starts 20 consumers against one profile and workspace and proves only one authentication call occurs. A separate test kills a process while it owns the lock and proves the operating system releases the lock for the next process. Timeout, dead-marker throttling, failed validation, unsafe files, identity separation, and private atomic publication have focused tests as well.
+- **Diagnostics use existing structured process logs rather than a new metrics backend.** The broker logs lock waits over 50 milliseconds, successful publication duration, dead-marker creation, recovery, and publication failures. Logs include only profile and normalized host—never bearer tokens, refresh tokens, or credential fingerprints. The repository does not currently have a universal client-side metrics sink, so adding a separate telemetry transport solely for this feature would create more failure surface than it removes.

--- a/dev/lint/lint_no_direct_databricks_auth.py
+++ b/dev/lint/lint_no_direct_databricks_auth.py
@@ -1,0 +1,35 @@
+"""Reject direct SDK authentication outside the credential broker."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_ALLOWED = Path("omnigent/databricks_auth_broker.py")
+
+
+def main() -> int:
+    violations: list[str] = []
+    for path in Path("omnigent").rglob("*.py"):
+        if path == _ALLOWED:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "authenticate"
+            ):
+                violations.append(
+                    f"{path}:{node.lineno}: use token_for_config(), not .authenticate()"
+                )
+    if violations:
+        print("Direct credential refresh bypasses machine-wide serialization:", file=sys.stderr)
+        print("\n".join(violations), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/omnigent/databricks_auth_broker.py
+++ b/omnigent/databricks_auth_broker.py
@@ -1,0 +1,587 @@
+"""Machine-wide coordination for Databricks workspace credentials."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import getpass
+import hashlib
+import json
+import logging
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+from filelock import FileLock, Timeout
+
+_logger = logging.getLogger(__name__)
+
+_LOCK_TIMEOUT_S = 30.0
+_REFRESH_SKEW_S = 60.0
+_PROBE_INTERVAL_S = 15.0
+_AUTH_COMMAND_TIMEOUT_S = 20.0
+_MAX_STATE_BYTES = 64 * 1024
+
+
+class AuthConfig(Protocol):
+    """Small subset of the Databricks SDK config used by the broker."""
+
+    def authenticate(self) -> dict[str, str]: ...
+
+
+TokenValidator = Callable[[str, str], None]
+
+
+class DatabricksCredentialError(OSError):
+    """Base class for coordinated Databricks authentication failures."""
+
+
+class DatabricksCredentialsDeadError(DatabricksCredentialError):
+    """The profile must be repaired with ``databricks auth login``."""
+
+
+@dataclass(frozen=True)
+class AuthIdentity:
+    """A Databricks profile and workspace pair."""
+
+    profile: str
+    workspace_host: str
+    key: str
+
+    @classmethod
+    def create(cls, profile: str | None, workspace_host: str) -> AuthIdentity:
+        normalized_host = normalize_workspace_host(workspace_host)
+        normalized_profile = (profile or "DEFAULT").strip() or "DEFAULT"
+        digest = hashlib.sha256(normalized_host.encode()).hexdigest()[:16]
+        safe_profile = "".join(
+            char if char.isalnum() or char in ("-", "_") else "-" for char in normalized_profile
+        )[:64]
+        return cls(
+            profile=normalized_profile,
+            workspace_host=normalized_host,
+            key=f"{safe_profile}-{digest}",
+        )
+
+
+@dataclass(frozen=True)
+class SharedToken:
+    """Bearer token and publication metadata read from shared state."""
+
+    token: str
+    expires_at: float | None
+    published_at: float
+
+    def usable(self, now: float) -> bool:
+        return self.expires_at is None or self.expires_at > now + _REFRESH_SKEW_S
+
+
+def normalize_workspace_host(host: str) -> str:
+    """Return a stable HTTPS workspace URL without a trailing slash."""
+    value = host.strip()
+    if "://" not in value:
+        value = f"https://{value}"
+    parsed = urlsplit(value)
+    scheme = parsed.scheme.lower()
+    hostname = (parsed.hostname or "").lower()
+    if not hostname:
+        raise ValueError(f"invalid Databricks workspace host: {host!r}")
+    port = f":{parsed.port}" if parsed.port is not None else ""
+    return urlunsplit((scheme, f"{hostname}{port}", "", "", ""))
+
+
+def _state_root() -> Path:
+    return Path.home() / ".omnigent" / "auth" / "databricks"
+
+
+def _runtime_root() -> Path:
+    xdg_runtime = os.environ.get("XDG_RUNTIME_DIR")
+    if xdg_runtime:
+        return Path(xdg_runtime) / "omnigent" / "auth" / "databricks"
+    user_key = hashlib.sha256(getpass.getuser().encode()).hexdigest()[:12]
+    return Path(tempfile.gettempdir()) / f"omnigent-{user_key}" / "auth" / "databricks"
+
+
+def _current_uid() -> int | None:
+    getuid = getattr(os, "getuid", None)
+    return int(getuid()) if getuid is not None else None
+
+
+def _ensure_private_dir(path: Path) -> None:
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    info = path.lstat()
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise DatabricksCredentialError(f"unsafe credential state directory: {path}")
+    uid = _current_uid()
+    if uid is not None and info.st_uid != uid:
+        raise DatabricksCredentialError(
+            f"credential state directory is not owned by this user: {path}"
+        )
+    if stat.S_IMODE(info.st_mode) & 0o077:
+        path.chmod(0o700)
+
+
+def _safe_read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return None
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise DatabricksCredentialError(f"unsafe credential state file: {path}")
+    uid = _current_uid()
+    if (uid is not None and info.st_uid != uid) or stat.S_IMODE(info.st_mode) & 0o077:
+        raise DatabricksCredentialError(
+            f"credential state file has unsafe ownership or mode: {path}"
+        )
+    if info.st_size > _MAX_STATE_BYTES:
+        raise DatabricksCredentialError(f"credential state file is too large: {path}")
+    try:
+        raw = path.read_text(encoding="utf-8")
+        value = json.loads(raw)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise DatabricksCredentialError(f"invalid credential state file: {path}") from exc
+    if not isinstance(value, dict):
+        raise DatabricksCredentialError(f"invalid credential state file: {path}")
+    return value
+
+
+def _atomic_write_json(path: Path, value: dict[str, Any]) -> None:
+    _ensure_private_dir(path.parent)
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    if len(encoded) > _MAX_STATE_BYTES:
+        raise DatabricksCredentialError("credential state exceeds size limit")
+    fd, raw_temp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(raw_temp)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb", closefd=True) as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        with suppress(FileNotFoundError):
+            temp_path.unlink()
+
+
+def _token_expiry(token: str) -> float | None:
+    """Read an unverified JWT ``exp`` claim; opaque PATs have no expiry."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        payload = parts[1] + "=" * (-len(parts[1]) % 4)
+        decoded = json.loads(base64.urlsafe_b64decode(payload).decode())
+        expiry = decoded.get("exp")
+        return float(expiry) if isinstance(expiry, (int, float)) else None
+    except (ValueError, UnicodeError, json.JSONDecodeError):
+        return None
+
+
+def _permanent_auth_failure(exc: BaseException) -> bool:
+    text = str(exc).lower()
+    return any(
+        marker in text
+        for marker in (
+            "invalid_grant",
+            "refresh token is invalid",
+            "refresh token has expired",
+            "refresh token reuse",
+        )
+    )
+
+
+def _credential_source_fingerprint() -> str:
+    digest = hashlib.sha256()
+    paths = (
+        Path(os.environ.get("DATABRICKS_CONFIG_FILE") or Path.home() / ".databrickscfg"),
+        Path.home() / ".databricks" / "token-cache.json",
+    )
+    for path in paths:
+        digest.update(str(path).encode())
+        try:
+            info = path.stat()
+        except OSError:
+            digest.update(b"missing")
+        else:
+            digest.update(f"{info.st_ino}:{info.st_size}:{info.st_mtime_ns}".encode())
+    for name in ("DATABRICKS_CONFIG_PROFILE", "DATABRICKS_HOST", "DATABRICKS_TOKEN"):
+        digest.update(name.encode())
+        digest.update(os.environ.get(name, "").encode())
+    return digest.hexdigest()
+
+
+def _validate_workspace_token(workspace_host: str, token: str) -> None:
+    """Prove that a bearer is accepted by the intended workspace."""
+    response = httpx.get(
+        f"{workspace_host}/api/2.0/workspace/get-status",
+        params={"path": "/"},
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10.0,
+        follow_redirects=False,
+    )
+    response.raise_for_status()
+
+
+class DatabricksAuthBroker:
+    """Publish and consume one bearer per user, profile, and workspace."""
+
+    def __init__(
+        self,
+        config: AuthConfig,
+        *,
+        profile: str | None,
+        workspace_host: str,
+        failure_message: str | None = None,
+        token_validator: TokenValidator | None = None,
+    ) -> None:
+        self._config = config
+        # SDK-backed service-principal and cloud-provider exchanges honor this
+        # setting. OAuth-U2M uses the separately bounded CLI child below.
+        sdk_timeout = getattr(config, "http_timeout_seconds", None)
+        if isinstance(sdk_timeout, (int, float)) and sdk_timeout > _AUTH_COMMAND_TIMEOUT_S:
+            config_with_timeout: Any = config
+            config_with_timeout.http_timeout_seconds = _AUTH_COMMAND_TIMEOUT_S
+        self.identity = AuthIdentity.create(profile, workspace_host)
+        self._failure_message = failure_message
+        self._token_validator = token_validator or _validate_workspace_token
+
+    @property
+    def _token_path(self) -> Path:
+        return _state_root() / f"{self.identity.key}.json"
+
+    @property
+    def _dead_path(self) -> Path:
+        return _state_root() / f"{self.identity.key}.dead"
+
+    @property
+    def _lock_path(self) -> Path:
+        return _runtime_root() / f"{self.identity.key}.lock"
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        _ensure_private_dir(self._lock_path.parent)
+        try:
+            info = self._lock_path.lstat()
+        except FileNotFoundError:
+            pass
+        else:
+            uid = _current_uid()
+            if (
+                stat.S_ISLNK(info.st_mode)
+                or not stat.S_ISREG(info.st_mode)
+                or (uid is not None and info.st_uid != uid)
+                or stat.S_IMODE(info.st_mode) & 0o077
+            ):
+                raise DatabricksCredentialError(
+                    f"credential lock file has unsafe ownership or mode: {self._lock_path}"
+                )
+        lock = FileLock(self._lock_path, mode=0o600)
+        started = time.monotonic()
+        try:
+            with lock.acquire(timeout=_LOCK_TIMEOUT_S):
+                waited = time.monotonic() - started
+                if waited >= 0.05:
+                    _logger.info(
+                        "Waited %.3fs for Databricks credential broker lock (profile=%r host=%s)",
+                        waited,
+                        self.identity.profile,
+                        self.identity.workspace_host,
+                    )
+                yield
+        except Timeout as exc:
+            raise DatabricksCredentialError(
+                f"timed out waiting for Databricks credential lock for {self.identity.profile!r}"
+            ) from exc
+
+    def current_token(self) -> str:
+        """Return a shared bearer, refreshing once under the machine lock."""
+        with self._locked():
+            now = time.time()
+            monotonic_now = time.monotonic()
+            dead = self._read_dead()
+            last_probe_monotonic = float(dead.get("last_probe_monotonic", -1.0)) if dead else -1.0
+            elapsed = monotonic_now - last_probe_monotonic
+            if dead is not None and 0.0 <= elapsed < _PROBE_INTERVAL_S:
+                raise DatabricksCredentialsDeadError(self._dead_message(dead))
+
+            shared = self._read_token()
+            if dead is None and shared is not None and shared.usable(now):
+                return shared.token
+
+            if dead is not None:
+                # Claim this machine-wide probe slot before doing network work.
+                # A failed probe must not allow every waiting process to probe.
+                dead["last_probe_at"] = now
+                dead["last_probe_monotonic"] = monotonic_now
+                _atomic_write_json(self._dead_path, dead)
+            return self._refresh_locked(now, recovering=dead is not None)
+
+    def invalidate(self, rejected_token: str | None = None) -> None:
+        """Discard a rejected shared bearer without marking login dead."""
+        with self._locked():
+            shared = self._read_token()
+            if shared is None or rejected_token is None or shared.token == rejected_token:
+                with suppress(FileNotFoundError):
+                    self._token_path.unlink()
+
+    def _refresh_locked(self, now: float, *, recovering: bool) -> str:
+        refresh_started = time.monotonic()
+        before = _credential_source_fingerprint()
+        try:
+            headers = self._authenticate()
+            after = _credential_source_fingerprint()
+            if before != after:
+                # A concurrent `databricks auth login` changed the credential
+                # source. Discard the result that may have used the old source.
+                headers = self._authenticate()
+            elif str(getattr(self._config, "auth_type", "") or "").lower() in {
+                "databricks-cli",
+                "oauth-u2m",
+            }:
+                # OAuth-U2M credentials may live in Keychain/credential
+                # manager, whose changes are not visible through file stats.
+                # A second ordinary lookup is cheap (the first populated the
+                # CLI cache) and closes the common login-during-refresh race.
+                second = self._authenticate()
+                if second != headers:
+                    headers = second
+        except Exception as exc:
+            if _permanent_auth_failure(exc):
+                dead = self._write_dead(now, exc)
+                raise DatabricksCredentialsDeadError(self._dead_message(dead)) from exc
+            raise DatabricksCredentialError(
+                self._failure_message or self._login_message()
+            ) from exc
+
+        auth_value = headers.get("Authorization", "")
+        if not auth_value.startswith("Bearer "):
+            raise DatabricksCredentialError("Databricks authentication returned no bearer token")
+        token = auth_value.removeprefix("Bearer ")
+        if recovering:
+            try:
+                self._token_validator(self.identity.workspace_host, token)
+            except Exception:  # noqa: BLE001 -- validators may use any HTTP client.
+                # A still-valid cached access token may have been revoked. The
+                # ordinary probe deliberately avoids rotation; only after the
+                # workspace rejects it do we ask OAuth-U2M for one fresh token.
+                try:
+                    headers = self._authenticate(force_refresh=True)
+                    auth_value = headers.get("Authorization", "")
+                    if not auth_value.startswith("Bearer "):
+                        raise DatabricksCredentialError(
+                            "Databricks authentication returned no bearer token"
+                        )
+                    token = auth_value.removeprefix("Bearer ")
+                    self._token_validator(self.identity.workspace_host, token)
+                except Exception as retry_exc:
+                    raise DatabricksCredentialsDeadError(
+                        self._dead_message(self._read_dead() or {})
+                    ) from retry_exc
+        try:
+            self._publish(token, now)
+        except Exception:
+            _logger.exception(
+                "Databricks credential publication failed (profile=%r host=%s)",
+                self.identity.profile,
+                self.identity.workspace_host,
+            )
+            raise
+        _logger.info(
+            "Published Databricks credential in %.3fs (profile=%r host=%s recovery=%s)",
+            time.monotonic() - refresh_started,
+            self.identity.profile,
+            self.identity.workspace_host,
+            recovering,
+        )
+        if recovering:
+            with suppress(FileNotFoundError):
+                self._dead_path.unlink()
+            _logger.info(
+                "Databricks authentication recovered for profile %r", self.identity.profile
+            )
+        return token
+
+    def _authenticate(self, *, force_refresh: bool = False) -> dict[str, str]:
+        """Authenticate with a bounded CLI child for OAuth-U2M profiles."""
+        auth_type = str(getattr(self._config, "auth_type", "") or "").lower()
+        if auth_type not in {"databricks-cli", "oauth-u2m"}:
+            return self._config.authenticate()
+        command = ["databricks", "auth", "token"]
+        if self.identity.profile == "DEFAULT":
+            command.extend(("--host", self.identity.workspace_host))
+        else:
+            command.extend(("--profile", self.identity.profile))
+        if force_refresh:
+            command.append("--force-refresh")
+        command.extend(("--output", "json"))
+        try:
+            result = subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=_AUTH_COMMAND_TIMEOUT_S,
+            )
+            payload = json.loads(result.stdout)
+            token = payload.get("access_token")
+            if not isinstance(token, str) or not token:
+                raise DatabricksCredentialError("Databricks CLI returned no bearer token")
+            return {"Authorization": f"Bearer {token}"}
+        except subprocess.TimeoutExpired as exc:
+            raise DatabricksCredentialError("Databricks credential command timed out") from exc
+        except (OSError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            detail = (
+                exc.stderr.strip() if isinstance(exc, subprocess.CalledProcessError) else str(exc)
+            )
+            raise DatabricksCredentialError(
+                detail or "Databricks credential command failed"
+            ) from exc
+
+    def _read_token(self) -> SharedToken | None:
+        value = _safe_read_json(self._token_path)
+        if value is None:
+            return None
+        if (
+            value.get("profile") != self.identity.profile
+            or value.get("workspace_host") != self.identity.workspace_host
+            or not isinstance(value.get("token"), str)
+            or not isinstance(value.get("published_at"), (int, float))
+        ):
+            raise DatabricksCredentialError(
+                f"credential state identity mismatch: {self._token_path}"
+            )
+        expires_at = value.get("exp")
+        if expires_at is not None and not isinstance(expires_at, (int, float)):
+            raise DatabricksCredentialError(f"invalid token expiry: {self._token_path}")
+        return SharedToken(
+            value["token"], float(expires_at) if expires_at else None, value["published_at"]
+        )
+
+    def _read_dead(self) -> dict[str, Any] | None:
+        value = _safe_read_json(self._dead_path)
+        if value is None:
+            return None
+        if (
+            value.get("profile") != self.identity.profile
+            or value.get("workspace_host") != self.identity.workspace_host
+        ):
+            raise DatabricksCredentialError(f"dead marker identity mismatch: {self._dead_path}")
+        return value
+
+    def _publish(self, token: str, now: float) -> None:
+        _atomic_write_json(
+            self._token_path,
+            {
+                "version": 1,
+                "profile": self.identity.profile,
+                "workspace_host": self.identity.workspace_host,
+                "token": token,
+                "exp": _token_expiry(token),
+                "published_at": now,
+            },
+        )
+
+    def _write_dead(self, now: float, exc: BaseException) -> dict[str, Any]:
+        marker = {
+            "version": 1,
+            "profile": self.identity.profile,
+            "workspace_host": self.identity.workspace_host,
+            "detected_at": now,
+            "last_probe_at": now,
+            "last_probe_monotonic": time.monotonic(),
+            "source": "databricks-auth-broker",
+            "error": type(exc).__name__,
+            "remedy": self._login_command(),
+        }
+        _atomic_write_json(self._dead_path, marker)
+        _logger.error(
+            "Databricks credentials are invalid for profile %r; run `%s`",
+            self.identity.profile,
+            marker["remedy"],
+        )
+        return marker
+
+    def _login_command(self) -> str:
+        if self.identity.profile == "DEFAULT":
+            return f"databricks auth login --host {self.identity.workspace_host}"
+        return f"databricks auth login --profile {self.identity.profile}"
+
+    def _login_message(self) -> str:
+        return (
+            f"Databricks authentication failed for profile {self.identity.profile!r}. "
+            f"Run: {self._login_command()}"
+        )
+
+    def _dead_message(self, marker: dict[str, Any]) -> str:
+        return (
+            f"Databricks credentials are invalid for profile {self.identity.profile!r}. "
+            f"Run: {marker.get('remedy', self._login_command())}"
+        )
+
+
+def token_for_config(
+    config: AuthConfig,
+    *,
+    profile: str | None = None,
+    workspace_host: str | None = None,
+    failure_message: str | None = None,
+) -> str:
+    """Public entry point for every in-process Databricks auth consumer."""
+    host = workspace_host or str(getattr(config, "host", "") or "")
+    resolved_profile = profile or getattr(config, "profile", None)
+    if not host:
+        raise DatabricksCredentialError("Databricks authentication resolved no workspace host")
+    return DatabricksAuthBroker(
+        config,
+        profile=resolved_profile,
+        workspace_host=host,
+        failure_message=failure_message,
+    ).current_token()
+
+
+def _main(argv: list[str] | None = None) -> int:
+    """Print one broker-coordinated token for harness helper commands."""
+    parser = argparse.ArgumentParser()
+    selector = parser.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--profile")
+    selector.add_argument("--host")
+    parser.add_argument("--workspace-host", required=True)
+    args = parser.parse_args(argv)
+    try:
+        from databricks.sdk.config import Config
+
+        if args.profile:
+            config = Config(profile=args.profile)
+            profile = args.profile
+        else:
+            config = Config(host=args.host, auth_type="databricks-cli")
+            profile = None
+        token = DatabricksAuthBroker(
+            config,
+            profile=profile,
+            workspace_host=args.workspace_host,
+        ).current_token()
+    except Exception as exc:  # noqa: BLE001 -- CLI boundary prints a safe summary.
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(token)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/omnigent/inner/credential_proxy.py
+++ b/omnigent/inner/credential_proxy.py
@@ -406,20 +406,14 @@ def _databricks_authenticate(config: object) -> str:
         scheme.
     """
     try:
-        headers = config.authenticate()  # type: ignore[attr-defined]
+        from omnigent.databricks_auth_broker import token_for_config
+
+        return token_for_config(config)  # type: ignore[arg-type]
     except Exception as exc:
         raise OmnigentError(
             f"Databricks authentication failed: {exc}",
             code=ErrorCode.INVALID_INPUT,
         ) from exc
-    auth = (headers or {}).get("Authorization", "")
-    if not isinstance(auth, str) or not auth.startswith("Bearer "):
-        raise OmnigentError(
-            "Databricks authentication returned a non-Bearer scheme; only "
-            "Bearer tokens (PAT / OAuth) are supported by the credential proxy.",
-            code=ErrorCode.INVALID_INPUT,
-        )
-    return auth.removeprefix("Bearer ").strip()
 
 
 def _prepare_databricks_runtime(

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -133,12 +133,15 @@ def _read_databrickscfg(profile: str | None = None) -> DatabricksCredentials | N
         # databricks-sdk should always be present (pinned in pyproject.toml),
         # but if it isn't we gracefully degrade to file reading.
         return _read_databrickscfg_file_fallback(profile)
+    from omnigent.databricks_auth_broker import token_for_config
 
     # ``None`` means "let the SDK decide" (env var / DEFAULT section).
     sdk_profile = profile or os.environ.get("DATABRICKS_CONFIG_PROFILE")
     try:
         cfg = Config(profile=sdk_profile)
-        headers = cfg.authenticate()
+        if not cfg.host:
+            return _read_databrickscfg_file_fallback(profile)
+        token = token_for_config(cfg, profile=sdk_profile)
     except ValueError as profile_exc:
         # ValueError is what Config raises for every user-facing resolution
         # failure (missing profile, malformed file, no credentials in env,
@@ -157,20 +160,21 @@ def _read_databrickscfg(profile: str | None = None) -> DatabricksCredentials | N
             )
             try:
                 cfg = Config()
-                headers = cfg.authenticate()
+                if not cfg.host:
+                    return _read_databrickscfg_file_fallback(profile)
+                token = token_for_config(cfg)
             except ValueError:
                 return _read_databrickscfg_file_fallback(profile)
         else:
             return _read_databrickscfg_file_fallback(profile)
 
     host = cfg.host
-    auth = headers.get("Authorization")
-    if not host or not auth or not auth.startswith("Bearer "):
+    if not host or not token:
         # Non-Bearer auth schemes (e.g. Basic) or missing host/auth are
         # treated as unresolved. None of our harnesses support non-Bearer
         # today.
         return None
-    return DatabricksCredentials(host=host, token=auth.removeprefix("Bearer "))
+    return DatabricksCredentials(host=host, token=token)
 
 
 def _read_databrickscfg_file_fallback(profile: str | None = None) -> DatabricksCredentials | None:
@@ -235,7 +239,7 @@ def databricks_bearer_token_command(
     profile: str | None = None,
     fallback_command: str | None = None,
 ) -> str:
-    """Build the shell command a harness runs to mint a workspace bearer token.
+    """Build a shell command that reads a broker-coordinated workspace token.
 
     The one definition of the generated helper, so the claude and codex
     harnesses cannot drift apart on which profile they authenticate as or how
@@ -248,56 +252,35 @@ def databricks_bearer_token_command(
     authenticating as *different* profiles for the same workspace, one of them
     re-authed and the other not.
 
-    **Refresh.** ``--force-refresh`` is attempted first: it renews a still-valid
-    cached token, which is what keeps a long gateway session from hitting a
-    mid-session 401. But it *fails* when the refresh token itself has gone
-    stale, and unconditionally forcing turned a perfectly usable cached access
-    token into a hard auth failure. So the forced attempt is speculative — its
-    output is captured and its stderr dropped — and an empty result falls back
-    to plain ``auth token``, which serves the cached token and renews it only
-    when it is near expiry. The fallback keeps its stderr so a genuine auth
-    failure is still visible. ``--force-refresh`` only exists in Databricks CLI
-    >= v0.296.0, so it stays behind the ``--help`` capability probe.
-
-    **Fallback command.** The named profile is the identity we *want*, but the
-    user may have authenticated under a different profile on the same host — a
-    config naming a credential-less profile would otherwise 401 every turn.
-    When the caller knows a token command that already worked (the one ucode
-    recorded, say), it runs last, once the named profile has yielded nothing.
+    All harnesses call the same Python broker used by the host and runner. The
+    old generated helper independently forced OAuth refreshes and was one of
+    the refresh-token collision paths this module exists to remove.
 
     :param host: Databricks workspace host, e.g.
         ``"https://example.databricks.com"``.
     :param profile: ``~/.databrickscfg`` profile name, e.g. ``"oss"``, or
         ``None`` to select the workspace by host.
-    :param fallback_command: Shell command printing a bearer token on stdout,
-        run only when the profile above yields an empty token.
+    :param fallback_command: Retained for source compatibility and ignored;
+        independent fallback refresh commands are intentionally forbidden.
     :returns: Shell command that prints a bearer token on stdout.
     """
-    selector = (
-        f"--profile {json.dumps(profile)}" if profile else f"--host {json.dumps(host.rstrip('/'))}"
-    )
-    mint = f"env -u DATABRICKS_CONFIG_PROFILE databricks auth token {selector}"
-    fallback = (
-        # ``eval`` on a quoted string: the recorded command is opaque shell,
-        # and inlining it bare would let its own quoting reshape this script.
-        f'if [ -z "$token" ]; then token=$(eval {shlex.quote(fallback_command)}); fi; '
-        if fallback_command
-        else ""
-    )
+    del fallback_command
+    import sys
+
+    args = [
+        sys.executable,
+        "-m",
+        "omnigent.databricks_auth_broker",
+        "--workspace-host",
+        host.rstrip("/"),
+    ]
+    args.extend(("--profile", profile) if profile else ("--host", host.rstrip("/")))
+    broker_command = shlex.join(args)
     return (
-        # An injected bearer wins: the runner already resolved one.
+        # An explicit test/CI bearer wins. Production helpers use the broker.
         'if [ -n "${DATABRICKS_BEARER:-}" ]; then '
         'printf "%s\\n" "$DATABRICKS_BEARER"; '
-        "else token=''; "
-        "if databricks auth token --help 2>&1 | grep -q force-refresh; then "
-        f"token=$({mint} --force-refresh --output json 2>/dev/null "
-        "| jq -r '.access_token // empty'); "
-        "fi; "
-        'if [ -z "$token" ]; then '
-        f"token=$({mint} --output json | jq -r '.access_token // empty'); "
-        "fi; "
-        f"{fallback}"
-        'printf "%s\\n" "$token"; fi'
+        f"else {broker_command}; fi"
     )
 
 
@@ -420,6 +403,7 @@ class _DatabricksBearerAuth(httpx.Auth):
         config: _DatabricksAuthConfig,
         profile_name: str | None = None,
         failure_message: str | None = None,
+        workspace_host: str | None = None,
     ) -> None:
         """
         :param config: Databricks SDK ``Config`` instance.
@@ -432,6 +416,17 @@ class _DatabricksBearerAuth(httpx.Auth):
         self._config = config
         self._profile_name = profile_name
         self._failure_message = failure_message
+        self._broker = None
+        resolved_host = workspace_host or getattr(config, "host", None)
+        if resolved_host:
+            from omnigent.databricks_auth_broker import DatabricksAuthBroker
+
+            self._broker = DatabricksAuthBroker(
+                config,
+                profile=profile_name,
+                workspace_host=resolved_host,
+                failure_message=failure_message,
+            )
 
     def _authenticate_headers(self) -> dict[str, str]:
         """
@@ -447,7 +442,9 @@ class _DatabricksBearerAuth(httpx.Auth):
             (expired refresh token, revoked credentials, etc.).
         """
         try:
-            return self._config.authenticate()
+            if self._broker is None:
+                raise DatabricksAuthError("Databricks authentication resolved no workspace host")
+            return {"Authorization": f"Bearer {self._broker.current_token()}"}
         except Exception as exc:
             if self._failure_message is not None:
                 raise DatabricksAuthError(self._failure_message) from exc
@@ -456,6 +453,11 @@ class _DatabricksBearerAuth(httpx.Auth):
                 f"Databricks authentication failed for profile {self._profile_name!r}. "
                 f"Run: databricks auth login{profile_flag}"
             ) from exc
+
+    def invalidate(self, rejected_token: str | None = None) -> None:
+        """Discard a rejected shared bearer so the broker can replace it."""
+        if self._broker is not None:
+            self._broker.invalidate(rejected_token)
 
     def current_token(self) -> str | None:
         """
@@ -489,7 +491,14 @@ class _DatabricksBearerAuth(httpx.Auth):
         auth_value = self._authenticate_headers().get("Authorization", "")
         if auth_value:
             request.headers["Authorization"] = auth_value
-        yield request
+        response = yield request
+        if self._broker is not None and response.status_code == 401:
+            rejected = auth_value.removeprefix("Bearer ") if auth_value else None
+            self._broker.invalidate(rejected)
+            retry_auth = self._authenticate_headers().get("Authorization", "")
+            if retry_auth:
+                request.headers["Authorization"] = retry_auth
+                yield request
 
 
 def _resolve_databricks_auth(
@@ -542,7 +551,6 @@ def _resolve_databricks_auth(
 
     try:
         cfg = Config(profile=sdk_profile)
-        cfg.authenticate()
     except ValueError:
         if profile is None and sdk_profile is not None:
             # Profile name came from the DATABRICKS_CONFIG_PROFILE env var,
@@ -562,7 +570,6 @@ def _resolve_databricks_auth(
             )
             try:
                 cfg = Config()
-                cfg.authenticate()
             except ValueError:
                 cfg = None
         else:
@@ -575,7 +582,13 @@ def _resolve_databricks_auth(
         ) from exc
 
     if cfg is not None and cfg.host:
-        return _DatabricksBearerAuth(cfg, profile_name=profile), cfg.host
+        auth = _DatabricksBearerAuth(
+            cfg,
+            profile_name=sdk_profile,
+            workspace_host=cfg.host,
+        )
+        auth.current_token()
+        return auth, cfg.host
 
     # SDK-based resolution failed (simple PAT profile, missing auth_type,
     # etc.). Fall back to reading ~/.databrickscfg directly — static PATs
@@ -589,7 +602,14 @@ def _resolve_databricks_auth(
                 "authenticate": lambda _self: {"Authorization": f"Bearer {creds.token}"},
             },
         )()
-        return _DatabricksBearerAuth(static_cfg, profile_name=profile), creds.host
+        return (
+            _DatabricksBearerAuth(
+                static_cfg,
+                profile_name=profile or os.environ.get("DATABRICKS_CONFIG_PROFILE"),
+                workspace_host=creds.host,
+            ),
+            creds.host,
+        )
 
     profile_flag = f" -p {profile}" if profile else ""
     raise DatabricksAuthError(
@@ -643,17 +663,29 @@ def _resolve_databricks_auth_for_host(host: str) -> tuple[_DatabricksBearerAuth,
     for profile_name in _databrickscfg_profiles_for_host(host):
         try:
             cfg = _sdk_config(profile=profile_name)
-            cfg.authenticate()
+            if not cfg.host:
+                continue
+            auth = _DatabricksBearerAuth(
+                cfg,
+                profile_name=profile_name,
+                workspace_host=cfg.host,
+            )
+            auth.current_token()
         except Exception:  # noqa: BLE001 — try the next matching profile
             logger.debug("profile %r matched host %s but did not authenticate", profile_name, host)
             continue
-        return _DatabricksBearerAuth(cfg, profile_name=profile_name), cfg.host or host
+        return auth, cfg.host or host
     try:
         host_cfg = _sdk_config(host=host, auth_type="databricks-cli")
-        host_cfg.authenticate()
+        auth = _DatabricksBearerAuth(
+            host_cfg,
+            failure_message=host_failure,
+            workspace_host=host,
+        )
+        auth.current_token()
     except Exception as exc:
         raise DatabricksAuthError(host_failure) from exc
-    return _DatabricksBearerAuth(host_cfg, failure_message=host_failure), host
+    return auth, host
 
 
 def _databrickscfg_profiles_for_host(host: str) -> list[str]:

--- a/omnigent/llms/adapters/databricks.py
+++ b/omnigent/llms/adapters/databricks.py
@@ -72,11 +72,12 @@ class DatabricksAdapter(OpenAICompatibleAdapter):
         if cfg is None:
             return None
         try:
-            headers = cfg.authenticate()
+            from omnigent.databricks_auth_broker import token_for_config
+
+            token = token_for_config(cfg, profile=profile)
         except Exception:
             # Token refresh or auth failure — fall back to configparser path.
             return None
-        token = (headers.get("Authorization") or "").removeprefix("Bearer ").strip()
         if not token or not cfg.host:
             return None
         return {

--- a/omnigent/opencode_native_provider.py
+++ b/omnigent/opencode_native_provider.py
@@ -251,9 +251,10 @@ def _databricks_bearer_token(profile: str) -> str | None:
     try:
         from databricks.sdk.core import Config
 
-        headers = Config(profile=profile).authenticate() or {}
-        authz = headers.get("Authorization", "")
-        return authz.split(" ", 1)[1] if authz.lower().startswith("bearer ") else None
+        config = Config(profile=profile)
+        from omnigent.databricks_auth_broker import token_for_config
+
+        return token_for_config(config, profile=profile)
     except Exception as exc:  # noqa: BLE001 - SDK absent / bad profile / auth failure.
         _logger.info("opencode MCP databricks token resolve failed for %r: %r", profile, exc)
         return None
@@ -288,11 +289,9 @@ def resolve_databricks_gateway(
         host = (config.host or "").rstrip("/")
         if not host:
             return None
-        headers = config.authenticate() or {}
-        authz = headers.get("Authorization", "")
-        token = authz.split(" ", 1)[1] if authz.lower().startswith("bearer ") else ""
-        if not token:
-            return None
+        from omnigent.databricks_auth_broker import token_for_config
+
+        token = token_for_config(config, profile=profile, workspace_host=host)
     except Exception as exc:  # noqa: BLE001 - SDK absent / auth failure / bad profile.
         _logger.info("opencode Databricks gateway resolve failed for %r: %r", profile, exc)
         return None

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -611,6 +611,15 @@ def _make_auth_token_factory(
         except DatabricksAuthError:
             return None
 
+    def _invalidate_sdk_token() -> bool:
+        """Invalidate the rejected publication before the one allowed retry."""
+        if sdk_auth is None:
+            return False
+        sdk_auth.invalidate()
+        return True
+
+    _sdk_token.invalidate = _invalidate_sdk_token  # type: ignore[attr-defined]
+
     def _factory() -> str | None:
         """Return a fresh auth token.
 
@@ -651,6 +660,8 @@ def _make_auth_token_factory(
             if still_valid:
                 return still_valid
         return _sdk_token()
+
+    _factory.invalidate = _invalidate_sdk_token  # type: ignore[attr-defined]
 
     # Probe once to check if a user credential is available.
     try:
@@ -1602,7 +1613,7 @@ async def _run_tunnel_from_env() -> None:
                         allowed_origins=frozenset({allowed_origin}),
                     )
                 )
-        except Exception:  # noqa: BLE001 — optimization only; never block the tunnel
+        except Exception:  # noqa: BLE001 — optional listener must not crash the runner
             _logger.warning(
                 "direct-attach listener setup failed",
                 exc_info=True,

--- a/omnigent/runtime/credentials/databricks.py
+++ b/omnigent/runtime/credentials/databricks.py
@@ -308,9 +308,20 @@ def _call_sdk_authenticate(profile: str | None) -> WorkspaceCreds | None:
 
     # ``None`` means "let the SDK decide" (env var / DEFAULT section).
     sdk_profile = profile or os.environ.get("DATABRICKS_CONFIG_PROFILE")
+    from omnigent.databricks_auth_broker import (
+        DatabricksAuthBroker,
+        DatabricksCredentialError,
+    )
+
     try:
         cfg = Config(profile=sdk_profile)
-        headers = cfg.authenticate()
+        if not cfg.host:
+            return None
+        token = DatabricksAuthBroker(
+            cfg,
+            profile=sdk_profile,
+            workspace_host=cfg.host,
+        ).current_token()
     except ValueError as exc:
         # INFO (not WARNING): expired tokens raise here. WARNING would
         # surface via root's lastResort handler to stderr, drowning the
@@ -323,15 +334,17 @@ def _call_sdk_authenticate(profile: str | None) -> WorkspaceCreds | None:
             exc_info=True,
         )
         return None
+    except DatabricksCredentialError as exc:
+        if "returned no bearer token" in str(exc):
+            return None
+        raise
 
     host = cfg.host
-    auth = headers.get("Authorization")
-    if not host or not auth or not auth.startswith("Bearer "):
-        # Non-Bearer auth schemes (Basic, etc.) are unsupported.
+    if not host:
         return None
     return WorkspaceCreds(
         host=_strip_trailing_slash(host),
-        token=auth.removeprefix("Bearer "),
+        token=token,
     )
 
 

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -687,13 +687,14 @@ def _config_bearer(
         (auth failure degrades to unauthenticated rather than failing the turn).
     """
     try:
-        headers = config.authenticate()
+        from omnigent.databricks_auth_broker import token_for_config
+
+        token = token_for_config(config)
     except Exception:  # noqa: BLE001 — auth failure degrades to unauthenticated
         _logger.warning(
             "ExternalRoutingClient: could not resolve auth from %s", label, exc_info=True
         )
         return None
-    token = (dict(headers or {}).get("Authorization") or "").removeprefix("Bearer ").strip()
     if not token:
         return None
     return _bearer_auth(token)

--- a/omnigent/tools/mcp.py
+++ b/omnigent/tools/mcp.py
@@ -108,15 +108,9 @@ def _resolve_databricks_token(profile: str) -> str:
 
     try:
         client = WorkspaceClient(profile=profile)
-        result = client.config.authenticate()
-        # SDK returns either a dict (newer versions) or a callable
-        # that produces headers (older versions).
-        headers: dict[str, str] = result if isinstance(result, dict) else result(None)
-        auth_header = headers.get("Authorization", "")
-        if auth_header.startswith("Bearer "):
-            return auth_header[len("Bearer ") :]
-        # Some auth flows return the token directly.
-        return auth_header
+        from omnigent.databricks_auth_broker import token_for_config
+
+        return token_for_config(client.config, profile=profile)
     except Exception as exc:
         raise RuntimeError(
             f"Failed to resolve Databricks token from profile {profile!r}: {exc}"

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -3020,6 +3020,7 @@ def test_databricks_token_auth_resolves_sdk_once(
             return {"Authorization": "Bearer tok-xyz"}
 
     cfg = _CountingConfig()
+    cfg.host = "https://ex.databricks.com"
     resolve_calls = {"n": 0}
 
     def _fake_resolve(
@@ -3053,9 +3054,8 @@ def test_databricks_token_auth_resolves_sdk_once(
         f"_resolve_databricks_auth called {resolve_calls['n']}x; expected 1 "
         f"(resolve-once-and-cache)."
     )
-    # authenticate() runs per request (4) — cheap in-memory SDK cache hits,
-    # NOT CLI shell-outs. That's the behavior the fix preserves.
-    assert cfg.authenticate_calls == 4
+    # One publication serves all four requests.
+    assert cfg.authenticate_calls == 1
 
 
 def test_databricks_token_auth_sets_org_header(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -574,3 +574,14 @@ def lowered_idle_thresholds(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(terminal_module, "_IDLE_POLL_INTERVAL_SECONDS", 0.1)
     monkeypatch.setattr(terminal_module, "_IDLE_MARKER_SUBSTRINGS", [])
     monkeypatch.setattr(terminal_module, "_IDLE_MARKER_THRESHOLD_SECONDS", 0.4)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_databricks_auth_broker_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Never share broker credentials between tests or with the developer's home."""
+    monkeypatch.setattr(
+        "omnigent.databricks_auth_broker._state_root", lambda: tmp_path / "broker-state"
+    )
+    monkeypatch.setattr(
+        "omnigent.databricks_auth_broker._runtime_root", lambda: tmp_path / "broker-runtime"
+    )

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -522,10 +522,9 @@ class TestConstructor(unittest.TestCase):
                 "https://example.cloud.databricks.com/ai-gateway/anthropic",
             )
             self.assertEqual(executor._extra_env["CLAUDE_CODE_API_KEY_HELPER_TTL_MS"], "900000")
-            self.assertIn(
-                'databricks auth token --host "https://example.cloud.databricks.com"',
-                executor._extra_env["OMNIGENT_CLAUDE_API_KEY_HELPER"],
-            )
+            helper = executor._extra_env["OMNIGENT_CLAUDE_API_KEY_HELPER"]
+            self.assertIn("omnigent.databricks_auth_broker", helper)
+            self.assertIn("--host https://example.cloud.databricks.com", helper)
             self.assertNotIn("ANTHROPIC_AUTH_TOKEN", executor._extra_env)
 
     def test_databricks_explicit_profile_selects_by_profile(self):
@@ -552,19 +551,12 @@ class TestConstructor(unittest.TestCase):
         ):
             executor = ClaudeSDKExecutor(gateway=True, databricks_profile="oss")
         helper = executor._extra_env["OMNIGENT_CLAUDE_API_KEY_HELPER"]
-        # Proves the selector is --profile, not --host. A regression to --host
-        # makes a two-profiles-one-host workspace yield an empty token → 401.
-        self.assertIn('databricks auth token --profile "oss"', helper)
+        # Proves the helper uses the shared broker with an unambiguous profile.
+        self.assertIn("omnigent.databricks_auth_broker", helper)
+        self.assertIn("--profile oss", helper)
         self.assertNotIn("--host", helper)
-        # `--force-refresh` only exists in Databricks CLI >= v0.296.0, so it
-        # stays behind a `--help` capability probe — an older CLI rejects the
-        # unknown flag and yields an empty token → silent 401.
-        self.assertIn("databricks auth token --help", helper)
-        # And even where it exists it is only ATTEMPTED: it fails outright on a
-        # stale refresh token, so an empty result must fall back to the cached
-        # token rather than turning a usable credential into an auth failure.
-        self.assertIn("--force-refresh", helper)
-        self.assertIn('if [ -z "$token" ]; then', helper)
+        self.assertNotIn("databricks auth token", helper)
+        self.assertNotIn("--force-refresh", helper)
 
     def test_databricks_flag_no_creds_raises(self):
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
@@ -1239,10 +1231,9 @@ class TestResolveGatewayEnv(unittest.TestCase):
                 "https://example.databricks.com/ai-gateway/anthropic",
             )
             self.assertEqual(env["CLAUDE_CODE_API_KEY_HELPER_TTL_MS"], "900000")
-            self.assertIn(
-                'databricks auth token --host "https://example.databricks.com"',
-                env["OMNIGENT_CLAUDE_API_KEY_HELPER"],
-            )
+            helper = env["OMNIGENT_CLAUDE_API_KEY_HELPER"]
+            self.assertIn("omnigent.databricks_auth_broker", helper)
+            self.assertIn("--host https://example.databricks.com", helper)
             self.assertEqual(
                 env["ANTHROPIC_CUSTOM_HEADERS"],
                 "x-databricks-use-coding-agent-mode: true",

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -229,32 +229,22 @@ class TestCodexExecutor(unittest.TestCase):
             "https://example-profile-workspace.cloud.databricks.com",
         )
         self.assertNotIn("DATABRICKS_TOKEN", executor._env)
-        # The fix: with an explicit profile, the bearer-token helper selects by
-        # --profile (unambiguous), never --host. A regression to --host makes a
-        # workspace with two profiles on one host return an empty token → 401.
+        # The helper selects the unambiguous profile through the shared broker.
         self.assertTrue(
             any(
-                "databricks auth token --profile" in override
+                "omnigent.databricks_auth_broker" in override
+                and "--profile test-profile" in override
                 for override in executor._codex_config_overrides
             )
         )
         self.assertFalse(
             any("--host" in override for override in executor._codex_config_overrides)
         )
-        # `--force-refresh` only exists in Databricks CLI >= v0.296.0, so it
-        # stays behind a `--help` capability probe — an older CLI rejects the
-        # unknown flag and yields an empty token → silent 401.
         auth_override = next(
-            o for o in executor._codex_config_overrides if "databricks auth token" in o
+            o for o in executor._codex_config_overrides if "omnigent.databricks_auth_broker" in o
         )
-        self.assertIn("databricks auth token --help", auth_override)
-        # And even where it exists it is only ATTEMPTED: it fails outright on a
-        # stale refresh token, so an empty result must fall back to the cached
-        # token rather than turning a usable credential into an auth failure.
-        self.assertIn("--force-refresh", auth_override)
-        # (the TOML fragment escapes the shell's quotes, so match on the test)
-        self.assertIn("if [ -z ", auth_override)
-        self.assertIn("$token", auth_override)
+        self.assertNotIn("databricks auth token", auth_override)
+        self.assertNotIn("--force-refresh", auth_override)
 
     def test_constructor_databricks_flag_with_host_override_skips_profile_lookup(self):
         with (

--- a/tests/inner/test_credential_proxy.py
+++ b/tests/inner/test_credential_proxy.py
@@ -263,13 +263,8 @@ class _FakeConfig:
         return {"Authorization": f"Bearer {self._tokens[idx]}"}
 
 
-def test_databricks_provider_resolves_host_and_refreshes() -> None:
-    """The provider reads the host once and re-mints past the throttle window.
-
-    Within the throttle window ``resolve()`` returns the cached token
-    (one ``authenticate()`` call); once the window elapses it re-mints,
-    which is what keeps a long session alive across OAuth expiry.
-    """
+def test_databricks_provider_resolves_host_and_reuses_shared_opaque_token() -> None:
+    """Opaque tokens remain shared until Databricks rejects them."""
     fake = _FakeConfig("https://ws.cloud.databricks.com/", ["tok-1", "tok-2"])
     clock = {"now": 0.0}
     provider = DatabricksProfileTokenProvider(
@@ -285,9 +280,9 @@ def test_databricks_provider_resolves_host_and_refreshes() -> None:
     clock["now"] = 50.0  # still inside the window -> cached, no re-mint
     assert provider.resolve() == "tok-1"
     assert fake.authenticate_calls == 1
-    clock["now"] = 150.0  # past the window -> re-mint
-    assert provider.resolve() == "tok-2"
-    assert fake.authenticate_calls == 2
+    clock["now"] = 150.0
+    assert provider.resolve() == "tok-1"
+    assert fake.authenticate_calls == 1
 
 
 def test_databricks_provider_requires_host() -> None:

--- a/tests/inner/test_databricks_auth_command.py
+++ b/tests/inner/test_databricks_auth_command.py
@@ -1,219 +1,55 @@
-"""Tests for the generated Databricks bearer-token helper command.
-
-The one command every harness installs to mint a workspace token
-(``apiKeyHelper`` for Claude Code, ``auth.command`` for Codex), so its profile
-selection and its refresh behaviour are asserted in one place.
-"""
+"""Tests for the generated, broker-backed Databricks token helper."""
 
 from __future__ import annotations
 
-from pathlib import Path
+import os
+import subprocess
 
 import pytest
 
 
-def _run_generated_helper(
-    command: str,
-    tmp_path: Path,
-    *,
-    force_refresh_works: bool,
-    cached_token_works: bool,
-    bearer: str | None = None,
-) -> str:
-    """
-    Run *command* against a fake ``databricks`` CLI and return its stdout.
+def test_generated_helper_uses_central_broker_and_never_refreshes_directly() -> None:
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
 
-    :param command: The generated helper command.
-    :param tmp_path: Directory the fake CLI is written into and prepended to
-        ``PATH``.
-    :param force_refresh_works: Whether ``--force-refresh`` succeeds. ``False``
-        is the stale-refresh-token case.
-    :param cached_token_works: Whether plain ``auth token`` succeeds.
-    :param bearer: Value for ``DATABRICKS_BEARER``, or ``None`` to unset it.
-    :returns: The helper's stdout, stripped.
-    """
-    import os
-    import subprocess
+    command = databricks_bearer_token_command("https://example.databricks.com", "agent")
 
-    fake = tmp_path / "databricks"
-    fake.write_text(
-        "#!/bin/sh\n"
-        'case "$*" in *--help*) echo "  --force-refresh"; exit 0;; esac\n'
-        'case "$*" in *--force-refresh*)\n'
-        '  [ "$FORCE_OK" = 1 ] && { echo \'{"access_token":"fresh"}\'; exit 0; }\n'
-        "  exit 1;;\n"
-        "*)\n"
-        '  [ "$CACHED_OK" = 1 ] && { echo \'{"access_token":"cached"}\'; exit 0; }\n'
-        "  exit 1;;\n"
-        "esac\n"
+    assert "omnigent.databricks_auth_broker" in command
+    assert "--workspace-host https://example.databricks.com" in command
+    assert "--profile agent" in command
+    assert "databricks auth token" not in command
+    assert "--force-refresh" not in command
+
+
+def test_generated_helper_selects_by_host_without_a_profile() -> None:
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    command = databricks_bearer_token_command("https://example.databricks.com/", None)
+
+    assert "--host https://example.databricks.com" in command
+    assert "--profile" not in command
+
+
+def test_recorded_fallback_command_is_not_embedded() -> None:
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    command = databricks_bearer_token_command(
+        "https://example.databricks.com",
+        "agent",
+        fallback_command="dangerous-independent-refresh --force-refresh",
     )
-    fake.chmod(0o755)
-    env = {
-        **os.environ,
-        "PATH": f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}",
-        "FORCE_OK": "1" if force_refresh_works else "0",
-        "CACHED_OK": "1" if cached_token_works else "0",
-    }
-    env.pop("DATABRICKS_BEARER", None)
-    if bearer is not None:
-        env["DATABRICKS_BEARER"] = bearer
+
+    assert "dangerous-independent-refresh" not in command
+    assert "--force-refresh" not in command
+
+
+@pytest.mark.posix_only
+def test_explicit_injected_bearer_still_short_circuits_broker() -> None:
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    command = databricks_bearer_token_command("https://example.databricks.com", "agent")
+    env = {**os.environ, "DATABRICKS_BEARER": "injected"}
     result = subprocess.run(
-        ["sh", "-c", command], env=env, capture_output=True, text=True, check=False
-    )
-    return result.stdout.strip()
-
-
-def _recorded_fallback(tmp_path: Path) -> str:
-    """
-    Write a stub standing in for the token command ucode recorded.
-
-    :param tmp_path: Directory on the helper's ``PATH``.
-    :returns: The command to pass as ``fallback_command``; running it prints
-        ``"recorded"`` and touches ``tmp_path / "fallback-ran"``.
-    """
-    stub = tmp_path / "ucode-token"
-    stub.write_text(f"#!/bin/sh\n: > {tmp_path / 'fallback-ran'}\necho recorded\n")
-    stub.chmod(0o755)
-    # Quoting the stub exercises the eval path against a command that carries
-    # its own quotes, the shape ucode actually records.
-    return 'ucode-token --host "https://example.databricks.com"'
-
-
-@pytest.mark.posix_only
-def test_the_generated_helper_serves_the_cached_token_when_a_refresh_fails(
-    tmp_path: Path,
-) -> None:
-    """
-    A stale refresh token must not cost a perfectly valid cached access token.
-
-    ``--force-refresh`` is worth attempting — it renews a still-valid token and
-    keeps a long gateway session off a mid-session 401 — but it fails outright
-    once the refresh token has gone stale. Forcing it unconditionally turned
-    that into a hard auth failure with a usable credential sitting right there.
-    """
-    from omnigent.inner.databricks_executor import databricks_bearer_token_command
-
-    command = databricks_bearer_token_command("https://example.databricks.com", "agent")
-
-    # Healthy: the forced refresh answers, so the token is the fresh one.
-    assert (
-        _run_generated_helper(command, tmp_path, force_refresh_works=True, cached_token_works=True)
-        == "fresh"
-    )
-    # The live incident: the refresh token is stale, the cached one is fine.
-    assert (
-        _run_generated_helper(
-            command, tmp_path, force_refresh_works=False, cached_token_works=True
-        )
-        == "cached"
-    )
-    # Genuinely unauthenticated: nothing to print, and no crash.
-    assert (
-        _run_generated_helper(
-            command, tmp_path, force_refresh_works=False, cached_token_works=False
-        )
-        == ""
+        ["sh", "-c", command], env=env, capture_output=True, text=True, check=True
     )
 
-
-def test_the_generated_helper_selects_by_profile_when_one_is_named() -> None:
-    """
-    A named profile is unambiguous; host lookup is only the fallback.
-
-    Two profiles can share a workspace host, and selecting by host then either
-    fails outright or resolves to whichever the CLI picks — which is how a pane
-    and the server end up authenticating as different identities.
-    """
-    from omnigent.inner.databricks_executor import databricks_bearer_token_command
-
-    named = databricks_bearer_token_command("https://example.databricks.com", "agent")
-    assert '--profile "agent"' in named
-    assert "--host" not in named
-
-    unnamed = databricks_bearer_token_command("https://example.databricks.com/", None)
-    assert '--host "https://example.databricks.com"' in unnamed
-    assert "--profile" not in unnamed
-
-
-@pytest.mark.posix_only
-def test_the_named_profile_wins_and_the_recorded_command_stays_unused(
-    tmp_path: Path,
-) -> None:
-    """The pinned profile is the identity we want whenever it can mint a token."""
-    from omnigent.inner.databricks_executor import databricks_bearer_token_command
-
-    command = databricks_bearer_token_command(
-        "https://example.databricks.com", "agent", fallback_command=_recorded_fallback(tmp_path)
-    )
-
-    assert (
-        _run_generated_helper(command, tmp_path, force_refresh_works=True, cached_token_works=True)
-        == "fresh"
-    )
-    assert not (tmp_path / "fallback-ran").exists()
-
-
-@pytest.mark.posix_only
-def test_the_recorded_command_runs_when_the_named_profile_yields_nothing(
-    tmp_path: Path,
-) -> None:
-    """
-    A config naming a credential-less profile must not 401 a working session.
-
-    The user may have authenticated under a different profile on the same host,
-    and the command ucode recorded is the one known to have worked.
-    """
-    from omnigent.inner.databricks_executor import databricks_bearer_token_command
-
-    command = databricks_bearer_token_command(
-        "https://example.databricks.com", "DEFAULT", fallback_command=_recorded_fallback(tmp_path)
-    )
-
-    assert (
-        _run_generated_helper(
-            command, tmp_path, force_refresh_works=False, cached_token_works=False
-        )
-        == "recorded"
-    )
-    assert (tmp_path / "fallback-ran").exists()
-
-
-@pytest.mark.posix_only
-def test_an_injected_bearer_short_circuits_both_the_profile_and_the_fallback(
-    tmp_path: Path,
-) -> None:
-    """The runner already resolved a token; nothing else should be consulted."""
-    from omnigent.inner.databricks_executor import databricks_bearer_token_command
-
-    command = databricks_bearer_token_command(
-        "https://example.databricks.com", "agent", fallback_command=_recorded_fallback(tmp_path)
-    )
-
-    assert (
-        _run_generated_helper(
-            command,
-            tmp_path,
-            force_refresh_works=False,
-            cached_token_works=False,
-            bearer="injected",
-        )
-        == "injected"
-    )
-    assert not (tmp_path / "fallback-ran").exists()
-
-
-@pytest.mark.posix_only
-def test_without_a_recorded_command_an_unauthenticated_profile_stays_empty(
-    tmp_path: Path,
-) -> None:
-    """No fallback to reach for: print nothing rather than crash."""
-    from omnigent.inner.databricks_executor import databricks_bearer_token_command
-
-    command = databricks_bearer_token_command("https://example.databricks.com", "agent")
-
-    assert (
-        _run_generated_helper(
-            command, tmp_path, force_refresh_works=False, cached_token_works=False
-        )
-        == ""
-    )
+    assert result.stdout.strip() == "injected"

--- a/tests/inner/test_databricks_executor.py
+++ b/tests/inner/test_databricks_executor.py
@@ -16,9 +16,11 @@ import databricks.sdk.config as _sdk_config_mod
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from omnigent.inner.databricks_executor import (
+    DatabricksAuthError,
     DatabricksExecutor,
     _convert_messages,
     _convert_tools_to_openai,
+    _DatabricksBearerAuth,
 )
 from omnigent.inner.executor import (
     ExecutorConfig,
@@ -709,8 +711,6 @@ from pathlib import Path as _Path  # noqa: E402
 import pytest  # noqa: E402
 
 from omnigent.inner.databricks_executor import (  # noqa: E402
-    DatabricksAuthError,
-    _DatabricksBearerAuth,
     _read_databrickscfg,
     _read_databrickscfg_file_fallback,
     _read_databrickscfg_host,
@@ -979,7 +979,8 @@ def test_codex_executor_gateway_uses_host_only_oauth_profile(
 
     overrides = "\n".join(executor._codex_config_overrides)
     assert "https://oauth-host.example.com/ai-gateway/codex/v1" in overrides
-    assert 'databricks auth token --profile \\"oauth-profile\\"' in overrides
+    assert "omnigent.databricks_auth_broker" in overrides
+    assert "--profile oauth-profile" in overrides
 
 
 def test_read_databrickscfg_no_config_file_returns_none(
@@ -1445,13 +1446,8 @@ def test_resolve_databricks_auth_explicit_profile_not_found_raises(
     )
 
 
-def test_bearer_auth_injects_fresh_token_per_request():
-    """``_DatabricksBearerAuth`` calls ``Config.authenticate()`` per request.
-
-    Verifies that a fresh token is injected into each HTTP request,
-    and that different calls can return different tokens (simulating
-    OAuth refresh).
-    """
+def test_bearer_auth_reuses_broker_token_between_requests():
+    """Requests share the broker's published token instead of reminting."""
     import httpx
 
     from omnigent.inner.databricks_executor import _DatabricksBearerAuth
@@ -1459,6 +1455,8 @@ def test_bearer_auth_injects_fresh_token_per_request():
     call_count = 0
 
     class _RotatingConfig:
+        host = "https://failure.example.com"
+
         def authenticate(self):
             nonlocal call_count
             call_count += 1
@@ -1474,9 +1472,9 @@ def test_bearer_auth_injects_fresh_token_per_request():
     request2 = httpx.Request("GET", "https://example.com/v1/chat")
     gen2 = auth.auth_flow(request2)
     next(gen2)
-    assert request2.headers["Authorization"] == "Bearer tok-2"
+    assert request2.headers["Authorization"] == "Bearer tok-1"
 
-    assert call_count == 2
+    assert call_count == 1
 
 
 def test_bearer_auth_raises_on_expired_refresh_token():
@@ -1495,6 +1493,8 @@ def test_bearer_auth_raises_on_expired_refresh_token():
     )
 
     class _DeadConfig:
+        host = "https://example.com"
+
         def authenticate(self):
             raise ValueError("token expired")
 
@@ -1649,6 +1649,7 @@ def test_bearer_auth_current_token_reuses_config_and_strips_prefix() -> None:
 
         def __init__(self) -> None:
             self.authenticate_calls = 0
+            self.host = "https://example.com"
 
         def authenticate(self) -> dict[str, str]:
             self.authenticate_calls += 1
@@ -1662,10 +1663,7 @@ def test_bearer_auth_current_token_reuses_config_and_strips_prefix() -> None:
     # Bare token (prefix stripped) on every call. A failure here means
     # current_token returned the raw header or the wrong field.
     assert tokens == ["dapi-XYZ"] * 4
-    # All 4 calls went through the SAME wrapped config — proving reuse, so
-    # the SDK's own cache (not a rebuilt Config) backs repeat calls. If the
-    # method rebuilt Config, it would not be this single object's counter.
-    assert cfg.authenticate_calls == 4
+    assert cfg.authenticate_calls == 1
 
 
 @pytest.mark.parametrize(
@@ -1685,10 +1683,13 @@ def test_bearer_auth_current_token_none_for_non_bearer(headers: dict[str, str]) 
     class _Config:
         """Config double returning a fixed (non-Bearer) header set."""
 
+        host = "https://example.com"
+
         def authenticate(self) -> dict[str, str]:
             return headers
 
-    assert _DatabricksBearerAuth(_Config()).current_token() is None
+    with pytest.raises(DatabricksAuthError):
+        _DatabricksBearerAuth(_Config()).current_token()
 
 
 def test_bearer_auth_current_token_wraps_failure_as_auth_error() -> None:
@@ -1701,6 +1702,8 @@ def test_bearer_auth_current_token_wraps_failure_as_auth_error() -> None:
 
     class _FailingConfig:
         """Config double whose authenticate() always raises."""
+
+        host = "https://failure.example.com"
 
         def authenticate(self) -> dict[str, str]:
             raise RuntimeError("token endpoint unreachable")

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -150,6 +150,8 @@ def test_make_auth_token_factory_returns_factory_when_databricks_creds_available
     class _Cfg:
         """Config double whose authenticate() yields a Bearer header."""
 
+        host = "https://ex.test"
+
         def authenticate(self) -> dict[str, str]:
             return {"Authorization": "Bearer fresh-token"}
 
@@ -2256,6 +2258,7 @@ def test_make_auth_token_factory_resolves_sdk_auth_once(
 
         def __init__(self) -> None:
             self.authenticate_calls = 0
+            self.host = "https://ex.databricks.com"
 
         def authenticate(self) -> dict[str, str]:
             self.authenticate_calls += 1
@@ -2292,12 +2295,8 @@ def test_make_auth_token_factory_resolves_sdk_auth_once(
         f"(resolve-once-and-cache). >1 means the per-request auth tax "
         f"regressed."
     )
-    # authenticate() runs once per token fetch: the factory's own probe (1)
-    # plus the 5 explicit calls = 6. These are cheap in-memory SDK cache
-    # hits, NOT CLI shell-outs — that's the behavior the fix preserves.
-    assert cfg.authenticate_calls == 6, (
-        f"Expected 6 authenticate() calls (probe + 5), got {cfg.authenticate_calls}."
-    )
+    # The broker publishes once; all later fetches read that publication.
+    assert cfg.authenticate_calls == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -1049,8 +1049,8 @@ async def test_external_routing_client_sends_bearer_auth() -> None:
 
 
 @pytest.mark.asyncio
-async def test_external_routing_client_mints_fresh_token_per_call_from_profile() -> None:
-    """With a databricks_profile, each call re-authenticates (OAuth refresh)."""
+async def test_external_routing_client_reuses_broker_token_from_profile() -> None:
+    """With a Databricks profile, calls share the broker token."""
     import httpx
 
     from omnigent.server.smart_routing import ExternalRoutingClient
@@ -1072,6 +1072,9 @@ async def test_external_routing_client_mints_fresh_token_per_call_from_profile()
     # Stub the SDK Config so each authenticate() yields the next token — proving
     # the client re-resolves auth per call rather than caching a stale bearer.
     class _FakeConfig:
+        host = "https://host"
+        profile = "agent"
+
         def authenticate(self) -> dict[str, str]:
             return {"Authorization": next(tokens)}
 
@@ -1080,7 +1083,7 @@ async def test_external_routing_client_mints_fresh_token_per_call_from_profile()
     with _patch_httpx(httpx.MockTransport(handler)):
         await client.route("hi", {"h": ["m"]})
         await client.route("hi again", {"h": ["m"]})
-    assert captured == ["Bearer tok-1", "Bearer tok-2"]
+    assert captured == ["Bearer tok-1", "Bearer tok-1"]
 
 
 # ── Per-request auth: auth_provider and the ambient SDK chain ──────────────
@@ -1266,8 +1269,8 @@ async def test_ambient_credential_is_used_when_it_names_the_router_host() -> Non
     with _ambient_sdk(config), _patch_httpx(httpx.MockTransport(_auth_handler(captured))):
         await client.route("hi", {"h": ["m"]})
         await client.route("hi again", {"h": ["m"]})
-    # Re-authenticated per call, so an expiring OAuth token is refreshed.
-    assert captured == ["Bearer ambient-tok-1", "Bearer ambient-tok-2"]
+    # Both calls consume the same machine-wide publication.
+    assert captured == ["Bearer ambient-tok-1", "Bearer ambient-tok-1"]
 
 
 @pytest.mark.databricks

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -472,7 +472,8 @@ def test_build_codex_native_server_uses_profile_host_without_static_token(
 
     overrides = "\n".join(app_server.config_overrides)
     assert "https://example.cloud.databricks.com/ai-gateway/codex/v1" in overrides
-    assert 'databricks auth token --profile \\"oss\\"' in overrides
+    assert "omnigent.databricks_auth_broker" in overrides
+    assert "--profile oss" in overrides
 
 
 def test_build_codex_native_server_without_bypass_emits_no_bypass_config(

--- a/tests/test_databricks_auth_broker.py
+++ b/tests/test_databricks_auth_broker.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import stat
+import time
+from pathlib import Path
+
+import pytest
+
+from omnigent.databricks_auth_broker import (
+    AuthIdentity,
+    DatabricksAuthBroker,
+    DatabricksCredentialError,
+    DatabricksCredentialsDeadError,
+    normalize_workspace_host,
+)
+
+
+class _Config:
+    def __init__(self, token: str = "opaque-pat", error: Exception | None = None) -> None:
+        self.token = token
+        self.error = error
+        self.calls = 0
+
+    def authenticate(self) -> dict[str, str]:
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return {"Authorization": f"Bearer {self.token}"}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_broker_dirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("omnigent.databricks_auth_broker._state_root", lambda: tmp_path / "state")
+    monkeypatch.setattr(
+        "omnigent.databricks_auth_broker._runtime_root", lambda: tmp_path / "runtime"
+    )
+
+
+def test_identity_normalizes_host_and_separates_workspaces() -> None:
+    first = AuthIdentity.create("oss", "HTTPS://Example.COM/")
+    equivalent = AuthIdentity.create("oss", "https://example.com")
+    other = AuthIdentity.create("oss", "https://other.example.com")
+
+    assert normalize_workspace_host("Example.COM/") == "https://example.com"
+    assert first == equivalent
+    assert first.key != other.key
+
+
+def test_broker_publishes_private_shared_token(tmp_path: Path) -> None:
+    config = _Config()
+    broker = DatabricksAuthBroker(
+        config,
+        profile="oss",
+        workspace_host="https://example.com",
+    )
+
+    assert broker.current_token() == "opaque-pat"
+    assert broker.current_token() == "opaque-pat"
+    assert config.calls == 1
+
+    state_files = list((tmp_path / "state").glob("*.json"))
+    assert len(state_files) == 1
+    payload = json.loads(state_files[0].read_text())
+    assert payload["profile"] == "oss"
+    assert payload["workspace_host"] == "https://example.com"
+    assert payload["token"] == "opaque-pat"
+    assert payload["exp"] is None
+    assert stat.S_IMODE(state_files[0].stat().st_mode) == 0o600
+    assert stat.S_IMODE(state_files[0].parent.stat().st_mode) == 0o700
+
+
+def test_broker_refreshes_expired_shared_jwt() -> None:
+    def _jwt(expiry: float) -> str:
+        import base64
+
+        payload = (
+            base64.urlsafe_b64encode(json.dumps({"exp": expiry}).encode()).decode().rstrip("=")
+        )
+        return f"header.{payload}.signature"
+
+    config = _Config(_jwt(time.time() - 1))
+    broker = DatabricksAuthBroker(config, profile="oss", workspace_host="https://example.com")
+    broker.current_token()
+    config.token = _jwt(time.time() + 3600)
+
+    assert broker.current_token() == config.token
+    assert config.calls == 2
+
+
+def test_broker_rejects_symlink_state_file(tmp_path: Path) -> None:
+    config = _Config()
+    broker = DatabricksAuthBroker(config, profile="oss", workspace_host="https://example.com")
+    token_path = broker._token_path
+    token_path.parent.mkdir(mode=0o700, parents=True)
+    target = tmp_path / "target"
+    target.write_text("{}")
+    token_path.symlink_to(target)
+
+    with pytest.raises(DatabricksCredentialError, match="unsafe credential state file"):
+        broker.current_token()
+
+
+def test_broker_rejects_world_readable_state_file() -> None:
+    config = _Config()
+    broker = DatabricksAuthBroker(config, profile="oss", workspace_host="https://example.com")
+    broker._token_path.parent.mkdir(mode=0o700, parents=True)
+    broker._token_path.write_text("{}")
+    os.chmod(broker._token_path, 0o644)
+
+    with pytest.raises(DatabricksCredentialError, match="unsafe ownership or mode"):
+        broker.current_token()
+
+
+def test_permanent_failure_is_marked_dead_and_probes_are_rate_limited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_000.0
+    monkeypatch.setattr("omnigent.databricks_auth_broker.time.time", lambda: now)
+    monkeypatch.setattr("omnigent.databricks_auth_broker.time.monotonic", lambda: now)
+    config = _Config(error=ValueError("invalid_grant: refresh token has expired"))
+    broker = DatabricksAuthBroker(config, profile="oss", workspace_host="https://example.com")
+
+    with pytest.raises(DatabricksCredentialsDeadError, match="databricks auth login"):
+        broker.current_token()
+    assert config.calls == 1
+
+    with pytest.raises(DatabricksCredentialsDeadError):
+        broker.current_token()
+    assert config.calls == 1
+
+    now += 15.0
+    with pytest.raises(DatabricksCredentialsDeadError):
+        broker.current_token()
+    assert config.calls == 2
+
+    # The failed probe claimed the interval before running, so an immediate
+    # waiter does not make another credential request.
+    with pytest.raises(DatabricksCredentialsDeadError):
+        broker.current_token()
+    assert config.calls == 2
+
+
+def test_dead_marker_clears_only_after_workspace_accepts_repaired_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_000.0
+    monkeypatch.setattr("omnigent.databricks_auth_broker.time.time", lambda: now)
+    monkeypatch.setattr("omnigent.databricks_auth_broker.time.monotonic", lambda: now)
+    config = _Config(error=ValueError("invalid_grant"))
+    validated: list[str] = []
+
+    def _validate(_host: str, token: str) -> None:
+        validated.append(token)
+
+    broker = DatabricksAuthBroker(
+        config,
+        profile="oss",
+        workspace_host="https://example.com",
+        token_validator=_validate,
+    )
+    with pytest.raises(DatabricksCredentialsDeadError):
+        broker.current_token()
+
+    config.error = None
+    config.token = "repaired"
+    now += 15.0
+    assert broker.current_token() == "repaired"
+    assert validated == ["repaired"]
+    assert not broker._dead_path.exists()
+
+
+def test_failed_workspace_validation_keeps_dead_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = 1_000.0
+    monkeypatch.setattr("omnigent.databricks_auth_broker.time.time", lambda: now)
+    monkeypatch.setattr("omnigent.databricks_auth_broker.time.monotonic", lambda: now)
+    config = _Config(error=ValueError("invalid_grant"))
+
+    def _reject(_host: str, _token: str) -> None:
+        raise RuntimeError("401")
+
+    broker = DatabricksAuthBroker(
+        config,
+        profile="oss",
+        workspace_host="https://example.com",
+        token_validator=_reject,
+    )
+    with pytest.raises(DatabricksCredentialsDeadError):
+        broker.current_token()
+    config.error = None
+    now += 15.0
+    with pytest.raises(DatabricksCredentialsDeadError):
+        broker.current_token()
+    assert broker._dead_path.exists()
+
+
+@pytest.mark.posix_only
+def test_twenty_processes_publish_one_token() -> None:
+    """Twenty simultaneous consumers cause exactly one authentication call."""
+    context = multiprocessing.get_context("fork")
+    calls = context.Value("i", 0)
+    start = context.Event()
+    results = context.Queue()
+
+    class _SharedConfig:
+        def authenticate(self) -> dict[str, str]:
+            with calls.get_lock():
+                calls.value += 1
+            return {"Authorization": "Bearer shared"}
+
+    def _consume() -> None:
+        start.wait()
+        broker = DatabricksAuthBroker(
+            _SharedConfig(), profile="oss", workspace_host="https://concurrent.example.com"
+        )
+        results.put(broker.current_token())
+
+    processes = [context.Process(target=_consume) for _ in range(20)]
+    for process in processes:
+        process.start()
+    start.set()
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+
+    assert [results.get(timeout=1) for _ in processes] == ["shared"] * 20
+    assert calls.value == 1
+
+
+@pytest.mark.posix_only
+def test_lock_is_released_when_refreshing_process_crashes() -> None:
+    context = multiprocessing.get_context("fork")
+    locked = context.Event()
+    broker = DatabricksAuthBroker(
+        _Config(), profile="oss", workspace_host="https://crash.example.com"
+    )
+
+    def _crash_holding_lock() -> None:
+        with broker._locked():
+            locked.set()
+            os._exit(17)
+
+    process = context.Process(target=_crash_holding_lock)
+    process.start()
+    assert locked.wait(timeout=5)
+    process.join(timeout=5)
+    assert process.exitcode == 17
+    assert broker.current_token() == "opaque-pat"
+
+
+def test_oauth_cli_timeout_is_temporary(monkeypatch: pytest.MonkeyPatch) -> None:
+    import subprocess
+
+    class _OAuthConfig(_Config):
+        auth_type = "databricks-cli"
+
+    def _timeout(*_args: object, **_kwargs: object) -> object:
+        raise subprocess.TimeoutExpired("databricks", 20)
+
+    monkeypatch.setattr("omnigent.databricks_auth_broker.subprocess.run", _timeout)
+    broker = DatabricksAuthBroker(
+        _OAuthConfig(), profile="oss", workspace_host="https://timeout.example.com"
+    )
+
+    with pytest.raises(DatabricksCredentialError, match="Run: databricks auth login"):
+        broker.current_token()
+    assert not broker._dead_path.exists()


### PR DESCRIPTION
## Related issue

Closes #5393

## Summary

- Adds one machine-wide credential broker per Databricks profile/workspace, with private atomic token publication and a process-safe lock.
- Stops refresh storms after a confirmed permanent failure, probes recovery every 15 seconds, and validates repaired credentials against the workspace before reconnecting.
- Moves host, runner, harness, MCP, routing, policy, and gateway consumers behind the broker and adds a pre-commit guard against new direct refresh paths.

ELI5: every process used to make its own copy of the same key. Now they share one locked key desk; one process renews the key and everyone else reads the result.

```text
host ─┐
runner ─┼─> profile+workspace lock ─> ordinary auth/refresh ─> private shared token
harness ┘                                      │
                                  permanent failure -> .dead -> 15s probe
```

The full design, incident evidence, edge cases, and per-step implementation audits are in `designs/CREDENTIAL_HARDENING.md`.

## Test Plan

- `1097 passed, 1 skipped` across broker, host, runner, harness, gateway, MCP, routing, CLI, and credential consumers.
- Includes a real 20-process race proving one authentication call and a process-crash lock-takeover test.
- Ruff, repository auth guard, file hygiene, and focused Pyrefly (`omnigent/databricks_auth_broker.py`: 0 errors) pass. Full-project Pyrefly is blocked locally only by optional packages absent from the lint-only environment (boto3, OpenTelemetry SDK/exporters, hindsight, Nimble); it reports no broker error.

## Demo

N/A — non-visual connectivity/authentication fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The integration suite covers host/runner reconnect auth, generated harness helpers, routing, MCP, CLI forwarding, and shared state behavior.

## Changelog

Databricks-backed hosts and runners now coordinate credential refreshes, avoiding refresh-token collisions and recovering automatically after login.