### PR TITLE
feat(desktop): support MDM-provided server preferences

### DIFF
--- a/tests/e2e_ui/desktop/test_setup_connect.py
+++ b/tests/e2e_ui/desktop/test_setup_connect.py
@@ -37,6 +37,7 @@ _PRELOAD_STUB = """
   window.__copiedTexts = [];
   window.omnigentSetup = {
     getServerUrl: () => Promise.resolve(""),
+    getManagedServers: () => Promise.resolve(__MANAGED_SERVERS__),
     getRecentServers: () => Promise.resolve(__RECENT_SERVERS__),
     setServerUrl: (value) => { window.__connectCalls.push(value); return Promise.resolve(); },
     copyText: (value) => { window.__copiedTexts.push(value); return Promise.resolve(); },
@@ -48,14 +49,19 @@ _PRELOAD_STUB = """
 _DEFAULT_PREFILL = "http://localhost:6767"
 
 
-def _open_setup_page(page: Page, recent_servers: Sequence[str] = ()) -> None:
+def _open_setup_page(
+    page: Page,
+    recent_servers: Sequence[str] = (),
+    managed_servers: Sequence[str] = (),
+) -> None:
     """Load the setup page with the preload bridge stubbed and prefill settled.
 
     :param page: Playwright page fixture.
     """
-    page.add_init_script(
-        _PRELOAD_STUB.replace("__RECENT_SERVERS__", json.dumps(list(recent_servers)))
-    )
+    preload = _PRELOAD_STUB.replace(
+        "__MANAGED_SERVERS__", json.dumps(list(managed_servers))
+    ).replace("__RECENT_SERVERS__", json.dumps(list(recent_servers)))
+    page.add_init_script(preload)
     page.goto(_SETUP_PAGE.as_uri())
     # getServerUrl() populates the input asynchronously; wait for that so the
     # per-test fill() below overwrites a settled value rather than racing it.
@@ -114,6 +120,30 @@ def test_loopback_connects_over_http_without_warning(page: Page) -> None:
 
     page.wait_for_function("() => window.__connectCalls.length === 1")
     assert page.evaluate("() => window.__connectCalls") == ["localhost:6767"]
+    expect(page.locator("#err")).to_have_text("")
+
+
+def test_managed_server_is_offered_without_auto_connecting(page: Page) -> None:
+    """An MDM server is separate from recents and connects with its exact path."""
+    managed_url = "https://mdm.example.com/ml/omnigents"
+    recent_url = "https://recent.example.com/"
+    _open_setup_page(page, [recent_url], [managed_url])
+
+    managed = page.locator("#managed")
+    expect(managed).to_be_visible()
+    expect(managed.locator(".recents-title")).to_have_text("Provided by your organization")
+    managed_button = page.locator("#managed-list .recent-btn")
+    expect(managed_button).to_have_text("mdm.example.com")
+    expect(managed_button).to_have_attribute("title", managed_url)
+
+    # MDM offers a choice; it never connects without the user's click.
+    assert page.evaluate("() => window.__connectCalls") == []
+    expect(page.locator("#recents")).to_be_visible()
+    expect(page.locator("#recents-list .recent-btn")).to_have_text("recent.example.com")
+
+    managed_button.click()
+    page.wait_for_function("() => window.__connectCalls.length === 1")
+    assert page.evaluate("() => window.__connectCalls") == [managed_url]
     expect(page.locator("#err")).to_have_text("")
 
 

--- a/web/electron/README.md
+++ b/web/electron/README.md
@@ -34,6 +34,11 @@ adds native niceties:
   window can also be opened against a **different server** (see "Multiple
   servers" below). Notifications and the dock badge are app-wide (one badge
   for all windows); a notification click focuses the window that fired it.
+- **macOS Managed Preferences for MDM-provided servers.** Administrators can
+  publish an HTTPS `serverUrls` list in the `ai.omnigent.desktop` preference
+  domain. The connect screen and in-app switcher show those choices under
+  **Provided by your organization** without auto-connecting or preventing a
+  manually entered server. See [Managed Preferences](docs/managed-preferences.md).
 - **A dock / taskbar badge showing the number of unread sessions** at all
   times (macOS dock badge, Linux Unity launcher count, via
   `app.setBadgeCount`). A session becomes "unread" when it finishes a turn
@@ -144,6 +149,7 @@ electron/
   package.json             # Electron + electron-builder deps and build config
   src/main.js              # main process: window, settings, menu, IPC, badge, notify
   src/preload.js           # contextBridge: window.omnigentDesktop + omnigentSetup
+  src/managed_preferences.js # read/validate macOS MDM server choices
   src/find_preload.js      # contextBridge for the find bar: window.omnigentFind
   src/browserViewRegistry.js  # per-conversation WebContentsView registry (browser pane)
   src/browserViewBounds.js    # CSS-px → window-DIP bounds conversion (browser pane)
@@ -151,6 +157,7 @@ electron/
   setup/index.html         # the bundled "connect to server" setup page
   find/index.html          # the bundled find-in-page bar (Cmd/Ctrl+F)
   icons/                   # app icons
+  docs/managed-preferences.md # public MDM configuration contract
 ```
 
 Native niceties beyond notifications/badge: a right-click context menu

--- a/web/electron/docs/managed-preferences.md
+++ b/web/electron/docs/managed-preferences.md
@@ -1,0 +1,128 @@
+# Managed Preferences (macOS)
+
+Administrators can use macOS MDM Managed Preferences to provide server URLs to
+Omnigent Desktop. People can then choose their organization’s server instead of
+typing it.
+
+The preference domain is the desktop bundle identifier:
+
+```text
+ai.omnigent.desktop
+```
+
+## Key
+
+| Key          | Type             | Required | Default | Description                                                                       |
+| ------------ | ---------------- | -------- | ------- | --------------------------------------------------------------------------------- |
+| `serverUrls` | Array of strings | No       | `[]`    | Server URLs to offer, most-preferred first. Each must use `https://`. At most 10. |
+
+A schemeless host is accepted and interpreted as `https://`. Paths are
+preserved, so an administrator can provide a workspace mount directly:
+
+```text
+https://my-workspace.cloud.databricks.com/ml/omnigents
+```
+
+Entries with the same origin are collapsed, keeping the first. An invalid type,
+an insecure or malformed entry, or more than 10 entries rejects the whole list.
+
+## Behavior
+
+Managed servers appear under **Provided by your organization** on the connect
+screen and in the in-app server switcher. They are offered, not enforced:
+
+- Omnigent does not connect automatically.
+- People can still enter another server URL.
+- Managed values are read from macOS on demand rather than copied wholesale
+  into `settings.json`.
+- A managed workspace path is loaded as configured instead of being reduced to
+  its origin.
+
+Applying or removing a profile is reflected the next time the server switcher
+is opened or the connect screen is loaded.
+
+## MDM profile example
+
+Use the standard `com.apple.ManagedClient.preferences` payload and the
+`ai.omnigent.desktop` application preference domain. Most MDM products expose
+this as a custom settings or managed preferences payload.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadContent</key>
+      <dict>
+        <key>ai.omnigent.desktop</key>
+        <dict>
+          <key>Forced</key>
+          <array>
+            <dict>
+              <key>mcx_preference_settings</key>
+              <dict>
+                <key>serverUrls</key>
+                <array>
+                  <string>https://omnigent.corp.example.com</string>
+                  <string>https://my-workspace.cloud.databricks.com/ml/omnigents</string>
+                </array>
+              </dict>
+            </dict>
+          </array>
+        </dict>
+      </dict>
+      <key>PayloadDisplayName</key>
+      <string>Omnigent Desktop Managed Preferences</string>
+      <key>PayloadIdentifier</key>
+      <string>com.example.omnigent.preferences</string>
+      <key>PayloadType</key>
+      <string>com.apple.ManagedClient.preferences</string>
+      <key>PayloadUUID</key>
+      <string>45C6C548-5E50-4A42-8319-F437C07D8151</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+    </dict>
+  </array>
+  <key>PayloadDisplayName</key>
+  <string>Omnigent Desktop</string>
+  <key>PayloadIdentifier</key>
+  <string>com.example.omnigent</string>
+  <key>PayloadScope</key>
+  <string>User</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>984315D8-3729-4D19-BB34-F052A52F546B</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>
+```
+
+Replace the example organization identifiers and UUIDs before deployment.
+
+## Local verification
+
+For development only, the effective preference can be simulated with
+`defaults` while a **packaged Omnigent app** is closed. An unpackaged
+`electron .` / `just electron-dev` process uses Electron's development bundle
+identifier, not `ai.omnigent.desktop`, so it will not see this value:
+
+```bash
+defaults write ai.omnigent.desktop serverUrls -array \
+  "https://omnigent.corp.example.com" \
+  "https://my-workspace.cloud.databricks.com/ml/omnigents"
+```
+
+Remove the test value with:
+
+```bash
+defaults delete ai.omnigent.desktop serverUrls
+```
+
+Production deployment should use an MDM-forced preference rather than a local
+user default.

--- a/web/electron/setup/index.html
+++ b/web/electron/setup/index.html
@@ -401,6 +401,11 @@
       <button id="connect">Connect</button>
       <div class="err" id="err"></div>
 
+      <div class="recents" id="managed" hidden>
+        <p class="recents-title">Provided by your organization</p>
+        <div id="managed-list"></div>
+      </div>
+
       <div class="recents" id="recents" hidden>
         <p class="recents-title">Recent servers</p>
         <div id="recents-list"></div>
@@ -486,68 +491,75 @@
           });
       }
 
-      // Recently-connected servers (persisted by the main process after each
-      // successful non-ephemeral connection). The URL keeps its one-click Connect
-      // behavior; the adjacent clipboard action copies without navigating.
-      // An empty/unavailable list keeps the section hidden.
-      const recentsSection = document.getElementById("recents");
-      const recentsList = document.getElementById("recents-list");
+      // Organization-provided and recent servers share one rendering path.
+      // Managed choices are read-only offers: selecting one uses the ordinary
+      // explicit Connect flow and never auto-connects the app.
+      function renderServerList(urls, sectionId, listId, sourceLabel) {
+        if (!Array.isArray(urls) || urls.length === 0) return;
+        const section = document.getElementById(sectionId);
+        const list = document.getElementById(listId);
+        for (const url of urls) {
+          const label = serverDisplayLabel(url);
+          const row = document.createElement("div");
+          row.className = "recent-row";
+
+          const serverButton = document.createElement("button");
+          serverButton.type = "button";
+          serverButton.className = "recent-btn";
+          serverButton.textContent = label;
+          serverButton.title = sectionId === "managed" ? url : label;
+          serverButton.setAttribute("aria-label", `Connect to ${sourceLabel} server ${label}`);
+          serverButton.addEventListener("click", () => {
+            input.value = url;
+            void connect();
+          });
+
+          const copyButton = document.createElement("button");
+          copyButton.type = "button";
+          copyButton.className = "recent-copy";
+          copyButton.title = "Copy URL";
+          copyButton.setAttribute("aria-label", `Copy ${sourceLabel} server URL ${label}`);
+          copyButton.innerHTML = `
+            <svg class="copy-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <rect width="8" height="4" x="8" y="2" rx="1"></rect>
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
+            </svg>
+            <svg class="copied-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="m5 12 4 4L19 6"></path>
+            </svg>`;
+          copyButton.addEventListener("click", async (event) => {
+            event.stopPropagation();
+            err.textContent = "";
+            try {
+              await setup.copyText(url);
+              copyButton.dataset.copied = "true";
+              copyButton.title = "Copied";
+              copyButton.setAttribute("aria-label", `Copied ${sourceLabel} server URL ${label}`);
+              setTimeout(() => {
+                delete copyButton.dataset.copied;
+                copyButton.title = "Copy URL";
+                copyButton.setAttribute("aria-label", `Copy ${sourceLabel} server URL ${label}`);
+              }, 1500);
+            } catch {
+              err.textContent = `Could not copy ${sourceLabel} server URL.`;
+            }
+          });
+
+          row.append(serverButton, copyButton);
+          list.appendChild(row);
+        }
+        section.hidden = false;
+      }
+
+      setup
+        .getManagedServers()
+        .then((servers) =>
+          renderServerList(servers, "managed", "managed-list", "organization-provided"),
+        )
+        .catch(() => {});
       setup
         .getRecentServers()
-        .then((recents) => {
-          if (!Array.isArray(recents) || recents.length === 0) return;
-          for (const url of recents) {
-            const label = serverDisplayLabel(url);
-            const row = document.createElement("div");
-            row.className = "recent-row";
-
-            const serverButton = document.createElement("button");
-            serverButton.type = "button";
-            serverButton.className = "recent-btn";
-            serverButton.textContent = label;
-            serverButton.title = label;
-            serverButton.setAttribute("aria-label", `Connect to recent server ${label}`);
-            serverButton.addEventListener("click", () => {
-              input.value = url;
-              void connect();
-            });
-
-            const copyButton = document.createElement("button");
-            copyButton.type = "button";
-            copyButton.className = "recent-copy";
-            copyButton.title = "Copy URL";
-            copyButton.setAttribute("aria-label", `Copy recent server URL ${label}`);
-            copyButton.innerHTML = `
-              <svg class="copy-icon" viewBox="0 0 24 24" aria-hidden="true">
-                <rect width="8" height="4" x="8" y="2" rx="1"></rect>
-                <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-              </svg>
-              <svg class="copied-icon" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="m5 12 4 4L19 6"></path>
-              </svg>`;
-            copyButton.addEventListener("click", async (event) => {
-              event.stopPropagation();
-              err.textContent = "";
-              try {
-                await setup.copyText(url);
-                copyButton.dataset.copied = "true";
-                copyButton.title = "Copied";
-                copyButton.setAttribute("aria-label", `Copied recent server URL ${label}`);
-                setTimeout(() => {
-                  delete copyButton.dataset.copied;
-                  copyButton.title = "Copy URL";
-                  copyButton.setAttribute("aria-label", `Copy recent server URL ${label}`);
-                }, 1500);
-              } catch {
-                err.textContent = "Could not copy recent server URL.";
-              }
-            });
-
-            row.append(serverButton, copyButton);
-            recentsList.appendChild(row);
-          }
-          recentsSection.hidden = false;
-        })
+        .then((servers) => renderServerList(servers, "recents", "recents-list", "recent"))
         .catch(() => {});
 
       // The exact URL value the user has already been warned about — a

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -51,6 +51,7 @@ const { createBrowserViewRegistry } = require("./browserViewRegistry");
 const { createBrowserViewBoundsController } = require("./browserViewBounds");
 const { registerBrowserIpc } = require("./browserIpc");
 const { isDeveloperModeEnabled } = require("./developer_mode");
+const { excludingManagedServers, getManagedServerUrls } = require("./managed_preferences");
 const { registerSessionExpiryReload } = require("./session-expiry");
 const { decideWindowOpen, stripCrossOriginOpenerHeaders, WEB_SCHEMES } = require("./popupPolicy");
 const omnigentCli = require("./omnigent_cli");
@@ -100,6 +101,17 @@ const ICON_PNG = path.join(__dirname, "..", "icons", "icon.png");
 function developerModeEnabled() {
   return isDeveloperModeEnabled({
     isPackaged: app.isPackaged,
+    platform: process.platform,
+    getUserDefault:
+      typeof systemPreferences.getUserDefault === "function"
+        ? systemPreferences.getUserDefault.bind(systemPreferences)
+        : undefined,
+  });
+}
+
+/** Read the current macOS MDM-provided server list without persisting it. */
+function managedServerUrls() {
+  return getManagedServerUrls({
     platform: process.platform,
     getUserDefault:
       typeof systemPreferences.getUserDefault === "function"
@@ -2164,9 +2176,11 @@ function registerIpc() {
       // A server page must never be able to re-point which server is saved.
       throw new Error("set-server-url is only available to the setup page");
     }
-    const normalized = normalizeUrl(url); // throws → rejects → setup page shows error
-    // Bare Databricks workspace URLs serve a 404 at the root; expand them to
-    // the Omnigent UI mount so the user can paste just the workspace host.
+    // A managed choice is already validated and may name a workspace mount;
+    // preserve it exactly. The shared expansion is a no-op for paths, while a
+    // managed workspace root still gets the normal mount discovery.
+    const managedTarget = managedServerUrls().find((candidate) => candidate === url);
+    const normalized = managedTarget ?? normalizeUrl(url); // throws → setup page shows error
     const target = await expandDatabricksWorkspaceUrl(normalized);
     const win = BrowserWindow.fromWebContents(event.sender) ?? activeWindow();
     // Multi-server windows connect without touching the saved server —
@@ -2227,7 +2241,18 @@ function registerIpc() {
     if (!isSetupPageSender(event)) {
       throw new Error("get-recent-servers is only available to the setup page");
     }
-    return normalizeRecentServers(loadSettings().recent_servers);
+    const managed = managedServerUrls();
+    return excludingManagedServers(normalizeRecentServers(loadSettings().recent_servers), managed);
+  });
+
+  // Setup page → organization-provided server choices from macOS Managed
+  // Preferences. Re-read on every request so policy removal is never copied
+  // into or masked by settings.json.
+  ipcMain.handle("omnigent:get-managed-servers", (event) => {
+    if (!isSetupPageSender(event)) {
+      throw new Error("get-managed-servers is only available to the setup page");
+    }
+    return managedServerUrls();
   });
 
   ipcMain.handle("omnigent:copy-setup-text", (event, text) => {
@@ -2249,11 +2274,13 @@ function registerIpc() {
       return null;
     }
     const win = BrowserWindow.fromWebContents(event.sender);
-    const recents = loadSettings().recent_servers;
+    const managedServers = managedServerUrls();
+    const recents = excludingManagedServers(loadSettings().recent_servers, managedServers);
     return {
       // isPinnedOriginSender guarantees the sender window is tracked.
       currentOrigin: windows.get(win).origin,
-      recentServers: Array.isArray(recents) ? recents.filter((u) => typeof u === "string") : [],
+      managedServers,
+      recentServers: recents,
       // The connected server's manifest, forwarded so the SPA branches on the
       // same document the shell did rather than re-fetching it (and so an
       // older shell, which simply omits this field, is detectable as absent —
@@ -2263,19 +2290,18 @@ function registerIpc() {
   });
 
   // SPA title-bar server picker → re-point the SENDING window to another
-  // server. Only URLs already in the persisted recent-servers list are
-  // accepted: pinning is a privilege grant (notifications, badge, protocol
-  // grants), so a server page must never be able to pin a window to an
-  // arbitrary origin of its choosing — only to servers the user previously
-  // connected to by hand.
+  // server. Only URLs in the persisted recent list or the current managed list
+  // are accepted: pinning is a privilege grant (notifications, badge, protocol
+  // grants), so a server page must never choose an arbitrary origin.
   ipcMain.handle("omnigent:switch-server", (event, url) => {
     if (!isPinnedOriginSender(event)) {
       throw new Error("switch-server is only available to a connected server page");
     }
     const recents = loadSettings().recent_servers;
-    const known = Array.isArray(recents) && recents.includes(url);
-    if (!known) {
-      throw new Error("switch-server target must be a previously-connected server");
+    const knownRecent = Array.isArray(recents) && recents.includes(url);
+    const knownManaged = managedServerUrls().includes(url);
+    if (!knownRecent && !knownManaged) {
+      throw new Error("switch-server target must be a recent or managed server");
     }
     const win = BrowserWindow.fromWebContents(event.sender);
     const ephemeral = Boolean(win && windows.get(win)?.ephemeral);

--- a/web/electron/src/managed_preferences.js
+++ b/web/electron/src/managed_preferences.js
@@ -1,0 +1,108 @@
+"use strict";
+
+/** Public macOS Managed Preferences key in the ai.omnigent.desktop domain. */
+const SERVER_URLS_KEY = "serverUrls";
+
+/** Keep organization-provided choices bounded on the connect screen. */
+const MAX_SERVER_URLS = 10;
+
+/**
+ * Normalize one administrator-provided server URL while preserving its path.
+ * Managed servers require TLS; a schemeless host defaults to https://.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function normalizeManagedServerUrl(value) {
+  if (typeof value !== "string") throw new TypeError("server URL must be a string");
+  const trimmed = value.trim();
+  if (trimmed === "") throw new Error("server URL is empty");
+  const withScheme = trimmed.includes("://") ? trimmed : `https://${trimmed}`;
+  let url;
+  try {
+    url = new URL(withScheme);
+  } catch (error) {
+    throw new Error(`invalid server URL: ${error.message}`, { cause: error });
+  }
+  if (url.protocol !== "https:" || url.hostname === "") {
+    throw new Error("managed server URLs must use https://");
+  }
+  return url.toString();
+}
+
+/**
+ * Validate the serverUrls preference as one configuration. An invalid type,
+ * entry, or oversized list rejects the whole value rather than applying a
+ * surprising partial policy.
+ *
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+function parseManagedServerUrls(value) {
+  if (value == null) return [];
+  if (!Array.isArray(value) || value.length > MAX_SERVER_URLS) return [];
+
+  const urls = [];
+  const origins = new Set();
+  try {
+    for (const entry of value) {
+      const normalized = normalizeManagedServerUrl(entry);
+      const origin = new URL(normalized).origin;
+      if (origins.has(origin)) continue;
+      origins.add(origin);
+      urls.push(normalized);
+    }
+  } catch {
+    return [];
+  }
+  return urls;
+}
+
+/**
+ * Read effective macOS preferences. MDM-forced values and ordinary defaults
+ * share NSUserDefaults' effective-value API; callers treat the result as
+ * read-only and never copy the configured list into settings.json.
+ *
+ * @param {{
+ *   platform?: NodeJS.Platform,
+ *   getUserDefault?: (key: string, type: string) => unknown,
+ * }} [options]
+ * @returns {string[]}
+ */
+function getManagedServerUrls({ platform = process.platform, getUserDefault } = {}) {
+  if (platform !== "darwin" || typeof getUserDefault !== "function") return [];
+  try {
+    return parseManagedServerUrls(getUserDefault(SERVER_URLS_KEY, "array"));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Remove user recents whose origin is already supplied by the organization.
+ *
+ * @param {unknown} candidates
+ * @param {string[]} managedServers
+ * @returns {string[]}
+ */
+function excludingManagedServers(candidates, managedServers) {
+  if (!Array.isArray(candidates)) return [];
+  const managedOrigins = new Set(managedServers.map((url) => new URL(url).origin));
+  return candidates.filter((candidate) => {
+    if (typeof candidate !== "string") return false;
+    try {
+      return !managedOrigins.has(new URL(candidate).origin);
+    } catch {
+      return true;
+    }
+  });
+}
+
+module.exports = {
+  MAX_SERVER_URLS,
+  SERVER_URLS_KEY,
+  excludingManagedServers,
+  getManagedServerUrls,
+  normalizeManagedServerUrl,
+  parseManagedServerUrls,
+};

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -89,14 +89,13 @@ contextBridge.exposeInMainWorld("omnigentDesktop", {
     return () => ipcRenderer.removeListener("omnigent:open-path", listener);
   },
   /**
-   * Title-bar server picker data: the window's current server origin and the
-   * recently-connected server URLs (most recent first). Resolves null on
-   * pages that aren't a connected server.
+   * Server picker data: the current origin plus organization-provided and
+   * recently-connected server URLs. Resolves null off a connected server.
    */
   getServerPicker: () => ipcRenderer.invoke("omnigent:get-server-picker"),
   /**
-   * Re-point this window to a previously-connected server URL (must come
-   * from getServerPicker's recentServers list; anything else rejects).
+   * Re-point this window to a URL returned by getServerPicker (anything else
+   * rejects in the main process).
    */
   switchServer: (url) => ipcRenderer.invoke("omnigent:switch-server", url),
   /** Return this window to the bundled "connect to server" setup page. */
@@ -422,6 +421,8 @@ contextBridge.exposeInMainWorld("omnigentSetup", {
    * @param {string} url
    */
   setServerUrl: (url) => ipcRenderer.invoke("omnigent:set-server-url", url),
+  /** Organization-provided server URLs from macOS Managed Preferences. */
+  getManagedServers: () => ipcRenderer.invoke("omnigent:get-managed-servers"),
   /** Recently-connected server URLs, most recent first. */
   getRecentServers: () => ipcRenderer.invoke("omnigent:get-recent-servers"),
   /** Copy text from the bundled setup page to the native clipboard. */

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -22,6 +22,7 @@ const path = require("node:path");
 
 const mainSource = readFileSync(path.join(__dirname, "../src/main.js"), "utf8");
 const preloadSource = readFileSync(path.join(__dirname, "../src/preload.js"), "utf8");
+const setupSource = readFileSync(path.join(__dirname, "../setup/index.html"), "utf8");
 
 // Strip block comments, then line comments (leaving `://` in URLs intact).
 const liveCode = mainSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
@@ -39,6 +40,45 @@ describe("setup clipboard IPC wiring", () => {
       liveCode,
       /ipcMain\.handle\("omnigent:copy-setup-text",[\s\S]{0,200}!isSetupPageSender\(event\)[\s\S]{0,300}clipboard\.writeText\(text\)/,
     );
+  });
+});
+
+describe("managed server preference wiring", () => {
+  it("exposes managed servers only through the setup-page bridge", () => {
+    assert.match(
+      preloadSource,
+      /getManagedServers:\s*\(\)\s*=>\s*ipcRenderer\.invoke\("omnigent:get-managed-servers"\)/,
+    );
+    assert.match(
+      liveCode,
+      /ipcMain\.handle\("omnigent:get-managed-servers"[\s\S]{0,180}!isSetupPageSender\(event\)[\s\S]{0,180}return managedServerUrls\(\)/,
+    );
+  });
+
+  it("preserves a managed path while still expanding bare workspace roots", () => {
+    assert.match(
+      liveCode,
+      /managedTarget\s*\?\?\s*normalizeUrl\(url\)[\s\S]{0,120}await expandDatabricksWorkspaceUrl\(normalized\)/,
+    );
+  });
+
+  it("returns managed choices in the connected-server picker", () => {
+    assert.match(
+      liveCode,
+      /ipcMain\.handle\("omnigent:get-server-picker"[\s\S]{0,500}managedServers[\s\S]{0,100}recentServers:\s*recents/,
+    );
+  });
+
+  it("allows switching only to a recent or currently managed target", () => {
+    assert.match(
+      liveCode,
+      /ipcMain\.handle\("omnigent:switch-server"[\s\S]{0,500}knownRecent[\s\S]{0,200}managedServerUrls\(\)\.includes\(url\)[\s\S]{0,150}!knownRecent\s*&&\s*!knownManaged/,
+    );
+  });
+
+  it("renders organization-provided servers separately on setup", () => {
+    assert.match(setupSource, /Provided by your organization/);
+    assert.match(setupSource, /setup\s*\.getManagedServers\(\)/);
   });
 });
 
@@ -204,10 +244,10 @@ describe("recent-server startup wiring (src/main.js)", () => {
     );
   });
 
-  it("normalizes persisted targets before returning setup-page recents", () => {
+  it("normalizes persisted targets and excludes managed origins from setup recents", () => {
     assert.match(
       liveCode,
-      /ipcMain\.handle\("omnigent:get-recent-servers"[\s\S]{0,300}return normalizeRecentServers\(loadSettings\(\)\.recent_servers\)/,
+      /ipcMain\.handle\("omnigent:get-recent-servers"[\s\S]{0,400}excludingManagedServers\(\s*normalizeRecentServers\(loadSettings\(\)\.recent_servers\),\s*managed/,
     );
   });
 });

--- a/web/electron/test/managed_preferences.test.js
+++ b/web/electron/test/managed_preferences.test.js
@@ -1,0 +1,94 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  MAX_SERVER_URLS,
+  SERVER_URLS_KEY,
+  excludingManagedServers,
+  getManagedServerUrls,
+  parseManagedServerUrls,
+} = require("../src/managed_preferences");
+
+describe("managed server preferences", () => {
+  it("reads the macOS serverUrls array and preserves workspace paths", () => {
+    const calls = [];
+    const urls = getManagedServerUrls({
+      platform: "darwin",
+      getUserDefault: (...args) => {
+        calls.push(args);
+        return ["omnigent.example.com", "https://workspace.example.com/ml/omnigents?o=123"];
+      },
+    });
+
+    assert.deepEqual(calls, [[SERVER_URLS_KEY, "array"]]);
+    assert.deepEqual(urls, [
+      "https://omnigent.example.com/",
+      "https://workspace.example.com/ml/omnigents?o=123",
+    ]);
+  });
+
+  it("does not read macOS preferences on other platforms", () => {
+    let reads = 0;
+    const urls = getManagedServerUrls({
+      platform: "win32",
+      getUserDefault: () => {
+        reads += 1;
+        return ["https://omnigent.example.com"];
+      },
+    });
+
+    assert.deepEqual(urls, []);
+    assert.equal(reads, 0);
+  });
+
+  it("deduplicates by origin while keeping the first configured URL", () => {
+    assert.deepEqual(
+      parseManagedServerUrls([
+        "https://workspace.example.com/ml/omnigents",
+        "https://workspace.example.com/another-mount",
+        "https://other.example.com",
+      ]),
+      ["https://workspace.example.com/ml/omnigents", "https://other.example.com/"],
+    );
+  });
+
+  it("rejects an invalid configuration as a whole", () => {
+    assert.deepEqual(parseManagedServerUrls("https://omnigent.example.com"), []);
+    assert.deepEqual(
+      parseManagedServerUrls(["https://valid.example.com", "http://insecure.example.com"]),
+      [],
+    );
+    assert.deepEqual(
+      parseManagedServerUrls(Array.from({ length: MAX_SERVER_URLS + 1 }, (_, i) => `host${i}.com`)),
+      [],
+    );
+  });
+
+  it("fails closed when NSUserDefaults cannot be read", () => {
+    assert.deepEqual(
+      getManagedServerUrls({
+        platform: "darwin",
+        getUserDefault: () => {
+          throw new Error("NSUserDefaults unavailable");
+        },
+      }),
+      [],
+    );
+  });
+
+  it("filters recents already represented by a managed origin", () => {
+    assert.deepEqual(
+      excludingManagedServers(
+        [
+          "https://workspace.example.com/old-mount",
+          "https://personal.example.com/",
+          "hand-edited-invalid-value",
+          null,
+        ],
+        ["https://workspace.example.com/ml/omnigents"],
+      ),
+      ["https://personal.example.com/", "hand-edited-invalid-value"],
+    );
+  });
+});

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -156,9 +156,9 @@ interface ElectronDesktopApi extends NativeShellApi {
    * idle, so the web never shows a (duplicate) banner. Absent on older shells.
    */
   updates?: ElectronUpdateBridge;
-  /** Current server origin + recent servers, or null on a foreign page. */
+  /** Current server origin + managed/recent choices, or null on a foreign page. */
   getServerPicker?: () => Promise<ServerPickerInfo | null>;
-  /** Re-point this window to a previously-connected server URL. */
+  /** Re-point this window to a server URL returned by the picker. */
   switchServer?: (url: string) => Promise<void>;
   /** Return this window to the shell's "connect to server" setup page. */
   openServerSetup?: () => void;
@@ -288,6 +288,11 @@ export interface ElectronUpdateBridge {
 export interface ServerPickerInfo {
   /** Origin this window is connected to, e.g. `"http://localhost:8000"`. */
   currentOrigin: string;
+  /**
+   * Server URLs supplied through macOS Managed Preferences. Optional because a
+   * newer server-served SPA can run inside a desktop shell that predates MDM.
+   */
+  managedServers?: string[];
   /** Recently-connected server URLs, most recent first. */
   recentServers: string[];
   /**
@@ -674,8 +679,8 @@ export function onNativeInsets(callback: (insets: NativeInsets) => void): () => 
 }
 
 /**
- * Fetch the title-bar server picker data from the Electron shell: the
- * window's current server origin plus the recently-connected server list.
+ * Fetch server picker data from the Electron shell: the current origin plus
+ * organization-provided and recently-connected server lists.
  *
  * Resolves `null` outside the Electron shell, under a shell too old to
  * support the picker, or on a page the shell doesn't recognize as a
@@ -693,9 +698,9 @@ export async function getServerPicker(): Promise<ServerPickerInfo | null> {
 }
 
 /**
- * Ask the Electron shell to re-point this window to another
- * previously-connected server URL (one of `ServerPickerInfo.recentServers`).
- * The shell navigates the whole window, so on success this page unloads.
+ * Ask the Electron shell to re-point this window to another URL returned in
+ * `ServerPickerInfo.managedServers` or `recentServers`. The shell navigates the
+ * whole window, so on success this page unloads.
  */
 export async function switchServer(url: string): Promise<void> {
   const electron = electronApi();

--- a/web/src/shell/SidebarServerPicker.test.tsx
+++ b/web/src/shell/SidebarServerPicker.test.tsx
@@ -80,6 +80,41 @@ describe("SidebarServerPicker", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows managed servers before recents and switches to one", async () => {
+    getServerPicker.mockResolvedValue({
+      currentOrigin: "https://personal.example.com",
+      managedServers: ["https://managed.example.com/ml/omnigents"],
+      recentServers: ["https://managed.example.com/old-mount", "https://recent.example.com/"],
+    });
+    renderPicker();
+
+    await openMenu();
+    expect(await screen.findByText("Provided by your organization")).toBeInTheDocument();
+    expect(screen.getAllByText("managed.example.com")).toHaveLength(1);
+    expect(screen.getByText("Recents")).toBeInTheDocument();
+    expect(screen.getByText("recent.example.com")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("managed.example.com"));
+    await waitFor(() =>
+      expect(switchServer).toHaveBeenCalledWith("https://managed.example.com/ml/omnigents"),
+    );
+  });
+
+  it("shows a managed current server only in the organization section", async () => {
+    getServerPicker.mockResolvedValue({
+      currentOrigin: "https://managed.example.com",
+      managedServers: ["https://managed.example.com/ml/omnigents"],
+      recentServers: [],
+    });
+    renderPicker();
+
+    await openMenu();
+    expect(await screen.findByText("Provided by your organization")).toBeInTheDocument();
+    // Once on the sidebar row and once as the checked managed menu item.
+    expect(screen.getAllByText("managed.example.com")).toHaveLength(2);
+    expect(screen.queryByText("Recents")).toBeNull();
+  });
+
   it("switches to a recent server on select", async () => {
     getServerPicker.mockResolvedValue({
       currentOrigin: "http://localhost:8000",

--- a/web/src/shell/SidebarServerPicker.tsx
+++ b/web/src/shell/SidebarServerPicker.tsx
@@ -40,9 +40,9 @@ function originOf(url: string): string | null {
  * Server picker for the Electron desktop shell, pinned to the sidebar's bottom.
  *
  * A sidebar row (server glyph + current host + an upward chevron) that opens a
- * menu of recently-connected servers — selecting one re-points the whole window
- * via the shell — plus "Connect to new server…", which returns the window to
- * the shell's setup page.
+ * menu of organization-provided and recently-connected servers — selecting one
+ * re-points the whole window via the shell — plus "Connect to new server…",
+ * which returns the window to the shell's setup page.
  *
  * This deliberately lives at the bottom of the sidebar rather than in the
  * window's title bar. The macOS shell hides the native title bar (titleBarStyle
@@ -77,16 +77,28 @@ export function SidebarServerPicker() {
 
   if (!info) return null;
 
-  // The current server leads the list even when the recents file was edited
-  // out from under us; recents matching the current origin collapse into it.
-  const others = info.recentServers.filter((url) => originOf(url) !== info.currentOrigin);
+  const managed = Array.isArray(info.managedServers) ? info.managedServers : [];
+  const managedOrigins = new Set(managed.map(originOf).filter((origin) => origin !== null));
+  const currentIsManaged = managedOrigins.has(info.currentOrigin);
+  // The current server leads its section even when settings were edited out
+  // from under us. Managed origins are not repeated under Recents.
+  const recentOthers = info.recentServers.filter((url) => {
+    const origin = originOf(url);
+    return origin !== info.currentOrigin && (origin === null || !managedOrigins.has(origin));
+  });
   const currentHost = hostOf(info.currentOrigin);
 
   return (
     // shrink-0 keeps the row at its natural height so the scrolling session
     // list above (flex-1) gives up space instead of squashing it.
     <div className="shrink-0 px-2 pt-1 pb-2" data-testid="sidebar-server-picker-row">
-      <DropdownMenu>
+      <DropdownMenu
+        onOpenChange={(open) => {
+          // Re-read when opened so a newly applied/removed MDM profile appears
+          // without restarting the server-served SPA.
+          if (open) void getServerPicker().then(setInfo);
+        }}
+      >
         <DropdownMenuTrigger asChild>
           <Button
             type="button"
@@ -113,18 +125,55 @@ export function SidebarServerPicker() {
         {/* side="top" — the trigger sits at the bottom of the window, so the
             menu must grow upward rather than off-screen. */}
         <DropdownMenuContent side="top" align="start" className="min-w-56">
-          <DropdownMenuLabel className="text-muted-foreground">Recents</DropdownMenuLabel>
-          <DropdownMenuItem disabled className="gap-2 opacity-100">
-            <CheckIcon className="size-4 shrink-0" />
-            <span className="truncate font-medium">{currentHost}</span>
-          </DropdownMenuItem>
-          {others.map((url) => (
-            <DropdownMenuItem key={url} className="gap-2" onSelect={() => void switchServer(url)}>
-              {/* Spacer aligns hosts under the current-server check. */}
-              <span className="size-4 shrink-0" aria-hidden="true" />
-              <span className="truncate">{hostOf(url)}</span>
-            </DropdownMenuItem>
-          ))}
+          {managed.length > 0 ? (
+            <>
+              <DropdownMenuLabel className="text-muted-foreground">
+                Provided by your organization
+              </DropdownMenuLabel>
+              {managed.map((url) => {
+                const isCurrent = originOf(url) === info.currentOrigin;
+                return (
+                  <DropdownMenuItem
+                    key={url}
+                    disabled={isCurrent}
+                    className={cn("gap-2", isCurrent && "opacity-100")}
+                    onSelect={isCurrent ? undefined : () => void switchServer(url)}
+                  >
+                    {isCurrent ? (
+                      <CheckIcon className="size-4 shrink-0" />
+                    ) : (
+                      <span className="size-4 shrink-0" aria-hidden="true" />
+                    )}
+                    <span className={cn("truncate", isCurrent && "font-medium")}>
+                      {hostOf(url)}
+                    </span>
+                  </DropdownMenuItem>
+                );
+              })}
+            </>
+          ) : null}
+          {!currentIsManaged || recentOthers.length > 0 ? (
+            <>
+              {managed.length > 0 ? <DropdownMenuSeparator /> : null}
+              <DropdownMenuLabel className="text-muted-foreground">Recents</DropdownMenuLabel>
+              {!currentIsManaged ? (
+                <DropdownMenuItem disabled className="gap-2 opacity-100">
+                  <CheckIcon className="size-4 shrink-0" />
+                  <span className="truncate font-medium">{currentHost}</span>
+                </DropdownMenuItem>
+              ) : null}
+              {recentOthers.map((url) => (
+                <DropdownMenuItem
+                  key={url}
+                  className="gap-2"
+                  onSelect={() => void switchServer(url)}
+                >
+                  <span className="size-4 shrink-0" aria-hidden="true" />
+                  <span className="truncate">{hostOf(url)}</span>
+                </DropdownMenuItem>
+              ))}
+            </>
+          ) : null}
           <DropdownMenuSeparator />
           <DropdownMenuItem className="gap-2" onSelect={() => openServerSetup()}>
             <PlusIcon className="size-4 shrink-0" />


### PR DESCRIPTION
## Related issue

[OMNI-5582](https://linear.app/omnigent/issue/OMNI-5582/add-support-to-managed-preferences-in-omnigent-desktop)

## Summary

- Let macOS administrators provide an ordered HTTPS `serverUrls` list through Managed Preferences without enforcing or auto-connecting a server.
- Show organization-provided servers separately on the desktop setup page and sidebar switcher while preserving IPC sender checks and switch-target allowlisting.
- Document the public MDM payload and validate malformed, insecure, duplicate, and oversized configurations before exposing them.

ELI5: MDM gives macOS a trusted list of company servers, and Omnigent offers that list alongside the user's own recent servers.

```text
MDM profile -> macOS NSUserDefaults -> Electron IPC -> setup page / server switcher
```

## Test Plan

- `node --test web/electron/test/managed_preferences.test.js web/electron/test/main.test.js`
- `node --test web/electron/test/update-main.test.js`
- `pnpm --dir web exec vitest run src/shell/SidebarServerPicker.test.tsx src/lib/nativeBridge.test.ts`
- `pnpm --dir web type-check`
- `pnpm --dir web exec oxlint --deny-warnings --report-unused-disable-directives src/lib/nativeBridge.ts src/shell/SidebarServerPicker.tsx src/shell/SidebarServerPicker.test.tsx`
- `pnpm --dir web exec prettier --check electron/README.md electron/docs/managed-preferences.md electron/setup/index.html electron/src/main.js electron/src/preload.js electron/src/managed_preferences.js electron/test/main.test.js electron/test/managed_preferences.test.js src/lib/nativeBridge.ts src/shell/SidebarServerPicker.tsx src/shell/SidebarServerPicker.test.tsx`

## Demo

<img width="1010" height="842" alt="image" src="https://github.com/user-attachments/assets/7e97e865-a0f4-481e-8f19-51b4d69b42a5" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The parser, IPC wiring, old-shell compatibility, managed/recent rendering, and switch behavior are covered by focused Electron and Vitest tests.

## Changelog

Administrators can provide Omnigent Desktop server choices through macOS Managed Preferences.
