### PR TITLE
fix(host): make service enable and upgrades recoverable

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -663,52 +663,14 @@ _SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_S = int(
     )
 )
 
-_LOCAL_DAEMON_ENV_ALLOWLIST: frozenset[str] = frozenset(
+# Credentials must be resolved at the component that consumes them, not retained
+# by the long-lived host process. These names are otherwise part of the generic
+# runner allowlist for legacy runtime behavior, so exclude them at this boundary.
+_HOST_DAEMON_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset(
     {
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "ANTHROPIC_BASE_URL",
-        "ANTHROPIC_BEDROCK_BASE_URL",
-        "AWS_BEARER_TOKEN_BEDROCK",
-        # M8 (security 2026-07-15): CLAUDE_CODE_OAUTH_TOKEN is listed in
-        # HARNESS_CREDENTIAL_ENV_VARS (connect.py) for forwarding host->runner,
-        # but _build_host_daemon_env (this file) only allows _RUNNER_ENV_ALLOWLIST
-        # + _LOCAL_DAEMON_ENV_ALLOWLIST. CLAUDE_CODE_OAUTH_TOKEN is in neither,
-        # so it is STRIPPED from the daemon env at launch. The daemon starts without it,
-        # so _build_runner_env has no token to forward even though HARNESS_CREDENTIAL_ENV_VARS
-        # includes it. Net effect: `claude setup-token` subscription auth never reaches
-        # the claude subprocess under the claude-sdk harness on macOS local (non-cloud) runs.
-        # Fix: add to the daemon allowlist so it survives the cli->daemon env strip.
-        # Security: it's a credential, same class as ANTHROPIC_API_KEY which is already here.
-        "CLAUDE_CODE_OAUTH_TOKEN",
-        "CLAUDE_CODE_USE_BEDROCK",
-        "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
-        "COHERE_API_KEY",
-        "DEEPSEEK_API_KEY",
-        "GEMINI_API_KEY",
-        "GOOGLE_API_KEY",
-        "GROQ_API_KEY",
-        "MISTRAL_API_KEY",
-        "OMNIGENT_DATABASE_URI",
-        "OPENAI_API_KEY",
-        "OPENAI_BASE_URL",
-        "OPENAI_ORG_ID",
-        "OPENAI_ORGANIZATION",
-        "OPENROUTER_API_KEY",
-        "PERPLEXITY_API_KEY",
-        "TOGETHER_API_KEY",
-        "VOYAGE_API_KEY",
-        "XAI_API_KEY",
+        "OMNIGENT_DEBUG_LOG_CLIENT_SECRET",
+        "OMNIGENT_DATABRICKS_EXTRA_HEADERS",
     }
-)
-_LOCAL_DAEMON_ENV_PREFIXES: tuple[str, ...] = (
-    "ANTHROPIC_DEFAULT_",
-    "AZURE_OPENAI_",
-    "DATABRICKS_",
-    "MLFLOW_",
-    "OTEL_",
-    "OMNIGENT_",
-    "OPENAI_",
 )
 _HOST_DAEMON_PROXY_ENV_ALLOWLIST: frozenset[str] = frozenset(
     {
@@ -3234,16 +3196,12 @@ def _build_host_daemon_env(
     """
     Build the environment for the background host daemon.
 
-    Remote daemons connect to an already-running Omnigent server, so they only
-    need process essentials, TLS trust, and Databricks auth. Local daemons
-    also start the local Omnigent server; that server is the user's local runtime
-    and must inherit Omnigent config plus provider credentials such as
-    ``OPENAI_API_KEY`` and ``OPENAI_BASE_URL``. Both modes are allowlisted:
-    local mode carries the runtime/provider vars needed by the local server,
-    but unrelated shell secrets are not inherited merely because the daemon
-    runs on the user's machine. Runners launched by the daemon still pass
-    through :func:`omnigent.host.connect._build_runner_env`, so these
-    local-server credentials do not leak into runner subprocesses.
+    Both local and remote daemons receive only process/runtime selectors, TLS
+    paths, locale/telemetry settings, and proxy configuration. Provider keys,
+    Databricks bearer credentials, database credentials, and custom passthrough
+    values are deliberately absent: the long-lived host is not a model-secret
+    boundary. Credential resolution belongs at the server or harness launch
+    boundary that consumes the secret.
 
     :param server_url: Omnigent server URL for remote mode, e.g.
         ``"https://example.databricksapps.com"``, or a falsey value
@@ -3255,30 +3213,25 @@ def _build_host_daemon_env(
         _RUNNER_ENV_ALLOWLIST_PREFIXES,
     )
 
-    if not server_url:
-        daemon_env_prefixes = (*_RUNNER_ENV_ALLOWLIST_PREFIXES, *_LOCAL_DAEMON_ENV_PREFIXES)
-        env = {
-            key: value
-            for key, value in os.environ.items()
-            if key in _RUNNER_ENV_ALLOWLIST
-            or key in _LOCAL_DAEMON_ENV_ALLOWLIST
+    del server_url  # Local and remote hosts share the same secret-free boundary.
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if (
+            key in _RUNNER_ENV_ALLOWLIST
             or key in _HOST_DAEMON_PROXY_ENV_ALLOWLIST
-            or key.startswith(daemon_env_prefixes)
-        }
-    else:
-        # Allowlist the remote daemon's environment (W8): pass process
-        # essentials + TLS trust + standard proxy selectors + the user's
-        # Databricks auth (the daemon authenticates to the server with it), but
-        # not unrelated provider secrets like ANTHROPIC_API_KEY / OPENAI_API_KEY.
-        daemon_env_prefixes = (*_RUNNER_ENV_ALLOWLIST_PREFIXES, "DATABRICKS_")
-        env = {
-            key: value
-            for key, value in os.environ.items()
-            if key in _RUNNER_ENV_ALLOWLIST
-            or key in _HOST_DAEMON_PROXY_ENV_ALLOWLIST
-            or key.startswith(daemon_env_prefixes)
-        }
-    return env
+            or key.startswith(_RUNNER_ENV_ALLOWLIST_PREFIXES)
+        )
+        and key not in _HOST_DAEMON_CREDENTIAL_ENV_VARS
+    }
+
+
+def _build_host_service_env(*, server_url: str | None) -> dict[str, str]:
+    """Build the persistent subset of the host daemon environment."""
+    environment = _build_host_daemon_env(server_url=server_url)
+    for ephemeral in ("TERM", "TERMINFO", "TERMINFO_DIRS"):
+        environment.pop(ephemeral, None)
+    return environment
 
 
 def _read_host_pid_file() -> tuple[int, str] | None:
@@ -4899,6 +4852,53 @@ def _wait_for_local_sessions_to_drain() -> None:
             last = count
 
 
+def _capture_upgrade_host_service() -> HostServiceStatus:
+    """Capture persistent host-service state before replacing the installation."""
+    from omnigent.host.service import user_host_service_status
+
+    return user_host_service_status()
+
+
+def _finish_upgrade_host_service(
+    snapshot: HostServiceStatus,
+    *,
+    succeeded: bool,
+) -> None:
+    """Restore a stopped service after failure or refresh it after success."""
+    if not snapshot.installed or snapshot.configured_target is None:
+        return
+    from omnigent.host.service import (
+        HostServiceError,
+        enable_user_host_service,
+        start_user_host_service,
+    )
+
+    if snapshot.configured_target != _LOCAL_DAEMON_MARKER:
+        if succeeded:
+            click.echo(
+                "The remote host service is still using its prior process environment. "
+                "Run `omnigent host enable` to restart it on the upgraded installation."
+            )
+        return
+    try:
+        if succeeded:
+            enable_user_host_service(
+                None,
+                environment=_build_host_service_env(server_url=None),
+            )
+            click.echo("Refreshed and restarted the local host user service.")
+        elif snapshot.manager_state == "running":
+            start_user_host_service(None)
+            click.echo("Restored the local host user service after the failed upgrade.")
+    except HostServiceError as exc:
+        action = "refresh" if succeeded else "restore"
+        click.echo(
+            f"Warning: could not {action} the host user service: {exc}. "
+            "Run `omnigent host enable` after checking the service status.",
+            err=True,
+        )
+
+
 def _drain_and_stop_local_server(*, force: bool) -> None:
     """Drain (or force-stop) the local server + daemon before an upgrade.
 
@@ -4995,14 +4995,17 @@ def _upgrade_vcs_install(
             f"No automatic upgrade command is known for this install. {suggestion.command}."
         )
 
+    service_snapshot = _capture_upgrade_host_service()
     _drain_and_stop_local_server(force=force)
 
     console = Console()
     code = _run_upgrade_command(suggestion.command, console)
     if code != 0:
+        _finish_upgrade_host_service(service_snapshot, succeeded=False)
         raise click.ClickException(
             _upgrade_failure_message(code, set(info.extras) | set(extra_overrides))
         )
+    _finish_upgrade_host_service(service_snapshot, succeeded=True)
 
     # Verify by commit, not exit code: a re-pull of a ref that hasn't moved (or
     # a pinned ref, or a cached reinstall) exits 0 without changing anything.
@@ -5141,14 +5144,17 @@ def _upgrade_to_nightly(
         )
         return
 
+    service_snapshot = _capture_upgrade_host_service()
     _drain_and_stop_local_server(force=force)
 
     console = Console()
     code = _run_upgrade_command(suggestion.command, console)
     if code != 0:
+        _finish_upgrade_host_service(service_snapshot, succeeded=False)
         raise click.ClickException(
             _upgrade_failure_message(code, set(info.extras) | set(extra_overrides))
         )
+    _finish_upgrade_host_service(service_snapshot, succeeded=True)
 
     # Same trust-the-disk verification as the release path: re-read the
     # version in a fresh subprocess instead of believing the exit code.
@@ -5410,14 +5416,17 @@ def upgrade(
         )
         return
 
+    service_snapshot = _capture_upgrade_host_service()
     _drain_and_stop_local_server(force=force)
 
     console = Console()
     code = _run_upgrade_command(suggestion.command, console)
     if code != 0:
+        _finish_upgrade_host_service(service_snapshot, succeeded=False)
         raise click.ClickException(
             _upgrade_failure_message(code, set(info.extras) | set(extra_overrides))
         )
+    _finish_upgrade_host_service(service_snapshot, succeeded=True)
 
     # Trust the installed version, not the installer's exit code. The running
     # process still has the OLD version loaded, so re-read it in a fresh
@@ -9484,6 +9493,8 @@ def _echo_host_service_status(status: HostServiceStatus) -> None:
     if status.log is not None:
         log = _display_path(Path(status.log)) if status.kind == "launchd" else status.log
         click.echo(f"  logs:    {log}")
+    if status.executable_error is not None:
+        click.echo(f"  executable error: {status.executable_error}", err=True)
     if status.definition_error is not None:
         click.echo(f"  definition error: {status.definition_error}", err=True)
     if status.manager_error is not None:
@@ -9528,18 +9539,34 @@ def host_enable(
 
     from omnigent.host.service import user_host_service_status
 
-    previous_service = user_host_service_status(probe_manager=False)
+    previous_service = user_host_service_status()
     target = _normalize_daemon_target(resolved_server)
     record = _find_daemon_record(target)
-    if record is not None:
-        _terminate_daemon(record, force=False)
+    retired_unmanaged_daemon = False
+    record_is_managed = (
+        record is not None
+        and previous_service.manager_state == "running"
+        and previous_service.manager_pid == record.pid
+    )
+
+    def _retire_unmanaged_daemon() -> None:
+        nonlocal retired_unmanaged_daemon
+        if record is not None and not record_is_managed:
+            _terminate_daemon(record, force=False)
+            retired_unmanaged_daemon = True
+
+    def _restore_unmanaged_daemon() -> None:
+        if retired_unmanaged_daemon:
+            _ensure_host_daemon(resolved_server)
 
     from omnigent.host.service import HostServiceError, enable_user_host_service
 
     try:
         service = enable_user_host_service(
             resolved_server,
-            environment=_build_host_daemon_env(server_url=resolved_server),
+            environment=_build_host_service_env(server_url=resolved_server),
+            before_activate=_retire_unmanaged_daemon,
+            on_rollback=_restore_unmanaged_daemon,
         )
     except HostServiceError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -28,7 +28,6 @@ from websockets.exceptions import ConnectionClosed, InvalidStatus, InvalidURI
 
 from omnigent._platform import IS_POSIX, WINDOWS_ENV_PASSTHROUGH
 from omnigent.debug_logging import PRIMARY_SESSION_ID_ENV_VAR, USER_ID_ENV_VAR
-from omnigent.env_credentials import env_names_with_omnigent_prefix
 from omnigent.gateway_inference import gateway_inference_map
 from omnigent.harness_aliases import canonicalize_harness, is_claude_sdk_harness_name
 from omnigent.harness_availability import HARNESS_BINARY_MISSING, HarnessAvailability
@@ -458,14 +457,10 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         "OMNIGENT_LOG_LEVEL",
         "OMNIGENT_LOG_TO_STDERR",
         LOG_TTY_FD_ENV_VAR,
-        # Debug-log sink config + creds (OMNI-4198). The runner uploads its OWN
-        # process logs to the debug-logs table, so it needs these — including the
-        # service-principal secret. That is the one deliberate exception to the
-        # "no secrets" rule: it is the app's SP creds for log upload (not a user
-        # secret), and the runner is a trusted child. Without them the runner's
-        # sink never arms and runner logs never reach the table.
+        # Debug-log sink routing is safe to propagate, but its client secret is
+        # resolved by the component that uploads logs rather than retained in
+        # the generic runner environment.
         "OMNIGENT_DEBUG_LOG_CLIENT_ID",
-        "OMNIGENT_DEBUG_LOG_CLIENT_SECRET",
         "OMNIGENT_DEBUG_LOG_WORKSPACE_URL",
         "OMNIGENT_DEBUG_LOG_ENDPOINT",
         # Secret-store backend selector. The CLI's `configure harnesses` stores
@@ -498,11 +493,9 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # trigger threshold. Not a secret — a plain integer.
         "AP_CONTEXT_WINDOW_OVERRIDE",
         # Claude Code's Bedrock-mode switch: a non-secret boolean flag that
-        # turns on AWS Bedrock / Bedrock-compatible gateway mode. The matching
-        # credential (AWS_BEARER_TOKEN_BEDROCK) and endpoint
-        # (ANTHROPIC_BEDROCK_BASE_URL) are NOT here: they are credentials and
-        # live in HARNESS_CREDENTIAL_ENV_VARS, mirroring ANTHROPIC_API_KEY /
-        # ANTHROPIC_BASE_URL. Safe to propagate: not a secret.
+        # turns on AWS Bedrock / Bedrock-compatible gateway mode. Credentials
+        # and endpoints are resolved at the harness launch boundary instead of
+        # entering the generic runner environment.
         "CLAUDE_CODE_USE_BEDROCK",
         # Claude Code's Bedrock-auth-skip switch: a non-secret boolean flag
         # that disables AWS SigV4 auth so Claude Code can talk to a LiteLLM
@@ -546,73 +539,14 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # host→runner intrinsically, so the setter need not also list it in
         # OMNIGENT_RUNNER_ENV_PASSTHROUGH.
         "OMNIGENT_DATABRICKS_EXTRA_HEADERS",
-        # The operator's env-forwarding control var itself. Without it here, the
-        # var is stripped before it reaches the daemon in --server mode (the
-        # remote daemon prefixes are DATABRICKS_ + LC_/MLFLOW_/OTEL_/OMNIGENT_OTEL_,
-        # not plain OMNIGENT_), so _build_runner_env never sees the names it lists
-        # and the whole passthrough is a no-op remotely. It carries only env var
-        # NAMES, not secrets, so allowlisting it leaks nothing on its own.
-        # (Literal, not RUNNER_ENV_PASSTHROUGH_ENV_VAR, which is defined below.)
-        "OMNIGENT_RUNNER_ENV_PASSTHROUGH",
     }
     # Windows system / profile constants (SYSTEMROOT is mandatory for Winsock,
     # USERPROFILE for Path.home(), etc.); a no-op on POSIX. See _platform.
     | set(WINDOWS_ENV_PASSTHROUGH)
 )
-# Allowed by prefix: locale family (``LC_*``), MLflow, and OpenTelemetry config —
-# both the standard ``OTEL_*`` vars and Omnigent's ``OMNIGENT_OTEL_*`` knobs
-# (capture-content, FastAPI toggle) so they reach the runner/harness too.
-_RUNNER_ENV_ALLOWLIST_PREFIXES: tuple[str, ...] = ("LC_", "MLFLOW_", "OTEL_", "OMNIGENT_OTEL_")
-
-# Harness credential / endpoint env vars forwarded host→runner when
-# present. These are the names the harnesses themselves resolve —
-# ANTHROPIC_* for claude-sdk / pi (claude-code also honors
-# ANTHROPIC_AUTH_TOKEN + ANTHROPIC_BASE_URL for gateways, and
-# ANTHROPIC_MODEL to pin a gateway-served model (must travel with the
-# key/endpoint, else native Claude launches with a default the gateway
-# rejects), AWS_BEARER_TOKEN_BEDROCK + ANTHROPIC_BEDROCK_BASE_URL for Bedrock mode,
-# and CLAUDE_CODE_OAUTH_TOKEN for `claude setup-token` subscription auth),
-# OPENAI_* for codex / openai-agents (CODEX_ACCESS_TOKEN is the codex
-# CLI's headless ChatGPT-workspace credential, minted in the ChatGPT
-# admin console — Business/Enterprise plans), GEMINI_API_KEY for the
-# gemini family. GIT_TOKEN / GIT_USERNAME feed the sandbox host
-# image's git credential helper (deploy/docker/Dockerfile `host`
-# target) so the agent's own fetch/push against a private repository
-# authenticates, not just the launch-time clone. Unlike the rest of
-# the host's environment, these are credentials the host owner sets
-# PRECISELY so their runners can use them (on a laptop: exported keys;
-# on a server-managed sandbox: the deployment's injected provider
-# secrets) — forwarding them is the intent, not a leak. Vars absent
-# from the host env are simply not set.
-_BASE_HARNESS_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset(
-    {
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "ANTHROPIC_BASE_URL",
-        "ANTHROPIC_MODEL",
-        "ANTHROPIC_BEDROCK_BASE_URL",
-        "AWS_BEARER_TOKEN_BEDROCK",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-        "CODEX_ACCESS_TOKEN",
-        "OPENAI_API_KEY",
-        "OPENAI_BASE_URL",
-        "GEMINI_API_KEY",
-        "GIT_TOKEN",
-        "GIT_USERNAME",
-    }
-)
-HARNESS_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset(
-    name
-    for canonical in _BASE_HARNESS_CREDENTIAL_ENV_VARS
-    for name in env_names_with_omnigent_prefix(canonical)
-)
-
-# Comma-separated EXTRA env var names to forward host→runner, beyond
-# HARNESS_CREDENTIAL_ENV_VARS — for provider wiring the defaults don't
-# cover (custom gateway vars, `providers:`-config `env:` refs, exotic
-# SDK knobs). Operator-controlled: the host owner names exactly what
-# their runners need; everything unnamed stays behind the allowlist.
-RUNNER_ENV_PASSTHROUGH_ENV_VAR: str = "OMNIGENT_RUNNER_ENV_PASSTHROUGH"
+# Only locale variables are safe as a prefix family. Telemetry/MLflow prefixes
+# may include bearer headers or tokens and must be resolved by their consumers.
+_RUNNER_ENV_ALLOWLIST_PREFIXES: tuple[str, ...] = ("LC_",)
 
 # HTTP statuses on the WebSocket upgrade that are worth retrying. Everything
 # else in the 4xx range is a permanent client error (auth, authorization,
@@ -669,11 +603,9 @@ def _build_runner_env(
     :data:`_RUNNER_ENV_ALLOWLIST`) so the host owner's secrets don't leak
     into runners, then layers on the runner wiring vars.
 
-    Harness credentials are the deliberate exception to the allowlist:
-    the names in :data:`HARNESS_CREDENTIAL_ENV_VARS` (plus any extras
-    the host owner lists in :data:`RUNNER_ENV_PASSTHROUGH_ENV_VAR`)
-    forward when present, so runners can authenticate to LLM providers
-    with the credentials the host owner provisioned for them.
+    Provider and harness credentials are deliberately excluded. They are
+    resolved at the harness launch boundary rather than retained by every
+    generic runner process.
 
     :param base_env: Host process environment to filter, e.g.
         ``os.environ``.
@@ -692,35 +624,10 @@ def _build_runner_env(
         at boot. ``None`` (unknown / older server) omits the stamp.
     :returns: The runner subprocess environment.
     """
-    extra_names = {
-        name.strip()
-        for name in base_env.get(RUNNER_ENV_PASSTHROUGH_ENV_VAR, "").split(",")
-        if name.strip()
-    }
-    # Forward env vars that the providers config references via
-    # ``api_key_ref: env:VAR`` or ``api_key: $VAR``. Without this, a user
-    # who configures a gateway provider with a custom env var (e.g.
-    # ``api_key_ref: env:MY_TOKEN``) would need to manually add it to
-    # OMNIGENT_RUNNER_ENV_PASSTHROUGH — their credential resolves fine in
-    # the CLI/daemon but silently drops before reaching the runner subprocess.
-    from omnigent.errors import OmnigentError as _OmnigentError
-
-    try:
-        from omnigent.onboarding.provider_config import (
-            load_config,
-            provider_credential_env_vars,
-        )
-
-        config_env_vars = provider_credential_env_vars(load_config())
-    except (OSError, _OmnigentError):
-        config_env_vars = frozenset()
-    forwarded = HARNESS_CREDENTIAL_ENV_VARS | extra_names | config_env_vars
     env = {
         key: value
         for key, value in base_env.items()
-        if key in _RUNNER_ENV_ALLOWLIST
-        or key.startswith(_RUNNER_ENV_ALLOWLIST_PREFIXES)
-        or key in forwarded
+        if key in _RUNNER_ENV_ALLOWLIST or key.startswith(_RUNNER_ENV_ALLOWLIST_PREFIXES)
     }
     env["RUNNER_SERVER_URL"] = server_url
     env[RUNNER_ID_ENV_VAR] = runner_id

--- a/omnigent/host/service.py
+++ b/omnigent/host/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import platform
 import plistlib
@@ -10,7 +11,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, TypeAlias
@@ -49,6 +50,8 @@ class HostServiceStatus:
     installed: bool = False
     configured_target: str | None = None
     executable: str | None = None
+    executable_valid: bool | None = None
+    executable_error: str | None = None
     definition_error: str | None = None
     manager_state: HostServiceManagerState = "stopped"
     manager_pid: int | None = None
@@ -66,6 +69,8 @@ class HostServiceStatus:
             "installed": self.installed,
             "configured_target": self.configured_target,
             "executable": self.executable,
+            "executable_valid": self.executable_valid,
+            "executable_error": self.executable_error,
             "definition_error": self.definition_error,
             "manager_state": self.manager_state,
             "manager_pid": self.manager_pid,
@@ -135,6 +140,18 @@ def _read_systemd_definition(path: Path) -> tuple[str, str]:
         raise ValueError("systemd definition has no ExecStart command")
     command = [part.replace("$$", "$").replace("%%", "%") for part in shlex.split(exec_value)]
     return _service_command_details(command)
+
+
+def _validate_executable(executable: str) -> str | None:
+    """Return an actionable error when a configured Python is unusable."""
+    path = Path(executable)
+    if not path.is_absolute():
+        return "configured Python executable is not an absolute path"
+    if not path.is_file():
+        return f"configured Python executable does not exist: {path}"
+    if not os.access(path, os.X_OK):
+        return f"configured Python executable is not executable: {path}"
+    return None
 
 
 def _read_service_definition(service: HostService) -> tuple[str | None, str | None, str | None]:
@@ -273,6 +290,7 @@ def user_host_service_status(*, probe_manager: bool = True) -> HostServiceStatus
         )
 
     target, executable, definition_error = _read_service_definition(service)
+    executable_error = _validate_executable(executable) if executable is not None else None
     manager_state: HostServiceManagerState = "stopped"
     manager_pid: int | None = None
     enabled: bool | None = service.path.exists()
@@ -295,6 +313,8 @@ def user_host_service_status(*, probe_manager: bool = True) -> HostServiceStatus
         installed=service.path.exists(),
         configured_target=target,
         executable=executable,
+        executable_valid=None if executable is None else executable_error is None,
+        executable_error=executable_error,
         definition_error=definition_error,
         manager_state=manager_state,
         manager_pid=manager_pid,
@@ -442,35 +462,56 @@ def _restore_file(path: Path, previous: bytes | None) -> None:
         _atomic_write(path, previous)
 
 
-def _enable_launchd(service: HostService, content: bytes) -> None:
-    assert service.log_path is not None
-    service.log_path.parent.mkdir(parents=True, exist_ok=True)
-    previous = service.path.read_bytes() if service.path.exists() else None
+@dataclass(frozen=True)
+class _ServiceSnapshot:
+    """Definition and manager state captured before an enable transaction."""
+
+    content: bytes | None
+    status: HostServiceStatus
+
+
+def _snapshot_service(service: HostService) -> _ServiceSnapshot:
+    content = service.path.read_bytes() if service.path.exists() else None
+    return _ServiceSnapshot(content=content, status=user_host_service_status())
+
+
+def _activate_launchd(service: HostService) -> None:
     domain = f"gui/{os.getuid()}"
     _run_best_effort(["launchctl", "bootout", f"{domain}/{service.label}"])
-    _atomic_write(service.path, content)
-    try:
-        _run_checked(["launchctl", "bootstrap", domain, str(service.path)])
-    except HostServiceError:
-        _restore_file(service.path, previous)
-        if previous is not None:
+    _run_checked(["launchctl", "bootstrap", domain, str(service.path)])
+
+
+def _activate_systemd(service: HostService, *, changed: bool) -> None:
+    _run_checked(["systemctl", "--user", "daemon-reload"])
+    _run_checked(["systemctl", "--user", "enable", "--now", service.label])
+    if changed:
+        _run_checked(["systemctl", "--user", "restart", service.label])
+
+
+def _restore_service(service: HostService, snapshot: _ServiceSnapshot) -> None:
+    """Best-effort restore of the definition and prior manager state."""
+    if service.kind == "launchd":
+        domain = f"gui/{os.getuid()}"
+        _run_best_effort(["launchctl", "bootout", f"{domain}/{service.label}"])
+        _restore_file(service.path, snapshot.content)
+        if snapshot.content is not None and snapshot.status.manager_state == "running":
             _run_best_effort(["launchctl", "bootstrap", domain, str(service.path)])
-        raise
+        return
 
-
-def _enable_systemd(service: HostService, content: bytes) -> None:
-    previous = service.path.read_bytes() if service.path.exists() else None
-    changed = previous != content
-    _atomic_write(service.path, content)
-    try:
-        _run_checked(["systemctl", "--user", "daemon-reload"])
-        _run_checked(["systemctl", "--user", "enable", "--now", service.label])
-        if previous is not None and changed:
-            _run_checked(["systemctl", "--user", "restart", service.label])
-    except HostServiceError:
-        _restore_file(service.path, previous)
-        _run_best_effort(["systemctl", "--user", "daemon-reload"])
-        raise
+    if snapshot.content is None:
+        _run_best_effort(["systemctl", "--user", "disable", "--now", service.label])
+    else:
+        _run_best_effort(["systemctl", "--user", "stop", service.label])
+    _restore_file(service.path, snapshot.content)
+    _run_best_effort(["systemctl", "--user", "daemon-reload"])
+    if snapshot.content is None:
+        return
+    if snapshot.status.enabled:
+        _run_best_effort(["systemctl", "--user", "enable", service.label])
+    else:
+        _run_best_effort(["systemctl", "--user", "disable", service.label])
+    if snapshot.status.manager_state == "running":
+        _run_best_effort(["systemctl", "--user", "start", service.label])
 
 
 def _record_service(service: HostService) -> None:
@@ -571,22 +612,49 @@ def enable_user_host_service(
     server_url: str | None,
     *,
     environment: Mapping[str, str],
+    before_activate: Callable[[], None] | None = None,
+    on_rollback: Callable[[], None] | None = None,
 ) -> HostService:
-    """Install, enable, and start the current user's host service."""
+    """Transactionally install, enable, and start the user's host service."""
     service = _service_for_current_platform()
     command = _service_command(server_url)
+    executable_error = _validate_executable(command[0])
+    if executable_error is not None:
+        raise HostServiceError(executable_error)
     clean_environment = _clean_environment(environment)
+    snapshot = _snapshot_service(service)
     if service.kind == "launchd":
+        assert service.log_path is not None
+        service.log_path.parent.mkdir(parents=True, exist_ok=True)
         content = _launchd_payload(
             service,
             command=command,
             environment=clean_environment,
         )
-        _enable_launchd(service, content)
     else:
         content = _systemd_unit(command=command, environment=clean_environment)
-        _enable_systemd(service, content)
-    _record_service(service)
+
+    try:
+        _atomic_write(service.path, content)
+        if before_activate is not None:
+            before_activate()
+        if service.kind == "launchd":
+            _activate_launchd(service)
+        else:
+            _activate_systemd(
+                service,
+                changed=snapshot.content is not None and snapshot.content != content,
+            )
+        _record_service(service)
+    except Exception:
+        _restore_service(service, snapshot)
+        if snapshot.content is None:
+            with contextlib.suppress(Exception):
+                _forget_service(service)
+        if on_rollback is not None:
+            with contextlib.suppress(Exception):
+                on_rollback()
+        raise
     return service
 
 

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -185,16 +185,10 @@ def test_ensure_host_daemon_local_spawns_local_flag(
     assert (tmp_path / "host.pid").read_text().splitlines()[1] == "local"
 
 
-def test_ensure_host_daemon_local_inherits_data_dir_and_db_uri(
+def test_ensure_host_daemon_local_inherits_paths_but_not_database_credentials(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """The local daemon inherits the runtime data-dir + DB URI vars.
-
-    In local mode the daemon owns the local Omnigent server, so it must resolve the
-    same config home, data dir, and DB URI the CLI assumes — otherwise the CLI
-    reads the local-server pidfile from one dir while the daemon writes it to
-    another and discovery times out.
-    """
+    """The local daemon keeps runtime paths without retaining a credential URI."""
     captured: dict[str, object] = {}
     _patch_daemon_spawn(monkeypatch, tmp_path, captured)
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path / "iso"))
@@ -205,18 +199,13 @@ def test_ensure_host_daemon_local_inherits_data_dir_and_db_uri(
     env = captured["env"]
     assert isinstance(env, dict)
     assert env["OMNIGENT_CONFIG_HOME"] == str(tmp_path / "iso")
-    assert env["OMNIGENT_DATABASE_URI"] == "postgresql://u:pw@h/db"
+    assert "OMNIGENT_DATABASE_URI" not in env
 
 
-def test_build_host_daemon_env_local_preserves_server_credentials(
+def test_build_host_daemon_env_local_strips_provider_credentials(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Local daemon env carries credentials needed by its Omnigent server.
-
-    The daemon's local server is the process that performs LLM calls, so
-    stripping ``OPENAI_*`` here makes default persistent ``omnigent run``
-    invocations hang or fail after booting a credential-less server.
-    """
+    """A local daemon does not retain model or database credentials."""
     monkeypatch.setenv("PATH", "/usr/bin")
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setenv("OPENAI_BASE_URL", "https://example.databricks.com/serving-endpoints")
@@ -224,17 +213,24 @@ def test_build_host_daemon_env_local_preserves_server_credentials(
     monkeypatch.setenv("OMNIGENT_DATABASE_URI", "postgresql://u:pw@h/db")
     monkeypatch.setenv("GITHUB_TOKEN", "unrelated-github-secret")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "unrelated-aws-secret")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "authorization=secret")
+    monkeypatch.setenv("MLFLOW_TRACKING_TOKEN", "mlflow-secret")
 
     env = _build_host_daemon_env(server_url=None)
     empty_string_env = _build_host_daemon_env(server_url="")
 
-    assert env["OPENAI_API_KEY"] == "test-key"
-    assert env["OPENAI_BASE_URL"] == "https://example.databricks.com/serving-endpoints"
-    assert env["ANTHROPIC_API_KEY"] == "test-anthropic-key"
-    assert env["OMNIGENT_DATABASE_URI"] == "postgresql://u:pw@h/db"
-    assert "GITHUB_TOKEN" not in env
-    assert "AWS_SECRET_ACCESS_KEY" not in env
-    assert empty_string_env["OPENAI_API_KEY"] == "test-key"
+    for name in (
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "OMNIGENT_DATABASE_URI",
+        "GITHUB_TOKEN",
+        "AWS_SECRET_ACCESS_KEY",
+        "OTEL_EXPORTER_OTLP_HEADERS",
+        "MLFLOW_TRACKING_TOKEN",
+    ):
+        assert name not in env
+        assert name not in empty_string_env
 
 
 def test_build_host_daemon_env_local_forwards_bedrock_skip_auth(
@@ -272,28 +268,19 @@ def test_build_host_daemon_env_remote_strips_provider_credentials(
     assert "OPENAI_API_KEY" not in env
     assert "OPENAI_BASE_URL" not in env
     assert "ANTHROPIC_API_KEY" not in env
-    # Databricks auth is intentionally preserved for the daemon's server auth.
-    assert env["DATABRICKS_TOKEN"] == "test-databricks-token"
+    assert "DATABRICKS_TOKEN" not in env
 
 
-def test_build_host_daemon_env_remote_keeps_runner_env_passthrough(
+def test_build_host_daemon_env_remote_strips_runner_env_passthrough(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The operator env-forwarding control var survives the remote daemon hop.
-
-    ``OMNIGENT_RUNNER_ENV_PASSTHROUGH`` names extra env vars for the daemon to
-    forward on to runners. In ``--server`` mode the daemon env is allowlisted by
-    a prefix set that includes ``DATABRICKS_`` but *not* plain ``OMNIGENT_``, so
-    without an explicit allowlist entry the control var itself is stripped here —
-    and ``_build_runner_env`` never sees the names it lists, making the whole
-    passthrough a silent no-op remotely. It carries only var names, not secrets.
-    """
+    """The removed generic credential-passthrough mechanism does not reach the host."""
     monkeypatch.setenv("PATH", "/usr/bin")
     monkeypatch.setenv("OMNIGENT_RUNNER_ENV_PASSTHROUGH", "MY_GATEWAY_TOKEN")
 
     env = _build_host_daemon_env(server_url="https://example.databricksapps.com")
 
-    assert env["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] == "MY_GATEWAY_TOKEN"
+    assert "OMNIGENT_RUNNER_ENV_PASSTHROUGH" not in env
 
 
 def test_ensure_host_daemon_reuses_same_target(

--- a/tests/cli/test_host_daemon_env.py
+++ b/tests/cli/test_host_daemon_env.py
@@ -7,10 +7,7 @@ from typing import Final
 import pytest
 
 from omnigent.cli import _build_host_daemon_env
-from omnigent.host.connect import (
-    RUNNER_ENV_PASSTHROUGH_ENV_VAR,
-    _build_runner_env,
-)
+from omnigent.host.connect import _build_runner_env
 
 _REMOTE_SERVER_URL: Final = "https://example.databricksapps.com"
 _PROXY_ENV: Final = {
@@ -25,16 +22,12 @@ _PROXY_ENV: Final = {
 }
 
 
-@pytest.mark.parametrize(
-    ("server_url", "keeps_provider_secret"),
-    [(None, True), (_REMOTE_SERVER_URL, False)],
-)
-def test_host_daemon_env_preserves_proxy_vars_and_provider_secret_split(
+@pytest.mark.parametrize("server_url", [None, _REMOTE_SERVER_URL])
+def test_host_daemon_env_preserves_proxy_vars_without_provider_secrets(
     monkeypatch: pytest.MonkeyPatch,
     server_url: str | None,
-    keeps_provider_secret: bool,
 ) -> None:
-    """Proxy selectors reach both daemon modes without widening provider secrets."""
+    """Proxy selectors reach both daemon modes without provider credentials."""
     # Given
     for name, value in _PROXY_ENV.items():
         monkeypatch.setenv(name, value)
@@ -47,7 +40,7 @@ def test_host_daemon_env_preserves_proxy_vars_and_provider_secret_split(
     # Then
     assert {name: env.get(name) for name in _PROXY_ENV} == _PROXY_ENV
     assert env["DATABRICKS_CONFIG_PROFILE"] == "corp"
-    assert ("OPENAI_API_KEY" in env) is keeps_provider_secret
+    assert "OPENAI_API_KEY" not in env
 
 
 def test_runner_env_excludes_proxy_vars_by_default() -> None:
@@ -69,14 +62,14 @@ def test_runner_env_excludes_proxy_vars_by_default() -> None:
     assert set(_PROXY_ENV).isdisjoint(env)
 
 
-def test_runner_env_explicit_proxy_passthrough_remains_available() -> None:
-    """Runner proxy forwarding remains opt-in through the existing passthrough."""
+def test_runner_env_removed_passthrough_does_not_forward_proxy_credentials() -> None:
+    """The removed generic passthrough cannot inject proxy values into runners."""
     # Given
     explicit_names = {"HTTPS_PROXY", "http_proxy"}
     base_env = {
         "PATH": "/usr/bin",
         **_PROXY_ENV,
-        RUNNER_ENV_PASSTHROUGH_ENV_VAR: ",".join(explicit_names),
+        "OMNIGENT_RUNNER_ENV_PASSTHROUGH": ",".join(explicit_names),
     }
 
     # When
@@ -90,10 +83,8 @@ def test_runner_env_explicit_proxy_passthrough_remains_available() -> None:
     )
 
     # Then
-    assert {name: env[name] for name in explicit_names} == {
-        name: _PROXY_ENV[name] for name in explicit_names
-    }
-    assert (set(_PROXY_ENV) - explicit_names).isdisjoint(env)
+    assert set(_PROXY_ENV).isdisjoint(env)
+    assert "OMNIGENT_RUNNER_ENV_PASSTHROUGH" not in env
 
 
 _CLAUDE_TOOL_SEARCH_ENV: Final = {

--- a/tests/cli/test_upgrade_command.py
+++ b/tests/cli/test_upgrade_command.py
@@ -146,6 +146,49 @@ def test_upgrade_runs_installer_and_drains_first(
     assert "Upgraded to v0.2.0" in result.output
 
 
+def test_upgrade_refreshes_local_host_service_after_success(
+    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
+) -> None:
+    """A successful upgrade rewrites and restarts a stopped local service."""
+    from omnigent.host.service import HostService, HostServiceStatus
+
+    monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda *_a, **_k: "0.2.0")
+    service_path = Path("/tmp/omnigent-host.service")
+    snapshot = HostServiceStatus(
+        supported=True,
+        kind="systemd_user",
+        path=service_path,
+        label=service_path.name,
+        installed=True,
+        configured_target="local",
+        manager_state="running",
+        enabled=True,
+    )
+    monkeypatch.setattr("omnigent.cli._capture_upgrade_host_service", lambda: snapshot)
+    monkeypatch.setattr("omnigent.cli._stop_local_server_and_daemon", lambda *, force: True)
+    monkeypatch.setattr("omnigent.update_check._run_upgrade_command", lambda *_a, **_k: 0)
+    monkeypatch.setattr(
+        "omnigent.update_check._probe_installed_distribution", lambda: ("0.2.0", None)
+    )
+    monkeypatch.setattr(
+        "omnigent.cli._build_host_daemon_env",
+        lambda **kw: {"HOME": "/home/alice", "TERM": "xterm"},
+    )
+    refreshed: list[tuple[str | None, dict[str, str]]] = []
+
+    def _enable(server_url: str | None, *, environment: dict[str, str]) -> HostService:
+        refreshed.append((server_url, environment))
+        return HostService(kind="systemd_user", path=service_path, label=service_path.name)
+
+    monkeypatch.setattr("omnigent.host.service.enable_user_host_service", _enable)
+
+    result = CliRunner().invoke(cli, ["upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert refreshed == [(None, {"HOME": "/home/alice"})]
+    assert "Refreshed and restarted" in result.output
+
+
 def test_upgrade_force_skips_drain_and_force_stops(
     monkeypatch: pytest.MonkeyPatch, _wheel_install: None
 ) -> None:
@@ -184,6 +227,39 @@ def test_upgrade_install_failure_surfaces(
 
     assert result.exit_code != 0
     assert "exited with status 3" in result.output
+
+
+def test_upgrade_failure_restores_previously_running_local_service(
+    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
+) -> None:
+    """A failed installer does not strand the service stopped for replacement."""
+    from omnigent.host.service import HostServiceStatus
+
+    monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda *_a, **_k: "0.2.0")
+    snapshot = HostServiceStatus(
+        supported=True,
+        kind="systemd_user",
+        path=Path("/tmp/omnigent-host.service"),
+        label="omnigent-host.service",
+        installed=True,
+        configured_target="local",
+        manager_state="running",
+        enabled=True,
+    )
+    monkeypatch.setattr("omnigent.cli._capture_upgrade_host_service", lambda: snapshot)
+    monkeypatch.setattr("omnigent.cli._stop_local_server_and_daemon", lambda *, force: True)
+    monkeypatch.setattr("omnigent.update_check._run_upgrade_command", lambda *_a, **_k: 3)
+    restored: list[str | None] = []
+    monkeypatch.setattr(
+        "omnigent.host.service.start_user_host_service",
+        lambda server: restored.append(server) or snapshot,
+    )
+
+    result = CliRunner().invoke(cli, ["upgrade"])
+
+    assert result.exit_code != 0
+    assert restored == [None]
+    assert "Restored the local host user service" in result.output
 
 
 def test_upgrade_index_unreachable(monkeypatch: pytest.MonkeyPatch, _wheel_install: None) -> None:

--- a/tests/e2e/test_host_e2e.py
+++ b/tests/e2e/test_host_e2e.py
@@ -78,11 +78,9 @@ def _spawn_host_daemon(
     host_id gets overwritten and never shows online. A unique name per test
     keeps each host its own row.
 
-    The daemon's environment carries ``OPENAI_BASE_URL`` and
-    ``OPENAI_API_KEY`` pointing at the mock LLM server.  The host
-    daemon forwards ``OPENAI_*`` to its runner subprocesses via
-    ``HARNESS_CREDENTIAL_ENV_VARS``, so the runner's openai-agents
-    executor hits the mock server.
+    The runner resolves an explicit mock provider from its isolated config at
+    harness launch. The long-lived host and generic runner environments never
+    receive the provider key.
 
     :param tmp_path: Per-test temp dir used as the daemon's ``HOME``.
     :param live_server: Server URL the daemon registers with, e.g.
@@ -99,7 +97,21 @@ def _spawn_host_daemon(
     host_name = f"e2e-host-{uuid.uuid4().hex[:12]}"
     (omni_dir / "config.yaml").write_text(
         yaml.safe_dump(
-            {"host": {"host_id": host_id, "name": host_name}},
+            {
+                "host": {"host_id": host_id, "name": host_name},
+                "providers": {
+                    "host-e2e-openai": {
+                        "kind": "key",
+                        "default": ["openai"],
+                        "openai": {
+                            "base_url": f"{mock_llm_server_url}/v1",
+                            "api_key": "mock-key",
+                            "wire_api": "responses",
+                            "models": {"default": "gpt-5.4"},
+                        },
+                    }
+                },
+            },
             default_flow_style=False,
             sort_keys=True,
         )
@@ -110,8 +122,6 @@ def _spawn_host_daemon(
     env = {
         **os.environ,
         "HOME": str(tmp_path),
-        "OPENAI_BASE_URL": f"{mock_llm_server_url}/v1",
-        "OPENAI_API_KEY": "mock-key",
         PROCESS_LOG_FILE_ENV_VAR: str(daemon_log),
     }
     with open(daemon_log, "w") as log_fh:
@@ -178,6 +188,9 @@ def _write_smoke_agent_yaml(tmp_path: Path) -> Path:
                 "executor:",
                 "  harness: openai-agents",
                 "  model: gpt-5.4",
+                "  auth:",
+                "    type: provider",
+                "    name: host-e2e-openai",
                 "prompt: |",
                 "  You are a terse smoke-test assistant.",
                 "  Follow the user's instruction exactly.",
@@ -301,7 +314,6 @@ def test_host_name_only_config_generates_host_id(
     live_server: str,
     http_client: httpx.Client,
     tmp_path: Path,
-    mock_llm_server_url: str,
 ) -> None:
     """
     A config.yaml that names the host but omits host_id must register
@@ -326,8 +338,6 @@ def test_host_name_only_config_generates_host_id(
     env = {
         **os.environ,
         "HOME": str(tmp_path),
-        "OPENAI_BASE_URL": f"{mock_llm_server_url}/v1",
-        "OPENAI_API_KEY": "mock-key",
         PROCESS_LOG_FILE_ENV_VAR: str(daemon_log),
     }
     with open(daemon_log, "w") as log_fh:
@@ -789,18 +799,15 @@ def test_host_death_kills_runners(
 #
 # Skipped when ``claude`` or ``tmux`` are absent from PATH — the test
 # launches a real Claude Code TUI in a tmux session via the host daemon.
-# All LLM calls hit the shared mock server: the daemon's environment
-# carries ``ANTHROPIC_BASE_URL`` pointing at the mock and
-# ``ANTHROPIC_API_KEY=mock-key``; both flow to the runner via the host's
-# ``HARNESS_CREDENTIAL_ENV_VARS`` allowlist.
+# All LLM calls hit the shared mock server through an explicit provider config
+# resolved when the harness launches; the host and generic runner retain no key.
 
 
 def _write_claude_native_agent_yaml(tmp_path: Path) -> Path:
     """Create a minimal ``claude-native`` agent dir for the host e2e.
 
-    No ``executor.auth`` — auth flows via ``ANTHROPIC_API_KEY`` /
-    ``ANTHROPIC_BASE_URL`` injected into the daemon's environment (and
-    therefore inherited by the runner's tmux session).
+    The named provider resolves at harness launch rather than through the host
+    or generic runner environment.
 
     :param tmp_path: Pytest temp directory.
     :returns: Path to the agent directory.
@@ -816,6 +823,9 @@ def _write_claude_native_agent_yaml(tmp_path: Path) -> Path:
                 "  You are a terse test assistant. Reply exactly as asked.",
                 "executor:",
                 "  harness: claude-native",
+                "  auth:",
+                "    type: provider",
+                "    name: host-e2e-anthropic",
                 "",
             ]
         )
@@ -863,10 +873,8 @@ def _spawn_host_daemon_for_mock_claude(
 ) -> _SpawnedHostDaemon:
     """Spawn an isolated host daemon wired to the mock Anthropic LLM.
 
-    Like :func:`_spawn_host_daemon` but sets ``ANTHROPIC_BASE_URL`` and
-    ``ANTHROPIC_API_KEY`` so the runner's Claude TUI hits the mock server
-    instead of prompting for OAuth. Both vars are in
-    ``HARNESS_CREDENTIAL_ENV_VARS`` and flow daemon→runner automatically.
+    Like :func:`_spawn_host_daemon` but configures an Anthropic provider that
+    the runner resolves only when launching Claude.
 
     The Anthropic SDK appends ``/v1/messages`` to ``ANTHROPIC_BASE_URL``,
     so the URL must NOT include ``/v1``.
@@ -885,7 +893,20 @@ def _spawn_host_daemon_for_mock_claude(
     host_name = f"e2e-host-{uuid.uuid4().hex[:12]}"
     (omni_dir / "config.yaml").write_text(
         yaml.safe_dump(
-            {"host": {"host_id": host_id, "name": host_name}},
+            {
+                "host": {"host_id": host_id, "name": host_name},
+                "providers": {
+                    "host-e2e-anthropic": {
+                        "kind": "key",
+                        "default": ["anthropic"],
+                        "anthropic": {
+                            "base_url": mock_llm_server_url,
+                            "api_key": "mock-key",
+                            "models": {"default": "claude-sonnet-4-5"},
+                        },
+                    }
+                },
+            },
             default_flow_style=False,
             sort_keys=True,
         )
@@ -894,12 +915,6 @@ def _spawn_host_daemon_for_mock_claude(
     env = {
         **os.environ,
         "HOME": str(tmp_path),
-        # ANTHROPIC_BASE_URL is in HARNESS_CREDENTIAL_ENV_VARS so it flows
-        # daemon→runner. The Anthropic SDK appends /v1/messages; omit /v1.
-        "ANTHROPIC_BASE_URL": mock_llm_server_url,
-        # ANTHROPIC_API_KEY bypasses the Claude CLI's OAuth login — no
-        # ~/.claude.json account is needed when an explicit API key is set.
-        "ANTHROPIC_API_KEY": "mock-key",
         # Suppress beta headers so the mock server doesn't reject them.
         "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
         PROCESS_LOG_FILE_ENV_VAR: str(daemon_log),

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -301,7 +301,9 @@ def test_host_enable_subcommand_installs_user_service(
         server_url: str | None,
         *,
         environment: dict[str, str],
+        **kwargs: object,
     ) -> HostService:
+        del kwargs
         captured.append((server_url, environment))
         return HostService(kind="systemd_user", path=service_path, label=service_path.name)
 
@@ -317,6 +319,91 @@ def test_host_enable_subcommand_installs_user_service(
     assert result.exit_code == 0, result.output
     assert captured == [(None, {"HOME": str(tmp_path)})]
     assert "Enabled the Omnigent host user service for local" in result.output
+
+
+def test_host_enable_restores_unmanaged_daemon_when_activation_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed service transaction restores the daemon it retired."""
+    from omnigent.cli import _HostDaemonRecord
+    from omnigent.host.service import HostServiceError, HostServiceStatus
+
+    record = _HostDaemonRecord(
+        pid=4242,
+        target="local",
+        mode="local",
+        server_url=None,
+        log_path=None,
+        started_at=1,
+    )
+    monkeypatch.setattr("omnigent.cli._find_daemon_record", lambda target: record)
+    monkeypatch.setattr("omnigent.cli._build_host_daemon_env", lambda **kw: {})
+    monkeypatch.setattr(
+        "omnigent.host.service.user_host_service_status",
+        lambda: HostServiceStatus(supported=True, manager_state="stopped"),
+    )
+    events: list[str] = []
+    monkeypatch.setattr(
+        "omnigent.cli._terminate_daemon",
+        lambda daemon, *, force: events.append("retired"),
+    )
+    monkeypatch.setattr(
+        "omnigent.cli._ensure_host_daemon",
+        lambda server: events.append("restored") or False,
+    )
+
+    def _fail_enable(
+        server_url: str | None,
+        *,
+        environment: dict[str, str],
+        before_activate: object,
+        on_rollback: object,
+    ) -> None:
+        del server_url, environment
+        assert callable(before_activate)
+        assert callable(on_rollback)
+        before_activate()
+        on_rollback()
+        raise HostServiceError("activation failed")
+
+    monkeypatch.setattr("omnigent.host.service.enable_user_host_service", _fail_enable)
+
+    result = CliRunner().invoke(cli, ["host", "enable", "--server", ""])
+
+    assert result.exit_code != 0
+    assert "activation failed" in result.output
+    assert events == ["retired", "restored"]
+
+
+def test_host_service_environment_excludes_credentials_and_terminal_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Persistent definitions retain runtime paths but no secret material."""
+    from omnigent.cli import _build_host_service_env
+
+    monkeypatch.setenv("HOME", "/home/alice")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("TERM", "xterm-256color")
+    monkeypatch.setenv("TERMINFO", "/tmp/terminfo")
+    monkeypatch.setenv("TERMINFO_DIRS", "/a:/b")
+    monkeypatch.setenv("OPENAI_API_KEY", "model-secret")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "workspace-secret")
+    monkeypatch.setenv("OMNIGENT_DEBUG_LOG_CLIENT_SECRET", "logging-secret")
+
+    environment = _build_host_service_env(server_url=None)
+
+    assert environment["HOME"] == "/home/alice"
+    assert environment["PATH"] == "/usr/bin"
+    for name in (
+        "TERM",
+        "TERMINFO",
+        "TERMINFO_DIRS",
+        "OPENAI_API_KEY",
+        "DATABRICKS_TOKEN",
+        "OMNIGENT_DEBUG_LOG_CLIENT_SECRET",
+    ):
+        assert name not in environment
 
 
 def test_host_enable_reports_persistent_target_replacement(

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1893,13 +1893,9 @@ def test_handle_stat_expands_tilde(tmp_path: Path, monkeypatch) -> None:
 
 def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     """
-    A spawned runner inherits only allowlisted host env vars — process
-    essentials pass through, the host owner's NON-HARNESS secrets do
-    not — plus the runner wiring vars. Harness credentials
-    (HARNESS_CREDENTIAL_ENV_VARS) are the deliberate exception: the
-    host owner provisions those precisely so runners can use them.
-    Guards against unrelated host secrets (cloud creds, workspace
-    tokens) leaking into every runner subprocess.
+    A spawned runner inherits only non-secret allowlisted host values plus
+    runner wiring. Provider and harness credentials stay out of the generic
+    runner and are resolved only at the harness launch boundary.
     """
     base = {
         "PATH": "/usr/bin:/bin",
@@ -1922,6 +1918,10 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
         "OMNIGENT_LOG_LEVEL": "DEBUG",
         "OMNIGENT_LOG_TO_STDERR": "1",
         "OMNIGENT_LOG_TTY_FD": "9",
+        "OMNIGENT_DEBUG_LOG_CLIENT_SECRET": "debug-log-secret",
+        "OMNIGENT_RUNNER_ENV_PASSTHROUGH": "SOME_RANDOM_VAR",
+        "OTEL_EXPORTER_OTLP_HEADERS": "authorization=secret",
+        "MLFLOW_TRACKING_TOKEN": "mlflow-secret",
     }
 
     env = _build_runner_env(
@@ -1947,10 +1947,7 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     # falls back to the ~/.databrickscfg default and can read a different token
     # store than the host/daemon, failing to mint a token (runner tunnel 401).
     assert env["DATABRICKS_AUTH_STORAGE"] == "plaintext"
-    # Harness credentials forward — they exist FOR the runner's
-    # harnesses (laptop: exported keys; managed sandbox: the
-    # deployment's injected provider secrets).
-    assert env["ANTHROPIC_API_KEY"] == "sk-harness"
+    assert "ANTHROPIC_API_KEY" not in env
     # The sandbox-image environment descriptor forwards: Claude Code
     # needs it to allow --dangerously-skip-permissions under root in
     # sandbox containers. Only the baked host image ever sets it.
@@ -1984,6 +1981,10 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     # Non-harness secrets are stripped — the point of the allowlist.
     assert "DATABRICKS_TOKEN" not in env
     assert "AWS_SECRET_ACCESS_KEY" not in env
+    assert "OMNIGENT_DEBUG_LOG_CLIENT_SECRET" not in env
+    assert "OMNIGENT_RUNNER_ENV_PASSTHROUGH" not in env
+    assert "OTEL_EXPORTER_OTLP_HEADERS" not in env
+    assert "MLFLOW_TRACKING_TOKEN" not in env
     # Non-allowlisted vars are dropped (allowlist, not denylist).
     assert "SOME_RANDOM_VAR" not in env
     # Runner wiring is layered on.
@@ -1996,14 +1997,8 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     assert env[RUNNER_PARENT_PID_ENV_VAR] == "42"
 
 
-def test_build_runner_env_forwards_harness_credentials_and_endpoints() -> None:
-    """
-    Every var in HARNESS_CREDENTIAL_ENV_VARS forwards when present —
-    keys AND endpoint wiring (base URLs travel with their credentials
-    or gateway setups break in confusing ways). Absent vars are simply
-    not set rather than defaulted.
-    """
-    from omnigent.host.connect import HARNESS_CREDENTIAL_ENV_VARS
+def test_build_runner_env_strips_harness_credentials_and_endpoints() -> None:
+    """Generic runners never inherit provider credential material."""
 
     base = {
         "PATH": "/usr/bin",
@@ -2034,9 +2029,6 @@ def test_build_runner_env_forwards_harness_credentials_and_endpoints() -> None:
     for name in (
         "ANTHROPIC_API_KEY",
         "ANTHROPIC_BASE_URL",
-        # The gateway model pin travels with the key/endpoint — without it a
-        # LiteLLM-style gateway session launches Claude Code model-less and
-        # the gateway rejects Claude Code's own default model.
         "ANTHROPIC_MODEL",
         "CLAUDE_CODE_OAUTH_TOKEN",
         "CODEX_ACCESS_TOKEN",
@@ -2045,22 +2037,15 @@ def test_build_runner_env_forwards_harness_credentials_and_endpoints() -> None:
         "GEMINI_API_KEY",
         "AWS_BEARER_TOKEN_BEDROCK",
         "ANTHROPIC_BEDROCK_BASE_URL",
+        "ANTHROPIC_AUTH_TOKEN",
     ):
-        # Pins each conventional name into the default set — dropping
-        # one breaks that harness's credentials on managed sandboxes.
-        assert name in HARNESS_CREDENTIAL_ENV_VARS
-        assert env[name] == base[name]
-    # ANTHROPIC_AUTH_TOKEN wasn't in base: present in the default set
-    # but never invented into the env.
-    assert "ANTHROPIC_AUTH_TOKEN" in HARNESS_CREDENTIAL_ENV_VARS
-    assert "ANTHROPIC_AUTH_TOKEN" not in env
-    # A secret not on the credential set / allowlist is not forwarded.
+        assert name not in env
+    # Unrelated secrets remain outside the non-secret allowlist too.
     assert "MY_UNRELATED_SECRET" not in env
 
 
-def test_build_runner_env_forwards_omnigent_prefixed_harness_credentials() -> None:
-    """Prefixed harness credential aliases forward without creating raw names."""
-    from omnigent.host.connect import HARNESS_CREDENTIAL_ENV_VARS
+def test_build_runner_env_strips_omnigent_prefixed_harness_credentials() -> None:
+    """Prefixed credential aliases do not bypass the runner boundary."""
 
     base = {
         "PATH": "/usr/bin",
@@ -2077,17 +2062,12 @@ def test_build_runner_env_forwards_omnigent_prefixed_harness_credentials() -> No
         parent_pid=42,
     )
 
-    assert "OMNIGENT_ANTHROPIC_API_KEY" in HARNESS_CREDENTIAL_ENV_VARS
-    assert env["OMNIGENT_ANTHROPIC_API_KEY"] == "sk-prefixed"
+    assert "OMNIGENT_ANTHROPIC_API_KEY" not in env
     assert "ANTHROPIC_API_KEY" not in env
 
 
-def test_build_runner_env_passthrough_extends_forwarded_set() -> None:
-    """
-    OMNIGENT_RUNNER_ENV_PASSTHROUGH names EXTRA vars to forward (for
-    `providers:`-config `env:` refs and custom gateway wiring) without
-    opening the allowlist to anything unnamed.
-    """
+def test_build_runner_env_strips_removed_passthrough_values() -> None:
+    """The legacy generic passthrough cannot inject credentials into runners."""
     base = {
         "PATH": "/usr/bin",
         "HOME": "/root",
@@ -2106,25 +2086,19 @@ def test_build_runner_env_passthrough_extends_forwarded_set() -> None:
         parent_pid=42,
     )
 
-    # Named extras forward (whitespace around commas tolerated).
-    assert env["MY_GATEWAY_TOKEN"] == "tok-123"
-    assert env["MY_GATEWAY_URL"] == "https://llm.internal.example.com"
-    # Anything unnamed stays behind the allowlist.
-    assert "UNLISTED_SECRET" not in env
+    for name in (
+        "OMNIGENT_RUNNER_ENV_PASSTHROUGH",
+        "MY_GATEWAY_TOKEN",
+        "MY_GATEWAY_URL",
+        "UNLISTED_SECRET",
+    ):
+        assert name not in env
 
 
-def test_build_runner_env_passthrough_survives_remote_daemon_hop(
+def test_credential_passthrough_is_absent_from_daemon_and_runner(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """OMNIGENT_RUNNER_ENV_PASSTHROUGH forwards a named var through BOTH hops.
-
-    In ``--server`` mode the env crosses two strips: CLI→daemon
-    (``_build_host_daemon_env``) then daemon→runner (``_build_runner_env``). The
-    control var must survive the first hop or the second never sees the names it
-    lists. A named var travels via the ``DATABRICKS_`` prefix on the first hop and
-    the passthrough on the second, so it must reach the runner; an unnamed secret
-    must not.
-    """
+    """Neither host nor generic runner retains explicitly named credentials."""
     from omnigent.cli import _build_host_daemon_env
 
     monkeypatch.setenv("PATH", "/usr/bin")
@@ -2134,8 +2108,9 @@ def test_build_runner_env_passthrough_survives_remote_daemon_hop(
 
     server = "https://example.databricksapps.com"
     daemon_env = _build_host_daemon_env(server_url=server)
-    # The first hop must keep the control var (regression guard for the remote no-op).
-    assert daemon_env["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] == "DATABRICKS_LINEAR_API_KEY"
+    assert "OMNIGENT_RUNNER_ENV_PASSTHROUGH" not in daemon_env
+    assert "DATABRICKS_LINEAR_API_KEY" not in daemon_env
+    assert "DATABRICKS_UNNAMED" not in daemon_env
 
     runner_env = _build_runner_env(
         daemon_env,
@@ -2146,8 +2121,7 @@ def test_build_runner_env_passthrough_survives_remote_daemon_hop(
         parent_pid=42,
     )
 
-    # The named var reaches the runner; an unnamed one does not.
-    assert runner_env["DATABRICKS_LINEAR_API_KEY"] == "lin-secret"
+    assert "DATABRICKS_LINEAR_API_KEY" not in runner_env
     assert "DATABRICKS_UNNAMED" not in runner_env
 
 

--- a/tests/host/test_service.py
+++ b/tests/host/test_service.py
@@ -266,7 +266,11 @@ def test_enable_launchd_user_service(tmp_path: Path, monkeypatch: pytest.MonkeyP
     monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "state"))
     monkeypatch.setattr(service.platform, "system", lambda: "Darwin")
     monkeypatch.setattr(service.os, "getuid", lambda: 501)
-    monkeypatch.setattr(service.sys, "executable", "/opt/omnigent/bin/python")
+    python = tmp_path / "bin/python"
+    python.parent.mkdir()
+    python.write_text("#!/bin/sh\n")
+    python.chmod(0o700)
+    monkeypatch.setattr(service.sys, "executable", str(python))
     calls = _capture_runs(monkeypatch)
 
     installed = service.enable_user_host_service(
@@ -278,7 +282,7 @@ def test_enable_launchd_user_service(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert installed.path == tmp_path / "Library/LaunchAgents/ai.omnigent.host.plist"
     assert payload["Label"] == "ai.omnigent.host"
     assert payload["ProgramArguments"] == [
-        "/opt/omnigent/bin/python",
+        str(python),
         "-m",
         "omnigent.host.service_entry",
         "--server",
@@ -288,6 +292,8 @@ def test_enable_launchd_user_service(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert payload["KeepAlive"] == {"SuccessfulExit": False}
     assert "ProcessType" not in payload
     assert calls == [
+        ["launchctl", "print", "gui/501/ai.omnigent.host"],
+        ["launchctl", "print-disabled", "gui/501"],
         ["launchctl", "bootout", "gui/501/ai.omnigent.host"],
         [
             "launchctl",
@@ -322,7 +328,11 @@ def test_enable_systemd_user_service(tmp_path: Path, monkeypatch: pytest.MonkeyP
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
     monkeypatch.setattr(service.platform, "system", lambda: "Linux")
-    monkeypatch.setattr(service.sys, "executable", "/opt/omnigent/bin/python")
+    python = tmp_path / "bin/python"
+    python.parent.mkdir()
+    python.write_text("#!/bin/sh\n")
+    python.chmod(0o700)
+    monkeypatch.setattr(service.sys, "executable", str(python))
     calls = _capture_runs(monkeypatch)
 
     installed = service.enable_user_host_service(
@@ -333,15 +343,173 @@ def test_enable_systemd_user_service(tmp_path: Path, monkeypatch: pytest.MonkeyP
     unit = installed.path.read_text()
     assert installed.path == tmp_path / "xdg/systemd/user/omnigent-host.service"
     assert 'Environment="HOME=' in unit
-    assert (
-        'ExecStart="/opt/omnigent/bin/python" "-m" "omnigent.host.service_entry" "--local"'
-    ) in unit
+    assert f'ExecStart="{python}" "-m" "omnigent.host.service_entry" "--local"' in unit
     assert "Restart=on-failure" in unit
     assert "RestartPreventExitStatus=78 143" in unit
-    assert calls == [
+    assert calls[0][:4] == ["systemctl", "--user", "show", "omnigent-host.service"]
+    assert calls[1:] == [
         ["systemctl", "--user", "daemon-reload"],
         ["systemctl", "--user", "enable", "--now", "omnigent-host.service"],
     ]
+
+
+def test_enable_systemd_rolls_back_definition_and_callback_on_activation_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.setattr(service.platform, "system", lambda: "Linux")
+    python = tmp_path / "bin/python"
+    python.parent.mkdir()
+    python.write_text("#!/bin/sh\n")
+    python.chmod(0o700)
+    monkeypatch.setattr(service.sys, "executable", str(python))
+    path = tmp_path / ".config/systemd/user/omnigent-host.service"
+    monkeypatch.setattr(
+        service,
+        "user_host_service_status",
+        lambda: service.HostServiceStatus(
+            supported=True,
+            kind="systemd_user",
+            path=path,
+            label=path.name,
+            installed=False,
+            manager_state="stopped",
+        ),
+    )
+    checked: list[list[str]] = []
+
+    def _checked(args: list[str]) -> None:
+        checked.append(list(args))
+        if "enable" in args:
+            raise service.HostServiceError("activation failed")
+
+    rollback_calls: list[list[str]] = []
+    monkeypatch.setattr(service, "_run_checked", _checked)
+    monkeypatch.setattr(
+        service,
+        "_run_best_effort",
+        lambda args: (
+            rollback_calls.append(list(args)) or subprocess.CompletedProcess(args, 0, "", "")
+        ),
+    )
+    monkeypatch.setattr(service, "_record_service", lambda installed: None)
+    monkeypatch.setattr(service, "_forget_service", lambda installed: None)
+    retired: list[str] = []
+    restored: list[str] = []
+
+    with pytest.raises(service.HostServiceError, match="activation failed"):
+        service.enable_user_host_service(
+            None,
+            environment={"HOME": str(tmp_path)},
+            before_activate=lambda: retired.append("retired"),
+            on_rollback=lambda: restored.append("restored"),
+        )
+
+    assert retired == ["retired"]
+    assert restored == ["restored"]
+    assert not path.exists()
+    assert checked == [
+        ["systemctl", "--user", "daemon-reload"],
+        ["systemctl", "--user", "enable", "--now", "omnigent-host.service"],
+    ]
+    assert rollback_calls == [
+        ["systemctl", "--user", "disable", "--now", "omnigent-host.service"],
+        ["systemctl", "--user", "daemon-reload"],
+    ]
+
+
+def test_enable_systemd_restores_running_previous_service_on_ledger_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.setattr(service.platform, "system", lambda: "Linux")
+    old_python = tmp_path / "old/python"
+    old_python.parent.mkdir()
+    old_python.write_text("#!/bin/sh\n")
+    old_python.chmod(0o700)
+    new_python = tmp_path / "new/python"
+    new_python.parent.mkdir()
+    new_python.write_text("#!/bin/sh\n")
+    new_python.chmod(0o700)
+    monkeypatch.setattr(service.sys, "executable", str(new_python))
+    path = tmp_path / ".config/systemd/user/omnigent-host.service"
+    path.parent.mkdir(parents=True)
+    previous = service._systemd_unit(
+        command=[str(old_python), "-m", "omnigent.host.service_entry", "--local"],
+        environment={"HOME": str(tmp_path)},
+    )
+    path.write_bytes(previous)
+    monkeypatch.setattr(
+        service,
+        "user_host_service_status",
+        lambda: service.HostServiceStatus(
+            supported=True,
+            kind="systemd_user",
+            path=path,
+            label=path.name,
+            installed=True,
+            configured_target="local",
+            manager_state="running",
+            manager_pid=4242,
+            enabled=True,
+        ),
+    )
+    checked: list[list[str]] = []
+    rollback_calls: list[list[str]] = []
+    monkeypatch.setattr(service, "_run_checked", lambda args: checked.append(list(args)))
+    monkeypatch.setattr(
+        service,
+        "_run_best_effort",
+        lambda args: (
+            rollback_calls.append(list(args)) or subprocess.CompletedProcess(args, 0, "", "")
+        ),
+    )
+
+    def _fail_record(installed: service.HostService) -> None:
+        del installed
+        raise service.HostServiceError("ledger failed")
+
+    monkeypatch.setattr(service, "_record_service", _fail_record)
+
+    with pytest.raises(service.HostServiceError, match="ledger failed"):
+        service.enable_user_host_service(None, environment={"HOME": str(tmp_path)})
+
+    assert path.read_bytes() == previous
+    assert checked == [
+        ["systemctl", "--user", "daemon-reload"],
+        ["systemctl", "--user", "enable", "--now", "omnigent-host.service"],
+        ["systemctl", "--user", "restart", "omnigent-host.service"],
+    ]
+    assert rollback_calls == [
+        ["systemctl", "--user", "stop", "omnigent-host.service"],
+        ["systemctl", "--user", "daemon-reload"],
+        ["systemctl", "--user", "enable", "omnigent-host.service"],
+        ["systemctl", "--user", "start", "omnigent-host.service"],
+    ]
+
+
+def test_status_reports_missing_configured_executable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.setattr(service.platform, "system", lambda: "Linux")
+    installed = service._service_for_current_platform()
+    installed.path.parent.mkdir(parents=True)
+    missing = tmp_path / "removed/python"
+    installed.path.write_bytes(
+        service._systemd_unit(
+            command=[str(missing), "-m", "omnigent.host.service_entry", "--local"],
+            environment={},
+        )
+    )
+
+    status = service.user_host_service_status(probe_manager=False)
+
+    assert status.executable_valid is False
+    assert str(missing) in (status.executable_error or "")
 
 
 def test_systemd_unit_escapes_specifiers_and_literal_dollars() -> None:


### PR DESCRIPTION
## Related issue

https://linear.app/omnigent/issue/OMNI-5596/harden-omnigent-host-service-enable-upgrades-and-environment-handling

Stacked on #5476 (which is stacked on #5475).

## Summary

- Make `omni host enable` transactional across definition writes, manager activation, uninstall-ledger recording, and unmanaged-daemon retirement, restoring the prior service/process on failure.
- Validate the persisted Python executable and expose stale executable diagnostics through host-service status.
- Refresh and restart local user services after successful upgrades, restore them after failed upgrades, and provide explicit recovery guidance for remote services.
- Remove provider, database, Databricks bearer, telemetry-token, and custom-passthrough credential values from host daemon and generic runner environments; harness tests now use explicit provider configuration resolved at launch.
- Exclude ephemeral terminal metadata from persisted service environments and remove the prompt to refresh shell credentials into service definitions.

### ELI5

Enabling or upgrading a host service now behaves like replacing a tire with a jack: if the new setup fails, Omnigent puts the working setup back instead of leaving the host stranded.

```text
snapshot -> stage definition -> retire old daemon -> activate -> record
    ^                                                  |
    +---------------- rollback on failure -------------+
```

## Test Plan

- `uv run pytest tests/host/test_service.py tests/host/test_cli_host.py::test_host_enable_subcommand_installs_user_service tests/host/test_cli_host.py::test_host_enable_restores_unmanaged_daemon_when_activation_fails tests/host/test_cli_host.py::test_host_service_environment_excludes_credentials_and_terminal_values tests/host/test_cli_host.py::test_host_enable_reports_persistent_target_replacement tests/cli/test_upgrade_command.py::test_upgrade_runs_installer_and_drains_first tests/cli/test_upgrade_command.py::test_upgrade_refreshes_local_host_service_after_success tests/cli/test_upgrade_command.py::test_upgrade_install_failure_surfaces tests/cli/test_upgrade_command.py::test_upgrade_failure_restores_previously_running_local_service tests/cli/test_upgrade_command.py::test_upgrade_force_skips_drain_and_force_stops tests/cli/test_upgrade_command.py::test_upgrade_git_install_repulls_and_verifies_commit tests/cli/test_upgrade_command.py::test_upgrade_nightly_installs_pinned_tag`
- `uv run pytest tests/cli/test_backend.py::test_build_host_daemon_env_local_strips_provider_credentials tests/host/test_connect.py::test_build_runner_env_strips_harness_credentials_and_endpoints tests/host/test_connect.py::test_credential_passthrough_is_absent_from_daemon_and_runner tests/cli/test_host_daemon_env.py tests/e2e/test_host_e2e.py::test_host_launch_runner_and_session_round_trip`
- `uv run pre-commit run --files omnigent/cli.py omnigent/host/service.py tests/cli/test_upgrade_command.py tests/host/test_cli_host.py tests/host/test_service.py`
- `uv run omni host status --json` and confirmed the new executable-validity field is present when no service is installed.

## Demo

N/A — service lifecycle and upgrade recovery behavior only.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests inject activation and ledger failures, verify definition/manager/daemon rollback, exercise stale executable diagnostics, prove credential sentinels are absent from host/service/generic-runner environments, and cover upgrade restoration. The targeted host E2E confirms explicit provider configuration still reaches the harness launch boundary. Manually verified the status JSON schema on macOS.

## Changelog

Host-service enable and upgrade failures now restore the previous working setup, while host daemons and generic runners no longer retain model-provider credential values.
