### PR TITLE
Widen chat layout on ultra-wide screens

### DIFF
--- a/tests/e2e_ui/chat/test_chat_responsive_width.py
+++ b/tests/e2e_ui/chat/test_chat_responsive_width.py
@@ -1,0 +1,84 @@
+"""E2E coverage for responsive chat and prose widths."""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import seed_committed_turn
+
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+_PROSE_MARKER = "Responsive prose width marker"
+_TABLE_MARKER = "Responsive table width marker"
+
+
+@pytest.mark.parametrize(
+    ("viewport_width", "expected_frame_width", "expected_prose_width"),
+    [
+        pytest.param(1920, 768, 736, id="desktop"),
+        pytest.param(2400, 896, 768, id="wide-desktop"),
+        pytest.param(3440, 1376, 963.2, id="ultrawide"),
+        pytest.param(4096, 1600, 1024, id="4k"),
+    ],
+)
+def test_chat_width_scales_while_prose_remains_readable(
+    page: Page,
+    seeded_session: tuple[str, str],
+    viewport_width: int,
+    expected_frame_width: float,
+    expected_prose_width: float,
+) -> None:
+    """The chat frame scales on wide screens while ordinary prose stays capped."""
+    base_url, session_id = seeded_session
+    seed_committed_turn(
+        session_id,
+        prompt="Show a prose example.",
+        reply=f"{_PROSE_MARKER}. " + "This sentence fills the available reading width. " * 30,
+        response_id="resp_responsive_prose",
+    )
+    seed_committed_turn(
+        session_id,
+        prompt="Show a comparison table.",
+        reply=(
+            f"{_TABLE_MARKER}.\n\n"
+            "| View | Intended behavior |\n"
+            "| --- | --- |\n"
+            "| Prose | Keeps a readable line length |\n"
+            "| Tables | Uses the full conversation column |"
+        ),
+        response_id="resp_responsive_table",
+    )
+
+    page.set_viewport_size({"width": viewport_width, "height": 1080})
+    page.goto(f"{base_url}/c/{session_id}")
+
+    prose = page.locator(_ASSISTANT).filter(has_text=_PROSE_MARKER)
+    table = page.locator(_ASSISTANT).filter(has_text=_TABLE_MARKER)
+    expect(prose).to_be_visible(timeout=30_000)
+    expect(table.locator("table")).to_be_visible(timeout=30_000)
+
+    widths = page.evaluate(
+        """({ proseMarker, tableMarker }) => {
+          const frame = document.querySelector('.chat-conversation-content');
+          const bubbles = [...document.querySelectorAll(
+            '[data-testid="message-bubble"][data-role="assistant"]'
+          )];
+          const prose = bubbles.find((bubble) => bubble.textContent.includes(proseMarker));
+          const table = bubbles.find((bubble) => bubble.textContent.includes(tableMarker));
+          const frameStyle = getComputedStyle(frame);
+          return {
+            frame: frame.getBoundingClientRect().width,
+            frameInner:
+              frame.clientWidth -
+              parseFloat(frameStyle.paddingLeft) -
+              parseFloat(frameStyle.paddingRight),
+            prose: prose.getBoundingClientRect().width,
+            table: table.getBoundingClientRect().width,
+          };
+        }""",
+        {"proseMarker": _PROSE_MARKER, "tableMarker": _TABLE_MARKER},
+    )
+
+    assert widths["frame"] == pytest.approx(expected_frame_width, abs=1)
+    assert widths["prose"] == pytest.approx(expected_prose_width, abs=1)
+    assert widths["table"] == pytest.approx(widths["frameInner"], abs=1)

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -358,7 +358,7 @@ describe("BubbleView dispatch", () => {
     // under an answered turn.
     render(<BubbleView bubble={foldOnlyBubble([toolItem("c4")])} />);
     const bubble = screen.getByTestId("message-bubble");
-    expect(bubble).toHaveClass("max-w-3xl", "min-[2561px]:max-w-4xl");
+    expect(bubble).toHaveClass("max-w-3xl", "min-[2561px]:max-w-[clamp(56rem,28vw,64rem)]");
     expect(bubble.firstElementChild).toHaveClass("w-full");
     expect(bubble.firstElementChild).not.toHaveClass("w-fit");
   });

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -358,7 +358,7 @@ describe("BubbleView dispatch", () => {
     // under an answered turn.
     render(<BubbleView bubble={foldOnlyBubble([toolItem("c4")])} />);
     const bubble = screen.getByTestId("message-bubble");
-    expect(bubble).toHaveClass("max-w-3xl");
+    expect(bubble).toHaveClass("max-w-3xl", "min-[2561px]:max-w-4xl");
     expect(bubble.firstElementChild).toHaveClass("w-full");
     expect(bubble.firstElementChild).not.toHaveClass("w-fit");
   });

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3949,7 +3949,9 @@ function AssistantBubble({
         data-testid="message-bubble"
         data-role="assistant"
         className={
-          spansFullColumn ? "max-w-full" : "max-w-3xl min-[2561px]:max-w-4xl"
+          spansFullColumn
+            ? "max-w-full"
+            : "max-w-3xl min-[2561px]:max-w-[clamp(56rem,28vw,64rem)]"
         }
       >
         {/* A fold-only bubble takes w-full at the ordinary max-w-3xl cap

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -388,7 +388,7 @@ export function collectBubbleMarkdown(items: RenderItem[]): string {
 
 // All chat-column elements must share this width to stay aligned.
 const CHAT_COLUMN_WIDTH =
-  "max-w-3xl min-[1921px]:max-w-4xl min-[2561px]:max-w-[clamp(64rem,30vw,76rem)]";
+  "max-w-3xl min-[1921px]:max-w-4xl min-[2561px]:max-w-[clamp(64rem,40vw,100rem)]";
 
 const TABLE_SEPARATOR_RE = /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/;
 const DISPLAY_MATH_RE = /(^|\n)\s*(\$\$[\s\S]*?\$\$|\\\[[\s\S]*?\\\])/;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -387,7 +387,8 @@ export function collectBubbleMarkdown(items: RenderItem[]): string {
 }
 
 // All chat-column elements must share this width to stay aligned.
-const CHAT_COLUMN_WIDTH = "max-w-3xl min-[1921px]:max-w-4xl min-[2561px]:max-w-5xl";
+const CHAT_COLUMN_WIDTH =
+  "max-w-3xl min-[1921px]:max-w-4xl min-[2561px]:max-w-[clamp(64rem,30vw,76rem)]";
 
 const TABLE_SEPARATOR_RE = /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/;
 const DISPLAY_MATH_RE = /(^|\n)\s*(\$\$[\s\S]*?\$\$|\\\[[\s\S]*?\\\])/;
@@ -3947,7 +3948,9 @@ function AssistantBubble({
         from="assistant"
         data-testid="message-bubble"
         data-role="assistant"
-        className={spansFullColumn ? "max-w-full" : "max-w-3xl"}
+        className={
+          spansFullColumn ? "max-w-full" : "max-w-3xl min-[2561px]:max-w-4xl"
+        }
       >
         {/* A fold-only bubble takes w-full at the ordinary max-w-3xl cap
             rather than shrink-wrapping to the summary row's ~110px, which

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3949,9 +3949,7 @@ function AssistantBubble({
         data-testid="message-bubble"
         data-role="assistant"
         className={
-          spansFullColumn
-            ? "max-w-full"
-            : "max-w-3xl min-[2561px]:max-w-[clamp(56rem,28vw,64rem)]"
+          spansFullColumn ? "max-w-full" : "max-w-3xl min-[2561px]:max-w-[clamp(56rem,28vw,64rem)]"
         }
       >
         {/* A fold-only bubble takes w-full at the ordinary max-w-3xl cap


### PR DESCRIPTION
## Related issue

N/A — no existing issue was found for this small UI adjustment.

## Summary

- Let the shared chat frame grow fluidly from 1024px to 1600px on ultra-wide viewports, staying near 40% of the viewport.
- Let ordinary assistant messages grow from 896px to 1024px across ultra-wide viewports, while tables, images, math, and forms continue to use the full chat frame.
- Add deterministic Playwright coverage for the rendered frame, prose, and full-width table geometry at representative desktop through 4K viewports.

Expected maximum widths when the conversation is not constrained by another panel:

| Viewport | Chat view | Usable after gutters | Ordinary prose | Chat view / viewport |
| ---: | ---: | ---: | ---: | ---: |
| 1440px | 768px | 736px | 736px | 53.3% |
| 1920px | 768px | 736px | 736px | 40.0% |
| 2400px | 896px | 864px | 768px | 37.3% |
| 2560px | 896px | 864px | 768px | 35.0% |
| 3440px | 1376px | 1344px | 963.2px | 40.0% |
| 3840px | 1536px | 1504px | 1024px | 40.0% |
| 4096px | 1600px | 1568px | 1024px | 39.1% |
| 5120px | 1600px | 1568px | 1024px | 31.3% |

The existing tiers naturally converge on 40% at their upper bounds: 768px at 1920px and 1024px at 2560px. The previous ultra-wide rule drifted down to about 30% at 4K, which made the conversation feel disproportionately small. `clamp(64rem, 40vw, 100rem)` preserves that established proportion through 4K while the 1600px ceiling prevents unbounded growth. Ordinary prose uses its own `clamp(56rem, 28vw, 64rem)` measure, reaching 1024px on 4K without stretching to the full frame.

## Test Plan

- `uv run pytest tests/e2e_ui/chat/test_chat_responsive_width.py -q`
- `pnpm --dir web exec vitest run src/pages/ChatPage.indicators.test.tsx`
- `pre-commit run --all-files`
- At a 4096px CSS viewport, verify the chat frame resolves to 1600px and ordinary assistant messages cap at 1024px.

The E2E test checks the 1920px, 2400px, 3440px, and 4096px rows above and verifies that a markdown table uses the full inner chat frame at each resolution.

## Demo

4K layout dimensions:

| Element | Before | After |
| --- | ---: | ---: |
| Chat frame | 1024px | 1600px |
| Usable frame after gutters | 992px | 1568px |
| Ordinary assistant message | 768px | 1024px |

The frame occupies about 39% of a 4096px viewport while prose occupies 25%, keeping long answers narrower than rich content.

Before:
<img width="3952" height="2242" alt="image" src="https://github.com/user-attachments/assets/e1e42362-2b50-4442-a2f2-c7c5a9556cbe" />

After:
<img width="3952" height="2242" alt="image" src="https://github.com/user-attachments/assets/aca3ee92-877f-4283-a9a1-560a79864c45" />

VDO:

https://github.com/user-attachments/assets/3ad7ecff-1dd8-44e0-bf78-5cf9e24c6b44

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit assertion covers the bounded ultra-wide prose class. The deterministic Playwright test seeds prose and a markdown table without invoking an LLM, then measures real browser geometry at 1920px, 2400px, 3440px, and 4096px. Manual verification covers the final 4K composition with the sidebar open and collapsed.

## Changelog

Ultra-wide displays now use more of the available space while keeping assistant replies readable.
