### PR TITLE
feat(config): host/project-level env_passthrough allowlist (fixes #5442)

### DIFF
--- a/examples/config_env_passthrough.yaml
+++ b/examples/config_env_passthrough.yaml
@@ -1,0 +1,91 @@
+# config_env_passthrough — demonstrates host/project-level env_passthrough
+#
+# Problem this solves
+# -------------------
+# Without host/project-level env_passthrough you must repeat the same
+# ``env_passthrough`` block in every agent spec:
+#
+#   os_env:
+#     sandbox:
+#       env_passthrough:
+#         - AWS_PROFILE
+#         - GITHUB_TOKEN     # <-- copy-pasted into every spec
+#
+# The new ``env_passthrough`` key in ~/.omnigent/config.yaml (host level)
+# or .omnigent/config.yaml (project level) declares the allowlist ONCE and
+# it flows into every harness subprocess automatically.
+#
+# Setup (one-time, host level)
+# ----------------------------
+# Add to ~/.omnigent/config.yaml:
+#
+#   env_passthrough:
+#     - AWS_PROFILE
+#     - GITHUB_TOKEN
+#
+# After that, EVERY agent run on this machine inherits those names — no
+# per-spec changes needed.
+#
+# Setup (project level)
+# ---------------------
+# Add the same block to .omnigent/config.yaml at the repo root.
+# Project-level names are MERGED with host-level names (union, no duplicates).
+#
+# Resolution order (lowest → highest priority)
+# --------------------------------------------
+#   BASE_ALLOW_EXACT (always-on defaults: PATH, HOME, USER, …)
+#     ∪ host-level  env_passthrough  (~/.omnigent/config.yaml)
+#     ∪ project-level env_passthrough (.omnigent/config.yaml)
+#     ∪ per-spec  os_env.sandbox.env_passthrough  (unchanged)
+#
+# Name-only allowlist
+# -------------------
+# The config only names variables; values are read from the LIVE environment
+# at subprocess spawn time (same behaviour as per-spec env_passthrough).
+# A config file cannot inject a value, only opt a name in.
+#
+# Usage
+# -----
+#   # 1. Export the variable you want the agent to see:
+#   export GITHUB_TOKEN=ghp_...
+#
+#   # 2. Declare it once in ~/.omnigent/config.yaml (or .omnigent/config.yaml):
+#   #      env_passthrough:
+#   #        - GITHUB_TOKEN
+#
+#   # 3. Run — no env_passthrough in the spec itself needed:
+#   omnigent run examples/config_env_passthrough.yaml \
+#       --profile <profile> \
+#       --prompt "Print the value of GITHUB_TOKEN with sys_os_shell."
+#
+# The agent should print the real token value, proving it was passed through
+# from the host config without an explicit per-spec declaration.
+
+name: config_env_passthrough_demo
+description: >-
+  Shows host/project-level env_passthrough: declare a variable allowlist once
+  in ~/.omnigent/config.yaml and it flows into every harness subprocess
+  automatically, without repeating env_passthrough in each agent spec.
+
+executor:
+  model: claude-sonnet-4-5
+  profile: default
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: native
+    # No env_passthrough block here — the allowlist comes entirely from
+    # ~/.omnigent/config.yaml or .omnigent/config.yaml.
+    #
+    # You CAN still add per-spec entries; they are merged with the
+    # config-level list. For example, to additionally pass MY_SECRET only
+    # for this agent:
+    #
+    #   env_passthrough:
+    #     - MY_SECRET
+
+prompt: |
+  You are a helpful assistant. When asked, use sys_os_shell to inspect
+  environment variables and report what you find.

--- a/omnigent/config.py
+++ b/omnigent/config.py
@@ -122,7 +122,7 @@ def env_passthrough_names(
     :returns: Sorted tuple of unique variable names, possibly empty.
     """
     g = global_cfg if global_cfg is not None else load_global_config()
-    l = local_cfg if local_cfg is not None else load_local_config()
+    lc = local_cfg if local_cfg is not None else load_local_config()
 
     def _names(cfg: _Config) -> list[str]:
         raw = cfg.get("env_passthrough")
@@ -132,7 +132,7 @@ def env_passthrough_names(
             return [str(n) for n in raw if n]
         return []
 
-    return tuple(sorted(set(_names(g)) | set(_names(l))))
+    return tuple(sorted(set(_names(g)) | set(_names(lc))))
 
 
 __all__ = [

--- a/omnigent/config.py
+++ b/omnigent/config.py
@@ -93,7 +93,50 @@ def load_effective_config() -> _Config:
     return _merge_effective_config(load_global_config(), load_local_config())
 
 
+def env_passthrough_names(
+    global_cfg: _Config | None = None,
+    local_cfg: _Config | None = None,
+) -> tuple[str, ...]:
+    """Return the union of env-var names declared in global and project config.
+
+    Reads ``env_passthrough`` from the global config (``~/.omnigent/config.yaml``)
+    and the project config (``.omnigent/config.yaml``), then returns their union
+    as a sorted tuple of unique names.  Project-level names are honoured on top of
+    global ones; neither set removes names declared by the other.
+
+    This is the documented *config-level* escape hatch: a name listed here is
+    admitted into every harness subprocess on top of :data:`BASE_ALLOW_EXACT`,
+    without requiring the same entry to be repeated in every agent spec's
+    ``os_env.sandbox.env_passthrough``.  Per-spec declarations continue to work
+    and union on top of this set at spawn time.
+
+    The function only forwards *names*; it never reads or forwards *values*.
+    Values are read from the omnigent process's own environment at spawn time by
+    :func:`omnigent.inner.agent_env.clean_agent_env`, exactly as the per-spec
+    field works today.
+
+    :param global_cfg: Pre-loaded global config dict; if ``None``, loads from
+        the default global path.
+    :param local_cfg: Pre-loaded project config dict; if ``None``, loads from
+        ``.omnigent/config.yaml`` relative to the current directory.
+    :returns: Sorted tuple of unique variable names, possibly empty.
+    """
+    g = global_cfg if global_cfg is not None else load_global_config()
+    l = local_cfg if local_cfg is not None else load_local_config()
+
+    def _names(cfg: _Config) -> list[str]:
+        raw = cfg.get("env_passthrough")
+        if not raw:
+            return []
+        if isinstance(raw, list):
+            return [str(n) for n in raw if n]
+        return []
+
+    return tuple(sorted(set(_names(g)) | set(_names(l))))
+
+
 __all__ = [
+    "env_passthrough_names",
     "global_config_path",
     "load_effective_config",
     "load_global_config",

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -60,7 +60,7 @@ from pathlib import Path
 from typing import Any, Protocol, TypeAlias
 
 from omnigent.inner._acp_omnigent_mcp import OmnigentAcpMcp
-from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
+from omnigent.inner.agent_env import clean_agent_env, config_passthrough, declared_passthrough
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import (
     Executor,
@@ -611,6 +611,7 @@ class AcpExecutor(Executor):
             allow_prefixes=(),
             extra_allowed=(
                 *getattr(config, "env_passthrough", ()),
+                *config_passthrough(),
                 *declared_passthrough(self._os_env),
             ),
         )

--- a/omnigent/inner/agent_env.py
+++ b/omnigent/inner/agent_env.py
@@ -108,6 +108,33 @@ def clean_agent_env(
     }
 
 
+def config_passthrough(
+    global_cfg: object | None = None,
+    local_cfg: object | None = None,
+) -> tuple[str, ...]:
+    """Env-var names declared in the host/project config for all harnesses.
+
+    Reads ``env_passthrough`` from both the global config
+    (``~/.omnigent/config.yaml``) and the project config
+    (``.omnigent/config.yaml``) and returns their union.  This is the
+    project/global-level escape hatch described in the :mod:`omnigent.config`
+    documentation: a name listed here is admitted into *every* harness
+    subprocess without requiring the same entry to be repeated in each agent
+    spec's ``os_env.sandbox.env_passthrough``.
+
+    :param global_cfg: Pre-loaded global config dict; if ``None``, loads from
+        the default global path.  Injectable for tests.
+    :param local_cfg: Pre-loaded project config dict; if ``None``, loads from
+        ``.omnigent/config.yaml`` relative to the current directory.
+        Injectable for tests.
+    :returns: Sorted tuple of unique variable names from both config files,
+        possibly empty.
+    """
+    from omnigent.config import env_passthrough_names
+
+    return env_passthrough_names(global_cfg=global_cfg, local_cfg=local_cfg)
+
+
 def declared_passthrough(os_env: object | None) -> tuple[str, ...]:
     """Env-var names the spec declared for passthrough.
 

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -43,7 +43,7 @@ from omnigent.codex_model_vocabulary import (
     EXTENDED_MODEL_DEFAULT_EFFORT,
     EXTENDED_MODEL_EFFORTS,
 )
-from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
+from omnigent.inner.agent_env import clean_agent_env, config_passthrough, declared_passthrough
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.model_fallbacks import CODEX_CATALOG_CLONE_SOURCE_SLUG, CODEX_DEFAULT_MODEL
 from omnigent.reasoning_effort import CODEX_EFFORTS, EFFORT_ALIASES, validate_effort
@@ -494,7 +494,7 @@ def _clean_codex_env(extra_allow: Iterable[str] = ()) -> dict[str, str]:
             *_CODEX_OMNIGENT_LAUNCH_ENV_VARS,
         ),
         deny_exact=_CODEX_ENV_DENY_EXACT,
-        extra_allowed=extra_allow,
+        extra_allowed=(*config_passthrough(), *extra_allow),
     )
 
 

--- a/omnigent/inner/goose_executor.py
+++ b/omnigent/inner/goose_executor.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from typing import Any, Protocol, TypeAlias
 
 from omnigent.inner._acp_omnigent_mcp import OmnigentAcpMcp
-from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
+from omnigent.inner.agent_env import clean_agent_env, config_passthrough, declared_passthrough
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import (
     Executor,
@@ -323,7 +323,7 @@ class GooseExecutor(Executor):
         """
         env = clean_agent_env(
             allow_prefixes=("GOOSE_",),
-            extra_allowed=declared_passthrough(self._os_env),
+            extra_allowed=(*config_passthrough(), *declared_passthrough(self._os_env)),
         )
         env.update(self._provider_env())
         return env

--- a/omnigent/inner/hermes_executor.py
+++ b/omnigent/inner/hermes_executor.py
@@ -48,7 +48,7 @@ import tempfile
 from collections.abc import AsyncIterator
 from pathlib import Path
 
-from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
+from omnigent.inner.agent_env import clean_agent_env, config_passthrough, declared_passthrough
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import (
     Executor,
@@ -465,7 +465,7 @@ class HermesExecutor(Executor):
         """
         proc_env = clean_agent_env(
             allow_prefixes=("HERMES_",),
-            extra_allowed=declared_passthrough(self._os_env),
+            extra_allowed=(*config_passthrough(), *declared_passthrough(self._os_env)),
         )
         if self._hermes_home is not None:
             proc_env["HERMES_HOME"] = str(self._hermes_home)

--- a/omnigent/inner/kimi_executor.py
+++ b/omnigent/inner/kimi_executor.py
@@ -65,7 +65,7 @@ from collections.abc import AsyncIterator, Mapping, Sequence
 from pathlib import Path
 
 from omnigent.harness_startup_config import resolve_harness_path
-from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
+from omnigent.inner.agent_env import clean_agent_env, config_passthrough, declared_passthrough
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import (
     EnqueuedContent,
@@ -245,7 +245,7 @@ class KimiExecutor(Executor):
         # while no longer handing the CLI every other provider's key (#3445).
         return clean_agent_env(
             allow_prefixes=("KIMI_", "MOONSHOT_"),
-            extra_allowed=declared_passthrough(self._os_env),
+            extra_allowed=(*config_passthrough(), *declared_passthrough(self._os_env)),
         )
 
     def _sandbox_launch_path(self, spawn_env_names: Sequence[str]) -> str:

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -50,7 +50,7 @@ from typing import Any, NotRequired, TypeAlias, TypedDict, cast
 from urllib.parse import urlparse as _urlparse
 
 from omnigent import model_catalog
-from omnigent.inner.agent_env import clean_agent_env
+from omnigent.inner.agent_env import clean_agent_env, config_passthrough
 from omnigent.inner.native_attachments import parse_data_uri
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.json_types import JsonValue
@@ -957,13 +957,17 @@ def _clean_pi_env(extra_allowed: Sequence[str] | None = None) -> dict[str, str]:
 
     :param extra_allowed: Extra exact names to pass through, e.g. the spec's
         ``os_env.sandbox.env_passthrough`` entries. ``None`` means no extras.
+        These are unioned on top of the host/project-level ``env_passthrough``
+        pulled from :func:`omnigent.inner.agent_env.config_passthrough`, which
+        provides the same allowlist to every harness without repeating it in
+        each spec.
     :returns: Filtered environment dict, ready to extend with the executor's
         own variables (``PI_CODING_AGENT_DIR``, ...).
     """
     return clean_agent_env(
         allow_prefixes=_PI_ENV_ALLOW_PREFIXES,
         allow_exact=_PI_ENV_ALLOW_EXACT,
-        extra_allowed=extra_allowed or (),
+        extra_allowed=(*config_passthrough(), *(extra_allowed or ())),
     )
 
 

--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Any, Protocol, TypeAlias
 
 from omnigent.inner._acp_omnigent_mcp import OmnigentAcpMcp
-from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
+from omnigent.inner.agent_env import clean_agent_env, config_passthrough, declared_passthrough
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import (
     Executor,
@@ -416,7 +416,7 @@ class QwenExecutor(Executor):
         """
         env = clean_agent_env(
             allow_prefixes=("QWEN_", "OPENAI_", "DASHSCOPE_"),
-            extra_allowed=declared_passthrough(self._os_env),
+            extra_allowed=(*config_passthrough(), *declared_passthrough(self._os_env)),
         )
         env.update(await self._resolve_gateway_env())
         return env

--- a/tests/test_agent_spawn_env_canary.py
+++ b/tests/test_agent_spawn_env_canary.py
@@ -280,3 +280,103 @@ def test_acp_agent_declaration_passes_only_what_it_names(hostile_env, monkeypatc
     assert env.get("XAI_API_KEY") == "declared-and-wanted"
     for name in CANARY_SECRETS:
         assert name not in env, name
+
+
+# ---------------------------------------------------------------------------
+# config_passthrough — host/project-level allowlist that flows to every
+# harness subprocess without requiring per-spec repetition (#5442).
+# ---------------------------------------------------------------------------
+
+
+def test_config_passthrough_empty_when_no_config():
+    """Injectable form: empty dicts on both sides → empty tuple."""
+    from omnigent.inner.agent_env import config_passthrough
+
+    assert config_passthrough(global_cfg={}, local_cfg={}) == ()
+
+
+def test_config_passthrough_unions_global_and_project():
+    """Project names are honoured on top of global ones; both flow through."""
+    from omnigent.inner.agent_env import config_passthrough
+
+    g = {"env_passthrough": ["FOO"]}
+    loc = {"env_passthrough": ["BAR", "FOO"]}
+    assert config_passthrough(global_cfg=g, local_cfg=loc) == ("BAR", "FOO")
+
+
+def test_config_passthrough_flows_into_clean_agent_env(hostile_env, monkeypatch):
+    """A name in project config reaches the spawned env without a per-spec entry.
+
+    This is the core promise of #5442: a project declares an ambient var once
+    at the host/project level, and every harness sees it — no per-spec
+    repetition, no code changes.
+    """
+    from omnigent.inner.agent_env import clean_agent_env, config_passthrough
+
+    src = {**hostile_env, "TAVILY_API_KEY": "value-from-ambient-env"}
+    names = config_passthrough(
+        global_cfg={"env_passthrough": ["TAVILY_API_KEY"]},
+        local_cfg={},
+    )
+    env = clean_agent_env(extra_allowed=names, source=src)
+
+    assert env.get("TAVILY_API_KEY") == "value-from-ambient-env"
+    # The ambient allowlist is names-only: it does not open the gate for other
+    # secrets on the host.
+    for name in CANARY_SECRETS:
+        if name != "TAVILY_API_KEY":
+            assert name not in env, name
+
+
+def test_config_passthrough_does_not_forward_values_not_in_env(monkeypatch):
+    """Name-only allowlist: naming a var in config does NOT inject its value.
+
+    If the omnigent process's own environment does not hold the name, the
+    filter has nothing to forward — a config file cannot magically produce a
+    secret value it does not have.
+    """
+    from omnigent.inner.agent_env import clean_agent_env, config_passthrough
+
+    monkeypatch.setattr("os.environ", {"HOME": "/home/x", "PATH": "/usr/bin"})
+    names = config_passthrough(
+        global_cfg={"env_passthrough": ["NOT_IN_ENV_ANYWHERE"]},
+        local_cfg={},
+    )
+    env = clean_agent_env(extra_allowed=names)
+
+    assert "NOT_IN_ENV_ANYWHERE" not in env
+
+
+def test_config_passthrough_unions_with_per_spec_declaration(hostile_env, monkeypatch):
+    """Spec's own ``env_passthrough`` unions on top of the config-level one.
+
+    Both surfaces stay valid: the config-level allowlist covers the common
+    ambient vars (project-wide), and the per-spec field still opts in agent-
+    specific auth variables (per-agent). Neither replaces the other.
+    """
+    from omnigent.inner.agent_env import clean_agent_env, config_passthrough, declared_passthrough
+
+    class _Sandbox:
+        env_passthrough = ("SPEC_ONLY_VAR",)
+
+    class _OsEnv:
+        sandbox = _Sandbox()
+
+    src = {
+        **hostile_env,
+        "CONFIG_ONLY_VAR": "from-project-config",
+        "SPEC_ONLY_VAR": "from-agent-spec",
+    }
+    env = clean_agent_env(
+        extra_allowed=(
+            *config_passthrough(
+                global_cfg={"env_passthrough": ["CONFIG_ONLY_VAR"]},
+                local_cfg={},
+            ),
+            *declared_passthrough(_OsEnv()),
+        ),
+        source=src,
+    )
+
+    assert env.get("CONFIG_ONLY_VAR") == "from-project-config"
+    assert env.get("SPEC_ONLY_VAR") == "from-agent-spec"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from omnigent.config import _merge_effective_config, global_config_path, load_effective_config
+from omnigent.config import (
+    _merge_effective_config,
+    env_passthrough_names,
+    global_config_path,
+    load_effective_config,
+)
 
 
 def test_effective_config_deep_merges_harness_mapping(
@@ -79,3 +84,61 @@ def test_effective_config_merges_project_over_user(
     monkeypatch.chdir(project)
 
     assert load_effective_config() == {"profile": "local", "model": "global-model"}
+
+
+# ---------------------------------------------------------------------------
+# env_passthrough_names — host/project-level allowlist that unions with the
+# per-spec ``os_env.sandbox.env_passthrough`` list at spawn time (#5442).
+# ---------------------------------------------------------------------------
+
+
+def test_env_passthrough_names_empty_when_no_config() -> None:
+    """No config on either side → empty tuple, never a None or a KeyError."""
+    assert env_passthrough_names(global_cfg={}, local_cfg={}) == ()
+
+
+def test_env_passthrough_names_reads_global_only() -> None:
+    g = {"env_passthrough": ["FOO", "BAR"]}
+    assert env_passthrough_names(global_cfg=g, local_cfg={}) == ("BAR", "FOO")
+
+
+def test_env_passthrough_names_reads_project_only() -> None:
+    loc = {"env_passthrough": ["PROJ_VAR"]}
+    assert env_passthrough_names(global_cfg={}, local_cfg=loc) == ("PROJ_VAR",)
+
+
+def test_env_passthrough_names_unions_global_and_project() -> None:
+    """Project names are honoured on top of global ones — neither removes the other."""
+    g = {"env_passthrough": ["FOO", "BAR"]}
+    loc = {"env_passthrough": ["BAZ", "FOO"]}
+    # Union, sorted, deduped
+    assert env_passthrough_names(global_cfg=g, local_cfg=loc) == ("BAR", "BAZ", "FOO")
+
+
+def test_env_passthrough_names_ignores_non_list_values() -> None:
+    """A misconfigured scalar / mapping under env_passthrough shouldn't crash."""
+    g = {"env_passthrough": "OOPS_SCALAR"}
+    loc = {"env_passthrough": {"OOPS": "MAP"}}
+    assert env_passthrough_names(global_cfg=g, local_cfg=loc) == ()
+
+
+def test_env_passthrough_names_filters_empty_names() -> None:
+    """Empty strings in the list are dropped, not admitted as a wildcard."""
+    g = {"env_passthrough": ["FOO", "", None, "BAR"]}
+    assert env_passthrough_names(global_cfg=g, local_cfg={}) == ("BAR", "FOO")
+
+
+def test_env_passthrough_names_loads_from_disk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Default path: reads from OMNIGENT_CONFIG_HOME + cwd/.omnigent."""
+    config_home = tmp_path / "home"
+    project = tmp_path / "project"
+    config_home.mkdir()
+    (project / ".omnigent").mkdir(parents=True)
+    (config_home / "config.yaml").write_text("env_passthrough: [GLOBAL_A]\n")
+    (project / ".omnigent" / "config.yaml").write_text("env_passthrough: [PROJ_B]\n")
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(config_home))
+    monkeypatch.chdir(project)
+
+    assert env_passthrough_names() == ("GLOBAL_A", "PROJ_B")


### PR DESCRIPTION
## Summary

Add a host/project-level `env_passthrough` allowlist so a set of environment variable *names* declared once in `.omnigent/config.yaml` (or `~/.omnigent/config.yaml`) flows into every harness subprocess, without repeating the same entry in every agent spec.

Fixes #5442.

## Motivation

`os_env.sandbox.env_passthrough` is currently only settable *per agent spec* (`omnigent/spec/validator.py:482`). A user maintaining several specs (implementer, reviewer, orchestrator) has to copy the same `env_passthrough: [...]` line into every one. When a new ambient var is needed (paths, endpoints, feature flags read by MCP servers) it must be added to N files; when a new spec is added, the line has to be remembered. The failure mode is silent — the stripped variable surfaces deep inside a harness as "cannot locate X."

Issue #5442 proposes closing this gap by admitting a host/project-level allowlist on top of `BASE_ALLOW_EXACT`, unioned with per-spec `env_passthrough`. This PR is the minimal implementation of that proposal.

## Design

Resolution order (matches the shape proposed in the issue, and mirrors the precedence already used for `harness.default` / `model`):

```
BASE_ALLOW_EXACT
  ∪ global env_passthrough        (~/.omnigent/config.yaml)
  ∪ project env_passthrough       (.omnigent/config.yaml)
  ∪ spec os_env.sandbox.env_passthrough    (unchanged, still per-spec)
```

- **Name-only allowlist.** The config file forwards names; values are read from omnigent's own process environment at spawn time, exactly as the per-spec field works today. A config file cannot inject an arbitrary value — the security property #3445/#3479 established is preserved.
- **Per-spec field unchanged.** Every spec that declares `env_passthrough` today keeps working identically; the new source unions on top. No breaking change.
- **Applies uniformly at the omnigent→harness boundary.** Every harness's own env handling downstream (settings block, MCP server env) still applies.

## Changes

**New public API**

- `omnigent.config.env_passthrough_names(global_cfg=None, local_cfg=None) -> tuple[str, ...]` — reads `env_passthrough` from global + local config and returns their sorted, deduped union. Dependency-injectable for tests. Tolerant of missing / mistyped values (returns `()` rather than raising).
- `omnigent.inner.agent_env.config_passthrough(global_cfg=None, local_cfg=None) -> tuple[str, ...]` — thin wrapper over the above. Lives in `agent_env` alongside `declared_passthrough` so executors don't need to import `omnigent.config` directly.

**Executor wiring**

Every executor's `clean_agent_env(...)` call now unions `config_passthrough()` into `extra_allowed` alongside the existing `declared_passthrough(self._os_env)`. Updated: `acp_executor.py`, `kimi_executor.py`, `qwen_executor.py`, `goose_executor.py`, `hermes_executor.py`, `codex_executor.py`, `pi_executor.py`.

## Test plan

Added 12 unit tests covering the new surface:

**`tests/test_config.py`** (7 new tests)

- Empty / global-only / project-only / union cases for `env_passthrough_names`
- Ignores non-list `env_passthrough` values (misconfigured scalar or mapping) without raising
- Filters empty names (empty strings are dropped, not admitted as a wildcard)
- End-to-end load from disk using `OMNIGENT_CONFIG_HOME` + `cwd/.omnigent`

**`tests/test_agent_spawn_env_canary.py`** (5 new tests)

- `config_passthrough` returns empty on empty configs
- Unions global + project names
- Config-named var actually flows into `clean_agent_env` output
- **Name-only guarantee**: a name in config that isn't in the omnigent process env is NOT injected (a config file cannot inject a value it does not have)
- Per-spec `os_env.sandbox.env_passthrough` unions on top of the config-level list

All new tests pass locally. Existing tests in these two files continue to pass.

## Non-goals

- Managed-settings tier (read-only, non-overridable) — the issue's "scope considerations" mentions this could follow the same pattern later; not required for the core feature and not included here.
- Wildcards / patterns in `env_passthrough` — remains name-exact, same as the per-spec field.

## Compatibility

- Purely additive. Every spec that today declares `env_passthrough` under `os_env.sandbox` keeps working identically.
- If neither `~/.omnigent/config.yaml` nor `.omnigent/config.yaml` declares `env_passthrough`, behaviour is unchanged (the new call returns an empty tuple).
- No config schema migration required.
