### PR TITLE
fix(web): preserve preset colors when customizing

### DIFF
--- a/tests/e2e_ui/sessions/test_color_theme.py
+++ b/tests/e2e_ui/sessions/test_color_theme.py
@@ -52,6 +52,8 @@ def _computed_theme_tokens(page: Page) -> dict[str, str]:
         "border",
         "ring",
         "brand-accent",
+        "sidebar-active",
+        "sidebar-active-foreground",
     ]
     return page.evaluate(
         "names => { const probe = document.createElement('div'); "

--- a/tests/e2e_ui/sessions/test_color_theme.py
+++ b/tests/e2e_ui/sessions/test_color_theme.py
@@ -44,6 +44,39 @@ def _html_has_dark(page: Page) -> bool:
     return page.evaluate("() => document.documentElement.classList.contains('dark')")
 
 
+def _computed_theme_tokens(page: Page) -> dict[str, str]:
+    names = [
+        "background",
+        "card",
+        "sidebar",
+        "border",
+        "ring",
+        "brand-accent",
+    ]
+    return page.evaluate(
+        "names => { const probe = document.createElement('div'); "
+        "const canvas = document.createElement('canvas'); canvas.width = canvas.height = 1; "
+        "const context = canvas.getContext('2d'); document.body.append(probe); "
+        "const values = Object.fromEntries(names.map(name => { "
+        "probe.style.color = `var(--${name})`; context.clearRect(0, 0, 1, 1); "
+        "context.fillStyle = getComputedStyle(probe).color; context.fillRect(0, 0, 1, 1); "
+        "return [name, Array.from(context.getImageData(0, 0, 1, 1).data).join(',')]; "
+        "})); probe.remove(); return values; }",
+        names,
+    )
+
+
+def _set_contrast(page: Page, value: int) -> None:
+    page.get_by_test_id("custom-theme-contrast").evaluate(
+        "(element, next) => { "
+        "const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set; "
+        "setter.call(element, String(next)); "
+        "element.dispatchEvent(new Event('input', { bubbles: true })); "
+        "}",
+        value,
+    )
+
+
 def _theme_radiogroup(page: Page) -> Locator:
     """The appearance-mode radiogroup ("Mode"). Matched exactly so it can't also
     resolve the "Color theme" / "Terminal theme" radiogroups, whose cards reuse
@@ -145,7 +178,7 @@ def test_guided_custom_theme_applies_to_both_modes_and_persists(
     _pick_palette(page, "GitHub")
     page.get_by_test_id("custom-theme-accent-trigger").click()
     accent = page.get_by_test_id("custom-theme-accent-input")
-    expect(accent).to_have_value("#0969DA")
+    expect(accent).to_have_value("#1F883D")
     accent.fill("#2563eb")
 
     expect(_color_theme_select(page)).to_contain_text("Custom")
@@ -173,6 +206,7 @@ def test_guided_custom_theme_applies_to_both_modes_and_persists(
         ".getPropertyValue('--custom-dark-background').trim()"
     )
     assert light_background and dark_background and light_background != dark_background
+    assert dark_background == "#0d1117"
 
     dark = _theme_radiogroup(page).get_by_role("radio", name="Dark")
     dark.click()
@@ -199,6 +233,25 @@ def test_guided_custom_theme_applies_to_both_modes_and_persists(
     assert surface_background == "rgba(0, 0, 0, 0)", (
         "workspace content should not cover the translucent rail"
     )
+
+
+def test_contrast_round_trip_restores_preset_tokens(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    page.emulate_media(color_scheme="light")
+    base_url, _session_id = seeded_session
+    _open_appearance(page, base_url)
+
+    for mode in ["Light", "Dark"]:
+        _theme_radiogroup(page).get_by_role("radio", name=mode).click()
+        for palette in ["Omnigent", "Dracula", "GitHub", "Catppuccin", "Gruvbox", "Nord"]:
+            _pick_palette(page, palette)
+            before = _computed_theme_tokens(page)
+            _set_contrast(page, 53)
+            _set_contrast(page, 50)
+
+            expect(_color_theme_select(page)).to_contain_text("Custom")
+            assert _computed_theme_tokens(page) == before, f"{mode} {palette} did not round-trip"
 
 
 def test_custom_theme_colors_can_be_randomized(

--- a/tests/e2e_ui/sessions/test_color_theme.py
+++ b/tests/e2e_ui/sessions/test_color_theme.py
@@ -54,8 +54,33 @@ def _computed_theme_tokens(page: Page) -> dict[str, str]:
         "brand-accent",
         "sidebar-active",
         "sidebar-active-foreground",
+        "foreground",
+        "card-solid",
+        "card-foreground",
+        "tray",
+        "popover",
+        "popover-foreground",
+        "primary",
+        "primary-foreground",
+        "secondary",
+        "secondary-foreground",
+        "muted",
+        "muted-foreground",
+        "code-bg",
+        "accent",
+        "accent-foreground",
+        "border-strong",
+        "button-border",
+        "input",
+        "sidebar-foreground",
+        "sidebar-primary",
+        "sidebar-primary-foreground",
+        "sidebar-accent",
+        "sidebar-accent-foreground",
+        "sidebar-border",
+        "sidebar-ring",
     ]
-    return page.evaluate(
+    colors = page.evaluate(
         "names => { const probe = document.createElement('div'); "
         "const canvas = document.createElement('canvas'); canvas.width = canvas.height = 1; "
         "const context = canvas.getContext('2d'); document.body.append(probe); "
@@ -66,6 +91,13 @@ def _computed_theme_tokens(page: Page) -> dict[str, str]:
         "})); probe.remove(); return values; }",
         names,
     )
+    backgrounds = page.evaluate(
+        "() => Object.fromEntries([['shell', document.querySelector('.app-shell')], "
+        "['conversation-sidebar', document.querySelector('.conversations-sidebar')]]"
+        ".map(([name, element]) => { const style = getComputedStyle(element); "
+        "return [name, `${style.backgroundColor}|${style.backgroundImage}`]; }))"
+    )
+    return {**colors, **backgrounds}
 
 
 def _set_contrast(page: Page, value: int) -> None:

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1976,6 +1976,12 @@ aside[aria-label="Workspace"][data-maximized] {
 .dark[data-theme="custom"] .app-shell {
   background: var(--custom-dark-shell-background);
 }
+:root:not(.dark)[data-theme="custom"] .conversations-sidebar {
+  background: var(--custom-light-sidebar-background);
+}
+.dark[data-theme="custom"] .conversations-sidebar {
+  background: var(--custom-dark-sidebar-background);
+}
 .theme-contrast-range {
   appearance: none;
   height: 0.375rem;
@@ -2020,12 +2026,12 @@ aside[aria-label="Workspace"][data-maximized] {
 @media (min-width: 48rem) {
   :root:not(.dark)[data-theme="custom"][data-custom-translucent-sidebar]
     :is(.conversations-sidebar, aside[aria-label="Workspace"]:not([data-maximized])) {
-    background-color: var(--custom-light-sidebar);
+    background: var(--custom-light-sidebar);
     backdrop-filter: blur(20px) saturate(1.12);
   }
   .dark[data-theme="custom"][data-custom-translucent-sidebar]
     :is(.conversations-sidebar, aside[aria-label="Workspace"]:not([data-maximized])) {
-    background-color: var(--custom-dark-sidebar);
+    background: var(--custom-dark-sidebar);
     backdrop-filter: blur(20px) saturate(1.12);
   }
   :root[data-theme="custom"][data-custom-translucent-sidebar]

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1905,72 +1905,113 @@ aside[aria-label="Workspace"][data-maximized] {
   --foreground: var(--custom-light-foreground);
   --card: var(--custom-light-card);
   --card-solid: var(--custom-light-card-solid);
-  --card-foreground: var(--custom-light-foreground);
-  --tray: var(--custom-light-card);
-  --popover: var(--custom-light-card-solid);
-  --popover-foreground: var(--custom-light-foreground);
+  --card-foreground: var(--custom-light-card-foreground);
+  --tray: var(--custom-light-tray);
+  --popover: var(--custom-light-popover);
+  --popover-foreground: var(--custom-light-popover-foreground);
   --primary: var(--custom-light-primary);
   --primary-foreground: var(--custom-light-primary-foreground);
   --secondary: var(--custom-light-secondary);
-  --secondary-foreground: var(--custom-light-foreground);
+  --secondary-foreground: var(--custom-light-secondary-foreground);
   --muted: var(--custom-light-muted);
   --muted-foreground: var(--custom-light-muted-foreground);
   --code-bg: var(--custom-light-code-bg);
   --accent: var(--custom-light-accent);
-  --accent-foreground: var(--custom-light-foreground);
+  --accent-foreground: var(--custom-light-accent-foreground);
   --border: var(--custom-light-border);
   --border-strong: var(--custom-light-border-strong);
-  --button-border: var(--custom-light-border);
-  --input: var(--custom-light-border);
-  --ring: var(--custom-light-primary);
-  --brand-accent: var(--custom-light-primary);
+  --button-border: var(--custom-light-button-border);
+  --input: var(--custom-light-input);
+  --ring: var(--custom-light-ring);
+  --brand-accent: var(--custom-light-brand-accent);
   --sidebar: var(--custom-light-sidebar);
-  --sidebar-foreground: var(--custom-light-foreground);
-  --sidebar-primary: var(--custom-light-primary);
-  --sidebar-primary-foreground: var(--custom-light-primary-foreground);
-  --sidebar-accent: var(--custom-light-accent);
-  --sidebar-accent-foreground: var(--custom-light-foreground);
-  --sidebar-border: var(--custom-light-border);
-  --sidebar-ring: var(--custom-light-primary);
+  --sidebar-foreground: var(--custom-light-sidebar-foreground);
+  --sidebar-primary: var(--custom-light-sidebar-primary);
+  --sidebar-primary-foreground: var(--custom-light-sidebar-primary-foreground);
+  --sidebar-accent: var(--custom-light-sidebar-accent);
+  --sidebar-accent-foreground: var(--custom-light-sidebar-accent-foreground);
+  --sidebar-border: var(--custom-light-sidebar-border);
+  --sidebar-ring: var(--custom-light-sidebar-ring);
 }
 .dark[data-theme="custom"] {
   --background: var(--custom-dark-background);
   --foreground: var(--custom-dark-foreground);
   --card: var(--custom-dark-card);
   --card-solid: var(--custom-dark-card-solid);
-  --card-foreground: var(--custom-dark-foreground);
-  --tray: var(--custom-dark-card);
-  --popover: var(--custom-dark-card-solid);
-  --popover-foreground: var(--custom-dark-foreground);
+  --card-foreground: var(--custom-dark-card-foreground);
+  --tray: var(--custom-dark-tray);
+  --popover: var(--custom-dark-popover);
+  --popover-foreground: var(--custom-dark-popover-foreground);
   --primary: var(--custom-dark-primary);
   --primary-foreground: var(--custom-dark-primary-foreground);
   --secondary: var(--custom-dark-secondary);
-  --secondary-foreground: var(--custom-dark-foreground);
+  --secondary-foreground: var(--custom-dark-secondary-foreground);
   --muted: var(--custom-dark-muted);
   --muted-foreground: var(--custom-dark-muted-foreground);
   --code-bg: var(--custom-dark-code-bg);
   --accent: var(--custom-dark-accent);
-  --accent-foreground: var(--custom-dark-foreground);
+  --accent-foreground: var(--custom-dark-accent-foreground);
   --border: var(--custom-dark-border);
   --border-strong: var(--custom-dark-border-strong);
-  --button-border: var(--custom-dark-border);
-  --input: var(--custom-dark-border);
-  --ring: var(--custom-dark-primary);
-  --brand-accent: var(--custom-dark-primary);
+  --button-border: var(--custom-dark-button-border);
+  --input: var(--custom-dark-input);
+  --ring: var(--custom-dark-ring);
+  --brand-accent: var(--custom-dark-brand-accent);
   --sidebar: var(--custom-dark-sidebar);
-  --sidebar-foreground: var(--custom-dark-foreground);
-  --sidebar-primary: var(--custom-dark-primary);
-  --sidebar-primary-foreground: var(--custom-dark-primary-foreground);
-  --sidebar-accent: var(--custom-dark-accent);
-  --sidebar-accent-foreground: var(--custom-dark-foreground);
-  --sidebar-border: var(--custom-dark-border);
-  --sidebar-ring: var(--custom-dark-primary);
+  --sidebar-foreground: var(--custom-dark-sidebar-foreground);
+  --sidebar-primary: var(--custom-dark-sidebar-primary);
+  --sidebar-primary-foreground: var(--custom-dark-sidebar-primary-foreground);
+  --sidebar-accent: var(--custom-dark-sidebar-accent);
+  --sidebar-accent-foreground: var(--custom-dark-sidebar-accent-foreground);
+  --sidebar-border: var(--custom-dark-sidebar-border);
+  --sidebar-ring: var(--custom-dark-sidebar-ring);
 }
 :root:not(.dark)[data-theme="custom"] .app-shell {
   background: var(--custom-light-shell-background);
 }
 .dark[data-theme="custom"] .app-shell {
   background: var(--custom-dark-shell-background);
+}
+.theme-contrast-range {
+  appearance: none;
+  height: 0.375rem;
+  border-radius: 9999px;
+  background: linear-gradient(
+    to right,
+    var(--primary) 0%,
+    var(--primary) var(--range-progress),
+    var(--input) var(--range-progress),
+    var(--input) 100%
+  );
+}
+.theme-contrast-range::-webkit-slider-runnable-track {
+  height: 0.375rem;
+  border-radius: 9999px;
+  background: transparent;
+}
+.theme-contrast-range::-moz-range-track {
+  height: 0.375rem;
+  border-radius: 9999px;
+  background: transparent;
+}
+.theme-contrast-range::-moz-range-progress {
+  background: transparent;
+}
+.theme-contrast-range::-webkit-slider-thumb {
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-top: -0.1875rem;
+  appearance: none;
+  border: 0;
+  border-radius: 9999px;
+  background: var(--primary);
+}
+.theme-contrast-range::-moz-range-thumb {
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 0;
+  border-radius: 9999px;
+  background: var(--primary);
 }
 @media (min-width: 48rem) {
   :root:not(.dark)[data-theme="custom"][data-custom-translucent-sidebar]

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1932,6 +1932,8 @@ aside[aria-label="Workspace"][data-maximized] {
   --sidebar-accent-foreground: var(--custom-light-sidebar-accent-foreground);
   --sidebar-border: var(--custom-light-sidebar-border);
   --sidebar-ring: var(--custom-light-sidebar-ring);
+  --sidebar-active: var(--custom-light-sidebar-active);
+  --sidebar-active-foreground: var(--custom-light-sidebar-active-foreground);
 }
 .dark[data-theme="custom"] {
   --background: var(--custom-dark-background);
@@ -1965,6 +1967,8 @@ aside[aria-label="Workspace"][data-maximized] {
   --sidebar-accent-foreground: var(--custom-dark-sidebar-accent-foreground);
   --sidebar-border: var(--custom-dark-sidebar-border);
   --sidebar-ring: var(--custom-dark-sidebar-ring);
+  --sidebar-active: var(--custom-dark-sidebar-active);
+  --sidebar-active-foreground: var(--custom-dark-sidebar-active-foreground);
 }
 :root:not(.dark)[data-theme="custom"] .app-shell {
   background: var(--custom-light-shell-background);

--- a/web/src/lib/customTheme.test.ts
+++ b/web/src/lib/customTheme.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   applyCustomTheme,
   createCustomThemeFromPalette,
+  customThemeSwatches,
   DEFAULT_CUSTOM_THEME,
   deriveCustomTheme,
   readCustomTheme,
@@ -108,6 +109,25 @@ describe("customTheme", () => {
     expect(adjusted.light).not.toEqual(palette.tokens.light);
     expect(adjusted.dark).not.toEqual(palette.tokens.dark);
     expect(deriveCustomTheme({ ...theme, contrast: 50 })).toEqual(palette.tokens);
+  });
+
+  it.each(PALETTES)("keeps the exact $label preview at contrast 50", (palette) => {
+    const swatches = customThemeSwatches(createCustomThemeFromPalette(palette));
+
+    expect(swatches).toEqual({ light: palette.light, dark: palette.dark });
+  });
+
+  it("shows explicitly customized accents in the preview", () => {
+    const palette = PALETTES.find((candidate) => candidate.id === "omni")!;
+    const theme = createCustomThemeFromPalette(palette);
+    const swatches = customThemeSwatches({
+      ...theme,
+      accent: "#2563eb",
+      darkAccent: "#2563eb",
+    });
+
+    expect(swatches.light.accent).toBe("#2563eb");
+    expect(swatches.dark.accent).toBe("#2563eb");
   });
 
   it("derives readable light and dark variants from the same configuration", () => {

--- a/web/src/lib/customTheme.test.ts
+++ b/web/src/lib/customTheme.test.ts
@@ -111,6 +111,16 @@ describe("customTheme", () => {
     expect(deriveCustomTheme({ ...theme, contrast: 50 })).toEqual(palette.tokens);
   });
 
+  it("keeps Omnigent's selected-session colors after contrast changes", () => {
+    const theme = createCustomThemeFromPalette(PALETTES[0]);
+    const variants = deriveCustomTheme({ ...theme, contrast: 53 });
+
+    expect(variants.light.sidebarActive).toBe("rgba(240, 1, 150, 0.1)");
+    expect(variants.light.sidebarActiveForeground).toBe("#651249");
+    expect(variants.dark.sidebarActive).toBe("rgba(240, 1, 150, 0.15)");
+    expect(variants.dark.sidebarActiveForeground).toBe("#f472b6");
+  });
+
   it.each(PALETTES)("keeps the exact $label preview at contrast 50", (palette) => {
     const swatches = customThemeSwatches(createCustomThemeFromPalette(palette));
 

--- a/web/src/lib/customTheme.test.ts
+++ b/web/src/lib/customTheme.test.ts
@@ -33,7 +33,9 @@ describe("customTheme", () => {
     const theme = {
       basePalette: "github" as const,
       accent: "#1267d6",
+      darkAccent: "#238636",
       tint: "#dce8f7",
+      darkTint: "#0d1117",
       contrast: 72,
       translucentSidebar: true,
     };
@@ -44,35 +46,90 @@ describe("customTheme", () => {
     expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "null")).toEqual(theme);
   });
 
+  it("restores the dark tint for legacy saved themes", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        basePalette: "github",
+        accent: "#1f883d",
+        tint: "#f6f8fa",
+        contrast: 51,
+        translucentSidebar: false,
+      }),
+    );
+
+    expect(readCustomTheme().darkTint).toBe("#0d1117");
+  });
+
+  it("restores the dark accent for legacy saved themes", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        basePalette: "github",
+        accent: "#1f883d",
+        tint: "#f6f8fa",
+        darkTint: "#0d1117",
+        contrast: 51,
+        translucentSidebar: false,
+      }),
+    );
+
+    expect(readCustomTheme().darkAccent).toBe("#238636");
+  });
+
   it("creates one editable configuration from a built-in palette", () => {
     const github = PALETTES.find((palette) => palette.id === "github");
     expect(github).toBeDefined();
 
     expect(createCustomThemeFromPalette(github!)).toEqual({
       basePalette: "github",
-      accent: "#0969da",
+      accent: "#1f883d",
+      darkAccent: "#238636",
       tint: "#f6f8fa",
+      darkTint: "#0d1117",
       contrast: 50,
       translucentSidebar: false,
     });
+  });
+
+  it.each(PALETTES)("uses the exact $label tokens at contrast 50", (palette) => {
+    const theme = createCustomThemeFromPalette(palette);
+    const variants = deriveCustomTheme(theme);
+
+    expect(variants.light).toEqual(palette.tokens.light);
+    expect(variants.dark).toEqual(palette.tokens.dark);
+  });
+
+  it.each(PALETTES)("restores the exact $label tokens after changing contrast", (palette) => {
+    const theme = createCustomThemeFromPalette(palette);
+
+    const adjusted = deriveCustomTheme({ ...theme, contrast: 68 });
+
+    expect(adjusted.light).not.toEqual(palette.tokens.light);
+    expect(adjusted.dark).not.toEqual(palette.tokens.dark);
+    expect(deriveCustomTheme({ ...theme, contrast: 50 })).toEqual(palette.tokens);
   });
 
   it("derives readable light and dark variants from the same configuration", () => {
     const variants = deriveCustomTheme({
       basePalette: "omni",
       accent: "#2563eb",
+      darkAccent: "#2563eb",
       tint: "#dbeafe",
+      darkTint: "#160e24",
       contrast: 60,
       translucentSidebar: false,
     });
 
-    expect(variants.light.background).toBe("#f4f7ff");
-    expect(variants.dark.background).toBe("#393c47");
+    expect(variants.light.background).not.toBe(PALETTES[0].tokens.light.background);
+    expect(variants.dark.background).toBe("#160e24");
     expect(variants.light.primary).toBe("#2563eb");
     expect(variants.dark.primary).toBe("#2563eb");
     expect(variants.light.primaryForeground).toBe("#ffffff");
     expect(variants.dark.primaryForeground).toBe("#ffffff");
     expect(variants.light.foreground).not.toBe(variants.dark.foreground);
+    expect(variants.light.shellBackground).toBe(PALETTES[0].tokens.light.shellBackground);
+    expect(variants.dark.shellBackground).toBe(PALETTES[0].tokens.dark.shellBackground);
   });
 
   it("keeps muted helper text at WCAG AA contrast for every allowed contrast setting", () => {
@@ -90,9 +147,11 @@ describe("customTheme", () => {
 
     for (const contrast of [0, 50, 100]) {
       const variants = deriveCustomTheme({
-        basePalette: "omni",
+        basePalette: "github",
         accent: "#777777",
+        darkAccent: "#777777",
         tint: "#ffffff",
+        darkTint: "#0d1117",
         contrast,
         translucentSidebar: false,
       });
@@ -117,14 +176,16 @@ describe("customTheme", () => {
     applyCustomTheme({
       basePalette: "omni",
       accent: "#2563eb",
+      darkAccent: "#2563eb",
       tint: "#dbeafe",
+      darkTint: "#160e24",
       contrast: 60,
       translucentSidebar: true,
     });
 
     const style = document.documentElement.style;
-    expect(style.getPropertyValue("--custom-light-background")).toBe("#f4f7ff");
-    expect(style.getPropertyValue("--custom-dark-background")).toBe("#393c47");
+    expect(style.getPropertyValue("--custom-light-background")).not.toBe("");
+    expect(style.getPropertyValue("--custom-dark-background")).toBe("#160e24");
     expect(style.getPropertyValue("--custom-light-sidebar")).toMatch(/^rgba\(/);
     expect(style.getPropertyValue("--custom-dark-sidebar")).toMatch(/^rgba\(/);
     expect(document.documentElement).toHaveAttribute("data-custom-translucent-sidebar");

--- a/web/src/lib/customTheme.ts
+++ b/web/src/lib/customTheme.ts
@@ -442,22 +442,28 @@ export function customThemeSwatches(theme: CustomTheme): {
   light: PaletteSwatch;
   dark: PaletteSwatch;
 } {
-  const variants = deriveCustomTheme(theme);
+  const normalized = normalizeTheme(theme) ?? DEFAULT_CUSTOM_THEME;
+  const palette =
+    PALETTES.find((candidate) => candidate.id === normalized.basePalette) ?? PALETTES[0];
+  const reference = generateCustomTheme(createCustomThemeFromPalette(palette));
+  const current = generateCustomTheme({ ...normalized, translucentSidebar: false });
+
+  const swatch = (
+    base: PaletteSwatch,
+    referenceVariant: GeneratedThemeVariant,
+    currentVariant: GeneratedThemeVariant,
+  ): PaletteSwatch => ({
+    bg: rebaseColor(base.bg, referenceVariant.background, currentVariant.background),
+    card: rebaseColor(base.card, referenceVariant.cardSolid, currentVariant.cardSolid),
+    accent:
+      currentVariant.primary === referenceVariant.primary ? base.accent : currentVariant.primary,
+    border: rebaseColor(base.border, referenceVariant.border, currentVariant.border),
+    text: rebaseColor(base.text, referenceVariant.foreground, currentVariant.foreground),
+  });
+
   return {
-    light: {
-      bg: variants.light.background,
-      card: variants.light.cardSolid,
-      accent: variants.light.primary,
-      border: variants.light.border,
-      text: variants.light.foreground,
-    },
-    dark: {
-      bg: variants.dark.background,
-      card: variants.dark.cardSolid,
-      accent: variants.dark.primary,
-      border: variants.dark.border,
-      text: variants.dark.foreground,
-    },
+    light: swatch(palette.light, reference.light, current.light),
+    dark: swatch(palette.dark, reference.dark, current.dark),
   };
 }
 

--- a/web/src/lib/customTheme.ts
+++ b/web/src/lib/customTheme.ts
@@ -1,7 +1,9 @@
 import {
   isThemePalette,
+  PALETTES,
   type PaletteMeta,
   type PaletteSwatch,
+  type PaletteTokens,
   type ThemePalette,
 } from "./themePalette";
 
@@ -11,15 +13,19 @@ const HEX_COLOR = /^#[0-9a-f]{6}$/i;
 export interface CustomTheme {
   basePalette: ThemePalette;
   accent: string;
+  darkAccent: string;
   tint: string;
+  darkTint: string;
   contrast: number;
   translucentSidebar: boolean;
 }
 
 export const DEFAULT_CUSTOM_THEME: CustomTheme = {
   basePalette: "omni",
-  accent: "#df3c85",
-  tint: "#f3e9f4",
+  accent: "#11171c",
+  darkAccent: "#e8ecf0",
+  tint: "#ffffff",
+  darkTint: "#0e1013",
   contrast: 50,
   translucentSidebar: false,
 };
@@ -30,23 +36,7 @@ interface Rgb {
   b: number;
 }
 
-export interface DerivedThemeVariant {
-  background: string;
-  foreground: string;
-  card: string;
-  cardSolid: string;
-  primary: string;
-  primaryForeground: string;
-  secondary: string;
-  muted: string;
-  mutedForeground: string;
-  codeBackground: string;
-  accent: string;
-  border: string;
-  borderStrong: string;
-  sidebar: string;
-  shellBackground: string;
-}
+export type DerivedThemeVariant = PaletteTokens;
 
 export interface DerivedCustomTheme {
   light: DerivedThemeVariant;
@@ -77,7 +67,15 @@ function normalizeTheme(value: unknown): CustomTheme | null {
   return {
     basePalette: candidate.basePalette,
     accent: candidate.accent.toLowerCase(),
+    darkAccent: isHexColor(candidate.darkAccent)
+      ? candidate.darkAccent.toLowerCase()
+      : (PALETTES.find((palette) => palette.id === candidate.basePalette)?.tokens.dark.primary ??
+        DEFAULT_CUSTOM_THEME.darkAccent),
     tint: candidate.tint.toLowerCase(),
+    darkTint: isHexColor(candidate.darkTint)
+      ? candidate.darkTint.toLowerCase()
+      : (PALETTES.find((palette) => palette.id === candidate.basePalette)?.tokens.dark.background ??
+        DEFAULT_CUSTOM_THEME.darkTint),
     contrast: Math.round(clamp(candidate.contrast, 0, 100)),
     translucentSidebar: candidate.translucentSidebar,
   };
@@ -108,8 +106,10 @@ export function writeCustomTheme(theme: CustomTheme): void {
 export function createCustomThemeFromPalette(palette: PaletteMeta): CustomTheme {
   return {
     basePalette: palette.id,
-    accent: palette.light.accent.toLowerCase(),
-    tint: palette.light.bg.toLowerCase(),
+    accent: palette.tokens.light.primary.toLowerCase(),
+    darkAccent: palette.tokens.dark.primary.toLowerCase(),
+    tint: palette.tokens.light.background.toLowerCase(),
+    darkTint: palette.tokens.dark.background.toLowerCase(),
     contrast: 50,
     translucentSidebar: false,
   };
@@ -140,11 +140,6 @@ function mix(first: string, second: string, secondWeight: number): string {
     g: firstRgb.g * (1 - weight) + secondRgb.g * weight,
     b: firstRgb.b * (1 - weight) + secondRgb.b * weight,
   });
-}
-
-function rgba(hex: string, alpha: number): string {
-  const color = hexToRgb(hex);
-  return `rgba(${color.r}, ${color.g}, ${color.b}, ${alpha})`;
 }
 
 function luminance(hex: string): number {
@@ -191,11 +186,92 @@ function readableForeground(background: string): "#111318" | "#ffffff" {
   return darkContrast >= lightContrast ? "#111318" : "#ffffff";
 }
 
-export function deriveCustomTheme(theme: CustomTheme): DerivedCustomTheme {
+type GeneratedThemeVariant = Pick<
+  PaletteTokens,
+  | "background"
+  | "foreground"
+  | "card"
+  | "cardSolid"
+  | "primary"
+  | "primaryForeground"
+  | "secondary"
+  | "muted"
+  | "mutedForeground"
+  | "codeBackground"
+  | "accent"
+  | "border"
+  | "borderStrong"
+  | "sidebar"
+>;
+
+interface GeneratedCustomTheme {
+  light: GeneratedThemeVariant;
+  dark: GeneratedThemeVariant;
+}
+
+interface CssColor extends Rgb {
+  alpha: number;
+}
+
+function parseCssColor(value: string): CssColor | null {
+  const hex = /^#([0-9a-f]{6})([0-9a-f]{2})?$/i.exec(value);
+  if (hex) {
+    return {
+      ...hexToRgb(`#${hex[1]}`),
+      alpha: hex[2] ? Number.parseInt(hex[2], 16) / 255 : 1,
+    };
+  }
+  const rgb = /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/i.exec(
+    value,
+  );
+  if (!rgb) return null;
+  return {
+    r: Number(rgb[1]),
+    g: Number(rgb[2]),
+    b: Number(rgb[3]),
+    alpha: rgb[4] ? Number(rgb[4]) : 1,
+  };
+}
+
+function formatCssColor(color: CssColor, template: string): string {
+  const rgb = rgbToHex(color);
+  if (template.startsWith("#") && color.alpha === 1) return rgb;
+  if (template.length === 9) {
+    const alpha = Math.round(clamp(color.alpha, 0, 1) * 255)
+      .toString(16)
+      .padStart(2, "0");
+    return `${rgb}${alpha}`;
+  }
+  return `rgba(${Math.round(clamp(color.r, 0, 255))}, ${Math.round(clamp(color.g, 0, 255))}, ${Math.round(clamp(color.b, 0, 255))}, ${Math.round(clamp(color.alpha, 0, 1) * 1000) / 1000})`;
+}
+
+function rebaseColor(base: string, reference: string, current: string): string {
+  if (current === reference) return base;
+  const baseColor = parseCssColor(base);
+  const referenceColor = parseCssColor(reference);
+  const currentColor = parseCssColor(current);
+  if (!baseColor || !referenceColor || !currentColor) return base;
+  return formatCssColor(
+    {
+      r: baseColor.r + currentColor.r - referenceColor.r,
+      g: baseColor.g + currentColor.g - referenceColor.g,
+      b: baseColor.b + currentColor.b - referenceColor.b,
+      alpha: baseColor.alpha,
+    },
+    base,
+  );
+}
+
+function setAlpha(color: string, alpha: number): string {
+  const parsed = parseCssColor(color);
+  return parsed ? formatCssColor({ ...parsed, alpha }, "rgba") : color;
+}
+
+function generateCustomTheme(theme: CustomTheme): GeneratedCustomTheme {
   const normalized = normalizeTheme(theme) ?? DEFAULT_CUSTOM_THEME;
   const contrast = normalized.contrast / 100;
   const lightBackground = mix(normalized.tint, "#fffdff", 0.79 - contrast * 0.15);
-  const darkBackground = mix(normalized.tint, "#0b0b13", 0.72 + contrast * 0.1);
+  const darkBackground = normalized.darkTint;
 
   const lightCard = mix(lightBackground, "#ffffff", 0.72 + contrast * 0.16);
   const darkCard = mix(darkBackground, "#ffffff", 0.05 + contrast * 0.08);
@@ -233,16 +309,15 @@ export function deriveCustomTheme(theme: CustomTheme): DerivedCustomTheme {
       accent: mix(lightBackground, normalized.accent, 0.09 + contrast * 0.06),
       border: lightBorder,
       borderStrong: mix(lightBackground, lightForeground, 0.18 + contrast * 0.12),
-      sidebar: normalized.translucentSidebar ? rgba(lightSidebar, 0.72) : lightSidebar,
-      shellBackground: `linear-gradient(155deg, ${lightCard} 0%, ${lightBackground} 62%, ${mix(lightBackground, normalized.accent, 0.06)} 100%)`,
+      sidebar: lightSidebar,
     },
     dark: {
       background: darkBackground,
       foreground: darkForeground,
       card: darkCard,
       cardSolid: darkCard,
-      primary: normalized.accent,
-      primaryForeground: readableForeground(normalized.accent),
+      primary: normalized.darkAccent,
+      primaryForeground: readableForeground(normalized.darkAccent),
       secondary: darkMuted,
       muted: darkMuted,
       mutedForeground: darkMutedForeground,
@@ -250,9 +325,116 @@ export function deriveCustomTheme(theme: CustomTheme): DerivedCustomTheme {
       accent: mix(darkBackground, normalized.accent, 0.14 + contrast * 0.08),
       border: darkBorder,
       borderStrong: mix(darkBackground, darkForeground, 0.2 + contrast * 0.12),
-      sidebar: normalized.translucentSidebar ? rgba(darkSidebar, 0.72) : darkSidebar,
-      shellBackground: `radial-gradient(ellipse at 18% 24%, ${rgba(normalized.accent, 0.12)} 0%, transparent 52%), linear-gradient(155deg, ${darkCard} 0%, ${darkBackground} 68%, ${mix(darkBackground, "#000000", 0.16)} 100%)`,
+      sidebar: darkSidebar,
     },
+  };
+}
+
+function rebaseVariant(
+  base: PaletteTokens,
+  reference: GeneratedThemeVariant,
+  current: GeneratedThemeVariant,
+  primary: string,
+  translucentSidebar: boolean,
+): DerivedThemeVariant {
+  const primaryChanged = primary !== base.primary.toLowerCase();
+  const foreground = rebaseColor(base.foreground, reference.foreground, current.foreground);
+  const card = rebaseColor(base.card, reference.card, current.card);
+  const cardSolid = rebaseColor(base.cardSolid, reference.cardSolid, current.cardSolid);
+  const accent = rebaseColor(base.accent, reference.accent, current.accent);
+  const accentForeground = rebaseColor(
+    base.accentForeground,
+    reference.foreground,
+    current.foreground,
+  );
+  const border = rebaseColor(base.border, reference.border, current.border);
+  const sidebar = rebaseColor(base.sidebar, reference.sidebar, current.sidebar);
+
+  return {
+    background: rebaseColor(base.background, reference.background, current.background),
+    foreground,
+    card,
+    cardSolid,
+    cardForeground: rebaseColor(base.cardForeground, reference.foreground, current.foreground),
+    tray: rebaseColor(base.tray, reference.card, current.card),
+    popover: rebaseColor(base.popover, reference.cardSolid, current.cardSolid),
+    popoverForeground: rebaseColor(
+      base.popoverForeground,
+      reference.foreground,
+      current.foreground,
+    ),
+    primary: primaryChanged ? primary : base.primary,
+    primaryForeground: primaryChanged ? readableForeground(primary) : base.primaryForeground,
+    secondary: rebaseColor(base.secondary, reference.secondary, current.secondary),
+    secondaryForeground: rebaseColor(
+      base.secondaryForeground,
+      reference.foreground,
+      current.foreground,
+    ),
+    muted: rebaseColor(base.muted, reference.muted, current.muted),
+    mutedForeground: rebaseColor(
+      base.mutedForeground,
+      reference.mutedForeground,
+      current.mutedForeground,
+    ),
+    codeBackground: rebaseColor(
+      base.codeBackground,
+      reference.codeBackground,
+      current.codeBackground,
+    ),
+    accent,
+    accentForeground,
+    border,
+    borderStrong: rebaseColor(base.borderStrong, reference.borderStrong, current.borderStrong),
+    buttonBorder: rebaseColor(base.buttonBorder, reference.border, current.border),
+    input: rebaseColor(base.input, reference.border, current.border),
+    ring: primaryChanged ? primary : base.ring,
+    brandAccent: primaryChanged ? primary : base.brandAccent,
+    sidebar: translucentSidebar ? setAlpha(sidebar, 0.72) : sidebar,
+    sidebarForeground: rebaseColor(
+      base.sidebarForeground,
+      reference.foreground,
+      current.foreground,
+    ),
+    sidebarPrimary: primaryChanged ? primary : base.sidebarPrimary,
+    sidebarPrimaryForeground: primaryChanged
+      ? readableForeground(primary)
+      : base.sidebarPrimaryForeground,
+    sidebarAccent: rebaseColor(base.sidebarAccent, reference.accent, current.accent),
+    sidebarAccentForeground: rebaseColor(
+      base.sidebarAccentForeground,
+      reference.foreground,
+      current.foreground,
+    ),
+    sidebarBorder: rebaseColor(base.sidebarBorder, reference.border, current.border),
+    sidebarRing: primaryChanged ? primary : base.sidebarRing,
+    shellBackground: base.shellBackground,
+  };
+}
+
+export function deriveCustomTheme(theme: CustomTheme): DerivedCustomTheme {
+  const normalized = normalizeTheme(theme) ?? DEFAULT_CUSTOM_THEME;
+  const palette =
+    PALETTES.find((candidate) => candidate.id === normalized.basePalette) ?? PALETTES[0];
+  const referenceTheme = createCustomThemeFromPalette(palette);
+  const reference = generateCustomTheme(referenceTheme);
+  const current = generateCustomTheme({ ...normalized, translucentSidebar: false });
+
+  return {
+    light: rebaseVariant(
+      palette.tokens.light,
+      reference.light,
+      current.light,
+      normalized.accent,
+      normalized.translucentSidebar,
+    ),
+    dark: rebaseVariant(
+      palette.tokens.dark,
+      reference.dark,
+      current.dark,
+      normalized.darkAccent,
+      normalized.translucentSidebar,
+    ),
   };
 }
 
@@ -284,16 +466,33 @@ const TOKEN_MAP = {
   foreground: "foreground",
   card: "card",
   cardSolid: "card-solid",
+  cardForeground: "card-foreground",
+  tray: "tray",
+  popover: "popover",
+  popoverForeground: "popover-foreground",
   primary: "primary",
   primaryForeground: "primary-foreground",
   secondary: "secondary",
+  secondaryForeground: "secondary-foreground",
   muted: "muted",
   mutedForeground: "muted-foreground",
   codeBackground: "code-bg",
   accent: "accent",
+  accentForeground: "accent-foreground",
   border: "border",
   borderStrong: "border-strong",
+  buttonBorder: "button-border",
+  input: "input",
+  ring: "ring",
+  brandAccent: "brand-accent",
   sidebar: "sidebar",
+  sidebarForeground: "sidebar-foreground",
+  sidebarPrimary: "sidebar-primary",
+  sidebarPrimaryForeground: "sidebar-primary-foreground",
+  sidebarAccent: "sidebar-accent",
+  sidebarAccentForeground: "sidebar-accent-foreground",
+  sidebarBorder: "sidebar-border",
+  sidebarRing: "sidebar-ring",
   shellBackground: "shell-background",
 } as const;
 

--- a/web/src/lib/customTheme.ts
+++ b/web/src/lib/customTheme.ts
@@ -408,6 +408,8 @@ function rebaseVariant(
     ),
     sidebarBorder: rebaseColor(base.sidebarBorder, reference.border, current.border),
     sidebarRing: primaryChanged ? primary : base.sidebarRing,
+    sidebarActive: base.sidebarActive,
+    sidebarActiveForeground: base.sidebarActiveForeground,
     shellBackground: base.shellBackground,
   };
 }
@@ -499,6 +501,8 @@ const TOKEN_MAP = {
   sidebarAccentForeground: "sidebar-accent-foreground",
   sidebarBorder: "sidebar-border",
   sidebarRing: "sidebar-ring",
+  sidebarActive: "sidebar-active",
+  sidebarActiveForeground: "sidebar-active-foreground",
   shellBackground: "shell-background",
 } as const;
 

--- a/web/src/lib/customTheme.ts
+++ b/web/src/lib/customTheme.ts
@@ -410,6 +410,7 @@ function rebaseVariant(
     sidebarRing: primaryChanged ? primary : base.sidebarRing,
     sidebarActive: base.sidebarActive,
     sidebarActiveForeground: base.sidebarActiveForeground,
+    sidebarBackground: base.sidebarBackground,
     shellBackground: base.shellBackground,
   };
 }
@@ -503,6 +504,7 @@ const TOKEN_MAP = {
   sidebarRing: "sidebar-ring",
   sidebarActive: "sidebar-active",
   sidebarActiveForeground: "sidebar-active-foreground",
+  sidebarBackground: "sidebar-background",
   shellBackground: "shell-background",
 } as const;
 

--- a/web/src/lib/themePalette.test.ts
+++ b/web/src/lib/themePalette.test.ts
@@ -96,6 +96,8 @@ describe("themePalette", () => {
       expect(palette.label.length).toBeGreaterThan(0);
       expect(palette.light.bg).toMatch(/^#|rgb/);
       expect(palette.dark.bg).toMatch(/^#|rgb/);
+      expect(palette.tokens.light.shellBackground.length).toBeGreaterThan(0);
+      expect(palette.tokens.dark.shellBackground.length).toBeGreaterThan(0);
     }
   });
 });

--- a/web/src/lib/themePalette.ts
+++ b/web/src/lib/themePalette.ts
@@ -88,6 +88,7 @@ export interface PaletteTokens {
   sidebarRing: string;
   sidebarActive: string;
   sidebarActiveForeground: string;
+  sidebarBackground: string;
   shellBackground: string;
 }
 
@@ -132,6 +133,7 @@ function paletteTokens(tokens: PaletteTokenInput): PaletteTokens {
     sidebarRing: tokens.ring,
     sidebarActive: "color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar))",
     sidebarActiveForeground: "var(--sidebar-foreground)",
+    sidebarBackground: "var(--sidebar)",
     ...tokens,
   };
 }
@@ -193,6 +195,7 @@ export const PALETTES: readonly PaletteMeta[] = [
         sidebarRing: "#2272b4",
         sidebarActive: "rgba(240, 1, 150, 0.1)",
         sidebarActiveForeground: "#651249",
+        sidebarBackground: "linear-gradient(90deg, #fffefe, #fcf6fa)",
         shellBackground: "var(--background)",
       }),
       dark: paletteTokens({
@@ -204,6 +207,7 @@ export const PALETTES: readonly PaletteMeta[] = [
         primary: "#e8ecf0",
         primaryForeground: "#11171c",
         secondary: "#1f272d",
+        secondaryForeground: "#e8ecf0",
         muted: "color-mix(in srgb, #92a4b3 15%, #262f36)",
         mutedForeground: "#92a4b3",
         codeBackground: "oklch(0.38 0.005 240)",
@@ -224,6 +228,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         sidebarRing: "oklch(0.92 0.003 240 / 0.4)",
         sidebarActive: "rgba(240, 1, 150, 0.15)",
         sidebarActiveForeground: "#f472b6",
+        sidebarBackground:
+          "linear-gradient(transparent 35%, rgba(92, 48, 108, 0.2)), linear-gradient(135deg, rgba(255, 255, 255, 0.04), transparent 60%)",
         shellBackground:
           "radial-gradient(rgba(100, 40, 180, 0.12), transparent 50%), radial-gradient(at 80% 20%, rgba(80, 30, 140, 0.08), transparent 45%), linear-gradient(145deg, #1a0e2d, #0e1418, #130e1b)",
       }),

--- a/web/src/lib/themePalette.ts
+++ b/web/src/lib/themePalette.ts
@@ -86,6 +86,8 @@ export interface PaletteTokens {
   sidebarAccentForeground: string;
   sidebarBorder: string;
   sidebarRing: string;
+  sidebarActive: string;
+  sidebarActiveForeground: string;
   shellBackground: string;
 }
 
@@ -128,6 +130,8 @@ function paletteTokens(tokens: PaletteTokenInput): PaletteTokens {
     sidebarAccentForeground: tokens.accentForeground,
     sidebarBorder: tokens.border,
     sidebarRing: tokens.ring,
+    sidebarActive: "color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar))",
+    sidebarActiveForeground: "var(--sidebar-foreground)",
     ...tokens,
   };
 }
@@ -187,6 +191,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         sidebar: "#fdfafa",
         sidebarPrimary: "#2272b4",
         sidebarRing: "#2272b4",
+        sidebarActive: "rgba(240, 1, 150, 0.1)",
+        sidebarActiveForeground: "#651249",
         shellBackground: "var(--background)",
       }),
       dark: paletteTokens({
@@ -216,6 +222,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         sidebarAccentForeground: "oklch(0.965 0.003 240)",
         sidebarBorder: "oklch(0.28 0.005 240)",
         sidebarRing: "oklch(0.92 0.003 240 / 0.4)",
+        sidebarActive: "rgba(240, 1, 150, 0.15)",
+        sidebarActiveForeground: "#f472b6",
         shellBackground:
           "radial-gradient(rgba(100, 40, 180, 0.12), transparent 50%), radial-gradient(at 80% 20%, rgba(80, 30, 140, 0.08), transparent 45%), linear-gradient(145deg, #1a0e2d, #0e1418, #130e1b)",
       }),

--- a/web/src/lib/themePalette.ts
+++ b/web/src/lib/themePalette.ts
@@ -54,6 +54,84 @@ export interface PaletteSwatch {
   text: string;
 }
 
+export interface PaletteTokens {
+  background: string;
+  foreground: string;
+  card: string;
+  cardSolid: string;
+  cardForeground: string;
+  tray: string;
+  popover: string;
+  popoverForeground: string;
+  primary: string;
+  primaryForeground: string;
+  secondary: string;
+  secondaryForeground: string;
+  muted: string;
+  mutedForeground: string;
+  codeBackground: string;
+  accent: string;
+  accentForeground: string;
+  border: string;
+  borderStrong: string;
+  buttonBorder: string;
+  input: string;
+  ring: string;
+  brandAccent: string;
+  sidebar: string;
+  sidebarForeground: string;
+  sidebarPrimary: string;
+  sidebarPrimaryForeground: string;
+  sidebarAccent: string;
+  sidebarAccentForeground: string;
+  sidebarBorder: string;
+  sidebarRing: string;
+  shellBackground: string;
+}
+
+type PaletteTokenInput = Pick<
+  PaletteTokens,
+  | "background"
+  | "foreground"
+  | "card"
+  | "cardSolid"
+  | "primary"
+  | "primaryForeground"
+  | "secondary"
+  | "muted"
+  | "mutedForeground"
+  | "codeBackground"
+  | "accent"
+  | "accentForeground"
+  | "border"
+  | "borderStrong"
+  | "ring"
+  | "sidebar"
+  | "shellBackground"
+> &
+  Partial<PaletteTokens>;
+
+function paletteTokens(tokens: PaletteTokenInput): PaletteTokens {
+  return {
+    cardForeground: tokens.foreground,
+    tray: tokens.card,
+    popover: tokens.cardSolid,
+    popoverForeground: tokens.foreground,
+    secondaryForeground: tokens.foreground,
+    buttonBorder: tokens.border,
+    input: tokens.border,
+    brandAccent: tokens.ring,
+    sidebarForeground: tokens.foreground,
+    sidebarPrimary: tokens.ring,
+    sidebarPrimaryForeground: tokens.primaryForeground,
+    sidebarAccent: tokens.accent,
+    sidebarAccentForeground: tokens.accentForeground,
+    sidebarBorder: tokens.border,
+    sidebarRing: tokens.ring,
+    ...tokens,
+  };
+}
+
 export interface PaletteMeta {
   id: ThemePalette;
   /** Display name shown under the swatch. */
@@ -64,6 +142,10 @@ export interface PaletteMeta {
   light: PaletteSwatch;
   /** Swatch colors for the dark rendering of this palette. */
   dark: PaletteSwatch;
+  tokens: {
+    light: PaletteTokens;
+    dark: PaletteTokens;
+  };
 }
 
 // Swatch colors are a hand-picked summary of each palette's CSS block — enough
@@ -82,6 +164,62 @@ export const PALETTES: readonly PaletteMeta[] = [
       text: "#11171c",
     },
     dark: { bg: "#160e24", card: "#28223a", accent: "#df3c85", border: "#2a2440", text: "#f4f5f7" },
+    tokens: {
+      light: paletteTokens({
+        background: "#ffffff",
+        foreground: "#27272a",
+        card: "#ffffff",
+        cardSolid: "#ffffff",
+        popoverForeground: "#11171c",
+        primary: "#11171c",
+        primaryForeground: "#ffffff",
+        secondary: "#eceef1",
+        muted: "#0000000f",
+        mutedForeground: "#71717a",
+        codeBackground: "#0000000f",
+        accent: "#d7edfe",
+        accentForeground: "#04355d",
+        border: "#e4e4e7",
+        borderStrong: "#a1a1aa",
+        buttonBorder: "#d6d6d6",
+        ring: "#11171c",
+        brandAccent: "#df3c85",
+        sidebar: "#fdfafa",
+        sidebarPrimary: "#2272b4",
+        sidebarRing: "#2272b4",
+        shellBackground: "var(--background)",
+      }),
+      dark: paletteTokens({
+        background: "#0e1013",
+        foreground: "oklch(0.965 0.003 240)",
+        card: "rgba(31, 39, 45, 0.6)",
+        cardSolid: "#181f25",
+        popover: "rgba(26, 33, 41, 0.8)",
+        primary: "#e8ecf0",
+        primaryForeground: "#11171c",
+        secondary: "#1f272d",
+        muted: "color-mix(in srgb, #92a4b3 15%, #262f36)",
+        mutedForeground: "#92a4b3",
+        codeBackground: "oklch(0.38 0.005 240)",
+        accent: "#04355d",
+        accentForeground: "#4299e0",
+        border: "oklch(0.28 0.005 240)",
+        borderStrong: "#a1a1aa",
+        buttonBorder: "#d6d6d6",
+        input: "oklch(0.28 0.005 240)",
+        ring: "#e8ecf0",
+        brandAccent: "#df3c85",
+        sidebar: "rgba(17, 23, 28, 0.75)",
+        sidebarPrimary: "oklch(0.64 0.22 254)",
+        sidebarPrimaryForeground: "oklch(0.12 0.004 240)",
+        sidebarAccent: "oklch(0.245 0.005 240)",
+        sidebarAccentForeground: "oklch(0.965 0.003 240)",
+        sidebarBorder: "oklch(0.28 0.005 240)",
+        sidebarRing: "oklch(0.92 0.003 240 / 0.4)",
+        shellBackground:
+          "radial-gradient(rgba(100, 40, 180, 0.12), transparent 50%), radial-gradient(at 80% 20%, rgba(80, 30, 140, 0.08), transparent 45%), linear-gradient(145deg, #1a0e2d, #0e1418, #130e1b)",
+      }),
+    },
   },
   {
     id: "dracula",
@@ -95,6 +233,50 @@ export const PALETTES: readonly PaletteMeta[] = [
       text: "#1e1a2b",
     },
     dark: { bg: "#282a36", card: "#343746", accent: "#bd93f9", border: "#44475a", text: "#f8f8f2" },
+    tokens: {
+      light: paletteTokens({
+        background: "#f7f5fd",
+        foreground: "#1e1a2b",
+        card: "#ffffff",
+        cardSolid: "#ffffff",
+        primary: "#7c3aed",
+        primaryForeground: "#ffffff",
+        secondary: "#efeaf9",
+        muted: "#efeaf9",
+        mutedForeground: "#6b6786",
+        codeBackground: "#efeaf9",
+        accent: "#f3e8ff",
+        accentForeground: "#6b21a8",
+        border: "#e6e0f2",
+        borderStrong: "#b6abd6",
+        ring: "#7c3aed",
+        brandAccent: "#d6409f",
+        sidebar: "#f3f0fa",
+        shellBackground: "linear-gradient(160deg, #faf8ff 0%, #f5f1fd 50%, #f3eefb 100%)",
+      }),
+      dark: paletteTokens({
+        background: "#282a36",
+        foreground: "#f8f8f2",
+        card: "rgba(68, 71, 90, 0.5)",
+        cardSolid: "#343746",
+        popover: "rgba(33, 34, 44, 0.92)",
+        primary: "#bd93f9",
+        primaryForeground: "#282a36",
+        secondary: "#343746",
+        muted: "#3b3d4d",
+        mutedForeground: "#b3b8d4",
+        codeBackground: "#21222c",
+        accent: "#3b304f",
+        accentForeground: "#ff79c6",
+        border: "#44475a",
+        borderStrong: "#5a5d75",
+        ring: "#bd93f9",
+        brandAccent: "#ff79c6",
+        sidebar: "rgba(33, 34, 44, 0.8)",
+        shellBackground:
+          "radial-gradient(ellipse at 20% 40%, rgba(189, 147, 249, 0.14) 0%, transparent 50%), radial-gradient(ellipse at 80% 20%, rgba(255, 121, 198, 0.1) 0%, transparent 45%), linear-gradient(160deg, #2a2c3a 0%, #282a36 55%, #21222c 100%)",
+      }),
+    },
   },
   {
     id: "github",
@@ -108,6 +290,48 @@ export const PALETTES: readonly PaletteMeta[] = [
       text: "#1f2328",
     },
     dark: { bg: "#0d1117", card: "#161b22", accent: "#58a6ff", border: "#30363d", text: "#e6edf3" },
+    tokens: {
+      light: paletteTokens({
+        background: "#f6f8fa",
+        foreground: "#1f2328",
+        card: "#ffffff",
+        cardSolid: "#ffffff",
+        primary: "#1f883d",
+        primaryForeground: "#ffffff",
+        secondary: "#eaeef2",
+        muted: "#eaeef2",
+        mutedForeground: "#59636e",
+        codeBackground: "#eff1f3",
+        accent: "#ddf4ff",
+        accentForeground: "#0550ae",
+        border: "#d1d9e0",
+        borderStrong: "#afb8c1",
+        ring: "#0969da",
+        sidebar: "#f6f8fa",
+        shellBackground: "linear-gradient(180deg, #fbfcfd 0%, #f6f8fa 100%)",
+      }),
+      dark: paletteTokens({
+        background: "#0d1117",
+        foreground: "#e6edf3",
+        card: "rgba(22, 27, 34, 0.72)",
+        cardSolid: "#161b22",
+        popover: "rgba(22, 27, 34, 0.9)",
+        primary: "#238636",
+        primaryForeground: "#ffffff",
+        secondary: "#21262d",
+        muted: "#21262d",
+        mutedForeground: "#8b949e",
+        codeBackground: "#1c2128",
+        accent: "#121d2f",
+        accentForeground: "#58a6ff",
+        border: "#30363d",
+        borderStrong: "#444c56",
+        ring: "#58a6ff",
+        sidebar: "rgba(13, 17, 23, 0.75)",
+        sidebarPrimaryForeground: "#0d1117",
+        shellBackground: "linear-gradient(160deg, #0d1117 0%, #0a0e14 100%)",
+      }),
+    },
   },
   {
     id: "catppuccin",
@@ -121,6 +345,49 @@ export const PALETTES: readonly PaletteMeta[] = [
       text: "#4c4f69",
     },
     dark: { bg: "#1e1e2e", card: "#313244", accent: "#cba6f7", border: "#45475a", text: "#cdd6f4" },
+    tokens: {
+      light: paletteTokens({
+        background: "#eff1f5",
+        foreground: "#4c4f69",
+        card: "#ffffff",
+        cardSolid: "#ffffff",
+        primary: "#8839ef",
+        primaryForeground: "#ffffff",
+        secondary: "#e6e9ef",
+        muted: "#e6e9ef",
+        mutedForeground: "#6c6f85",
+        codeBackground: "#e6e9ef",
+        accent: "#ccd0da",
+        accentForeground: "#8839ef",
+        border: "#ccd0da",
+        borderStrong: "#acb0be",
+        ring: "#8839ef",
+        brandAccent: "#ea76cb",
+        sidebar: "#e6e9ef",
+        shellBackground: "linear-gradient(160deg, #f2f3f7 0%, #eff1f5 60%, #e9ecf2 100%)",
+      }),
+      dark: paletteTokens({
+        background: "#1e1e2e",
+        foreground: "#cdd6f4",
+        card: "rgba(49, 50, 68, 0.6)",
+        cardSolid: "#282938",
+        popover: "rgba(24, 24, 37, 0.92)",
+        primary: "#cba6f7",
+        primaryForeground: "#1e1e2e",
+        secondary: "#313244",
+        muted: "#313244",
+        mutedForeground: "#a6adc8",
+        codeBackground: "#181825",
+        accent: "#45475a",
+        accentForeground: "#cba6f7",
+        border: "#45475a",
+        borderStrong: "#585b70",
+        ring: "#cba6f7",
+        sidebar: "rgba(24, 24, 37, 0.8)",
+        shellBackground:
+          "radial-gradient(ellipse at 20% 30%, rgba(203, 166, 247, 0.12) 0%, transparent 55%), radial-gradient(ellipse at 80% 20%, rgba(245, 194, 231, 0.08) 0%, transparent 45%), linear-gradient(160deg, #232336 0%, #1e1e2e 60%, #181825 100%)",
+      }),
+    },
   },
   {
     id: "gruvbox",
@@ -134,6 +401,48 @@ export const PALETTES: readonly PaletteMeta[] = [
       text: "#3c3836",
     },
     dark: { bg: "#282828", card: "#3c3836", accent: "#fe8019", border: "#504945", text: "#ebdbb2" },
+    tokens: {
+      light: paletteTokens({
+        background: "#fbf1c7",
+        foreground: "#3c3836",
+        card: "#fffdf2",
+        cardSolid: "#fffdf2",
+        primary: "#d65d0e",
+        primaryForeground: "#ffffff",
+        secondary: "#ebdbb2",
+        muted: "#ebdbb2",
+        mutedForeground: "#7c6f64",
+        codeBackground: "#ebdbb2",
+        accent: "#f2e5bc",
+        accentForeground: "#af3a03",
+        border: "#e6d5a8",
+        borderStrong: "#bdae93",
+        ring: "#d65d0e",
+        sidebar: "#f4e8bc",
+        shellBackground: "linear-gradient(160deg, #fbf3cd 0%, #fbf1c7 55%, #f7ecbb 100%)",
+      }),
+      dark: paletteTokens({
+        background: "#282828",
+        foreground: "#ebdbb2",
+        card: "rgba(60, 56, 54, 0.6)",
+        cardSolid: "#32302f",
+        popover: "rgba(29, 32, 33, 0.92)",
+        primary: "#fe8019",
+        primaryForeground: "#282828",
+        secondary: "#3c3836",
+        muted: "#3c3836",
+        mutedForeground: "#a89984",
+        codeBackground: "#1d2021",
+        accent: "#504945",
+        accentForeground: "#fe8019",
+        border: "#504945",
+        borderStrong: "#665c54",
+        ring: "#fe8019",
+        sidebar: "rgba(29, 32, 33, 0.8)",
+        shellBackground:
+          "radial-gradient(ellipse at 20% 30%, rgba(254, 128, 25, 0.1) 0%, transparent 55%), radial-gradient(ellipse at 80% 20%, rgba(250, 189, 47, 0.07) 0%, transparent 45%), linear-gradient(160deg, #32302f 0%, #282828 60%, #1d2021 100%)",
+      }),
+    },
   },
   {
     id: "nord",
@@ -147,6 +456,49 @@ export const PALETTES: readonly PaletteMeta[] = [
       text: "#2e3440",
     },
     dark: { bg: "#2e3440", card: "#3b4252", accent: "#88c0d0", border: "#4c566a", text: "#eceff4" },
+    tokens: {
+      light: paletteTokens({
+        background: "#eceff4",
+        foreground: "#2e3440",
+        card: "#e5e9f0",
+        cardSolid: "#e5e9f0",
+        primary: "#5e81ac",
+        primaryForeground: "#eceff4",
+        secondary: "#d8dee9",
+        muted: "#d8dee9",
+        mutedForeground: "#4c566a",
+        codeBackground: "#d8dee9",
+        accent: "#e5e9f0",
+        accentForeground: "#5e81ac",
+        border: "#d8dee9",
+        borderStrong: "#81a1c1",
+        ring: "#5e81ac",
+        sidebar: "#e5e9f0",
+        sidebarAccent: "#d8dee9",
+        shellBackground: "linear-gradient(160deg, #eceff4 0%, #e5e9f0 55%, #d8dee9 100%)",
+      }),
+      dark: paletteTokens({
+        background: "#2e3440",
+        foreground: "#eceff4",
+        card: "rgba(59, 66, 82, 0.6)",
+        cardSolid: "#3b4252",
+        popover: "rgba(46, 52, 64, 0.92)",
+        primary: "#88c0d0",
+        primaryForeground: "#2e3440",
+        secondary: "#3b4252",
+        muted: "#434c5e",
+        mutedForeground: "#d8dee9",
+        codeBackground: "#3b4252",
+        accent: "#434c5e",
+        accentForeground: "#88c0d0",
+        border: "#4c566a",
+        borderStrong: "#81a1c1",
+        ring: "#88c0d0",
+        sidebar: "rgba(46, 52, 64, 0.8)",
+        shellBackground:
+          "radial-gradient(ellipse at 20% 30%, rgba(136, 192, 208, 0.12) 0%, transparent 55%), radial-gradient(ellipse at 80% 20%, rgba(94, 129, 172, 0.08) 0%, transparent 45%), linear-gradient(160deg, #434c5e 0%, #2e3440 60%, #2e3440 100%)",
+      }),
+    },
   },
 ] as const;
 

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -348,7 +348,7 @@ describe("SettingsPage", () => {
 
     fireEvent.click(screen.getByTestId("custom-theme-accent-trigger"));
     const accent = screen.getByTestId("custom-theme-accent-input") as HTMLInputElement;
-    expect(accent.value).toBe("#0969DA");
+    expect(accent.value).toBe("#1F883D");
     fireEvent.change(accent, { target: { value: "#2563eb" } });
 
     expect(select.value).toBe("custom");
@@ -357,10 +357,51 @@ describe("SettingsPage", () => {
     expect(JSON.parse(localStorage.getItem("omnigent:custom-theme") ?? "null")).toMatchObject({
       basePalette: "github",
       accent: "#2563eb",
+      darkAccent: "#2563eb",
     });
     expect(document.documentElement.style.getPropertyValue("--custom-light-primary")).toBe(
       "#2563eb",
     );
+  });
+
+  it("keeps the preset primary color when contrast creates a custom theme", () => {
+    renderPage("/settings/appearance");
+    fireEvent.change(screen.getByTestId("color-theme-select"), {
+      target: { value: "github" },
+    });
+
+    fireEvent.change(screen.getByTestId("custom-theme-contrast"), {
+      target: { value: "68" },
+    });
+
+    expect(document.documentElement.getAttribute("data-theme")).toBe("custom");
+    expect(document.documentElement.style.getPropertyValue("--custom-light-primary")).toBe(
+      "#1f883d",
+    );
+    expect(document.documentElement.style.getPropertyValue("--custom-dark-primary")).toBe(
+      "#238636",
+    );
+    expect(document.documentElement.style.getPropertyValue("--custom-dark-background")).toBe(
+      "#0d1117",
+    );
+  });
+
+  it("restores Dracula surfaces when contrast returns to 50", () => {
+    renderPage("/settings/appearance");
+    fireEvent.change(screen.getByTestId("color-theme-select"), {
+      target: { value: "dracula" },
+    });
+
+    const contrast = screen.getByTestId("custom-theme-contrast");
+    fireEvent.change(contrast, { target: { value: "53" } });
+    fireEvent.change(contrast, { target: { value: "50" } });
+
+    const style = document.documentElement.style;
+    expect(style.getPropertyValue("--custom-light-background")).toBe("#f7f5fd");
+    expect(style.getPropertyValue("--custom-light-card")).toBe("#ffffff");
+    expect(style.getPropertyValue("--custom-light-sidebar")).toBe("#f3f0fa");
+    expect(style.getPropertyValue("--custom-light-border")).toBe("#e6e0f2");
+    expect(style.getPropertyValue("--custom-light-brand-accent")).toBe("#d6409f");
   });
 
   it("persists the shared contrast and translucent-sidebar controls", () => {
@@ -371,6 +412,9 @@ describe("SettingsPage", () => {
     });
     fireEvent.click(screen.getByTestId("custom-theme-translucent-sidebar"));
 
+    expect(screen.getByTestId("custom-theme-contrast")).toHaveStyle({
+      "--range-progress": "68%",
+    });
     expect(screen.getByTestId("color-theme-select")).toHaveValue("custom");
     expect(screen.getByTestId("custom-theme-contrast-value")).toHaveTextContent("68");
     expect(JSON.parse(localStorage.getItem("omnigent:custom-theme") ?? "null")).toMatchObject({

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -29,6 +29,7 @@
 
 import {
   lazy,
+  type CSSProperties,
   type ReactNode,
   Suspense,
   useCallback,
@@ -758,7 +759,7 @@ function ColorThemeControl() {
             label="Accent"
             value={editableTheme.accent}
             testId="custom-theme-accent"
-            onChange={(accent) => updateCustomTheme({ accent })}
+            onChange={(accent) => updateCustomTheme({ accent, darkAccent: accent })}
           />
           <ThemeColorPicker
             label="Background tint"
@@ -783,7 +784,8 @@ function ColorThemeControl() {
                 aria-label="Theme contrast"
                 data-testid="custom-theme-contrast"
                 onChange={(event) => updateCustomTheme({ contrast: Number(event.target.value) })}
-                className="h-1.5 min-w-0 flex-1 cursor-pointer accent-primary"
+                className="theme-contrast-range min-w-0 flex-1 cursor-pointer"
+                style={{ "--range-progress": `${editableTheme.contrast}%` } as CSSProperties}
               />
               <output
                 htmlFor="custom-theme-contrast"


### PR DESCRIPTION
## Related issue

N/A — no issue number was provided.

## Summary

- Treat each preset's complete light/dark semantic token map as the custom-theme baseline, so Contrast 50 is exactly the selected preset.
- Apply contrast as a delta from that baseline, preserving sidebar, selected-session, card, border, ring, brand accent, control colors, and shell gradients across preset-to-custom conversion.
- Keep each preset's curated preview at the identity point while reflecting explicit custom accent and contrast changes.
- Preserve selector-level shell and conversation-sidebar backgrounds, including Omnigent's flagship gradients.
- Preserve per-mode primary colors and migrate older saved custom themes that lack dark-mode fields.

ELI5: the old slider's “50” was only a label. Moving it switched to a separate color generator, so returning to 50 could not restore the preset. Now 50 is an identity point and contrast moves relative to the real preset.

```text
Preset tokens ── Contrast 50 ──> identical custom tokens
      │
      └── Contrast 53 ──> small delta ── Contrast 50 ──> identical preset tokens
```

## Before / after color matrix

The **Before** columns show the old Custom output immediately after touching Contrast or Translucent sidebars and returning to Contrast 50. The **After** columns show this PR's Custom output at Contrast 50, which is identical to the selected built-in preset. Card values use the opaque `--card-solid` surface; Primary is the action/slider color.

| Preset | Mode | Canvas before | Canvas after | Card before | Card after | Primary / slider before | Primary / slider after |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Omnigent | Light | `#fefbfe` | `#ffffff` | `#fffeff` | `#ffffff` | `#df3c85` | `#11171c` |
| Omnigent | Dark | `#434148` | `#0e1013` | `#545258` | `#181f25` | `#df3c85` | `#e8ecf0` |
| Dracula | Light | `#fdfbfe` | `#f7f5fd` | `#fffeff` | `#ffffff` | `#7c3aed` | `#7c3aed` |
| Dracula | Dark | `#414149` | `#282a36` | `#525259` | `#343746` | `#7c3aed` | `#bd93f9` |
| GitHub | Light | `#fcfcfe` | `#f6f8fa` | `#fefeff` | `#ffffff` | `#0969da` | `#1f883d` |
| GitHub | Dark | `#414248` | `#0d1117` | `#525358` | `#161b22` | `#0969da` | `#238636` |
| Catppuccin | Light | `#fafafc` | `#eff1f5` | `#fefefe` | `#ffffff` | `#8839ef` | `#8839ef` |
| Catppuccin | Dark | `#3f4047` | `#1e1e2e` | `#505158` | `#282938` | `#8839ef` | `#cba6f7` |
| Gruvbox | Light | `#fefaef` | `#fbf1c7` | `#fffefc` | `#fffdf2` | `#d65d0e` | `#d65d0e` |
| Gruvbox | Dark | `#42403c` | `#282828` | `#53514e` | `#32302f` | `#d65d0e` | `#fe8019` |
| Nord | Light | `#faf9fc` | `#eceff4` | `#fefefe` | `#e5e9f0` | `#5e81ac` | `#5e81ac` |
| Nord | Dark | `#3f3f47` | `#2e3440` | `#505058` | `#3b4252` | `#5e81ac` | `#88c0d0` |

## Surface behavior

| Part | Before | After |
| --- | --- | --- |
| Contrast 50 | Regenerated an approximation; `50 → 53 → 50` did not restore the preset | Identity point; the round trip restores every rendered theme value |
| Dark-mode accent | Reused the light preview accent in both modes, e.g. GitHub `#0969da` | Preserves per-mode primary colors, e.g. GitHub dark `#238636` |
| Omnigent dark shell | Generated gray gradient around `#545258 → #434148 → #36343a` | Restores purple near-black shell `#1a0e2d → #0e1418 → #130e1b` with both radial blooms |
| Omnigent conversation sidebar | Replaced the flagship gradient with flat generated surfaces: light `#fefcfe`, dark `#49474d` | Restores light `#fffefe → #fcf6fa` and the dark purple/white overlay gradients |
| Omnigent selected session | Fell back to neutral gray: light about `#eeedef`, dark about `#565459` | Restores pink wash: light `rgba(240, 1, 150, 0.10)` / `#651249`; dark `rgba(240, 1, 150, 0.15)` / `#f472b6` |
| Cards, borders, rings, popovers | Several values were regenerated or inherited from Omnigent | Each preset keeps its complete light/dark semantic baseline |
| Translucent sidebars | Rebuilt sidebar colors and could replace preset gradients | Changes only sidebar translucency; the preset palette remains the base |
| Palette preview | Switched to raw generated tokens, e.g. Omnigent dark `#434148` / `#545258` | Keeps curated identity, e.g. Omnigent dark `#160e24` / `#28223a` |
| Semantic coverage | Applied 15 generated values; omitted secondary foregrounds, active-session colors, and selector-owned backgrounds | Verifies 34 semantic colors plus rendered shell and conversation-sidebar backgrounds |

## Test Plan

- `pnpm --dir web exec vitest run src/lib/customTheme.test.ts src/lib/themePalette.test.ts src/pages/SettingsPage.test.tsx` — 91 tests passed.
- `python -m pytest tests/e2e_ui/sessions/test_color_theme.py -q` — 5 Chromium tests passed.
- The E2E round-trip test covers all six presets in both light and dark mode across all 34 semantic colors plus rendered shell and conversation-sidebar backgrounds.
- `pnpm --dir web exec tsc -b`
- `pnpm --dir web exec oxlint --deny-warnings --report-unused-disable-directives .`
- Changed-file pre-commit hooks passed; unavailable worktree-local Python hooks were run from the main checkout where available or skipped when unrelated.

## Demo


https://github.com/user-attachments/assets/631ecb16-8cda-49f7-9937-e6bceabfadb6



N/A — the regression is subtle color drift across several surfaces; the browser test compares rendered RGBA values before and after each 50 → 53 → 50 round trip.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests enforce exact token, selected-session, and preview identity at Contrast 50 for every preset. The browser test verifies all semantic colors and rendered shell/sidebar backgrounds round-trip for all presets in light and dark mode, while the existing E2E cases cover persistence, accent editing, and translucent sidebars.

## Changelog

Color themes now retain their original backgrounds, sidebars, gradients, sidebar surfaces, selected-session highlights, previews, and control colors when appearance settings are adjusted or returned to Contrast 50.
