### PR TITLE
Fix error divider alignment at wide widths

### DIFF
--- a/tests/e2e_ui/chat/test_failure_error_card.py
+++ b/tests/e2e_ui/chat/test_failure_error_card.py
@@ -320,23 +320,20 @@ def test_persisted_failure_expands_retries_and_dismisses_locally(
 
 
 @pytest.mark.parametrize("viewport_width", [1440, 2400])
-def test_error_row_divider_spans_the_chat_column(
+def test_error_row_divider_aligns_with_message_edges(
     page: Page,
     seeded_session: tuple[str, str],
     viewport_width: int,
 ) -> None:
-    """The banner's dashed rule spans the full chat column, not just the pill.
+    """The dashed rule runs from the assistant edge to the user edge.
 
     Regression net for the error-only shrink-wrap: ``MessageContent``
     defaults to ``w-fit``, so an error-only bubble once clipped the rule to
-    the 560px pill (~592px) instead of the column. Widths are compared
-    against a long-text assistant turn measured in the same viewport — no
-    hardcoded pixel values. Runs at two widths since the column is
-    responsive below its ``max-w-3xl`` cap: 2400px lets the column reach
-    the cap (where the shrink-wrap shows — the pill fits inside it), while
-    1440px squeezes the column below the pill's width (``max-w-full`` caps
-    the pill either way) and locks the invariant against a wrapper that
-    narrows the row below the column.
+    the 560px pill. The full-width error turn must instead start where an
+    assistant message starts and end where a right-aligned user message
+    ends. Edges are measured from real messages in the same viewport, with
+    no hardcoded pixel values. Both widths guard the responsive conversation
+    column and the wider desktop layout.
 
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)`` from the local server.
@@ -364,25 +361,45 @@ def test_error_row_divider_spans_the_chat_column(
     pill = page.get_by_test_id("error-pill")
     expect(pill).to_be_visible(timeout=15_000)
 
-    widths = page.evaluate(
+    edges = page.evaluate(
         """() => {
           const pill = document.querySelector('[data-testid="error-pill"]');
           const row = pill.parentElement;
           const divider = row.querySelector('span[aria-hidden="true"]');
           const bubbles = [...document.querySelectorAll('[data-testid="message-bubble"]')];
-          const textBubble = bubbles.find((b) =>
-            b.textContent.includes('stretches the chat column'));
+          const assistantBubble = bubbles.find((bubble) =>
+            bubble.dataset.role === 'assistant' &&
+            bubble.textContent.includes('stretches the chat column'));
+          const userBubble = bubbles.find((bubble) =>
+            bubble.dataset.role === 'user' &&
+            bubble.textContent.includes('Write something long.'));
+          const rowRect = row.getBoundingClientRect();
+          const dividerRect = divider.getBoundingClientRect();
+          const assistantRect = assistantBubble.firstElementChild.getBoundingClientRect();
+          const userRect = userBubble.firstElementChild.getBoundingClientRect();
           return {
-            row: row.getBoundingClientRect().width,
-            divider: divider.getBoundingClientRect().width,
-            textTurn: textBubble.firstElementChild.getBoundingClientRect().width,
+            rowLeft: rowRect.left,
+            rowRight: rowRect.right,
+            dividerLeft: dividerRect.left,
+            dividerRight: dividerRect.right,
+            assistantLeft: assistantRect.left,
+            userRight: userRect.right,
           };
         }"""
     )
-    assert abs(widths["row"] - widths["textTurn"]) <= 2, (
-        f"error row spans {widths['row']:.0f}px but the chat column spans "
-        f"{widths['textTurn']:.0f}px — the banner shrink-wrapped the pill"
+    assert abs(edges["rowLeft"] - edges["assistantLeft"]) <= 2, (
+        f"error row starts at {edges['rowLeft']:.0f}px but the assistant message starts at "
+        f"{edges['assistantLeft']:.0f}px"
     )
-    assert abs(widths["divider"] - widths["row"]) <= 1, (
-        f"dashed rule spans {widths['divider']:.0f}px of its {widths['row']:.0f}px row"
+    assert abs(edges["rowRight"] - edges["userRight"]) <= 2, (
+        f"error row ends at {edges['rowRight']:.0f}px but the user message ends at "
+        f"{edges['userRight']:.0f}px"
+    )
+    assert abs(edges["dividerLeft"] - edges["rowLeft"]) <= 1, (
+        f"dashed rule starts at {edges['dividerLeft']:.0f}px but its row starts at "
+        f"{edges['rowLeft']:.0f}px"
+    )
+    assert abs(edges["dividerRight"] - edges["rowRight"]) <= 1, (
+        f"dashed rule ends at {edges['dividerRight']:.0f}px but its row ends at "
+        f"{edges['rowRight']:.0f}px"
     )

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -243,6 +243,7 @@ describe("BubbleView dispatch", () => {
 
     const bubble = screen.getByTestId("message-bubble");
     expect(screen.getByTestId("error-pill")).toBeInTheDocument();
+    expect(bubble).toHaveClass("max-w-full");
     expect(bubble.firstElementChild).toHaveClass("w-full");
     expect(screen.queryByTestId("message-timestamp")).not.toBeInTheDocument();
   });
@@ -262,6 +263,7 @@ describe("BubbleView dispatch", () => {
 
     const bubble = screen.getByTestId("message-bubble");
     expect(screen.getByTestId("error-pill")).toBeInTheDocument();
+    expect(bubble).toHaveClass("max-w-full");
     expect(bubble.firstElementChild).toHaveClass("w-full");
     expect(screen.getByTestId("message-timestamp")).toBeInTheDocument();
   });

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3939,6 +3939,7 @@ function AssistantBubble({
   // element — the hover footer's timestamp/actions belong to assistant text,
   // not to the error.
   const errorOnly = hasError && !markdownText;
+  const spansFullColumn = isWide || hasError;
 
   return (
     <>
@@ -3946,14 +3947,14 @@ function AssistantBubble({
         from="assistant"
         data-testid="message-bubble"
         data-role="assistant"
-        className={isWide ? "max-w-full" : "max-w-3xl"}
+        className={spansFullColumn ? "max-w-full" : "max-w-3xl"}
       >
         {/* A fold-only bubble takes w-full at the ordinary max-w-3xl cap
             rather than shrink-wrapping to the summary row's ~110px, which
             collapsed the row's trailing hairline (a flex-1 span) to zero
             and stopped its click target short of the column. Keeping the
             cap lands the hairline where an answered turn's does. */}
-        <MessageContent className={isWide || foldOnly || hasError ? "w-full" : undefined}>
+        <MessageContent className={spansFullColumn || foldOnly ? "w-full" : undefined}>
           <BlockRenderer
             items={bubble.items}
             sessionStatus={sessionStatus}


### PR DESCRIPTION
## Related issue

N/A — reported during local UI verification.

## Summary

- Make error-bearing assistant messages own the full conversation column so the dotted divider always aligns from the assistant-message left edge to the user-message right edge.
- Add component and E2E regression assertions for the real edge-alignment contract across standard and wide viewports.

## Test Plan

- **Unit:** `pnpm --dir web exec vitest run src/pages/ChatPage.indicators.test.tsx` — 1 file and 26 tests passed; covers the error bubble's outer and inner full-width contracts.
- **E2E:** `.venv/bin/pytest 'tests/e2e_ui/chat/test_failure_error_card.py::test_error_row_divider_aligns_with_message_edges' -v --ui-skip-build --tracing=retain-on-failure --screenshot=only-on-failure --video=retain-on-failure -m 'not visual and not nightly'` — 2/2 Chromium cases passed at 1440 px and 2400 px; verifies the divider against real assistant and user message edges.
- **Static:** `.venv/bin/pre-commit run --files tests/e2e_ui/chat/test_failure_error_card.py`, `pnpm --dir web type-check`, Prettier on the changed frontend files, oxlint on the changed frontend files, and `git diff --check` — all passed.
- **Manual:** Verified exact 0 px left/right alignment deltas in the SP2K browser and at 2200 px (4xl) and 2800 px (5xl) headless viewports, in both light and dark themes.

## Demo

| Light | Dark |
| --- | --- |
| ![Error divider aligned in light mode](https://raw.githubusercontent.com/zhengwin/omnigent/error-divider-demo-assets/tmp-screenshots/error-divider-light.png) | ![Error divider aligned in dark mode](https://raw.githubusercontent.com/zhengwin/omnigent/error-divider-demo-assets/tmp-screenshots/error-divider-dark.png) |

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused E2E test verifies both responsive viewports against real message edges; manual checks extend coverage through the 4xl and 5xl layout breakpoints and both themes.

## Changelog

Error dividers now stay aligned with the assistant and user message edges on wide screens.