### PR TITLE
fix(web): full-bleed the chat error banner to the conversation pane

### DIFF
--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -839,6 +839,8 @@ function renderItem(
           cause={item.cause}
           remediation={item.remediation}
           onRetry={onRetryError ? () => onRetryError(item) : undefined}
+          // The message stream renders inside the `@container/chat` pane.
+          fullBleed
         />
       );
     case "policy_denied":

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -138,6 +138,14 @@ function parseErrorMessage(rawMessage: string): ParsedErrorMessage {
  * unclassified failure reads as English) and finally to the raw message/code —
  * never a blank panel.
  */
+// Break the banner out of the chat text-column so its dashed rule reaches the
+// conversation pane's left/right edges and the pill centers in the full pane
+// rather than the narrower message column. `cqi` is the width of the
+// `@container/chat` pane; the negative inline margins pull the full-pane box
+// back over the column's auto-margins and side padding. Every render site sits
+// inside that container.
+const FULL_BLEED_CHAT_PANE = "w-[100cqi] mx-[calc(50%-50cqi)]";
+
 export function ErrorBanner({
   message,
   code,
@@ -201,7 +209,7 @@ export function ErrorBanner({
       <div
         data-testid="error-reconnecting"
         className={cn(
-          TOOL_SURFACE_WIDTH_CLASS,
+          FULL_BLEED_CHAT_PANE,
           "relative flex min-h-14 items-center justify-center py-2",
         )}
       >
@@ -245,7 +253,12 @@ export function ErrorBanner({
   };
 
   return (
-    <div className="relative mb-[24px] flex w-full flex-col items-center px-[16px]">
+    <div
+      className={cn(
+        FULL_BLEED_CHAT_PANE,
+        "relative mb-[24px] flex flex-col items-center px-[16px]",
+      )}
+    >
       <span
         aria-hidden="true"
         className="pointer-events-none absolute top-[20px] right-0 left-0 h-px"

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -49,6 +49,14 @@ interface ErrorBannerProps {
   remediation?: string;
   /** Reconnect the existing session without replaying or duplicating user input. */
   onRetry?: () => Promise<void>;
+  /**
+   * Full-bleed the banner to the `@container/chat` pane edges. Opt-in, and only
+   * safe from render sites that sit inside that container (the in-thread error
+   * paths). Off by default so out-of-pane banners (the connection / sandbox
+   * status banner) — which have no `container-type` ancestor and would resolve
+   * `cqi` against the viewport — keep their column width.
+   */
+  fullBleed?: boolean;
 }
 
 /**
@@ -142,8 +150,9 @@ function parseErrorMessage(rawMessage: string): ParsedErrorMessage {
 // conversation pane's left/right edges and the pill centers in the full pane
 // rather than the narrower message column. `cqi` is the width of the
 // `@container/chat` pane; the negative inline margins pull the full-pane box
-// back over the column's auto-margins and side padding. Every render site sits
-// inside that container.
+// back over the column's auto-margins and side padding. Applied only via the
+// `fullBleed` prop, and only from render sites that live inside that container
+// — with no `container-type` ancestor `cqi` would resolve against the viewport.
 const FULL_BLEED_CHAT_PANE = "w-[100cqi] mx-[calc(50%-50cqi)]";
 
 export function ErrorBanner({
@@ -153,6 +162,7 @@ export function ErrorBanner({
   cause,
   remediation,
   onRetry,
+  fullBleed = false,
 }: ErrorBannerProps) {
   const headline = title || FAILURE_CODE_DESCRIPTIONS[code] || "Something went wrong";
   const parsed = useMemo(() => parseErrorMessage(message), [message]);
@@ -209,7 +219,7 @@ export function ErrorBanner({
       <div
         data-testid="error-reconnecting"
         className={cn(
-          FULL_BLEED_CHAT_PANE,
+          fullBleed ? FULL_BLEED_CHAT_PANE : TOOL_SURFACE_WIDTH_CLASS,
           "relative flex min-h-14 items-center justify-center py-2",
         )}
       >
@@ -255,7 +265,7 @@ export function ErrorBanner({
   return (
     <div
       className={cn(
-        FULL_BLEED_CHAT_PANE,
+        fullBleed ? FULL_BLEED_CHAT_PANE : "w-full",
         "relative mb-[24px] flex flex-col items-center px-[16px]",
       )}
     >

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3941,9 +3941,11 @@ function AssistantBubble({
   const hasElicitation = bubble.items.some((it) => it.kind === "elicitation");
   const isWide =
     hasElicitation || containsMarkdownTable(bubble.items) || containsDisplayMath(bubble.items);
-  // An error banner's dashed rule spans the full chat column: MessageContent
-  // is w-fit, so without w-full an error-only bubble shrink-wraps the 560px
-  // pill and the rule clips to it instead of reaching the column edges.
+  // The error banner full-bleeds to the conversation pane's edges via a
+  // container-relative breakout, which centers on its column. Keeping
+  // MessageContent w-full (it is otherwise w-fit) makes an error-only bubble
+  // fill the centered column instead of shrink-wrapping the 560px pill, so the
+  // breakout stays symmetric and the dashed rule reaches both pane edges.
   const hasError = bubble.items.some((it) => it.kind === "error");
   // A bubble carrying an error but no prose stands alone as a thread-level
   // element — the hover footer's timestamp/actions belong to assistant text,

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4042,7 +4042,7 @@ function AssistantBubble({
           dropped host connection already carries its own error pill inside the
           bubble and leaves `bubble.error` null, so this stays hidden there. */}
       {bubble.lifecycle === "failed" && bubble.error && (
-        <ErrorBanner message={bubble.error} source="" code="" />
+        <ErrorBanner message={bubble.error} source="" code="" fullBleed />
       )}
     </>
   );


### PR DESCRIPTION
## Related issue

N/A — reported directly (no tracked issue).

## Summary

- The "Something went wrong" error banner in the chat pane centered within the
  narrow message text-column, and its dashed rule spanned only that column — so
  on a wide window the dashes stopped well short of the pane edges and the pill
  read as off-center.
- The banner now **full-bleeds to the `@container/chat` conversation pane**: a
  container-relative breakout (`w-[100cqi]` + `mx-[calc(50%-50cqi)]`) makes the
  dashed rule reach both pane edges and centers the pill in the full pane. The
  reconnecting state gets the same treatment so the error→reconnecting
  transition stays consistent.
- The `hasError → w-full` escape hatch in `ChatPage` is kept (it's load-bearing:
  it keeps `MessageContent` filling the centered column so the breakout lands
  symmetrically) and its stale comment is updated.

## Test Plan

- `pnpm exec vitest run` on `StatusBlocks.test.tsx` + `BlockRenderer.test.tsx` —
  **112/112 pass**.
- `pre-commit` on the changed files: web prettier, oxlint, and TypeScript type
  check all pass.
- Manual geometry verification via a throwaway Vite preview + headless browser
  measuring exact `getBoundingClientRect` values, across viewport widths, for
  both render paths (turn-level failure and in-bubble error block):

  | width | dashed rule vs pane edges | pill centering in pane | horizontal scroll |
  |---|---|---|---|
  | 500px (mobile) | L=0, R=0 | 16 / 16 | none |
  | 1200px | L=0, R=0 | 296 / 296 | none |
  | 1600px | L=0, R=0 | 496 / 496 | none |

  (A ~4px asymmetry appears only in the narrow band where the TurnRail left-inset
  intentionally grows the gutter; it's cleanly clipped by the pane's
  `overflow-hidden`, so no horizontal scrollbar and no visible offset.)

To verify by hand: run the web app, trigger an error banner in the chat pane (a
turn-level send/stream failure, a harness "launch failed", or a `runner_error`
block). On a wide window confirm the dotted line runs edge-to-edge across the
pane and the red pill is centered; resize narrow / open the sidebar and confirm
it stays centered with no horizontal scrollbar.

## Demo

Text-column width = the width of a message bubble; pane = the full conversation area.

**Before** — pill centered in the text-column, dashes stop at the column edges:

```
pane |          - - - -( ! Something went wrong        X )- - - -          | pane
                 ^ dashes reach only the narrower text column; big empty gutters
```

**After** — pill centered in the pane, dashes reach the pane edges:

```
pane |- - - - - - - - -( ! Something went wrong        X )- - - - - - - - -| pane
      ^ dashed rule spans the full conversation pane, pill centered in the pane
```

<!-- Before/after screenshots captured locally (with debug outlines marking the
     pane in red and the text-column in blue) can be dragged in here. -->

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Purely a layout/CSS change (Tailwind class strings + a comment); the existing
`StatusBlocks`/`BlockRenderer` unit tests assert the banner's structure and
still pass. Geometry can't be asserted in jsdom, so it was verified manually by
measuring rendered pixel boxes across viewport widths (table above).

## Changelog

The chat error banner now spans the full conversation width and centers correctly.
