### PR TITLE
fix(upgrade): stop `omni upgrade` deleting the install it says is intact

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4874,6 +4874,7 @@ def _upgrade_vcs_install(
         _probe_installed_distribution,
         _remote_git_head,
         _run_upgrade_command,
+        _upgrade_failure_message,
     )
 
     current_sha = info.commit_sha or ""
@@ -4928,7 +4929,7 @@ def _upgrade_vcs_install(
     code = _run_upgrade_command(suggestion.command, console)
     if code != 0:
         raise click.ClickException(
-            f"Upgrade command exited with status {code}; your previous install is intact."
+            _upgrade_failure_message(code, set(info.extras) | set(extra_overrides))
         )
 
     # Verify by commit, not exit code: a re-pull of a ref that hasn't moved (or
@@ -4997,6 +4998,7 @@ def _upgrade_to_nightly(
         _latest_nightly_version,
         _probe_installed_distribution,
         _run_upgrade_command,
+        _upgrade_failure_message,
         _uv_tool_receipt_path,
     )
 
@@ -5073,7 +5075,7 @@ def _upgrade_to_nightly(
     code = _run_upgrade_command(suggestion.command, console)
     if code != 0:
         raise click.ClickException(
-            f"Upgrade command exited with status {code}; your previous install is intact."
+            _upgrade_failure_message(code, set(info.extras) | set(extra_overrides))
         )
 
     # Same trust-the-disk verification as the release path: re-read the
@@ -5195,6 +5197,7 @@ def upgrade(
         _probe_installed_distribution,
         _read_installed_wheel_info,
         _run_upgrade_command,
+        _upgrade_failure_message,
         _uv_tool_receipt_path,
         fetch_latest_version,
     )
@@ -5341,7 +5344,7 @@ def upgrade(
     code = _run_upgrade_command(suggestion.command, console)
     if code != 0:
         raise click.ClickException(
-            f"Upgrade command exited with status {code}; your previous install is intact."
+            _upgrade_failure_message(code, set(info.extras) | set(extra_overrides))
         )
 
     # Trust the installed version, not the installer's exit code. The running

--- a/omnigent/update_check.py
+++ b/omnigent/update_check.py
@@ -1438,6 +1438,20 @@ _PRERELEASE_FLAG = {
 }
 
 
+def _uv_python_pin() -> str:
+    """Return uv's ``--python`` flag pinned to the running interpreter.
+
+    ``install.sh`` installs with an explicit ``--python``, so an upgrade that
+    omits it lets uv resolve the *default* interpreter instead. When the two
+    differ uv cannot reuse the existing tool environment: it recreates it,
+    removing the old executables before the replacement is built. A build
+    failure then leaves no working install behind. omnigent runs from that
+    same tool environment, so pinning our own interpreter keeps the upgrade
+    in place.
+    """
+    return f" --python {sys.version_info.major}.{sys.version_info.minor}"
+
+
 def _pip_invocation() -> str:
     """Return the pip command prefix bound to the running interpreter.
 
@@ -1489,6 +1503,7 @@ def _build_upgrade_suggestion(
     allow_prerelease: bool = False,
     extra_overrides: tuple[str, ...] = (),
     target_version: str | None = None,
+    target_vcs_url: str | None = None,
 ) -> _UpgradeSuggestion:
     """Build the right upgrade command for the user's install shape.
 
@@ -1505,6 +1520,10 @@ def _build_upgrade_suggestion(
         metadata.
     :param target_version: Pin the upgrade to a specific version instead
         of resolving the latest release.
+    :param target_vcs_url: Install from this VCS URL instead of the one
+        recorded at install time, so a registry install can be moved onto a
+        git source (how ``--nightly`` hops onto a tag). Takes precedence
+        over ``info.vcs_url``.
     :returns: A :class:`_UpgradeSuggestion` whose ``command`` is the
         line printed in the nag panel and whose ``runnable`` flag
         tells the caller whether the line is an actual invocation
@@ -1515,27 +1534,37 @@ def _build_upgrade_suggestion(
     pre = _PRERELEASE_FLAG.get(installer or "", "") if allow_prerelease else ""
     extras = sorted(set(info.extras) | set(extra_overrides))
 
-    if info.vcs_url:
-        # VCS install — we know the exact source URL.
-        vcs_url_with_extras = info.vcs_url
+    source_url = target_vcs_url or info.vcs_url
+    if source_url:
+        # Installing from an exact source URL: either the one this install
+        # recorded, or a caller-supplied retarget (a nightly tag).
+        vcs_url_with_extras = source_url
         if extras:
             # Strip any existing fragment and append an egg spec with extras.
             base = vcs_url_with_extras.split("#", 1)[0]
             vcs_url_with_extras = f"{base}#egg={_package_spec(extras=extras)}"
         if installer == "uv":
             return _UpgradeSuggestion(
-                command=f"uv tool install --reinstall {vcs_url_with_extras}{pre}",
+                command=(
+                    f"uv tool install --reinstall{_uv_python_pin()} {vcs_url_with_extras}{pre}"
+                ),
                 runnable=True,
             )
         if installer == "pipx":
-            if extras:
+            # ``pipx reinstall`` re-pulls the spec pipx recorded, so it only
+            # works as an in-place refresh. Extras and a retarget both need
+            # the spec spelled out.
+            if extras or target_vcs_url is not None:
                 return _UpgradeSuggestion(
                     command=f"pipx install --force {vcs_url_with_extras}",
                     runnable=True,
                 )
-            # pipx tracks the original spec; ``reinstall`` re-pulls it.
             return _UpgradeSuggestion(command=f"pipx reinstall {_DIST_NAME}{pre}", runnable=True)
-        if installer in ("pip", None):
+        # An unknown installer is only assumed to be pip when the install
+        # itself came from a VCS URL. On a retarget we know nothing about how
+        # omnigent was installed, so guessing could write to the wrong
+        # environment; fall through to the non-runnable suggestion instead.
+        if installer == "pip" or (installer is None and info.vcs_url is not None):
             return _UpgradeSuggestion(
                 command=(
                     f"{_pip_invocation()} install --force-reinstall {vcs_url_with_extras}{pre}"
@@ -1561,7 +1590,7 @@ def _build_upgrade_suggestion(
             # version), not extras. Reinstall with the full PEP 508 spec
             # to preserve the extras the user originally requested.
             return _UpgradeSuggestion(
-                command=f"uv tool install --reinstall {registry_spec}{pre}",
+                command=f"uv tool install --reinstall{_uv_python_pin()} {registry_spec}{pre}",
                 runnable=True,
             )
         return _UpgradeSuggestion(command=f"uv tool upgrade {_DIST_NAME}{pre}", runnable=True)
@@ -1654,39 +1683,32 @@ def _build_nightly_upgrade_suggestion(
 ) -> _UpgradeSuggestion:
     """Build the command that moves this install onto a nightly tag.
 
+    A nightly hop is an ordinary VCS install pinned to a tag, so it reuses
+    :func:`_build_upgrade_suggestion` with the tag URL as the retarget rather
+    than duplicating the per-installer mapping. That keeps one place deciding
+    which installer flag is safe: an upgrade must never remove the working
+    install before the replacement builds, and nightlies build from source
+    (they compile the web UI), so a failure here is the likely case, not the
+    rare one.
+
     Nightlies are git tags, not index releases, so every installer gets a
     git-pinned spec for the canonical repo. That includes registry installs
     (this is how an index install hops onto the nightly channel) and VCS
-    installs of a fork (nightly tags only exist upstream). Extras follow
-    the same union rule as :func:`_build_upgrade_suggestion`; the CLI
-    refuses the registry install shapes that cannot record extras (pip /
-    ``uv pip``) before building.
+    installs of a fork (nightly tags only exist upstream). Extras follow the
+    same union rule as :func:`_build_upgrade_suggestion`; the CLI refuses the
+    registry install shapes that cannot record extras (pip / ``uv pip``)
+    before building.
 
     :param info: Metadata from ``_read_installed_wheel_info``.
     :param nightly_version: Target version without the leading ``v``.
     :param extra_overrides: Extras supplied with ``omni upgrade --extra``.
     :returns: See :func:`_build_upgrade_suggestion`.
     """
-    extras = sorted(set(info.extras) | set(extra_overrides))
-    spec = f"git+{_NIGHTLY_REPO_URL}@v{nightly_version}"
-    if extras:
-        # Same egg-fragment shape the VCS upgrade path uses for extras.
-        spec = f"{spec}#egg={_package_spec(extras=extras)}"
-    installer = info.detected_installer or info.installer
-    if installer == "uv":
-        # --force: replacing a registry install with a git-sourced one (or
-        # hopping between tags) is an overwrite, not an upgrade, in uv's model.
-        return _UpgradeSuggestion(command=f"uv tool install --force {spec}", runnable=True)
-    if installer == "pipx":
-        return _UpgradeSuggestion(command=f"pipx install --force {spec}", runnable=True)
-    if installer == "pip" or (installer is None and info.vcs_url is not None):
-        return _UpgradeSuggestion(
-            command=f"{_pip_invocation()} install --force-reinstall {spec}", runnable=True
-        )
-    if installer == "poetry":
-        return _UpgradeSuggestion(command=f"poetry add --force {spec}", runnable=True)
-    # Unknown installer on a registry install: don't guess the tool.
-    return _UpgradeSuggestion(command=f"install {_DIST_NAME} from {spec}", runnable=False)
+    return _build_upgrade_suggestion(
+        info,
+        extra_overrides=extra_overrides,
+        target_vcs_url=f"git+{_NIGHTLY_REPO_URL}@v{nightly_version}",
+    )
 
 
 def _run_upgrade_command(command: str, console: Console) -> int:
@@ -1794,6 +1816,36 @@ def _probe_installed_distribution() -> tuple[str | None, str | None]:
     version = lines[0].strip() if lines and lines[0].strip() else None
     commit = lines[1].strip() if len(lines) >= 2 and lines[1].strip() else None
     return version, commit
+
+
+def _upgrade_failure_message(code: int, extras: Collection[str] = ()) -> str:
+    """Describe a failed upgrade, after checking whether the install survived.
+
+    uv and pipx replace the tool environment before the replacement is built,
+    so a failed build can leave nothing runnable behind. Claiming the previous
+    install is intact on the strength of the exit code alone sends the user to
+    look at their PATH instead of at a missing install, so read the disk the
+    same way the success path does.
+
+    :param code: The installer's exit status.
+    :param extras: Extras this install had, so the recovery line reinstalls
+        the same shape.
+    :returns: The message body for the raised ``ClickException``.
+    """
+    version, _ = _probe_installed_distribution()
+    if version is not None:
+        return f"Upgrade command exited with status {code}; your previous install is intact."
+    extra_flags = "".join(f" --extra {extra}" for extra in sorted(extras))
+    return (
+        f"Upgrade command exited with status {code}, and omnigent is no longer "
+        "installed: the installer replaced the old environment before the new "
+        "build failed. Your agents, history and credentials are untouched; "
+        "reinstall the CLI to get back:\n\n"
+        f"    curl -fsSL https://omnigent.ai/install.sh | sh -s --{extra_flags}\n"
+        "    omnigent login <SERVER-URL>\n\n"
+        "If the web UI build was what failed, install Node 22 LTS and pnpm "
+        "first, or set OMNIGENT_SKIP_WEB_UI=true to install without it."
+    )
 
 
 def _split_vcs_url(vcs_url: str) -> tuple[str, str | None]:

--- a/scripts/update_nightly.sh
+++ b/scripts/update_nightly.sh
@@ -18,6 +18,10 @@
 set -euo pipefail
 
 REPO="${OMNIGENT_REPO:-https://github.com/omnigent-ai/omnigent}"
+# Match install.sh: pinning the interpreter keeps uv reusing the existing
+# tool environment instead of recreating it (which removes the working
+# install before the new wheel is built, so a build failure leaves none).
+PYTHON_VERSION="${OMNIGENT_PYTHON_VERSION:-3.12}"
 
 # Newest nightly tag: strictly vX.Y.Z.devYYYYMMDD (the 8-digit date also
 # screens out legacy .dev0-style tags). Version sorts before date, so the
@@ -39,5 +43,6 @@ if command -v omnigent >/dev/null 2>&1 \
 fi
 
 echo "update_nightly: installing ${tag}"
-uv tool install --force "omnigent @ git+${REPO}@${tag}"
+uv tool install --reinstall --python "$PYTHON_VERSION" \
+  "omnigent @ git+${REPO}@${tag}"
 omnigent --version

--- a/tests/cli/test_update_check.py
+++ b/tests/cli/test_update_check.py
@@ -509,7 +509,12 @@ from omnigent.update_check import (  # noqa: E402
     _read_uv_tool_extras,
     _run_installed_wheel_check,
     _unredact_ssh_userinfo,
+    _uv_python_pin,
 )
+
+# uv upgrade commands pin the interpreter omnigent is running under, so
+# expectations derive the flag instead of hardcoding a python version.
+_UV_PY = _uv_python_pin()
 
 
 @pytest.fixture(autouse=True)
@@ -770,7 +775,7 @@ def test_read_wheel_info_repairs_redacted_ssh_user(
     assert suggestion.runnable is True
     assert (
         suggestion.command
-        == "uv tool install --reinstall git+ssh://git@github.com/omnigent-ai/omnigent.git"
+        == f"uv tool install --reinstall{_UV_PY} git+ssh://git@github.com/omnigent-ai/omnigent.git"
     )
 
 
@@ -867,7 +872,7 @@ def test_read_wheel_info_handles_corrupt_direct_url(
     [
         # uv + git install — recommend ``uv tool install --reinstall``
         # with the original URL so the user pulls a fresh commit.
-        ("uv", _FAKE_GIT_URL, f"uv tool install --reinstall {_FAKE_GIT_URL}", True),
+        ("uv", _FAKE_GIT_URL, f"uv tool install --reinstall{_UV_PY} {_FAKE_GIT_URL}", True),
         # uv + registry install — ``uv tool upgrade`` resolves from the
         # configured index. The user doesn't need to remember the spec.
         ("uv", None, "uv tool upgrade omnigent", True),
@@ -1512,7 +1517,7 @@ def test_build_upgrade_suggestion_allow_prerelease() -> None:
         _build_upgrade_suggestion(
             _info("uv", vcs_url="git+https://x/omnigent.git"), allow_prerelease=True
         ).command
-        == "uv tool install --reinstall git+https://x/omnigent.git --prerelease allow"
+        == f"uv tool install --reinstall{_UV_PY} git+https://x/omnigent.git --prerelease allow"
     )
 
 
@@ -1554,11 +1559,11 @@ def test_build_upgrade_suggestion_preserves_uv_tool_extras() -> None:
     # With extras → reinstall with the PEP 508 spec.
     assert (
         _build_upgrade_suggestion(_make_info("uv", extras=("all",))).command
-        == "uv tool install --reinstall omnigent[all]"
+        == f"uv tool install --reinstall{_UV_PY} omnigent[all]"
     )
     assert (
         _build_upgrade_suggestion(_make_info("uv", extras=("server", "all"))).command
-        == "uv tool install --reinstall omnigent[all,server]"
+        == f"uv tool install --reinstall{_UV_PY} omnigent[all,server]"
     )
 
 
@@ -1566,13 +1571,13 @@ def test_build_upgrade_suggestion_uv_target_version() -> None:
     """A pinned target version produces ``install --reinstall`` with the spec."""
     assert (
         _build_upgrade_suggestion(_make_info("uv"), target_version="0.2.0").command
-        == "uv tool install --reinstall omnigent==0.2.0"
+        == f"uv tool install --reinstall{_UV_PY} omnigent==0.2.0"
     )
     assert (
         _build_upgrade_suggestion(
             _make_info("uv", extras=("all",)), target_version="0.2.0"
         ).command
-        == "uv tool install --reinstall omnigent==0.2.0[all]"
+        == f"uv tool install --reinstall{_UV_PY} omnigent==0.2.0[all]"
     )
 
 
@@ -1582,11 +1587,11 @@ def test_build_upgrade_suggestion_extra_overrides_win() -> None:
         _build_upgrade_suggestion(
             _make_info("uv", extras=("all",)), extra_overrides=("server",)
         ).command
-        == "uv tool install --reinstall omnigent[all,server]"
+        == f"uv tool install --reinstall{_UV_PY} omnigent[all,server]"
     )
     assert (
         _build_upgrade_suggestion(_make_info("uv"), extra_overrides=("all",)).command
-        == "uv tool install --reinstall omnigent[all]"
+        == f"uv tool install --reinstall{_UV_PY} omnigent[all]"
     )
 
 
@@ -1604,11 +1609,11 @@ def test_build_upgrade_suggestion_vcs_preserves_extras() -> None:
     git_url = "git+https://github.com/example-org/omnigent.git"
     assert (
         _build_upgrade_suggestion(_make_info("uv", vcs_url=git_url)).command
-        == f"uv tool install --reinstall {git_url}"
+        == f"uv tool install --reinstall{_UV_PY} {git_url}"
     )
     assert (
         _build_upgrade_suggestion(_make_info("uv", vcs_url=git_url, extras=("all",))).command
-        == f"uv tool install --reinstall {git_url}#egg=omnigent[all]"
+        == f"uv tool install --reinstall{_UV_PY} {git_url}#egg=omnigent[all]"
     )
 
 
@@ -2445,7 +2450,7 @@ def test_cli_upgrade_dry_run_uv_tool_with_extras(
     runner = CliRunner()
     result = runner.invoke(cli, ["upgrade", "--dry-run"])
     assert result.exit_code == 0
-    assert "uv tool install --reinstall omnigent[all]" in result.output
+    assert f"uv tool install --reinstall{_UV_PY} omnigent[all]" in result.output
     assert "Would run:" in result.output
 
 

--- a/tests/cli/test_upgrade_command.py
+++ b/tests/cli/test_upgrade_command.py
@@ -11,9 +11,16 @@ from omnigent.cli import cli
 from omnigent.host.local_server import LocalServerInfo
 from omnigent.update_check import (
     _build_nightly_upgrade_suggestion,
+    _build_upgrade_suggestion,
     _InstalledWheelInfo,
     _newest_nightly_version,
+    _upgrade_failure_message,
+    _uv_python_pin,
 )
+
+# uv upgrade commands pin the interpreter omnigent is running under, so
+# expectations derive the flag instead of hardcoding a python version.
+_UV_PY = _uv_python_pin()
 
 
 def _uv_registry_info() -> _InstalledWheelInfo:
@@ -490,7 +497,9 @@ def test_upgrade_git_install_repulls_and_verifies_commit(
     result = CliRunner().invoke(cli, ["upgrade"])
 
     assert result.exit_code == 0, result.output
-    assert ran == ["uv tool install --reinstall git+https://github.com/omnigent-ai/omnigent.git"]
+    assert ran == [
+        f"uv tool install --reinstall{_UV_PY} git+https://github.com/omnigent-ai/omnigent.git"
+    ]
     assert "Updated to git bbbbbbbbb" in result.output
 
 
@@ -578,7 +587,13 @@ def test_nightly_suggestion_shapes_per_installer() -> None:
         )
 
     uv = _build_nightly_upgrade_suggestion(info_for("uv"), version)
-    assert (uv.command, uv.runnable) == (f"uv tool install --force {spec}", True)
+    # ``--reinstall``, never ``--force``: uv's ``--force`` removes the working
+    # install before the replacement is built, and nightlies build from source,
+    # so a failed build would leave nothing behind.
+    assert (uv.command, uv.runnable) == (
+        f"uv tool install --reinstall{_UV_PY} {spec}",
+        True,
+    )
     pipx = _build_nightly_upgrade_suggestion(info_for("pipx"), version)
     assert (pipx.command, pipx.runnable) == (f"pipx install --force {spec}", True)
     pip = _build_nightly_upgrade_suggestion(info_for("pip"), version)
@@ -626,7 +641,8 @@ def test_upgrade_nightly_installs_pinned_tag(
 
     assert result.exit_code == 0, result.output
     assert ran == [
-        "uv tool install --force git+https://github.com/omnigent-ai/omnigent@v0.2.0.dev20260804"
+        f"uv tool install --reinstall{_UV_PY} "
+        "git+https://github.com/omnigent-ai/omnigent@v0.2.0.dev20260804"
     ]
     assert "Upgraded to nightly v0.2.0.dev20260804" in result.output
 
@@ -681,7 +697,7 @@ def test_nightly_suggestion_preserves_and_unions_extras() -> None:
 
     assert suggestion.runnable
     assert suggestion.command == (
-        "uv tool install --force "
+        f"uv tool install --reinstall{_UV_PY} "
         "git+https://github.com/omnigent-ai/omnigent@v0.9.0.dev20260804#egg=omnigent[all,server]"
     )
 
@@ -733,7 +749,7 @@ def test_upgrade_nightly_dry_run_prints_without_running(
 
     assert result.exit_code == 0, result.output
     assert (
-        "Would run: uv tool install --force "
+        f"Would run: uv tool install --reinstall{_UV_PY} "
         "git+https://github.com/omnigent-ai/omnigent@v0.2.0.dev20260804" in result.output
     )
 
@@ -746,3 +762,118 @@ def test_upgrade_nightly_rejects_target_version(
 
     assert result.exit_code == 2, result.output
     assert "mutually exclusive" in result.output
+
+
+def test_nightly_uv_never_uses_destructive_force() -> None:
+    """No uv upgrade command may use ``--force``, whatever the install shape.
+
+    uv's ``--force`` removes the tool environment (and the ``omni`` /
+    ``omnigent`` executables) before the replacement is built. Nightlies build
+    from source, so the build can fail, and then nothing is left to fall back
+    to. ``--reinstall`` performs the same registry-to-git hop and the same
+    tag-to-tag hop while keeping the working install until the new one exists.
+    """
+    version = "0.9.0.dev20260804"
+    for extras in ((), ("databricks",)):
+        for vcs_url in (None, "git+https://github.com/a-fork/omnigent.git"):
+            info = _InstalledWheelInfo(
+                install_time_epoch=0.0,
+                installer="uv",
+                vcs_url=vcs_url,
+                commit_sha=None,
+                is_editable=False,
+                package_version="0.8.2",
+                detected_installer="uv",
+                extras=extras,
+            )
+            command = _build_nightly_upgrade_suggestion(info, version).command
+            assert "--force" not in command, command
+            assert command.startswith(f"uv tool install --reinstall{_UV_PY} ")
+            # Always the nightly tag, never the fork's recorded URL.
+            assert f"git+https://github.com/omnigent-ai/omnigent@v{version}" in command
+
+
+def test_nightly_pipx_spells_out_the_tag_instead_of_reinstall() -> None:
+    """pipx must not fall back to ``reinstall`` for a nightly hop.
+
+    ``pipx reinstall`` re-pulls the spec pipx recorded at install time, i.e.
+    the *old* tag, which would silently no-op the upgrade. Only the extras-less
+    in-place refresh may use it.
+    """
+
+    def pipx_info(vcs_url: str | None) -> _InstalledWheelInfo:
+        return _InstalledWheelInfo(
+            install_time_epoch=0.0,
+            installer="pipx",
+            vcs_url=vcs_url,
+            commit_sha=None,
+            is_editable=False,
+            package_version="0.8.2",
+            detected_installer="pipx",
+        )
+
+    nightly = _build_nightly_upgrade_suggestion(pipx_info(None), "0.9.0.dev20260804")
+    assert nightly.command == (
+        "pipx install --force git+https://github.com/omnigent-ai/omnigent@v0.9.0.dev20260804"
+    )
+    # An ordinary extras-less VCS refresh still uses the cheap re-pull.
+    same_source = _build_upgrade_suggestion(pipx_info("git+https://host/omnigent.git"))
+    assert same_source.command == "pipx reinstall omnigent"
+
+
+def test_upgrade_failure_message_reports_a_destroyed_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed upgrade must not claim the old install survived when it didn't."""
+    monkeypatch.setattr(
+        "omnigent.update_check._probe_installed_distribution", lambda: (None, None)
+    )
+
+    message = _upgrade_failure_message(1, {"databricks"})
+
+    assert "your previous install is intact" not in message
+    assert "no longer installed" in message
+    # Actionable recovery, preserving the extras this install had.
+    assert "install.sh | sh -s -- --extra databricks" in message
+    assert "omnigent login" in message
+    assert "OMNIGENT_SKIP_WEB_UI=true" in message
+
+
+def test_upgrade_failure_message_confirms_a_surviving_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the probe still finds omnigent, the reassuring message is correct."""
+    monkeypatch.setattr(
+        "omnigent.update_check._probe_installed_distribution", lambda: ("0.8.2", None)
+    )
+
+    message = _upgrade_failure_message(1)
+
+    assert message == "Upgrade command exited with status 1; your previous install is intact."
+
+
+def test_upgrade_nightly_failure_surfaces_recovery_when_install_is_gone(
+    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
+) -> None:
+    """A failed nightly build that took the install with it must say so.
+
+    This is the reported bug end to end: the web-UI build fails, the installer
+    exits non-zero, and the CLI used to answer "your previous install is
+    intact" purely from the exit code, sending the user to inspect PATH while
+    ``omni`` was actually gone.
+    """
+    monkeypatch.setattr(
+        "omnigent.update_check._latest_nightly_version", lambda: "0.2.0.dev20260804"
+    )
+    monkeypatch.setattr("omnigent.update_check._run_upgrade_command", lambda *_a: 1)
+    # The installer replaced the environment, then the build failed.
+    monkeypatch.setattr(
+        "omnigent.update_check._probe_installed_distribution", lambda: (None, None)
+    )
+
+    result = CliRunner().invoke(cli, ["upgrade", "--nightly"])
+
+    assert result.exit_code != 0
+    assert "your previous install is intact" not in result.output
+    assert "no longer installed" in result.output
+    assert "install.sh" in result.output


### PR DESCRIPTION
## Related issue

Closes #

<!-- No issue filed yet: reported directly by a user installing the nightly on
macOS. Happy to file one and link it if a maintainer prefers. #4686 is the
sibling report (the web-UI build failing on Node 25); it covers the build
failure itself, not the destroyed install or the misleading message. -->

## Summary

`omni upgrade --nightly` on a machine without pnpm deletes the CLI and then
tells you it didn't:

```
Error: Upgrade command exited with status 1; your previous install is intact.
$ omni
zsh: command not found: omni
```

**ELI5:** the installer throws away the old install before it knows the new one
can be built. The build then fails, and the error message reports on the
installer's exit code rather than on whether anything survived.

```
before                                        after
------                                        -----
drain + stop local server                     drain + stop local server
uv tool install --force <git tag>             uv tool install --reinstall --python 3.12 <git tag>
  ├─ delete tool env + omni/omnigent shims      ├─ build wheel (pnpm compiles the web UI)
  └─ build wheel  ← pnpm missing, FAILS         │    └─ FAILS -> old install still on disk
       nothing left to fall back to             └─ swap only once the new build exists
exit 1 -> "your previous install is intact"   exit 1 -> probe disk, report what is actually true
         (untrue, and the CLI is gone)
```

Three defects stack up:

1. **`uv tool install --force` is destructive-first.** It removes the tool
   environment and the `omni` / `omnigent` shims before the replacement is
   built. Nightlies are git tags, so they build from source and compile the web
   UI, which `setup.py` deliberately aborts when pnpm/node is missing. So this
   is a deterministic brick on a node-less machine, not bad luck. `--force` was
   used only by the nightly path.
2. **No path passed `--python`,** though `install.sh` pins 3.12. uv then
   resolves the *default* interpreter (conda base 3.13.5 for the reporter), and
   when the two differ it must recreate the tool environment, which destroys the
   install **even under `--reinstall`**. This one is not nightly-specific: it
   exposes plain `omni upgrade` on source-built installs too.
3. **The failure branch trusted the exit code.** The success branch immediately
   below already reads the disk instead ("Trust the installed version, not the
   installer's exit code"); the failure branch now does the same, and prints
   recovery steps preserving the install's extras when omnigent is really gone.

The nightly command builder was a near-copy of the release builder that had
diverged on exactly that one destructive flag, so it now delegates to
`_build_upgrade_suggestion` with the tag as a retarget (~30 lines deleted). One
place decides which installer flag is safe. Two divergences are kept
deliberately, both covered by tests: `pipx reinstall` re-pulls the spec pipx
recorded (the *old* tag), so a retarget spells the spec out; and an unknown
installer is only assumed to be pip when the install itself came from a VCS URL,
so a retarget never guesses.

`scripts/update_nightly.sh` carried the same two hazards and gets the same fix.

## Test Plan

**Automated** (`pytest tests/cli/test_upgrade_command.py tests/cli/test_update_check.py`,
154 passed). New tests assert no uv command can use `--force` across every
install shape, that pipx spells out the tag rather than re-pulling the old one,
and that a failed upgrade with a destroyed install reports the truth plus
recovery. Existing expectations now derive the interpreter pin from
`_uv_python_pin()` rather than hardcoding a python version, so the suite passes
on whatever interpreter runs it.

**Behaviour verified directly against uv 0.11.14**, in an isolated
`UV_TOOL_DIR`/`UV_TOOL_BIN_DIR` with a dummy package whose build exits non-zero
(standing in for the pnpm failure):

| command | build fails, same python | build fails, different python |
|---|---|---|
| `uv tool install --reinstall <spec>` | survives | **destroyed** |
| `uv tool install --force <spec>` | **destroyed** | **destroyed** |
| `uv tool upgrade omnigent` | survives | n/a |

This is what identified `--force` as the primary cause and the missing
`--python` as a second, independent one. I also checked the claim in the comment
that justified `--force`, and it does not hold on current uv: `--reinstall`
completes the registry-to-git hop (receipt advances to the new version) *and*
the tag-to-tag hop, verified with the requirement string held identical, which
is the case where a no-op would be most likely. The resulting command
(`--reinstall` + pinned `--python`) exits 1 on a failed build with the old
install still running.

**Regression check:** `pytest tests/cli/` gives an identical failure set (101,
all pre-existing in my environment) on this branch and on pristine `origin/main`,
with 21 net new passing tests. `ruff format`, `ruff check`, `pyrefly` (0 errors)
and the three custom lint hooks all pass.

## Demo

N/A (non-visual CLI change; the before/after messages are quoted above).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The destructive behaviour lives in uv, not in our code, so it cannot be
asserted from our test suite: unit tests pin the emitted command strings, and
the uv matrix above (isolated tool dir, dummy failing build, uv 0.11.14) is what
establishes that those strings are the safe ones. Worth re-checking if we ever
bump the supported uv floor.

Not verified: the same run on macOS with a genuinely missing pnpm, i.e. the
reporter's exact machine. The mechanism is platform-independent (uv tool env
handling), but a macOS confirmation before release would be worth having.

## Changelog

A failed `omni upgrade` no longer removes your existing install, and reports
accurately when an upgrade leaves nothing installed
