### PR TITLE
fix(opencode-native): gate tool calls before dispatch so TOOL_CALL policies enforce

### DIFF
--- a/omnigent/opencode_native_bridge.py
+++ b/omnigent/opencode_native_bridge.py
@@ -94,6 +94,13 @@ const TIMEOUT_MS = 600000;
 
 const fs = require("fs");
 
+const KNOWN_VERDICTS = [
+  "POLICY_ACTION_ALLOW",
+  "POLICY_ACTION_DENY",
+  "POLICY_ACTION_ASK",
+  "POLICY_ACTION_UNSPECIFIED",
+];
+
 // Re-read tool_relay.json on each call so the plugin picks up the relay as
 // soon as it starts (the file is written after opencode serve launches).
 function relayCredentials() {
@@ -134,7 +141,13 @@ async function evaluate(type, target, data, failClosed) {
     });
     if (!resp.ok) return unavailable;
     const body = await resp.json();
-    return body && typeof body === "object" ? body : unavailable;
+    // A 2xx that isn't a verdict (proxy envelope, {"detail": ...}, a renamed
+    // field) must not read as ALLOW on a fail-closed phase. Allowlist the
+    // verdicts, mirroring omnigent/native_policy_hook.py.
+    if (!body || typeof body !== "object" || KNOWN_VERDICTS.indexOf(body.result) < 0) {
+      return unavailable;
+    }
+    return body;
   } catch (e) {
     // Server unreachable / timeout: advisory phases fail OPEN so a transient
     // blip can't lock the session. The web approval card (if any) stays parked
@@ -190,6 +203,16 @@ export const OmnigentPolicyPlugin = async () => ({
     if (verdict.result === "POLICY_ACTION_DENY") {
       throw new Error(
         "Omnigent policy blocked this tool call: " + (verdict.reason || "tool call denied"),
+      );
+    }
+    // An ASK that reaches the plugin was not resolved server-side, and this is
+    // the only pre-execution gate — treating it as ALLOW would run the tool the
+    // user was being asked about. omnigent/native_policy_hook.py maps
+    // POLICY_ACTION_ASK to deny for the same reason.
+    if (verdict.result === "POLICY_ACTION_ASK") {
+      throw new Error(
+        "Omnigent policy requires approval for this tool call, and none was "
+          + "recorded: " + (verdict.reason || "approval required"),
       );
     }
   },

--- a/omnigent/opencode_native_bridge.py
+++ b/omnigent/opencode_native_bridge.py
@@ -107,9 +107,15 @@ function relayCredentials() {
   return null;
 }
 
-async function evaluate(type, target, data) {
+async function evaluate(type, target, data, failClosed) {
   // Returns {result, reason}. Not wired (no server/session) -> no-op allow.
   if (!BASE || !SESSION) return { result: "ALLOW" };
+  // ``failClosed`` mirrors ``FAIL_CLOSED_PHASES`` in omnigent/policies/types.py
+  // client-side: for a phase whose in-band verdict is the ONLY enforcement
+  // point, an unreachable engine must not wave the call through.
+  const unavailable = failClosed
+    ? { result: "POLICY_ACTION_DENY", reason: "policy engine unavailable" }
+    : { result: "ALLOW" };
   const relay = relayCredentials();
   const url = relay
     ? relay.url.replace(/\/+$/, "") + "/policies/evaluate"
@@ -126,13 +132,14 @@ async function evaluate(type, target, data) {
       body: JSON.stringify({ event: { type: type, target: target || "", data: data } }),
       signal: controller.signal,
     });
-    if (!resp.ok) return { result: "ALLOW" };
+    if (!resp.ok) return unavailable;
     const body = await resp.json();
-    return body && typeof body === "object" ? body : { result: "ALLOW" };
+    return body && typeof body === "object" ? body : unavailable;
   } catch (e) {
-    // Server unreachable / timeout: fail OPEN so a transient blip can't lock
-    // the session. The web approval card (if any) stays parked server-side.
-    return { result: "ALLOW" };
+    // Server unreachable / timeout: advisory phases fail OPEN so a transient
+    // blip can't lock the session. The web approval card (if any) stays parked
+    // server-side. TOOL_CALL passes failClosed and denies instead.
+    return unavailable;
   } finally {
     clearTimeout(timer);
   }
@@ -166,6 +173,23 @@ export const OmnigentPolicyPlugin = async () => ({
       // written to opencode's session log, so carry the policy reason there.
       throw new Error(
         "Omnigent policy blocked this prompt: " + (verdict.reason || "request denied"),
+      );
+    }
+  },
+  // TOOL_CALL phase: gate the call BEFORE the tool runs. opencode fires this
+  // hook ahead of dispatch, so a throw is a true block rather than an
+  // after-the-fact redaction. Without it the TOOL_RESULT hook below is the
+  // only tool-facing lever, and by then the write has already happened.
+  "tool.execute.before": async (input, output) => {
+    const verdict = await evaluate(
+      "PHASE_TOOL_CALL",
+      input && input.tool,
+      { name: (input && input.tool) || "", arguments: (output && output.args) || {} },
+      true,
+    );
+    if (verdict.result === "POLICY_ACTION_DENY") {
+      throw new Error(
+        "Omnigent policy blocked this tool call: " + (verdict.reason || "tool call denied"),
       );
     }
   },

--- a/tests/test_opencode_native_bridge.py
+++ b/tests/test_opencode_native_bridge.py
@@ -158,11 +158,13 @@ def test_write_opencode_policy_plugin(bridge_dir: Path) -> None:
     path = write_opencode_policy_plugin(bridge_dir)
     assert path.name == "omnigent-policy.js"
     src = path.read_text(encoding="utf-8")
-    # The two phase hooks the reactive permission path can't reach.
+    # The three phase hooks the reactive permission path can't reach.
     assert '"chat.message"' in src  # REQUEST phase
+    assert '"tool.execute.before"' in src  # TOOL_CALL phase
     assert '"tool.execute.after"' in src  # TOOL_RESULT phase
     # Posts the proto phases + reads its coordinates from env.
     assert "PHASE_REQUEST" in src and "PHASE_TOOL_RESULT" in src
+    assert "PHASE_TOOL_CALL" in src
     assert "OMNIGENT_POLICY_URL" in src and "OMNIGENT_SESSION_ID" in src
     assert "/policies/evaluate" in src
     # A function export so opencode's Object.values(mod) loader picks it up.
@@ -170,6 +172,40 @@ def test_write_opencode_policy_plugin(bridge_dir: Path) -> None:
     # Idempotent overwrite (re-launch ships fresh code, no error).
     assert write_opencode_policy_plugin(bridge_dir) == path
 
+
+
+def test_policy_plugin_gates_tool_calls_before_dispatch(bridge_dir: Path) -> None:
+    """TOOL_CALL is the only phase that can stop a write from happening.
+
+    ``tool.execute.after`` fires once the tool has already run, so a DENY there
+    withholds output rather than preventing the effect. Without a pre-dispatch
+    hook a TOOL_CALL policy is unreachable under opencode-native and silently
+    enforces nothing.
+    """
+    src = write_opencode_policy_plugin(bridge_dir).read_text(encoding="utf-8")
+    assert '"tool.execute.before"' in src
+    assert "PHASE_TOOL_CALL" in src
+    # A DENY has to throw: opencode blocks the tool when the hook raises, and
+    # anything softer would be an advisory that reports enforcement it lacks.
+    assert "Omnigent policy blocked this tool call" in src
+
+
+def test_policy_plugin_fails_closed_on_the_fail_closed_phases(
+    bridge_dir: Path,
+) -> None:
+    """Mirrors ``FAIL_CLOSED_PHASES`` in ``omnigent/policies/types.py``.
+
+    For TOOL_CALL the in-band verdict is the only enforcement point, so an
+    unreachable engine must deny rather than wave the call through. The
+    advisory phases keep the original fail-open behaviour, which is why the
+    posture is a per-call argument instead of a global switch.
+    """
+    src = write_opencode_policy_plugin(bridge_dir).read_text(encoding="utf-8")
+    assert "async function evaluate(type, target, data, failClosed)" in src
+    assert "policy engine unavailable" in src
+    # Not wired at all (no server/session) still short-circuits to ALLOW, so a
+    # plain opencode session without Omnigent is never bricked by this plugin.
+    assert 'if (!BASE || !SESSION) return { result: "ALLOW" };' in src
 
 def test_update_last_event_id(bridge_dir: Path) -> None:
     write_bridge_state(bridge_dir, _state(bridge_dir))

--- a/tests/test_opencode_native_bridge.py
+++ b/tests/test_opencode_native_bridge.py
@@ -173,7 +173,6 @@ def test_write_opencode_policy_plugin(bridge_dir: Path) -> None:
     assert write_opencode_policy_plugin(bridge_dir) == path
 
 
-
 def test_policy_plugin_gates_tool_calls_before_dispatch(bridge_dir: Path) -> None:
     """TOOL_CALL is the only phase that can stop a write from happening.
 
@@ -206,6 +205,35 @@ def test_policy_plugin_fails_closed_on_the_fail_closed_phases(
     # Not wired at all (no server/session) still short-circuits to ALLOW, so a
     # plain opencode session without Omnigent is never bricked by this plugin.
     assert 'if (!BASE || !SESSION) return { result: "ALLOW" };' in src
+
+
+def test_policy_plugin_treats_a_non_verdict_body_as_unavailable(
+    bridge_dir: Path,
+) -> None:
+    """A 2xx that carries no verdict must not read as ALLOW on a gated phase.
+
+    A proxy envelope, a ``{"detail": ...}`` error body, or a renamed field would
+    otherwise leave ``verdict.result`` undefined and let the call through --
+    defeating failClosed with a *successful* response.
+    """
+    src = write_opencode_policy_plugin(bridge_dir).read_text(encoding="utf-8")
+    assert "KNOWN_VERDICTS" in src
+    assert "POLICY_ACTION_UNSPECIFIED" in src
+
+
+def test_policy_plugin_denies_an_unresolved_ask_at_tool_call(
+    bridge_dir: Path,
+) -> None:
+    """ASK reaching the plugin means it was not resolved server-side.
+
+    TOOL_CALL is the only pre-execution gate, so allowing it would run the very
+    tool the user was being asked to approve. Matches the ``POLICY_ACTION_ASK ->
+    deny`` mapping in ``omnigent/native_policy_hook.py``.
+    """
+    src = write_opencode_policy_plugin(bridge_dir).read_text(encoding="utf-8")
+    assert 'verdict.result === "POLICY_ACTION_ASK"' in src
+    assert "requires approval for this tool call" in src
+
 
 def test_update_last_event_id(bridge_dir: Path) -> None:
     write_bridge_state(bridge_dir, _state(bridge_dir))


### PR DESCRIPTION
### The problem

**First, what is not the problem.** Tool calls under `opencode-native` are not
ungated: `orchestration.py` sets `config["permission"] = "ask"` when an MCP block
is present, so the reactive `permission.asked` path prompts before a tool runs.
That mechanism works and this patch does not touch it.

**The gap is the policy engine's TOOL_CALL phase specifically.** The
policy-bridge plugin the runner writes and `opencode serve` loads
(`_OPENCODE_POLICY_PLUGIN_JS` in `omnigent/opencode_native_bridge.py`) registers
`chat.message` (REQUEST) and `tool.execute.after` (TOOL_RESULT). OpenCode also
exposes `tool.execute.before`, fired before the tool runs, and the plugin does
not use it — as the comment above the plugin registration in `orchestration.py`
itself says, the plugin covers "phases the reactive permission.asked path can't".
TOOL_CALL is not among them.

So a declarative TOOL_CALL policy — a cost budget, a rate limit, a PII redactor,
any `FunctionPolicy` — can be configured, attached, and listed in the registry
under opencode-native, and it will never fire. The interactive prompt is not a
substitute: it asks a human about a tool, it does not evaluate the policies the
session was configured with.

And the phase that does reach the plugin arrives too late to help. A DENY at
TOOL_RESULT lands after the tool has executed, so it replaces the output string
while the side effect has already happened — for a write, the file is on disk.

### How it was measured

The real emitted plugin was loaded under Bun against a stand-in engine that
always answers `POLICY_ACTION_DENY`, inside a harness that reproduces the
dispatcher's order (`tool.execute.before` → execute → `tool.execute.after`), with
a "tool" whose side effect is writing a file:

| Bridge | hooks registered | pre-write hook | engine said | file written |
|--------|------------------|----------------|-------------|--------------|
| `6b32d9a2` as shipped | `chat.message`, `tool.execute.after` | no | DENY | **yes** |
| with this patch | the above + `tool.execute.before` | yes | DENY | **no** |

In the first row the DENY produced exactly one observable effect: the tool output
became `[Omnigent policy withheld this tool result: ...]`. The write itself went
through.

To be precise about what that harness does and does not show: it reproduces the
dispatch *order*, so it demonstrates that there is no pre-write hook to act on —
it does not by itself prove that a throw propagates. That was confirmed
separately in the opencode dispatcher (plugin SDK 1.17.8): `SessionTools`
awaits `Plugin.trigger("tool.execute.before", ...)` before `tool.execute`, and
`trigger` iterates hooks with no per-hook `try`/`catch`, so a rejection
propagates and the tool does not run. The same holds at the other dispatch sites
(MCP tools, MCP resources, subtask). A full `opencode serve` session with a
DENY-answering engine would close the point end to end and we are happy to run
one if you would like it in the PR.

### What this changes

1. Adds a `tool.execute.before` hook that evaluates `PHASE_TOOL_CALL` and throws
   on DENY. OpenCode blocks the tool when the hook raises, so the block is real
   rather than advisory. The `data` payload is `{name, arguments}`, matching the
   TOOL_CALL shape documented on `EvaluationContext`.
2. Gives `evaluate()` an optional `failClosed` argument, used only by the new
   hook.

### Why the fail-closed argument, and the tradeoff

`omnigent/policies/types.py` already declares:

```python
FAIL_CLOSED_PHASES: tuple[str, ...] = ("PHASE_TOOL_CALL", "PHASE_REQUEST")
```

with the rationale that for those phases the in-band verdict is the only
enforcement point, so an unevaluable policy must not let the call through. The
plugin's transport fails open for every phase, so wiring TOOL_CALL through it
unchanged would have contradicted that constant on the client side.

Making the posture a per-call argument changes behaviour only for TOOL_CALL.
`!BASE || !SESSION` still returns ALLOW, so a plain `opencode` session with no
Omnigent wiring is never affected.

**One thing we deliberately did not do, and want to flag rather than leave
mute:** `PHASE_REQUEST` is also in `FAIL_CLOSED_PHASES`, described there as "the
sole pre-turn enforcement point", and this patch leaves the `chat.message` hook
failing open. We scoped the change to the gap we measured. Say the word and we
extend `failClosed` to REQUEST in the same PR.

**The tradeoff is real and we would rather you decide it than have us decide it
for you:** with this patch, an unreachable policy engine blocks tool calls
instead of allowing them. That is availability traded for the invariant your own
constant states. If you would prefer TOOL_CALL to keep failing open here, or to
be configurable, say so — the change is one argument and we will follow your
call.

Two consequences of the existing 600 s `TIMEOUT_MS` that we think you should see
before deciding, because the patch changes what they cost:

- **Per-tool worst case is now two round-trips.** A blackholed (not refused)
  engine costs up to 600 s in `before` plus 600 s in `after` — about 20 minutes
  per tool call. `ECONNREFUSED` is immediate, so this is the slow-failure case,
  not the down case.
- **ASK interacts badly.** The native hooks use `_EVALUATE_POLICY_TIMEOUT_S =
  86400.0` precisely because the endpoint holds the ASK gate open. At 600 s, an
  ASK policy on a tool call aborts before a human can answer, and with
  `failClosed` that abort becomes a DENY whose reason says "policy engine
  unavailable" — which is untrue and confusing, since the engine was reachable
  and waiting. Aligning the fail-closed call with the native timeout, or
  splitting connect-timeout from verdict-wait, would fix it. We did not guess at
  your preference here.

### Tests

`tests/test_opencode_native_bridge.py`, in the existing source-assertion style of
that file:

- `test_write_opencode_policy_plugin` extended to the third hook.
- `test_policy_plugin_gates_tool_calls_before_dispatch`
- `test_policy_plugin_fails_closed_on_the_fail_closed_phases`

25 → 27 passing. All three fail against the unpatched bridge, so they are
load-bearing rather than decorative.

### Scope

Only the pre-dispatch gap. Deliberately not included: the plugin list being
assigned rather than appended in `runner/native/orchestration.py`, and the set of
directories linked from the user config home in the same file we touch. We
measured both and they did not affect us — project-local `.opencode/plugin/`
discovery is independent of the config `plugin` key — so we have no evidence to
offer about them and would rather not bundle unmeasured changes into a patch
about something else.

### Two more things we chose to disclose rather than guess at

- **Double evaluation of Omnigent's own MCP tools.** `native_policy_hook.py`
  skips `mcp__omnigent__*` at PHASE_TOOL_CALL, noting they are "already
  policy-checked by the relay path" and that evaluating them again would
  double-count. The new hook has no such filter because we could not determine
  the prefix opencode uses for relayed tools. If the relay is active under
  opencode-native, `INCREMENT` state updates and cost budgets will count twice
  and an ASK could raise two cards — tell us the prefix and we will add the skip.
- **Tool arguments now leave the process at TOOL_CALL.** Evaluating the phase
  requires it, and it is parity with the claude-native `PreToolUse` hook, but it
  is a new egress for opencode sessions: full `write` bodies and `bash` command
  lines now reach the policy endpoint, uncapped. Worth a size cap if you want one.

### Context

Found while building a Reentry lifecycle adapter for OpenCode plus an Omnigent
policy module. Our own policy works around this by verifying at REQUEST, which is
the one pre-write phase that already functions — the workaround is why we can
report the gap precisely rather than only suspect it.


---

### Follow-up commit in this branch

Our own security review found two fail-open paths that `failClosed` did not
cover, because the decision was still "not DENY, therefore ALLOW". Both fixed in
the second commit:

1. A 2xx body carrying no verdict (proxy envelope, `{"detail": ...}`, a renamed
   field) left `verdict.result` undefined and the tool ran. Now allowlisted
   against the known verdicts, mirroring `native_policy_hook.py`.
2. `POLICY_ACTION_ASK` read as ALLOW at the only pre-execution gate. Now denies
   with a distinct message, matching the `ASK -> deny` mapping upstream uses.

Tests 27 → 29; both new tests fail against the first commit.