### PR TITLE
Fix stale Codex turn steering after completion

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -474,6 +474,22 @@ def _inject_mcp_server_config(
     config_path.write_text(rendered, encoding="utf-8")
 
 
+class CodexAppServerResponseError(RuntimeError):
+    """Structured JSON-RPC error returned by the Codex app-server."""
+
+    def __init__(self, error: object) -> None:
+        """Preserve the JSON-RPC code and message while remaining a RuntimeError."""
+        self.error = error
+        self.code: int | None = None
+        self.message: str | None = None
+        if isinstance(error, dict):
+            code = error.get("code")
+            message = error.get("message")
+            self.code = code if isinstance(code, int) else None
+            self.message = message if isinstance(message, str) else None
+        super().__init__(str(error))
+
+
 class CodexAppServerClient:
     """JSON-RPC client for a Codex app-server.
 
@@ -569,7 +585,7 @@ class CodexAppServerClient:
         :param method: App-server method, e.g. ``"thread/start"``.
         :param params: JSON-serializable method parameters.
         :returns: Decoded response envelope.
-        :raises RuntimeError: If the app-server returns an error.
+        :raises CodexAppServerResponseError: If the app-server returns an error.
         """
         if self._ws is None:
             raise RuntimeError("Codex app-server client is not connected")
@@ -590,7 +606,7 @@ class CodexAppServerClient:
         response = await future
         error = response.get("error")
         if error:
-            raise RuntimeError(str(error))
+            raise CodexAppServerResponseError(error)
         return response
 
     async def notify(self, method: str, params: CodexParams | None = None) -> None:

--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import os
@@ -9,6 +10,7 @@ import re
 import secrets
 import sys
 import tempfile
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -19,6 +21,7 @@ CODEX_NATIVE_BRIDGE_DIR_ENV_VAR = "HARNESS_CODEX_NATIVE_BRIDGE_DIR"
 CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR = "HARNESS_CODEX_NATIVE_REQUEST_SESSION_ID"
 
 _STATE_FILE = "state.json"
+_STATE_LOCK_FILE = "state.lock"
 _STARTUP_ERROR_FILE = "startup_error.json"
 # Per-MCP-server startup state mirrored from Codex's
 # ``mcpServer/startupStatus/updated`` notifications. Written by the
@@ -422,9 +425,37 @@ def write_codex_config_model(bridge_dir: Path, model: str) -> bool:
     return True
 
 
-def write_bridge_state(bridge_dir: Path, state: CodexNativeBridgeState) -> None:
+@contextlib.contextmanager
+def _bridge_state_lock(bridge_dir: Path) -> Iterator[None]:
     """
-    Persist shared native Codex state atomically.
+    Serialize bridge-state read/modify/write cycles across local processes.
+
+    :param bridge_dir: Native Codex bridge directory.
+    :returns: Context manager holding the bridge's process lock.
+    """
+    bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - native Codex is POSIX-only today.
+        yield
+        return
+    fd = os.open(
+        bridge_dir / _STATE_LOCK_FILE,
+        os.O_CREAT | os.O_RDWR | getattr(os, "O_CLOEXEC", 0),
+        0o600,
+    )
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _write_bridge_state_unlocked(bridge_dir: Path, state: CodexNativeBridgeState) -> None:
+    """
+    Atomically replace bridge state while the caller holds its state lock.
 
     :param bridge_dir: Native Codex bridge directory.
     :param state: State payload to persist.
@@ -454,6 +485,18 @@ def write_bridge_state(bridge_dir: Path, state: CodexNativeBridgeState) -> None:
             os.unlink(tmp_name)
 
 
+def write_bridge_state(bridge_dir: Path, state: CodexNativeBridgeState) -> None:
+    """
+    Persist shared native Codex state atomically under a process lock.
+
+    :param bridge_dir: Native Codex bridge directory.
+    :param state: State payload to persist.
+    :returns: None.
+    """
+    with _bridge_state_lock(bridge_dir):
+        _write_bridge_state_unlocked(bridge_dir, state)
+
+
 def clear_bridge_state(bridge_dir: Path) -> None:
     """
     Remove stale native Codex runtime state for a bridge directory.
@@ -468,15 +511,16 @@ def clear_bridge_state(bridge_dir: Path) -> None:
     :param bridge_dir: Native Codex bridge directory.
     :returns: None.
     """
-    for name in (
-        _STATE_FILE,
-        _STARTUP_ERROR_FILE,
-        _MCP_STARTUP_FILE,
-    ):
-        try:
-            (bridge_dir / name).unlink()
-        except FileNotFoundError:
-            continue
+    with _bridge_state_lock(bridge_dir):
+        for name in (
+            _STATE_FILE,
+            _STARTUP_ERROR_FILE,
+            _MCP_STARTUP_FILE,
+        ):
+            try:
+                (bridge_dir / name).unlink()
+            except FileNotFoundError:
+                continue
 
 
 def write_bridge_startup_error(bridge_dir: Path, message: str) -> None:
@@ -738,20 +782,21 @@ def update_active_turn_id(bridge_dir: Path, active_turn_id: str | None) -> None:
         or ``None`` when no turn is running.
     :returns: None.
     """
-    state = read_bridge_state(bridge_dir)
-    if state is None:
-        return
-    write_bridge_state(
-        bridge_dir,
-        CodexNativeBridgeState(
-            session_id=state.session_id,
-            socket_path=state.socket_path,
-            thread_id=state.thread_id,
-            codex_home=state.codex_home,
-            active_turn_id=active_turn_id,
-            cwd=state.cwd,
-        ),
-    )
+    with _bridge_state_lock(bridge_dir):
+        state = read_bridge_state(bridge_dir)
+        if state is None:
+            return
+        _write_bridge_state_unlocked(
+            bridge_dir,
+            CodexNativeBridgeState(
+                session_id=state.session_id,
+                socket_path=state.socket_path,
+                thread_id=state.thread_id,
+                codex_home=state.codex_home,
+                active_turn_id=active_turn_id,
+                cwd=state.cwd,
+            ),
+        )
 
 
 def update_thread_id(bridge_dir: Path, thread_id: str, active_turn_id: str | None = None) -> None:
@@ -767,20 +812,21 @@ def update_thread_id(bridge_dir: Path, thread_id: str, active_turn_id: str | Non
         ``"turn_abc123"``, or ``None`` when no turn is running yet.
     :returns: None.
     """
-    state = read_bridge_state(bridge_dir)
-    if state is None:
-        return
-    write_bridge_state(
-        bridge_dir,
-        CodexNativeBridgeState(
-            session_id=state.session_id,
-            socket_path=state.socket_path,
-            thread_id=thread_id,
-            codex_home=state.codex_home,
-            active_turn_id=active_turn_id,
-            cwd=state.cwd,
-        ),
-    )
+    with _bridge_state_lock(bridge_dir):
+        state = read_bridge_state(bridge_dir)
+        if state is None:
+            return
+        _write_bridge_state_unlocked(
+            bridge_dir,
+            CodexNativeBridgeState(
+                session_id=state.session_id,
+                socket_path=state.socket_path,
+                thread_id=thread_id,
+                codex_home=state.codex_home,
+                active_turn_id=active_turn_id,
+                cwd=state.cwd,
+            ),
+        )
 
 
 def clear_active_turn_id_if_matches(bridge_dir: Path, completed_turn_id: str | None) -> bool:
@@ -807,24 +853,25 @@ def clear_active_turn_id_if_matches(bridge_dir: Path, completed_turn_id: str | N
     :returns: ``True`` when bridge state was cleared or did not exist,
         ``False`` when a stale or ambiguous terminal event was ignored.
     """
-    state = read_bridge_state(bridge_dir)
-    if state is None:
-        return True
-    if completed_turn_id is None:
-        # No-id terminal mid-turn is ambiguous — ignore (clearing posts a premature idle).
-        if state.active_turn_id is not None:
+    with _bridge_state_lock(bridge_dir):
+        state = read_bridge_state(bridge_dir)
+        if state is None:
+            return True
+        if completed_turn_id is None:
+            # No-id terminal mid-turn is ambiguous — ignore (clearing posts a premature idle).
+            if state.active_turn_id is not None:
+                return False
+        elif state.active_turn_id != completed_turn_id:
             return False
-    elif state.active_turn_id != completed_turn_id:
-        return False
-    write_bridge_state(
-        bridge_dir,
-        CodexNativeBridgeState(
-            session_id=state.session_id,
-            socket_path=state.socket_path,
-            thread_id=state.thread_id,
-            codex_home=state.codex_home,
-            active_turn_id=None,
-            cwd=state.cwd,
-        ),
-    )
-    return True
+        _write_bridge_state_unlocked(
+            bridge_dir,
+            CodexNativeBridgeState(
+                session_id=state.session_id,
+                socket_path=state.socket_path,
+                thread_id=state.thread_id,
+                codex_home=state.codex_home,
+                active_turn_id=None,
+                cwd=state.cwd,
+            ),
+        )
+        return True

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -1036,6 +1036,14 @@ class _CodexTurnStatusEdge:
     error: _CodexTerminalError | None = None
 
 
+@dataclass(frozen=True)
+class _PreparedTerminalTurn:
+    """Terminal control-state result retained while output delivery drains."""
+
+    handled: bool
+    edge: _CodexTurnStatusEdge | None
+
+
 # Codex ``item/completed`` item types that represent a built-in tool call.
 # Each maps to a builder that extracts a normalized :class:`_CodexToolCall`.
 # ``_TOOL_ITEM_BUILDERS`` is populated after the builders are defined.
@@ -3252,6 +3260,15 @@ async def _handle_terminal_turn_boundary(
     :param forwarder_state: Optional Plan-mode prompt state.
     :returns: None.
     """
+    # Reconcile control state before any network-backed output flush. Transcript
+    # and status posts retain their original order below, but a slow consumer
+    # can no longer leave a completed Codex turn steerable in bridge state.
+    terminal = _prepare_terminal_turn_event(
+        bridge_dir,
+        method,
+        params,
+        forwarder_state=forwarder_state,
+    )
     if delta_coalescer is not None:
         await delta_coalescer.flush()
     # Safety net: if a compaction was reported in progress but Codex never
@@ -3274,14 +3291,9 @@ async def _handle_terminal_turn_boundary(
         params=params,
         forwarder_state=forwarder_state,
     )
-    handled = await _handle_terminal_turn_event(
-        client,
-        session_id,
-        bridge_dir,
-        method,
-        params,
-        forwarder_state=forwarder_state,
-    )
+    handled = terminal.handled
+    if terminal.edge is not None:
+        await _post_turn_status_edge(client, session_id, terminal.edge)
     if handled:
         await elicitation_tracker.resolve_by_terminal_turn_event(
             client,
@@ -4169,27 +4181,22 @@ def _turn_started_status_edge(
     )
 
 
-async def _handle_terminal_turn_event(
-    client: httpx.AsyncClient,
-    session_id: str,
+def _prepare_terminal_turn_event(
     bridge_dir: Path,
     method: str,
     params: _JsonObject,
     *,
     forwarder_state: _CodexForwarderState | None = None,
-) -> bool:
+) -> _PreparedTerminalTurn:
     """
-    Handle a terminal-observed Codex turn completion/failure event.
+    Reconcile a terminal Codex turn and retain its later status post.
 
-    :param client: HTTP client for Omnigent event posts.
-    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
     :param bridge_dir: Native Codex bridge directory.
     :param method: Codex method, e.g. ``"turn/completed"``.
     :param params: Codex turn event params.
     :param forwarder_state: Optional connection state used to suppress a
         terminal boundary whose standalone error was already surfaced.
-    :returns: ``True`` when the terminal event belonged to the active turn
-        and its lifecycle was handled, ``False`` when it was stale.
+    :returns: Whether the event was handled and its optional status edge.
     """
     terminal_turn_id = _terminal_turn_id_from_params(params)
     if (
@@ -4204,7 +4211,7 @@ async def _handle_terminal_turn_event(
             method,
             terminal_turn_id,
         )
-        return True
+        return _PreparedTerminalTurn(handled=True, edge=None)
     edge = _terminal_turn_status_edge(bridge_dir, method, params)
     if edge is None:
         _logger.info(
@@ -4212,9 +4219,8 @@ async def _handle_terminal_turn_event(
             method,
             terminal_turn_id,
         )
-        return False
-    await _post_turn_status_edge(client, session_id, edge)
-    return True
+        return _PreparedTerminalTurn(handled=False, edge=None)
+    return _PreparedTerminalTurn(handled=True, edge=edge)
 
 
 def _terminal_turn_status_edge(

--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -12,11 +12,17 @@ from collections.abc import AsyncIterator, Mapping
 from pathlib import Path
 from typing import cast
 
-from omnigent.codex_native_app_server import client_for_transport
+from omnigent.codex_native_app_server import (
+    CodexAppServerClient,
+    CodexAppServerResponseError,
+    client_for_transport,
+)
 from omnigent.codex_native_bridge import (
     CODEX_NATIVE_BRIDGE_DIR_ENV_VAR,
     CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
+    CodexNativeBridgeState,
     cancel_pending_mcp_startup,
+    clear_active_turn_id_if_matches,
     mcp_startup_waiting_detail,
     read_bridge_startup_error,
     read_bridge_state,
@@ -47,6 +53,147 @@ from omnigent.reasoning_effort import (
 )
 
 _logger = logging.getLogger(__name__)
+
+_NO_ACTIVE_TURN_ERROR_CODE = -32600
+_NO_ACTIVE_TURN_ERROR_MESSAGE = "no active turn to steer"
+
+
+def _is_no_active_turn_to_steer(error: CodexAppServerResponseError) -> bool:
+    """Return whether Codex explicitly rejected a steer because the turn ended."""
+    return (
+        error.code == _NO_ACTIVE_TURN_ERROR_CODE
+        and error.message is not None
+        and error.message.strip().casefold() == _NO_ACTIVE_TURN_ERROR_MESSAGE
+    )
+
+
+async def _start_codex_turn(
+    client: CodexAppServerClient,
+    *,
+    bridge_dir: Path,
+    state: CodexNativeBridgeState,
+    input_items: list[dict[str, object]],
+    settings_overrides: Mapping[str, object],
+) -> None:
+    """Apply optional settings and start one Codex turn on an idle thread."""
+    if settings_overrides:
+        await client.request(
+            "thread/settings/update",
+            {
+                "threadId": state.thread_id,
+                **settings_overrides,
+            },
+        )
+        switched_model = settings_overrides.get("model")
+        if isinstance(switched_model, str) and switched_model:
+            if not write_codex_config_model(bridge_dir, switched_model):
+                _logger.warning(
+                    "Failed to mirror codex model switch into config.toml: model=%s",
+                    switched_model,
+                )
+    response = await client.request(
+        "turn/start",
+        {
+            "threadId": state.thread_id,
+            "input": input_items,
+            "environments": [
+                {
+                    "environmentId": "local",
+                    "cwd": state.cwd or str(Path.cwd()),
+                }
+            ],
+        },
+    )
+    result = _json_object(response.get("result"))
+    turn = _json_object(result.get("turn")) if result is not None else None
+    turn_id = turn.get("id") if turn is not None else None
+    if isinstance(turn_id, str) and turn_id:
+        update_active_turn_id(bridge_dir, turn_id)
+        _logger.info("Codex native started turn: turn_id=%s", turn_id)
+
+
+async def _steer_codex_turn(
+    client: CodexAppServerClient,
+    *,
+    bridge_dir: Path,
+    state: CodexNativeBridgeState,
+    input_items: list[dict[str, object]],
+) -> None:
+    """Steer one bridge-recorded active Codex turn."""
+    assert state.active_turn_id is not None
+    response = await client.request(
+        "turn/steer",
+        {
+            "threadId": state.thread_id,
+            "expectedTurnId": state.active_turn_id,
+            "input": input_items,
+        },
+    )
+    result = _json_object(response.get("result"))
+    turn_id = result.get("turnId") if result is not None else None
+    if isinstance(turn_id, str) and turn_id:
+        update_active_turn_id(bridge_dir, turn_id)
+        _logger.info("Codex native steered active turn: turn_id=%s", turn_id)
+
+
+async def _inject_codex_turn(
+    client: CodexAppServerClient,
+    *,
+    bridge_dir: Path,
+    state: CodexNativeBridgeState,
+    input_items: list[dict[str, object]],
+    settings_overrides: Mapping[str, object],
+) -> None:
+    """Steer an active turn or start one, recovering one proven stale steer."""
+    if state.active_turn_id is None:
+        await _start_codex_turn(
+            client,
+            bridge_dir=bridge_dir,
+            state=state,
+            input_items=input_items,
+            settings_overrides=settings_overrides,
+        )
+        return
+
+    expected_turn_id = state.active_turn_id
+    try:
+        await _steer_codex_turn(
+            client,
+            bridge_dir=bridge_dir,
+            state=state,
+            input_items=input_items,
+        )
+        return
+    except CodexAppServerResponseError as error:
+        if not _is_no_active_turn_to_steer(error):
+            raise
+
+    # Codex authoritatively says A ended. Clear A only if it is still the
+    # bridge's value; a concurrent turn/started(B) must survive this recovery.
+    clear_active_turn_id_if_matches(bridge_dir, expected_turn_id)
+    recovered_state = read_bridge_state(bridge_dir)
+    if recovered_state is None or recovered_state.session_id != state.session_id:
+        raise RuntimeError("Codex native bridge changed while recovering a stale turn")
+    if recovered_state.active_turn_id is not None:
+        _logger.info(
+            "Codex native stale steer raced with a newer turn; steering turn_id=%s",
+            recovered_state.active_turn_id,
+        )
+        await _steer_codex_turn(
+            client,
+            bridge_dir=bridge_dir,
+            state=recovered_state,
+            input_items=input_items,
+        )
+        return
+    _logger.info("Codex native reconciled completed stale turn: turn_id=%s", expected_turn_id)
+    await _start_codex_turn(
+        client,
+        bridge_dir=bridge_dir,
+        state=recovered_state,
+        input_items=input_items,
+        settings_overrides=settings_overrides,
+    )
 
 
 class CodexNativeExecutor(Executor):
@@ -109,24 +256,18 @@ class CodexNativeExecutor(Executor):
             )
             await client.connect()
             try:
-                response = await client.request(
-                    "turn/steer",
-                    {
-                        "threadId": state.thread_id,
-                        "expectedTurnId": state.active_turn_id,
-                        "input": input_items,
-                    },
+                await _inject_codex_turn(
+                    client,
+                    bridge_dir=self._bridge_dir,
+                    state=state,
+                    input_items=input_items,
+                    settings_overrides={},
                 )
             except Exception:  # noqa: BLE001 - steering is best-effort from the runner facade.
                 _logger.warning("Codex native turn/steer failed", exc_info=True)
                 return False
             finally:
                 await client.close()
-            result = _json_object(response.get("result"))
-            turn_id = result.get("turnId") if result is not None else None
-            if isinstance(turn_id, str) and turn_id:
-                update_active_turn_id(self._bridge_dir, turn_id)
-                _logger.info("Codex native steered active turn: turn_id=%s", turn_id)
             return True
 
     async def interrupt_session(self, session_key: str) -> bool:
@@ -276,67 +417,13 @@ class CodexNativeExecutor(Executor):
                                 "objective": goal_objective,
                             },
                         )
-                    if state.active_turn_id is not None:
-                        response = await client.request(
-                            "turn/steer",
-                            {
-                                "threadId": state.thread_id,
-                                "expectedTurnId": state.active_turn_id,
-                                "input": input_items,
-                            },
-                        )
-                        result = _json_object(response.get("result"))
-                        turn_id = result.get("turnId") if result is not None else None
-                        if isinstance(turn_id, str) and turn_id:
-                            update_active_turn_id(self._bridge_dir, turn_id)
-                            _logger.info("Codex native steered active turn: turn_id=%s", turn_id)
-                    else:
-                        # A web ``/model`` pick reaches Codex through
-                        # ``thread/settings/update`` (its
-                        # ``ThreadSettingsUpdateParams`` carries ``model`` /
-                        # ``effort``), NOT ``turn/start`` — whose params are
-                        # input/context only. Apply settings first so the
-                        # change persists for this and later turns, then send
-                        # the bare turn.
-                        if settings_overrides:
-                            await client.request(
-                                "thread/settings/update",
-                                {
-                                    "threadId": state.thread_id,
-                                    **settings_overrides,
-                                },
-                            )
-                            # Mirror the accepted switch into config.toml —
-                            # the file the forwarder's model mirror and the
-                            # cost-gate hook read. thread/settings/update does
-                            # not write it, so without this the stale launch
-                            # model is mirrored back at the next turn/started
-                            # and silently reverts the switch.
-                            switched_model = settings_overrides.get("model")
-                            if isinstance(switched_model, str) and switched_model:
-                                if not write_codex_config_model(self._bridge_dir, switched_model):
-                                    _logger.warning(
-                                        "Failed to mirror codex model switch into "
-                                        "config.toml: model=%s",
-                                        switched_model,
-                                    )
-                        turn_params: dict[str, object] = {
-                            "threadId": state.thread_id,
-                            "input": input_items,
-                            "environments": [
-                                {
-                                    "environmentId": "local",
-                                    "cwd": state.cwd or str(Path.cwd()),
-                                }
-                            ],
-                        }
-                        response = await client.request("turn/start", turn_params)
-                        result = _json_object(response.get("result"))
-                        turn = _json_object(result.get("turn")) if result is not None else None
-                        turn_id = turn.get("id") if turn is not None else None
-                        if isinstance(turn_id, str) and turn_id:
-                            update_active_turn_id(self._bridge_dir, turn_id)
-                            _logger.info("Codex native started turn: turn_id=%s", turn_id)
+                    await _inject_codex_turn(
+                        client,
+                        bridge_dir=self._bridge_dir,
+                        state=state,
+                        input_items=input_items,
+                        settings_overrides=settings_overrides,
+                    )
                 except Exception as exc:  # noqa: BLE001 - converted into a harness error event.
                     error_msg = f"Codex native executor error: {exc}"
                     # Name the servers a still-unsettled MCP startup is

--- a/tests/e2e/test_host_codex_native_e2e.py
+++ b/tests/e2e/test_host_codex_native_e2e.py
@@ -30,6 +30,11 @@ from pathlib import Path
 import httpx
 import pytest
 
+from omnigent.codex_native_bridge import (
+    bridge_dir_for_bridge_id,
+    read_bridge_state,
+    update_active_turn_id,
+)
 from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.native_coding_agents import CODEX_NATIVE_AGENT_NAME
 from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
@@ -263,6 +268,83 @@ def _poll_for_assistant_marker(
         f"No assistant message containing {marker!r} within {timeout}s — "
         "the codex-native message was not answered."
     )
+
+
+def _poll_for_active_codex_turn(bridge_dir: Path, *, timeout: float) -> str:
+    """Return the active Codex turn id once the native bridge publishes it."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        state = read_bridge_state(bridge_dir)
+        if state is not None and state.active_turn_id is not None:
+            return state.active_turn_id
+        time.sleep(0.05)
+    raise AssertionError(f"Codex bridge {bridge_dir} published no active turn within {timeout}s")
+
+
+def _wait_for_codex_turn_idle(
+    client: httpx.Client,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+    timeout: float,
+) -> None:
+    """Wait until both Omnigent and the native bridge agree the turn ended."""
+    deadline = time.monotonic() + timeout
+    last_status: object = None
+    last_active_turn: str | None = None
+    while time.monotonic() < deadline:
+        response = client.get(f"/v1/sessions/{session_id}")
+        response.raise_for_status()
+        last_status = response.json().get("status")
+        state = read_bridge_state(bridge_dir)
+        last_active_turn = state.active_turn_id if state is not None else None
+        if last_status == "idle" and state is not None and last_active_turn is None:
+            return
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(
+        f"Codex turn did not settle within {timeout}s "
+        f"(session status={last_status!r}, active turn={last_active_turn!r})"
+    )
+
+
+def _poll_for_marker_without_new_error(
+    client: httpx.Client,
+    *,
+    session_id: str,
+    marker: str,
+    prior_error_ids: set[object],
+    timeout: float,
+) -> str:
+    """Return a marker reply, failing early if the turn persists an error."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        response = client.get(
+            f"/v1/sessions/{session_id}/items",
+            params={"limit": 50, "order": "asc"},
+        )
+        response.raise_for_status()
+        items = response.json().get("data", [])
+        for item in items:
+            text = _assistant_text(item)
+            if marker in text:
+                return text
+        new_errors = [
+            item
+            for item in items
+            if item.get("type") == "error" and item.get("id") not in prior_error_ids
+        ]
+        if new_errors:
+            raise AssertionError(
+                f"Codex persisted an error instead of replying with {marker!r}: {new_errors!r}"
+            )
+        snapshot = client.get(f"/v1/sessions/{session_id}")
+        snapshot.raise_for_status()
+        if snapshot.json().get("status") == "failed":
+            raise AssertionError(
+                f"Codex turn failed instead of replying with {marker!r}: {snapshot.json()!r}"
+            )
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(f"No assistant message containing {marker!r} within {timeout}s")
 
 
 def _poll_for_child_session(
@@ -1442,6 +1524,112 @@ def test_codex_native_web_model_effort_override_survives_turn(
             "model_override did not persist after the override turn; got "
             f"{after.json().get('model_override')!r}, expected {target_model!r}"
         )
+    finally:
+        daemon.send_signal(signal.SIGTERM)
+        try:
+            daemon.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            daemon.kill()
+            daemon.wait()
+
+
+@pytest.mark.skipif(
+    os.environ.get("OMNIGENT_E2E_CODEX_NATIVE") != "1" or shutil.which("codex") is None,
+    reason=(
+        "codex-native stale-steer recovery e2e needs `codex` on PATH and "
+        "OMNIGENT_E2E_CODEX_NATIVE=1 to run"
+    ),
+)
+def test_codex_native_stale_completed_turn_recovers_with_new_turn(
+    live_server: str,
+    http_client: httpx.Client,
+    tmp_path: Path,
+) -> None:
+    """A stale completed turn id is reconciled before the next web message."""
+    workspace = tmp_path / "codex_ws"
+    workspace.mkdir()
+    first_marker = f"FIRST_{uuid.uuid4().hex[:6].upper()}"
+    second_marker = f"SECOND_{uuid.uuid4().hex[:6].upper()}"
+
+    daemon = _spawn_host_daemon(tmp_path=tmp_path, live_server=live_server)
+    try:
+        host_id = _online_host_id(http_client, timeout=30.0)
+        agent_id = _codex_native_agent_id(http_client)
+        session_id = _create_codex_host_session(
+            http_client,
+            agent_id=agent_id,
+            host_id=host_id,
+            workspace=str(workspace),
+        )
+        bridge_dir = bridge_dir_for_bridge_id(session_id)
+
+        # Complete a real first Codex turn and retain its id. The forwarder
+        # normally clears this id when it processes turn/completed.
+        _send_user_text(
+            http_client,
+            session_id=session_id,
+            text=f"Reply with exactly one word: {first_marker}",
+        )
+        completed_turn_id = _poll_for_active_codex_turn(bridge_dir, timeout=30.0)
+        _poll_for_assistant_marker(
+            http_client,
+            session_id=session_id,
+            marker=first_marker,
+            timeout=180.0,
+        )
+        _wait_for_codex_turn_idle(
+            http_client,
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            timeout=60.0,
+        )
+
+        before = http_client.get(
+            f"/v1/sessions/{session_id}/items",
+            params={"limit": 50, "order": "asc"},
+        )
+        before.raise_for_status()
+        prior_error_ids = {
+            item.get("id") for item in before.json().get("data", []) if item.get("type") == "error"
+        }
+
+        # Recreate the production race: Omnigent still believes completed
+        # turn A is active while Codex already considers the thread idle.
+        update_active_turn_id(bridge_dir, completed_turn_id)
+        stale_state = read_bridge_state(bridge_dir)
+        assert stale_state is not None
+        assert stale_state.active_turn_id == completed_turn_id
+
+        _send_user_text(
+            http_client,
+            session_id=session_id,
+            text=f"Reply with exactly one word: {second_marker}",
+        )
+        text = _poll_for_marker_without_new_error(
+            http_client,
+            session_id=session_id,
+            marker=second_marker,
+            prior_error_ids=prior_error_ids,
+            timeout=180.0,
+        )
+        assert second_marker in text
+        _wait_for_codex_turn_idle(
+            http_client,
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            timeout=60.0,
+        )
+        after = http_client.get(
+            f"/v1/sessions/{session_id}/items",
+            params={"limit": 50, "order": "asc"},
+        )
+        after.raise_for_status()
+        new_errors = [
+            item
+            for item in after.json().get("data", [])
+            if item.get("type") == "error" and item.get("id") not in prior_error_ids
+        ]
+        assert new_errors == [], f"stale-turn recovery persisted errors: {new_errors!r}"
     finally:
         daemon.send_signal(signal.SIGTERM)
         try:

--- a/tests/e2e/test_sessions_fork_e2e.py
+++ b/tests/e2e/test_sessions_fork_e2e.py
@@ -265,10 +265,10 @@ def test_full_fork_replays_whole_history(
     )
 
 
-# Compaction-cursor remapping is server-side behavior introduced in v0.11.
+# Compaction-cursor remapping is server-side behavior introduced after v0.11.
 # A new runner paired with an old server must skip this new-server contract.
 @pytest.mark.compat_smoke
-@pytest.mark.min_server_version("0.11.0")
+@pytest.mark.min_server_version("0.12.0")
 def test_fork_preserves_compacted_context_boundary(
     http_client: httpx.Client,
     live_runner_id: str,

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 
+from omnigent.codex_native_app_server import CodexAppServerResponseError
 from omnigent.codex_native_bridge import (
     CodexNativeBridgeState,
     read_bridge_state,
@@ -620,6 +621,136 @@ def test_next_web_message_starts_new_codex_turn_after_forwarder_marks_idle(
         "turn/start",
         "turn/start",
     ]
+
+
+def test_stale_completed_turn_steer_retries_once_as_new_turn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Codex's explicit no-active-turn response reconciles and starts once."""
+
+    class _StaleSteerClient(_FakeCodexNativeClient):
+        """Reject the stale steer with Codex's structured JSON-RPC error."""
+
+        async def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            """Reject only the first steer and delegate the recovery start."""
+            if method == "turn/steer":
+                type(self).requests.append((method, params))
+                raise CodexAppServerResponseError(
+                    {"code": -32600, "message": "no active turn to steer"}
+                )
+            return await super().request(method, params)
+
+    _StaleSteerClient.requests = []
+    _StaleSteerClient.created = []
+    _StaleSteerClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _StaleSteerClient,
+    )
+    _seed_bridge(tmp_path, active_turn_id="turn_completed")
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    events = _collect_turn_events(executor, "follow up")
+
+    assert [type(event) for event in events] == [TurnComplete]
+    assert [method for method, _params in _StaleSteerClient.requests] == [
+        "turn/steer",
+        "turn/start",
+    ]
+    assert _StaleSteerClient.requests[0][1]["expectedTurnId"] == "turn_completed"
+    state = read_bridge_state(tmp_path)
+    assert state is not None
+    assert state.active_turn_id == "turn_1"
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(RuntimeError("request timed out"), id="ambiguous-timeout"),
+        pytest.param(
+            CodexAppServerResponseError({"code": -32600, "message": "invalid turn id"}),
+            id="other-json-rpc-error",
+        ),
+    ],
+)
+def test_steer_does_not_retry_ambiguous_or_unrelated_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    error: Exception,
+) -> None:
+    """Only Codex's explicit idle semantic is safe to retry."""
+
+    class _FailingSteerClient(_FakeCodexNativeClient):
+        """Raise the parameterized failure for every steer."""
+
+        async def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            """Fail steering and delegate all other methods."""
+            if method == "turn/steer":
+                type(self).requests.append((method, params))
+                raise error
+            return await super().request(method, params)
+
+    _FailingSteerClient.requests = []
+    _FailingSteerClient.created = []
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FailingSteerClient,
+    )
+    _seed_bridge(tmp_path, active_turn_id="turn_maybe_active")
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    events = _collect_turn_events(executor, "do not duplicate")
+
+    assert [type(event) for event in events] == [ExecutorError]
+    assert [method for method, _params in _FailingSteerClient.requests] == ["turn/steer"]
+    state = read_bridge_state(tmp_path)
+    assert state is not None
+    assert state.active_turn_id == "turn_maybe_active"
+
+
+def test_stale_steer_recovery_preserves_and_steers_concurrent_new_turn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A concurrent turn B is steered, never cleared or double-started."""
+
+    class _RacingSteerClient(_FakeCodexNativeClient):
+        """Publish turn B just before rejecting the stale steer to turn A."""
+
+        async def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            """Model turn B winning the bridge-state race during stale recovery."""
+            type(self).requests.append((method, params))
+            if method == "turn/steer" and params["expectedTurnId"] == "turn_a":
+                from omnigent.codex_native_bridge import update_active_turn_id
+
+                update_active_turn_id(tmp_path, "turn_b")
+                raise CodexAppServerResponseError(
+                    {"code": -32600, "message": "no active turn to steer"}
+                )
+            if method == "turn/steer":
+                return {"result": {"turnId": "turn_b"}}
+            raise AssertionError(f"recovery must not double-start: {method}")
+
+    _RacingSteerClient.requests = []
+    _RacingSteerClient.created = []
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _RacingSteerClient,
+    )
+    _seed_bridge(tmp_path, active_turn_id="turn_a")
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    events = _collect_turn_events(executor, "follow up")
+
+    assert [type(event) for event in events] == [TurnComplete]
+    assert [
+        (method, params.get("expectedTurnId")) for method, params in _RacingSteerClient.requests
+    ] == [("turn/steer", "turn_a"), ("turn/steer", "turn_b")]
+    assert all(method != "turn/start" for method, _params in _RacingSteerClient.requests)
+    state = read_bridge_state(tmp_path)
+    assert state is not None
+    assert state.active_turn_id == "turn_b"
 
 
 async def test_concurrent_steering_during_turn_start_is_not_dropped(

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -2286,6 +2286,72 @@ def test_forwarder_tracks_active_turn_across_terminal_event_sequences(
     ] == expected_statuses
 
 
+def test_terminal_turn_clears_control_state_before_blocked_delta_flush(tmp_path: Path) -> None:
+    """A slow output flush cannot leave a completed Codex turn steerable."""
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_123",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_123",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id="turn_123",
+        ),
+    )
+    posted: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Capture posts that must remain ordered after the output flush."""
+        posted.append(json.loads(request.content))
+        return httpx.Response(202, json={"queued": False})
+
+    async def run() -> None:
+        """Block output delivery and inspect bridge control state mid-boundary."""
+        flush_entered = asyncio.Event()
+        release_flush = asyncio.Event()
+
+        class _BlockingDeltaCoalescer:
+            """Delta coalescer that parks the terminal handler in ``flush``."""
+
+            async def flush(self) -> None:
+                """Signal entry and wait until the assertion releases delivery."""
+                flush_entered.set()
+                await release_flush.wait()
+
+        async with httpx.AsyncClient(
+            base_url="http://127.0.0.1:8000",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            task = asyncio.create_task(
+                codex_native_forwarder._handle_event(
+                    client,
+                    session_id="conv_123",
+                    bridge_dir=tmp_path,
+                    usage_coalescer=_usage_coalescer(client),
+                    elicitation_tracker=_elicitation_tracker(),
+                    event=_completed_event("turn_123"),
+                    delta_coalescer=_BlockingDeltaCoalescer(),  # type: ignore[arg-type]
+                )
+            )
+            await asyncio.wait_for(flush_entered.wait(), timeout=5.0)
+
+            state = read_bridge_state(tmp_path)
+            assert state is not None
+            assert state.active_turn_id is None
+            assert posted == [], "terminal status must still follow pending output delivery"
+
+            release_flush.set()
+            await asyncio.wait_for(task, timeout=5.0)
+
+    asyncio.run(run())
+
+    assert [
+        payload["data"]["status"]
+        for payload in posted
+        if payload["type"] == "external_session_status"
+    ] == ["idle"]
+
+
 def test_forwarder_posts_agent_item_after_stale_terminal_event(tmp_path: Path) -> None:
     """
     Stale turn completion does not block newer Codex response mirroring.

--- a/tests/test_codex_native_bridge.py
+++ b/tests/test_codex_native_bridge.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 
 import pytest
 
+from omnigent import codex_native_bridge
 from omnigent.codex_native_bridge import (
     CodexNativeBridgeState,
     cancel_pending_mcp_startup,
@@ -24,6 +26,7 @@ from omnigent.codex_native_bridge import (
     read_mcp_startup,
     read_policy_hook_config,
     settle_pending_mcp_startup,
+    update_active_turn_id,
     update_mcp_server_startup,
     write_bridge_startup_error,
     write_bridge_state,
@@ -292,6 +295,58 @@ def test_clear_active_turn_id_if_matches_no_state_returns_true(bridge_dir: Path)
     """
     # bridge_dir exists (fixture) but no state.json was written.
     assert clear_active_turn_id_if_matches(bridge_dir, "turn_1") is True
+
+
+def test_active_turn_compare_and_clear_is_atomic_with_concurrent_update(
+    bridge_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clearing turn A cannot overwrite a concurrent turn-B state update."""
+    _seed_active_turn(bridge_dir, "turn_a")
+    original_write = codex_native_bridge._write_bridge_state_unlocked
+    clear_write_entered = threading.Event()
+    release_clear_write = threading.Event()
+    update_finished = threading.Event()
+    clear_result: list[bool] = []
+
+    def blocking_write(path: Path, state: CodexNativeBridgeState) -> None:
+        """Hold turn A's clear after its read while it owns the state lock."""
+        if state.active_turn_id is None:
+            clear_write_entered.set()
+            assert release_clear_write.wait(timeout=5.0)
+        original_write(path, state)
+
+    monkeypatch.setattr(codex_native_bridge, "_write_bridge_state_unlocked", blocking_write)
+
+    def clear_turn_a() -> None:
+        """Clear turn A through the compare-and-swap helper."""
+        clear_result.append(clear_active_turn_id_if_matches(bridge_dir, "turn_a"))
+
+    def publish_turn_b() -> None:
+        """Publish the newer turn B and signal when its locked update lands."""
+        update_active_turn_id(bridge_dir, "turn_b")
+        update_finished.set()
+
+    clear_thread = threading.Thread(target=clear_turn_a)
+    update_thread = threading.Thread(target=publish_turn_b)
+    clear_thread.start()
+    assert clear_write_entered.wait(timeout=5.0)
+    update_thread.start()
+    try:
+        assert not update_finished.wait(timeout=0.1), (
+            "turn B wrote while turn A's compare-and-clear still held the state lock"
+        )
+    finally:
+        release_clear_write.set()
+        clear_thread.join(timeout=5.0)
+        update_thread.join(timeout=5.0)
+
+    assert not clear_thread.is_alive()
+    assert not update_thread.is_alive()
+    assert clear_result == [True]
+    state = read_bridge_state(bridge_dir)
+    assert state is not None
+    assert state.active_turn_id == "turn_b"
 
 
 def test_bridge_startup_error_round_trips_and_is_cleared(bridge_dir: Path) -> None:


### PR DESCRIPTION
## Related issue

N/A — found while investigating a production Codex-native session from logs; no public issue was filed.

## Summary

- Clear a terminal Codex turn from bridge control state as soon as `turn/completed` is observed, before potentially slow transcript/delta delivery, while preserving the existing transcript-before-status ordering.
- Preserve structured app-server RPC errors and recover only the authoritative `-32600: no active turn to steer` response: compare-and-clear the expected stale ID, reread state, then deliver the message once via `turn/start` (or steer a concurrently started newer turn).
- Serialize bridge state read/modify/write cycles across local processes so stale-turn cleanup cannot erase a concurrent `turn/started(B)` update.
- Gate the newly landed compacted-fork compatibility E2E on server v0.12: released v0.11 predates that server-side remapping contract and failed deterministically in this PR's new-runner/old-server lane.

ELI5: Omnigent sometimes still had turn A marked “active” after Codex had finished it, so the next message was sent to a closed turn. The bridge now closes its bookkeeping promptly and, if Codex catches the tiny remaining race, safely starts turn B instead of showing an error.

```mermaid
sequenceDiagram
    participant C as Codex
    participant B as Native bridge
    participant O as Output delivery
    C->>B: turn/completed(A)
    B->>B: compare-and-clear active A
    B->>O: flush transcript/deltas
    B->>O: post idle(A)
    Note over B,C: If a follow-up raced the notification
    B->>C: turn/steer(A)
    C-->>B: -32600 no active turn
    B->>B: clear A, reread state
    B->>C: turn/start(B) once
```

## Test Plan

- Red proof on unmodified `upstream/main` with only the new E2E added: failed in 16s with a durable error item containing `{'code': -32600, 'message': 'no active turn to steer'}`.
- Same real host + Codex app-server E2E on this branch: passed twice (17s and 19.48s), returned the second marker, and persisted no new error item.
- `pytest` across the five affected Codex app-server/bridge/executor/forwarder files: 431 passed.
- Focused race/error tests: 14 passed (explicit recovery, no retry for ambiguous failures, concurrent turn preservation, control-state clear before blocked output flush).
- `pre-commit run --all-files`: passed.
- `tests/test_server_compat.py`: 26 passed; the corrected v0.12 feature gate also passed file-scoped pre-commit checks.
- Full `tests/e2e/` matrix: 333 passed and 102 skipped; 31 unrelated local provider/environment failures (mock routing and unavailable gateway credentials). The added regression passed both in the matrix and in isolation.

## Demo

N/A — backend lifecycle fix with automated real-app-server coverage.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The E2E starts a real host and native Codex app-server, completes turn A, restores A as the stale bridge ID, then sends turn B through the same sessions API used by the Web UI. It fails on main at the real RPC boundary and passes on this branch without persisting an error.

## Changelog

Codex web sessions now recover follow-up messages that arrive while a completed turn is still draining output.
