### PR TITLE
fix(web): preserve remembered host during refresh

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -1212,6 +1212,77 @@ async def _drive_remembers_last_picked_host(base_url: str, session_id: str) -> N
             await browser.close()
 
 
+def test_start_session_waits_for_refreshed_remembered_host(
+    seeded_session: tuple[str, str],
+) -> None:
+    """Cached Mac-only hosts do not displace a remembered VM during refresh."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_waits_for_refreshed_remembered_host(base_url, session_id))
+
+
+async def _drive_waits_for_refreshed_remembered_host(base_url: str, session_id: str) -> None:
+    alpha_id, _alpha_name = _HOST_ALPHA
+    beta_id, beta_name = _HOST_BETA
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        release_refresh = asyncio.Event()
+        route_state = {"delay_refresh": False, "initial_requests": 0}
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page, created_session_id=session_id, create_bodies=create_bodies
+            )
+
+            async def handle_hosts(route: Route) -> None:
+                if route_state["delay_refresh"]:
+                    await release_refresh.wait()
+                    body = _two_hosts_body()
+                else:
+                    route_state["initial_requests"] += 1
+                    body = json.dumps(
+                        {
+                            "hosts": [
+                                {
+                                    "host_id": alpha_id,
+                                    "name": _HOST_ALPHA[1],
+                                    "owner": "e2e",
+                                    "status": "online",
+                                }
+                            ]
+                        }
+                    )
+                await route.fulfill(status=200, content_type="application/json", body=body)
+
+            # Registered after the common route so this stateful handler wins.
+            await page.route("**/v1/hosts", handle_hosts)
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:last-host-choice",
+                    "{beta_id}"
+                );"""
+            )
+
+            # ChatPage and Sidebar warm the shared host-query cache while the
+            # stub exposes only the Mac. No landing draft exists on this path.
+            await page.goto(f"{base_url}/c/{session_id}")
+            await page.get_by_test_id("new-chat-button").wait_for(state="visible", timeout=30_000)
+            await _wait_until(lambda: route_state["initial_requests"] >= 2)
+
+            # NewChat mounts with cached Mac-only data and immediately starts a
+            # fresh request. Hold it so the intermediate choice is observable.
+            route_state["delay_refresh"] = True
+            await page.get_by_test_id("new-chat-button").click()
+            chip = page.get_by_test_id("new-chat-landing-host-chip")
+            await expect(chip).to_contain_text("Choose host")
+
+            release_refresh.set()
+            await expect(chip).to_contain_text(beta_name)
+        finally:
+            release_refresh.set()
+            await browser.close()
+
+
 def _managed_info_body() -> str:
     """Stub body for ``GET /v1/info``: a managed deployment offering a sandbox.
 

--- a/web/src/lib/hostPreferences.ts
+++ b/web/src/lib/hostPreferences.ts
@@ -6,8 +6,9 @@
 // snapshot it when the user explicitly picks a host (or the managed sandbox),
 // so the next visit starts from the last choice instead of the auto-picked
 // default — the sandbox in managed deployments, the first online host in OSS.
-// The consumer still validates a stored host id against the live host list and
-// falls back to the default when that host is gone or offline.
+// The consumer still validates a stored host id against the live host list. It
+// waits for any active host-list refresh before falling back when that host is
+// gone or offline.
 
 const STORAGE_KEY = "omnigent:last-host-choice";
 const SANDBOX_PROVIDER_KEY = "omnigent:last-sandbox-provider";

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -676,9 +676,10 @@ function host(status: "online" | "offline", i = 1): Host {
   return { host_id: `host_${i}`, name: `machine-${i}`, owner: "me", status };
 }
 
-function mockHosts(hosts: Host[]) {
+function mockHosts(hosts: Host[], queryState: Partial<ReturnType<typeof useHosts>> = {}) {
   useHostsMock.mockReturnValue({
     data: hosts,
+    ...queryState,
   } as unknown as ReturnType<typeof useHosts>);
 }
 
@@ -964,6 +965,36 @@ describe("NewChatLandingScreen", () => {
     // "click New session in the sidebar" placeholder. If it regressed to
     // the placeholder, the composer input would be absent and this fails.
     expect(screen.getByTestId("new-chat-landing-input")).toBeTruthy();
+  });
+
+  it("does not replace a missing remembered host with the first cached host", async () => {
+    localStorage.setItem("omnigent:last-host-choice", "host_2");
+    // The shared query cache can render an older host list first while a
+    // background refresh is already fetching the continuously-live VM.
+    mockHosts([host("online", 1)], { isFetching: true });
+    renderLanding();
+
+    const chip = screen.getByTestId("new-chat-landing-host-chip");
+    await waitFor(() => expect(chip).toHaveTextContent("Choose host"));
+
+    // Model the fresh /v1/hosts response. Because the stale Mac never filled
+    // selectedHostId, the remembered VM can still win when it appears.
+    mockHosts([host("online", 1), host("online", 2)], { isFetching: false });
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "rerender" },
+    });
+
+    await waitFor(() => expect(chip).toHaveTextContent("machine-2"));
+  });
+
+  it("falls back after a fresh host list confirms the remembered host is gone", async () => {
+    localStorage.setItem("omnigent:last-host-choice", "host_2");
+    mockHosts([host("online", 1)], { isFetching: false });
+    renderLanding();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip")).not.toHaveTextContent("Choose host"),
+    );
   });
 
   it("uses a home-specific focus shadow without a resting shadow or focus border", () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2091,7 +2091,11 @@ export function NewChatLandingScreen() {
   const { data: agents } = useAvailableAgents();
   // refetchOnFocus: returning from a terminal `omni setup` must clear the
   // readiness badge even if the live push was missed while the tab was hidden.
-  const { data: hosts, isLoading: hostsLoading } = useHosts({ refetchOnFocus: true });
+  const {
+    data: hosts,
+    isLoading: hostsLoading,
+    isFetching: hostsFetching,
+  } = useHosts({ refetchOnFocus: true });
 
   const agentList = useMemo(
     () =>
@@ -2678,7 +2682,11 @@ export function NewChatLandingScreen() {
         setSelectedHostId(stored.host_id);
         return;
       }
-      // Stored host is gone or offline — fall through to the default.
+      // Cached data can omit the remembered host while a fresh list is already
+      // in flight. Let that refresh settle before using the normal fallback.
+      if (hostsFetching) return;
+      // The fresh list confirms the stored host is gone or offline — fall
+      // through to the default.
     }
 
     if (managedSandboxesEnabled) {
@@ -2691,6 +2699,7 @@ export function NewChatLandingScreen() {
   }, [
     hosts,
     hostsLoading,
+    hostsFetching,
     selectedHostId,
     sandboxSelected,
     managedSandboxesEnabled,


### PR DESCRIPTION
## Related issue

N/A

## Summary

- When the landing screen receives cached host data while React Query is actively refreshing, wait for the fresh response before deciding a remembered host is unavailable.
- Preserve the existing fallback after the refresh settles: if the remembered host is genuinely gone or offline, select the normal default.

**ELI5:** If the app briefly shows an older list containing only your Mac, it now waits for the current list before replacing your saved VM. If the current list confirms the VM is unavailable, the existing fallback still works.

```text
stored preference: VM
cached hosts:      Mac + refreshing  -> wait
fresh hosts:       Mac + VM          -> select VM
fresh hosts:       Mac only          -> fall back to Mac
```

## Test Plan

- `pnpm --dir web exec vitest run src/shell/NewChatDialog.test.tsx src/shell/NewChatDialog.flow.test.tsx src/lib/hostPreferences.test.ts`
- `pnpm --dir web exec oxlint --deny-warnings --report-unused-disable-directives src/shell/NewChatDialog.tsx src/shell/NewChatDialog.test.tsx src/lib/hostPreferences.ts`
- `pnpm --dir web type-check`
- `pnpm --dir web build`
- `env -u OMNIGENT -u OMNIGENT_PROCESS_LOG_FILE -u OMNIGENT_RUNNER_DELEGATED_AUTH -u OMNIGENT_RUNNER_ID -u OMNIGENT_RUNNER_PARENT_PID -u OMNIGENT_RUNNER_WORKSPACE -u OMNIGENT_RUNNER_ZYGOTE_HARNESS_FD -u RUNNER_SERVER_URL uv run --no-sync pytest tests/e2e_ui/start_session/test_start_session.py::test_start_session_waits_for_refreshed_remembered_host -q -p no:randomly --ui-skip-build`
- `uv run --no-sync ruff check tests/e2e_ui/start_session/test_start_session.py`
- `git diff --check`

## Demo

N/A — this changes asynchronous host restoration rather than static visuals. The Playwright regression warms a cached Mac-only host list, holds the background refresh, verifies the picker does not select the Mac, then returns the remembered VM and verifies it is restored.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added unit coverage for both sides of the refresh boundary and a Playwright regression for the user-visible cached-host race: wait while cached data refreshes, select the remembered VM when it appears, and retain the original fallback after a settled response where it is absent.

## Changelog

The new-session picker waits for a current host list before replacing your remembered host with another machine.