### PR TITLE
test(e2e_ui): add an OIDC/SSO login recording lane driven by a fake IdP

### DIFF
--- a/tests/e2e_ui/auth/_fake_idp.py
+++ b/tests/e2e_ui/auth/_fake_idp.py
@@ -1,0 +1,198 @@
+"""A minimal, real HTTP OIDC identity provider for e2e login-flow recordings.
+
+The OIDC login journey can't be filmed today because an unauthenticated
+Playwright navigation is bounced to the deployment's *real* SSO provider. This
+stands up a fake IdP the recorder can drive headlessly instead: a genuine HTTP
+server (not an in-process mock) so a spawned ``omnigent server`` subprocess can
+reach it over the network, exactly as it would a real issuer.
+
+It serves the four things stock OIDC mode expects (see
+``omnigent/server/oidc.py::OIDCConfig.from_env`` and
+``routes/auth.py::_resolve_oidc_email``), so **no product code changes**:
+
+- ``GET /.well-known/openid-configuration`` — discovery doc naming the
+  authorize/token/jwks endpoints (fetched at server boot).
+- ``GET /authorize`` — the user-facing sign-in page: a single "Continue as
+  <email>" link that 302s back to the server's ``/auth/callback`` with the
+  ``code`` + ``state`` echoed. This is the frame the recording captures.
+- ``POST /token`` — exchanges the code for a response carrying an
+  **RS256-signed ``id_token``** (``iss`` = issuer, ``aud`` = client_id,
+  ``email`` + ``email_verified: true``).
+- ``GET /jwks`` — the RSA public key the server verifies that ``id_token``
+  against.
+
+The signing keypair is generated per-instance, so the token the server
+verifies is genuinely signed by the key the JWKS advertises — a real crypto
+round-trip, not a bypass.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+import jwt
+import uvicorn
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from tests.e2e_ui.conftest import _find_free_port
+
+# The email the fake IdP asserts. Admission is unrestricted by default (empty
+# allowlist admits any IdP user), so any address works; a stable one keeps the
+# recorded journey legible.
+FAKE_IDP_EMAIL = "e2e-user@example.test"
+_KID = "e2e-fake-idp-key"
+
+
+@dataclass
+class FakeIdP:
+    """A running fake OIDC IdP.
+
+    :param issuer: The issuer URL (also the discovery base) — feed this to
+        ``OMNIGENT_OIDC_ISSUER``.
+    :param client_id: The client id the server must present (and that the
+        signed ``id_token`` carries as its audience).
+    :param client_secret: The client secret the server presents at ``/token``.
+    :param email: The email the signed ``id_token`` asserts.
+    """
+
+    issuer: str
+    client_id: str
+    client_secret: str
+    email: str
+
+
+def _build_app(issuer: str, client_id: str, email: str, private_pem: bytes) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/.well-known/openid-configuration")
+    async def discovery() -> JSONResponse:
+        return JSONResponse(
+            {
+                "issuer": issuer,
+                "authorization_endpoint": f"{issuer}/authorize",
+                "token_endpoint": f"{issuer}/token",
+                "jwks_uri": f"{issuer}/jwks",
+                "userinfo_endpoint": f"{issuer}/userinfo",
+                "response_types_supported": ["code"],
+                "subject_types_supported": ["public"],
+                "id_token_signing_alg_values_supported": ["RS256"],
+            }
+        )
+
+    @app.get("/jwks")
+    async def jwks() -> JSONResponse:
+        # Advertise the RSA public key the id_token is signed with, as a JWK.
+        from cryptography.hazmat.primitives import serialization
+
+        private_key = serialization.load_pem_private_key(private_pem, password=None)
+        jwk = jwt.algorithms.RSAAlgorithm.to_jwk(private_key.public_key(), as_dict=True)
+        jwk["kid"] = _KID
+        jwk["use"] = "sig"
+        jwk["alg"] = "RS256"
+        return JSONResponse({"keys": [jwk]})
+
+    @app.get("/authorize")
+    async def authorize(redirect_uri: str, state: str) -> HTMLResponse:
+        # The user-facing sign-in page. One click continues the OAuth flow by
+        # bouncing back to the server's callback with a fixed code + the state.
+        continue_url = f"{redirect_uri}?code=fake-auth-code&state={state}"
+        return HTMLResponse(
+            "<!doctype html><html><head><title>Fake IdP Sign-in</title></head>"
+            "<body style='font-family:sans-serif;padding:2rem'>"
+            "<h1>Fake IdP</h1>"
+            f"<p>Sign in as <b>{email}</b> to continue.</p>"
+            f"<a id='fake-idp-continue' href='{continue_url}'>Continue as {email}</a>"
+            "</body></html>"
+        )
+
+    @app.post("/token")
+    async def token() -> JSONResponse:
+        # Any code is accepted; return an RS256-signed id_token the server
+        # verifies against /jwks. iss/aud/email must match what the callback
+        # checks (issuer, client_id, verified email).
+        now = int(time.time())
+        id_token = jwt.encode(
+            {
+                "iss": issuer,
+                "aud": client_id,
+                "sub": "fake-idp-subject",
+                "email": email,
+                "email_verified": True,
+                "iat": now,
+                "exp": now + 300,
+            },
+            private_pem,
+            algorithm="RS256",
+            headers={"kid": _KID},
+        )
+        return JSONResponse(
+            {
+                "access_token": "fake-access-token",
+                "token_type": "Bearer",
+                "expires_in": 300,
+                "id_token": id_token,
+            }
+        )
+
+    return app
+
+
+@contextmanager
+def fake_idp(
+    *, client_id: str = "e2e-client", client_secret: str = "e2e-secret"
+) -> Iterator[FakeIdP]:
+    """Run a fake OIDC IdP on a background thread; yield its handle.
+
+    The issuer is a plain-``http`` loopback URL so the spawned server can fetch
+    discovery and JWKS without TLS. Generates a fresh RSA keypair per instance.
+    """
+    from cryptography.hazmat.primitives import serialization
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    port = _find_free_port()
+    issuer = f"http://127.0.0.1:{port}"
+    app = _build_app(issuer, client_id, FAKE_IDP_EMAIL, private_pem)
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    try:
+        # Wait for the discovery endpoint to answer before yielding, so a
+        # consumer that boots a server against this issuer won't race the boot.
+        import httpx
+
+        deadline = time.monotonic() + 15.0
+        while time.monotonic() < deadline:
+            try:
+                r = httpx.get(f"{issuer}/.well-known/openid-configuration", timeout=1.0)
+                if r.status_code == 200:
+                    break
+            except httpx.HTTPError:
+                pass
+            time.sleep(0.1)
+        else:
+            raise RuntimeError(f"fake IdP did not come up on {issuer}")
+
+        yield FakeIdP(
+            issuer=issuer,
+            client_id=client_id,
+            client_secret=client_secret,
+            email=FAKE_IDP_EMAIL,
+        )
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)

--- a/tests/e2e_ui/auth/_fake_idp.py
+++ b/tests/e2e_ui/auth/_fake_idp.py
@@ -33,6 +33,7 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+from html import escape
 from urllib.parse import quote
 
 import jwt
@@ -40,7 +41,6 @@ import uvicorn
 from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, JSONResponse
-from markupsafe import escape
 
 from tests.e2e_ui.conftest import _find_free_port
 

--- a/tests/e2e_ui/auth/_fake_idp.py
+++ b/tests/e2e_ui/auth/_fake_idp.py
@@ -122,9 +122,11 @@ def _build_app(issuer: str, client_id: str, email: str, private_pem: bytes) -> F
 
     @app.post("/token")
     async def token() -> JSONResponse:
-        # Any code is accepted; return an RS256-signed id_token the server
-        # verifies against /jwks. iss/aud/email must match what the callback
-        # checks (issuer, client_id, verified email).
+        # Any code is accepted (PKCE code_verifier/challenge is intentionally
+        # NOT validated — the goal is filming the journey, so this lane does not
+        # exercise/guard the server's PKCE handling). Return an RS256-signed
+        # id_token the server verifies against /jwks. iss/aud/email must match
+        # what the callback checks (issuer, client_id, verified email).
         now = int(time.time())
         id_token = jwt.encode(
             {

--- a/tests/e2e_ui/auth/_fake_idp.py
+++ b/tests/e2e_ui/auth/_fake_idp.py
@@ -33,12 +33,14 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+from urllib.parse import quote
 
 import jwt
 import uvicorn
 from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, JSONResponse
+from markupsafe import escape
 
 from tests.e2e_ui.conftest import _find_free_port
 
@@ -101,13 +103,20 @@ def _build_app(issuer: str, client_id: str, email: str, private_pem: bytes) -> F
     async def authorize(redirect_uri: str, state: str) -> HTMLResponse:
         # The user-facing sign-in page. One click continues the OAuth flow by
         # bouncing back to the server's callback with a fixed code + the state.
-        continue_url = f"{redirect_uri}?code=fake-auth-code&state={state}"
+        # redirect_uri/state are request query params, so escape them before
+        # reflecting into HTML: URL-encode into the href, HTML-escape for text.
+        continue_url = (
+            f"{quote(redirect_uri, safe=':/?#[]@!$&()*+,;=')}"
+            f"?code=fake-auth-code&state={quote(state, safe='')}"
+        )
+        safe_href = escape(continue_url)
+        safe_email = escape(email)
         return HTMLResponse(
             "<!doctype html><html><head><title>Fake IdP Sign-in</title></head>"
             "<body style='font-family:sans-serif;padding:2rem'>"
             "<h1>Fake IdP</h1>"
-            f"<p>Sign in as <b>{email}</b> to continue.</p>"
-            f"<a id='fake-idp-continue' href='{continue_url}'>Continue as {email}</a>"
+            f"<p>Sign in as <b>{safe_email}</b> to continue.</p>"
+            f"<a id='fake-idp-continue' href='{safe_href}'>Continue as {safe_email}</a>"
             "</body></html>"
         )
 

--- a/tests/e2e_ui/auth/_oidc_server.py
+++ b/tests/e2e_ui/auth/_oidc_server.py
@@ -1,0 +1,160 @@
+"""Shared helper: spawn a dedicated *OIDC-mode* Omnigent server pointed at a
+fake in-process IdP, so the SPA's login-redirect journey can be filmed.
+
+The shared ``live_server`` runs single-user with auth off, and the accounts
+helper (``_accounts_server.py``) drives a password form — neither exercises the
+OIDC redirect an SSO deployment uses. This spins up ``omnigent server`` in
+stock OIDC mode (``OMNIGENT_AUTH_PROVIDER=oidc``) with the issuer pointed at a
+:func:`tests.e2e_ui.auth._fake_idp.fake_idp` instance, so navigating the SPA
+bounces through ``/auth/login`` → the fake IdP sign-in page → ``/auth/callback``
+→ an authenticated session — all headless, all filmable.
+
+Served through the public-looking loopback alias (``_PUBLIC_LOOPBACK_HOST``,
+mapped to 127.0.0.1 by the browser launch args) so the redirect URI / cookie
+origin and the browser's origin agree.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import httpx
+
+from tests.e2e_ui.auth._accounts_server import public_loopback_url
+from tests.e2e_ui.auth._fake_idp import FakeIdP, fake_idp
+from tests.e2e_ui.conftest import (
+    _HEALTH_POLL_INTERVAL_S,
+    _HEALTH_TIMEOUT_S,
+    _REPO_ROOT,
+    _TEST_AGENT_YAML,
+    _find_free_port,
+)
+
+
+@dataclass
+class OIDCServer:
+    """A running OIDC-mode server wired to a fake IdP.
+
+    :param base_url: Loopback base URL (``http://127.0.0.1:<port>``) for REST.
+    :param public_url: The same server via the public-looking loopback alias,
+        so the browser and the server share one origin (cookies stick).
+    :param idp: The fake IdP the server authenticates against.
+    """
+
+    base_url: str
+    public_url: str
+    idp: FakeIdP
+
+
+def _terminate(proc: subprocess.Popen[bytes]) -> None:
+    """SIGTERM with a short grace period, escalating to SIGKILL."""
+    if proc.poll() is None:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def spawn_oidc_server(mock_llm_server_url: str, server_tmp) -> Iterator[OIDCServer]:
+    """Spawn an OIDC-mode server wired to a fake IdP; yield a handle.
+
+    The fake IdP must be up *before* the server boots, because stock OIDC mode
+    fetches the discovery document at construction time
+    (``OIDCConfig.from_env``). The redirect URI is on the public-loopback alias
+    so the session cookie is issued for the browser-visible origin.
+
+    :param mock_llm_server_url: Session-scoped mock LLM base (no real creds).
+    :param server_tmp: A per-test temp dir (``tmp_path_factory.mktemp(...)``).
+    :yields: An :class:`OIDCServer` handle.
+    """
+    with fake_idp() as idp:
+        port = _find_free_port()
+        log_path = server_tmp / "server.log"
+        db_path = server_tmp / "test.db"
+        artifact_dir = server_tmp / "artifacts"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        agent_yaml_path = server_tmp / "hello_world.yaml"
+        agent_yaml_path.write_text(_TEST_AGENT_YAML)
+
+        base_url = f"http://127.0.0.1:{port}"
+        public_url = public_loopback_url(base_url)
+        # The callback (and thus the session cookie) must be issued for the
+        # browser-visible origin, so derive the redirect URI from public_url.
+        redirect_uri = f"{public_url}/auth/callback"
+        pythonpath = f"{_REPO_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}"
+
+        server_env = {
+            **os.environ,
+            "PYTHONPATH": pythonpath,
+            "OMNIGENT_AUTH_PROVIDER": "oidc",
+            "OMNIGENT_AUTH_ENABLED": "1",
+            "OMNIGENT_LOCAL_SINGLE_USER": "",
+            "OMNIGENT_OIDC_ISSUER": idp.issuer,
+            "OMNIGENT_OIDC_CLIENT_ID": idp.client_id,
+            "OMNIGENT_OIDC_CLIENT_SECRET": idp.client_secret,
+            "OMNIGENT_OIDC_REDIRECT_URI": redirect_uri,
+            "OMNIGENT_OIDC_COOKIE_SECRET": secrets.token_hex(32),
+            "OPENAI_BASE_URL": f"{mock_llm_server_url}/v1",
+            "OPENAI_API_KEY": "mock-key",
+            "ANTHROPIC_API_KEY": "",
+        }
+
+        log_handle = open(log_path, "w")  # noqa: SIM115 — lives for the Popen; closed in finally
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "from omnigent.cli import main; main()",
+                "server",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--database-uri",
+                f"sqlite:///{db_path}",
+                "--artifact-location",
+                str(artifact_dir),
+                "--agent",
+                str(agent_yaml_path),
+            ],
+            env=server_env,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+        )
+
+        try:
+            deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+            ready = False
+            last_error = "not polled yet"
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    last_error = f"server exited early with code {proc.returncode}"
+                    break
+                try:
+                    if httpx.get(f"{base_url}/health", timeout=2).status_code == 200:
+                        ready = True
+                        break
+                except (httpx.ConnectError, httpx.ReadError, httpx.TimeoutException) as exc:
+                    last_error = f"{type(exc).__name__}: {exc}"
+                time.sleep(_HEALTH_POLL_INTERVAL_S)
+            if not ready:
+                log_handle.flush()
+                log_text = log_path.read_text() if log_path.exists() else ""
+                raise RuntimeError(
+                    f"oidc server not healthy within {_HEALTH_TIMEOUT_S:.0f}s on "
+                    f"{base_url} (last_error={last_error}).\n{log_text[-3000:]}"
+                )
+
+            yield OIDCServer(base_url=base_url, public_url=public_url, idp=idp)
+        finally:
+            _terminate(proc)
+            log_handle.close()

--- a/tests/e2e_ui/auth/_oidc_server.py
+++ b/tests/e2e_ui/auth/_oidc_server.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import os
 import secrets
-import signal
 import subprocess
 import sys
 import time
@@ -27,7 +26,7 @@ from dataclasses import dataclass
 
 import httpx
 
-from tests.e2e_ui.auth._accounts_server import public_loopback_url
+from tests.e2e_ui.auth._accounts_server import _terminate, public_loopback_url
 from tests.e2e_ui.auth._fake_idp import FakeIdP, fake_idp
 from tests.e2e_ui.conftest import (
     _HEALTH_POLL_INTERVAL_S,
@@ -51,17 +50,6 @@ class OIDCServer:
     base_url: str
     public_url: str
     idp: FakeIdP
-
-
-def _terminate(proc: subprocess.Popen[bytes]) -> None:
-    """SIGTERM with a short grace period, escalating to SIGKILL."""
-    if proc.poll() is None:
-        proc.send_signal(signal.SIGTERM)
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=5)
 
 
 def spawn_oidc_server(mock_llm_server_url: str, server_tmp) -> Iterator[OIDCServer]:

--- a/tests/e2e_ui/auth/test_oidc_login_flow.py
+++ b/tests/e2e_ui/auth/test_oidc_login_flow.py
@@ -1,0 +1,68 @@
+"""E2E: the OIDC/SSO login journey, driven headlessly against a fake IdP.
+
+An unauthenticated SPA navigation in OIDC mode bounces to the IdP's sign-in
+page and, after the user authenticates, lands back in the app authenticated.
+Deployments use a real SSO provider, so this journey can't be filmed against
+the live app — the recorder would be bounced to real SSO. This test wires the
+server to a fake in-process IdP (:mod:`tests.e2e_ui.auth._fake_idp`) so the
+whole redirect chain runs locally and headlessly:
+
+    SPA → /v1/me 401 (login_url) → /auth/login → 302 fake IdP /authorize
+        → "Continue" → /auth/callback (code+state, signed id_token) → app
+
+This is the reproduction lane for auth/OIDC login bugs (T3): the recorded video
+shows the real sign-in page and the authenticated landing, not a proxy.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.auth._oidc_server import OIDCServer, spawn_oidc_server
+
+
+@pytest.fixture(scope="module")
+def oidc_server(
+    built_spa: None,
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[OIDCServer]:
+    """A dedicated OIDC-mode server wired to a fake IdP."""
+    server_tmp = tmp_path_factory.mktemp("e2e_ui_oidc_login")
+    yield from spawn_oidc_server(mock_llm_server_url, server_tmp)
+
+
+def test_oidc_login_redirects_through_idp_to_authenticated_app(
+    oidc_server: OIDCServer, page: Page
+) -> None:
+    """Navigating the SPA unauthenticated lands on the IdP sign-in page;
+    continuing there returns to the app authenticated.
+
+    Drives the full OIDC redirect chain against the fake IdP and asserts both
+    ends a user observes: the sign-in page (naming the identity) and the
+    authenticated app shell (the composer).
+    """
+    # 1. Land on the SPA unauthenticated. The client probes /v1/me, gets a 401
+    #    with login_url, and redirects the browser to /auth/login, which 302s
+    #    to the fake IdP's /authorize page. Playwright follows the 302s.
+    page.goto(oidc_server.public_url)
+
+    # 2. The fake IdP sign-in page is shown, naming the identity to sign in as.
+    continue_link = page.locator("#fake-idp-continue")
+    expect(continue_link).to_be_visible(timeout=15_000)
+    expect(continue_link).to_contain_text(oidc_server.idp.email)
+
+    # 3. Continue through the IdP → /auth/callback exchanges the code for a
+    #    signed id_token, mints the session cookie, and 302s back to the app.
+    continue_link.click()
+
+    # 4. Back in the authenticated app: no longer on any auth page, and the
+    #    app shell (the sidebar, which renders only for an authenticated
+    #    session) is shown. Assert on the shell rather than the composer, since
+    #    the post-login landing route need not be a chat with a composer.
+    expect(page).not_to_have_url(re.compile(r"/authorize|/auth/login"), timeout=15_000)
+    expect(page.locator('[data-testid="sidebar-brand"]')).to_be_visible(timeout=15_000)


### PR DESCRIPTION
## Related issue

Infrastructure for repro-agent — a generic recording capability, not a fix for
one issue.

## Summary

repro-agent can't film any journey behind OIDC/SSO login today: an
unauthenticated Playwright navigation is bounced to the deployment's real SSO
provider, which the recorder can't drive. This adds a **fake in-process IdP** so
the whole OIDC redirect chain runs locally and headlessly, giving repro-agent a
reusable lane to film auth journeys against.

- `_fake_idp.py` — a real HTTP OIDC IdP: discovery + `/authorize` + `/token`
  (RS256-signed `id_token`) + `/jwks`, per-instance RSA keypair (a genuine
  crypto round-trip, not a bypass).
- `_oidc_server.py` — spawns `omnigent server` in OIDC mode wired to the fake
  IdP, through the public-loopback alias so cookie/redirect origins agree.
- `test_oidc_login_flow.py` — films SPA → `/v1/me` 401 → `/auth/login` → fake
  IdP sign-in → `/auth/callback` → authenticated shell.

No product-code change; test-only. Green on `main`.

## Test Plan

`pytest tests/e2e_ui/auth/test_oidc_login_flow.py` — passes on `main` (verified
3× stable), producing a video of the redirect chain and a screenshot of the
authenticated shell.

## Demo

N/A — test/CI infrastructure; the lane produces demos for future auth-bug
reproductions.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the lane locally against `main` (green, 3×), inspected
the recorded video + authenticated-shell screenshot. Fake-IdP crypto is a real
RS256 round-trip verified against the advertised JWKS, so it doesn't weaken the
callback's signature/`iss`/`aud`/`email_verified` checks.

This pull request and its description were written by Isaac.