### PR TITLE
feat(omnidev): open the UI when ready

### DIFF
--- a/dev/omnidev/README.md
+++ b/dev/omnidev/README.md
@@ -60,7 +60,9 @@ in `web/` when needed — `node_modules/` is missing, or `package.json` /
 `pnpm-lock.yaml` is newer than it — so a fresh checkout or a new dependency
 doesn't make Vite fail its dependency scan. Output streams into the `vite` pane.
 
-Open the UI at the `ui` URL shown in the header (the Vite dev server).
+Once Vite begins serving, omnidev opens the `ui` URL shown in the header in
+your default browser. If the platform browser launcher is unavailable, startup
+continues and the combined log tells you to open that URL manually.
 
 ## Isolation
 

--- a/dev/omnidev/src/browser.rs
+++ b/dev/omnidev/src/browser.rs
@@ -1,0 +1,87 @@
+//! Open the omnidev UI in the platform browser without going through a shell.
+
+use std::io::ErrorKind;
+use std::process::Stdio;
+
+use anyhow::{bail, Context, Result};
+use tokio::process::Command;
+
+struct OpenCommand {
+    program: &'static str,
+    args: Vec<String>,
+}
+
+/// Open `url` with the platform's standard browser launcher.
+pub async fn open(url: &str) -> Result<()> {
+    for candidate in candidates(url) {
+        let status = Command::new(candidate.program)
+            .args(&candidate.args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await;
+        match status {
+            Ok(status) if status.success() => return Ok(()),
+            Ok(status) => bail!("{} exited with {status}", candidate.program),
+            Err(error) if error.kind() == ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("starting browser opener {}", candidate.program));
+            }
+        }
+    }
+    bail!("no supported browser opener was found")
+}
+
+#[cfg(target_os = "macos")]
+fn candidates(url: &str) -> Vec<OpenCommand> {
+    vec![OpenCommand {
+        program: "/usr/bin/open",
+        args: vec![url.into()],
+    }]
+}
+
+#[cfg(target_os = "linux")]
+fn candidates(url: &str) -> Vec<OpenCommand> {
+    vec![
+        OpenCommand {
+            program: "xdg-open",
+            args: vec![url.into()],
+        },
+        OpenCommand {
+            program: "gio",
+            args: vec!["open".into(), url.into()],
+        },
+    ]
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn candidates(_url: &str) -> Vec<OpenCommand> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn macos_uses_open() {
+        let commands = candidates("http://localhost:5173");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].program, "/usr/bin/open");
+        assert_eq!(commands[0].args, ["http://localhost:5173"]);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn linux_uses_desktop_openers() {
+        let commands = candidates("http://localhost:5173");
+        assert_eq!(commands.len(), 2);
+        assert_eq!(commands[0].program, "xdg-open");
+        assert_eq!(commands[0].args, ["http://localhost:5173"]);
+        assert_eq!(commands[1].program, "gio");
+        assert_eq!(commands[1].args, ["open", "http://localhost:5173"]);
+    }
+}

--- a/dev/omnidev/src/main.rs
+++ b/dev/omnidev/src/main.rs
@@ -11,6 +11,7 @@
 //!   against the current checkout's pod via pinned `uv run --python …`, with the pod's
 //!   isolated env applied. Requires a checkout, like the supervisor.
 
+mod browser;
 mod install;
 mod lan;
 mod lock;

--- a/dev/omnidev/src/supervisor.rs
+++ b/dev/omnidev/src/supervisor.rs
@@ -12,6 +12,7 @@ use tokio::process::Command;
 use tokio::sync::mpsc;
 use tokio::time::{sleep, timeout};
 
+use crate::browser;
 use crate::omnigent_cmd;
 use crate::pod::Pod;
 use crate::process::ProcSpec;
@@ -141,6 +142,7 @@ impl Supervisor {
         if self.vite_enabled {
             self.prepare_vite().await;
             self.spawn(ProcId::Vite);
+            self.open_ui_when_ready();
         }
 
         loop {
@@ -167,6 +169,33 @@ impl Supervisor {
                 }
             }
         }
+    }
+
+    /// Open one browser tab after Vite starts serving the displayed UI URL.
+    fn open_ui_when_ready(&self) {
+        let addr = format!("127.0.0.1:{}", self.pod.ports.vite);
+        let host = format!("localhost:{}", self.pod.ports.vite);
+        let url = self.pod.vite_display_url();
+        let shared = self.shared.clone();
+        tokio::spawn(async move {
+            for _ in 0..120 {
+                if http_ok(&addr, "/", &host).await {
+                    shared.lock().unwrap().event(format!("opening UI {url}"));
+                    if let Err(error) = browser::open(&url).await {
+                        shared
+                            .lock()
+                            .unwrap()
+                            .event(format!("could not open UI {url}: {error:#}"));
+                    }
+                    return;
+                }
+                sleep(Duration::from_millis(250)).await;
+            }
+            shared
+                .lock()
+                .unwrap()
+                .event(format!("UI did not become ready; open {url} manually"));
+        });
     }
 
     async fn start_backend(&mut self) {
@@ -578,7 +607,7 @@ impl Supervisor {
     async fn wait_healthy(&self) -> bool {
         let addr = format!("127.0.0.1:{}", self.pod.ports.server);
         for _ in 0..120 {
-            if health_ok(&addr).await {
+            if http_ok(&addr, "/health", &addr).await {
                 return true;
             }
             sleep(Duration::from_millis(250)).await;
@@ -606,14 +635,13 @@ fn backoff_secs(attempt: u32) -> u64 {
     }
 }
 
-/// Minimal HTTP/1.0 `GET /health` returning true on a `200` status line. Avoids
-/// pulling an HTTP client dependency just for a readiness probe.
-async fn health_ok(addr: &str) -> bool {
+/// Minimal HTTP/1.0 readiness probe. Avoids an HTTP client dependency.
+async fn http_ok(addr: &str, path: &str, host: &str) -> bool {
     let Ok(Ok(mut stream)) = timeout(Duration::from_secs(1), TcpStream::connect(addr)).await else {
         return false;
     };
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    let req = format!("GET /health HTTP/1.0\r\nHost: {addr}\r\n\r\n");
+    let req = format!("GET {path} HTTP/1.0\r\nHost: {host}\r\n\r\n");
     if stream.write_all(req.as_bytes()).await.is_err() {
         return false;
     }
@@ -622,5 +650,34 @@ async fn health_ok(addr: &str) -> bool {
         return false;
     };
     let head = String::from_utf8_lossy(&buf[..n]);
-    head.starts_with("HTTP/1.") && head.contains(" 200")
+    let status = head.lines().next().unwrap_or_default();
+    status.starts_with("HTTP/1.") && status.split_whitespace().nth(1) == Some("200")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn http_probe_sends_requested_path_and_host() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0_u8; 256];
+            let n = stream.read(&mut buf).await.unwrap();
+            let request = String::from_utf8_lossy(&buf[..n]);
+            assert!(request.starts_with("GET /ready HTTP/1.0\r\n"));
+            assert!(request.contains("\r\nHost: localhost:5173\r\n"));
+            stream
+                .write_all(b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n")
+                .await
+                .unwrap();
+        });
+
+        assert!(http_ok(&addr.to_string(), "/ready", "localhost:5173").await);
+        server.await.unwrap();
+    }
 }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Open omnidev's UI automatically instead of requiring developers to copy the displayed URL.
- Wait for Vite to return HTTP 200 before invoking the platform browser launcher.
- Keep browser-launch failures non-fatal and preserve the displayed URL as a manual fallback.

**ELI5:** After omnidev starts the website, it waits until the page is actually available and then opens it in the default browser. If the computer cannot open a browser, omnidev keeps running and shows the URL.

```text
spawn Vite --> poll UI URL --> HTTP 200 --> open default browser
                         \--> timeout/error --> log manual URL
```

## Test Plan

- `cargo fmt --manifest-path dev/omnidev/Cargo.toml --check`
- `cargo check --manifest-path dev/omnidev/Cargo.toml`
- `cargo test --manifest-path dev/omnidev/Cargo.toml browser::tests::macos_uses_open -- --exact`
- `cargo test --manifest-path dev/omnidev/Cargo.toml supervisor::tests::http_probe_sends_requested_path_and_host -- --exact`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused Rust tests cover platform launcher selection and the HTTP readiness request used to gate browser opening.

## Changelog

omnidev now opens its UI in your default browser as soon as Vite is ready.
