### PR TITLE
fix(ci): don't re-request a reviewer after they review on an edit

### DIFF
--- a/.github/workflows/auto-assign-reviewer.js
+++ b/.github/workflows/auto-assign-reviewer.js
@@ -214,23 +214,30 @@ module.exports = async ({ github, context, core }) => {
   // fallback -- otherwise a routine title/body edit would thrash a
   // deliberately-chosen reviewer.
   //
-  // EXCEPTION: if the PR currently has NO managed reviewer, don't bail -- fall
+  // EXCEPTION: if the PR currently has NO managed pick, don't bail -- fall
   // through to the load-balanced pick. Under `cancel-in-progress: true` this
   // same edit can cancel the still-running `opened` job before it assigned
   // anyone (its LLM ranking step is network-bound and slow); bailing here would
-  // then leave the PR permanently unassigned. Skipping only when a managed
-  // reviewer is already in place preserves the anti-thrash intent (there is
-  // nothing to thrash when none is set) while guaranteeing every PR gets one.
+  // then leave the PR permanently unassigned. Skipping only when a managed pick
+  // is already in place preserves the anti-thrash intent (there is nothing to
+  // thrash when none is set) while guaranteeing every PR gets one.
+  //
+  // "Managed pick" checks BOTH requested reviewers and assignees: GitHub drops a
+  // reviewer from `requested_reviewers` once they submit a review, but leaves
+  // them in `assignees` (the two are kept in sync when we assign). Checking only
+  // reviewers would treat a post-review edit as "nothing set" and re-request /
+  // reshuffle -- the exact thrash this guard prevents -- so the assignee, which
+  // survives review, is the durable signal.
   const action = context.payload && context.payload.action;
   if (action === "edited" && issueReviewers.length === 0) {
-    const hasManagedReviewer = (pr.requested_reviewers || []).some(
-      (r) => managed.has((r.login || "").toLowerCase())
-    );
-    if (hasManagedReviewer) {
-      core.info("Edited event, nothing to adopt, managed reviewer already set; leaving reviewer/assignee unchanged.");
+    const hasManagedPick =
+      (pr.requested_reviewers || []).some((r) => managed.has((r.login || "").toLowerCase())) ||
+      (pr.assignees || []).some((a) => managed.has((a.login || "").toLowerCase()));
+    if (hasManagedPick) {
+      core.info("Edited event, nothing to adopt, managed reviewer/assignee already set; leaving reviewer/assignee unchanged.");
       return;
     }
-    core.info("Edited event, nothing to adopt and no managed reviewer set (opened run may have been cancelled); assigning the load-balanced pick.");
+    core.info("Edited event, nothing to adopt and no managed reviewer/assignee set (opened run may have been cancelled); assigning the load-balanced pick.");
   }
 
   // --- Global open-review load (stateless fairness signal).

--- a/.github/workflows/auto-assign-reviewer.test.js
+++ b/.github/workflows/auto-assign-reviewer.test.js
@@ -406,4 +406,20 @@ function assert(name, cond, detail) {
   assert("edited, nothing to adopt, only external reviewer -> adds managed pick, keeps external",
     r.added.includes("dhruv0811") && !r.removed.includes("some-external-human"),
     JSON.stringify(r));
+
+  // 26. `edited` with nothing to adopt, a managed ASSIGNEE present but NO
+  //     requested reviewer: models a PR whose managed reviewer already submitted
+  //     a review (GitHub drops them from requested_reviewers but keeps them in
+  //     assignees). The assignee is the durable "already picked" signal, so this
+  //     must be a no-op -- not a re-request/reshuffle of the reviewer.
+  r = await run({
+    action: "edited",
+    files: ["omnigent/inner/foo.py"],
+    load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
+    current: [], currentAssignees: ["dbczumar"],
+    linkedIssues: [],
+  });
+  assert("edited, nothing to adopt, managed assignee (post-review) -> unchanged",
+    r.added.length === 0 && r.removed.length === 0 &&
+    r.assigned.length === 0 && r.unassigned.length === 0, JSON.stringify(r));
 })();


### PR DESCRIPTION
## Related issue

No closing issue — a follow-up to #5242 addressing a non-blocking review note on
that PR (*Type of change: Test / CI*, so no issue is required).

## Summary

**ELI5:** When a PR says "fixes #123", we try to hand it to whoever owns #123, and
we're careful not to shuffle a reviewer around on unrelated edits. But GitHub has
a quirk: once a reviewer *submits* their review, GitHub quietly takes them off the
"requested reviewers" list. Our guard only looked at that list, so after a review
an unrelated typo-fix edit made the PR look reviewer-less — and we'd re-request a
(possibly different) reviewer, the very shuffle we meant to avoid. This also looks
at the *assignee*, which GitHub keeps, so the PR still counts as "already
handled."

#5242 added an `edited` trigger with a promote-only guard: on an edit with no
adoptable linked issue, do nothing **unless** the PR has no managed pick yet (the
cancel-in-progress race), in which case fall through to the load-balanced pick.
That guard read only `pr.requested_reviewers`. GitHub removes a user from
`requested_reviewers` the moment they submit a review — but keeps them in
`assignees` (the two are kept in sync when we assign). So a **post-review** edit
saw "no managed reviewer", fell through, and re-requested review / reshuffled the
assignee — the exact thrash the guard exists to prevent.

Fix: the guard now treats a managed **reviewer OR assignee** as "already picked".
The assignee survives review submission, so it's the durable signal.

```mermaid
flowchart TD
    E["edited, nothing to adopt"] --> Q{"managed reviewer<br/>OR assignee present?"}
    Q -->|yes| KEEP["no-op — leave the pick<br/>(survives post-review edits)"]
    Q -->|no| LB["load-balanced pick<br/>(opened run may have<br/>been cancelled)"]
```

The cancel-in-progress fall-through is unaffected: in that race **neither**
reviewer nor assignee is set, so the guard still correctly falls through.

## Test Plan

- `node .github/workflows/auto-assign-reviewer.test.js` — **38/38 assertions pass**
  (37 + 1 new). The new case models a post-review PR (managed assignee present,
  `requested_reviewers` empty) and asserts an `edited` event with nothing to adopt
  is a no-op. Verified it genuinely guards the fix: under the old
  reviewers-only check that case re-requested `dhruv0811` and reshuffled the
  assignee.
- `pre-commit run --files .github/workflows/auto-assign-reviewer.{js,test.js}` — passes.

## Demo

N/A — CI workflow logic change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The decision logic in `auto-assign-reviewer.js` is covered by the offline unit
test (`auto-assign-reviewer.test.js`), extended here with the post-review case.
The change is confined to that logic; there is no YAML/trigger change.

## Changelog

N/A — internal CI/automation change with no user-facing behavior (per the
template, the Changelog line is dropped for CI changes).

This pull request and its description were written by Isaac.
