### PR TITLE
fix(terminals): disable tmux mouse mode

### DIFF
--- a/omnigent/entities/session_resources.py
+++ b/omnigent/entities/session_resources.py
@@ -160,10 +160,8 @@ def terminal_resource_view(session_id: str, entry: TerminalListEntry) -> Session
             "tmux_socket": str(entry.instance.socket_path),
             "tmux_target": entry.instance.tmux_target,
             # Effective web-attach transport (``"pty"`` / ``"control"``) absent
-            # a per-attach ``?transport=`` override, so the browser can pick
-            # the matching mouse/selection behavior. Control mode lets xterm
-            # own scrollback + selection; PTY mode still needs the modifier
-            # workarounds + hint bar.
+            # a per-attach ``?transport=`` override, so the browser can select
+            # the matching bridge and clipboard behavior.
             "terminal_transport": _resolve_transport_for_view(entry),
         },
     )

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -212,7 +212,7 @@ def _tmux_command_sequence(commands: list[list[str]]) -> list[str]:
     file.
 
     :param commands: Tmux commands without the leading ``tmux`` argv,
-        e.g. ``[["set-option", "-g", "mouse", "on"], ["new-session"]]``.
+        e.g. ``[["set-option", "-g", "mouse", "off"], ["new-session"]]``.
     :returns: Flattened argv suffix with command separators.
     """
     sequence: list[str] = []
@@ -295,9 +295,10 @@ def _tmux_input_option_commands(scrollback: int) -> list[list[str]]:
 
     ``history-limit`` is generated per terminal because it comes from
     ``TerminalEnvSpec.scrollback``. ``set-clipboard external`` exports tmux
-    copy-mode selections without trusting pane OSC 52 requests. ``mouse on``
-    makes the attached web terminal scrollable. ``focus-events on`` lets interactive programs
-    observe pane focus changes. ``extended-keys`` with CSI-u formatting
+    copy-mode selections without trusting pane OSC 52 requests. ``mouse off``
+    leaves scrolling and text selection to the attached terminal instead of
+    tmux copy mode. ``focus-events on`` lets interactive programs observe pane
+    focus changes. ``extended-keys`` with CSI-u formatting
     lets programs inside tmux receive Kitty Keyboard Protocol keys such
     as Shift+Enter when the attached terminal supports them. Terminals
     without that protocol ignore tmux's request, and the quiet tmux
@@ -315,7 +316,7 @@ def _tmux_input_option_commands(scrollback: int) -> list[list[str]]:
         # Export tmux copy-mode selections to attached terminals without letting
         # pane applications create tmux buffers through OSC 52.
         ["set-option", "-sq", "set-clipboard", "external"],
-        ["set-option", "-g", "mouse", "on"],
+        ["set-option", "-g", "mouse", "off"],
         ["set-option", "-g", "focus-events", "on"],
         ["set-option", "-g", "escape-time", "0"],
     ]

--- a/tests/e2e_ui/sessions/test_terminal_view_url.py
+++ b/tests/e2e_ui/sessions/test_terminal_view_url.py
@@ -61,6 +61,8 @@ def test_transcript_views_survive_cold_reload(
 
     expect(page).to_have_url(re.compile(r"[?&]view=terminal(?:&|$)"))
     expect(terminal_button).to_have_attribute("aria-pressed", "true")
+    # PTY terminals use native selection now that managed tmux mouse mode is off.
+    expect(page.get_by_test_id("terminal-selection-hint")).to_have_count(0)
 
     # Remove the same-tab fallback so the reload must restore from the URL.
     page.evaluate("window.sessionStorage.clear()")

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -676,6 +676,17 @@ async def test_launch_omits_keep_alive_options_by_default(
 
 
 @pytest.mark.asyncio
+async def test_launch_disables_tmux_mouse_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Managed terminals leave scrolling and text selection to the client."""
+    cmd = await _capture_launch_argv(tmp_path, monkeypatch, keep_alive_after_exit=False)
+    assert contains_subsequence(cmd, ["set-option", "-g", "mouse", "off"])
+    assert not contains_subsequence(cmd, ["set-option", "-g", "mouse", "on"])
+
+
+@pytest.mark.asyncio
 async def test_launch_enables_csi_u_extended_keys_quietly(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -512,7 +512,7 @@ describe("TerminalSession", () => {
     onInput?: () => void,
     clipboardEnabled = true,
     onClipboardRequest?: (text: string) => void,
-    nativeSelection = false,
+    controlMode = false,
   ) {
     const states: ConnectionState[] = [];
     const container = document.createElement("div");
@@ -524,7 +524,7 @@ describe("TerminalSession", () => {
       false,
       onActivity,
       onInput,
-      nativeSelection,
+      controlMode,
       clipboardEnabled,
       onClipboardRequest,
     );

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -265,13 +265,10 @@ export function loadWebglRenderer(term: Terminal): WebglAddon | null {
  * Populate the clipboard from a terminal text selection on a browser
  * ``copy`` event.
  *
- * The attached tmux session runs with ``mouse on``, so a plain click-drag
- * is captured by tmux for its own copy-mode and never becomes a browser
- * selection; the user makes a selection with Shift-drag (non-Mac) or
- * ⌥-drag (Mac, via ``macOptionClickForcesSelection``). xterm renders that
- * selection in its own layer rather than a DOM range, so the browser's
- * default copy of it is unreliable — we feed ``term.getSelection()`` into
- * the event's ``clipboardData`` ourselves. ``getSelection()`` already
+ * xterm renders terminal selections in its own layer rather than a DOM range,
+ * so the browser's default copy is unreliable — we feed
+ * ``term.getSelection()`` into the event's ``clipboardData`` ourselves.
+ * ``getSelection()`` already
  * rejoins soft-wrapped rows, so a paragraph the terminal wrapped across
  * several rows copies back as one logical line.
  *
@@ -434,8 +431,8 @@ export function sgrWheelReports(lines: number, col: number, row: number): string
  * xterm's built-in wheel→report conversion is unusable with macOS
  * trackpads: it damps sub-50px pixel deltas by ×0.3 and emits at most one
  * report per DOM event regardless of magnitude, so two-finger scrolling
- * over a mouse-tracking TUI (Claude Code, tmux with ``mouse on``) barely
- * moves. This helper replaces that path: deltas convert to lines at face
+ * over a mouse-tracking TUI (such as Claude Code) barely moves. This helper
+ * replaces that path: deltas convert to lines at face
  * value, the fractional remainder accumulates in *partial* so a run of
  * small trackpad deltas still adds up, and one report is emitted per whole
  * line (capped at {@link WHEEL_REPORTS_MAX_PER_EVENT}; the excess is
@@ -443,10 +440,9 @@ export function sgrWheelReports(lines: number, col: number, row: number): string
  * after the gesture).
  *
  * The event is only consumed when the pane program is tracking the mouse
- * with SGR encoding — both tmux ``mouse on`` (PTY transport) and Claude
- * Code's own tracking (control transport) request SGR. Otherwise the
- * caller must let xterm handle the wheel natively so, e.g., a plain shell
- * on the control transport scrolls xterm's own scrollback. Shift-wheel is
+ * with SGR encoding, such as Claude Code on the control transport. Otherwise
+ * the caller must let xterm handle the wheel natively so, e.g., a plain shell
+ * scrolls xterm's own scrollback. Shift-wheel is
  * also left to xterm, mirroring its built-in escape hatch.
  *
  * Pure helper — exported for direct unit testing; production code calls it
@@ -558,12 +554,8 @@ export class TerminalSession {
    *     server. This is a best-effort UI activity signal, not a shell
    *     job-state oracle.
    * :param onInput: Called when user input is sent to the terminal.
-   * :param nativeSelection: When ``true`` (control-mode transport), xterm
-   *     owns the character buffer and mouse, so plain click-drag selects and
-   *     the browser's own copy works — the ``macOptionClickForcesSelection``
-   *     workaround and the custom ``copy`` listener are skipped. When
-   *     ``false`` (PTY transport, the default), tmux runs with ``mouse on``
-   *     and captures drags, so both workarounds stay wired.
+   * :param controlMode: Whether this is the control transport. Control mode
+   *     forwards raw pane output, so pane OSC 52 must not be accepted directly.
    * :param clipboardEnabled: Whether tmux copies may write the local clipboard.
    * :param onClipboardRequest: Receives validated tmux copy-mode text.
    */
@@ -574,7 +566,7 @@ export class TerminalSession {
     isDark = false,
     onActivity?: TerminalActivityListener,
     onInput?: TerminalInputListener,
-    nativeSelection = false,
+    controlMode = false,
     clipboardEnabled = true,
     onClipboardRequest?: TerminalClipboardListener,
   ) {
@@ -595,14 +587,6 @@ export class TerminalSession {
       // cell's foreground luminance only when it lacks contrast against
       // its actual background.
       minimumContrastRatio: 4.5,
-      // PTY transport only: the attached tmux session runs with `mouse on`
-      // (terminal.py) so the wheel pages through scrollback, but tmux then
-      // captures every mouse drag for its own copy-mode, so a plain
-      // click-drag never produces a browser text selection. xterm's escape
-      // hatch `macOptionClickForcesSelection` lets Mac users ⌥-drag to select,
-      // then ⌘-C copies. In control mode xterm owns the mouse and plain drag
-      // selects natively, so the forced-selection workaround is unnecessary.
-      macOptionClickForcesSelection: !nativeSelection,
       // Opt into xterm's proposed APIs, matching openui's terminal setup.
       allowProposedApi: true,
     });
@@ -612,7 +596,7 @@ export class TerminalSession {
       // Control mode forwards raw pane output, so accepting pane OSC 52 there
       // would bypass tmux's `set-clipboard external` trust boundary. Its copy
       // path is the typed websocket message emitted from tmux notifications.
-      if (!nativeSelection && this.osc52ClipboardEnabled) {
+      if (!controlMode && this.osc52ClipboardEnabled) {
         const text = parseOsc52Clipboard(data);
         if (text !== null) this.requestClipboardWrite(text);
       }
@@ -648,7 +632,7 @@ export class TerminalSession {
 
     // Make the browser copy gesture (right-click → Copy and Edit → Copy on
     // every platform, ⌘C on macOS) yield the terminal selection as text.
-    // Without this, a Shift/⌥-drag selection has no working copy path on
+    // Without this, an xterm selection has no working copy path on
     // Linux/Windows — Ctrl+C is SIGINT, and xterm's selection layer isn't a
     // DOM range the browser copies on its own. Capture phase + the shared
     // abort signal so `dispose()` removes it for free. Ctrl+C is never
@@ -852,11 +836,9 @@ export class TerminalSession {
    * Whether the pane program requested SGR mouse encoding (``?1006h``).
    *
    * The public ``IModes`` exposes the tracking mode but not the encoding,
-   * so this feature-detects xterm's core mouse service. Both tmux with
-   * ``mouse on`` (PTY transport) and Claude Code (control transport) request
-   * SGR; when the private shape is missing or the encoding is anything else,
-   * the wheel handler defers to xterm rather than synthesizing reports the
-   * program could not parse.
+   * so this feature-detects xterm's core mouse service. When a pane program
+   * requests SGR tracking (for example Claude Code on the control transport),
+   * reports are synthesized; otherwise the wheel handler defers to xterm.
    */
   private sgrMouseEncodingActive(): boolean {
     // eslint-disable-next-line no-underscore-dangle

--- a/web/src/components/blocks/TerminalView.test.tsx
+++ b/web/src/components/blocks/TerminalView.test.tsx
@@ -19,7 +19,6 @@ import {
   RECONNECT_BACKOFF_MS,
   RECONNECT_STABLE_MS,
   buildAttachPath,
-  selectionHintText,
 } from "./TerminalView";
 
 const clipboardMock = vi.hoisted(() => ({
@@ -32,7 +31,7 @@ const terminalSessionMock = vi.hoisted(() => ({
   instances: [] as {
     url: string;
     container: HTMLDivElement;
-    nativeSelection: boolean;
+    controlMode: boolean;
     clipboardEnabled: boolean;
     onClipboardRequest?: (text: string) => void;
     onState: (state: ConnectionState) => void;
@@ -60,14 +59,14 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
       _isDark?: boolean,
       _onActivity?: () => void,
       _onInput?: () => void,
-      nativeSelection = false,
+      controlMode = false,
       clipboardEnabled = true,
       onClipboardRequest?: (text: string) => void,
     ) {
       terminalSessionMock.instances.push({
         url,
         container,
-        nativeSelection,
+        controlMode,
         clipboardEnabled,
         onClipboardRequest,
         onState,
@@ -164,12 +163,12 @@ describe("buildAttachPath", () => {
 });
 
 describe("control-mode transport", () => {
-  it("forwards ?transport=control and enables native selection when transport=control", async () => {
+  it("forwards ?transport=control and marks the session as control mode", async () => {
     render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" transport="control" />);
     await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
     const inst = terminalSessionMock.instances[0];
     expect(inst.url).toContain("transport=control");
-    expect(inst.nativeSelection).toBe(true);
+    expect(inst.controlMode).toBe(true);
   });
 
   it("disables clipboard bridging for read-only attaches", async () => {
@@ -185,19 +184,13 @@ describe("control-mode transport", () => {
     expect(terminalSessionMock.instances[0].clipboardEnabled).toBe(false);
   });
 
-  it("hides the selection hint bar in control mode", async () => {
-    render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" transport="control" />);
-    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
-    expect(screen.queryByTestId("terminal-selection-hint")).toBeNull();
-  });
-
-  it("keeps the hint bar and PTY behavior by default (no transport prop)", async () => {
+  it("keeps PTY clipboard behavior without rendering a selection hint", async () => {
     render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />);
     await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
     const inst = terminalSessionMock.instances[0];
     expect(inst.url).not.toContain("transport");
-    expect(inst.nativeSelection).toBe(false);
-    expect(screen.getByTestId("terminal-selection-hint")).toBeInTheDocument();
+    expect(inst.controlMode).toBe(false);
+    expect(screen.queryByTestId("terminal-selection-hint")).toBeNull();
   });
 });
 
@@ -811,27 +804,5 @@ describe("automatic reconnect", () => {
     await act(async () => {});
     expect(terminalSessionMock.instances).toHaveLength(1);
     expect(screen.getByText("Bridge closed: code 4405")).toBeInTheDocument();
-  });
-});
-
-describe("selectionHintText", () => {
-  it("tells macOS users to hold Option and copy with Command", () => {
-    // On macOS the force-selection modifier is Option and Cmd+C copies
-    // (Cmd isn't forwarded to the shell). Both must appear; a regression
-    // to Shift/Ctrl here would print the wrong keys for Mac users.
-    const hint = selectionHintText(true);
-    expect(hint).toContain("⌥");
-    expect(hint).toContain("⌘C");
-  });
-
-  it("tells non-macOS users to hold Shift and copy via right-click", () => {
-    // Elsewhere the modifier is Shift, and Ctrl+C is SIGINT (not copy),
-    // so the hint must say Shift and must point at right-click → Copy
-    // rather than a Ctrl+C shortcut that would kill the user's process.
-    const hint = selectionHintText(false);
-    expect(hint).toContain("Shift");
-    expect(hint).toContain("right-click");
-    expect(hint).not.toContain("⌘");
-    expect(hint.toLowerCase()).not.toContain("ctrl");
   });
 });

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -97,11 +97,9 @@ interface TerminalViewProps {
   /**
    * Web-attach transport for this terminal (``"control"`` / ``"pty"``),
    * from the terminal resource's ``metadata.terminal_transport``. Control
-   * mode gives the browser xterm native scrollback + selection, so the
-   * mouse/selection workarounds and the hint bar are dropped. ``undefined``
-   * (or ``"pty"``) keeps the legacy PTY behavior. When set, it is also
-   * forwarded to the server as ``?transport=`` so the attach matches the
-   * behavior the UI renders for.
+   * mode gives browser xterm ownership of scrollback; PTY mode attaches a
+   * tmux client. When set, it is also forwarded to the server as
+   * ``?transport=`` so the attach matches the behavior the UI renders for.
    */
   transport?: "control" | "pty";
   /**
@@ -136,8 +134,8 @@ export function TerminalView({
   active = true,
   directAttachUrl,
 }: TerminalViewProps) {
-  // Control mode: xterm owns the buffer + mouse, so plain drag selects and
-  // the normal copy gesture works — no forced-selection modifier, no hint bar.
+  // Control mode forwards raw pane output and uses typed clipboard messages;
+  // PTY mode attaches a tmux client and accepts trusted tmux OSC 52 writes.
   const controlMode = transport === "control";
   const [state, setState] = useState<ConnectionState>({ kind: "connecting" });
   const [connectAttempt, setConnectAttempt] = useState(0);
@@ -763,20 +761,6 @@ export function TerminalView({
       <div className="min-h-0 flex-1 overflow-hidden p-1">
         <div key={connectAttempt} ref={attachSession} className="h-full w-full overflow-hidden" />
       </div>
-      {/* PTY transport only: the attached tmux session runs with `mouse on`,
-          so a plain click-drag is captured by tmux (copy-mode) instead of
-          making a browser selection — the user can't select-and-copy without a
-          platform-specific modifier, and there's no other discoverable cue, so
-          surface it as a persistent hint. Control mode gives xterm native
-          selection, so the hint is unnecessary and omitted. */}
-      {!controlMode && (
-        <div
-          data-testid="terminal-selection-hint"
-          className="shrink-0 select-none px-2 py-1 text-[10px] text-muted-foreground/70"
-        >
-          {selectionHintText(isMacPlatform())}
-        </div>
-      )}
       {state.kind !== "connected" && (
         <StatusOverlay
           state={state}
@@ -788,50 +772,6 @@ export function TerminalView({
       )}
     </div>
   );
-}
-
-/**
- * Detect whether the current browser is running on macOS.
- *
- * Used to pick the correct text-selection modifier and copy shortcut
- * for the terminal hint: macOS bypasses tmux mouse capture with Option
- * and copies with Command, while other platforms use Shift.
- *
- * Prefers the modern ``navigator.userAgentData.platform`` and falls
- * back to the deprecated-but-universal ``navigator.platform``.
- *
- * :returns: ``true`` on macOS, ``false`` elsewhere (and in any
- *     non-browser context where ``navigator`` is undefined).
- */
-export function isMacPlatform(): boolean {
-  if (typeof navigator === "undefined") return false;
-  const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
-  const platform = uaData?.platform ?? navigator.platform ?? "";
-  return /mac/i.test(platform);
-}
-
-/**
- * Build the persistent selection/copy hint shown under the terminal.
- *
- * The attached tmux session captures plain mouse drags for its own
- * copy-mode, so the user must hold a modifier to make a native browser
- * selection (xterm's ``shouldForceSelection``: Option on macOS, Shift
- * elsewhere). Copying the selection is wired in
- * {@link TerminalSession} via a ``copy`` listener, so on macOS ``Cmd+C``
- * copies; on other platforms ``Ctrl+C`` stays SIGINT, so we point users
- * at right-click → Copy (the cross-platform copy gesture) instead.
- *
- * Pure helper — exported for direct unit testing.
- *
- * :param isMac: Whether the browser is on macOS, e.g. from
- *     :func:`isMacPlatform`.
- * :returns: The hint string to render, e.g.
- *     ``"Hold ⌥ and drag to select · ⌘C to copy"``.
- */
-export function selectionHintText(isMac: boolean): string {
-  return isMac
-    ? "Hold ⌥ and drag to select · ⌘C to copy"
-    : "Hold Shift and drag to select · right-click to copy";
 }
 
 function StatusOverlay({


### PR DESCRIPTION
## Related issue

[OMNI-5586](https://linear.app/omnigent/issue/OMNI-5586/disable-mouse-mode-in-tmux)

## Summary

- Disable tmux mouse mode so the attached terminal owns scrolling and text selection.
- Remove the obsolete PTY selection modifier workaround and hint while preserving transport-specific clipboard handling.
- Add backend, component, and browser regression coverage.

## Test Plan

- `uv run pytest tests/inner/test_terminal.py::test_launch_disables_tmux_mouse_mode -q`
- `uv run pytest tests/e2e_ui/sessions/test_terminal_view_url.py::test_transcript_views_survive_cold_reload -q`
- `cd web && npm test -- --run src/components/blocks/TerminalSession.test.ts src/components/blocks/TerminalView.test.tsx`
- `uv run ruff check omnigent/inner/terminal.py omnigent/entities/session_resources.py tests/inner/test_terminal.py`
- `cd web && npx tsc -p tsconfig.app.json --noEmit`
- `cd web && npx prettier --check src/components/blocks/TerminalSession.ts src/components/blocks/TerminalSession.test.ts src/components/blocks/TerminalView.tsx src/components/blocks/TerminalView.test.tsx`
- `cd web && npx oxlint --deny-warnings --report-unused-disable-directives src/components/blocks/TerminalSession.ts src/components/blocks/TerminalSession.test.ts src/components/blocks/TerminalView.tsx src/components/blocks/TerminalView.test.tsx`

## Demo

N/A — the visual change removes the obsolete PTY modifier hint; browser coverage verifies it is absent.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused tests cover the tmux launch option, terminal session behavior, hint removal, and browser rendering.

## Changelog

Terminal text can be selected and scrolled without tmux capturing mouse input.
