### PR TITLE
fix(web): keep stopped terminal sessions resumable

### DIFF
--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -35,13 +35,12 @@ independent session.
 
 from __future__ import annotations
 
-import json
 import re
 import time
 from pathlib import Path
 
 import httpx
-from playwright.sync_api import Page, Route, expect
+from playwright.sync_api import Page, expect
 
 from tests.e2e_ui.conftest import open_right_rail
 
@@ -143,41 +142,25 @@ def test_new_shell_accepts_typed_command(page: Page, terminal_session: tuple[str
     expect(terminal_view).to_have_attribute("data-state", "connected")
 
 
-def test_terminal_toggle_stays_disabled_when_only_a_shell_is_open(
+def test_empty_terminal_view_remains_selectable_and_resumable(
     page: Page, terminal_session: tuple[str, str]
 ) -> None:
-    """A live rail shell does not enable or populate the agent Terminal view."""
+    """A stopped terminal-first session exposes its resume state in Terminal."""
     base_url, session_id = terminal_session
 
-    # Runner-hosted SDK sessions auto-create ``terminal_tui_main`` when the
-    # parity sidecar is available (as it is in CI). Hide that pane from this
-    # browser's terminal snapshot and stream so the test deterministically
-    # models the cache window from the bug: a user shell has landed while the
-    # agent pane has not. The shell itself is still launched and attached
-    # through the real runner below.
-    def _serve_shells_only(route: Route) -> None:
-        response = route.fetch()
-        payload = response.json()
-        rows = payload.get("data", [])
-        shells = [
-            row
-            for row in rows
-            if isinstance(row, dict)
-            and isinstance(row.get("metadata"), dict)
-            and str(row["metadata"].get("session_key", "")).startswith("u-")
-        ]
-        payload["data"] = shells
-        payload["first_id"] = shells[0]["id"] if shells else None
-        payload["last_id"] = shells[-1]["id"] if shells else None
-        payload["has_more"] = False
-        route.fulfill(
-            status=response.status,
-            headers={**response.headers, "content-type": "application/json"},
-            body=json.dumps(payload),
-        )
-
+    # Hide terminal resources and their live updates to model the observable
+    # state immediately after stopping a session. Resource cleanup can arrive
+    # before the health poll reports the runner offline, so the UI must infer
+    # that an empty, non-starting inventory is resumable on its own.
     terminal_list = re.compile(rf"/v1/sessions/{re.escape(session_id)}/resources/terminals\?.*")
-    page.route(terminal_list, _serve_shells_only)
+    page.route(
+        terminal_list,
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"data":[],"first_id":null,"last_id":null,"has_more":false}',
+        ),
+    )
     page.route(f"**/v1/sessions/{session_id}/stream*", lambda route: route.abort())
 
     terminal_first = httpx.patch(
@@ -188,20 +171,16 @@ def test_terminal_toggle_stays_disabled_when_only_a_shell_is_open(
     terminal_first.raise_for_status()
 
     page.goto(f"{base_url}/c/{session_id}")
-    _open_new_shell(page)
 
-    rail = page.get_by_role("complementary", name="Workspace")
-    shell_view = rail.get_by_test_id("terminal-view").last
-    expect(shell_view).to_have_attribute("data-state", "connected", timeout=60_000)
-
-    # This is the cache window from the bug: the user shell is live while the
-    # session's agent terminal is absent.
     terminal_button = page.get_by_test_id("view-mode-terminal")
-    expect(terminal_button).to_be_disabled()
-    expect(page.locator('[data-testid="main-terminal-view"][data-visible="true"]')).to_have_count(
-        0
-    )
-    expect(shell_view).to_be_visible()
+    expect(terminal_button).to_be_enabled()
+    terminal_button.click()
+    expect(terminal_button).to_have_attribute("aria-pressed", "true")
+
+    terminal_view = page.locator('[data-testid="main-terminal-view"][data-visible="true"]')
+    expect(terminal_view).to_be_visible()
+    expect(terminal_view).to_contain_text("The harness is not running.")
+    expect(terminal_view.get_by_role("button", name="Resume session")).to_be_enabled()
 
 
 def test_shell_wheel_scroll_reaches_mouse_tracking_program(

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1607,9 +1607,8 @@ interface MainAgentSurfaceProps {
    *  Never includes child-session activity and never gates Stop/Interrupt. */
   showsWorking: boolean;
   /**
-   * Strict runner-tunnel liveness, used only to gate the inline terminal
-   * view (the PTY dies the moment the runner tunnel drops). The reconnect
-   * affordances key off `liveness` instead.
+   * Strict runner-tunnel liveness. The terminal view remains selectable when
+   * this is false and uses it to show the stopped-harness resume state.
    */
   runnerOnline: boolean | undefined;
   /** Derived open-session liveness — drives the reconnect hint/banner. */
@@ -2064,6 +2063,17 @@ function MainAgentSurface({
     mountTerminal && conversationId
       ? updateWarmTerminalSurfaces(warmTerminals, conversationId, terminalReadOnly)
       : warmTerminals;
+  const handleTerminalResume = useCallback(async () => {
+    if (!conversationId) throw new Error("Session is not available");
+    if (liveness.kind === "host_offline" || liveness.kind === "local_stranded") {
+      onShowReconnectHelp();
+      return;
+    }
+    const result = await retrySession(conversationId);
+    if (!result.recovered) {
+      throw new Error("The session is already connected; no recovery was performed");
+    }
+  }, [conversationId, liveness.kind, onShowReconnectHelp]);
   const terminalSurfaces = renderedTerminals.map((entry) => {
     const isActive = mountTerminal && entry.conversationId === conversationId;
     const isShown = isActive && showTerminal;
@@ -2077,6 +2087,8 @@ function MainAgentSurface({
           conversationId={entry.conversationId}
           initialTerminalKey={isActive ? terminalFirst?.terminalViewKey : null}
           visible={isShown}
+          runnerOnline={isActive ? runnerOnline : undefined}
+          onResume={isActive ? handleTerminalResume : undefined}
           onSurfaceElement={isActive ? setTerminalSurfaceEl : undefined}
           readOnly={entry.readOnly}
         />
@@ -3217,7 +3229,6 @@ export function ConnectionIndicator({
     terminalFirst?.isTerminalFirst === true &&
     !terminalFirst.isShellView &&
     sandboxStatus?.stage !== "failed" &&
-    !unreachable &&
     !keyboardVisible &&
     surfaceFrontmost;
   useNativeChatTerminalBar(terminalFirst, nativeBarVisible);
@@ -3242,32 +3253,51 @@ export function ConnectionIndicator({
     // `local_stranded` keeps the banner everywhere (no host, hence no badge).
     const composerOnScreen = !(terminalFirst?.isTerminalFirst && terminalFirst.view === "terminal");
     if (liveness.kind === "host_offline" && composerOnScreen) {
-      return null;
+      return nativeBarVisible ? (
+        <div
+          aria-hidden
+          className={cn(
+            "omnigent-native-bottom-spacer",
+            terminalFirst?.view === "chat" && "omnigent-native-bottom-spacer--chat",
+          )}
+        />
+      ) : null;
     }
     return (
-      <div className={cn("mx-auto mb-4 flex w-full justify-center px-6", CHAT_COLUMN_WIDTH)}>
-        {/* Reconnect affordance styled as the destructive error pill (never
-            raw red text). Keeps its own click → reconnect dialog rather than
-            the ErrorBanner's async Retry, since some states need the picker. */}
-        <button
-          type="button"
-          data-testid="disconnected-indicator"
-          onClick={onShowReconnectHelp}
-          className="flex items-center gap-2 rounded-[12px] px-4 py-2 text-sm text-destructive transition-[filter] hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-          style={{
-            background:
-              "color-mix(in srgb, var(--destructive) 4%, var(--app-shell-bg, var(--background)))",
-            border: "1px solid color-mix(in srgb, var(--destructive) 32%, transparent)",
-          }}
-        >
-          <WifiOffIcon className="size-3.5 shrink-0" />
-          <span>
-            {liveness.kind === "host_offline"
-              ? "Host is offline — click to reconnect"
-              : "Agent disconnected — click to reconnect"}
-          </span>
-        </button>
-      </div>
+      <>
+        <div className={cn("mx-auto mb-4 flex w-full justify-center px-6", CHAT_COLUMN_WIDTH)}>
+          {/* Reconnect affordance styled as the destructive error pill (never
+              raw red text). Keeps its own click → reconnect dialog rather than
+              the ErrorBanner's async Retry, since some states need the picker. */}
+          <button
+            type="button"
+            data-testid="disconnected-indicator"
+            onClick={onShowReconnectHelp}
+            className="flex items-center gap-2 rounded-[12px] px-4 py-2 text-sm text-destructive transition-[filter] hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            style={{
+              background:
+                "color-mix(in srgb, var(--destructive) 4%, var(--app-shell-bg, var(--background)))",
+              border: "1px solid color-mix(in srgb, var(--destructive) 32%, transparent)",
+            }}
+          >
+            <WifiOffIcon className="size-3.5 shrink-0" />
+            <span>
+              {liveness.kind === "host_offline"
+                ? "Host is offline — click to reconnect"
+                : "Agent disconnected — click to reconnect"}
+            </span>
+          </button>
+        </div>
+        {nativeBarVisible && (
+          <div
+            aria-hidden
+            className={cn(
+              "omnigent-native-bottom-spacer",
+              terminalFirst?.view === "chat" && "omnigent-native-bottom-spacer--chat",
+            )}
+          />
+        )}
+      </>
     );
   }
 
@@ -3496,7 +3526,7 @@ function useNativeChatTerminalBar(
 ): void {
   const native = isIOSShell();
   const view = ctx?.view ?? "chat";
-  const terminalsAvailable = ctx?.terminalsAvailable ?? false;
+  const terminalEnabled = ctx?.isTerminalFirst === true;
   const terminalStartingUp = ctx?.terminalStartingUp ?? false;
 
   // Keep `setView` reachable from the subscribe-once effect without
@@ -3509,11 +3539,11 @@ function useNativeChatTerminalBar(
     if (!native) return;
     setNativeViewMode({
       mode: view,
-      terminalEnabled: terminalsAvailable,
+      terminalEnabled,
       terminalStartingUp,
       visible,
     });
-  }, [native, view, terminalsAvailable, terminalStartingUp, visible]);
+  }, [native, view, terminalEnabled, terminalStartingUp, visible]);
 
   // Belt-and-suspenders: hide the bar if the host component ever unmounts.
   useEffect(() => {

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -760,7 +760,7 @@ describe("TerminalFirstContext", () => {
     expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_bash_s1");
   });
 
-  it("does not enable Terminal view when only a user shell is cached", () => {
+  it("allows Terminal view when only a user shell is cached", () => {
     mockConversations([
       {
         id: "conv_native",
@@ -776,8 +776,13 @@ describe("TerminalFirstContext", () => {
 
     renderShell("/c/conv_native");
 
-    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminals-available", "false");
-    expect(screen.getByTestId("view-mode-terminal")).toBeDisabled();
+    const probe = screen.getByTestId("view-probe");
+    expect(probe).toHaveAttribute("data-terminals-available", "false");
+    const terminalToggle = screen.getByTestId("view-mode-terminal");
+    expect(terminalToggle).toBeEnabled();
+    fireEvent.click(terminalToggle);
+    expect(probe).toHaveAttribute("data-view", "terminal");
+    expect(probe).toHaveAttribute("data-terminal-view-key", "");
   });
 
   it("flags a child (sub-agent) session terminal-first from the snapshot when the sidebar omits it", () => {
@@ -892,17 +897,18 @@ describe("TerminalFirstContext", () => {
     expect(probe).toHaveAttribute("data-terminals-available", "false");
     expect(probe).toHaveAttribute("data-view", "chat");
 
-    fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
+    const terminalToggle = screen.getByTestId("view-mode-terminal");
+    expect(terminalToggle).toBeEnabled();
+    fireEvent.click(terminalToggle);
 
     expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "terminal");
     expect(screen.queryByTestId("terminals-panel")).toBeNull();
   });
 
-  it("falls back to chat when an open terminal view loses its terminal", () => {
-    // A runner stop / disconnect empties the terminal list (useTerminals clears
-    // it on the runner-offline edge). Landing while the terminal view is open,
-    // that would strand the user on "No terminals available"; the view must
-    // fall back to chat, where the composer can resume the session.
+  it("stays in Terminal when an open agent terminal loses its runner", () => {
+    // A runner stop / disconnect empties the terminal list. Keep the user's
+    // selected view so its stopped-harness state can explain what happened and
+    // offer the resume action instead of unexpectedly switching back to Chat.
     mockConversations([
       { id: "conv_native", permission_level: null, labels: { "omnigent.ui": "terminal" } },
     ]);
@@ -946,8 +952,7 @@ describe("TerminalFirstContext", () => {
     useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
     rerender(makeTree());
 
-    // Fell back to chat rather than stranding on "No terminals available".
-    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "terminal");
   });
 
   it("stays in terminal view while the terminal is relaunching", () => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1515,10 +1515,10 @@ export function AppShell() {
   // Shells do not make the Terminal-view toggle available: that control owns
   // only the session's agent REPL/vendor pane.
   const terminalsAvailable = agentTerminal !== null;
-  // Single pill-facing "loading" signal: not yet openable, but coming up —
+  // Single pill-facing "loading" signal: the PTY is not ready, but is coming up —
   // either the runner is launching/relaunching (liveness `starting`, known the
   // instant a message is sent) or it's up and auto-creating the PTY
-  // (`terminalPending`). Idle stopped sessions are neither → greyed, not spinning.
+  // (`terminalPending`). Idle stopped sessions are neither → no spinner.
   // Suppressed once the session has failed AND no send is in flight: a runner
   // that crashed before connecting (`runner_failed_to_start`), or a host that
   // refused the launch (`harness_not_configured`), sits in the `starting` grace
@@ -1548,30 +1548,31 @@ export function AppShell() {
   // affordance. The PANEL_NO_TERMINAL_KEY sentinel ("") is falsy, so
   // "open with no target" stays a pill view.
   const isShellView = terminalFirst && !!panelInitialKey && !isAgentTerminalKey(panelInitialKey);
-  const terminalViewTargetAvailable = isShellView
-    ? terminals.some((terminal) => terminalTabKey(terminal) === panelInitialKey)
-    : terminalsAvailable;
+  const shellViewTargetAvailable =
+    isShellView && terminals.some((terminal) => terminalTabKey(terminal) === panelInitialKey);
 
-  // A runner stop/disconnect empties the terminal list; if that lands while the
-  // open agent terminal or explicit mobile shell disappears, flip back to chat
-  // rather than stranding the user on an empty surface.
-  // Edge-triggered + startingUp-guarded so a cold boot / relaunch isn't yanked.
-  const hadTerminalRef = useRef(false);
+  // An explicit user shell has no useful empty state: if it disappears, return
+  // to chat. The agent-terminal view is different — it remains selectable when
+  // the runner is offline and owns the resume affordance shown in that state.
+  // Edge-triggered + startingUp-guarded so a shell relaunch isn't yanked.
+  const hadShellTerminalRef = useRef(false);
   useEffect(() => {
     if (
       terminalFirst &&
       panelOpen &&
-      hadTerminalRef.current &&
-      !terminalViewTargetAvailable &&
+      isShellView &&
+      hadShellTerminalRef.current &&
+      !shellViewTargetAvailable &&
       !terminalStartingUp
     ) {
       setPanelInitialKey(null);
     }
-    hadTerminalRef.current = terminalViewTargetAvailable;
+    hadShellTerminalRef.current = shellViewTargetAvailable;
   }, [
     terminalFirst,
     panelOpen,
-    terminalViewTargetAvailable,
+    isShellView,
+    shellViewTargetAvailable,
     terminalStartingUp,
     setPanelInitialKey,
   ]);

--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -1,6 +1,6 @@
 import type * as UseTerminalsModule from "@/hooks/useTerminals";
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type TerminalInfo, useTerminals } from "@/hooks/useTerminals";
@@ -18,10 +18,14 @@ vi.mock("@/components/blocks/TerminalView", () => ({
     sessionId,
     terminalId,
     readOnly,
+    onResume,
+    resumePending,
   }: {
     sessionId: string;
     terminalId: string;
     readOnly?: boolean;
+    onResume?: () => void | Promise<void>;
+    resumePending?: boolean;
   }) => {
     // Assign once per mount (useRef(arg) evaluates arg every render but keeps
     // the first value), so the id is stable across re-renders and only changes
@@ -35,7 +39,14 @@ vi.mock("@/components/blocks/TerminalView", () => ({
         data-terminal-id={terminalId}
         data-read-only={String(readOnly ?? false)}
         data-instance={String(instance.current)}
-      />
+        data-resume-pending={String(resumePending ?? false)}
+      >
+        {onResume && (
+          <button type="button" onClick={() => void onResume()}>
+            Resume terminal
+          </button>
+        )}
+      </div>
     );
   },
 }));
@@ -99,6 +110,8 @@ function renderView({
   initialTerminalKey = null,
   readOnly = false,
   conversationId = "conv_sdk",
+  runnerOnline,
+  onResume,
   setView,
 }: {
   terminals: TerminalInfo[];
@@ -106,6 +119,8 @@ function renderView({
   initialTerminalKey?: string | null;
   readOnly?: boolean;
   conversationId?: string;
+  runnerOnline?: boolean;
+  onResume?: () => void | Promise<void>;
   setView?: (view: "chat" | "terminal") => void;
 }) {
   useTerminalsMock.mockReturnValue({ terminals, isLoading: false, error: null });
@@ -115,6 +130,8 @@ function renderView({
         conversationId={conversationId}
         initialTerminalKey={initialTerminalKey}
         readOnly={readOnly}
+        runnerOnline={runnerOnline}
+        onResume={onResume}
       />
     </TerminalFirstContextProvider>,
   );
@@ -199,6 +216,27 @@ describe("MainTerminalView — terminal-first SDK sessions", () => {
 
     expect(screen.queryByTestId("terminal-view")).toBeNull();
     expect(screen.getByText("Agent terminal unavailable.")).toBeInTheDocument();
+  });
+
+  it("treats an empty terminal inventory as resumable before health catches up", async () => {
+    const onResume = vi.fn().mockResolvedValue(undefined);
+    renderView({ terminals: [], onResume });
+
+    expect(screen.getByText("The harness is not running.")).toBeInTheDocument();
+    expect(screen.getByText("Resume the session to reconnect the terminal.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Resume session" }));
+
+    await waitFor(() => expect(onResume).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps the offline state actionable when resuming fails", async () => {
+    const onResume = vi.fn().mockRejectedValue(new Error("host offline"));
+    renderView({ terminals: [], runnerOnline: false, onResume });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resume session" }));
+
+    expect(await screen.findByText("Couldn't resume session: host offline")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Resume session" })).toBeEnabled();
   });
 });
 

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -13,9 +13,10 @@
 // single header row (identity + close X). There is no tab strip here —
 // shells are opened and created from the rail's tab strip ("+" menu).
 
-import { TerminalIcon, XIcon } from "lucide-react";
+import { Loader2Icon, TerminalIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TerminalView } from "@/components/blocks/TerminalView";
+import { Button } from "@/components/ui/button";
 import {
   AGENT_TERMINAL_IDS,
   findAgentTerminal,
@@ -54,6 +55,10 @@ interface MainTerminalViewProps {
    * instead. Default false (owner / single-user).
    */
   readOnly?: boolean;
+  /** Known runner-tunnel state for the active session. */
+  runnerOnline?: boolean;
+  /** Relaunch or reconnect the session without replaying user input. */
+  onResume?: () => void | Promise<void>;
   /**
    * Exposes the outer terminal surface so the iOS native shell can show its
    * server switcher only while this surface is actually frontmost.
@@ -66,6 +71,8 @@ export function MainTerminalView({
   initialTerminalKey,
   visible = true,
   readOnly = false,
+  runnerOnline,
+  onResume,
   onSurfaceElement,
 }: MainTerminalViewProps) {
   const { terminals } = useTerminals(conversationId);
@@ -81,6 +88,28 @@ export function MainTerminalView({
   const [activeKey, setActiveKey] = useState(initialTerminalKey || "");
   const { getStatus, setTerminalConnectionState, markTerminalActive } =
     useTerminalStatuses(terminals);
+  const [resumePending, setResumePending] = useState(false);
+  const [resumeError, setResumeError] = useState<string | null>(null);
+  const runnerOffline = runnerOnline === false;
+  // Resource cleanup can beat the health poll when a session is stopped. An
+  // empty, non-starting inventory is therefore resumable even before liveness
+  // has caught up and explicitly reported the runner offline.
+  const resumeAvailable =
+    onResume !== undefined &&
+    (runnerOffline || (terminals.length === 0 && terminalFirstCtx?.terminalStartingUp !== true));
+  const handleResume = useCallback(async () => {
+    if (!onResume) return;
+    setResumeError(null);
+    setResumePending(true);
+    try {
+      await onResume();
+    } catch (error) {
+      setResumeError(resumeErrorText(error));
+      throw error;
+    } finally {
+      setResumePending(false);
+    }
+  }, [onResume]);
   // No manual keyboard padding here: this view is flow content inside the
   // app-shell, which useIOSViewportLock sizes to the visual viewport, so the
   // terminal already sits above the keyboard. (Fixed overlays like the mobile
@@ -156,9 +185,32 @@ export function MainTerminalView({
     >
       <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden rounded-lg border border-border bg-card p-3 shadow-sm">
         {activeTerminal === null ? (
-          <div className="flex flex-1 items-center justify-center text-muted-foreground text-ui">
-            {terminals.length === 0 ? "No terminals available." : "Agent terminal unavailable."}
-          </div>
+          resumeAvailable ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+              <div className="space-y-1">
+                <p className="font-medium text-foreground text-ui">The harness is not running.</p>
+                <p className="text-muted-foreground text-sm">
+                  Resume the session to reconnect the terminal.
+                </p>
+              </div>
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                disabled={resumePending}
+                onClick={() => void handleResume().catch(() => {})}
+                componentId="diagnostics.main-terminal.resume"
+              >
+                {resumePending && <Loader2Icon className="size-3.5 animate-spin" aria-hidden />}
+                {resumePending ? "Resuming…" : "Resume session"}
+              </Button>
+              {resumeError && <p className="text-destructive text-sm">{resumeError}</p>}
+            </div>
+          ) : (
+            <div className="flex flex-1 items-center justify-center text-muted-foreground text-ui">
+              {terminals.length === 0 ? "No terminals available." : "Agent terminal unavailable."}
+            </div>
+          )
         ) : (
           <>
             {isShellView && activeTerminal && (
@@ -199,6 +251,8 @@ export function MainTerminalView({
                     transport={activeTerminal.transport}
                     active={visible}
                     directAttachUrl={activeTerminal.directAttachUrl}
+                    onResume={runnerOffline && onResume ? handleResume : undefined}
+                    resumePending={resumePending}
                     onStateChange={(state) => {
                       setTerminalConnectionState(activeTerminal.id, state);
                     }}
@@ -212,4 +266,9 @@ export function MainTerminalView({
       </div>
     </div>
   );
+}
+
+function resumeErrorText(error: unknown): string {
+  if (error instanceof Error && error.message) return `Couldn't resume session: ${error.message}`;
+  return "Couldn't resume session.";
 }

--- a/web/src/shell/TerminalFirstContext.tsx
+++ b/web/src/shell/TerminalFirstContext.tsx
@@ -60,14 +60,15 @@ export interface TerminalFirstContextValue {
   /** Switch view. `"terminal"` opens the terminal surface. */
   setView: (view: TerminalFirstView) => void;
   /**
-   * True when the agent terminal exists and is reachable. User shells do not
-   * enable the Terminal-view toggle; they open through the workspace rail.
+   * True when the agent terminal exists and is reachable. This controls
+   * background pre-warming, not whether the Terminal view can be selected;
+   * user shells open separately through the workspace rail.
    */
   terminalsAvailable: boolean;
   /**
-   * True while the terminal is coming up but not yet openable — drives the
-   * spinner on the "Terminal" pill so it reads as "loading" rather than a
-   * permanently greyed-out button. The single pill-facing "loading" signal:
+   * True while the terminal is coming up but its PTY is not available — drives
+   * the spinner on the selectable "Terminal" segment. The single pill-facing
+   * "loading" signal:
    * AppShell folds the two underlying sources into it, since neither alone
    * covers the whole launch:
    *
@@ -78,7 +79,7 @@ export interface TerminalFirstContextValue {
    *     (`terminalPending` SSE), which covers the window after it connects.
    *
    * Always false once `terminalsAvailable` is true, and for an idle stopped
-   * session (a greyed button, not "loading").
+   * session. The view remains selectable in every state.
    */
   terminalStartingUp: boolean;
 }

--- a/web/src/shell/ViewModeToggle.test.tsx
+++ b/web/src/shell/ViewModeToggle.test.tsx
@@ -125,20 +125,25 @@ describe("ViewModeToggle", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent("Chat view");
   });
 
-  it("disables the Terminal segment and shows a spinner while the terminal is coming up", () => {
-    renderToggle(makeCtx({ terminalsAvailable: false, terminalStartingUp: true }));
+  it("keeps the Terminal segment usable and shows a spinner while the terminal is coming up", () => {
+    const setView = vi.fn();
+    renderToggle(makeCtx({ setView, terminalsAvailable: false, terminalStartingUp: true }));
     const terminal = terminalSegment();
-    expect(terminal).toBeDisabled();
-    // The name carries the reason, so the disabled state explains itself.
+    expect(terminal).toBeEnabled();
     expect(terminal).toHaveAccessibleName(/starting up/i);
     expect(terminal.querySelector(".animate-spin")).not.toBeNull();
+    fireEvent.click(terminal);
+    expect(setView).toHaveBeenCalledWith("terminal");
   });
 
-  it("disables the Terminal segment WITHOUT a spinner when no terminal exists and none is coming up", () => {
-    renderToggle(makeCtx({ terminalsAvailable: false, terminalStartingUp: false }));
+  it("keeps the Terminal segment usable when the runner is offline", () => {
+    const setView = vi.fn();
+    renderToggle(makeCtx({ setView, terminalsAvailable: false, terminalStartingUp: false }));
     const terminal = terminalSegment();
-    expect(terminal).toBeDisabled();
+    expect(terminal).toBeEnabled();
     expect(terminal.querySelector(".animate-spin")).toBeNull();
+    fireEvent.click(terminal);
+    expect(setView).toHaveBeenCalledWith("terminal");
   });
 
   it("leaves the Chat segment usable while the terminal is unavailable", () => {

--- a/web/src/shell/ViewModeToggle.tsx
+++ b/web/src/shell/ViewModeToggle.tsx
@@ -22,7 +22,7 @@ export function ViewModeToggle() {
   const ctx = useTerminalFirst();
   if (!ctx || !ctx.isTerminalFirst || ctx.isShellView || isIOSShell()) return null;
 
-  const { view, setView, terminalsAvailable, terminalStartingUp } = ctx;
+  const { view, setView, terminalStartingUp } = ctx;
   const terminalLabel = terminalStartingUp ? "Terminal is starting up…" : "Terminal view";
 
   return (
@@ -42,12 +42,9 @@ export function ViewModeToggle() {
       >
         <MessagesSquareIcon className="size-3.5" />
       </ViewModeSegment>
-      {/* Terminal stays disabled until a PTY is reachable; the spinner while
-          it's coming up reads as "loading" rather than a dead segment. */}
       <ViewModeSegment
         label={terminalLabel}
         active={view === "terminal"}
-        disabled={!terminalsAvailable}
         onClick={() => setView("terminal")}
         testId="view-mode-terminal"
       >
@@ -70,23 +67,18 @@ export function ViewModeToggle() {
 function ViewModeSegment({
   label,
   active,
-  disabled = false,
   onClick,
   testId,
   children,
 }: {
   label: string;
   active: boolean;
-  disabled?: boolean;
   onClick: () => void;
   testId: string;
   children: React.ReactNode;
 }) {
   return (
     <Tooltip>
-      {/* Wrapper span owns hover/focus: a disabled button gets no pointer
-          events, so the tooltip explaining *why* it's disabled would never
-          open if it anchored to the button itself. */}
       <TooltipTrigger asChild>
         <span className="inline-flex">
           <Button
@@ -95,7 +87,6 @@ function ViewModeSegment({
             size="icon-xs"
             aria-label={label}
             aria-pressed={active}
-            disabled={disabled}
             onClick={onClick}
             data-testid={testId}
             className={cn(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Keep the Terminal destination selectable when its runner or agent PTY is unavailable instead of forcing users back to Chat.
- Show a stopped-harness explanation with a Resume session action, including pending, reconnect, and failure handling.
- Preserve the behavior for explicit user shells, keep the iOS native switcher available offline, and cover the empty-inventory health-poll race.

**ELI5:** Stopping a session removes its terminal before the health indicator always catches up. The empty terminal page now recognizes that state and gives the user a direct way to start it again.

```text
runner stops → terminal resources disappear → Terminal stays selectable
             → stopped-harness message → Resume session → terminal reconnects
```

## Test Plan

- `cd web && npm test -- --run src/shell/ViewModeToggle.test.tsx src/shell/MainTerminalView.test.tsx src/shell/AppShell.test.tsx src/pages/ChatPage.test.ts src/pages/ChatPage.indicators.test.tsx` (324 tests passed)
- `cd web && npm run type-check`
- `cd web && npm run build`
- `uv run ruff check tests/e2e_ui/shells/test_new_shell.py`
- `uv run ruff format --check tests/e2e_ui/shells/test_new_shell.py`
- `uv run pytest tests/e2e_ui/shells/test_new_shell.py::test_empty_terminal_view_remains_selectable_and_resumable -q`

## Demo


https://github.com/user-attachments/assets/d4c5bc54-ff50-4374-b45b-399317dc28ec


## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused Vitest suites cover navigation, terminal-loss persistence, resume success/failure, and the empty-inventory race. The browser test covers the visible stopped-harness state and enabled Terminal navigation.

## Changelog

Stopped terminal sessions now stay accessible and can be resumed directly from Terminal view.
