### PR TITLE
test(electron): add a desktop-shell recording lane for repro-agent

### DIFF
--- a/dev/repro-agent/AGENTS.md
+++ b/dev/repro-agent/AGENTS.md
@@ -185,8 +185,10 @@ journey, not a workaround for it.
 **Stamp each sub-symptom with the user-facing surface it shows on.** Alongside
 the verdict you will give each facet (Step 2), record where a user *sees* the
 failure: `web` (the web SPA), `terminal` (a TUI or shell pane rendered inside
-the app — a native-harness pane, an embedded shell), or `cli` (a command-line
-surface outside the app: the `omnigent` CLI, the REPL, a host daemon's output).
+the app — a native-harness pane, an embedded shell), `cli` (a command-line
+surface outside the app: the `omnigent` CLI, the REPL, a host daemon's output),
+or `desktop` (a failure in the Electron desktop shell itself — the setup/connect
+page, a native dialog, the window/popup policy — not the SPA it hosts).
 The surface picks the kind of test you author (Step 3) and the recorder that
 captures it (Step 4).
 
@@ -325,9 +327,9 @@ saved under `recordings/<slug>/` in your workspace:
   behaving correctly on the running build (e.g. `recordings/1234/fixed-picker.webm`).
 
 `not_reproduced` and `needs_more_info` facets have nothing to film — skip them.
-A `web` / `terminal` / `cli` facet is expected to yield a recording: reproduce it
-on that surface and film it. Only an `api` facet (a failure no user observes on
-any surface) legitimately has no recording.
+A `web` / `terminal` / `cli` / `desktop` facet is expected to yield a recording:
+reproduce it on that surface and film it. Only an `api` facet (a failure no user
+observes on any surface) legitimately has no recording.
 
 **Record exactly the verdict-appropriate clip per facet — nothing else.** One
 recording per `reproduced` facet (`kind: "before"`) and one per `already_fixed`
@@ -486,6 +488,25 @@ cause is named from what you observed rather than guessed.
   `recordings: []` for that facet and name the specific blocker in `evidence`
   (per the empty-recordings rule above), exactly as you would for an unreachable
   `web`/`terminal` lane. The authored test still ships; it just isn't the video.
+- **`desktop` facets (Electron shell)** — when the failure lives in the desktop
+  shell itself (the dead-end 401 fallback to the setup page, in-window IdP
+  rendering, the session-expiry reload, the OAuth-popup / window-open policy,
+  the native host-enrollment dialog) rather than in the SPA, the browser tools
+  and the `tests/e2e_ui/` Playwright lane can't reach it: the defect is in
+  Electron's main process, and Python Playwright has **no** Electron API. Use
+  the JS desktop lane in `web/electron/e2e/` instead — **copy the reference test
+  `desktop_connect.e2e.js`**, which launches the REAL packaged shell under
+  `_electron.launch({ recordVideo })` (via `desktopHarness.js`, which spawns the
+  same mock-LLM + `omnigent server` pair the Python suite does) and films the
+  actual window. Pass `serverUrl` to `launchDesktop` when the failure is *past*
+  connect (boot straight into the shell); omit it to film the connect/setup/
+  fallback flow itself. Run with `node --test e2e/desktop_<slug>.e2e.js` from
+  `web/electron` (wrap in `xvfb-run -a` on a headless box), after building the
+  SPA. This lane needs `electron` + `playwright` on disk (neither is in the
+  web-test CI path); the harness **skips** cleanly when they're absent, so if
+  they can't be installed here keep `recordings: []` and name the missing dep in
+  `evidence` (a real environment limit, not a `not_reproduced`). See
+  `web/electron/e2e/README.md`.
 
 A recording must end on the outcome the user observes — the failure (wrong screen
 state, bad output, error) for a `before` recording, or the correct end state for a
@@ -558,7 +579,7 @@ Field meanings:
   `already_fixed`).
 - `facets` — an array of the per-sub-symptom breakdown from Steps 1–2, each an
   object with `symptom`, its own `verdict` (same four literals), its `surface`
-  (`web` / `terminal` / `cli` / `api`, from Step 1), and one line of
+  (`web` / `terminal` / `cli` / `desktop` / `api`, from Step 1), and one line of
   `evidence`. Always a list, even for a single-symptom bug (then it's one
   element). This is what stops a partially-landed fix from being averaged into a
   misleading single verdict.

--- a/dev/repro-agent/AGENTS.md
+++ b/dev/repro-agent/AGENTS.md
@@ -501,12 +501,14 @@ cause is named from what you observed rather than guessed.
   actual window. Pass `serverUrl` to `launchDesktop` when the failure is *past*
   connect (boot straight into the shell); omit it to film the connect/setup/
   fallback flow itself. Run with `node --test e2e/desktop_<slug>.e2e.js` from
-  `web/electron` (wrap in `xvfb-run -a` on a headless box), after building the
-  SPA. This lane needs `electron` + `playwright` on disk (neither is in the
-  web-test CI path); the harness **skips** cleanly when they're absent, so if
-  they can't be installed here keep `recordings: []` and name the missing dep in
-  `evidence` (a real environment limit, not a `not_reproduced`). See
-  `web/electron/e2e/README.md`.
+  `web/electron`, after building the SPA. On a headless box wrap it in
+  `xvfb-run -a` and set `OMNIGENT_PW_NO_SANDBOX=1` so Electron's Chromium starts
+  (the repro-agent CI sets both for you, and points `OMNIGENT_PYTHON` at the
+  venv the harness spawns the server with). This lane needs `electron` +
+  `playwright` on disk (neither is in the fast `web-test` CI path); the harness
+  **skips** cleanly when they're absent, so if they can't be installed here keep
+  `recordings: []` and name the missing dep in `evidence` (a real environment
+  limit, not a `not_reproduced`). See `web/electron/e2e/README.md`.
 
 A recording must end on the outcome the user observes — the failure (wrong screen
 state, bad output, error) for a `before` recording, or the correct end state for a

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,6 +432,9 @@ importers:
       electron-builder:
         specifier: ^26.0.0
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
+      playwright:
+        specifier: ^1.62.1
+        version: 1.62.1
 
 packages:
 
@@ -5862,6 +5865,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -7485,6 +7493,16 @@ packages:
   pkijs@3.4.0:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
     engines: {node: '>=16.0.0'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -10080,7 +10098,7 @@ snapshots:
       '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      http-proxy-agent: 7.0.2(supports-color@10.2.2)
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       openai: 6.26.0(ws@8.21.1)(zod@4.4.3)
       partial-json: 0.1.7
@@ -15360,6 +15378,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -15732,13 +15753,6 @@ snapshots:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  http-proxy-agent@7.0.2(supports-color@7.2.0):
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17397,6 +17411,14 @@ snapshots:
       pvtsutils: 1.3.6
       pvutils: 1.1.5
       tslib: 2.8.1
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,10 +88,18 @@ allowBuilds:
   '@google/genai': true
   '@vscode/vsce-sign': true
   canvas: true
+  # electron + playwright: the desktop recording lane (web/electron/e2e/) needs
+  # their postinstall scripts to run — electron downloads its ~100MB runtime
+  # binary and playwright its driver. Without these, `pnpm install` in the
+  # electron package "succeeds" but leaves the binaries absent, so the lane
+  # can't launch. Dev/test only (both are web/electron devDependencies; not
+  # bundled into the shipped app).
+  electron: true
   electron-winstaller: true
   esbuild: true
   keytar: true
   msw: true
+  playwright: true
   protobufjs: true
   sharp: true
   workerd: true

--- a/web/electron/e2e/README.md
+++ b/web/electron/e2e/README.md
@@ -1,0 +1,80 @@
+# Desktop-shell recording lane (Electron)
+
+The reproduction/recording lane for bugs that live in the **Electron desktop
+shell** — the main process, not the SPA. Examples: the dead-end 401 fallback
+to the setup page, in-window IdP rendering (RFC 8252), the session-expiry
+reload, window-open / OAuth-popup policy, the native host-enrollment dialog.
+
+## Why this isn't a `tests/e2e_ui/` pytest lane
+
+Every other recording lane is a pytest-playwright test under `tests/e2e_ui/`,
+because the bug is in the SPA and pytest-playwright's `--video` films the
+browser page. The desktop shell is different on two counts:
+
+1. **The defect is in Electron's main process**, which a plain browser page
+   never exercises — you have to drive the real packaged app.
+2. **Python Playwright has no Electron API.** `_electron.launch()` exists only
+   in the JavaScript Playwright. So this lane is a small **JS** harness in the
+   `web/electron` package, run with `node --test` (the same runner as the rest
+   of `web/electron/test/`), not pytest.
+
+The harness still spawns the **same** mock-LLM + `omnigent server` pair the
+Python suite spawns (`desktopHarness.js` mirrors the env + argv of
+`tests/e2e_ui/conftest.py`), so the shell talks to the same deterministic fake
+backend — no real provider creds.
+
+## Files
+
+- `desktopHarness.js` — spawns the mock LLM + `omnigent server`, and launches
+  the real desktop shell under `_electron.launch({ recordVideo })` in an
+  isolated `userData` dir. `launchDesktop({ serverUrl })` pre-seeds a saved
+  server so the app boots straight into the shell (skip connect); omit it to
+  film the connect journey.
+- `desktop_connect.e2e.js` — the reference test to **copy** for a desktop bug:
+  launch → setup page → type URL → Connect → land in the shell. Its `.webm` is
+  the desktop journey footage.
+
+## Prerequisites
+
+This lane needs two heavy deps that are deliberately **not** in the web-test CI
+path (they'd bloat the fast unit-test job):
+
+```bash
+# From the repo root, once:
+pnpm --filter web run build          # build the SPA the server serves
+cd web/electron && pnpm install      # brings in electron
+pnpm add -D playwright               # Playwright core (has _electron)
+```
+
+On a headless CI box, wrap the run in `xvfb-run` so Electron has a display.
+The harness skips cleanly (not fails) when `electron` or `playwright` are
+absent, so a checkout without them stays green.
+
+## Running
+
+```bash
+cd web/electron
+# after building the SPA (see above):
+node --test e2e/desktop_connect.e2e.js
+# headless CI:
+xvfb-run -a node --test e2e/desktop_connect.e2e.js
+```
+
+The recorded video lands in `e2e/recordings/<slug>/`. As with every lane,
+recordings are workspace artifacts — leave them uncommitted; CI's artifact
+bundle collects them.
+
+## Authoring a desktop reproduction
+
+1. Copy `desktop_connect.e2e.js` to `e2e/desktop_<slug>.e2e.js`.
+2. If the bug's failure is **past** connect, pass `serverUrl` to
+   `launchDesktop` so the app boots straight into the shell; if the bug is in
+   the connect / setup / fallback flow itself, launch without it (as the
+   reference does) and drive the setup page.
+3. Drive the real window to the failing state and assert on it. For a
+   `reproduced` facet the assertion FAILS on the running build — the failing
+   run's video is the before-fix footage. Close the app in a `finally` so the
+   video is flushed even when the assertion fails.
+4. Move the emitted `*.webm` to a stable `before-`/`fixed-<facet>.webm` name,
+   and write the journey `caption` for the handoff, exactly as the other lanes
+   do (see `dev/repro-agent/AGENTS.md`, Step 4).

--- a/web/electron/e2e/README.md
+++ b/web/electron/e2e/README.md
@@ -36,19 +36,19 @@ backend — no real provider creds.
 
 ## Prerequisites
 
-This lane needs two heavy deps that are deliberately **not** in the web-test CI
-path (they'd bloat the fast unit-test job):
+`electron` and `playwright` are `web/electron` devDependencies (Playwright is
+the one with the `_electron` API). The fast `web-test` CI job installs with
+`--filter web`, so it never pulls them — only a `web/electron` install does:
 
 ```bash
 # From the repo root, once:
 pnpm --filter web run build          # build the SPA the server serves
-cd web/electron && pnpm install      # brings in electron
-pnpm add -D playwright               # Playwright core (has _electron)
+cd web/electron && pnpm install      # brings in electron + playwright
 ```
 
 On a headless CI box, wrap the run in `xvfb-run` so Electron has a display.
-The harness skips cleanly (not fails) when `electron` or `playwright` are
-absent, so a checkout without them stays green.
+The harness still skips cleanly (not fails) when `electron` or `playwright`
+are absent (e.g. a `--filter web`-only checkout), so those runs stay green.
 
 ## Running
 
@@ -60,7 +60,17 @@ node --test e2e/desktop_connect.e2e.js
 xvfb-run -a node --test e2e/desktop_connect.e2e.js
 ```
 
-The recorded video lands in `e2e/recordings/<slug>/`. As with every lane,
+`spawnServer` runs `omnigent server` via `python3` by default; point it at the
+right interpreter with `OMNIGENT_PYTHON` when your `omnigent` lives in a venv:
+
+```bash
+OMNIGENT_PYTHON=/path/to/.venv/bin/python node --test e2e/desktop_connect.e2e.js
+```
+
+The recorded video lands in `e2e/recordings/<slug>/`. Playwright writes it as a
+raw `page@<hash>.webm`; call `saveRecording(recordDir, "<name>")` after
+`electronApp.close()` (as the reference test does) to rename it to a stable
+`<name>.webm` and drop the incidental extra contexts. As with every lane,
 recordings are workspace artifacts — leave them uncommitted; CI's artifact
 bundle collects them.
 
@@ -75,6 +85,7 @@ bundle collects them.
    `reproduced` facet the assertion FAILS on the running build — the failing
    run's video is the before-fix footage. Close the app in a `finally` so the
    video is flushed even when the assertion fails.
-4. Move the emitted `*.webm` to a stable `before-`/`fixed-<facet>.webm` name,
-   and write the journey `caption` for the handoff, exactly as the other lanes
-   do (see `dev/repro-agent/AGENTS.md`, Step 4).
+4. Call `saveRecording(RECORD_DIR, "before-<facet>")` (or `fixed-<facet>`)
+   after the app closes to name the clip, and write the journey `caption` for
+   the handoff, exactly as the other lanes do (see `dev/repro-agent/AGENTS.md`,
+   Step 4).

--- a/web/electron/e2e/README.md
+++ b/web/electron/e2e/README.md
@@ -56,8 +56,10 @@ are absent (e.g. a `--filter web`-only checkout), so those runs stay green.
 cd web/electron
 # after building the SPA (see above):
 node --test e2e/desktop_connect.e2e.js
-# headless CI:
-xvfb-run -a node --test e2e/desktop_connect.e2e.js
+# headless CI (needs a virtual display; set OMNIGENT_PW_NO_SANDBOX so Electron's
+# Chromium starts under xvfb / as root / in a container — same flag the Python
+# e2e_ui suite uses):
+OMNIGENT_PW_NO_SANDBOX=1 xvfb-run -a node --test e2e/desktop_connect.e2e.js
 ```
 
 `spawnServer` runs `omnigent server` via `python3` by default; point it at the

--- a/web/electron/e2e/README.md
+++ b/web/electron/e2e/README.md
@@ -67,12 +67,17 @@ right interpreter with `OMNIGENT_PYTHON` when your `omnigent` lives in a venv:
 OMNIGENT_PYTHON=/path/to/.venv/bin/python node --test e2e/desktop_connect.e2e.js
 ```
 
-The recorded video lands in `e2e/recordings/<slug>/`. Playwright writes it as a
-raw `page@<hash>.webm`; call `saveRecording(recordDir, "<name>")` after
-`electronApp.close()` (as the reference test does) to rename it to a stable
-`<name>.webm` and drop the incidental extra contexts. As with every lane,
-recordings are workspace artifacts — leave them uncommitted; CI's artifact
-bundle collects them.
+The recorded video lands in `e2e/recordings/<slug>/`. Playwright writes one raw
+`page@<hash>.webm` per page context — the main shell window, plus any OAuth
+popup or in-window IdP view, which record separately. Call
+`saveRecording(recordDir, "<name>")` after `electronApp.close()` (as the
+reference test does) to rename **all** of them to stable names: the largest
+becomes `<name>.webm` and any others `<name>-2.webm`, `<name>-3.webm`, … It
+returns the list of saved paths. For a popup / IdP bug the subject is the popup
+clip (often the smaller one), so when there is more than one, inspect each and
+point the handoff at the one that shows the failure — don't assume the largest.
+As with every lane, recordings are workspace artifacts — leave them
+uncommitted; CI's artifact bundle collects them.
 
 ## Authoring a desktop reproduction
 
@@ -83,9 +88,11 @@ bundle collects them.
    reference does) and drive the setup page.
 3. Drive the real window to the failing state and assert on it. For a
    `reproduced` facet the assertion FAILS on the running build — the failing
-   run's video is the before-fix footage. Close the app in a `finally` so the
-   video is flushed even when the assertion fails.
-4. Call `saveRecording(RECORD_DIR, "before-<facet>")` (or `fixed-<facet>`)
-   after the app closes to name the clip, and write the journey `caption` for
-   the handoff, exactly as the other lanes do (see `dev/repro-agent/AGENTS.md`,
-   Step 4).
+   run's video is the before-fix footage.
+4. Close the app AND call `saveRecording` in the `finally` block (as the
+   reference test does), so the clip is named on the failing path too — a
+   `reproduced` facet's run throws, and if you name the clip after the
+   `try/finally` it never runs on the very path that produces the before-fix
+   footage. Use `saveRecording(RECORD_DIR, "before-<facet>")` (or
+   `fixed-<facet>`), then write the journey `caption` for the handoff exactly as
+   the other lanes do (see `dev/repro-agent/AGENTS.md`, Step 4).

--- a/web/electron/e2e/desktopHarness.js
+++ b/web/electron/e2e/desktopHarness.js
@@ -46,11 +46,21 @@ const MOCK_LLM_SERVER = path.join(
 /** The Python interpreter used to run the server + mock (override for venvs). */
 const PYTHON = process.env.OMNIGENT_PYTHON || "python3";
 
-/** A minimal agent spec, mirroring conftest's _TEST_AGENT_YAML. */
+/** A minimal agent spec, mirroring conftest's _TEST_AGENT_YAML. The
+ * ``executor.harness`` is required (the spec loader rejects the spec without
+ * it), so keep the shape in sync with the Python suite's fixture. */
 const TEST_AGENT_YAML = `name: hello_world
-description: A minimal agent for desktop e2e recording.
-instructions: You are a helpful assistant. Keep replies short.
-model: gpt-4o
+prompt: You are a friendly assistant. Say hello and answer questions.
+
+executor:
+  model: gpt-4o-mini
+  harness: openai-agents
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
 `;
 
 const HEALTH_TIMEOUT_MS = 30_000;
@@ -278,6 +288,37 @@ async function launchDesktop(opts) {
   return { electronApp, window, userDataDir };
 }
 
+/**
+ * After the Electron app has closed (which flushes the video), rename the
+ * recorded clip to a stable name at `recordDir`'s root. Playwright writes one
+ * `page@<hash>.webm` per page context under `recordDir`; the shell window is
+ * the largest, so pick that and move it to `<name>.webm` (dropping the rest, so
+ * the same footage isn't collected twice). Returns the final path, or null when
+ * no video was produced.
+ *
+ * Call this AFTER `electronApp.close()`.
+ *
+ * @param {string} recordDir The dir passed to `launchDesktop`.
+ * @param {string} name Stable base name, e.g. `"before-connect"` (no suffix).
+ * @returns {string | null} Absolute path to the renamed `.webm`, or null.
+ */
+function saveRecording(recordDir, name) {
+  if (!fs.existsSync(recordDir)) return null;
+  const clips = fs
+    .readdirSync(recordDir)
+    .filter((f) => f.endsWith(".webm"))
+    .map((f) => path.join(recordDir, f))
+    .filter((p) => fs.statSync(p).isFile());
+  if (clips.length === 0) return null;
+  // The shell window's video is the largest; incidental contexts are tiny.
+  clips.sort((a, b) => fs.statSync(b).size - fs.statSync(a).size);
+  const [primary, ...rest] = clips;
+  const dest = path.join(recordDir, `${name}.webm`);
+  fs.renameSync(primary, dest);
+  for (const leftover of rest) fs.rmSync(leftover, { force: true });
+  return dest;
+}
+
 module.exports = {
   APP_ROOT,
   REPO_ROOT,
@@ -286,4 +327,5 @@ module.exports = {
   findFreePort,
   spawnServer,
   launchDesktop,
+  saveRecording,
 };

--- a/web/electron/e2e/desktopHarness.js
+++ b/web/electron/e2e/desktopHarness.js
@@ -298,8 +298,18 @@ async function launchDesktop(opts) {
   }
   fs.mkdirSync(opts.recordDir, { recursive: true });
 
+  const args = [APP_ROOT, `--user-data-dir=${userDataDir}`];
+  // Headless-Linux / CI hardening, gated on the same env var the Python e2e_ui
+  // suite uses (conftest.browser_type_launch_args). Under xvfb — and especially
+  // as root or in a container — Electron's Chromium refuses to start without
+  // --no-sandbox, and --disable-dev-shm-usage avoids the tiny /dev/shm a
+  // container gives it. Off by default so local (macOS/dev) runs are unchanged.
+  if (process.env.OMNIGENT_PW_NO_SANDBOX) {
+    args.push("--no-sandbox", "--disable-dev-shm-usage");
+  }
+
   const electronApp = await electron.launch({
-    args: [APP_ROOT, `--user-data-dir=${userDataDir}`],
+    args,
     recordVideo: { dir: opts.recordDir },
     // Dev builds read dev-app-update.yml and would try to reach the update
     // endpoint; a version override keeps the app off the update path.

--- a/web/electron/e2e/desktopHarness.js
+++ b/web/electron/e2e/desktopHarness.js
@@ -176,8 +176,25 @@ async function spawnServer(tmpDir) {
     env: { ...process.env, PYTHONPATH: REPO_ROOT },
     stdio: ["ignore", mockOut, mockOut],
   });
+  // A bad PYTHON (ENOENT) fires 'error' async; surface it as a rejection rather
+  // than an uncaught event that crashes the runner. Record it so the health
+  // wait can report it instead of a bare timeout.
+  let mockSpawnError = null;
+  mockProc.on("error", (err) => {
+    mockSpawnError = err;
+  });
   const mockUrl = `http://127.0.0.1:${mockPort}`;
-  await waitForHealthy(`${mockUrl}/stats`, "mock LLM server", mockLog);
+  try {
+    await waitForHealthy(`${mockUrl}/stats`, "mock LLM server", mockLog);
+  } catch (err) {
+    if (mockProc.exitCode === null) mockProc.kill("SIGTERM");
+    try {
+      fs.closeSync(mockOut);
+    } catch {
+      /* already closed */
+    }
+    throw mockSpawnError ?? err;
+  }
 
   const serverOut = fs.openSync(serverLog, "w");
   // Strip ambient runner/host env so a nested runner (if the journey starts a
@@ -218,6 +235,10 @@ async function spawnServer(tmpDir) {
       stdio: ["ignore", serverOut, serverOut],
     },
   );
+  let serverSpawnError = null;
+  serverProc.on("error", (err) => {
+    serverSpawnError = err;
+  });
   const serverUrl = `http://127.0.0.1:${serverPort}`;
 
   const close = async () => {
@@ -244,7 +265,7 @@ async function spawnServer(tmpDir) {
     await waitForHealthy(`${serverUrl}/health`, "omnigent server", serverLog);
   } catch (err) {
     await close();
-    throw err;
+    throw serverSpawnError ?? err;
   }
   return { serverUrl, close };
 }
@@ -284,39 +305,59 @@ async function launchDesktop(opts) {
     // endpoint; a version override keeps the app off the update path.
     env: { ...process.env, OMNIGENT_DESKTOP_VERSION_OVERRIDE: "999.0.0" },
   });
-  const window = await electronApp.firstWindow();
+  // If firstWindow() throws after launch() succeeded, close the app here so the
+  // Electron process isn't orphaned (the caller never got a handle to close).
+  let window;
+  try {
+    window = await electronApp.firstWindow();
+  } catch (err) {
+    await electronApp.close().catch(() => {});
+    throw err;
+  }
   return { electronApp, window, userDataDir };
 }
 
 /**
  * After the Electron app has closed (which flushes the video), rename the
- * recorded clip to a stable name at `recordDir`'s root. Playwright writes one
- * `page@<hash>.webm` per page context under `recordDir`; the shell window is
- * the largest, so pick that and move it to `<name>.webm` (dropping the rest, so
- * the same footage isn't collected twice). Returns the final path, or null when
- * no video was produced.
+ * recorded clip(s) to stable names at `recordDir`'s root. Playwright writes one
+ * `page@<hash>.webm` per page context (the shell window, plus any OAuth popup /
+ * in-window IdP `WebContentsView`). ALL clips are kept — the subject of a
+ * popup/IdP bug is the popup, which is often shorter/smaller than the main
+ * window, so we must not delete by size. Only the raw `page@<hash>.webm` names
+ * (the ones the CURRENT launch produced) are renamed; already-named clips from
+ * a prior `saveRecording` are left alone, so calling twice is safe.
+ *
+ * The largest raw clip (usually the main window) becomes `<name>.webm`; any
+ * additional raw clips become `<name>-2.webm`, `<name>-3.webm`, … in
+ * descending-size order. When multiple clips exist, inspect each and point the
+ * handoff at the one that shows the failure (see e2e/README.md).
  *
  * Call this AFTER `electronApp.close()`.
  *
  * @param {string} recordDir The dir passed to `launchDesktop`.
  * @param {string} name Stable base name, e.g. `"before-connect"` (no suffix).
- * @returns {string | null} Absolute path to the renamed `.webm`, or null.
+ * @returns {string[]} Absolute paths of the saved `.webm`(s), largest first;
+ *   empty when no video was produced.
  */
 function saveRecording(recordDir, name) {
-  if (!fs.existsSync(recordDir)) return null;
-  const clips = fs
+  if (!fs.existsSync(recordDir)) return [];
+  // Only the raw per-context files this launch wrote; leave anything already
+  // renamed (from a prior call) untouched so repeat calls don't clobber.
+  const raw = fs
     .readdirSync(recordDir)
-    .filter((f) => f.endsWith(".webm"))
+    .filter((f) => f.startsWith("page@") && f.endsWith(".webm"))
     .map((f) => path.join(recordDir, f))
     .filter((p) => fs.statSync(p).isFile());
-  if (clips.length === 0) return null;
-  // The shell window's video is the largest; incidental contexts are tiny.
-  clips.sort((a, b) => fs.statSync(b).size - fs.statSync(a).size);
-  const [primary, ...rest] = clips;
-  const dest = path.join(recordDir, `${name}.webm`);
-  fs.renameSync(primary, dest);
-  for (const leftover of rest) fs.rmSync(leftover, { force: true });
-  return dest;
+  if (raw.length === 0) return [];
+  // Largest first so the primary (usually the main window) takes the bare name.
+  raw.sort((a, b) => fs.statSync(b).size - fs.statSync(a).size);
+  const saved = [];
+  raw.forEach((clip, i) => {
+    const dest = path.join(recordDir, i === 0 ? `${name}.webm` : `${name}-${i + 1}.webm`);
+    fs.renameSync(clip, dest);
+    saved.push(dest);
+  });
+  return saved;
 }
 
 module.exports = {

--- a/web/electron/e2e/desktopHarness.js
+++ b/web/electron/e2e/desktopHarness.js
@@ -1,0 +1,289 @@
+// Recording harness for the Omnigent desktop shell (Electron).
+//
+// Every OTHER e2e recording lane is a pytest-playwright test under
+// tests/e2e_ui/, because the bug lives in the SPA and pytest-playwright's
+// `--video` films the browser page. The desktop shell is different: the bug
+// lives in the Electron main process (window-open policy, the dead-end 401
+// fallback, in-window IdP rendering, session-expiry reload), which a browser
+// page never exercises. Python Playwright also has NO Electron API
+// (`_electron` is JS-only), so this lane can't ride the Python suite at all.
+//
+// So this is the desktop analog of tests/e2e_ui/auth/_oidc_server.py: a small
+// JS harness that (1) spawns the same mock-LLM + `omnigent server` pair the
+// Python suite spawns, and (2) launches the REAL packaged main process via
+// Playwright's `_electron.launch({ recordVideo })`, so the recorded video is
+// the actual desktop window — the setup page, the connect, and the shell (or
+// the failure) a desktop user sees — not a browser tab standing in for it.
+//
+// Requires `electron` and `playwright` on disk (both are heavy and NOT in the
+// web-test CI path); see e2e/README.md. Callers that can't satisfy those skip
+// gracefully via `desktopDepsAvailable()`.
+
+"use strict";
+
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const net = require("node:net");
+const os = require("node:os");
+const path = require("node:path");
+const http = require("node:http");
+
+/** Repo root: web/electron/e2e → ../../.. */
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+/** The Electron app package root (its package.json `main` is src/main.js). */
+const APP_ROOT = path.resolve(__dirname, "..");
+/** The SPA the server serves; the Python suite builds it into here too. */
+const WEB_UI_DIST = path.join(REPO_ROOT, "omnigent", "server", "static", "web-ui");
+/** The mock LLM server the Python suite drives, reused verbatim. */
+const MOCK_LLM_SERVER = path.join(
+  REPO_ROOT,
+  "tests",
+  "server",
+  "integration",
+  "mock_llm_server.py",
+);
+
+/** The Python interpreter used to run the server + mock (override for venvs). */
+const PYTHON = process.env.OMNIGENT_PYTHON || "python3";
+
+/** A minimal agent spec, mirroring conftest's _TEST_AGENT_YAML. */
+const TEST_AGENT_YAML = `name: hello_world
+description: A minimal agent for desktop e2e recording.
+instructions: You are a helpful assistant. Keep replies short.
+model: gpt-4o
+`;
+
+const HEALTH_TIMEOUT_MS = 30_000;
+const HEALTH_POLL_MS = 500;
+
+/**
+ * Whether the two heavy runtime deps this lane needs are importable. Callers
+ * (e.g. the example test) skip when false instead of failing, so a checkout
+ * without them stays green.
+ *
+ * @returns {{ ok: boolean, missing: string[] }}
+ */
+function desktopDepsAvailable() {
+  const missing = [];
+  for (const dep of ["playwright", "electron"]) {
+    try {
+      require.resolve(dep);
+    } catch {
+      missing.push(dep);
+    }
+  }
+  return { ok: missing.length === 0, missing };
+}
+
+/** Sleep `ms` milliseconds. Block body so the Promise executor returns nothing. */
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/** Resolve a free TCP port by binding to :0 and reading it back. */
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+/** GET a URL, resolving the status code (or rejecting on connect error). */
+function httpStatus(url) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      res.resume(); // drain
+      resolve(res.statusCode);
+    });
+    req.on("error", reject);
+    req.setTimeout(2000, () => req.destroy(new Error("timeout")));
+  });
+}
+
+/** Poll `url` until it returns 200 or the deadline passes. */
+async function waitForHealthy(url, label, logPath) {
+  const deadline = Date.now() + HEALTH_TIMEOUT_MS;
+  let lastError = "not polled yet";
+  // Health polling is inherently sequential — each probe must await the prior
+  // one and the backoff between them; parallelizing defeats the purpose.
+  /* oxlint-disable no-await-in-loop */
+  while (Date.now() < deadline) {
+    try {
+      if ((await httpStatus(url)) === 200) return;
+    } catch (err) {
+      lastError = `${err && err.code ? err.code : err}`;
+    }
+    await sleep(HEALTH_POLL_MS);
+  }
+  /* oxlint-enable no-await-in-loop */
+  const log = logPath && fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8") : "";
+  throw new Error(
+    `${label} not healthy within ${HEALTH_TIMEOUT_MS / 1000}s at ${url} ` +
+      `(last_error=${lastError}).\n${log.slice(-3000)}`,
+  );
+}
+
+/**
+ * Spawn the mock-LLM server and an `omnigent server` wired to it, mirroring
+ * the env + argv of tests/e2e_ui/conftest.py's `mock_llm_server` +
+ * `live_server` fixtures (so the desktop shell talks to the same fake backend
+ * the Python lanes do — no real provider creds, deterministic replies).
+ *
+ * The caller MUST have built the SPA into WEB_UI_DIST first (see README): the
+ * server serves it from there, and building it lazily under the recorder
+ * starves the boot. Throws if the dist dir is missing so the failure is named,
+ * not a blank window.
+ *
+ * @param {string} tmpDir A scratch dir for the db, artifacts, agent, and logs.
+ * @returns {Promise<{ serverUrl: string, close: () => Promise<void> }>}
+ */
+async function spawnServer(tmpDir) {
+  if (!fs.existsSync(path.join(WEB_UI_DIST, "index.html"))) {
+    throw new Error(
+      `SPA bundle missing at ${WEB_UI_DIST}. Build it first:\n` +
+        `  pnpm --filter web install && pnpm --filter web run build`,
+    );
+  }
+
+  const mockPort = await findFreePort();
+  const serverPort = await findFreePort();
+  const mockLog = path.join(tmpDir, "mock_llm.log");
+  const serverLog = path.join(tmpDir, "server.log");
+  const dbPath = path.join(tmpDir, "test.db");
+  const artifactDir = path.join(tmpDir, "artifacts");
+  const agentYaml = path.join(tmpDir, "hello_world.yaml");
+  fs.mkdirSync(artifactDir, { recursive: true });
+  fs.writeFileSync(agentYaml, TEST_AGENT_YAML);
+
+  const mockOut = fs.openSync(mockLog, "w");
+  const mockProc = spawn(PYTHON, [MOCK_LLM_SERVER, String(mockPort)], {
+    env: { ...process.env, PYTHONPATH: REPO_ROOT },
+    stdio: ["ignore", mockOut, mockOut],
+  });
+  const mockUrl = `http://127.0.0.1:${mockPort}`;
+  await waitForHealthy(`${mockUrl}/stats`, "mock LLM server", mockLog);
+
+  const serverOut = fs.openSync(serverLog, "w");
+  // Strip ambient runner/host env so a nested runner (if the journey starts a
+  // host) boots clean rather than taking the zygote-fork path and hanging —
+  // the same leak the Python recorder guards against. Rebuild by filtering
+  // (rather than deleting keys) to keep the object shape static.
+  const cleanEnv = Object.fromEntries(
+    Object.entries(process.env).filter(
+      ([key]) => !key.startsWith("OMNIGENT_RUNNER_") && !key.startsWith("OMNIGENT_HOST_"),
+    ),
+  );
+  const serverProc = spawn(
+    PYTHON,
+    [
+      "-c",
+      "from omnigent.cli import main; main()",
+      "server",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(serverPort),
+      "--database-uri",
+      `sqlite:///${dbPath}`,
+      "--artifact-location",
+      artifactDir,
+      "--agent",
+      agentYaml,
+    ],
+    {
+      env: {
+        ...cleanEnv,
+        PYTHONPATH: REPO_ROOT,
+        OPENAI_BASE_URL: `${mockUrl}/v1`,
+        OPENAI_API_KEY: "mock-key",
+        ANTHROPIC_API_KEY: "",
+        OMNIGENT_WEB_UI_DIST: WEB_UI_DIST,
+      },
+      stdio: ["ignore", serverOut, serverOut],
+    },
+  );
+  const serverUrl = `http://127.0.0.1:${serverPort}`;
+
+  const close = async () => {
+    for (const proc of [serverProc, mockProc]) {
+      if (proc.exitCode === null) {
+        proc.kill("SIGTERM");
+      }
+    }
+    // Give them a moment; escalate is left to process teardown.
+    await sleep(200);
+    try {
+      fs.closeSync(serverOut);
+    } catch {
+      /* already closed */
+    }
+    try {
+      fs.closeSync(mockOut);
+    } catch {
+      /* already closed */
+    }
+  };
+
+  try {
+    await waitForHealthy(`${serverUrl}/health`, "omnigent server", serverLog);
+  } catch (err) {
+    await close();
+    throw err;
+  }
+  return { serverUrl, close };
+}
+
+/**
+ * Launch the real desktop shell (Electron main process) under Playwright with
+ * video recording on, in an isolated userData dir so it never touches the
+ * developer's real settings. Optionally pre-seed a saved `server_url` so the
+ * app boots straight onto the server (skipping the setup page) — for a bug
+ * whose failure is PAST connect. Omit it to film the connect journey itself.
+ *
+ * @param {object} opts
+ * @param {string} opts.recordDir Directory the .webm video is written into.
+ * @param {string} [opts.serverUrl] Pre-seed settings.json's server_url with
+ *   this, so the shell auto-connects on launch.
+ * @param {string} [opts.userDataDir] Override the isolated userData dir
+ *   (defaults to a fresh temp dir).
+ * @returns {Promise<{ electronApp: import("playwright").ElectronApplication,
+ *   window: import("playwright").Page, userDataDir: string }>}
+ */
+async function launchDesktop(opts) {
+  const { _electron: electron } = require("playwright");
+  const userDataDir = opts.userDataDir || fs.mkdtempSync(path.join(os.tmpdir(), "omni-desktop-"));
+  fs.mkdirSync(userDataDir, { recursive: true });
+  if (opts.serverUrl) {
+    fs.writeFileSync(
+      path.join(userDataDir, "settings.json"),
+      JSON.stringify({ server_url: opts.serverUrl }, null, 2),
+    );
+  }
+  fs.mkdirSync(opts.recordDir, { recursive: true });
+
+  const electronApp = await electron.launch({
+    args: [APP_ROOT, `--user-data-dir=${userDataDir}`],
+    recordVideo: { dir: opts.recordDir },
+    // Dev builds read dev-app-update.yml and would try to reach the update
+    // endpoint; a version override keeps the app off the update path.
+    env: { ...process.env, OMNIGENT_DESKTOP_VERSION_OVERRIDE: "999.0.0" },
+  });
+  const window = await electronApp.firstWindow();
+  return { electronApp, window, userDataDir };
+}
+
+module.exports = {
+  APP_ROOT,
+  REPO_ROOT,
+  WEB_UI_DIST,
+  desktopDepsAvailable,
+  findFreePort,
+  spawnServer,
+  launchDesktop,
+};

--- a/web/electron/e2e/desktop_connect.e2e.js
+++ b/web/electron/e2e/desktop_connect.e2e.js
@@ -1,0 +1,68 @@
+// Example desktop-shell recording lane: the connect journey.
+//
+// This is the reference test a repro-agent COPIES for a desktop-shell bug
+// (see e2e/README.md). It films the real Electron window: launch on the
+// bundled setup page, type a server URL, Connect, and land in the app shell.
+// The recorded .webm is the desktop journey a user sees — the artifact the
+// repro-agent attaches for a `web`/desktop facet.
+//
+// Run: `node --test e2e/desktop_connect.e2e.js` from web/electron, AFTER
+// building the SPA (pnpm --filter web run build). Skips cleanly when electron
+// or playwright aren't installed (they're not in the web-test CI path).
+
+"use strict";
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { desktopDepsAvailable, spawnServer, launchDesktop } = require("./desktopHarness");
+
+const deps = desktopDepsAvailable();
+const RECORD_DIR = path.join(__dirname, "recordings", "desktop-connect");
+
+describe(
+  "desktop shell — connect journey",
+  { skip: deps.ok ? false : `missing deps: ${deps.missing.join(", ")}` },
+  () => {
+    let tmpDir;
+    let server;
+
+    before(async () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "omni-desktop-e2e-"));
+      server = await spawnServer(tmpDir);
+    });
+
+    after(async () => {
+      if (server) await server.close();
+      if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("connects from the setup page and lands in the app shell", async () => {
+      // Launch WITHOUT a pre-seeded server so the journey starts on the bundled
+      // setup page — the connect flow is part of the desktop journey we film.
+      const { electronApp, window } = await launchDesktop({ recordDir: RECORD_DIR });
+      try {
+        // 1. The bundled "connect to server" setup page is shown.
+        const urlField = window.locator("#url");
+        await urlField.waitFor({ state: "visible", timeout: 15_000 });
+
+        // 2. Type the server URL and Connect.
+        await urlField.fill(server.serverUrl);
+        await window.locator("#connect").click();
+
+        // 3. The server's SPA takes over the window — the app shell renders.
+        //    (Landing page varies; the sidebar brand is always present.)
+        const brand = window.locator('[data-testid="sidebar-brand"]');
+        await brand.waitFor({ state: "visible", timeout: 20_000 });
+        assert.ok(await brand.isVisible(), "app shell did not render after connect");
+      } finally {
+        // Video is flushed on close; do it in finally so a failed assertion
+        // still yields footage of the failure.
+        await electronApp.close();
+      }
+    });
+  },
+);

--- a/web/electron/e2e/desktop_connect.e2e.js
+++ b/web/electron/e2e/desktop_connect.e2e.js
@@ -48,7 +48,8 @@ describe(
     it("connects from the setup page and lands in the app shell", async () => {
       // Launch WITHOUT a pre-seeded server so the journey starts on the bundled
       // setup page — the connect flow is part of the desktop journey we film.
-      const { electronApp, window } = await launchDesktop({ recordDir: RECORD_DIR });
+      const { electronApp, window, userDataDir } = await launchDesktop({ recordDir: RECORD_DIR });
+      let saved;
       try {
         // 1. The bundled "connect to server" setup page is shown.
         const urlField = window.locator("#url");
@@ -66,14 +67,15 @@ describe(
         await landed.waitFor({ state: "visible", timeout: 20_000 });
         assert.ok(await landed.isVisible(), "app shell did not render after connect");
       } finally {
-        // Video is flushed on close; do it in finally so a failed assertion
-        // still yields footage of the failure.
+        // Video is flushed on close, so close and name the clip HERE — a
+        // `reproduced` facet's run FAILS (the primary repro use), and the
+        // before-fix footage must still be saved on that path, not just on
+        // pass. Rename to the stable name the repro-agent handoff points at.
         await electronApp.close();
+        saved = saveRecording(RECORD_DIR, "connect-journey");
+        fs.rmSync(userDataDir, { recursive: true, force: true });
       }
-      // Rename the raw page@<hash>.webm to a stable name at the record-dir
-      // root — the name a repro-agent handoff points at (before-/fixed-<facet>).
-      const clip = saveRecording(RECORD_DIR, "connect-journey");
-      assert.ok(clip, "no desktop recording was produced");
+      assert.ok(saved && saved.length > 0, "no desktop recording was produced");
     });
   },
 );

--- a/web/electron/e2e/desktop_connect.e2e.js
+++ b/web/electron/e2e/desktop_connect.e2e.js
@@ -18,7 +18,12 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
-const { desktopDepsAvailable, spawnServer, launchDesktop } = require("./desktopHarness");
+const {
+  desktopDepsAvailable,
+  spawnServer,
+  launchDesktop,
+  saveRecording,
+} = require("./desktopHarness");
 
 const deps = desktopDepsAvailable();
 const RECORD_DIR = path.join(__dirname, "recordings", "desktop-connect");
@@ -54,15 +59,21 @@ describe(
         await window.locator("#connect").click();
 
         // 3. The server's SPA takes over the window — the app shell renders.
-        //    (Landing page varies; the sidebar brand is always present.)
-        const brand = window.locator('[data-testid="sidebar-brand"]');
-        await brand.waitFor({ state: "visible", timeout: 20_000 });
-        assert.ok(await brand.isVisible(), "app shell did not render after connect");
+        //    Key on the home composer heading, reliably visible on the desktop
+        //    layout (the sidebar brand collapses into the macOS title-bar row
+        //    and reads as hidden there).
+        const landed = window.getByText("What should we build?");
+        await landed.waitFor({ state: "visible", timeout: 20_000 });
+        assert.ok(await landed.isVisible(), "app shell did not render after connect");
       } finally {
         // Video is flushed on close; do it in finally so a failed assertion
         // still yields footage of the failure.
         await electronApp.close();
       }
+      // Rename the raw page@<hash>.webm to a stable name at the record-dir
+      // root — the name a repro-agent handoff points at (before-/fixed-<facet>).
+      const clip = saveRecording(RECORD_DIR, "connect-journey");
+      assert.ok(clip, "no desktop recording was produced");
     });
   },
 );

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -34,7 +34,8 @@
   },
   "devDependencies": {
     "electron": "^42.3.2",
-    "electron-builder": "^26.0.0"
+    "electron-builder": "^26.0.0",
+    "playwright": "^1.62.1"
   },
   "build": {
     "appId": "ai.omnigent.desktop",


### PR DESCRIPTION
## Related issue

No single issue — infrastructure for repro-agent. Unblocks recording the
desktop-shell auth bugs the web/OIDC lane only partially films (e.g. OMNI-2977
dead-end 401, OMNI-2915 in-window IdP, OMNI-2224 Okta MFA hang).

## Summary

Bugs that live in the **Electron desktop shell** — the dead-end 401 fallback to
the setup page, in-window IdP rendering (RFC 8252), the session-expiry reload,
the window-open / OAuth-popup policy, the native host-enrollment dialog — can't
be filmed by any existing repro-agent recording lane. Every other lane is a
pytest-playwright test under `tests/e2e_ui/`, but:

- the defect is in **Electron's main process**, which a plain browser page never
  exercises, and
- **Python Playwright has no Electron API** (`_electron.launch()` is JS-only),
  and there's no `@playwright/test` in the repo.

So this adds a small **JS** lane under `web/electron/e2e/` (run with `node --test`,
the same runner as the rest of `web/electron/test/`) that spawns the *same*
mock-LLM + `omnigent server` pair the Python suite spawns and launches the REAL
packaged shell via `_electron.launch({ recordVideo })` — so the recorded video is
the actual desktop window (setup page, connect, and the shell or the failure a
user sees), not a browser tab standing in for it.

- `desktopHarness.js` — spawns the backend (mirrors `tests/e2e_ui/conftest.py`
  env/argv, strips leaked runner env) and `launchDesktop({ serverUrl?, recordDir })`
  launches the shell in an isolated `userData` dir. `desktopDepsAvailable()` gates
  a clean skip when `electron`/`playwright` aren't installed.
- `desktop_connect.e2e.js` — the reference test a repro-agent copies (launch →
  setup page → type URL → Connect → land in the shell).
- `README.md` — why it's JS not pytest, prereqs, how to author a reproduction.
- `dev/repro-agent/AGENTS.md` — a `desktop` facets block in Step 4 and a new
  `desktop` surface stamp.

## Test Plan

- `node --check` on both JS files; oxlint clean (repo `oxlint-disable
  no-await-in-loop` around the intentional sequential health-poll); `tsc -b`
  clean; prettier clean — all via `pre-commit run`.
- `node --test e2e/desktop_connect.e2e.js` **skips cleanly** when
  `electron`/`playwright` are absent (they're not in the web-test CI path), so a
  checkout without them stays green.
- Confirmed bare `node --test` (the `test` script) does **not** collect
  `e2e/*.e2e.js`, so the fast unit-test job is untouched.
- **Not yet exercised live** — the launch/record path needs `electron` +
  `playwright` on disk and a display (`xvfb-run` on CI); that end-to-end run is
  the follow-up.

## Demo

N/A — this is test/CI infrastructure; the lane itself produces the demos for
future desktop-bug reproductions.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered lint/format/type-check (via pre-commit) and the
skip-when-deps-absent path. The live `_electron.launch` recording path can't run
in a headless checkout without `electron`/`playwright` + a display, so it's
verified structurally here and left for a follow-up live run (documented in the
lane README).

This pull request and its description were written by Isaac.