### PR TITLE
feat(polly-review): add pi-hosted open-weights and grok reviewers

### DIFF
--- a/.github/scripts/polly_timeline.py
+++ b/.github/scripts/polly_timeline.py
@@ -1,0 +1,211 @@
+"""Summarize where a Polly run's wall clock went, from its process logs.
+
+``omnigent run -p`` prints only the final assistant text, so the process logs
+under ``$OMNIGENT_DATA_DIR/logs`` are the only per-turn record. Rather than
+parse prose log messages (which change freely), this merges every timestamped
+log line and reports the largest gaps between consecutive lines: a long gap is
+a stall, and the lines either side of it bracket whatever was slow.
+
+One file can carry two clocks: Omnigent's formatter emits local time-only
+("02:12:55"), while httpx/stdlib lines carry a UTC date ("2026-07-14T01:12:53
++0000"). Those are offset by the machine's UTC offset, so interleaving them
+invents huge fake gaps. Each file therefore keeps only its dominant stamp
+style and reports how many lines that skipped.
+
+Usage: python polly_timeline.py <logs-dir> [top-n]
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Omnigent process logs come in three shapes, sometimes in one file:
+#   "INFO  08-26 01:20:32.625 logger func | msg"  (level first, MM-DD)
+#   "06:19:37 INFO  [logger] msg"                 (time only)
+#   "2026-07-14T01:12:53+0000 INFO:logger:msg"    (UTC, full date)
+# Each is matched separately so the day scale is never guessed.
+_LEVEL = r"(?:TRACE|DEBUG|INFO|WARN|WARNING|ERROR|CRITICAL|FATAL)"
+_FRAC = r"(?:[.,](\d{1,6}))?"
+_PATTERNS = (
+    # level, MM-DD, clock  -> day scale is month*31+day
+    ("md", re.compile(rf"^{_LEVEL}\s+(\d{{2}})-(\d{{2}})\s+(\d{{2}}):(\d{{2}}):(\d{{2}}){_FRAC}")),
+    # full ISO date -> day scale is the proleptic ordinal
+    (
+        "iso",
+        re.compile(rf"^\[?(\d{{4}})-(\d{{2}})-(\d{{2}})[T ](\d{{2}}):(\d{{2}}):(\d{{2}}){_FRAC}"),
+    ),
+    # clock only, optionally after a level -> no day scale, wrap heuristic
+    ("tod", re.compile(rf"^(?:{_LEVEL}\s+)?(\d{{2}}):(\d{{2}}):(\d{{2}}){_FRAC}")),
+)
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_DAY = 86400.0
+
+
+def _stamp(line: str) -> tuple[str, float | None, float] | None:
+    """Classify one line's timestamp.
+
+    :returns: ``(kind, day_or_None, seconds_within_day)``, or ``None`` when the
+        line carries no timestamp. ``day`` is ``None`` only for ``"tod"``.
+    """
+    text = _ANSI.sub("", line).lstrip()
+    for kind, pattern in _PATTERNS:
+        match = pattern.match(text)
+        if match is None:
+            continue
+        groups = match.groups()
+        frac = groups[-1]
+        micros = int(frac.ljust(6, "0")) / 1_000_000 if frac else 0.0
+        if kind == "md":
+            month, day, hh, mm, ss = (int(g) for g in groups[:5])
+            return kind, float(month * 31 + day), hh * 3600 + mm * 60 + ss + micros
+        if kind == "iso":
+            year, month, day, hh, mm, ss = (int(g) for g in groups[:6])
+            return (
+                kind,
+                float(datetime(year, month, day, tzinfo=timezone.utc).toordinal()),
+                (hh * 3600 + mm * 60 + ss + micros),
+            )
+        hh, mm, ss = (int(g) for g in groups[:3])
+        return kind, None, hh * 3600 + mm * 60 + ss + micros
+    return None
+
+
+def _file_events(path: Path) -> tuple[list[tuple[float, str, str]], int]:
+    """Parse one log file into (absolute_seconds, label, text) tuples.
+
+    Keeps only the file's dominant timestamp shape, so two clocks in different
+    timezones (or on different day scales) cannot invent gaps. Clock-only
+    stamps have no date, so a near-midnight backwards step is read as a wrap.
+
+    :returns: The kept events, and how many stamped lines were skipped as
+        belonging to a minority shape.
+    """
+    label = f"{path.parent.name}/{path.name}"
+    parsed: list[tuple[str, float | None, float, str]] = []
+    for raw in path.read_text(errors="replace").splitlines():
+        stamp = _stamp(raw)
+        if stamp is not None:
+            kind, day, seconds = stamp
+            parsed.append((kind, day, seconds, raw.strip()))
+    if not parsed:
+        return [], 0
+
+    counts: dict[str, int] = {}
+    for kind, _, _, _ in parsed:
+        counts[kind] = counts.get(kind, 0) + 1
+    dominant = max(counts, key=lambda kind: counts[kind])
+    kept = [(day, seconds, text) for kind, day, seconds, text in parsed if kind == dominant]
+
+    events: list[tuple[float, str, str]] = []
+    if dominant == "tod":
+        offset = 0.0
+        previous = None
+        for _, seconds, text in kept:
+            # Only a near-midnight wrap counts. Any other backwards step is
+            # out-of-order interleaving, which the sort below handles; treating
+            # it as a new day would invent a 24h gap.
+            if previous is not None and previous > 23 * 3600 and seconds < 3600:
+                offset += _DAY
+            previous = seconds
+            events.append((seconds + offset, label, text))
+    else:
+        for day, seconds, text in kept:
+            assert day is not None
+            events.append((day * _DAY + seconds, label, text))
+    return events, len(parsed) - len(kept)
+
+
+def _selftest() -> int:
+    """Assert the three stamp shapes parse and that gaps come out right."""
+    md = _stamp("INFO  08-26 01:20:32.625 logger func | msg")
+    assert md is not None and md[0] == "md", md
+    assert md[2] == 1 * 3600 + 20 * 60 + 32.625, md
+
+    tod = _stamp("06:19:37 INFO  [logger] msg")
+    assert tod is not None and tod[0] == "tod" and tod[1] is None, tod
+    assert tod[2] == 6 * 3600 + 19 * 60 + 37, tod
+
+    iso = _stamp("2026-07-14T01:12:53+0000 INFO:httpx:msg")
+    assert iso is not None and iso[0] == "iso" and iso[1] is not None, iso
+
+    assert _stamp("no timestamp here") is None
+    assert _stamp("Traceback (most recent call last):") is None
+
+    # A file mixing shapes keeps only the dominant one.
+    tmp = Path(tempfile.mkdtemp()) / "runner.log"
+    tmp.write_text(
+        "INFO  08-26 01:00:00.000 a f | one\n"
+        "INFO  08-26 01:00:05.000 a f | two\n"
+        "2026-07-14T01:12:53+0000 INFO:httpx:minority\n"
+    )
+    events, skipped = _file_events(tmp)
+    assert skipped == 1, skipped
+    assert len(events) == 2, events
+    assert events[1][0] - events[0][0] == 5.0, events
+
+    # Clock-only wrap: 23:59:59 -> 00:00:01 is 2s, not -86398s.
+    wrap = Path(tempfile.mkdtemp()) / "cli.log"
+    wrap.write_text("23:59:59 INFO  [a] late\n00:00:01 INFO  [a] early\n")
+    wrapped, _ = _file_events(wrap)
+    assert wrapped[1][0] - wrapped[0][0] == 2.0, wrapped
+    print("selftest OK")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "--selftest":
+        return _selftest()
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else ".")
+    top_n = int(sys.argv[2]) if len(sys.argv) > 2 else 25
+    files = sorted(p for p in root.rglob("*.log") if p.is_file())
+    if not files:
+        print(f"no .log files under {root}")
+        return 0
+
+    # Gaps are computed WITHIN each file. Different files can use different
+    # clocks (local time-only vs UTC-dated), so merging their timelines would
+    # compare incompatible scales; a stall shows up in whichever file was
+    # waiting, which is what we want to see anyway.
+    all_gaps: list[tuple[float, tuple[float, str, str], tuple[float, str, str]]] = []
+    total_span = 0.0
+    print(f"## {len(files)} log file(s)\n")
+    for path in files:
+        events, skipped = _file_events(path)
+        # Threads append out of order; gaps mean nothing unless chronological.
+        events.sort(key=lambda event: event[0])
+        label = f"{path.parent.name}/{path.name}"
+        note = f"  (skipped {skipped} on the minority clock)" if skipped else ""
+        span = events[-1][0] - events[0][0] if len(events) > 1 else 0.0
+        total_span = max(total_span, span)
+        size = path.stat().st_size
+        print(f"  {size:>10,}B {len(events):>6} lines {span:>9.1f}s  {label}{note}")
+        all_gaps.extend(
+            (events[i + 1][0] - events[i][0], events[i], events[i + 1])
+            for i in range(len(events) - 1)
+        )
+
+    if not all_gaps:
+        print("\nnot enough timestamped lines to build a timeline")
+        return 0
+
+    all_gaps.sort(key=lambda gap: gap[0], reverse=True)
+    shown = [gap for gap in all_gaps[:top_n] if gap[0] >= 1.0]
+    covered = sum(gap[0] for gap in shown)
+    share = 100 * covered / total_span if total_span else 0
+    print(
+        f"\n## longest file spans {total_span:.1f}s; top {len(shown)} gap(s) >=1s "
+        f"cover {covered:.1f}s ({share:.0f}% of that span)\n"
+    )
+    for secs, before, after in shown:
+        print(f"  {secs:7.1f}s gap  [{before[1]}]")
+        print(f"      before {before[2][:100]}")
+        print(f"      after  {after[2][:100]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -261,7 +261,7 @@ jobs:
           # outside the checked-out tree for the same reason as the others.
           PI_CLI_DIR="${RUNNER_TEMP}/omnigent-pi-cli"
           mkdir -p "$PI_CLI_DIR" && cd "$PI_CLI_DIR"
-          npm install --ignore-scripts --no-audit --no-fund @earendil-works/pi-coding-agent@0.84.2
+          npm install --ignore-scripts --no-audit --no-fund @earendil-works/pi-coding-agent@0.79.0
           echo "$PI_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Set LLM credentials
@@ -395,9 +395,18 @@ jobs:
           # Extra reviewers, each a `pi` dispatch pinned to one gateway model.
           # An unset variable drops that reviewer rather than naming a model the
           # deployment can't run (a bad model/worker pair fails the dispatch).
+          def _model_var(name):
+              # A gateway endpoint name only. Anything else (notably a newline or
+              # a quote) could append instructions to a prompt that runs with
+              # LLM_API_KEY in the environment.
+              value = os.environ.get(name, '').strip()
+              if value and not re.fullmatch(r'[A-Za-z0-9._-]+', value):
+                  raise SystemExit(f"{name} is not a bare model id: {value!r}")
+              return value
+
           extra_reviewers = [
-              (os.environ.get('OMNIGENT_OSS_MODEL', '').strip(), 'open-weights'),
-              (os.environ.get('OMNIGENT_GROK_MODEL', '').strip(), 'xAI'),
+              (_model_var('OMNIGENT_OSS_MODEL'), 'open-weights'),
+              (_model_var('OMNIGENT_GROK_MODEL'), 'xAI'),
           ]
           extra_reviewer_lines = "\n".join(
               f"- `pi` with `args.model: \"{model}\"` ({label})"
@@ -628,8 +637,27 @@ jobs:
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
           echo "Created new comment"
 
-      - name: Upload logs on failure
-        if: failure()
+      # Redact before upload: ``::add-mask::`` hides the key from LOGS but not
+      # from artifact files, and this repo is public.
+      - name: Redact credentials from the log
+        if: always()
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          set -euo pipefail
+          [ -f polly-stderr.log ] || exit 0
+          if [ -n "${LLM_API_KEY:-}" ]; then
+            python3 - "$LLM_API_KEY" <<'PY'
+          import pathlib, sys
+          p = pathlib.Path("polly-stderr.log")
+          p.write_text(p.read_text(errors="replace").replace(sys.argv[1], "***REDACTED***"))
+          PY
+          fi
+
+      # Uploaded on success too: ``-p`` prints only the final assistant text, so
+      # stderr is the sole record of how long each turn and sub-agent took.
+      - name: Upload logs
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: polly-review-logs-${{ github.run_id }}

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -83,7 +83,12 @@ jobs:
         github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Wall clock is set by the SLOWEST single reviewer, not by their count:
+    # measured sub-agent durations on one run were 496s / 273s / 130s / 77s for
+    # a 580s run. Observed runs have reached ~20 min, and a timeout loses the
+    # whole review (the sentinel never lands, so nothing is posted), so keep
+    # real headroom above that.
+    timeout-minutes: 45
     steps:
       - name: Validate /review command
         id: trigger

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -40,6 +40,11 @@ env:
   OMNIGENT_SKIP_WEB_UI: "true"
   UV_INDEX_URL: https://pypi.org/simple
   PIP_INDEX_URL: https://pypi.org/simple
+  # Pin the data dir into the workspace: server / runner / harness process logs
+  # land in <data-dir>/logs, and `-p` prints only the final assistant text, so
+  # these files are the only record of where a run's wall clock went.
+  OMNIGENT_DATA_DIR: ${{ github.workspace }}/.omnigent-data
+  OMNIGENT_LOG_LEVEL: DEBUG
 
 jobs:
   # Security precondition gate (security-gate.yml): untrusted PRs wait for
@@ -554,6 +559,8 @@ jobs:
           set -euo pipefail
 
           prompt=$(cat /tmp/review_prompt.txt)
+          echo "::notice::polly start $(date -u +%H:%M:%S)"
+          started=$SECONDS
 
           # Run Polly headlessly with -p; it starts a local server, sends
           # one turn, prints the assistant response, and exits.
@@ -564,6 +571,8 @@ jobs:
             2>polly-stderr.log \
             | tee /tmp/polly_output.txt \
             || { echo "::warning::Polly review exited non-zero"; cat polly-stderr.log; }
+
+          echo "::notice::polly finished in $((SECONDS - started))s"
 
           # Strip any sub-agent coordination preamble that leaks before
           # the actual review.  Primary: look for the sentinel we asked the
@@ -637,22 +646,40 @@ jobs:
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
           echo "Created new comment"
 
+      # Where the run's wall clock went. `-p` prints only the final assistant
+      # text, so the process logs are the sole per-turn record; print the
+      # biggest stalls into the step log so no artifact download is needed.
+      - name: Summarize run timeline
+        if: always()
+        run: |
+          set -euo pipefail
+          logs="${OMNIGENT_DATA_DIR}/logs"
+          [ -d "$logs" ] || { echo "no process logs at $logs"; exit 0; }
+          python3 .github/scripts/polly_timeline.py "$logs" 25 || true
+
       # Redact before upload: ``::add-mask::`` hides the key from LOGS but not
       # from artifact files, and this repo is public.
-      - name: Redact credentials from the log
+      - name: Redact credentials from the logs
         if: always()
         env:
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
           set -euo pipefail
-          [ -f polly-stderr.log ] || exit 0
-          if [ -n "${LLM_API_KEY:-}" ]; then
-            python3 - "$LLM_API_KEY" <<'PY'
-          import pathlib, sys
-          p = pathlib.Path("polly-stderr.log")
-          p.write_text(p.read_text(errors="replace").replace(sys.argv[1], "***REDACTED***"))
+          [ -n "${LLM_API_KEY:-}" ] || exit 0
+          python3 - "$LLM_API_KEY" <<'PY'
+          import os, pathlib, sys
+          key = sys.argv[1]
+          targets = [pathlib.Path("polly-stderr.log")]
+          logs = pathlib.Path(os.environ["OMNIGENT_DATA_DIR"]) / "logs"
+          targets += [p for p in logs.rglob("*.log") if p.is_file()] if logs.is_dir() else []
+          for path in targets:
+              if not path.is_file():
+                  continue
+              text = path.read_text(errors="replace")
+              if key in text:
+                  path.write_text(text.replace(key, "***REDACTED***"))
+                  print(f"redacted {path}")
           PY
-          fi
 
       # Uploaded on success too: ``-p`` prints only the final assistant text, so
       # stderr is the sole record of how long each turn and sub-agent took.
@@ -664,5 +691,7 @@ jobs:
           path: |
             polly-stderr.log
             /tmp/polly_output.txt
+            /tmp/review_prompt.txt
+            ${{ github.workspace }}/.omnigent-data/logs/
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -251,6 +251,19 @@ jobs:
           npm install --ignore-scripts --no-audit --no-fund @openai/codex@0.139.0
           echo "$CODEX_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 
+      - name: Install Pi CLI
+        if: steps.trigger.outputs.skip != 'true' && steps.creds.outputs.available == 'true'
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          # Pi is the third review vendor: unlike claude/codex it can run any
+          # gateway model, so it carries the OSS + grok reviewers. Installed
+          # outside the checked-out tree for the same reason as the others.
+          PI_CLI_DIR="${RUNNER_TEMP}/omnigent-pi-cli"
+          mkdir -p "$PI_CLI_DIR" && cd "$PI_CLI_DIR"
+          npm install --ignore-scripts --no-audit --no-fund @earendil-works/pi-coding-agent@0.84.2
+          echo "$PI_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
+
       - name: Set LLM credentials
         if: steps.trigger.outputs.skip != 'true' && steps.creds.outputs.available == 'true'
         env:
@@ -324,6 +337,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          # Extra pi-hosted reviewers. Either may be empty; the prompt then
+          # omits that reviewer instead of asking for a model that can't run.
+          OMNIGENT_OSS_MODEL: ${{ vars.OMNIGENT_CI_OSS_MODEL }}
+          OMNIGENT_GROK_MODEL: ${{ vars.OMNIGENT_CI_GROK_MODEL }}
         run: |
           set -euo pipefail
 
@@ -353,7 +370,7 @@ jobs:
           # Build the review prompt — the diff is NOT embedded in the prompt.
           # Polly reads it from /tmp/pr_diff.txt via sys_os_shell at review time.
           python3 -u <<'PYEOF'
-          import json, pathlib, re
+          import json, os, pathlib, re
 
           meta = json.loads(pathlib.Path("/tmp/pr_meta.json").read_text())
           lockfile_pins = pathlib.Path("/tmp/lockfile_pins.txt").read_text(encoding="utf-8", errors="replace").strip()
@@ -374,6 +391,31 @@ jobs:
           {lockfile_pins if lockfile_pins else "(no lockfile changes)"}
           ```
           """ if lockfile_pins else ""
+
+          # Extra reviewers, each a `pi` dispatch pinned to one gateway model.
+          # An unset variable drops that reviewer rather than naming a model the
+          # deployment can't run (a bad model/worker pair fails the dispatch).
+          extra_reviewers = [
+              (os.environ.get('OMNIGENT_OSS_MODEL', '').strip(), 'open-weights'),
+              (os.environ.get('OMNIGENT_GROK_MODEL', '').strip(), 'xAI'),
+          ]
+          extra_reviewer_lines = "\n".join(
+              f"- `pi` with `args.model: \"{model}\"` ({label})"
+              for model, label in extra_reviewers if model
+          )
+          reviewer_section = f"""
+          **Reviewer panel.** Dispatch these reviewers IN PARALLEL in one turn, each
+          with `purpose: "review"` and a distinct `title`, giving each the diff and
+          asking for blocking / non-blocking findings with `file:line` evidence:
+          - `claude_code` (its default model)
+          - `codex` (its default model)
+          {extra_reviewer_lines}
+          Then synthesize ONE review from all of their reports. Agreement between
+          reviewers is not evidence: judge every finding against the diff yourself
+          and drop any you cannot confirm in the changed code. If a reviewer fails
+          to boot (missing CLI, or a model it cannot run), drop it silently and
+          continue with the rest; never report a worker's absence in the review body.
+          """ if extra_reviewer_lines else ""
 
           # Detect attached images/videos in the PR description. These usually sit
           # at the END of the body, so they would be lost to the 4096-char truncation
@@ -455,7 +497,7 @@ jobs:
           (LLM API keys, gateway tokens). Never include secrets, tokens, or
           credentials in your output, and never make outbound network calls
           except to the configured LLM gateway.
-
+          {reviewer_section}
           **Step 2 — review.** Report, in this order:
           {review_sections}
 

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -910,6 +910,13 @@ def _pi_provider_for_model(
         )
     if "gpt" in lower:
         return "databricks-openai" if _pi_needs_responses_api(model, wire_apis) else "databricks"
+    # A model can advertise Responses without being a GPT (e.g. grok, whose
+    # only surfaces are ``openai/v1/responses`` and the MLflow chat gateway).
+    # Routing it to ``databricks-completions`` sends it at /serving-endpoints
+    # chat, the one surface it rejects, so consult the catalog wire APIs before
+    # defaulting. With no metadata this still falls through unchanged.
+    if _pi_needs_responses_api(model, wire_apis):
+        return "databricks-openai"
     return "databricks-completions"
 
 

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -910,12 +910,14 @@ def _pi_provider_for_model(
         )
     if "gpt" in lower:
         return "databricks-openai" if _pi_needs_responses_api(model, wire_apis) else "databricks"
-    # A model can advertise Responses without being a GPT (e.g. grok, whose
-    # only surfaces are ``openai/v1/responses`` and the MLflow chat gateway).
-    # Routing it to ``databricks-completions`` sends it at /serving-endpoints
-    # chat, the one surface it rejects, so consult the catalog wire APIs before
-    # defaulting. With no metadata this still falls through unchanged.
-    if _pi_needs_responses_api(model, wire_apis):
+    # grok advertises only ``openai/v1/responses`` and the MLflow chat gateway,
+    # so ``databricks-completions`` aims it at the one surface it rejects.
+    # Deliberately scoped to the grok family rather than "advertises Responses":
+    # ``_databricks_model_wire_catalog`` indexes wire metadata under BOTH the
+    # ``system.ai.*`` and ``databricks-*`` spellings, and the gateway rejects
+    # Responses for the ``databricks-*`` alias of kimi / glm / qwen3 (see
+    # ``pi_model_compatibility``), so the broader condition would misroute those.
+    if "grok" in lower and _pi_needs_responses_api(model, wire_apis):
         return "databricks-openai"
     return "databricks-completions"
 

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -411,6 +411,16 @@ class TestPiProviderForModel(unittest.TestCase):
             "databricks-completions",
         )
 
+    def test_databricks_alias_of_responses_model_stays_on_chat(self):
+        # Wire metadata is indexed under both spellings, so these aliases DO
+        # carry OPENAI_RESPONSES. The gateway still rejects Responses for the
+        # ``databricks-`` spelling ("Responses API passthrough is not supported
+        # for model databricks-kimi-k3"), so they must stay on chat.
+        both = frozenset({ModelWireAPI.OPENAI_CHAT, ModelWireAPI.OPENAI_RESPONSES})
+        for model in ("databricks-kimi-k3", "databricks-glm-5-2", "databricks-qwen3-next-80b"):
+            with self.subTest(model=model):
+                self.assertEqual(_pi_provider_for_model(model, both), "databricks-completions")
+
 
 # ---------------------------------------------------------------------------
 # _split_pi_prompt tests

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -391,6 +391,26 @@ class TestPiProviderForModel(unittest.TestCase):
             "databricks-completions",
         )
 
+    def test_catalog_responses_non_gpt_model(self):
+        # grok serves only openai/v1/responses + the MLflow chat gateway, so
+        # /serving-endpoints chat (databricks-completions) would 400.
+        self.assertEqual(
+            _pi_provider_for_model(
+                "databricks-grok-4-6",
+                frozenset({ModelWireAPI.OPENAI_CHAT, ModelWireAPI.OPENAI_RESPONSES}),
+            ),
+            "databricks-openai",
+        )
+
+    def test_catalog_chat_only_non_gpt_model(self):
+        self.assertEqual(
+            _pi_provider_for_model(
+                "databricks-kimi-k3",
+                frozenset({ModelWireAPI.OPENAI_CHAT}),
+            ),
+            "databricks-completions",
+        )
+
 
 # ---------------------------------------------------------------------------
 # _split_pi_prompt tests


### PR DESCRIPTION
## Related issue

No issue. Maintainer-authored CI capability change plus the routing fix it
depends on.

## Summary

Polly's CI review panel ran on exactly two vendors, `claude_code` and `codex`,
which is the bare minimum independent cross-vendor review needs. Lose either
one to an npm hiccup and the review cannot run at all.

- **Adds `pi` as a third review worker** (`@earendil-works/pi-coding-agent`).
  Pi is the multi-model worker, so it carries an open-weights reviewer and an
  xAI one, each pinned to one gateway model via `args.model`.
- **Gates each extra reviewer on an optional repo variable**
  (`OMNIGENT_CI_OSS_MODEL`, `OMNIGENT_CI_GROK_MODEL`). An unset variable drops
  that reviewer rather than asking Polly for a model the deployment cannot run,
  so this is inert until the variables are set.
- **Fixes Pi's provider routing for Responses-only non-GPT models**, which is
  what grok needs.

**ELI5:** Pi decides which gateway URL to talk to by looking at the model name.
Anything that was not Claude and not GPT fell into the "plain chat" bucket.
grok is the case where that guess is wrong: it only speaks the Responses API
and the MLflow chat gateway, so the plain-chat URL is the single surface it
rejects. Pi already had a helper that answers this correctly from catalog
metadata; the router just never asked it on that branch.

```
_pi_provider_for_model("databricks-grok-4-6", wire_apis={OPENAI_CHAT, OPENAI_RESPONSES})

  before                                    after
  ------                                    -----
  claude?      no                           claude?      no
  system.ai.?  no                           system.ai.?  no
  gpt?         no  -> asks wire_apis        gpt?         no  -> asks wire_apis
  fallthrough                               needs responses?  YES
    -> databricks-completions                 -> databricks-openai
       {host}/serving-endpoints                  {host}/ai-gateway/codex/v1
       400 Invalid task type llm/v1/chat         200
```

The fix consults `_pi_needs_responses_api` at the shared fallthrough instead of
special-casing grok, so any future Responses-only non-GPT model routes
correctly. With no catalog metadata the fallthrough is byte-for-byte unchanged.

## Test Plan

- `pytest tests/inner/test_pi_executor.py` : 156 passed, including two new
  routing cases.
- `ruff check` and `ruff format` clean on both changed Python files.
- Executed the workflow's embedded prompt builder directly against all three
  variable combinations (both set / one set / neither) and asserted the
  rendered prompt. This caught a bug during development: the reviewer section
  was built but never interpolated into the prompt template.
- Verified every model id against the live gateway before wiring it in:
  - `databricks-grok-4-6` on `mlflow/v1/chat/completions` returns
    `finish_reason=tool_calls`; on the codex Responses gateway it returns
    `global.xai.grok-4.6`. On `/serving-endpoints` chat it returns 400
    `Invalid task type llm/v1/chat`, which is the bug above.
  - `databricks-kimi-k3` returns `finish_reason=tool_calls` on
    `/serving-endpoints` chat, so it needs no routing change.
  - Confirmed `gpt-oss-*` is deliberately excluded by `unsupported_in_pi()`, so
    it is not a candidate for the OSS slot.
- Confirmed Pi's credential path works under this workflow: the
  `_read_databrickscfg` fallback resolves "first section with both host and
  token", which matches the lowercase `[default]` the workflow already writes.

Not yet exercised end to end in CI: `issue_comment` always runs `main`'s copy
of a workflow, so the four-reviewer panel can only be observed after this
merges. See Coverage notes.

## Demo

N/A, no user-visible surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The routing fix is covered by unit tests: grok's wire-API set routes to
`databricks-openai`, and a chat-only non-GPT id still routes to
`databricks-completions` so the no-metadata path cannot regress.

The workflow half is verified manually because CI cannot self-test it. Two
things are worth watching on the first real run after merge:

1. **Wall clock.** Two-reviewer runs currently finish in roughly 10 minutes
   against a 30-minute job timeout. Four reviewers run in parallel so this
   should not be additive, but grok and kimi are slower to first token.
2. **Fan-out cap.** Polly's `spawn_bounds` policy sets
   `max_dispatches_per_turn: 6`. Four reviewers in one turn fits, but it is the
   ceiling if a fifth is added later.

Until `OMNIGENT_CI_OSS_MODEL` and `OMNIGENT_CI_GROK_MODEL` are set, the prompt
renders exactly as it does today and only the Pi install step is new.

## Changelog

Pi can now run Databricks gateway models that only serve the Responses API, such as grok

This pull request and its description were written by Isaac.
