### PR TITLE
fix(repro-agent): cli recordings must run the real command and wait for its output

### DIFF
--- a/dev/repro-agent/AGENTS.md
+++ b/dev/repro-agent/AGENTS.md
@@ -453,6 +453,30 @@ cause is named from what you observed rather than guessed.
   already-running process and `Wait /pattern/` on the observable outcome. Keep
   the tape's own steps fast (sub-second each) so no `Wait` straddles a boot.
 
+  **Film the REAL command the user runs — not an API-call stand-in for it.**
+  When the failure surfaces as a command's console output, the tape must run
+  *that command* and capture *its* output — even when reproducing it needs a
+  precondition you have to stage first. Do **not** substitute a script that pokes
+  the underlying endpoint (a `curl`/`httpx` to `POST /auth/login`, a Python
+  snippet inspecting a response) as a proxy for the command: that films the
+  mechanism, not the failure the user sees, and is the same circular
+  substitution as filming the test. Stage the precondition, then run the command.
+  Example — the "host 403s after its login expires" journey: seed an **expired**
+  `auth_tokens.json` (the state `omnigent login` leaves once the JWT lapses —
+  write the entry with a past `expires_at`), then `Type` the actual
+  `omnigent host --server <url>` command and `Wait` for the console failure it
+  prints (e.g. `EXPIRED` / `Connection refused (HTTP 403)`). That console frame
+  is the recording. Only when the command genuinely cannot be driven here (name
+  why) do you fall back to `recordings: []` — never to an endpoint-poke proxy.
+
+  **End the tape on the OUTPUT, not a fixed timer.** A common failure is a clip
+  that stops on an empty prompt because the tape said "run command → `Sleep 10`
+  → stop" and the command's output took longer than the sleep to appear. Always
+  end on a `Wait /<pattern>/` that matches the *observable result line* (the
+  error text, the value, the exit message), with only a short trailing `Sleep`
+  after it lands — never a bare `Sleep`/short total duration as the stop
+  condition. The clip must show the outcome, not the moment before it.
+
   **A clip of the reproduction TEST running is NOT the journey — never fall back
   to it.** If the journey tape won't render (server boot times out, `ttyd`
   missing, VHS unavailable), do **not** substitute a recording of


### PR DESCRIPTION
## Related issue

N/A — dev-agent tooling change; follow-up to #5429.

## Summary

A repro-agent run on OMNI-1873 exposed two cli-lane recording gaps (visible in the uploaded clip: it froze on an empty `Server:` prompt and never showed the ticket's actual 403):

- **It filmed a proxy, not the real command.** OMNI-1873's user-facing failure is `omnigent host` printing a `403 / EXPIRED` message when a host's login has lapsed. Instead of staging that, the agent filmed a script poking `POST /auth/login` to show the response lacks a `refresh_token` — the *mechanism* one layer up, not the failure a user sees. That's the same circular substitution as filming the test (already banned in #5429), just subtler.
- **The tape ended on a timer, not the output.** The clip stopped on a fixed `Sleep` before the command's output rendered, so it cut off on a blank prompt.

Two additions to Step 4's cli-facet guidance:

1. **Film the real command, not an API-call stand-in.** When the failure is a command's console output, stage whatever precondition it needs (e.g. seed an expired `auth_tokens.json` — the state `omnigent login` leaves once the JWT lapses) and run the actual command (`omnigent host --server <url>`), capturing its console failure. Fall back to `recordings: []` (naming why) only when the command truly can't be driven — never to an endpoint-poke proxy.
2. **End the tape on the output, not a fixed timer.** Stop on a `Wait /pattern/` matching the observable result line, with only a short trailing `Sleep` — never a bare `Sleep`/short duration, which freezes the clip on an empty prompt.

ELI5: the recording should show the user actually running `omnigent host` and seeing the error — not a behind-the-scenes API call standing in for it — and it should keep rolling until that error text appears on screen.

## Test Plan

- Spec-only change (agent instructions). No product code touched.
- Behavioral validation is the repro-agent workflow run dispatched against OMNI-1873 on this branch (`ref=fix-repro-cli-real-command`): the clip should now show `omnigent host` printing the EXPIRED/403 message (a `fixed`-verdict facet on current main, since the misleading-message fix already landed), captured to completion — not a proxy `POST /auth/login` snippet that cuts off early.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Prompt/spec change with no executable code; verified by a live repro-agent workflow dispatch against OMNI-1873 (the ticket whose recording surfaced both gaps).

This pull request and its description were written by Isaac.