### PR TITLE
ci(ui-preview): let labelled fork PRs run the preview

### DIFF
--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -4,6 +4,15 @@ name: UI Preview
 # The preview is ephemeral (SQLite + local artifacts) and ships no LLM/runner --
 # Omnigent runs agent turns on a runner the reviewer connects from their own
 # machine. See .github/ui-preview/README.md.
+#
+# Fork PRs are supported: the `ui-preview` label is the trust boundary. Applying
+# a label needs Triage+ on the repo, so an outside contributor cannot self-label
+# their fork PR -- only a maintainer (or a trusted bot acting after checks pass)
+# can. The build/deploy jobs run on `pull_request_target` (base-repo context,
+# with secrets) once labelled. NOTE: the label vouches for the PR as labelled; a
+# later push (`synchronize`) re-runs with the label still attached, so gate the
+# secret-bearing deploy behind a protected Environment / "require approval for
+# outside collaborators" if you need per-commit re-approval.
 
 on:
   push:
@@ -41,7 +50,6 @@ jobs:
       && github.event.action != 'closed'
       && contains(github.event.pull_request.labels.*.name, 'ui-preview')
       && github.event.pull_request.draft == false
-      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -81,7 +89,6 @@ jobs:
         github.event.action != 'closed'
         && contains(github.event.pull_request.labels.*.name, 'ui-preview')
         && github.event.pull_request.draft == false
-        && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
       )
     runs-on: ubuntu-latest
     permissions:
@@ -97,7 +104,8 @@ jobs:
           # checkout v7 blocks fork PR checkout on `pull_request_target` by
           # default; opt in since this job builds the preview from fork code.
           # Safe: it has no secrets (only `contents: read`), and the
-          # author_association guard above restricts it to OWNER/MEMBER/COLLABORATOR.
+          # `ui-preview` label gate above restricts it to PRs a maintainer (or a
+          # trusted bot) has labelled -- an outside contributor cannot self-label.
           allow-unsafe-pr-checkout: true
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0


### PR DESCRIPTION
## Related issue

<!-- Test / CI change; no issue required. -->

Closes #

## Summary

The UI Preview workflow never ran for fork PRs. Both the `notify` and `build`
jobs gated on `github.event.pull_request.author_association` being
`OWNER`/`MEMBER`/`COLLABORATOR`, which is `NONE` for a PR opened from a fork, so
outside-contributor PRs were silently skipped even when labelled.

This drops the `author_association` check from those two gates. The `ui-preview`
label becomes the sole trust boundary — and it's a real one: applying a label
requires Triage+ permission on the repo, so an outside contributor **cannot**
self-label their own fork PR. Only a maintainer (or a trusted bot acting after
checks pass) can. The workflow already runs on `pull_request_target` with fork
checkout opted in (`allow-unsafe-pr-checkout: true`) and keeps secrets out of
the fork-code `build` job, so labelling is now sufficient to preview a fork PR.

A header note documents the trust model and the one residual caveat: the label
vouches for the PR *as labelled*; a later push (`synchronize`) re-runs with the
label still attached. If per-commit re-approval is required, gate the
secret-bearing `deploy` job behind a protected Environment / "require approval
for outside collaborators" — left as a follow-up, not in this PR.

## Test Plan

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ui-preview.yml'))"` — YAML parses.
- Confirmed no `author_association` references remain in the workflow.
- Full manual verification requires a labelled fork PR against the base repo
  (the deploy path needs Databricks secrets that only run in base-repo context),
  which can't be exercised from a local checkout.

## Demo

N/A — CI workflow change, no user-facing UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the workflow YAML parses and no `author_association` gate remains. The
end-to-end deploy path (labelled fork PR → Databricks Apps preview) depends on
base-repo secrets and cannot be run from a local checkout; it will be exercised
by the first labelled fork PR after merge.

## Changelog

<!-- Not user-facing; CI-only. -->
