### PR TITLE
test(e2e-ui): fix agent-info popover hover-close race

### DIFF
--- a/tests/e2e_ui/agents/test_agent_info_popover.py
+++ b/tests/e2e_ui/agents/test_agent_info_popover.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import httpx
 import pytest
 from playwright.sync_api import Page, expect
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 _COMPOSER = "Ask the agent anything…"
 _AGENT_INFO_TRIGGER = '[data-testid="agent-info-trigger"]'
@@ -153,6 +154,17 @@ def _open_popover(page: Page) -> None:
     the same way a real user's pointer does, and the settle wait lets the
     animation finish so the control is at rest before callers click it.
 
+    The pointer-park itself is part of the race, not just its cure: leaving the
+    trigger to reach the panel schedules the 150ms hover-close, and the panel's
+    ``pointerenter`` (``cancelCloseOnEnter``) is what cancels it. Under load the
+    event loop can stall >150ms between those two handlers, so the close timer
+    fires and the panel animates shut *while* ``panel.hover()`` is still waiting
+    for it to be "visible and stable" — a lost race that, with hover's default
+    30s timeout, became a 30s hang and hard failure. So the park + settle live
+    inside the retry: hover on a short timeout, then re-confirm the panel stayed
+    open after settling; a lost race re-arms from a closed state instead of
+    hanging.
+
     :param page: Playwright page on a ``/c/<id>`` route.
     """
     page.keyboard.press("Escape")
@@ -163,20 +175,29 @@ def _open_popover(page: Page) -> None:
         trigger.click()
         try:
             expect(panel).to_be_visible(timeout=3_000)
+            # Land the pointer on the panel so leaving the trigger can't
+            # schedule a hover-close under a subsequent in-panel click, then let
+            # the open animation settle so in-panel controls are stable geometry.
+            # Reaching the panel is itself what arms the hover-close, so a short
+            # hover timeout keeps a lost race a quick retry rather than a 30s hang.
+            panel.hover(timeout=3_000)
+            page.wait_for_timeout(_PANEL_SETTLE_MS)
+            # The hover-close may still have fired if the event loop stalled
+            # past the 150ms timer before ``pointerenter`` cancelled it; only
+            # accept the open once the panel survives the settle.
+            expect(panel).to_be_visible(timeout=1_000)
             break
-        except AssertionError:
-            # The hover-open was toggled shut by the same click; re-arm from a
-            # closed state and try again.
+        except (AssertionError, PlaywrightTimeoutError):
+            # The hover-open was toggled shut by the same click, or a hover-close
+            # won the race and dismissed the panel; re-arm from a closed state.
             page.keyboard.press("Escape")
     else:
+        trigger.click()
         expect(panel).to_be_visible(timeout=3_000)
+        panel.hover(timeout=3_000)
+        page.wait_for_timeout(_PANEL_SETTLE_MS)
     # "Policies" section label proves the popover content mounted.
     expect(page.get_by_text("Policies", exact=True)).to_be_visible(timeout=15_000)
-    # Land the pointer on the panel so leaving the trigger can't schedule a
-    # hover-close under a subsequent in-panel click, then let the open
-    # animation settle so in-panel controls are stable geometry.
-    panel.hover()
-    page.wait_for_timeout(_PANEL_SETTLE_MS)
 
 
 def test_agent_info_policy_add_and_remove(


### PR DESCRIPTION
## Related issue

Closes #

## Summary

`tests/e2e_ui/agents/test_agent_info_popover.py` has been flaky in CI. All the popover tests funnel through the `_open_popover` helper, whose `panel.hover()` step loses a race under load:

- Reaching the panel is what *arms* the auto-close — leaving the trigger fires `pointerleave` → schedules a 150ms `HOVER_CLOSE_DELAY_MS` timer (`AgentInfoButton` in `web/src/components/AgentInfo.tsx`), and only the panel's `pointerenter` (`cancelCloseOnEnter`) cancels it.
- Under load the JS event loop stalls >150ms between those two handlers, so the close timer fires and the panel animates shut *while* `panel.hover()` is still waiting for it to be "visible and stable". With hover's default 30s timeout, a lost race became a 30-second hang and hard failure.

The fix folds the pointer-park + settle **into** the existing retry loop: hover on a short timeout, then re-confirm the panel stayed open after settling. A lost race (`AssertionError` / `PlaywrightTimeoutError`) now presses Escape and re-arms from a closed state instead of hanging. Test-harness only — no product code changed.

## Test Plan

The failure only reproduces under event-loop contention (a fast dev machine passes it in isolation). Reproduced reliably by running the whole file under `-n 2` xdist contention, which starves the event loop the way loaded CI does:

```bash
# Old code: panel.hover() 30s hang surfaces within ~4 rounds
for r in $(seq 1 6); do rtk proxy python -m pytest tests/e2e_ui/agents/test_agent_info_popover.py -o addopts="" -p no:randomly -n 2 -q; done

# After the fix: 12 rounds / 60 whole-file executions, 0 failures
for r in $(seq 1 12); do rtk proxy python -m pytest tests/e2e_ui/agents/test_agent_info_popover.py -o addopts="" -p no:randomly -n 2 -q; done
```

- Before: reproduced the `panel.hover()` 30s hang (trace resolves to `<div … data-state="closed">`) within ~4 rounds.
- After: 12/12 clean rounds (60 whole-file runs), plus the target test 5/5 in isolation. `ruff format` + `ruff check` clean.

## Demo

N/A — non-visual test-harness change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Stabilizes an existing e2e test; no behavior change. Verified by reproducing the flake under `-n 2` xdist contention on the old code, then confirming 60 whole-file executions pass on the fix.

This pull request and its description were written by Isaac.