### PR TITLE
[OMNI-3726] fix(web): stop an un-renderable mermaid diagram from blanking the app

### DIFF
--- a/tests/e2e_ui/chat/test_chat_mermaid_diagram.py
+++ b/tests/e2e_ui/chat/test_chat_mermaid_diagram.py
@@ -1,0 +1,80 @@
+"""E2E: mermaid diagrams in chat render, and an un-renderable one degrades.
+
+Streamdown renders mermaid diagrams behind ``React.lazy``. Suspense catches a
+*pending* import, not a failed one — a rejected lazy import is re-thrown on
+every subsequent render, so without an error boundary above it React unmounts
+the whole tree and the user sees a blank page instead of one broken diagram.
+
+The second test aborts the mermaid chunk request, which is the faithful stand-in
+for the real-world trigger: a tab holding a stale ``index.html`` after the SPA is
+rebuilt, whose hashed mermaid chunk no longer exists on the server.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, Route, expect
+
+_AGENT_NAME = "hello_world"
+# Every emitted mermaid chunk, so this keeps matching across rebuilds (the
+# hashes change on every build).
+_MERMAID_CHUNKS = "**/mermaid-*.js"
+
+# Trailing prose after the fence: proves the surrounding message survives.
+_MERMAID_MESSAGE = (
+    "Here is the architecture:\n\n"
+    "```mermaid\n"
+    "flowchart LR\n"
+    "  A[Client] --> B[Server]\n"
+    "  B --> C[(Database)]\n"
+    "```\n\n"
+    "That is the shape of it.\n"
+)
+
+
+@pytest.fixture
+def mermaid_chat_session(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str]]:
+    """Seed a settled assistant bubble carrying a mermaid fence (no LLM turn)."""
+    base_url, session_id = seeded_session
+    httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_assistant_message",
+            "data": {"agent": _AGENT_NAME, "text": _MERMAID_MESSAGE},
+        },
+        timeout=10.0,
+    ).raise_for_status()
+    yield (base_url, session_id)
+
+
+def test_mermaid_fence_renders_as_a_diagram(
+    page: Page, mermaid_chat_session: tuple[str, str]
+) -> None:
+    """A mermaid fence in an assistant bubble becomes an SVG diagram."""
+    base_url, session_id = mermaid_chat_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    block = page.locator('[data-streamdown="mermaid-block"]').first
+    expect(block).to_be_visible(timeout=30_000)
+    # Mermaid stamps its output with aria-roledescription (e.g. "flowchart-v2"),
+    # which distinguishes the diagram from the block's own control icons.
+    expect(block.locator("svg[aria-roledescription]")).to_be_visible(timeout=30_000)
+
+
+def test_unrenderable_diagram_degrades_instead_of_blanking_the_app(
+    page: Page, mermaid_chat_session: tuple[str, str]
+) -> None:
+    """A diagram that cannot load must not unmount the app around it."""
+    base_url, session_id = mermaid_chat_session
+    page.route(_MERMAID_CHUNKS, lambda route: Route.abort(route, "failed"))
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # The app is still mounted: the shell renders and the composer is usable.
+    expect(page.get_by_placeholder("Ask the agent anything…")).to_be_visible(timeout=30_000)
+    assert page.evaluate("() => document.getElementById('root')?.children.length ?? 0") > 0
+
+    # The message's content survives as markdown source rather than vanishing.
+    expect(page.get_by_text("That is the shape of it.")).to_be_visible(timeout=30_000)

--- a/web/src/components/ai-elements/MarkdownErrorBoundary.test.tsx
+++ b/web/src/components/ai-elements/MarkdownErrorBoundary.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MessageResponse } from "./message";
+
+afterEach(cleanup);
+
+// A throw anywhere inside the markdown pipeline (Streamdown renders mermaid
+// diagrams behind React.lazy, whose rejected import is re-thrown on every
+// render) used to unmount the whole app, because nothing above it caught.
+// Simulated here with a component override that throws during render.
+describe("markdown rendering is contained to the block that fails", () => {
+  const MARKDOWN = "the diagram source";
+  const Boom = () => {
+    throw new Error("markdown pipeline exploded");
+  };
+
+  it("falls back to the source instead of propagating the throw", () => {
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // Renders without throwing: the boundary catches, so React keeps the
+      // surrounding tree (in the real app, the entire page) mounted.
+      const { container } = render(
+        <div data-testid="app">
+          <MessageResponse components={{ p: Boom }}>{MARKDOWN}</MessageResponse>
+        </div>,
+      );
+      expect(container.querySelector('[data-testid="app"]')).toBeTruthy();
+      expect(container.textContent).toContain(MARKDOWN);
+    } finally {
+      errors.mockRestore();
+    }
+  });
+});

--- a/web/src/components/ai-elements/MarkdownErrorBoundary.tsx
+++ b/web/src/components/ai-elements/MarkdownErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+/**
+ * Contains a throw from the markdown pipeline to the one block that threw.
+ *
+ * Streamdown renders mermaid diagrams behind `React.lazy`, and a rejected lazy
+ * import is re-thrown on every subsequent render (Suspense catches pending
+ * imports, not failed ones). With no boundary above it React unmounts the whole
+ * tree, so a single un-renderable diagram — a stale tab whose hashed mermaid
+ * chunk no longer exists, say — blanks the entire app.
+ *
+ * Wrap every `Streamdown` seam so a block that can't render degrades to its own
+ * markdown source and the rest of the page keeps working. Deliberately does not
+ * reset when `children` change: React.lazy caches a rejection forever, so a
+ * retry would only throw again.
+ */
+export class MarkdownErrorBoundary extends Component<
+  { children: ReactNode; source: ReactNode },
+  { failed: boolean }
+> {
+  override state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Markdown rendering failed; falling back to source", error, info.componentStack);
+  }
+
+  override render() {
+    if (!this.state.failed) return this.props.children;
+    return (
+      <div>
+        <p className="mb-1 text-muted-foreground text-xs">Could not render this markdown.</p>
+        <div className="whitespace-pre-wrap wrap-anywhere font-mono text-sm">
+          {this.props.source}
+        </div>
+      </div>
+    );
+  }
+}

--- a/web/src/components/ai-elements/message.tsx
+++ b/web/src/components/ai-elements/message.tsx
@@ -22,6 +22,8 @@ import {
 } from "react";
 import { Streamdown, type StreamdownProps } from "streamdown";
 
+import { MarkdownErrorBoundary } from "./MarkdownErrorBoundary";
+
 import {
   CHAT_LINK_SAFETY,
   FILE_LINK_STREAMDOWN_REHYPE_PLUGINS,
@@ -448,24 +450,26 @@ export const MessageResponse = memo(
     const messageControls = useMemo(() => getChatCodeControls(controls), [controls]);
 
     return (
-      <Streamdown
-        // wrap-anywhere is inherited, giving every prose descendant (including inline code) a break opportunity.
-        className={cn(
-          "size-full wrap-anywhere [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
-          className,
-        )}
-        plugins={STREAMDOWN_PLUGINS}
-        // Let links open on a plain click (and cmd/ctrl-click in a new tab)
-        // instead of Streamdown's default "Open external link?" modal.
-        linkSafety={CHAT_LINK_SAFETY}
-        {...props}
-        components={messageComponents}
-        controls={messageControls}
-        // Block remote image fetches that can exfiltrate data through URLs.
-        rehypePlugins={
-          markFileLinks ? FILE_LINK_STREAMDOWN_REHYPE_PLUGINS : SECURE_STREAMDOWN_REHYPE_PLUGINS
-        }
-      />
+      <MarkdownErrorBoundary source={props.children}>
+        <Streamdown
+          // wrap-anywhere is inherited, giving every prose descendant (including inline code) a break opportunity.
+          className={cn(
+            "size-full wrap-anywhere [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+            className,
+          )}
+          plugins={STREAMDOWN_PLUGINS}
+          // Let links open on a plain click (and cmd/ctrl-click in a new tab)
+          // instead of Streamdown's default "Open external link?" modal.
+          linkSafety={CHAT_LINK_SAFETY}
+          {...props}
+          components={messageComponents}
+          controls={messageControls}
+          // Block remote image fetches that can exfiltrate data through URLs.
+          rehypePlugins={
+            markFileLinks ? FILE_LINK_STREAMDOWN_REHYPE_PLUGINS : SECURE_STREAMDOWN_REHYPE_PLUGINS
+          }
+        />
+      </MarkdownErrorBoundary>
     );
   },
 );

--- a/web/src/components/ai-elements/reasoning.tsx
+++ b/web/src/components/ai-elements/reasoning.tsx
@@ -9,6 +9,7 @@ import { Streamdown } from "streamdown";
 
 import { normalizeExplicitMathDelimiters } from "./mathMarkdown";
 import { Shimmer } from "./shimmer";
+import { MarkdownErrorBoundary } from "./MarkdownErrorBoundary";
 import {
   CHAT_LINK_SAFETY,
   SECURE_STREAMDOWN_REHYPE_PLUGINS,
@@ -195,16 +196,18 @@ export const ReasoningContent = memo(({ className, children, ...props }: Reasoni
       )}
       {...props}
     >
-      <Streamdown
-        plugins={STREAMDOWN_PLUGINS}
-        // Let links open on a plain click (and cmd/ctrl-click in a new tab)
-        // instead of Streamdown's default "Open external link?" modal.
-        linkSafety={CHAT_LINK_SAFETY}
-        // Block remote image fetches that can exfiltrate data through URLs.
-        rehypePlugins={SECURE_STREAMDOWN_REHYPE_PLUGINS}
-      >
-        {normalizedChildren}
-      </Streamdown>
+      <MarkdownErrorBoundary source={normalizedChildren}>
+        <Streamdown
+          plugins={STREAMDOWN_PLUGINS}
+          // Let links open on a plain click (and cmd/ctrl-click in a new tab)
+          // instead of Streamdown's default "Open external link?" modal.
+          linkSafety={CHAT_LINK_SAFETY}
+          // Block remote image fetches that can exfiltrate data through URLs.
+          rehypePlugins={SECURE_STREAMDOWN_REHYPE_PLUGINS}
+        >
+          {normalizedChildren}
+        </Streamdown>
+      </MarkdownErrorBoundary>
     </CollapsibleContent>
   );
 });

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -43,6 +43,7 @@ import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { rehypeGithubAlerts } from "rehype-github-alerts";
 import { mermaid } from "@streamdown/mermaid";
+import { MarkdownErrorBoundary } from "@/components/ai-elements/MarkdownErrorBoundary";
 import { Streamdown } from "streamdown";
 import type { Comment } from "@/hooks/useComments";
 import {
@@ -143,9 +144,11 @@ const MERMAID_STREAMDOWN_PLUGINS = { mermaid };
 function MermaidPreview({ source }: { source: string }) {
   return (
     <div data-testid="mermaid-preview" className="not-prose my-4 overflow-auto">
-      <Streamdown plugins={MERMAID_STREAMDOWN_PLUGINS}>
-        {`\`\`\`mermaid\n${source.replace(/\n$/, "")}\n\`\`\``}
-      </Streamdown>
+      <MarkdownErrorBoundary source={source}>
+        <Streamdown plugins={MERMAID_STREAMDOWN_PLUGINS}>
+          {`\`\`\`mermaid\n${source.replace(/\n$/, "")}\n\`\`\``}
+        </Streamdown>
+      </MarkdownErrorBoundary>
     </div>
   );
 }


### PR DESCRIPTION
## Related issue

Internal: **OMNI-3726** ("mermaid graph crashes the page"). No public GitHub issue exists for this one, so there is no `Closes #` keyword to add.

## Summary

An agent message carrying a mermaid graph could take the whole page down to a blank screen.

**The diagram source was never the trigger.** I put 17 diagram shapes through the real chat path (flowchart, graph, sequence, class, stateDiagram-v2, er, gantt, pie, journey, mindmap, timeline, gitGraph, quadrant, xychart, plus subgraphs, quoted/paren labels, `<br/>`, `classDef`, `%%{init}%%`, a 60-node graph, three diagrams in one message, a fence nested in a numbered list) and every valid one rendered. Invalid syntax already shows Streamdown's own "Mermaid Error" card.

**ELI5:** the app had no seatbelt. One broken diagram was enough to throw the whole car out.

Concretely, `grep -rn "ErrorBoundary|componentDidCatch|getDerivedStateFromError" web/src/` returned nothing: there was no error boundary anywhere in the web app. Streamdown renders mermaid through `React.lazy`. Suspense catches a *pending* import, not a failed one, and `React.lazy` caches a rejection and re-throws it on every later render. With nothing catching above it, React unmounts the entire tree.

```mermaid
flowchart TD
  A["mermaid fence in an agent message"] --> B["Streamdown: React.lazy(mermaid chunk)"]
  B -->|"chunk loads"| C["diagram renders"]
  B -->|"chunk fails"| D["rejection cached, re-thrown every render"]
  D --> E["before: no boundary, React unmounts everything -> blank page"]
  D --> F["after: MarkdownErrorBoundary catches -> bubble falls back to source"]
```

Only mermaid is fatal. `lazyCodePlugin` loads Shiki with a bare `void import().then(...)`, so a failed chunk there is just an unhandled rejection and code renders unhighlighted. Mermaid is the only thing in the transcript behind `React.lazy`.

The likely trigger in practice is a tab left open across an SPA rebuild. Chunk hashes change every build (I watched `mermaid-GHXKKRXX-DVJ3XzGc.js` become `mermaid-GHXKKRXX-DGduUeTs.js` on my own rebuild), so a stale in-memory module graph asks for a chunk that no longer exists.

The fix adds `MarkdownErrorBoundary` (42 lines, React's own `getDerivedStateFromError`, no new dependency) and wraps all three `<Streamdown>` seams, so every caller is covered:

| Seam | Covers |
| --- | --- |
| `message.tsx` | chat bubbles, plan review, block renderer, user bubbles |
| `reasoning.tsx` | reasoning panel |
| `CodeViewer.tsx` | markdown Preview pane |

Two deliberate choices, both noted in the code: granularity is per message bubble rather than per block, because Streamdown owns block splitting; and the boundary does not reset on new children, because `React.lazy` caches a rejection forever and a retry would only throw again.

## Test Plan

Repro, with no dependence on chunk hashes so it survives rebuilds: seed an assistant message carrying a mermaid fence, abort `**/mermaid-*.js`, then read `document.getElementById('root').children.length`.

| Case | `#root` children | Transcript | pageerror |
| --- | --- | --- | --- |
| **Before**: mermaid message, mermaid chunk aborted | **0, app unmounted (blank)** | gone | `Failed to fetch dynamically imported module: .../mermaid-GHXKKRXX-*.js` |
| **After**: identical | **2, app alive** | shown as markdown source | none |
| Control: same aborts, code fence instead of a diagram | 2 | shown | none (chunk never requested) |

The control matters: with no diagram in the transcript the mermaid chunk is never fetched and the app is fine, so the blanking is caused by the diagram and not by the request blocking.

Both new guards were confirmed to fail without the fix. Unwrapping `message.tsx` and rebuilding the SPA makes the e2e test fail on "composer not visible" (the blank page); removing `getDerivedStateFromError` makes the unit test fail on the propagated throw.

```bash
# unit
cd web && npx vitest run src/components/ai-elements/MarkdownErrorBoundary.test.tsx

# e2e (new chat coverage + the pre-existing Preview-pane test)
pytest tests/e2e_ui/chat/test_chat_mermaid_diagram.py \
       tests/e2e_ui/files/test_markdown_mermaid_preview.py -v
```

Also green: 5953 web unit tests (0 failures), `tsc -b`, `oxlint --deny-warnings`, `prettier --check`, and `pre-commit run --files` on every touched file.

## Demo

Screenshots, all at 1280x800 against a real production SPA build with the mermaid chunk request aborted.

**Before**: entirely blank page. The sidebar, transcript, and composer are all gone; the only recovery is a reload.

**After**: the app is intact and the message keeps its content as markdown source, under a quiet "Could not render this markdown." line.

**Healthy path, unchanged**: a normal mermaid fence still renders as a diagram with its usual pan/zoom and download chrome.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the part a test cannot assert, which is that a valid diagram is not the bug: 17 diagram shapes were rendered through the real chat path and inspected, and invalid syntax was confirmed to land on Streamdown's own error card rather than a crash. The before/after screenshots above were captured the same way.

Automated coverage is the two committed guards. The unit test pins containment cheaply, with no chunk names involved, by making a component override throw during render. The e2e test pins the user-visible symptom end to end against a real build, and adds the first chat-side mermaid coverage in the suite (the pre-existing mermaid test only covers the file Preview pane).

## Changelog

A mermaid diagram that fails to load no longer blanks the page; the message falls back to its markdown source.
