### PR TITLE
feat(web): give the mobile sidebar a ChatGPT-style drawer

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -828,10 +828,10 @@ aside[aria-label="Workspace"][data-maximized] {
   /* Leading-edge shadow so the drawer reads as a native layer lifted above the
      chat while it slides, instead of a flat sheet. Scoped to the open/dragging
      state via `:not([data-collapsed])` (the sidebar sets `data-collapsed` only
-     when closed) so the full-bleed overlay doesn't cast a sliver along the
-     screen's left edge while parked off-screen. It's visible only mid-slide and
-     mid-drag — fully open the drawer covers the viewport, so its right edge (and
-     the shadow) sit past the screen. iOS-only: the web overlay is unchanged. */
+     when closed) so the drawer doesn't cast a sliver along the screen's left
+     edge while parked off-screen. The drawer stops short of the right edge, so
+     the shadow stays visible while open, separating it from the strip of chat
+     behind. iOS-only: the web overlay is unchanged. */
   :is([data-ios-native], [data-android-native]) .conversations-sidebar:not([data-collapsed]) {
     box-shadow: 8px 0 28px -6px rgb(0 0 0 / 0.22);
   }

--- a/web/src/shell/Sidebar.mobileDrawer.test.tsx
+++ b/web/src/shell/Sidebar.mobileDrawer.test.tsx
@@ -1,0 +1,175 @@
+// Behaviour tests for the mobile sidebar drawer shape: it stops short of the
+// right edge so a strip of the chat stays visible, tapping that strip dismisses
+// it (replacing the collapse toggle, which is now desktop-only), and Search /
+// Settings float at the top and bottom of the drawer.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { Conversation } from "@/hooks/useConversations";
+
+vi.mock("@/hooks/useConversations", () => ({
+  useConversations: vi.fn(),
+  useConnectedConversations: () => [],
+  useStopAndDeleteConversation: () => ({ mutate: vi.fn() }),
+  usePinnedConversations: () => ({
+    data: { conversations: [], filterHonored: true },
+    isSuccess: true,
+  }),
+  useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
+  setConversationPinned: vi.fn(() => Promise.resolve({})),
+  PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
+  useRenameConversation: () => ({ mutate: vi.fn() }),
+  useLeaveSession: () => ({ mutate: vi.fn(), isPending: false }),
+  useArchiveConversation: () => ({ mutate: vi.fn() }),
+  useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkMoveToProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useStopSession: () => ({ mutate: vi.fn() }),
+  useProjects: () => ({ data: [] }),
+  useProjectSessions: () => ({
+    data: undefined,
+    isLoading: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+  useMoveToProject: () => ({ mutate: vi.fn() }),
+  useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectConfig: () => ({ data: undefined, isLoading: false }),
+  useUpdateProjectConfig: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  fetchProjectSessionIds: () => Promise.resolve([]),
+  PROJECT_LABEL_KEY: "omni_project",
+}));
+
+vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
+
+vi.mock("@/lib/serverOrigin", () => ({
+  isCurrentServerLocal: () => false,
+  isLocalServerOrigin: (origin: string) =>
+    ["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"].includes(new URL(origin).hostname),
+}));
+
+import { useConversations } from "@/hooks/useConversations";
+import { Sidebar } from "./Sidebar";
+
+const useConvMock = vi.mocked(useConversations);
+
+function conv(id: string, partial: Partial<Conversation> = {}): Conversation {
+  return {
+    id,
+    object: "conversation",
+    title: id,
+    created_at: 0,
+    updated_at: 0,
+    labels: {},
+    permission_level: null,
+    status: "idle",
+    ...partial,
+  };
+}
+
+function mockConversations(conversations: Conversation[]) {
+  useConvMock.mockImplementation(
+    () =>
+      ({
+        data: {
+          pages: [
+            {
+              data: conversations,
+              first_id: conversations[0]?.id ?? null,
+              last_id: conversations.at(-1)?.id ?? null,
+              has_more: false,
+            },
+          ],
+          pageParams: [undefined],
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+        fetchNextPage: vi.fn(),
+        hasNextPage: false,
+        isFetchingNextPage: false,
+      }) as unknown as ReturnType<typeof useConversations>,
+  );
+}
+
+function renderSidebar(props: { open?: boolean; onClose?: () => void; route?: string } = {}) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={[props.route ?? "/"]}>
+          <Sidebar open={props.open ?? true} onClose={props.onClose ?? vi.fn()} />
+        </MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockConversations([conv("conv_a")]);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("mobile sidebar drawer", () => {
+  it("dismisses when the exposed strip of the chat is tapped", () => {
+    const onClose = vi.fn();
+    renderSidebar({ onClose });
+
+    fireEvent.click(screen.getByTestId("sidebar-scrim"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the scrim inert while the drawer is closed", () => {
+    renderSidebar({ open: false });
+
+    expect(screen.getByTestId("sidebar-scrim")).toHaveClass("pointer-events-none", "opacity-0");
+  });
+
+  it("stops the drawer short of the right edge so the chat stays reachable", () => {
+    renderSidebar();
+
+    expect(screen.getByRole("complementary", { name: "Conversations" })).toHaveClass(
+      "max-md:right-14",
+    );
+  });
+
+  it("drops the peek strip and the scrim on the settings page, where Back is the only exit", () => {
+    renderSidebar({ route: "/settings" });
+
+    expect(screen.queryByTestId("sidebar-scrim")).toBeNull();
+    expect(screen.getByRole("complementary", { name: "Conversations" })).not.toHaveClass(
+      "max-md:right-14",
+    );
+  });
+
+  it("floats Settings at the bottom and hides the desktop collapse toggle on mobile", () => {
+    renderSidebar();
+
+    // Search stays in the header row (top); Settings gets its own float at the
+    // bottom of the session list.
+    const headerActions = screen.getByTestId("sidebar-header-actions");
+    expect(within(headerActions).getByTestId("sidebar-search-button")).toBeInTheDocument();
+
+    const float = screen.getByTestId("sidebar-settings-float");
+    expect(float).toHaveAttribute("href", "/settings");
+    expect(float.closest("a, button")).toHaveClass("absolute", "bottom-3", "md:hidden");
+
+    // The header-row Settings copy and the collapse toggle are desktop-only.
+    expect(screen.getByTestId("settings-button")).toHaveClass("max-md:hidden");
+    expect(within(headerActions).getByRole("button", { name: "Close sidebar" })).toHaveClass(
+      "max-md:hidden",
+    );
+  });
+});

--- a/web/src/shell/Sidebar.mobileDrawer.test.tsx
+++ b/web/src/shell/Sidebar.mobileDrawer.test.tsx
@@ -134,7 +134,35 @@ describe("mobile sidebar drawer", () => {
   it("keeps the scrim inert while the drawer is closed", () => {
     renderSidebar({ open: false });
 
-    expect(screen.getByTestId("sidebar-scrim")).toHaveClass("pointer-events-none", "opacity-0");
+    const scrim = screen.getByTestId("sidebar-scrim");
+    expect(scrim).toHaveClass("pointer-events-none", "opacity-0");
+    // Untappable is not enough for a focusable control: parked, it must also
+    // leave the tab order and the a11y tree. (Not `inert` — React 18 drops the
+    // boolean form, so this would silently stay reachable.)
+    expect(scrim).toHaveAttribute("tabindex", "-1");
+    expect(scrim).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("exposes the dismiss as a labeled control, not a bare click target", () => {
+    // With the collapse toggle gone on mobile, the scrim is the only
+    // non-navigational way out — so it has to be reachable and announced,
+    // not just tappable.
+    renderSidebar();
+
+    const scrim = screen.getByTestId("sidebar-scrim");
+    expect(scrim.tagName).toBe("BUTTON");
+    expect(scrim).toHaveAttribute("aria-label", "Close sidebar");
+    expect(scrim).toHaveAttribute("tabindex", "0");
+    expect(scrim).toHaveAttribute("aria-hidden", "false");
+  });
+
+  it("stacks the scrim above chat chrome but below the drawer", () => {
+    // Chat chrome (ChatPage's jump-to-top pill) also sits at z-40 and renders
+    // after the sidebar, so a same-z scrim would lose the tie inside the strip.
+    renderSidebar();
+
+    expect(screen.getByTestId("sidebar-scrim")).toHaveClass("z-[45]");
+    expect(screen.getByRole("complementary", { name: "Conversations" })).toHaveClass("z-50");
   });
 
   it("stops the drawer short of the right edge so the chat stays reachable", () => {
@@ -171,5 +199,13 @@ describe("mobile sidebar drawer", () => {
     expect(within(headerActions).getByRole("button", { name: "Close sidebar" })).toHaveClass(
       "max-md:hidden",
     );
+  });
+
+  it("gives the session list a gutter so the last row clears the floating chip", () => {
+    // The chip doesn't scroll, so without this the bottom row's always-visible
+    // kebab sits underneath it and can't be tapped.
+    renderSidebar();
+
+    expect(screen.getByRole("navigation")).toHaveClass("max-md:pb-14");
   });
 });

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -707,15 +707,31 @@ export function Sidebar({
       {/* Mobile: the drawer stops short of the right edge, leaving a strip of
       the chat visible; this scrim covers that strip so tapping it dismisses the
       drawer — the gesture that replaced the collapse icon. Full-bleed and
-      behind the drawer (z-40 vs z-50), so only the strip is actually reachable.
-      Tracks the finger during an edge-swipe drag. */}
+      behind the drawer (z-45 vs z-50), so only the strip is actually reachable.
+      Tracks the finger during an edge-swipe drag.
+
+      A labeled <button>, not a bare div: with the collapse toggle gone on
+      mobile this is the drawer's only non-navigational way out, so it has to be
+      reachable by keyboard and announced by a screen reader, not just findable
+      by sighted users with a pointer. Parked, it leaves the tab order and the
+      a11y tree via tabIndex/aria-hidden rather than the `inert` the drawer
+      uses: React 18 doesn't know `inert` as a boolean attribute and drops it,
+      so a focusable control relying on it would stay tabbable while closed.
+
+      z-45, not z-40: chat chrome also sits at z-40 (ChatPage's jump-to-top
+      pill) and renders after the sidebar, so a same-z peer that ever takes
+      pointer events would win the tie inside the exposed strip and swallow the
+      dismiss. Strictly between chat chrome and the drawer's z-50. */}
       {!inSettings && (
-        <div
+        <button
+          type="button"
           data-testid="sidebar-scrim"
-          aria-hidden="true"
+          aria-label="Close sidebar"
           onClick={onClose}
+          tabIndex={effectiveOpen ? 0 : -1}
+          aria-hidden={!effectiveOpen}
           className={cn(
-            "fixed inset-0 z-40 bg-black/25 transition-opacity duration-200 ease-out md:hidden",
+            "fixed inset-0 z-[45] bg-black/25 transition-opacity duration-200 ease-out md:hidden",
             effectiveOpen ? "opacity-100" : "pointer-events-none opacity-0",
           )}
           style={dragging ? { opacity: dragProgress, transition: "none" } : undefined}
@@ -1011,7 +1027,11 @@ export function Sidebar({
                 ref={scrollContainerRef}
                 // Keep wheel/touch scrolling without letting classic-scrollbar
                 // platforms reserve a wide, permanently visible Sidebar gutter.
-                className="relative flex-1 overflow-y-auto px-2 pt-4 pb-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                // max-md:pb-14 is the floating Settings chip's clearance: the
+                // chip is a non-scrolling sibling pinned bottom-right, so
+                // without a gutter the last row's always-visible kebab parks
+                // underneath it and can't be tapped.
+                className="relative flex-1 overflow-y-auto px-2 pt-4 pb-3 [scrollbar-width:none] max-md:pb-14 [&::-webkit-scrollbar]:hidden"
               >
                 <ConversationList
                   conversationsQuery={conversationsQuery}

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -67,7 +67,7 @@ import {
 } from "@dnd-kit/core";
 import { useQueryClient } from "@tanstack/react-query";
 import { Link, useLocation, useNavigate, useParams } from "@/lib/routing";
-import { SidebarHeaderActions } from "./SidebarHeaderActions";
+import { SidebarHeaderActions, SidebarSettingsButton } from "./SidebarHeaderActions";
 import omnigentWordmark from "@/assets/omnigent-wordmark.svg";
 import { Button } from "@/components/ui/button";
 import {
@@ -703,255 +703,238 @@ export function Sidebar({
   useEffect(() => cancelPeekClose, [cancelPeekClose]);
 
   return (
-    <aside
-      aria-label="Conversations"
-      onPointerEnter={cancelPeekClose}
-      onPointerLeave={() => {
-        if (!peek) return;
-        cancelPeekClose();
-        // Defer closing if any context menu is open
-        const tryClose = () => {
-          if (document.querySelector('[role="menu"][data-state="open"]')) {
-            peekCloseTimer.current = setTimeout(tryClose, 200);
-            return;
-          }
-          onClose();
-        };
-        peekCloseTimer.current = setTimeout(tryClose, 200);
-      }}
-      className={cn(
-        // Base: bg + flex column. No transition — expand/collapse snaps
-        // instantly (animating the width also lagged drag-to-resize).
-        // conversations-sidebar only matters under the macOS Electron
-        // shell, where it pushes the card below the traffic lights
-        // (see the [data-electron-mac] rules in index.css).
-        "conversations-sidebar flex flex-col bg-card md:select-none",
-        // Mobile (default): fixed full-screen overlay, slide via
-        // translate-x. Stays edge-to-edge — the floating-card
-        // treatment below is desktop-only.
-        // bg-card-solid (opaque): the overlay sits on top of the chat, and
-        // WebKit drops the glass rule's backdrop-filter once a Radix popper
-        // opens (and never repaints it), letting the chat bleed through the
-        // 60%-alpha glass --card. Desktop keeps the translucent bg-card —
-        // there the sidebar pushes content aside, so nothing sits behind it.
-        "max-md:bg-card-solid",
-        "fixed inset-0 z-50",
-        // Mobile only: animate the slide so the iOS edge-swipe settles
-        // smoothly on release. Suppressed inline while a drag is live (the
-        // overlay must track the finger 1:1). Scoped to transform so it can't
-        // re-introduce the width-animation lag the base comment warns about,
-        // and gated to mobile so the desktop floating card is unaffected.
-        "max-md:transition-transform max-md:duration-200 max-md:ease-out",
-        effectiveOpen ? "translate-x-0" : "-translate-x-full",
-        // Desktop: a full-height panel flush to the window edge, carrying
-        // the brand gradient canvas (see html:not(.dark) .conversations-sidebar
-        // in index.css) and separated from the white content by a right
-        // divider — no outer margin or rounding. Width (the user-resizable
-        // variable) animates →0 to push main; when closed the border
-        // collapses too so nothing lingers.
-        "md:translate-x-0 md:overflow-hidden",
-        // Normal desktop flow: relative panel that pushes main. Suppressed while
-        // peeking so its `md:inset-auto`/`md:relative` don't override the
-        // floating-card positioning below (same `md:` layer, source order wins).
-        !peek && "md:relative md:inset-auto",
-        open || peek ? "md:m-0 md:w-[var(--sidebar-width)] " : "md:m-0 md:w-0 md:border-0",
-        // Peek: float as a card 4px off the viewport edge (capped at 300px wide),
-        // ringed and shadowed, sliding+fading in from the left so it reads as an
-        // overlay rather than a push.
-        peek &&
-          "is-peek md:absolute md:inset-2 p-0 md:max-w-[400px] ring-1 ring-border rounded-xl md:shadow-xl animate-in fade-in slide-in-from-left-4 duration-200 ease-out",
+    <>
+      {/* Mobile: the drawer stops short of the right edge, leaving a strip of
+      the chat visible; this scrim covers that strip so tapping it dismisses the
+      drawer — the gesture that replaced the collapse icon. Full-bleed and
+      behind the drawer (z-40 vs z-50), so only the strip is actually reachable.
+      Tracks the finger during an edge-swipe drag. */}
+      {!inSettings && (
+        <div
+          data-testid="sidebar-scrim"
+          aria-hidden="true"
+          onClick={onClose}
+          className={cn(
+            "fixed inset-0 z-40 bg-black/25 transition-opacity duration-200 ease-out md:hidden",
+            effectiveOpen ? "opacity-100" : "pointer-events-none opacity-0",
+          )}
+          style={dragging ? { opacity: dragProgress, transition: "none" } : undefined}
+        />
       )}
-      style={
-        {
-          "--sidebar-width": `${sidebarWidth}px`,
-          // Track the finger: map the 0→1 open fraction to translateX
-          // -100%→0% and kill the transition so it follows the drag exactly.
-          ...(dragging
-            ? { transform: `translateX(${(dragProgress - 1) * 100}%)`, transition: "none" }
-            : null),
-        } as CSSProperties
-      }
-      // Hide from the accessibility tree when closed so screen readers
-      // don't see the empty-state contents while focus is elsewhere.
-      aria-hidden={!effectiveOpen}
-      data-collapsed={!effectiveOpen || undefined}
-      // Match the keyboard-focus story: when closed, the sidebar's
-      // children shouldn't receive tabs.
-      inert={!effectiveOpen}
-    >
-      {/* Right-edge resize handle (desktop only), mirroring the right rail's
+      <aside
+        aria-label="Conversations"
+        onPointerEnter={cancelPeekClose}
+        onPointerLeave={() => {
+          if (!peek) return;
+          cancelPeekClose();
+          // Defer closing if any context menu is open
+          const tryClose = () => {
+            if (document.querySelector('[role="menu"][data-state="open"]')) {
+              peekCloseTimer.current = setTimeout(tryClose, 200);
+              return;
+            }
+            onClose();
+          };
+          peekCloseTimer.current = setTimeout(tryClose, 200);
+        }}
+        className={cn(
+          // Base: bg + flex column. No transition — expand/collapse snaps
+          // instantly (animating the width also lagged drag-to-resize).
+          // conversations-sidebar only matters under the macOS Electron
+          // shell, where it pushes the card below the traffic lights
+          // (see the [data-electron-mac] rules in index.css).
+          "conversations-sidebar flex flex-col bg-card md:select-none",
+          // Mobile (default): a fixed drawer that slides in via translate-x
+          // and stops short of the right edge, leaving a tappable strip of the
+          // chat behind it. The floating-card treatment below is desktop-only.
+          // bg-card-solid (opaque): the overlay sits on top of the chat, and
+          // WebKit drops the glass rule's backdrop-filter once a Radix popper
+          // opens (and never repaints it), letting the chat bleed through the
+          // 60%-alpha glass --card. Desktop keeps the translucent bg-card —
+          // there the sidebar pushes content aside, so nothing sits behind it.
+          "max-md:bg-card-solid",
+          // `max-md:right-14` is the ChatGPT-style peek strip: the drawer covers
+          // most of the phone but stops short of the right edge so the chat stays
+          // visible (and tappable through the scrim) behind it.
+          "fixed inset-0 z-50",
+          // The settings nav takes the sidebar over and its "Back" row is the
+          // only way out, so there the drawer stays full-bleed (and gets no
+          // dismiss scrim) rather than offering a tap that strands the user.
+          !inSettings && "max-md:right-14",
+          // Mobile only: animate the slide so the iOS edge-swipe settles
+          // smoothly on release. Suppressed inline while a drag is live (the
+          // overlay must track the finger 1:1). Scoped to transform so it can't
+          // re-introduce the width-animation lag the base comment warns about,
+          // and gated to mobile so the desktop floating card is unaffected.
+          "max-md:transition-transform max-md:duration-200 max-md:ease-out",
+          effectiveOpen ? "translate-x-0" : "-translate-x-full",
+          // Desktop: a full-height panel flush to the window edge, carrying
+          // the brand gradient canvas (see html:not(.dark) .conversations-sidebar
+          // in index.css) and separated from the white content by a right
+          // divider — no outer margin or rounding. Width (the user-resizable
+          // variable) animates →0 to push main; when closed the border
+          // collapses too so nothing lingers.
+          "md:translate-x-0 md:overflow-hidden",
+          // Normal desktop flow: relative panel that pushes main. Suppressed while
+          // peeking so its `md:inset-auto`/`md:relative` don't override the
+          // floating-card positioning below (same `md:` layer, source order wins).
+          !peek && "md:relative md:inset-auto",
+          open || peek ? "md:m-0 md:w-[var(--sidebar-width)] " : "md:m-0 md:w-0 md:border-0",
+          // Peek: float as a card 4px off the viewport edge (capped at 300px wide),
+          // ringed and shadowed, sliding+fading in from the left so it reads as an
+          // overlay rather than a push.
+          peek &&
+            "is-peek md:absolute md:inset-2 p-0 md:max-w-[400px] ring-1 ring-border rounded-xl md:shadow-xl animate-in fade-in slide-in-from-left-4 duration-200 ease-out",
+        )}
+        style={
+          {
+            "--sidebar-width": `${sidebarWidth}px`,
+            // Track the finger: map the 0→1 open fraction to translateX
+            // -100%→0% and kill the transition so it follows the drag exactly.
+            ...(dragging
+              ? { transform: `translateX(${(dragProgress - 1) * 100}%)`, transition: "none" }
+              : null),
+          } as CSSProperties
+        }
+        // Hide from the accessibility tree when closed so screen readers
+        // don't see the empty-state contents while focus is elsewhere.
+        aria-hidden={!effectiveOpen}
+        data-collapsed={!effectiveOpen || undefined}
+        // Match the keyboard-focus story: when closed, the sidebar's
+        // children shouldn't receive tabs.
+        inert={!effectiveOpen}
+      >
+        {/* Right-edge resize handle (desktop only), mirroring the right rail's
           left-edge handle. Hidden on mobile, where the sidebar is a
           full-screen overlay with no resize affordance; the parent's ``inert``
           when closed also keeps it from being draggable while collapsed.
           Hidden while peeking too — the peek card is a fixed-width flyout, not
           a resizable panel. */}
-      {!peek && (
-        <div
-          {...resizeHandleProps}
-          className="absolute inset-y-0 right-0 z-10 hidden w-1 cursor-col-resize transition-colors hover:bg-primary/30 active:bg-primary/50 md:block"
-        />
-      )}
-      {inSettings ? (
-        <SettingsSidebarBody onNavClick={onNavClick} />
-      ) : (
-        <>
-          {/* sidebar-header-row is the hook for the macOS Electron shell, where
+        {!peek && (
+          <div
+            {...resizeHandleProps}
+            className="absolute inset-y-0 right-0 z-10 hidden w-1 cursor-col-resize transition-colors hover:bg-primary/30 active:bg-primary/50 md:block"
+          />
+        )}
+        {inSettings ? (
+          <SettingsSidebarBody onNavClick={onNavClick} />
+        ) : (
+          <>
+            {/* sidebar-header-row is the hook for the macOS Electron shell, where
           this row shares the window's top strip with the traffic lights: the
           brand mark is dropped and the actions slide left to sit beside the
           window controls (see the [data-electron-mac] rules in index.css).
           Inert in a browser and on other platforms, which keep the row below. */}
-          <div className="sidebar-header-row flex h-12 shrink-0 items-center justify-between pr-3 pl-4">
-            {/* Brand mark doubles as the "home" affordance: clicking it
+            <div className="sidebar-header-row flex h-12 shrink-0 items-center justify-between pr-3 pl-4">
+              {/* Brand mark doubles as the "home" affordance: clicking it
             returns to `/`, the new-session composer. Without this there
             is no way back to the landing composer once you're inside a
             session. Reuses onNavClick so a plain primary click closes
             the sidebar on mobile (where it's a full-screen overlay) but
             modifier/middle clicks still open `/` in a new tab. */}
-            <Link
-              to="/"
-              onClick={onNavClick}
-              data-testid="sidebar-brand"
-              componentId="sidebar.home"
-              className="sidebar-brand rounded-none transition-opacity duration-200 ease-[var(--ease-otto)] hover:opacity-70"
-            >
-              {branding.app_name ? (
-                <span className="text-[15px] font-semibold tracking-tight">
-                  {branding.app_name}
-                </span>
-              ) : (
-                <img
-                  src={omnigentWordmark}
-                  alt="Omnigent"
-                  data-testid="sidebar-wordmark"
-                  className="h-[15px] w-auto shrink-0 translate-y-px dark:invert"
-                />
-              )}
-            </Link>
-            {/* On the macOS shell this copy is hidden and an identical cluster
+              <Link
+                to="/"
+                onClick={onNavClick}
+                data-testid="sidebar-brand"
+                componentId="sidebar.home"
+                className="sidebar-brand rounded-none transition-opacity duration-200 ease-[var(--ease-otto)] hover:opacity-70"
+              >
+                {branding.app_name ? (
+                  <span className="text-[15px] font-semibold tracking-tight">
+                    {branding.app_name}
+                  </span>
+                ) : (
+                  <img
+                    src={omnigentWordmark}
+                    alt="Omnigent"
+                    data-testid="sidebar-wordmark"
+                    className="h-[15px] w-auto shrink-0 translate-y-px dark:invert"
+                  />
+                )}
+              </Link>
+              {/* On the macOS shell this copy is hidden and an identical cluster
             renders in the title-bar strip instead (see AppShell), so the icons
             keep their place when the sidebar collapses or peeks. Everywhere
             else this is the only copy. */}
-            <SidebarHeaderActions
-              expanded={!peek}
-              // onOpen is optional (the sidebar renders standalone in tests), so
-              // fall back to a no-op rather than widening the child's contract.
-              onToggle={peek ? () => onOpen?.() : onClose}
-              onOpenSearch={onOpenSearch}
-            />
-          </div>
+              <SidebarHeaderActions
+                expanded={!peek}
+                // onOpen is optional (the sidebar renders standalone in tests), so
+                // fall back to a no-op rather than widening the child's contract.
+                onToggle={peek ? () => onOpen?.() : onClose}
+                onOpenSearch={onOpenSearch}
+              />
+            </div>
 
-          <div className="flex flex-col gap-0 px-2 pt-2 pb-0" data-testid="sidebar-primary-nav">
-            {/* "New session" routes to the home composer ("/"), which now owns
+            <div className="flex flex-col gap-0 px-2 pt-2 pb-0" data-testid="sidebar-primary-nav">
+              {/* "New session" routes to the home composer ("/"), which now owns
             session creation end-to-end (host/workspace/worktree chips +
             send). Rendered as a Link so cmd/middle-click opens it in a new
             tab; onNavClick still closes the sidebar on a plain mobile tap. */}
-            <Button
-              asChild
-              className={cn(
-                // px-2 + gap-2 puts the icon on the sidebar's left (red) column
-                // and the label on the label (blue) column — matching section
-                // headers and project folders. border-0 drops the Button base's
-                // transparent 1px border so the icon lands exactly on that
-                // column, flush with the Inbox row and folder rows.
-                SIDEBAR_ROW,
-                "w-full justify-start border-0 font-normal",
-                SIDEBAR_HOVER_HIGHLIGHT,
-                isNewChatPage && SIDEBAR_ACTIVE_HIGHLIGHT,
-              )}
-              variant="ghost"
-              data-testid="new-chat-button"
-            >
-              {/* New session always creates a session the viewer owns, which
+              <Button
+                asChild
+                className={cn(
+                  // px-2 + gap-2 puts the icon on the sidebar's left (red) column
+                  // and the label on the label (blue) column — matching section
+                  // headers and project folders. border-0 drops the Button base's
+                  // transparent 1px border so the icon lands exactly on that
+                  // column, flush with the Inbox row and folder rows.
+                  SIDEBAR_ROW,
+                  "w-full justify-start border-0 font-normal",
+                  SIDEBAR_HOVER_HIGHLIGHT,
+                  isNewChatPage && SIDEBAR_ACTIVE_HIGHLIGHT,
+                )}
+                variant="ghost"
+                data-testid="new-chat-button"
+              >
+                {/* New session always creates a session the viewer owns, which
               lands under "My sessions" — so snap the tab back there on click
               (the button stays visible on both tabs). */}
-              <Link
-                to="/"
-                componentId="sidebar.new_chat"
-                onClick={(e) => {
-                  switchTab("mine");
-                  onNavClick(e);
-                }}
-              >
-                <SquarePenIcon
-                  className={cn(
-                    "ui-icon",
-                    isNewChatPage
-                      ? "text-[var(--sidebar-active-foreground)]"
-                      : "text-muted-foreground",
-                  )}
-                />
-                New session
-              </Link>
-            </Button>
-            {/* Keep Scheduled in the primary nav group with the same row treatment as New session. */}
-            <Button
-              asChild
-              className={cn(
-                // Same shared nav-row construct as "New session" / "Inbox" so
-                // the active-pill, hover, insets, icon column, and text weight
-                // all match post-refactor.
-                SIDEBAR_ROW,
-                "w-full justify-start border-0 font-normal",
-                SIDEBAR_HOVER_HIGHLIGHT,
-                isTasksPage && SIDEBAR_ACTIVE_HIGHLIGHT,
-              )}
-              variant="ghost"
-              data-testid="scheduled-tasks-nav"
-            >
-              <Link to="/tasks" onClick={onNavClick} componentId="sidebar.tasks">
-                <ClockIcon
-                  className={cn(
-                    "ui-icon",
-                    isTasksPage
-                      ? "text-[var(--sidebar-active-foreground)]"
-                      : "text-muted-foreground",
-                  )}
-                />
-                Automations
-              </Link>
-            </Button>
-            <Button
-              asChild
-              variant="ghost"
-              className={cn(
-                SIDEBAR_ROW,
-                "w-full justify-start border-0 font-normal",
-                SIDEBAR_HOVER_HIGHLIGHT,
-                isInboxPage && SIDEBAR_ACTIVE_HIGHLIGHT,
-              )}
-              data-testid="inbox-button"
-            >
-              <Link to="/inbox" onClick={onNavClick} componentId="sidebar.inbox">
-                <InboxIcon
-                  className={cn(
-                    "ui-icon",
-                    isInboxPage
-                      ? "text-[var(--sidebar-active-foreground)]"
-                      : "text-muted-foreground",
-                  )}
-                />
-                Inbox
-                {inboxCount > 0 && (
-                  <span
-                    aria-label={
-                      inboxCount === 1
-                        ? "1 inbox item waiting"
-                        : `${inboxCount} inbox items waiting`
-                    }
+                <Link
+                  to="/"
+                  componentId="sidebar.new_chat"
+                  onClick={(e) => {
+                    switchTab("mine");
+                    onNavClick(e);
+                  }}
+                >
+                  <SquarePenIcon
                     className={cn(
-                      "ml-auto inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-10 font-medium text-[var(--sidebar-active-foreground)] tabular-nums",
-                      // The active Inbox row already paints the translucent
-                      // --sidebar-active wash; repainting it on the nested
-                      // badge would double-composite to a darker fill.
-                      isInboxPage ? "bg-transparent" : "bg-[var(--sidebar-active)]",
+                      "ui-icon",
+                      isNewChatPage
+                        ? "text-[var(--sidebar-active-foreground)]"
+                        : "text-muted-foreground",
                     )}
-                  >
-                    {inboxCount}
-                  </span>
+                  />
+                  New session
+                </Link>
+              </Button>
+              {/* Keep Scheduled in the primary nav group with the same row treatment as New session. */}
+              <Button
+                asChild
+                className={cn(
+                  // Same shared nav-row construct as "New session" / "Inbox" so
+                  // the active-pill, hover, insets, icon column, and text weight
+                  // all match post-refactor.
+                  SIDEBAR_ROW,
+                  "w-full justify-start border-0 font-normal",
+                  SIDEBAR_HOVER_HIGHLIGHT,
+                  isTasksPage && SIDEBAR_ACTIVE_HIGHLIGHT,
                 )}
-              </Link>
-            </Button>
-            {usagePageEnabled && (
+                variant="ghost"
+                data-testid="scheduled-tasks-nav"
+              >
+                <Link to="/tasks" onClick={onNavClick} componentId="sidebar.tasks">
+                  <ClockIcon
+                    className={cn(
+                      "ui-icon",
+                      isTasksPage
+                        ? "text-[var(--sidebar-active-foreground)]"
+                        : "text-muted-foreground",
+                    )}
+                  />
+                  Automations
+                </Link>
+              </Button>
               <Button
                 asChild
                 variant="ghost"
@@ -959,62 +942,117 @@ export function Sidebar({
                   SIDEBAR_ROW,
                   "w-full justify-start border-0 font-normal",
                   SIDEBAR_HOVER_HIGHLIGHT,
-                  isUsagePage && SIDEBAR_ACTIVE_HIGHLIGHT,
+                  isInboxPage && SIDEBAR_ACTIVE_HIGHLIGHT,
                 )}
-                data-testid="usage-nav"
+                data-testid="inbox-button"
               >
-                <Link to="/usage" onClick={onNavClick} componentId="sidebar.usage">
-                  <WalletIcon
+                <Link to="/inbox" onClick={onNavClick} componentId="sidebar.inbox">
+                  <InboxIcon
                     className={cn(
                       "ui-icon",
-                      isUsagePage
+                      isInboxPage
                         ? "text-[var(--sidebar-active-foreground)]"
                         : "text-muted-foreground",
                     )}
                   />
-                  Usage
+                  Inbox
+                  {inboxCount > 0 && (
+                    <span
+                      aria-label={
+                        inboxCount === 1
+                          ? "1 inbox item waiting"
+                          : `${inboxCount} inbox items waiting`
+                      }
+                      className={cn(
+                        "ml-auto inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-10 font-medium text-[var(--sidebar-active-foreground)] tabular-nums",
+                        // The active Inbox row already paints the translucent
+                        // --sidebar-active wash; repainting it on the nested
+                        // badge would double-composite to a darker fill.
+                        isInboxPage ? "bg-transparent" : "bg-[var(--sidebar-active)]",
+                      )}
+                    >
+                      {inboxCount}
+                    </span>
+                  )}
                 </Link>
               </Button>
-            )}
-          </div>
+              {usagePageEnabled && (
+                <Button
+                  asChild
+                  variant="ghost"
+                  className={cn(
+                    SIDEBAR_ROW,
+                    "w-full justify-start border-0 font-normal",
+                    SIDEBAR_HOVER_HIGHLIGHT,
+                    isUsagePage && SIDEBAR_ACTIVE_HIGHLIGHT,
+                  )}
+                  data-testid="usage-nav"
+                >
+                  <Link to="/usage" onClick={onNavClick} componentId="sidebar.usage">
+                    <WalletIcon
+                      className={cn(
+                        "ui-icon",
+                        isUsagePage
+                          ? "text-[var(--sidebar-active-foreground)]"
+                          : "text-muted-foreground",
+                      )}
+                    />
+                    Usage
+                  </Link>
+                </Button>
+              )}
+            </div>
 
-          <nav
-            ref={scrollContainerRef}
-            // Keep wheel/touch scrolling without letting classic-scrollbar
-            // platforms reserve a wide, permanently visible Sidebar gutter.
-            className="relative flex-1 overflow-y-auto px-2 pt-4 pb-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-          >
-            <ConversationList
-              conversationsQuery={conversationsQuery}
-              scrollContainerRef={scrollContainerRef}
-              onRowClick={onNavClick}
-              searchQuery=""
-              newSessionProjectName={newSessionProjectName}
-              activeTab={activeTab}
-              onActiveTabChange={switchTab}
-              multiUser={multiUser}
-              pinnedConversationIds={pinnedConversationIds}
-              pinnedConversations={pinnedConversations}
-              onTogglePinned={togglePinnedConversation}
-              onEnterSelectionMode={enterSelectionMode}
-              selectionMode={selectionMode}
-              selectionScope={selectionScope}
-              selectedIds={selectedIds}
-              onToggleSelected={toggleSelected}
-              onDeselectAll={deselectAll}
-              onExitSelectionMode={exitSelectionMode}
-              getVisibleIdsRef={getVisibleIdsRef}
-            />
-          </nav>
+            {/* Wrapper (not the `aside`) anchors the floating Settings button:
+          absolute-positioning inside the aside would place it in the native
+          safe-area padding, under the home indicator. */}
+            <div className="relative flex min-h-0 flex-1 flex-col">
+              <nav
+                ref={scrollContainerRef}
+                // Keep wheel/touch scrolling without letting classic-scrollbar
+                // platforms reserve a wide, permanently visible Sidebar gutter.
+                className="relative flex-1 overflow-y-auto px-2 pt-4 pb-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+              >
+                <ConversationList
+                  conversationsQuery={conversationsQuery}
+                  scrollContainerRef={scrollContainerRef}
+                  onRowClick={onNavClick}
+                  searchQuery=""
+                  newSessionProjectName={newSessionProjectName}
+                  activeTab={activeTab}
+                  onActiveTabChange={switchTab}
+                  multiUser={multiUser}
+                  pinnedConversationIds={pinnedConversationIds}
+                  pinnedConversations={pinnedConversations}
+                  onTogglePinned={togglePinnedConversation}
+                  onEnterSelectionMode={enterSelectionMode}
+                  selectionMode={selectionMode}
+                  selectionScope={selectionScope}
+                  selectedIds={selectedIds}
+                  onToggleSelected={toggleSelected}
+                  onDeselectAll={deselectAll}
+                  onExitSelectionMode={exitSelectionMode}
+                  getVisibleIdsRef={getVisibleIdsRef}
+                />
+              </nav>
+              {/* Mobile: Settings floats over the bottom of the session list, with
+          Search floating at the top of the header row — the two icons the
+          drawer keeps once the collapse toggle is gone. */}
+              <SidebarSettingsButton
+                testId="sidebar-settings-float"
+                className="absolute right-3 bottom-3 shadow-md max-md:bg-muted md:hidden"
+              />
+            </div>
 
-          {/* Desktop server picker, pinned below the scrolling session list.
+            {/* Desktop server picker, pinned below the scrolling session list.
           Self-hiding: renders nothing outside the Electron shell (see
           SidebarServerPicker), so browsers keep an unchanged sidebar that ends
           with the list. */}
-          <SidebarServerPicker />
-        </>
-      )}
-    </aside>
+            <SidebarServerPicker />
+          </>
+        )}
+      </aside>
+    </>
   );
 }
 

--- a/web/src/shell/SidebarHeaderActions.tsx
+++ b/web/src/shell/SidebarHeaderActions.tsx
@@ -3,6 +3,7 @@ import { PanelLeftOpenIcon, PanelRightOpenIcon, SearchIcon, SettingsIcon } from 
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Link } from "@/lib/routing";
+import { cn } from "@/lib/utils";
 
 /**
  * Search / Settings / sidebar-toggle cluster from the sidebar's header row.
@@ -53,40 +54,8 @@ export function SidebarHeaderActions({
 }) {
   return (
     <div className="flex items-center gap-1" data-testid="sidebar-header-actions">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            aria-label="Search"
-            onClick={() => onOpenSearch?.()}
-            className="size-6 text-muted-foreground hover:text-foreground"
-            data-testid="sidebar-search-button"
-          >
-            <SearchIcon className="ui-icon" />
-          </Button>
-        </TooltipTrigger>
-        {/* Bottom placement keeps the tooltip clear of the macOS Electron
-        shell's traffic lights at the window's top edge. */}
-        <TooltipContent side="bottom">Search</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            asChild
-            variant="ghost"
-            size="icon-xs"
-            aria-label="Settings"
-            className="size-6 text-muted-foreground hover:text-foreground"
-          >
-            <Link to="/settings" onClick={onSettingsClick} data-testid="settings-button">
-              <SettingsIcon className="ui-icon" />
-            </Link>
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Settings</TooltipContent>
-      </Tooltip>
+      <SidebarSearchButton onOpenSearch={onOpenSearch} />
+      <SidebarSettingsButton onSettingsClick={onSettingsClick} className="max-md:hidden" />
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
@@ -97,7 +66,11 @@ export function SidebarHeaderActions({
             onClick={onToggle}
             onPointerEnter={onTogglePointerEnter}
             onPointerLeave={onTogglePointerLeave}
-            className="size-6 text-muted-foreground hover:text-foreground"
+            // Mobile drops the toggle entirely: there the sidebar is a drawer
+            // that leaves a strip of the chat visible, and tapping that strip
+            // is how you get back — a collapse icon would be a second, worse
+            // way to do the same thing.
+            className="size-6 text-muted-foreground hover:text-foreground max-md:hidden"
           >
             {/* panel-right-open reads as "push the panel away" while the sidebar
             is open; panel-left-open as "bring it back" once it is collapsed or
@@ -114,5 +87,93 @@ export function SidebarHeaderActions({
         </TooltipContent>
       </Tooltip>
     </div>
+  );
+}
+
+/**
+ * Mobile treatment shared by the two floating icon buttons: a round chip that
+ * reads as lifted off the session list, sized for a thumb. On desktop these
+ * stay flat 24px ghost icons in the header row.
+ */
+const SIDEBAR_FLOAT_BUTTON =
+  "size-6 text-muted-foreground hover:text-foreground max-md:size-9 max-md:rounded-full max-md:bg-muted/70 max-md:text-foreground";
+
+const SIDEBAR_FLOAT_ICON = "ui-icon max-md:size-[18px]";
+
+/**
+ * Search (command palette) icon button.
+ *
+ * Split out of the cluster because the mobile sidebar places it on its own —
+ * floating at the top of the drawer, away from Settings, which floats at the
+ * bottom.
+ *
+ * @param onOpenSearch - Opens the command palette. Optional so the button can
+ *   render standalone (e.g. in tests).
+ * @param className - Extra classes, e.g. the mobile float's positioning.
+ */
+export function SidebarSearchButton({
+  onOpenSearch,
+  className,
+}: {
+  onOpenSearch?: () => void;
+  className?: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Search"
+          onClick={() => onOpenSearch?.()}
+          className={cn(SIDEBAR_FLOAT_BUTTON, className)}
+          data-testid="sidebar-search-button"
+        >
+          <SearchIcon className={SIDEBAR_FLOAT_ICON} />
+        </Button>
+      </TooltipTrigger>
+      {/* Bottom placement keeps the tooltip clear of the macOS Electron
+      shell's traffic lights at the window's top edge. */}
+      <TooltipContent side="bottom">Search</TooltipContent>
+    </Tooltip>
+  );
+}
+
+/**
+ * Settings icon button — a `Link` to `/settings`.
+ *
+ * @param onSettingsClick - Extra click handler; navigation itself is the
+ *   Link's job.
+ * @param className - Extra classes, e.g. the mobile float's positioning.
+ * @param testId - `data-testid` on the link.
+ */
+export function SidebarSettingsButton({
+  onSettingsClick,
+  className,
+  testId = "settings-button",
+}: {
+  onSettingsClick?: () => void;
+  className?: string;
+  /** Distinguishes the header-row copy from the mobile floating copy. */
+  testId?: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          asChild
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Settings"
+          className={cn(SIDEBAR_FLOAT_BUTTON, className)}
+        >
+          <Link to="/settings" onClick={onSettingsClick} data-testid={testId}>
+            <SettingsIcon className={SIDEBAR_FLOAT_ICON} />
+          </Link>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Settings</TooltipContent>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
## Related issue

No tracking issue — requested directly.

## Summary

On a phone the sidebar opened as a `fixed inset-0` overlay covering the whole
screen, so the only way back to the chat was the "collapse left panel" icon in
its header — a small target, and a confusing one on a phone, where nothing is
actually being collapsed. The chat you came from was completely hidden, so the
overlay never read as sitting *on top of* anything.

This makes it a drawer, following the ChatGPT iOS pattern:

- **It stops short of the right edge** (`max-md:right-14`), leaving a 56px strip
  of the chat visible, and a scrim over that strip dismisses it on tap. That
  gesture replaces the collapse icon, which is now desktop-only. The scrim fades
  with the drawer and tracks the finger during the existing iOS/Android
  edge-swipe drag.
- **Search and Settings become the drawer's two floating controls** — Search
  stays in the header row at the top, Settings floats over the bottom of the
  session list, both as round 36px chips instead of 24px flat icons.
- **`/settings` is exempt**: the settings nav takes the sidebar over and its
  "Back" row is the only way out, so there the drawer stays full-bleed and gets
  no dismiss scrim rather than offering a tap that would strand you on a page
  whose only exit is clipped and `inert`.

`SidebarHeaderActions` grows two exported sub-components (`SidebarSearchButton`,
`SidebarSettingsButton`) so the header-row and floating placements share one
definition. **Desktop is unchanged** — same flat 24px Search / Settings /
collapse cluster, same push-panel and peek-card behaviour.

## Test Plan

Automated, from `web/`:

- `npx vitest run src/shell/Sidebar src/shell/settingsNav.test.tsx src/shell/ChatHeader.test.tsx src/shell/AppShell.test.tsx` — 409 passed, including the 5 new tests in `Sidebar.mobileDrawer.test.tsx`.
- `npx tsc -b`, `npx oxlint --deny-warnings src/shell/`, `pre-commit run --files <changed>` — all clean.

Manual (not yet run — see Coverage notes):

1. `cd web && npm run dev`, then narrow the viewport below 768px.
2. Open the sidebar from the chat header. It slides in leaving a sliver of chat
   on the right; there is no collapse icon in its header.
3. Tap the sliver → the drawer dismisses and you are back on the chat.
4. Tap the round Search chip (top-right) → command palette opens.
5. Scroll the session list — the round Settings gear stays pinned bottom-right,
   floating over the list. Tap it → the sidebar swaps to the settings nav,
   full-bleed with no sliver, and "Back" returns you.
6. Widen past 768px → desktop cluster and push behaviour unchanged.
7. On the iOS/Android shell, left-edge swipe → drawer tracks the finger with the
   scrim darkening in step, settling with a shadow along its right edge.

## Demo

⚠️ Screen recording still to be attached — this needs a device/simulator I don't
have here. The steps above reproduce it.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Worth being explicit about the limits of the new tests: jsdom does not evaluate
media queries, so `Sidebar.mobileDrawer.test.tsx` asserts *behaviour and class
contracts* (the scrim calls `onClose`, the scrim is `pointer-events-none` while
closed, the drawer carries `max-md:right-14`, both are dropped on `/settings`,
the floats and the desktop-only toggle carry the right responsive classes) — it
cannot assert what the layout actually looks like at a phone width. The visual
result has not been eyeballed in a browser yet; that is what the manual steps
above and the pending recording are for.

## Changelog

The mobile sidebar is now a drawer you dismiss by tapping the chat beside it, with Search and Settings floating at its top and bottom
