### PR TITLE
fix(web): use draft message icon in session list

### DIFF
--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -34,6 +34,7 @@ import {
   LaptopIcon,
   Loader2Icon,
   MailIcon,
+  MessageCircleDashedIcon,
   Maximize2Icon,
   Minimize2Icon,
   MoreHorizontalIcon,
@@ -3607,7 +3608,7 @@ function ConversationRow({
               data-testid="conversation-draft-indicator"
               className="inline-flex h-5 shrink-0 items-center justify-center text-muted-foreground"
             >
-              <PencilIcon aria-hidden className="size-3.5" />
+              <MessageCircleDashedIcon aria-hidden className="size-3.5" />
             </span>
           )}
         </span>


### PR DESCRIPTION
## Related issue

N/A — maintainer UX adjustment.

## Summary

- Make composer drafts easier to recognize in the session list.
- Replace the pencil draft indicator with Lucide's dashed message-circle icon.

## Test Plan

- `pnpm --dir web test src/shell/Sidebar.test.tsx`

## Demo

<img width="653" height="518" alt="image" src="https://github.com/user-attachments/assets/dc142771-d9ac-4b73-a494-d56770962fe9" />

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing Sidebar test verifies draft indicator visibility and accessibility.

## Changelog

Session drafts now use a dashed message icon in the session list.
