### PR TITLE
fix(onboarding): gate nimble_extract behind the nimble extra

### DIFF
--- a/omnigent/onboarding/agent/tools/python/list_builtin_tools.py
+++ b/omnigent/onboarding/agent/tools/python/list_builtin_tools.py
@@ -20,7 +20,6 @@ _TOOL_CLASSES: dict[str, tuple[str, str]] = {
     "download_file": ("omnigent.tools.builtins.download_file", "DownloadFileTool"),
     "export_agent": ("omnigent.tools.builtins.export_agent", "ExportAgentTool"),
     "list_files": ("omnigent.tools.builtins.list_files", "ListFilesTool"),
-    "nimble_extract": ("omnigent.tools.builtins.nimble_extract", "NimbleExtractTool"),
     "search_conversations": (
         "omnigent.tools.builtins.search_conversations",
         "SearchConversationsTool",
@@ -38,20 +37,29 @@ def _hindsight_available() -> bool:
     return importlib.util.find_spec("hindsight_client") is not None
 
 
-def _nimble_research_available() -> bool:
+def _nimble_available() -> bool:
     """Return True when the optional ``nimble-python`` SDK is installed."""
     import importlib.util
 
     return importlib.util.find_spec("nimble_python") is not None
 
 
-# nimble_research needs the `nimble` extra's SDK; advertised only when it is
-# installed, so the assistant never recommends an unusable tool.
-# nimble_extract talks raw httpx and stays unconditional.
-if _nimble_research_available():
-    _TOOL_CLASSES["nimble_research"] = (
-        "omnigent.tools.builtins.nimble_research",
-        "NimbleResearchTool",
+# Both Nimble tools need a Nimble account and API key, so the `nimble` extra
+# is the opt-in signal for the pair: advertised only when it is installed, so
+# the assistant never recommends a tool the author cannot use. Runtime is
+# unaffected: a spec may still enable either by name.
+if _nimble_available():
+    _TOOL_CLASSES.update(
+        {
+            "nimble_extract": (
+                "omnigent.tools.builtins.nimble_extract",
+                "NimbleExtractTool",
+            ),
+            "nimble_research": (
+                "omnigent.tools.builtins.nimble_research",
+                "NimbleResearchTool",
+            ),
+        }
     )
 
 

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -310,11 +310,13 @@ if _hindsight_available():
 # between the reserved-name check and the factory dispatch.
 BUILTIN_NAMES: frozenset[str] = frozenset(_BUILTIN_REGISTRY.keys())
 
-# Subset of names that have a user-facing factory. Used by the
-# onboarding ``list_builtin_tools`` helper, which only lists
-# tools an agent spec can actually enable via
-# ``tools.builtins`` — framework-owned names would just confuse
-# the agent author.
+# Subset of names that have a user-facing factory: the tools an
+# agent spec can actually enable via ``tools.builtins``.
+# The onboarding ``list_builtin_tools`` helper covers the same
+# ground but keeps its own hand-maintained table, because it must
+# not import this package (see that module's docstring), so a new
+# builtin, or a new optional-extra gate, has to be added in both
+# places.
 INSTANTIABLE_BUILTINS: frozenset[str] = frozenset(
     name for name, factory in _BUILTIN_REGISTRY.items() if factory is not None
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,9 +246,10 @@ cursor = ["cursor-sdk>=0.1.7"]
 # _reflect). The tools import the client lazily, so only users who enable a
 # Hindsight memory tool need this extra.
 hindsight = ["hindsight-client>=0.4.0"]
-# Nimble research runs (the `nimble_research` builtin). The tool imports the
-# nimble-python client lazily, so only users who enable nimble_research need
-# this extra. nimble_extract talks raw httpx and needs no extra.
+# The Nimble builtins (`nimble_research`, `nimble_extract`). nimble_research
+# imports the nimble-python client lazily; nimble_extract talks raw httpx and
+# needs no client at runtime. Installing this extra is the opt-in signal that
+# surfaces both tools in the onboarding assistant's builtin list.
 nimble = ["nimble-python>=1.2.0,<2"]
 # Slack integration (`omni integration slack`). The @omnigent socket-mode bot
 # lives in the separate `omnigent-slack` package (heavy deps — slack_bolt /

--- a/tests/onboarding/test_list_builtin_tools.py
+++ b/tests/onboarding/test_list_builtin_tools.py
@@ -1,0 +1,90 @@
+"""Tests for the onboarding ``list_builtin_tools`` helper's optional-extra gates.
+
+The helper keeps its own hand-maintained table of builtins (it must not import
+``omnigent.tools.builtins``), so its optional-extra gates can drift from the
+real registry. These tests pin the gates.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from collections.abc import Generator
+from importlib.machinery import ModuleSpec
+
+import pytest
+
+import omnigent.onboarding.agent.tools.python.list_builtin_tools as list_tools_mod
+
+
+def _reload_with_specs(
+    monkeypatch: pytest.MonkeyPatch,
+    present: set[str],
+) -> None:
+    """Reload the helper with only ``present`` optional SDKs visible.
+
+    ``find_spec`` is patched rather than the packages installed/uninstalled,
+    because the gates probe via :func:`importlib.util.find_spec` (no import).
+
+    :param monkeypatch: pytest monkeypatch fixture.
+    :param present: Optional SDK module names that should appear installed.
+    """
+    real_find_spec = importlib.util.find_spec
+    optional = {"nimble_python", "hindsight_client"}
+
+    def fake_find_spec(name: str, package: str | None = None) -> ModuleSpec | None:
+        if name in optional:
+            return ModuleSpec(name, None) if name in present else None
+        return real_find_spec(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    importlib.reload(list_tools_mod)
+
+
+@pytest.fixture(autouse=True)
+def _restore_module() -> Generator[None, None, None]:
+    """Reload the helper against the real environment after each test."""
+    yield
+    importlib.reload(list_tools_mod)
+
+
+def test_nimble_tools_absent_when_sdk_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the ``nimble`` extra neither Nimble tool is advertised.
+
+    ``nimble_extract`` needs no client at runtime, but it needs the same Nimble
+    account as ``nimble_research``, so the extra gates the pair: otherwise the
+    assistant recommends a tool the agent author has no credentials for.
+    """
+    _reload_with_specs(monkeypatch, present=set())
+
+    assert "nimble_extract" not in list_tools_mod._TOOL_CLASSES
+    assert "nimble_research" not in list_tools_mod._TOOL_CLASSES
+
+
+def test_nimble_tools_present_when_sdk_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With the ``nimble`` extra installed both Nimble tools are advertised."""
+    _reload_with_specs(monkeypatch, present={"nimble_python"})
+
+    assert "nimble_extract" in list_tools_mod._TOOL_CLASSES
+    assert "nimble_research" in list_tools_mod._TOOL_CLASSES
+
+
+def test_hindsight_tools_gated_on_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Hindsight gate keys off ``hindsight-client``, independently of Nimble."""
+    hindsight = {"hindsight_retain", "hindsight_recall", "hindsight_reflect"}
+
+    _reload_with_specs(monkeypatch, present=set())
+    assert not hindsight & set(list_tools_mod._TOOL_CLASSES)
+
+    _reload_with_specs(monkeypatch, present={"hindsight_client"})
+    assert hindsight <= set(list_tools_mod._TOOL_CLASSES)
+    assert "nimble_extract" not in list_tools_mod._TOOL_CLASSES
+
+
+def test_unconditional_tools_always_advertised(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tools with no optional dependency survive every gate combination."""
+    _reload_with_specs(monkeypatch, present=set())
+
+    assert {"web_search", "web_fetch", "list_files", "upload_file"} <= set(
+        list_tools_mod._TOOL_CLASSES
+    )


### PR DESCRIPTION
## Related issue

Linear OMNI-2898 (no GitHub issue for this one). Labelled `validated:reproduced` by repro-agent.

## Summary

- The onboarding assistant's `list_builtin_tools` advertised `nimble_extract` on **every** install, while its sibling `nimble_research` was gated on the `nimble` extra's SDK. Both tools need the same Nimble account and API key, so an agent author without one was recommended a tool they could not use.
- `nimble_extract` now sits in the same gate as `nimble_research`.
- Also corrects the two comments that let the gate drift (see below).

**The gate is discovery-only.** It changes what the onboarding assistant offers, not what an agent can run:

| no `nimble` extra installed | before | after |
| --- | --- | --- |
| `nimble_extract` listed by `list_builtin_tools` | yes | no |
| `nimble_research` listed by `list_builtin_tools` | no | no |
| either tool works when a spec names it in `tools.builtins` | yes | yes (unchanged) |

`nimble_extract` still talks raw `httpx` and needs no client at runtime; installing the extra is simply the opt-in signal that the author has a Nimble account.

**Root cause.** `list_builtin_tools.py` keeps a second, hand-maintained copy of the builtin table because it must not import `omnigent.tools.builtins` (that transitive chain conflicts with the `mcp` pip package in subprocess environments). A comment on `INSTANTIABLE_BUILTINS` claimed the onboarding helper consumed it, which it never did (only tests reference it), so nothing flagged the missing gate when `nimble_extract` was added. That comment is now corrected to say a new builtin, or a new optional-extra gate, has to land in both places. The `nimble` extra comment in `pyproject.toml` is updated for the same reason.

Deduplicating the two tables is deliberately out of scope: the duplication exists for the import conflict above, and unwinding it is a much larger change than this bug warrants.

## Test Plan

- **New** `tests/onboarding/test_list_builtin_tools.py` (4 tests). This module had no test coverage at all before; the tests pin both optional-extra gates plus the ungated tools, mirroring the existing `tests/tools/builtins/test_hindsight.py` gate pattern.
- Confirmed the tests actually catch the bug, rather than passing either way:
  ```
  at HEAD (bug present):  2 failed, 2 passed
  with this change:       4 passed
  ```
- Confirmed the before-state on a real install without the `nimble` extra:
  ```
  nimble_python installed:    False
  nimble_extract advertised?  True     <- the bug
  nimble_research advertised? False
  ```
- `ruff format`, `ruff check`, and `pyrefly` clean on the changed files; the four `.venv`-invoked lint hooks (`no-global-asyncio-patch`, `no-skipped-tests`, `no-hardcoded-models`, `sync-version-py`) pass.
- `tests/tools/builtins/test_registry_unified.py`, `test_hindsight.py`, and `tests/onboarding/test_onboarding_agent.py` show identical results before and after this change (12 pre-existing failures in that local env, which lacks the `hindsight` extra).

## Demo

N/A (no visual change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the half the unit tests cannot reach: that the change is discovery-only. The unit tests pin the gate on `_TOOL_CLASSES`; separately I traced that a builtin reaches an agent only via `ToolManager._register_builtins()` iterating `spec.tools.builtins` (`omnigent/tools/manager.py:329`), with no auto-registration path, so hiding `nimble_extract` from the onboarding list cannot stop a spec from enabling it.

## Changelog

The onboarding assistant no longer recommends the `nimble_extract` builtin unless the `nimble` extra is installed, matching how it already treated `nimble_research`.
