### PR TITLE
fix(web): make mobile search palette a full-screen sheet

### DIFF
--- a/tests/e2e_ui/mobile/test_mobile_command_palette.py
+++ b/tests/e2e_ui/mobile/test_mobile_command_palette.py
@@ -1,0 +1,81 @@
+"""E2E: the command palette is a full-screen sheet at a phone viewport.
+
+``CommandPalette.tsx`` renders two layouts off ``useIsMobileViewport()``:
+the desktop palette is a centered card anchored at ``top-1/4`` and capped at
+``sm:max-w-2xl``; the mobile palette is a top-anchored full-screen sheet sized
+to the keyboard-aware visible viewport, so the soft keyboard can't cover the
+search field and results. ``CommandPalette.test.tsx`` asserts the class swap in
+jsdom, but jsdom does not apply the ``max-md`` media query the hook mirrors, so
+it can't prove the real responsive geometry — that is what these tests pin.
+
+Both open the palette with the window-level ⌘/Ctrl+K hotkey (viewport
+independent), so neither depends on the mobile drawer's search entry point.
+No LLM turn is needed — this is client-side layout + routing.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, ViewportSize, expect
+
+# iPhone-12-class portrait viewport — below the Tailwind ``md`` breakpoint
+# (768px) so ``useIsMobileViewport`` reports mobile and the sheet layout applies.
+_MOBILE_VIEWPORT: ViewportSize = {"width": 390, "height": 844}
+
+_COMPOSER = "Ask the agent anything…"
+
+
+def _open_palette(page: Page, base_url: str, session_id: str) -> None:
+    """Load the session at a phone width and open the palette via ⌘/Ctrl+K."""
+    page.set_viewport_size(_MOBILE_VIEWPORT)
+    page.goto(f"{base_url}/c/{session_id}")
+    # Wait for the shell to be interactive before firing the window-level hotkey.
+    expect(page.get_by_placeholder(_COMPOSER)).to_be_visible(timeout=30_000)
+    page.keyboard.press("Control+k")
+    expect(page.get_by_test_id("command-palette-input")).to_be_focused(timeout=10_000)
+
+
+def test_mobile_command_palette_is_a_fullscreen_sheet(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """At a phone width the palette fills the screen from the top.
+
+    Asserts the geometry that separates the mobile sheet from the desktop
+    centered card: the dialog is anchored at the very top (not ``top-1/4``),
+    spans the full width (not ``sm:max-w-2xl``), and fills essentially the whole
+    viewport height. A regression back to the centered card — the layout the
+    keyboard used to overlap — would fail here.
+    """
+    base_url, session_id = seeded_session
+    _open_palette(page, base_url, session_id)
+
+    box = page.get_by_role("dialog").bounding_box()
+    assert box is not None, "the palette dialog should have a layout box"
+    # Top-anchored: safe-area insets are 0 in headless chromium, so the sheet
+    # starts at the very top rather than a quarter of the way down.
+    assert box["y"] <= 8, f"sheet is not top-anchored (y={box['y']})"
+    # Full-bleed width and near-full height — the centered card would be far
+    # narrower and shorter.
+    assert box["width"] >= _MOBILE_VIEWPORT["width"] - 8, (
+        f"sheet is not full-width (w={box['width']})"
+    )
+    assert box["height"] >= _MOBILE_VIEWPORT["height"] * 0.85, (
+        f"sheet does not fill the viewport height (h={box['height']})"
+    )
+
+    # The mobile-only explicit close affordance is present (the sheet has no
+    # visible ⌘K/Esc hint for touch users).
+    expect(page.get_by_role("button", name="Close search")).to_be_visible()
+
+
+def test_mobile_command_palette_close_button_dismisses(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Tapping the mobile close button dismisses the full-screen sheet."""
+    base_url, session_id = seeded_session
+    _open_palette(page, base_url, session_id)
+
+    page.get_by_role("button", name="Close search").click()
+
+    expect(page.get_by_test_id("command-palette-input")).to_have_count(0)

--- a/web/src/shell/CommandPalette.test.tsx
+++ b/web/src/shell/CommandPalette.test.tsx
@@ -217,6 +217,80 @@ describe("CommandPalette — input", () => {
   });
 });
 
+describe("CommandPalette — mobile full-screen sheet", () => {
+  // useIsMobileViewport reads window.matchMedia("(max-width: 767.98px)").matches.
+  // The global test-setup stubs matchMedia to always report false (desktop);
+  // flip it here so the palette renders its keyboard-safe mobile layout.
+  function setMobile(isMobile: boolean) {
+    window.matchMedia = ((query: string) => ({
+      matches: isMobile,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+  }
+
+  function dialogContent() {
+    return document.querySelector("[data-slot=dialog-content]");
+  }
+
+  afterEach(() => setMobile(false));
+
+  it("renders a top-anchored full-screen sheet with a close button on mobile", () => {
+    setMobile(true);
+    renderPalette();
+
+    // The sheet drops the centered-card geometry (top-1/4 → top-0, rounded → none)
+    // so it fills the keyboard-aware viewport instead of hiding behind the keyboard.
+    const content = dialogContent();
+    expect(content?.className).toContain("rounded-none");
+    expect(content?.className).not.toContain("top-1/4");
+    // …and offers an explicit close affordance (no ⌘K/Esc hint on touch).
+    expect(screen.getByLabelText("Close search")).toBeTruthy();
+  });
+
+  it("keeps the centered dialog and shows no close button on desktop", () => {
+    setMobile(false);
+    renderPalette();
+
+    expect(dialogContent()?.className).toContain("top-1/4");
+    expect(screen.queryByLabelText("Close search")).toBeNull();
+  });
+
+  it("closes the palette when the mobile close button is tapped", () => {
+    setMobile(true);
+    const onOpenChange = vi.fn();
+    renderPalette({ onOpenChange });
+
+    fireEvent.click(screen.getByLabelText("Close search"));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("still searches from the mobile input", () => {
+    vi.useFakeTimers();
+    try {
+      setMobile(true);
+      setSessions([conv("c1", "Fix the parser")]);
+      renderPalette();
+
+      fireEvent.change(screen.getByTestId("command-palette-input"), {
+        target: { value: "deploy" },
+      });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(useConversations).toHaveBeenCalledWith("deploy", true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("CommandPalette — actions", () => {
   it("lists the built-in action commands", () => {
     renderPalette();

--- a/web/src/shell/CommandPalette.tsx
+++ b/web/src/shell/CommandPalette.tsx
@@ -26,9 +26,13 @@ import {
   PanelRightIcon,
   SettingsIcon,
   SquarePenIcon,
+  XIcon,
 } from "lucide-react";
 import { useNavigate } from "@/lib/routing";
 import { useConversations } from "@/hooks/useConversations";
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
   Command,
@@ -101,6 +105,7 @@ export function CommandPalette({
   onToggleRightSidebar,
 }: CommandPaletteProps) {
   const navigate = useNavigate();
+  const isMobile = useIsMobileViewport();
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
 
@@ -219,21 +224,70 @@ export function CommandPalette({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         aria-describedby={undefined}
-        className="top-1/4 translate-y-0 overflow-hidden p-0 sm:max-w-2xl"
+        // Mobile: a top-anchored full-screen sheet sized to the keyboard-aware
+        // visible viewport (--omnigent-viewport-height), so the input and results
+        // sit above the soft keyboard instead of a centered card whose lower half
+        // hides behind it. Desktop keeps the centered command palette.
+        className={cn(
+          "overflow-hidden p-0",
+          isMobile
+            ? "inset-x-0 top-0 h-full max-h-full w-full max-w-full translate-x-0 translate-y-0 gap-0 rounded-none border-0 shadow-none"
+            : "top-1/4 translate-y-0 sm:max-w-2xl",
+        )}
+        style={
+          isMobile
+            ? {
+                top: 0,
+                height: "var(--omnigent-viewport-height, 100dvh)",
+                maxHeight: "var(--omnigent-viewport-height, 100dvh)",
+                paddingTop: "var(--omnigent-safe-top, 0px)",
+              }
+            : undefined
+        }
         showCloseButton={false}
       >
         <DialogTitle className="sr-only">Command palette</DialogTitle>
         {/* shouldFilter=false: the server filters sessions and we filter actions
             (see file header). vimBindings=false: keep Ctrl+K/J from doubling as
             list-nav on Win/Linux, where Ctrl+K is also the opener. */}
-        <Command shouldFilter={false} vimBindings={false} label="Command palette">
-          <CommandInput
-            value={query}
-            onValueChange={setQuery}
-            placeholder="Search sessions or run a command"
-            data-testid="command-palette-input"
-          />
-          <CommandList>
+        <Command
+          shouldFilter={false}
+          vimBindings={false}
+          label="Command palette"
+          className={isMobile ? "h-full" : undefined}
+        >
+          {isMobile ? (
+            // Search field and an explicit close button share a top row; the
+            // full-screen sheet has no ⌘K/Esc affordance the way the desktop
+            // dialog does, so the X is how touch users dismiss it.
+            <div className="flex items-center gap-1 p-1">
+              <div className="min-w-0 flex-1">
+                <CommandInput
+                  value={query}
+                  onValueChange={setQuery}
+                  placeholder="Search sessions or run a command"
+                  data-testid="command-palette-input"
+                />
+              </div>
+              <Button
+                variant="ghost"
+                size="icon-lg"
+                className="shrink-0 rounded-full"
+                onClick={close}
+                aria-label="Close search"
+              >
+                <XIcon className="size-5 text-muted-foreground" />
+              </Button>
+            </div>
+          ) : (
+            <CommandInput
+              value={query}
+              onValueChange={setQuery}
+              placeholder="Search sessions or run a command"
+              data-testid="command-palette-input"
+            />
+          )}
+          <CommandList className={isMobile ? "max-h-none flex-1" : undefined}>
             <CommandEmpty>
               {isFetching && debouncedQuery ? "Searching…" : "No results found"}
             </CommandEmpty>

--- a/web/src/shell/CommandPalette.tsx
+++ b/web/src/shell/CommandPalette.tsx
@@ -240,7 +240,11 @@ export function CommandPalette({
                 top: 0,
                 height: "var(--omnigent-viewport-height, 100dvh)",
                 maxHeight: "var(--omnigent-viewport-height, 100dvh)",
+                // Pad both insets: safe-top clears the notch, safe-bottom keeps
+                // the last row above the home indicator when the keyboard is
+                // closed (the visible-viewport height then spans the home bar).
                 paddingTop: "var(--omnigent-safe-top, 0px)",
+                paddingBottom: "var(--omnigent-safe-bottom, 0px)",
               }
             : undefined
         }
@@ -250,12 +254,8 @@ export function CommandPalette({
         {/* shouldFilter=false: the server filters sessions and we filter actions
             (see file header). vimBindings=false: keep Ctrl+K/J from doubling as
             list-nav on Win/Linux, where Ctrl+K is also the opener. */}
-        <Command
-          shouldFilter={false}
-          vimBindings={false}
-          label="Command palette"
-          className={isMobile ? "h-full" : undefined}
-        >
+        {/* Command's base class is `size-full`, so it already fills the sheet. */}
+        <Command shouldFilter={false} vimBindings={false} label="Command palette">
           {isMobile ? (
             // Search field and an explicit close button share a top row; the
             // full-screen sheet has no ⌘K/Esc affordance the way the desktop


### PR DESCRIPTION
## Related issue

Closes #

## Summary

On mobile the command/search palette opened as a centered card anchored at `top-1/4` that grew downward, so the iOS soft keyboard covered its lower half — including the focused search input (see the first screenshot in the report). This renders it instead as a **top-anchored full-screen sheet** on mobile:

- Sized to the keyboard-aware visible viewport via the existing `--omnigent-viewport-height` variable (with `--omnigent-safe-top` padding), so the sheet always ends exactly at the top of the keyboard.
- Search field and an explicit **X close button** share a top row (the full-screen sheet has no visible ⌘K/Esc affordance for touch users), and the results list drops its `max-h-72` cap to fill the space above the keyboard.
- Desktop is untouched — it keeps the centered `top-1/4` command palette.

The mobile/desktop split uses the existing `useIsMobileViewport()` hook (Tailwind `md` breakpoint, 768px).

## Test Plan

- `pnpm type-check`, `pnpm lint`, and `pre-commit` all pass.
- `pnpm exec vitest run src/shell/CommandPalette.test.tsx` — 20 passed (4 new tests covering the mobile layout: full-screen classes + close button on mobile, centered dialog + no close button on desktop, close button dismisses, and search still works from the mobile input).
- Manual: open the app under a <768px viewport (device emulation or the iOS shell), trigger the palette (⌘K / sidebar Search), and confirm the field sits at the top with the keyboard open and results filling the space above it — no overlap. Confirm the desktop palette is unchanged at ≥768px.

## Demo

The `ui-preview` label is applied so reviewers can exercise the new mobile layout in the preview build. Before/after: previously the palette (centered card) was overlapped by the keyboard on iOS; now it is a full-screen top-anchored sheet with the results above the keyboard.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added four unit tests that mock `matchMedia` to assert the mobile full-screen sheet (top-anchored geometry, close button, working search) versus the unchanged desktop dialog. Also added a Playwright e2e_ui test (`tests/e2e_ui/mobile/test_mobile_command_palette.py`) that opens the palette at a 390×844 viewport and asserts the mobile sheet geometry (top-anchored, full-width, near-full-height) and the close button, satisfying the E2E UI Required gate. Manual verification covers the actual keyboard-overlap behaviour, which jsdom's layout can't exercise — checked on a narrow viewport that the field and results stay above the soft keyboard.

## Changelog

The mobile search palette now opens as a full-screen sheet so the keyboard no longer covers the search field and results

This pull request and its description were written by Isaac.

