### PR TITLE
fix(notifications): guard new Notification() against Illegal constructor

### DIFF
--- a/web/src/lib/browserNotifications.test.ts
+++ b/web/src/lib/browserNotifications.test.ts
@@ -117,6 +117,24 @@ describe("showNotification", () => {
     expect(showNotification({ title: "X" })).toBeNull();
   });
 
+  it("returns null (no throw) when the constructor is illegal on this platform", () => {
+    // Mobile Chrome / Android expose `Notification` as a function and report
+    // permission "granted", yet `new Notification()` throws "Illegal
+    // constructor" (the API is service-worker-only there). showNotification is
+    // called from a React effect, so a rethrow would trip the page's error
+    // boundary — it must degrade to a no-op instead.
+    const throwingCtor = vi.fn(() => {
+      throw new TypeError("Failed to construct 'Notification': Illegal constructor.");
+    }) as unknown as typeof Notification;
+    (throwingCtor as unknown as { permission: NotificationPermission }).permission = "granted";
+    vi.stubGlobal("Notification", throwingCtor);
+    let result: Notification | null = null;
+    expect(() => {
+      result = showNotification({ title: "X", body: "done" });
+    }).not.toThrow();
+    expect(result).toBeNull();
+  });
+
   it("focuses, runs onClick, and closes when clicked", () => {
     installNotification("granted");
     const focus = vi.spyOn(window, "focus").mockImplementation(() => {});

--- a/web/src/lib/browserNotifications.ts
+++ b/web/src/lib/browserNotifications.ts
@@ -65,7 +65,8 @@ export interface ShowNotificationParams {
 }
 
 /**
- * Show a notification, or no-op when unsupported or not yet granted.
+ * Show a notification, or no-op when unsupported, not yet granted, or the
+ * constructor is unusable on this platform.
  *
  * Clicking focuses the originating window, runs `onClick` (navigation),
  * and closes the toast. Returns the created Notification (for tests) or
@@ -89,7 +90,15 @@ export function showNotification({
     return null;
   }
   if (!isNotificationSupported() || Notification.permission !== "granted") return null;
-  const notification = new Notification(title, { body, tag });
+  // Some platforms (e.g. mobile Chrome) expose the constructor and report
+  // permission "granted" but still throw on `new Notification()`. Degrade to a
+  // no-op rather than let it escape into the caller.
+  let notification: Notification;
+  try {
+    notification = new Notification(title, { body, tag });
+  } catch {
+    return null;
+  }
   notification.onclick = () => {
     window.focus();
     onClick?.();


### PR DESCRIPTION
## Problem

An uncaught exception was tripping the `omnigent_page` panel/error boundary in production (surfaced as a `PANEL_BOUNDARY … status: FAILURE` JS alert, us-east-1). The stack pointed at `new Notification(title, { body, tag })` in `showNotification`.

`showNotification` gates on:

```ts
if (!isNotificationSupported() || Notification.permission !== "granted") return null;
```

where `isNotificationSupported()` is just `typeof window.Notification === "function"`. **Both gates pass on mobile Chrome / Android**, yet the page-scoped constructor throws `TypeError: Illegal constructor` there — the Notification API is only reachable via `ServiceWorkerRegistration.showNotification()`, which we deliberately don't use (see the file header).

## Why it blanked the UI

`showNotification` is called **synchronously** from the `useIdleNotifications` React effect (the new-elicitation path, `notify()` → `showNotification()`). The throw escaped the effect during React's commit phase and hit the page error boundary. (The turn-end path calls it from inside a `setTimeout` + promise, so that one surfaces as a global unhandled rejection rather than a boundary hit — same root cause, different symptom.)

## Fix

There's no reliable synchronous feature-test for "constructor is invocable", so guard the call itself: wrap the construction in `try/catch` and degrade to a no-op (`return null`) on failure. A toast that can't be shown must never escape into the caller.

Adds a regression test: a constructor that reports permission `"granted"` but throws on `new` makes `showNotification` return `null` without throwing.

## Verification

- `vitest run browserNotifications.test.ts` → 13 passed (+1 new)
- `oxlint --deny-warnings` on the changed files → clean
- `tsc -b` (whole `web` project) → exit 0

This pull request and its description were written by Isaac.