### PR TITLE
fix(native): stabilize and persist Claude model selection

### DIFF
--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -105,15 +105,15 @@ class Conversation:
         the supported set; invalid values fail with ``invalid_input``.
     :param reported_model: The model the harness last REPORTED the
         session is actually on, verbatim in the harness's own
-        spelling, e.g. ``"claude-opus-4-8[1m]"``. Written only by
-        harness reports (``external_model_change``); never by user
-        picks. The only model value UI surfaces display. ``None``
-        means no report has arrived yet.
+        spelling, e.g. ``"claude-opus-4-8[1m]"``. Written by harness
+        reports (``external_model_change``), and the only model value
+        UI surfaces display. ``None`` means no report has arrived yet.
     :param model_override: Per-session LLM model override — the user's
         REQUEST, e.g. ``"claude-opus-4-7"``. ``None`` means use the
         agent default from the spec's ``llm.model``. Mutable via
-        ``PATCH /v1/sessions/{id}`` and the REPL's ``/model``
-        command. Mirrors the persistence shape of
+        ``PATCH /v1/sessions/{id}`` and, for non-routed sessions, the
+        harness's exact model report after an in-pane ``/model`` command.
+        Smart-Routed reports do not overwrite it. Mirrors the persistence shape of
         ``reasoning_effort`` so the web UI and the TUI stay
         in sync — both read it from the session snapshot and
         write it through the same PATCH endpoint.

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -2154,16 +2154,17 @@ async def _persist_external_model_change(
     writes ``reported_model`` VERBATIM (the harness's own spelling,
     never collapsed to a picker alias) so the value survives reload,
     and publishes a ``session.model`` SSE event so every surface
-    re-renders from it. The user's request (``model_override``) is
-    deliberately untouched: requests and reports are separate roles,
-    and only reports are ever displayed. Unlike the PATCH path
+    re-renders from it. For a plain session, the exact report also
+    becomes ``model_override`` so an in-pane model choice survives a
+    cold resume. Smart-Routed sessions keep requests and reports
+    separate so a routed arm is not accidentally pinned. Unlike the PATCH path
     (:func:`update_session`), this does NOT forward a ``model_change``
     back to the runner — the terminal is already on the model, so
     re-injecting ``/model`` would loop.
 
-    No-ops (no write, no event) when the reported model already equals
-    the persisted ``reported_model`` — the steady state between real
-    changes, since forwarders re-observe on every poll.
+    No-ops when both persisted values already match. When only
+    ``reported_model`` matches, the request is repaired without
+    re-publishing the display event.
 
     :param session_id: Session/conversation identifier, e.g.
         ``"conv_abc123"``.
@@ -2172,7 +2173,7 @@ async def _persist_external_model_change(
     :param body: External model-change event body. ``data.model`` must
         be a non-empty string — the harness's verbatim model, e.g.
         ``"claude-opus-4-8[1m]"`` or ``"gpt-5.6-luna"``.
-    :param conversation_store: Store used to upsert ``reported_model``.
+    :param conversation_store: Store used to upsert the model state.
     :raises OmnigentError: If ``data.model`` is missing or not a
         non-empty string.
     """
@@ -2183,13 +2184,33 @@ async def _persist_external_model_change(
             code=ErrorCode.INVALID_INPUT,
         )
     model = raw_model.strip()
-    if conv.reported_model == model:
-        return
-    await asyncio.to_thread(
-        conversation_store.update_conversation,
-        session_id,
-        reported_model=model,
+    from omnigent.runner.subagent_routing import routing_class_from_snapshot
+
+    routing_class = routing_class_from_snapshot(
+        cost_control_mode=conv.cost_control_mode_override,
+        harness_override=conv.harness_override,
+        labels=conv.labels,
     )
+    persist_override = not routing_class.routing_enabled
+    reported_changed = conv.reported_model != model
+    override_changed = persist_override and conv.model_override != model
+    if not reported_changed and not override_changed:
+        return
+    if override_changed:
+        await asyncio.to_thread(
+            conversation_store.update_conversation,
+            session_id,
+            reported_model=model,
+            model_override=model,
+        )
+    else:
+        await asyncio.to_thread(
+            conversation_store.update_conversation,
+            session_id,
+            reported_model=model,
+        )
+    if not reported_changed:
+        return
     event = SessionModelEvent(
         type="session.model",
         conversation_id=session_id,

--- a/tests/runner/test_app_claude_native_launch_args.py
+++ b/tests/runner/test_app_claude_native_launch_args.py
@@ -119,11 +119,19 @@ def test_build_claude_native_base_args(
             "sid-123",
             ("--resume", "sid-123", "--effort", "high", "--verbose", "--model", "claude-opus-4-7"),
         ),
+        # Exact context variants survive the same cold-resume argv path.
+        (
+            None,
+            "databricks-claude-opus-5[1m]",
+            None,
+            "sid-456",
+            ("--resume", "sid-456", "--model", "databricks-claude-opus-5[1m]"),
+        ),
         # No resume id → no --resume (fresh launch, or no local
         # transcript could be synthesized).
         (None, None, ["--verbose"], None, ("--verbose",)),
     ],
-    ids=["resume-only", "resume-first-ordering", "no-resume"],
+    ids=["resume-only", "resume-first-ordering", "resume-exact-model", "no-resume"],
 )
 def test_build_claude_native_base_args_resume_prefix(
     reasoning_effort: str | None,

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -5993,9 +5993,9 @@ async def test_post_external_model_change_publishes_session_model(
     A native forwarder posts this with the model the harness is actually
     on — the launch's own report, or an in-pane switch — in the
     harness's own spelling. The value must land VERBATIM on the
-    snapshot's ``llm_model`` (the display authority) while the user's
-    request (``model_override``) stays untouched: reports and requests
-    are separate roles.
+    snapshot's ``llm_model`` (the display authority). For a plain session,
+    the exact value also becomes the next launch request so an in-pane
+    ``/model`` choice survives a cold resume.
     """
     published: list[tuple[str, dict[str, Any]]] = []
     monkeypatch.setattr(
@@ -6016,11 +6016,37 @@ async def test_post_external_model_change_publishes_session_model(
     assert published[0][1]["conversation_id"] == session["id"]
     assert published[0][1]["model"] == "claude-opus-4-8[1m]"
 
-    # Persisted verbatim so a reload restores the display; the request
-    # slot is untouched.
+    # Persisted verbatim for both display and the next cold launch.
     snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
     assert snapshot["llm_model"] == "claude-opus-4-8[1m]"
-    assert snapshot["model_override"] is None
+    assert snapshot["model_override"] == "claude-opus-4-8[1m]"
+
+
+async def test_post_external_model_change_does_not_pin_smart_routing(
+    client: httpx.AsyncClient,
+) -> None:
+    """A routed model report remains display truth, not a launch request."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    patch = await client.patch(
+        f"/v1/sessions/{session['id']}",
+        json={
+            "cost_control_mode_override": "on",
+            "model_override": "smart-routing",
+            "silent": True,
+        },
+    )
+    assert patch.status_code == 200, patch.text
+
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={"type": "external_model_change", "data": {"model": "claude-opus-5[1m]"}},
+    )
+    assert resp.status_code == 202, resp.text
+
+    snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
+    assert snapshot["llm_model"] == "claude-opus-5[1m]"
+    assert snapshot["model_override"] == "smart-routing"
 
 
 async def test_post_external_model_change_dedupes_when_unchanged(
@@ -6028,7 +6054,7 @@ async def test_post_external_model_change_dedupes_when_unchanged(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    A repeat ``external_model_change`` for the already-reported model
+    A repeat ``external_model_change`` for the already-persisted model
     is a no-op: no second ``session.model`` event, no redundant write.
 
     Forwarders re-observe on every poll, so the steady state is the same
@@ -6067,6 +6093,42 @@ async def test_post_external_model_change_dedupes_when_unchanged(
     assert resp.status_code == 202, resp.text
     # Already reported — nothing re-published.
     assert [event["type"] for _, event in published] == []
+
+
+async def test_post_external_model_change_repairs_stale_plain_override(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repeated report repairs an older coarse request without another event."""
+    published: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda sid, ev: published.append((sid, ev)),
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    first = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={"type": "external_model_change", "data": {"model": "claude-opus-5[1m]"}},
+    )
+    assert first.status_code == 202, first.text
+    patch = await client.patch(
+        f"/v1/sessions/{session['id']}",
+        json={"model_override": "opus", "silent": True},
+    )
+    assert patch.status_code == 200, patch.text
+    published.clear()
+
+    repeated = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={"type": "external_model_change", "data": {"model": "claude-opus-5[1m]"}},
+    )
+    assert repeated.status_code == 202, repeated.text
+
+    snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
+    assert snapshot["model_override"] == "claude-opus-5[1m]"
+    assert published == []
 
 
 async def test_post_external_model_change_rejects_empty_model(

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -844,6 +844,29 @@ describe("Composer model/effort label", () => {
     // tests, where the Radix Select actually mounts its option rows.
   });
 
+  it("formats a concrete Claude model while its catalog is temporarily unavailable", () => {
+    useChatStore.setState({
+      selectedModel: null,
+      sessionModelOverride: null,
+      llmModel: "databricks-claude-opus-4-8[1m]",
+    });
+    renderWithTooltips(
+      <Composer
+        {...composerProps({
+          agents: [{ id: "a1", name: "claude" }],
+          selectedAgentId: "a1",
+          modelPickerKind: "claude",
+          showModels: true,
+          showEffort: false,
+          codexModelOptions: [],
+        })}
+      />,
+    );
+
+    expect(label()).toHaveTextContent("Opus 4.8 (1M context)");
+    expect(label()).not.toHaveTextContent("databricks-claude-opus-4-8[1m]");
+  });
+
   it("hides the label when the model/effort is unresolved (nothing to show yet)", () => {
     // A claude-native session before the snapshot fills llmModel/selectedEffort
     // has no model label and no effort label. The read-only label renders

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4284,6 +4284,7 @@ function ContextRing({ contextWindow, tokensUsed }: { contextWindow: number; tok
 export function formatStatusModelLabel(
   model: string | null,
   codexModelOptions: readonly NativeModelOption[] = [],
+  formatConcreteClaude = false,
 ): string | null {
   const raw = model?.trim();
   if (!raw) return null;
@@ -4302,6 +4303,15 @@ export function formatStatusModelLabel(
     if (alias[2]) label += ` ${alias[2]}`;
     if (alias[3]) label += " (1M context)";
     return label;
+  }
+  const concreteClaude = formatConcreteClaude
+    ? lower.match(/claude-(fable|opus|sonnet|haiku)-(\d+)(?:[-.](\d+))?/)
+    : null;
+  if (concreteClaude !== null) {
+    const [, family, major, minor] = concreteClaude;
+    const version = minor ? `${major}.${minor}` : major;
+    const longContext = lower.endsWith("[1m]") ? " (1M context)" : "";
+    return `${family[0]!.toUpperCase()}${family.slice(1)} ${version}${longContext}`;
   }
   return raw;
 }
@@ -7103,7 +7113,10 @@ function ComposerModelEffortLabel({
   const selectedEffort = useSessionEffort();
   const costControlModeOverride = useChatStore((s) => s.costControlModeOverride);
   const pendingModelChange = useChatStore((s) => s.pendingModelChange);
-  const { modelLabel } = useResolvedComposerModel(modelPickerKind, codexModelOptions);
+  const { effectiveModel, modelLabel } = useResolvedComposerModel(
+    modelPickerKind,
+    codexModelOptions,
+  );
   const routingOn = costRoutingEligible && costControlModeOverride === "on";
   // An asked-but-unconfirmed switch on a reported-model session: the chip
   // keeps the harness's model; this spinner is the honest "asked, not yet
@@ -7135,7 +7148,11 @@ function ComposerModelEffortLabel({
   // SDK/bundle sessions (no native picker) still surface their resolved model
   // in the label even though the gear modal has no Model dropdown for them —
   // showModels gates only the modal control, not this read-out.
-  const model = showModels || modelPickerKind === null ? modelLabel : null;
+  const statusModelLabel =
+    modelPickerKind === "claude"
+      ? formatStatusModelLabel(effectiveModel, codexModelOptions, true)
+      : modelLabel;
+  const model = showModels || modelPickerKind === null ? statusModelLabel : null;
   // SDK/bundle agents (e.g. Polly) that resolve no model/effort fall back to
   // the harness identity ("Polly (Pi)") so the slot isn't empty. Scoped to
   // SDK/bundle (modelPickerKind === null): native wrappers keep an empty label

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -6895,6 +6895,46 @@ describe("chatStore — bindStream sticky-pref handoff", () => {
     window.localStorage.removeItem("omnigent.picker.model");
   });
 
+  it("keeps a resolved Claude catalog across transient empty refreshes", async () => {
+    seedSession("conv_cn_catalog_refresh", []);
+    let snapshotCount = 0;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (
+        url.split("?")[0] === "/v1/sessions/conv_cn_catalog_refresh" &&
+        (init?.method ?? "GET") === "GET"
+      ) {
+        snapshotCount += 1;
+        return mockResponse({
+          id: "conv_cn_catalog_refresh",
+          agent_id: "agent_xyz",
+          status: "idle",
+          created_at: 0,
+          items: [],
+          labels: { "omnigent.wrapper": "claude-code-native-ui" },
+          model_override: "opus",
+          model_options: snapshotCount === 1 ? CLAUDE_MODEL_OPTIONS : [],
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    await useChatStore.getState().switchTo("conv_cn_catalog_refresh");
+    expect(useChatStore.getState().codexModelOptions).toEqual(CLAUDE_MODEL_OPTIONS);
+
+    handleSessionEvent({
+      type: "session_model_options",
+      conversationId: "conv_cn_catalog_refresh",
+    });
+    await tick();
+
+    expect(snapshotCount).toBeGreaterThanOrEqual(3);
+    expect(useChatStore.getState()).toMatchObject({
+      sessionModelOverride: "opus",
+      codexModelOptions: CLAUDE_MODEL_OPTIONS,
+    });
+  });
+
   it("refetches a resolved Claude catalog when its event races the bind snapshot", async () => {
     seedSession("conv_cn_race", []);
     window.localStorage.setItem("omnigent.picker.model", "opus");

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -5022,6 +5022,11 @@ async function refetchRunnerBackedSessionState(
   }
   // No sticky-model graft here: the sticky pick is a pure preference under
   // the reported-model semantics, so a delayed catalog only hydrates state.
+  const preserveResolvedModelOptions =
+    (session.codexModelOptions ?? []).length === 0 &&
+    currentState.codexModelOptions.length > 0 &&
+    currentState.boundAgentId === session.agentId &&
+    nativeModelFamilyForSession(session) !== null;
   const statePatch: Partial<ConversationState> =
     options.applyBindingPatch === true
       ? sessionBindingPatch(session)
@@ -5029,6 +5034,9 @@ async function refetchRunnerBackedSessionState(
           skills: session.skills ?? [],
           codexModelOptions: session.codexModelOptions ?? [],
         };
+  if (preserveResolvedModelOptions) {
+    statePatch.codexModelOptions = currentState.codexModelOptions;
+  }
   setterFor(conversationId)(statePatch);
 }
 


### PR DESCRIPTION
## Related issue

N/A — reported directly from an affected production conversation.

## Summary

- Preserve an already-resolved native model catalog when a same-agent runner refresh temporarily returns an empty catalog.
- Keep the Claude-native composer label stable during hydration by formatting a concrete ID such as `databricks-claude-opus-4-8[1m]` as `Opus 4.8 (1M context)`.
- Persist a plain native session's exact harness-reported model into `model_override`, so an in-pane choice such as `Opus 5 (1M context)` survives a cold resume instead of falling back to the coarse `opus` alias.
- Keep Smart-Routed sessions unpinned: routed model reports continue to update display truth only and do not replace the Smart Routing launch request.
- Repair older plain sessions whose `reported_model` is already exact but whose `model_override` is still stale or coarse.

ELI5: there were two related state gaps. During page hydration, the UI briefly lost the friendly model catalog and exposed the raw provider ID. On a later cold resume, the server launched from the older coarse request (`opus`) rather than the exact model Claude had reported (`databricks-claude-opus-5[1m]`). This keeps the display stable and saves the exact non-routed selection for the next launch.

```text
Plain Claude session
   ├─ reported_model: databricks-claude-opus-5[1m]
   ├─ model_override: opus                 (before)
   └─ model_options: transiently []
                         │
                         ▼
       Preserve catalog + persist exact report
                         │
                         ▼
   display: Opus 5 (1M context)
   resume:  --model databricks-claude-opus-5[1m]
```

## Test Plan

- `uv run pytest tests/server/integration/test_sessions_endpoints.py -k 'external_model_change' -q`
- `uv run pytest tests/runner/test_app_claude_native_launch_args.py -k 'resume_prefix' -q`
- `pnpm --dir web test --run src/store/chatStore.test.ts src/pages/ChatPage.composer.test.tsx`
- `pnpm --dir web type-check`
- `pnpm --dir web lint`
- `.venv/bin/pyrefly check`
- `uv run ruff format --check omnigent/entities/conversation.py omnigent/server/routes/_sessions/helpers.py tests/runner/test_app_claude_native_launch_args.py tests/server/integration/test_sessions_endpoints.py`
- `uv run ruff check omnigent/entities/conversation.py omnigent/server/routes/_sessions/helpers.py tests/runner/test_app_claude_native_launch_args.py tests/server/integration/test_sessions_endpoints.py`
- `web/node_modules/.bin/prettier --check web/src/pages/ChatPage.composer.test.tsx web/src/pages/ChatPage.tsx web/src/store/chatStore.test.ts web/src/store/chatStore.ts`
- `git diff --check`

## Demo

Before: reopening a long-running Claude conversation could alternate between `Opus 4.8 (1M context)` and `databricks-claude-opus-4-8[1m]` for several seconds. After the runner slept and relaunched, an exact `Opus 5 (1M context)` selection could also resume from the stale `opus` request.

After: the composer consistently displays the friendly exact model while runner-backed metadata hydrates, and a non-Smart-Routed session relaunches with the exact harness-reported model. Smart-Routed reports remain display-only and do not pin a routed arm.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression coverage reproduces the affected hydration state, verifies exact model persistence and stale-override repair for plain sessions, verifies Smart Routing remains unpinned, and verifies an exact `[1m]` model reaches Claude's cold-resume argv.

## Changelog

Claude model names no longer flicker while conversations load, and exact non-routed model selections now survive cold resumes.
