### PR TITLE
fix(ui-preview): use `omnigent host --server` for the connect hint

### DIFF
--- a/.github/ui-preview/README.md
+++ b/.github/ui-preview/README.md
@@ -23,7 +23,7 @@ on teardown.
 
 There is **no LLM or runner baked into the preview** -- Omnigent runs agent
 turns on a runner the user connects from their own machine or sandbox
-(`omnigent run … --server <preview-url>`), where the model credentials live. So
+(`omnigent host --server <preview-url>`), where the model credentials live. So
 the preview is for reviewing the UI's look-and-feel and navigation; to drive a
 real session, connect your own host to the preview URL.
 

--- a/.github/ui-preview/app.py
+++ b/.github/ui-preview/app.py
@@ -6,7 +6,7 @@ and self-contained* so a fresh app can be created and torn down per PR with no
 external state: a SQLite database + local-disk artifact store under a temp dir.
 
 There is no bundled LLM or runner. Omnigent executes agent turns on a runner
-that the user connects from their own machine/sandbox (``omnigent run … --server
+that the user connects from their own machine/sandbox (``omnigent host --server
 <url>``), so the preview only needs to serve the web UI + API. A reviewer browses
 the UI as-is, and can connect their own host to drive a real session.
 

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -340,9 +340,14 @@ jobs:
           | **Commit** | $COMMIT_SHA |
           | **Run** | ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} |
 
+          The preview serves the UI only. To drive a real session, connect your own host from your machine or sandbox:
+
+          \`\`\`sh
+          omnigent host --server ${APP_URL}
+          \`\`\`
+
           > [!NOTE]
           > This preview is only accessible to maintainers with workspace access.
-          > It serves the UI only -- connect your own host (\`omnigent run … --server <url>\`) to drive a real session.
           > The preview updates automatically when new commits are pushed."
 
           COMMENT_ID=$(gh api --paginate \


### PR DESCRIPTION
## Related issue

N/A — CI/docs copy fix, no issue required (Test / CI).

## Summary

- The UI-preview connect hint told reviewers to run `omnigent run … --server <url>`, but `run` executes an agent turn. Registering your own host against the preview server is `omnigent host --server <url>` (see `omnigent/cli.py` `host` command: "Register this machine as a host with a server").
- Fixed the hint in three places: the PR comment posted by the `deploy` job in `.github/workflows/ui-preview.yml`, the `.github/ui-preview/README.md`, and the `.github/ui-preview/app.py` docstring.
- The PR comment now surfaces the command as a copy-pasteable fenced block with the real preview URL (`${APP_URL}`) substituted in, instead of a `<url>` placeholder buried in the note.

## Test Plan

- `pre-commit` runs clean on the changed files (ruff format/check, YAML, model-id guard).
- No functional code changed; the workflow comment renders on the next `ui-preview`-labelled PR. To verify end-to-end: push a `web/` change to a PR, add the `ui-preview` label, and confirm the `deploy` job's *Comment on PR* step posts a comment whose fenced block reads `omnigent host --server https://…` with the app URL filled in.

## Demo

N/A — the change is CI workflow / docs copy; no app UI is affected.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified locally that `pre-commit run` passes on the three changed files. The corrected command was confirmed against `omnigent/cli.py`, where the `host` group is documented as "Register this machine as a host with a server" and accepts `--server <url>`. There is no automated test for the workflow's posted comment text; correctness is confirmed by reading the CLI definition.
