### PR TITLE
fix(codex): reject chat-only provider routes

### DIFF
--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -46,6 +46,7 @@ from omnigent.onboarding.detected import (
 from omnigent.onboarding.provider_config import (
     ANTHROPIC_FAMILY,
     BEDROCK_KIND,
+    CHAT_WIRE_API,
     CLI_CONFIG_KIND,
     DATABRICKS_KIND,
     OPENAI_FAMILY,
@@ -740,8 +741,18 @@ def _apply_provider_family(
     :param harness_type: ``"claude-sdk"`` or ``"codex"``.
     :param family: The resolved provider family for this harness.
     :raises OmnigentError: If no model is resolvable (neither the spec nor
-        the family declares one).
+        the family declares one), or if a Codex provider is configured for
+        the unsupported Chat Completions wire API.
     """
+    if harness_type == "codex" and family.wire_api == CHAT_WIRE_API:
+        raise OmnigentError(
+            "The 'codex' harness requires an OpenAI Responses API endpoint, but "
+            f"provider endpoint {family.base_url!r} is configured with "
+            "'wire_api: chat'. Choose a Responses-capable endpoint and set "
+            "'wire_api: responses', or use a harness that supports Chat Completions.",
+            code=ErrorCode.INVALID_INPUT,
+        )
+
     cfg = _UCODE_HARNESS_CONFIGS[harness_type]
     env[_HARNESS_GATEWAY_FLAG[harness_type]] = "true"
     env[cfg.base_url_key] = family.base_url

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -26,6 +26,7 @@ from types import SimpleNamespace
 import pytest
 import yaml as _yaml
 
+from omnigent.errors import OmnigentError
 from omnigent.runtime.workflow import (
     _build_claude_sdk_spawn_env,
     _build_codex_spawn_env,
@@ -321,6 +322,64 @@ def test_codex_uses_openai_global_default(config_home: Path) -> None:
     assert env["HARNESS_CODEX_GATEWAY_AUTH_COMMAND"] == "printf %s sk-oai-secret"
     assert env["HARNESS_CODEX_MODEL"] == "gpt-default-model"
     # Codex defaults to the Responses wire API when the family omits wire_api.
+    assert env["HARNESS_CODEX_WIRE_API"] == "responses"
+
+
+def test_codex_rejects_chat_only_openrouter_before_harness_spawn(config_home: Path) -> None:
+    """A chat-only OpenRouter route fails before Codex can make a bad request."""
+    _write_config(
+        config_home,
+        {
+            "providers": {
+                "openrouter": {
+                    "kind": "gateway",
+                    "default": True,
+                    "openai": _key_family(
+                        "https://openrouter.ai/api/v1",
+                        "sk-or-test",
+                        "stealth/ox-alpha",
+                        wire_api="chat",
+                    ),
+                }
+            }
+        },
+    )
+    spec = _make_spec(harness="codex")
+
+    with pytest.raises(OmnigentError) as raised:
+        _build_codex_spawn_env(spec, workdir=None)
+
+    message = str(raised.value).lower()
+    assert "codex" in message
+    assert "chat" in message
+    assert "responses" in message
+    assert "openrouter.ai/api/v1" in message
+
+
+def test_codex_accepts_explicit_responses_wire_at_same_provider_url(config_home: Path) -> None:
+    """The chat-wire guard does not reject a Responses-capable route by vendor name."""
+    _write_config(
+        config_home,
+        {
+            "providers": {
+                "openrouter": {
+                    "kind": "gateway",
+                    "default": True,
+                    "openai": _key_family(
+                        "https://openrouter.ai/api/v1",
+                        "sk-or-test",
+                        "openai/gpt-5",
+                        wire_api="responses",
+                    ),
+                }
+            }
+        },
+    )
+    spec = _make_spec(harness="codex")
+
+    env = _build_codex_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CODEX_GATEWAY_BASE_URL"] == "https://openrouter.ai/api/v1"
     assert env["HARNESS_CODEX_WIRE_API"] == "responses"
 
 


### PR DESCRIPTION
## Related issue

Closes #5448

## Summary

- Reject Chat-Completions-only provider routes before spawning the Codex harness, which only supports the Responses wire API.
- Return actionable guidance naming the endpoint, current wire, required wire, and alternate harness path.
- Preserve explicit Responses and Databricks routes.

ELI5: Codex speaks Responses, while this OpenRouter configuration advertised Chat. We now stop at configuration time with a useful explanation instead of launching a session guaranteed to fail with a generic provider 400.

```mermaid
flowchart LR
  A[Resolve Codex provider] --> B{wire_api}
  B -->|chat| C[400 invalid_input before spawn]
  B -->|responses| D[Spawn Codex harness]
```

## Test Plan

- Focused red/green regression and same-URL Responses control: 2 passed.
- OpenAI Responses and Databricks preservation slice: 6 passed.
- Broader provider/Codex suite with host ambient discovery neutralized: 118 passed.
- Real `HarnessProcessManager`: Chat route produced HTTP 400 with no process/socket; Responses route produced HTTP 201 with a real Codex harness socket.
- Pre-commit on both touched files, including Ruff, Pyrefly, and repository policy checks: passed.

## Demo

N/A — non-visual runtime change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification exercised the runner HTTP boundary and a real harness process manager. The chat route was rejected before process creation; the Responses control created the expected subprocess/socket.

## Changelog

Codex sessions now explain incompatible Chat-only provider routes before launch instead of failing later with a generic provider error.
