### PR TITLE
fix(electron): defer the post-cleanup quit handoff

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -3095,22 +3095,17 @@ if (!gotLock) {
       .finally(() => {
         if (quitCleanupDone) return; // the hard cap already forced the exit
         quitCleanupDone = true;
-        // Hand off to a user-approved install if one is pending; otherwise
-        // complete the deferred quit. quitAndInstall() re-issues app.quit()
-        // (via setImmediate) only when it can actually install — so if the
-        // staged update is gone and install() returns false, fall back to a
-        // plain quit and then a forced exit after a short grace, rather than
-        // leave the app up waiting for an update that won't install. The
-        // installer is spawned synchronously inside quitAndInstall(), so by
-        // the time the fallback fires the update is already underway (or was
-        // never going to install) — force-exiting only ensures we quit.
-        if (updater.quitAndInstallIfPending()) {
-          clearQuitForceExitTimer();
-          const fallback = setTimeout(() => app.exit(0), quitInstallFallbackMs);
-          if (typeof fallback.unref === "function") fallback.unref();
-        } else {
-          app.quit();
-        }
+        // Re-entering app.quit() while Electron is unwinding the prevented quit
+        // can stop after before-quit, so resume on the next event-loop turn.
+        setImmediate(() => {
+          if (updater.quitAndInstallIfPending()) {
+            clearQuitForceExitTimer();
+            const fallback = setTimeout(() => app.exit(0), quitInstallFallbackMs);
+            if (typeof fallback.unref === "function") fallback.unref();
+          } else {
+            app.quit();
+          }
+        });
       });
   });
 }

--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -22,6 +22,7 @@ function loadMainHarness({
 
   const ipcHandlers = new Map();
   const appEvents = new Map();
+  const mainImmediates = [];
   const calls = {
     appQuit: 0,
     appExit: 0,
@@ -194,6 +195,9 @@ function loadMainHarness({
       if (specifier in localRequires) return localRequires[specifier];
       return mainRequire(specifier);
     },
+    setImmediate: (callback, ...args) => {
+      mainImmediates.push(() => callback(...args));
+    },
     setInterval,
     setTimeout,
   };
@@ -216,7 +220,12 @@ function loadMainHarness({
       unpinned: { sender, senderFrame: { url: "https://evil.example/app" } },
     },
     ipcHandlers,
+    pendingMainImmediates: () => mainImmediates.length,
     readSettings: () => JSON.parse(fs.readFileSync(path.join(userData, "settings.json"), "utf8")),
+    runMainImmediates: () => {
+      const pending = mainImmediates.splice(0);
+      for (const run of pending) run();
+    },
   };
 }
 
@@ -501,6 +510,10 @@ describe("auto-update main-process wiring", () => {
     await flushPromises();
 
     assert.equal(prevented, 1);
+    assert.deepEqual(harness.calls.quitAndInstall, []);
+    assert.equal(harness.pendingMainImmediates(), 1);
+
+    harness.runMainImmediates();
     assert.deepEqual(harness.calls.quitAndInstall, [[false, true]]);
     assert.equal(harness.calls.appQuit, 1);
   });
@@ -529,6 +542,11 @@ describe("auto-update main-process wiring", () => {
     harness.api.setQuitTimeouts({ installFallback: 10 });
     harness.appEvents.get("before-quit")({ preventDefault: () => {} });
     await flushPromises();
+    assert.deepEqual(harness.calls.quitAndInstall, []);
+    assert.equal(harness.pendingMainImmediates(), 1);
+
+    harness.runMainImmediates();
+    assert.deepEqual(harness.calls.quitAndInstall, [[false, true]]);
     assert.equal(harness.calls.appQuit, 1); // still no re-issued quit
     assert.equal(harness.calls.appExit, 0); // fallback not fired yet
 
@@ -546,6 +564,10 @@ describe("auto-update main-process wiring", () => {
 
     harness.appEvents.get("before-quit")({ preventDefault: () => {} });
     await flushPromises();
+    assert.equal(harness.calls.appQuit, 0);
+    assert.equal(harness.pendingMainImmediates(), 1);
+
+    harness.runMainImmediates();
     assert.equal(harness.calls.appQuit, 1);
     assert.equal(harness.calls.appExit, 0);
 
@@ -562,8 +584,11 @@ describe("auto-update main-process wiring", () => {
 
     harness.appEvents.get("before-quit")({ preventDefault: () => {} });
     await flushPromises();
-    assert.equal(harness.calls.appQuit, 1);
+    assert.equal(harness.calls.appQuit, 0);
+    assert.equal(harness.pendingMainImmediates(), 1);
 
+    harness.runMainImmediates();
+    assert.equal(harness.calls.appQuit, 1);
     harness.appEvents.get("quit")();
     await new Promise((resolve) => {
       setTimeout(resolve, 30);
@@ -590,6 +615,7 @@ describe("auto-update main-process wiring", () => {
     harness.appEvents.get("before-quit")({ preventDefault: () => {} });
     await flushPromises();
     assert.equal(harness.calls.appQuit, 0); // shutdown hung, no re-issued quit
+    assert.equal(harness.pendingMainImmediates(), 0);
     assert.equal(harness.calls.appExit, 0); // cap not fired yet
 
     await new Promise((resolve) => {


### PR DESCRIPTION
## Related issue

[OMNI-5548](https://linear.app/omnigent/issue/OMNI-5548/desktop-app-sometimes-does-not-fully-quit-when-cmdq)

Stacked on #5413.

## Summary

- Defer the post-cleanup quit/install handoff until the next event-loop turn so Electron finishes unwinding the prevented `before-quit` event.
- Verify normal quits and update installs do not begin reentrantly from the cleanup Promise microtask.

**ELI5:** Omnigent paused quitting to clean up its server, then asked Electron to quit again before Electron had finished handling the first request. Electron acknowledged that nested request but left both windows open. The retry now waits one event-loop turn.

```text
Cmd+Q -> prevent quit -> async cleanup -> current quit unwinds
                                          |
                                          v next event-loop turn
                                    app.quit() / installer
```

## Test Plan

- `node --test web/electron/test/update-main.test.js web/electron/test/update_overlay.test.js`
- `uv run --no-sync pre-commit run`
- Reproduced the original event sequence on macOS: the nested quit returned with two windows open, while the second physical Cmd+Q completed shutdown.

## Demo

N/A — application lifecycle change with no visual UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The main-process harness controls `setImmediate` and verifies that normal and update-install handoffs remain pending until the next event-loop turn.

## Changelog

Cmd+Q now closes the desktop app on the first press after shutdown cleanup.

