### PR TITLE
fix(web): use configured UI font in welcome composer

### DIFF
--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2754,6 +2754,17 @@ describe("NewChatLandingScreen skill pills", () => {
     expect(screen.getByTestId("skill-pill-compare").textContent).toBe("/compare");
   });
 
+  it("lets the textarea and skill prompt inherit the app font family", () => {
+    mockAgents([debbyAgent()]);
+    renderLanding();
+
+    const localFontFamily = /(^|\s)font-(sans|serif|mono|\[)/;
+    for (const element of [input(), screen.getByText("Describe a task, or try a skill")]) {
+      expect(element.className).not.toMatch(localFontFamily);
+      expect(element.style.fontFamily).toBe("");
+    }
+  });
+
   it("hides pills for agents outside the allowlist even when they carry skills", () => {
     // Same skills, non-allowlisted name: no pill row. Fails if the gate
     // ever degrades to "any agent with skills", which would spam the

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -4391,21 +4391,21 @@ export function NewChatLandingScreen() {
                 // top of it. Phones expect to be tapped before they type.
                 autoFocus={!isMobileViewport}
                 data-testid="new-chat-landing-input"
-                // Compose-pill text spec: SF Pro Text system stack at
-                // 14px/20px. (Note: sub-16px inputs make mobile Safari
+                // Compose-pill text spec: inherited UI font at 14px/20px.
+                // (Note: sub-16px inputs make mobile Safari
                 // auto-zoom on focus — accepted tradeoff per the design.)
                 // Heights are border-box (12px top + 8px bottom padding lives
                 // inside them): max 200px = the spec's 180px of content.
                 // A 60px floor holds two 20px lines plus that padding;
                 // useAutoGrowTextarea expands from there to the unchanged cap.
-                className="block min-h-[60px] max-h-[200px] w-full resize-none overflow-y-auto bg-transparent px-4 pt-3 pb-2 font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-ui leading-5 text-foreground outline-none [scrollbar-width:none] placeholder:text-muted-foreground md:select-text [&::-webkit-scrollbar]:hidden"
+                className="block min-h-[60px] max-h-[200px] w-full resize-none overflow-y-auto bg-transparent px-4 pt-3 pb-2 text-ui leading-5 text-foreground outline-none [scrollbar-width:none] placeholder:text-muted-foreground md:select-text [&::-webkit-scrollbar]:hidden"
               />
               {/* Gated on an empty draft so it reads as the placeholder.
                   pointer-events-none lets clicks fall through to focus the
                   textarea; the pills themselves opt back in. */}
               {pillSkills.length > 0 && message.length === 0 && (
                 <div className="pointer-events-none absolute inset-x-4 top-3 flex flex-wrap items-center gap-2">
-                  <span className="font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-ui leading-5 text-muted-foreground">
+                  <span className="text-ui leading-5 text-muted-foreground">
                     Describe a task, or try a skill
                   </span>
                   <SkillPills skills={pillSkills} onPick={applySkillPill} />


### PR DESCRIPTION
## Related issue

N/A — no issue linked.

## Summary

- The welcome-screen composer hardcoded the SF Pro system stack, so it ignored the UI font family selected in Appearance settings on web and desktop.
- Remove the textarea and placeholder overrides so both inherit the same `--ui-font-family` used by the rest of Omnigent.

## Test Plan

- `uvx --from 'pre-commit>=3.5' pre-commit run` — passed, including Prettier, oxlint, and TypeScript checks.
- `pnpm --dir web exec vitest run src/shell/NewChatDialog.test.tsx src/shell/NewChatDialog.flow.test.tsx src/shell/NewChatDialog.projectPrefill.test.tsx` — 350 tests passed; 3 existing host-picker tests failed because "This machine" was not rendered, unrelated to the font-only diff.
- Manual visual verification: pending before marking the PR ready. Set a custom UI font under Settings → Appearance, return to the welcome screen, and confirm the composer text and skill placeholder use that font in web and Electron.

## Demo

### Before
<img width="1370" height="764" alt="Screenshot 2026-08-25 at 17 51 23" src="https://github.com/user-attachments/assets/40634dc9-7bfe-4608-9508-7634ae172b1d" />

### After
<img width="1119" height="559" alt="Screenshot 2026-08-25 at 17 51 55" src="https://github.com/user-attachments/assets/2f1ce2e6-4b64-49e8-8bb2-42561bd71b72" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

No automated test was added for removing two hardcoded font utility classes. The welcome composer now uses the existing inherited UI font contract already used by the in-session composer; lint, formatting, and TypeScript checks cover the code change. Manual visual verification remains pending while the PR is draft.

## Changelog

The welcome screen composer now follows your selected UI font.
