### PR TITLE
refactor(cli): centralize Omnigent server URL handling in a ServerUrl value type

### DIFF
--- a/integrations/slack/src/omnigent_slack/notifications.py
+++ b/integrations/slack/src/omnigent_slack/notifications.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit, urlunsplit
 
 from omnigent_slack.models import ThreadKey
 from omnigent_slack.omnigent import OutputFile
@@ -218,5 +219,19 @@ class SlackNotifier:
         # Link to the session's conversation page in the Omnigent web UI, where a
         # user can continue a thread that's mid-turn in Slack (the web UI accepts
         # concurrent input and shows any pending actions).
-        base = self._server_url.rstrip("/")
+        #
+        # A Databricks workspace-hosted server is configured by its API proxy
+        # mount (``https://<ws>/api/2.0/omnigent``), but the web UI lives on the
+        # workspace SPA mount (``https://<ws>/omnigent``) — linking to the API
+        # mount answers JSON, not the UI. Map the path and keep any ``?o=<org>``
+        # workspace selector from the configured URL so multi-workspace (SPOG)
+        # hosts open in the right workspace. (This bot is standalone — it can't
+        # import ``omnigent.server_url`` — so the mount mapping is mirrored
+        # here.)
+        parts = urlsplit(self._server_url.rstrip("/"))
+        if parts.path == "/api/2.0/omnigent":
+            return urlunsplit(
+                (parts.scheme, parts.netloc, f"/omnigent/c/{session_id}", parts.query, "")
+            )
+        base = urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
         return f"{base}/c/{session_id}"

--- a/integrations/slack/tests/test_notifications.py
+++ b/integrations/slack/tests/test_notifications.py
@@ -38,3 +38,35 @@ def test_format_policy_denied() -> None:
     text = format_policy_denied("No shell commands allowed.")
     assert "Blocked by policy" in text
     assert "No shell commands allowed." in text
+
+
+def test_session_web_link_plain_server() -> None:
+    """A plain server URL links straight to its /c/<id> conversation route."""
+    import logging
+
+    from omnigent_slack.notifications import SlackNotifier
+
+    notifier = SlackNotifier(server_url="http://localhost:6767/", logger=logging.getLogger("test"))
+    assert notifier._session_web_link("conv_abc") == "http://localhost:6767/c/conv_abc"
+
+
+def test_session_web_link_maps_workspace_api_mount_to_ui() -> None:
+    """A workspace-hosted API mount links to the /omnigent web UI, keeping ?o=.
+
+    The bot is configured with the API proxy mount
+    (``https://<ws>/api/2.0/omnigent``), but that mount answers JSON — the
+    conversation page lives on the workspace SPA mount. The ``?o=<org>``
+    selector must survive so multi-workspace hosts open the right workspace.
+    """
+    import logging
+
+    from omnigent_slack.notifications import SlackNotifier
+
+    notifier = SlackNotifier(
+        server_url="https://ws.databricks.com/api/2.0/omnigent?o=123",
+        logger=logging.getLogger("test"),
+    )
+    assert (
+        notifier._session_web_link("conv_abc")
+        == "https://ws.databricks.com/omnigent/c/conv_abc?o=123"
+    )

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -558,8 +558,11 @@ def run_attach(
     # snapshot gives the agent name + harness for an honest banner.
     info = _attach_session_info(base_url=base_url, conversation_id=conversation_id)
     if not info.runner_online:
+        from omnigent.server_url import display_server_url
+
         raise click.ClickException(
-            f"Session {conversation_id} has no online runner on {base_url} — its "
+            f"Session {conversation_id} has no online runner on "
+            f"{display_server_url(base_url)} — its "
             "host is offline. `attach` never starts a runner; bring the host back "
             "(`omnigent run` locally, or reconnect it with `omnigent host`), "
             "then attach again."
@@ -1534,8 +1537,10 @@ def _unreachable_server_message(base_url: str) -> str:
             "It may have stopped — run `omnigent stop`, then try again. "
             "Server logs are under ~/.omnigent/logs/server/."
         )
+    from omnigent.server_url import display_server_url
+
     return (
-        f"Could not connect to the Omnigent server at {base_url}. "
+        f"Could not connect to the Omnigent server at {display_server_url(base_url)}. "
         "Check the URL, your network connection, and any HTTP proxy settings."
     )
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -82,6 +82,8 @@ from omnigent.integration_daemon import IntegrationDaemon
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.onboarding.sandboxes import available_providers as _sandbox_providers
 from omnigent.process_logging import LOG_LEVEL_ENV_VAR, LOG_TO_STDERR_ENV_VAR, data_dir, env_truthy
+from omnigent.server_url import ServerUrl
+from omnigent.server_url import org_id_from_url as _org_id_from_url
 
 if TYPE_CHECKING:
     import socket
@@ -2853,7 +2855,9 @@ def _terminate_host_unit(record: _HostDaemonRecord, *, reason: str) -> None:
         ``"config changed (auth)"`` or ``"host tunnel is offline"``.
     :returns: None.
     """
-    click.echo(f"Restarting host daemon for {record.target!r} ({reason}).", err=True)
+    click.echo(
+        f"Restarting host daemon for {_host_display_url(record.target)!r} ({reason}).", err=True
+    )
     # Best-effort: a daemon that refuses to die shouldn't hard-fail the
     # run — the fresh daemon's record overwrites this one regardless.
     with contextlib.suppress(click.ClickException):
@@ -3364,13 +3368,17 @@ def _ensure_databricks_server_auth(server: str, *, non_interactive: bool = False
         if refreshed_probe.status_code == 200:
             store_databricks_auth(server, workspace_host, org_id=org_id)
             return
-    login_cmd = f"omnigent login {server}"
+    # User-facing: show the display form (the workspace /omnigent URL, with
+    # ?o= when known), not the internal API mount; it round-trips through
+    # `omnigent login` back to the same API base.
+    display = ServerUrl(api_base=server, org_id=org_id).display
+    login_cmd = f"omnigent login {display}"
     if non_interactive or not sys.stdin.isatty():
         raise click.ClickException(
-            f"Not signed in to {server} (Databricks-fronted; /v1/me answered "
+            f"Not signed in to {display} (Databricks-fronted; /v1/me answered "
             f"HTTP {probe.status_code}). Run `{login_cmd}` and retry."
         )
-    click.echo(f"Not signed in to {server} — running `{login_cmd}` first.")
+    click.echo(f"Not signed in to {display} — running `{login_cmd}` first.")
     _databricks_login(server, workspace_host, org_id=org_id)
 
 
@@ -3413,7 +3421,7 @@ def _ensure_backend(server: str | None) -> str:
         # is hidden under the longer daemon wait.
         import concurrent.futures
 
-        server = _resolve_server_url(server)
+        server = _resolve_server_url(server).api_base
         with (
             runner_startup_progress(initial_message=STARTUP_PHASE_CONNECTING_REMOTE),
             concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool,
@@ -4670,7 +4678,8 @@ def diagnose(server: str | None, json_output: bool) -> None:
         "(pass --server to report)" if snap["server_url"] is None else "(unreachable)"
     )
     click.echo(f"server  {server_line}")
-    click.echo(f"url     {snap['server_url'] or '(none)'}")
+    # Human view shows the display form; the --json view keeps the wire URL.
+    click.echo(f"url     {_host_display_url(snap['server_url']) or '(none)'}")
     click.echo(f"auth    {snap['auth_source']} ({snap['auth_source_origin']})")
     click.echo(f"os      {snap['os']}")
     click.echo(f"python  {snap['python']}")
@@ -5835,7 +5844,7 @@ def resume(
 
     run_resume(
         target=target,
-        server=_resolve_server_url(server) if server else server,
+        server=_resolve_server_url(server).api_base if server else server,
     )
 
 
@@ -7328,7 +7337,7 @@ def _dispatch_run(
             # Normalize like every other entry point: expand a bare workspace
             # URL to its /api/2.0/omnigent mount and strip any ?o= query. Else
             # a direct ``--server`` request hits the root and bounces to /login.
-            base_url = _resolve_server_url(server)
+            base_url = _resolve_server_url(server).api_base
             # Direct ``--server`` (no AGENT) has no local runner to bind, so an
             # interactive resume-by-id is an ATTACH: route it through the
             # `attach` pair (`_require_live_conversation` + `run_attach`), not
@@ -7565,7 +7574,7 @@ def _resolve_attach_server(server: str | None, configured_server: str | None) ->
     """
     chosen = server if server is not None else configured_server
     if chosen:
-        return _resolve_server_url(chosen)
+        return _resolve_server_url(chosen).api_base
     local = local_server_url_if_healthy()
     return local.rstrip("/") if local else None
 
@@ -7597,15 +7606,18 @@ def _require_live_conversation(
     )
     # ``_host_http_json`` reports transport failures as status 0 (never
     # raises), so the server-down and missing-session cases both land here.
+    from omnigent.server_url import display_server_url
+
     if result.status_code == 0:
         raise click.ClickException(
-            f"Couldn't reach a server at {base_url}: {_host_error_text(result.body)}. "
+            f"Couldn't reach a server at {display_server_url(base_url)}: "
+            f"{_host_error_text(result.body)}. "
             "`attach` never starts a server — check the URL, or start one with "
             "`omnigent run`."
         )
     if result.status_code != 200:
         raise click.ClickException(
-            f"No live session '{conversation_id}' on {base_url} "
+            f"No live session '{conversation_id}' on {display_server_url(base_url)} "
             f"(server returned {result.status_code}). Run `omnigent host status` "
             "to list live sessions, or `omnigent run <agent.yaml>` to start one."
         )
@@ -7666,9 +7678,11 @@ def attach(
             "`--server <url>`."
         )
     if conversation is None:
+        from omnigent.server_url import display_server_url
+
         raise click.ClickException(
             "Nothing to attach to: `attach` joins a LIVE session by id. "
-            f"Run `omnigent host status` to list sessions on {base_url}, or "
+            f"Run `omnigent host status` to list sessions on {display_server_url(base_url)}, or "
             "`omnigent run <agent.yaml>` to start a new one."
         )
     _require_live_conversation(base_url=base_url, conversation_id=conversation)
@@ -8174,7 +8188,8 @@ def _maybe_open_host_web_ui(
         cfg = _load_effective_config()
     if _resolve_auto_open_conversation_setting(cfg) is False:
         return
-    from omnigent.conversation_browser import display_server_url, open_conversation_url
+    from omnigent.conversation_browser import open_conversation_url
+    from omnigent.server_url import display_server_url
 
     web_url = display_server_url(server_url)
     try:
@@ -8227,8 +8242,10 @@ def _run_background_host(
         if _local_daemon_serves_target(target, server or None):
             local_record = _find_daemon_record(_LOCAL_DAEMON_MARKER)
             if local_record is not None:
+                from omnigent.server_url import display_server_url
+
                 _confirm_background_host_registered(local_record)
-                click.echo(f"The local host daemon already serves {target}.")
+                click.echo(f"The local host daemon already serves {display_server_url(target)}.")
                 return
         raise click.ClickException(
             "Could not spawn the background host daemon. See ~/.omnigent/logs/host/ for details."
@@ -8256,7 +8273,11 @@ def _run_background_host(
         bold=True,
     )
     click.echo(f"{headline} (pid {record.pid}).")
-    _echo_host_field("server", _cli_style(server_url, fg="cyan"))
+    # User-facing: the display form (workspace /omnigent URL with ?o= when
+    # known) — the API mount is an implementation detail.
+    from omnigent.server_url import display_server_url
+
+    _echo_host_field("server", _cli_style(display_server_url(server_url), fg="cyan"))
     if record.log_path is not None:
         _echo_host_field("log", _display_path(Path(record.log_path)))
     click.echo()
@@ -8373,7 +8394,7 @@ def host(
     if server is None:
         server = cfg.get("server")
     if server:
-        server = _resolve_server_url(server)
+        server = _resolve_server_url(server).api_base
     # Remote mode is decided here, before the local-mode branch reassigns
     # ``server`` to the spawned loopback URL — only a remote target needs
     # the sign-in pre-flight.
@@ -8466,7 +8487,7 @@ def _resolve_host_server(server: str | None) -> str | None:
     if server is None:
         configured = _load_effective_config().get("server")
         server = str(configured) if configured else None
-    return _resolve_server_url(server) if server else None
+    return _resolve_server_url(server).api_base if server else None
 
 
 def _daemon_base_url(record: _HostDaemonRecord) -> str | None:
@@ -9065,6 +9086,25 @@ def _host_link_safe(url: str) -> bool:
     return bool(url) and not any(char in _HOST_LINK_UNSAFE_CHARS or char < " " for char in url)
 
 
+def _host_display_url(value: _HostJsonValue) -> _HostJsonValue:
+    """Map a server-URL payload value to its user-facing display form.
+
+    Human-rendered rows show the workspace ``/omnigent`` URL (with ``?o=``
+    when known) instead of the internal API mount; non-URL values (the
+    local daemon marker, ``None``) pass through. JSON output keeps the raw
+    wire values — only apply this at render time.
+
+    :param value: Candidate URL, e.g.
+        ``"https://ws.databricks.com/api/2.0/omnigent"``.
+    :returns: The display URL, or *value* unchanged when it is not a URL.
+    """
+    if isinstance(value, str) and value.startswith(("http://", "https://")):
+        from omnigent.server_url import display_server_url
+
+        return display_server_url(value)
+    return value
+
+
 def _host_link_target(value: _HostJsonValue) -> str | None:
     """
     Build a hyperlink target from a server URL.
@@ -9122,8 +9162,8 @@ def _host_target_label(payload: _HostPayload, *, width: int) -> str:
     :param width: Maximum label width, e.g. ``48``.
     :returns: Compact target label for headers and error rows.
     """
-    target = _host_display_value(payload.get("target"))
-    server_url = payload.get("server_url")
+    target = _host_display_value(_host_display_url(payload.get("target")))
+    server_url = _host_display_url(payload.get("server_url"))
     if target == _LOCAL_DAEMON_MARKER and server_url:
         target = f"local ({server_url})"
     return _host_shorten(target, max_chars=width)
@@ -9278,8 +9318,8 @@ def _echo_daemon_payloads(payloads: list[_HostPayload]) -> None:
         target = _host_target_label(payload, width=max(24, min(console.width - 2, 96)))
         process = _host_display_value(payload.get("process"), missing="unknown")
         host_status = _host_display_value(payload.get("host_status"), missing="unknown")
-        server_link = _host_link_target(payload.get("server_url"))
-        target_link = server_link or _host_link_target(payload.get("target"))
+        server_link = _host_link_target(_host_display_url(payload.get("server_url")))
+        target_link = server_link or _host_link_target(_host_display_url(payload.get("target")))
         console.print(f"[bold cyan]{_host_linked(target, target=target_link)}[/bold cyan]")
         console.print(
             "  "
@@ -9289,7 +9329,7 @@ def _echo_daemon_payloads(payloads: list[_HostPayload]) -> None:
             f"host=[{_host_status_style(host_status)}]{host_status}[/]"
         )
         server_text = _host_shorten(
-            payload.get("server_url"),
+            _host_display_url(payload.get("server_url")),
             max_chars=max(24, console.width - 11),
         )
         console.print(f"  server={_host_linked(server_text, target=server_link)}")
@@ -9356,7 +9396,7 @@ def host_enable(
     except HostServiceError as exc:
         raise click.ClickException(str(exc)) from exc
 
-    click.echo(f"Enabled the Omnigent host user service for {target}.")
+    click.echo(f"Enabled the Omnigent host user service for {_host_display_url(target)}.")
     click.echo(f"Service definition: {_display_path(service.path)}")
     if service.log_path is not None:
         click.echo(f"Service output: {_display_path(service.log_path)}")
@@ -9491,10 +9531,13 @@ def _stop_daemon_sessions(
     result = _sessions_for_daemon(record)
     if result.error is not None:
         if force:
-            click.echo(f"{record.target}: skipping session stop: {result.error}", err=True)
+            click.echo(
+                f"{_host_display_url(record.target)}: skipping session stop: {result.error}",
+                err=True,
+            )
             return 0
         raise click.ClickException(
-            f"{record.target}: {result.error} — retry with --force to stop the "
+            f"{_host_display_url(record.target)}: {result.error} — retry with --force to stop the "
             f"daemon anyway, or --daemon-only to skip the session stop entirely."
         )
     if result.base_url is None:
@@ -9554,7 +9597,7 @@ def _signal_daemon_pid(record: _HostDaemonRecord, sig: int) -> bool:
         # reuse, or a daemon started under a different account). Drop the
         # stale record and warn rather than crashing the CLI on the EPERM.
         click.echo(
-            f"Skipping stale daemon record for {record.target!r}: pid "
+            f"Skipping stale daemon record for {_host_display_url(record.target)!r}: pid "
             f"{record.pid} is owned by another user and is not this daemon.",
             err=True,
         )
@@ -9593,7 +9636,8 @@ def _terminate_daemon(record: _HostDaemonRecord, *, force: bool) -> None:
                 return
             time.sleep(0.1)
     raise click.ClickException(
-        f"Daemon {record.pid} for {record.target!r} did not exit; retry with --force."
+        f"Daemon {record.pid} for {_host_display_url(record.target)!r} did not exit; "
+        "retry with --force."
     )
 
 
@@ -9635,7 +9679,10 @@ def host_stop(
         if not daemon_only:
             stopped = _stop_daemon_sessions(record, force=force)
         _terminate_daemon(record, force=force)
-        click.echo(f"Stopped {record.target} daemon pid={record.pid}; sessions_stopped={stopped}.")
+        click.echo(
+            f"Stopped {_host_display_url(record.target)} daemon "
+            f"pid={record.pid}; sessions_stopped={stopped}."
+        )
 
 
 @host.command("stop-session")
@@ -10815,7 +10862,7 @@ def _workspace_api_server_url(server: str) -> str:
 
     import httpx as _httpx
 
-    from omnigent.conversation_browser import (
+    from omnigent.server_url import (
         WORKSPACE_API_PATH,
         WORKSPACE_UI_PATH,
         display_server_url,
@@ -10990,9 +11037,9 @@ def _databricks_root_is_usable(server: str) -> bool:
     return _databricks_workspace_login_target(root, probe) is not None
 
 
-def _resolve_server_url(server: str) -> str:
+def _resolve_server_url(server: str) -> ServerUrl:
     """
-    Normalize a user-supplied ``--server`` value to the Omnigent API base.
+    Normalize a user-supplied ``--server`` value to a :class:`ServerUrl`.
 
     Every ``--server`` entry point (and ``login``) needs the same
     normalization, so they all route through here: strip a trailing slash,
@@ -11000,6 +11047,11 @@ def _resolve_server_url(server: str) -> str:
     then expand a bare Databricks workspace URL — or the ``/omnigent``
     web-UI URL the internal user guide hands out — to the
     ``/api/2.0/omnigent`` mount.
+
+    The ``?o=`` workspace selector is captured off the raw input (the
+    expansion strips it before probing) and rides on the returned value;
+    when the input carries none, the selector recorded by a previous
+    ``omnigent login`` for the resolved base is used instead.
 
     The URL is always tried as the user gave it first. Only when that fails
     to resolve, and only for an Azure custom (vanity) workspace URL, is the
@@ -11009,15 +11061,18 @@ def _resolve_server_url(server: str) -> str:
 
     :param server: A non-empty ``--server`` value, e.g.
         ``"example.cloud.databricks.com/omnigent"``.
-    :returns: The normalized API base URL without a trailing slash, e.g.
-        ``"https://example.cloud.databricks.com/api/2.0/omnigent"``.
+    :returns: The resolved :class:`ServerUrl` — requests target its
+        ``api_base`` (e.g.
+        ``"https://example.cloud.databricks.com/api/2.0/omnigent"``),
+        user-facing messages show its ``display`` form.
     :raises click.ClickException: If *server* is a local-server alias (empty or
         ``"local"``) rather than a URL. Callers route those to local mode before
         reaching here (see ``_is_local_server_request`` / ``_ensure_backend``);
         normalizing one would yield a nonsense target — the bare scheme
         ``"https:"`` for an empty value, or the unroutable ``https://local``.
     """
-    from omnigent.conversation_browser import display_server_url, strip_conversation_path
+    from omnigent.conversation_browser import strip_conversation_path
+    from omnigent.server_url import display_server_url
 
     if _is_local_server_request(server):
         raise click.ClickException(
@@ -11025,6 +11080,16 @@ def _resolve_server_url(server: str) -> str:
             "a remote URL is required. Pass `--server local` to the command you "
             "meant to run locally, or give this one a URL."
         )
+
+    # The ``?o=`` selector lives on the raw input; the expansion below strips
+    # it before probing, so capture it first. It becomes the resolved value's
+    # org id (raw input wins over a stored login record).
+    org_id = _org_id_from_url(server)
+
+    def _resolved(api_base: str) -> ServerUrl:
+        if org_id is not None:
+            return ServerUrl(api_base=api_base, org_id=org_id)
+        return ServerUrl.from_api_base(api_base)
 
     # A URL copied from the browser while a conversation is open carries the
     # SPA's ``/c/<id>`` route. The SPA catch-all answers any GET under it with
@@ -11034,21 +11099,21 @@ def _resolve_server_url(server: str) -> str:
     expanded = _workspace_api_server_url(normalized)
     candidate = _canonical_azure_databricks_url(normalized)
     if candidate is None:
-        return expanded  # not a vanity Azure workspace URL
+        return _resolved(expanded)  # not a vanity Azure workspace URL
     # A URL "resolved" if the expansion adopted a mount for it, or if the root
     # answers on its own. Compare against the root the expansion probed, not the
     # raw input: it drops the ?o= selector first, and that selector is what makes
     # a URL a candidate here, so comparing raw would always look like an adoption.
     if expanded != _probe_root(normalized) or _databricks_root_is_usable(normalized):
-        return expanded
+        return _resolved(expanded)
     canonical = _workspace_api_server_url(candidate)
     if canonical == _probe_root(candidate) and not _databricks_root_is_usable(candidate):
-        return expanded  # the canonical host is no better; keep what the user typed
+        return _resolved(expanded)  # the canonical host is no better; keep what the user typed
     click.echo(
         f"Note: {display_server_url(normalized)} did not answer as a workspace; "
         f"using its canonical host {display_server_url(canonical)}."
     )
-    return canonical
+    return _resolved(canonical)
 
 
 def _databricks_workspace_login_target(server: str, probe: httpx.Response) -> str | None:
@@ -11095,24 +11160,6 @@ def _databricks_workspace_login_target(server: str, probe: httpx.Response) -> st
                 return f"https://{parsed.netloc}"
 
     return None
-
-
-def _org_id_from_url(url: str) -> str | None:
-    """Extract the ``?o=<workspace-id>`` workspace selector from *url*.
-
-    A Databricks host can front many workspaces under one hostname, where
-    the bare host resolves to the account and ``?o=<workspace-id>`` picks
-    the workspace. The selector is threaded into both the login (to bind
-    the grant to the workspace) and every API request (to route to it).
-
-    :param url: A user-supplied server URL, possibly carrying ``?o=``,
-        e.g. ``"https://acme.databricks.com/?o=123"``.
-    :returns: The workspace id, e.g. ``"123"``, or ``None`` when absent.
-    """
-    from urllib.parse import parse_qs, urlsplit
-
-    values = parse_qs(urlsplit(url).query).get("o")
-    return values[0] if values and values[0] else None
 
 
 def _host_with_org(workspace_host: str, org_id: str | None) -> str:
@@ -11175,7 +11222,10 @@ def _databricks_login(server: str, workspace_host: str, org_id: str | None = Non
         databricks_sdk_installed,
     )
 
-    click.echo(f"{server} authenticates via the Databricks workspace {workspace_host}.")
+    # User-facing: the display form (workspace /omnigent URL with ?o= when
+    # known) — the API mount is an implementation detail.
+    display = ServerUrl(api_base=server, org_id=org_id).display
+    click.echo(f"{display} authenticates via the Databricks workspace {workspace_host}.")
 
     if not databricks_sdk_installed():
         raise click.ClickException(
@@ -11201,14 +11251,14 @@ def _databricks_login(server: str, workspace_host: str, org_id: str | None = Non
         # validated against the issuer). One fresh browser login
         # replaces the bad cache entry; then re-verify.
         click.echo(
-            f"The cached Databricks credentials were rejected by {server} "
+            f"The cached Databricks credentials were rejected by {display} "
             f"(HTTP {verify.status_code}) — refreshing the workspace login."
         )
         token = _login_and_mint_workspace_token(workspace_host, org_id)
         verify = _verify_databricks_server_token(server, token, org_id)
     if verify.status_code != 200:
         raise click.ClickException(
-            f"{workspace_host} accepted the login, but {server} rejected the token "
+            f"{workspace_host} accepted the login, but {display} rejected the token "
             f"(HTTP {verify.status_code}). Check that your user has access to this app."
         )
     user_id: str | None = None
@@ -11229,7 +11279,7 @@ def _databricks_login(server: str, workspace_host: str, org_id: str | None = Non
     )
     who = f" as {user_id}" if user_id else ""
     click.echo(
-        f"Logged in{who}. Commands targeting {server} now mint workspace tokens automatically."
+        f"Logged in{who}. Commands targeting {display} now mint workspace tokens automatically."
     )
 
 
@@ -11369,11 +11419,14 @@ def _remember_default_server(server: str) -> None:
     rare, and the server the user most recently logged in to is the best
     available signal of intent.
 
-    :param server: Normalized server URL the login succeeded against, e.g.
-        ``"https://example.databricks.com/api/2.0/omnigent"``.
+    :param server: Normalized API base URL the login succeeded against, e.g.
+        ``"https://example.databricks.com/api/2.0/omnigent"``. Stored as-is
+        (the wire form); the confirmation shows the display form.
     """
+    from omnigent.server_url import display_server_url
+
     _save_global_config({"server": server})
-    click.echo(f"Set {server} as your default server.")
+    click.echo(f"Set {display_server_url(server)} as your default server.")
 
 
 @cli.command("login")
@@ -11419,10 +11472,11 @@ def login(server_url: str) -> None:
     """
     import httpx as _httpx
 
-    server = _resolve_server_url(server_url)
-    # Read the ``?o=`` selector from the raw input: normalization strips the
-    # query when expanding to the API mount.
-    org_id = _org_id_from_url(server_url)
+    resolved = _resolve_server_url(server_url)
+    server = resolved.api_base
+    # The ``?o=`` selector rides on the resolved value (read off the raw
+    # input; normalization strips the query when expanding to the API mount).
+    org_id = resolved.org_id
 
     # ── Step 0: Probe the server's auth mode. ──────────────────
     # /v1/me returns a JSON ``login_url`` on 401 — "/login" for

--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -26,10 +26,11 @@ import os
 import stat
 import tempfile
 import time
-import urllib.parse
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from omnigent.server_url import is_workspace_hosted_url
 
 if TYPE_CHECKING:
     import httpx
@@ -542,28 +543,6 @@ DATABRICKS_ORG_ID_HEADER = "X-Databricks-Org-Id"
 # one replica when they carry the same key (the host_id). Omitted for an
 # unsharded / single-replica deployment, which needs no sticky routing.
 OMNIGENT_SLICE_KEY_HEADER = "X-Databricks-Omnigent-Slice-Key"
-
-# A host-sharded deployment mounts the API at this path; an unsharded /
-# single-replica server mounts elsewhere (usually the root). This is the
-# routing-relevant shape of a server URL, so it lives here next to the
-# request-header builder that keys off it (rather than in the browser-link
-# helpers, which only borrow it).
-WORKSPACE_API_PATH = "/api/2.0/omnigent"
-
-
-def is_workspace_hosted_url(base_url: str) -> bool:
-    """Whether *base_url* is a host-sharded deployment mount.
-
-    True for the host-sharded mount (``https://<host>/api/2.0/omnigent``), which
-    is the only deployment fronted by the sharding layer. Used to gate behavior
-    that only applies there (see :func:`databricks_request_headers`).
-
-    :param base_url: Omnigent server base URL, e.g.
-        ``"https://example.databricks.com/api/2.0/omnigent"``.
-    :returns: ``True`` when the URL path is the workspace API mount.
-    """
-    return urllib.parse.urlsplit(base_url.rstrip("/")).path == WORKSPACE_API_PATH
-
 
 # Opaque extra request headers for dev/test: a JSON object of header name→value
 # in :data:`DATABRICKS_EXTRA_HEADERS_ENV_VAR`. Databricks deployments use it to

--- a/omnigent/cli_sandbox.py
+++ b/omnigent/cli_sandbox.py
@@ -146,8 +146,12 @@ def _print_ready_banner(provider: str, sandbox_id: str, server_url: str) -> None
     ui.console.print()
     ui.success("Sandbox ready.")
     ui.console.print()
+    from omnigent.server_url import display_server_url
+
     ui.kv("Sandbox", f"{sandbox_id}  (provider: {provider})")
-    ui.kv("Server", server_url)
+    # Display form (workspace /omnigent URL); the suggested command below
+    # keeps the wire URL — both round-trip, but the command is what runs.
+    ui.kv("Server", display_server_url(server_url))
     ui.console.print()
     click.echo("To register the sandbox as a host with your server:")
     click.echo(

--- a/omnigent/conversation_browser.py
+++ b/omnigent/conversation_browser.py
@@ -9,13 +9,10 @@ import urllib.parse
 import webbrowser
 from collections.abc import Callable
 
-# The workspace-hosted API mount (routing-relevant shape) lives in cli_auth
-# next to the header builder that keys off it; the browser-link helpers below
-# only need it to map the API base onto the UI mount. The UI mount is a
-# browser-link concern, so it stays here.
-from omnigent.cli_auth import WORKSPACE_API_PATH
-
-WORKSPACE_UI_PATH = "/omnigent"
+# The server-URL shape (API mount, UI mount, display mapping) lives in
+# ``omnigent.server_url`` — the one representation of a server URL. The
+# helpers below only borrow it to build browser links.
+from omnigent.server_url import WORKSPACE_UI_PATH, ServerUrl
 
 # Client-side SPA route for one conversation (see web/src/App.tsx's
 # ``c/:conversationId``). ``conversation_url`` appends it; ``strip_conversation_path``
@@ -50,32 +47,6 @@ def strip_conversation_path(url: str) -> str:
     )
 
 
-def display_server_url(base_url: str) -> str:
-    """
-    Map an Omnigent server base URL to the user-facing form to show.
-
-    Databricks workspace-hosted servers are connected to on the API proxy
-    mount (``https://<ws>/api/2.0/omnigent``), but the URL a user
-    recognizes — and that the web UI lives on — is the workspace SPA mount
-    (``https://<ws>/omnigent``). Rewrites the API path to the UI path for
-    those (dropping any ``?o=<org>`` query), so the startup banner shows
-    the clean ``/omnigent`` URL instead of the internal API path. Every
-    other URL (local ``http://127.0.0.1:<port>``, a custom remote) is
-    returned unchanged apart from a trailing-slash trim.
-
-    :param base_url: Omnigent server base URL, e.g.
-        ``"https://example.databricks.com/api/2.0/omnigent"`` or
-        ``"http://127.0.0.1:6767"``.
-    :returns: The display URL, e.g.
-        ``"https://example.databricks.com/omnigent"`` or
-        ``"http://127.0.0.1:6767"``.
-    """
-    parsed = urllib.parse.urlsplit(base_url.rstrip("/"))
-    if parsed.path == WORKSPACE_API_PATH:
-        return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, WORKSPACE_UI_PATH, "", ""))
-    return base_url.rstrip("/")
-
-
 def conversation_url(base_url: str, conversation_id: str) -> str:
     """
     Build the browser URL for an Omnigent conversation.
@@ -92,17 +63,15 @@ def conversation_url(base_url: str, conversation_id: str) -> str:
     :returns: Browser URL, e.g. ``"http://127.0.0.1:6767/c/conv_abc123"``.
     """
     encoded_id = urllib.parse.quote(conversation_id, safe="")
-    parsed = urllib.parse.urlsplit(base_url.rstrip("/"))
-    if parsed.path == WORKSPACE_API_PATH:
-        from omnigent.cli_auth import load_databricks_org_id
-
-        org_id = load_databricks_org_id(base_url)
+    server = ServerUrl.from_api_base(base_url)
+    if server.is_workspace_hosted:
+        parsed = urllib.parse.urlsplit(server.api_base)
         return urllib.parse.urlunsplit(
             (
                 parsed.scheme,
                 parsed.netloc,
                 f"{WORKSPACE_UI_PATH}/c/{encoded_id}",
-                urllib.parse.urlencode({"o": org_id}) if org_id else "",
+                urllib.parse.urlencode({"o": server.org_id}) if server.org_id else "",
                 "",
             )
         )

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1196,6 +1196,20 @@ class HostProcess:
         host_part = base.split("://", 1)[1] if "://" in base else base
         return f"{scheme}://{host_part}/v1/hosts/{self._identity.host_id}/tunnel"
 
+    def _login_hint_url(self) -> str:
+        """The server URL to show in ``omnigent login`` remedy hints.
+
+        The display form (the workspace ``/omnigent`` URL with ``?o=``
+        when known) rather than the internal API mount — it reads right
+        and round-trips through ``omnigent login`` to the same server.
+
+        :returns: The display URL, e.g.
+            ``"https://ws.databricks.com/omnigent?o=123"``.
+        """
+        from omnigent.server_url import display_server_url
+
+        return display_server_url(self._server_url)
+
     def _credentials_fix_hint(self) -> str:
         """Build the remedy for a credential failure.
 
@@ -1205,7 +1219,7 @@ class HostProcess:
             command, e.g. ``"Run `omnigent login <url>` ..."``.
         """
         return (
-            f"Run `omnigent login {self._server_url}` to authenticate (it "
+            f"Run `omnigent login {self._login_hint_url()}` to authenticate (it "
             "detects Databricks-fronted servers and logs in to the right "
             "workspace), or check your ambient Databricks credentials."
         )
@@ -1227,7 +1241,7 @@ class HostProcess:
         """
         return (
             "If this server uses Omnigent accounts or OIDC login, run "
-            f"`omnigent login {self._server_url}` to authenticate."
+            f"`omnigent login {self._login_hint_url()}` to authenticate."
         )
 
     def _fatal_upgrade_error(self, exc: InvalidURI | InvalidStatus) -> HostConnectError | None:
@@ -1326,7 +1340,7 @@ class HostProcess:
                         f"{self._auth_retry_streak} times in a row — this is no "
                         "longer a transient network blip. If it persists, the "
                         "stored credential is likely no longer valid: run "
-                        f"`omnigent login {self._server_url}` and restart the "
+                        f"`omnigent login {self._login_hint_url()}` and restart the "
                         "host. Still retrying."
                     )
                     _logger.warning("%s", escalated)
@@ -1361,11 +1375,12 @@ class HostProcess:
             from omnigent.cli_auth import stored_token_status
 
             if stored_token_status(self._server_url) == "expired":
+                login_url = self._login_hint_url()
                 return HostConnectError(
                     "Connection refused (HTTP 403): your stored login "
-                    f"session for {self._server_url} has EXPIRED, so the "
+                    f"session for {login_url} has EXPIRED, so the "
                     "tunnel was dialed without credentials. Run `omnigent "
-                    f"login {self._server_url}` to re-authenticate, then "
+                    f"login {login_url}` to re-authenticate, then "
                     "restart the host."
                 )
             return HostConnectError(
@@ -3599,7 +3614,13 @@ def run_host_process(
     identity = load_or_create_host_identity(path)
     if not path.exists():
         print(f"Auto-generated {path} ({identity.host_id}, name: {identity.name})")
-    print(f"Connecting to {server_url} as {identity.name!r} ({identity.host_id})")
+    # User-facing: the display form (workspace /omnigent URL with ?o= when
+    # known) — the API mount is an implementation detail.
+    from omnigent.server_url import display_server_url
+
+    print(
+        f"Connecting to {display_server_url(server_url)} as {identity.name!r} ({identity.host_id})"
+    )
     # Tell the user where logs land up front — `omnigent host` used to run
     # silently, so a stuck/quiet host gave no hint where to look. Session
     # work goes to per-runner files under the runner dir (the exact
@@ -3625,5 +3646,9 @@ def run_host_process(
         # instead of the old behavior of reconnecting silently forever.
         # The dedicated code (not a bare 1) tells a supervisor this can never
         # succeed, so it stops retrying instead of looping on a bad credential.
-        print(f"\n✗ Could not connect to {server_url}.\n{exc}", file=sys.stderr, flush=True)
+        print(
+            f"\n✗ Could not connect to {display_server_url(server_url)}.\n{exc}",
+            file=sys.stderr,
+            flush=True,
+        )
         raise SystemExit(HOST_FATAL_EXIT_CODE) from exc

--- a/omnigent/onboarding/sandboxes/bootstrap.py
+++ b/omnigent/onboarding/sandboxes/bootstrap.py
@@ -504,7 +504,9 @@ def login_app_oauth_in_sandbox(
             "The in-sandbox login needs the server URL — pass --server, or --no-auth to skip."
         )
 
-    click.echo(f"▸ Logging sandbox '{sandbox_id}' in to {server_url}")
+    from omnigent.server_url import display_server_url
+
+    click.echo(f"▸ Logging sandbox '{sandbox_id}' in to {display_server_url(server_url)}")
     if workspace is not None:
         # Reset ~/.databrickscfg to exactly one [DEFAULT] entry shaped
         # like what `databricks auth login` itself writes (host +
@@ -669,7 +671,12 @@ def connect_sandbox_host(
         config.yaml (usually ``socket.gethostname()``).
     :raises click.ClickException: If the remote command exits non-zero.
     """
-    click.echo(f"▸ Registering sandbox '{sandbox_id}' as a host with {server_url}")
+    from omnigent.server_url import display_server_url
+
+    click.echo(
+        f"▸ Registering sandbox '{sandbox_id}' as a host with {display_server_url(server_url)}"
+    )
+    # The executed command keeps the wire URL — it must work verbatim in-sandbox.
     if host_name is not None:
         set_sandbox_host_name(launcher, sandbox_id, host_name)
     click.echo("  → running `omnigent host` in the sandbox (Ctrl-C to detach)")

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -493,9 +493,8 @@ def _render_startup_banner_ansi(
         ``None`` for the minimal banner.
     :returns: ANSI-styled string ready to be written to stdout.
     """
-    from omnigent.cli_auth import is_workspace_hosted_url
-    from omnigent.conversation_browser import display_server_url
     from omnigent.inner.banner import BannerLine, startup_banner_strings
+    from omnigent.server_url import display_server_url, is_workspace_hosted_url
 
     remote = _is_remote_server_url(server_url)
     # User-facing form of the URL: a Databricks workspace-hosted server is
@@ -4513,7 +4512,7 @@ async def run_repl(
         #   - the server is a Databricks workspace mount — a workspace build
         #     reports no meaningful version string (its /api/version returns a
         #     placeholder like "source"), so showing it is noise.
-        from omnigent.cli_auth import is_workspace_hosted_url
+        from omnigent.server_url import is_workspace_hosted_url
 
         _show_version = _header is not None and not (
             server_url is not None and is_workspace_hosted_url(server_url)

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -429,12 +429,17 @@ async def serve_tunnel(
                 # fresh token each attempt, so the session survives
                 # once credentials become valid again.
                 if not ever_connected and login_redirect_streak >= _LOGIN_REDIRECT_FATAL_ATTEMPTS:
+                    # Show the display form (workspace /omnigent URL, ?o=
+                    # when known), not the internal API mount; it round-trips
+                    # through `omnigent login` to the same server.
+                    from omnigent.server_url import display_server_url
+
                     raise RuntimeError(
                         f"{RUNNER_TUNNEL_REJECTION_PREFIX}"
                         f"(redirect to non-WebSocket URL {redirect_url} "
                         f"persisted across {login_redirect_streak} attempts); "
                         "the server likely requires auth — "
-                        f"run `omnigent login {server_url}` or "
+                        f"run `omnigent login {display_server_url(server_url)}` or "
                         "`omnigent setup` to configure credentials"
                     ) from exc
                 retry_reason = (
@@ -449,11 +454,20 @@ async def serve_tunnel(
                         not ever_connected
                         and http_auth_rejection_streak >= _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS
                     ):
-                        login_hint = (
-                            f"run `databricks auth login --host {server_url}` to re-authenticate"
-                            if server_url
-                            else "check remote server authentication"
-                        )
+                        if server_url:
+                            # `omnigent login` detects the fronting workspace
+                            # itself — unlike a raw `databricks auth login
+                            # --host`, which would need the workspace host,
+                            # not the server URL (for workspace-hosted
+                            # servers the API mount is the wrong --host).
+                            from omnigent.server_url import display_server_url
+
+                            login_hint = (
+                                f"run `omnigent login {display_server_url(server_url)}` "
+                                "to re-authenticate"
+                            )
+                        else:
+                            login_hint = "check remote server authentication"
                         raise RuntimeError(
                             f"{RUNNER_TUNNEL_REJECTION_PREFIX}"
                             f"(HTTP {http_status} persisted across "

--- a/omnigent/server_url.py
+++ b/omnigent/server_url.py
@@ -1,0 +1,182 @@
+"""The one representation of an Omnigent server URL.
+
+An Omnigent server is addressed by two related but distinct URLs:
+
+- the **API base** — what requests are sent to. For a Databricks
+  workspace-hosted deployment this is the API proxy mount
+  (``https://<ws>/api/2.0/omnigent``), an implementation detail.
+- the **display URL** — what the user recognizes and what messages,
+  login hints, and browser opens should show. For workspace-hosted
+  deployments this is the workspace SPA mount (``https://<ws>/omnigent``),
+  carrying the ``?o=<org>`` workspace selector when one is known so a
+  copy-pasted URL still routes to the right workspace on a
+  multi-workspace (SPOG) host.
+
+:class:`ServerUrl` binds the two together with the org id, so callers
+never rebuild either form ad hoc: wire traffic uses
+:attr:`ServerUrl.api_base`, anything user-facing uses
+:attr:`ServerUrl.display`.
+"""
+
+from __future__ import annotations
+
+import urllib.parse
+from dataclasses import dataclass
+
+# A host-sharded Databricks deployment mounts the API at this path; an
+# unsharded / single-replica server mounts elsewhere (usually the root).
+# This is the routing-relevant shape of a server URL (see
+# ``omnigent.cli_auth.databricks_request_headers``, which keys off it).
+WORKSPACE_API_PATH = "/api/2.0/omnigent"
+
+# The workspace SPA mount the web UI lives on — the URL shape users
+# recognize for a workspace-hosted deployment.
+WORKSPACE_UI_PATH = "/omnigent"
+
+
+def is_workspace_hosted_url(base_url: str) -> bool:
+    """Whether *base_url* is a host-sharded deployment mount.
+
+    True for the host-sharded mount (``https://<host>/api/2.0/omnigent``), which
+    is the only deployment fronted by the sharding layer. Used to gate behavior
+    that only applies there (see
+    :func:`omnigent.cli_auth.databricks_request_headers`).
+
+    :param base_url: Omnigent server base URL, e.g.
+        ``"https://example.databricks.com/api/2.0/omnigent"``.
+    :returns: ``True`` when the URL path is the workspace API mount.
+    """
+    return urllib.parse.urlsplit(base_url.rstrip("/")).path == WORKSPACE_API_PATH
+
+
+def org_id_from_url(url: str) -> str | None:
+    """Extract the ``?o=<workspace-id>`` workspace selector from *url*.
+
+    A Databricks host can front many workspaces under one hostname, where
+    the bare host resolves to the account and ``?o=<workspace-id>`` picks
+    the workspace. The selector is threaded into both the login (to bind
+    the grant to the workspace) and every API request (to route to it).
+
+    :param url: A user-supplied server URL, possibly carrying ``?o=``,
+        e.g. ``"https://acme.databricks.com/?o=123"``.
+    :returns: The workspace id, e.g. ``"123"``, or ``None`` when absent.
+    """
+    values = urllib.parse.parse_qs(urllib.parse.urlsplit(url).query).get("o")
+    return values[0] if values and values[0] else None
+
+
+@dataclass(frozen=True)
+class ServerUrl:
+    """An Omnigent server URL: canonical API base plus workspace selector.
+
+    Construct via :meth:`from_api_base` (which resolves the org id from
+    the URL itself or the stored login record), or directly when the org
+    id is already in hand (e.g. parsed from raw ``--server`` input).
+    """
+
+    api_base: str
+    """Canonical API base without trailing slash, query, or fragment,
+    e.g. ``"https://ws.databricks.com/api/2.0/omnigent"`` or
+    ``"http://127.0.0.1:6767"``. Every request targets this."""
+
+    org_id: str | None = None
+    """The ``?o=`` workspace selector when known, e.g. ``"123"``. Routes
+    requests and browser links on multi-workspace (SPOG) hosts."""
+
+    def __post_init__(self) -> None:
+        # Enforce the documented ``api_base`` invariant (no trailing slash,
+        # query, or fragment) on every construction path: callers append
+        # request paths to it, so a stray ``?o=`` would corrupt them
+        # (``…?o=123/v1/me``). A ``?o=`` selector on the URL becomes the org
+        # id when none was given explicitly.
+        stripped = self.api_base.rstrip("/")
+        parsed = urllib.parse.urlsplit(stripped)
+        if parsed.query or parsed.fragment:
+            if self.org_id is None:
+                object.__setattr__(self, "org_id", org_id_from_url(stripped))
+            stripped = urllib.parse.urlunsplit(
+                (parsed.scheme, parsed.netloc, parsed.path, "", "")
+            ).rstrip("/")
+        object.__setattr__(self, "api_base", stripped)
+
+    @classmethod
+    def from_api_base(cls, api_base: str) -> ServerUrl:
+        """Build a :class:`ServerUrl` from an API base string.
+
+        The org id is taken from the URL's own ``?o=`` query when present
+        (and the query is stripped off the stored base), else from the
+        ``omnigent login`` record for the base, else left unset.
+
+        :param api_base: The API base URL, possibly carrying ``?o=``, e.g.
+            ``"https://ws.databricks.com/api/2.0/omnigent?o=123"``.
+        :returns: The parsed :class:`ServerUrl`.
+        """
+        # ``__post_init__`` strips the query/fragment and absorbs a ``?o=``
+        # selector into ``org_id``; only the stored-record fallback lives here.
+        resolved = cls(api_base=api_base)
+        if resolved.org_id is not None:
+            return resolved
+        # Deferred: cli_auth imports this module's constants at load time.
+        from omnigent.cli_auth import load_databricks_org_id
+
+        return cls(
+            api_base=resolved.api_base,
+            org_id=load_databricks_org_id(resolved.api_base),
+        )
+
+    @property
+    def is_workspace_hosted(self) -> bool:
+        """Whether this server is a Databricks workspace-hosted mount."""
+        return is_workspace_hosted_url(self.api_base)
+
+    @property
+    def workspace_host(self) -> str | None:
+        """The fronting workspace origin for a workspace-hosted server.
+
+        :returns: e.g. ``"https://ws.databricks.com"``, or ``None`` when
+            this server is not workspace-hosted.
+        """
+        if not self.is_workspace_hosted:
+            return None
+        parsed = urllib.parse.urlsplit(self.api_base)
+        return f"{parsed.scheme}://{parsed.netloc}"
+
+    @property
+    def display(self) -> str:
+        """The user-facing form of this server URL.
+
+        Workspace-hosted servers show the SPA mount the user recognizes
+        (``https://<ws>/omnigent``) instead of the internal API proxy
+        path, with ``?o=<org>`` appended when the selector is known — so
+        the URL both reads right and, when copy-pasted (into a browser or
+        ``omnigent login``), still routes to the right workspace. Every
+        other URL is shown as-is.
+
+        :returns: e.g. ``"https://ws.databricks.com/omnigent?o=123"`` or
+            ``"http://127.0.0.1:6767"``.
+        """
+        if not self.is_workspace_hosted:
+            return self.api_base
+        parsed = urllib.parse.urlsplit(self.api_base)
+        query = urllib.parse.urlencode({"o": self.org_id}) if self.org_id else ""
+        return urllib.parse.urlunsplit(
+            (parsed.scheme, parsed.netloc, WORKSPACE_UI_PATH, query, "")
+        )
+
+
+def display_server_url(base_url: str) -> str:
+    """Map an Omnigent server base URL to the user-facing form to show.
+
+    Convenience wrapper over :attr:`ServerUrl.display` for call sites that
+    hold a plain API-base string: the org id is resolved from the URL's
+    own ``?o=`` query or the stored ``omnigent login`` record (see
+    :meth:`ServerUrl.from_api_base`).
+
+    :param base_url: Omnigent server base URL, e.g.
+        ``"https://example.databricks.com/api/2.0/omnigent"`` or
+        ``"http://127.0.0.1:6767"``.
+    :returns: The display URL, e.g.
+        ``"https://example.databricks.com/omnigent?o=123"`` or
+        ``"http://127.0.0.1:6767"``.
+    """
+    return ServerUrl.from_api_base(base_url).display

--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -487,9 +487,12 @@ def test_login_threads_org_id_through_workspace_login_and_verify(
     # The verify request routes to the workspace via ?o= (and used the token).
     assert fake.requests[-1]["params"] == {"o": _ORG_ID}
     assert fake.requests[-1]["authorization"] == "Bearer tok-fresh"
-    # The selector is persisted (from the URL, authoritative over any header).
-    assert load_databricks_org_id(_SELECTOR_URL) == _ORG_ID
-    assert load_databricks_workspace_host(_SELECTOR_URL) == _WORKSPACE
+    # The selector is persisted (from the URL, authoritative over any header),
+    # keyed by the canonical query-free base — ``ServerUrl`` never lets ``?o=``
+    # onto ``api_base``, so the store key is the bare host even though the
+    # identity-patched expansion above didn't strip the query itself.
+    assert load_databricks_org_id(_WORKSPACE) == _ORG_ID
+    assert load_databricks_workspace_host(_WORKSPACE) == _WORKSPACE
 
 
 # ── login sets the default server ───────────────────────────────────
@@ -683,7 +686,9 @@ def test_azure_vanity_url_falls_back_to_probed_canonical_host(
 
     result = cli_mod._resolve_server_url(f"{vanity_root}/?o=4173618801742158")
 
-    assert result == f"{canonical_root}/api/2.0/omnigent"
+    assert result.api_base == f"{canonical_root}/api/2.0/omnigent"
+    # The ?o= selector rides on the resolved value even though the probes strip it.
+    assert result.org_id == "4173618801742158"
     # The vanity root is probed first and the canonical host only after it fails.
     assert probed[0] == f"{vanity_root}/v1/me"
     assert f"{canonical_root}/v1/me" in probed
@@ -701,7 +706,7 @@ def test_azure_vanity_url_that_answers_is_never_rewritten(
 
     result = cli_mod._resolve_server_url(f"{vanity_root}/?o=4173618801742158")
 
-    assert result == vanity_root
+    assert result.api_base == vanity_root
     # No canonical host was ever synthesized or probed. The vanity root is asked
     # twice: once by the expansion, once by the usable check, which is the cost of
     # the expansion not reporting whether the URL it returned actually answered.
@@ -725,7 +730,7 @@ def test_azure_vanity_url_kept_when_canonical_host_is_dead(
 
     result = cli_mod._resolve_server_url(f"{vanity_root}/?o=4173618801742158")
 
-    assert result == vanity_root
+    assert result.api_base == vanity_root
     assert f"{canonical_root}/v1/me" in probed
 
 
@@ -1041,8 +1046,11 @@ def test_resolve_server_url_defaults_scheme_and_expands(
         },
     )
 
-    assert cli_mod._resolve_server_url("example.databricks.com") == _WORKSPACE_API_URL
-    assert cli_mod._resolve_server_url("example.databricks.com/omnigent") == _WORKSPACE_API_URL
+    assert cli_mod._resolve_server_url("example.databricks.com").api_base == _WORKSPACE_API_URL
+    assert (
+        cli_mod._resolve_server_url("example.databricks.com/omnigent").api_base
+        == _WORKSPACE_API_URL
+    )
 
 
 def test_resolve_server_url_strips_query_and_expands(
@@ -1066,7 +1074,9 @@ def test_resolve_server_url_strips_query_and_expands(
         },
     )
 
-    assert cli_mod._resolve_server_url(f"{_WORKSPACE}/?o=2850744067564480") == _WORKSPACE_API_URL
+    resolved = cli_mod._resolve_server_url(f"{_WORKSPACE}/?o=2850744067564480")
+    assert resolved.api_base == _WORKSPACE_API_URL
+    assert resolved.org_id == "2850744067564480"
     # The probes hit the CLEAN root/mount — never a ?o=-corrupted URL (which
     # would push the path into the query string, e.g. ``…/?o=123/v1/me``).
     assert probed and all("o=" not in url and "%2F" not in url for url in probed)
@@ -1082,10 +1092,9 @@ def test_resolve_server_url_strips_query_on_full_mount(
     """
     probed = _scripted_normalizer_httpx(monkeypatch, {})  # any probe fails the test
 
-    assert (
-        cli_mod._resolve_server_url(f"{_WORKSPACE_API_URL}?o=2850744067564480")
-        == _WORKSPACE_API_URL
-    )
+    resolved = cli_mod._resolve_server_url(f"{_WORKSPACE_API_URL}?o=2850744067564480")
+    assert resolved.api_base == _WORKSPACE_API_URL
+    assert resolved.org_id == "2850744067564480"
     assert probed == []
 
 

--- a/tests/test_conversation_browser.py
+++ b/tests/test_conversation_browser.py
@@ -9,69 +9,6 @@ import pytest
 import omnigent.conversation_browser as browser
 
 
-@pytest.mark.parametrize(
-    "url,expected",
-    [
-        # Databricks workspace API mount → the recognizable /omnigent SPA URL.
-        (
-            "https://e2-dogfood.staging.cloud.databricks.com/api/2.0/omnigent",
-            "https://e2-dogfood.staging.cloud.databricks.com/omnigent",
-        ),
-        # A trailing ``?o=<org>`` selector on the API base is dropped.
-        (
-            "https://ws.databricks.com/api/2.0/omnigent?o=123",
-            "https://ws.databricks.com/omnigent",
-        ),
-        # Trailing slash on the API mount still maps cleanly.
-        (
-            "https://ws.databricks.com/api/2.0/omnigent/",
-            "https://ws.databricks.com/omnigent",
-        ),
-        # Non-Databricks URLs pass through unchanged (sans trailing slash).
-        ("http://127.0.0.1:6767", "http://127.0.0.1:6767"),
-        ("https://omnigent-02m5.onrender.com/", "https://omnigent-02m5.onrender.com"),
-    ],
-)
-def test_display_server_url_maps_databricks_api_mount(url: str, expected: str) -> None:
-    """
-    ``display_server_url`` rewrites the Databricks API mount to the SPA URL.
-
-    What this proves: the startup banner shows the workspace ``/omnigent``
-    URL a user recognizes instead of the internal ``/api/2.0/omnigent``
-    proxy path, while every other target is shown verbatim. A regression
-    that stopped mapping would leak the API path back into the banner.
-
-    :returns: None.
-    """
-    assert browser.display_server_url(url) == expected
-
-
-@pytest.mark.parametrize(
-    "url,expected",
-    [
-        ("https://ws.databricks.com/api/2.0/omnigent", True),
-        ("https://ws.databricks.com/api/2.0/omnigent/", True),
-        ("https://ws.databricks.com/omnigent", False),  # the SPA URL, not the API mount
-        ("http://127.0.0.1:6767", False),
-        ("https://omnigent-02m5.onrender.com", False),
-    ],
-)
-def test_is_workspace_hosted_url(url: str, expected: bool) -> None:
-    """
-    ``is_workspace_hosted_url`` is true only for the workspace API mount.
-
-    What this proves: the predicate the banner uses to suppress the
-    server-version row fires for ``/api/2.0/omnigent`` and nothing else, so
-    non-Databricks targets keep showing their version. (Now defined in
-    ``cli_auth`` next to the header builder that gates on it.)
-
-    :returns: None.
-    """
-    from omnigent.cli_auth import is_workspace_hosted_url
-
-    assert is_workspace_hosted_url(url) is expected
-
-
 def test_conversation_url_quotes_session_id() -> None:
     """
     Conversation URLs percent-encode ids before appending them to the base URL.

--- a/tests/test_server_url.py
+++ b/tests/test_server_url.py
@@ -1,0 +1,208 @@
+"""Tests for the :class:`omnigent.server_url.ServerUrl` value type.
+
+The one representation of an Omnigent server URL: requests target
+``api_base``, user-facing messages show ``display``. These tests pin the
+mapping between the two and the ``?o=`` (SPOG workspace selector)
+threading, so a regression can't leak the internal API mount back into
+user-facing text or drop the selector from copy-pasteable URLs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.server_url import (
+    ServerUrl,
+    display_server_url,
+    is_workspace_hosted_url,
+    org_id_from_url,
+)
+
+_WORKSPACE_API = "https://ws.databricks.com/api/2.0/omnigent"
+
+
+def test_api_base_is_normalized() -> None:
+    """A trailing slash is trimmed so equality and store keys are stable."""
+    assert ServerUrl(f"{_WORKSPACE_API}/").api_base == _WORKSPACE_API
+
+
+def test_direct_construction_strips_query_into_org_id() -> None:
+    """``api_base`` never carries a query — callers append request paths to it.
+
+    A ``?o=`` slipped into a direct construction becomes the org id instead of
+    corrupting later ``f"{api_base}/v1/…"`` URLs; an explicitly passed org id
+    wins over the URL's own selector.
+    """
+    absorbed = ServerUrl(f"{_WORKSPACE_API}?o=123")
+    assert absorbed.api_base == _WORKSPACE_API
+    assert absorbed.org_id == "123"
+
+    explicit = ServerUrl(f"{_WORKSPACE_API}?o=123", org_id="456")
+    assert explicit.api_base == _WORKSPACE_API
+    assert explicit.org_id == "456"
+
+
+@pytest.mark.parametrize(
+    "api_base,org_id,expected",
+    [
+        # Workspace-hosted: the UI mount the user recognizes, with the
+        # selector when known so a copy-paste routes to the right workspace.
+        (_WORKSPACE_API, "123", "https://ws.databricks.com/omnigent?o=123"),
+        (_WORKSPACE_API, None, "https://ws.databricks.com/omnigent"),
+        # Everything else is shown as-is — including Databricks Apps hosts,
+        # whose URL carries no internal path to hide.
+        ("http://127.0.0.1:6767", None, "http://127.0.0.1:6767"),
+        (
+            "https://myapp-123.aws.databricksapps.com",
+            "123",
+            "https://myapp-123.aws.databricksapps.com",
+        ),
+    ],
+)
+def test_display(api_base: str, org_id: str | None, expected: str) -> None:
+    """``display`` hides the API mount and carries ``?o=`` when known."""
+    assert ServerUrl(api_base, org_id=org_id).display == expected
+
+
+def test_workspace_host() -> None:
+    """The fronting workspace origin resolves only for workspace mounts."""
+    assert ServerUrl(_WORKSPACE_API).workspace_host == "https://ws.databricks.com"
+    assert ServerUrl("http://127.0.0.1:6767").workspace_host is None
+
+
+def test_from_api_base_prefers_url_selector_over_store(tmp_path, monkeypatch) -> None:
+    """A ``?o=`` on the URL itself wins; the query is stripped off api_base.
+
+    The explicit selector is the user's freshest intent — a stale stored
+    record must not override it, and the wire base must stay query-free
+    (callers append paths like ``/v1/me``).
+    """
+    from omnigent.cli_auth import store_databricks_auth
+
+    monkeypatch.setattr(
+        "omnigent.cli_auth._token_file_path",
+        lambda: tmp_path / "auth_tokens.json",
+    )
+    store_databricks_auth(_WORKSPACE_API, "https://ws.databricks.com", org_id="999")
+
+    resolved = ServerUrl.from_api_base(f"{_WORKSPACE_API}?o=123")
+
+    assert resolved.api_base == _WORKSPACE_API
+    assert resolved.org_id == "123"
+
+
+def test_from_api_base_falls_back_to_login_record(tmp_path, monkeypatch) -> None:
+    """Without a URL selector, the ``omnigent login`` record supplies it."""
+    from omnigent.cli_auth import store_databricks_auth
+
+    monkeypatch.setattr(
+        "omnigent.cli_auth._token_file_path",
+        lambda: tmp_path / "auth_tokens.json",
+    )
+    store_databricks_auth(_WORKSPACE_API, "https://ws.databricks.com", org_id="999")
+
+    resolved = ServerUrl.from_api_base(_WORKSPACE_API)
+
+    assert resolved.org_id == "999"
+    assert resolved.display == "https://ws.databricks.com/omnigent?o=999"
+
+
+def test_display_round_trips_through_login_resolution(monkeypatch) -> None:
+    """The display URL, pasted into ``omnigent login``, resolves back.
+
+    The whole point of showing ``https://<ws>/omnigent?o=<org>`` in
+    messages and login hints is that copy-pasting it reaches the same
+    server: the resolver expands the UI mount back to the API base and
+    recaptures the selector.
+    """
+    import omnigent.cli as cli_mod
+
+    def fake_get(url: str, **kwargs: object):
+        import httpx
+
+        request = httpx.Request("GET", url)
+        if url == "https://ws.databricks.com/v1/me":
+            return httpx.Response(404, headers={"server": "databricks"}, request=request)
+        if url == f"{_WORKSPACE_API}/v1/me":
+            return httpx.Response(
+                401,
+                headers={"www-authenticate": 'Bearer realm="DatabricksRealm"'},
+                request=request,
+            )
+        raise AssertionError(f"unexpected probe {url}")
+
+    monkeypatch.setattr("httpx.get", fake_get)
+    shown = ServerUrl(_WORKSPACE_API, org_id="123").display
+
+    resolved = cli_mod._resolve_server_url(shown)
+
+    assert resolved.api_base == _WORKSPACE_API
+    assert resolved.org_id == "123"
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://acme.databricks.com/?o=123", "123"),
+        ("https://acme.databricks.com", None),
+        ("https://acme.databricks.com/?o=", None),
+    ],
+)
+def test_org_id_from_url(url: str, expected: str | None) -> None:
+    """The ``?o=`` selector parses out of a raw URL, absent → ``None``."""
+    assert org_id_from_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        # Databricks workspace API mount → the recognizable /omnigent SPA URL.
+        (
+            "https://e2-dogfood.staging.cloud.databricks.com/api/2.0/omnigent",
+            "https://e2-dogfood.staging.cloud.databricks.com/omnigent",
+        ),
+        # A trailing ``?o=<org>`` selector on the API base is kept on the
+        # display URL so a copy-paste still routes to the right workspace.
+        (
+            "https://ws.databricks.com/api/2.0/omnigent?o=123",
+            "https://ws.databricks.com/omnigent?o=123",
+        ),
+        # Trailing slash on the API mount still maps cleanly.
+        (
+            "https://ws.databricks.com/api/2.0/omnigent/",
+            "https://ws.databricks.com/omnigent",
+        ),
+        # Non-Databricks URLs pass through unchanged (sans trailing slash).
+        ("http://127.0.0.1:6767", "http://127.0.0.1:6767"),
+        ("https://omnigent-02m5.onrender.com/", "https://omnigent-02m5.onrender.com"),
+    ],
+)
+def test_display_server_url_maps_databricks_api_mount(url: str, expected: str) -> None:
+    """The plain-string wrapper rewrites the Databricks API mount to the SPA URL.
+
+    What this proves: the startup banner shows the workspace ``/omnigent``
+    URL a user recognizes instead of the internal ``/api/2.0/omnigent``
+    proxy path, while every other target is shown verbatim. A regression
+    that stopped mapping would leak the API path back into the banner.
+    """
+    assert display_server_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://ws.databricks.com/api/2.0/omnigent", True),
+        ("https://ws.databricks.com/api/2.0/omnigent/", True),
+        ("https://ws.databricks.com/omnigent", False),  # the SPA URL, not the API mount
+        ("http://127.0.0.1:6767", False),
+        ("https://omnigent-02m5.onrender.com", False),
+    ],
+)
+def test_is_workspace_hosted_url(url: str, expected: bool) -> None:
+    """``is_workspace_hosted_url`` is true only for the workspace API mount.
+
+    What this proves: the predicate the REPL banner uses to suppress the
+    server-version row fires for ``/api/2.0/omnigent`` and nothing else, so
+    non-Databricks targets keep showing their version.
+    """
+    assert is_workspace_hosted_url(url) is expected


### PR DESCRIPTION
## Related issue

[OMNI-5488](https://linear.app/omnigent/issue/OMNI-5488/centralize-how-we-handle-omnigent-server-urls)

## Summary

Server URLs were handled ad hoc as plain strings: the internal Databricks API
mount (`/api/2.0/omnigent`) leaked into user-facing messages and `omnigent
login` hints, and the `?o=` workspace selector (SPOG routing) was parsed,
stored, and re-appended in scattered places — and silently dropped from some
copy-pasteable URLs.

- New `omnigent/server_url.py` with a frozen `ServerUrl` value type — the one
  representation of a server URL: requests target `api_base`, user-facing
  text shows `display` (the workspace `/omnigent` UI mount with `?o=<org>`
  when known, which round-trips through `omnigent login` to the same server).
  The workspace mount constants and `is_workspace_hosted_url` now live here;
  all callers import from the new module (no compat re-exports).
  `__post_init__` enforces the api_base invariant (no trailing slash,
  query, or fragment) on every construction path, absorbing a stray
  `?o=` into the org id.
- `_resolve_server_url` returns a `ServerUrl`, capturing the `?o=` selector
  off the raw input (falling back to the stored login record) instead of
  losing it during mount expansion; `login` reads the selector from the
  resolved value.
- User-facing messages and login hints ("Not signed in to …", "… authenticates
  via …", host-tunnel and runner-tunnel auth remedies, default-server
  confirmation) show the display form instead of the raw API mount.
- `omni host` banners (background `server:` row, foreground "Connecting
  to …", "already serves …") show the display form too.
- Remaining user-facing leaks converted: `omni host status` rows and
  links, host stop/restart messages, attach/chat connect errors, the
  foreground host failure banner, and sandbox onboarding echoes
  (executed commands keep the wire URL).
- Bug fix: the runner-tunnel auth-rejection hint suggested
  `databricks auth login --host <api-mount>` — the API mount is the
  wrong `--host`. It now suggests `omnigent login <display-url>`,
  which detects the fronting workspace itself.
- Bug fix: the Slack bot's "Open in Omnigent" links pointed at the
  API mount (`…/api/2.0/omnigent/c/<id>`, which answers JSON) for
  workspace-hosted servers; they now map to the `/omnigent` web UI
  and keep the configured `?o=` selector. `omni host enable` and the
  human `omnigent version` output show the display form too.
- `display_server_url` now keeps the `?o=` selector, so the web-UI open and
  startup banner route to the right workspace on multi-workspace hosts.

```
user --server input ──▶ _resolve_server_url ──▶ ServerUrl
                                                 ├─ .api_base  ─▶ requests / storage keys
                                                 └─ .display   ─▶ messages, login hints, browser
```

## Test Plan

- `uv run pytest tests/test_server_url.py tests/test_conversation_browser.py
  tests/cli/test_login_databricks.py tests/cli/test_backend.py` — all green;
  targeted `tests/host/test_connect.py -k "login or hint or auth_rejection"`.
- New `tests/test_server_url.py` pins the display mapping, `?o=` precedence
  (URL selector over stored record), and the display→login round-trip.
- `uv run pytest integrations/slack/tests/test_notifications.py` (needs
  the `slack` extra) — covers the workspace-mount web-link mapping.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

## Changelog

Messages and login hints for Databricks workspace-hosted servers now show the
`https://<workspace>/omnigent?o=<org>` URL you recognize instead of the internal
`/api/2.0/omnigent` API mount, and browser opens keep the `?o=` workspace selector.

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>








