### PR TITLE
fix(web): three mobile fixes — landing keyboard, stray native bar, matching sidebar chips

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -942,6 +942,49 @@ aside[aria-label="Workspace"][data-maximized] {
     transition-duration: 1ms;
   }
 }
+
+/* Liquid glass for the mobile sidebar's two floating chips (Search at the top
+ * of the header row, Settings over the bottom of the session list) — the iOS
+ * control idiom.
+ *
+ * The rim, the specular top edge, and the drop shadow do the work, not the
+ * blur: the surface behind these chips is the sidebar's own near-flat card, so
+ * blurring it alone would leave nothing to see. The blur earns its keep on the
+ * Settings chip, which floats over the scrolling session list and frosts the
+ * row titles passing under it.
+ *
+ * Scoped to `width < 48rem` so the class is inert on desktop, where the same
+ * two icons are flat ghost buttons in the header row. Both chips share it so
+ * they can't drift apart again.
+ *
+ * Backdrop sampling stops at the sidebar: the `.conversations-sidebar` carries
+ * a translate for its slide, which makes it a backdrop root, so the chips frost
+ * the drawer's own content rather than the chat behind it — which is what we
+ * want. If WebKit drops the filter (it does, once a Radix popper opens — see
+ * `max-md:bg-card-solid` on the sidebar), the fill and rim still read as a
+ * chip. */
+@media (width < 48rem) {
+  .sidebar-glass-chip {
+    /* -webkit- must come BEFORE the unprefixed property: LightningCSS (vite
+     * build) collapses the pair and keeps only the last declaration. */
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    backdrop-filter: blur(20px) saturate(180%);
+    background-color: rgba(255, 255, 255, 0.6);
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.8),
+      0 1px 2px rgba(0, 0, 0, 0.05),
+      0 6px 16px rgba(0, 0, 0, 0.07);
+  }
+
+  .dark .sidebar-glass-chip {
+    background-color: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.12),
+      0 2px 10px rgba(0, 0, 0, 0.45);
+  }
+}
 /* Share button — glassy pink effect (both modes). The vertical
  * gradient alone does the embossed work (lighter top = light catch,
  * darker bottom = shadow, simulating a convex surface lit from above);

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -168,7 +168,9 @@ import {
   controlHost,
   getHostIdentity,
   isElectronShell,
+  isIOSShell,
   onHostStatusChanged,
+  setNativeViewMode,
   type HostIdentity,
 } from "@/lib/nativeBridge";
 import {
@@ -2067,6 +2069,22 @@ export function NewChatLandingScreen() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
+  const isMobileViewport = useIsMobileViewport();
+  // No session here, so there is nothing to switch between: assert the iOS
+  // shell's native Chat/Terminal bar is hidden. ChatPage's own bar is driven by
+  // the session surface and hides itself on unmount, but that is the only thing
+  // holding the native state down — and the bar was showing over this screen,
+  // so state the truth for this route instead of trusting a teardown that runs
+  // elsewhere. Idempotent, and re-asserted on every mount of this screen.
+  useEffect(() => {
+    if (!isIOSShell()) return;
+    setNativeViewMode({
+      mode: "chat",
+      terminalEnabled: false,
+      terminalStartingUp: false,
+      visible: false,
+    });
+  }, []);
   const heading = useHeading();
   const poweredBy = usePoweredBy();
   const serverUrl = getCliServerUrl();
@@ -4365,7 +4383,13 @@ export function NewChatLandingScreen() {
                 placeholder={pillSkills.length > 0 ? "" : placeholderText}
                 aria-label={placeholderText}
                 rows={1}
-                autoFocus
+                // Desktop only. This screen mounts on every arrival at "/" —
+                // including ones the user didn't make to type, like Back out of
+                // Settings — and on a phone focusing the field throws up the
+                // keyboard (and auto-zooms, per the note below) over whatever
+                // is on screen, sometimes with the sidebar drawer still open on
+                // top of it. Phones expect to be tapped before they type.
+                autoFocus={!isMobileViewport}
                 data-testid="new-chat-landing-input"
                 // Compose-pill text spec: SF Pro Text system stack at
                 // 14px/20px. (Note: sub-16px inputs make mobile Safari

--- a/web/src/shell/NewChatLandingScreen.mobileChrome.test.tsx
+++ b/web/src/shell/NewChatLandingScreen.mobileChrome.test.tsx
@@ -1,0 +1,152 @@
+// The landing screen's mobile chrome. Two rules, both about arriving at "/"
+// on a phone:
+//   1. The composer is not focused, so landing here — including on the way
+//      back out of Settings — never throws up the keyboard unasked.
+//   2. The iOS shell's native Chat/Terminal bar is pushed hidden: there is no
+//      session here, so there is nothing to switch between.
+
+import type * as UseConversationsModule from "@/hooks/useConversations";
+import type * as AgentLabelsModule from "@/lib/agentLabels";
+import type * as NativeBridgeModule from "@/lib/nativeBridge";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Host } from "@/hooks/useHosts";
+import { useHosts } from "@/hooks/useHosts";
+import type { AvailableAgent } from "@/hooks/useAvailableAgents";
+import { useAvailableAgents } from "@/hooks/useAvailableAgents";
+import { isIOSShell, setNativeViewMode } from "@/lib/nativeBridge";
+import { NewChatLandingScreen } from "./NewChatDialog";
+
+vi.mock("@/lib/routing", () => ({
+  useNavigate: () => vi.fn(),
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+
+vi.mock("@/store/chatStore", () => ({ setPendingInitialPrompt: vi.fn() }));
+vi.mock("@/lib/identity", () => ({ authenticatedFetch: vi.fn() }));
+vi.mock("@/hooks/useHosts", () => ({
+  useHosts: vi.fn(),
+  useHostModelOptions: vi.fn(() => ({ data: [] })),
+  useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useInstallingHarnesses: vi.fn(() => new Set<string>()),
+}));
+vi.mock("@/hooks/useAvailableAgents", () => ({ useAvailableAgents: vi.fn() }));
+vi.mock("@/hooks/useHostFilesystem", () => ({
+  useHostFilesystem: () => ({ data: undefined }),
+  useCreateHostDirectory: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/useHostWorktrees", () => ({
+  useHostWorktrees: () => ({ data: [], isError: false }),
+}));
+vi.mock("@/hooks/useDirectorySessions", () => ({ useDirectorySessions: () => ({ data: [] }) }));
+vi.mock("@/hooks/RunnerHealthProvider", () => ({
+  useRunnerHealthRegistration: () => new Map<string, boolean>(),
+}));
+vi.mock("@/hooks/useConversations", async (importOriginal) => ({
+  ...(await importOriginal<typeof UseConversationsModule>()),
+  useProjects: () => ({ data: [], isLoading: false }),
+  useProjectConfig: () => ({ data: undefined, isLoading: false }),
+}));
+vi.mock("@/lib/agentLabels", async (importOriginal) => ({
+  ...(await importOriginal<typeof AgentLabelsModule>()),
+  useBrainHarnessLabels: () => ({}),
+  useHarnessSetupSteps: () => ({}),
+}));
+// Only the two native entry points under test are stubbed; the rest of the
+// bridge keeps its real (no-op outside a shell) behaviour.
+vi.mock("@/lib/nativeBridge", async (importOriginal) => ({
+  ...(await importOriginal<typeof NativeBridgeModule>()),
+  isIOSShell: vi.fn(() => false),
+  setNativeViewMode: vi.fn(),
+}));
+
+/** Point `matchMedia` at a phone-width (or desktop-width) viewport. */
+function setViewport(mobile: boolean): void {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: mobile && query.includes("max-width"),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+function renderLanding(): void {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(<NewChatLandingScreen />, {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(useHosts).mockReturnValue({
+    data: [{ host_id: "host_1", name: "laptop", owner: "corey", status: "online" } as Host],
+  } as ReturnType<typeof useHosts>);
+  vi.mocked(useAvailableAgents).mockReturnValue({
+    data: [
+      {
+        id: "ag_hello",
+        name: "hello_world",
+        display_name: "Hello World",
+        description: null,
+        harness: null,
+        skills: [],
+      } as AvailableAgent,
+    ],
+  } as ReturnType<typeof useAvailableAgents>);
+  vi.mocked(isIOSShell).mockReturnValue(false);
+  vi.mocked(setNativeViewMode).mockClear();
+  setViewport(false);
+});
+
+afterEach(() => {
+  cleanup();
+  setViewport(false);
+});
+
+describe("NewChatLandingScreen keyboard behaviour", () => {
+  it("focuses the composer on desktop so typing can start immediately", () => {
+    renderLanding();
+
+    expect(document.activeElement).toBe(screen.getByTestId("new-chat-landing-input"));
+  });
+
+  it("leaves the composer unfocused on a phone, so arriving never raises the keyboard", () => {
+    setViewport(true);
+    renderLanding();
+
+    expect(document.activeElement).not.toBe(screen.getByTestId("new-chat-landing-input"));
+  });
+});
+
+describe("NewChatLandingScreen native Chat/Terminal bar", () => {
+  it("pushes the bar hidden in the iOS shell — there is no session to switch", () => {
+    vi.mocked(isIOSShell).mockReturnValue(true);
+    renderLanding();
+
+    expect(vi.mocked(setNativeViewMode)).toHaveBeenCalledWith({
+      mode: "chat",
+      terminalEnabled: false,
+      terminalStartingUp: false,
+      visible: false,
+    });
+  });
+
+  it("leaves the native bridge alone outside the iOS shell", () => {
+    renderLanding();
+
+    expect(vi.mocked(setNativeViewMode)).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/shell/Sidebar.mobileDrawer.test.tsx
+++ b/web/src/shell/Sidebar.mobileDrawer.test.tsx
@@ -201,6 +201,39 @@ describe("mobile sidebar drawer", () => {
     );
   });
 
+  it("gives both floating chips one shared glass treatment", () => {
+    // These drifted apart once — Settings landed opaque with a heavier shadow
+    // than Search. The look now lives in a single CSS class, so assert both
+    // wear it and neither carries a competing background or shadow utility.
+    renderSidebar();
+
+    const search = screen.getByTestId("sidebar-search-button");
+    const settings = screen.getByTestId("sidebar-settings-float").closest("a, button")!;
+
+    // Where the chip sits, and which breakpoint it shows at, legitimately
+    // differ; everything about how it looks must not.
+    // `relative` is the Button base's own position, which tailwind-merge drops
+    // from the floating copy in favour of `absolute` — placement, not looks.
+    const PLACEMENT = new Set([
+      "absolute",
+      "relative",
+      "right-3",
+      "bottom-3",
+      "md:hidden",
+      "max-md:hidden",
+    ]);
+    const appearance = (el: Element) =>
+      el.className
+        .split(/\s+/)
+        .filter((c) => c && !PLACEMENT.has(c))
+        .sort()
+        .join(" ");
+
+    expect(search).toHaveClass("sidebar-glass-chip");
+    expect(settings).toHaveClass("sidebar-glass-chip");
+    expect(appearance(settings)).toBe(appearance(search));
+  });
+
   it("gives the session list a gutter so the last row clears the floating chip", () => {
     // The chip doesn't scroll, so without this the bottom row's always-visible
     // kebab sits underneath it and can't be tapped.

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1060,7 +1060,7 @@ export function Sidebar({
           drawer keeps once the collapse toggle is gone. */}
               <SidebarSettingsButton
                 testId="sidebar-settings-float"
-                className="absolute right-3 bottom-3 shadow-md max-md:bg-muted md:hidden"
+                className="absolute right-3 bottom-3 md:hidden"
               />
             </div>
 

--- a/web/src/shell/SidebarHeaderActions.tsx
+++ b/web/src/shell/SidebarHeaderActions.tsx
@@ -91,12 +91,15 @@ export function SidebarHeaderActions({
 }
 
 /**
- * Mobile treatment shared by the two floating icon buttons: a round chip that
- * reads as lifted off the session list, sized for a thumb. On desktop these
- * stay flat 24px ghost icons in the header row.
+ * Mobile treatment shared by the two floating icon buttons: a thumb-sized round
+ * chip in iOS liquid glass. The look lives in one CSS class
+ * (`.sidebar-glass-chip` in index.css) that both chips wear, so Search and
+ * Settings can't drift apart — they had, one landing opaque with a heavier
+ * shadow than the other. On desktop the class is inert (it is scoped to the
+ * mobile breakpoint) and these stay flat 24px ghost icons in the header row.
  */
 const SIDEBAR_FLOAT_BUTTON =
-  "size-6 text-muted-foreground hover:text-foreground max-md:size-9 max-md:rounded-full max-md:bg-muted/70 max-md:text-foreground";
+  "sidebar-glass-chip size-6 text-muted-foreground hover:text-foreground max-md:size-9 max-md:rounded-full max-md:text-foreground";
 
 const SIDEBAR_FLOAT_ICON = "ui-icon max-md:size-[18px]";
 


### PR DESCRIPTION
## Related issue

No tracking issue — all three reported directly from a phone.

## Summary

Three mobile fixes. The first two are landing-screen bugs; the third is a
follow-up to #5427, folded in here rather than carried as its own PR.

**1. Arriving at `/` raised the keyboard.** The landing composer carried a bare
`autoFocus`, and this screen mounts on *every* arrival at `/` — including ones
the user didn't make in order to type. Backing out of Settings is the clear
case: the sidebar drawer deliberately stays open so you land on the session list
(see `SettingsSidebarBody`'s Back row), and the keyboard rises behind it, over a
field you can't even see. The same focus also triggers mobile Safari's sub-16px
auto-zoom, which the composer's own comment already flags as a tradeoff.

Now gated on the viewport: desktop still focuses on mount, phones wait to be
tapped. **Tradeoff worth naming:** tapping "New session" on a phone no longer
lands you on a live keyboard — one extra tap. That matches what phone apps
generally do (ChatGPT included), but it is a behaviour change, not just a bug
fix, so say so if you'd rather have it back only for that path.

**2. The native Chat/Terminal bar floated over the landing screen.** There is no
session here, so there is nothing to switch between. That bar's state is pushed
from `ChatPage`'s session surface (`useNativeChatTerminalBar`), and its only way
of taking it back down is an unmount teardown — the landing screen never says
anything about it, so a stale `visible: true` survives onto this route.

The landing screen now asserts the state its route implies (`visible: false`) on
mount. **Being straight about this one:** I could not pin down the exact
transition that leaves the stale `true` behind — the native side
(`WebShellView` / `WebViewModel`) is a faithful mirror of what the web pushes,
and on paper the teardown should fire. Rather than guess at the path, I made the
route that must never show the bar state that fact itself. It is idempotent and
self-healing, and it fixes the symptom regardless of which transition caused it —
but it treats the symptom, and the underlying teardown may still be leaky for
other routes. Worth a follow-up if it shows up anywhere else.

**3. The drawer's two floating chips didn't match.** Raised in review of #5427,
where they had drifted:

| | before |
|---|---|
| Search | `max-md:bg-muted/70` |
| Settings | `max-md:bg-muted` + `shadow-md` |

Search was a 70%-alpha wash, Settings an opaque one with a medium shadow — enough
to read as unrelated controls. Neither difference earned anything: the opaque
fill existed to stop row titles showing through the chip that floats over the
session list, and any plain fill does that.

Both now wear one iOS-style liquid glass treatment, defined once as
`.sidebar-glass-chip` in `index.css` so they can't come apart again: frosted
`backdrop-filter: blur(20px) saturate(180%)`, a translucent fill, a hairline rim,
a specular top edge, and a soft drop shadow.

**The rim, specular edge and shadow carry the look, not the blur.** The surface
behind these chips is the sidebar's own near-flat card, so blurring it alone
would leave nothing to see. The blur earns its keep on the Settings chip, which
frosts the row titles scrolling under it. Backdrop sampling stops at the drawer —
`.conversations-sidebar` carries a translate for its slide, making it a backdrop
root — so the chips frost the drawer's own content rather than the chat behind
it, which is what we want. Scoped to `width < 48rem`, so **desktop is
untouched**: both icons stay the flat 24px ghost buttons they are today.

## Test Plan

Automated, from `web/`:

- `npx vitest run src/shell/Sidebar src/index.css.test.ts src/shell/NewChat src/pages/ChatPage src/shell/AppShell.test.tsx src/shell/settingsNav.test.tsx src/shell/MobilePanelDrawer.test.tsx` — 1306 passed.
- New: 4 tests in `NewChatLandingScreen.mobileChrome.test.tsx` (focus on desktop / no focus on a phone; `visible: false` pushed in the iOS shell, bridge untouched elsewhere).
- New: a guard in `Sidebar.mobileDrawer.test.tsx` that both chips carry `.sidebar-glass-chip` **and** have identical class lists once placement classes are excluded — the assertion that would have caught the original drift.
- `index.css.test.ts` picks the new CSS rule up **for free**: its existing sweep over every `backdrop-filter` rule confirms the `-webkit-` form is declared first and survives LightningCSS minification, which is the prod-only "transparent glass" bug that test exists to catch. Verified the new rule appears in its cases (`… minification: .sidebar-glass-chip {` ✓).
- `npx tsc -b`, `npx oxlint --deny-warnings src/`, `pre-commit run --files <changed>` — clean.

Manual (not yet run — I have no iOS device here):

1. In the iOS shell, open a Claude Code (terminal-first) session so the native
   Chat/Terminal bar appears.
2. Tap "New session" in the sidebar → the bar should disappear, and the keyboard
   should **not** come up.
3. Open the sidebar → Settings → any section → Back. You should land on the
   session list with the drawer open, **no keyboard**, and no Chat/Terminal bar.
4. Tap the composer → keyboard comes up as normal, and typing/sending still works.
5. With the sidebar open: Search (top-right) and Settings (bottom-right) should
   read as the *same* chip — same fill, same rim, same shadow. Scroll the session
   list under the Settings chip: row titles should frost as they pass beneath it,
   not show through sharply. Check light **and** dark mode.
6. On desktop (browser, >768px): `/` should still focus the composer on arrival,
   and both sidebar icons should be flat ghost icons — no chip, no shadow.

## Demo

⚠️ Screen recording still to be attached — needs a device I don't have here.
The first two symptoms are visible in the reporter's screenshots; the third is
purely visual and genuinely needs eyes on it before merge.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The landing-screen tests drive `NewChatLandingScreen` with a stubbed `matchMedia`
and a stubbed native bridge, so they cover the decisions but not the real iOS
shell — the Swift side is unchanged and untested here. The desktop-focus case is
included deliberately so the mobile assertion cannot pass vacuously.

For the glass change, being explicit because this is what tests are worst at: the
unit guard pins that the two chips share one class and one appearance, and the
CSS test pins that the blur survives the build. **Neither says it looks good.**
jsdom applies no stylesheet, so nothing here renders the glass; whether the fill
and rim values are right on a real screen, in both themes, is unverified.

None of the three symptoms has been reproduced end-to-end by me — all come from
the reporter's screenshots, and the manual steps above are still unrun.

## Changelog

Opening a new session on a phone no longer pops the keyboard on arrival, the Chat/Terminal switcher no longer floats over the new-session screen, and the mobile sidebar's Search and Settings buttons now share one iOS-style liquid-glass treatment
