### PR TITLE
feat(web): show draft indicators in session list

### DIFF
--- a/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
+++ b/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
@@ -13,9 +13,10 @@ live session list -> sidebar render order -> window keydown handler ->
 client-side navigation to ``/c/{id}``.
 
 - ``test_ctrl_arrow_switches_session_from_focused_composer``: focus the
-  composer, leave a draft, press Ctrl+Down, and assert the route moved and the
-  draft survives the round trip. A regression that restored the editable-field
-  guard would stay put here.
+  composer, leave a draft, press Ctrl+Down, and assert the route moved, the
+  inactive row gains its draft indicator, and the draft survives the round
+  trip. A regression that restored the editable-field guard would stay put
+  here.
 - ``test_ctrl_arrow_still_switches_session_from_body_focus``: blur the
   composer so the keydown targets the body, press Ctrl+Down, and assert the
   route leaves the current session.
@@ -55,8 +56,11 @@ def test_ctrl_arrow_switches_session_from_focused_composer(
 
     page.goto(f"{base_url}/c/{session_a}")
 
-    expect(page.locator(f'a[href="/c/{session_a}"]')).to_be_visible(timeout=30_000)
+    session_a_link = page.locator(f'a[href="/c/{session_a}"]')
+    expect(session_a_link).to_be_visible(timeout=30_000)
     expect(page.locator(f'a[href="/c/{session_b}"]')).to_be_visible()
+    session_a_row = page.locator("li").filter(has=session_a_link)
+    draft_indicator = session_a_row.get_by_test_id("conversation-draft-indicator")
 
     # Focus the composer and leave an unsent draft — the exact condition the
     # editable-field guard used to suppress.
@@ -64,6 +68,9 @@ def test_ctrl_arrow_switches_session_from_focused_composer(
     expect(composer).to_be_visible()
     composer.click()
     composer.fill("an unsent draft that must survive the switch")
+    # The open composer already exposes its own content, so its active sidebar
+    # row does not need a redundant draft marker.
+    expect(draft_indicator).to_have_count(0)
 
     # ControlOrMeta maps to the real platform modifier (Cmd on macOS, Ctrl
     # elsewhere); CI runs Linux chromium, so this is Ctrl+Down.
@@ -75,6 +82,8 @@ def test_ctrl_arrow_switches_session_from_focused_composer(
     assert "/c/" in page.url and session_a not in page.url, (
         f"expected to switch to another session, still at {page.url}"
     )
+    expect(draft_indicator).to_be_visible()
+    expect(draft_indicator).to_have_accessible_name("Draft")
 
     # Drafts are per-session, so the composer we landed on is a different one;
     # stepping back restores the draft, proving the chord navigated rather than
@@ -84,6 +93,7 @@ def test_ctrl_arrow_switches_session_from_focused_composer(
     expect(page.get_by_placeholder(_COMPOSER)).to_have_value(
         "an unsent draft that must survive the switch"
     )
+    expect(draft_indicator).to_have_count(0)
 
 
 def test_ctrl_arrow_still_switches_session_from_body_focus(

--- a/web/src/lib/sessionDrafts.ts
+++ b/web/src/lib/sessionDrafts.ts
@@ -1,0 +1,87 @@
+import { useSyncExternalStore } from "react";
+
+export interface SessionDraft {
+  text: string;
+  files: File[];
+}
+
+const SESSION_DRAFTS_KEY = "omnigent.sessionDrafts";
+const listeners = new Set<() => void>();
+
+function loadDraftsFromStorage(): Map<string, SessionDraft> {
+  if (typeof window === "undefined") return new Map();
+  try {
+    const raw = window.sessionStorage.getItem(SESSION_DRAFTS_KEY);
+    if (!raw) return new Map();
+    const entries = JSON.parse(raw) as Record<string, string>;
+    const drafts = new Map<string, SessionDraft>();
+    for (const [id, text] of Object.entries(entries)) {
+      if (text) drafts.set(id, { text, files: [] });
+    }
+    return drafts;
+  } catch {
+    return new Map();
+  }
+}
+
+function saveDraftsToStorage(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const entries: Record<string, string> = {};
+    for (const [id, draft] of sessionDrafts) {
+      if (draft.text) entries[id] = draft.text;
+    }
+    if (Object.keys(entries).length === 0) {
+      window.sessionStorage.removeItem(SESSION_DRAFTS_KEY);
+    } else {
+      window.sessionStorage.setItem(SESSION_DRAFTS_KEY, JSON.stringify(entries));
+    }
+  } catch {
+    // Storage full or unavailable — drafts still work in-memory.
+  }
+}
+
+const sessionDrafts = loadDraftsFromStorage();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function notifyListeners(): void {
+  for (const listener of listeners) listener();
+}
+
+export function getSessionDraft(conversationId: string): SessionDraft | undefined {
+  return sessionDrafts.get(conversationId);
+}
+
+export function setSessionDraft(conversationId: string, draft: SessionDraft): void {
+  if (draft.text === "" && draft.files.length === 0) {
+    sessionDrafts.delete(conversationId);
+  } else {
+    sessionDrafts.set(conversationId, draft);
+  }
+  saveDraftsToStorage();
+  notifyListeners();
+}
+
+export function hasSessionDraft(conversationId: string): boolean {
+  const draft = sessionDrafts.get(conversationId);
+  return draft !== undefined && (draft.text.trim() !== "" || draft.files.length > 0);
+}
+
+export function useHasSessionDraft(conversationId: string): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => hasSessionDraft(conversationId),
+    () => false,
+  );
+}
+
+/** Clear all drafts, primarily for logout/reset flows and isolated tests. */
+export function clearSessionDrafts(): void {
+  sessionDrafts.clear();
+  saveDraftsToStorage();
+  notifyListeners();
+}

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -8,6 +8,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-li
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatStore } from "@/store/chatStore";
+import { clearSessionDrafts, hasSessionDraft } from "@/lib/sessionDrafts";
 
 // Composer reads workspace files via a TanStack query hook (for "@"-file
 // mentions). These slash-command tests don't exercise that, so stub the hook
@@ -111,6 +112,28 @@ function activeRow(): HTMLElement | null {
 function renderWithTooltips(ui: ReactElement) {
   return render(<TooltipProvider>{ui}</TooltipProvider>);
 }
+
+describe("Composer session drafts", () => {
+  beforeEach(() => {
+    clearSessionDrafts();
+    useChatStore.setState({ conversationId: "conv_draft" });
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearSessionDrafts();
+  });
+
+  it("publishes unfinished text for the sidebar and clears it after send", async () => {
+    render(<Composer {...composerProps()} />);
+
+    fireEvent.change(textarea(), { target: { value: "unfinished message" } });
+    await waitFor(() => expect(hasSessionDraft("conv_draft")).toBe(true));
+
+    fireEvent.submit(textarea().closest("form")!);
+    await waitFor(() => expect(hasSessionDraft("conv_draft")).toBe(false));
+  });
+});
 
 describe("Composer growth layout", () => {
   afterEach(() => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -140,6 +140,7 @@ import {
   rankMentionEntries,
 } from "@/lib/composerMentions";
 import { useMentionBrowser } from "@/hooks/useMentionBrowser";
+import { getSessionDraft, setSessionDraft } from "@/lib/sessionDrafts";
 // Re-exported so existing tests importing these from "./ChatPage" keep working
 // after the pure helpers moved to the shared lib.
 export { detectMentionAt, mentionMarkerFor };
@@ -675,47 +676,6 @@ function truncateTitle(raw: string, max = 60): string {
   const cut = lastSpace > max - 10 ? lastSpace : slice.length;
   return slice.slice(0, cut).join("").trimEnd() + "…";
 }
-
-// Per-session draft storage — module-level so it survives the Composer
-// unmount/remount that happens during the loading gate between session
-// switches (ChatPage returns <HydratingPlaceholder /> while
-// loadingConversation is true, which unmounts the entire chat surface).
-// Text drafts are also persisted to sessionStorage so they survive page
-// refreshes; File objects can't be serialized, so only text round-trips.
-const SESSION_DRAFTS_KEY = "omnigent.sessionDrafts";
-
-function loadDraftsFromStorage(): Map<string, { text: string; files: File[] }> {
-  try {
-    const raw = window.sessionStorage.getItem(SESSION_DRAFTS_KEY);
-    if (!raw) return new Map();
-    const entries = JSON.parse(raw) as Record<string, string>;
-    const map = new Map<string, { text: string; files: File[] }>();
-    for (const [id, text] of Object.entries(entries)) {
-      if (text) map.set(id, { text, files: [] });
-    }
-    return map;
-  } catch {
-    return new Map();
-  }
-}
-
-function saveDraftsToStorage(drafts: Map<string, { text: string; files: File[] }>): void {
-  try {
-    const obj: Record<string, string> = {};
-    for (const [id, draft] of drafts) {
-      if (draft.text) obj[id] = draft.text;
-    }
-    if (Object.keys(obj).length === 0) {
-      window.sessionStorage.removeItem(SESSION_DRAFTS_KEY);
-    } else {
-      window.sessionStorage.setItem(SESSION_DRAFTS_KEY, JSON.stringify(obj));
-    }
-  } catch {
-    // Storage full or unavailable — drafts still work in-memory.
-  }
-}
-
-const sessionDrafts = loadDraftsFromStorage();
 
 /**
  * Single component that drives the chat surface. Streaming + history
@@ -4809,9 +4769,8 @@ export function Composer({
   );
 
   // Preserve unsent text + file attachments per session so switching
-  // tabs and coming back restores the draft. The drafts map lives at
-  // module scope (not useRef) because Composer unmounts during the
-  // loading gate between session switches.
+  // tabs and coming back restores the draft. The shared draft store also lets
+  // the sidebar surface which sessions have unfinished composer content.
   const conversationId = useChatStore((s) => s.conversationId);
   const queuedMessages = useChatStore((s) => s.queuedMessages);
   const sessionStatus = useChatStore((s) => s.sessionStatus);
@@ -4884,7 +4843,7 @@ export function Composer({
   }, []);
 
   useEffect(() => {
-    const restored = conversationId ? sessionDrafts.get(conversationId) : undefined;
+    const restored = conversationId ? getSessionDraft(conversationId) : undefined;
     setValue(restored?.text ?? "");
     setFiles(restored?.files ?? []);
     dirtyRef.current = false;
@@ -4897,16 +4856,19 @@ export function Composer({
 
     return () => {
       if (!conversationId || !dirtyRef.current) return;
-      const text = valueRef.current;
-      const draftFiles = filesRef.current;
-      if (text || draftFiles.length > 0) {
-        sessionDrafts.set(conversationId, { text, files: draftFiles });
-      } else {
-        sessionDrafts.delete(conversationId);
-      }
-      saveDraftsToStorage(sessionDrafts);
+      setSessionDraft(conversationId, {
+        text: valueRef.current,
+        files: filesRef.current,
+      });
     };
   }, [conversationId]);
+
+  // Publish edits as they happen so the open sidebar updates immediately,
+  // rather than only learning about a draft when this composer unmounts.
+  useEffect(() => {
+    if (!conversationId || settledConversationId !== conversationId || !dirtyRef.current) return;
+    setSessionDraft(conversationId, { text: value, files });
+  }, [conversationId, settledConversationId, value, files]);
 
   // Adding a reply quote (via the floating "Reply" button) should drop the
   // caret straight into the composer so the user can type immediately. Only

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -6,13 +6,14 @@
 // are no longer listed here — they live on the Settings page.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { useEffect } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Conversation } from "@/hooks/useConversations";
 import { FALLBACK_SERVER_INFO, type ServerInfo } from "@/lib/capabilities";
+import { clearSessionDrafts, setSessionDraft } from "@/lib/sessionDrafts";
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
 
 // Project mocks are declared via vi.hoisted so they exist before the hoisted
@@ -267,6 +268,7 @@ beforeEach(() => {
   useHostsMock.mockReset();
   useHostsMock.mockReturnValue({ data: [] });
   localStorage.clear();
+  clearSessionDrafts();
   projectsMock.length = 0;
   moveToProjectSpy.mockReset();
   deleteProjectSpy.mockReset();
@@ -318,6 +320,25 @@ describe("Sidebar session list", () => {
     expect(scroller).toHaveClass("overflow-y-auto", "[scrollbar-width:none]");
     expect(scroller.className).toContain("[&::-webkit-scrollbar]:hidden");
     expect(scroller.className).not.toContain("scrollbar-gutter");
+  });
+
+  it("shows a draft icon only beside sessions with unfinished composer content", () => {
+    mockConversations([
+      conv("conv_draft", "Codex", { title: "Draft session" }),
+      conv("conv_empty", "Codex", { title: "Empty session" }),
+    ]);
+    renderSidebar();
+
+    const draftRow = screen.getByText("Draft session").closest("li")!;
+    const emptyRow = screen.getByText("Empty session").closest("li")!;
+    expect(within(draftRow).queryByTestId("conversation-draft-indicator")).toBeNull();
+
+    act(() => setSessionDraft("conv_draft", { text: "unfinished message", files: [] }));
+
+    const indicator = within(draftRow).getByTestId("conversation-draft-indicator");
+    expect(indicator).toHaveAccessibleName("Draft");
+    expect(indicator.parentElement).toHaveClass("absolute", "right-[4.5rem]", "md:right-1");
+    expect(within(emptyRow).queryByTestId("conversation-draft-indicator")).toBeNull();
   });
 
   it("uses balanced title padding until row actions are revealed", () => {
@@ -1953,6 +1974,18 @@ describe("Sidebar active-row auto-scroll", () => {
     expect(scrollIntoView).toHaveBeenCalledTimes(1);
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
 
+    vi.restoreAllMocks();
+  });
+
+  it("hides the draft indicator for the active conversation", () => {
+    vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(() => {});
+    mockConversations([conv("conv_active", "Claude Code", { title: "Active draft" })]);
+    setSessionDraft("conv_active", { text: "visible in the open composer", files: [] });
+
+    renderAtRoute("/c/conv_active");
+
+    const row = screen.getByText("Active draft").closest("li")!;
+    expect(within(row).queryByTestId("conversation-draft-indicator")).toBeNull();
     vi.restoreAllMocks();
   });
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -146,6 +146,7 @@ import { sumPendingApprovals } from "@/lib/inbox";
 import { isSessionStoppable } from "@/lib/sessionStop";
 import { getCurrentUserId, resolveIdentity } from "@/lib/identity";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
+import { useHasSessionDraft } from "@/lib/sessionDrafts";
 import { getSessionState, type SessionState } from "@/hooks/useSessionState";
 import { useChatStore } from "@/store/chatStore";
 import {
@@ -3196,6 +3197,7 @@ function ConversationRow({
   }, [conversation.title, pendingTitle, rename.isSuccess, rename.isError]);
 
   const label = pendingTitle ?? conversationDisplayLabel(conversation);
+  const hasDraft = useHasSessionDraft(conversation.id);
   // Recompute unseen state the moment the last-seen map changes (e.g. the
   // user picks "Mark as unread" on this row) rather than waiting for the
   // next conversations poll.
@@ -3233,6 +3235,11 @@ function ConversationRow({
       : hasUnseenMessages
         ? { kind: "unseen" as const }
         : (derivedState ?? (isStartingUp ? { kind: "starting" as const } : null));
+  // Drafts share the row's trailing indicator slot, but the active session's
+  // composer already makes its draft visible. Live session state wins while
+  // present; otherwise only an inactive row needs the draft marker.
+  const showDraftIndicator = hasDraft && !isActive;
+  const hasTrailingIndicator = sessionState !== null || showDraftIndicator;
 
   // Drag-and-drop: a row is grabbable when the viewer owns it (re-filing is
   // owner-only, like the Move-to-project kebab item), outside selection /
@@ -3438,7 +3445,7 @@ function ConversationRow({
         !selectionMode &&
           (sessionState?.kind === "awaiting"
             ? "pr-48 md:pr-29"
-            : sessionState !== null
+            : hasTrailingIndicator
               ? "pr-28 md:pr-8"
               : "pr-28 md:pr-2"),
         // The narrowed reserve must track exactly when the trailing controls
@@ -3485,10 +3492,8 @@ function ConversationRow({
       }}
       title={isMobile ? (conversation.title ?? conversation.id) : undefined}
     >
-      {/* Row 1: the session name. Status markers (working, needs-approval,
-          unseen) render in the trailing session-state slot below, not inline
-          here. Leading icons (agent type, pin, shared) were removed to keep
-          rows text-clean; pinned rows still group under "Pinned". */}
+      {/* Row 1: the session name. Working, needs-approval, unseen, and draft
+          markers render in the shared trailing indicator slot below. */}
       <div className="flex w-full items-center gap-1.5">
         <span className="relative min-w-0 truncate">
           {label}
@@ -3591,9 +3596,20 @@ function ConversationRow({
             <SquareIcon className="size-4 text-muted-foreground" />
           )}
         </span>
-      ) : sessionState !== null ? (
+      ) : hasTrailingIndicator ? (
         <span className={SESSION_STATE_SLOT_CLASS}>
-          <SessionStateBadge state={sessionState} />
+          {sessionState !== null ? (
+            <SessionStateBadge state={sessionState} />
+          ) : (
+            <span
+              role="img"
+              aria-label="Draft"
+              data-testid="conversation-draft-indicator"
+              className="inline-flex h-5 shrink-0 items-center justify-center text-muted-foreground"
+            >
+              <PencilIcon aria-hidden className="size-3.5" />
+            </span>
+          )}
         </span>
       ) : null}
       {/* Trailing controls (pin + kebab) share one absolutely-positioned flex


### PR DESCRIPTION
## Related issue

[OMNI-5549](https://linear.app/omnigent/issue/OMNI-5549/show-draft-icon-in-session-list)

## Summary

- Make unfinished composer drafts visible from inactive session rows, without duplicating the indicator on the active session.
- Move per-session draft persistence into a reactive shared store so the sidebar updates while the user types and clears after send.
- Reuse the existing trailing status-indicator slot; live session state takes precedence over the draft pencil.

ELI5: typing updates the shared draft store, and inactive sidebar rows subscribe to it.

```text
Composer edit -> per-session draft store -> inactive sidebar row pencil
```

## Test Plan

- `pnpm --dir web test src/pages/ChatPage.composer.test.tsx src/shell/Sidebar.test.tsx`
- `pnpm --dir web type-check`
- `pnpm --dir web exec oxlint --deny-warnings --report-unused-disable-directives src/lib/sessionDrafts.ts src/pages/ChatPage.tsx src/pages/ChatPage.composer.test.tsx src/shell/Sidebar.tsx src/shell/Sidebar.test.tsx`
- `uv run --no-sync pytest tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py::test_ctrl_arrow_switches_session_from_focused_composer -q`

## Demo

![Inactive session showing the draft pencil in the sidebar indicator slot](https://github.com/user-attachments/assets/96121ff1-4b68-4d11-8991-eeb4447232dc)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Vitest covers reactive draft publication, clearing after send, sidebar placement, and active-row suppression. Playwright covers the draft indicator across a real session switch and verifies draft restoration.

## Changelog

Unsent drafts now show a pencil beside inactive sessions in the sidebar.
