### PR TITLE
feat(web): configure the default transcript view

### DIFF
--- a/web/src/lib/transcriptViewPreferences.test.ts
+++ b/web/src/lib/transcriptViewPreferences.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  normalizeTranscriptViewDefault,
+  readTranscriptViewDefault,
+  TRANSCRIPT_VIEW_DEFAULT,
+  writeTranscriptViewDefault,
+} from "./transcriptViewPreferences";
+
+const STORAGE_KEY = "omnigent:default-transcript-view";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("transcriptViewPreferences — read/write", () => {
+  it("returns chat when nothing is stored", () => {
+    expect(readTranscriptViewDefault()).toBe(TRANSCRIPT_VIEW_DEFAULT);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("stores terminal and clears the key for chat", () => {
+    writeTranscriptViewDefault("terminal");
+    expect(readTranscriptViewDefault()).toBe("terminal");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("terminal");
+
+    writeTranscriptViewDefault("chat");
+    expect(readTranscriptViewDefault()).toBe("chat");
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("normalizeTranscriptViewDefault", () => {
+  it("passes through valid values", () => {
+    expect(normalizeTranscriptViewDefault("chat")).toBe("chat");
+    expect(normalizeTranscriptViewDefault("terminal")).toBe("terminal");
+  });
+
+  it("maps unknown, null, and garbage to chat", () => {
+    expect(normalizeTranscriptViewDefault("auto")).toBe("chat");
+    expect(normalizeTranscriptViewDefault("bogus")).toBe("chat");
+    expect(normalizeTranscriptViewDefault(null)).toBe("chat");
+    expect(normalizeTranscriptViewDefault(undefined)).toBe("chat");
+  });
+});

--- a/web/src/lib/transcriptViewPreferences.ts
+++ b/web/src/lib/transcriptViewPreferences.ts
@@ -1,0 +1,58 @@
+// Persisted default surface for terminal-first chat transcripts.
+//
+// Terminal-first sessions expose both the rendered Chat transcript and the
+// agent's live terminal. This preference chooses which surface opens when a
+// session has no per-tab view selection; AppShell's sessionStorage state still
+// wins after the user switches a particular chat.
+
+const STORAGE_KEY = "omnigent:default-transcript-view";
+
+export const transcriptViewDefaults = ["chat", "terminal"] as const;
+export type TranscriptViewDefault = (typeof transcriptViewDefaults)[number];
+
+/** Preserve the existing product behavior for users without a saved choice. */
+export const TRANSCRIPT_VIEW_DEFAULT: TranscriptViewDefault = "chat";
+
+/** Return whether a string is one of the supported transcript surfaces. */
+export function isTranscriptViewDefault(
+  value: string | null | undefined,
+): value is TranscriptViewDefault {
+  return value === "chat" || value === "terminal";
+}
+
+/** Normalize storage drift or manual edits to the product default. */
+export function normalizeTranscriptViewDefault(
+  value: string | null | undefined,
+): TranscriptViewDefault {
+  return isTranscriptViewDefault(value) ? value : TRANSCRIPT_VIEW_DEFAULT;
+}
+
+/**
+ * Read the default surface for terminal-first transcripts.
+ *
+ * Returns "chat" when no preference exists, during server rendering, or when
+ * localStorage is unavailable/corrupt.
+ */
+export function readTranscriptViewDefault(): TranscriptViewDefault {
+  if (typeof window === "undefined") return TRANSCRIPT_VIEW_DEFAULT;
+  try {
+    return normalizeTranscriptViewDefault(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return TRANSCRIPT_VIEW_DEFAULT;
+  }
+}
+
+/** Persist a transcript default, clearing storage for the product default. */
+export function writeTranscriptViewDefault(value: TranscriptViewDefault): void {
+  if (typeof window === "undefined") return;
+  try {
+    const normalized = normalizeTranscriptViewDefault(value);
+    if (normalized === TRANSCRIPT_VIEW_DEFAULT) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, normalized);
+    }
+  } catch {
+    // localStorage quota or access errors shouldn't break settings.
+  }
+}

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -306,6 +306,24 @@ describe("SettingsPage", () => {
     expect(screen.getByTestId("terminal-theme-auto")).toHaveAttribute("aria-checked", "false");
   });
 
+  it("defaults transcripts to Chat and persists a Terminal default", () => {
+    renderPage("/settings/appearance");
+
+    expect(screen.getByRole("radiogroup", { name: "Default transcript view" })).toBeInTheDocument();
+    expect(screen.getByTestId("transcript-view-default-chat")).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(localStorage.getItem("omnigent:default-transcript-view")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("transcript-view-default-terminal"));
+    expect(screen.getByTestId("transcript-view-default-terminal")).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(localStorage.getItem("omnigent:default-transcript-view")).toBe("terminal");
+  });
+
   it("renders the color theme dropdown, defaults to Omnigent, and applies a palette on change", () => {
     localStorage.clear();
     renderPage("/settings/appearance");
@@ -458,6 +476,7 @@ describe("SettingsPage", () => {
     fireEvent.change(screen.getByTestId("color-theme-select") as HTMLSelectElement, {
       target: { value: "github" },
     });
+    fireEvent.click(screen.getByTestId("transcript-view-default-terminal"));
     fireEvent.click(screen.getByTestId("workspace-panel-default-collapsed"));
     fireEvent.click(screen.getByTestId("hide-unconfigured-harnesses-toggle"));
     fireEvent.click(screen.getByTestId("ui-font-size-inc"));
@@ -473,6 +492,7 @@ describe("SettingsPage", () => {
 
     // Sanity: the non-default choices were persisted.
     expect(localStorage.getItem("omnigent:terminal-theme")).toBe("dark");
+    expect(localStorage.getItem("omnigent:default-transcript-view")).toBe("terminal");
     expect(localStorage.getItem("omnigent:ui-theme-palette")).toBe(JSON.stringify("github"));
     expect(localStorage.getItem("omnigent:ui-font-size")).toBe("15");
     expect(localStorage.getItem("omnigent:code-font-size")).toBe("15");
@@ -498,8 +518,12 @@ describe("SettingsPage", () => {
     expect((screen.getByTestId("color-theme-select") as HTMLSelectElement).value).toBe("omni");
     expect(document.documentElement.getAttribute("data-theme")).toBeNull();
 
-    // Terminal theme, workspace panel, and harness visibility are restored.
+    // Terminal theme, transcript view, workspace panel, and harness visibility are restored.
     expect(screen.getByTestId("terminal-theme-auto")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("transcript-view-default-chat")).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
     expect(screen.getByTestId("workspace-panel-default-open")).toHaveAttribute(
       "aria-checked",
       "true",

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -10,7 +10,7 @@
  * Sections:
  *
  * - **Appearance** — theme mode (System / Light / Dark), terminal theme,
- *   Workspace panel default for new chats, and UI/code font controls.
+ *   default transcript view, Workspace panel default, and UI/code font controls.
  * - **Git** — Git behavior, e.g. the default base branch pre-filled when
  *   naming a new worktree branch in the composer.
  * - **Keyboard shortcuts** — the full shortcuts reference, shown inline.
@@ -45,6 +45,7 @@ import {
   KeyRoundIcon,
   LaptopMinimalIcon,
   LogOutIcon,
+  MessagesSquareIcon,
   MinusIcon,
   MonitorIcon,
   MoonIcon,
@@ -52,6 +53,7 @@ import {
   PanelRightIcon,
   PlusIcon,
   SunIcon,
+  TerminalIcon,
   Trash2Icon,
   UserCogIcon,
 } from "lucide-react";
@@ -137,6 +139,12 @@ import {
   writeWorkspacePanelDefault,
   type WorkspacePanelDefault,
 } from "@/lib/workspacePanelPreferences";
+import {
+  readTranscriptViewDefault,
+  TRANSCRIPT_VIEW_DEFAULT,
+  writeTranscriptViewDefault,
+  type TranscriptViewDefault,
+} from "@/lib/transcriptViewPreferences";
 import { readDefaultBaseBranch, writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 import {
   DEFAULT_HIDE_UNCONFIGURED_HARNESSES,
@@ -274,6 +282,15 @@ const terminalThemeCards: { mode: TerminalThemeMode; label: string; icon: typeof
   { mode: "auto", label: "Match app", icon: MonitorIcon },
   { mode: "light", label: "Light", icon: SunIcon },
   { mode: "dark", label: "Dark", icon: MoonIcon },
+];
+
+const transcriptViewCards: {
+  value: TranscriptViewDefault;
+  label: string;
+  icon: typeof MessagesSquareIcon;
+}[] = [
+  { value: "chat", label: "Chat", icon: MessagesSquareIcon },
+  { value: "terminal", label: "Terminal", icon: TerminalIcon },
 ];
 
 const workspacePanelCards: {
@@ -545,6 +562,37 @@ function TerminalThemeControl() {
         items={terminalThemeCards.map((card) => ({
           value: card.mode,
           testId: `terminal-theme-${card.mode}`,
+          body: iconCardBody(card.icon, card.label),
+        }))}
+      />
+    </ThemeSubsection>
+  );
+}
+
+/** Default surface for terminal-first transcripts without a per-tab choice. */
+function TranscriptViewDefaultControl() {
+  const [value, setValue] = useState(() => readTranscriptViewDefault());
+  const labelId = useId();
+  const choose = useCallback((next: TranscriptViewDefault) => {
+    setValue(next);
+    writeTranscriptViewDefault(next);
+  }, []);
+  return (
+    <ThemeSubsection
+      labelId={labelId}
+      title="Default transcript view"
+      helper="Choose whether terminal-backed chats open in Chat or Terminal view. A view selected in a chat is remembered for the current tab."
+    >
+      <CardRadioGroup<TranscriptViewDefault>
+        labelledBy={labelId}
+        value={value}
+        onSelect={choose}
+        componentId="settings.appearance.transcript_view"
+        className="grid grid-cols-2 gap-3"
+        cardClassName="items-center gap-2 p-4"
+        items={transcriptViewCards.map((card) => ({
+          value: card.value,
+          testId: `transcript-view-default-${card.value}`,
           body: iconCardBody(card.icon, card.label),
         }))}
       />
@@ -863,6 +911,8 @@ function AppearanceSection() {
     writeCustomTheme(DEFAULT_CUSTOM_THEME);
     applyCustomTheme(DEFAULT_CUSTOM_THEME);
 
+    writeTranscriptViewDefault(TRANSCRIPT_VIEW_DEFAULT);
+
     writeWorkspacePanelDefault(WORKSPACE_PANEL_DEFAULT);
 
     writeHideUnconfiguredHarnesses(DEFAULT_HIDE_UNCONFIGURED_HARNESSES);
@@ -887,6 +937,7 @@ function AppearanceSection() {
           "omnigent:terminal-theme",
           "omnigent:ui-theme-palette",
           "omnigent:custom-theme",
+          "omnigent:default-transcript-view",
           "omnigent:default-workspace-panel",
           "omnigent:hide-unconfigured-harnesses",
         ]) {
@@ -928,6 +979,8 @@ function AppearanceSection() {
         <TerminalThemeControl />
 
         {!isEmbedded && <ColorThemeControl />}
+
+        <TranscriptViewDefaultControl />
 
         <WorkspacePanelDefaultControl />
 

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -1047,9 +1047,8 @@ describe("TerminalFirstContext", () => {
   });
 
   it("does not restore terminal view in a fresh tab (sessionStorage scope)", () => {
-    // First-time visitors must still land in chat view — the persistence
-    // is sessionStorage, so a new tab starts with no stored preference.
-    // This is the deliberate default.
+    // First-time visitors still land in chat view when no Appearance override
+    // exists. Per-chat persistence remains scoped to sessionStorage.
     useEnvironmentMock.mockReturnValue({
       data: { available: true, root: null },
       isLoading: false,
@@ -1070,6 +1069,60 @@ describe("TerminalFirstContext", () => {
     renderShell("/c/conv_native");
     expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
     expect(screen.getByRole("button", { name: "Chat" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("opens terminal-first transcripts in Terminal when configured", () => {
+    localStorage.setItem("omnigent:default-transcript-view", "terminal");
+    mockConversations([
+      {
+        id: "conv_native",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal" },
+      },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_claude_main", name: "claude", session: "main", running: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_native");
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "terminal");
+  });
+
+  it("remembers an explicit Chat choice over the Terminal default", () => {
+    localStorage.setItem("omnigent:default-transcript-view", "terminal");
+    mockConversations([
+      {
+        id: "conv_native",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal" },
+      },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_claude_main", name: "claude", session: "main", running: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    const { unmount } = renderShell("/c/conv_native");
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "terminal");
+    fireEvent.click(screen.getByRole("button", { name: "Chat" }));
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
+
+    unmount();
+    renderShell("/c/conv_native");
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
+  });
+
+  it("does not apply the Terminal default to regular chat sessions", () => {
+    localStorage.setItem("omnigent:default-transcript-view", "terminal");
+    mockConversations([{ id: "conv_regular", permission_level: null, labels: {} }]);
+
+    renderShell("/c/conv_regular");
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
   });
 });
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -39,6 +39,7 @@ import {
   readDefaultWorkspacePanelOpen,
   writeDefaultWorkspacePanelOpen,
 } from "@/lib/workspacePanelPreferences";
+import { readTranscriptViewDefault } from "@/lib/transcriptViewPreferences";
 import { updateOverlayToastOffset } from "@/lib/updateOverlayInset";
 import {
   Dialog,
@@ -152,6 +153,12 @@ import type { RightRailTab } from "./railTabs";
  * open as closable soft tabs in the rail's tab strip. The Agents tab only
  * appears once there's more than one agent (the root has at least one child).
  */
+
+// `null` in panel state means Chat view, but an absent sessionStorage entry
+// means "use the configured default." Keep an explicit marker so choosing Chat
+// can override a Terminal default when the user returns to that conversation.
+const CHAT_VIEW_STORAGE_VALUE = "__chat__";
+
 export function AppShell() {
   // Cmd/Ctrl+Enter accepts the pending harness approval prompt. Bound once
   // here so it works on every chat route, regardless of where focus sits.
@@ -864,29 +871,25 @@ export function AppShell() {
   );
 
   // Persist the Chat/TUI toggle position per-conversation so leaving and
-  // re-entering a native session doesn't drop the user back into chat
-  // view. sessionStorage scope: same tab, cleared on tab close —
-  // a deliberately narrow scope so a stale "terminal view" preference
-  // can't survive across browser sessions, where the user's mental model
-  // may have moved on.
+  // re-entering a native session restores the view the user chose instead of
+  // reapplying the global default. sessionStorage scope: same tab, cleared on
+  // tab close — a deliberately narrow scope so stale view choices don't carry
+  // into a later browsing session.
   const setPanelInitialKey = useCallback(
     (key: string | null) => {
       setPanelInitialKeyState(key);
       if (!conversationId) return;
       const storageKey = `omnigent.web.panel-key:${conversationId}`;
-      if (key === null) {
-        sessionStorage.removeItem(storageKey);
-      } else {
-        sessionStorage.setItem(storageKey, key);
-      }
+      sessionStorage.setItem(storageKey, key === null ? CHAT_VIEW_STORAGE_VALUE : key);
     },
     [conversationId],
   );
 
   // Restore the per-session workspace state when switching conversations:
   // rail open-state, selected tab, and the open file tabs. The Chat/TUI toggle
-  // is restored from sessionStorage; the Files scope and the active file also
-  // honor URL search params so shared links open to the right view.
+  // is restored from sessionStorage; with no per-tab choice, terminal-first
+  // sessions use the Appearance default. The Files scope and the active file
+  // also honor URL search params so shared links open to the right view.
   useEffect(() => {
     setExecutionLogsKey(null);
     setFilesPanelOpen(false);
@@ -913,8 +916,14 @@ export function AppShell() {
     }
     const persisted = readSessionWorkspaceState(conversationId);
 
-    const stored = sessionStorage.getItem(`omnigent.web.panel-key:${conversationId}`);
-    setPanelInitialKeyState(stored);
+    const storageKey = `omnigent.web.panel-key:${conversationId}`;
+    const stored = sessionStorage.getItem(storageKey);
+    const defaultToTerminal = terminalFirst && readTranscriptViewDefault() === "terminal";
+    setPanelInitialKeyState(
+      stored === CHAT_VIEW_STORAGE_VALUE
+        ? null
+        : (stored ?? (defaultToTerminal ? PANEL_NO_TERMINAL_KEY : null)),
+    );
 
     // Restore the selected rail tab (the Files vs Changes scope is now the tab
     // itself). ``nextTab`` stays null when there's no persisted tab and no file
@@ -967,6 +976,17 @@ export function AppShell() {
 
     stateConvRef.current = conversationId;
   }, [conversationId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Child sessions are absent from the sidebar, so their terminal-first label
+  // can arrive after the conversation restore above. Apply the Terminal default
+  // at that point only when this tab still has no explicit per-chat choice.
+  useEffect(() => {
+    if (!conversationId || !terminalFirst) return;
+    const storageKey = `omnigent.web.panel-key:${conversationId}`;
+    if (sessionStorage.getItem(storageKey) === null && readTranscriptViewDefault() === "terminal") {
+      setPanelInitialKeyState(PANEL_NO_TERMINAL_KEY);
+    }
+  }, [conversationId, terminalFirst]);
 
   // Persist the per-session rail tab + open file tabs whenever they change.
   // Keyed on the state (not conversationId) and targeted at the conversation


### PR DESCRIPTION
## Related issue

N/A — maintainer feature.

## Summary

- Add an Appearance setting that chooses whether terminal-backed sessions open in Chat or Terminal view.
- Preserve each chat's explicit view choice for the current browser tab so it overrides the configured default.
- Include the preference in appearance reset and cover preference storage, settings UI, and AppShell behavior.

**ELI5:** The setting picks the first view. Once you switch a particular chat, that chat remembers your choice for the rest of the tab.

```text
Appearance default ──┐
                     ├─> transcript opens in Chat or Terminal
Per-chat tab choice ─┘   (wins when present)
```

## Test Plan

- `pnpm --dir web exec vitest run src/lib/transcriptViewPreferences.test.ts src/pages/SettingsPage.test.tsx src/shell/AppShell.test.tsx`
- `pnpm --dir web exec tsc -b --pretty false`
- `pnpm --dir web exec oxlint --deny-warnings --report-unused-disable-directives src/lib/transcriptViewPreferences.ts src/lib/transcriptViewPreferences.test.ts src/pages/SettingsPage.tsx src/pages/SettingsPage.test.tsx src/shell/AppShell.tsx src/shell/AppShell.test.tsx`
- Opened Settings → Appearance in the local dev app, selected Terminal, and verified the card state and stored preference updated.

## Demo

N/A — visual change is limited to the new Appearance settings radiogroup.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the control renders in Appearance, defaults to Chat, and persists Terminal when selected.

## Changelog

Choose whether terminal-backed chats open in Chat or Terminal view by default.
