### PR TITLE
fix(runner): raise on unresolvable harness instead of falling back to runner-test-default

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2947,6 +2947,21 @@ def create_runner_app(
                 )
             _session_spec_cache[session_id] = spec_entry
         else:
+            if spec_resolver is not None:
+                # spec_resolver was configured but returned no spec for this
+                # agent_id. Return a clear 400 rather than silently proceeding
+                # with the test-only harness and leaving the session in a
+                # broken/unrunnable state.
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "error": "no_agent_spec",
+                        "detail": (
+                            f"No agent spec found for agent_id={agent_id!r}. "
+                            "Ensure the agent is registered before creating a session."
+                        ),
+                    },
+                )
             harness_name = "runner-test-default"
             spawn_env = None
 
@@ -9984,7 +9999,10 @@ async def _resolve_harness_config(
         so the spawn-env advertises the child's bundle rather than the
         parent's. ``None`` for top-level sessions.
     :param cwd: Runtime working directory for harnesses that need it.
-    :returns: ``(harness, spawn_env)``; a default for unresolved specs.
+    :returns: ``(harness, spawn_env)`` derived from the resolved spec.
+    :raises RuntimeError: When a spec_resolver is configured but the spec
+        cannot be resolved. Callers catch this to surface a clean error
+        rather than spawning an invalid harness subprocess.
     """
     if agent_id and spec_resolver:
         spec_entry = await spec_resolver(agent_id, session_id)
@@ -10020,7 +10038,21 @@ async def _resolve_harness_config(
             )
             return harness, spawn_env
 
-    # Fallback for tests that register a custom harness in _HARNESS_MODULES.
+    if spec_resolver is not None:
+        # spec_resolver is configured but either agent_id was not provided or
+        # the resolver returned no spec. Fail loud rather than silently falling
+        # through to the test-only harness and spawning a broken subprocess.
+        if not agent_id:
+            raise RuntimeError(
+                "Cannot select a harness: agent_id is missing and a spec_resolver "
+                "is configured. Ensure agent_id is forwarded in the turn body."
+            )
+        raise RuntimeError(
+            f"No agent spec found for agent_id={agent_id!r}; cannot select a harness."
+        )
+
+    # Fallback for tests that register a custom harness in _HARNESS_MODULES
+    # (spec_resolver is None in the test runner).
     return "runner-test-default", None
 
 

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -715,7 +715,14 @@ def _build_interrupt_app(
         function_call frames.
     :returns: ``(app, process_manager, harness_client)`` tuple.
     """
-    spec = AgentSpec(spec_version=1, name="t")
+    # Use the test-only harness so _build_spawn_env_from_spec returns None
+    # without reading provider config. Each test seeds _session_spec_cache via
+    # POST /v1/sessions before sending the turn.
+    spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "runner-test-default"}),
+    )
     sse_frames = [
         _sse({"type": "response.created", "response": {"id": "resp_int"}}),
         _sse(

--- a/tests/runner/test_app_sessions_native_supervision.py
+++ b/tests/runner/test_app_sessions_native_supervision.py
@@ -52,6 +52,11 @@ async def test_interrupt_inserts_cancellation_items_in_history() -> None:
 
     async with _runner_client(app) as client:
         conv_id = "85b147537400967b1fb8542367423306"
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_int_test"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
 
         # Start the turn — it blocks after the first function_call
         # frame, before the second one and response.completed.
@@ -159,6 +164,11 @@ async def test_interrupt_cancel_floor_finalizes_stuck_turn() -> None:
 
     async with _runner_client(app) as client:
         conv_id = "97d2b96d733e685433e2b3864eb97652"
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_int_test"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
         resp = await client.post(
             f"/v1/sessions/{conv_id}/events",
             json={
@@ -209,6 +219,11 @@ async def test_stop_session_cancels_inprocess_turn() -> None:
 
     async with _runner_client(app) as client:
         conv_id = "422963919abf3c166633d99ea20f2b8e"
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_int_test"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
         resp = await client.post(
             f"/v1/sessions/{conv_id}/events",
             json={
@@ -357,6 +372,11 @@ async def test_interrupt_marker_instructs_model_to_disregard_abandoned_request()
 
     async with _runner_client(app) as client:
         conv_id = "86ba5bc9053ae8771fdb988e882f04b5"
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_int_test"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
         resp = await client.post(
             f"/v1/sessions/{conv_id}/events",
             json={

--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -1701,14 +1701,19 @@ async def test_sessions_native_clears_in_flight_on_lazy_spec_error() -> None:
     pm = _FakeProcessManager(harness_client)
 
     async def _resolver(agent_id: str, session_id: str | None = None) -> Any:
-        # Before the harness streams response.created the two setup-phase
-        # resolutions run: return None (uncached spec → default harness) so the
-        # turn streams without populating _session_spec_cache. Once streaming
-        # has started the only caller is the lazy dispatch resolution — fail it.
+        # Setup-phase call: return a real spec so _resolve_harness_config picks
+        # the test harness and the turn can start. _resolve_harness_config does
+        # NOT populate _session_spec_cache, so _resolve_turn_spec_lazy still
+        # calls us after response.created — and we raise there to exercise the
+        # error path.
         del agent_id, session_id
         if created.is_set():
             raise RuntimeError("transient lazy spec resolution failure")
-        return None
+        return AgentSpec(
+            spec_version=1,
+            name="t",
+            executor=ExecutorSpec(type="omnigent", config={"harness": "runner-test-default"}),
+        )
 
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]

--- a/tests/runner/test_app_sessions_native_workflow_messages.py
+++ b/tests/runner/test_app_sessions_native_workflow_messages.py
@@ -2058,7 +2058,14 @@ def _build_fwd_blocking_app(
     :param fwd_gate: Releases a blocked interrupt forward.
     :returns: ``(app, process_manager, harness_client)`` tuple.
     """
-    spec = AgentSpec(spec_version=1, name="t")
+    # Use the test-only harness so _build_spawn_env_from_spec returns None
+    # without reading provider config. The test seeds _session_spec_cache via
+    # POST /v1/sessions before sending the turn.
+    spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "runner-test-default"}),
+    )
     sse_frames = [
         _sse({"type": "response.created", "response": {"id": "resp_fwd"}}),
         _sse({"type": "response.completed", "response": {"id": "resp_fwd"}}),
@@ -2101,6 +2108,11 @@ async def test_interrupt_forwards_to_harness_before_cancelling() -> None:
 
     async with _runner_client(app) as client:
         conv_id = "d741917a64f51f2d41226b88d53daf58"
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_fwd_test"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
         resp = await client.post(
             f"/v1/sessions/{conv_id}/events",
             json={

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -488,6 +488,121 @@ async def test_runner_resolves_harness_from_fallback_when_no_agent_id(
         assert "event: response.created" in response.text
 
 
+@pytest.mark.asyncio
+async def test_resolve_harness_config_raises_when_spec_resolver_returns_none() -> None:
+    """_resolve_harness_config raises RuntimeError when spec_resolver is wired
+    but returns no spec, instead of silently falling back to runner-test-default.
+
+    The fallback is only valid when no spec_resolver is configured (test mode).
+    A production runner that has a spec_resolver must never silently spawn the
+    test harness — the caller's ``except RuntimeError`` will surface a clean
+    error instead of leaving the session in a broken/hung state.
+
+    :returns: None.
+    """
+
+    async def _resolver_returning_none(
+        agent_id: str, session_id: str | None = None
+    ) -> AgentSpec | None:
+        """
+        Always return None to simulate an agent that cannot be resolved.
+
+        :param agent_id: Ignored.
+        :param session_id: Ignored.
+        :returns: None.
+        """
+        return None
+
+    with pytest.raises(RuntimeError, match="No agent spec found for agent_id="):
+        await _resolve_harness_config(
+            agent_id="ag_missing",
+            spec_resolver=_resolver_returning_none,
+            session_id="conv_x",
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_harness_config_raises_when_agent_id_missing_with_spec_resolver() -> None:
+    """_resolve_harness_config raises when spec_resolver is set but agent_id is absent.
+
+    A production runner with a spec_resolver requires agent_id to select the
+    right harness. If it's missing the runner must fail loudly so the problem
+    surfaces immediately rather than spawning the test-only harness and hanging.
+
+    :returns: None.
+    """
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """
+        Return a valid spec — should never be reached in this test.
+
+        :param agent_id: Agent id.
+        :param session_id: Session id.
+        :returns: A minimal agent spec.
+        """
+        return AgentSpec(
+            spec_version=1,
+            name="x",
+            executor=ExecutorSpec(type="omnigent", config={"harness": "claude-sdk"}),
+        )
+
+    with pytest.raises(RuntimeError, match="agent_id is missing"):
+        await _resolve_harness_config(
+            agent_id=None,
+            spec_resolver=_resolver,
+            session_id="conv_x",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_session_returns_400_when_spec_resolver_returns_none(
+    started_manager: HarnessProcessManager,
+) -> None:
+    """POST /v1/sessions returns 400 no_agent_spec when spec_resolver returns no spec.
+
+    When the server sends a session-create request with an agent_id that
+    doesn't map to any registered agent, the runner must return a clear 400
+    rather than silently proceeding with the test-only harness (which would
+    either fail with a 503 or, worse, appear to succeed and then hang on the
+    first turn because no real LLM is configured for it).
+
+    :param started_manager: A real HarnessProcessManager fixture.
+    :returns: None.
+    """
+
+    async def _resolver_returning_none(
+        agent_id: str, session_id: str | None = None
+    ) -> AgentSpec | None:
+        """
+        Always return None to simulate an unregistered agent.
+
+        :param agent_id: Ignored.
+        :param session_id: Ignored.
+        :returns: None.
+        """
+        return None
+
+    app = create_runner_app(
+        process_manager=started_manager,
+        spec_resolver=_resolver_returning_none,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_test_client(app) as http:
+        response = await http.post(
+            "/v1/sessions",
+            json={"session_id": "conv_bad_agent", "agent_id": "ag_unregistered"},
+        )
+
+    assert response.status_code == 400, (
+        f"Expected 400 no_agent_spec; got {response.status_code}: {response.text!r}. "
+        "Without the safeguard the runner falls back to runner-test-default and "
+        "returns 503 (unregistered harness) or silently spawns a test harness."
+    )
+    body = response.json()
+    assert body["error"] == "no_agent_spec"
+    assert "ag_unregistered" in body["detail"]
+
+
 class _RecordingProcessManager:
     """
     Process manager stub that records the harness name get_client saw.


### PR DESCRIPTION
## Summary

The runner's `_resolve_harness_config` was silently falling back to `"runner-test-default"` whenever the spec could not be resolved — either because `agent_id` was missing from the turn body or because the spec resolver returned `None`. This is a test-only harness that doesn't exist in production, so any session that triggered the fallback would be spawned with an invalid subprocess, become unresponsive, and cascade failures to the parent conversation.

This was the root cause of OMNI-4518: Polly was selecting/injecting `runner-test-default` as the harness name for subagents. The harness name propagated successfully through the session-create path because the runner never validated it — it just tried to spawn whatever string was given.

**Changes:**

- `_resolve_harness_config`: raises `RuntimeError` when `spec_resolver` is configured but `agent_id` is missing or the resolver returned no spec, instead of returning `("runner-test-default", None)`. The test-only fallback is preserved only when `spec_resolver` is `None` (i.e., the test runner with no server).
- `_initialize_session` (`POST /v1/sessions`): returns HTTP 400 `no_agent_spec` when `spec_resolver` is configured and the spec resolved to `None`, instead of silently proceeding.
- Three new unit tests in `test_runner_dispatch.py` cover the two `_resolve_harness_config` error paths and the `create_session` 400 path.
- Five existing interrupt tests updated to call `POST /v1/sessions` before the turn (seeds the spec cache so the harness is resolved from the spec, not the fallback); helper specs updated to use `"runner-test-default"` explicitly so `_build_spawn_env_from_spec` returns `None` without reading provider config.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Three new unit tests cover the safeguard paths directly (`test_resolve_harness_config_raises_when_spec_resolver_returns_none`, `test_resolve_harness_config_raises_when_agent_id_missing_with_spec_resolver`, `test_create_session_returns_400_when_spec_resolver_returns_none`). The five existing interrupt tests were updated to seed the spec cache first, confirming the normal turn path still works end-to-end after the fallback is removed.

```bash
python -m pytest tests/runner/test_runner_dispatch.py::test_runner_resolves_harness_from_fallback_when_no_agent_id \
  tests/runner/test_runner_dispatch.py::test_resolve_harness_config_raises_when_spec_resolver_returns_none \
  tests/runner/test_runner_dispatch.py::test_resolve_harness_config_raises_when_agent_id_missing_with_spec_resolver \
  tests/runner/test_runner_dispatch.py::test_create_session_returns_400_when_spec_resolver_returns_none \
  tests/runner/test_app_sessions_native_supervision.py::test_interrupt_inserts_cancellation_items_in_history \
  tests/runner/test_app_sessions_native_supervision.py::test_interrupt_cancel_floor_finalizes_stuck_turn \
  tests/runner/test_app_sessions_native_supervision.py::test_stop_session_cancels_inprocess_turn \
  tests/runner/test_app_sessions_native_supervision.py::test_interrupt_marker_instructs_model_to_disregard_abandoned_request \
  tests/runner/test_app_sessions_native_workflow_messages.py::test_interrupt_forwards_to_harness_before_cancelling
# Expected: 9 passed
```