### PR TITLE
fix(claude-native): stop re-uploading finished sub-agent transcripts on resume

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -44,7 +44,7 @@ import threading
 import time
 import urllib.parse
 from collections.abc import Awaitable, Callable, Mapping
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -433,6 +433,14 @@ class ClaudeTranscriptItem:
         :func:`omnigent.claude_native_forwarder._forward_available_items`)
         instead of rendering the summary as a user bubble. Defaults to
         ``False`` for every ordinary transcript item.
+    :param record_byte_offset: Byte offset immediately after the JSONL
+        record this item was parsed from, e.g. ``4096`` — the cursor
+        position that has fully consumed the item's record. Populated only
+        by :func:`read_transcript_items_from_offset`; the sub-agent
+        forwarder advances its durable cursor to this value once every item
+        sharing the record has been posted, so a cut-short drain resumes at
+        a record boundary rather than re-reading from the start. Defaults to
+        ``0`` for items produced by other readers.
     """
 
     source_id: str
@@ -440,6 +448,7 @@ class ClaudeTranscriptItem:
     data: _JsonObject
     response_id: str
     is_compact_summary: bool = False
+    record_byte_offset: int = 0
 
 
 @dataclass(frozen=True)
@@ -2444,6 +2453,10 @@ def read_transcript_items_from_offset(
             settled_response_id=active_settled_id,
             include_sidechains=include_sidechains,
         )
+        # Tag each item with the byte offset immediately after its source
+        # record, so a consumer can advance a durable cursor one record at a
+        # time (the sub-agent forwarder commits progress per record).
+        parsed = [replace(item, record_byte_offset=record.next_byte_offset) for item in parsed]
         items.extend(parsed)
         # Post-compaction output continues the SAME turn: a batch holding
         # the compact summary AND the resumed output must not parse the

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -786,20 +786,6 @@ async def forward_claude_transcript_to_session(
     state = _read_forward_state(bridge_dir)
     hook_state: HookForwardState | None = None
     subagent_state = _read_subagent_forward_state(bridge_dir)
-    # Cold-start boundary for _forward_available_subagents: a sub-agent whose
-    # metadata predates this launch is historical and, on a resume, is skipped
-    # rather than re-mirrored from offset 0.
-    subagent_cold_start_ts = time.time()
-    # Sub-agents already tracked from a prior run (loaded from disk above): on a
-    # resume their pre-existing transcript is skipped to EOF once — their child
-    # conversations already hold it, and a prior run's stall-cancelled drain can
-    # leave their byte_offset at 0, which would otherwise re-upload the whole
-    # transcript. This is the parent's start_at_end, applied to sub-agents.
-    # Mutated (drained) as each is skipped; genuinely-new sub-agents spawned
-    # this run are never in this set, so they still upload from offset 0.
-    subagent_cold_start_eof_pending: set[str] = (
-        set(subagent_state.subagents) if start_at_end else set()
-    )
     # Live assistant-text streaming. The delta cursor is independent of
     # the transcript/subagent cursors and survives /clear and /fork
     # (the deltas file belongs to the long-lived Claude process). The
@@ -1000,7 +986,7 @@ async def forward_claude_transcript_to_session(
                             # (the user-message reset only fires on the next turn).
                             response_id=state.current_response_id,
                         )
-                        # Re-seed from disk (written per item): a poll the
+                        # Re-seed from disk (written per record): a poll the
                         # stall deadline cancels never returns its advanced
                         # state, so re-read to resume instead of re-uploading.
                         subagent_state = await asyncio.to_thread(
@@ -1016,9 +1002,6 @@ async def forward_claude_transcript_to_session(
                             start_retry_tracker=subagent_start_retries,
                             item_retry_tracker=subagent_item_retries,
                             status_retry_tracker=subagent_status_retries,
-                            start_at_end=start_at_end,
-                            cold_start_ts=subagent_cold_start_ts,
-                            cold_start_eof_pending=subagent_cold_start_eof_pending,
                         )
                         # Reconcile + POST cumulative cost AFTER sub-agents are
                         # forwarded so the estimate sees this poll's sub-agent
@@ -1333,9 +1316,6 @@ async def _forward_available_subagents(
     start_retry_tracker: _PostRetryTracker,
     item_retry_tracker: _PostRetryTracker,
     status_retry_tracker: _PostRetryTracker,
-    start_at_end: bool = False,
-    cold_start_ts: float = 0.0,
-    cold_start_eof_pending: set[str] | None = None,
 ) -> SubagentForwardState:
     """
     Discover new Claude Task-tool sub-agents on disk, mint Omnigent child
@@ -1347,7 +1327,11 @@ async def _forward_available_subagents(
     offset for every sub-agent already seen. Sub-agents whose
     ``.meta.json`` appears for the first time are registered with AP
     via ``external_subagent_start``; sub-agents already in ``state``
-    just have their ``.jsonl`` tailed forward.
+    just have their ``.jsonl`` tailed forward. The tail cursor advances
+    one record at a time (see ``record_byte_offset``), so a drain the
+    stall deadline cancels resumes at the last fully-posted record on the
+    next poll instead of re-reading — and a sub-agent already forwarded
+    by a prior run resumes at its persisted end offset, not offset 0.
 
     :param client: Omnigent HTTP client.
     :param parent_session_id: Parent (claude-native) conversation id.
@@ -1364,18 +1348,6 @@ async def _forward_available_subagents(
     :param status_retry_tracker: Backoff tracker for failed
         ``external_session_status`` POSTs (keyed by
         ``status:<child_id>``).
-    :param start_at_end: When ``True`` (resume/reattach), a sub-agent
-        newly discovered on disk whose metadata predates ``cold_start_ts``
-        is skipped rather than registered + mirrored from offset 0 — it was
-        already forwarded by the prior run.
-    :param cold_start_ts: Unix time of this forwarder launch; the boundary
-        for the ``start_at_end`` skip above.
-    :param cold_start_eof_pending: Ids of sub-agents already tracked in
-        ``state`` at forwarder launch. On the first tail pass that reaches
-        one (``start_at_end`` only), its cursor is jumped to end-of-file and
-        the id removed from the set — skipping pre-existing history whose
-        prior-run drain may have been stall-cancelled at offset 0, then
-        tailing new appends normally. ``None`` disables the jump.
     :returns: Updated state with new sub-agents registered and
         existing sub-agents' cursors advanced.
     """
@@ -1393,16 +1365,6 @@ async def _forward_available_subagents(
         subagent_id = meta_path.stem.removeprefix("agent-").removesuffix(".meta")
         if subagent_id in updated.subagents:
             continue
-        # Cold-start skip (resume/reattach): a sub-agent whose metadata
-        # predates this launch was already forwarded last run; re-uploading it
-        # re-broadcasts items Omnigent has, like start_at_end for the parent.
-        if start_at_end:
-            try:
-                meta_mtime: float | None = meta_path.stat().st_mtime
-            except OSError:
-                meta_mtime = None
-            if meta_mtime is not None and meta_mtime <= cold_start_ts:
-                continue
         retry_key = f"subagent_start:{subagent_id}"
         if start_retry_tracker.retry_delay_s(retry_key) is not None:
             continue
@@ -1498,32 +1460,6 @@ async def _forward_available_subagents(
         jsonl_path = subagents_dir / f"agent-{subagent_id}.jsonl"
         if not jsonl_path.exists():
             continue
-        # Cold-start EOF skip (resume): a sub-agent carried over from a prior
-        # run has its pre-existing history skipped to end-of-file once, then
-        # tails new appends normally. Without this, a prior run whose drain the
-        # stall deadline cancelled leaves byte_offset at 0, so every accumulated
-        # sub-agent re-uploads its whole transcript on resume. Mirrors the
-        # parent's start_at_end. Done before the read so this pass posts nothing.
-        if cold_start_eof_pending is not None and subagent_id in cold_start_eof_pending:
-            cold_start_eof_pending.discard(subagent_id)
-            try:
-                eof_offset = jsonl_path.stat().st_size
-            except OSError:
-                eof_offset = entry.byte_offset
-            if eof_offset > entry.byte_offset:
-                new_entry = SubagentEntry(
-                    subagent_id=entry.subagent_id,
-                    child_conversation_id=entry.child_conversation_id,
-                    byte_offset=eof_offset,
-                    seen_source_ids=entry.seen_source_ids,
-                    last_activity_ts=entry.last_activity_ts,
-                    last_status=entry.last_status,
-                )
-                updated = SubagentForwardState(
-                    subagents={**updated.subagents, subagent_id: new_entry}
-                )
-                await _write_subagent_forward_state_async(bridge_dir, updated)
-            continue
         # Reuse the parent-transcript parser, but pass
         # ``include_sidechains=True`` — every record in a sub-agent's
         # own ``agent-<id>.jsonl`` carries ``isSidechain: true``
@@ -1545,7 +1481,36 @@ async def _forward_available_subagents(
         items_failed = False
         seen_source_ids = list(entry.seen_source_ids)
         seen = set(seen_source_ids)
+        # Durable cursor advances one record at a time: ``committed_offset`` is
+        # the end offset of the last record whose items all posted (or were
+        # skipped), so a drain cut short by the stall deadline or a transient
+        # failure resumes at a record boundary rather than re-reading from the
+        # start. One record can expand to several items, so a record is only
+        # committed once we cross into the next one.
+        committed_offset = entry.byte_offset
+        current_record_offset: int | None = None
         for item in result.items:
+            # Crossing into a new record means every item of the previous one
+            # was handled without breaking — persist its end offset so the
+            # progress survives a later cancel/failure at this boundary.
+            if (
+                current_record_offset is not None
+                and item.record_byte_offset != current_record_offset
+            ):
+                committed_offset = current_record_offset
+                new_entry = SubagentEntry(
+                    subagent_id=entry.subagent_id,
+                    child_conversation_id=entry.child_conversation_id,
+                    byte_offset=committed_offset,
+                    seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
+                    last_activity_ts=now if had_item else entry.last_activity_ts,
+                    last_status=new_entry.last_status,
+                )
+                updated = SubagentForwardState(
+                    subagents={**updated.subagents, subagent_id: new_entry}
+                )
+                await _write_subagent_forward_state_async(bridge_dir, updated)
+            current_record_offset = item.record_byte_offset
             if item.source_id in seen:
                 continue
             retry_key = f"subagent_item:{entry.child_conversation_id}:{item.source_id}"
@@ -1598,7 +1563,7 @@ async def _forward_available_subagents(
                     new_entry = SubagentEntry(
                         subagent_id=entry.subagent_id,
                         child_conversation_id=entry.child_conversation_id,
-                        byte_offset=entry.byte_offset,
+                        byte_offset=committed_offset,
                         seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                         last_activity_ts=new_entry.last_activity_ts,
                         last_status=new_entry.last_status,
@@ -1627,7 +1592,7 @@ async def _forward_available_subagents(
                     new_entry = SubagentEntry(
                         subagent_id=entry.subagent_id,
                         child_conversation_id=entry.child_conversation_id,
-                        byte_offset=entry.byte_offset,
+                        byte_offset=committed_offset,
                         seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                         last_activity_ts=new_entry.last_activity_ts,
                         last_status=new_entry.last_status,
@@ -1663,37 +1628,27 @@ async def _forward_available_subagents(
             new_entry = SubagentEntry(
                 subagent_id=entry.subagent_id,
                 child_conversation_id=entry.child_conversation_id,
-                byte_offset=entry.byte_offset,
+                byte_offset=committed_offset,
                 seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                 last_activity_ts=now,
                 last_status=new_entry.last_status,
             )
             updated = SubagentForwardState(subagents={**updated.subagents, subagent_id: new_entry})
             await _write_subagent_forward_state_async(bridge_dir, updated)
-        # Only advance the cursor when every item this tick was
-        # posted successfully (or there were no items at all).
-        # Advancing past a failed item permanently skips it.
-        if not items_failed and (result.byte_offset != entry.byte_offset or had_item):
+        # A clean pass (no transient failure) consumed every record the reader
+        # returned, so advance to its end offset — this also covers trailing
+        # records that produced no items. A cut-short pass leaves ``new_entry``
+        # at ``committed_offset`` (the last fully-posted record) from the loop
+        # above, so the next poll resumes there and re-reads only the failed
+        # record; advancing past a failed item would permanently skip it.
+        if not items_failed and (result.byte_offset != new_entry.byte_offset or had_item):
             new_entry = SubagentEntry(
                 subagent_id=entry.subagent_id,
                 child_conversation_id=entry.child_conversation_id,
                 byte_offset=result.byte_offset,
                 seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                 last_activity_ts=now if had_item else entry.last_activity_ts,
-                last_status=entry.last_status,
-            )
-        elif had_item:
-            # Items DID flow but a later post failed — still record
-            # the activity timestamp so the status badge advances,
-            # but leave byte_offset at the previous tick's value so
-            # the failed items get retried.
-            new_entry = SubagentEntry(
-                subagent_id=entry.subagent_id,
-                child_conversation_id=entry.child_conversation_id,
-                byte_offset=entry.byte_offset,
-                seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
-                last_activity_ts=now,
-                last_status=entry.last_status,
+                last_status=new_entry.last_status,
             )
 
         # Quiescence-based status. Sub-agent transcripts don't carry

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -790,6 +790,16 @@ async def forward_claude_transcript_to_session(
     # metadata predates this launch is historical and, on a resume, is skipped
     # rather than re-mirrored from offset 0.
     subagent_cold_start_ts = time.time()
+    # Sub-agents already tracked from a prior run (loaded from disk above): on a
+    # resume their pre-existing transcript is skipped to EOF once — their child
+    # conversations already hold it, and a prior run's stall-cancelled drain can
+    # leave their byte_offset at 0, which would otherwise re-upload the whole
+    # transcript. This is the parent's start_at_end, applied to sub-agents.
+    # Mutated (drained) as each is skipped; genuinely-new sub-agents spawned
+    # this run are never in this set, so they still upload from offset 0.
+    subagent_cold_start_eof_pending: set[str] = (
+        set(subagent_state.subagents) if start_at_end else set()
+    )
     # Live assistant-text streaming. The delta cursor is independent of
     # the transcript/subagent cursors and survives /clear and /fork
     # (the deltas file belongs to the long-lived Claude process). The
@@ -1008,6 +1018,7 @@ async def forward_claude_transcript_to_session(
                             status_retry_tracker=subagent_status_retries,
                             start_at_end=start_at_end,
                             cold_start_ts=subagent_cold_start_ts,
+                            cold_start_eof_pending=subagent_cold_start_eof_pending,
                         )
                         # Reconcile + POST cumulative cost AFTER sub-agents are
                         # forwarded so the estimate sees this poll's sub-agent
@@ -1324,6 +1335,7 @@ async def _forward_available_subagents(
     status_retry_tracker: _PostRetryTracker,
     start_at_end: bool = False,
     cold_start_ts: float = 0.0,
+    cold_start_eof_pending: set[str] | None = None,
 ) -> SubagentForwardState:
     """
     Discover new Claude Task-tool sub-agents on disk, mint Omnigent child
@@ -1352,11 +1364,18 @@ async def _forward_available_subagents(
     :param status_retry_tracker: Backoff tracker for failed
         ``external_session_status`` POSTs (keyed by
         ``status:<child_id>``).
-    :param start_at_end: When ``True`` (resume/reattach), sub-agents whose
-        metadata predates ``cold_start_ts`` are skipped rather than mirrored
-        from offset 0 — they were already forwarded by the prior run.
+    :param start_at_end: When ``True`` (resume/reattach), a sub-agent
+        newly discovered on disk whose metadata predates ``cold_start_ts``
+        is skipped rather than registered + mirrored from offset 0 — it was
+        already forwarded by the prior run.
     :param cold_start_ts: Unix time of this forwarder launch; the boundary
         for the ``start_at_end`` skip above.
+    :param cold_start_eof_pending: Ids of sub-agents already tracked in
+        ``state`` at forwarder launch. On the first tail pass that reaches
+        one (``start_at_end`` only), its cursor is jumped to end-of-file and
+        the id removed from the set — skipping pre-existing history whose
+        prior-run drain may have been stall-cancelled at offset 0, then
+        tailing new appends normally. ``None`` disables the jump.
     :returns: Updated state with new sub-agents registered and
         existing sub-agents' cursors advanced.
     """
@@ -1478,6 +1497,32 @@ async def _forward_available_subagents(
             continue
         jsonl_path = subagents_dir / f"agent-{subagent_id}.jsonl"
         if not jsonl_path.exists():
+            continue
+        # Cold-start EOF skip (resume): a sub-agent carried over from a prior
+        # run has its pre-existing history skipped to end-of-file once, then
+        # tails new appends normally. Without this, a prior run whose drain the
+        # stall deadline cancelled leaves byte_offset at 0, so every accumulated
+        # sub-agent re-uploads its whole transcript on resume. Mirrors the
+        # parent's start_at_end. Done before the read so this pass posts nothing.
+        if cold_start_eof_pending is not None and subagent_id in cold_start_eof_pending:
+            cold_start_eof_pending.discard(subagent_id)
+            try:
+                eof_offset = jsonl_path.stat().st_size
+            except OSError:
+                eof_offset = entry.byte_offset
+            if eof_offset > entry.byte_offset:
+                new_entry = SubagentEntry(
+                    subagent_id=entry.subagent_id,
+                    child_conversation_id=entry.child_conversation_id,
+                    byte_offset=eof_offset,
+                    seen_source_ids=entry.seen_source_ids,
+                    last_activity_ts=entry.last_activity_ts,
+                    last_status=entry.last_status,
+                )
+                updated = SubagentForwardState(
+                    subagents={**updated.subagents, subagent_id: new_entry}
+                )
+                await _write_subagent_forward_state_async(bridge_dir, updated)
             continue
         # Reuse the parent-transcript parser, but pass
         # ``include_sidechains=True`` — every record in a sub-agent's

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -786,6 +786,10 @@ async def forward_claude_transcript_to_session(
     state = _read_forward_state(bridge_dir)
     hook_state: HookForwardState | None = None
     subagent_state = _read_subagent_forward_state(bridge_dir)
+    # Cold-start boundary for _forward_available_subagents: a sub-agent whose
+    # metadata predates this launch is historical and, on a resume, is skipped
+    # rather than re-mirrored from offset 0.
+    subagent_cold_start_ts = time.time()
     # Live assistant-text streaming. The delta cursor is independent of
     # the transcript/subagent cursors and survives /clear and /fork
     # (the deltas file belongs to the long-lived Claude process). The
@@ -986,6 +990,12 @@ async def forward_claude_transcript_to_session(
                             # (the user-message reset only fires on the next turn).
                             response_id=state.current_response_id,
                         )
+                        # Re-seed from disk (written per item): a poll the
+                        # stall deadline cancels never returns its advanced
+                        # state, so re-read to resume instead of re-uploading.
+                        subagent_state = await asyncio.to_thread(
+                            _read_subagent_forward_state, bridge_dir
+                        )
                         subagent_state = await _forward_available_subagents(
                             client=client,
                             parent_session_id=current_session_id,
@@ -996,6 +1006,8 @@ async def forward_claude_transcript_to_session(
                             start_retry_tracker=subagent_start_retries,
                             item_retry_tracker=subagent_item_retries,
                             status_retry_tracker=subagent_status_retries,
+                            start_at_end=start_at_end,
+                            cold_start_ts=subagent_cold_start_ts,
                         )
                         # Reconcile + POST cumulative cost AFTER sub-agents are
                         # forwarded so the estimate sees this poll's sub-agent
@@ -1310,6 +1322,8 @@ async def _forward_available_subagents(
     start_retry_tracker: _PostRetryTracker,
     item_retry_tracker: _PostRetryTracker,
     status_retry_tracker: _PostRetryTracker,
+    start_at_end: bool = False,
+    cold_start_ts: float = 0.0,
 ) -> SubagentForwardState:
     """
     Discover new Claude Task-tool sub-agents on disk, mint Omnigent child
@@ -1338,6 +1352,11 @@ async def _forward_available_subagents(
     :param status_retry_tracker: Backoff tracker for failed
         ``external_session_status`` POSTs (keyed by
         ``status:<child_id>``).
+    :param start_at_end: When ``True`` (resume/reattach), sub-agents whose
+        metadata predates ``cold_start_ts`` are skipped rather than mirrored
+        from offset 0 — they were already forwarded by the prior run.
+    :param cold_start_ts: Unix time of this forwarder launch; the boundary
+        for the ``start_at_end`` skip above.
     :returns: Updated state with new sub-agents registered and
         existing sub-agents' cursors advanced.
     """
@@ -1355,6 +1374,16 @@ async def _forward_available_subagents(
         subagent_id = meta_path.stem.removeprefix("agent-").removesuffix(".meta")
         if subagent_id in updated.subagents:
             continue
+        # Cold-start skip (resume/reattach): a sub-agent whose metadata
+        # predates this launch was already forwarded last run; re-uploading it
+        # re-broadcasts items Omnigent has, like start_at_end for the parent.
+        if start_at_end:
+            try:
+                meta_mtime: float | None = meta_path.stat().st_mtime
+            except OSError:
+                meta_mtime = None
+            if meta_mtime is not None and meta_mtime <= cold_start_ts:
+                continue
         retry_key = f"subagent_start:{subagent_id}"
         if start_retry_tracker.retry_delay_s(retry_key) is not None:
             continue

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5171,6 +5171,127 @@ async def test_subagent_watcher_forwards_transcript_items_to_child_session(
         server.server_close()
 
 
+async def test_subagent_watcher_eof_skips_preexisting_history_on_resume(
+    tmp_path: Path,
+) -> None:
+    """
+    On a resume, a sub-agent already tracked in state at ``byte_offset=0``
+    has its pre-existing transcript skipped to EOF instead of re-uploaded.
+
+    This is the resume re-upload bug: a prior run whose drain the stall
+    deadline cancelled leaves the cursor at 0, so every accumulated
+    sub-agent would otherwise re-post its whole transcript. The first tail
+    pass (id in ``cold_start_eof_pending``) must post nothing and jump the
+    cursor to end-of-file; a later append then forwards normally.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    subagent_jsonl = _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="old1",
+        agent_type="Explore",
+        description="finished last run",
+        tool_use_id="toolu_old",
+        transcript_records=[
+            {
+                "isSidechain": True,
+                "type": "user",
+                "uuid": "sa-user-old",
+                "message": {"role": "user", "content": "go"},
+            },
+            {
+                "isSidechain": True,
+                "type": "assistant",
+                "uuid": "sa-assistant-old",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "done"}],
+                },
+            },
+        ],
+    )
+    # Tracked from a prior run, cursor stuck at 0 (drain never completed).
+    state = forwarder.SubagentForwardState(
+        subagents={
+            "old1": forwarder.SubagentEntry(
+                subagent_id="old1",
+                child_conversation_id="conv_child_old",
+            )
+        }
+    )
+    posted_items: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """
+        Record any conversation-item posts; accept everything.
+
+        :param request: Request issued by the forwarder.
+        :returns: Canned Omnigent response.
+        """
+        body = json.loads(request.content.decode("utf-8"))
+        if body.get("type") == "external_conversation_item":
+            posted_items.append(body["data"]["item_data"]["content"][0]["text"])
+        return httpx.Response(202, json={})
+
+    pending = {"old1"}
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        first = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=state,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            start_at_end=True,
+            cold_start_eof_pending=pending,
+        )
+        # Nothing re-uploaded; cursor jumped to EOF; id drained from pending.
+        assert posted_items == []
+        assert first.subagents["old1"].byte_offset == subagent_jsonl.stat().st_size
+        assert pending == set()
+
+        # A new append after the resume tails normally (not skipped again).
+        with subagent_jsonl.open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(
+                    {
+                        "isSidechain": True,
+                        "type": "assistant",
+                        "uuid": "sa-assistant-new",
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "after resume"}],
+                        },
+                    }
+                )
+                + "\n"
+            )
+        second = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=first,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            start_at_end=True,
+            cold_start_eof_pending=pending,
+        )
+
+    assert posted_items == ["after resume"]
+    assert second.subagents["old1"].byte_offset == subagent_jsonl.stat().st_size
+
+
 async def test_subagent_watcher_retry_skips_previously_posted_items(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5171,18 +5171,18 @@ async def test_subagent_watcher_forwards_transcript_items_to_child_session(
         server.server_close()
 
 
-async def test_subagent_watcher_eof_skips_preexisting_history_on_resume(
+async def test_subagent_watcher_advances_cursor_per_record_on_partial_drain(
     tmp_path: Path,
 ) -> None:
     """
-    On a resume, a sub-agent already tracked in state at ``byte_offset=0``
-    has its pre-existing transcript skipped to EOF instead of re-uploaded.
+    A drain cut short by a failed post commits the cursor to the last
+    fully-posted record, so the retry resumes there instead of re-reading
+    (and re-posting) the whole transcript from offset 0.
 
-    This is the resume re-upload bug: a prior run whose drain the stall
-    deadline cancelled leaves the cursor at 0, so every accumulated
-    sub-agent would otherwise re-post its whole transcript. The first tail
-    pass (id in ``cold_start_eof_pending``) must post nothing and jump the
-    cursor to end-of-file; a later append then forwards normally.
+    Three records; the third's post fails transiently once. The first pass
+    must leave ``byte_offset`` at the boundary after the second record — not
+    at 0 (the old behaviour) and not at EOF — and the retry must post only
+    the third record.
     """
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
@@ -5190,52 +5190,67 @@ async def test_subagent_watcher_eof_skips_preexisting_history_on_resume(
     transcript_path.write_text("", encoding="utf-8")
     subagent_jsonl = _seed_subagent_on_disk(
         transcript_path=transcript_path,
-        subagent_id="old1",
+        subagent_id="rec1",
         agent_type="Explore",
-        description="finished last run",
-        tool_use_id="toolu_old",
+        description="per-record cursor",
+        tool_use_id="toolu_rec",
         transcript_records=[
             {
                 "isSidechain": True,
                 "type": "user",
-                "uuid": "sa-user-old",
+                "uuid": "sa-user",
                 "message": {"role": "user", "content": "go"},
             },
             {
                 "isSidechain": True,
                 "type": "assistant",
-                "uuid": "sa-assistant-old",
-                "message": {
-                    "role": "assistant",
-                    "content": [{"type": "text", "text": "done"}],
-                },
+                "uuid": "sa-one",
+                "message": {"role": "assistant", "content": [{"type": "text", "text": "one"}]},
+            },
+            {
+                "isSidechain": True,
+                "type": "assistant",
+                "uuid": "sa-two",
+                "message": {"role": "assistant", "content": [{"type": "text", "text": "two"}]},
             },
         ],
     )
-    # Tracked from a prior run, cursor stuck at 0 (drain never completed).
+    # Byte offset immediately after the second record — the boundary the
+    # cut-short drain must commit to. Robust to serialization: the position
+    # right after the second newline.
+    data = subagent_jsonl.read_bytes()
+    newlines = [i for i, byte in enumerate(data) if byte == 0x0A]
+    boundary_after_second = newlines[1] + 1
+
     state = forwarder.SubagentForwardState(
         subagents={
-            "old1": forwarder.SubagentEntry(
-                subagent_id="old1",
-                child_conversation_id="conv_child_old",
+            "rec1": forwarder.SubagentEntry(
+                subagent_id="rec1",
+                child_conversation_id="conv_child_rec",
             )
         }
     )
     posted_items: list[str] = []
+    fail_two_once = {"count": 0}
 
     def handler(request: httpx.Request) -> httpx.Response:
         """
-        Record any conversation-item posts; accept everything.
+        Fail the third record's item once; accept everything else.
 
         :param request: Request issued by the forwarder.
         :returns: Canned Omnigent response.
         """
         body = json.loads(request.content.decode("utf-8"))
-        if body.get("type") == "external_conversation_item":
-            posted_items.append(body["data"]["item_data"]["content"][0]["text"])
+        if body.get("type") != "external_conversation_item":
+            return httpx.Response(202, json={})
+        text = body["data"]["item_data"]["content"][0]["text"]
+        posted_items.append(text)
+        if text == "two" and fail_two_once["count"] == 0:
+            fail_two_once["count"] += 1
+            return httpx.Response(503, json={"error": "try again"})
         return httpx.Response(202, json={})
 
-    pending = {"old1"}
+    item_retry_tracker = forwarder._PostRetryTracker(base_delay_s=0.0)
     async with httpx.AsyncClient(
         transport=httpx.MockTransport(handler),
         base_url="http://ap",
@@ -5248,32 +5263,15 @@ async def test_subagent_watcher_eof_skips_preexisting_history_on_resume(
             state=state,
             agent_name="claude-native-ui",
             start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
-            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=item_retry_tracker,
             status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
-            start_at_end=True,
-            cold_start_eof_pending=pending,
         )
-        # Nothing re-uploaded; cursor jumped to EOF; id drained from pending.
-        assert posted_items == []
-        assert first.subagents["old1"].byte_offset == subagent_jsonl.stat().st_size
-        assert pending == set()
+        # First two records posted; the third failed. The cursor sits at the
+        # boundary after the second record — durable progress, not 0, not EOF.
+        assert posted_items == ["go", "one", "two"]
+        assert first.subagents["rec1"].byte_offset == boundary_after_second
+        assert 0 < boundary_after_second < subagent_jsonl.stat().st_size
 
-        # A new append after the resume tails normally (not skipped again).
-        with subagent_jsonl.open("a", encoding="utf-8") as handle:
-            handle.write(
-                json.dumps(
-                    {
-                        "isSidechain": True,
-                        "type": "assistant",
-                        "uuid": "sa-assistant-new",
-                        "message": {
-                            "role": "assistant",
-                            "content": [{"type": "text", "text": "after resume"}],
-                        },
-                    }
-                )
-                + "\n"
-            )
         second = await forwarder._forward_available_subagents(
             client=client,
             parent_session_id="conv_parent",
@@ -5282,14 +5280,19 @@ async def test_subagent_watcher_eof_skips_preexisting_history_on_resume(
             state=first,
             agent_name="claude-native-ui",
             start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
-            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=item_retry_tracker,
             status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
-            start_at_end=True,
-            cold_start_eof_pending=pending,
         )
 
-    assert posted_items == ["after resume"]
-    assert second.subagents["old1"].byte_offset == subagent_jsonl.stat().st_size
+    # The retry resumed at the boundary and re-posted only the third record
+    # ("go"/"one" were not re-read), then advanced to EOF.
+    assert posted_items == ["go", "one", "two", "two"]
+    assert second.subagents["rec1"].byte_offset == subagent_jsonl.stat().st_size
+    assert set(second.subagents["rec1"].seen_source_ids) == {
+        "sa-user:0:message",
+        "sa-one:0:message",
+        "sa-two:0:message",
+    }
 
 
 async def test_subagent_watcher_retry_skips_previously_posted_items(
@@ -5400,80 +5403,6 @@ async def test_subagent_watcher_retry_skips_previously_posted_items(
         "sa-user-retry:0:message",
         "sa-assistant-retry:0:message",
     }
-
-
-async def test_subagent_watcher_skips_pre_launch_subagents_on_resume(
-    tmp_path: Path,
-) -> None:
-    """
-    On a resume (``start_at_end=True``), a sub-agent whose metadata predates
-    the forwarder launch is historical — the prior run already forwarded it —
-    so it is not re-registered or re-uploaded. A sub-agent created after the
-    launch still registers normally.
-    """
-    transcript_path = tmp_path / "session.jsonl"
-    transcript_path.write_text("", encoding="utf-8")
-    bridge_dir = tmp_path / "bridge"
-    bridge_dir.mkdir()
-
-    old_jsonl = _seed_subagent_on_disk(
-        transcript_path=transcript_path,
-        subagent_id="old1",
-        agent_type="Explore",
-        description="ran last session",
-        tool_use_id="toolu_old",
-    )
-    new_jsonl = _seed_subagent_on_disk(
-        transcript_path=transcript_path,
-        subagent_id="new1",
-        agent_type="Explore",
-        description="spawned this session",
-        tool_use_id="toolu_new",
-    )
-    # Place the launch boundary between the two sub-agents' metadata.
-    os.utime(old_jsonl.with_name("agent-old1.meta.json"), (1_000.0, 1_000.0))
-    cold_start_ts = 2_000.0
-    os.utime(new_jsonl.with_name("agent-new1.meta.json"), (3_000.0, 3_000.0))
-
-    started: list[str] = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        """
-        Record ``external_subagent_start`` ids and mint a child id.
-
-        :param request: Request issued by the forwarder.
-        :returns: Canned Omnigent response.
-        """
-        body = json.loads(request.content.decode("utf-8"))
-        if body.get("type") == "external_subagent_start":
-            sid = body["data"]["subagent_id"]
-            started.append(sid)
-            return httpx.Response(202, json={"child_session_id": f"conv_{sid}"})
-        return httpx.Response(202, json={})
-
-    async with httpx.AsyncClient(
-        transport=httpx.MockTransport(handler),
-        base_url="http://ap",
-    ) as client:
-        result = await forwarder._forward_available_subagents(
-            client=client,
-            parent_session_id="conv_parent",
-            bridge_dir=bridge_dir,
-            transcript_path=transcript_path,
-            state=forwarder.SubagentForwardState(subagents={}),
-            agent_name="claude-native-ui",
-            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
-            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
-            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
-            start_at_end=True,
-            cold_start_ts=cold_start_ts,
-        )
-
-    # The pre-launch sub-agent is skipped wholesale; the post-launch one
-    # registers and is tracked.
-    assert started == ["new1"]
-    assert "old1" not in result.subagents
-    assert result.subagents["new1"].child_conversation_id == "conv_new1"
 
 
 async def test_subagent_watcher_skips_subagents_already_in_state(

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5281,6 +5281,80 @@ async def test_subagent_watcher_retry_skips_previously_posted_items(
     }
 
 
+async def test_subagent_watcher_skips_pre_launch_subagents_on_resume(
+    tmp_path: Path,
+) -> None:
+    """
+    On a resume (``start_at_end=True``), a sub-agent whose metadata predates
+    the forwarder launch is historical — the prior run already forwarded it —
+    so it is not re-registered or re-uploaded. A sub-agent created after the
+    launch still registers normally.
+    """
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    old_jsonl = _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="old1",
+        agent_type="Explore",
+        description="ran last session",
+        tool_use_id="toolu_old",
+    )
+    new_jsonl = _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="new1",
+        agent_type="Explore",
+        description="spawned this session",
+        tool_use_id="toolu_new",
+    )
+    # Place the launch boundary between the two sub-agents' metadata.
+    os.utime(old_jsonl.with_name("agent-old1.meta.json"), (1_000.0, 1_000.0))
+    cold_start_ts = 2_000.0
+    os.utime(new_jsonl.with_name("agent-new1.meta.json"), (3_000.0, 3_000.0))
+
+    started: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """
+        Record ``external_subagent_start`` ids and mint a child id.
+
+        :param request: Request issued by the forwarder.
+        :returns: Canned Omnigent response.
+        """
+        body = json.loads(request.content.decode("utf-8"))
+        if body.get("type") == "external_subagent_start":
+            sid = body["data"]["subagent_id"]
+            started.append(sid)
+            return httpx.Response(202, json={"child_session_id": f"conv_{sid}"})
+        return httpx.Response(202, json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        result = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=forwarder.SubagentForwardState(subagents={}),
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            start_at_end=True,
+            cold_start_ts=cold_start_ts,
+        )
+
+    # The pre-launch sub-agent is skipped wholesale; the post-launch one
+    # registers and is tracked.
+    assert started == ["new1"]
+    assert "old1" not in result.subagents
+    assert result.subagents["new1"].child_conversation_id == "conv_new1"
+
+
 async def test_subagent_watcher_skips_subagents_already_in_state(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Related issue

No tracked issue — diagnosed from a live resumed session's runner logs (maintainer PR).

## Summary

Resuming a long-lived native Claude Code session re-uploaded **every accumulated sub-agent's whole transcript** to the server — thousands of duplicate `external_conversation_item` POSTs, serialized over a ~300 ms-RTT link, which the 300 s stall deadline kept cancelling before it could finish, so the session felt permanently slow and new turns queued behind the backlog.

**Root cause: the durable sub-agent cursor (`byte_offset`) advanced coarsely.** A tail pass reads a sub-agent's transcript from its cursor **to EOF in one shot** and only advances `byte_offset` to the end after the *entire* batch posts. When the 300 s stall deadline cancelled a drain mid-way, `byte_offset` stayed at `0`. The cursor map (`subagent_forwarder.json`) **does persist across a runner restart** — it lives in a bridge dir keyed by conversation id, not a per-launch temp dir — but a persisted `byte_offset` of `0` is indistinguishable from a sub-agent that was never forwarded, so on resume every accumulated sub-agent re-read from `0` and re-posted its whole transcript.

**Fix: advance the cursor one record at a time.**

- `read_transcript_items_from_offset` now tags each item with the byte offset immediately after its source JSONL record (`ClaudeTranscriptItem.record_byte_offset`).
- The sub-agent tail loop commits the cursor **per record** — persisting a record's end offset once all of its items have posted.
- The re-seed of `subagent_state` from disk each poll is kept: a stall-cancel abandons the drain without returning, so re-reading the (per-record-updated) file lets the next poll resume from the last committed record instead of the caller's stale in-memory copy.

Because the state file persists across restarts, this fixes the resume re-upload directly: a sub-agent fully forwarded by a prior run now has its cursor persisted **at EOF**, so a resume uploads nothing; a drain cut short by the stall deadline or a transient failure resumes at the **last fully-posted record**, not offset 0; and nothing is dropped — a sub-agent still running or mid-drain across a resume keeps its real cursor and continues. It also removes the per-poll re-parse-from-0: an idle sub-agent's cursor sits at EOF, so the poll reads nothing instead of re-parsing (and re-deduping) the whole file, and the bounded `seen_source_ids` ring goes back to being a frontier retry-guard rather than load-bearing for correctness on large transcripts.

**Scope note:** earlier commits on this branch tried two resume-time heuristics (skip sub-agents whose `.meta.json` predates launch; EOF-jump sub-agents already in state). **Both are removed in the final commit** — they guessed "finished" from metadata age, which silently dropped a sub-agent still running across the resume or one whose initial drain crashed mid-way. The per-record cursor is exact and needs no guess. (Polly reviewed an intermediate state where the description still advertised those heuristics; this description reflects the delivered code.)

### ELI5

The forwarder copies each sub-agent's transcript to the server and keeps a bookmark of how far it got. The bookmark only moved after copying an entire transcript in one go — so a copy interrupted partway by the 5-minute watchdog left the bookmark at the very start, and on resume it recopied everything from the beginning. Fix: move the bookmark forward after each record, so an interrupted or resumed copy picks up exactly where it left off.

```
before:  byte_offset  0 ─────────────(all-or-nothing)─────────────▶ EOF
         interrupted drain  →  stays at 0  →  resume re-uploads everything ❌

after:   byte_offset  0 ─▶ r1 ─▶ r2 ─▶ r3 ─▶ … ─▶ EOF   (commit per record)
         interrupted after r2  →  resume starts at r2, posts only r3+  ✅
         finished last run     →  cursor at EOF        →  resume uploads nothing ✅
```

## Test Plan

- `.venv/bin/python -m pytest tests/test_claude_native_forwarder.py -q` → **147 passed**, including the new `test_subagent_watcher_advances_cursor_per_record_on_partial_drain` (3-record sub-agent whose 3rd record's post fails once: the cursor commits to the boundary after record 2 — asserted `0 < offset < EOF` — and the retry posts only record 3, then reaches EOF).
- `tests/test_claude_native_bridge.py` → **271 passed** (reader change); `tests/host/test_cli_session_import.py` → **42 passed** (session import shares the reader).
- `ruff check` + `ruff format --check` clean; pyrefly clean on both source files.
- Manual before/after: resume a long-lived native-Claude session with accumulated sub-agents and `tail -f` the runner log — after the one-time backlog drain, no flood of `/events` POSTs to old child-session ids, and an idle session's poll reads nothing.

## Demo

Backend forwarder change — no UI surface. Evidence is in the runner log. The **before** state, measured from the affected session's log (`runner-0ef803ae…-132549.log`, 74 min):

```
event POSTs to /v1/sessions/<id>/events : 11,788  (86% of all log lines)
  spread across ~8 OLD sub-agent child sessions, e.g.
    dddb6c3c… 2431   0e74f28b… 2371   61e7a090… 1755   …
  parent session 0ef803ae…            :    352
stall-deadline warning ("iteration exceeded 300s") : every 5 min, 15×
```

Every one of those child sessions had `byte_offset: 0` on disk despite multi-hundred-KB transcripts — the coarse-cursor re-upload this PR fixes. **After** the fix, the same `tail -f` shows only the live turn's events once the one-time backlog has drained (manual check above).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit test covers the core behaviour: a partial drain commits the cursor to a record boundary (not 0, not EOF) and the resume posts only the un-sent record. The end-to-end resume path (runner restart on a session with accumulated sub-agents over a slow link) is exercised manually, since it needs a live runner plus real on-disk state. Trade accepted with the change: the first clean run after this ships still uploads a session's already-accumulated backlog once (whatever was genuinely never forwarded), then stays quiet — as opposed to the removed heuristic, which skipped that backlog but could drop still-running sub-agents.

## Changelog

Resumed native Claude Code sessions no longer re-upload finished sub-agent transcripts; the sub-agent forwarder now tracks progress per transcript record, fixing slow, laggy turns after a reattach.
