### PR TITLE
ci(e2e-ui): report slowest test durations

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -296,8 +296,12 @@ jobs:
           # pytest_collection_modifyitems in tests/e2e_ui/conftest.py), which
           # evens out wall-clock better than pytest-shard's hash-bucketing.
           # --group is 1-indexed, so map the 0-indexed shard_id with +1.
+          # --durations surfaces the slowest test phases (setup/call/teardown)
+          # at the end of each shard's log so we can see where the wall-clock
+          # goes and rebalance; the 1s floor keeps trivial phases out.
           uv run pytest tests/e2e_ui \
             -v --tb=long --showlocals --log-level=INFO -r a \
+            --durations=25 --durations-min=1.0 \
             --ui-skip-build \
             --splits="$NUM_SHARDS" \
             --group="$((SHARD_ID + 1))" \


### PR DESCRIPTION
## Related issue

N/A — Test / CI change, no issue required.

## Summary

- The e2e-ui suite takes ~20 min (pinned against the 20-min shard timeout), runs serially within each of 3 shards, and we had **no per-test timing visibility** in CI — so we can't tell whether the time is spread evenly (→ parallelize / re-shard) or concentrated in a few heavy tests (→ mark nightly).
- Adds `--durations=25 --durations-min=1.0` to the e2e-ui pytest step so each shard's log ends with a table of its 25 slowest test phases (setup/call/teardown) that took ≥1s.
- Log-only diagnostic: no new deps, no artifacts, no change to test behavior.

## Test Plan

- Verified the flags are valid pytest options; locally reproducible with:
  `uv run --no-sync pytest tests/e2e_ui -m "not visual and not nightly" --durations=25 --durations-min=1.0 -q`
- The real signal is this PR's own e2e-ui CI run: each shard log will print the "slowest durations" table, which we'll use to decide the next optimization step.

## Demo

N/A — non-visual CI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Log-only change to a CI workflow's pytest invocation (adds reporting flags). It alters no product code and no test logic, so there is nothing to add automated coverage for; correctness is confirmed by the e2e-ui job running green and emitting the durations table.

This pull request and its description were written by Isaac.