### PR TITLE
fix(web): clear duplicate user message after reconnect

### DIFF
--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -8434,6 +8434,46 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     await loop;
   });
 
+  it("acks an optimistic user bubble when reconnect backfills its committed item", async () => {
+    const before = userMessage("ack_pre", "before the gap");
+    seedSession("conv_reconnect_ack", [before]);
+    const sinks = routeStreamOpens();
+    const controller = new AbortController();
+    useChatStore.setState({
+      conversationId: "conv_reconnect_ack",
+      abortController: controller,
+      blocks: itemsToBlocks([before]),
+      pendingUserMessages: [
+        {
+          tempId: "pend_gap",
+          content: [{ type: "input_text", text: "only once" }],
+          posted: true,
+        },
+      ],
+    });
+
+    const loop = startStreamPump("conv_reconnect_ack", controller, setState, getState);
+    await drainAsync();
+    expect(sinks).toHaveLength(1);
+
+    const committed = userMessage("ack_gap", "only once");
+    const reply = assistantMessage("ack_gap", "the reply");
+    seedSessionItems("conv_reconnect_ack", [before, committed, reply]);
+    sinks[0]!.error();
+    await drainAsync();
+    expect(sinks).toHaveLength(2);
+
+    const state = useChatStore.getState();
+    expect(state.pendingUserMessages).toEqual([]);
+    expect(state.blocks.map((b) => b.ctx.itemId)).toEqual([before.id, committed.id, reply.id]);
+
+    const last = sinks[1]!;
+    last.push("data: [DONE]\n\n");
+    last.close();
+    await drainAsync(2);
+    await loop;
+  });
+
   it("keeps a heartbeat-alive stream connected across many stall windows", async () => {
     seedSession("conv_hb", []);
     const sinks = routeStreamOpens();

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -3827,6 +3827,14 @@ async function reconcileOnReconnect(id: string, set: Setter, get: Getter): Promi
     );
     const unseen = snapshotBlocks.filter((b) => b.ctx.itemId && !seen.has(b.ctx.itemId));
     const patch: Partial<ChatState> = reconnectStatusPatch(session, s);
+    // `session.input.consumed` is not replayed, so recovered user blocks are
+    // the durable equivalent of its FIFO acknowledgement.
+    const recoveredUserInputs = unseen.filter(
+      (b) => b.type === "user_message" && !isSystemUserContent(b.content),
+    ).length;
+    if (recoveredUserInputs > 0) {
+      patch.pendingUserMessages = s.pendingUserMessages.slice(recoveredUserInputs);
+    }
     let nextBlocks = s.blocks;
     if (unseen.length > 0) {
       // Splice the gap's committed items ahead of the active turn's


### PR DESCRIPTION
## Related issue

N/A — found while investigating a production Omnigent session from logs; no public issue was filed.

## Summary

- Treat newly backfilled, non-system user blocks as the durable FIFO acknowledgement for a `session.input.consumed` event missed during an SSE disconnect.
- Clear the corresponding optimistic entries atomically with reconnect reconciliation so the committed prompt remains before the reply and is rendered once.
- Limit acknowledgement to unseen blocks, preserving legitimate repeated prompts and historical messages.

ELI5: the reconnect already recovered the saved message, but forgot to remove its temporary on-screen copy. It now removes that copy during the same state update.

```text
optimistic prompt -> SSE gap (consumed event lost) -> /items backfill -> dequeue temporary copy
                                                        |
                                                        +-> prompt, then reply
```

## Test Plan

- Red proof with only the regression test applied to `upstream/main`: failed because `pendingUserMessages` still contained `pend_gap` after reconnect.
- `pnpm --dir web exec vitest run src/store/chatStore.test.ts` — 370 passed.
- Prettier, oxlint, and TypeScript checks passed for the affected frontend files.
- `uvx pre-commit run` — passed all staged-file hooks.

## Demo

N/A — a reliable manual capture would require dropping the ephemeral consumed event in the narrow interval after the user item persists but before delivery. The regression test deterministically creates that exact transport gap and was verified red on `upstream/main` and green on this branch.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression test persists a user message and assistant reply during a simulated stream gap, reconnects, and verifies that the pending queue is empty and committed blocks remain in user-then-assistant order.

## Changelog

Resumed web sessions no longer repeat a sent message beneath the agent's reply.
