### PR TITLE
fix(electron): hide update overlay and finish quitting

### DIFF
--- a/justfile
+++ b/justfile
@@ -77,11 +77,11 @@ _ensure-electron:
 
 [group('electron')]
 electron-dev: _ensure-web _ensure-electron
-    pnpm --filter web/electron run dev
+    pnpm --filter ./web/electron run dev
 
 [group('electron')]
 electron-build: _ensure-web _ensure-electron
-    pnpm --filter web/electron run build
+    pnpm --filter ./web/electron run build
 
 # --- Lint ---
 

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -3057,6 +3057,13 @@ if (!gotLock) {
   // pidfile that the next launch reuses or `omnigent server stop` reclaims.
   let quitCleanupDone = false;
   let quitCleanupStarted = false;
+  let quitForceExitTimer = null;
+  const clearQuitForceExitTimer = () => {
+    if (quitForceExitTimer === null) return;
+    clearTimeout(quitForceExitTimer);
+    quitForceExitTimer = null;
+  };
+  app.on("quit", clearQuitForceExitTimer);
   app.on("before-quit", (event) => {
     if (quitCleanupDone) return;
     // A second quit (e.g. Cmd-Q again during the SIGKILL grace window) must not
@@ -3069,12 +3076,12 @@ if (!gotLock) {
     // unref'd so the cap itself can't hold the event loop open; app.exit()
     // bypasses before-quit/will-quit, so it's the guaranteed way out when
     // app.quit() proves unreliable.
-    const cap = setTimeout(() => {
-      if (quitCleanupDone) return;
+    quitForceExitTimer = setTimeout(() => {
+      quitForceExitTimer = null;
       quitCleanupDone = true;
       app.exit(0);
     }, quitCleanupTimeoutMs);
-    if (typeof cap.unref === "function") cap.unref();
+    if (typeof quitForceExitTimer.unref === "function") quitForceExitTimer.unref();
 
     // resolvedCliPath() is evaluated inside the async IIFE so a throw (a future
     // change to settings/CLI resolution) becomes a rejection caught below,
@@ -3088,7 +3095,6 @@ if (!gotLock) {
       .finally(() => {
         if (quitCleanupDone) return; // the hard cap already forced the exit
         quitCleanupDone = true;
-        clearTimeout(cap);
         // Hand off to a user-approved install if one is pending; otherwise
         // complete the deferred quit. quitAndInstall() re-issues app.quit()
         // (via setImmediate) only when it can actually install — so if the
@@ -3099,6 +3105,7 @@ if (!gotLock) {
         // the time the fallback fires the update is already underway (or was
         // never going to install) — force-exiting only ensures we quit.
         if (updater.quitAndInstallIfPending()) {
+          clearQuitForceExitTimer();
           const fallback = setTimeout(() => app.exit(0), quitInstallFallbackMs);
           if (typeof fallback.unref === "function") fallback.unref();
         } else {

--- a/web/electron/src/update_overlay.js
+++ b/web/electron/src/update_overlay.js
@@ -26,6 +26,7 @@ const OVERLAY_INSET = 12;
  *   checkForUpdates: Function, downloadUpdate: Function, installUpdateNow: Function }} deps.updater
  * @param {string} deps.overlayPage Absolute path to the built overlay HTML.
  * @param {string} deps.preloadPath Absolute path to update_overlay_preload.js.
+ * @param {NodeJS.Platform} [deps.platform] Runtime platform (injectable for tests).
  */
 function createUpdateOverlay({
   BrowserWindow,
@@ -34,6 +35,7 @@ function createUpdateOverlay({
   updater,
   overlayPage,
   preloadPath,
+  platform = process.platform,
 }) {
   /** @type {Map<Electron.BrowserWindow, Electron.BrowserWindow>} parent -> overlay */
   const overlays = new Map();
@@ -104,6 +106,9 @@ function createUpdateOverlay({
         nodeIntegration: false,
       },
     });
+    if (platform === "darwin") {
+      overlay.excludedFromShownWindowsMenu = true;
+    }
     overlays.set(parent, overlay);
 
     // The ?theme= URL param is only a pre-paint hint to avoid a flash before

--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -539,6 +539,38 @@ describe("auto-update main-process wiring", () => {
     assert.equal(harness.calls.appQuit, 1); // never re-issued
   });
 
+  it("force-exits if the re-issued normal quit does not terminate", async (t) => {
+    const harness = loadMainHarness({ settings: { update_mode: "manual" } });
+    t.after(harness.cleanup);
+    harness.api.setQuitTimeouts({ cleanup: 10 });
+
+    harness.appEvents.get("before-quit")({ preventDefault: () => {} });
+    await flushPromises();
+    assert.equal(harness.calls.appQuit, 1);
+    assert.equal(harness.calls.appExit, 0);
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 30);
+    });
+    assert.equal(harness.calls.appExit, 1);
+  });
+
+  it("cancels the normal quit fallback once quit is reached", async (t) => {
+    const harness = loadMainHarness({ settings: { update_mode: "manual" } });
+    t.after(harness.cleanup);
+    harness.api.setQuitTimeouts({ cleanup: 10 });
+
+    harness.appEvents.get("before-quit")({ preventDefault: () => {} });
+    await flushPromises();
+    assert.equal(harness.calls.appQuit, 1);
+
+    harness.appEvents.get("quit")();
+    await new Promise((resolve) => {
+      setTimeout(resolve, 30);
+    });
+    assert.equal(harness.calls.appExit, 0);
+  });
+
   it("force-exits if before-quit cleanup hangs past the safety cap", async (t) => {
     // A stuck shutdown (e.g. a hung `omnigent server stop`, or the known
     // Electron hazard where re-issuing app.quit() after before-quit's

--- a/web/electron/test/update_overlay.test.js
+++ b/web/electron/test/update_overlay.test.js
@@ -60,7 +60,7 @@ class FakeWindow extends EventEmitter {
   }
 }
 
-function makeOverlay() {
+function makeOverlay({ platform = process.platform } = {}) {
   const onHandlers = new Map();
   const handleHandlers = new Map();
   const windows = [];
@@ -91,12 +91,23 @@ function makeOverlay() {
     updater,
     overlayPage: "/overlay.html",
     preloadPath: "/preload.js",
+    platform,
   });
   controller.registerIpc();
   return { controller, handleHandlers, onHandlers, windows };
 }
 
-describe("update overlay height reservation", () => {
+describe("update overlay", () => {
+  it("excludes the overlay from the macOS shown-windows menu", () => {
+    const mac = makeOverlay({ platform: "darwin" });
+    const macOverlay = mac.controller.ensureOverlay(new FakeWindow());
+    assert.equal(macOverlay.excludedFromShownWindowsMenu, true);
+
+    const linux = makeOverlay({ platform: "linux" });
+    const linuxOverlay = linux.controller.ensureOverlay(new FakeWindow());
+    assert.equal(linuxOverlay.excludedFromShownWindowsMenu, undefined);
+  });
+
   it("broadcasts visible height to the parent and supports an initial read", async () => {
     const { controller, handleHandlers, onHandlers, windows } = makeOverlay();
     const parent = new FakeWindow();


### PR DESCRIPTION
## Related issue

[OMNI-5543](https://linear.app/omnigent/issue/OMNI-5543/desktop-has-a-omnigent-update-window-all-the-time)

## Summary

- Exclude the shell-owned update overlay from the macOS Dock and shown-windows menu.
- Keep the normal-quit safety timer armed until Electron confirms shutdown, so a dropped deferred quit cannot strand the app.
- Correct the Electron `just` recipes to use pnpm's directory-filter syntax.

**ELI5:** The update banner is implemented as a tiny helper window. macOS was listing that helper like a normal window, and the quit fallback stopped watching too early. The helper is now hidden from the list, while the fallback watches until the app actually quits.

```text
Update overlay -> excluded from macOS window list
Cmd+Q -> cleanup -> app.quit() -> quit event -> cancel fallback
                              `-> no quit event -> force exit
```

## Test Plan

- `node --test web/electron/test/update_overlay.test.js web/electron/test/update-main.test.js`
- `git diff --check`
- `just --dry-run electron-dev`
- `pnpm --filter ./web/electron exec pwd`
- Manually reproduced the extra Dock window on macOS without the commit, then verified it disappears and Cmd+Q quits with the commit.

## Demo

Before: the Dock menu showed a persistent **Omnigent Update** window, as captured in OMNI-5543.

After: manually verified the Dock menu only shows the Omnigent app window and Cmd+Q exits the app.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression tests cover macOS overlay exclusion and both the forced and confirmed normal-quit paths. Manual before/after testing confirmed the Dock menu and Cmd+Q behavior on macOS.

## Changelog

Omnigent no longer shows a permanent update window in the macOS Dock and reliably finishes quitting.
