### PR TITLE
fix(qwen): serialize stdin writes in _send

### DIFF
--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -249,6 +249,9 @@ class QwenExecutor(Executor):
 
         # Asyncio subprocess (created on first run_turn call).
         self._proc: asyncio.subprocess.Process | None = None
+        # Serializes stdin writes: run_turn (prompt / request replies) and the
+        # adapter's interrupt_session() write from different tasks.
+        self._write_lock = asyncio.Lock()
 
         # Queue fed by the stdout-reader coroutine.
         self._queue: asyncio.Queue[_AcpJsonObject] = asyncio.Queue()
@@ -551,8 +554,9 @@ class QwenExecutor(Executor):
         """Write one newline-terminated JSON message to qwen stdin."""
         assert self._proc and self._proc.stdin
         encoded = (json.dumps(msg) + "\n").encode("utf-8")
-        self._proc.stdin.write(encoded)
-        await self._proc.stdin.drain()
+        async with self._write_lock:
+            self._proc.stdin.write(encoded)
+            await self._proc.stdin.drain()
 
     async def _rpc(
         self,


### PR DESCRIPTION
## Related issue

Closes #5481

## Summary

#4877 (merged) made `interrupt_session()` send ACP `session/cancel` to the qwen subprocess's stdin via `_notify` → `_send`, which runs from a **different task** than `run_turn` (prompt / permission replies). `QwenExecutor._send` did the write + `drain()` with no lock, so the two can race — and concurrent `StreamWriter.drain()` can raise, turning a Stop click mid-turn into an unhandled error on the write path.

Polly flagged this as a blocking issue on #4877, but the PR merged before the fix landed (the fork had *Allow edits from maintainers* off, so it couldn't be pushed to that branch). This is the follow-up.

The fix mirrors the sibling `AcpExecutor`, which already serializes exactly this `run_turn`-vs-`interrupt_session` case with a `self._write_lock`:

```python
async def _send(self, msg):
    ...
    async with self._write_lock:
        self._proc.stdin.write(encoded)
        await self._proc.stdin.drain()
```

qwen-only — Devin / generic ACP already carry the lock.

<details>
<summary>ELI5</summary>

Two parts of the code can talk to qwen at the same moment: your turn (sending a prompt) and the Stop button (sending "cancel"). They were both allowed to write down the pipe at once, and Python's stream can throw if two writers flush concurrently — so a Stop click could error. The lock makes them take turns.
</details>

## Test Plan

- `ruff format --check` / `ruff check` clean; `pyrefly check --extra all` → 0 errors.
- `tests/inner/test_qwen_executor.py` → **93 passed** — the PR's own suite, confirming the lock doesn't regress the `_send` write path.

## Demo

N/A — backend concurrency fix, no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Lock-only, mirroring `AcpExecutor` — which added the same `_write_lock` without a dedicated concurrency test, so this keeps parity rather than introducing a bespoke (and easily flaky) race test. The existing 93 qwen tests exercise the `_send` write path and pass unchanged; manual verification is that suite plus `ruff`/`pyrefly`.

## Changelog

Clicking Stop during an active qwen turn no longer risks an unhandled error from a concurrent stdin write
