### PR TITLE
fix(onboarding): reflect the Claude Code managed-settings gateway (reland #5404)

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -254,11 +254,24 @@ _SESSION_LABELS = {
     _WRAPPER_LABEL_KEY: _WRAPPER_LABEL_VALUE,
 }
 _CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
-_CLAUDE_CODE_MANAGED_SETTINGS_PATHS: tuple[Path, ...] = (
-    Path("/Library/Application Support/ClaudeCode/managed-settings.json"),
-    Path("/etc/claude-code/managed-settings.json"),
-    Path(os.environ.get("PROGRAMDATA", "C:/ProgramData")) / "ClaudeCode" / "managed-settings.json",
-)
+# Test override for the managed-settings chain. ``None`` means "use the ambient
+# detector's chain" — the single canonical definition (``ambient`` owns both the
+# path list and the parser). Binding a *copy* here would create a second source
+# of host state that a test fixture could neutralize independently of the other,
+# so both readers below resolve through ``_managed_settings_paths`` at call time.
+_CLAUDE_CODE_MANAGED_SETTINGS_PATHS: tuple[Path, ...] | None = None
+
+
+def _managed_settings_paths() -> tuple[Path, ...]:
+    """The Claude Code managed-settings chain to read (ambient's, or a test override)."""
+    override = _CLAUDE_CODE_MANAGED_SETTINGS_PATHS
+    if override is not None:
+        return override
+    from omnigent.onboarding.ambient import CLAUDE_CODE_MANAGED_SETTINGS_PATHS
+
+    return CLAUDE_CODE_MANAGED_SETTINGS_PATHS
+
+
 _CLAUDE_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 _RESUME_ACTION_SWITCH = "switch"
 _RESUME_ACTION_MOVE = "move"
@@ -633,7 +646,7 @@ def _managed_claude_model_config() -> ClaudeNativeUcodeConfig | None:
         _ANTHROPIC_CUSTOM_MODEL_OPTION_ENV,
         _ANTHROPIC_CUSTOM_MODEL_OPTION_NAME_ENV,
     }
-    for path in _CLAUDE_CODE_MANAGED_SETTINGS_PATHS:
+    for path in _managed_settings_paths():
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
@@ -666,25 +679,9 @@ def managed_claude_gateway_signal() -> tuple[str | None, bool]:
     :returns: ``(base_url, has_credential)`` from the first readable managed
         settings file, or ``(None, False)`` when none is present or parseable.
     """
-    for path in _CLAUDE_CODE_MANAGED_SETTINGS_PATHS:
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            continue
-        if not isinstance(payload, dict):
-            continue
-        raw_env = payload.get("env")
-        env = raw_env if isinstance(raw_env, dict) else {}
-        raw_base_url = env.get("ANTHROPIC_BASE_URL")
-        base_url = raw_base_url.strip() if isinstance(raw_base_url, str) else None
-        has_helper = bool(payload.get("apiKeyHelper"))
-        use_gateway = str(env.get("CLAUDE_CODE_USE_GATEWAY", "")).strip().lower() not in (
-            "",
-            "0",
-            "false",
-        )
-        return base_url or None, has_helper or use_gateway
-    return None, False
+    from omnigent.onboarding.ambient import claude_managed_gateway
+
+    return claude_managed_gateway(_managed_settings_paths())
 
 
 def claude_native_model_options(

--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -1148,6 +1148,22 @@ def _promote_global_auth_to_provider() -> str | None:
     return name
 
 
+def _claude_managed_gateway_label() -> str | None:
+    """Display label for a Claude credential backed by Claude Code's managed gateway.
+
+    When Claude Code's own settings deliver a gateway credential (enterprise
+    ``ANTHROPIC_BASE_URL`` + ``apiKeyHelper``), the Claude "subscription" the
+    machine really carries is that gateway, so setup names it as such (e.g.
+    ``"Databricks AI Gateway"``) instead of the generic ``"Subscription"``.
+    Purely a display derivation from live managed settings — nothing persisted.
+
+    :returns: The gateway label, or ``None`` when no managed credential is present.
+    """
+    from omnigent.onboarding.ambient import claude_managed_gateway_display_name
+
+    return claude_managed_gateway_display_name()
+
+
 def _compact_credential_label(det: DetectedProvider) -> str:
     """A short, brand-qualified label for an auto-configured credential.
 
@@ -1168,6 +1184,12 @@ def _compact_credential_label(det: DetectedProvider) -> str:
     from omnigent.onboarding.configure_models import credential_label
 
     if det.kind == SUBSCRIPTION_KIND:
+        # A Claude login whose real backing is Claude Code's managed-settings
+        # gateway names that gateway, so the callout matches Codex-Databricks.
+        if det.name == "claude":
+            gateway = _claude_managed_gateway_label()
+            if gateway is not None:
+                return gateway
         # Fallback to the raw CLI name is unreachable for today's detections
         # (see _CLI_LOGIN_BRAND) but keeps an added CLI readable, not crashing.
         brand = _CLI_LOGIN_BRAND.get(det.name, det.name)
@@ -1284,7 +1306,17 @@ def _credential_label(name: str, entry: ProviderEntry) -> str:
     :returns: A human label, e.g. ``"Anthropic API Key"`` or ``"Databricks (oss)"``.
     """
     from omnigent.onboarding.configure_models import credential_label
+    from omnigent.onboarding.provider_config import SUBSCRIPTION_KIND
 
+    # A Claude subscription whose real backing is Claude Code's managed-settings
+    # gateway reads as that gateway (e.g. "Databricks AI Gateway") rather than
+    # the generic "Subscription", so the credential the user recognizes is named
+    # — the Claude analogue of the "Codex-Databricks" row. Display only; the
+    # persisted entry stays a plain subscription (no new shape on disk).
+    if entry.kind == SUBSCRIPTION_KIND and entry.cli == "claude":
+        gateway = _claude_managed_gateway_label()
+        if gateway is not None:
+            return gateway
     return credential_label(
         entry.kind, name, profile=entry.profile, display_name=entry.display_name
     )

--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -34,6 +34,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
+from urllib.parse import urlsplit
 
 from omnigent.env_credentials import getenv_nonempty_with_omnigent_prefix
 from omnigent.onboarding import codex_auth_readiness
@@ -61,6 +62,20 @@ _OLLAMA_URL = f"http://{_OLLAMA_HOST}:{_OLLAMA_PORT}"
 # Timeout (seconds) for the Ollama TCP probe — short so setup stays snappy
 # when nothing is listening.
 _OLLAMA_PROBE_TIMEOUT = 0.25
+
+# Claude Code's enterprise "managed settings" chain, highest precedence first.
+# An enterprise install (the shape ``isaac configure claude`` writes) configures
+# Claude Code here and nowhere else: an ``env`` block pinning
+# ``ANTHROPIC_BASE_URL`` at a gateway plus a top-level ``apiKeyHelper`` that
+# prints the bearer token. Managed settings win at Claude Code's own launch, so
+# this file alone is a complete, working credential — but it belongs to Claude
+# Code, not omnigent: we reflect it (readiness + label), we never adopt it into
+# a ``providers:`` shape (see ``claude_managed_gateway``).
+CLAUDE_CODE_MANAGED_SETTINGS_PATHS: tuple[Path, ...] = (
+    Path("/Library/Application Support/ClaudeCode/managed-settings.json"),
+    Path("/etc/claude-code/managed-settings.json"),
+    Path(os.environ.get("PROGRAMDATA", "C:/ProgramData")) / "ClaudeCode" / "managed-settings.json",
+)
 
 # Maps each provider whose env key we surface to the served model family.
 # Providers absent here (or mapped to ``None``) are reported with
@@ -455,6 +470,81 @@ def claude_auth_has_credential(creds_path: Path) -> bool:
     return False
 
 
+def claude_managed_gateway(
+    paths: tuple[Path, ...] | None = None,
+) -> tuple[str | None, bool]:
+    """Read the credential Claude Code applies from its managed settings chain.
+
+    The single canonical parser for Claude Code's managed-settings credential,
+    shared by ambient detection, the readiness gate, and the Smart-Routing
+    gateway check (:func:`omnigent.claude_native.managed_claude_gateway_signal`
+    delegates here). A credential counts as delivered when the file carries a
+    top-level ``apiKeyHelper`` (a token-printing command) or a truthy
+    ``env.CLAUDE_CODE_USE_GATEWAY``.
+
+    The **first readable, object-shaped** file decides, matching Claude Code's
+    own precedence: a settings file that exists but pins no credential reports
+    "none" rather than falling through to a lower-precedence file it would
+    itself override.
+
+    :param paths: Settings files to read, highest precedence first; defaults to
+        :data:`CLAUDE_CODE_MANAGED_SETTINGS_PATHS`.
+    :returns: ``(base_url, has_credential)`` from the first readable file, or
+        ``(None, False)`` when none is present or parseable. ``base_url`` is the
+        gateway ``env.ANTHROPIC_BASE_URL`` (``None`` when unset — a helper alone
+        credentials api.anthropic.com); ``has_credential`` is whether Claude
+        Code has a usable credential to apply at launch.
+    """
+    for path in CLAUDE_CODE_MANAGED_SETTINGS_PATHS if paths is None else paths:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        raw_env = payload.get("env")
+        env = raw_env if isinstance(raw_env, dict) else {}
+        raw_base_url = env.get("ANTHROPIC_BASE_URL")
+        base_url = raw_base_url.strip() if isinstance(raw_base_url, str) else None
+        has_helper = bool(payload.get("apiKeyHelper"))
+        use_gateway = str(env.get("CLAUDE_CODE_USE_GATEWAY", "")).strip().lower() not in (
+            "",
+            "0",
+            "false",
+        )
+        return base_url or None, has_helper or use_gateway
+    return None, False
+
+
+def claude_managed_gateway_display_name(paths: tuple[Path, ...] | None = None) -> str | None:
+    """A human label for the managed-settings credential, when one is delivered.
+
+    Used by the setup / ``/model`` display layer to show the Claude credential
+    as its actual backing (e.g. ``"Databricks AI Gateway"``) rather than the
+    generic ``"Subscription"``. Purely a display derivation from live managed
+    settings — nothing is persisted.
+
+    :param paths: Settings files to read; defaults to
+        :data:`CLAUDE_CODE_MANAGED_SETTINGS_PATHS`.
+    :returns: ``"Databricks AI Gateway"`` for a recognized Databricks gateway,
+        the gateway host for another gateway, ``"Claude Code gateway"`` for a
+        credential with no pinned base URL, or ``None`` when no credential is
+        delivered.
+    """
+    base_url, has_credential = claude_managed_gateway(paths)
+    if not has_credential:
+        return None
+    if base_url is None:
+        return "Claude Code gateway"
+    # Lazy: the gateway-URL allowlist lives in its own module and is only
+    # needed once a base URL is actually present.
+    from omnigent.databricks_ai_gateway import is_databricks_ai_gateway_url
+
+    if is_databricks_ai_gateway_url(base_url):
+        return "Databricks AI Gateway"
+    return urlsplit(base_url).hostname or "Claude Code gateway"
+
+
 def _claude_login_detected() -> bool:
     """Return whether a usable Claude Code subscription login is present.
 
@@ -640,12 +730,27 @@ def _detect_providers_now() -> list[DetectedProvider]:
             )
         )
 
-    # 2. Claude CLI login. Like codex (below), existence alone is not enough —
-    #    an empty / logged-out ``.credentials.json`` carries no usable login.
-    #    On macOS the credential lives in the Keychain rather than the file, so
-    #    detection falls back to the CLI's own status check there. See
-    #    ``_claude_login_detected`` / ``claude_auth_has_credential``.
-    if _claude_login_detected():
+    # 2. Claude Code credential. Prefer the managed-settings gateway — read
+    #    straight from the enterprise settings file (no subprocess, works on
+    #    Linux where there is no Keychain, and it is what Claude Code actually
+    #    applies at launch). Fall back to a CLI login otherwise (which on macOS
+    #    reads the Keychain via ``claude auth status``). Either way it is
+    #    surfaced as a ``subscription``: the credential lives in Claude Code's
+    #    own files and Claude Code applies it itself, so omnigent must NOT adopt
+    #    a gateway/cli-config provider shape for it — native routing defers to
+    #    Claude Code's settings (a subscription resolves to "no override"), and
+    #    the in-process SDK falls back to its own auth. Persisting a new shape
+    #    here is exactly what a released/stale runner's parser rejects.
+    if claude_managed_gateway()[1]:
+        detected.append(
+            DetectedProvider(
+                name="claude",
+                kind=SUBSCRIPTION_KIND,
+                family=ANTHROPIC_FAMILY,
+                source="Claude Code managed settings",
+            )
+        )
+    elif _claude_login_detected():
         detected.append(
             DetectedProvider(
                 name="claude",

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -57,6 +57,7 @@ from omnigent.onboarding.harness_install import (
 from omnigent.onboarding.provider_config import (
     _EXECUTOR_TYPE_HARNESS_ALIASES,
     _HARNESS_FAMILY,
+    ANTHROPIC_FAMILY,
     GEMINI_FAMILY,
     OPENAI_FAMILY,
     PI_SURFACE,
@@ -359,6 +360,32 @@ def _family_provider_configured(harness: str) -> bool:
     return provider is not None and provider.kind != SUBSCRIPTION_KIND
 
 
+def _claude_managed_gateway_configured() -> bool:
+    """Whether Claude Code's own settings chain carries a usable credential.
+
+    The structural companion to :func:`_family_provider_configured` (which sees
+    only omnigent's ``providers:`` config). An enterprise install configures
+    Claude Code directly — a gateway ``ANTHROPIC_BASE_URL`` + ``apiKeyHelper`` in
+    its managed settings — and Claude Code applies that at its own launch, so
+    the harness is genuinely usable with nothing in ``config.yaml`` and no CLI
+    subscription login. Crediting it here is what stops an enterprise host from
+    reading "needs-auth" (the "Claude Code isn't configured on <host>" banner).
+
+    Local, synchronous, side-effect free (one JSON file read) and never raises:
+    any error fails to ``False`` so readiness falls through to the CLI status
+    probe rather than crashing the refresh.
+
+    :returns: ``True`` when Claude Code's managed settings deliver a credential.
+    """
+    try:
+        from omnigent.onboarding.ambient import claude_managed_gateway
+
+        return claude_managed_gateway()[1]
+    except Exception:
+        _logger.debug("readiness: claude managed-settings check failed", exc_info=True)
+        return False
+
+
 def _installer_only_availability(install_key: str) -> HarnessAvailability:
     """Return availability for a binary-gated harness without login commands.
 
@@ -413,6 +440,14 @@ def _cli_family_availability(canonical: str, install_key: str) -> HarnessAvailab
     from omnigent.onboarding.harness_install import harness_cli_logged_in
 
     if _family_provider_configured(canonical):
+        return True
+    # Claude Code's own managed settings can carry a complete gateway credential
+    # (enterprise ``ANTHROPIC_BASE_URL`` + ``apiKeyHelper``) that omnigent's
+    # config knows nothing about, and that is what a claude-native launch
+    # actually routes through. Credit it structurally (one local file read, no
+    # subprocess) before the status probe, so an enterprise host reads ready
+    # without depending on the probe resolving the CLI on PATH.
+    if install_key == ANTHROPIC_FAMILY and _claude_managed_gateway_configured():
         return True
     return (
         True

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -44,6 +44,7 @@ never ``gemini``.
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass, field, replace
 from typing import Literal
@@ -58,6 +59,8 @@ from omnigent.env_credentials import (
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.spec.parser import check_unresolved_env_vars
+
+_logger = logging.getLogger(__name__)
 
 # Family keys. ``anthropic`` is the Messages-API surface (Claude SDK,
 # native Claude); ``openai`` is the Responses/Chat surface (Codex,
@@ -124,6 +127,14 @@ LOCAL_KIND = "local"
 DATABRICKS_KIND: Literal["databricks"] = "databricks"
 CLI_CONFIG_KIND = "cli-config"
 BEDROCK_KIND = "bedrock"
+
+# The CLIs whose own config file this build knows how to drive for a
+# ``cli-config`` provider. A ``cli-config`` entry naming any other CLI is a
+# shape from a newer build (or a stale entry a newer build wrote, e.g. a
+# ``cli: claude`` gateway): :func:`load_providers` SKIPS it with a warning
+# rather than raising, so one such entry cannot crash every turn's config
+# parse — the forward-compatibility gap that broke released runners.
+_CLI_CONFIG_RECOGNIZED_CLIS = frozenset({"codex"})
 _VALID_KINDS = (
     KEY_KIND,
     SUBSCRIPTION_KIND,
@@ -956,6 +967,24 @@ def load_providers(config: dict[str, object]) -> dict[str, ProviderEntry]:
                 f"provider {str(name)!r} must be a mapping.",
                 code=ErrorCode.INVALID_INPUT,
             )
+        # Forward compatibility: a ``cli-config`` entry naming a CLI this build
+        # doesn't drive (e.g. a ``cli: claude`` gateway written by a newer
+        # build) is SKIPPED, not fatal. Raising here would propagate out of the
+        # whole parse and fail turn setup on every harness — the version-skew
+        # break that took down released runners. One unknown provider is
+        # ignored; the rest of the config still loads.
+        if (
+            raw.get("kind") == CLI_CONFIG_KIND
+            and raw.get("cli") not in _CLI_CONFIG_RECOGNIZED_CLIS
+        ):
+            _logger.warning(
+                "provider %r: ignoring cli-config entry for unrecognized cli %r "
+                "(a newer build may understand it; this build drives %s).",
+                str(name),
+                raw.get("cli"),
+                sorted(_CLI_CONFIG_RECOGNIZED_CLIS),
+            )
+            continue
         result[str(name)] = _parse_provider(str(name), raw)
     return result
 

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -3408,3 +3408,50 @@ def test_credential_label_bedrock_not_duplicated() -> None:
 
     assert credential_label(BEDROCK_KIND, "bedrock") == "AWS Bedrock"
     assert credential_label(BEDROCK_KIND, "nexus") == "AWS Bedrock (nexus)"
+
+
+def test_claude_subscription_relabeled_as_managed_gateway(tmp_path, monkeypatch) -> None:
+    """A Claude subscription backed by the managed gateway shows the gateway name.
+
+    Answers the "why don't we get a clean Claude-Databricks like Codex-Databricks"
+    gap: when Claude Code's managed settings deliver the gateway, both the
+    per-credential row label and the adoption callout name it "Databricks AI
+    Gateway" instead of the generic "Subscription". Display only — the entry is
+    a plain subscription (no new persisted shape). With no managed gateway the
+    label stays "Subscription".
+    """
+    import json
+
+    from omnigent.cli_config import _compact_credential_label, _credential_label
+    from omnigent.onboarding import ambient
+    from omnigent.onboarding.ambient import DetectedProvider
+    from omnigent.onboarding.provider_config import ProviderEntry
+
+    entry = ProviderEntry(name="claude", kind="subscription", cli="claude")
+    det = DetectedProvider(
+        name="claude",
+        kind="subscription",
+        family="anthropic",
+        source="Claude Code managed settings",
+    )
+
+    # No managed gateway → generic labels.
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (tmp_path / "none.json",))
+    assert _credential_label("claude", entry) == "Subscription"
+    assert _compact_credential_label(det) == "Claude Subscription"
+
+    # Managed Databricks gateway present → both surfaces name it.
+    settings = tmp_path / "managed-settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://dbc.cloud.databricks.com/ai-gateway/anthropic"
+                },
+                "apiKeyHelper": "print-token",
+            }
+        )
+    )
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (settings,))
+    assert _credential_label("claude", entry) == "Databricks AI Gateway"
+    assert _compact_credential_label(det) == "Databricks AI Gateway"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -366,6 +366,49 @@ def _isolate_codex_native_state(
 
 
 @pytest.fixture()
+def claude_managed_settings() -> None:
+    """Opt back in to the host's real Claude Code managed-settings chain.
+
+    Request this alongside a test that must read the machine's actual
+    ``managed-settings.json``; :func:`_isolate_claude_managed_settings` then
+    leaves the path list alone.
+
+    :returns: None.
+    """
+
+
+@pytest.fixture(autouse=True)
+def _isolate_claude_managed_settings(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the host's Claude Code managed settings out of ambient detection.
+
+    ``omnigent.onboarding.ambient`` reads Claude Code's enterprise managed
+    settings to detect a gateway the CLI authenticates itself. Those paths are
+    **absolute and machine-global** (``/Library/Application Support/ClaudeCode/…``,
+    ``/etc/claude-code/…``), so unlike ``~/.claude`` they are NOT redirected by
+    a test's tmp ``$HOME`` — a developer's or CI runner's real enterprise install
+    would otherwise add a phantom Claude credential to every detection assertion.
+    ``claude_native`` resolves this same tuple at call time, so neutralizing it
+    here covers its Smart-Routing gateway check and managed model overrides too.
+
+    ``autouse=True`` because the alternative leaves us one missed test away from
+    host-dependent failures that reproduce only on configured machines. Tests
+    that exercise the detection pass an explicit ``paths=`` argument (the readers
+    take one) or request :func:`claude_managed_settings`.
+
+    :param request: Pytest request, inspected for the opt-in fixture.
+    :param monkeypatch: Pytest monkeypatch fixture; restores the tuple at
+        teardown.
+    :returns: None.
+    """
+    if "claude_managed_settings" in request.fixturenames:
+        return
+    monkeypatch.setattr("omnigent.onboarding.ambient.CLAUDE_CODE_MANAGED_SETTINGS_PATHS", ())
+
+
+@pytest.fixture()
 def untracked_cache_start() -> None:
     """Opt back in to the real :meth:`GitFilesystemRegistry.start`.
 

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -805,3 +805,142 @@ def test_prewarm_detect_providers_failure_falls_back_to_fresh_sweep(
     ambient.prewarm_detect_providers()
     assert detect_providers() == []
     assert sweeps == ["sweep", "sweep"]
+
+
+# --- Claude Code managed-settings gateway (the `isaac configure claude` shape) ---
+#
+# The credential lives in Claude Code's own enterprise settings, so omnigent
+# REFLECTS it (readiness + label) but surfaces it as the existing `subscription`
+# credential — never a new `cli-config` provider shape, which released/stale
+# runners reject at parse (the version-skew break that got the first attempt
+# reverted). These tests pin that: detection yields a subscription, and the
+# managed paths are read from an explicit tuple (absolute paths escape $HOME).
+
+_ISAAC_CLAUDE_SETTINGS: dict[str, object] = {
+    "env": {
+        "ANTHROPIC_BASE_URL": "https://dbc-test.cloud.databricks.com/ai-gateway/anthropic",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "system.ai.claude-opus-4-8",
+    },
+    "apiKeyHelper": "jq -r '.access_token' ~/.databricks/model-serving-token.json",
+}
+
+
+def _write_managed_settings(home, monkeypatch, payload: object):
+    """Write a Claude Code managed-settings file and point detection at it."""
+    import json
+
+    path = home / "managed-settings.json"
+    path.write_text(json.dumps(payload))
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (path,))
+    return path
+
+
+def test_claude_managed_gateway_reads_base_url_and_credential(clean_env, monkeypatch) -> None:
+    """An isaac-style settings file yields (base_url, has_credential=True)."""
+    _write_managed_settings(clean_env, monkeypatch, _ISAAC_CLAUDE_SETTINGS)
+    base_url, has_credential = ambient.claude_managed_gateway()
+    assert base_url == "https://dbc-test.cloud.databricks.com/ai-gateway/anthropic"
+    assert has_credential is True
+
+
+def test_claude_managed_gateway_detected_as_subscription_not_cli_config(
+    clean_env, monkeypatch
+) -> None:
+    """The managed gateway surfaces as a `claude` SUBSCRIPTION, never `cli-config`.
+
+    This is the load-bearing safety property: a `cli-config cli:claude` entry is
+    a poison pill an older runner's parser rejects, breaking every turn. Failure
+    here means the revert's root cause has been reintroduced.
+    """
+    _write_managed_settings(clean_env, monkeypatch, _ISAAC_CLAUDE_SETTINGS)
+    detected = detect_providers()
+    assert [(d.name, d.kind, d.family) for d in detected] == [
+        ("claude", "subscription", "anthropic")
+    ]
+    assert detected[0].source == "Claude Code managed settings"
+    assert all(d.kind != "cli-config" or d.name != "claude" for d in detected)
+
+
+def test_claude_managed_gateway_wins_over_cli_login_no_double_count(
+    clean_env, monkeypatch
+) -> None:
+    """Gateway present AND `claude auth status` logged-in → ONE claude subscription.
+
+    `claude auth status` reports a managed apiKeyHelper as logged in, so the two
+    signals describe the same credential; detection must not emit it twice.
+    """
+    from omnigent.onboarding import harness_install
+
+    monkeypatch.setattr(harness_install, "harness_cli_logged_in", lambda key: True)
+    _write_managed_settings(clean_env, monkeypatch, _ISAAC_CLAUDE_SETTINGS)
+    claude_rows = [d for d in detect_providers() if d.name == "claude"]
+    assert len(claude_rows) == 1
+    assert claude_rows[0].source == "Claude Code managed settings"
+
+
+def test_claude_cli_login_still_detected_without_managed_gateway(clean_env, monkeypatch) -> None:
+    """With no managed gateway, an ordinary CLI login is still detected."""
+    from omnigent.onboarding import harness_install
+
+    monkeypatch.setattr(harness_install, "harness_cli_logged_in", lambda key: True)
+    monkeypatch.setattr(ambient.sys, "platform", "darwin")
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", ())
+    claude_rows = [d for d in detect_providers() if d.name == "claude"]
+    assert [(d.kind, d.source) for d in claude_rows] == [("subscription", "claude CLI login")]
+
+
+def test_claude_managed_gateway_synthesizes_a_subscription_entry(clean_env, monkeypatch) -> None:
+    """The adopted/synthesized entry is a plain subscription — old-parser-safe.
+
+    Proves the shape written to (and merged into) config.yaml is
+    `{kind: subscription, cli: claude}` — a value every released parser accepts —
+    with NO `cli-config` / `model_provider` / new field.
+    """
+    from omnigent.onboarding.detected import synthesize_detected_entries
+
+    _write_managed_settings(clean_env, monkeypatch, _ISAAC_CLAUDE_SETTINGS)
+    entries = synthesize_detected_entries(detect_providers())
+    assert entries["claude"] == {"kind": "subscription", "cli": "claude"}
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        (_ISAAC_CLAUDE_SETTINGS, "Databricks AI Gateway"),
+        (
+            {
+                "env": {"ANTHROPIC_BASE_URL": "https://llm.corp.example.com/v1"},
+                "apiKeyHelper": "print-token",
+            },
+            "llm.corp.example.com",
+        ),
+        ({"apiKeyHelper": "print-token"}, "Claude Code gateway"),  # helper, no base URL
+        ({"env": {"ANTHROPIC_BASE_URL": "https://x.cloud.databricks.com/ai-gateway/a"}}, None),
+        ({"env": {"MCP_TOOL_TIMEOUT": "1"}}, None),
+    ],
+)
+def test_claude_managed_gateway_display_name(
+    clean_env, monkeypatch, payload: object, expected: object
+) -> None:
+    """The display label reflects the backing; None when no credential is delivered."""
+    _write_managed_settings(clean_env, monkeypatch, payload)
+    assert ambient.claude_managed_gateway_display_name() == expected
+
+
+def test_claude_managed_gateway_missing_file_is_graceful(clean_env, monkeypatch) -> None:
+    """An absent settings file yields (None, False) rather than raising."""
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (clean_env / "nope.json",))
+    assert ambient.claude_managed_gateway() == (None, False)
+    assert [d for d in detect_providers() if d.name == "claude"] == []
+
+
+def test_claude_managed_gateway_first_readable_file_decides(clean_env, monkeypatch) -> None:
+    """A higher-precedence file without a gateway is not overridden by a lower one."""
+    import json
+
+    high = clean_env / "high.json"
+    high.write_text(json.dumps({"env": {"MCP_TOOL_TIMEOUT": "1"}}))
+    low = clean_env / "low.json"
+    low.write_text(json.dumps(_ISAAC_CLAUDE_SETTINGS))
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (high, low))
+    assert ambient.claude_managed_gateway() == (None, False)

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -649,3 +649,62 @@ def test_antigravity_native_requires_credential(
     monkeypatch.setattr(_ga, "gemini_login_detected", lambda: True)
     assert harness_is_configured("antigravity-native") is True
     assert harness_is_configured("native-antigravity") is True
+
+
+def test_claude_ready_via_managed_gateway_without_provider_or_cli_login(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Claude reads ready from its own managed-settings gateway alone.
+
+    The enterprise state (`isaac configure claude`): nothing in omnigent's
+    config, no subscription login the probe can see, but Claude Code's managed
+    settings pin an AI Gateway + apiKeyHelper and the CLI applies them itself.
+    This is the exact "Claude Code isn't configured on <host>" dead end — the
+    structural check must go green WITHOUT the `claude auth status` subprocess.
+    """
+    import json
+
+    from omnigent.onboarding import ambient
+
+    _all_clis_installed(monkeypatch)
+    monkeypatch.setattr(
+        "omnigent.onboarding.harness_readiness._family_provider_configured", lambda _h: False
+    )
+    # The subprocess probe stays broken; readiness must not depend on it.
+    monkeypatch.setattr(hi, "harness_cli_logged_in", lambda key, **_kw: False)
+    settings = tmp_path / "managed-settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://dbc.cloud.databricks.com/ai-gateway/anthropic"
+                },
+                "apiKeyHelper": "print-token",
+            }
+        )
+    )
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (settings,))
+
+    result = configured_harness_map()
+    assert result["claude-native"] is True
+    assert result["native-claude"] is True
+
+
+def test_claude_needs_auth_without_gateway_provider_or_login(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No managed gateway + no provider + no login → still `needs-auth`.
+
+    Guards the structural check from going green on nothing: an absent settings
+    file must not credit a credential that isn't there.
+    """
+    from omnigent.onboarding import ambient
+
+    _all_clis_installed(monkeypatch)
+    monkeypatch.setattr(
+        "omnigent.onboarding.harness_readiness._family_provider_configured", lambda _h: False
+    )
+    monkeypatch.setattr(hi, "harness_cli_logged_in", lambda key, **_kw: False)
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (tmp_path / "absent.json",))
+
+    assert configured_harness_map()["claude-native"] == "needs-auth"

--- a/tests/onboarding/test_provider_config.py
+++ b/tests/onboarding/test_provider_config.py
@@ -679,13 +679,12 @@ def test_parse_cli_config_entry() -> None:
 @pytest.mark.parametrize(
     "body,message_fragment",
     [
-        # Only codex has config-file model providers; a claude analog would
-        # be a deliberate extension, not a silently-accepted value.
-        (
-            {"kind": "cli-config", "cli": "claude", "model_provider": "X"},
-            "requires cli: 'codex'",
-        ),
-        # The pin target is the entry's whole point — fail loud without it.
+        # A `cli: codex` cli-config is recognized, so a missing model_provider
+        # (its whole point) is a real error and must fail loud. (An unrecognized
+        # cli like `claude` is instead SKIPPED by load_providers for forward
+        # compatibility — see
+        # test_load_providers_skips_unrecognized_cli_config_cli_without_raising —
+        # so it is intentionally NOT in this "fails loud" list.)
         ({"kind": "cli-config", "cli": "codex"}, "'model_provider'"),
     ],
 )
@@ -897,3 +896,93 @@ def test_provider_credential_env_vars_empty_for_keychain_and_auth_command() -> N
         }
     }
     assert provider_credential_env_vars(config) == frozenset()
+
+
+def test_load_providers_skips_unrecognized_cli_config_cli_without_raising() -> None:
+    """A `cli-config` entry naming an unknown CLI is skipped, not fatal.
+
+    This is the version-skew guard: the first attempt persisted a
+    `cli: claude` cli-config entry that OLDER runners' parser rejected, and
+    because `load_providers` had no per-entry isolation, that single entry
+    raised and crashed turn setup for EVERY harness. Now such an entry is
+    dropped with a warning and the rest of the config still loads.
+    """
+    from omnigent.onboarding.provider_config import load_providers
+
+    config = {
+        "providers": {
+            # The poison pill a newer build might write / that the reverted
+            # build left in the field.
+            "claude-databricks": {
+                "kind": "cli-config",
+                "cli": "claude",
+                "display_name": "Databricks AI Gateway",
+                "default": True,
+            },
+            "openai": {
+                "kind": "key",
+                "openai": {"api_key": "sk-x", "base_url": "https://api.openai.com/v1"},
+            },
+        }
+    }
+    parsed = load_providers(config)  # must NOT raise
+    assert set(parsed) == {"openai"}
+    assert "claude-databricks" not in parsed
+
+
+def test_load_providers_still_accepts_codex_cli_config() -> None:
+    """The recognized `cli: codex` cli-config still parses (no over-broad skip)."""
+    from omnigent.onboarding.provider_config import load_providers
+
+    parsed = load_providers(
+        {
+            "providers": {
+                "codex-databricks": {
+                    "kind": "cli-config",
+                    "cli": "codex",
+                    "model_provider": "Databricks",
+                }
+            }
+        }
+    )
+    assert parsed["codex-databricks"].cli == "codex"
+    assert parsed["codex-databricks"].model_provider == "Databricks"
+
+
+def test_load_providers_still_raises_on_malformed_known_shape() -> None:
+    """Resilience is targeted: a malformed KNOWN shape still fails loud.
+
+    Skipping is only for an unrecognized cli-config CLI (a newer-build shape).
+    A recognized shape with a real error (a `key` provider configuring no
+    family) must still raise so user typos aren't silently dropped.
+    """
+    from omnigent.errors import OmnigentError
+    from omnigent.onboarding.provider_config import load_providers
+
+    with pytest.raises(OmnigentError):
+        load_providers({"providers": {"bad": {"kind": "key"}}})
+
+
+def test_claude_sdk_resolution_survives_stray_cli_config_claude_entry() -> None:
+    """The EXACT reverted failure: claude-sdk resolution over a poisoned config.
+
+    The revert stack was `_build_claude_sdk_spawn_env` →
+    `_resolve_provider_for_build` → `default_provider_for_harness("claude-sdk")`
+    → `load_providers` → raise. With resilience the stray entry is skipped, so
+    resolution returns the next usable anthropic default (or None) instead of
+    crashing every claude-sdk turn.
+    """
+    from omnigent.onboarding.provider_config import default_provider_for_harness
+
+    config = {
+        "providers": {
+            "claude-databricks": {"kind": "cli-config", "cli": "claude", "default": True},
+            "vendor-anthropic": {
+                "kind": "key",
+                "default": "anthropic",
+                "anthropic": {"api_key": "sk-x", "base_url": "https://api.anthropic.com"},
+            },
+        }
+    }
+    entry = default_provider_for_harness(config, "claude-sdk")  # must NOT raise
+    assert entry is not None and entry.name == "vendor-anthropic"


### PR DESCRIPTION
## Related issue

Relands the intent of #5404, which was reverted in #5414. No separate tracking issue — this is a maintainer re-land of a recently reverted change, done the version-skew-safe way this time.

## Summary

**The goal: an enterprise Claude Code install (the `isaac configure claude` shape) gets detected as a valid, ready credential.** That install configures Claude Code through its **own managed settings only** — a gateway `ANTHROPIC_BASE_URL` + `apiKeyHelper` in `/Library/Application Support/ClaudeCode/managed-settings.json` (macOS) / `/etc/claude-code/managed-settings.json` (Linux). omnigent never read that file, so an enterprise host showed **"Claude Code isn't configured on `<host>`"** and `omni setup` saw nothing to adopt.

#5404 fixed detection but adopted a **`cli-config` provider with `cli: claude`**. That shape is rejected by released/stale runners' parser (which only accepts `cli: codex`), and because `load_providers` has no per-entry isolation, one such entry **raised and crashed turn setup for every harness** (the observed failure was a claude-sdk turn). The config mutation also persisted past the code rollback — hence the revert.

This re-land **reflects** the gateway instead of adopting a new persisted shape:

- **Detection** reads Claude Code's managed settings directly — `ambient.claude_managed_gateway()`, now the single canonical parser (the Smart-Routing signal and readiness delegate to it). Reading the **file** (not the macOS keychain via a `claude auth status` subprocess) means it detects on **Linux** too, which old versions never did. The credential is surfaced as the existing **`subscription`** kind: old-parser-safe (every released build accepts `subscription cli:claude`) and routes safely — native defers to Claude Code's own settings, and the in-process SDK falls back to its own auth (a subscription is a no-op in `configure_agent_harness_with_provider`, not a raise). **Nothing new is written to `providers:`.**
- **Readiness** gains a structural `_claude_managed_gateway_configured()` check (one local file read, before the subprocess), so an enterprise host stops reading "isn't configured".
- **`load_providers` resilience** — a `cli-config` entry naming an unrecognized cli is now **skipped with a warning** instead of raising, so a config poisoned by the reverted build can no longer crash turn setup, and this class of version-skew break cannot recur.
- **Display only** — a Claude subscription backed by the managed gateway reads as `Databricks AI Gateway` rather than the generic `Subscription`.

### Version-skew design (why no two-phase release is needed)

Old runners only choke on a shape they **parse** — i.e. under `providers:`. This change never puts anything new there: detection surfaces the credential as a plain `subscription`, and readiness/label are derived live. So **new versions detect the isaac gateway robustly; old versions keep their existing (limited, macOS-only) detection and simply never see anything that could break them.**

```mermaid
graph TD
  MS["Claude Code managed settings<br/>(ANTHROPIC_BASE_URL + apiKeyHelper)"]
  MS -->|"claude_managed_gateway() reads the file"| DET["detected: claude / subscription<br/>source: managed settings"]
  DET --> RDY["readiness: structural check → ready<br/>(no subprocess; works on Linux)"]
  DET --> SR["Smart Routing: gateway-backed = true"]
  DET -.->|"NEVER a cli-config cli:claude<br/>(the shape old runners reject)"| X["✗ not persisted"]
```

### Deliberately deferred

A distinct ⚙️ `cli-config` **"Claude-Databricks"** row (the exact Codex-Databricks look). That requires a representation new versions render and old versions ignore; it's a follow-up and is intentionally **not** in this PR to keep the re-land minimal and provably old-safe.

## Test Plan

Verified against a **real enterprise macOS host with a config already poisoned by the reverted build** (a persisted `cli-config cli:claude` entry):

- The exact reverted stack (`_build_claude_sdk_spawn_env` → `_resolve_provider_for_build` → `load_providers`) now builds **without raising** — falls back to the host's anthropic key.
- `claude-native` readiness reads **ready** even under a minimal `PATH` where the `claude auth status` subprocess can't run.
- Native routing resolves to `None` (Claude Code applies its managed settings).
- Smart Routing reports the launch gateway-backed.

New unit tests (25): managed-settings parser (Databricks/other/helper-only/absent/precedence + display name), gateway-preferring detection (subscription, not cli-config; no double-count with a CLI login), `load_providers` skip-unrecognized-cli-config resilience + the poisoned-config claude-sdk regression + a guard that a malformed *known* shape still raises, readiness-via-gateway (and its negative), and the subscription→gateway relabel.

~2600 tests pass across every touched area (`tests/onboarding/`, `tests/cli/test_configure_models.py`, `tests/test_gateway_inference.py`, `tests/test_claude_native.py`, `tests/test_model_catalog.py`, `tests/test_pi_native_credentials.py`, codex suites, `tests/repl/`). Pre-commit clean (ruff format/check, pyrefly). The only failures are pre-existing/environmental and confirmed identical on `main`: `tests/onboarding/sandboxes/test_base.py` (shell out to system `python3` lacking `yaml`; pass under `uv run`) and `test_claude_sdk_falls_back_to_first_available_anthropic_credential`.

## Demo

Detection on a real enterprise host (read-only), the behaviour the reland restores:

```
1. isaac managed-settings gateway detected:
     base_url       = https://<workspace>.cloud.databricks.com/ai-gateway/anthropic
     has_credential = True
     recognized as Databricks gateway = True
2. surfaced in detect_providers():  claude / subscription  (source: Claude Code managed settings)
3. claude-native readiness (the web banner): True
4. Smart Routing sees it as gateway-backed: True
```

Setup credential list (the Claude harness), rendered against the poisoned config — no crash, gateway named:

```
    🔑 Anthropic API Key
    🎟️ Databricks AI Gateway
    + Add a credential
    ← Back
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was done on a real enterprise macOS host whose `~/.omnigent/config.yaml` already carried the reverted build's `cli-config cli:claude` poison entry — the exact field state the revert was about. Confirmed: `load_providers` skips it (warns) instead of raising; the claude-sdk spawn-env build no longer crashes; `claude-native` readiness is green (incl. under a stripped `PATH`); native routing returns `None` so Claude Code applies its managed settings; and Smart Routing reports gateway-backed. The interactive picker itself isn't automated (needs a driven TTY) — its credential-row label and the readiness status are unit-tested, the render was checked by hand.

## Changelog

`omni setup` and harness readiness now detect an enterprise Claude Code gateway (`ANTHROPIC_BASE_URL` + `apiKeyHelper`) directly from its managed settings, cross-platform, so an isaac-configured Claude reads as configured instead of "Claude Code isn't configured on this host"

This pull request and its description were written by Isaac.
