### PR TITLE
fix(web): restore transcript view from URL

### DIFF
--- a/tests/e2e_ui/sessions/test_terminal_view_url.py
+++ b/tests/e2e_ui/sessions/test_terminal_view_url.py
@@ -1,0 +1,83 @@
+"""Browser e2e: transcript views survive a cold reload through the URL."""
+
+from __future__ import annotations
+
+import json
+import re
+
+import httpx
+from playwright.sync_api import Page, Route, expect
+
+
+def test_transcript_views_survive_cold_reload(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Selecting Terminal or Chat writes and restores the explicit URL view."""
+    base_url, session_id = seeded_session
+    response = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"labels": {"omnigent.ui": "terminal"}},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+
+    # Supply the session's agent pane deterministically. The URL behavior does
+    # not need a live PTY, only the same resource shape the runner publishes.
+    def _serve_agent_terminal(route: Route) -> None:
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "terminal_tui_main",
+                            "type": "terminal",
+                            "session_id": session_id,
+                            "name": "tui:main",
+                            "metadata": {
+                                "terminal_name": "tui",
+                                "session_key": "main",
+                                "running": True,
+                            },
+                        }
+                    ],
+                    "first_id": "terminal_tui_main",
+                    "last_id": "terminal_tui_main",
+                    "has_more": False,
+                }
+            ),
+        )
+
+    terminal_list = re.compile(rf"/v1/sessions/{re.escape(session_id)}/resources/terminals\?.*")
+    page.route(terminal_list, _serve_agent_terminal)
+
+    page.goto(f"{base_url}/c/{session_id}")
+    terminal_button = page.get_by_test_id("view-mode-terminal")
+    expect(terminal_button).to_be_enabled(timeout=60_000)
+    terminal_button.click()
+
+    expect(page).to_have_url(re.compile(r"[?&]view=terminal(?:&|$)"))
+    expect(terminal_button).to_have_attribute("aria-pressed", "true")
+
+    # Remove the same-tab fallback so the reload must restore from the URL.
+    page.evaluate("window.sessionStorage.clear()")
+    page.reload()
+
+    terminal_button = page.get_by_test_id("view-mode-terminal")
+    expect(terminal_button).to_have_attribute("aria-pressed", "true", timeout=60_000)
+    expect(page).to_have_url(re.compile(r"[?&]view=terminal(?:&|$)"))
+
+    chat_button = page.get_by_test_id("view-mode-chat")
+    chat_button.click()
+    expect(page).to_have_url(re.compile(r"[?&]view=chat(?:&|$)"))
+    expect(chat_button).to_have_attribute("aria-pressed", "true")
+
+    page.evaluate("window.sessionStorage.clear()")
+    page.reload()
+
+    chat_button = page.get_by_test_id("view-mode-chat")
+    expect(chat_button).to_have_attribute("aria-pressed", "true", timeout=60_000)
+    expect(page).to_have_url(re.compile(r"[?&]view=chat(?:&|$)"))

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -635,6 +635,117 @@ describe("AppShell header", () => {
     expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
   });
 
+  it("restores terminal view from the URL on refresh", () => {
+    mockConversations([
+      {
+        id: "conv_terminal",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal" },
+      },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        {
+          id: "terminal_claude_main",
+          name: "claude",
+          session: "main",
+          running: true,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_terminal?file=README.md&view=terminal");
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "terminal");
+    expect(screen.getByTestId("url-params")).toHaveTextContent("file=README.md");
+    expect(screen.getByTestId("url-params")).toHaveTextContent("view=terminal");
+  });
+
+  it("restores an explicit chat view over a stored terminal view", () => {
+    mockConversations([
+      {
+        id: "conv_terminal",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal" },
+      },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        {
+          id: "terminal_claude_main",
+          name: "claude",
+          session: "main",
+          running: true,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    sessionStorage.setItem("omnigent.web.panel-key:conv_terminal", "terminal:terminal_claude_main");
+
+    renderShell("/c/conv_terminal?view=chat");
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
+    expect(screen.getByTestId("url-params")).toHaveTextContent("view=chat");
+  });
+
+  it("restores terminal view when session labels load after the initial refresh", async () => {
+    mockConversations([]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        {
+          id: "terminal_claude_main",
+          name: "claude",
+          session: "main",
+          running: true,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const makeTree = () => (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_terminal?view=terminal"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <LocationDisplay />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(makeTree());
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
+
+    mockConversations([
+      {
+        id: "conv_terminal",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal" },
+      },
+    ]);
+    rerender(makeTree());
+
+    await waitFor(() =>
+      expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "terminal"),
+    );
+  });
+
   it("shows the terminal-startup spinner while a terminal-first session is coming up", () => {
     // Baseline for the suppression test below: terminalPending (PTY being
     // created) with no terminals available drives terminalStartingUp true.
@@ -863,14 +974,18 @@ describe("TerminalFirstContext", () => {
     fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
 
     // After flip: view is "terminal", drawer still NOT mounted (inline
-    // render lives in ChatPage), and the rail's files panel remains.
+    // render lives in ChatPage), and the rail's files panel remains. The URL
+    // records the view so refreshing returns to the same surface.
     expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "terminal");
+    expect(screen.getByTestId("url-params")).toHaveTextContent("view=terminal");
     expect(screen.queryByTestId("terminals-panel")).toBeNull();
     expect(screen.getByTestId("files-panel")).toBeInTheDocument();
 
-    // Toggling back to Chat returns the probe to "chat".
+    // Toggling back to Chat returns the probe to "chat" and records that
+    // explicit choice for refreshes where Terminal may be the default.
     fireEvent.click(screen.getByRole("button", { name: "Chat" }));
     expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
+    expect(screen.getByTestId("url-params")).toHaveTextContent("view=chat");
   });
 
   it("flips to an empty Terminal view when a terminal-first session has no terminal resource", () => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -872,17 +872,27 @@ export function AppShell() {
 
   // Persist the Chat/TUI toggle position per-conversation so leaving and
   // re-entering a native session restores the view the user chose instead of
-  // reapplying the global default. sessionStorage scope: same tab, cleared on
-  // tab close — a deliberately narrow scope so stale view choices don't carry
-  // into a later browsing session.
+  // reapplying the global default. Keep the explicit choice in the URL too so
+  // a refresh or shared link restores either surface.
   const setPanelInitialKey = useCallback(
     (key: string | null) => {
       setPanelInitialKeyState(key);
-      if (!conversationId) return;
-      const storageKey = `omnigent.web.panel-key:${conversationId}`;
-      sessionStorage.setItem(storageKey, key === null ? CHAT_VIEW_STORAGE_VALUE : key);
+      if (conversationId) {
+        const storageKey = `omnigent.web.panel-key:${conversationId}`;
+        sessionStorage.setItem(storageKey, key === null ? CHAT_VIEW_STORAGE_VALUE : key);
+      }
+      if (terminalFirst) {
+        setSearchParams(
+          (prev) => {
+            const next = new URLSearchParams(prev);
+            next.set("view", key === null ? "chat" : "terminal");
+            return next;
+          },
+          { replace: true },
+        );
+      }
     },
-    [conversationId],
+    [conversationId, setSearchParams, terminalFirst],
   );
 
   // Restore the per-session workspace state when switching conversations:
@@ -918,11 +928,18 @@ export function AppShell() {
 
     const storageKey = `omnigent.web.panel-key:${conversationId}`;
     const stored = sessionStorage.getItem(storageKey);
+    const requestedView = terminalFirst ? searchParams.get("view") : null;
+    const terminalKey =
+      agentTerminal === null ? PANEL_NO_TERMINAL_KEY : terminalTabKey(agentTerminal);
     const defaultToTerminal = terminalFirst && readTranscriptViewDefault() === "terminal";
     setPanelInitialKeyState(
-      stored === CHAT_VIEW_STORAGE_VALUE
+      requestedView === "chat"
         ? null
-        : (stored ?? (defaultToTerminal ? PANEL_NO_TERMINAL_KEY : null)),
+        : requestedView === "terminal"
+          ? terminalKey
+          : stored === CHAT_VIEW_STORAGE_VALUE
+            ? null
+            : (stored ?? (defaultToTerminal ? terminalKey : null)),
     );
 
     // Restore the selected rail tab (the Files vs Changes scope is now the tab
@@ -977,16 +994,27 @@ export function AppShell() {
     stateConvRef.current = conversationId;
   }, [conversationId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Child sessions are absent from the sidebar, so their terminal-first label
-  // can arrive after the conversation restore above. Apply the Terminal default
-  // at that point only when this tab still has no explicit per-chat choice.
+  // Session metadata can arrive after the restore effect above. Once the
+  // terminal-first label is known, apply URL state first, then the per-tab
+  // choice, then the configured default.
   useEffect(() => {
     if (!conversationId || !terminalFirst) return;
-    const storageKey = `omnigent.web.panel-key:${conversationId}`;
-    if (sessionStorage.getItem(storageKey) === null && readTranscriptViewDefault() === "terminal") {
-      setPanelInitialKeyState(PANEL_NO_TERMINAL_KEY);
+    const requestedView = searchParams.get("view");
+    const stored = sessionStorage.getItem(`omnigent.web.panel-key:${conversationId}`);
+    const terminalKey =
+      agentTerminal === null ? PANEL_NO_TERMINAL_KEY : terminalTabKey(agentTerminal);
+    if (requestedView === "chat") {
+      setPanelInitialKeyState(null);
+    } else if (requestedView === "terminal") {
+      setPanelInitialKeyState(terminalKey);
+    } else if (stored === CHAT_VIEW_STORAGE_VALUE) {
+      setPanelInitialKeyState(null);
+    } else if (stored !== null) {
+      setPanelInitialKeyState(stored);
+    } else if (readTranscriptViewDefault() === "terminal") {
+      setPanelInitialKeyState(terminalKey);
     }
-  }, [conversationId, terminalFirst]);
+  }, [agentTerminal, conversationId, searchParams, terminalFirst]);
 
   // Persist the per-session rail tab + open file tabs whenever they change.
   // Keyed on the state (not conversationId) and targeted at the conversation


### PR DESCRIPTION
## Related issue

N/A — maintainer fix.

## Summary

- Keep the terminal-first Chat/Terminal toggle synchronized with `?view=terminal` while preserving unrelated query parameters.
- Restore Terminal view after refresh, including when session labels load after the shell's initial restore pass.

## Test Plan

- `pnpm --dir web test src/shell/AppShell.test.tsx`
- `pnpm --dir web type-check`
- `pnpm --dir web exec oxlint --deny-warnings --report-unused-disable-directives src/shell/AppShell.tsx src/shell/AppShell.test.tsx`
- `pnpm --dir web exec prettier --check src/shell/AppShell.tsx src/shell/AppShell.test.tsx`
- `uv run ruff check tests/e2e_ui/sessions/test_terminal_view_url.py`
- `uv run ruff format --check tests/e2e_ui/sessions/test_terminal_view_url.py`
- `uv run pytest tests/e2e_ui/sessions/test_terminal_view_url.py -q`

## Demo

https://github.com/user-attachments/assets/ecd265bc-af34-427f-b16a-39e3a0347e7f

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added AppShell coverage for URL synchronization, query-parameter preservation, and delayed session metadata, plus a Playwright cold-reload regression test that clears the session-storage fallback.

## Changelog

Terminal view now stays selected when you refresh the page.
