### PR TITLE
feat(host): add user service enable and disable commands

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -7962,9 +7962,9 @@ class _HostGroup(click.Group):
     ``omnigent host <url>`` is shorthand for ``omnigent host
     --server <url>`` when ``<url>`` is URL-like or the empty local-mode
     marker. A leading positional token that matches a registered
-    management subcommand (``status``, ``stop``, ``stop-session``)
-    still dispatches to that subcommand, and other unknown tokens fall
-    through to Click's normal unknown-command error.
+    management subcommand (``enable``, ``disable``, ``status``, ``stop``,
+    ``stop-session``) still dispatches to that subcommand, and other unknown
+    tokens fall through to Click's normal unknown-command error.
     """
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
@@ -8335,10 +8335,13 @@ def host(
       omnigent host --server https://omnigent-app.databricksapps.com
       omnigent host ""   # spawn + connect to a local server
       omnigent host --background   # spawn detached, return immediately
+      omnigent host enable   # install and start a per-user system service
+      omnigent host disable  # stop and remove the per-user system service
 
     The server URL may be given positionally (``omnigent host
     <url>``) or via ``--server <url>``. A leading ``status``, ``stop``,
-    or ``stop-session`` token still runs that management subcommand.
+    ``enable``, ``disable``, or ``stop-session`` token still runs that
+    management subcommand.
 
     When the target server is Databricks-fronted and you are not signed
     in, ``host`` runs the same flow ``omnigent login`` would before
@@ -8360,6 +8363,7 @@ def host(
     """
     ctx.ensure_object(dict)
     ctx.obj["server"] = server
+    ctx.obj["non_interactive"] = non_interactive
     if ctx.invoked_subcommand is not None:
         return
     # Kept before the config fallback below: `--background` echoes a `host
@@ -9304,6 +9308,76 @@ def _echo_daemon_payloads(payloads: list[_HostPayload]) -> None:
             )
             console.print(f"  [red]error={_host_markup(message)}[/red]")
         _add_host_payload_sessions_table(console, payload)
+
+
+@host.command("enable")
+@click.option("--server", default=None, help="Server target for the persistent service.")
+@click.option(
+    "--non-interactive",
+    is_flag=True,
+    default=False,
+    help="Do not launch browser sign-in while preparing the service.",
+)
+@click.pass_context
+def host_enable(
+    ctx: click.Context,
+    server: str | None,
+    non_interactive: bool,
+) -> None:
+    """Install and start the host as a per-user system service.
+
+    :param ctx: Click context carrying group-level options.
+    :param server: Optional server target; empty selects local mode.
+    :param non_interactive: Fail instead of launching browser sign-in.
+    """
+    if server is None:
+        server = _host_group_option(ctx, "server")
+    resolved_server = _resolve_host_server(server)
+    group_obj = ctx.obj if isinstance(ctx.obj, dict) else {}
+    non_interactive = non_interactive or bool(group_obj.get("non_interactive"))
+    if resolved_server:
+        _ensure_databricks_server_auth(
+            resolved_server,
+            non_interactive=non_interactive or not _stdin_is_tty(),
+        )
+
+    target = _normalize_daemon_target(resolved_server)
+    record = _find_daemon_record(target)
+    if record is not None:
+        _terminate_daemon(record, force=False)
+
+    from omnigent.host.service import HostServiceError, enable_user_host_service
+
+    try:
+        service = enable_user_host_service(
+            resolved_server,
+            environment=_build_host_daemon_env(server_url=resolved_server),
+        )
+    except HostServiceError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo(f"Enabled the Omnigent host user service for {target}.")
+    click.echo(f"Service definition: {_display_path(service.path)}")
+    if service.log_path is not None:
+        click.echo(f"Service output: {_display_path(service.log_path)}")
+
+
+@host.command("disable")
+def host_disable() -> None:
+    """Stop and remove the current user's host system service."""
+    from omnigent.host.service import HostServiceError, disable_user_host_service
+
+    try:
+        service = disable_user_host_service()
+    except HostServiceError as exc:
+        raise click.ClickException(str(exc)) from exc
+    # Service managers stop with SIGTERM, which can leave the foreground
+    # daemon's registry record behind after the process has exited.
+    for record in _list_daemon_records():
+        if not _pid_alive(record.pid):
+            _delete_daemon_record(record)
+    click.echo("Disabled the Omnigent host user service.")
+    click.echo(f"Removed service definition: {_display_path(service.path)}")
 
 
 @host.command("status")

--- a/omnigent/host/service.py
+++ b/omnigent/host/service.py
@@ -1,0 +1,303 @@
+"""Install the Omnigent host as a per-user operating-system service."""
+
+from __future__ import annotations
+
+import os
+import platform
+import plistlib
+import re
+import subprocess
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from omnigent.process_logging import data_dir
+
+LAUNCHD_LABEL = "ai.omnigent.host"
+SYSTEMD_UNIT = "omnigent-host.service"
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class HostServiceError(RuntimeError):
+    """Raised when a host service cannot be installed or removed."""
+
+
+@dataclass(frozen=True)
+class HostService:
+    """Description of the current platform's per-user host service."""
+
+    kind: Literal["launchd", "systemd_user"]
+    path: Path
+    label: str
+    log_path: Path | None = None
+
+
+def _service_for_current_platform() -> HostService:
+    """Return the current platform's per-user service description."""
+    system = platform.system()
+    if system == "Darwin":
+        log_path = data_dir() / "logs" / "host" / "service.log"
+        return HostService(
+            kind="launchd",
+            path=Path.home() / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist",
+            label=LAUNCHD_LABEL,
+            log_path=log_path,
+        )
+    if system == "Linux":
+        config_home = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+        return HostService(
+            kind="systemd_user",
+            path=config_home / "systemd" / "user" / SYSTEMD_UNIT,
+            label=SYSTEMD_UNIT,
+        )
+    raise HostServiceError(
+        f"Host services are supported on macOS and Linux, not {system or 'this platform'}."
+    )
+
+
+def _service_command(server_url: str | None) -> list[str]:
+    """Build the persistent service entry-point command."""
+    mode = ["--server", server_url] if server_url else ["--local"]
+    return [sys.executable, "-m", "omnigent.host.service_entry", *mode]
+
+
+def _clean_environment(environment: Mapping[str, str]) -> dict[str, str]:
+    """Validate environment values before persisting them in a service file."""
+    cleaned: dict[str, str] = {}
+    for key, value in environment.items():
+        if not _ENV_NAME_RE.fullmatch(key):
+            raise HostServiceError(f"Cannot persist invalid environment variable name {key!r}.")
+        if "\x00" in value or "\n" in value or "\r" in value:
+            raise HostServiceError(f"Cannot persist multiline environment variable {key!r}.")
+        cleaned[key] = value
+    return dict(sorted(cleaned.items()))
+
+
+def _launchd_payload(
+    service: HostService,
+    *,
+    command: Sequence[str],
+    environment: Mapping[str, str],
+) -> bytes:
+    """Render a launchd user-agent plist."""
+    assert service.log_path is not None
+    payload = {
+        "Label": service.label,
+        "ProgramArguments": list(command),
+        "EnvironmentVariables": dict(environment),
+        "RunAtLoad": True,
+        # service_entry maps permanent host failures to a successful exit.
+        "KeepAlive": {"SuccessfulExit": False},
+        "ThrottleInterval": 10,
+        "StandardOutPath": str(service.log_path),
+        "StandardErrorPath": str(service.log_path),
+        "ProcessType": "Background",
+    }
+    return plistlib.dumps(payload, fmt=plistlib.FMT_XML, sort_keys=True)
+
+
+def _systemd_quote(value: str, *, escape_dollar: bool = False) -> str:
+    """Quote one systemd unit value without invoking a shell."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("%", "%%")
+    if escape_dollar:
+        escaped = escaped.replace("$", "$$")
+    return f'"{escaped}"'
+
+
+def _systemd_unit(
+    *,
+    command: Sequence[str],
+    environment: Mapping[str, str],
+) -> bytes:
+    """Render a systemd user service unit."""
+    env_lines = [
+        f"Environment={_systemd_quote(f'{key}={value}')}" for key, value in environment.items()
+    ]
+    lines = [
+        "[Unit]",
+        "Description=Omnigent host",
+        "Wants=network-online.target",
+        "After=network-online.target",
+        "",
+        "[Service]",
+        "Type=simple",
+        *env_lines,
+        "ExecStart=" + " ".join(_systemd_quote(part, escape_dollar=True) for part in command),
+        "Restart=on-failure",
+        "RestartPreventExitStatus=78 143",
+        "RestartSec=10s",
+        "",
+        "[Install]",
+        "WantedBy=default.target",
+        "",
+    ]
+    return "\n".join(lines).encode()
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    """Atomically write a private service definition."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+        path.chmod(0o600)
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
+
+
+def _run_checked(args: Sequence[str]) -> None:
+    """Run one service-manager command and surface a concise failure."""
+    try:
+        subprocess.run(
+            list(args),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise HostServiceError(f"Required service manager {args[0]!r} was not found.") from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise HostServiceError(
+            f"Service manager command failed ({' '.join(args)}){suffix}"
+        ) from exc
+
+
+def _run_best_effort(args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    """Run an idempotent service-manager cleanup command."""
+    try:
+        return subprocess.run(
+            list(args),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise HostServiceError(f"Required service manager {args[0]!r} was not found.") from exc
+
+
+def _restore_file(path: Path, previous: bytes | None) -> None:
+    """Restore a service definition after a manager command fails."""
+    if previous is None:
+        path.unlink(missing_ok=True)
+    else:
+        _atomic_write(path, previous)
+
+
+def _enable_launchd(service: HostService, content: bytes) -> None:
+    assert service.log_path is not None
+    service.log_path.parent.mkdir(parents=True, exist_ok=True)
+    previous = service.path.read_bytes() if service.path.exists() else None
+    domain = f"gui/{os.getuid()}"
+    _run_best_effort(["launchctl", "bootout", f"{domain}/{service.label}"])
+    _atomic_write(service.path, content)
+    try:
+        _run_checked(["launchctl", "bootstrap", domain, str(service.path)])
+    except HostServiceError:
+        _restore_file(service.path, previous)
+        if previous is not None:
+            _run_best_effort(["launchctl", "bootstrap", domain, str(service.path)])
+        raise
+
+
+def _enable_systemd(service: HostService, content: bytes) -> None:
+    previous = service.path.read_bytes() if service.path.exists() else None
+    changed = previous != content
+    _atomic_write(service.path, content)
+    try:
+        _run_checked(["systemctl", "--user", "daemon-reload"])
+        _run_checked(["systemctl", "--user", "enable", "--now", service.label])
+        if previous is not None and changed:
+            _run_checked(["systemctl", "--user", "restart", service.label])
+    except HostServiceError:
+        _restore_file(service.path, previous)
+        _run_best_effort(["systemctl", "--user", "daemon-reload"])
+        raise
+
+
+def _record_service(service: HostService) -> None:
+    """Add the service to the uninstall ledger."""
+    from omnigent.install_ledger import LaunchAgentEntry, record_launch_agent
+
+    try:
+        record_launch_agent(
+            LaunchAgentEntry(
+                kind=service.kind,
+                path=str(service.path),
+                label=service.label,
+                source="recorded",
+                confidence="certain",
+            )
+        )
+    except OSError as exc:
+        raise HostServiceError(
+            f"The service was enabled, but its uninstall record could not be written: {exc}"
+        ) from exc
+
+
+def _forget_service(service: HostService) -> None:
+    """Remove the service from install ledgers."""
+    from omnigent.install_ledger import remove_launch_agent
+
+    try:
+        remove_launch_agent(kind=service.kind, label=service.label)
+    except OSError as exc:
+        raise HostServiceError(
+            f"The service was disabled, but its uninstall record could not be updated: {exc}"
+        ) from exc
+
+
+def enable_user_host_service(
+    server_url: str | None,
+    *,
+    environment: Mapping[str, str],
+) -> HostService:
+    """Install, enable, and start the current user's host service."""
+    service = _service_for_current_platform()
+    command = _service_command(server_url)
+    clean_environment = _clean_environment(environment)
+    if service.kind == "launchd":
+        content = _launchd_payload(
+            service,
+            command=command,
+            environment=clean_environment,
+        )
+        _enable_launchd(service, content)
+    else:
+        content = _systemd_unit(command=command, environment=clean_environment)
+        _enable_systemd(service, content)
+    _record_service(service)
+    return service
+
+
+def disable_user_host_service() -> HostService:
+    """Stop, disable, and remove the current user's host service."""
+    service = _service_for_current_platform()
+    if service.kind == "launchd":
+        domain = f"gui/{os.getuid()}"
+        service_target = f"{domain}/{service.label}"
+        _run_best_effort(["launchctl", "bootout", service_target])
+        if _run_best_effort(["launchctl", "print", service_target]).returncode == 0:
+            raise HostServiceError(f"launchd service {service.label!r} is still running.")
+        service.path.unlink(missing_ok=True)
+    else:
+        disable_args = ["systemctl", "--user", "disable", "--now", service.label]
+        if service.path.exists():
+            _run_checked(disable_args)
+        else:
+            _run_best_effort(disable_args)
+        service.path.unlink(missing_ok=True)
+        _run_checked(["systemctl", "--user", "daemon-reload"])
+    _forget_service(service)
+    return service

--- a/omnigent/host/service_entry.py
+++ b/omnigent/host/service_entry.py
@@ -1,0 +1,44 @@
+"""Process entry point used by launchd and systemd host services."""
+
+from __future__ import annotations
+
+import argparse
+
+import click
+
+from omnigent.host import HOST_FATAL_EXIT_CODE
+
+
+def main() -> int:
+    """Run the foreground host command and normalize permanent failures."""
+    parser = argparse.ArgumentParser(description="Omnigent host service")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--server", help="Remote Omnigent server URL.")
+    mode.add_argument("--local", action="store_true", help="Run a local Omnigent server.")
+    args = parser.parse_args()
+
+    from omnigent.cli import cli
+
+    server = "" if args.local else args.server
+    try:
+        cli.main(
+            args=["host", "--server", server, "--non-interactive"],
+            prog_name="omnigent",
+            standalone_mode=False,
+        )
+    except click.ClickException as exc:
+        exc.show()
+        return exc.exit_code
+    except click.Abort:
+        click.echo("Aborted!", err=True)
+        return 1
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 1
+        # A permanent auth/config failure should leave the service enabled but
+        # stopped instead of entering a supervisor restart loop.
+        return 0 if code == HOST_FATAL_EXIT_CODE else code
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/omnigent/install_ledger.py
+++ b/omnigent/install_ledger.py
@@ -500,7 +500,8 @@ def observed_launch_agents(*, deep: bool) -> list[LaunchAgentEntry]:
                     confidence="high",
                 )
             )
-    systemd_dir = Path.home() / ".config" / "systemd" / "user"
+    config_home = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    systemd_dir = config_home / "systemd" / "user"
     if systemd_dir.is_dir():
         for path in sorted(systemd_dir.glob("*omnigent*.service")):
             entries.append(
@@ -640,3 +641,52 @@ def write_install_ledger_from_env() -> InstallLedger:
             )
     write_ledger(ledger)
     return ledger
+
+
+def _touch_ledger(ledger: InstallLedger) -> None:
+    """Refresh timestamps after a direct ledger mutation."""
+    now = utc_now()
+    ledger.updated_at = now
+    ledger.last_validated_at = now
+    ledger.generator["wrote_at"] = now
+
+
+def record_launch_agent(entry: LaunchAgentEntry) -> None:
+    """Record or replace one service-manager artifact for uninstall."""
+    real_path = ledger_path()
+    real = load_ledger(real_path)
+    if real is not None and real.ledger_source == "installer":
+        ledger = real
+        destination = real_path
+    else:
+        destination = backfill_ledger_path()
+        ledger = load_ledger(destination)
+        if ledger is None:
+            ledger = new_ledger(source="backfill", strategy="service-enable", deep=True)
+
+    ledger.entries.launch_agents = [
+        current
+        for current in ledger.entries.launch_agents
+        if not (current.kind == entry.kind and current.label == entry.label)
+    ]
+    ledger.entries.launch_agents.append(entry)
+    _touch_ledger(ledger)
+    write_ledger(ledger, path=destination)
+
+
+def remove_launch_agent(*, kind: str, label: str) -> None:
+    """Remove a service-manager artifact from all valid install ledgers."""
+    for path in (ledger_path(), backfill_ledger_path()):
+        ledger = load_ledger(path)
+        if ledger is None:
+            continue
+        remaining = [
+            entry
+            for entry in ledger.entries.launch_agents
+            if not (entry.kind == kind and entry.label == label)
+        ]
+        if len(remaining) == len(ledger.entries.launch_agents):
+            continue
+        ledger.entries.launch_agents = remaining
+        _touch_ledger(ledger)
+        write_ledger(ledger, path=path)

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -287,6 +287,62 @@ def test_host_status_subcommand_still_dispatches(
     )
 
 
+def test_host_enable_subcommand_installs_user_service(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify ``host enable`` resolves the target and installs its service."""
+    from omnigent.host.service import HostService
+
+    captured: list[tuple[str | None, dict[str, str]]] = []
+    service_path = tmp_path / "omnigent-host.service"
+
+    def _enable(
+        server_url: str | None,
+        *,
+        environment: dict[str, str],
+    ) -> HostService:
+        captured.append((server_url, environment))
+        return HostService(kind="systemd_user", path=service_path, label=service_path.name)
+
+    monkeypatch.setattr("omnigent.cli._find_daemon_record", lambda target: None)
+    monkeypatch.setattr(
+        "omnigent.cli._build_host_daemon_env",
+        lambda *, server_url: {"HOME": str(tmp_path)},
+    )
+    monkeypatch.setattr("omnigent.host.service.enable_user_host_service", _enable)
+
+    result = CliRunner().invoke(cli, ["host", "enable", "--server", ""])
+
+    assert result.exit_code == 0, result.output
+    assert captured == [(None, {"HOME": str(tmp_path)})]
+    assert "Enabled the Omnigent host user service for local" in result.output
+
+
+def test_host_disable_subcommand_removes_user_service(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify ``host disable`` dispatches to the service remover."""
+    from omnigent.host.service import HostService
+
+    service_path = tmp_path / "omnigent-host.service"
+    removed: list[bool] = []
+
+    def _disable() -> HostService:
+        removed.append(True)
+        return HostService(kind="systemd_user", path=service_path, label=service_path.name)
+
+    monkeypatch.setattr("omnigent.host.service.disable_user_host_service", _disable)
+    monkeypatch.setattr("omnigent.cli._list_daemon_records", list)
+
+    result = CliRunner().invoke(cli, ["host", "disable"])
+
+    assert result.exit_code == 0, result.output
+    assert removed == [True]
+    assert "Disabled the Omnigent host user service" in result.output
+
+
 def test_host_rejects_unknown_plain_token_as_subcommand(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/host/test_service.py
+++ b/tests/host/test_service.py
@@ -1,0 +1,160 @@
+"""Tests for per-user host service installation."""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from omnigent.host import service
+
+
+def _capture_runs(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+    calls: list[list[str]] = []
+
+    def _run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(args))
+        returncode = 1 if args[:2] == ["launchctl", "print"] else 0
+        return subprocess.CompletedProcess(args, returncode, "", "")
+
+    monkeypatch.setattr(service.subprocess, "run", _run)
+    monkeypatch.setattr(service, "_record_service", lambda installed: None)
+    monkeypatch.setattr(service, "_forget_service", lambda installed: None)
+    return calls
+
+
+def test_enable_launchd_user_service(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "state"))
+    monkeypatch.setattr(service.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(service.os, "getuid", lambda: 501)
+    monkeypatch.setattr(service.sys, "executable", "/opt/omnigent/bin/python")
+    calls = _capture_runs(monkeypatch)
+
+    installed = service.enable_user_host_service(
+        "https://example.com",
+        environment={"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"},
+    )
+
+    payload = plistlib.loads(installed.path.read_bytes())
+    assert installed.path == tmp_path / "Library/LaunchAgents/ai.omnigent.host.plist"
+    assert payload["Label"] == "ai.omnigent.host"
+    assert payload["ProgramArguments"] == [
+        "/opt/omnigent/bin/python",
+        "-m",
+        "omnigent.host.service_entry",
+        "--server",
+        "https://example.com",
+    ]
+    assert payload["EnvironmentVariables"]["PATH"] == "/usr/bin:/bin"
+    assert payload["KeepAlive"] == {"SuccessfulExit": False}
+    assert calls == [
+        ["launchctl", "bootout", "gui/501/ai.omnigent.host"],
+        [
+            "launchctl",
+            "bootstrap",
+            "gui/501",
+            str(installed.path),
+        ],
+    ]
+    assert installed.path.stat().st_mode & 0o777 == 0o600
+
+
+def test_disable_launchd_user_service(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(service.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(service.os, "getuid", lambda: 502)
+    path = tmp_path / "Library/LaunchAgents/ai.omnigent.host.plist"
+    path.parent.mkdir(parents=True)
+    path.write_text("old")
+    calls = _capture_runs(monkeypatch)
+
+    removed = service.disable_user_host_service()
+
+    assert removed.path == path
+    assert not path.exists()
+    assert calls == [
+        ["launchctl", "bootout", "gui/502/ai.omnigent.host"],
+        ["launchctl", "print", "gui/502/ai.omnigent.host"],
+    ]
+
+
+def test_enable_systemd_user_service(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(service.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(service.sys, "executable", "/opt/omnigent/bin/python")
+    calls = _capture_runs(monkeypatch)
+
+    installed = service.enable_user_host_service(
+        None,
+        environment={"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"},
+    )
+
+    unit = installed.path.read_text()
+    assert installed.path == tmp_path / "xdg/systemd/user/omnigent-host.service"
+    assert 'Environment="HOME=' in unit
+    assert (
+        'ExecStart="/opt/omnigent/bin/python" "-m" "omnigent.host.service_entry" "--local"'
+    ) in unit
+    assert "Restart=on-failure" in unit
+    assert "RestartPreventExitStatus=78 143" in unit
+    assert calls == [
+        ["systemctl", "--user", "daemon-reload"],
+        ["systemctl", "--user", "enable", "--now", "omnigent-host.service"],
+    ]
+
+
+def test_systemd_unit_escapes_specifiers_and_literal_dollars() -> None:
+    unit = service._systemd_unit(
+        command=["/opt/$tools/python", "--server", "https://example.com/%h/$target"],
+        environment={"CONFIG": "$HOME/%h"},
+    ).decode()
+
+    assert 'Environment="CONFIG=$HOME/%%h"' in unit
+    assert (
+        'ExecStart="/opt/$$tools/python" "--server" "https://example.com/%%h/$$target"'
+    ) in unit
+
+
+def test_disable_systemd_user_service(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.setattr(service.platform, "system", lambda: "Linux")
+    path = tmp_path / ".config/systemd/user/omnigent-host.service"
+    path.parent.mkdir(parents=True)
+    path.write_text("old")
+    calls = _capture_runs(monkeypatch)
+
+    removed = service.disable_user_host_service()
+
+    assert removed.path == path
+    assert not path.exists()
+    assert calls == [
+        ["systemctl", "--user", "disable", "--now", "omnigent-host.service"],
+        ["systemctl", "--user", "daemon-reload"],
+    ]
+
+
+def test_host_service_rejects_unsupported_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service.platform, "system", lambda: "Windows")
+
+    with pytest.raises(service.HostServiceError, match="macOS and Linux"):
+        service.enable_user_host_service(None, environment={})
+
+
+def test_service_entry_maps_fatal_host_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    from omnigent.cli import cli
+    from omnigent.host import HOST_FATAL_EXIT_CODE, service_entry
+
+    monkeypatch.setattr(sys, "argv", ["service-entry", "--local"])
+
+    def _fatal(**kwargs: object) -> None:
+        raise SystemExit(HOST_FATAL_EXIT_CODE)
+
+    monkeypatch.setattr(cli, "main", _fatal)
+
+    assert service_entry.main() == 0

--- a/tests/test_install_ledger.py
+++ b/tests/test_install_ledger.py
@@ -195,3 +195,45 @@ def test_deep_backfill_observes_external_config_and_launch_agents(
     assert ledger.entries.launch_agents[0].path == str(launch_agent)
     assert cursor_config.exists()
     assert launch_agent.exists()
+
+
+def test_record_and_remove_launch_agent_preserves_other_entries(
+    tmp_path: Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    state.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(state))
+
+    ledger = install_ledger.new_ledger(source="installer", strategy="install", deep=False)
+    unrelated = install_ledger.LaunchAgentEntry(
+        kind="launchd",
+        path=str(home / "Library/LaunchAgents/other.plist"),
+        label="ai.example.other",
+    )
+    stale = install_ledger.LaunchAgentEntry(
+        kind="launchd",
+        path=str(home / "Library/LaunchAgents/old.plist"),
+        label="ai.omnigent.host",
+    )
+    ledger.entries.launch_agents = [unrelated, stale]
+    install_ledger.write_ledger(ledger)
+
+    current = install_ledger.LaunchAgentEntry(
+        kind="launchd",
+        path=str(home / "Library/LaunchAgents/ai.omnigent.host.plist"),
+        label="ai.omnigent.host",
+        confidence="certain",
+    )
+    install_ledger.record_launch_agent(current)
+
+    recorded = install_ledger.load_ledger(install_ledger.ledger_path())
+    assert recorded is not None
+    assert recorded.entries.launch_agents == [unrelated, current]
+
+    install_ledger.remove_launch_agent(kind="launchd", label="ai.omnigent.host")
+
+    removed = install_ledger.load_ledger(install_ledger.ledger_path())
+    assert removed is not None
+    assert removed.entries.launch_agents == [unrelated]


### PR DESCRIPTION
## Related issue

https://linear.app/omnigent/issue/OMNI-5583/add-omni-host-enabledisable-command-to-install-omnigent-host-as-a

## Summary

- Let users keep an Omnigent host available across terminal sessions with `omni host enable`, using a launchd agent on macOS or a systemd user service on Linux.
- Add `omni host disable` to stop and remove the service cleanly, including stale daemon-record cleanup and uninstall-ledger updates.
- Preserve the host's required environment securely in private service definitions and avoid supervisor restart loops after permanent configuration failures.

### ELI5

`omni host enable` asks the operating system to keep the host running for the current user. `omni host disable` asks it to stop and forget that background job.

```text
omni host enable
       |
       +-- macOS --> launchd user agent --+
       |                                  +--> Omnigent host
       +-- Linux --> systemd user unit ---+
```

## Test Plan

- `uv run pytest tests/host/test_service.py tests/host/test_cli_host.py::test_host_enable_subcommand_installs_user_service tests/host/test_cli_host.py::test_host_disable_subcommand_removes_user_service tests/host/test_cli_host.py::test_host_status_subcommand_still_dispatches tests/test_install_ledger.py::test_record_and_remove_launch_agent_preserves_other_entries tests/test_install_ledger.py::test_deep_backfill_observes_external_config_and_launch_agents`
- `uv run pre-commit run --files omnigent/cli.py omnigent/install_ledger.py omnigent/host/service.py omnigent/host/service_entry.py tests/host/test_cli_host.py tests/host/test_service.py tests/test_install_ledger.py`
- Verified `uv run omni host --help`, `uv run omni host enable --help`, and `uv run omni host disable --help` expose the new commands and options.

## Demo

N/A — command-line and operating-system service integration only.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover command dispatch, launchd and systemd definitions and lifecycle calls, service-manager escaping, fatal-exit behavior, unsupported platforms, and install-ledger updates.

## Changelog

`omni host enable` can now keep your host running as a per-user macOS or Linux service, and `omni host disable` removes it.
