### PR TITLE
fix(web): make the mobile Shells drawer usable — notch inset + shell targeting

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -930,8 +930,7 @@ aside[aria-label="Workspace"][data-maximized] {
       [data-testid="file-viewer"],
       [data-testid="files-panel-drawer"],
       [data-testid="terminals-panel"],
-      [data-testid="subagents-panel-drawer"],
-      [data-testid="todos-panel-drawer"]
+      .mobile-panel-drawer
     ) {
     padding-top: var(--omnigent-safe-top);
     padding-bottom: var(--omnigent-safe-bottom);

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -634,14 +634,16 @@ describe("index.css native safe-area insets for mobile overlays", () => {
   // dynamic island with no way to dismiss the panel. Selecting the shared
   // `.mobile-panel-drawer` class covers every drawer built from
   // `MobilePanelDrawer`, present and future.
-  const rule = cssSource.match(
-    /:is\(\[data-ios-native\], \[data-android-native\]\)\s*:is\(([^)]*)\)\s*\{([^}]*)\}/,
-  );
+  // Balance-aware slice instead of `[^)]*`: a selector in this list may well
+  // grow a functional pseudo-class (`:not(...)`), which a naive capture would
+  // truncate at its first `)` — silently dropping selectors from the assertions
+  // below.
+  const rule = extractInsetRule(cssSource);
 
   it("has the inset rule this test exists to protect", () => {
     expect(rule).not.toBeNull();
-    expect(rule?.[2]).toContain("padding-top: var(--omnigent-safe-top)");
-    expect(rule?.[2]).toContain("padding-bottom: var(--omnigent-safe-bottom)");
+    expect(rule?.body).toContain("padding-top: var(--omnigent-safe-top)");
+    expect(rule?.body).toContain("padding-bottom: var(--omnigent-safe-bottom)");
   });
 
   it.each([
@@ -651,6 +653,36 @@ describe("index.css native safe-area insets for mobile overlays", () => {
     '[data-testid="terminals-panel"]',
     ".mobile-panel-drawer",
   ])("insets %s", (selector) => {
-    expect(rule?.[1]).toContain(selector);
+    expect(rule?.selectors).toContain(selector);
   });
 });
+
+/**
+ * Slice the native safe-area inset rule out of the CSS source.
+ *
+ * Walks parens/braces so a selector containing `)` (e.g. `:not(...)`) can't
+ * truncate the selector list, and returns the selector text and declaration
+ * body separately. `null` when the rule is gone (a real failure, not a silent
+ * pass).
+ */
+function extractInsetRule(css: string): { selectors: string; body: string } | null {
+  // The native prefix appears on several rules; the inset rule is the one whose
+  // subject is an `:is(...)` selector list.
+  const match = /:is\(\[data-ios-native\], \[data-android-native\]\)\s*:is\(/.exec(css);
+  if (match === null) return null;
+  let depth = 1; // the `:is(` the match ends on
+  let i = match.index + match[0].length;
+  for (; i < css.length; i += 1) {
+    if (css[i] === "(") depth += 1;
+    else if (css[i] === ")") {
+      depth -= 1;
+      if (depth === 0) break;
+    }
+  }
+  if (depth !== 0) return null;
+  const selectors = css.slice(match.index + match[0].length, i);
+  const bodyStart = css.indexOf("{", i);
+  const bodyEnd = css.indexOf("}", bodyStart);
+  if (bodyStart === -1 || bodyEnd === -1) return null;
+  return { selectors, body: css.slice(bodyStart + 1, bodyEnd) };
+}

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -625,3 +625,32 @@ describe("index.css native conversation breadcrumb", () => {
     );
   });
 });
+
+describe("index.css native safe-area insets for mobile overlays", () => {
+  // The `fixed inset-0` overlays cover the whole screen on a phone, status bar
+  // and home indicator included, so each one needs the safe-area padding. The
+  // Shells drawer once missed it (the rule listed drawers by `data-testid` and
+  // its id was never added), putting the title and Close button under the
+  // dynamic island with no way to dismiss the panel. Selecting the shared
+  // `.mobile-panel-drawer` class covers every drawer built from
+  // `MobilePanelDrawer`, present and future.
+  const rule = cssSource.match(
+    /:is\(\[data-ios-native\], \[data-android-native\]\)\s*:is\(([^)]*)\)\s*\{([^}]*)\}/,
+  );
+
+  it("has the inset rule this test exists to protect", () => {
+    expect(rule).not.toBeNull();
+    expect(rule?.[2]).toContain("padding-top: var(--omnigent-safe-top)");
+    expect(rule?.[2]).toContain("padding-bottom: var(--omnigent-safe-bottom)");
+  });
+
+  it.each([
+    ".conversations-sidebar",
+    '[data-testid="file-viewer"]',
+    '[data-testid="files-panel-drawer"]',
+    '[data-testid="terminals-panel"]',
+    ".mobile-panel-drawer",
+  ])("insets %s", (selector) => {
+    expect(rule?.[1]).toContain(selector);
+  });
+});

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -3589,3 +3589,76 @@ describe("Mobile header actions menu", () => {
     expect(screen.queryByRole("menuitem", { name: /^resume$/i })).toBeNull();
   });
 });
+
+describe("Terminal-first shells — opening a shell from the mobile drawer", () => {
+  function openSessionMenu() {
+    const trigger = screen.getByTestId("session-actions-menu");
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    return trigger;
+  }
+
+  it("keeps the tapped shell as the terminal-view target", () => {
+    // Terminal-first sessions render the terminal inline in main, and opening a
+    // shell also writes `?view=terminal`. That param names only the surface, so
+    // re-deriving the target from it sent the user to the agent's pane — the
+    // chat's Terminal view — instead of the shell they tapped.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      { id: "conv_native", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_tui_main", name: "tui", session: "main", running: true },
+        { id: "terminal_main", name: "zsh", session: "main", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    useSessionAgentMock.mockReturnValue({
+      data: { id: "ag_x", name: "polly", terminals: ["zsh"] },
+    } as ReturnType<typeof useSessionAgent>);
+
+    renderShell("/c/conv_native");
+    openSessionMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /^Shells/i }));
+
+    const drawer = screen.getByTestId("shells-panel-drawer");
+    expect(drawer).toHaveAttribute("data-state", "open");
+    fireEvent.click(within(drawer).getByRole("button", { name: /rail: open terminal/i }));
+
+    // Drawer dismissed, terminal surface showing the tapped shell — not
+    // `terminal:terminal_tui_main`, the agent pane.
+    expect(screen.getByTestId("shells-panel-drawer")).toHaveAttribute("data-state", "closed");
+    const probe = screen.getByTestId("view-probe");
+    expect(probe).toHaveAttribute("data-view", "terminal");
+    expect(probe).toHaveAttribute("data-terminal-view-key", "terminal:terminal_main");
+  });
+
+  it("still opens the agent pane for a bare ?view=terminal deep link", () => {
+    // No stored target: the param alone must land on the agent's terminal.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      { id: "conv_native", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_tui_main", name: "tui", session: "main", running: true },
+        { id: "terminal_main", name: "zsh", session: "main", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_native?view=terminal");
+
+    const probe = screen.getByTestId("view-probe");
+    expect(probe).toHaveAttribute("data-view", "terminal");
+    expect(probe).toHaveAttribute("data-terminal-view-key", "terminal:terminal_tui_main");
+  });
+});

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -3064,6 +3064,10 @@ describe("Mobile session menu", () => {
     const drawer = screen.getByTestId("shells-panel-drawer");
     expect(drawer).toHaveAttribute("data-state", "open");
     expect(within(drawer).getByTestId("inline-terminals-section")).toBeInTheDocument();
+    // The drawer covers the whole phone screen; without the safe-area class
+    // its header (title + Close) renders under the status bar / dynamic
+    // island and the panel can't be dismissed.
+    expect(drawer).toHaveClass("mobile-panel-drawer");
   });
 
   it("opens the Agents drawer and mounts the subagents panel", () => {
@@ -3111,6 +3115,7 @@ describe("Mobile session menu", () => {
       "data-conversation-id",
       "conv_abc",
     );
+    expect(openDrawer).toHaveClass("mobile-panel-drawer");
   });
 
   it("opens the files drawer in the tree view from the Files entry", () => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -159,6 +159,23 @@ import type { RightRailTab } from "./railTabs";
 // can override a Terminal default when the user returns to that conversation.
 const CHAT_VIEW_STORAGE_VALUE = "__chat__";
 
+/**
+ * Resolve the terminal-view target for `?view=terminal`.
+ *
+ * The URL param names only the SURFACE (chat vs terminal), never which
+ * terminal, so restoring straight from it would rewrite a rail-opened shell
+ * to the agent pane. The precise target lives in the per-session store, which
+ * the panel setter writes alongside the param — prefer it, and fall back to
+ * the agent terminal for a deep link that carries no stored target.
+ *
+ * :param stored: Per-session stored panel key (null when absent).
+ * :param agentKey: The session's agent-terminal key (or the no-target sentinel).
+ * :returns: The terminal key the view should open on.
+ */
+function resolveTerminalViewKey(stored: string | null, agentKey: string): string {
+  return stored !== null && stored !== CHAT_VIEW_STORAGE_VALUE ? stored : agentKey;
+}
+
 export function AppShell() {
   // Cmd/Ctrl+Enter accepts the pending harness approval prompt. Bound once
   // here so it works on every chat route, regardless of where focus sits.
@@ -936,7 +953,7 @@ export function AppShell() {
       requestedView === "chat"
         ? null
         : requestedView === "terminal"
-          ? terminalKey
+          ? resolveTerminalViewKey(stored, terminalKey)
           : stored === CHAT_VIEW_STORAGE_VALUE
             ? null
             : (stored ?? (defaultToTerminal ? terminalKey : null)),
@@ -1006,7 +1023,7 @@ export function AppShell() {
     if (requestedView === "chat") {
       setPanelInitialKeyState(null);
     } else if (requestedView === "terminal") {
-      setPanelInitialKeyState(terminalKey);
+      setPanelInitialKeyState(resolveTerminalViewKey(stored, terminalKey));
     } else if (stored === CHAT_VIEW_STORAGE_VALUE) {
       setPanelInitialKeyState(null);
     } else if (stored !== null) {

--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -361,6 +361,23 @@ describe("MainTerminalView — persistent hidden mount", () => {
     expect(screen.getByTestId("terminal-view").getAttribute("data-instance")).toBe(instance);
   });
 
+  it("falls back to the agent pane when the restored target no longer exists", () => {
+    // `?view=terminal` resolves against the per-session stored panel key, which
+    // can name a shell that has since been closed. The stale key must degrade to
+    // the agent terminal, not leave the pane empty.
+    renderView({
+      terminals: [REPL_TERMINAL],
+      initialTerminalKey: "terminal:terminal_bash_gone",
+    });
+
+    expect(screen.getByTestId("terminal-view")).toHaveAttribute(
+      "data-terminal-id",
+      "terminal_tui_main",
+    );
+    // No shell header: the pane is the agent's, not a phantom shell.
+    expect(screen.queryByRole("button", { name: "Close shell" })).toBeNull();
+  });
+
   it("resets a shell selection to the agent terminal while hidden", () => {
     // Open on a rail shell, then close the view (AppShell nulls the
     // target key when the view closes). The old unmount-on-close forgot

--- a/web/src/shell/MobilePanelDrawer.test.tsx
+++ b/web/src/shell/MobilePanelDrawer.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MobilePanelDrawer } from "./MobilePanelDrawer";
+
+afterEach(cleanup);
+
+function renderDrawer(props: Partial<Parameters<typeof MobilePanelDrawer>[0]> = {}) {
+  return render(
+    <MobilePanelDrawer
+      open
+      title="Shells"
+      onClose={() => {}}
+      testId="shells-panel-drawer"
+      {...props}
+    >
+      <div data-testid="drawer-body" />
+    </MobilePanelDrawer>,
+  );
+}
+
+describe("MobilePanelDrawer", () => {
+  it("carries the safe-area hook class so the header clears the notch", () => {
+    // The drawer is a `fixed inset-0` overlay on phones. Without this class
+    // the native shells' inset rule (index.css) misses it and the title +
+    // Close button render under the status bar / dynamic island — leaving no
+    // way to dismiss the panel.
+    renderDrawer();
+    expect(screen.getByTestId("shells-panel-drawer")).toHaveClass("mobile-panel-drawer");
+  });
+
+  it("keeps the safe-area class while closed", () => {
+    // The class must not be state-dependent: the drawer animates in from the
+    // right, so the inset has to be in place before it is on screen.
+    renderDrawer({ open: false });
+    expect(screen.getByTestId("shells-panel-drawer")).toHaveClass("mobile-panel-drawer");
+  });
+
+  it("renders the title and a working Close button", () => {
+    const onClose = vi.fn();
+    renderDrawer({ onClose });
+
+    expect(screen.getByRole("heading", { name: "Shells" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("mounts children only while open", () => {
+    const { rerender } = renderDrawer({ open: false });
+    expect(screen.queryByTestId("drawer-body")).toBeNull();
+
+    rerender(
+      <MobilePanelDrawer open title="Shells" onClose={() => {}} testId="shells-panel-drawer">
+        <div data-testid="drawer-body" />
+      </MobilePanelDrawer>,
+    );
+    expect(screen.getByTestId("drawer-body")).toBeInTheDocument();
+  });
+});

--- a/web/src/shell/MobilePanelDrawer.tsx
+++ b/web/src/shell/MobilePanelDrawer.tsx
@@ -59,7 +59,10 @@ export function MobilePanelDrawer({
       data-testid={testId}
       data-state={open ? "open" : "closed"}
       className={cn(
-        "flex flex-col overflow-hidden bg-card transition-[translate] duration-150 ease-out",
+        // `mobile-panel-drawer` is the hook the native shells use to inset the
+        // drawer past the status bar / home indicator (see index.css); without
+        // it the header sits under the notch and Close is untappable.
+        "mobile-panel-drawer flex flex-col overflow-hidden bg-card transition-[translate] duration-150 ease-out",
         "fixed inset-0 z-50 shadow-lg md:hidden",
         open ? "translate-x-0" : "translate-x-full",
       )}


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- On a phone the Shells panel opens as a `fixed inset-0` overlay, so it covers the status bar and home indicator too. `index.css` already pads the mobile overlays by the OS safe area on the native shells, but it selected them by a hardcoded list of `data-testid`s and the Shells drawer's id was never added (the list still named a `todos-panel-drawer` that no longer exists).
- Result: the drawer's header — the title and its only Close button — rendered under the status bar / dynamic island, so the panel couldn't be dismissed and there was no way back to the chat.
- Fix: give `MobilePanelDrawer` a stable `mobile-panel-drawer` class and key the inset rule off that, so every drawer built from the component (Shells, Agents, and future ones) is covered without editing the CSS again.

**Second fix — tapping a shell opened the agent pane instead.** In a terminal-first session, opening a shell calls `setPanelInitialKey`, which also writes `?view=terminal` so a refresh restores the surface. The resulting `searchParams` change re-runs the URL-restore effect, which re-derived the target from the param alone — and that param says only *chat* or *terminal*, never *which* terminal — so it overwrote the tapped shell with the agent terminal key and dumped the user in the chat's Terminal view. `?view=terminal` now resolves against the per-session stored panel key (written by the same setter), falling back to the agent terminal only when there is no stored target, so a bare `?view=terminal` deep link still opens the agent pane.

## Test Plan

- `pnpm --filter web run test` over the touched files — `src/shell/MobilePanelDrawer.test.tsx` (new), `src/index.css.test.ts`, `src/shell/AppShell.test.tsx` — 177 tests pass on top of latest `origin/main`.
- The new `index.css` regression test was verified to fail when `.mobile-panel-drawer` is removed from the inset rule.
- `pre-commit run --files ...` clean (prettier, oxlint, tsc).
- Full web suite: 6022 passed, 3 expected-fail, 1 skipped.
- Manual, on a notched device: session menu FAB → **Shells**. The title and **X** now sit below the dynamic island and X dismisses the drawer; same for **Agents**. Checked a non-notched device for stray gaps.
- Manual, terminal-first session: FAB → **Shells** → tap a shell. It opens that shell (its name in the header), not the agent's terminal.

## Demo

<!-- Before/after screenshot of the Shells drawer on a notched device. -->

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The safe-area padding is a CSS rule jsdom does not apply, so the tests pin the wiring instead: the drawer keeps the `mobile-panel-drawer` class (open and closed), the Shells and Agents drawers carry it end-to-end through `AppShell`, and a CSS-source test asserts the native inset rule still selects it alongside the other four overlays. The visual result was confirmed by hand on a notched device.

## Changelog

On mobile, the Shells and Agents panels no longer open underneath the status bar, and tapping a shell opens that shell instead of the agent's terminal.

This pull request and its description were written by Isaac.
