### PR TITLE
feat(web): give the mobile sidebar's floating chips one liquid-glass look

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -942,6 +942,49 @@ aside[aria-label="Workspace"][data-maximized] {
     transition-duration: 1ms;
   }
 }
+
+/* Liquid glass for the mobile sidebar's two floating chips (Search at the top
+ * of the header row, Settings over the bottom of the session list) — the iOS
+ * control idiom.
+ *
+ * The rim, the specular top edge, and the drop shadow do the work, not the
+ * blur: the surface behind these chips is the sidebar's own near-flat card, so
+ * blurring it alone would leave nothing to see. The blur earns its keep on the
+ * Settings chip, which floats over the scrolling session list and frosts the
+ * row titles passing under it.
+ *
+ * Scoped to `width < 48rem` so the class is inert on desktop, where the same
+ * two icons are flat ghost buttons in the header row. Both chips share it so
+ * they can't drift apart again.
+ *
+ * Backdrop sampling stops at the sidebar: the `.conversations-sidebar` carries
+ * a translate for its slide, which makes it a backdrop root, so the chips frost
+ * the drawer's own content rather than the chat behind it — which is what we
+ * want. If WebKit drops the filter (it does, once a Radix popper opens — see
+ * `max-md:bg-card-solid` on the sidebar), the fill and rim still read as a
+ * chip. */
+@media (width < 48rem) {
+  .sidebar-glass-chip {
+    /* -webkit- must come BEFORE the unprefixed property: LightningCSS (vite
+     * build) collapses the pair and keeps only the last declaration. */
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    backdrop-filter: blur(20px) saturate(180%);
+    background-color: rgba(255, 255, 255, 0.6);
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.8),
+      0 1px 2px rgba(0, 0, 0, 0.05),
+      0 6px 16px rgba(0, 0, 0, 0.07);
+  }
+
+  .dark .sidebar-glass-chip {
+    background-color: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.12),
+      0 2px 10px rgba(0, 0, 0, 0.45);
+  }
+}
 /* Share button — glassy pink effect (both modes). The vertical
  * gradient alone does the embossed work (lighter top = light catch,
  * darker bottom = shadow, simulating a convex surface lit from above);

--- a/web/src/shell/Sidebar.mobileDrawer.test.tsx
+++ b/web/src/shell/Sidebar.mobileDrawer.test.tsx
@@ -201,6 +201,39 @@ describe("mobile sidebar drawer", () => {
     );
   });
 
+  it("gives both floating chips one shared glass treatment", () => {
+    // These drifted apart once — Settings landed opaque with a heavier shadow
+    // than Search. The look now lives in a single CSS class, so assert both
+    // wear it and neither carries a competing background or shadow utility.
+    renderSidebar();
+
+    const search = screen.getByTestId("sidebar-search-button");
+    const settings = screen.getByTestId("sidebar-settings-float").closest("a, button")!;
+
+    // Where the chip sits, and which breakpoint it shows at, legitimately
+    // differ; everything about how it looks must not.
+    // `relative` is the Button base's own position, which tailwind-merge drops
+    // from the floating copy in favour of `absolute` — placement, not looks.
+    const PLACEMENT = new Set([
+      "absolute",
+      "relative",
+      "right-3",
+      "bottom-3",
+      "md:hidden",
+      "max-md:hidden",
+    ]);
+    const appearance = (el: Element) =>
+      el.className
+        .split(/\s+/)
+        .filter((c) => c && !PLACEMENT.has(c))
+        .sort()
+        .join(" ");
+
+    expect(search).toHaveClass("sidebar-glass-chip");
+    expect(settings).toHaveClass("sidebar-glass-chip");
+    expect(appearance(settings)).toBe(appearance(search));
+  });
+
   it("gives the session list a gutter so the last row clears the floating chip", () => {
     // The chip doesn't scroll, so without this the bottom row's always-visible
     // kebab sits underneath it and can't be tapped.

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1060,7 +1060,7 @@ export function Sidebar({
           drawer keeps once the collapse toggle is gone. */}
               <SidebarSettingsButton
                 testId="sidebar-settings-float"
-                className="absolute right-3 bottom-3 shadow-md max-md:bg-muted md:hidden"
+                className="absolute right-3 bottom-3 md:hidden"
               />
             </div>
 

--- a/web/src/shell/SidebarHeaderActions.tsx
+++ b/web/src/shell/SidebarHeaderActions.tsx
@@ -91,12 +91,15 @@ export function SidebarHeaderActions({
 }
 
 /**
- * Mobile treatment shared by the two floating icon buttons: a round chip that
- * reads as lifted off the session list, sized for a thumb. On desktop these
- * stay flat 24px ghost icons in the header row.
+ * Mobile treatment shared by the two floating icon buttons: a thumb-sized round
+ * chip in iOS liquid glass. The look lives in one CSS class
+ * (`.sidebar-glass-chip` in index.css) that both chips wear, so Search and
+ * Settings can't drift apart — they had, one landing opaque with a heavier
+ * shadow than the other. On desktop the class is inert (it is scoped to the
+ * mobile breakpoint) and these stay flat 24px ghost icons in the header row.
  */
 const SIDEBAR_FLOAT_BUTTON =
-  "size-6 text-muted-foreground hover:text-foreground max-md:size-9 max-md:rounded-full max-md:bg-muted/70 max-md:text-foreground";
+  "sidebar-glass-chip size-6 text-muted-foreground hover:text-foreground max-md:size-9 max-md:rounded-full max-md:text-foreground";
 
 const SIDEBAR_FLOAT_ICON = "ui-icon max-md:size-[18px]";
 


### PR DESCRIPTION
## Related issue

No tracking issue — follow-up to #5427, raised in review.

## Summary

The mobile drawer's two floating chips are the same control in two places, but
they had drifted apart in #5427:

| | before |
|---|---|
| Search | `max-md:bg-muted/70` |
| Settings | `max-md:bg-muted` + `shadow-md` |

So Search was a 70%-alpha wash and Settings an opaque one with a medium shadow
under it — enough to read as unrelated controls. Neither difference was earning
anything: the opaque fill existed to stop row titles showing through the chip
that floats over the session list, and any plain fill already does that.

Both now wear one iOS-style liquid glass treatment, defined once as
`.sidebar-glass-chip` in `index.css` so they can't come apart again:

- frosted `backdrop-filter: blur(20px) saturate(180%)`
- a translucent fill, a hairline rim, a specular top edge, and a soft drop shadow

**The rim, specular edge and shadow carry the look, not the blur.** The surface
behind these chips is the sidebar's own near-flat card, so blurring it alone
would leave nothing to see. The blur earns its keep on the Settings chip, which
floats over the scrolling session list and frosts the row titles passing under
it. Backdrop sampling stops at the drawer — `.conversations-sidebar` carries a
translate for its slide, making it a backdrop root — so the chips frost the
drawer's own content rather than the chat behind it, which is what we want.

Scoped to `width < 48rem`, so **desktop is untouched**: the class is inert above
the breakpoint and both icons stay the flat 24px ghost buttons they are today.

## Test Plan

Automated, from `web/`:

- `npx vitest run src/shell/Sidebar src/index.css.test.ts src/shell/settingsNav.test.tsx src/shell/AppShell.test.tsx` — 454 passed.
- `index.css.test.ts` picks the new rule up **for free**: its existing sweep over every `backdrop-filter` rule confirms the `-webkit-` form is declared first and survives LightningCSS minification, which is the prod-only "transparent glass" bug that test exists to catch. Verified the new rule appears in its cases (`… minification: .sidebar-glass-chip {` ✓).
- New unit guard: both chips carry `.sidebar-glass-chip` **and** their class lists are identical once placement classes are excluded — the assertion that would have caught the original drift.
- `npx tsc -b`, `npx oxlint --deny-warnings src/shell/`, `pre-commit run --files <changed>` — clean.

Manual (not yet run):

1. On a phone (or a <768px viewport), open the sidebar.
2. Search (top-right) and Settings (bottom-right) should read as the *same*
   chip — same fill, same rim, same shadow.
3. Scroll the session list under the Settings chip: row titles should frost as
   they pass beneath it, not show through sharply.
4. Check both light and dark mode.
5. Widen past 768px: both icons should be flat ghost icons in the header row,
   no chip, no shadow.

## Demo

⚠️ Screen recording still to be attached — this is a purely visual change on a
device I don't have here, so it genuinely needs eyes on it before merge.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Being explicit, because this is the kind of change tests are worst at: the unit
guard pins that the two chips share one class and one appearance, and the CSS
test pins that the blur survives the build. **Neither says the result looks
good.** jsdom applies no stylesheet, so nothing here renders the glass. Whether
the fill and rim values are right on a real screen — in both themes, over the
white card at the top and over scrolling text at the bottom — is unverified and
needs the manual pass above.

## Changelog

The mobile sidebar's Search and Settings buttons now share one iOS-style liquid-glass treatment
