### PR TITLE
fix(runtime): require exact match in Kiro pending-input resolver

### DIFF
--- a/omnigent/runtime/pending_inputs.py
+++ b/omnigent/runtime/pending_inputs.py
@@ -312,7 +312,12 @@ def resolve_matching_text(conversation_id: str, text: str) -> MatchedDrain:
         match_index: int | None = None
         for index, (_pending_id, entry) in enumerate(ordered):
             entry_text = _normalize_text(_content_text(entry.content))
-            if entry_text and (needle == entry_text or needle.endswith(entry_text)):
+            # Exact match only: an unanchored suffix check ("noyes".endswith("yes"))
+            # can pick an unrelated queued entry whenever its text happens to trail
+            # a different accepted prompt, handing that entry's file attachments to
+            # the wrong persisted message. A miss falls through to "no match" below,
+            # the same fail-safe path already used for terminal-typed text.
+            if entry_text and needle == entry_text:
                 match_index = index
                 break
         if match_index is None:

--- a/tests/runtime/test_pending_inputs.py
+++ b/tests/runtime/test_pending_inputs.py
@@ -206,6 +206,23 @@ def test_resolve_matching_text_leaves_entries_when_no_text_matches() -> None:
     assert [entry["pending_id"] for entry in pending_inputs.snapshot_for("conv_a")] == [first]
 
 
+def test_resolve_matching_text_does_not_match_on_unanchored_suffix() -> None:
+    """A short pending entry must not be matched by an unrelated prompt that
+    merely ends with its text (e.g. queued "ok" vs. an accepted "...still ok"),
+    or that entry's file attachments would be merged into the wrong message."""
+    short_entry = pending_inputs.record(
+        "conv_a", [_text_block("ok"), {"type": "input_image", "url": "img://1"}]
+    )
+
+    drained = pending_inputs.resolve_matching_text("conv_a", "Let's continue - ok")
+
+    assert drained.matched is None
+    assert drained.skipped == []
+    assert [entry["pending_id"] for entry in pending_inputs.snapshot_for("conv_a")] == [
+        short_entry
+    ]
+
+
 def test_resolve_removes_entry_idempotently() -> None:
     """
     :func:`resolve` drops an entry by id (forward-failed rollback).


### PR DESCRIPTION
## Related issue

Closes #5409

## Summary
- `resolve_matching_text()` (the Kiro-native path that matches a queued
  web-composer entry back to its persisted transcript message) accepted
  `needle.endswith(entry_text)` as a match, not just exact equality. That's
  an unanchored suffix check: a short queued entry (e.g. `"ok"`) could be
  matched against a later, unrelated accepted prompt that merely ends in the
  same text (e.g. `"Let's continue - ok"`).
- Because the caller merges the matched entry's file/image blocks into the
  persisted item, this silently misattributed attachments to the wrong
  message in durable conversation history, with the real match later
  re-persisted out of order and mislabeled with a `kiro_native_prompt_not_recorded`
  error.
- Fix: require exact text equality. A miss now falls through to the
  existing, already-tested "no match" path instead of guessing.


## Test Plan


- Added `tests/runtime/test_pending_inputs.py::test_resolve_matching_text_does_not_match_on_unanchored_suffix`,
  reproducing the misattribution: a queued `"ok"` + image entry must not
  match an unrelated accepted prompt `"Let's continue - ok"`.
- Confirmed the new test fails against the pre-fix code (`git stash` the
  source file, rerun the image attachment lands on the wrong message) and
  passes with the fix restored.
- `python -m pytest tests/runtime/test_pending_inputs.py -v` -> 16 passed.
- `python -m pytest tests/runtime/test_pending_inputs.py tests/server/routes/test_session_resources.py -k "kiro or pending" -v` -> 19 passed, confirming the legitimate exact-match / skip-older-failed-entry flow (`test_kiro_external_prompt_matches_pending_and_reports_skipped_input`) is unaffected.

## Demo

`N/A` -> backend logic fix.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [X] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`N/A`

## Changelog

Fixed a bug where a Kiro-native session could attach an uploaded file to the wrong chat message.
