### PR TITLE
fix(tests): isolate runtime spawn-env tests from ambient host state

### DIFF
--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -1,0 +1,94 @@
+"""
+Ambient-discovery isolation for the runtime spawn-env tests.
+
+The spawn-env builders merge ambient provider detection
+(``omnigent/onboarding/ambient.py``) into the effective config, and several
+of those probes read real host state that no amount of ``$HOME`` isolation
+can reach: vendor API keys in the environment (bare and ``OMNIGENT_``-
+prefixed, plus the Claude-on-Vertex GCP triple), a TCP connect to a local
+Ollama server, and (on macOS) a ``claude auth status`` subprocess that reads
+the Keychain. Any one synthesizes an ambient provider that shadows the
+configured one under test, so the same test passes on a clean box and fails
+on a developer's machine.
+
+The autouse fixture here severs those host-state channels while keeping the
+``$HOME``-scoped credentials-file check intact, so a test can still simulate
+a login by writing that file under its isolated home. It also clears the
+harness login-probe TTL cache around every test, since a positive verdict
+cached by one test outlives that test by two minutes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+
+from omnigent.onboarding import ambient, harness_install
+from omnigent.onboarding.providers import PROVIDER_ENV_VARS
+
+# Claude Code's Vertex AI routing is detected from these three GCP env vars,
+# which PROVIDER_ENV_VARS does not cover.
+_VERTEX_ENV_VARS = (
+    "CLAUDE_CODE_USE_VERTEX",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "CLOUD_ML_REGION",
+)
+
+# Captured before the autouse patch below rebinds them, so the calibration
+# controls can prove the ambient state is real rather than coincidentally absent.
+_REAL_OLLAMA_REACHABLE = ambient._ollama_reachable
+_REAL_CLAUDE_LOGIN_DETECTED = ambient._claude_login_detected
+
+
+@pytest.fixture(autouse=True)
+def _isolate_ambient_discovery(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """
+    Keep host state out of ambient provider detection.
+
+    Four channels are closed. Vendor API keys in the developer's environment
+    (bare, ``OMNIGENT_``-prefixed, and the Vertex triple) are cleared, since
+    detection reads each of them. A live Ollama accepting TCP on the probe
+    port would be detected as a provider that shadows the configured one, so
+    the reachability probe is pinned to ``False``. The Claude login detector
+    is narrowed to its ``$HOME``-scoped credentials-file check, which tests
+    can drive by writing that file under an isolated home, while the macOS
+    Keychain fallback (a ``claude auth status`` subprocess that ignores
+    ``$HOME``) is severed. The login-probe cache is cleared on both sides of
+    the test, so a positive verdict cached by one test — its TTL outlives the
+    test — can never be consumed by another.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: Iterator yielding once, with the caches cleared around the test.
+    """
+    for env_var in (*PROVIDER_ENV_VARS.values(), *_VERTEX_ENV_VARS):
+        monkeypatch.delenv(env_var, raising=False)
+        monkeypatch.delenv(f"OMNIGENT_{env_var}", raising=False)
+    monkeypatch.setattr(ambient, "_ollama_reachable", lambda: False)
+    monkeypatch.setattr(
+        ambient,
+        "_claude_login_detected",
+        lambda: ambient.claude_auth_has_credential(ambient._claude_credentials_path()),
+    )
+    harness_install._LOGIN_PROBE_CACHE.clear()
+    yield
+    harness_install._LOGIN_PROBE_CACHE.clear()
+
+
+@pytest.fixture
+def real_ambient_probes() -> SimpleNamespace:
+    """
+    Expose the unpatched ambient probes for calibration assertions.
+
+    A test that isolates ambient state should first prove the state would
+    have been visible without the isolation; otherwise it passes vacuously on
+    a machine where no Ollama runs and no Claude login exists.
+
+    :returns: Namespace with ``ollama_reachable`` and ``claude_login_detected``
+        bound to the real, unpatched probe functions.
+    """
+    return SimpleNamespace(
+        ollama_reachable=_REAL_OLLAMA_REACHABLE,
+        claude_login_detected=_REAL_CLAUDE_LOGIN_DETECTED,
+    )

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -20,12 +20,16 @@ subprocess spawn, no real CLI.
 
 from __future__ import annotations
 
+import socket
+import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import yaml as _yaml
 
+from omnigent.onboarding import ambient, harness_install
 from omnigent.runtime.workflow import (
     _build_claude_sdk_spawn_env,
     _build_codex_spawn_env,
@@ -1671,3 +1675,164 @@ def test_spawn_env_legacy_env_wins_over_config_command(
 
     # The builder must not set OMNIGENT_* from config when the legacy env wins.
     assert f"OMNIGENT_{harness.upper()}_PATH" not in env
+
+
+# ── Ambient-isolation controls ─────────────────────────────────────────────
+
+
+def test_live_ollama_cannot_shadow_codex_fallback(
+    config_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    real_ambient_probes: SimpleNamespace,
+) -> None:
+    """A live Ollama on the probe port must not shadow the configured openai fallback.
+
+    Ambient detection connects to the local Ollama port and synthesizes a
+    provider from a successful connect; that provider would outrank the
+    configured-but-not-default openai credential the codex head falls back to.
+    A real listener is bound and the probe pointed at it, so the calibration
+    assertion proves the isolation patch is what suppresses detection rather
+    than the port being coincidentally dead on this machine.
+    """
+    listener = socket.socket()
+    try:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(8)
+        host, port = listener.getsockname()
+        # The probe reads these module globals at call time.
+        monkeypatch.setattr(ambient, "_OLLAMA_HOST", host)
+        monkeypatch.setattr(ambient, "_OLLAMA_PORT", port)
+
+        # Calibration: the unpatched probe sees the live listener.
+        assert real_ambient_probes.ollama_reachable() is True
+        # Isolation: the autouse patch, not a dead port, suppresses detection.
+        assert ambient._ollama_reachable() is False
+
+        monkeypatch.setenv("HOME", str(config_home))
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        config = {
+            "providers": {
+                "vendor-openai": {  # configured, but NOT marked default
+                    "kind": "key",
+                    "openai": _key_family(
+                        "https://openai.example.com/v1",
+                        "sk-oai-secret",
+                        "gpt-default-model",
+                    ),
+                }
+            }
+        }
+        _write_config(config_home, config)
+        spec = _make_spec(harness="codex")
+
+        env = _build_codex_spawn_env(spec, workdir=None)
+
+        assert env["HARNESS_CODEX_GATEWAY"] == "true"
+        assert env["HARNESS_CODEX_GATEWAY_BASE_URL"] == "https://openai.example.com/v1"
+        assert env["HARNESS_CODEX_GATEWAY_AUTH_COMMAND"] == "printf %s sk-oai-secret"
+    finally:
+        listener.close()
+
+
+def test_claude_cli_login_cannot_shadow_claude_sdk_fallback(
+    config_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    real_ambient_probes: SimpleNamespace,
+) -> None:
+    """A Keychain-backed Claude CLI login must not shadow the anthropic fallback.
+
+    On macOS the login detector falls back to ``claude auth status``, which
+    reads the Keychain and so reports a login regardless of ``$HOME``; the
+    resulting subscription provider would outrank the configured-but-not-default
+    anthropic credential the brain head falls back to. ``sys.platform`` is
+    pinned to darwin so the macOS-only branch is exercised on every CI OS, and
+    the calibration assertion proves the unpatched detector would report the
+    simulated login.
+    """
+    monkeypatch.setattr(sys, "platform", "darwin")
+    # ``_claude_login_detected`` imports this name from the module at call
+    # time, so the module attribute is the seam.
+    monkeypatch.setattr(harness_install, "harness_cli_logged_in", lambda *args, **kwargs: True)
+    monkeypatch.setenv("HOME", str(config_home))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    # Calibration: file check misses under the isolated HOME, so the darwin
+    # CLI fallback fires and the unpatched detector reports a login.
+    assert real_ambient_probes.claude_login_detected() is True
+    # Isolation: the patched detector never consults the CLI.
+    assert ambient._claude_login_detected() is False
+
+    config = {
+        "providers": {
+            "vendor-anthropic": {  # configured, but NOT marked default
+                "kind": "key",
+                "anthropic": _key_family(
+                    "https://anthropic.example.com/v1",
+                    "sk-ant-secret",
+                    "claude-default-model",
+                ),
+            }
+        }
+    }
+    _write_config(config_home, config)
+    spec = _make_spec(harness="claude-sdk")
+
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_GATEWAY"] == "true"
+    assert env["HARNESS_CLAUDE_SDK_GATEWAY_BASE_URL"] == "https://anthropic.example.com/v1"
+    assert env["HARNESS_CLAUDE_SDK_GATEWAY_AUTH_COMMAND"] == "printf %s sk-ant-secret"
+
+
+def test_stale_login_cache_cannot_shadow_claude_sdk_fallback(
+    config_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    real_ambient_probes: SimpleNamespace,
+) -> None:
+    """A TTL-cached login verdict from an earlier test must not shadow the fallback.
+
+    An earlier test's ambient sweep can run ``claude auth status`` while a
+    vendor key sits in the environment; the CLI reports a login for that key
+    and the positive verdict is TTL-cached per ``(key, binary)``, outliving the
+    test that produced it. A later test with an isolated ``$HOME`` would then
+    consume the stale positive and route through a subscription provider
+    instead of its configured anthropic credential. The fixture boundary must
+    make that cache unreachable.
+    """
+    monkeypatch.setattr(sys, "platform", "darwin")
+    # Prime the cache under the key production writes: (family, resolved
+    # binary path). Binary resolution is stubbed so the cache is hit — and the
+    # status subprocess never spawns — on machines with no claude install.
+    fake_binary = "/fake/bin/claude"
+    monkeypatch.setattr(
+        harness_install, "shutil", SimpleNamespace(which=lambda _name: fake_binary)
+    )
+    harness_install._LOGIN_PROBE_CACHE[("anthropic", fake_binary)] = time.monotonic() + 3600.0
+    monkeypatch.setenv("HOME", str(config_home))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    # Calibration: the unpatched detector consumes the stale positive.
+    assert real_ambient_probes.claude_login_detected() is True
+    # Isolation: the patched detector never reaches the cache.
+    assert ambient._claude_login_detected() is False
+
+    config = {
+        "providers": {
+            "vendor-anthropic": {  # configured, but NOT marked default
+                "kind": "key",
+                "anthropic": _key_family(
+                    "https://anthropic.example.com/v1",
+                    "sk-ant-secret",
+                    "claude-default-model",
+                ),
+            }
+        }
+    }
+    _write_config(config_home, config)
+    spec = _make_spec(harness="claude-sdk")
+
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_GATEWAY"] == "true"
+    assert env["HARNESS_CLAUDE_SDK_GATEWAY_BASE_URL"] == "https://anthropic.example.com/v1"
+    assert env["HARNESS_CLAUDE_SDK_GATEWAY_AUTH_COMMAND"] == "printf %s sk-ant-secret"


### PR DESCRIPTION
<!-- AI-written description following the repo template. -->

## Related issue

Closes #5449

## Summary

- The provider spawn-env tests isolate `$HOME`, but two ambient-detection probes read host state `$HOME` cannot reach: `_ollama_reachable()` does a real TCP connect to `localhost:11434`, and on macOS `_claude_login_detected()` falls back to a `claude auth status` subprocess whose **positive** verdicts are TTL-cached for 120s in `harness_install._LOGIN_PROBE_CACHE`. Either channel synthesizes an ambient provider that outranks the configured-but-not-default credential under test, so 3 tests fail on developer machines (2 with a live Ollama, 1 on macOS).
- The macOS failure is deeper than a Keychain credential: `test_detected_ambient_key_routes_with_no_config` sets `ANTHROPIC_API_KEY` during its ambient sweep, `claude auth status` reports `loggedIn: true` for an env API key, and the cached positive is consumed by the later `$HOME`-isolated test. On macOS with `claude` on `PATH`, the file self-pollutes deterministically — no Keychain login required (a real one is a second, independent priming path).
- A third channel found while hardening the fix: vendor keys in the developer's environment. Detection reads every `PROVIDER_ENV_VARS` entry through `getenv_nonempty_with_omnigent_prefix` (so `OMNIGENT_ANTHROPIC_API_KEY` etc. count too) plus the Claude-on-Vertex GCP triple, while the module's existing `_clear_ambient_keys` fixture clears only three unprefixed names. Ordinary omnigent env vars (`OMNIGENT_*_API_KEY`, `OPENROUTER_API_KEY`, `CLAUDE_CODE_USE_VERTEX` + project + region) each reproduce the same shadowing — measured up to 7 failures in this file.
- Fix: a new `tests/runtime/conftest.py` autouse fixture clears every ambient-detected env key (bare + `OMNIGENT_`-prefixed + the Vertex triple), pins `_ollama_reachable` to `False`, narrows `_claude_login_detected` to its `$HOME`-scoped credentials-file check (severing the Keychain/CLI fallback while keeping file-simulated logins working), and clears the login-probe cache on both sides of every test. Three calibrated control tests prove the isolation is active rather than vacuous, per the issue's acceptance criteria; the cache control primes the exact key shape production writes (`(family, resolved-binary-path)`) with binary resolution stubbed, so it exercises the cache-hit path deterministically even on machines with no `claude` install.

ELI5: the tests built a sealed room (`$HOME` in a temp dir) but two windows still opened onto the real machine — a network peek at Ollama and a Keychain peek via the Claude CLI, the latter with a 2-minute memory. We board up both windows for every test in the room, and add tests that first prove each window *would* have let the outside in before checking that it no longer does.

```
                        before                      after
ambient sweep ──► env keys        (HOME-scoped ✓)   unchanged
              ──► claude login ──► credentials file (HOME-scoped ✓)   unchanged
              │                └─► darwin: `claude auth status` ──► Keychain / 120s +cache ✗   severed
              └─► ollama: TCP connect localhost:11434 ✗                                        pinned False
```

## Test Plan

- Reproduced all 3 failures from the issue on macOS 26 (Apple Silicon) at `d755311f`: `test_codex_falls_back_to_first_available_openai_credential` + `test_codex_dismissed_config_provider_pins_openai` with a listener bound on `127.0.0.1:11434`, and `test_claude_sdk_falls_back_to_first_available_anthropic_credential` plain (this machine has a Claude Keychain login; the failure also reproduces with just the two tests `test_detected_ambient_key_routes_with_no_config` + the claude-sdk fallback test, confirming the cache-priming chain).
- After the fix: `pytest tests/runtime/test_provider_spawn_env.py tests/runtime/test_pi_spawn_env.py tests/runtime/test_claude_sdk_spawn_env.py` → 91 passed under every ambient combination, with a real Claude Keychain credential present throughout: plain; live listener on 11434; `OMNIGENT_ANTHROPIC_API_KEY` + `OMNIGENT_OPENAI_API_KEY`; the Vertex triple; `OPENROUTER_API_KEY`; and all of those at once plus `GEMINI_API_KEY` — identical results per the acceptance criteria.
- Full `pytest tests/runtime/` (minus two files that don't collect in this venv for pre-existing reasons: `test_telemetry*.py` need `opentelemetry.sdk`; `credentials/test_databricks.py` errors need `databricks.sdk`) → 1186 passed, same counts with and without the live listener.
- Negative control: with the new conftest removed and a listener on 11434, the two codex tests fail again — the fixture is load-bearing, not coincidental.
- Calibrated controls in-tree: each control first asserts the *unpatched* probe sees the simulated ambient state (live listener via repointed `_OLLAMA_HOST/_PORT`; `sys.platform` pinned to darwin with a patched `harness_cli_logged_in`; a primed `_LOGIN_PROBE_CACHE` entry), then asserts the patched seam suppresses it, then re-runs the exact end-to-end fallback scenario that used to be shadowed.
- `pre-commit run --files tests/runtime/conftest.py tests/runtime/test_provider_spawn_env.py` → clean.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = the with/without-ambient-state matrix above (live TCP listener on the Ollama port, real macOS Keychain credential, and the conftest-removed negative control), which CI cannot exercise both sides of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
