### PR TITLE
docs(resolve-agent): close the superseded PR when taking over / replacing

### DIFF
--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -324,9 +324,14 @@ review comment on that PR, so the author knows), then **switch to the author pat
 (Step 2B) and open your own PR** that resolves the bug correctly. In your PR,
 reference the existing one and summarize why a fresh approach was warranted.
 Record `mode: "authored_fix"` and put the reviewed PR's number in your prose so
-the two are linked. Use this escape hatch deliberately, not for style
-preferences — a working, root-cause-sound PR should be reviewed and improved in
-place, not replaced.
+the two are linked. **Then close the superseded PR** (same reason as the fork
+take-over: two open PRs on one issue trip the duplicate-PR automation, which
+auto-closes the newer one — yours): `gh pr comment <old> --body 'Superseded by
+#<yours> — a different approach was needed; see there.'` then `gh pr close <old>`.
+If the close is rejected (e.g. a contributor's PR the App token can't close), note
+it in `maintainer_review` and ask the maintainer to close it — don't leave both
+open. Use this escape hatch deliberately, not for style preferences — a working,
+root-cause-sound PR should be reviewed and improved in place, not replaced.
 
 When you keep the PR, you drive it to landable per Step 4 — pushing fixes directly
 when its branch is in-repo, or (for a fork PR you can't push to that needs a fix)
@@ -623,8 +628,20 @@ can land a fix depends on where its branch lives:
     - Credit the original author on the commits (`Co-authored-by: <name> <email>`,
       read from `gh pr view <pr> --json commits`).
     - In your PR body, link the fork PR (`Builds on #<pr> by @<author>`) and say
-      why you re-opened it (couldn't push to the fork). Post a comment on the fork
-      PR pointing to yours, so the contributor isn't blindsided.
+      why you re-opened it (couldn't push to the fork).
+    - **Close the fork PR so it doesn't collide with yours.** Two open PRs that fix
+      the same issue trip the repo's duplicate-PR automation, which will auto-close
+      the **newer** one — i.e. *yours*. Once your PR is open, comment on the fork PR
+      pointing to yours and close it:
+      ```
+      gh pr comment <fork-pr> --body 'Superseded by #<your-pr> — I took this over to add a fix I could not push to your fork (App tokens can’t push to forks). Your commits are carried over with credit. Thanks @<author>!'
+      gh pr close <fork-pr>
+      ```
+      This both keeps the contributor informed and stops the dedup bot from closing
+      your PR as the duplicate. If the close is rejected (an App token may not be
+      able to close a contributor’s fork PR), **say so in `maintainer_review`** and
+      ask the maintainer to close `#<fork-pr>` in favor of yours — never leave both
+      silently open.
     - Set `mode: "authored_fix"`, record the fork PR's number in `reviewed_pr_url`,
       and drive **your** PR through the rest of Step 4 (you can push to it).
   - **If the fork PR needs no fix** (repro passes against it, CI green, review

--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -328,9 +328,12 @@ the two are linked. **Then close the superseded PR** (same reason as the fork
 take-over: two open PRs on one issue trip the duplicate-PR automation, which
 auto-closes the newer one — yours): `gh pr comment <old> --body 'Superseded by
 #<yours> — a different approach was needed; see there.'` then `gh pr close <old>`.
-If the close is rejected (e.g. a contributor's PR the App token can't close), note
-it in `maintainer_review` and ask the maintainer to close it — don't leave both
-open. Use this escape hatch deliberately, not for style preferences — a working,
+Closing a PR is a base-repo operation (it flips `state` on the PR object in
+`omnigent-ai/omnigent`), so `pull_requests: write` covers it **even for a
+contributor's fork PR** — expect the close to succeed; run it. Only if it returns
+a real error, record that error in `maintainer_review` and ask the maintainer to
+close it — never leave both open. Use this escape hatch deliberately, not for
+style preferences — a working,
 root-cause-sound PR should be reviewed and improved in place, not replaced.
 
 When you keep the PR, you drive it to landable per Step 4 — pushing fixes directly
@@ -638,10 +641,13 @@ can land a fix depends on where its branch lives:
       gh pr close <fork-pr>
       ```
       This both keeps the contributor informed and stops the dedup bot from closing
-      your PR as the duplicate. If the close is rejected (an App token may not be
-      able to close a contributor’s fork PR), **say so in `maintainer_review`** and
-      ask the maintainer to close `#<fork-pr>` in favor of yours — never leave both
-      silently open.
+      your PR as the duplicate. Closing a PR is a base-repo operation (it flips
+      `state` on the PR object in `omnigent-ai/omnigent`), so `pull_requests: write`
+      covers it **even though the head branch is on a fork** — the fork-push
+      restriction does not apply to a close. Expect it to succeed; run it. Only if
+      the close returns a real error, **record that error in `maintainer_review`**
+      and ask the maintainer to close `#<fork-pr>` in favor of yours — never leave
+      both silently open.
     - Set `mode: "authored_fix"`, record the fork PR's number in `reviewed_pr_url`,
       and drive **your** PR through the rest of Step 4 (you can push to it).
   - **If the fork PR needs no fix** (repro passes against it, CI green, review


### PR DESCRIPTION
## Related issue

N/A — process/docs fix for the resolve-agent spec (Refactor / chore).

## Summary

When resolve-agent **takes over** a fork PR (or **replaces** a wrong-approach PR), it opens its own PR but left the original open. Two open PRs targeting the same issue trip the repo's **duplicate-PR automation**, which auto-closes the **newer** one — i.e. resolve-agent's own PR. This just happened: **#5520** got a "duplicate, closing" comment while the fork PR it took over (**#5206**) stayed open against #5205.

Both PR-superseding paths now close the original after opening the new one:

- **Fork take-over** (Step 4 "push or take over"): after opening your PR, `gh pr comment <fork-pr>` pointing to yours + `gh pr close <fork-pr>`, keeping the `Co-authored-by` / `Builds on #<pr>` credit.
- **Wrong-approach escape hatch** (Step 2A): same — comment + `gh pr close <old>`.

**Closing works with the App's existing permissions.** Closing a PR is a base-repo operation — it flips `state` on the PR object in `omnigent-ai/omnigent` — so `pull_requests: write` covers it **even when the head branch is on a fork**. The fork-push restriction (why take-over exists) does not apply to a close. The spec tells the agent to expect the close to succeed and run it; the maintainer-fallback remains only as a genuine-error catch, not a predicted failure.

## Test Plan

Spec-only change (no code). Verified the failure mode on #5520 (duplicate-close comment; fork #5206 still open). Confirmed both PR-opening paths in AGENTS.md now include the close step. `pre-commit run --files dev/resolve-agent/AGENTS.md` passes.

## Demo

N/A — non-visual spec change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Not applicable

## Coverage notes

Prompt/spec text for the resolve-agent; behavior is exercised by resolve-agent CI runs. Verified against the #5520/#5206 duplicate-close incident.

This pull request and its description were written by Isaac.