### PR TITLE
Keep session actions visible and fix sidebar hover

### DIFF
--- a/tests/e2e_ui/sessions/test_header_session_menu.py
+++ b/tests/e2e_ui/sessions/test_header_session_menu.py
@@ -10,25 +10,20 @@ import httpx
 from playwright.sync_api import Page, expect
 
 
-def test_header_session_menu_reveals_horizontal_ellipsis_on_hover(
+def test_header_session_menu_always_shows_horizontal_ellipsis(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """The desktop trigger is hidden at rest and uses a horizontal ellipsis."""
+    """The desktop trigger stays visible and uses a horizontal ellipsis."""
     base_url, session_id = seeded_session
     page.goto(f"{base_url}/c/{session_id}")
 
-    breadcrumb = page.get_by_role("navigation", name="Conversation")
     trigger = page.get_by_test_id("header-conversation-actions")
-    expect(breadcrumb).to_be_visible(timeout=30_000)
-    expect(trigger).to_be_visible()
+    expect(trigger).to_be_visible(timeout=30_000)
 
-    expect(trigger).to_have_css("opacity", "0")
+    expect(trigger).to_have_css("opacity", "1")
     expect(trigger.locator("svg.lucide-ellipsis")).to_have_count(1)
     expect(trigger.locator("svg.lucide-ellipsis-vertical")).to_have_count(0)
-
-    breadcrumb.hover()
-    expect(trigger).to_have_css("opacity", "1")
 
     trigger.click()
     viewport = page.viewport_size

--- a/tests/e2e_ui/sessions/test_header_session_menu.py
+++ b/tests/e2e_ui/sessions/test_header_session_menu.py
@@ -10,6 +10,35 @@ import httpx
 from playwright.sync_api import Page, expect
 
 
+def test_header_session_menu_reveals_horizontal_ellipsis_on_hover(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The desktop trigger is hidden at rest and uses a horizontal ellipsis."""
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    breadcrumb = page.get_by_role("navigation", name="Conversation")
+    trigger = page.get_by_test_id("header-conversation-actions")
+    expect(breadcrumb).to_be_visible(timeout=30_000)
+    expect(trigger).to_be_visible()
+
+    expect(trigger).to_have_css("opacity", "0")
+    expect(trigger.locator("svg.lucide-ellipsis")).to_have_count(1)
+    expect(trigger.locator("svg.lucide-ellipsis-vertical")).to_have_count(0)
+
+    breadcrumb.hover()
+    expect(trigger).to_have_css("opacity", "1")
+
+    trigger.click()
+    viewport = page.viewport_size
+    assert viewport is not None
+    page.mouse.move(viewport["width"] - 4, viewport["height"] - 4)
+
+    expect(page.get_by_role("menu")).to_be_visible()
+    expect(trigger).to_have_css("opacity", "1")
+
+
 def test_header_session_menu_renames_owner_and_hides_for_subagent(
     page: Page,
     seeded_session: tuple[str, str],

--- a/tests/e2e_ui/sessions/test_sidebar_toggle_hotkeys.py
+++ b/tests/e2e_ui/sessions/test_sidebar_toggle_hotkeys.py
@@ -30,6 +30,8 @@ and always has content (the Agents tab is unconditional).
 
 from __future__ import annotations
 
+import re
+
 from playwright.sync_api import Page, expect
 
 _COMPOSER = "Ask the agent anything…"
@@ -41,6 +43,7 @@ _RIGHT_CHORD = "Control+Alt+BracketRight"
 # rail unmounts entirely when closed, so it reads off the complementary role.
 _CONVERSATIONS = 'aside[aria-label="Conversations"]'
 _DRAFT = "an unsent draft the sidebar chord must not disturb"
+_PEEK_CLASS = re.compile(r"(^|\s)is-peek(\s|$)")
 
 
 def test_sidebar_toggle_hotkeys(
@@ -87,3 +90,69 @@ def test_sidebar_toggle_hotkeys(
     # ... and ⌘⌥] again brings it back.
     page.keyboard.press(_RIGHT_CHORD)
     expect(workspace).to_be_visible()
+
+
+def test_sidebar_click_cancels_pending_peek(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A quick press pins the sidebar open instead of losing to the peek timer."""
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    conversations = page.locator(_CONVERSATIONS)
+    expect(page.get_by_role("complementary", name="Workspace")).to_be_visible(timeout=30_000)
+
+    page.keyboard.press(_LEFT_CHORD)
+    expect(conversations).to_have_attribute("data-collapsed", "true")
+
+    trigger = page.get_by_role("button", name="Open sidebar")
+    expect(trigger).to_be_visible()
+    trigger.hover()
+    page.wait_for_timeout(300)
+
+    page.mouse.down()
+    try:
+        page.wait_for_timeout(200)
+        expect(conversations).to_have_attribute("data-collapsed", "true")
+        expect(conversations).not_to_have_class(_PEEK_CLASS)
+    finally:
+        page.mouse.up()
+
+    expect(conversations).not_to_have_attribute("data-collapsed", "true")
+    expect(conversations).not_to_have_class(_PEEK_CLASS)
+    page.wait_for_timeout(200)
+    expect(conversations).not_to_have_class(_PEEK_CLASS)
+
+
+def test_sidebar_peek_is_opaque_in_dark_mode(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The dark-mode hover preview uses the opaque sidebar surface."""
+    page.emulate_media(color_scheme="dark")
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    conversations = page.locator(_CONVERSATIONS)
+    expect(page.get_by_role("complementary", name="Workspace")).to_be_visible(timeout=30_000)
+    expect(page.locator("html")).to_have_class(re.compile(r"(^|\s)dark(\s|$)"))
+
+    page.keyboard.press(_LEFT_CHORD)
+    expect(conversations).to_have_attribute("data-collapsed", "true")
+
+    page.get_by_role("button", name="Open sidebar").hover()
+    expect(conversations).to_have_class(_PEEK_CLASS)
+
+    colors = conversations.evaluate(
+        """element => {
+          const probe = document.createElement("div");
+          probe.style.backgroundColor = "var(--card-solid)";
+          document.body.appendChild(probe);
+          const expected = getComputedStyle(probe).backgroundColor;
+          const actual = getComputedStyle(element).backgroundColor;
+          probe.remove();
+          return { actual, expected };
+        }"""
+    )
+    assert colors["actual"] == colors["expected"]

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -467,6 +467,15 @@
   background: var(--sidebar);
 }
 
+/* A desktop peek floats over the chat instead of pushing it aside, so its
+ * gradient layers need an opaque base rather than the translucent card color. */
+:root:not(.dark):not([data-theme]) .conversations-sidebar.is-peek,
+:root:not(.dark)[data-theme] .conversations-sidebar.is-peek,
+.dark:not([data-theme]) .conversations-sidebar.is-peek,
+.dark[data-theme] .conversations-sidebar.is-peek {
+  background-color: var(--card-solid);
+}
+
 /* Edge treatment is mode-specific but palette-independent. */
 html:not(.dark) .conversations-sidebar:not(.is-peek) {
   border-right: none;

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -260,6 +260,9 @@ describe("index.css sidebar canvas", () => {
     /html:not\(\.dark\) \.conversations-sidebar(?::not\(\.is-peek\))? \{[^}]*\}/,
   )?.[0];
   const darkEdgeRule = cssSource.match(/\.dark \.conversations-sidebar \{[^}]*\}/)?.[0];
+  const peekBackgroundRule = cssSource.match(
+    /:root:not\(\.dark\):not\(\[data-theme\]\) \.conversations-sidebar\.is-peek,[\s\S]*?\.dark\[data-theme\] \.conversations-sidebar\.is-peek \{[^}]*\}/,
+  )?.[0];
 
   it("uses the specified left-to-right gradient for Omnigent light only", () => {
     expect(omniLightRule).toContain("background: #fffefe");
@@ -282,6 +285,14 @@ describe("index.css sidebar canvas", () => {
     expect(darkEdgeRule).toContain(`box-shadow: ${shadow}`);
     expect(lightEdgeRule).toContain("border-right: none");
     expect(darkEdgeRule).toContain("border-right: 1px solid rgb(255 255 255 / 2%)");
+  });
+
+  it("backs floating peek cards with the opaque card color in every theme", () => {
+    expect(peekBackgroundRule).toContain(".dark:not([data-theme]) .conversations-sidebar.is-peek");
+    expect(peekBackgroundRule).toContain(
+      ":root:not(.dark)[data-theme] .conversations-sidebar.is-peek",
+    );
+    expect(peekBackgroundRule).toContain("background-color: var(--card-solid)");
   });
 });
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1196,7 +1196,9 @@ export function AppShell() {
   // dwell-to-peek would only work on a button the user can no longer see.
   // Same 400ms as ChatHeader: a quick pass-over must not open the card.
   const titleBarPeekTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const titleBarPeekRequest = useRef(0);
   const cancelTitleBarPeek = useCallback(() => {
+    titleBarPeekRequest.current += 1;
     if (titleBarPeekTimer.current) {
       clearTimeout(titleBarPeekTimer.current);
       titleBarPeekTimer.current = null;
@@ -1204,7 +1206,10 @@ export function AppShell() {
   }, []);
   const armTitleBarPeek = useCallback(() => {
     cancelTitleBarPeek();
+    const request = titleBarPeekRequest.current;
     titleBarPeekTimer.current = setTimeout(() => {
+      titleBarPeekTimer.current = null;
+      if (titleBarPeekRequest.current !== request) return;
       setSidebarPeek(true);
       setSidebarOpen(false);
     }, 400);
@@ -1738,6 +1743,7 @@ export function AppShell() {
                   // icon/tooltip lied until the sidebar was really open.
                   expanded={sidebarOpen}
                   onToggle={() => {
+                    cancelTitleBarPeek();
                     // Mirrors the ⌘⌥[ hotkey: a peeking sidebar counts as open,
                     // so toggling from peek pins it open rather than collapsing.
                     if (sidebarOpen) {
@@ -1754,6 +1760,7 @@ export function AppShell() {
                   // Only meaningful while collapsed — peeking or open, there is
                   // nothing to peek at.
                   onTogglePointerEnter={sidebarOpen || sidebarPeek ? undefined : armTitleBarPeek}
+                  onTogglePointerDown={cancelTitleBarPeek}
                   onTogglePointerLeave={cancelTitleBarPeek}
                 />
               </div>

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -75,6 +75,7 @@ function renderHeader(props: {
   hasRailContent?: boolean;
   showFilesPanel?: boolean;
   mobileMenu?: typeof mobileMenu;
+  onOpenSidebar?: (peek?: boolean) => void;
 }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
@@ -83,7 +84,7 @@ function renderHeader(props: {
         <TooltipProvider>
           <ChatHeader
             sidebarOpen={props.sidebarOpen}
-            onOpenSidebar={() => {}}
+            onOpenSidebar={props.onOpenSidebar ?? (() => {})}
             isChildSession={props.isChildSession ?? false}
             // Defaults to no active session: PresenceAvatars / AgentInfoButton /
             // right-panel toggle / rail entries all gate on conversationId and
@@ -187,6 +188,25 @@ describe("ChatHeader — open-sidebar toggle visibility", () => {
     // present. A regression here would hide the only way to reopen the
     // sidebar via pointer.
     expect(screen.getByRole("button", { name: "Open sidebar" })).toBeInTheDocument();
+  });
+
+  it("cancels the pending peek as soon as the toggle is pressed", () => {
+    vi.useFakeTimers();
+    const onOpenSidebar = vi.fn();
+    try {
+      renderHeader({ sidebarOpen: false, onOpenSidebar });
+      const toggle = screen.getByRole("button", { name: "Open sidebar" });
+
+      fireEvent.pointerEnter(toggle);
+      fireEvent.pointerDown(toggle);
+      act(() => vi.advanceTimersByTime(400));
+
+      expect(onOpenSidebar).not.toHaveBeenCalledWith(true);
+      fireEvent.click(toggle);
+      expect(onOpenSidebar).toHaveBeenLastCalledWith(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -508,6 +528,7 @@ describe("ChatHeader — title-adjacent conversation actions", () => {
     const trigger = screen.getByRole("button", { name: "Conversation actions" });
     expect(title).toHaveClass("min-w-0", "truncate");
     expect(title.parentElement).toBe(trigger.parentElement);
+    expect(trigger.closest("nav.conversation-breadcrumb")).toHaveClass("group/breadcrumb");
     expect(title.compareDocumentPosition(trigger) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -528,7 +528,7 @@ describe("ChatHeader — title-adjacent conversation actions", () => {
     const trigger = screen.getByRole("button", { name: "Conversation actions" });
     expect(title).toHaveClass("min-w-0", "truncate");
     expect(title.parentElement).toBe(trigger.parentElement);
-    expect(trigger.closest("nav.conversation-breadcrumb")).toHaveClass("group/breadcrumb");
+    expect(trigger.closest("nav.conversation-breadcrumb")).not.toHaveClass("group/breadcrumb");
     expect(title.compareDocumentPosition(trigger) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -206,14 +206,16 @@ export function ChatHeader({
   onToggleRightPanel,
   mobileMenu,
 }: ChatHeaderProps) {
-  // Dwell on the toggle for 1s to peek the sidebar; leaving before then cancels
+  // Dwell on the toggle for 400ms to peek the sidebar; leaving before then cancels
   // the pending peek so a quick pass-over never opens it. Peek is a desktop
   // hover affordance — on mobile the toggle just opens the full-screen overlay,
   // so a tap's synthetic pointerenter must not trigger it.
   const isMobile = useIsMobileViewport();
   const { trackClick } = useOmnigentAnalytics();
   const peekTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const peekRequest = useRef(0);
   const cancelPeek = useCallback(() => {
+    peekRequest.current += 1;
     if (peekTimer.current) {
       clearTimeout(peekTimer.current);
       peekTimer.current = null;
@@ -222,7 +224,10 @@ export function ChatHeader({
   const onPeekSidebar = useCallback(() => {
     if (isMobile) return;
     cancelPeek();
+    const request = peekRequest.current;
     peekTimer.current = setTimeout(() => {
+      peekTimer.current = null;
+      if (peekRequest.current !== request) return;
       onOpenSidebar(true);
     }, 400);
   }, [isMobile, onOpenSidebar, cancelPeek]);
@@ -391,6 +396,7 @@ export function ChatHeader({
                   MOBILE_GLASS_PILL,
                 )}
                 onPointerEnter={onPeekSidebar}
+                onPointerDown={cancelPeek}
                 onPointerLeave={cancelPeek}
               >
                 <PanelLeftIcon className="size-4" />

--- a/web/src/shell/ConversationBreadcrumb.tsx
+++ b/web/src/shell/ConversationBreadcrumb.tsx
@@ -64,7 +64,7 @@ export function ConversationBreadcrumb({
     <nav
       aria-label="Conversation"
       className={cn(
-        "conversation-breadcrumb group/breadcrumb flex min-w-0 items-center gap-1.5 text-ui",
+        "conversation-breadcrumb flex min-w-0 items-center gap-1.5 text-ui",
         className,
       )}
     >

--- a/web/src/shell/ConversationBreadcrumb.tsx
+++ b/web/src/shell/ConversationBreadcrumb.tsx
@@ -63,7 +63,10 @@ export function ConversationBreadcrumb({
   return (
     <nav
       aria-label="Conversation"
-      className={cn("conversation-breadcrumb flex min-w-0 items-center gap-1.5 text-ui", className)}
+      className={cn(
+        "conversation-breadcrumb group/breadcrumb flex min-w-0 items-center gap-1.5 text-ui",
+        className,
+      )}
     >
       {projectName && (
         <div className="hidden md:flex min-w-0 items-center gap-1.5 text-ui shrink-0">

--- a/web/src/shell/ConversationBreadcrumb.tsx
+++ b/web/src/shell/ConversationBreadcrumb.tsx
@@ -63,10 +63,7 @@ export function ConversationBreadcrumb({
   return (
     <nav
       aria-label="Conversation"
-      className={cn(
-        "conversation-breadcrumb flex min-w-0 items-center gap-1.5 text-ui",
-        className,
-      )}
+      className={cn("conversation-breadcrumb flex min-w-0 items-center gap-1.5 text-ui", className)}
     >
       {projectName && (
         <div className="hidden md:flex min-w-0 items-center gap-1.5 text-ui shrink-0">

--- a/web/src/shell/HeaderConversationMenu.test.tsx
+++ b/web/src/shell/HeaderConversationMenu.test.tsx
@@ -101,6 +101,13 @@ describe("HeaderConversationMenu", () => {
     renderMenu();
     const trigger = screen.getByRole("button", { name: "Conversation actions" });
     expect(trigger).toHaveAttribute("aria-haspopup", "menu");
+    expect(trigger).toHaveClass(
+      "md:opacity-0",
+      "md:group-hover/breadcrumb:opacity-100",
+      "md:group-focus-within/breadcrumb:opacity-100",
+      "data-[state=open]:opacity-100",
+    );
+    expect(trigger.querySelector("svg")).toHaveClass("lucide-ellipsis");
 
     openMenu();
     expect(screen.getAllByRole("menuitem").map((item) => item.textContent?.trim())).toEqual([

--- a/web/src/shell/HeaderConversationMenu.test.tsx
+++ b/web/src/shell/HeaderConversationMenu.test.tsx
@@ -101,12 +101,10 @@ describe("HeaderConversationMenu", () => {
     renderMenu();
     const trigger = screen.getByRole("button", { name: "Conversation actions" });
     expect(trigger).toHaveAttribute("aria-haspopup", "menu");
-    expect(trigger).toHaveClass(
-      "md:opacity-0",
-      "md:group-hover/breadcrumb:opacity-100",
-      "md:group-focus-within/breadcrumb:opacity-100",
-      "data-[state=open]:opacity-100",
-    );
+    expect(trigger).not.toHaveClass("md:opacity-0");
+    expect(trigger).not.toHaveClass("md:group-hover/breadcrumb:opacity-100");
+    expect(trigger).not.toHaveClass("md:group-focus-within/breadcrumb:opacity-100");
+    expect(trigger).not.toHaveClass("data-[state=open]:opacity-100");
     expect(trigger.querySelector("svg")).toHaveClass("lucide-ellipsis");
 
     openMenu();

--- a/web/src/shell/HeaderConversationMenu.tsx
+++ b/web/src/shell/HeaderConversationMenu.tsx
@@ -10,7 +10,7 @@ import {
   ArchiveIcon,
   CheckIcon,
   ChevronLeftIcon,
-  EllipsisVerticalIcon,
+  EllipsisIcon,
   FolderInputIcon,
   GitBranchIcon,
   InfoIcon,
@@ -369,9 +369,9 @@ export function HeaderConversationMenu({
             size={isMobile ? "icon" : "icon-xs"}
             aria-label="Conversation actions"
             data-testid="header-conversation-actions"
-            className="shrink-0 border-none text-muted-foreground hover:text-foreground max-md:rounded-full"
+            className="shrink-0 border-none text-muted-foreground transition-opacity hover:text-foreground max-md:rounded-full md:opacity-0 md:group-hover/breadcrumb:opacity-100 md:group-focus-within/breadcrumb:opacity-100 data-[state=open]:opacity-100"
           >
-            <EllipsisVerticalIcon className={isMobile ? "size-4" : "size-3.5"} />
+            <EllipsisIcon className={isMobile ? "size-4" : "size-3.5"} />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent

--- a/web/src/shell/HeaderConversationMenu.tsx
+++ b/web/src/shell/HeaderConversationMenu.tsx
@@ -369,7 +369,7 @@ export function HeaderConversationMenu({
             size={isMobile ? "icon" : "icon-xs"}
             aria-label="Conversation actions"
             data-testid="header-conversation-actions"
-            className="shrink-0 border-none text-muted-foreground transition-opacity hover:text-foreground max-md:rounded-full md:opacity-0 md:group-hover/breadcrumb:opacity-100 md:group-focus-within/breadcrumb:opacity-100 data-[state=open]:opacity-100"
+            className="shrink-0 border-none text-muted-foreground hover:text-foreground max-md:rounded-full"
           >
             <EllipsisIcon className={isMobile ? "size-4" : "size-3.5"} />
           </Button>

--- a/web/src/shell/SidebarHeaderActions.tsx
+++ b/web/src/shell/SidebarHeaderActions.tsx
@@ -27,6 +27,7 @@ export function SidebarHeaderActions({
   onOpenSearch,
   onSettingsClick,
   onTogglePointerEnter,
+  onTogglePointerDown,
   onTogglePointerLeave,
 }: {
   /**
@@ -50,6 +51,7 @@ export function SidebarHeaderActions({
    * so the behaviour has to ride along with it or dwell-to-peek disappears.
    */
   onTogglePointerEnter?: () => void;
+  onTogglePointerDown?: () => void;
   onTogglePointerLeave?: () => void;
 }) {
   return (
@@ -65,6 +67,7 @@ export function SidebarHeaderActions({
             aria-label={expanded ? "Close sidebar" : "Open sidebar"}
             onClick={onToggle}
             onPointerEnter={onTogglePointerEnter}
+            onPointerDown={onTogglePointerDown}
             onPointerLeave={onTogglePointerLeave}
             // Mobile drops the toggle entirely: there the sidebar is a drawer
             // that leaves a strip of the chat visible, and tapping that strip


### PR DESCRIPTION
## Related issue

Follow-up to #5248 and an internal sidebar interaction report.

## Summary

- Use a horizontal ellipsis for session actions and keep it visible beside the session title on desktop and mobile.
- Cancel the delayed sidebar peek on pointer down and ignore stale timer callbacks in both the chat header and macOS title bar.
- Back floating sidebar peeks with an opaque theme color so chat content cannot bleed through.

**ELI5:** pressing the sidebar button now cancels its hover preview before opening the real sidebar.

```text
hover -> start 400 ms peek timer
press -> cancel timer
click -> open docked sidebar
```

## Test Plan

- CI: `Pre-commit checks`, `web test`, and all three `E2E UI Tests` shards on the final commit.
- `pnpm exec prettier --check src/shell/ConversationBreadcrumb.tsx` — passed for the final formatting fix.
- Manually verified the always-visible horizontal session menu in light and dark themes with matching 24×24 geometry, zero vertical-center drift, and a 6px title-to-button gap.
- Previously verified the rapid hover → press → release sequence where the sidebar remains docked open and opaque.

## Demo

**Session title actions:** the horizontal ellipsis remains visible at rest in light and dark themes.

<img width="900" height="180" alt="session-actions-always-visible-light" src="https://github.com/user-attachments/assets/51451514-a335-4b54-bd7e-a3a56d53eb03" />
<img width="900" height="180" alt="session-actions-always-visible-dark" src="https://github.com/user-attachments/assets/9e8b8818-cf28-445e-9b8e-acb2c1ad8007" />

**A fast press opens the docked sidebar without a delayed peek winning the race:**

![Fast sidebar press opens the docked sidebar](https://github.com/user-attachments/assets/686d3903-efcd-4497-bdea-13f3e632ecc4)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added regression coverage for the always-visible horizontal menu, pointer-down cancellation of pending peeks, and opaque peek backgrounds. Manually verified the final menu geometry in light and dark themes and previously exercised the timing-sensitive click path.

## Changelog

Session title actions now use an always-visible horizontal menu, and sidebar clicks no longer lose to delayed hover previews.