### PR TITLE
feat(logging): mirror SSE events to the debug-log table + fix server/host sink delivery

### DIFF
--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -601,6 +601,9 @@ def debug_sink_enabled() -> bool:
     callers skip building records entirely when the sink is off, so the feature
     adds no cost for OSS / non-internal users who never enabled it.
     """
+    # Intentionally lock-free: a single global-object read is atomic under the
+    # GIL, and this is a best-effort gate — a stale read only mis-times one
+    # record around enable/close, never corrupts state.
     return _active_sink is not None and not _active_sink.closed
 
 

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -570,6 +570,32 @@ class ZerobusLogHandler(logging.Handler):
 _active_sink: ZerobusLogHandler | None = None
 _sink_lock = threading.Lock()
 
+# Dedicated logger for the server's outgoing SSE-event stream. It gets the sink
+# as its sole handler with ``propagate=False`` (wired in attach_debug_log_sink),
+# so its high-volume, table-only records — one per emitted event, names + safe
+# ids, never content — never reach the on-disk/stderr logs.
+SSE_LOGGER_NAME = "omnigent.sse_events"
+
+
+def debug_sink_enabled() -> bool:
+    """Whether the debug-log sink is active in this process.
+
+    A cheap gate for opt-in, table-only logging (e.g. the SSE-event stream):
+    callers skip building records entirely when the sink is off, so the feature
+    adds no cost for OSS / non-internal users who never enabled it.
+    """
+    return _active_sink is not None and not _active_sink.closed
+
+
+def sse_event_logger() -> logging.Logger:
+    """Return the table-only logger for SSE events (see :data:`SSE_LOGGER_NAME`).
+
+    Records go only to the debug sink (attached with ``propagate=False`` in
+    :func:`attach_debug_log_sink`); when the sink is disabled the logger has no
+    handlers and records are dropped -- so gate on :func:`debug_sink_enabled`.
+    """
+    return logging.getLogger(SSE_LOGGER_NAME)
+
 
 def attach_debug_log_sink(loggers: list[logging.Logger], *, source: str, level: int) -> None:
     """Attach the shared debug-log sink to *loggers* when configured.
@@ -601,3 +627,10 @@ def attach_debug_log_sink(loggers: list[logging.Logger], *, source: str, level: 
         _active_sink.setLevel(level)
         for target in loggers:
             target.addHandler(_active_sink)
+        # Table-only SSE-event logger: the sink is its sole handler and it does
+        # not propagate to root, so per-token delta events populate the table
+        # without flooding the on-disk/stderr logs.
+        sse_logger = logging.getLogger(SSE_LOGGER_NAME)
+        sse_logger.setLevel(level)
+        sse_logger.propagate = False
+        sse_logger.addHandler(_active_sink)

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -472,14 +472,32 @@ class ZerobusLogHandler(logging.Handler):
                 pass
 
     def _run(self) -> None:
-        while not self._stop.is_set():
-            batch = self._collect_batch(self._FLUSH_WAIT)
-            if batch:
-                self._post(batch)
-        # Drain whatever is left on shutdown.
-        remaining = self._collect_batch(0.0)
-        if remaining:
-            self._post(remaining)
+        # This worker owns the client captured at start and closes it on exit,
+        # so close() never shuts the client down from another thread while a
+        # post/token-mint is in flight (which raises inside httpx and would
+        # otherwise kill this thread with an uncaught exception).
+        client = self._client
+        try:
+            while not self._stop.is_set():
+                try:
+                    batch = self._collect_batch(self._FLUSH_WAIT)
+                    if batch:
+                        self._post(batch)
+                except Exception:  # noqa: BLE001 — the uploader thread must never die
+                    # A transient error (or a closed client during a shutdown
+                    # race) must not kill the worker: emit()'s self-heal only
+                    # revives a *stopped* thread, so a crash would silently end
+                    # delivery for the process. Drop and keep going.
+                    time.sleep(0.1)
+            # Best-effort drain of whatever is left on shutdown.
+            remaining = self._collect_batch(0.0)
+            if remaining:
+                self._post(remaining)
+        except Exception:  # noqa: BLE001 — shutdown drain is best-effort
+            pass
+        finally:
+            with contextlib.suppress(Exception):
+                client.close()
 
     _FLUSH_WAIT = _FLUSH_INTERVAL_S
 
@@ -551,18 +569,17 @@ class ZerobusLogHandler(logging.Handler):
     def close(self) -> None:
         if self._closed:
             return
-        # Capture the worker we are tearing down first. A concurrent emit()
-        # (which runs under the handler lock) can revive the sink during the
-        # join below — reassigning self._stop/_thread/_client to fresh ones — so
-        # stop and close the captured locals, never the revived worker.
-        stop, thread, client = self._stop, self._thread, self._client
+        # Signal the worker and let it finish and close its own client. Capture
+        # the worker we are tearing down first: a concurrent emit() (under the
+        # handler lock) can revive the sink during the join below, reassigning
+        # self._stop/_thread to fresh ones. Do NOT close the client here — the
+        # worker's shutdown drain may still be minting a token / posting, and
+        # closing it underneath raises inside httpx and kills the thread.
+        stop, thread = self._stop, self._thread
         self._closed = True
         stop.set()
         thread.join(timeout=5.0)
-        try:
-            client.close()
-        finally:
-            super().close()
+        super().close()
 
 
 # Process-wide sink; recreated only if a prior instance was closed (e.g. a

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -417,13 +417,31 @@ def configure_process_logging(
     # so it captures the same records this process writes to disk.
     from omnigent.debug_logging import attach_debug_log_sink
 
-    sink_targets = (
-        [logging.getLogger()] if root else [logging.getLogger(name) for name in logger_names]
-    )
+    sink_targets = _debug_sink_target_loggers(logger_names, root=root)
     attach_debug_log_sink(sink_targets, source=destination, level=resolved_level)
 
     logging.captureWarnings(True)
     return path
+
+
+def _debug_sink_target_loggers(logger_names: Sequence[str], *, root: bool) -> list[logging.Logger]:
+    """Loggers the debug-log sink must attach to, mirroring the file handler.
+
+    The sink has to sit wherever a record is actually handled. A package logger
+    with ``propagate=False`` (e.g. ``omnigent`` under the CLI diagnostics setup)
+    never reaches root, so a root-only sink would miss every record logged under
+    it. This matches the file-handler placement in
+    :func:`configure_process_logging` exactly, so the sink captures the same
+    records the process writes to disk.
+    """
+    targets: list[logging.Logger] = []
+    if root:
+        targets.append(logging.getLogger())
+    for name in logger_names:
+        logger = logging.getLogger(name)
+        if not logger.propagate or not root:
+            targets.append(logger)
+    return targets
 
 
 def _add_handler_once(logger: logging.Logger, handler: logging.Handler) -> None:

--- a/omnigent/runtime/session_stream.py
+++ b/omnigent/runtime/session_stream.py
@@ -90,18 +90,22 @@ _SSE_WARN_TYPES = frozenset(
     {"response.failed", "response.error", "turn.failed", "response.policy_denied"}
 )
 # Top-level event fields safe to log — stable identifiers, closed enums, and
-# pure numerics only. Deliberately excludes human/LLM-authored free text such
-# as ``reason`` (PolicyDeniedEvent's deny reason is LLM-generated and can quote
-# the content it evaluated) and ``blocked_on`` (a free-form "human phrase"),
-# alongside the content fields dropped in _sse_safe_attributes.
+# pure numerics only. Deliberately excludes human/LLM-authored free text
+# (``reason`` — PolicyDeniedEvent's deny reason is LLM-generated and can quote
+# the content it evaluated — and ``blocked_on``, a free-form "human phrase") and
+# ``tool_name`` (author-defined for custom/MCP tools; ``call_id`` still
+# correlates a call to its result without naming the tool), alongside the
+# content fields dropped in _sse_safe_attributes.
 _SSE_SAFE_KEYS = (
     "status",
     "call_id",
-    "tool_name",
+    "message_id",
     "phase",
     "attempt",
     "max_attempts",
     "sequence_number",
+    "index",
+    "final",
     "model",
     "context_tokens",
     "context_window",
@@ -114,8 +118,8 @@ def _sse_safe_attributes(event: dict[str, Any]) -> dict[str, object]:
 
     A strict whitelist: content and free-text fields (``delta`` text, tool
     ``arguments`` / outputs, message/reasoning ``data``, ``error.message``,
-    and human/LLM-authored ``reason`` / ``blocked_on``) are never read, so no
-    model response or user content reaches the debug table.
+    human/LLM-authored ``reason`` / ``blocked_on``, and ``tool_name``) are never
+    read, so no model response or user content reaches the debug table.
     """
     attrs: dict[str, object] = {}
     for key in _SSE_SAFE_KEYS:

--- a/omnigent/runtime/session_stream.py
+++ b/omnigent/runtime/session_stream.py
@@ -89,22 +89,19 @@ _SSE_SKIP_TYPES = frozenset(
 _SSE_WARN_TYPES = frozenset(
     {"response.failed", "response.error", "turn.failed", "response.policy_denied"}
 )
-# Top-level event fields safe to log — identifiers/dimensions, never content.
+# Top-level event fields safe to log — stable identifiers, closed enums, and
+# pure numerics only. Deliberately excludes human/LLM-authored free text such
+# as ``reason`` (PolicyDeniedEvent's deny reason is LLM-generated and can quote
+# the content it evaluated) and ``blocked_on`` (a free-form "human phrase"),
+# alongside the content fields dropped in _sse_safe_attributes.
 _SSE_SAFE_KEYS = (
     "status",
-    "source",
     "call_id",
-    "message_id",
     "tool_name",
     "phase",
     "attempt",
     "max_attempts",
-    "delay_seconds",
     "sequence_number",
-    "reason",
-    "blocked_on",
-    "index",
-    "final",
     "model",
     "context_tokens",
     "context_window",
@@ -115,8 +112,9 @@ _SSE_SAFE_KEYS = (
 def _sse_safe_attributes(event: dict[str, Any]) -> dict[str, object]:
     """Extract only safe identifiers/dimensions from an SSE event.
 
-    A strict whitelist: content fields (``delta`` text, tool ``arguments`` /
-    outputs, message/reasoning ``data``, error messages) are never read, so no
+    A strict whitelist: content and free-text fields (``delta`` text, tool
+    ``arguments`` / outputs, message/reasoning ``data``, ``error.message``,
+    and human/LLM-authored ``reason`` / ``blocked_on``) are never read, so no
     model response or user content reaches the debug table.
     """
     attrs: dict[str, object] = {}

--- a/omnigent/runtime/session_stream.py
+++ b/omnigent/runtime/session_stream.py
@@ -27,11 +27,13 @@ Consumer (SSE endpoint, async):
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import threading
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from typing import Any
 
+from omnigent.debug_logging import debug_event, debug_sink_enabled, sse_event_logger
 from omnigent.runtime import inflight_text, pending_elicitations
 
 _logger = logging.getLogger(__name__)
@@ -78,6 +80,89 @@ def _enqueue_or_overflow(
     queue.put_nowait(_OVERFLOW)
 
 
+# ── SSE-event debug logging (table-only; see omnigent.debug_logging) ──────────
+# Frequent, low-signal events not worth a debug-log row.
+_SSE_SKIP_TYPES = frozenset(
+    {"session.terminal.activity", "session.heartbeat", "response.heartbeat"}
+)
+# Failure events logged at WARNING so the table's level column flags them.
+_SSE_WARN_TYPES = frozenset(
+    {"response.failed", "response.error", "turn.failed", "response.policy_denied"}
+)
+# Top-level event fields safe to log — identifiers/dimensions, never content.
+_SSE_SAFE_KEYS = (
+    "status",
+    "source",
+    "call_id",
+    "message_id",
+    "tool_name",
+    "phase",
+    "attempt",
+    "max_attempts",
+    "delay_seconds",
+    "sequence_number",
+    "reason",
+    "blocked_on",
+    "index",
+    "final",
+    "model",
+    "context_tokens",
+    "context_window",
+    "total_cost_usd",
+)
+
+
+def _sse_safe_attributes(event: dict[str, Any]) -> dict[str, object]:
+    """Extract only safe identifiers/dimensions from an SSE event.
+
+    A strict whitelist: content fields (``delta`` text, tool ``arguments`` /
+    outputs, message/reasoning ``data``, error messages) are never read, so no
+    model response or user content reaches the debug table.
+    """
+    attrs: dict[str, object] = {}
+    for key in _SSE_SAFE_KEYS:
+        value = event.get(key)
+        if value is not None and not isinstance(value, (dict, list)):
+            attrs[key] = value
+    response = event.get("response")
+    if isinstance(response, dict) and isinstance(response.get("id"), str):
+        attrs["response_id"] = response["id"]
+    elif isinstance(event.get("response_id"), str):
+        attrs["response_id"] = event["response_id"]
+    item = event.get("item")
+    if isinstance(item, dict):
+        if isinstance(item.get("id"), str):
+            attrs["item_id"] = item["id"]
+        if isinstance(item.get("type"), str):
+            attrs["item_type"] = item["type"]
+    error = event.get("error")
+    if isinstance(error, dict):
+        if error.get("code") is not None:
+            attrs["error_code"] = error["code"]
+        if error.get("source") is not None:
+            attrs["error_source"] = error["source"]
+    return attrs
+
+
+def _log_sse_event(conversation_id: str, event: dict[str, Any]) -> None:
+    """Mirror one emitted SSE event to the debug-log table (best-effort).
+
+    No-op unless the debug-log sink is enabled. Logs the event name and safe
+    ids only (never content); heartbeats / terminal-activity are skipped, and
+    failure events go at WARNING. Never raises into :func:`publish`.
+    """
+    with contextlib.suppress(Exception):
+        if not debug_sink_enabled():
+            return
+        event_type = event.get("type")
+        if not isinstance(event_type, str) or event_type in _SSE_SKIP_TYPES:
+            return
+        level = logging.WARNING if event_type in _SSE_WARN_TYPES else logging.INFO
+        extra = debug_event(event_type, session_id=conversation_id)
+        extra["attributes"] = _sse_safe_attributes(event)
+        sse_event_logger().log(level, "sse %s", event_type, extra=extra)
+
+
 def publish(conversation_id: str, event: dict[str, Any]) -> None:
     """
     Broadcast an event to every active subscriber of the given
@@ -102,6 +187,10 @@ def publish(conversation_id: str, event: dict[str, Any]) -> None:
         the union before serializing, so an unmodelled event
         fails loud at the SSE boundary.
     """
+    # Mirror the emitted event to the debug-log table (best-effort, table-only,
+    # no-op unless the sink is enabled). Done first so it captures every event
+    # the server produces — including ones with no live subscriber.
+    _log_sse_event(conversation_id, event)
     # Track reconnect state and centrally suppress or rewrite native deltas
     # before they reach subscribers.
     live_event = inflight_text.record_publish(conversation_id, event)

--- a/tests/runtime/test_session_stream.py
+++ b/tests/runtime/test_session_stream.py
@@ -21,6 +21,9 @@ end-to-end publish pipeline.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import logging
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -742,3 +745,93 @@ async def test_inflight_replay_via_pre_ready_snapshot_does_not_duplicate_window_
     assert deltas.count("Hello world") == 1, (
         f"joined prefix should be replayed exactly once, got deltas={deltas!r}"
     )
+
+
+# ── SSE-event debug logging ───────────────────────────────────────────────────
+
+
+def test_sse_safe_attributes_whitelists_ids_and_excludes_content() -> None:
+    # The whitelist captures identifiers/dimensions and NEVER content — no model
+    # text, tool arguments/outputs, message data, or error messages.
+    event = {
+        "type": "response.output_item.done",
+        "response": {"id": "resp_123", "output": [{"secret": "assistant text"}]},
+        "item": {
+            "id": "item_1",
+            "type": "function_call",
+            "arguments": '{"query": "pii"}',
+            "data": "PII payload",
+        },
+        "call_id": "call_9",
+        "tool_name": "search.web",
+        "status": "completed",
+        "delta": "streamed model tokens",
+        "error": {"code": "timeout", "source": "llm", "message": "raw provider detail"},
+    }
+    attrs = session_stream._sse_safe_attributes(event)
+    assert attrs["response_id"] == "resp_123"
+    assert attrs["item_id"] == "item_1"
+    assert attrs["item_type"] == "function_call"
+    assert attrs["call_id"] == "call_9"
+    assert attrs["tool_name"] == "search.web"
+    assert attrs["status"] == "completed"
+    assert attrs["error_code"] == "timeout"
+    assert attrs["error_source"] == "llm"
+    # No content leaks, in any key or value.
+    flat = repr(attrs).lower()
+    for forbidden in ("delta", "arguments", "data", "message", "output"):
+        assert forbidden not in attrs
+    for leaked in ("streamed model tokens", "pii", "assistant text", "raw provider detail"):
+        assert leaked.lower() not in flat
+
+
+@contextlib.contextmanager
+def _capturing_sse_logger() -> Iterator[list[logging.LogRecord]]:
+    """Attach a capturing handler to the SSE logger for the duration of the block."""
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    logger = session_stream.sse_event_logger()
+    old_level = logger.level
+    logger.setLevel(logging.INFO)
+    handler = _Capture()
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(old_level)
+
+
+def test_log_sse_event_logs_kept_and_skips_noise(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(session_stream, "debug_sink_enabled", lambda: True)
+    with _capturing_sse_logger() as records:
+        session_stream._log_sse_event(
+            "conv_1", {"type": "response.completed", "response": {"id": "resp_1"}, "delta": "text"}
+        )
+        session_stream._log_sse_event("conv_1", {"type": "response.heartbeat"})
+        session_stream._log_sse_event("conv_1", {"type": "session.terminal.activity"})
+        session_stream._log_sse_event(
+            "conv_1", {"type": "response.failed", "error": {"code": "timeout", "message": "x"}}
+        )
+
+    # Heartbeat + terminal-activity skipped; the two meaningful events logged.
+    assert [r.event_name for r in records] == ["response.completed", "response.failed"]
+    completed = records[0]
+    assert completed.session_id == "conv_1"
+    assert completed.levelno == logging.INFO
+    assert completed.attributes == {"response_id": "resp_1"}  # no delta text
+    failed = records[1]
+    assert failed.levelno == logging.WARNING  # failures flagged in the level column
+    assert failed.attributes.get("error_code") == "timeout"
+    assert "message" not in failed.attributes
+
+
+def test_log_sse_event_noop_when_sink_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(session_stream, "debug_sink_enabled", lambda: False)
+    with _capturing_sse_logger() as records:
+        session_stream._log_sse_event("conv_1", {"type": "response.completed"})
+    assert records == []

--- a/tests/runtime/test_session_stream.py
+++ b/tests/runtime/test_session_stream.py
@@ -764,6 +764,9 @@ def test_sse_safe_attributes_whitelists_ids_and_excludes_content() -> None:
             "data": "PII payload",
         },
         "call_id": "call_9",
+        "message_id": "msg_5",
+        "index": 3,
+        "final": True,
         "tool_name": "search.web",
         "status": "completed",
         "delta": "streamed model tokens",
@@ -778,16 +781,28 @@ def test_sse_safe_attributes_whitelists_ids_and_excludes_content() -> None:
     assert attrs["item_id"] == "item_1"
     assert attrs["item_type"] == "function_call"
     assert attrs["call_id"] == "call_9"
-    assert attrs["tool_name"] == "search.web"
+    assert attrs["message_id"] == "msg_5"
+    assert attrs["index"] == 3
+    assert attrs["final"] is True
     assert attrs["status"] == "completed"
     assert attrs["error_code"] == "timeout"
     assert attrs["error_source"] == "llm"
-    # Free-text dimensions are excluded outright.
+    # Free-text / author-defined dimensions are excluded outright.
     assert "reason" not in attrs
     assert "blocked_on" not in attrs
+    assert "tool_name" not in attrs
     # No content leaks, in any key or value.
     flat = repr(attrs).lower()
-    for forbidden in ("delta", "arguments", "data", "message", "output", "reason", "blocked_on"):
+    for forbidden in (
+        "delta",
+        "arguments",
+        "data",
+        "message",
+        "output",
+        "reason",
+        "blocked_on",
+        "tool_name",
+    ):
         assert forbidden not in attrs
     for leaked in (
         "streamed model tokens",

--- a/tests/runtime/test_session_stream.py
+++ b/tests/runtime/test_session_stream.py
@@ -752,7 +752,8 @@ async def test_inflight_replay_via_pre_ready_snapshot_does_not_duplicate_window_
 
 def test_sse_safe_attributes_whitelists_ids_and_excludes_content() -> None:
     # The whitelist captures identifiers/dimensions and NEVER content — no model
-    # text, tool arguments/outputs, message data, or error messages.
+    # text, tool arguments/outputs, message data, error messages, or the
+    # human/LLM-authored free text carried in reason / blocked_on.
     event = {
         "type": "response.output_item.done",
         "response": {"id": "resp_123", "output": [{"secret": "assistant text"}]},
@@ -766,6 +767,10 @@ def test_sse_safe_attributes_whitelists_ids_and_excludes_content() -> None:
         "tool_name": "search.web",
         "status": "completed",
         "delta": "streamed model tokens",
+        # Free-text fields that must NOT be captured (e.g. an LLM-generated
+        # policy deny reason quoting the content it evaluated).
+        "reason": "blocked because the prompt asked to exfiltrate secret_pii_value",
+        "blocked_on": "waiting on user secret_pii_value confirmation",
         "error": {"code": "timeout", "source": "llm", "message": "raw provider detail"},
     }
     attrs = session_stream._sse_safe_attributes(event)
@@ -777,11 +782,20 @@ def test_sse_safe_attributes_whitelists_ids_and_excludes_content() -> None:
     assert attrs["status"] == "completed"
     assert attrs["error_code"] == "timeout"
     assert attrs["error_source"] == "llm"
+    # Free-text dimensions are excluded outright.
+    assert "reason" not in attrs
+    assert "blocked_on" not in attrs
     # No content leaks, in any key or value.
     flat = repr(attrs).lower()
-    for forbidden in ("delta", "arguments", "data", "message", "output"):
+    for forbidden in ("delta", "arguments", "data", "message", "output", "reason", "blocked_on"):
         assert forbidden not in attrs
-    for leaked in ("streamed model tokens", "pii", "assistant text", "raw provider detail"):
+    for leaked in (
+        "streamed model tokens",
+        "pii",
+        "assistant text",
+        "raw provider detail",
+        "secret_pii_value",
+    ):
         assert leaked.lower() not in flat
 
 

--- a/tests/test_process_logging.py
+++ b/tests/test_process_logging.py
@@ -18,6 +18,7 @@ from omnigent.process_logging import (
     LOG_TTY_FD_ENV_VAR,
     PROCESS_LOG_FILE_ENV_VAR,
     TerminalLogFormatter,
+    _debug_sink_target_loggers,
     _unlink_if_empty,
     child_logging_popen_kwargs,
     configure_process_logging,
@@ -301,3 +302,25 @@ def test_configure_registers_the_empty_log_sweep_for_self_allocated_paths(
         for handler in list(logger.handlers):
             logger.removeHandler(handler)
             handler.close()
+
+
+def test_debug_sink_targets_follow_non_propagating_package_logger() -> None:
+    # cli_diagnostics sets our package loggers to propagate=False with their own
+    # handlers, so records logged under them never reach root. The debug-log
+    # sink (attached to root) must therefore also attach to such loggers, or it
+    # sees nothing — the bug that left server/host rows undelivered.
+    name = "omnigent.test.sink_target_propagation"
+    logger = logging.getLogger(name)
+    original = logger.propagate
+    try:
+        logger.propagate = False
+        targets = _debug_sink_target_loggers((name,), root=True)
+        assert logging.getLogger() in targets  # root, for propagating loggers
+        assert logger in targets  # and the non-propagating package logger itself
+
+        logger.propagate = True
+        targets = _debug_sink_target_loggers((name,), root=True)
+        # A propagating logger reaches root already; root-only avoids double-ship.
+        assert targets == [logging.getLogger()]
+    finally:
+        logger.propagate = original


### PR DESCRIPTION
## Related issue

Tracked in Linear **OMNI-4198** (Omnigent Debuggability). No GitHub issue. Builds on the debug-log sink (#5331, #5348).

## Summary

Two logging changes. The second was found while manually verifying the first.

### 1. Mirror outgoing SSE events to the debug-log table *(feat)*

Log every event the server broadcasts through `session_stream.publish()` (the single SSE fan-out chokepoint) into the debug-logs table, so a session's server-produced event timeline is queryable alongside its logs — **event names and safe ids only, never content**.

- **Table-only, no log flooding:** rows go to a dedicated `omnigent.sse_events` logger (`propagate=False`) whose sole handler is the debug sink, so high-volume per-event rows (deltas included) never reach on-disk/stderr logs. Gated on `debug_sink_enabled()` → zero cost when the sink is off.
- **No PII/content:** a strict whitelist pulls only ids/dimensions (`response_id`, item id/type, `call_id`, `tool_name`, `status`, `phase`, retry/usage metrics, `error` code/source). `delta` text, tool args/outputs, message/reasoning data, and error messages are **never read**.
- Heartbeats + `session.terminal.activity` skipped; failure events (`response.failed`/`error`, `turn.failed`, `policy_denied`) at WARNING; deltas kept (name + ids) for stream cadence. Logged before the inflight-suppression/fan-out so it captures every produced event, and never raises into `publish()`.

### 2. Fix debug-log delivery from CLI-launched processes (server/host) *(fix)*

Manual verification of #1 surfaced that the sink was delivering **nothing** from the server (and only non-`omnigent` loggers from the host) — so no server rows, including SSE events, ever reached the table. Two independent bugs:

- **Sink attached to the wrong logger.** `configure_process_logging` attaches the sink to the **root** logger, but the CLI's `cli_diagnostics` setup (runs for `omnigent server`/`host`) puts the `omnigent` / `omnigent_ui_sdk` package loggers on **`propagate=False`** with their own handlers. So `omnigent.*` records never reach root, and a root-only sink saw none of them — every server row and most host rows were silently dropped. The **runner** was unaffected (separate entrypoint, no diagnostics setup). Fix: attach the sink to the same loggers the on-disk file handler lands on — root **plus** any package logger whose `propagate` is False — via a new `_debug_sink_target_loggers()` helper that mirrors the file-handler placement exactly.
- **Uploader thread could die on a closed client.** On shutdown (uvicorn's startup `dictConfig` `close()`s the sink), the worker's drain `_post()` mints a token / posts on `self._client` while `close()` closes it from another thread → `RuntimeError("Cannot send a request, as the client has been closed")`, which `_post` didn't catch (only `httpx.HTTPError`), killing the thread. Fix: the worker owns and closes its own client on exit, `close()` no longer closes it cross-thread, and `_run()` guards every iteration so the thread can never die (`emit()`'s self-heal only revives a *stopped* thread, so a crash would end delivery for the whole process).

```mermaid
flowchart LR
  A[session_stream.publish event] --> B[_log_sse_event best-effort]
  B -->|sink off| Z[no-op]
  B -->|sink on| C[whitelist safe ids, drop content]
  C --> D[omnigent.sse_events logger, propagate=False]
  D --> E[ZeroBus sink]
  A --> G[inflight suppression + subscriber fan-out]
  H[omnigent.* records] --> E
  E --> F[Delta table]
```

## Test Plan

- `pytest tests/runtime/test_session_stream.py tests/test_debug_logging.py tests/test_process_logging.py` → **56 passed**, including:
  - SSE: `_sse_safe_attributes` whitelist asserts no content leaks; skip/keep/WARNING classification; sink-disabled no-op.
  - Delivery fix: `_debug_sink_target_loggers` follows a `propagate=False` package logger (and stays root-only for a propagating one); `close()`-during-revive keeps the revived client alive; init-failure suppression.
- `ruff` + `pyrefly` clean on the touched modules.
- **Verified end-to-end against a live local `omnigent server`** (sink env set): with the fix, `source='server'` rows went from **0 → 16**, and the worker trace showed `attach: targets=['root','omnigent']` → `emit: ENTER omnigent.server.app` → `post: status=200`. Restart the server + host to pick up the fix, run a claude-native turn, then query the table for `source='server'` and `logger_name='omnigent.sse_events'`.

## Demo

N/A — backend logging change, no UI.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the pure logic — the SSE safe-attribute whitelist (asserting no content leaks), the skip/keep/WARNING classification, the sink-disabled no-op, and (for the fix) the sink target-logger selection and the shutdown close/revive path. The end-to-end delivery path depends on a live sink + Databricks creds, so it was verified manually against a live local server (server-source rows, including `omnigent.sse_events`, now land in the table) rather than in CI.

This pull request and its description were written by Isaac.
