### PR TITLE
feat(host): expose persistent user-service status

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -90,6 +90,7 @@ if TYPE_CHECKING:
 
     import httpx
 
+    from omnigent.host.service import HostServiceStatus
     from omnigent.install_ledger import InstallLedger
     from omnigent.onboarding.acp_auth import AcpAgentEntry
     from omnigent.server.smart_routing import LLMRoutingClient
@@ -9350,8 +9351,34 @@ def _echo_daemon_payloads(payloads: list[_HostPayload]) -> None:
         _add_host_payload_sessions_table(console, payload)
 
 
+def _echo_host_service_status(status: HostServiceStatus) -> None:
+    """Render the per-user host service as a separate status block."""
+    click.echo(_cli_style("User service", bold=True))
+    if not status.supported:
+        click.echo(f"  state:   unavailable ({status.manager_error or 'unsupported platform'})")
+        return
+    click.echo(f"  state:   {status.manager_state}")
+    click.echo(f"  installed: {'yes' if status.installed else 'no'}")
+    if status.path is not None:
+        click.echo(f"  file:    {_display_path(status.path)}")
+    if status.configured_target is not None:
+        click.echo(f"  target:  {status.configured_target}")
+    if status.manager_pid is not None:
+        click.echo(f"  pid:     {status.manager_pid}")
+    if status.enabled is not None:
+        click.echo(f"  autostart: {'enabled' if status.enabled else 'disabled'}")
+    if status.log is not None:
+        log = _display_path(Path(status.log)) if status.kind == "launchd" else status.log
+        click.echo(f"  logs:    {log}")
+    if status.definition_error is not None:
+        click.echo(f"  definition error: {status.definition_error}", err=True)
+    if status.manager_error is not None:
+        click.echo(f"  manager error: {status.manager_error}", err=True)
+    click.echo()
+
+
 @host.command("enable")
-@click.option("--server", default=None, help="Server target for the persistent service.")
+@click.option("--server", default=None, help="Server target for the single persistent service.")
 @click.option(
     "--non-interactive",
     is_flag=True,
@@ -9365,6 +9392,10 @@ def host_enable(
     non_interactive: bool,
 ) -> None:
     """Install and start the host as a per-user system service.
+
+    Each user has one persistent service target. Enabling a different target
+    replaces the prior service definition; unmanaged hosts may still use
+    multiple targets.
 
     :param ctx: Click context carrying group-level options.
     :param server: Optional server target; empty selects local mode.
@@ -9381,6 +9412,9 @@ def host_enable(
             non_interactive=non_interactive or not _stdin_is_tty(),
         )
 
+    from omnigent.host.service import user_host_service_status
+
+    previous_service = user_host_service_status(probe_manager=False)
     target = _normalize_daemon_target(resolved_server)
     record = _find_daemon_record(target)
     if record is not None:
@@ -9396,7 +9430,18 @@ def host_enable(
     except HostServiceError as exc:
         raise click.ClickException(str(exc)) from exc
 
-    click.echo(f"Enabled the Omnigent host user service for {_host_display_url(target)}.")
+    if (
+        previous_service.installed
+        and previous_service.configured_target is not None
+        and previous_service.configured_target != target
+    ):
+        click.echo(
+            "Replaced the persistent host service target "
+            f"{_host_display_url(previous_service.configured_target)} with "
+            f"{_host_display_url(target)}."
+        )
+    else:
+        click.echo(f"Enabled the Omnigent host user service for {_host_display_url(target)}.")
     click.echo(f"Service definition: {_display_path(service.path)}")
     if service.log_path is not None:
         click.echo(f"Service output: {_display_path(service.log_path)}")
@@ -9447,6 +9492,10 @@ def host_status(
         server = _host_group_option(ctx, "server")
     records = _selected_daemon_records(server=server, all_targets=all_targets, default_all=True)
 
+    from omnigent.host.service import user_host_service_status
+
+    service_status = user_host_service_status()
+
     # Build payloads in parallel so HTTP calls to independent servers overlap.
     # Dead-process records skip the network entirely (see _add_daemon_host_status),
     # but live ones each take a full auth-resolution + round-trip — parallelising
@@ -9461,8 +9510,15 @@ def host_status(
     with concurrent.futures.ThreadPoolExecutor() as pool:
         payloads = list(pool.map(_build, records))
     if json_output:
-        click.echo(json.dumps({"daemons": payloads}, indent=2, sort_keys=True))
+        click.echo(
+            json.dumps(
+                {"service": service_status.to_dict(), "daemons": payloads},
+                indent=2,
+                sort_keys=True,
+            )
+        )
         return
+    _echo_host_service_status(service_status)
     _echo_daemon_payloads(payloads)
 
 

--- a/omnigent/host/service.py
+++ b/omnigent/host/service.py
@@ -6,19 +6,22 @@ import os
 import platform
 import plistlib
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, TypeAlias
+from xml.parsers.expat import ExpatError
 
 from omnigent.process_logging import data_dir
 
 LAUNCHD_LABEL = "ai.omnigent.host"
 SYSTEMD_UNIT = "omnigent-host.service"
 _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+HostServiceManagerState: TypeAlias = Literal["running", "stopped", "failed", "unavailable"]
 
 
 class HostServiceError(RuntimeError):
@@ -33,6 +36,43 @@ class HostService:
     path: Path
     label: str
     log_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class HostServiceStatus:
+    """Installed definition and service-manager state for the user service."""
+
+    supported: bool
+    kind: str | None = None
+    path: Path | None = None
+    label: str | None = None
+    installed: bool = False
+    configured_target: str | None = None
+    executable: str | None = None
+    definition_error: str | None = None
+    manager_state: HostServiceManagerState = "stopped"
+    manager_pid: int | None = None
+    enabled: bool | None = None
+    manager_error: str | None = None
+    log: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable service status payload."""
+        return {
+            "supported": self.supported,
+            "kind": self.kind,
+            "path": str(self.path) if self.path is not None else None,
+            "label": self.label,
+            "installed": self.installed,
+            "configured_target": self.configured_target,
+            "executable": self.executable,
+            "definition_error": self.definition_error,
+            "manager_state": self.manager_state,
+            "manager_pid": self.manager_pid,
+            "enabled": self.enabled,
+            "manager_error": self.manager_error,
+            "log": self.log,
+        }
 
 
 def _service_for_current_platform() -> HostService:
@@ -55,6 +95,212 @@ def _service_for_current_platform() -> HostService:
         )
     raise HostServiceError(
         f"Host services are supported on macOS and Linux, not {system or 'this platform'}."
+    )
+
+
+def _service_command_details(command: Sequence[object]) -> tuple[str, str]:
+    """Return the executable and target from an Omnigent service command."""
+    if not all(isinstance(part, str) for part in command):
+        raise ValueError("service command arguments must be strings")
+    parts = [part for part in command if isinstance(part, str)]
+    if len(parts) < 4 or parts[1:3] != ["-m", "omnigent.host.service_entry"]:
+        raise ValueError("service command is not an Omnigent host service entry point")
+    mode = parts[3:]
+    if mode == ["--local"]:
+        return parts[0], "local"
+    if len(mode) == 2 and mode[0] == "--server" and mode[1]:
+        return parts[0], mode[1]
+    raise ValueError("service command must select exactly one local or remote target")
+
+
+def _read_launchd_definition(path: Path) -> tuple[str, str]:
+    """Read the executable and target from an Omnigent launchd plist."""
+    payload = plistlib.loads(path.read_bytes())
+    if not isinstance(payload, dict) or payload.get("Label") != LAUNCHD_LABEL:
+        raise ValueError("launchd definition has an unexpected label")
+    command = payload.get("ProgramArguments")
+    if not isinstance(command, list):
+        raise ValueError("launchd definition has no ProgramArguments array")
+    return _service_command_details(command)
+
+
+def _read_systemd_definition(path: Path) -> tuple[str, str]:
+    """Read the executable and target from an Omnigent systemd unit."""
+    exec_value: str | None = None
+    for line in path.read_text().splitlines():
+        if line.startswith("ExecStart="):
+            exec_value = line.removeprefix("ExecStart=")
+            break
+    if exec_value is None:
+        raise ValueError("systemd definition has no ExecStart command")
+    command = [part.replace("$$", "$").replace("%%", "%") for part in shlex.split(exec_value)]
+    return _service_command_details(command)
+
+
+def _read_service_definition(service: HostService) -> tuple[str | None, str | None, str | None]:
+    """Return configured target, executable, and a safe parse error."""
+    if not service.path.exists():
+        return None, None, None
+    try:
+        if service.kind == "launchd":
+            executable, target = _read_launchd_definition(service.path)
+        else:
+            executable, target = _read_systemd_definition(service.path)
+    except (OSError, ValueError, plistlib.InvalidFileException, ExpatError) as exc:
+        return None, None, str(exc)
+    return target, executable, None
+
+
+def _run_probe(args: Sequence[str]) -> tuple[subprocess.CompletedProcess[str] | None, str | None]:
+    """Run a bounded read-only service-manager probe."""
+    try:
+        return (
+            subprocess.run(
+                list(args),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            ),
+            None,
+        )
+    except FileNotFoundError:
+        return None, f"service manager {args[0]!r} was not found"
+    except subprocess.TimeoutExpired:
+        return None, f"service manager probe timed out: {' '.join(args)}"
+    except OSError as exc:
+        return None, f"service manager probe failed: {exc}"
+
+
+def _launchd_manager_status(
+    service: HostService,
+) -> tuple[HostServiceManagerState, int | None, bool | None, str | None]:
+    """Probe one launchd user agent without changing it."""
+    domain = f"gui/{os.getuid()}"
+    target = f"{domain}/{service.label}"
+    result, error = _run_probe(["launchctl", "print", target])
+    if result is None:
+        return "unavailable", None, None, error
+
+    enabled: bool | None = service.path.exists()
+    disabled_result, _ = _run_probe(["launchctl", "print-disabled", domain])
+    if disabled_result is not None and disabled_result.returncode == 0:
+        match = re.search(
+            rf'"?{re.escape(service.label)}"?\s*=>\s*(true|false)',
+            disabled_result.stdout,
+            flags=re.IGNORECASE,
+        )
+        if match is not None:
+            enabled = match.group(1).lower() != "true"
+
+    if result.returncode != 0:
+        return "stopped", None, enabled, None
+    pid_match = re.search(r"^\s*pid\s*=\s*(\d+)\s*$", result.stdout, flags=re.MULTILINE)
+    pid = int(pid_match.group(1)) if pid_match is not None else None
+    state_match = re.search(r"^\s*state\s*=\s*(\S+)\s*$", result.stdout, flags=re.MULTILINE)
+    state = state_match.group(1).lower() if state_match is not None else ""
+    exit_match = re.search(
+        r"^\s*last exit code\s*=\s*(-?\d+)\s*$",
+        result.stdout,
+        flags=re.MULTILINE,
+    )
+    exit_code = int(exit_match.group(1)) if exit_match is not None else 0
+    if pid is not None or state == "running":
+        return "running", pid, enabled, None
+    if exit_code != 0:
+        return "failed", None, enabled, f"last exit code: {exit_code}"
+    return "stopped", None, enabled, None
+
+
+def _systemd_manager_status(
+    service: HostService,
+) -> tuple[HostServiceManagerState, int | None, bool | None, str | None]:
+    """Probe one systemd user service without changing it."""
+    args = [
+        "systemctl",
+        "--user",
+        "show",
+        service.label,
+        "--no-pager",
+        "--property=LoadState",
+        "--property=ActiveState",
+        "--property=SubState",
+        "--property=MainPID",
+        "--property=UnitFileState",
+        "--property=Result",
+    ]
+    result, error = _run_probe(args)
+    if result is None:
+        return "unavailable", None, None, error
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        if "connect" in detail.lower() or "bus" in detail.lower():
+            return "unavailable", None, None, detail or "systemd user manager is unavailable"
+        return "stopped", None, False if service.path.exists() else None, None
+
+    values: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        key, separator, value = line.partition("=")
+        if separator:
+            values[key] = value
+    pid_value = values.get("MainPID", "")
+    pid = int(pid_value) if pid_value.isdigit() and int(pid_value) > 0 else None
+    unit_state = values.get("UnitFileState")
+    enabled = (
+        unit_state in {"enabled", "enabled-runtime", "linked", "linked-runtime", "alias"}
+        if unit_state
+        else None
+    )
+    active = values.get("ActiveState", "")
+    result_name = values.get("Result", "")
+    if active == "active":
+        return "running", pid, enabled, None
+    if active == "failed" or result_name not in {"", "success"}:
+        detail = result_name or values.get("SubState") or "failed"
+        return "failed", pid, enabled, f"result: {detail}"
+    return "stopped", pid, enabled, None
+
+
+def user_host_service_status(*, probe_manager: bool = True) -> HostServiceStatus:
+    """Inspect the current user's generated host-service definition and manager."""
+    try:
+        service = _service_for_current_platform()
+    except HostServiceError as exc:
+        return HostServiceStatus(
+            supported=False,
+            manager_state="unavailable",
+            manager_error=str(exc),
+        )
+
+    target, executable, definition_error = _read_service_definition(service)
+    manager_state: HostServiceManagerState = "stopped"
+    manager_pid: int | None = None
+    enabled: bool | None = service.path.exists()
+    manager_error: str | None = None
+    if probe_manager:
+        if service.kind == "launchd":
+            manager_state, manager_pid, enabled, manager_error = _launchd_manager_status(service)
+        else:
+            manager_state, manager_pid, enabled, manager_error = _systemd_manager_status(service)
+    log = (
+        str(service.log_path)
+        if service.log_path is not None
+        else f"journalctl --user -u {service.label}"
+    )
+    return HostServiceStatus(
+        supported=True,
+        kind=service.kind,
+        path=service.path,
+        label=service.label,
+        installed=service.path.exists(),
+        configured_target=target,
+        executable=executable,
+        definition_error=definition_error,
+        manager_state=manager_state,
+        manager_pid=manager_pid,
+        enabled=enabled,
+        manager_error=manager_error,
+        log=log,
     )
 
 

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -319,6 +319,82 @@ def test_host_enable_subcommand_installs_user_service(
     assert "Enabled the Omnigent host user service for local" in result.output
 
 
+def test_host_enable_reports_persistent_target_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second persistent target is explicit instead of silently replacing the first."""
+    from omnigent.host.service import HostService, HostServiceStatus
+
+    service_path = tmp_path / "omnigent-host.service"
+    monkeypatch.setattr("omnigent.cli._ensure_databricks_server_auth", lambda *args, **kw: None)
+    monkeypatch.setattr("omnigent.cli._find_daemon_record", lambda target: None)
+    monkeypatch.setattr("omnigent.cli._build_host_daemon_env", lambda **kw: {})
+    monkeypatch.setattr(
+        "omnigent.host.service.user_host_service_status",
+        lambda **kw: HostServiceStatus(
+            supported=True,
+            kind="systemd_user",
+            path=service_path,
+            label=service_path.name,
+            installed=True,
+            configured_target="https://old.example.com",
+        ),
+    )
+    monkeypatch.setattr(
+        "omnigent.host.service.enable_user_host_service",
+        lambda *args, **kw: HostService(
+            kind="systemd_user",
+            path=service_path,
+            label=service_path.name,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["host", "enable", "--server", "https://new.example.com"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (
+        "Replaced the persistent host service target https://old.example.com "
+        "with https://new.example.com."
+    ) in result.output
+
+
+def test_host_status_json_includes_user_service(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Service-manager state is independent from daemon registry rows."""
+    from omnigent.host.service import HostServiceStatus
+
+    monkeypatch.setattr("omnigent.cli._selected_daemon_records", lambda **kw: [])
+    monkeypatch.setattr(
+        "omnigent.host.service.user_host_service_status",
+        lambda: HostServiceStatus(
+            supported=True,
+            kind="systemd_user",
+            path=tmp_path / "omnigent-host.service",
+            label="omnigent-host.service",
+            installed=True,
+            configured_target="local",
+            manager_state="stopped",
+            enabled=True,
+            log="journalctl --user -u omnigent-host.service",
+        ),
+    )
+
+    result = CliRunner().invoke(cli, ["host", "status", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["service"]["configured_target"] == "local"
+    assert payload["service"]["manager_state"] == "stopped"
+    assert payload["service"]["enabled"] is True
+    assert payload["daemons"] == []
+
+
 def test_host_disable_subcommand_removes_user_service(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/host/test_service.py
+++ b/tests/host/test_service.py
@@ -26,6 +26,140 @@ def _capture_runs(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
     return calls
 
 
+def test_launchd_status_reports_target_pid_and_autostart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "state"))
+    monkeypatch.setattr(service.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(service.os, "getuid", lambda: 501)
+    installed = service._service_for_current_platform()
+    installed.path.parent.mkdir(parents=True)
+    installed.path.write_bytes(
+        service._launchd_payload(
+            installed,
+            command=[
+                "/opt/omnigent/bin/python",
+                "-m",
+                "omnigent.host.service_entry",
+                "--server",
+                "https://example.com",
+            ],
+            environment={},
+        )
+    )
+
+    def _run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if args[1] == "print":
+            return subprocess.CompletedProcess(args, 0, "state = running\n    pid = 4242\n", "")
+        assert args[1] == "print-disabled"
+        return subprocess.CompletedProcess(args, 0, '"ai.omnigent.host" => false\n', "")
+
+    monkeypatch.setattr(service.subprocess, "run", _run)
+
+    status = service.user_host_service_status()
+
+    assert status.installed is True
+    assert status.configured_target == "https://example.com"
+    assert status.executable == "/opt/omnigent/bin/python"
+    assert status.manager_state == "running"
+    assert status.manager_pid == 4242
+    assert status.enabled is True
+    assert status.definition_error is None
+
+
+def test_systemd_status_reports_failed_local_service(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.setattr(service.platform, "system", lambda: "Linux")
+    installed = service._service_for_current_platform()
+    installed.path.parent.mkdir(parents=True)
+    installed.path.write_bytes(
+        service._systemd_unit(
+            command=[
+                "/opt/$tools/python",
+                "-m",
+                "omnigent.host.service_entry",
+                "--local",
+            ],
+            environment={},
+        )
+    )
+    show = "\n".join(
+        [
+            "LoadState=loaded",
+            "ActiveState=failed",
+            "SubState=failed",
+            "MainPID=0",
+            "UnitFileState=enabled",
+            "Result=exit-code",
+        ]
+    )
+    monkeypatch.setattr(
+        service.subprocess,
+        "run",
+        lambda args, **kwargs: subprocess.CompletedProcess(args, 0, show, ""),
+    )
+
+    status = service.user_host_service_status()
+
+    assert status.configured_target == "local"
+    assert status.executable == "/opt/$tools/python"
+    assert status.manager_state == "failed"
+    assert status.enabled is True
+    assert status.manager_error == "result: exit-code"
+    assert status.log == "journalctl --user -u omnigent-host.service"
+
+
+def test_service_status_degrades_on_foreign_definition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(service.platform, "system", lambda: "Darwin")
+    path = tmp_path / "Library/LaunchAgents/ai.omnigent.host.plist"
+    path.parent.mkdir(parents=True)
+    path.write_text("not a plist")
+
+    status = service.user_host_service_status(probe_manager=False)
+
+    assert status.installed is True
+    assert status.configured_target is None
+    assert status.definition_error is not None
+
+
+def test_service_status_degrades_on_truncated_xml_plist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(service.platform, "system", lambda: "Darwin")
+    path = tmp_path / "Library/LaunchAgents/ai.omnigent.host.plist"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(
+        b'<?xml version="1.0" encoding="UTF-8"?>\n'
+        b'<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" '
+        b'"http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+        b'<plist version="1.0"><dict><key>Label</key>'
+    )
+
+    status = service.user_host_service_status(probe_manager=False)
+
+    assert status.installed is True
+    assert status.configured_target is None
+    assert status.definition_error is not None
+
+
+def test_service_status_reports_unsupported_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service.platform, "system", lambda: "Windows")
+
+    status = service.user_host_service_status()
+
+    assert status.supported is False
+    assert status.manager_state == "unavailable"
+    assert "macOS and Linux" in (status.manager_error or "")
+
+
 def test_enable_launchd_user_service(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "state"))


### PR DESCRIPTION
## Related issue

https://linear.app/omnigent/issue/OMNI-5594/expose-omnigent-host-user-service-state-and-persistent-target

## Summary

- Make `omni host status` report the per-user launchd/systemd service independently from transient daemon records, including its configured target, manager state, PID, autostart state, definition path, and log guidance.
- Parse only Omnigent-generated definitions and degrade safely when the platform, manager, or definition is unavailable or invalid.
- Make the one-persistent-target-per-user contract explicit and report when `omni host enable` replaces a prior target.

### ELI5

The CLI can now answer both “is a host process running?” and “has my operating system been told to keep one running?” instead of treating them as the same question.

```text
omni host status
  ├─ user service: installed / target / manager state / logs
  └─ daemon rows: current host processes and sessions
```

## Test Plan

- `uv run pytest tests/host/test_service.py tests/host/test_cli_host.py::test_host_enable_subcommand_installs_user_service tests/host/test_cli_host.py::test_host_enable_reports_persistent_target_replacement tests/host/test_cli_host.py::test_host_status_json_includes_user_service tests/host/test_cli_host.py::test_host_status_subcommand_still_dispatches tests/cli/test_backend.py::test_host_status_json_reports_daemon_host_and_sessions tests/cli/test_backend.py::test_host_status_reports_unreachable_daemon_without_traceback`
- `uv run pre-commit run --files omnigent/cli.py omnigent/host/service.py tests/host/test_cli_host.py tests/host/test_service.py`
- `uv run omni host status --json` and validated the emitted service block on macOS with no service installed.

## Demo

N/A — command-line status output only.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the JSON service block on macOS. Unit tests cover launchd and systemd definition parsing, manager state, PID/autostart reporting, failed services, unsupported platforms, malformed definitions, JSON rendering, and target replacement messaging.

## Changelog

`omni host status` now shows whether your per-user host service is installed, what it targets, whether it is running, and where to find its logs.
