### PR TITLE
feat(host): make lifecycle commands service-aware

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4319,6 +4319,7 @@ def _stop_local_server_and_daemon(*, force: bool) -> bool:
         called, ``False`` otherwise.
     """
     was_running = local_server_url_if_healthy() is not None
+    _stop_enabled_host_service(None)
     local_record = _find_daemon_record(_LOCAL_DAEMON_MARKER)
     if local_record is not None:
         # A stubborn daemon shouldn't block stopping the server.
@@ -4397,10 +4398,16 @@ def server_stop(force: bool) -> None:
         does not exit on SIGTERM.
     :returns: None.
     """
+    service_managed = _user_service_owns_target(None)
     if _stop_local_server_and_daemon(force=force):
         click.echo("Stopped the background server.")
     else:
         click.echo("No background server is running.")
+    if service_managed:
+        click.echo(
+            "The host user service remains installed and will start again at login; "
+            "remove it with `omnigent host disable`."
+        )
 
 
 @server.command("status")
@@ -4513,13 +4520,28 @@ def stop(force: bool) -> None:
     """
     stopped = 0
     failures: list[str] = []
+    service_stopped = False
+    service_target: str | None = None
+    from omnigent.host.service import user_host_service_status
+
+    service_status = user_host_service_status()
+    if service_status.installed and service_status.configured_target is not None:
+        service_target = service_status.configured_target
     for record in _list_daemon_records():
         # Terminating the daemon reaps its runners (orphan-watchdog), so the
         # off-switch doesn't need the graceful per-session HTTP stop that
         # `host stop` does — that keeps teardown quiet and dependency-free.
         try:
+            server_url = None if record.target == _LOCAL_DAEMON_MARKER else record.target
+            service_stopped = _stop_enabled_host_service(server_url) or service_stopped
             _terminate_daemon(record, force=force)
             stopped += 1
+        except click.ClickException as exc:
+            failures.append(exc.message)
+    if service_target is not None and not service_stopped:
+        server_url = None if service_target == _LOCAL_DAEMON_MARKER else service_target
+        try:
+            service_stopped = _stop_enabled_host_service(server_url)
         except click.ClickException as exc:
             failures.append(exc.message)
     server_was_running = local_server_url_if_healthy() is not None
@@ -4537,6 +4559,8 @@ def stop(force: bool) -> None:
         parts.append("the background server")
     if orphan_pid is not None:
         parts.append(f"an untracked server on :{_DEFAULT_LOCAL_PORT} (pid {orphan_pid})")
+    if service_stopped:
+        parts.append("the host user service (autostart remains enabled)")
     if parts:
         click.echo("Stopped " + " and ".join(parts) + ".")
     else:
@@ -8201,6 +8225,62 @@ def _maybe_open_host_web_ui(
         click.echo(f"Open the Omnigent web UI: {web_url}", err=True)
 
 
+def _start_enabled_host_service(
+    server: str | None,
+    *,
+    stop_command: str,
+    non_interactive: bool,
+) -> bool:
+    """Start the installed service when it owns *server*."""
+    from omnigent.host.service import (
+        HostServiceError,
+        start_user_host_service,
+        user_host_service_owns_target,
+        user_host_service_status,
+    )
+
+    service_status = user_host_service_status()
+    if not user_host_service_owns_target(service_status, server):
+        return False
+    was_running = service_status.manager_state == "running"
+    try:
+        service_status = start_user_host_service(server)
+    except HostServiceError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    target = _normalize_daemon_target(server)
+    deadline = time.monotonic() + _BACKGROUND_HOST_REGISTRATION_GRACE_S
+    record = _find_daemon_record(target)
+    while record is None and time.monotonic() < deadline:
+        time.sleep(0.1)
+        record = _find_daemon_record(target)
+    if record is None:
+        detail = f" Check {service_status.log}." if service_status.log else ""
+        raise click.ClickException(
+            f"The host user service did not create its daemon record.{detail}"
+        )
+    if record.mode == "local":
+        server_url = _discover_local_server_url()
+        _update_daemon_resolved_server_url(target, server_url)
+        record = _find_daemon_record(target) or record
+    else:
+        server_url = target
+    _confirm_background_host_registered(record)
+
+    headline = "Host user service already running" if was_running else "Started host user service"
+    click.echo(f"{_cli_style(headline, fg='green', bold=True)} (pid {record.pid}).")
+    _echo_host_field("server", _cli_style(server_url, fg="cyan"))
+    if service_status.log is not None:
+        _echo_host_field("log", service_status.log)
+    click.echo()
+    click.echo(_cli_style("Stop it with (autostart remains enabled):", dim=True))
+    click.echo(f"  {_cli_style(stop_command, bold=True)}")
+    click.echo(_cli_style("Remove autostart with:", dim=True))
+    click.echo(f"  {_cli_style('omnigent host disable', bold=True)}")
+    _maybe_open_host_web_ui(server_url, non_interactive=non_interactive)
+    return True
+
+
 def _run_background_host(
     server: str | None,
     *,
@@ -8234,6 +8314,12 @@ def _run_background_host(
     if server:
         _ensure_databricks_server_auth(server, non_interactive=non_interactive)
     target = _normalize_daemon_target(server)
+    if _start_enabled_host_service(
+        server,
+        stop_command=stop_command,
+        non_interactive=non_interactive,
+    ):
+        return
     previous = _find_daemon_record(target)
     _ensure_host_daemon(server or None)
     record = _find_daemon_record(target)
@@ -9351,6 +9437,34 @@ def _echo_daemon_payloads(payloads: list[_HostPayload]) -> None:
         _add_host_payload_sessions_table(console, payload)
 
 
+def _user_service_owns_target(server: str | None) -> bool:
+    """Return whether the installed user service owns *server*."""
+    from omnigent.host.service import user_host_service_owns_target, user_host_service_status
+
+    return user_host_service_owns_target(user_host_service_status(), server)
+
+
+def _stop_enabled_host_service(server: str | None) -> bool:
+    """Stop the installed service for *server* while retaining autostart."""
+    from omnigent.host.service import (
+        HostServiceError,
+        stop_user_host_service,
+        user_host_service_owns_target,
+        user_host_service_status,
+    )
+
+    status = user_host_service_status()
+    if not user_host_service_owns_target(status, server):
+        return False
+    if status.manager_state == "stopped":
+        return True
+    try:
+        stop_user_host_service(server)
+    except HostServiceError as exc:
+        raise click.ClickException(str(exc)) from exc
+    return True
+
+
 def _echo_host_service_status(status: HostServiceStatus) -> None:
     """Render the per-user host service as a separate status block."""
     click.echo(_cli_style("User service", bold=True))
@@ -9727,18 +9841,51 @@ def host_stop(
     if server is None:
         server = _host_group_option(ctx, "server")
     records = _selected_daemon_records(server=server, all_targets=all_targets, default_all=False)
+    from omnigent.host.service import user_host_service_status
+
+    service_status = user_host_service_status()
+    selected_target = _normalize_daemon_target(_resolve_host_server(server))
+    service_target = service_status.configured_target
     if not records:
+        should_stop_service = service_target is not None and (
+            all_targets or service_target == selected_target
+        )
+        if should_stop_service:
+            service_url = None if service_target == _LOCAL_DAEMON_MARKER else service_target
+            if _stop_enabled_host_service(service_url):
+                click.echo(
+                    f"Stopped {service_target} host user service; autostart remains enabled. "
+                    "Remove it with `omnigent host disable`."
+                )
+                return
         click.echo("No matching host daemon found.")
         return
+    managed_targets: set[str] = set()
     for record in records:
         stopped = 0
         if not daemon_only:
             stopped = _stop_daemon_sessions(record, force=force)
+        service_url = None if record.target == _LOCAL_DAEMON_MARKER else record.target
+        service_managed = _stop_enabled_host_service(service_url)
+        if service_managed:
+            managed_targets.add(record.target)
         _terminate_daemon(record, force=force)
+        suffix = (
+            " Autostart remains enabled; remove it with `omnigent host disable`."
+            if service_managed
+            else ""
+        )
         click.echo(
             f"Stopped {_host_display_url(record.target)} daemon "
-            f"pid={record.pid}; sessions_stopped={stopped}."
+            f"pid={record.pid}; sessions_stopped={stopped}.{suffix}"
         )
+    if all_targets and service_target is not None and service_target not in managed_targets:
+        service_url = None if service_target == _LOCAL_DAEMON_MARKER else service_target
+        if _stop_enabled_host_service(service_url):
+            click.echo(
+                f"Stopped {_host_display_url(service_target)} host user service; "
+                "autostart remains enabled. Remove it with `omnigent host disable`."
+            )
 
 
 @host.command("stop-session")

--- a/omnigent/host/service.py
+++ b/omnigent/host/service.py
@@ -505,6 +505,68 @@ def _forget_service(service: HostService) -> None:
         ) from exc
 
 
+def _normalized_target(server_url: str | None) -> str:
+    """Return the service target key used by daemon records and definitions."""
+    return server_url.rstrip("/") if server_url else "local"
+
+
+def user_host_service_owns_target(
+    status: HostServiceStatus,
+    server_url: str | None,
+) -> bool:
+    """Return whether an installed generated service owns the requested target."""
+    return (
+        status.supported
+        and status.installed
+        and status.definition_error is None
+        and status.configured_target == _normalized_target(server_url)
+    )
+
+
+def start_user_host_service(server_url: str | None) -> HostServiceStatus:
+    """Start an installed service for *server_url* without changing autostart."""
+    status = user_host_service_status()
+    if not user_host_service_owns_target(status, server_url):
+        raise HostServiceError(
+            f"The installed host service does not own {_normalized_target(server_url)!r}."
+        )
+    if status.manager_state == "running":
+        return status
+    if status.manager_state == "unavailable":
+        raise HostServiceError(status.manager_error or "The user service manager is unavailable.")
+
+    service = _service_for_current_platform()
+    if service.kind == "launchd":
+        domain = f"gui/{os.getuid()}"
+        _run_best_effort(["launchctl", "bootout", f"{domain}/{service.label}"])
+        _run_checked(["launchctl", "bootstrap", domain, str(service.path)])
+    else:
+        _run_checked(["systemctl", "--user", "daemon-reload"])
+        _run_checked(["systemctl", "--user", "start", service.label])
+    return user_host_service_status()
+
+
+def stop_user_host_service(server_url: str | None) -> HostServiceStatus:
+    """Stop an installed service for *server_url* without removing autostart."""
+    status = user_host_service_status()
+    if not user_host_service_owns_target(status, server_url):
+        raise HostServiceError(
+            f"The installed host service does not own {_normalized_target(server_url)!r}."
+        )
+    if status.manager_state == "unavailable":
+        raise HostServiceError(status.manager_error or "The user service manager is unavailable.")
+
+    service = _service_for_current_platform()
+    if service.kind == "launchd":
+        target = f"gui/{os.getuid()}/{service.label}"
+        _run_best_effort(["launchctl", "bootout", target])
+        if _run_best_effort(["launchctl", "print", target]).returncode == 0:
+            raise HostServiceError(f"launchd service {service.label!r} is still running.")
+    else:
+        _run_checked(["systemctl", "--user", "stop", service.label])
+    return user_host_service_status()
+
+
 def enable_user_host_service(
     server_url: str | None,
     *,

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -1387,6 +1387,60 @@ def test_host_stop_stops_sessions_before_daemon(
     assert "sessions_stopped=1" in result.output
 
 
+def test_host_stop_disarms_service_after_sessions_before_daemon(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A managed service is stopped only after its live sessions can shut down."""
+    from omnigent.host.service import HostServiceStatus
+
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target="https://server.example.com",
+        mode="server",
+        server_url="https://server.example.com",
+    )
+    events: list[str] = []
+    monkeypatch.setattr(
+        cli,
+        "_stop_daemon_sessions",
+        lambda record, *, force: events.append("sessions") or 1,
+    )
+    monkeypatch.setattr(
+        "omnigent.host.service.user_host_service_status",
+        lambda: HostServiceStatus(
+            supported=True,
+            kind="systemd_user",
+            path=tmp_path / "omnigent-host.service",
+            label="omnigent-host.service",
+            installed=True,
+            configured_target="https://server.example.com",
+            manager_state="running",
+            enabled=True,
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_stop_enabled_host_service",
+        lambda server: events.append("service") or True,
+    )
+    monkeypatch.setattr(
+        cli,
+        "_terminate_daemon",
+        lambda record, *, force: events.append("daemon"),
+    )
+
+    result = CliRunner().invoke(
+        cli_group,
+        ["host", "stop", "--server", "https://server.example.com"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert events == ["sessions", "service", "daemon"]
+    assert "Autostart remains enabled" in result.output
+
+
 def test_host_stop_daemon_only_skips_session_stop(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/cli/test_server_lifecycle.py
+++ b/tests/cli/test_server_lifecycle.py
@@ -302,6 +302,36 @@ def test_server_stop_stops_server_and_local_daemon(monkeypatch: pytest.MonkeyPat
     stop_server.assert_called_once_with()  # and the server stopped
 
 
+def test_server_stop_disarms_local_service_before_daemon(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The local service manager is stopped before its daemon is signalled."""
+    local_record = _record()
+    events: list[str] = []
+    monkeypatch.setattr("omnigent.cli._user_service_owns_target", lambda server: True)
+    monkeypatch.setattr(
+        "omnigent.cli._stop_enabled_host_service",
+        lambda server: events.append("service") or True,
+    )
+    monkeypatch.setattr(
+        "omnigent.cli._find_daemon_record",
+        lambda target: local_record if target == "local" else None,
+    )
+    monkeypatch.setattr(
+        "omnigent.cli._terminate_daemon",
+        lambda record, *, force: events.append("daemon"),
+    )
+    monkeypatch.setattr("omnigent.cli.local_server_url_if_healthy", lambda: None)
+    monkeypatch.setattr("omnigent.cli.stop_local_omnigent_server", Mock())
+    monkeypatch.setattr("omnigent.cli.stop_untracked_local_server", lambda: None)
+
+    result = CliRunner().invoke(cli, ["server", "stop"])
+
+    assert result.exit_code == 0, result.output
+    assert events == ["service", "daemon"]
+    assert "service remains installed" in result.output
+
+
 def test_server_stop_no_server_running(monkeypatch: pytest.MonkeyPatch) -> None:
     """``server stop`` reports nothing running when no background server exists."""
     monkeypatch.setattr("omnigent.cli.local_server_url_if_healthy", lambda: None)
@@ -342,6 +372,42 @@ def test_stop_terminates_all_daemons_and_server(monkeypatch: pytest.MonkeyPatch)
     assert terminated == records  # both daemons terminated
     stop_server.assert_called_once_with()
     assert "Stopped 2 daemon(s) and the background server." in result.output
+
+
+def test_stop_handles_running_service_without_daemon_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The global off switch reaches a service during its record startup window."""
+    from omnigent.host.service import HostServiceStatus
+
+    monkeypatch.setattr("omnigent.cli._list_daemon_records", list)
+    monkeypatch.setattr(
+        "omnigent.host.service.user_host_service_status",
+        lambda: HostServiceStatus(
+            supported=True,
+            kind="systemd_user",
+            path=tmp_path / "omnigent-host.service",
+            label="omnigent-host.service",
+            installed=True,
+            configured_target="https://server.example.com",
+            manager_state="running",
+            enabled=True,
+        ),
+    )
+    stopped: list[str | None] = []
+    monkeypatch.setattr(
+        "omnigent.cli._stop_enabled_host_service",
+        lambda server: stopped.append(server) or True,
+    )
+    monkeypatch.setattr("omnigent.cli.local_server_url_if_healthy", lambda: None)
+    monkeypatch.setattr("omnigent.cli.stop_local_omnigent_server", Mock())
+    monkeypatch.setattr("omnigent.cli.stop_untracked_local_server", lambda: None)
+
+    result = CliRunner().invoke(cli, ["stop"])
+
+    assert result.exit_code == 0, result.output
+    assert stopped == ["https://server.example.com"]
+    assert "autostart remains enabled" in result.output
 
 
 def test_stop_nothing_running(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -419,6 +419,40 @@ def test_host_disable_subcommand_removes_user_service(
     assert "Disabled the Omnigent host user service" in result.output
 
 
+def test_host_stop_stops_service_without_daemon_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A service in its startup window can be stopped before its record appears."""
+    from omnigent.host.service import HostServiceStatus
+
+    monkeypatch.setattr("omnigent.cli._selected_daemon_records", lambda **kw: [])
+    monkeypatch.setattr(
+        "omnigent.host.service.user_host_service_status",
+        lambda: HostServiceStatus(
+            supported=True,
+            kind="systemd_user",
+            path=tmp_path / "omnigent-host.service",
+            label="omnigent-host.service",
+            installed=True,
+            configured_target="local",
+            manager_state="running",
+            enabled=True,
+        ),
+    )
+    stopped: list[str | None] = []
+    monkeypatch.setattr(
+        "omnigent.cli._stop_enabled_host_service",
+        lambda server: stopped.append(server) or True,
+    )
+
+    result = CliRunner().invoke(cli, ["host", "stop", "--server", ""])
+
+    assert result.exit_code == 0, result.output
+    assert stopped == [None]
+    assert "autostart remains enabled" in result.output
+
+
 def test_host_rejects_unknown_plain_token_as_subcommand(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -918,6 +952,55 @@ def test_host_background_spawns_detached_daemon(
     # its URL is reported too (the Web UI is otherwise unreachable).
     assert spawned_args and "--local" in spawned_args[0]
     assert "server: http://127.0.0.1:6767" in result.output
+
+
+def test_host_background_starts_installed_service_without_spawning_daemon(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An installed service owns startup instead of competing with a detached daemon."""
+    from omnigent.cli import _HostDaemonRecord, _write_daemon_record
+    from omnigent.host.service import HostServiceStatus
+
+    spawned_args, _ = _patch_background_host_spawn(monkeypatch, tmp_path)
+    _write_daemon_record(
+        _HostDaemonRecord(
+            pid=4242,
+            target="local",
+            mode="local",
+            server_url=None,
+            log_path=None,
+            started_at=int(time.time()),
+        )
+    )
+    status = HostServiceStatus(
+        supported=True,
+        kind="launchd",
+        path=tmp_path / "ai.omnigent.host.plist",
+        label="ai.omnigent.host",
+        installed=True,
+        configured_target="local",
+        manager_state="running",
+        manager_pid=4242,
+        enabled=True,
+        log=str(tmp_path / "service.log"),
+    )
+    starts: list[str | None] = []
+    monkeypatch.setattr("omnigent.host.service.user_host_service_status", lambda: status)
+
+    def _start(server_url: str | None) -> HostServiceStatus:
+        starts.append(server_url)
+        return status
+
+    monkeypatch.setattr("omnigent.host.service.start_user_host_service", _start)
+
+    result = CliRunner().invoke(cli, ["host", "--background", "--server", ""])
+
+    assert result.exit_code == 0, result.output
+    assert starts == [""]
+    assert spawned_args == []
+    assert "Host user service already running" in result.output
+    assert "autostart remains enabled" in result.output
 
 
 def test_host_background_fails_when_daemon_never_registers(

--- a/tests/host/test_service.py
+++ b/tests/host/test_service.py
@@ -160,6 +160,107 @@ def test_service_status_reports_unsupported_platform(monkeypatch: pytest.MonkeyP
     assert "macOS and Linux" in (status.manager_error or "")
 
 
+def test_start_systemd_service_preserves_definition_and_autostart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.setattr(service.platform, "system", lambda: "Linux")
+    path = tmp_path / ".config/systemd/user/omnigent-host.service"
+    path.parent.mkdir(parents=True)
+    path.write_text("definition")
+    statuses = iter(
+        [
+            service.HostServiceStatus(
+                supported=True,
+                kind="systemd_user",
+                path=path,
+                label=path.name,
+                installed=True,
+                configured_target="local",
+                manager_state="stopped",
+                enabled=True,
+            ),
+            service.HostServiceStatus(
+                supported=True,
+                kind="systemd_user",
+                path=path,
+                label=path.name,
+                installed=True,
+                configured_target="local",
+                manager_state="running",
+                manager_pid=4242,
+                enabled=True,
+            ),
+        ]
+    )
+    monkeypatch.setattr(service, "user_host_service_status", lambda: next(statuses))
+    calls: list[list[str]] = []
+    monkeypatch.setattr(service, "_run_checked", lambda args: calls.append(list(args)))
+
+    status = service.start_user_host_service(None)
+
+    assert status.manager_state == "running"
+    assert path.exists()
+    assert calls == [
+        ["systemctl", "--user", "daemon-reload"],
+        ["systemctl", "--user", "start", "omnigent-host.service"],
+    ]
+
+
+def test_stop_launchd_service_preserves_definition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(service.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(service.os, "getuid", lambda: 503)
+    path = tmp_path / "Library/LaunchAgents/ai.omnigent.host.plist"
+    path.parent.mkdir(parents=True)
+    path.write_text("definition")
+    statuses = iter(
+        [
+            service.HostServiceStatus(
+                supported=True,
+                kind="launchd",
+                path=path,
+                label="ai.omnigent.host",
+                installed=True,
+                configured_target="https://example.com",
+                manager_state="running",
+                manager_pid=4242,
+                enabled=True,
+            ),
+            service.HostServiceStatus(
+                supported=True,
+                kind="launchd",
+                path=path,
+                label="ai.omnigent.host",
+                installed=True,
+                configured_target="https://example.com",
+                manager_state="stopped",
+                enabled=True,
+            ),
+        ]
+    )
+    monkeypatch.setattr(service, "user_host_service_status", lambda: next(statuses))
+    calls: list[list[str]] = []
+
+    def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 1 if args[1] == "print" else 0, "", "")
+
+    monkeypatch.setattr(service, "_run_best_effort", _run)
+
+    status = service.stop_user_host_service("https://example.com")
+
+    assert status.manager_state == "stopped"
+    assert path.exists()
+    assert calls == [
+        ["launchctl", "bootout", "gui/503/ai.omnigent.host"],
+        ["launchctl", "print", "gui/503/ai.omnigent.host"],
+    ]
+
+
 def test_enable_launchd_user_service(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "state"))


### PR DESCRIPTION
## Related issue

https://linear.app/omnigent/issue/OMNI-5595/make-omnigent-start-and-stop-commands-service-aware

Stacked on #5475.

## Summary

- Start an installed launchd/systemd service from `omni start` and `omni host --background` instead of spawning a competing unmanaged daemon.
- Stop the service manager before terminating service-owned daemons from `omni host stop`, `omni stop`, and local `omni server stop`, while preserving the installed autostart definition.
- Keep session shutdown ahead of service and daemon teardown, handle service startup windows without daemon records, and explain that `host disable` removes autostart.

### ELI5

When the operating system is responsible for the host, Omnigent now asks the operating system to start or stop it instead of fighting the supervisor process.

```text
start -> launchd/systemd -> host
stop sessions -> launchd/systemd stop -> daemon cleanup
```

## Test Plan

- `uv run pytest tests/host/test_service.py tests/host/test_cli_host.py::test_host_background_starts_installed_service_without_spawning_daemon tests/host/test_cli_host.py::test_host_stop_stops_service_without_daemon_record tests/cli/test_backend.py::test_host_stop_stops_sessions_before_daemon tests/cli/test_backend.py::test_host_stop_disarms_service_after_sessions_before_daemon tests/cli/test_backend.py::test_host_stop_daemon_only_skips_session_stop tests/cli/test_server_lifecycle.py::test_server_stop_stops_server_and_local_daemon tests/cli/test_server_lifecycle.py::test_server_stop_disarms_local_service_before_daemon tests/cli/test_server_lifecycle.py::test_stop_terminates_all_daemons_and_server tests/cli/test_server_lifecycle.py::test_stop_handles_running_service_without_daemon_record tests/cli/test_server_lifecycle.py::test_stop_nothing_running`
- `uv run pytest tests/host/test_cli_host.py::test_host_background_spawns_detached_daemon tests/host/test_cli_host.py::test_host_background_reuses_running_daemon tests/host/test_cli_host.py::test_start_spawns_background_host_and_suggests_stop tests/cli/test_server_lifecycle.py::test_server_stop_no_server_running tests/cli/test_server_lifecycle.py::test_stop_surfaces_failures_and_suggests_force tests/cli/test_server_lifecycle.py::test_stop_clears_stale_legacy_host_pid tests/cli/test_upgrade_command.py::test_upgrade_runs_installer_and_drains_first`
- `uv run pre-commit run --files omnigent/cli.py omnigent/host/service.py tests/host/test_service.py tests/host/test_cli_host.py tests/cli/test_backend.py tests/cli/test_server_lifecycle.py`

## Demo

N/A — command-line and service-manager lifecycle behavior only.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused tests cover manager-preserving start/stop operations, session/service/daemon ordering, startup windows, local and remote targets, global and server-specific stop commands, and unchanged unmanaged-daemon behavior.

## Changelog

Omnigent lifecycle commands now cooperate with an enabled host user service instead of letting launchd or systemd restart a supposedly stopped host.
