### PR TITLE
feat(import): use the harness's own session title on import

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5919,6 +5919,7 @@ def import_session_command(
             "source": imported.source,
             "external_session_id": imported.external_session_id,
             "workspace": imported.workspace,
+            "title": imported.native_title,
             "force": force,
             "items": [
                 {

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -55,6 +55,7 @@ class ImportSessionRequest(BaseModel):
     source: ImportSource
     external_session_id: str = Field(min_length=1, max_length=128)
     workspace: str | None = Field(default=None, max_length=2048)
+    title: str | None = Field(default=None, max_length=512)
     force: bool = False
     items: list[ImportItemInput] = Field(min_length=1, max_length=100_000)
 
@@ -174,7 +175,7 @@ def create_imports_router(
         try:
             conversation = await asyncio.to_thread(
                 conversation_store.create_conversation,
-                title=title_from_items(items),
+                title=(body.title or "").strip() or title_from_items(items),
                 agent_id=agent_id,
                 workspace=body.workspace,
                 conversation_id=_import_conversation_id(body.source, body.external_session_id),

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sqlite3
 import subprocess
 from hashlib import sha256
 from pathlib import Path
@@ -276,6 +277,39 @@ def _claude_workspace(transcript_path: Path) -> str | None:
     return None
 
 
+def _claude_native_title(transcript_path: Path) -> str | None:
+    """Return Claude Code's own session title, custom name over AI-generated.
+
+    Claude appends ``custom-title`` (user rename) and ``ai-title`` (generated)
+    lines to the JSONL as they change; the last of each wins. A user's rename
+    beats the AI title.
+    """
+    custom: str | None = None
+    ai: str | None = None
+    try:
+        with transcript_path.open(encoding="utf-8") as handle:
+            for line in handle:
+                if "-title" not in line:  # cheap prefilter; the type is custom-title / ai-title
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                if record.get("type") == "custom-title":
+                    value = record.get("customTitle")
+                    if isinstance(value, str) and value.strip():
+                        custom = value.strip()
+                elif record.get("type") == "ai-title":
+                    value = record.get("aiTitle")
+                    if isinstance(value, str) and value.strip():
+                        ai = value.strip()
+    except OSError:
+        return None
+    return custom or ai
+
+
 def load_claude_session(
     session_id: str,
     *,
@@ -312,6 +346,7 @@ def load_claude_session(
         external_session_id=session_id,
         workspace=_claude_workspace(transcript_path),
         items=items,
+        native_title=_claude_native_title(transcript_path),
     )
 
 
@@ -432,6 +467,71 @@ def _find_archived_codex_rollout(codex_home: Path, session_id: str) -> Path | No
     return max(matches, key=lambda path: path.stat().st_mtime) if matches else None
 
 
+def _codex_thread_name_from_index(home: Path, session_id: str) -> str | None:
+    """Return the user's thread rename from ``session_index.jsonl``, if any.
+
+    Renaming a Codex thread appends ``{id, thread_name, updated_at}`` here; it
+    is codex's authoritative rename store and, unlike ``threads.title`` in the
+    state DB, always reflects the rename. Last entry for the id wins.
+    """
+    index = home / "session_index.jsonl"
+    name: str | None = None
+    try:
+        with index.open(encoding="utf-8") as handle:
+            for line in handle:
+                if session_id not in line:  # cheap prefilter before JSON parse
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(record, dict) and record.get("id") == session_id:
+                    value = record.get("thread_name")
+                    if isinstance(value, str) and value.strip():
+                        name = value.strip()
+    except OSError:
+        return None
+    return name
+
+
+def _codex_native_title(home: Path, session_id: str) -> str | None:
+    """Return the user's custom Codex thread title, or None if auto-derived.
+
+    A rename lands in ``session_index.jsonl`` (``thread_name``) — the reliable
+    source — so check that first. As a fallback, ``state_<n>.sqlite``'s
+    ``threads.title`` holds the raw first user message until renamed, so only a
+    title that diverges from ``first_user_message`` is a real custom name;
+    otherwise the first-message synthesis is better.
+    """
+    indexed = _codex_thread_name_from_index(home, session_id)
+    if indexed:
+        return indexed
+
+    def _state_db_version(path: Path) -> int:
+        match = re.search(r"state_(\d+)\.sqlite$", path.name)
+        return int(match.group(1)) if match else -1
+
+    dbs = sorted(home.glob("state_*.sqlite"), key=_state_db_version, reverse=True)
+    for db in dbs:
+        try:
+            con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+            try:
+                row = con.execute(
+                    "SELECT title, first_user_message FROM threads WHERE id = ?",
+                    (session_id,),
+                ).fetchone()
+            finally:
+                con.close()
+        except sqlite3.Error:
+            continue
+        if row is None:
+            continue
+        title = (row[0] or "").strip()
+        first_message = (row[1] or "").strip()
+        return title if title and title != first_message else None
+    return None
+
+
 def load_codex_session(
     session_id: str,
     *,
@@ -482,6 +582,7 @@ def load_codex_session(
         external_session_id=session_id,
         workspace=workspace,
         items=tuple(items),
+        native_title=_codex_native_title(home, session_id),
     )
 
 
@@ -1189,11 +1290,18 @@ def load_opencode_session(
         )
     workspace_value = info.get("directory") if isinstance(info, dict) else None
     workspace = workspace_value.strip() if isinstance(workspace_value, str) else None
+    # OpenCode auto-generates a session title (info.title); carry it as the
+    # native title instead of synthesizing from the first message.
+    title_value = info.get("title") if isinstance(info, dict) else None
+    native_title = (
+        title_value.strip() if isinstance(title_value, str) and title_value.strip() else None
+    )
     return LocalSessionImport(
         source="opencode",
         external_session_id=session_id,
         workspace=workspace or None,
         items=items,
+        native_title=native_title,
     )
 
 

--- a/omnigent/session_import/models.py
+++ b/omnigent/session_import/models.py
@@ -33,11 +33,15 @@ class LocalSessionImport:
     external_session_id: str
     workspace: str | None
     items: tuple[NewConversationItem, ...]
+    # The harness's own session title (Claude's custom/ai title, Codex's thread
+    # title) when the transcript carried one; None to fall back to the first
+    # user message.
+    native_title: str | None = None
 
     @property
     def title(self) -> str | None:
-        """Return a sidebar title derived from the first user message."""
-        return title_from_items(self.items)
+        """Prefer the harness's own title, else derive from the first user message."""
+        return self.native_title or title_from_items(self.items)
 
 
 def title_from_items(items: Sequence[NewConversationItem]) -> str | None:

--- a/openapi.json
+++ b/openapi.json
@@ -2233,6 +2233,18 @@
             "title": "Source",
             "type": "string"
           },
+          "title": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
           "workspace": {
             "anyOf": [
               {

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -75,6 +75,7 @@ def test_import_command_loads_local_session_and_posts_normalized_items(tmp_path:
         "source": "claude",
         "external_session_id": session_id,
         "workspace": "/repo",
+        "title": None,
         "force": False,
         "items": [
             {

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -75,6 +75,38 @@ async def test_import_session_creates_normal_session_and_blocks_duplicate(
     assert [item["type"] for item in items.json()["data"]] == ["message", "message"]
 
 
+async def test_import_session_uses_native_title_when_supplied(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A supplied harness title becomes the conversation title over the first message."""
+    _seed_claude_agent(db_uri)
+    payload = {
+        "source": "claude",
+        "external_session_id": "claude-titled-1",
+        "title": "My renamed thread",
+        "items": [
+            {
+                "type": "message",
+                "response_id": "claude:turn-1",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "inspect TODO.md"}],
+                },
+            }
+        ],
+    }
+
+    created = await client.post("/v1/imports", json=payload)
+
+    assert created.status_code == 201
+    conversation = SqlAlchemyConversationStore(db_uri).get_conversation(
+        created.json()["session_id"]
+    )
+    assert conversation is not None
+    assert conversation.title == "My renamed thread"
+
+
 async def test_concurrent_identical_imports_return_one_session(
     client: httpx.AsyncClient,
     db_uri: str,

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -209,6 +210,7 @@ def test_load_opencode_session_preserves_messages_files_and_tools(
         "info": {
             "id": "ses_import",
             "directory": "/repo",
+            "title": "OpenCode session title",
             "version": "1.17.18",
         },
         "messages": [
@@ -258,6 +260,8 @@ def test_load_opencode_session_preserves_messages_files_and_tools(
     assert imported.source == "opencode"
     assert imported.external_session_id == "ses_import"
     assert imported.workspace == "/repo"
+    assert imported.native_title == "OpenCode session title"
+    assert imported.title == "OpenCode session title"
     assert [item.type for item in imported.items] == [
         "message",
         "message",
@@ -377,6 +381,72 @@ def test_load_claude_session_normalizes_parent_transcript(tmp_path: Path) -> Non
     ]
     assert imported.items[1].data.model_dump()["call_id"] == "toolu_read_1"
     assert imported.items[3].data.model_dump()["agent"] == "claude-native-ui"
+
+
+def _write_claude_transcript_with_titles(
+    tmp_path: Path,
+    session_id: str,
+    *,
+    ai_title: str | None,
+    custom_title: str | None,
+) -> None:
+    """Write a minimal Claude transcript, optionally stamped with title lines."""
+    transcript = tmp_path / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records: list[dict[str, object]] = [
+        {
+            "type": "user",
+            "uuid": "user-1",
+            "cwd": "/repo",
+            "message": {"role": "user", "content": "inspect TODO.md"},
+        }
+    ]
+    if ai_title is not None:
+        records.append({"type": "ai-title", "aiTitle": ai_title, "sessionId": session_id})
+    if custom_title is not None:
+        records.append(
+            {"type": "custom-title", "customTitle": custom_title, "sessionId": session_id}
+        )
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+
+
+def test_load_claude_session_prefers_custom_title_over_ai_title(tmp_path: Path) -> None:
+    """A user rename (custom-title) wins over the generated ai-title."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    _write_claude_transcript_with_titles(
+        tmp_path, session_id, ai_title="Generated summary", custom_title="My renamed thread"
+    )
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    assert imported.native_title == "My renamed thread"
+    assert imported.title == "My renamed thread"
+
+
+def test_load_claude_session_falls_back_to_ai_title(tmp_path: Path) -> None:
+    """With no rename, the generated ai-title is used over the first message."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    _write_claude_transcript_with_titles(
+        tmp_path, session_id, ai_title="Generated summary", custom_title=None
+    )
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    assert imported.native_title == "Generated summary"
+    assert imported.title == "Generated summary"
+
+
+def test_load_claude_session_synthesizes_title_without_native(tmp_path: Path) -> None:
+    """No title lines → the title is synthesized from the first user message."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    _write_claude_transcript_with_titles(tmp_path, session_id, ai_title=None, custom_title=None)
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    assert imported.native_title is None
+    assert imported.title == "inspect TODO.md"
 
 
 def test_load_claude_session_rejects_empty_history(tmp_path: Path) -> None:
@@ -554,6 +624,103 @@ def test_load_codex_session_normalizes_response_items(tmp_path: Path) -> None:
         "call_id": "call_2",
         "output": "",
     }
+
+
+def _write_codex_rollout(tmp_path: Path, session_id: str, *, first_message: str) -> None:
+    """Write a minimal importable Codex rollout with one user message."""
+    rollout = (
+        tmp_path
+        / "sessions"
+        / "2026"
+        / "07"
+        / "15"
+        / f"rollout-2026-07-15T12-00-00-{session_id}.jsonl"
+    )
+    rollout.parent.mkdir(parents=True)
+    records = [
+        {"type": "session_meta", "payload": {"id": session_id, "cwd": "/repo"}},
+        {"type": "turn_context", "payload": {"turn_id": "turn_1", "cwd": "/repo"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": first_message}],
+            },
+        },
+    ]
+    rollout.write_text("".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8")
+
+
+def _write_codex_threads_db(
+    tmp_path: Path, session_id: str, *, title: str, first_user_message: str
+) -> None:
+    """Write a codex ``state_5.sqlite`` holding one thread's title metadata."""
+    con = sqlite3.connect(tmp_path / "state_5.sqlite")
+    try:
+        con.execute("CREATE TABLE threads (id TEXT, title TEXT, first_user_message TEXT)")
+        con.execute(
+            "INSERT INTO threads (id, title, first_user_message) VALUES (?, ?, ?)",
+            (session_id, title, first_user_message),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def test_load_codex_session_uses_custom_thread_title(tmp_path: Path) -> None:
+    """A renamed Codex thread (title != first message) carries its custom name."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    _write_codex_rollout(tmp_path, session_id, first_message="inspect TODO.md")
+    _write_codex_threads_db(
+        tmp_path, session_id, title="my renamed thread", first_user_message="inspect TODO.md"
+    )
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    assert imported.native_title == "my renamed thread"
+    assert imported.title == "my renamed thread"
+
+
+def test_load_codex_session_ignores_auto_thread_title(tmp_path: Path) -> None:
+    """An un-renamed thread (title == first message) synthesizes from items instead."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    _write_codex_rollout(tmp_path, session_id, first_message="inspect TODO.md")
+    _write_codex_threads_db(
+        tmp_path, session_id, title="inspect TODO.md", first_user_message="inspect TODO.md"
+    )
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    assert imported.native_title is None
+    assert imported.title == "inspect TODO.md"
+
+
+def test_load_codex_session_uses_session_index_rename(tmp_path: Path) -> None:
+    """A rename lives in session_index.jsonl even when threads.title still lags.
+
+    Renaming a Codex thread records ``thread_name`` in ``session_index.jsonl``
+    while ``threads.title`` can keep the original first message — so the index
+    must win.
+    """
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    _write_codex_rollout(tmp_path, session_id, first_message="inspect TODO.md")
+    _write_codex_threads_db(
+        tmp_path, session_id, title="inspect TODO.md", first_user_message="inspect TODO.md"
+    )
+    # An earlier auto entry, then the user's rename — last entry for the id wins.
+    (tmp_path / "session_index.jsonl").write_text(
+        json.dumps({"id": session_id, "thread_name": "inspect TODO.md"})
+        + "\n"
+        + json.dumps({"id": session_id, "thread_name": "my-renamed-thread"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    assert imported.native_title == "my-renamed-thread"
+    assert imported.title == "my-renamed-thread"
 
 
 def test_load_codex_session_finds_archived_rollout(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

N/A — small import-fidelity enhancement.

## Summary

When importing a local session, carry the harness's **own** session name instead
of always synthesizing a title from the first user message.

- **Claude**: prefer the user rename (`custom-title`) over the generated
  `ai-title`; fall back to first-message synthesis when neither is present.
- **Codex**: use the thread rename from `session_index.jsonl` (`thread_name`) —
  codex's authoritative rename store — falling back to `state_*.sqlite`'s
  `threads.title` only when it diverges from the first message; otherwise
  synthesize. (Codex writes renames to the index, not the state DB, so reading
  only the state DB missed them.)
- **OpenCode**: carry its auto-generated `info.title` from the export.
- Other harnesses expose no title, so they keep first-message synthesis.

`LocalSessionImport` gains `native_title`; the CLI forwards it and
`POST /v1/imports` accepts an optional `title` that becomes the conversation
title when present.

## Test Plan

```
uv run ruff check . && uv run ruff format --check .
uv run pytest tests/test_session_import.py tests/server/routes/test_imports.py tests/cli/test_import.py
```

Unit tests cover: Claude custom-title over ai-title and synthesis fallback;
Codex `session_index.jsonl` rename winning over a lagging `threads.title`, plus
the state-DB rename and auto-derived (synthesize) cases; OpenCode `info.title`;
and `POST /v1/imports` honoring a supplied title.

## Demo

N/A — non-visual (import title fidelity).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the unit tests above.

## Changelog

Imported Claude Code, Codex, and OpenCode sessions now keep their original
session title.
