### PR TITLE
feat(acp): surface an ACP agent's sub-agents as child sessions

### DIFF
--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -7,6 +7,7 @@ packages contribute additional harnesses through the
 
 from __future__ import annotations
 
+import dataclasses
 import importlib
 import importlib.metadata
 import logging
@@ -42,6 +43,7 @@ from omnigent.harness_capabilities import (
     Resume,
 )
 from omnigent.harness_install_spec import HarnessInstallSpec
+from omnigent.inner.devin import DEVIN_ACP_EXTENSION
 
 _logger = logging.getLogger(__name__)
 
@@ -648,6 +650,15 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
 for _acp_cli_name in ACP_CLI_HARNESSES:
     _BUILTIN_CAPABILITIES[_acp_cli_name] = _BUILTIN_CAPABILITIES["acp"]
 
+# Devin is the one row that diverges: its own wrap injects a vendor extension
+# (omnigent.inner.devin), so it surfaces the agent's sub-agents as child sessions
+# where a generic ACP agent cannot. Derived from the extension so this declared
+# capability cannot drift from the dialect that implements it.
+_BUILTIN_CAPABILITIES["devin"] = dataclasses.replace(
+    _BUILTIN_CAPABILITIES["acp"],
+    subagents=DEVIN_ACP_EXTENSION.surfaces_subagents,
+)
+
 
 _BUILTIN_CONTRIBUTION = HarnessContribution(
     name="omnigent",
@@ -683,9 +694,12 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         | set(ACP_CLI_HARNESSES)
     ),
     harness_modules={
-        # Every catalog row runs the shared generic ACP wrap.
+        # Every catalog row runs the shared generic ACP wrap...
         **dict.fromkeys(ACP_CLI_HARNESSES, "omnigent.inner.acp_harness"),
         "acp": "omnigent.inner.acp_harness",
+        # ...except a row with vendor behavior, which runs its own thin wrap to
+        # inject an AcpExtension into the same shared executor.
+        "devin": "omnigent.inner.devin.harness",
         "antigravity": "omnigent.inner.antigravity_harness",
         "antigravity-native": "omnigent.inner.antigravity_native_harness",
         "claude-native": "omnigent.inner.claude_native_harness",

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -60,6 +60,7 @@ from pathlib import Path
 from typing import Any, Protocol, TypeAlias
 
 from omnigent.inner._acp_omnigent_mcp import OmnigentAcpMcp
+from omnigent.inner.acp_subagents import SubAgentStart, read_subagent_events
 from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import (
@@ -69,6 +70,8 @@ from omnigent.inner.executor import (
     ExecutorEvent,
     Message,
     ReasoningChunk,
+    SubAgentCompleted,
+    SubAgentStarted,
     TextChunk,
     ToolCallComplete,
     ToolCallRequest,
@@ -1225,6 +1228,20 @@ class AcpExecutor(Executor):
 
         elif update_type == _UPDATE_CONFIG_OPTION:
             self._note_config_options(update.get("configOptions"))
+
+        # Sub-agent lifecycle rides on these updates in a per-agent dialect
+        # (Devin: cognition.ai/subagent_* on the _meta). A source recognizes its
+        # own dialect and normalizes it; the runner mints a child session per
+        # start so the "Subagents" panel lists it. See omnigent.inner.acp_subagents.
+        for sub in read_subagent_events(update):
+            if isinstance(sub, SubAgentStart):
+                events.append(
+                    SubAgentStarted(child_key=sub.child_key, title=sub.title, task=sub.task)
+                )
+            else:
+                events.append(
+                    SubAgentCompleted(child_key=sub.child_key, ok=sub.ok, summary=sub.summary)
+                )
 
         return events
 

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -60,6 +60,7 @@ from pathlib import Path
 from typing import Any, Protocol, TypeAlias
 
 from omnigent.inner._acp_omnigent_mcp import OmnigentAcpMcp
+from omnigent.inner.acp_extension import NO_ACP_EXTENSION, AcpExtension
 from omnigent.inner.acp_subagents import SubAgentStart, read_subagent_events
 from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
@@ -302,6 +303,8 @@ class AcpExecutor(Executor):
         config: AcpAgentConfig,
         cwd: str | None = None,
         os_env: OSEnvSpec | None = None,
+        *,
+        extension: AcpExtension = NO_ACP_EXTENSION,
     ) -> None:
         """Initialize the generic ACP executor.
 
@@ -311,8 +314,13 @@ class AcpExecutor(Executor):
         :param os_env: Environment / sandbox spec. When its ``sandbox`` is not
             ``"none"``, the whole agent process tree is wrapped in the platform
             sandbox (bwrap/seatbelt) at spawn — see :meth:`_sandbox_launch_path`.
+        :param extension: Vendor behavior for the agent being driven, injected by
+            that vendor's harness wrap (e.g.
+            :mod:`omnigent.inner.devin.harness`). The default is protocol-only,
+            so the generic ``acp`` harness reads no vendor field.
         """
         self._config = config
+        self._extension = extension
         self._cwd = cwd or os.getcwd()
         self._os_env = os_env
         # Advertise ``clientCapabilities.fs`` so the agent delegates file
@@ -1229,11 +1237,11 @@ class AcpExecutor(Executor):
         elif update_type == _UPDATE_CONFIG_OPTION:
             self._note_config_options(update.get("configOptions"))
 
-        # Sub-agent lifecycle rides on these updates in a per-agent dialect
-        # (Devin: cognition.ai/subagent_* on the _meta). A source recognizes its
-        # own dialect and normalizes it; the runner mints a child session per
-        # start so the "Subagents" panel lists it. See omnigent.inner.acp_subagents.
-        for sub in read_subagent_events(update):
+        # Sub-agent lifecycle rides on these updates in a per-agent dialect, so
+        # only the sources this agent's extension supplies can recognize it —
+        # none for a generic ACP agent. The runner mints a child session per
+        # start so the "Subagents" panel lists it.
+        for sub in read_subagent_events(update, self._extension.subagent_sources):
             if isinstance(sub, SubAgentStart):
                 events.append(
                     SubAgentStarted(child_key=sub.child_key, title=sub.title, task=sub.task)

--- a/omnigent/inner/acp_extension.py
+++ b/omnigent/inner/acp_extension.py
@@ -1,0 +1,75 @@
+"""Vendor extension seam for the generic ACP executor.
+
+The Agent Client Protocol leaves the interesting capabilities unspecified —
+sub-agents, permission-option semantics, hook surfaces — so agents fill those
+gaps in their own dialects. :class:`AcpExtension` is the single seam where such
+vendor behavior attaches to :class:`~omnigent.inner.acp_executor.AcpExecutor`,
+which keeps the executor protocol-pure: it reads only ACP-standard fields plus
+whatever an extension hands it.
+
+An extension is **composed at the harness boundary, not discovered**. A vendor's
+harness wrap passes its extension to the shared ACP wrap
+(:func:`omnigent.inner.acp_harness.create_app`); the generic ``acp`` harness and
+every other builtin ACP row run with :data:`NO_ACP_EXTENSION` and behave exactly
+as they did before any extension existed. There is no registry to consult and no
+harness-name branch anywhere in the generic path.
+
+That composition is what keeps a vendor liftable. Everything vendor-specific is
+one package plus one ``create_app()`` — the same shape as a community harness
+plugin under ``omnigent.community.harness.<name>`` — so moving a vendor out of
+core is a directory move plus an entry point, not a rewrite. See
+:mod:`omnigent.inner.devin` for the worked example.
+
+**Adding a capability is additive**: give :class:`AcpExtension` a field with a
+neutral default, read it at the one place in the executor where it applies, and
+populate it from the vendor's extension. Everything that doesn't set it is
+unaffected.
+
+The live candidate is ``initialize``-time client capabilities. Devin reports
+sub-agents unconditionally, but Claude Code's ACP bridge gates its nested
+transcript on the client opting in with
+``clientCapabilities._meta["subagent-transcript"] = true`` and then relates
+nested updates via ``_meta.claudeCode.parentToolUseId``. Supporting that dialect
+therefore needs an extension to contribute handshake fields, not just read
+frames — an ``initialize`` capability contribution alongside
+:attr:`AcpExtension.subagent_sources`. Others: filtering which permission
+options reach the approval card (an agent may offer "switch to bypass mode"),
+resolving a vendor ``_meta`` tool name when the protocol's ``title`` is absent,
+and vendor-specific tool-gating hooks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from omnigent.inner.acp_subagents import AcpSubAgentSource
+
+
+@dataclass(frozen=True)
+class AcpExtension:
+    """Vendor behavior layered onto the generic ACP executor.
+
+    :param name: The vendor this extension speaks for, e.g. ``"devin"``. Used in
+        logs and to identify the extension in tests; never matched against a
+        harness id to select behavior (the harness wrap does the selecting).
+    :param subagent_sources: Dialects that recognize this vendor's sub-agent
+        lifecycle reporting (see :mod:`omnigent.inner.acp_subagents`). Empty —
+        the default — means the executor does no sub-agent scanning at all.
+    """
+
+    name: str
+    subagent_sources: tuple[AcpSubAgentSource, ...] = field(default=())
+
+    @property
+    def surfaces_subagents(self) -> bool:
+        """Whether this vendor's sub-agents become Omnigent child sessions.
+
+        The source of truth for the harness's declared ``subagents`` capability,
+        so the capability matrix cannot drift from what the code actually does.
+        """
+        return bool(self.subagent_sources)
+
+
+# The generic ACP harness and every builtin ACP CLI row that declares no vendor
+# behavior. Reads as "protocol only".
+NO_ACP_EXTENSION = AcpExtension(name="acp")

--- a/omnigent/inner/acp_harness.py
+++ b/omnigent/inner/acp_harness.py
@@ -53,6 +53,7 @@ import os
 from fastapi import FastAPI
 
 from omnigent.inner.acp_executor import AcpAgentConfig, AcpExecutor
+from omnigent.inner.acp_extension import NO_ACP_EXTENSION, AcpExtension
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import Executor
 from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
@@ -124,8 +125,12 @@ def _resolve_os_env() -> OSEnvSpec:
     )
 
 
-def _build_acp_executor() -> Executor:
-    """Construct an :class:`AcpExecutor` from env-var config (lazily, on first turn)."""
+def _build_acp_executor(extension: AcpExtension = NO_ACP_EXTENSION) -> Executor:
+    """Construct an :class:`AcpExecutor` from env-var config (lazily, on first turn).
+
+    :param extension: Vendor behavior to inject, from the calling wrap. Defaults
+        to protocol-only for the generic ``acp`` harness.
+    """
     command = os.environ.get(_ENV_COMMAND, "").strip()
     if not command:
         raise RuntimeError(
@@ -152,16 +157,25 @@ def _build_acp_executor() -> Executor:
         permission_mode=permission_mode,
         inject_system_prompt=inject_system_prompt,
     )
-    return AcpExecutor(config=config, cwd=cwd, os_env=_resolve_os_env())
+    return AcpExecutor(config=config, cwd=cwd, os_env=_resolve_os_env(), extension=extension)
 
 
-def create_app() -> FastAPI:
+def create_app(extension: AcpExtension = NO_ACP_EXTENSION) -> FastAPI:
     """Build the generic ACP harness's FastAPI app (required entry point).
 
     The wrapped :class:`AcpExecutor` is constructed lazily on the first turn, so
     a missing command / absent agent binary surfaces as a request-time error
     rather than an app-boot crash.
+
+    :param extension: Vendor behavior for the agent this process drives. A
+        vendor's own wrap calls this with its extension (see
+        :mod:`omnigent.inner.devin.harness`); the runner calls it with no
+        argument for ``harness: acp`` and for a builtin ACP CLI row that declares
+        no vendor behavior.
+    :returns: The app the runner serves.
     """
     label = os.environ.get(_ENV_NAME, "").strip() or "ACP agent"
-    adapter = ExecutorAdapter(executor_factory=_build_acp_executor, harness_label=label)
+    adapter = ExecutorAdapter(
+        executor_factory=lambda: _build_acp_executor(extension), harness_label=label
+    )
     return adapter.build()

--- a/omnigent/inner/acp_subagents.py
+++ b/omnigent/inner/acp_subagents.py
@@ -1,32 +1,26 @@
-"""Surface an ACP agent's sub-agents as Omnigent child sessions.
+"""Normalized sub-agent lifecycle for ACP agents.
 
 The Agent Client Protocol has not standardized sub-agents. An RFD proposes a
 ``tool_call`` with ``kind: "subagent"`` plus a ``childSessionId`` and a distinct
 child ``sessionId``, but no shipping agent emits that yet, so an agent that
-spawns sub-agents reports them in its own dialect. Devin, for instance, carries
-the whole lifecycle in vendor ``_meta`` on a ``tool_call_update`` whose
-``toolCallId`` is the sub-agent's ``agentId``::
+spawns sub-agents reports them in its own dialect.
 
-    _meta["cognition.ai/subagent_started"]   = {agentId, title, task}
-    _meta["cognition.ai/subagent_completed"] = {agentId, success, summary}
-
-An :class:`AcpSubAgentSource` maps one such dialect onto a small normalized
-lifecycle (:class:`SubAgentStart` / :class:`SubAgentEnd`).
-:class:`~omnigent.inner.acp_executor.AcpExecutor` runs the registered sources
-over every ``session/update`` and emits the matching
+This module owns only the **generic** half: a small normalized lifecycle
+(:class:`SubAgentStart` / :class:`SubAgentEnd`) and the
+:class:`AcpSubAgentSource` protocol that maps one dialect onto it. It reads no
+vendor field and names no vendor;
+:class:`~omnigent.inner.acp_executor.AcpExecutor` runs whatever sources its
+:class:`~omnigent.inner.acp_extension.AcpExtension` supplies and emits
 :class:`~omnigent.inner.executor.SubAgentStarted` /
-:class:`~omnigent.inner.executor.SubAgentCompleted` events; the runner turns
-those into child sessions via the same ``external_subagent_start`` path the
-native harnesses already use, so the web "Subagents" panel lists one row per
-child.
+:class:`~omnigent.inner.executor.SubAgentCompleted`, which the runner turns into
+Omnigent child sessions so the web "Subagents" panel lists one row per child.
 
-Supporting another agent's sub-agents means adding one source here — the
-executor, adapter, runner, and server child-session machinery are untouched. A
-source **self-gates** by recognizing its own dialect's markers, so it is inert
-for agents that don't speak it (Devin's source fires only on ``cognition.ai/*``
-keys) and there is no per-harness switch to maintain. When ACP standardizes the
-sub-agent convention, a single source keyed on the standard fields covers every
-compliant agent at once.
+A vendor's dialect lives with that vendor — see
+:class:`omnigent.inner.devin.subagents.DevinSubAgentSource` for the worked
+example — so supporting another agent means adding one source in that agent's
+own package, with nothing here or downstream to change. When ACP standardizes
+the convention, a single source keyed on the standard fields covers every
+compliant agent at once, and can ship here rather than per-vendor.
 """
 
 from __future__ import annotations
@@ -58,7 +52,7 @@ class SubAgentEnd:
 
     :param child_key: Matches the originating :attr:`SubAgentStart.child_key`.
     :param ok: Whether the sub-agent reported success.
-    :param summary: The sub-agent's closing summary, shown on the child row.
+    :param summary: The sub-agent's closing summary, shown in the child chat.
     """
 
     child_key: str
@@ -75,73 +69,30 @@ class AcpSubAgentSource(Protocol):
 
     Pure and stateless: given a single ACP ``session/update`` payload (the
     ``params.update`` object, which carries ``sessionUpdate`` and any ``_meta``),
-    return the sub-agent lifecycle events it carries — almost always none. An
-    implementation MUST self-gate on its own dialect's markers so it stays inert
-    for agents that don't speak it.
+    return the sub-agent lifecycle events it carries — almost always none.
+
+    An implementation MUST self-gate on its own dialect's markers rather than
+    assume it is only handed its own vendor's traffic. Two reasons: a source is
+    the only thing that knows its dialect, and self-gating means a source stays
+    correct if an agent's fork or a future multi-dialect wrap sends it frames it
+    does not recognize.
     """
 
     def read(self, update: Mapping[str, Any]) -> Sequence[SubAgentEvent]: ...
 
 
-# --- Devin (Cognition) --------------------------------------------------------
-# Devin conveys the sub-agent lifecycle only through vendor ``_meta``; there is
-# no ACP-standard field to read. The sub-agent's ``agentId`` is the stable key.
-_DEVIN_STARTED = "cognition.ai/subagent_started"
-_DEVIN_COMPLETED = "cognition.ai/subagent_completed"
-
-
-class DevinSubAgentSource:
-    """Reads Devin's ``cognition.ai/subagent_*`` ``_meta`` lifecycle.
-
-    Fires only when those keys are present, so it is inert for every other ACP
-    agent — the ``devin``-only gating is the dialect itself, not a harness check.
-    """
-
-    def read(self, update: Mapping[str, Any]) -> Sequence[SubAgentEvent]:
-        meta = update.get("_meta")
-        if not isinstance(meta, Mapping):
-            return ()
-        events: list[SubAgentEvent] = []
-        started = meta.get(_DEVIN_STARTED)
-        if isinstance(started, Mapping):
-            agent_id = started.get("agentId")
-            if isinstance(agent_id, str) and agent_id:
-                events.append(
-                    SubAgentStart(
-                        child_key=agent_id,
-                        title=str(started.get("title") or agent_id),
-                        task=str(started.get("task") or ""),
-                    )
-                )
-        completed = meta.get(_DEVIN_COMPLETED)
-        if isinstance(completed, Mapping):
-            agent_id = completed.get("agentId")
-            if isinstance(agent_id, str) and agent_id:
-                events.append(
-                    SubAgentEnd(
-                        child_key=agent_id,
-                        ok=bool(completed.get("success", True)),
-                        summary=str(completed.get("summary") or ""),
-                    )
-                )
-        return tuple(events)
-
-
-# The dialects :class:`AcpExecutor` consults, in order. Each self-gates, so
-# listing a source is harmless for agents that don't speak its dialect. Add a
-# new vendor source — or the eventual ACP-standard subagent source — here.
-DEFAULT_ACP_SUBAGENT_SOURCES: tuple[AcpSubAgentSource, ...] = (DevinSubAgentSource(),)
-
-
 def read_subagent_events(
     update: Mapping[str, Any],
-    sources: Sequence[AcpSubAgentSource] = DEFAULT_ACP_SUBAGENT_SOURCES,
+    sources: Sequence[AcpSubAgentSource],
 ) -> list[SubAgentEvent]:
     """Run every source over one ``session/update``; return all events found.
 
     :param update: The ACP ``params.update`` object.
-    :param sources: Dialects to try; defaults to :data:`DEFAULT_ACP_SUBAGENT_SOURCES`.
-    :returns: All sub-agent lifecycle events the sources recognized (usually empty).
+    :param sources: Dialects to try, from the executor's
+        :class:`~omnigent.inner.acp_extension.AcpExtension`. Empty (the generic
+        ACP harness) short-circuits to no events.
+    :returns: All sub-agent lifecycle events the sources recognized (usually
+        empty).
     """
     out: list[SubAgentEvent] = []
     for source in sources:

--- a/omnigent/inner/acp_subagents.py
+++ b/omnigent/inner/acp_subagents.py
@@ -1,0 +1,149 @@
+"""Surface an ACP agent's sub-agents as Omnigent child sessions.
+
+The Agent Client Protocol has not standardized sub-agents. An RFD proposes a
+``tool_call`` with ``kind: "subagent"`` plus a ``childSessionId`` and a distinct
+child ``sessionId``, but no shipping agent emits that yet, so an agent that
+spawns sub-agents reports them in its own dialect. Devin, for instance, carries
+the whole lifecycle in vendor ``_meta`` on a ``tool_call_update`` whose
+``toolCallId`` is the sub-agent's ``agentId``::
+
+    _meta["cognition.ai/subagent_started"]   = {agentId, title, task}
+    _meta["cognition.ai/subagent_completed"] = {agentId, success, summary}
+
+An :class:`AcpSubAgentSource` maps one such dialect onto a small normalized
+lifecycle (:class:`SubAgentStart` / :class:`SubAgentEnd`).
+:class:`~omnigent.inner.acp_executor.AcpExecutor` runs the registered sources
+over every ``session/update`` and emits the matching
+:class:`~omnigent.inner.executor.SubAgentStarted` /
+:class:`~omnigent.inner.executor.SubAgentCompleted` events; the runner turns
+those into child sessions via the same ``external_subagent_start`` path the
+native harnesses already use, so the web "Subagents" panel lists one row per
+child.
+
+Supporting another agent's sub-agents means adding one source here — the
+executor, adapter, runner, and server child-session machinery are untouched. A
+source **self-gates** by recognizing its own dialect's markers, so it is inert
+for agents that don't speak it (Devin's source fires only on ``cognition.ai/*``
+keys) and there is no per-harness switch to maintain. When ACP standardizes the
+sub-agent convention, a single source keyed on the standard fields covers every
+compliant agent at once.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class SubAgentStart:
+    """A sub-agent began. Normalized output of an :class:`AcpSubAgentSource`.
+
+    :param child_key: Stable id for the sub-agent, unique within the parent
+        turn. Correlates a later :class:`SubAgentEnd` and is the idempotency key
+        when the child session is minted.
+    :param title: Short human label for the row, e.g. ``"mathutils"``.
+    :param task: The instruction the sub-agent was given, shown on the row.
+    """
+
+    child_key: str
+    title: str
+    task: str = ""
+
+
+@dataclass(frozen=True)
+class SubAgentEnd:
+    """A previously-started sub-agent finished.
+
+    :param child_key: Matches the originating :attr:`SubAgentStart.child_key`.
+    :param ok: Whether the sub-agent reported success.
+    :param summary: The sub-agent's closing summary, shown on the child row.
+    """
+
+    child_key: str
+    ok: bool = True
+    summary: str = ""
+
+
+SubAgentEvent = SubAgentStart | SubAgentEnd
+
+
+@runtime_checkable
+class AcpSubAgentSource(Protocol):
+    """Maps one agent's sub-agent dialect onto the normalized lifecycle.
+
+    Pure and stateless: given a single ACP ``session/update`` payload (the
+    ``params.update`` object, which carries ``sessionUpdate`` and any ``_meta``),
+    return the sub-agent lifecycle events it carries — almost always none. An
+    implementation MUST self-gate on its own dialect's markers so it stays inert
+    for agents that don't speak it.
+    """
+
+    def read(self, update: Mapping[str, Any]) -> Sequence[SubAgentEvent]: ...
+
+
+# --- Devin (Cognition) --------------------------------------------------------
+# Devin conveys the sub-agent lifecycle only through vendor ``_meta``; there is
+# no ACP-standard field to read. The sub-agent's ``agentId`` is the stable key.
+_DEVIN_STARTED = "cognition.ai/subagent_started"
+_DEVIN_COMPLETED = "cognition.ai/subagent_completed"
+
+
+class DevinSubAgentSource:
+    """Reads Devin's ``cognition.ai/subagent_*`` ``_meta`` lifecycle.
+
+    Fires only when those keys are present, so it is inert for every other ACP
+    agent — the ``devin``-only gating is the dialect itself, not a harness check.
+    """
+
+    def read(self, update: Mapping[str, Any]) -> Sequence[SubAgentEvent]:
+        meta = update.get("_meta")
+        if not isinstance(meta, Mapping):
+            return ()
+        events: list[SubAgentEvent] = []
+        started = meta.get(_DEVIN_STARTED)
+        if isinstance(started, Mapping):
+            agent_id = started.get("agentId")
+            if isinstance(agent_id, str) and agent_id:
+                events.append(
+                    SubAgentStart(
+                        child_key=agent_id,
+                        title=str(started.get("title") or agent_id),
+                        task=str(started.get("task") or ""),
+                    )
+                )
+        completed = meta.get(_DEVIN_COMPLETED)
+        if isinstance(completed, Mapping):
+            agent_id = completed.get("agentId")
+            if isinstance(agent_id, str) and agent_id:
+                events.append(
+                    SubAgentEnd(
+                        child_key=agent_id,
+                        ok=bool(completed.get("success", True)),
+                        summary=str(completed.get("summary") or ""),
+                    )
+                )
+        return tuple(events)
+
+
+# The dialects :class:`AcpExecutor` consults, in order. Each self-gates, so
+# listing a source is harmless for agents that don't speak its dialect. Add a
+# new vendor source — or the eventual ACP-standard subagent source — here.
+DEFAULT_ACP_SUBAGENT_SOURCES: tuple[AcpSubAgentSource, ...] = (DevinSubAgentSource(),)
+
+
+def read_subagent_events(
+    update: Mapping[str, Any],
+    sources: Sequence[AcpSubAgentSource] = DEFAULT_ACP_SUBAGENT_SOURCES,
+) -> list[SubAgentEvent]:
+    """Run every source over one ``session/update``; return all events found.
+
+    :param update: The ACP ``params.update`` object.
+    :param sources: Dialects to try; defaults to :data:`DEFAULT_ACP_SUBAGENT_SOURCES`.
+    :returns: All sub-agent lifecycle events the sources recognized (usually empty).
+    """
+    out: list[SubAgentEvent] = []
+    for source in sources:
+        out.extend(source.read(update))
+    return out

--- a/omnigent/inner/devin/__init__.py
+++ b/omnigent/inner/devin/__init__.py
@@ -1,0 +1,45 @@
+"""Devin harness — ACP-driven, layered on the generic ACP executor.
+
+Devin (Cognition's ``devin`` CLI) runs through Omnigent's generic ACP executor,
+so this package holds only what is genuinely Devin's: its sub-agent dialect
+(:mod:`.subagents`), the extension that declares it (:data:`DEVIN_ACP_EXTENSION`,
+composed below), and the harness wrap that injects it (:mod:`.harness`). Nothing
+in the generic ACP path names Devin.
+
+**Composition root.** This module assembles the extension from its parts, so a
+new Devin-specific capability is a new sibling module plus one field here — for
+example a ``hooks.py`` gating tool calls once ACP grows a hook surface — and the
+generic executor learns about it through
+:class:`~omnigent.inner.acp_extension.AcpExtension` rather than a Devin import.
+
+**Liftability.** The layout mirrors a community harness plugin
+(``omnigent/community/harness/<name>/{plugin.py,inner/}``, per
+https://omnigent.ai/docs/build/harnesses/community): a package of vendor code
+plus a ``create_app()``. Moving Devin out of core is that move plus an entry
+point in ``omnigent.community.harness`` — with two things to know:
+
+* a community plugin may not override a **builtin** harness name, so the move
+  means deleting Devin's builtin catalog row in the same change, not adding a
+  package alongside it; and
+* the plugin contract's public surface is
+  :class:`~omnigent.inner.executor.Executor` +
+  :class:`~omnigent.runtime.harnesses._executor_adapter.ExecutorAdapter`, so an
+  out-of-core Devin either imports the ACP executor from core (a private module
+  today) or carries its own ACP client, as ``omnigent-rovo`` does. Keeping this
+  package to dialect + wrap is what makes that choice cheap either way.
+"""
+
+from __future__ import annotations
+
+from omnigent.inner.acp_extension import AcpExtension
+from omnigent.inner.devin.subagents import DevinSubAgentSource
+
+#: Everything the generic ACP executor needs to behave as Devin. Injected by
+#: :func:`omnigent.inner.devin.harness.create_app`, and the source of truth for
+#: Devin's declared ``subagents`` capability in ``harness_plugins``.
+DEVIN_ACP_EXTENSION = AcpExtension(
+    name="devin",
+    subagent_sources=(DevinSubAgentSource(),),
+)
+
+__all__ = ["DEVIN_ACP_EXTENSION", "DevinSubAgentSource"]

--- a/omnigent/inner/devin/harness.py
+++ b/omnigent/inner/devin/harness.py
@@ -1,0 +1,28 @@
+"""``harness: devin`` wrap.
+
+The entry point :mod:`omnigent.runtime.harnesses._runner` invokes after the
+plugin registry resolves ``"devin"`` to this module. Devin speaks ACP, so this
+adds no protocol code: it delegates to the shared ACP wrap and injects
+:data:`~omnigent.inner.devin.DEVIN_ACP_EXTENSION`, which is the only thing that
+distinguishes a Devin harness process from a generic ``acp`` one.
+
+Env contract is the generic ACP one (``HARNESS_ACP_*``, see
+:mod:`omnigent.inner.acp_harness`) because Devin is a builtin ACP CLI row whose
+command and argv come from :data:`omnigent.acp_cli_harnesses.ACP_CLI_HARNESSES`.
+A Devin-specific variable would be declared here and read alongside it.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from omnigent.inner import acp_harness
+from omnigent.inner.devin import DEVIN_ACP_EXTENSION
+
+
+def create_app() -> FastAPI:
+    """Build the Devin harness's FastAPI app (required entry point).
+
+    :returns: The app the runner serves for a ``harness: devin`` session.
+    """
+    return acp_harness.create_app(extension=DEVIN_ACP_EXTENSION)

--- a/omnigent/inner/devin/subagents.py
+++ b/omnigent/inner/devin/subagents.py
@@ -1,0 +1,81 @@
+"""Devin's sub-agent dialect.
+
+Devin (Cognition's ``devin`` CLI, driven through ``devin acp``) delegates work to
+parallel sub-agents but reports the lifecycle only in vendor ``_meta`` — it emits
+none of the ACP sub-agent RFD's fields. Captured from a live turn that spawned
+three sub-agents (2026-08-25): no ``kind: "subagent"``, no ``childSessionId``,
+one session, and the whole lifecycle on a ``tool_call_update`` whose
+``toolCallId`` is the sub-agent's ``agentId``::
+
+    _meta["cognition.ai/subagent_started"]   = {agentId, title, task}
+    _meta["cognition.ai/subagent_completed"] = {agentId, success, summary}
+    _meta["cognition.ai/subagent_context"]   = {parentAgentId}   # provenance only
+
+Reading vendor ``_meta`` is not a shortcut here — it is the only structured
+sub-agent signal Devin emits, so there is no generic field to prefer. Confining
+it to this module is what keeps that coupling from reaching the generic ACP
+executor.
+
+Devin needs no capability negotiation: the same capture shows it emitting these
+keys while Omnigent advertised only ``clientCapabilities.fs``. That is dialect-
+specific, not a protocol rule — Claude Code's ACP bridge withholds its nested
+transcript unless the client opts in via
+``clientCapabilities._meta["subagent-transcript"]``, and keys parentage on
+``_meta.claudeCode.parentToolUseId`` instead. Two vendors, one concept, no shared
+field: the reason a dialect is per-vendor rather than a branch in the executor.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from omnigent.inner.acp_subagents import SubAgentEnd, SubAgentEvent, SubAgentStart
+
+# Devin conveys the sub-agent lifecycle only through these vendor ``_meta`` keys;
+# the sub-agent's ``agentId`` is the stable key across both edges.
+_STARTED = "cognition.ai/subagent_started"
+_COMPLETED = "cognition.ai/subagent_completed"
+
+
+class DevinSubAgentSource:
+    """Reads Devin's ``cognition.ai/subagent_*`` ``_meta`` lifecycle.
+
+    Fires only when those keys are present, so it stays inert for any frame that
+    does not carry Devin's dialect — the self-gating the
+    :class:`~omnigent.inner.acp_subagents.AcpSubAgentSource` protocol requires.
+    """
+
+    def read(self, update: Mapping[str, Any]) -> Sequence[SubAgentEvent]:
+        """Return the sub-agent lifecycle events carried by one ``session/update``.
+
+        :param update: The ACP ``params.update`` object.
+        :returns: Normalized start/end events, empty for a non-Devin frame.
+        """
+        meta = update.get("_meta")
+        if not isinstance(meta, Mapping):
+            return ()
+        events: list[SubAgentEvent] = []
+        started = meta.get(_STARTED)
+        if isinstance(started, Mapping):
+            agent_id = started.get("agentId")
+            if isinstance(agent_id, str) and agent_id:
+                events.append(
+                    SubAgentStart(
+                        child_key=agent_id,
+                        title=str(started.get("title") or agent_id),
+                        task=str(started.get("task") or ""),
+                    )
+                )
+        completed = meta.get(_COMPLETED)
+        if isinstance(completed, Mapping):
+            agent_id = completed.get("agentId")
+            if isinstance(agent_id, str) and agent_id:
+                events.append(
+                    SubAgentEnd(
+                        child_key=agent_id,
+                        ok=bool(completed.get("success", True)),
+                        summary=str(completed.get("summary") or ""),
+                    )
+                )
+        return tuple(events)

--- a/omnigent/inner/executor.py
+++ b/omnigent/inner/executor.py
@@ -262,6 +262,42 @@ class CompactionComplete(ExecutorEvent):
 
 
 @dataclass
+class SubAgentStarted(ExecutorEvent):
+    """A sub-agent the harness agent spawned has begun.
+
+    Surfaced so the runner can mint an Omnigent child session (the web
+    "Subagents" panel lists one row per child). ACP has no standardized
+    sub-agent signal, so a per-dialect ``AcpSubAgentSource`` normalizes an
+    agent's own reporting (e.g. Devin's ``cognition.ai/subagent_*`` ``_meta``)
+    into this event — see :mod:`omnigent.inner.acp_subagents`.
+
+    :param child_key: Stable, per-turn-unique id for the sub-agent, used both to
+        correlate the later :class:`SubAgentCompleted` and as the idempotency
+        key when the child session is minted.
+    :param title: Short human label for the row, e.g. ``"mathutils"``.
+    :param task: The instruction the sub-agent was given, shown on the row.
+    """
+
+    child_key: str
+    title: str
+    task: str = ""
+
+
+@dataclass
+class SubAgentCompleted(ExecutorEvent):
+    """A previously-started sub-agent finished. See :class:`SubAgentStarted`.
+
+    :param child_key: Matches the :attr:`SubAgentStarted.child_key`.
+    :param ok: Whether the sub-agent reported success.
+    :param summary: The sub-agent's closing summary, shown on the child row.
+    """
+
+    child_key: str
+    ok: bool = True
+    summary: str = ""
+
+
+@dataclass
 class TurnCancelled(ExecutorEvent):
     """The current assistant turn was cancelled before completion."""
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -640,6 +640,107 @@ async def _evaluate_policy_via_omnigent(
         await on_delivery_failure(conversation_id)
 
 
+# Bounded wait for a sub-agent's start edge to mint its child session before the
+# completion edge records the outcome. The mint POST carries its own timeout, so
+# this only guards the unexpected case where the start task never resolves.
+_SUBAGENT_MINT_WAIT_S: float = 30.0
+
+
+async def _mint_acp_subagent_child(
+    client: httpx.AsyncClient,
+    *,
+    parent_id: str,
+    child_key: str,
+    title: str,
+    task: str,
+    child_id_future: asyncio.Future[str],
+) -> None:
+    """Mint a child session for a harness-reported sub-agent (the start edge).
+
+    POSTs ``external_subagent_start`` — idempotent on ``child_key`` server-side —
+    and resolves ``child_id_future`` with the returned child id so the completion
+    edge can address the child. Best-effort: a failure resolves the future with
+    the exception (so the completion edge fails fast rather than hanging) and is
+    logged, never raised into the turn.
+
+    :param client: Omnigent HTTP client for the runner subprocess.
+    :param parent_id: The parent conversation the sub-agent belongs to.
+    :param child_key: Stable sub-agent id; the idempotency + correlation key.
+    :param title: Row label, forwarded as ``agent_type``.
+    :param task: The delegated instruction, forwarded as ``description``.
+    :param child_id_future: Resolved with the minted child session id.
+    """
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{parent_id}/events",
+            json={
+                "type": "external_subagent_start",
+                "data": {
+                    "subagent_id": child_key,
+                    "agent_type": title or child_key,
+                    "description": task,
+                    "tool_use_id": child_key,
+                },
+            },
+        )
+        resp.raise_for_status()
+        payload = resp.json() if resp.content else {}
+        child_id = payload.get("child_session_id") if isinstance(payload, dict) else None
+        if not (isinstance(child_id, str) and child_id):
+            raise ValueError("external_subagent_start returned no child_session_id")
+        if not child_id_future.done():
+            child_id_future.set_result(child_id)
+    except Exception as exc:  # noqa: BLE001 — surfacing a sub-agent must never break the turn
+        _logger.warning("acp sub-agent child mint failed (child_key=%s): %s", child_key, exc)
+        if not child_id_future.done():
+            child_id_future.set_exception(exc)
+
+
+async def _complete_acp_subagent_child(
+    client: httpx.AsyncClient,
+    *,
+    child_key: str,
+    ok: bool,
+    summary: str,
+    child_id_future: asyncio.Future[str],
+) -> None:
+    """Record a harness-reported sub-agent's outcome on its child session (end edge).
+
+    Waits (bounded) for the start edge to mint the child, then marks the child's
+    status (``idle`` on success, ``failed`` otherwise) with the summary attached
+    as its output. Best-effort: a missing or failed mint is logged and skipped,
+    never raised into the turn.
+
+    :param client: Omnigent HTTP client for the runner subprocess.
+    :param child_key: Stable sub-agent id, matching the start edge.
+    :param ok: Whether the sub-agent reported success.
+    :param summary: The sub-agent's closing summary, attached as the child output.
+    :param child_id_future: Future the start edge resolves with the child id.
+    """
+    from omnigent._native_post_delivery import post_external_session_status
+
+    try:
+        child_id = await asyncio.wait_for(
+            asyncio.shield(child_id_future), timeout=_SUBAGENT_MINT_WAIT_S
+        )
+    except Exception as exc:  # noqa: BLE001 — includes the start edge's own mint failure
+        _logger.warning(
+            "acp sub-agent child unavailable for completion (child_key=%s): %s", child_key, exc
+        )
+        return
+    try:
+        await post_external_session_status(
+            client,
+            session_id=child_id,
+            status="idle" if ok else "failed",
+            output=summary or None,
+        )
+    except Exception as exc:  # noqa: BLE001 — a status edge failure must not break the turn
+        _logger.warning(
+            "acp sub-agent completion status failed (child_key=%s): %s", child_key, exc
+        )
+
+
 def _response_body_preview(resp: object, *, limit: int = 500) -> str:
     """
     Return a short response-body preview for diagnostics.
@@ -6664,6 +6765,9 @@ def create_runner_app(
                     _omnigent_task_id = cast(str | None, body.get("task_id"))
                     _buffer = ""
                     _dispatch_tasks: list[_asyncio.Task[object]] = []
+                    # Sub-agent start edge → minted child id, so the completion
+                    # edge can address the child it created. Per-stream.
+                    _subagent_child_futures: dict[str, _asyncio.Future[str]] = {}
                     _text_acc: list[str] = []
                     _stream_failed_error: _JsonObject | None = None
                     async for chunk in harness_resp.aiter_text():
@@ -6913,6 +7017,51 @@ def create_runner_app(
                                             )
                                         )
                                     )
+                                    continue
+
+                                if _evt_type == "subagent.started":
+                                    # A harness reported spawning a sub-agent; mint
+                                    # a child session so it shows in the Subagents
+                                    # panel. Swallowed (never relayed to clients).
+                                    _sa_key = event.get("child_key", "")
+                                    if isinstance(_sa_key, str) and _sa_key:
+                                        _sa_start_future: _asyncio.Future[str] = (
+                                            _asyncio.get_running_loop().create_future()
+                                        )
+                                        _subagent_child_futures[_sa_key] = _sa_start_future
+                                        _dispatch_tasks.append(
+                                            _asyncio.create_task(
+                                                _mint_acp_subagent_child(
+                                                    server_client,
+                                                    parent_id=conv_id,
+                                                    child_key=_sa_key,
+                                                    title=event.get("title", ""),
+                                                    task=event.get("task", ""),
+                                                    child_id_future=_sa_start_future,
+                                                )
+                                            )
+                                        )
+                                    continue
+
+                                if _evt_type == "subagent.completed":
+                                    _sa_done_key = event.get("child_key", "")
+                                    _sa_done_future = (
+                                        _subagent_child_futures.get(_sa_done_key)
+                                        if isinstance(_sa_done_key, str)
+                                        else None
+                                    )
+                                    if _sa_done_future is not None:
+                                        _dispatch_tasks.append(
+                                            _asyncio.create_task(
+                                                _complete_acp_subagent_child(
+                                                    server_client,
+                                                    child_key=_sa_done_key,
+                                                    ok=bool(event.get("ok", True)),
+                                                    summary=event.get("summary", ""),
+                                                    child_id_future=_sa_done_future,
+                                                )
+                                            )
+                                        )
                                     continue
 
                             if event is None:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -718,6 +718,7 @@ async def _post_acp_subagent_message(
     child_key: str,
     role: str,
     text: str,
+    agent: str | None = None,
 ) -> None:
     """Append one message to an ACP sub-agent's child transcript.
 
@@ -730,8 +731,21 @@ async def _post_acp_subagent_message(
     :param child_key: Sub-agent id, used for the response id and log context.
     :param role: ``"user"`` (the delegated task) or ``"assistant"`` (its result).
     :param text: Message text.
+    :param agent: Author name for an ``"assistant"`` message (ignored for
+        ``"user"``). ``MessageData`` requires a non-empty ``agent`` on assistant
+        messages, so this falls back to *child_key* when unset.
     """
     block_type = "input_text" if role == "user" else "output_text"
+    item_data: dict[str, object] = {
+        "role": role,
+        "content": [{"type": block_type, "text": text}],
+    }
+    if role == "assistant":
+        # MessageData rejects an assistant message with no ``agent`` (its
+        # ``check_agent_for_assistant`` validator), so an assistant item that
+        # omits it 400s and the summary silently never lands. Mirror codex's
+        # assistant transcript post, which sets ``agent`` for this exact reason.
+        item_data["agent"] = agent or child_key
     try:
         resp = await client.post(
             f"/v1/sessions/{child_id}/events",
@@ -739,7 +753,7 @@ async def _post_acp_subagent_message(
                 "type": "external_conversation_item",
                 "data": {
                     "item_type": "message",
-                    "item_data": {"role": role, "content": [{"type": block_type, "text": text}]},
+                    "item_data": item_data,
                     "response_id": f"resp_acpsub_{child_key}",
                 },
             },
@@ -756,6 +770,7 @@ async def _complete_acp_subagent_child(
     ok: bool,
     summary: str,
     child_id_future: asyncio.Future[str],
+    title: str = "",
 ) -> None:
     """Record a harness-reported sub-agent's outcome on its child session (end edge).
 
@@ -769,6 +784,8 @@ async def _complete_acp_subagent_child(
     :param ok: Whether the sub-agent reported success.
     :param summary: The sub-agent's closing summary, attached as the child output.
     :param child_id_future: Future the start edge resolves with the child id.
+    :param title: The sub-agent's display name, used as the summary message's
+        author; falls back to *child_key* when empty.
     """
     from omnigent._native_post_delivery import post_external_session_status
 
@@ -785,7 +802,12 @@ async def _complete_acp_subagent_child(
     # reports, so it goes in the child's transcript, not just the status edge.
     if summary:
         await _post_acp_subagent_message(
-            client, child_id=child_id, child_key=child_key, role="assistant", text=summary
+            client,
+            child_id=child_id,
+            child_key=child_key,
+            role="assistant",
+            text=summary,
+            agent=title or child_key,
         )
     try:
         await post_external_session_status(
@@ -6827,6 +6849,9 @@ def create_runner_app(
                     # Sub-agent start edge → minted child id, so the completion
                     # edge can address the child it created. Per-stream.
                     _subagent_child_futures: dict[str, _asyncio.Future[str]] = {}
+                    # Sub-agent start edge → its title, so the completion edge can
+                    # author the summary message (assistant messages need one).
+                    _subagent_titles: dict[str, str] = {}
                     _text_acc: list[str] = []
                     _stream_failed_error: _JsonObject | None = None
                     async for chunk in harness_resp.aiter_text():
@@ -7088,6 +7113,7 @@ def create_runner_app(
                                             _asyncio.get_running_loop().create_future()
                                         )
                                         _subagent_child_futures[_sa_key] = _sa_start_future
+                                        _subagent_titles[_sa_key] = event.get("title", "")
                                         _dispatch_tasks.append(
                                             _asyncio.create_task(
                                                 _mint_acp_subagent_child(
@@ -7118,6 +7144,7 @@ def create_runner_app(
                                                     ok=bool(event.get("ok", True)),
                                                     summary=event.get("summary", ""),
                                                     child_id_future=_sa_done_future,
+                                                    title=_subagent_titles.get(_sa_done_key, ""),
                                                 )
                                             )
                                         )

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -657,29 +657,37 @@ async def _mint_acp_subagent_child(
 ) -> None:
     """Mint a child session for a harness-reported sub-agent (the start edge).
 
-    POSTs ``external_subagent_start`` — idempotent on ``child_key`` server-side —
-    and resolves ``child_id_future`` with the returned child id so the completion
-    edge can address the child. Best-effort: a failure resolves the future with
-    the exception (so the completion edge fails fast rather than hanging) and is
-    logged, never raised into the turn.
+    POSTs ``external_acp_subagent_start`` — idempotent on ``child_key``
+    server-side — then seeds the child's transcript with the delegated task as a
+    user message, so opening the row shows what the sub-agent was asked to do
+    instead of an empty chat. Resolves ``child_id_future`` with the child id so
+    the completion edge can address it.
+
+    Deliberately NOT the native ``external_subagent_start`` path: that one stamps
+    a claude-native wrapper label, which makes the UI title the child "Claude
+    Code" regardless of the real harness. The ACP path leaves the wrapper unset so
+    the child inherits its parent's harness identity (e.g. Devin).
+
+    Best-effort: a failure resolves the future with the exception (so the
+    completion edge fails fast rather than hanging) and is logged, never raised
+    into the turn.
 
     :param client: Omnigent HTTP client for the runner subprocess.
     :param parent_id: The parent conversation the sub-agent belongs to.
     :param child_key: Stable sub-agent id; the idempotency + correlation key.
-    :param title: Row label, forwarded as ``agent_type``.
-    :param task: The delegated instruction, forwarded as ``description``.
+    :param title: Row label for the child, e.g. ``"mathutils"``.
+    :param task: The delegated instruction, seeded as the child's first message.
     :param child_id_future: Resolved with the minted child session id.
     """
     try:
         resp = await client.post(
             f"/v1/sessions/{parent_id}/events",
             json={
-                "type": "external_subagent_start",
+                "type": "external_acp_subagent_start",
                 "data": {
                     "subagent_id": child_key,
-                    "agent_type": title or child_key,
+                    "title": title or child_key,
                     "description": task,
-                    "tool_use_id": child_key,
                 },
             },
         )
@@ -687,13 +695,58 @@ async def _mint_acp_subagent_child(
         payload = resp.json() if resp.content else {}
         child_id = payload.get("child_session_id") if isinstance(payload, dict) else None
         if not (isinstance(child_id, str) and child_id):
-            raise ValueError("external_subagent_start returned no child_session_id")
+            raise ValueError("external_acp_subagent_start returned no child_session_id")
         if not child_id_future.done():
             child_id_future.set_result(child_id)
     except Exception as exc:  # noqa: BLE001 — surfacing a sub-agent must never break the turn
         _logger.warning("acp sub-agent child mint failed (child_key=%s): %s", child_key, exc)
         if not child_id_future.done():
             child_id_future.set_exception(exc)
+        return
+    # Seed the child's chat with its task. Separate from the mint so a transcript
+    # failure still leaves a working row (the panel entry already exists).
+    if task:
+        await _post_acp_subagent_message(
+            client, child_id=child_id, child_key=child_key, role="user", text=task
+        )
+
+
+async def _post_acp_subagent_message(
+    client: httpx.AsyncClient,
+    *,
+    child_id: str,
+    child_key: str,
+    role: str,
+    text: str,
+) -> None:
+    """Append one message to an ACP sub-agent's child transcript.
+
+    Uses the existing ``external_conversation_item`` bridge (the same path the
+    native forwarders use for sub-agent transcripts), so the child conversation
+    renders normally when opened. Best-effort and never raised into the turn.
+
+    :param client: Omnigent HTTP client for the runner subprocess.
+    :param child_id: The child session to append to.
+    :param child_key: Sub-agent id, used for the response id and log context.
+    :param role: ``"user"`` (the delegated task) or ``"assistant"`` (its result).
+    :param text: Message text.
+    """
+    block_type = "input_text" if role == "user" else "output_text"
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{child_id}/events",
+            json={
+                "type": "external_conversation_item",
+                "data": {
+                    "item_type": "message",
+                    "item_data": {"role": role, "content": [{"type": block_type, "text": text}]},
+                    "response_id": f"resp_acpsub_{child_key}",
+                },
+            },
+        )
+        resp.raise_for_status()
+    except Exception as exc:  # noqa: BLE001 — transcript is best-effort
+        _logger.warning("acp sub-agent %s message failed (child_key=%s): %s", role, child_key, exc)
 
 
 async def _complete_acp_subagent_child(
@@ -728,6 +781,12 @@ async def _complete_acp_subagent_child(
             "acp sub-agent child unavailable for completion (child_key=%s): %s", child_key, exc
         )
         return
+    # The sub-agent's closing summary is the only account of its work the agent
+    # reports, so it goes in the child's transcript, not just the status edge.
+    if summary:
+        await _post_acp_subagent_message(
+            client, child_id=child_id, child_key=child_key, role="assistant", text=summary
+        )
     try:
         await post_external_session_status(
             client,

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -31,6 +31,8 @@ from omnigent.inner.executor import (
     ExecutorEvent,
     Message,
     ReasoningChunk,
+    SubAgentCompleted,
+    SubAgentStarted,
     TextChunk,
     ToolCallComplete,
     ToolCallRequest,
@@ -774,6 +776,28 @@ class ExecutorAdapter(HarnessApp):
                     summary=event.summary,
                     summary_model=event.model,
                     compacted_messages=event.compacted_messages,
+                )
+            )
+        elif isinstance(event, SubAgentStarted):
+            from omnigent.server.schemas import SubagentStartedEvent
+
+            ctx.emit(
+                SubagentStartedEvent(
+                    type="subagent.started",
+                    child_key=event.child_key,
+                    title=event.title,
+                    task=event.task,
+                )
+            )
+        elif isinstance(event, SubAgentCompleted):
+            from omnigent.server.schemas import SubagentCompletedEvent
+
+            ctx.emit(
+                SubagentCompletedEvent(
+                    type="subagent.completed",
+                    child_key=event.child_key,
+                    ok=event.ok,
+                    summary=event.summary,
                 )
             )
         # ExecutorError handled by the caller (re-raises so the

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -145,6 +145,21 @@ _EXTERNAL_REASONING_EFFORT_CHANGE_TYPE: str = "external_reasoning_effort_change"
 _EXTERNAL_SUBAGENT_START_TYPE: str = "external_subagent_start"
 
 
+_EXTERNAL_ACP_SUBAGENT_START_TYPE: str = "external_acp_subagent_start"
+
+
+# Stable id an ACP agent gave the sub-agent it spawned (Devin's ``agentId``);
+# the idempotency key for the child row. Unlike the native families there is no
+# ``omnigent.wrapper`` value: an ACP sub-agent runs the SAME harness as its
+# parent, so leaving the wrapper unset lets the child's harness resolve to the
+# parent's (e.g. ``devin``) and the UI label it accordingly, instead of
+# mislabeling it as another vendor.
+_ACP_SUBAGENT_ID_LABEL_KEY = "omnigent.acp.subagent_id"
+
+
+_ACP_SUBAGENT_DESCRIPTION_LABEL_KEY = "omnigent.acp.subagent_description"
+
+
 _CLAUDE_NATIVE_SUBAGENT_WRAPPER_LABEL_VALUE = "claude-code-native-ui-subagent"
 
 
@@ -443,6 +458,7 @@ _ALLOWED_EVENT_TYPES: frozenset[str] = frozenset(ITEM_TYPE_TO_DATA_CLS.keys()) |
     _EXTERNAL_SESSION_TITLE_TYPE,
     _EXTERNAL_SESSION_TODOS_TYPE,
     _EXTERNAL_SUBAGENT_START_TYPE,
+    _EXTERNAL_ACP_SUBAGENT_START_TYPE,
     _EXTERNAL_CODEX_SUBAGENT_START_TYPE,
     _EXTERNAL_ANTIGRAVITY_SUBAGENT_START_TYPE,
     _EXTERNAL_CODEX_COLLABORATION_MODE_CHANGE_TYPE,

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -124,6 +124,8 @@ from omnigent.server.routes._session_create_validation import (
 # ``__all__`` and the facade's explicit re-exports, preserving its real runtime
 # bindings so a facade-level monkeypatch is honoured in this module too.
 from omnigent.server.routes._sessions.common import (  # noqa: F401
+    _ACP_SUBAGENT_DESCRIPTION_LABEL_KEY,
+    _ACP_SUBAGENT_ID_LABEL_KEY,
     _ANTIGRAVITY_NATIVE_HARNESS,
     _ANTIGRAVITY_NATIVE_SUBAGENT_CASCADE_ID_LABEL_KEY,
     _ANTIGRAVITY_NATIVE_SUBAGENT_DISPLAY_FALLBACK,
@@ -3015,6 +3017,138 @@ def _find_claude_native_subagent_child(
         if not page.has_more or page.last_id is None:
             return None
         after = page.last_id
+
+
+def _find_acp_subagent_child(
+    conversation_store: ConversationStore,
+    parent_id: str,
+    subagent_id: str,
+) -> Conversation | None:
+    """
+    Look up an existing ACP sub-agent child by its harness-side id.
+
+    Mirrors :func:`_find_claude_native_subagent_child` (including its
+    pagination, so a parent with many sub-agents still finds an older row)
+    but keys on :data:`_ACP_SUBAGENT_ID_LABEL_KEY`.
+
+    :param conversation_store: Store to query.
+    :param parent_id: Parent conversation id, e.g. ``"conv_parent987"``.
+    :param subagent_id: The agent's own sub-agent id, e.g. ``"a0ac9364"``.
+    :returns: The matching child :class:`Conversation`, or ``None``.
+    """
+    after: str | None = None
+    while True:
+        page = conversation_store.list_conversations(
+            kind="sub_agent",
+            parent_conversation_id=parent_id,
+            limit=100,
+            after=after,
+        )
+        for child in page.data:
+            if child.labels.get(_ACP_SUBAGENT_ID_LABEL_KEY) == subagent_id:
+                return child
+        if not page.has_more or page.last_id is None:
+            return None
+        after = page.last_id
+
+
+async def _persist_external_acp_subagent_start(
+    parent_id: str,
+    parent_conv: Conversation,
+    body: SessionEventInput,
+    conversation_store: ConversationStore,
+) -> str:
+    """
+    Mint a child :class:`Conversation` for an ACP agent's sub-agent.
+
+    The ACP counterpart of :func:`_persist_external_subagent_start`. An ACP
+    agent (e.g. Devin) runs its sub-agents inside its own single session, so the
+    child is a display row: it inherits the parent's ``agent_id`` and, crucially,
+    carries **no** ``omnigent.wrapper`` value. That absence is load-bearing — a
+    native subagent wrapper value makes the UI label the child with that vendor's
+    name (a Devin sub-agent minted through the claude path renders as "Claude
+    Code"), whereas with none the child's harness resolves through
+    :func:`_resolve_harness_impl` to the parent's (e.g. ``devin``) and the UI
+    labels it from the harness catalog.
+
+    Idempotent: a redelivery with the same ``subagent_id`` returns the existing
+    child id, with a title-collision recovery path matching the native helpers.
+
+    :param parent_id: Parent conversation id, e.g. ``"conv_parent987"``.
+    :param parent_conv: Pre-fetched parent row; its ``agent_id`` / ``runner_id``
+        are copied onto the child.
+    :param body: The POST event body. Required ``data`` keys: ``subagent_id``
+        (the agent's own id) and ``title`` (the row label). Optional:
+        ``description`` (the delegated task).
+    :param conversation_store: Store used to read existing children and create
+        the new row.
+    :returns: The child conversation id, e.g. ``"conv_child456"``.
+    :raises OmnigentError: 400 when a required key is missing or the parent has
+        no ``agent_id``.
+    """
+    subagent_id = body.data.get("subagent_id")
+    title_raw = body.data.get("title")
+    description = body.data.get("description") or ""
+    if not isinstance(subagent_id, str) or not subagent_id:
+        raise OmnigentError(
+            "external_acp_subagent_start requires non-empty data.subagent_id",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    if not isinstance(title_raw, str) or not title_raw:
+        raise OmnigentError(
+            "external_acp_subagent_start requires non-empty data.title",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    if not isinstance(description, str):
+        raise OmnigentError(
+            "external_acp_subagent_start data.description must be a string",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    if parent_conv.agent_id is None:
+        raise OmnigentError(
+            f"parent session {parent_id!r} has no agent_id; cannot create an ACP sub-agent child",
+            code=ErrorCode.INVALID_INPUT,
+        )
+
+    existing = await asyncio.to_thread(
+        _find_acp_subagent_child, conversation_store, parent_id, subagent_id
+    )
+    if existing is not None:
+        return existing.id
+
+    labels = {
+        _ACP_SUBAGENT_ID_LABEL_KEY: subagent_id,
+        _ACP_SUBAGENT_DESCRIPTION_LABEL_KEY: description,
+    }
+    # ``(parent_conversation_id, title)`` is unique, and an agent can give two
+    # parallel sub-agents the same label, so the stable id disambiguates. The
+    # rail hides the post-colon half, so the user still reads just the label.
+    title = f"{title_raw}:{subagent_id}"
+    try:
+        child = await asyncio.to_thread(
+            conversation_store.create_conversation,
+            kind="sub_agent",
+            title=title,
+            parent_conversation_id=parent_id,
+            agent_id=parent_conv.agent_id,
+            runner_id=parent_conv.runner_id,
+            sub_agent_name=title_raw,
+        )
+    except NameAlreadyExistsError:
+        # The unique index fired but the label lookup missed — a concurrent POST
+        # won the insert, or an earlier one died before ``set_labels``. Adopt the
+        # row and re-stamp, mirroring the native helpers' recovery.
+        adopted = await asyncio.to_thread(
+            _find_subagent_child_by_title, conversation_store, parent_id, title
+        )
+        if adopted is None:
+            raise
+        await asyncio.to_thread(conversation_store.set_labels, adopted.id, labels)
+        _publish_session_created(parent_id, adopted.id, parent_conv.agent_id)
+        return adopted.id
+    await asyncio.to_thread(conversation_store.set_labels, child.id, labels)
+    _publish_session_created(parent_id, child.id, parent_conv.agent_id)
+    return child.id
 
 
 def _find_subagent_child_by_title(

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -78,6 +78,7 @@ from omnigent.server.routes._sessions.common import (
     _ALLOWED_EVENT_TYPES,
     _APPROVAL_TYPE,
     _COMPACT_TYPE,
+    _EXTERNAL_ACP_SUBAGENT_START_TYPE,
     _EXTERNAL_ANTIGRAVITY_SUBAGENT_START_TYPE,
     _EXTERNAL_ASSISTANT_MESSAGE_TYPE,
     _EXTERNAL_CODEX_APPROVAL_MODE_CHANGE_TYPE,
@@ -137,6 +138,7 @@ from omnigent.server.routes._sessions.helpers import (
     _is_codex_native_subagent,
     _launch_runner_on_host,
     _parse_background_tasks,
+    _persist_external_acp_subagent_start,
     _persist_external_assistant_message,
     _persist_external_codex_approval_mode_change,
     _persist_external_codex_collaboration_mode_change,
@@ -547,6 +549,7 @@ def register_events_routes(
             _EXTERNAL_SESSION_TITLE_TYPE,
             _EXTERNAL_SESSION_TODOS_TYPE,
             _EXTERNAL_SUBAGENT_START_TYPE,
+            _EXTERNAL_ACP_SUBAGENT_START_TYPE,
             _EXTERNAL_CODEX_SUBAGENT_START_TYPE,
             _EXTERNAL_ANTIGRAVITY_SUBAGENT_START_TYPE,
             _EXTERNAL_CODEX_COLLABORATION_MODE_CHANGE_TYPE,
@@ -1442,6 +1445,16 @@ def register_events_routes(
                 body,
                 conversation_store,
             )
+            return {"queued": False, "child_session_id": child_id}
+        if body.type == _EXTERNAL_ACP_SUBAGENT_START_TYPE:
+            child_id = await _persist_external_acp_subagent_start(
+                session_id,
+                conv,
+                body,
+                conversation_store,
+            )
+            # Returned to the runner so it can address the sub-agent's transcript
+            # items and its completion status to the child id.
             return {"queued": False, "child_session_id": child_id}
         if body.type == "function_call_output":
             # A client-side tool's result tunneling back to a parked turn.

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -4533,7 +4533,60 @@ class PolicyEvaluationRequestEvent(_SSEEventBase):
     data: dict[str, Any]
 
 
-HarnessStreamEvent = ServerStreamEvent | InjectionConsumedEvent | PolicyEvaluationRequestEvent
+class SubagentStartedEvent(_SSEEventBase):
+    """
+    Runner-internal marker: the harness agent spawned a sub-agent.
+
+    ACP agents that delegate report it in their own dialect (see
+    :mod:`omnigent.inner.acp_subagents`); the executor normalizes that to a
+    :class:`~omnigent.inner.executor.SubAgentStarted`, which the adapter emits as
+    this event. The runner intercepts it in ``proxy_stream`` and POSTs
+    ``external_subagent_start`` to the Omnigent server, minting a child session so
+    the web "Subagents" panel lists one row per child. **Never** relayed to
+    external clients — the client learns of the child via ``session.created``.
+
+    :param type: Always ``"subagent.started"``.
+    :param child_key: Stable, per-turn-unique id for the sub-agent — the
+        idempotency key when the child is minted and the correlation key for the
+        later :class:`SubagentCompletedEvent`.
+    :param title: Short human label for the row, e.g. ``"mathutils"``.
+    :param task: The instruction the sub-agent was given.
+    """
+
+    type: Literal["subagent.started"]
+    child_key: str
+    title: str
+    task: str = ""
+
+
+class SubagentCompletedEvent(_SSEEventBase):
+    """
+    Runner-internal marker: a previously-announced sub-agent finished.
+
+    Emitted by the adapter from a
+    :class:`~omnigent.inner.executor.SubAgentCompleted`. The runner records the
+    outcome on the child session minted for the matching ``child_key`` (status +
+    the summary as its output). **Never** relayed to external clients.
+
+    :param type: Always ``"subagent.completed"``.
+    :param child_key: Matches the :attr:`SubagentStartedEvent.child_key`.
+    :param ok: Whether the sub-agent reported success.
+    :param summary: The sub-agent's closing summary.
+    """
+
+    type: Literal["subagent.completed"]
+    child_key: str
+    ok: bool = True
+    summary: str = ""
+
+
+HarnessStreamEvent = (
+    ServerStreamEvent
+    | InjectionConsumedEvent
+    | PolicyEvaluationRequestEvent
+    | SubagentStartedEvent
+    | SubagentCompletedEvent
+)
 
 
 # ── Projects ──────────────────────────────────────────────────────

--- a/tests/inner/devin/test_devin_harness.py
+++ b/tests/inner/devin/test_devin_harness.py
@@ -1,0 +1,86 @@
+"""Tests for the ``harness: devin`` wrap (:mod:`omnigent.inner.devin.harness`).
+
+The wrap is the only thing that distinguishes a Devin harness process from a
+generic ACP one, so these pin the injection itself. Everything below the wrap is
+shared ACP code and is covered by ``tests/inner/test_acp_executor.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.harness_plugins import harness_capabilities, harness_modules
+from omnigent.inner import acp_harness
+from omnigent.inner.acp_executor import AcpExecutor
+from omnigent.inner.acp_extension import NO_ACP_EXTENSION
+from omnigent.inner.devin import DEVIN_ACP_EXTENSION
+from omnigent.inner.devin import harness as devin_harness
+
+
+def test_create_app_injects_the_devin_extension(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Devin's wrap delegates to the shared ACP wrap with Devin's extension.
+
+    **What breaks if this fails**: the Devin harness runs as a plain ACP agent —
+    everything still works except the vendor behavior, silently. That is the
+    failure mode composition-over-discovery trades for, so it is asserted here.
+    """
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        acp_harness,
+        "create_app",
+        lambda extension=NO_ACP_EXTENSION: captured.setdefault("extension", extension),
+    )
+
+    devin_harness.create_app()
+
+    assert captured["extension"] is DEVIN_ACP_EXTENSION
+
+
+def test_shared_builder_carries_the_extension_onto_the_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The injected extension reaches the executor the adapter drives."""
+    monkeypatch.setenv("HARNESS_ACP_COMMAND", "devin acp")
+
+    ex = acp_harness._build_acp_executor(DEVIN_ACP_EXTENSION)
+    assert isinstance(ex, AcpExecutor)
+    assert ex._extension is DEVIN_ACP_EXTENSION
+
+
+def test_shared_builder_defaults_to_no_vendor_behavior(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The generic ``acp`` harness builds a protocol-only executor.
+
+    The other half of the injection: a builtin ACP row that declares no vendor
+    behavior (Grok, a user's ``acp:<slug>``) must not inherit Devin's dialect.
+    """
+    monkeypatch.setenv("HARNESS_ACP_COMMAND", "grok agent stdio")
+
+    ex = acp_harness._build_acp_executor()
+    assert isinstance(ex, AcpExecutor)
+    assert ex._extension is NO_ACP_EXTENSION
+    assert ex._extension.subagent_sources == ()
+
+
+def test_registry_points_devin_at_its_own_wrap() -> None:
+    """``harness: devin`` resolves to this wrap, not the shared one.
+
+    The registry entry is what makes the injection happen at all — without it
+    Devin gets the generic wrap and the extension is never constructed.
+    """
+    assert harness_modules()["devin"] == "omnigent.inner.devin.harness"
+    # Sibling ACP rows keep the shared wrap.
+    assert harness_modules()["grok"] == "omnigent.inner.acp_harness"
+    assert harness_modules()["acp"] == "omnigent.inner.acp_harness"
+
+
+def test_declared_capability_is_derived_from_the_extension() -> None:
+    """Devin's ``subagents`` capability tracks the extension, not a hand-edit.
+
+    ``/v1/harnesses`` publishes this matrix, so a dialect added or removed
+    without updating the declaration would publish a false capability.
+    """
+    caps = harness_capabilities()
+    assert caps["devin"].subagents is DEVIN_ACP_EXTENSION.surfaces_subagents is True
+    # Only Devin diverges from the shared generic ACP profile, and only there.
+    assert caps["grok"] == caps["acp"]
+    assert caps["devin"] != caps["acp"]

--- a/tests/inner/devin/test_devin_liftability.py
+++ b/tests/inner/devin/test_devin_liftability.py
@@ -1,0 +1,133 @@
+"""Structural guards that keep the Devin harness liftable and one-directional.
+
+The Devin package is shaped to become a community harness plugin
+(``omnigent.community.harness.devin``) if we ever move it out of core, and the
+generic ACP layer is shaped to never know Devin exists. Both properties are easy
+to erode with one convenient import, so they are asserted mechanically here
+rather than left to review.
+
+Imports are read from the AST, so a docstring cross-reference between layers is
+fine — only real dependencies count.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import omnigent
+
+_OMNIGENT_ROOT = pathlib.Path(omnigent.__file__).parent
+_DEVIN_PKG = _OMNIGENT_ROOT / "inner" / "devin"
+
+# What a lifted ``omnigent-devin`` package could still import from core. The ACP
+# executor/wrap entries are the deliberate coupling: reusing Omnigent's ACP
+# client is why this package is ~150 lines instead of the ~750 a from-scratch
+# community ACP harness carries (cf. ``omnigent-rovo``). Everything else here is
+# the plugin contract's own public surface.
+_ALLOWED_CORE_IMPORTS = frozenset(
+    {
+        "omnigent.inner.acp_executor",
+        "omnigent.inner.acp_extension",
+        "omnigent.inner.acp_harness",
+        "omnigent.inner.acp_subagents",
+        "omnigent.inner.executor",
+        "omnigent.runtime.harnesses._executor_adapter",
+    }
+)
+
+# The generic ACP layer. None of it may depend on a vendor package.
+_GENERIC_ACP_MODULES = (
+    _OMNIGENT_ROOT / "inner" / "acp_executor.py",
+    _OMNIGENT_ROOT / "inner" / "acp_extension.py",
+    _OMNIGENT_ROOT / "inner" / "acp_harness.py",
+    _OMNIGENT_ROOT / "inner" / "acp_subagents.py",
+)
+
+
+def _imported_modules(path: pathlib.Path) -> set[str]:
+    """Return every dotted name *path* imports, from its AST.
+
+    ``from X import Y`` is ambiguous statically — ``Y`` may be a submodule or a
+    symbol — so both ``X`` and ``X.Y`` are recorded and :func:`_is_allowed`
+    resolves the ambiguity against the allowlist.
+    """
+    tree = ast.parse(path.read_text(), filename=str(path))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            names.add(node.module)
+            names.update(f"{node.module}.{alias.name}" for alias in node.names)
+    return names
+
+
+def _is_allowed(name: str, allowed: frozenset[str]) -> bool:
+    """Whether a dotted import name resolves within the allowed module set.
+
+    Accepts an allowed module itself, a symbol imported from one
+    (``…acp_subagents.SubAgentStart``), and a parent package on the way to one
+    (``omnigent.inner`` from ``from omnigent.inner import acp_harness``) — none of
+    which is a dependency beyond the allowed module.
+    """
+    return any(
+        name == mod or name.startswith(f"{mod}.") or mod.startswith(f"{name}.") for mod in allowed
+    )
+
+
+def test_devin_package_only_imports_the_liftable_core_surface() -> None:
+    """Devin imports nothing from core that a community plugin could not.
+
+    **What breaks if this fails**: lifting Devin out stops being a move — the new
+    import drags in core internals (the server, runner, registry, or stores) that
+    a plugin cannot reach, and the extraction turns into a rewrite.
+    """
+    modules = sorted(_DEVIN_PKG.glob("*.py"))
+    assert modules, f"no modules found under {_DEVIN_PKG}"
+
+    offenders: dict[str, set[str]] = {}
+    for path in modules:
+        core = {
+            name
+            for name in _imported_modules(path)
+            if name.split(".")[0] == "omnigent"
+            and not name.startswith("omnigent.inner.devin")
+            and not _is_allowed(name, _ALLOWED_CORE_IMPORTS)
+        }
+        if core:
+            offenders[path.name] = core
+
+    assert not offenders, (
+        f"Devin imports core modules outside the liftable surface: {offenders}. "
+        f"Either route the need through AcpExtension, or add the module to "
+        f"_ALLOWED_CORE_IMPORTS with a note on how a lifted package would satisfy it."
+    )
+
+
+def test_generic_acp_layer_does_not_import_a_vendor() -> None:
+    """The generic ACP modules never import a vendor package.
+
+    **What breaks if this fails**: the vendor coupling the extension seam exists
+    to contain is back in the shared path, so every ACP agent pays for it and
+    lifting the vendor out breaks core.
+    """
+    offenders = {
+        path.name: sorted(n for n in _imported_modules(path) if "devin" in n)
+        for path in _GENERIC_ACP_MODULES
+    }
+    offenders = {name: found for name, found in offenders.items() if found}
+
+    assert not offenders, f"generic ACP modules import vendor code: {offenders}"
+
+
+def test_devin_wrap_exposes_the_harness_entry_point() -> None:
+    """The package exports ``create_app()`` — the whole harness-module contract.
+
+    Same requirement a community plugin's ``harness_modules`` target must meet,
+    so the wrap already satisfies the plugin contract as written.
+    """
+    from omnigent.inner.devin import harness
+
+    assert callable(harness.create_app)
+    assert harness.create_app.__code__.co_argcount == 0

--- a/tests/inner/devin/test_devin_subagents.py
+++ b/tests/inner/devin/test_devin_subagents.py
@@ -1,0 +1,160 @@
+"""Tests for Devin's sub-agent dialect (:mod:`omnigent.inner.devin.subagents`).
+
+The frame shapes below are copied verbatim from a live ``devin acp`` turn that
+delegated three parallel sub-agents (captured 2026-08-25): the lifecycle rides
+in vendor ``_meta`` on a ``tool_call_update`` whose ``toolCallId`` is the
+sub-agent's ``agentId``. Keeping the real shapes here means the source is tested
+against what Devin actually emits, not a paraphrase.
+"""
+
+from __future__ import annotations
+
+from omnigent.inner.acp_subagents import SubAgentEnd, SubAgentStart
+from omnigent.inner.devin import DEVIN_ACP_EXTENSION, DevinSubAgentSource
+
+# --- real captured frames (params.update objects) -----------------------------
+
+_DEVIN_STARTED = {
+    "sessionUpdate": "tool_call_update",
+    "toolCallId": "a0ac9364",
+    "status": "in_progress",
+    "_meta": {
+        "cognition.ai/subagent_started": {
+            "agentId": "a0ac9364",
+            "title": "mathutils",
+            "task": "In the directory /tmp/x create mathutils.py with add/sub/mul and tests.",
+        }
+    },
+}
+
+_DEVIN_COMPLETED = {
+    "sessionUpdate": "tool_call_update",
+    "toolCallId": "a0ac9364",
+    "status": "completed",
+    "_meta": {
+        "cognition.ai/subagent_completed": {
+            "agentId": "a0ac9364",
+            "success": True,
+            "summary": "Created mathutils.py and test_mathutils.py; 3 tests pass.",
+        }
+    },
+}
+
+# A nested tool call the sub-agent made — marks provenance, NOT a lifecycle edge.
+_DEVIN_CONTEXT = {
+    "sessionUpdate": "tool_call",
+    "toolCallId": "toolu_bdrk_01Ha8UacTecWfxbxgERXdGtN",
+    "title": "Wrote mathutils.py",
+    "_meta": {"cognition.ai/subagent_context": {"parentAgentId": "a0ac9364"}},
+}
+
+
+def test_devin_source_reads_a_start() -> None:
+    """``cognition.ai/subagent_started`` → a ``SubAgentStart`` keyed by agentId.
+
+    **What breaks if this fails**: Devin's spawned sub-agent never becomes a
+    child session, so the web "Subagents" panel stays empty for it.
+    """
+    events = DevinSubAgentSource().read(_DEVIN_STARTED)
+    assert events == (
+        SubAgentStart(
+            child_key="a0ac9364",
+            title="mathutils",
+            task="In the directory /tmp/x create mathutils.py with add/sub/mul and tests.",
+        ),
+    )
+
+
+def test_devin_source_reads_a_completion() -> None:
+    """``cognition.ai/subagent_completed`` → a ``SubAgentEnd`` with the summary."""
+    events = DevinSubAgentSource().read(_DEVIN_COMPLETED)
+    assert events == (
+        SubAgentEnd(
+            child_key="a0ac9364",
+            ok=True,
+            summary="Created mathutils.py and test_mathutils.py; 3 tests pass.",
+        ),
+    )
+
+
+def test_devin_source_ignores_context_marker() -> None:
+    """``subagent_context`` marks a nested call's provenance — not a lifecycle edge.
+
+    Treating it as a start/end would mint or close a phantom child on every tool
+    call the sub-agent makes.
+    """
+    assert DevinSubAgentSource().read(_DEVIN_CONTEXT) == ()
+
+
+def test_devin_source_self_gates_on_plain_frames() -> None:
+    """A frame without the Devin markers yields nothing — the source is inert.
+
+    This is the "applies only to acp devin" property: the source recognizes its
+    own dialect, so it is a no-op for every other ACP agent's traffic.
+    """
+    source = DevinSubAgentSource()
+    assert source.read({"sessionUpdate": "tool_call", "toolCallId": "x"}) == ()
+    assert source.read({"sessionUpdate": "agent_message_chunk", "content": {"text": "hi"}}) == ()
+    assert source.read({"_meta": {"cognition.ai/icon": "wrench"}}) == ()  # unrelated meta
+    assert source.read({"_meta": "not-a-dict"}) == ()  # malformed
+
+
+def test_devin_source_skips_a_blank_agent_id() -> None:
+    """A start/complete missing its agentId is dropped, not surfaced with a blank key.
+
+    The agentId is both the correlation and idempotency key, so a blank one would
+    mint an unaddressable child.
+    """
+    source = DevinSubAgentSource()
+    assert source.read({"_meta": {"cognition.ai/subagent_started": {"title": "x"}}}) == ()
+    assert source.read({"_meta": {"cognition.ai/subagent_started": {"agentId": ""}}}) == ()
+
+
+def test_devin_source_falls_back_title_to_agent_id() -> None:
+    """A start with no title still yields a usable row label (the agentId)."""
+    (start,) = DevinSubAgentSource().read(
+        {"_meta": {"cognition.ai/subagent_started": {"agentId": "abc123"}}}
+    )
+    assert isinstance(start, SubAgentStart)
+    assert start.child_key == "abc123" and start.title == "abc123" and start.task == ""
+
+
+def test_devin_extension_declares_the_dialect() -> None:
+    """The extension Devin's wrap injects carries exactly this dialect.
+
+    The composition root: without it the executor scans nothing and the Subagents
+    panel stays empty for Devin, however correct the source below is.
+    """
+    assert DEVIN_ACP_EXTENSION.name == "devin"
+    assert [type(src) for src in DEVIN_ACP_EXTENSION.subagent_sources] == [DevinSubAgentSource]
+    # The declared ``subagents`` capability is derived from this, so it must agree.
+    assert DEVIN_ACP_EXTENSION.surfaces_subagents is True
+
+
+def test_devin_dialect_reaches_the_executor_through_the_extension() -> None:
+    """A Devin frame becomes normalized events when the extension is injected.
+
+    Covers the dialect -> extension -> generic executor path in one assertion, so
+    a rename on either side of the seam fails here rather than silently.
+    """
+    from omnigent.inner.acp_executor import AcpAgentConfig, AcpExecutor
+    from omnigent.inner.executor import SubAgentCompleted, SubAgentStarted
+
+    ex = AcpExecutor(AcpAgentConfig(command="devin acp"), extension=DEVIN_ACP_EXTENSION)
+    started = ex._handle_session_update(_DEVIN_STARTED)
+    completed = ex._handle_session_update(_DEVIN_COMPLETED)
+
+    assert [e for e in started if isinstance(e, SubAgentStarted)] == [
+        SubAgentStarted(
+            child_key="a0ac9364",
+            title="mathutils",
+            task="In the directory /tmp/x create mathutils.py with add/sub/mul and tests.",
+        )
+    ]
+    assert [e for e in completed if isinstance(e, SubAgentCompleted)] == [
+        SubAgentCompleted(
+            child_key="a0ac9364",
+            ok=True,
+            summary="Created mathutils.py and test_mathutils.py; 3 tests pass.",
+        )
+    ]

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -356,74 +356,82 @@ def test_in_progress_tool_update_emits_nothing() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Sub-agent surfacing (dialect source -> normalized events)
+# Sub-agent surfacing (extension-supplied dialect -> normalized events)
 # ---------------------------------------------------------------------------
 
 
-def test_handle_session_update_emits_subagent_started() -> None:
-    """A Devin ``subagent_started`` frame yields a ``SubAgentStarted`` event.
+class _FakeSubAgentDialect:
+    """An invented dialect, so this generic suite names no vendor."""
 
-    This is the executor half of the seam: the runner turns this event into a
-    child session, so if it stops firing the "Subagents" panel goes empty for
-    Devin. The frame shape is copied from a real ``devin acp`` turn.
-    """
-    ex = AcpExecutor(AcpAgentConfig(command="devin acp"))
-    events = ex._handle_session_update(
-        {
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": "a0ac9364",
-            "status": "in_progress",
-            "_meta": {
-                "cognition.ai/subagent_started": {
-                    "agentId": "a0ac9364",
-                    "title": "mathutils",
-                    "task": "create mathutils.py + tests",
-                }
-            },
-        }
+    def read(self, update: dict[str, object]) -> tuple[object, ...]:
+        """Return a start/end for ``acme.dev/spawn`` / ``acme.dev/done``."""
+        from omnigent.inner.acp_subagents import SubAgentEnd, SubAgentStart
+
+        if isinstance(update.get("acme.dev/spawn"), dict):
+            return (SubAgentStart(child_key="w1", title="worker", task="do a thing"),)
+        if isinstance(update.get("acme.dev/done"), dict):
+            return (SubAgentEnd(child_key="w1", ok=True, summary="done"),)
+        return ()
+
+
+def _extended_executor() -> AcpExecutor:
+    """An executor whose extension supplies one dialect (a vendor's wrap does this)."""
+    from omnigent.inner.acp_extension import AcpExtension
+
+    return AcpExecutor(
+        AcpAgentConfig(command="x"),
+        extension=AcpExtension(name="acme", subagent_sources=(_FakeSubAgentDialect(),)),
     )
-    started = [e for e in events if isinstance(e, SubAgentStarted)]
-    assert started == [
-        SubAgentStarted(
-            child_key="a0ac9364", title="mathutils", task="create mathutils.py + tests"
-        )
+
+
+def test_handle_session_update_emits_subagent_started() -> None:
+    """An extension-recognized start becomes a ``SubAgentStarted`` event.
+
+    The executor half of the seam: the runner turns this event into a child
+    session, so if it stops firing the "Subagents" panel goes empty.
+    """
+    events = _extended_executor()._handle_session_update(
+        {"sessionUpdate": "tool_call_update", "acme.dev/spawn": {"id": "w1"}}
+    )
+    assert [e for e in events if isinstance(e, SubAgentStarted)] == [
+        SubAgentStarted(child_key="w1", title="worker", task="do a thing")
     ]
 
 
 def test_handle_session_update_emits_subagent_completed() -> None:
-    """A Devin ``subagent_completed`` frame yields a ``SubAgentCompleted`` event."""
-    ex = AcpExecutor(AcpAgentConfig(command="devin acp"))
-    events = ex._handle_session_update(
-        {
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": "a0ac9364",
-            "status": "completed",
-            "_meta": {
-                "cognition.ai/subagent_completed": {
-                    "agentId": "a0ac9364",
-                    "success": True,
-                    "summary": "3 tests pass.",
-                }
-            },
-        }
+    """An extension-recognized end becomes a ``SubAgentCompleted`` event."""
+    events = _extended_executor()._handle_session_update(
+        {"sessionUpdate": "tool_call_update", "acme.dev/done": {"id": "w1"}}
     )
-    completed = [e for e in events if isinstance(e, SubAgentCompleted)]
-    assert completed == [SubAgentCompleted(child_key="a0ac9364", ok=True, summary="3 tests pass.")]
+    assert [e for e in events if isinstance(e, SubAgentCompleted)] == [
+        SubAgentCompleted(child_key="w1", ok=True, summary="done")
+    ]
 
 
-def test_handle_session_update_no_subagent_events_for_plain_frames() -> None:
-    """Ordinary frames emit no sub-agent events — the scan is inert without the dialect.
+def test_generic_executor_does_no_subagent_scanning() -> None:
+    """With no extension, the executor is inert even for a dialect-shaped frame.
 
-    A plain tool_call still becomes a tool card (existing behavior), and no
-    SubAgent* event is produced, so non-Devin ACP agents are unaffected.
+    **What breaks if this fails**: every ACP agent — Grok, a user's own
+    ``acp:<slug>`` — gets some other vendor's dialect run against its frames,
+    which is the coupling the extension seam exists to prevent. The default must
+    read no vendor field at all.
     """
-    ex = AcpExecutor(AcpAgentConfig(command="goose acp"))
+    ex = AcpExecutor(AcpAgentConfig(command="x"))  # generic acp harness
     for frame in (
+        {"sessionUpdate": "tool_call_update", "acme.dev/spawn": {"id": "w1"}},
+        {"sessionUpdate": "tool_call_update", "_meta": {"cognition.ai/subagent_started": {}}},
         {"sessionUpdate": "agent_message_chunk", "content": {"text": "hi"}},
-        {"sessionUpdate": "tool_call", "toolCallId": "c1", "title": "Ran ls", "kind": "execute"},
     ):
         events = ex._handle_session_update(frame)
-        assert not any(isinstance(e, (SubAgentStarted, SubAgentCompleted)) for e in events)
+        assert not any(isinstance(e, (SubAgentStarted, SubAgentCompleted)) for e in events), frame
+
+
+def test_tool_cards_still_render_alongside_the_scan() -> None:
+    """The scan is additive — an ordinary tool_call still produces its card."""
+    events = _extended_executor()._handle_session_update(
+        {"sessionUpdate": "tool_call", "toolCallId": "c1", "title": "Ran ls", "kind": "execute"}
+    )
+    assert [type(e) for e in events] == [ToolCallRequest]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -30,6 +30,8 @@ from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import (
     ExecutorError,
     ReasoningChunk,
+    SubAgentCompleted,
+    SubAgentStarted,
     TextChunk,
     ToolCallComplete,
     ToolCallRequest,
@@ -351,6 +353,77 @@ def test_in_progress_tool_update_emits_nothing() -> None:
         )
         == []
     )
+
+
+# ---------------------------------------------------------------------------
+# Sub-agent surfacing (dialect source -> normalized events)
+# ---------------------------------------------------------------------------
+
+
+def test_handle_session_update_emits_subagent_started() -> None:
+    """A Devin ``subagent_started`` frame yields a ``SubAgentStarted`` event.
+
+    This is the executor half of the seam: the runner turns this event into a
+    child session, so if it stops firing the "Subagents" panel goes empty for
+    Devin. The frame shape is copied from a real ``devin acp`` turn.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="devin acp"))
+    events = ex._handle_session_update(
+        {
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "a0ac9364",
+            "status": "in_progress",
+            "_meta": {
+                "cognition.ai/subagent_started": {
+                    "agentId": "a0ac9364",
+                    "title": "mathutils",
+                    "task": "create mathutils.py + tests",
+                }
+            },
+        }
+    )
+    started = [e for e in events if isinstance(e, SubAgentStarted)]
+    assert started == [
+        SubAgentStarted(
+            child_key="a0ac9364", title="mathutils", task="create mathutils.py + tests"
+        )
+    ]
+
+
+def test_handle_session_update_emits_subagent_completed() -> None:
+    """A Devin ``subagent_completed`` frame yields a ``SubAgentCompleted`` event."""
+    ex = AcpExecutor(AcpAgentConfig(command="devin acp"))
+    events = ex._handle_session_update(
+        {
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "a0ac9364",
+            "status": "completed",
+            "_meta": {
+                "cognition.ai/subagent_completed": {
+                    "agentId": "a0ac9364",
+                    "success": True,
+                    "summary": "3 tests pass.",
+                }
+            },
+        }
+    )
+    completed = [e for e in events if isinstance(e, SubAgentCompleted)]
+    assert completed == [SubAgentCompleted(child_key="a0ac9364", ok=True, summary="3 tests pass.")]
+
+
+def test_handle_session_update_no_subagent_events_for_plain_frames() -> None:
+    """Ordinary frames emit no sub-agent events — the scan is inert without the dialect.
+
+    A plain tool_call still becomes a tool card (existing behavior), and no
+    SubAgent* event is produced, so non-Devin ACP agents are unaffected.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="goose acp"))
+    for frame in (
+        {"sessionUpdate": "agent_message_chunk", "content": {"text": "hi"}},
+        {"sessionUpdate": "tool_call", "toolCallId": "c1", "title": "Ran ls", "kind": "execute"},
+    ):
+        events = ex._handle_session_update(frame)
+        assert not any(isinstance(e, (SubAgentStarted, SubAgentCompleted)) for e in events)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/inner/test_acp_subagents.py
+++ b/tests/inner/test_acp_subagents.py
@@ -1,0 +1,163 @@
+"""Tests for the ACP sub-agent dialect seam (:mod:`omnigent.inner.acp_subagents`).
+
+The frame shapes below are copied verbatim from a live ``devin acp`` turn that
+delegated three parallel sub-agents (captured 2026-08-25): the lifecycle rides
+in vendor ``_meta`` on a ``tool_call_update`` whose ``toolCallId`` is the
+sub-agent's ``agentId``. Keeping the real shapes here means the source is tested
+against what Devin actually emits, not a paraphrase.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from omnigent.inner.acp_subagents import (
+    DevinSubAgentSource,
+    SubAgentEnd,
+    SubAgentEvent,
+    SubAgentStart,
+    read_subagent_events,
+)
+
+# --- real captured frames (params.update objects) -----------------------------
+
+_DEVIN_STARTED = {
+    "sessionUpdate": "tool_call_update",
+    "toolCallId": "a0ac9364",
+    "status": "in_progress",
+    "_meta": {
+        "cognition.ai/subagent_started": {
+            "agentId": "a0ac9364",
+            "title": "mathutils",
+            "task": "In the directory /tmp/x create mathutils.py with add/sub/mul and tests.",
+        }
+    },
+}
+
+_DEVIN_COMPLETED = {
+    "sessionUpdate": "tool_call_update",
+    "toolCallId": "a0ac9364",
+    "status": "completed",
+    "_meta": {
+        "cognition.ai/subagent_completed": {
+            "agentId": "a0ac9364",
+            "success": True,
+            "summary": "Created mathutils.py and test_mathutils.py; 3 tests pass.",
+        }
+    },
+}
+
+# A nested tool call the sub-agent made — marks provenance, NOT a lifecycle edge.
+_DEVIN_CONTEXT = {
+    "sessionUpdate": "tool_call",
+    "toolCallId": "toolu_bdrk_01Ha8UacTecWfxbxgERXdGtN",
+    "title": "Wrote mathutils.py",
+    "_meta": {"cognition.ai/subagent_context": {"parentAgentId": "a0ac9364"}},
+}
+
+
+def test_devin_source_reads_a_start() -> None:
+    """``cognition.ai/subagent_started`` → a ``SubAgentStart`` keyed by agentId.
+
+    **What breaks if this fails**: Devin's spawned sub-agent never becomes a
+    child session, so the web "Subagents" panel stays empty for it.
+    """
+    events = DevinSubAgentSource().read(_DEVIN_STARTED)
+    assert events == (
+        SubAgentStart(
+            child_key="a0ac9364",
+            title="mathutils",
+            task="In the directory /tmp/x create mathutils.py with add/sub/mul and tests.",
+        ),
+    )
+
+
+def test_devin_source_reads_a_completion() -> None:
+    """``cognition.ai/subagent_completed`` → a ``SubAgentEnd`` with the summary."""
+    events = DevinSubAgentSource().read(_DEVIN_COMPLETED)
+    assert events == (
+        SubAgentEnd(
+            child_key="a0ac9364",
+            ok=True,
+            summary="Created mathutils.py and test_mathutils.py; 3 tests pass.",
+        ),
+    )
+
+
+def test_devin_source_ignores_context_marker() -> None:
+    """``subagent_context`` marks a nested call's provenance — not a lifecycle edge.
+
+    Treating it as a start/end would mint or close a phantom child on every tool
+    call the sub-agent makes.
+    """
+    assert DevinSubAgentSource().read(_DEVIN_CONTEXT) == ()
+
+
+def test_devin_source_self_gates_on_plain_frames() -> None:
+    """A frame without the Devin markers yields nothing — the source is inert.
+
+    This is the "applies only to acp devin" property: the source recognizes its
+    own dialect, so it is a no-op for every other ACP agent's traffic.
+    """
+    source = DevinSubAgentSource()
+    assert source.read({"sessionUpdate": "tool_call", "toolCallId": "x"}) == ()
+    assert source.read({"sessionUpdate": "agent_message_chunk", "content": {"text": "hi"}}) == ()
+    assert source.read({"_meta": {"cognition.ai/icon": "wrench"}}) == ()  # unrelated meta
+    assert source.read({"_meta": "not-a-dict"}) == ()  # malformed
+
+
+def test_devin_source_skips_a_blank_agent_id() -> None:
+    """A start/complete missing its agentId is dropped, not surfaced with a blank key.
+
+    The agentId is both the correlation and idempotency key, so a blank one would
+    mint an unaddressable child.
+    """
+    source = DevinSubAgentSource()
+    assert source.read({"_meta": {"cognition.ai/subagent_started": {"title": "x"}}}) == ()
+    assert source.read({"_meta": {"cognition.ai/subagent_started": {"agentId": ""}}}) == ()
+
+
+def test_devin_source_falls_back_title_to_agent_id() -> None:
+    """A start with no title still yields a usable row label (the agentId)."""
+    (start,) = DevinSubAgentSource().read(
+        {"_meta": {"cognition.ai/subagent_started": {"agentId": "abc123"}}}
+    )
+    assert isinstance(start, SubAgentStart)
+    assert start.child_key == "abc123" and start.title == "abc123" and start.task == ""
+
+
+def test_read_subagent_events_uses_the_default_devin_source() -> None:
+    """The module-level helper wires the default sources (Devin today)."""
+    assert read_subagent_events(_DEVIN_STARTED) == [
+        SubAgentStart(
+            child_key="a0ac9364",
+            title="mathutils",
+            task="In the directory /tmp/x create mathutils.py with add/sub/mul and tests.",
+        )
+    ]
+    assert read_subagent_events({"sessionUpdate": "tool_call"}) == []
+
+
+def test_read_subagent_events_accepts_a_new_dialect_source() -> None:
+    """A future harness plugs in by passing its own source — no core change.
+
+    Proves the seam: a source keyed on a different marker is honored, and it
+    composes with others. This is the extension point for another vendor or the
+    eventual ACP-standard subagent convention.
+    """
+
+    class _FakeAcpSubAgentSource:
+        """A hypothetical agent that marks spawns with its own vendor key."""
+
+        def read(self, update: Mapping[str, Any]) -> Sequence[SubAgentEvent]:
+            spawn = update.get("acme.dev/spawn")
+            if isinstance(spawn, Mapping) and isinstance(spawn.get("id"), str):
+                return (SubAgentStart(child_key=spawn["id"], title=spawn.get("name", "worker")),)
+            return ()
+
+    update = {"acme.dev/spawn": {"id": "w1", "name": "indexer"}}
+    events = read_subagent_events(update, sources=[_FakeAcpSubAgentSource()])
+    assert events == [SubAgentStart(child_key="w1", title="indexer", task="")]
+    # And the Devin default is inert on this other dialect's frame.
+    assert read_subagent_events(update) == []

--- a/tests/inner/test_acp_subagents.py
+++ b/tests/inner/test_acp_subagents.py
@@ -1,10 +1,8 @@
-"""Tests for the ACP sub-agent dialect seam (:mod:`omnigent.inner.acp_subagents`).
+"""Tests for the generic sub-agent seam (:mod:`omnigent.inner.acp_subagents`).
 
-The frame shapes below are copied verbatim from a live ``devin acp`` turn that
-delegated three parallel sub-agents (captured 2026-08-25): the lifecycle rides
-in vendor ``_meta`` on a ``tool_call_update`` whose ``toolCallId`` is the
-sub-agent's ``agentId``. Keeping the real shapes here means the source is tested
-against what Devin actually emits, not a paraphrase.
+Vendor-free by design: this module must name no agent, so the fixtures here use
+invented dialects. Devin's real-frame coverage lives in
+``tests/inner/devin/test_devin_subagents.py``.
 """
 
 from __future__ import annotations
@@ -13,151 +11,77 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from omnigent.inner.acp_subagents import (
-    DevinSubAgentSource,
+    AcpSubAgentSource,
     SubAgentEnd,
     SubAgentEvent,
     SubAgentStart,
     read_subagent_events,
 )
 
-# --- real captured frames (params.update objects) -----------------------------
 
-_DEVIN_STARTED = {
-    "sessionUpdate": "tool_call_update",
-    "toolCallId": "a0ac9364",
-    "status": "in_progress",
-    "_meta": {
-        "cognition.ai/subagent_started": {
-            "agentId": "a0ac9364",
-            "title": "mathutils",
-            "task": "In the directory /tmp/x create mathutils.py with add/sub/mul and tests.",
-        }
-    },
-}
+class _SpawnDialect:
+    """A hypothetical agent that marks spawns with its own vendor key."""
 
-_DEVIN_COMPLETED = {
-    "sessionUpdate": "tool_call_update",
-    "toolCallId": "a0ac9364",
-    "status": "completed",
-    "_meta": {
-        "cognition.ai/subagent_completed": {
-            "agentId": "a0ac9364",
-            "success": True,
-            "summary": "Created mathutils.py and test_mathutils.py; 3 tests pass.",
-        }
-    },
-}
-
-# A nested tool call the sub-agent made — marks provenance, NOT a lifecycle edge.
-_DEVIN_CONTEXT = {
-    "sessionUpdate": "tool_call",
-    "toolCallId": "toolu_bdrk_01Ha8UacTecWfxbxgERXdGtN",
-    "title": "Wrote mathutils.py",
-    "_meta": {"cognition.ai/subagent_context": {"parentAgentId": "a0ac9364"}},
-}
+    def read(self, update: Mapping[str, Any]) -> Sequence[SubAgentEvent]:
+        """Return a start for ``acme.dev/spawn``, nothing otherwise."""
+        spawn = update.get("acme.dev/spawn")
+        if isinstance(spawn, Mapping) and isinstance(spawn.get("id"), str):
+            return (SubAgentStart(child_key=spawn["id"], title=spawn.get("name", "worker")),)
+        return ()
 
 
-def test_devin_source_reads_a_start() -> None:
-    """``cognition.ai/subagent_started`` → a ``SubAgentStart`` keyed by agentId.
+class _DoneDialect:
+    """A second, unrelated dialect — proves sources compose."""
 
-    **What breaks if this fails**: Devin's spawned sub-agent never becomes a
-    child session, so the web "Subagents" panel stays empty for it.
+    def read(self, update: Mapping[str, Any]) -> Sequence[SubAgentEvent]:
+        """Return an end for ``acme.dev/done``, nothing otherwise."""
+        done = update.get("acme.dev/done")
+        if isinstance(done, Mapping) and isinstance(done.get("id"), str):
+            return (SubAgentEnd(child_key=done["id"], ok=bool(done.get("ok", True))),)
+        return ()
+
+
+def test_sources_satisfy_the_protocol() -> None:
+    """A plain ``read``-shaped object is an :class:`AcpSubAgentSource`.
+
+    The protocol is runtime-checkable so a vendor package can implement it
+    without importing a base class — the low bar that keeps a dialect liftable.
     """
-    events = DevinSubAgentSource().read(_DEVIN_STARTED)
-    assert events == (
-        SubAgentStart(
-            child_key="a0ac9364",
-            title="mathutils",
-            task="In the directory /tmp/x create mathutils.py with add/sub/mul and tests.",
-        ),
-    )
+    assert isinstance(_SpawnDialect(), AcpSubAgentSource)
 
 
-def test_devin_source_reads_a_completion() -> None:
-    """``cognition.ai/subagent_completed`` → a ``SubAgentEnd`` with the summary."""
-    events = DevinSubAgentSource().read(_DEVIN_COMPLETED)
-    assert events == (
-        SubAgentEnd(
-            child_key="a0ac9364",
-            ok=True,
-            summary="Created mathutils.py and test_mathutils.py; 3 tests pass.",
-        ),
-    )
+def test_read_subagent_events_without_sources_is_inert() -> None:
+    """No sources -> no events, whatever the frame carries.
 
-
-def test_devin_source_ignores_context_marker() -> None:
-    """``subagent_context`` marks a nested call's provenance — not a lifecycle edge.
-
-    Treating it as a start/end would mint or close a phantom child on every tool
-    call the sub-agent makes.
+    This is the generic ACP harness's configuration: an agent Omnigent knows
+    nothing vendor-specific about must produce no sub-agent surfacing at all.
     """
-    assert DevinSubAgentSource().read(_DEVIN_CONTEXT) == ()
+    assert read_subagent_events({"acme.dev/spawn": {"id": "w1"}}, ()) == []
 
 
-def test_devin_source_self_gates_on_plain_frames() -> None:
-    """A frame without the Devin markers yields nothing — the source is inert.
+def test_read_subagent_events_runs_every_source() -> None:
+    """Each source contributes; a frame one recognizes is ignored by the other."""
+    sources: list[AcpSubAgentSource] = [_SpawnDialect(), _DoneDialect()]
 
-    This is the "applies only to acp devin" property: the source recognizes its
-    own dialect, so it is a no-op for every other ACP agent's traffic.
-    """
-    source = DevinSubAgentSource()
-    assert source.read({"sessionUpdate": "tool_call", "toolCallId": "x"}) == ()
-    assert source.read({"sessionUpdate": "agent_message_chunk", "content": {"text": "hi"}}) == ()
-    assert source.read({"_meta": {"cognition.ai/icon": "wrench"}}) == ()  # unrelated meta
-    assert source.read({"_meta": "not-a-dict"}) == ()  # malformed
-
-
-def test_devin_source_skips_a_blank_agent_id() -> None:
-    """A start/complete missing its agentId is dropped, not surfaced with a blank key.
-
-    The agentId is both the correlation and idempotency key, so a blank one would
-    mint an unaddressable child.
-    """
-    source = DevinSubAgentSource()
-    assert source.read({"_meta": {"cognition.ai/subagent_started": {"title": "x"}}}) == ()
-    assert source.read({"_meta": {"cognition.ai/subagent_started": {"agentId": ""}}}) == ()
-
-
-def test_devin_source_falls_back_title_to_agent_id() -> None:
-    """A start with no title still yields a usable row label (the agentId)."""
-    (start,) = DevinSubAgentSource().read(
-        {"_meta": {"cognition.ai/subagent_started": {"agentId": "abc123"}}}
-    )
-    assert isinstance(start, SubAgentStart)
-    assert start.child_key == "abc123" and start.title == "abc123" and start.task == ""
-
-
-def test_read_subagent_events_uses_the_default_devin_source() -> None:
-    """The module-level helper wires the default sources (Devin today)."""
-    assert read_subagent_events(_DEVIN_STARTED) == [
-        SubAgentStart(
-            child_key="a0ac9364",
-            title="mathutils",
-            task="In the directory /tmp/x create mathutils.py with add/sub/mul and tests.",
-        )
+    assert read_subagent_events({"acme.dev/spawn": {"id": "w1", "name": "indexer"}}, sources) == [
+        SubAgentStart(child_key="w1", title="indexer", task="")
     ]
-    assert read_subagent_events({"sessionUpdate": "tool_call"}) == []
+    assert read_subagent_events({"acme.dev/done": {"id": "w1", "ok": False}}, sources) == [
+        SubAgentEnd(child_key="w1", ok=False, summary="")
+    ]
+    # Both edges in one frame, in source order.
+    both = read_subagent_events(
+        {"acme.dev/spawn": {"id": "w2"}, "acme.dev/done": {"id": "w2"}}, sources
+    )
+    assert both == [SubAgentStart(child_key="w2", title="worker"), SubAgentEnd(child_key="w2")]
 
 
-def test_read_subagent_events_accepts_a_new_dialect_source() -> None:
-    """A future harness plugs in by passing its own source — no core change.
-
-    Proves the seam: a source keyed on a different marker is honored, and it
-    composes with others. This is the extension point for another vendor or the
-    eventual ACP-standard subagent convention.
-    """
-
-    class _FakeAcpSubAgentSource:
-        """A hypothetical agent that marks spawns with its own vendor key."""
-
-        def read(self, update: Mapping[str, Any]) -> Sequence[SubAgentEvent]:
-            spawn = update.get("acme.dev/spawn")
-            if isinstance(spawn, Mapping) and isinstance(spawn.get("id"), str):
-                return (SubAgentStart(child_key=spawn["id"], title=spawn.get("name", "worker")),)
-            return ()
-
-    update = {"acme.dev/spawn": {"id": "w1", "name": "indexer"}}
-    events = read_subagent_events(update, sources=[_FakeAcpSubAgentSource()])
-    assert events == [SubAgentStart(child_key="w1", title="indexer", task="")]
-    # And the Devin default is inert on this other dialect's frame.
-    assert read_subagent_events(update) == []
+def test_unrecognized_frames_yield_nothing() -> None:
+    """An ordinary ACP frame passes through every source untouched."""
+    sources: list[AcpSubAgentSource] = [_SpawnDialect(), _DoneDialect()]
+    for frame in (
+        {"sessionUpdate": "agent_message_chunk", "content": {"text": "hi"}},
+        {"sessionUpdate": "tool_call", "toolCallId": "c1", "title": "Ran ls"},
+        {"_meta": {"some.vendor/unrelated": {"id": "x"}}},
+    ):
+        assert read_subagent_events(frame, sources) == []

--- a/tests/runner/test_acp_subagent_forwarding.py
+++ b/tests/runner/test_acp_subagent_forwarding.py
@@ -1,0 +1,187 @@
+"""Runner forwarding of a harness's sub-agents to child sessions.
+
+The runner intercepts the runner-internal ``subagent.started`` / ``subagent.completed``
+SSE events (which the adapter emits from an ACP agent's normalized sub-agent
+lifecycle — see :mod:`omnigent.inner.acp_subagents`) and mints / finalizes a child
+session via the existing ``external_subagent_start`` + ``external_session_status``
+endpoints. These test the two forwarding helpers against a real-``Response`` stub.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.runner import app as runner_app_mod
+
+
+@dataclass
+class _Post:
+    """One recorded POST: the path and the JSON body."""
+
+    url: str
+    body: dict[str, Any]
+
+
+class _RecordingServerClient:
+    """Records POSTs and returns queued real ``httpx.Response`` objects.
+
+    A real stub (not ``MagicMock``) so an unexpected call fails loudly, and real
+    responses so ``raise_for_status`` runs its true logic. Matches the helpers'
+    call shape ``post(url, *, json=...)`` — no ``timeout`` kwarg.
+    """
+
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self._responses = list(responses)
+        self.calls: list[_Post] = []
+
+    async def post(self, url: str, *, json: dict[str, Any]) -> httpx.Response:
+        """Record the POST and pop the next queued response."""
+        self.calls.append(_Post(url=url, body=json))
+        assert self._responses, f"unexpected POST #{len(self.calls)} (no response queued)"
+        return self._responses.pop(0)
+
+
+def _resp(status: int, url: str, body: dict[str, Any]) -> httpx.Response:
+    """Build a real ``httpx.Response`` with a request attached (for raise_for_status)."""
+    return httpx.Response(status, request=httpx.Request("POST", f"http://test{url}"), json=body)
+
+
+@pytest.mark.asyncio
+async def test_mint_subagent_child_posts_start_and_resolves_id() -> None:
+    """The start edge POSTs ``external_subagent_start`` and resolves the child id.
+
+    **What breaks if this fails**: the sub-agent never becomes a child session,
+    so the Subagents panel stays empty and the completion edge can't address it.
+    """
+    url = "/v1/sessions/parent1/events"
+    client = _RecordingServerClient([_resp(200, url, {"child_session_id": "child_abc"})])
+    fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+
+    await runner_app_mod._mint_acp_subagent_child(
+        client,  # type: ignore[arg-type]
+        parent_id="parent1",
+        child_key="a0ac9364",
+        title="mathutils",
+        task="create mathutils.py",
+        child_id_future=fut,
+    )
+
+    assert fut.result() == "child_abc"
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    assert call.url == url
+    assert call.body["type"] == "external_subagent_start"
+    assert call.body["data"] == {
+        "subagent_id": "a0ac9364",
+        "agent_type": "mathutils",
+        "description": "create mathutils.py",
+        "tool_use_id": "a0ac9364",
+    }
+
+
+@pytest.mark.asyncio
+async def test_mint_subagent_child_falls_back_agent_type_to_child_key() -> None:
+    """A blank title still sends a non-empty ``agent_type`` (the child_key)."""
+    client = _RecordingServerClient(
+        [_resp(200, "/v1/sessions/p/events", {"child_session_id": "c"})]
+    )
+    fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    await runner_app_mod._mint_acp_subagent_child(
+        client,  # type: ignore[arg-type]
+        parent_id="p",
+        child_key="k1",
+        title="",
+        task="",
+        child_id_future=fut,
+    )
+    assert client.calls[0].body["data"]["agent_type"] == "k1"
+
+
+@pytest.mark.asyncio
+async def test_mint_subagent_child_records_failure_on_non_2xx() -> None:
+    """A failed mint resolves the future with an exception (best-effort, no raise).
+
+    The completion edge keys off that exception to fail fast instead of hanging
+    on a child that was never created.
+    """
+    url = "/v1/sessions/parent1/events"
+    client = _RecordingServerClient([_resp(500, url, {"error": "boom"})])
+    fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+
+    await runner_app_mod._mint_acp_subagent_child(
+        client,  # type: ignore[arg-type]
+        parent_id="parent1",
+        child_key="a0ac9364",
+        title="mathutils",
+        task="t",
+        child_id_future=fut,
+    )
+    assert fut.done()
+    assert fut.exception() is not None
+
+
+@pytest.mark.asyncio
+async def test_complete_subagent_child_posts_idle_status_with_summary() -> None:
+    """The success edge marks the child ``idle`` and attaches the summary as output."""
+    status_url = "/v1/sessions/child_abc/events"
+    client = _RecordingServerClient([_resp(200, status_url, {"ok": True})])
+    fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    fut.set_result("child_abc")
+
+    await runner_app_mod._complete_acp_subagent_child(
+        client,  # type: ignore[arg-type]
+        child_key="a0ac9364",
+        ok=True,
+        summary="3 tests pass",
+        child_id_future=fut,
+    )
+
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    assert call.url == status_url
+    assert call.body["type"] == "external_session_status"
+    assert call.body["data"]["status"] == "idle"
+    assert call.body["data"]["output"] == "3 tests pass"
+
+
+@pytest.mark.asyncio
+async def test_complete_subagent_child_marks_failed_when_not_ok() -> None:
+    """A failed sub-agent marks the child ``failed`` (the server surfaces the detail)."""
+    client = _RecordingServerClient([_resp(200, "/v1/sessions/child_abc/events", {})])
+    fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    fut.set_result("child_abc")
+
+    await runner_app_mod._complete_acp_subagent_child(
+        client,  # type: ignore[arg-type]
+        child_key="a0ac9364",
+        ok=False,
+        summary="blocked",
+        child_id_future=fut,
+    )
+    assert client.calls[0].body["data"]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_complete_subagent_child_skips_when_mint_failed() -> None:
+    """If the start edge's mint failed, completion logs and skips — no status POST.
+
+    Guards the correlation: a failed mint must never strand the turn or fire a
+    status POST against a child id that was never created.
+    """
+    client = _RecordingServerClient([])  # any POST would fail loudly (empty queue)
+    fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    fut.set_exception(RuntimeError("mint failed"))
+
+    await runner_app_mod._complete_acp_subagent_child(
+        client,  # type: ignore[arg-type]
+        child_key="a0ac9364",
+        ok=True,
+        summary="x",
+        child_id_future=fut,
+    )
+    assert client.calls == []

--- a/tests/runner/test_acp_subagent_forwarding.py
+++ b/tests/runner/test_acp_subagent_forwarding.py
@@ -2,9 +2,17 @@
 
 The runner intercepts the runner-internal ``subagent.started`` / ``subagent.completed``
 SSE events (which the adapter emits from an ACP agent's normalized sub-agent
-lifecycle — see :mod:`omnigent.inner.acp_subagents`) and mints / finalizes a child
-session via the existing ``external_subagent_start`` + ``external_session_status``
-endpoints. These test the two forwarding helpers against a real-``Response`` stub.
+lifecycle — see :mod:`omnigent.inner.acp_subagents`) and mints / fills a child
+session via ``external_acp_subagent_start``, ``external_conversation_item``, and
+``external_session_status``.
+
+Two properties these pin, both user-visible bugs when they regress:
+
+* the mint uses the **ACP** start type, not the native ``external_subagent_start``
+  — that one stamps a claude-native wrapper label, which titles the child
+  "Claude Code" whatever the real harness is; and
+* the child's transcript is seeded (task in, summary out), so opening the row
+  shows the sub-agent's work instead of an empty chat.
 """
 
 from __future__ import annotations
@@ -51,15 +59,24 @@ def _resp(status: int, url: str, body: dict[str, Any]) -> httpx.Response:
     return httpx.Response(status, request=httpx.Request("POST", f"http://test{url}"), json=body)
 
 
-@pytest.mark.asyncio
-async def test_mint_subagent_child_posts_start_and_resolves_id() -> None:
-    """The start edge POSTs ``external_subagent_start`` and resolves the child id.
+def _ok(url: str, body: dict[str, Any] | None = None) -> httpx.Response:
+    """A 200 for *url*."""
+    return _resp(200, url, body or {})
 
-    **What breaks if this fails**: the sub-agent never becomes a child session,
-    so the Subagents panel stays empty and the completion edge can't address it.
+
+@pytest.mark.asyncio
+async def test_mint_subagent_child_uses_the_acp_start_type() -> None:
+    """The start edge POSTs ``external_acp_subagent_start`` and resolves the child id.
+
+    **What breaks if this fails**: using the native ``external_subagent_start``
+    stamps a claude-native wrapper label on the child, so the UI titles a Devin
+    sub-agent "Claude Code" — the exact bug this type exists to avoid.
     """
-    url = "/v1/sessions/parent1/events"
-    client = _RecordingServerClient([_resp(200, url, {"child_session_id": "child_abc"})])
+    parent_url = "/v1/sessions/parent1/events"
+    child_url = "/v1/sessions/child_abc/events"
+    client = _RecordingServerClient(
+        [_ok(parent_url, {"child_session_id": "child_abc"}), _ok(child_url)]
+    )
     fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
 
     await runner_app_mod._mint_acp_subagent_child(
@@ -72,25 +89,61 @@ async def test_mint_subagent_child_posts_start_and_resolves_id() -> None:
     )
 
     assert fut.result() == "child_abc"
-    assert len(client.calls) == 1
-    call = client.calls[0]
-    assert call.url == url
-    assert call.body["type"] == "external_subagent_start"
-    assert call.body["data"] == {
+    mint = client.calls[0]
+    assert mint.url == parent_url
+    assert mint.body["type"] == "external_acp_subagent_start"
+    assert mint.body["data"] == {
         "subagent_id": "a0ac9364",
-        "agent_type": "mathutils",
+        "title": "mathutils",
         "description": "create mathutils.py",
-        "tool_use_id": "a0ac9364",
     }
+    # The native path's keys must not leak into the ACP payload.
+    assert "agent_type" not in mint.body["data"]
+    assert "tool_use_id" not in mint.body["data"]
 
 
 @pytest.mark.asyncio
-async def test_mint_subagent_child_falls_back_agent_type_to_child_key() -> None:
-    """A blank title still sends a non-empty ``agent_type`` (the child_key)."""
+async def test_mint_subagent_child_seeds_the_task_into_the_child_chat() -> None:
+    """The delegated task lands in the child's transcript as a user message.
+
+    **What breaks if this fails**: the row appears but opening it shows an empty
+    chat — the reported symptom.
+    """
+    parent_url = "/v1/sessions/parent1/events"
+    child_url = "/v1/sessions/child_abc/events"
     client = _RecordingServerClient(
-        [_resp(200, "/v1/sessions/p/events", {"child_session_id": "c"})]
+        [_ok(parent_url, {"child_session_id": "child_abc"}), _ok(child_url)]
     )
     fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+
+    await runner_app_mod._mint_acp_subagent_child(
+        client,  # type: ignore[arg-type]
+        parent_id="parent1",
+        child_key="a0ac9364",
+        title="mathutils",
+        task="create mathutils.py",
+        child_id_future=fut,
+    )
+
+    assert len(client.calls) == 2, "expected the mint plus the task message"
+    item = client.calls[1]
+    assert item.url == child_url, "the task must be addressed to the CHILD, not the parent"
+    assert item.body["type"] == "external_conversation_item"
+    assert item.body["data"]["item_type"] == "message"
+    assert item.body["data"]["item_data"] == {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "create mathutils.py"}],
+    }
+    assert item.body["data"]["response_id"]
+
+
+@pytest.mark.asyncio
+async def test_mint_subagent_child_skips_the_seed_without_a_task() -> None:
+    """No task text → no transcript POST (the row is still minted)."""
+    parent_url = "/v1/sessions/p/events"
+    client = _RecordingServerClient([_ok(parent_url, {"child_session_id": "c"})])
+    fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+
     await runner_app_mod._mint_acp_subagent_child(
         client,  # type: ignore[arg-type]
         parent_id="p",
@@ -99,18 +152,22 @@ async def test_mint_subagent_child_falls_back_agent_type_to_child_key() -> None:
         task="",
         child_id_future=fut,
     )
-    assert client.calls[0].body["data"]["agent_type"] == "k1"
+
+    assert fut.result() == "c"
+    assert len(client.calls) == 1
+    # A blank title still sends a usable label (the child_key).
+    assert client.calls[0].body["data"]["title"] == "k1"
 
 
 @pytest.mark.asyncio
 async def test_mint_subagent_child_records_failure_on_non_2xx() -> None:
-    """A failed mint resolves the future with an exception (best-effort, no raise).
+    """A failed mint resolves the future with an exception and posts no transcript.
 
     The completion edge keys off that exception to fail fast instead of hanging
     on a child that was never created.
     """
-    url = "/v1/sessions/parent1/events"
-    client = _RecordingServerClient([_resp(500, url, {"error": "boom"})])
+    parent_url = "/v1/sessions/parent1/events"
+    client = _RecordingServerClient([_resp(500, parent_url, {"error": "boom"})])
     fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
 
     await runner_app_mod._mint_acp_subagent_child(
@@ -121,15 +178,15 @@ async def test_mint_subagent_child_records_failure_on_non_2xx() -> None:
         task="t",
         child_id_future=fut,
     )
-    assert fut.done()
-    assert fut.exception() is not None
+    assert fut.done() and fut.exception() is not None
+    assert len(client.calls) == 1, "a failed mint must not attempt the transcript POST"
 
 
 @pytest.mark.asyncio
-async def test_complete_subagent_child_posts_idle_status_with_summary() -> None:
-    """The success edge marks the child ``idle`` and attaches the summary as output."""
-    status_url = "/v1/sessions/child_abc/events"
-    client = _RecordingServerClient([_resp(200, status_url, {"ok": True})])
+async def test_complete_subagent_child_posts_summary_then_idle_status() -> None:
+    """The success edge writes the summary into the child chat, then marks it idle."""
+    child_url = "/v1/sessions/child_abc/events"
+    client = _RecordingServerClient([_ok(child_url), _ok(child_url)])
     fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
     fut.set_result("child_abc")
 
@@ -141,18 +198,23 @@ async def test_complete_subagent_child_posts_idle_status_with_summary() -> None:
         child_id_future=fut,
     )
 
-    assert len(client.calls) == 1
-    call = client.calls[0]
-    assert call.url == status_url
-    assert call.body["type"] == "external_session_status"
-    assert call.body["data"]["status"] == "idle"
-    assert call.body["data"]["output"] == "3 tests pass"
+    assert len(client.calls) == 2
+    msg, status = client.calls
+    assert msg.url == child_url
+    assert msg.body["data"]["item_data"] == {
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "3 tests pass"}],
+    }
+    assert status.body["type"] == "external_session_status"
+    assert status.body["data"]["status"] == "idle"
+    assert status.body["data"]["output"] == "3 tests pass"
 
 
 @pytest.mark.asyncio
 async def test_complete_subagent_child_marks_failed_when_not_ok() -> None:
     """A failed sub-agent marks the child ``failed`` (the server surfaces the detail)."""
-    client = _RecordingServerClient([_resp(200, "/v1/sessions/child_abc/events", {})])
+    child_url = "/v1/sessions/child_abc/events"
+    client = _RecordingServerClient([_ok(child_url), _ok(child_url)])
     fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
     fut.set_result("child_abc")
 
@@ -163,15 +225,15 @@ async def test_complete_subagent_child_marks_failed_when_not_ok() -> None:
         summary="blocked",
         child_id_future=fut,
     )
-    assert client.calls[0].body["data"]["status"] == "failed"
+    assert client.calls[-1].body["data"]["status"] == "failed"
 
 
 @pytest.mark.asyncio
 async def test_complete_subagent_child_skips_when_mint_failed() -> None:
-    """If the start edge's mint failed, completion logs and skips — no status POST.
+    """If the start edge's mint failed, completion logs and skips — no POST at all.
 
     Guards the correlation: a failed mint must never strand the turn or fire a
-    status POST against a child id that was never created.
+    POST against a child id that was never created.
     """
     client = _RecordingServerClient([])  # any POST would fail loudly (empty queue)
     fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
@@ -185,3 +247,28 @@ async def test_complete_subagent_child_skips_when_mint_failed() -> None:
         child_id_future=fut,
     )
     assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_transcript_failure_does_not_break_the_turn() -> None:
+    """A rejected transcript POST is swallowed — the row still works.
+
+    The panel entry is the load-bearing part; a transcript hiccup must not raise
+    into the turn or lose the minted child.
+    """
+    parent_url = "/v1/sessions/parent1/events"
+    child_url = "/v1/sessions/child_abc/events"
+    client = _RecordingServerClient(
+        [_ok(parent_url, {"child_session_id": "child_abc"}), _resp(500, child_url, {"e": 1})]
+    )
+    fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+
+    await runner_app_mod._mint_acp_subagent_child(
+        client,  # type: ignore[arg-type]
+        parent_id="parent1",
+        child_key="a0ac9364",
+        title="mathutils",
+        task="t",
+        child_id_future=fut,
+    )
+    assert fut.result() == "child_abc", "the child id must survive a transcript failure"

--- a/tests/runner/test_acp_subagent_forwarding.py
+++ b/tests/runner/test_acp_subagent_forwarding.py
@@ -184,7 +184,13 @@ async def test_mint_subagent_child_records_failure_on_non_2xx() -> None:
 
 @pytest.mark.asyncio
 async def test_complete_subagent_child_posts_summary_then_idle_status() -> None:
-    """The success edge writes the summary into the child chat, then marks it idle."""
+    """The success edge writes the summary into the child chat, then marks it idle.
+
+    The summary item MUST carry an ``agent`` — ``MessageData`` rejects an
+    assistant message without one, so an item that omits it 400s and the summary
+    silently never lands (the reported "assistant response missing" bug). The
+    author is the sub-agent's title.
+    """
     child_url = "/v1/sessions/child_abc/events"
     client = _RecordingServerClient([_ok(child_url), _ok(child_url)])
     fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
@@ -196,6 +202,7 @@ async def test_complete_subagent_child_posts_summary_then_idle_status() -> None:
         ok=True,
         summary="3 tests pass",
         child_id_future=fut,
+        title="mathutils",
     )
 
     assert len(client.calls) == 2
@@ -203,11 +210,34 @@ async def test_complete_subagent_child_posts_summary_then_idle_status() -> None:
     assert msg.url == child_url
     assert msg.body["data"]["item_data"] == {
         "role": "assistant",
+        "agent": "mathutils",
         "content": [{"type": "output_text", "text": "3 tests pass"}],
     }
     assert status.body["type"] == "external_session_status"
     assert status.body["data"]["status"] == "idle"
     assert status.body["data"]["output"] == "3 tests pass"
+
+
+@pytest.mark.asyncio
+async def test_summary_author_falls_back_to_child_key_without_a_title() -> None:
+    """With no title, the assistant author is the child_key — never blank.
+
+    A blank ``agent`` fails the same ``MessageData`` validator, so the fallback
+    must be non-empty for the summary to persist at all.
+    """
+    child_url = "/v1/sessions/child_abc/events"
+    client = _RecordingServerClient([_ok(child_url), _ok(child_url)])
+    fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    fut.set_result("child_abc")
+
+    await runner_app_mod._complete_acp_subagent_child(
+        client,  # type: ignore[arg-type]
+        child_key="a0ac9364",
+        ok=True,
+        summary="done",
+        child_id_future=fut,
+    )
+    assert client.calls[0].body["data"]["item_data"]["agent"] == "a0ac9364"
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -2160,3 +2160,54 @@ async def test_run_turn_installs_the_choice_bridge_only_where_supported() -> Non
         assert installed is expected, type(executor).__name__
         # The yes/no bridge is installed on both — the choice bridge is additive.
         assert getattr(executor, "_elicitation_handler", None) is not None
+
+
+def test_translate_event_emits_subagent_started() -> None:
+    """A ``SubAgentStarted`` becomes the runner-internal ``subagent.started`` SSE event.
+
+    This is the harness half of the surfacing seam: the runner turns this event
+    into a child session. If it stops emitting, the Subagents panel goes empty
+    for the agent.
+    """
+    from omnigent.inner.executor import SubAgentStarted
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.server.schemas import SubagentStartedEvent
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    ctx = _RecordingTurnContext(response_id="resp_sa")
+    adapter._translate_event(
+        SubAgentStarted(child_key="a0ac9364", title="mathutils", task="create files"),
+        ctx,  # type: ignore[arg-type]
+    )
+    assert len(ctx.emitted) == 1
+    ev = ctx.emitted[0]
+    assert isinstance(ev, SubagentStartedEvent)
+    assert (ev.type, ev.child_key, ev.title, ev.task) == (
+        "subagent.started",
+        "a0ac9364",
+        "mathutils",
+        "create files",
+    )
+
+
+def test_translate_event_emits_subagent_completed() -> None:
+    """A ``SubAgentCompleted`` becomes the runner-internal ``subagent.completed`` SSE event."""
+    from omnigent.inner.executor import SubAgentCompleted
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.server.schemas import SubagentCompletedEvent
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    ctx = _RecordingTurnContext(response_id="resp_sa")
+    adapter._translate_event(
+        SubAgentCompleted(child_key="a0ac9364", ok=True, summary="3 tests pass"),
+        ctx,  # type: ignore[arg-type]
+    )
+    assert len(ctx.emitted) == 1
+    ev = ctx.emitted[0]
+    assert isinstance(ev, SubagentCompletedEvent)
+    assert (ev.type, ev.child_key, ev.ok, ev.summary) == (
+        "subagent.completed",
+        "a0ac9364",
+        True,
+        "3 tests pass",
+    )

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -990,6 +990,67 @@ async def test_external_acp_subagent_start_allows_duplicate_titles(
     assert len(ids) == 2, "parallel sub-agents with the same title must get distinct children"
 
 
+async def test_acp_subagent_summary_needs_an_agent_to_persist(
+    client: httpx.AsyncClient,
+) -> None:
+    """An assistant message seeded into an ACP sub-agent child must carry ``agent``.
+
+    This is the server contract the runner's summary-seeding depends on, and the
+    root cause of the reported "sub-agent's response is missing from its chat"
+    bug: ``MessageData`` rejects an assistant message with no ``agent``, so an
+    item that omits it 400s and never persists (the runner posts best-effort and
+    swallows the rejection). With ``agent`` set — as the fix now sends — it
+    persists and appears in the child's items, exactly as the summary must.
+    """
+    import json
+
+    agent = await create_test_agent(client)
+    parent = await _create_session(client, agent["id"])
+    mint = await client.post(
+        f"/v1/sessions/{parent['id']}/events",
+        json={
+            "type": "external_acp_subagent_start",
+            "data": {"subagent_id": "a0ac9364", "title": "mathutils", "description": "t"},
+        },
+    )
+    child_id = mint.json()["child_session_id"]
+
+    def _summary_event(*, with_agent: bool) -> dict[str, object]:
+        item_data: dict[str, object] = {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "3 tests pass"}],
+        }
+        if with_agent:
+            item_data["agent"] = "mathutils"
+        return {
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "message",
+                "item_data": item_data,
+                "response_id": "resp_acpsub_a0ac9364",
+            },
+        }
+
+    # Without agent: rejected — the exact server response that silently hid the
+    # summary when the runner swallowed it.
+    missing = await client.post(
+        f"/v1/sessions/{child_id}/events", json=_summary_event(with_agent=False)
+    )
+    assert missing.status_code == 400, (
+        f"expected reject, got {missing.status_code}: {missing.text}"
+    )
+
+    # With agent (the fix): accepted and present in the child's transcript.
+    ok = await client.post(f"/v1/sessions/{child_id}/events", json=_summary_event(with_agent=True))
+    assert ok.status_code in (200, 202), ok.text
+
+    items = (await client.get(f"/v1/sessions/{child_id}/items")).json()["data"]
+    assert any(it.get("type") == "message" for it in items)
+    assert "3 tests pass" in json.dumps(items), (
+        f"summary not persisted into child items: {items!r}"
+    )
+
+
 async def test_external_subagent_start_handles_duplicate_agent_type_and_description(
     client: httpx.AsyncClient,
 ) -> None:

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -897,6 +897,99 @@ async def test_external_subagent_start_mints_child_session(
     assert child["labels"]["omnigent.claude_native.description"] == "Trace the auth flow"
 
 
+async def test_external_acp_subagent_start_mints_child_without_a_vendor_wrapper(
+    client: httpx.AsyncClient,
+) -> None:
+    """An ACP sub-agent child carries no native wrapper label.
+
+    That absence is the fix: the UI resolves a child's displayed harness from its
+    ``omnigent.wrapper`` label first, so minting a Devin sub-agent through the
+    claude-native path (which stamps ``claude-code-native-ui-subagent``) titled it
+    **"Claude Code"**. With no wrapper value the child's harness resolves to the
+    parent's, and the UI labels it from the harness catalog instead.
+    """
+    agent = await create_test_agent(client)
+    parent = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{parent['id']}/events",
+        json={
+            "type": "external_acp_subagent_start",
+            "data": {
+                "subagent_id": "a0ac9364",
+                "title": "mathutils",
+                "description": "create mathutils.py plus tests",
+            },
+        },
+    )
+    assert resp.status_code in (200, 202), f"unexpected status {resp.status_code}: {resp.text}"
+    child_id = resp.json()["child_session_id"]
+
+    children = (await client.get(f"/v1/sessions/{parent['id']}/child_sessions")).json()["data"]
+    matching = [c for c in children if c["id"] == child_id]
+    assert len(matching) == 1, f"child {child_id} not in {children!r}"
+    child = matching[0]
+    assert child["parent_session_id"] == parent["id"]
+    assert child["kind"] == "sub_agent"
+    assert child["tool"] == "mathutils"
+    assert child["session_name"] == "a0ac9364"
+    # The ACP id + task are preserved for downstream surfaces...
+    assert child["labels"]["omnigent.acp.subagent_id"] == "a0ac9364"
+    assert child["labels"]["omnigent.acp.subagent_description"] == "create mathutils.py plus tests"
+    # ...and crucially NO vendor wrapper label is stamped.
+    assert "omnigent.wrapper" not in child["labels"], (
+        f"an ACP sub-agent must not claim a vendor wrapper identity: {child['labels']!r}"
+    )
+
+
+async def test_external_acp_subagent_start_is_idempotent_on_subagent_id(
+    client: httpx.AsyncClient,
+) -> None:
+    """A redelivery with the same ``subagent_id`` returns the same child.
+
+    The runner POSTs best-effort and an agent can re-announce a sub-agent, so a
+    retry must not mint a duplicate row in the panel.
+    """
+    agent = await create_test_agent(client)
+    parent = await _create_session(client, agent["id"])
+    payload = {
+        "type": "external_acp_subagent_start",
+        "data": {"subagent_id": "dup1", "title": "worker", "description": "do a thing"},
+    }
+
+    first = await client.post(f"/v1/sessions/{parent['id']}/events", json=payload)
+    second = await client.post(f"/v1/sessions/{parent['id']}/events", json=payload)
+    assert first.json()["child_session_id"] == second.json()["child_session_id"]
+
+    children = (await client.get(f"/v1/sessions/{parent['id']}/child_sessions")).json()["data"]
+    assert len([c for c in children if c["labels"].get("omnigent.acp.subagent_id") == "dup1"]) == 1
+
+
+async def test_external_acp_subagent_start_allows_duplicate_titles(
+    client: httpx.AsyncClient,
+) -> None:
+    """Two sub-agents sharing a title both register (distinct ids).
+
+    An agent can label parallel sub-agents identically; the stable id keeps the
+    ``(parent, title)`` unique index from rejecting the second.
+    """
+    agent = await create_test_agent(client)
+    parent = await _create_session(client, agent["id"])
+
+    ids = set()
+    for sub_id in ("s1", "s2"):
+        resp = await client.post(
+            f"/v1/sessions/{parent['id']}/events",
+            json={
+                "type": "external_acp_subagent_start",
+                "data": {"subagent_id": sub_id, "title": "worker", "description": "same task"},
+            },
+        )
+        assert resp.status_code in (200, 202), resp.text
+        ids.add(resp.json()["child_session_id"])
+    assert len(ids) == 2, "parallel sub-agents with the same title must get distinct children"
+
+
 async def test_external_subagent_start_handles_duplicate_agent_type_and_description(
     client: httpx.AsyncClient,
 ) -> None:

--- a/tests/test_acp_cli_harnesses.py
+++ b/tests/test_acp_cli_harnesses.py
@@ -144,16 +144,33 @@ def test_fake_row_login_command() -> None:
 # ---------------------------------------------------------------------------
 
 
+# Rows whose vendor behavior earns their own thin wrap, which injects an
+# AcpExtension into the same shared ACP executor (see omnigent.inner.devin).
+# Listing one here is deliberate: it declares that the row no longer runs the
+# shared wrap and may declare capabilities the generic profile does not.
+_VENDOR_WRAPS = {"devin": "omnigent.inner.devin.harness"}
+
+
 @pytest.mark.parametrize("name", sorted(ACP_CLI_HARNESSES))
 def test_catalog_row_is_fully_registered(name: str) -> None:
     """One catalog row must yield every registration a harness needs."""
     row = ACP_CLI_HARNESSES[name]
 
     assert name in valid_harnesses()
-    assert harness_modules()[name] == "omnigent.inner.acp_harness"
     assert harness_labels()[name] == row.label
-    # Same declared profile as the generic "acp" harness they run through.
-    assert harness_capabilities()[name] == harness_capabilities()["acp"]
+    assert harness_modules()[name] == _VENDOR_WRAPS.get(name, "omnigent.inner.acp_harness")
+
+    caps = harness_capabilities()
+    if name in _VENDOR_WRAPS:
+        # A vendor wrap injects an AcpExtension, so the row may declare more than
+        # the generic profile — but only on the axes that extension implements.
+        # Normalizing those back must reproduce "acp" exactly, so a vendor cannot
+        # quietly diverge on resume, auth, effort, or anything else.
+        assert caps[name].subagents is True, name
+        assert dataclasses.replace(caps[name], subagents=caps["acp"].subagents) == caps["acp"]
+    else:
+        # Same declared profile as the generic "acp" harness they run through.
+        assert caps[name] == caps["acp"]
     assert install_specs()[name] == row.install
     for spelling in (name, *row.aliases):
         assert harness_install_keys()[spelling] == name

--- a/tests/test_harness_capabilities.py
+++ b/tests/test_harness_capabilities.py
@@ -29,6 +29,7 @@ from omnigent.harness_plugins import (
     native_agents,
     valid_harnesses,
 )
+from omnigent.inner.devin import DEVIN_ACP_EXTENSION
 from omnigent.model_override import (
     _ANTIGRAVITY_FAMILY_HARNESSES,
     _CLAUDE_FAMILY_HARNESSES,
@@ -71,10 +72,24 @@ def test_model_family_matches_model_override_sets() -> None:
             assert family is ModelFamily.MULTI, harness
 
 
-def test_subagents_matches_native_wrapper_label() -> None:
-    # subagents is derivable: only native agents with a subagent_wrapper_label
-    # can spawn Omnigent native sub-agents.
+def test_subagents_matches_its_implementing_mechanism() -> None:
+    """``subagents`` is derivable — from the two mechanisms that implement it.
+
+    1. A **native** agent with a ``subagent_wrapper_label``: Omnigent intercepts
+       the vendor's own spawn and mints the child session.
+    2. An **ACP vendor extension** carrying a sub-agent dialect
+       (:mod:`omnigent.inner.devin`): the agent reports its sub-agent lifecycle in
+       its own ``_meta``, and the runner mints the child from that. No native
+       wrapper label is involved — deliberately, since the child inherits its
+       parent's harness identity rather than claiming a vendor's.
+
+    Keeping the derivation here means a harness cannot publish a ``subagents``
+    capability on ``/v1/harnesses`` that nothing implements, or implement one it
+    does not publish.
+    """
     subagent_capable = {agent.harness for agent in native_agents() if agent.subagent_wrapper_label}
+    if DEVIN_ACP_EXTENSION.surfaces_subagents:
+        subagent_capable.add("devin")
     for harness, capability in harness_capabilities().items():
         expected = harness in subagent_capable
         assert capability.subagents == expected, harness


### PR DESCRIPTION
## Related issue

Closes #5488

## Summary

An ACP agent that spawns sub-agents (Devin does) never appeared in the web
**Subagents** panel. A panel row is an Omnigent child session
(`GET /v1/sessions/{id}/child_sessions`, `kind="sub_agent"`), and each native
harness mints one via its *own* runner-side forwarder (Claude's Task tool, agy's
trajectory files, …). The generic ACP path had no such forwarder, so the panel
stayed empty even while the agent was clearly delegating.

ACP hasn't standardized sub-agents (an RFD proposes `tool_call` `kind:"subagent"`
+ a `childSessionId` and a distinct child `sessionId`), and no shipping agent
emits that yet — so this is a **per-dialect** problem. This adds a small seam plus
the Devin dialect, and wires it to the child-session machinery that already
exists:

| Layer | What's added |
|---|---|
| `omnigent/inner/acp_subagents.py` | `AcpSubAgentSource` protocol + `DevinSubAgentSource` (reads `cognition.ai/subagent_*`, **self-gates** on those keys) + `read_subagent_events` |
| `executor.py` / `acp_executor.py` | `SubAgentStarted`/`SubAgentCompleted` events, emitted per `session/update` |
| `schemas.py` / `_executor_adapter.py` | runner-internal `subagent.started`/`.completed` SSE events (in `HarnessStreamEvent`, never relayed to clients), emitted by the adapter |
| `runner/app.py` | `proxy_stream` intercepts them → reuses `external_subagent_start` to mint the child, marks it idle/failed with the summary on completion |

### Structure — Devin as a composed vendor layer

Devin's behavior is **composed at the harness boundary, not discovered**, so the
generic ACP path contains no vendor name and no harness-name branch:

```
 harness: devin ──► omnigent/inner/devin/harness.py      create_app()
                        └─ acp_harness.create_app(extension=DEVIN_ACP_EXTENSION)
                                                              │
 harness: acp / grok / acp:<slug> ──► acp_harness.create_app()│  (NO_ACP_EXTENSION)
                                              │               │
                                              ▼               ▼
                                        AcpExecutor(..., extension=…)
                                          reads only extension.subagent_sources
```

| | Before (first cut) | After |
|---|---|---|
| Devin's dialect | in `acp_subagents.py`, a core module | `omnigent/inner/devin/subagents.py` |
| Who runs it | **every** ACP agent, via a hardcoded default source list | only a harness whose wrap injects it |
| Generic default | Devin's `_meta` scan | reads no vendor field at all |
| `subagents` capability | hand-set | derived from `DEVIN_ACP_EXTENSION.surfaces_subagents` |

`omnigent/inner/devin/` is one directory — dialect, extension, wrap — mirroring a
community harness plugin's layout
(`omnigent/community/harness/<name>/{plugin.py,inner/}`), so lifting Devin out of
core is a move plus an entry point. Two constraints are written into the package
rather than discovered later: a plugin **may not override a builtin harness name**,
so the move deletes Devin's catalog row in the same change; and the plugin
contract's public surface is `Executor` + `ExecutorAdapter`, so an out-of-core
Devin either imports the ACP executor from core (a private module today) or
carries its own client, as `omnigent-rovo` does — keeping this package to
dialect + wrap is what makes that choice cheap either way.

**Extending it** is additive: a field on `AcpExtension` with a neutral default,
read at the one place it applies. The sourced next candidate is `initialize`-time
client capabilities — Devin reports sub-agents unconditionally, but Claude Code's
ACP bridge withholds its nested transcript unless the client opts in with
`clientCapabilities._meta["subagent-transcript"] = true` and keys parentage on
`_meta.claudeCode.parentToolUseId`. Two vendors, one concept, no shared field —
which is why a dialect is per-vendor rather than a branch in the executor.

### Child identity and transcript (fixes two reported bugs)

A first cut reused the claude-native `external_subagent_start`. Two things broke,
both visible:

| Symptom | Cause | Fix |
|---|---|---|
| The child row was titled **"Claude Code"** | that path stamps `omnigent.wrapper=claude-code-native-ui-subagent`, and the UI resolves a child's harness from the wrapper label *first* (`nativeCodingAgentForSubagentWrapper`) | mint with **no** wrapper value, so the harness resolves via `_resolve_harness_impl` to the parent's (`devin`) and the UI labels it from the harness catalog |
| Opening the child showed an **empty chat** | the mint only creates the row; nothing wrote conversation items | seed the transcript over the existing `external_conversation_item` bridge — the delegated task in, the sub-agent's summary out |

The absent wrapper label is load-bearing rather than an omission, so it is
asserted directly in an integration test.

**The devin-only scope is the dialect itself, not a harness switch** — the Devin
source fires only on `cognition.ai/*` keys, so it's inert for every other ACP
agent. Adding a dialect (another vendor's, or the eventual ACP standard) means
adding one `read()` implementation; nothing downstream moves. That extension
point is covered by a test.

<details>
<summary>ELI5 + the flow</summary>

Devin quietly farms work out to helper agents, but only mentions them in its own
vendor scribbles (`cognition.ai/subagent_*`). We now read those scribbles, and
for each helper we open a real Omnigent "child session" — which is exactly what
the Subagents panel lists. Another agent that scribbles differently gets its own
tiny reader; everything after the reader is shared.

```
 Devin frame (_meta cognition.ai/subagent_started)
   └─ DevinSubAgentSource.read()               ← the pluggable seam (self-gating)
        → SubAgentStarted(child_key,title,task) ← executor event
             → adapter emits "subagent.started"  ← runner-internal SSE (swallowed)
                  → proxy_stream POST external_subagent_start
                       → server mints kind="sub_agent" child + session.created
                            → Subagents panel row
 …subagent_completed → "subagent.completed" → mark child idle/failed + summary
```
</details>

Adds an **ACP-native** mint (`external_acp_subagent_start`), mirroring the
codex/antigravity precedent, and reuses `external_conversation_item` /
`external_session_status` for the child's transcript and outcome. Idempotent on
the sub-agent's stable id. The runner-internal events mirror
`policy_evaluation.requested` (intercept-by-type + `continue`), a known-safe
pattern, so nothing new reaches external clients.

## Test Plan

**485 passing** across the affected + neighbor suites; `ruff` + `pyrefly` + full
`pre-commit` clean; `uv.lock` untouched.

- `tests/inner/test_acp_subagents.py` — the source against **Devin's verbatim
  captured frames** (start/complete keyed by `agentId`), self-gating on plain
  frames, blank-id guard, and a **fake future dialect** proving a new source
  plugs in without touching the core.
- `tests/inner/test_acp_executor.py` — `_handle_session_update` emits the events
  from real frames, and stays inert for non-Devin traffic.
- `tests/runtime/harnesses/test_executor_adapter.py` — `_translate_event`
  produces the runner-internal SSE events with the right fields.
- `tests/runner/test_acp_subagent_forwarding.py` — the mint helper POSTs the
  correct `external_subagent_start` body and resolves the child id; the
  completion helper marks idle/failed with the summary; a failed mint records an
  exception so completion **fails fast rather than hanging**, and skips its POST
  (no phantom child). Real-`Response` stub so `raise_for_status` runs.
- `tests/server/integration/test_sessions_endpoints.py` — real HTTP: the minted
  child carries the ACP id + task labels and **no `omnigent.wrapper`**;
  redelivery is idempotent; two sub-agents sharing a title both register. These
  caught two real wiring gaps (the new type needed registering in
  `_ALLOWED_EVENT_TYPES` *and* in the payload-validation skip list) that unit
  tests would have missed.
- `tests/inner/devin/test_devin_liftability.py` — structural guards, both
  verified to fail on a real violation: Devin imports nothing outside the
  liftable core surface, and no generic ACP module imports a vendor.
- `tests/inner/devin/test_devin_harness.py` — the injection itself, since the
  failure mode of composition is a Devin process silently behaving as a plain ACP
  one. Also pins that the registry points `devin` at its own wrap and that the
  declared capability tracks the extension.
- `tests/inner/test_acp_subagents.py` / the executor's sub-agent cases are now
  **vendor-free** (invented dialects), and one asserts the generic executor does
  no sub-agent scanning at all — the property that makes this a layer rather than
  a branch.
- Neighbor suites run for blast radius: `test_app_sessions_native_wake_forwarders`,
  `test_runner_policy`, `test_schemas`, goose/qwen executors.

## Demo

N/A — no frontend change. The panel already renders child sessions; this makes
the server mint them for ACP sub-agents. The SSE event fields the adapter emits
and the exact POST bodies the runner sends are asserted directly in the tests
above.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Each layer is unit-tested, the mint is covered end-to-end over real HTTP, and the
seam is grounded in a real `devin acp` capture that delegated three parallel
sub-agents. What I have **not** done — and want to be plain about — is drive the
full harness→runner→server→panel loop live: confirming the row renders as *Devin*
and its chat shows the task/summary needs a real Devin turn plus a human glance at
the web UI, the same limitation as #5053/#5056. The identity mechanism is asserted
at the label level, not visually.

Two deliberate scoping calls for a reviewer:

- **Reading Devin's vendor `_meta` is the only option that surfaces anything
  today** — Devin emits no ACP-standard sub-agent signal (no `kind:"subagent"`,
  no `childSessionId`, one session). Unlike #5050 (where the protocol's own
  `toolCallId` was a strictly-better generic alternative), here there is no
  generic signal to prefer, so the coupling is quarantined behind
  `AcpSubAgentSource` rather than avoided. When the ACP standard lands, it's one
  more source.
- **The child's transcript is the task + the summary, not the sub-agent's every
  inner tool call.** Devin does tag those nested calls (`cognition.ai/subagent_context`
  carries the owning `parentAgentId`), so routing them into the child is a
  follow-up; they currently render in the parent stream. Task-in / summary-out is
  what makes the child chat meaningful today.

Also observed while capturing (out of scope here, worth its own look): Devin's
sub-agents were sandboxed to a different env root than the task dir, so their
`write` tool was denied and Devin fell back to writing via `exec`.

## Changelog

ACP agents that spawn sub-agents (e.g. Devin) now show each sub-agent as its own
row in the Subagents panel, instead of only the main agent
