### PR TITLE
fix(e2e_ui): record video for async_playwright tests via env-gated dir

### DIFF
--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -480,13 +480,29 @@ first, then re-run the SAME drivers with recording on against the fixed tree:
 
 ```bash
 pnpm --filter web install && pnpm --filter web run build   # once, up front
-pytest <test_path> --video on --screenshot on --output recordings/<slug>
+OMNIGENT_E2E_RECORD_DIR="$PWD/recordings/<slug>/raw" \
+  pytest <test_path> --screenshot on --output recordings/<slug>
 ```
 
-For `cli` facets, re-render `vhs recordings/<slug>/journey.tape`. pytest-playwright
-writes the video into a per-test subdir under `--output`; **move** it to a stable
-`recordings/<slug>/after-<facet>.<ext>` and delete the leftover subdir so the same
-footage isn't collected twice. For each after clip, write a `caption` describing
+**Record via `OMNIGENT_E2E_RECORD_DIR`, not `--video on`.** Most `tests/e2e_ui/`
+tests drive Playwright through `async_playwright()` + `browser.new_page()`
+directly — *not* the pytest-playwright `page` fixture — so the `--video on` flag
+records **nothing** for them (it only films the `page` fixture) and you'd get a
+false `recordings: []`. Setting `OMNIGENT_E2E_RECORD_DIR` makes the e2e_ui
+conftest inject `record_video_dir` into every page/context the test opens, so the
+journey is filmed no matter how the test opened the browser. Playwright writes the
+`.webm` (a random hash name) into that dir when the context closes. (If the repro
+test already hard-codes its own `record_video_dir` — repro-agent authors some
+tests that way — that explicit dir wins and the video lands there instead; check
+both locations.)
+
+For `cli` facets, re-render `vhs recordings/<slug>/journey.tape`. The video lands
+in `OMNIGENT_E2E_RECORD_DIR` under a hash name; **move** it to a stable
+`recordings/<slug>/after-<facet>.webm` and delete the leftover raw dir so the same
+footage isn't collected twice. If that dir has **no** `.webm` after the run, the
+recording genuinely didn't happen (the test errored before opening a page, or the
+fixture couldn't come online) — capture the reason per the omit rule below; never
+report an after-clip you didn't actually produce. For each after clip, write a `caption` describing
 **the actions that clip performs**, ending in the *correct* behavior (a passing
 run) — the same per-clip action-caption repro-agent writes, e.g. `"open the model
 picker → select the catalog → picker now shows friendly names"`. Carry each before

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -2232,6 +2232,47 @@ def _ui_defaults() -> None:
     expect.set_options(timeout=15_000)
 
 
+@pytest.fixture(autouse=True)
+def _record_video(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    """Capture a screen recording of the journey when recording is requested.
+
+    Most e2e_ui tests drive Playwright through ``async_playwright()`` directly
+    (``browser.new_page()`` / ``browser.new_context()``), not the
+    pytest-playwright ``page`` fixture, so ``pytest --video`` records nothing for
+    them. When ``OMNIGENT_E2E_RECORD_DIR`` is set, patch the async ``Browser``
+    methods to inject ``record_video_dir`` into every page/context they open, so
+    the rendered journey lands as a ``.webm`` regardless of how the test opened
+    the browser. A caller that already passes ``record_video_dir`` is left alone.
+    Playwright writes the file (a random hash name) when the context closes;
+    callers/harnesses pick it up from the directory. No-op when the env var is
+    unset, so ordinary runs are unaffected.
+    """
+    record_dir = os.environ.get("OMNIGENT_E2E_RECORD_DIR")
+    if not record_dir:
+        yield
+        return
+
+    from playwright.async_api import Browser as _AsyncBrowser
+
+    Path(record_dir).mkdir(parents=True, exist_ok=True)
+    _orig_new_page = _AsyncBrowser.new_page
+    _orig_new_context = _AsyncBrowser.new_context
+
+    async def _new_page(self: Any, *args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("record_video_dir", record_dir)
+        return await _orig_new_page(self, *args, **kwargs)
+
+    async def _new_context(self: Any, *args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("record_video_dir", record_dir)
+        return await _orig_new_context(self, *args, **kwargs)
+
+    monkeypatch.setattr(_AsyncBrowser, "new_page", _new_page)
+    monkeypatch.setattr(_AsyncBrowser, "new_context", _new_context)
+    yield
+
+
 @pytest.fixture
 def runner_id(live_server: str) -> str:
     """Token-bound id of the runner spawned by :func:`live_server`.


### PR DESCRIPTION
## Related issue

N/A — recorder infrastructure fix for the repro→resolve agent pipeline (Bug fix / Test-CI).

## Summary

The resolve-agent (and repro-agent) kept producing a false `recordings: []` for **web-surface** bugs. Root cause, confirmed by reading a live resolve session (OMNI-1519): the spec's recorder command is `pytest <test_path> --video on`, but **`--video on` only films the pytest-playwright `page` fixture**. **16 of ~30 `tests/e2e_ui/` files** (including OMNI-1519's `start_session/test_start_session.py` family) drive Playwright through `async_playwright()` + `browser.new_page()`/`new_context()` **directly**, so the flag never sees their browser — no `.webm` is written and the agent honestly reports nothing.

Fix:

- **`tests/e2e_ui/conftest.py`**: new autouse fixture `_record_video`. When `OMNIGENT_E2E_RECORD_DIR` is set, it patches the async `Browser.new_page`/`new_context` to inject `record_video_dir` (via `setdefault`, so a test that already passes its own dir — repro-agent authors some that way — still wins). No-op when the env var is unset, so ordinary runs are unaffected. Catches all ~100 inline `new_page()` call sites without editing any test.
- **`dev/resolve-agent/AGENTS.md`**: recorder step now sets `OMNIGENT_E2E_RECORD_DIR` instead of relying on the no-op `--video on`, explains the fixture-vs-direct distinction, and tells the agent the `.webm` lands in that dir (or the test's own dir) on context close.

## Test Plan

- **Mechanism verified live**: replicated the fixture's monkeypatch, launched real headless chromium, `browser.new_page()` → navigate → `context.close()`, confirmed a non-empty `.webm` was written to the record dir. (`--video on` on the same inline pattern writes nothing.)
- `ruff check` / `ruff format` / full pre-commit pass on both files.
- Fixture is a no-op unless `OMNIGENT_E2E_RECORD_DIR` is set, so existing e2e_ui runs are unchanged.

## Demo

N/A — test-infrastructure change (it *enables* demos rather than being one).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI

## Test coverage

- [x] Manual verification completed

## Coverage notes

Manually verified the record_video_dir injection produces a `.webm` against real headless chromium (the exact inline `async_playwright()` + `new_page()` pattern the 16 affected tests use). The fixture is env-gated and no-op by default, so it needs no new automated test; it's exercised whenever a recorder run sets `OMNIGENT_E2E_RECORD_DIR`.

This pull request and its description were written by Isaac.