### PR TITLE
fix(electron): show restart action only when update ready

### DIFF
--- a/web/electron/src/desktop_updater.js
+++ b/web/electron/src/desktop_updater.js
@@ -84,6 +84,8 @@ function isUpdateSecurityError(message) {
  *   config in an unpackaged build (main.js sets this from !app.isPackaged).
  * @param {() => string} [deps.getCurrentVersion] Version shown in update UI.
  *   Defaults to Electron's real app version.
+ * @param {(installReady: boolean) => void} [deps.onInstallReadyChange]
+ *   Called when a downloaded update becomes ready or stops being ready.
  * @returns {{
  *   getConfig: () => { mode: string, autoInstall: boolean, skippedVersion: string | null },
  *   setConfig: (patch?: object) => { mode: string, autoInstall: boolean, skippedVersion: string | null },
@@ -110,6 +112,7 @@ function createDesktopUpdater({
   iconPath,
   forceDevUpdateConfig = false,
   getCurrentVersion = () => app.getVersion(),
+  onInstallReadyChange = () => {},
 }) {
   let updateCheckTimer = null;
   let currentUpdateStatus = { state: "idle" };
@@ -144,7 +147,10 @@ function createDesktopUpdater({
   }
 
   function broadcast(status) {
+    const wasInstallReady = currentUpdateStatus.state === "downloaded";
     currentUpdateStatus = status;
+    const installReady = status.state === "downloaded";
+    if (installReady !== wasInstallReady) onInstallReadyChange(installReady);
     for (const win of BrowserWindow.getAllWindows()) {
       if (win.isDestroyed()) continue;
       try {

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -728,6 +728,7 @@ const updater = createDesktopUpdater({
   pinnedOrigin,
   iconPath: ICON_PNG,
   getCurrentVersion: () => currentDesktopVersion,
+  onInstallReadyChange: () => buildMenu(),
   // Dev builds use dev-app-update.yml, which mirrors the production HTTPS
   // endpoint; packaged builds always use their baked app-update.yml. Tying
   // this to !app.isPackaged — not an env var — ensures a packaged app can
@@ -1916,13 +1917,8 @@ function buildMenu() {
     {
       id: "restart_to_update",
       label: "Restart to Update",
+      visible: updater.getStatus().state === "downloaded",
       click: async () => {
-        // Production install path: the UpdateBanner toast is dismissible (and
-        // a user may have closed it), so the menubar must still offer a way to
-        // install a downloaded update. installUpdateNow() quits the app to
-        // hand off to the installer; it returns false when nothing is ready
-        // (e.g. the toast was for an update since skipped or not downloaded),
-        // which we surface with a native dialog instead of silently no-op'ing.
         if (!updater.installUpdateNow()) {
           await dialog.showMessageBox(activeWindow(), {
             type: "info",

--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -567,6 +567,27 @@ describe("auto-update main-process wiring", () => {
     assert.equal(harness.calls.appQuit, 0); // never re-issued
   });
 
+  it("shows Restart to Update only while an update is ready to install", (t) => {
+    const harness = loadMainHarness({
+      forceDevUpdateConfig: true,
+      settings: { update_mode: "manual" },
+    });
+    t.after(harness.cleanup);
+    harness.api.updater.init();
+
+    harness.api.buildMenu();
+    let restartItem = findMenuItem(harness.calls.setApplicationMenu.at(-1), "restart_to_update");
+    assert.equal(restartItem.visible, false);
+
+    harness.autoUpdater.emit("update-downloaded", { version: "0.4.0" });
+    restartItem = findMenuItem(harness.calls.setApplicationMenu.at(-1), "restart_to_update");
+    assert.equal(restartItem.visible, true);
+
+    harness.autoUpdater.emit("update-not-available");
+    restartItem = findMenuItem(harness.calls.setApplicationMenu.at(-1), "restart_to_update");
+    assert.equal(restartItem.visible, false);
+  });
+
   it("does not start the install path when no update is downloaded", async (t) => {
     const harness = loadMainHarness({
       forceDevUpdateConfig: true,
@@ -587,6 +608,7 @@ describe("auto-update main-process wiring", () => {
     harness.api.buildMenu();
     const restartItem = findMenuItem(harness.calls.setApplicationMenu.at(-1), "restart_to_update");
     assert.ok(restartItem);
+    assert.equal(restartItem.visible, false);
     restartItem.click();
     assert.equal(harness.api.updater.installPending, false);
     assert.equal(harness.calls.appQuit, 0);


### PR DESCRIPTION
## Related issue

[OMNI-5547](https://linear.app/omnigent/issue/OMNI-5547/hide-restart-to-update-by-default)

## Summary

- Hide the Server menu's **Restart to Update** action until an update is downloaded.
- Refresh the native menu when install readiness changes so users can return to a dismissed update prompt.

## Test Plan

- `node --test web/electron/test/update-main.test.js`
- `node --test web/electron/test/desktop_updater.test.js`
- `npx --yes prettier --check web/electron/src/main.js web/electron/src/desktop_updater.js web/electron/test/update-main.test.js`

## Demo

N/A — the native menu transition is driven by updater state and covered by the main-process integration harness.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The main-process harness simulates updater state transitions and verifies the native menu is hidden until an update is downloaded, then hidden again when it is no longer ready.

## Changelog

The Restart to Update menu action now appears only when an update is ready to install.
