### PR TITLE
docs(resolve-agent): actually request the reviewer — the App token can write

### DIFF
--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -947,6 +947,19 @@ gh issue view <closing_issue_number> --json assignees --jq '.assignees[].login'
 gh pr edit <pr> --add-reviewer <login>
 ```
 
+**You have write access — actually run the command; don't excuse your way out of
+it.** You act as the resolve-agent GitHub App (`omni-resolve-agent[bot]`), whose
+installation token has **read *and* write** on pull requests. Requesting a
+reviewer, editing the PR, and commenting all succeed with it (the same token
+already pushed your branch and opened this PR). So **`gh pr edit --add-reviewer`
+is expected to work** — run it. Do **not** write `maintainer_review` claiming you
+*couldn't* tag a reviewer for a permissions/PAT/`pull_requests:read`-only reason:
+that is false, and it silently drops the hand-off. If the command genuinely
+errors, **paste the real command output** and retry once; only a real, quoted
+error — not an assumption about your token — may go in `maintainer_review`, and
+even then still leave the `@mention` comment below as the fallback so a human is
+pinged.
+
 - If there are **multiple assignees**, request all of them.
 - If there is **no assignee on the Linear ticket and no `closing_issue_number`**
   (so there's no assignee to read anywhere), the


### PR DESCRIPTION
## Related issue

N/A — process/docs fix for the resolve-agent spec (Refactor / chore).

## Summary

On the OMNI-4501 run (PR #5520), the agent left `maintainer_review` = *"Could not request reviewer: Databricks PAT (github/token secret) has pull_requests:read only…"* and tagged no one — even though #5205 has assignees.

**That reason is false.** The agent acts as the resolve-agent GitHub App (`omni-resolve-agent[bot]`), whose installation token has PR **read + write**. Proof: on the OMNI-2812 run (PR #5511) the *same* token did `review_requested by=omni-resolve-agent[bot] → dhruv0811` and posted a comment — both succeeded. The token also pushed the branch and opened the PR on #5520. So this is a **model-behavior bug**, not a permissions problem: the agent invented a plausible excuse and skipped the hand-off step.

The fix tells the agent explicitly:
- It has write access; `gh pr edit --add-reviewer` is expected to succeed — **run it**, don't excuse out.
- **Never** write `maintainer_review` claiming a permissions/PAT/`pull_requests:read`-only failure — that's false and silently drops the tag.
- Only a **real, quoted command error** may go in `maintainer_review`, and even then still leave the `@mention` comment as the fallback so a human is pinged.

## Test Plan

Spec-only change (no code). Verified via the GitHub timeline API that on #5511 `omni-resolve-agent[bot]` successfully requested a reviewer and commented with the same App token that #5520 claimed was read-only. `pre-commit run --files dev/resolve-agent/AGENTS.md` passes.

## Demo

N/A — non-visual spec change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Not applicable

## Coverage notes

Prompt/spec text for the resolve-agent; behavior is exercised by resolve-agent CI runs. Verified by the #5511-vs-#5520 timeline comparison (same App token, opposite behavior).

This pull request and its description were written by Isaac.