### PR TITLE
fix(web): always show Projects '+' on mobile

### DIFF
--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -346,6 +346,29 @@ describe("quick pin/unpin hover button", () => {
     }
   });
 
+  it("keeps the Projects group-header actions visible on mobile, hover-revealed on desktop", () => {
+    // The "New project" (+) button is the only way to create a project, so its
+    // group-header wrapper must stay visible on mobile (no hover there) rather
+    // than fade out like the desktop-only session-header controls. jsdom
+    // doesn't evaluate media queries, so assert the responsive classes: base
+    // `flex` (shown at every breakpoint) with `md:opacity-0` + hover/focus
+    // reveals (so desktop keeps the fade-until-hover behavior unchanged).
+    mocks.projects = ["Sprint 42"];
+    renderSidebar();
+
+    const wrapper = screen.getByTestId("new-project").closest(".transition-opacity");
+    expect(wrapper).not.toBeNull();
+    // Visible on mobile: base display is `flex`, never `hidden`.
+    expect(wrapper).toHaveClass("flex");
+    expect(wrapper).not.toHaveClass("hidden");
+    // Desktop: fades out until the header is hovered / focused / a menu opens.
+    expect(wrapper).toHaveClass(
+      "md:opacity-0",
+      "md:group-hover/header:opacity-100",
+      "md:has-[:focus-visible]:opacity-100",
+    );
+  });
+
   it("hides the Projects list-actions kebab when there are no projects", () => {
     // With no projects, the kebab has nothing to offer (no expand/collapse, no
     // sessions to select) and would open empty — so it's hidden entirely,

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -2462,14 +2462,14 @@ function SectionGroup({
           onToggleCollapsed={onToggleCollapsed}
         />
         {headerAction && (
-          // Desktop-only, hover/keyboard-focus-revealed: a group-level bulk
-          // control (e.g. "expand all projects") is a pointer convenience, so it
-          // stays hidden until the header is hovered and never floats on touch
-          // viewports where there's no hover. Reveal on :focus-visible (keyboard)
-          // — NOT :focus-within — so clicking the button with the mouse doesn't
-          // leave it stuck visible: React reuses the same node when it swaps
+          // Always visible on mobile (no hover there, and the "New project"
+          // control lives here — the only way to create a project). On desktop
+          // it's hover/keyboard-focus-revealed: a group-level control is a
+          // pointer convenience there. Reveal on :focus-visible (keyboard) — NOT
+          // :focus-within — so clicking the button with the mouse doesn't leave
+          // it stuck visible: React reuses the same node when it swaps
           // expand↔revert, so the clicked button keeps focus afterward.
-          <div className="-translate-y-1/2 absolute top-1/2 right-1 hidden items-center transition-opacity md:flex md:opacity-0 md:has-[:focus-visible]:opacity-100 md:group-has-[[data-state=open]]/header:opacity-100 md:group-hover/header:opacity-100">
+          <div className="-translate-y-1/2 absolute top-1/2 right-1 flex items-center transition-opacity md:opacity-0 md:has-[:focus-visible]:opacity-100 md:group-has-[[data-state=open]]/header:opacity-100 md:group-hover/header:opacity-100">
             {headerAction}
           </div>
         )}


### PR DESCRIPTION
## Related issue

Closes #

## Summary

On mobile there was no way to create a project. The **New Project (+)** button
and the list-actions kebab live in the Projects group-header actions wrapper,
which was `hidden` on mobile and only revealed on desktop hover — and since `+`
is the only way to create a project, mobile users were stuck.

The wrapper now matches the session-header pattern: base `flex` (visible at
every breakpoint) with `md:opacity-0` + hover/focus reveals. Mobile always shows
the controls; desktop keeps its fade-until-hover behavior unchanged (the
previous `md:flex` was redundant once the base is `flex`, so desktop renders
identically).

## Test Plan

- `cd web && npm test` — added test passes; pre-existing `NewChatDialog.test.tsx`
  failures (3) are unrelated to this change (verified on a clean tree).
- `cd web && npm run build` — passes.
- Added `Sidebar.rowActions.test.tsx` case asserting the group-header wrapper is
  base `flex` (not `hidden`) with `md:opacity-0` + hover/focus reveals.
- Manual: below the `md` breakpoint the `+` shows without hovering and opens the
  New Project dialog; on desktop it still fades in on hover/focus.

## Demo

<!-- Add mobile screenshot showing the visible + button. -->

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a unit test asserting the responsive classes (jsdom doesn't evaluate media
queries, so the mobile/desktop split is verified via the Tailwind classes, per
the file's existing convention). Manually verified the `+` is visible on a
mobile-width viewport and still hover-revealed on desktop.

## Changelog

The Projects "+" (New project) button is now always visible on mobile, so you can create a project there

This pull request and its description were written by Isaac.
