### PR TITLE
fix(onboarding): detect the Claude Code managed-settings gateway

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -24,6 +24,10 @@ import uuid
 
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.llms.adapters._content import redact_binary_payloads
+from omnigent.onboarding.ambient import (
+    CLAUDE_CODE_MANAGED_SETTINGS_PATHS,
+    claude_managed_gateway,
+)
 from omnigent.runtime.tool_result_replay import (
     blocks_from_parsed_list,
     image_payloads_in_blocks,
@@ -254,11 +258,11 @@ _SESSION_LABELS = {
     _WRAPPER_LABEL_KEY: _WRAPPER_LABEL_VALUE,
 }
 _CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
-_CLAUDE_CODE_MANAGED_SETTINGS_PATHS: tuple[Path, ...] = (
-    Path("/Library/Application Support/ClaudeCode/managed-settings.json"),
-    Path("/etc/claude-code/managed-settings.json"),
-    Path(os.environ.get("PROGRAMDATA", "C:/ProgramData")) / "ClaudeCode" / "managed-settings.json",
-)
+# Test override for the managed-settings chain. ``None`` means "use the ambient
+# detector's chain", which is the single canonical definition — binding a *copy*
+# here would leave two independently-isolatable sources of the same host state,
+# so a fixture that neutralized one would silently miss this reader.
+_CLAUDE_CODE_MANAGED_SETTINGS_PATHS: tuple[Path, ...] | None = None
 _CLAUDE_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 _RESUME_ACTION_SWITCH = "switch"
 _RESUME_ACTION_MOVE = "move"
@@ -626,6 +630,20 @@ def _claude_model_display_name(tier: str, model_id: str) -> str:
     return f"{family} {'.'.join(version_parts)}" if version_parts else family
 
 
+def _managed_settings_paths() -> tuple[Path, ...]:
+    """The Claude Code managed-settings chain to read.
+
+    Resolved at call time so the ambient detector stays the single definition of
+    the chain (and the single place tests neutralize it), while a test that needs
+    to point *this* module somewhere specific can still set
+    :data:`_CLAUDE_CODE_MANAGED_SETTINGS_PATHS`.
+
+    :returns: The override when one is set, else the canonical ambient chain.
+    """
+    override = _CLAUDE_CODE_MANAGED_SETTINGS_PATHS
+    return CLAUDE_CODE_MANAGED_SETTINGS_PATHS if override is None else override
+
+
 def _managed_claude_model_config() -> ClaudeNativeUcodeConfig | None:
     """Read the model overrides Claude Code applies from managed settings."""
     allowed_env = {
@@ -633,7 +651,7 @@ def _managed_claude_model_config() -> ClaudeNativeUcodeConfig | None:
         _ANTHROPIC_CUSTOM_MODEL_OPTION_ENV,
         _ANTHROPIC_CUSTOM_MODEL_OPTION_NAME_ENV,
     }
-    for path in _CLAUDE_CODE_MANAGED_SETTINGS_PATHS:
+    for path in _managed_settings_paths():
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
@@ -666,25 +684,7 @@ def managed_claude_gateway_signal() -> tuple[str | None, bool]:
     :returns: ``(base_url, has_credential)`` from the first readable managed
         settings file, or ``(None, False)`` when none is present or parseable.
     """
-    for path in _CLAUDE_CODE_MANAGED_SETTINGS_PATHS:
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            continue
-        if not isinstance(payload, dict):
-            continue
-        raw_env = payload.get("env")
-        env = raw_env if isinstance(raw_env, dict) else {}
-        raw_base_url = env.get("ANTHROPIC_BASE_URL")
-        base_url = raw_base_url.strip() if isinstance(raw_base_url, str) else None
-        has_helper = bool(payload.get("apiKeyHelper"))
-        use_gateway = str(env.get("CLAUDE_CODE_USE_GATEWAY", "")).strip().lower() not in (
-            "",
-            "0",
-            "false",
-        )
-        return base_url or None, has_helper or use_gateway
-    return None, False
+    return claude_managed_gateway(_managed_settings_paths())
 
 
 def claude_native_model_options(
@@ -2908,6 +2908,7 @@ def _native_claude_config_from_entry(
     """
     from omnigent.onboarding.provider_config import (
         BEDROCK_KIND,
+        CLI_CONFIG_KIND,
         DATABRICKS_KIND,
         GATEWAY_KIND,
         KEY_KIND,
@@ -2921,6 +2922,15 @@ def _native_claude_config_from_entry(
     if entry.kind == DATABRICKS_KIND:
         _logger.info("native-claude routing: Databricks ucode profile %r", entry.profile)
         return _ucode_config_for_profile(entry.profile, refresh_models=refresh_models)
+    if entry.kind == CLI_CONFIG_KIND:
+        # The endpoint AND its credential live in Claude Code's own settings
+        # chain, which the CLI applies at its own launch — returning None is
+        # what routes through them, so omnigent must not override anything.
+        _logger.info(
+            "native-claude routing: Claude Code's own settings (cli-config provider %r)",
+            entry.name,
+        )
+        return None
     _logger.info("native-claude routing: Claude CLI login (subscription provider %r)", entry.name)
     return None
 

--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -544,6 +544,32 @@ def _family_credential_label(  # type: ignore[explicit-any]  # config is a yaml-
     return f"{base} ({hint})" if hint else base
 
 
+def _cli_config_source_label(cli: str | None) -> str:
+    """Name the config file a ``cli-config`` detection's credential lives in.
+
+    :param cli: The detection's ``cli`` — ``"codex"`` or ``"claude"``.
+    :returns: A short menu-label fragment, e.g. ``"Codex config"``.
+    """
+    return "Claude Code settings" if cli == "claude" else "Codex config"
+
+
+def _cli_config_source_description(det: DetectedProvider) -> str:
+    """Describe where a ``cli-config`` detection's credential comes from.
+
+    :param det: A ``kind="cli-config"`` detection.
+    :returns: One sentence for the add menu's description column.
+    """
+    if det.cli == "claude":
+        return (
+            "Use the AI Gateway your Claude Code managed settings pin and "
+            "authenticate; Claude Code applies them itself at launch."
+        )
+    return (
+        f"Use the {str(det.model_provider)!r} provider your ~/.codex/config.toml "
+        "defines and authenticates."
+    )
+
+
 def _configure_harness_add(family: str | None = None) -> str | None:
     """Run the interactive ``add a provider`` flow and persist the entry.
 
@@ -607,18 +633,23 @@ def _configure_harness_add(family: str | None = None) -> str | None:
     # the common cases, a preset provider/cli. When entered from a specific
     # harness, the menu is scoped to that harness's surface.
     options = add_menu_options_for_family(family) if family is not None else add_menu_options()
-    # A custom provider defined by the user's own ~/.codex/config.toml
-    # (e.g. isaac's Databricks AI Gateway) that is not currently configured
-    # gets its own add option. This is the only way back after Remove —
-    # removal dismisses the detection so it stops auto-adopting, and there
-    # is nothing to type/paste here (the credential lives in that file).
+    # A provider defined by the harness CLI's own config — isaac's Databricks AI
+    # Gateway in ~/.codex/config.toml (codex) or in Claude Code's managed
+    # settings (claude) — that is not currently configured gets its own add
+    # option. This is the only way back after Remove — removal dismisses the
+    # detection so it stops auto-adopting, and there is nothing to type/paste
+    # here (the credential lives in that file).
     cli_config_dets: list[DetectedProvider] = []
-    if family in (None, OPENAI_FAMILY):
+    if family in (None, OPENAI_FAMILY, ANTHROPIC_FAMILY):
         configured_names = set(load_providers(_load_global_config()))
         cli_config_dets = [
             d
             for d in detect_providers()
-            if d.kind == CLI_CONFIG_KIND and d.name not in configured_names
+            if d.kind == CLI_CONFIG_KIND
+            and d.name not in configured_names
+            # On a harness-scoped page, offer only that harness's own config
+            # credential — a codex table can't drive Claude, or vice versa.
+            and (family is None or d.family == family)
         ]
     # Base options first, then one row per detected config provider — the
     # selection index maps back into cli_config_dets below.
@@ -626,11 +657,8 @@ def _configure_harness_add(family: str | None = None) -> str | None:
     options = options + [
         AddOption(
             label=f"\N{GEAR}\N{VARIATION SELECTOR-16} {d.display_name or d.name} — "
-            "from your Codex config",
-            description=(
-                f"Use the {str(d.model_provider)!r} provider your ~/.codex/config.toml "
-                "defines and authenticates."
-            ),
+            f"from your {_cli_config_source_label(d.cli)}",
+            description=_cli_config_source_description(d),
             kind=CLI_CONFIG_KIND,
         )
         for d in cli_config_dets
@@ -657,12 +685,16 @@ def _configure_harness_add(family: str | None = None) -> str | None:
         # One detected-config row was appended per cli_config_dets entry, in
         # order, after the base options — map the selection back to its
         # detection. Nothing to prompt for: the provider definition AND its
-        # credential live in ~/.codex/config.toml; the entry only pins it.
+        # credential live in the CLI's own config file; the entry only names it.
         det = cli_config_dets[choice - base_option_count]
-        if det.model_provider is None:  # always set on cli-config detections
-            raise click.ClickException("internal: cli-config detection missing model_provider")
+        if det.cli is None:  # always set on cli-config detections
+            raise click.ClickException("internal: cli-config detection missing cli")
+        if det.cli == "codex" and det.model_provider is None:
+            raise click.ClickException(
+                "internal: codex cli-config detection missing model_provider"
+            )
         name = det.name
-        entry = build_cli_config_provider_entry("codex", det.model_provider, det.display_name)
+        entry = build_cli_config_provider_entry(det.cli, det.model_provider, det.display_name)
         # Re-adding is the user saying "I want this auto-detected credential
         # after all" — drop any standing dismissal so it behaves like an
         # ordinary detection again (e.g. re-adopts after a config self-heal).

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -21,7 +21,7 @@ Enumeration is deterministic per provider kind:
   ``"openai-compatible"``).
 - ``subscription`` → live CLI discovery for Cursor; curated static aliases for
   CLIs without a listing API (source ``"static"``, ``verified: false``).
-- ``cli-config`` → the codex curated static list (source ``"static"``,
+- ``cli-config`` → a curated static list (source ``"static"``,
   ``verified: false`` — the credential lives in the CLI's own config
   file and is resolved by the CLI at launch).
 - anything unresolvable → source ``"none"`` with an explanatory note,
@@ -232,7 +232,8 @@ class ResolvedModelProvider:
     :param auth_command: Shell command printing a bearer token, for
         providers configured with a dynamic credential.
     :param cli: ``"claude"`` / ``"codex"`` / ``"cursor-agent"`` for
-        ``kind="subscription"``; ``"codex"`` for ``kind="cli-config"``.
+        ``kind="subscription"``; ``"codex"`` / ``"claude"`` for
+        ``kind="cli-config"``.
     :param detail: Non-secret descriptor of how the provider resolved,
         e.g. ``"provider 'openrouter'"`` — used in listing notes.
     """
@@ -753,6 +754,8 @@ def _provider_from_entry(entry: ProviderEntry, harness_type: str) -> ResolvedMod
             detail=(
                 f"provider {entry.name!r} (codex config.toml model provider "
                 f"{entry.model_provider!r})"
+                if entry.cli == "codex"
+                else f"provider {entry.name!r} (Claude Code managed settings gateway)"
             ),
         )
     # Inline-family kinds: single-family harnesses get exactly their family;
@@ -1074,11 +1077,12 @@ def _static_subscription_listing(provider: ResolvedModelProvider) -> ModelListin
 def _static_cli_config_listing(provider: ResolvedModelProvider) -> ModelListing:
     """Build the curated static listing for a ``cli-config`` provider.
 
-    A ``cli-config`` provider pins a custom ``[model_providers.X]`` table in
-    the codex CLI's own ``config.toml``; its credential (an auth command /
-    env key in that file) is resolved by codex at launch, so the listing is
-    the codex curated ids with a note saying the credential is the CLI's to
-    resolve — not a "no credentials" preflight failure.
+    A ``cli-config`` provider names a credential the harness CLI's own config
+    already carries — a custom ``[model_providers.X]`` table in codex's
+    ``config.toml``, or a gateway pinned by Claude Code's managed settings. The
+    CLI resolves it at launch, so the listing carries a note saying the
+    credential is the CLI's to resolve — not a "no credentials" preflight
+    failure.
 
     :param provider: A ``kind="cli-config"`` provider descriptor.
     :returns: A ``source="static"`` listing with no models.

--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -34,6 +34,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
+from urllib.parse import urlsplit
 
 import tomllib
 
@@ -72,6 +73,19 @@ _OLLAMA_URL = f"http://{_OLLAMA_HOST}:{_OLLAMA_PORT}"
 # when nothing is listening.
 _OLLAMA_PROBE_TIMEOUT = 0.25
 
+# Claude Code's enterprise "managed settings" chain, in the CLI's own precedence
+# order. An enterprise install (the shape ``isaac configure claude`` writes)
+# configures Claude Code here and nowhere else: an ``env`` block pinning
+# ``ANTHROPIC_BASE_URL`` at a gateway plus a top-level ``apiKeyHelper`` command
+# that prints the bearer token. Managed settings win at Claude Code's own
+# launch, so this file alone is a complete, working credential — the Claude
+# analogue of a custom ``[model_providers.X]`` in ``~/.codex/config.toml``.
+CLAUDE_CODE_MANAGED_SETTINGS_PATHS: tuple[Path, ...] = (
+    Path("/Library/Application Support/ClaudeCode/managed-settings.json"),
+    Path("/etc/claude-code/managed-settings.json"),
+    Path(os.environ.get("PROGRAMDATA", "C:/ProgramData")) / "ClaudeCode" / "managed-settings.json",
+)
+
 # Maps each provider whose env key we surface to the served model family.
 # Providers absent here (or mapped to ``None``) are reported with
 # ``family=None`` — their key is detected but no harness surface is
@@ -104,10 +118,17 @@ class DetectedProvider:
     :param source: A human-readable descriptor of where the credential
         comes from, e.g. ``"$ANTHROPIC_API_KEY"``, ``"claude CLI login"``,
         or ``"http://localhost:11434"``.
-    :param model_provider: For ``kind="cli-config"`` only: the custom
-        provider id the CLI's config file selects, e.g. ``"Databricks"``
-        (the ``model_provider`` key in ``~/.codex/config.toml``). ``None``
-        for other kinds.
+    :param cli: For ``kind="cli-config"`` only: the CLI whose own config
+        file defines and authenticates the provider — ``"codex"`` (a
+        ``[model_providers.X]`` table in ``~/.codex/config.toml``) or
+        ``"claude"`` (a gateway ``env`` block + credential helper in Claude
+        Code's settings chain). ``None`` for other kinds.
+    :param model_provider: For a ``codex`` ``kind="cli-config"`` only: the
+        custom provider id the CLI's config file selects, e.g.
+        ``"Databricks"`` (the ``model_provider`` key in
+        ``~/.codex/config.toml``). ``None`` for other kinds — Claude Code has
+        no ``model_provider`` concept, its settings chain pins the endpoint
+        directly.
     :param display_name: For ``kind="cli-config"`` only: the provider's
         human display name from its config table (``name = "Databricks AI
         Gateway"``), falling back to :attr:`model_provider` when the table
@@ -118,6 +139,7 @@ class DetectedProvider:
     kind: DetectedKind
     family: str | None
     source: str
+    cli: str | None = None
     model_provider: str | None = None
     display_name: str | None = None
 
@@ -485,6 +507,7 @@ def codex_config_detection() -> DetectedProvider | None:
         kind=CLI_CONFIG_KIND,
         family=OPENAI_FAMILY,
         source=f"~/.codex/config.toml provider {codex_config.provider_id!r}",
+        cli="codex",
         model_provider=codex_config.provider_id,
         display_name=codex_config.display_name,
     )
@@ -601,6 +624,138 @@ def _claude_login_detected() -> bool:
 
         return harness_cli_logged_in(ANTHROPIC_FAMILY)
     return False
+
+
+@dataclass(frozen=True)
+class ClaudeConfigProvider:
+    """A gateway Claude Code's own settings chain defines and authenticates.
+
+    The Claude-side counterpart of :class:`CodexConfigProvider`. Claude Code has
+    no ``[model_providers.X]`` concept — its settings pin the endpoint directly —
+    so there is no provider id to record, only where requests go and the name to
+    show for it.
+
+    :param base_url: The settings' ``env.ANTHROPIC_BASE_URL``, e.g.
+        ``"https://<workspace>.cloud.databricks.com/ai-gateway/anthropic"``.
+    :param display_name: A human name for the endpoint, e.g. ``"Databricks AI
+        Gateway"`` for a recognized Databricks gateway, else its hostname.
+    :param slug: The config-name fragment identifying the endpoint kind, e.g.
+        ``"databricks"``, giving the stable entry name ``claude-databricks``.
+    """
+
+    base_url: str
+    display_name: str
+    slug: str
+
+
+def claude_managed_gateway(
+    paths: tuple[Path, ...] | None = None,
+) -> tuple[str | None, bool]:
+    """Read the gateway backing Claude Code applies from its managed settings.
+
+    The canonical parser for Claude Code's managed-settings credential, shared
+    by ambient detection and the Smart-Routing gateway check
+    (:func:`omnigent.claude_native.managed_claude_gateway_signal` delegates
+    here). A credential counts as delivered when the file carries a top-level
+    ``apiKeyHelper`` (a token-printing command) or a truthy
+    ``env.CLAUDE_CODE_USE_GATEWAY``.
+
+    The **first readable, object-shaped** file decides, matching Claude Code's
+    own precedence chain: a managed settings file that exists but pins no
+    ``ANTHROPIC_BASE_URL`` reports "no gateway" rather than falling through to a
+    lower-precedence file it would itself override.
+
+    :param paths: Settings files to read, highest precedence first; defaults to
+        :data:`CLAUDE_CODE_MANAGED_SETTINGS_PATHS`.
+    :returns: ``(base_url, has_credential)`` from the first readable file, or
+        ``(None, False)`` when none is present or parseable.
+    """
+    for path in CLAUDE_CODE_MANAGED_SETTINGS_PATHS if paths is None else paths:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        raw_env = payload.get("env")
+        env = raw_env if isinstance(raw_env, dict) else {}
+        raw_base_url = env.get("ANTHROPIC_BASE_URL")
+        base_url = raw_base_url.strip() if isinstance(raw_base_url, str) else None
+        has_helper = bool(payload.get("apiKeyHelper"))
+        use_gateway = str(env.get("CLAUDE_CODE_USE_GATEWAY", "")).strip().lower() not in (
+            "",
+            "0",
+            "false",
+        )
+        return base_url or None, has_helper or use_gateway
+    return None, False
+
+
+def claude_config_custom_provider(
+    paths: tuple[Path, ...] | None = None,
+) -> ClaudeConfigProvider | None:
+    """Detect a self-authenticating gateway in Claude Code's settings chain.
+
+    The Claude mirror of :func:`codex_config_custom_provider`. Enterprise
+    tooling configures Claude Code by writing its managed settings only — a
+    gateway ``ANTHROPIC_BASE_URL`` plus an ``apiKeyHelper`` that prints a bearer
+    token — so no ``.credentials.json`` / Keychain subscription is ever written
+    and the login detection sees nothing routable. This is the detection for
+    that state.
+
+    A settings file counts only when it pins **both** an endpoint and a way to
+    authenticate against it; either alone is not a usable credential (a bare
+    ``ANTHROPIC_BASE_URL`` still needs a key omnigent cannot supply).
+
+    :param paths: Settings files to read; defaults to
+        :data:`CLAUDE_CODE_MANAGED_SETTINGS_PATHS`.
+    :returns: The :class:`ClaudeConfigProvider`, or ``None`` when the chain
+        pins no gateway or delivers no credential for it.
+    """
+    base_url, has_credential = claude_managed_gateway(paths)
+    if base_url is None or not has_credential:
+        return None
+    # Lazy: the gateway-URL allowlist lives in its own module and is only
+    # needed once a gateway is actually present.
+    from omnigent.databricks_ai_gateway import is_databricks_ai_gateway_url
+
+    if is_databricks_ai_gateway_url(base_url):
+        return ClaudeConfigProvider(
+            base_url=base_url, display_name="Databricks AI Gateway", slug="databricks"
+        )
+    # A non-Databricks gateway is still a real credential; name it after its
+    # host so the entry stays stable and unambiguous.
+    host = urlsplit(base_url).hostname or base_url
+    return ClaudeConfigProvider(base_url=base_url, display_name=host, slug=_slug(host))
+
+
+def claude_config_detection(
+    paths: tuple[Path, ...] | None = None,
+) -> DetectedProvider | None:
+    """Return the ``cli-config`` detection for Claude Code's settings, if any.
+
+    The Claude twin of :func:`codex_config_detection` — the single constructor
+    for this detection, so callers that need to identify it on its own (the
+    setup add menu, the readiness gate) agree with :func:`detect_providers`.
+
+    :param paths: Settings files to read; defaults to
+        :data:`CLAUDE_CODE_MANAGED_SETTINGS_PATHS`.
+    :returns: A ``kind="cli-config"`` :class:`DetectedProvider` (stable name
+        ``claude-<slug>``, e.g. ``"claude-databricks"``) carrying no
+        ``model_provider`` — Claude Code has none to pin — or ``None`` when the
+        settings chain carries no self-authenticating gateway.
+    """
+    provider = claude_config_custom_provider(paths)
+    if provider is None:
+        return None
+    return DetectedProvider(
+        name=f"claude-{provider.slug}",
+        kind=CLI_CONFIG_KIND,
+        family=ANTHROPIC_FAMILY,
+        source=f"Claude Code managed settings gateway {provider.display_name!r}",
+        cli="claude",
+        display_name=provider.display_name,
+    )
 
 
 def _ollama_reachable() -> bool:
@@ -746,12 +901,32 @@ def _detect_providers_now() -> list[DetectedProvider]:
             )
         )
 
-    # 2. Claude CLI login. Like codex (below), existence alone is not enough —
+    # 2. A self-authenticating gateway in Claude Code's managed settings (e.g.
+    #    the Databricks AI Gateway written by ``isaac configure claude``, which
+    #    writes that file only — never a subscription credential — so the login
+    #    check below cannot see it). Ordered BEFORE the login check for the same
+    #    reason codex's config detection is: managed settings win at Claude
+    #    Code's own launch, so the auto-default must match what a plain
+    #    ``claude`` invocation actually does.
+    claude_config_det = claude_config_detection()
+    if claude_config_det is not None:
+        detected.append(claude_config_det)
+
+    # 2b. Claude CLI login. Like codex (below), existence alone is not enough —
     #    an empty / logged-out ``.credentials.json`` carries no usable login.
     #    On macOS the credential lives in the Keychain rather than the file, so
     #    detection falls back to the CLI's own status check there. See
     #    ``_claude_login_detected`` / ``claude_auth_has_credential``.
-    if _claude_login_detected():
+    #
+    #    Skipped when the gateway above was found: ``claude auth status`` reports
+    #    a managed ``apiKeyHelper`` as logged in (``authMethod:
+    #    "api_key_helper"``), so that probe is describing the very same
+    #    credential. Reporting it again as a ``subscription`` would double-count
+    #    one gateway as two providers and mislabel it as a Claude plan login.
+    #    A host with a managed gateway AND a separate personal Pro/Max login
+    #    therefore surfaces only the gateway — correct for routing, since managed
+    #    settings win at Claude Code's own launch either way.
+    if claude_config_det is None and _claude_login_detected():
         detected.append(
             DetectedProvider(
                 name="claude",

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -670,7 +670,9 @@ def _entry_models_summary(entry: ProviderEntry) -> str:
     if entry.kind == DATABRICKS_KIND:
         return f"profile: {entry.profile}"
     if entry.kind == CLI_CONFIG_KIND:
-        return f"~/.{entry.cli}/config.toml: {entry.model_provider}"
+        if entry.cli == "codex":
+            return f"~/.codex/config.toml: {entry.model_provider}"
+        return "via Claude Code managed settings"
     # Inline-family kinds: list each family's default model, else note the
     # base_url is set (a gateway without a pinned default model still works
     # — the spec/override picks the model).
@@ -839,34 +841,36 @@ def build_subscription_provider_entry(cli: str) -> dict[str, object]:
 
 def build_cli_config_provider_entry(
     cli: str,
-    model_provider: str,
+    model_provider: str | None,
     display_name: str | None,
 ) -> dict[str, object]:
     """Build a ``kind: cli-config`` provider entry body (config shape).
 
-    A cli-config provider pins a custom model provider defined in the
-    harness CLI's own config file (today: a ``[model_providers.X]`` table
-    in ``~/.codex/config.toml`` with self-contained auth, e.g. the
-    Databricks AI Gateway written by ``isaac configure codex``). The
-    provider definition and credential stay in that file; this entry only
-    records which provider the launch selects.
+    A cli-config provider names a credential the harness CLI's own config file
+    already defines and authenticates, so the entry carries no secret:
 
-    :param cli: The CLI whose config file defines the provider —
-        ``"codex"`` (the only CLI with config-file model providers today).
+    - ``codex`` — a ``[model_providers.X]`` table in ``~/.codex/config.toml``
+      with self-contained auth (the Databricks AI Gateway written by ``isaac
+      configure codex``), pinned by *model_provider*;
+    - ``claude`` — a gateway ``env.ANTHROPIC_BASE_URL`` plus a credential helper
+      in Claude Code's managed settings (the shape ``isaac configure claude``
+      writes). Claude Code applies these itself at launch, so there is nothing
+      to pin and *model_provider* is ``None``.
+
+    :param cli: The CLI whose config file defines the provider — ``"codex"`` or
+        ``"claude"`` (see :data:`~omnigent.onboarding.provider_config.CLI_CONFIG_CLIS`).
     :param model_provider: The ``[model_providers.X]`` id to pin, e.g.
-        ``"Databricks"``.
-    :param display_name: The provider table's ``name`` field, snapshotted
-        for display, e.g. ``"Databricks AI Gateway"``; ``None`` omits it
-        (labels fall back to the entry name).
+        ``"Databricks"``; ``None`` for ``claude`` (and omitted from the body).
+    :param display_name: The provider's display name, snapshotted for display,
+        e.g. ``"Databricks AI Gateway"``; ``None`` omits it (labels fall back to
+        the entry name).
     :returns: A provider entry body, e.g. ``{"kind": "cli-config", "cli":
         "codex", "model_provider": "Databricks", "display_name":
         "Databricks AI Gateway"}``.
     """
-    body: dict[str, object] = {
-        "kind": CLI_CONFIG_KIND,
-        "cli": cli,
-        "model_provider": model_provider,
-    }
+    body: dict[str, object] = {"kind": CLI_CONFIG_KIND, "cli": cli}
+    if model_provider:
+        body["model_provider"] = model_provider
     if display_name:
         body["display_name"] = display_name
     return body

--- a/omnigent/onboarding/detected.py
+++ b/omnigent/onboarding/detected.py
@@ -129,13 +129,16 @@ def _synthesize_entry(det: DetectedProvider) -> dict[str, object] | None:
         return build_subscription_provider_entry(det.name)
 
     if det.kind == "cli-config":
-        # A custom model provider defined (and authenticated) by the codex
-        # CLI's own config.toml — pin it by name; the credential stays in
-        # that file. ``model_provider`` is always set on this kind (the
-        # detector constructs it from the provider id it just matched).
-        if det.model_provider is None:
+        # A provider the harness CLI's own config file defines AND
+        # authenticates — record which CLI (and, for codex, which provider id)
+        # the launch selects; the credential stays in that file.
+        if det.cli is None:
             return None
-        return build_cli_config_provider_entry("codex", det.model_provider, det.display_name)
+        # codex pins a named ``[model_providers.X]``, so a detection missing it
+        # is unusable; claude has no id to pin (its settings name the endpoint).
+        if det.cli == "codex" and det.model_provider is None:
+            return None
+        return build_cli_config_provider_entry(det.cli, det.model_provider, det.display_name)
 
     if det.name == "vertex-claude":
         # Claude Code on Vertex AI — the CLI authenticates via its own env

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -57,6 +57,7 @@ from omnigent.onboarding.harness_install import (
 from omnigent.onboarding.provider_config import (
     _EXECUTOR_TYPE_HARNESS_ALIASES,
     _HARNESS_FAMILY,
+    ANTHROPIC_FAMILY,
     GEMINI_FAMILY,
     OPENAI_FAMILY,
     PI_SURFACE,
@@ -359,6 +360,32 @@ def _family_provider_configured(harness: str) -> bool:
     return provider is not None and provider.kind != SUBSCRIPTION_KIND
 
 
+def _claude_managed_gateway_configured() -> bool:
+    """Whether Claude Code's own settings chain carries a gateway credential.
+
+    The structural half of Claude readiness, parallel to
+    :func:`_family_provider_configured` (which only sees omnigent's
+    ``providers:`` config). An enterprise install configures Claude Code
+    directly — a gateway ``env.ANTHROPIC_BASE_URL`` plus an ``apiKeyHelper`` in
+    its managed settings — and Claude Code applies that at its own launch, so
+    the harness is genuinely usable with nothing in ``config.yaml``.
+
+    Local, synchronous, side-effect free (one JSON file read) and never raises:
+    any error fails to ``False`` so readiness falls through to the CLI status
+    probe rather than crashing the refresh.
+
+    :returns: ``True`` when the settings chain pins a gateway AND delivers a
+        credential for it, else ``False``.
+    """
+    try:
+        from omnigent.onboarding.ambient import claude_config_detection
+
+        return claude_config_detection() is not None
+    except Exception:
+        _logger.debug("readiness: claude managed-settings check failed", exc_info=True)
+        return False
+
+
 def _installer_only_availability(install_key: str) -> HarnessAvailability:
     """Return availability for a binary-gated harness without login commands.
 
@@ -404,15 +431,25 @@ def _cli_family_availability(canonical: str, install_key: str) -> HarnessAvailab
         from omnigent.onboarding.opencode_auth import opencode_auth_summary
 
         return True if opencode_auth_summary().has_provider else "needs-auth"
-    # claude: ready when EITHER an omnigent-managed provider serves the family
-    # (an API key / gateway the user set, incl. from the UI) OR the harness's
-    # own subscription login is present (`claude auth status`, a subprocess —
-    # the same probe the setup wizard uses; runs off the event loop on the
-    # throttled readiness refresh). Checking the config first avoids the
-    # subprocess on the common key-configured path.
+    # claude / cursor: ready when EITHER an omnigent-managed provider serves the
+    # family (an API key / gateway the user set, incl. from the UI) OR the
+    # harness's own login is present (`claude auth status`, a subprocess — the
+    # same probe the setup wizard uses; runs off the event loop on the throttled
+    # readiness refresh). Checking the config first avoids the subprocess on the
+    # common key-configured path.
     from omnigent.onboarding.harness_install import harness_cli_logged_in
 
     if _family_provider_configured(canonical):
+        return True
+    # Claude Code's own settings chain can carry a complete gateway credential
+    # (an enterprise ``ANTHROPIC_BASE_URL`` + ``apiKeyHelper``) that omnigent's
+    # config knows nothing about, and that is what the launch actually routes
+    # through — Claude Code applies managed settings itself. Credit it here:
+    # the check is structural (one local file read, no subprocess), so an
+    # enterprise host reads ready without depending on the status probe
+    # resolving the CLI. Mirrors the codex path, which credits its own
+    # config.toml provider the same way.
+    if install_key == ANTHROPIC_FAMILY and _claude_managed_gateway_configured():
         return True
     return (
         True

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -123,6 +123,12 @@ GATEWAY_KIND = "gateway"
 LOCAL_KIND = "local"
 DATABRICKS_KIND: Literal["databricks"] = "databricks"
 CLI_CONFIG_KIND = "cli-config"
+
+# The CLIs whose own config file can define AND authenticate a provider, so an
+# omnigent entry only has to name it: codex via a ``[model_providers.X]`` table
+# in ``~/.codex/config.toml``, claude via a gateway ``env`` block + credential
+# helper in Claude Code's managed settings.
+CLI_CONFIG_CLIS = frozenset({"codex", "claude"})
 BEDROCK_KIND = "bedrock"
 _VALID_KINDS = (
     KEY_KIND,
@@ -306,14 +312,14 @@ class ProviderEntry:
         :meth:`family` rather than indexing :attr:`families` directly.
     :param cli: For ``kind="subscription"`` and ``kind="cli-config"``: the
         CLI whose login / config file carries auth, ``"claude"`` or
-        ``"codex"`` (``cli-config`` supports only ``"codex"`` today).
-        ``None`` otherwise.
+        ``"codex"`` (see :data:`CLI_CONFIG_CLIS`). ``None`` otherwise.
     :param profile: For ``kind="databricks"`` only: the Databricks profile
         name from ``~/.databrickscfg``, e.g. ``"oss"``. ``None`` otherwise.
-    :param model_provider: For ``kind="cli-config"`` only: the custom
-        provider id in the CLI's config file that the launch pins, i.e. the
-        ``X`` in ``[model_providers.X]``, e.g. ``"Databricks"``. ``None``
-        otherwise.
+    :param model_provider: For a ``codex`` ``kind="cli-config"`` only: the
+        custom provider id in the CLI's config file that the launch pins,
+        i.e. the ``X`` in ``[model_providers.X]``, e.g. ``"Databricks"``.
+        ``None`` otherwise — a ``claude`` cli-config has no id to pin, since
+        Claude Code's settings chain names the endpoint directly.
     :param display_name: For ``kind="cli-config"`` only: the provider's
         human display name (the table's ``name`` field, snapshotted at
         adoption), e.g. ``"Databricks AI Gateway"``. ``None`` otherwise and
@@ -815,42 +821,54 @@ def _parse_provider(name: str, raw: dict[str, object]) -> ProviderEntry:
 
     if kind == CLI_CONFIG_KIND:
         cli_raw = raw.get("cli")
-        # Only codex has a model_provider concept; a claude analog (e.g. an
-        # isaac-written settings.json) would be a different mechanism and a
-        # deliberate extension, not a value to silently accept here.
-        if cli_raw != "codex":
+        if not isinstance(cli_raw, str) or cli_raw not in CLI_CONFIG_CLIS:
             raise OmnigentError(
-                f"provider {name!r}: kind 'cli-config' requires cli: 'codex' "
-                f"(the only CLI with config-file model providers), got {cli_raw!r}.",
+                f"provider {name!r}: kind 'cli-config' requires cli: 'codex' or "
+                "'claude' (the CLIs whose own config file defines and "
+                f"authenticates a provider), got {cli_raw!r}.",
                 code=ErrorCode.INVALID_INPUT,
             )
+        # Only codex names its provider: a ``[model_providers.X]`` table the
+        # launch pins by id. Claude Code's settings chain pins the endpoint
+        # directly, so there is no id to record and requiring one would reject a
+        # valid entry.
         model_provider_raw = raw.get("model_provider")
-        if not isinstance(model_provider_raw, str) or not model_provider_raw:
+        model_provider = (
+            model_provider_raw
+            if isinstance(model_provider_raw, str) and model_provider_raw
+            else None
+        )
+        if cli_raw == "codex" and model_provider is None:
             raise OmnigentError(
                 f"provider {name!r}: a 'model_provider' (the [model_providers.X] "
                 "id in ~/.codex/config.toml, e.g. 'Databricks') is required when "
-                "kind is 'cli-config'.",
+                "kind is 'cli-config' and cli is 'codex'.",
                 code=ErrorCode.INVALID_INPUT,
             )
         display_name_raw = raw.get("display_name")
+        # A cli-config provider serves exactly the surface its CLI drives, like
+        # that CLI's subscription: codex→openai, claude→anthropic.
+        served_family = OPENAI_FAMILY if cli_raw == "codex" else ANTHROPIC_FAMILY
         return ProviderEntry(
             name=name,
             kind=kind,
             cli=cli_raw,
-            model_provider=model_provider_raw,
+            model_provider=model_provider,
             display_name=display_name_raw if isinstance(display_name_raw, str) else None,
-            # A codex cli-config provider serves the openai surface, like a codex
-            # subscription. It may ALSO claim the pi scope (``default: [openai,
-            # pi]``) because a Databricks AI Gateway is pi-consumable (Pi speaks
-            # its Anthropic surface natively). This is allowed structurally —
-            # without reading the ambient ~/.codex/config.toml at parse — so a
-            # user can pin pi→Databricks; whether the pinned provider is a *real*
-            # Databricks gateway is validated at pi launch, which falls back to
-            # Pi's own login when it is not (see :func:`_cli_config_serves_pi`
-            # and ``resolve_pi_native_provider``). A codex subscription stays
-            # pi-incapable (its ``default: pi`` is still rejected at parse).
+            # A *codex* cli-config provider may ALSO claim the pi scope
+            # (``default: [openai, pi]``) because a Databricks AI Gateway is
+            # pi-consumable (Pi speaks its Anthropic surface natively). This is
+            # allowed structurally — without reading the ambient
+            # ~/.codex/config.toml at parse — so a user can pin pi→Databricks;
+            # whether the pinned provider is a *real* Databricks gateway is
+            # validated at pi launch, which falls back to Pi's own login when it
+            # is not (see :func:`_cli_config_serves_pi` and
+            # ``resolve_pi_native_provider``). A codex subscription stays
+            # pi-incapable (its ``default: pi`` is still rejected at parse), and
+            # so does a claude cli-config: pi reuses a pinned *codex* table, and
+            # Claude Code's managed credential is not readable outside its CLI.
             default_families=_parse_default_families(
-                name, default_raw, {OPENAI_FAMILY}, pi_capable=True
+                name, default_raw, {served_family}, pi_capable=cli_raw == "codex"
             ),
         )
 
@@ -1429,7 +1447,11 @@ def describe_active_credential(
             kind=provider.kind,
             family=None,
             model=model_override,
-            source=f"~/.codex/config.toml provider: {provider.model_provider}",
+            source=(
+                f"~/.codex/config.toml provider: {provider.model_provider}"
+                if provider.cli == "codex"
+                else "Claude Code managed settings gateway"
+            ),
             base_url=None,
         )
 

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -3408,3 +3408,60 @@ def test_credential_label_bedrock_not_duplicated() -> None:
 
     assert credential_label(BEDROCK_KIND, "bedrock") == "AWS Bedrock"
     assert credential_label(BEDROCK_KIND, "nexus") == "AWS Bedrock (nexus)"
+
+
+def test_cli_config_add_row_names_the_right_config_file() -> None:
+    """The add-menu row names the CLI whose config carries the credential.
+
+    Both harnesses can present an own-config credential, so the row must say
+    which file to look in. A shared "Codex config" string would tell an
+    enterprise Claude user to inspect ``~/.codex/config.toml``, which has
+    nothing to do with their credential.
+    """
+    from omnigent.cli_config import _cli_config_source_description, _cli_config_source_label
+    from omnigent.onboarding.ambient import DetectedProvider
+
+    assert _cli_config_source_label("claude") == "Claude Code settings"
+    assert _cli_config_source_label("codex") == "Codex config"
+
+    claude_det = DetectedProvider(
+        name="claude-databricks",
+        kind="cli-config",
+        family="anthropic",
+        source="Claude Code managed settings gateway 'Databricks AI Gateway'",
+        cli="claude",
+        display_name="Databricks AI Gateway",
+    )
+    codex_det = DetectedProvider(
+        name="codex-databricks",
+        kind="cli-config",
+        family="openai",
+        source="~/.codex/config.toml provider 'Databricks'",
+        cli="codex",
+        model_provider="Databricks",
+        display_name="Databricks AI Gateway",
+    )
+    # The Claude copy never points at codex's file, and vice versa.
+    claude_desc = _cli_config_source_description(claude_det)
+    assert "Claude Code managed settings" in claude_desc
+    assert "codex" not in claude_desc.lower()
+    assert "~/.codex/config.toml" in _cli_config_source_description(codex_det)
+
+
+def test_cli_config_credential_label_parity_across_clis() -> None:
+    """A Claude own-config credential labels like the Codex one already does.
+
+    ``Codex-Databricks`` was visible in setup while the Claude equivalent had no
+    entry at all; the labels must now be symmetric so the two read as one
+    family of credential.
+    """
+    from omnigent.onboarding.configure_models import credential_label
+
+    assert (
+        credential_label("cli-config", "claude-databricks", display_name="Databricks AI Gateway")
+        == "Claude-Databricks"
+    )
+    assert (
+        credential_label("cli-config", "codex-databricks", display_name="Databricks AI Gateway")
+        == "Codex-Databricks"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -366,6 +366,53 @@ def _isolate_codex_native_state(
 
 
 @pytest.fixture()
+def claude_managed_settings() -> None:
+    """Opt back in to the host's real Claude Code managed-settings chain.
+
+    Request this alongside a test that must read the machine's actual
+    ``managed-settings.json``; :func:`_isolate_claude_managed_settings` then
+    leaves the path list alone.
+
+    :returns: None.
+    """
+
+
+@pytest.fixture(autouse=True)
+def _isolate_claude_managed_settings(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the host's Claude Code managed settings out of ambient detection.
+
+    ``omnigent.onboarding.ambient`` reads Claude Code's enterprise managed
+    settings to detect a gateway the CLI authenticates itself (the shape ``isaac
+    configure claude`` writes). Those paths are **absolute and machine-global**
+    (``/Library/Application Support/ClaudeCode/…``, ``/etc/claude-code/…``), so
+    unlike ``~/.claude`` they are not redirected by a test's tmp ``$HOME`` — a
+    developer's or CI runner's real enterprise install would otherwise add a
+    phantom ``claude-databricks`` provider to every detection assertion.
+
+    Neutralizing the ambient tuple covers **every** reader: ``claude_native``
+    resolves the chain through ``_managed_settings_paths()`` at call time rather
+    than binding its own copy, so its Smart-Routing gateway check and managed
+    model overrides are isolated by this one patch too.
+
+    ``autouse=True`` because the alternative leaves us one missed test away from
+    host-dependent failures that reproduce only on configured machines. Tests
+    that exercise the detection pass an explicit ``paths=`` argument (the
+    reader takes one) or request :func:`claude_managed_settings`.
+
+    :param request: Pytest request, inspected for the opt-in fixture.
+    :param monkeypatch: Pytest monkeypatch fixture; restores the tuple at
+        teardown.
+    :returns: None.
+    """
+    if "claude_managed_settings" in request.fixturenames:
+        return
+    monkeypatch.setattr("omnigent.onboarding.ambient.CLAUDE_CODE_MANAGED_SETTINGS_PATHS", ())
+
+
+@pytest.fixture()
 def untracked_cache_start() -> None:
     """Opt back in to the real :meth:`GitFilesystemRegistry.start`.
 

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -458,6 +458,7 @@ _ISAAC_STYLE_DETECTION = DetectedProvider(
     kind="cli-config",
     family="openai",
     source="~/.codex/config.toml provider 'Databricks'",
+    cli="codex",
     model_provider="Databricks",
     display_name="Databricks AI Gateway",
 )
@@ -797,3 +798,195 @@ def test_prewarm_detect_providers_failure_falls_back_to_fresh_sweep(
     ambient.prewarm_detect_providers()
     assert detect_providers() == []
     assert sweeps == ["sweep", "sweep"]
+
+
+# --- Claude Code managed-settings gateway (the isaac configure claude shape) ---
+
+_ISAAC_STYLE_CLAUDE_SETTINGS: dict[str, object] = {
+    "env": {
+        "ANTHROPIC_BASE_URL": "https://dbc-test.cloud.databricks.com/ai-gateway/anthropic",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "system.ai.claude-opus-4-8",
+    },
+    "apiKeyHelper": "jq -r '.access_token' ~/.databricks/model-serving-token.json",
+}
+
+_ISAAC_STYLE_CLAUDE_DETECTION = DetectedProvider(
+    name="claude-databricks",
+    kind="cli-config",
+    family="anthropic",
+    source="Claude Code managed settings gateway 'Databricks AI Gateway'",
+    cli="claude",
+    display_name="Databricks AI Gateway",
+)
+
+
+def _write_claude_managed_settings(home, monkeypatch, payload: object):
+    """Write a Claude Code managed-settings file and point detection at it.
+
+    The real chain lives at absolute, machine-global paths, so tests redirect
+    the tuple rather than the (tmp) ``$HOME`` — overriding the autouse
+    ``_isolate_claude_managed_settings`` fixture for this one test.
+
+    :param home: The tmp HOME directory (from the ``clean_env`` fixture).
+    :param monkeypatch: pytest's attr patching fixture.
+    :param payload: The JSON value to write (a settings object, or any value
+        for the malformed cases).
+    :returns: The path written.
+    """
+    import json
+
+    path = home / "managed-settings.json"
+    path.write_text(json.dumps(payload))
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (path,))
+    return path
+
+
+def test_claude_managed_gateway_detected(clean_env, monkeypatch) -> None:
+    """An isaac-style managed-settings file (gateway + helper) is detected.
+
+    This is the exact state ``isaac configure claude`` leaves behind — no
+    ``.credentials.json`` and no Keychain subscription — which the login
+    detection cannot see. Failure means internal users' gateway-configured
+    Claude shows as "not configured" in setup, the Claude half of the bug the
+    codex config detection already fixed.
+    """
+    _write_claude_managed_settings(clean_env, monkeypatch, _ISAAC_STYLE_CLAUDE_SETTINGS)
+    assert detect_providers() == [_ISAAC_STYLE_CLAUDE_DETECTION]
+
+
+def test_claude_managed_gateway_suppresses_subscription_detection(clean_env, monkeypatch) -> None:
+    """The gateway wins and the CLI-login detection is dropped, not doubled.
+
+    ``claude auth status`` reports a managed ``apiKeyHelper`` as logged in
+    (``authMethod: "api_key_helper"``), so the login probe describes the SAME
+    credential. Failure means one gateway is adopted twice — once truthfully and
+    once mislabelled as a Claude plan subscription.
+    """
+    from omnigent.onboarding import harness_install
+
+    # A login the probe *would* report, exactly as on an enterprise Mac.
+    monkeypatch.setattr(harness_install, "harness_cli_logged_in", lambda key: True)
+    _write_claude_managed_settings(clean_env, monkeypatch, _ISAAC_STYLE_CLAUDE_SETTINGS)
+
+    assert [(d.name, d.kind) for d in detect_providers()] == [("claude-databricks", "cli-config")]
+
+
+def test_claude_subscription_still_detected_without_managed_gateway(
+    clean_env, monkeypatch
+) -> None:
+    """With no managed gateway, a real CLI login is still detected as before.
+
+    Guards the suppression above from swallowing the ordinary Pro/Max case.
+    """
+    from omnigent.onboarding import harness_install
+
+    monkeypatch.setattr(harness_install, "harness_cli_logged_in", lambda key: True)
+    # The Keychain fallback is darwin-gated; pin it so the test asserts the same
+    # behavior on Linux CI as on a Mac.
+    monkeypatch.setattr(ambient.sys, "platform", "darwin")
+
+    assert [(d.name, d.kind) for d in detect_providers()] == [("claude", "subscription")]
+
+
+@pytest.mark.parametrize(
+    "payload,reason",
+    [
+        # A base URL with no way to authenticate is not a usable credential.
+        (
+            {"env": {"ANTHROPIC_BASE_URL": "https://x.cloud.databricks.com/ai-gateway/a"}},
+            "gateway-without-credential",
+        ),
+        # A helper with no endpoint routes nowhere omnigent can vouch for.
+        ({"apiKeyHelper": "print-token"}, "credential-without-gateway"),
+        # Neither half present.
+        ({"env": {"MCP_TOOL_TIMEOUT": "1000"}}, "unrelated-settings"),
+        # Not an object at all.
+        ([1, 2, 3], "not-an-object"),
+    ],
+)
+def test_claude_managed_gateway_not_detected(
+    clean_env, monkeypatch, payload: object, reason: str
+) -> None:
+    """Half-configured or malformed managed settings detect nothing.
+
+    Failure means readiness would report a Claude credential that cannot
+    actually authenticate, stranding the launch at run time instead of
+    prompting the user to finish setup.
+    """
+    _write_claude_managed_settings(clean_env, monkeypatch, payload)
+    assert detect_providers() == [], reason
+
+
+def test_claude_managed_gateway_use_gateway_env_counts_as_credential(
+    clean_env, monkeypatch
+) -> None:
+    """A truthy ``CLAUDE_CODE_USE_GATEWAY`` delivers the credential too.
+
+    The ucode-style variant of the enterprise setup: no ``apiKeyHelper``, the
+    CLI mints its own gateway token. Parity with the Smart-Routing check, which
+    has always accepted this signal.
+    """
+    _write_claude_managed_settings(
+        clean_env,
+        monkeypatch,
+        {
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://dbc-test.cloud.databricks.com/ai-gateway/anthropic",
+                "CLAUDE_CODE_USE_GATEWAY": "1",
+            }
+        },
+    )
+    assert [d.name for d in detect_providers()] == ["claude-databricks"]
+
+
+def test_claude_managed_gateway_non_databricks_named_by_host(clean_env, monkeypatch) -> None:
+    """A non-Databricks gateway is still detected, named after its host.
+
+    The credential is real (endpoint + helper) even when it isn't a Databricks
+    AI Gateway, so it must not be dropped; only the Databricks *label* is
+    reserved for URLs the allowlist recognizes.
+    """
+    _write_claude_managed_settings(
+        clean_env,
+        monkeypatch,
+        {
+            "env": {"ANTHROPIC_BASE_URL": "https://llm.corp.example.com/v1"},
+            "apiKeyHelper": "print-token",
+        },
+    )
+    (det,) = detect_providers()
+    assert (det.name, det.cli, det.family) == (
+        "claude-llm-corp-example-com",
+        "claude",
+        "anthropic",
+    )
+    assert det.display_name == "llm.corp.example.com"
+
+
+def test_claude_managed_gateway_missing_file_is_graceful(clean_env, monkeypatch) -> None:
+    """An absent settings file detects nothing rather than raising."""
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (clean_env / "nope.json",))
+    assert ambient.claude_config_custom_provider() is None
+    assert ambient.claude_config_detection() is None
+
+
+def test_claude_managed_gateway_first_readable_file_decides(clean_env, monkeypatch) -> None:
+    """A higher-precedence file without a gateway is not overridden by a lower one.
+
+    Mirrors Claude Code's own precedence: the file the CLI would apply decides,
+    so omnigent never reports a credential the CLI would ignore.
+    """
+    import json
+
+    high = clean_env / "high.json"
+    high.write_text(json.dumps({"env": {"MCP_TOOL_TIMEOUT": "1"}}))
+    low = clean_env / "low.json"
+    low.write_text(json.dumps(_ISAAC_STYLE_CLAUDE_SETTINGS))
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (high, low))
+
+    assert ambient.claude_config_detection() is None
+    # An unreadable high-precedence entry is skipped, so the low one decides.
+    monkeypatch.setattr(
+        ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (clean_env / "absent.json", low)
+    )
+    assert ambient.claude_config_detection() == _ISAAC_STYLE_CLAUDE_DETECTION

--- a/tests/onboarding/test_detected.py
+++ b/tests/onboarding/test_detected.py
@@ -387,6 +387,7 @@ def _codex_config_det() -> DetectedProvider:
         kind="cli-config",
         family=OPENAI_FAMILY,
         source="~/.codex/config.toml provider 'Databricks'",
+        cli="codex",
         model_provider="Databricks",
         display_name="Databricks AI Gateway",
     )
@@ -501,3 +502,79 @@ def test_malformed_dismissed_detections_treated_as_empty() -> None:
     assert dismissed_detection_names({"dismissed_detections": [3, "codex-databricks"]}) == (
         frozenset({"codex-databricks"})
     )
+
+
+def _claude_config_det() -> DetectedProvider:
+    """An ambient Claude Code managed-settings gateway detection."""
+    return DetectedProvider(
+        name="claude-databricks",
+        kind="cli-config",
+        family=ANTHROPIC_FAMILY,
+        source="Claude Code managed settings gateway 'Databricks AI Gateway'",
+        cli="claude",
+        display_name="Databricks AI Gateway",
+    )
+
+
+def test_synthesize_claude_cli_config_entry() -> None:
+    """A claude cli-config detection synthesizes an entry with NO model_provider.
+
+    Claude Code pins its endpoint directly, so there is no
+    ``[model_providers.X]`` id to record. Asserted by full equality: emitting a
+    ``model_provider`` key here would be a fabricated pin, and omitting ``cli``
+    would fail config parsing on adoption.
+    """
+    entries = synthesize_detected_entries([_claude_config_det()])
+    assert entries == {
+        "claude-databricks": {
+            "kind": "cli-config",
+            "cli": "claude",
+            "display_name": "Databricks AI Gateway",
+        }
+    }
+
+
+def test_claude_cli_config_becomes_anthropic_default() -> None:
+    """A detected Claude gateway auto-defaults the anthropic surface.
+
+    The whole point of the detection: on an enterprise host with nothing in
+    config.yaml, the Claude harness must resolve this credential rather than
+    report "not configured". Failure means the setup dead end the codex side
+    never had.
+    """
+    from omnigent.onboarding.provider_config import default_provider_for_harness
+
+    merged = effective_config_with_detected({}, [_claude_config_det()])
+    entry = default_provider_for_harness(merged, "claude-sdk")
+    assert entry is not None
+    assert (entry.name, entry.kind, entry.cli) == ("claude-databricks", "cli-config", "claude")
+
+
+def test_claude_cli_config_detection_can_be_dismissed() -> None:
+    """Removing the adopted entry keeps the Claude gateway from bouncing back.
+
+    Its credential can't be "signed out" (it lives in an enterprise file), so
+    without the dismissal Remove would be a no-op on the next configure open.
+    """
+    config = {"dismissed_detections": ["claude-databricks"]}
+    assert providers_to_adopt(config, [_claude_config_det()]) == {}
+    merged = effective_config_with_detected(config, [_claude_config_det()])
+    assert "claude-databricks" not in (merged.get("providers") or {})
+
+
+def test_claude_and_codex_cli_configs_coexist() -> None:
+    """Both harnesses' own-config credentials are adopted side by side.
+
+    An internal machine has both; each must default its own surface, with no
+    cross-talk between the codex ``model_provider`` pin and the Claude gateway.
+    """
+    from omnigent.onboarding.provider_config import default_provider_for_harness
+
+    merged = effective_config_with_detected({}, [_claude_config_det(), _codex_config_det()])
+    claude = default_provider_for_harness(merged, "claude-sdk")
+    codex = default_provider_for_harness(merged, "codex")
+    assert claude is not None and codex is not None
+    assert claude.name == "claude-databricks"
+    assert codex.name == "codex-databricks"
+    assert claude.model_provider is None
+    assert codex.model_provider == "Databricks"

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -647,3 +647,75 @@ def test_antigravity_native_requires_credential(
     monkeypatch.setattr(_ga, "gemini_login_detected", lambda: True)
     assert harness_is_configured("antigravity-native") is True
     assert harness_is_configured("native-antigravity") is True
+
+
+def test_claude_ready_via_managed_settings_gateway_without_cli_login(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Claude reads ready from its own managed-settings gateway alone.
+
+    The enterprise state (``isaac configure claude``): nothing in omnigent's
+    config, no subscription login, but Claude Code's managed settings pin an AI
+    Gateway + ``apiKeyHelper`` and the CLI applies them at its own launch. The
+    check is structural, so it must NOT depend on the ``claude auth status``
+    subprocess — which is exactly what used to fail here, reporting
+    ``needs-auth`` and surfacing as "Claude Code isn't configured on <host>"
+    with nothing in setup able to fix it.
+    """
+    import json
+
+    from omnigent.onboarding import ambient
+
+    _all_clis_installed(monkeypatch)
+    monkeypatch.setattr(
+        "omnigent.onboarding.harness_readiness._family_provider_configured", lambda _h: False
+    )
+    # The fragile probe stays broken; readiness must not need it.
+    monkeypatch.setattr(hi, "harness_cli_logged_in", lambda key, **_kw: False)
+    settings = tmp_path / "managed-settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "ANTHROPIC_BASE_URL": (
+                        "https://dbc-test.cloud.databricks.com/ai-gateway/anthropic"
+                    )
+                },
+                "apiKeyHelper": "print-token",
+            }
+        )
+    )
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (settings,))
+
+    result = configured_harness_map()
+    assert result["claude-native"] is True
+    assert result["native-claude"] is True
+
+
+def test_claude_managed_settings_without_credential_still_needs_auth(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A managed gateway with no credential does NOT make Claude read ready.
+
+    A bare ``ANTHROPIC_BASE_URL`` is not something omnigent can authenticate
+    against, so crediting it would turn a real "finish setup" prompt into a
+    launch that dies on its first turn.
+    """
+    import json
+
+    from omnigent.onboarding import ambient
+
+    _all_clis_installed(monkeypatch)
+    monkeypatch.setattr(
+        "omnigent.onboarding.harness_readiness._family_provider_configured", lambda _h: False
+    )
+    monkeypatch.setattr(hi, "harness_cli_logged_in", lambda key, **_kw: False)
+    settings = tmp_path / "managed-settings.json"
+    settings.write_text(
+        json.dumps(
+            {"env": {"ANTHROPIC_BASE_URL": "https://dbc-t.cloud.databricks.com/ai-gateway/a"}}
+        )
+    )
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (settings,))
+
+    assert configured_harness_map()["claude-native"] == "needs-auth"

--- a/tests/onboarding/test_provider_config.py
+++ b/tests/onboarding/test_provider_config.py
@@ -671,13 +671,14 @@ def test_parse_cli_config_entry() -> None:
 @pytest.mark.parametrize(
     "body,message_fragment",
     [
-        # Only codex has config-file model providers; a claude analog would
-        # be a deliberate extension, not a silently-accepted value.
+        # Only codex and claude carry a config-file credential; any other CLI
+        # is a typo, not a silently-accepted value.
         (
-            {"kind": "cli-config", "cli": "claude", "model_provider": "X"},
-            "requires cli: 'codex'",
+            {"kind": "cli-config", "cli": "gemini", "model_provider": "X"},
+            "requires cli: 'codex' or 'claude'",
         ),
-        # The pin target is the entry's whole point — fail loud without it.
+        # For codex the pin target is the entry's whole point — fail loud
+        # without it. (Claude has no id to pin, so it is optional there.)
         ({"kind": "cli-config", "cli": "codex"}, "'model_provider'"),
     ],
 )
@@ -889,3 +890,84 @@ def test_provider_credential_env_vars_empty_for_keychain_and_auth_command() -> N
         }
     }
     assert provider_credential_env_vars(config) == frozenset()
+
+
+def test_parse_claude_cli_config_entry_without_model_provider() -> None:
+    """A claude cli-config entry parses with no ``model_provider``.
+
+    Claude Code's settings pin the endpoint directly, so there is no
+    ``[model_providers.X]`` id. Requiring one (as codex does) would reject the
+    enterprise Claude credential outright — the parse-level half of the bug.
+    """
+    from omnigent.onboarding.provider_config import load_providers
+
+    entries = load_providers(
+        {
+            "providers": {
+                "claude-databricks": {
+                    "kind": "cli-config",
+                    "cli": "claude",
+                    "display_name": "Databricks AI Gateway",
+                }
+            }
+        }
+    )
+    entry = entries["claude-databricks"]
+    assert (entry.kind, entry.cli, entry.model_provider) == ("cli-config", "claude", None)
+    assert entry.display_name == "Databricks AI Gateway"
+
+
+def test_claude_cli_config_serves_only_anthropic() -> None:
+    """A claude cli-config serves the anthropic surface and NOT pi.
+
+    Pi reuses a pinned *codex* ``[model_providers.X]`` table; Claude Code's
+    managed credential is not readable outside its own CLI, so claiming the pi
+    scope would strand a pi launch. Failure means pi could auto-default to a
+    credential it cannot use.
+    """
+    from omnigent.onboarding.provider_config import (
+        ANTHROPIC_FAMILY,
+        load_providers,
+        provider_families,
+    )
+
+    entry = load_providers({"providers": {"c": {"kind": "cli-config", "cli": "claude"}}})["c"]
+    assert provider_families(entry) == frozenset({ANTHROPIC_FAMILY})
+
+
+def test_claude_cli_config_rejects_pi_default_scope() -> None:
+    """``default: pi`` on a claude cli-config is a loud config error.
+
+    Same guard the codex *subscription* has: a scope the credential cannot serve
+    must fail at parse rather than at launch.
+    """
+    from omnigent.errors import OmnigentError
+    from omnigent.onboarding.provider_config import load_providers
+
+    with pytest.raises(OmnigentError):
+        load_providers(
+            {"providers": {"c": {"kind": "cli-config", "cli": "claude", "default": "pi"}}}
+        )
+
+
+def test_claude_cli_config_resolves_for_claude_harness() -> None:
+    """A default claude cli-config resolves as the claude harness's provider.
+
+    The routing half: ``default_provider_for_harness`` must hand the native /
+    SDK Claude launch this entry so the harness counts as configured.
+    """
+    from omnigent.onboarding.provider_config import (
+        default_provider_for_harness,
+        load_providers,
+    )
+
+    config = {
+        "providers": {
+            "claude-databricks": {"kind": "cli-config", "cli": "claude", "default": True}
+        }
+    }
+    # Sanity: the entry itself parses and claims the anthropic default.
+    assert load_providers(config)["claude-databricks"].default is True
+    for harness in ("claude-sdk", "claude-native"):
+        entry = default_provider_for_harness(config, harness)
+        assert entry is not None and entry.name == "claude-databricks", harness


### PR DESCRIPTION
## Related issue

Closes #

<!-- No tracking issue exists for this yet — it was found by direct reproduction on an
enterprise macOS host. Happy to file one if a maintainer wants it linked. -->

## Summary

An enterprise Claude Code install (the shape `isaac configure claude` writes) configures the CLI through its **own managed settings** only — a gateway `env.ANTHROPIC_BASE_URL` plus an `apiKeyHelper` that prints a bearer token. No `.credentials.json` and no Keychain subscription is ever written, so ambient detection saw nothing routable: the Claude harness reported "not configured" and `omnigent setup` offered nothing able to adopt it. Codex has had the equivalent detection for its own `~/.codex/config.toml` all along, so the **same machine** showed a clean `Codex-Databricks` credential and no Claude twin.

The reader already existed (`managed_claude_gateway_signal`) but was wired only into the Smart-Routing gateway check. This moves the canonical parser to `ambient.claude_managed_gateway` (`claude_native` now delegates, so there is one parser) and adds `claude_config_detection` → a `claude-databricks` `cli-config` detection carrying **no** `model_provider`, since Claude Code pins its endpoint directly and has no `[model_providers.X]` id to record.

Around that, `cli-config` stops being codex-only:

- `provider_config` accepts `cli: claude` via `CLI_CONFIG_CLIS` and requires `model_provider` for codex only. A claude entry serves the anthropic surface and never claims the `pi` scope — Claude Code's credential is not readable outside its own CLI.
- the setup add-menu row is ungated for anthropic and **filtered per family**, so a harness page only offers its own CLI's credential, and the copy names the right config file.
- Claude readiness gains a structural `_claude_managed_gateway_configured()` ahead of the `claude auth status` subprocess, mirroring how codex readiness credits its own config.

The mislabeled `claude` *subscription* detection is now suppressed when the gateway is found: `claude auth status` reports a managed helper as logged in (`authMethod: "api_key_helper"`), so it describes the same credential and would otherwise be adopted twice — once truthfully, once as a phantom plan login.

### ELI5

Isaac hides Claude's key in a different drawer than Codex's. omnigent only knew how to open Codex's drawer, so it kept saying "you have no Claude key" while staring at one. Now it opens both drawers, and labels what it finds the same way.

### Where each credential lives

```mermaid
graph LR
  subgraph host["enterprise host"]
    CX["~/.codex/config.toml<br/>model_provider = Databricks<br/>[model_providers.Databricks.auth]"]
    CL["managed-settings.json<br/>env.ANTHROPIC_BASE_URL<br/>apiKeyHelper"]
  end
  CX -->|"codex_config_detection()"| CXD["codex-databricks<br/>cli-config / cli: codex"]
  CL -->|"claude_config_detection() (new)"| CLD["claude-databricks<br/>cli-config / cli: claude"]
  CXD --> OK["setup menu + readiness + routing"]
  CLD --> OK
```

Before this change the lower path did not exist; the only Claude signal was a `claude auth status` subprocess that reported the gateway as a *subscription*.

### Why the readiness gate mattered

`_family_provider_configured()` reads `config.yaml` only, so on such a host it is `False` and readiness fell through to the status probe. That probe resolves the CLI with a bare `shutil.which`, while the installed-check next to it uses `resolve_cli_binary` (which searches known install dirs). So the binary could be *found* and the login probe still fail:

```
resolve_cli_binary(claude)       = ~/.local/bin/claude
harness_cli_installed(anthropic) = True
_family_provider_configured(...) = False   <- managed gateway invisible
harness_cli_logged_in(anthropic) = False   <- shutil.which miss
=> _harness_availability('claude-native') = 'needs-auth'
```

`needs-auth` has harness-specific UI copy only for Codex and Cursor, so Claude fell through to the generic *"Claude Code isn't configured on `<host>` — run `omni setup`"* — pointing at a setup flow that could not fix it. The structural check now returns `True` here without the subprocess.

## Test Plan

Unit tests (new, 15): Claude managed-settings detection (Databricks and non-Databricks gateways, `CLAUDE_CODE_USE_GATEWAY`, half-configured/malformed/missing files, precedence), the subscription-suppression and its guard that an ordinary Pro/Max login still detects, `cli-config` synthesis and dismissal, `provider_config` parse/family/pi-scope/routing, readiness green-from-managed-settings and its no-credential negative, and the add-menu copy + label parity.

`1829 passed` across `tests/onboarding/`, `tests/cli/test_configure_models.py`, `tests/test_gateway_inference.py`, `tests/test_claude_native.py`, `tests/test_model_catalog.py`, `tests/test_pi_native_credentials.py`, plus the codex suites. `pre-commit run` clean (ruff format, ruff check, pyrefly, all hooks).

One pre-existing failure, unrelated and confirmed identical on `origin/main`: `tests/runtime/test_provider_spawn_env.py::test_claude_sdk_falls_back_to_first_available_anthropic_credential`.

Manual verification on a real enterprise macOS host (Darwin 25.6.0) — see Demo.

### Test isolation note for reviewers

The managed-settings paths are **absolute** (`/Library/Application Support/...`, `/etc/claude-code/...`), so unlike `~/.claude` they are *not* redirected by a test's tmp `$HOME`. Without isolation, a developer's or CI runner's real enterprise install injects a phantom `claude-databricks` into every detection assertion — it broke 55 existing tests locally before the fixture landed. Hence the autouse `tests/conftest.py::_isolate_claude_managed_settings`, with an opt-in `claude_managed_settings` fixture; the new readers also take an explicit `paths=` argument. This is the same class of host-state leak as #4279.

## Demo

Captured by driving the **installed** `omni` (built from this branch) through `omni setup` in the `cli-setup-verify` sandbox on a real enterprise macOS host — throwaway `HOME` / `OMNIGENT_CONFIG_HOME` / `OMNIGENT_DATA_DIR`, with the run's guard confirming `real ~/.omnigent untouched: True`.

**1. Both own-config credentials are now auto-adopted** (before this change the banner named only `Codex-Databricks`):

```
  ✦ omnigent  setup

Found existing credentials on your machine, auto-configured for omnigent:
Claude-Databricks, Codex-Databricks
```

**2. The harness list** — Claude goes green off its managed-settings gateway alone, with no subscription and nothing else in `config.yaml`:

```
  Configure harnesses
    ❯  Claude                  ✓ Claude-Databricks
       Codex                   ✓ Codex-Databricks
       Cursor                  ✗ CLI needs login
       OpenCode                ✗ Not configured
```

**3. The Claude credential page** — same `⚙️` cli-config glyph Codex already had:

```
  Claude — select or add a credential

    ❯  ⚙️ Claude-Databricks  ✓ default
       + Add a credential
       ← Back
```

**4. The new add-menu row** (after a Remove, so the detection is offerable again) with its description line:

```
  What do you want to add?

       🔑 Anthropic — API key
       🎟️ Claude — subscription (Pro/Max)
       🌐 Gateway — custom base URL + key
       🧱 Databricks — workspace
       ☁ AWS Bedrock — API key
    ❯  ⚙️ Databricks AI Gateway — from your Claude Code settings

    Use the AI Gateway your Claude Code managed settings pin and authenticate;
    Claude Code applies them itself at launch.
```

**5. Per-family filtering** — the Codex page offers only *its* config, never Claude's:

```
       🧱 Databricks — workspace
       🔑 Other provider — API key
       ⚙️ Databricks AI Gateway — from your Codex config
```

**6. Remove → re-add round trip.** Removing states the dismissal semantics honestly (the credential is an enterprise file omnigent cannot sign out of):

```
  ✓ Removed Claude-Databricks — it stays on your machine but won'"'"'t be auto-configured again
  ...
  ✓ Added claude-databricks — default for Claude
```

and re-adding clears the dismissal. Persisted `config.yaml`:

```yaml
dismissed_detections: []
providers:
  claude-databricks:
    cli: claude
    default: true
    display_name: Databricks AI Gateway
    kind: cli-config
  codex-databricks:
    cli: codex
    default: true
    display_name: Databricks AI Gateway
    kind: cli-config
    model_provider: Databricks
```

Note the claude entry carries no `model_provider` — there is no `[model_providers.X]` id to pin.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification on an enterprise macOS host with both credentials present. Confirmed detection yields `claude-databricks` alongside `codex-databricks`; the persisted `providers:` block gets `default: true` for each; `default_provider_for_harness` resolves `claude-databricks` for both `claude-native` and `claude-sdk`; the setup label reads `Claude-Databricks`, matching `Codex-Databricks`; and `_native_claude_config_from_entry` returns `None` for the entry, which is what lets Claude Code apply its own managed settings (so routing is unchanged, only detection/labelling/gating). Also re-ran the `needs-auth` reproduction under a stripped `PATH` and confirmed it now reads ready.

Not covered automatically: the interactive picker itself (the add-menu row is built inside `_configure_harness_add`, which needs a driven TTY) — the row's user-facing strings and the family filter are unit-tested, the selection is verified manually.

## Changelog

`omnigent setup` now detects an enterprise Claude Code gateway (`ANTHROPIC_BASE_URL` + `apiKeyHelper`) and offers it as a `Claude-Databricks` credential, the way it already did for Codex

This pull request and its description were written by Isaac.
