### PR TITLE
Track ViewModeToggle in analytics

### DIFF
--- a/web/src/shell/ViewModeToggle.tsx
+++ b/web/src/shell/ViewModeToggle.tsx
@@ -39,6 +39,7 @@ export function ViewModeToggle() {
         active={view === "chat"}
         onClick={() => setView("chat")}
         testId="view-mode-chat"
+        componentId="chat.header.view_chat"
       >
         <MessagesSquareIcon className="size-3.5" />
       </ViewModeSegment>
@@ -47,6 +48,7 @@ export function ViewModeToggle() {
         active={view === "terminal"}
         onClick={() => setView("terminal")}
         testId="view-mode-terminal"
+        componentId="chat.header.view_terminal"
       >
         {terminalStartingUp ? (
           <Loader2Icon className="size-3.5 animate-spin" aria-hidden />
@@ -69,12 +71,14 @@ function ViewModeSegment({
   active,
   onClick,
   testId,
+  componentId,
   children,
 }: {
   label: string;
   active: boolean;
   onClick: () => void;
   testId: string;
+  componentId: string;
   children: React.ReactNode;
 }) {
   return (
@@ -89,6 +93,7 @@ function ViewModeSegment({
             aria-pressed={active}
             onClick={onClick}
             data-testid={testId}
+            componentId={componentId}
             className={cn(
               "border-none",
               active


### PR DESCRIPTION
## Related issue

N/A

## Summary

The header **Chat ↔ Terminal** view toggle (`ViewModeToggle`, shown on
terminal-first sessions) was not instrumented — it was missed by the earlier
analytics sweep because it lives in its own file. Thread `componentId` through
the shared `ViewModeSegment` so each segment reports a click to the host
analytics sink:

- `chat.header.view_chat`
- `chat.header.view_terminal`

The seam is opt-in and inert standalone (no host sink → no-op), so behavior is
unchanged for the app itself; this only starts emitting a click event to an
embedding host's analytics.

## Test Plan

- `cd web && npx tsc -b` — clean (the two segments now pass the required
  `componentId` prop).
- `cd web && npm run lint` — clean.
- Emit path is the existing `Button` `componentId` → `trackClick(id, "button")`
  contract already covered by `button.test.tsx`; verified live for the same
  primitive against the dev server (a `Button componentId` click emits
  `{ type: "click", componentId, componentKind: "button" }` and still runs the
  caller's `onClick`). No new test — this is a pass-a-prop change on an
  already-tested primitive.

## Demo

<!-- Expected emitted events when a terminal-first session's header toggle is clicked: -->

```
{ type: "click", componentId: "chat.header.view_terminal", componentKind: "button" }
{ type: "click", componentId: "chat.header.view_chat",     componentKind: "button" }
```

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Pass-a-prop change on the shared `Button` primitive, whose `componentId` →
`trackClick` behavior is already unit-tested (`button.test.tsx`) and was verified
live. No per-call-site test is warranted.

## Changelog

<!-- Analytics is inert standalone (no user-facing behavior change). Omit. -->
