### PR TITLE
Add real-turn credential setup for repro agent CI

### DIFF
--- a/dev/repro-agent/AGENTS.md
+++ b/dev/repro-agent/AGENTS.md
@@ -97,9 +97,35 @@ Your first turn is a fixed checklist — do all of it before Step 1:
    whether the recorders are available (Playwright browsers for
    `pytest --video`, `vhs` for CLI tapes): Step 4 degrades gracefully when they
    are missing.
+3. **Detect the CI real-turn lane without printing credentials:**
+   `test "${REPRO_AGENT_REAL_TURNS:-}" = 1 && echo real || echo standard`. In
+   the real lane, confirm `LLM_API_KEY` is set with `test -n "$LLM_API_KEY"`
+   and both `claude` and `codex` resolve with `command -v`. Never echo, inspect,
+   or include the token in evidence. If any prerequisite is missing, stop with
+   `needs_more_info` and name the missing CI setup; do not continue on a mock.
 
 If you cannot reach the app at all, stop and say so. Don't narrate a clean
 preflight.
+
+## Real turns in scheduled CI
+
+When `REPRO_AGENT_REAL_TURNS=1`, bugs involving Claude Code, Codex, or OpenAI
+Agents must be reproduced with at least one real turn through the affected
+harness (`claude-native`, `codex-native`, or `openai-agents`). The driver has
+installed a dual-family provider config: Claude uses the Anthropic gateway
+surface; Codex and OpenAI Agents use the OpenAI Responses surface. Create the
+same agent/session a user creates and send the turn through it. In `evidence`,
+name the harness and model and cite the observed response or terminal state,
+but never include credential values.
+
+Do not silently replace a real turn with a canned assistant item, a queued mock
+response, or a direct internal call. A missing CLI, rejected credential, or
+unavailable model is an environment failure (`needs_more_info` with the exact
+failure), not evidence that the product bug does or does not reproduce. The mock
+LLM remains appropriate only when the reported journey explicitly requires a
+controlled model fault such as a 429, truncated stream, or blocked response; in
+that case the injected fault is the real user-path precondition and must be
+called out in evidence.
 
 ## Step 1 — Reconstruct the user journey
 
@@ -240,7 +266,8 @@ truly cannot be made to run here do you fall back (naming the specific blocker i
 direct call or a hand-written end-state as if it were the reproduction.
 
 **When the failure only appears under a fault, the fault *is* the trigger —
-inject it.** A whole class of bugs is an error/recovery state that the happy
+inject it.** This is the explicit exception to the CI real-turn rule: a whole
+class of bugs is an error/recovery state that the happy
 path never reaches: the model errors mid-turn, a stream dies before completing,
 a dependency 500s, a sub-agent fails. For these the user's journey is "drive a
 normal turn *while* the dependency misbehaves", so you reproduce by making it
@@ -424,12 +451,15 @@ cause is named from what you observed rather than guessed.
   by the facet's verdict, as above). Save `tmux capture-pane -e` text dumps
   alongside as machine-checkable evidence. **For a native-harness pane
   (claude/codex/cursor/goose/hermes/kiro/… — the bug is in a real harness CLI's
-  output), don't hand-roll the launch: the existing render-parity tests already
-  drive the *real* CLI against the mock LLM with the terminal view shown, so copy
-  the closest one** (`tests/e2e_ui/messages/test_native_<harness>_render_parity.py`,
-  which use the `native_<harness>_session` / `native_<harness>_mock_session`
-  fixtures in `tests/e2e_ui/conftest.py`) and adapt its scripted turns to your
-  journey. The `--video on` recorder captures the pane with no extra plumbing.
+  output), don't hand-roll the launch: copy the closest existing render-parity
+  test** (`tests/e2e_ui/messages/test_native_<harness>_render_parity.py`, which
+  uses the `native_<harness>_mock_session` fixture in
+  `tests/e2e_ui/conftest.py`) and adapt it to the journey. Despite the legacy
+  fixture name, it deliberately uses the existing real gateway config whenever
+  `LLM_API_KEY` is set; it writes a mock provider only when the key is absent.
+  In the CI real-turn lane, do not queue or assert canned mock tokens—assert the
+  reported observable behavior around the real response instead. The
+  `--video on` recorder captures the pane with no extra plumbing.
   These tests skip when the harness CLI isn't installed; if the one your bug needs
   is unavailable here, keep `recordings: []` and name the missing CLI in
   `evidence` (a real environment limit, not a `not_reproduced`).

--- a/dev/repro-agent/README.md
+++ b/dev/repro-agent/README.md
@@ -19,6 +19,10 @@ reproduction test into **this** checkout.
   Playwright browsers (`playwright install chromium`) so the authored e2e_ui
   test can run with `--video on`, [`vhs`](https://github.com/charmbracelet/vhs)
   for CLI-journey tapes, and `ffmpeg` for `.mp4` conversion.
+- For the CI real-turn lane: the repository gateway values
+  `GATEWAY_BASE_URL`, `LLM_API_KEY`, `OMNIGENT_CI_ANTHROPIC_MODEL`, and
+  `OMNIGENT_CI_OPENAI_MODEL`, plus the pinned `claude` and `codex` CLIs from
+  `.github/ci-deps`.
 
 ## Usage
 
@@ -56,6 +60,32 @@ after it starts — useful for watching a live run or reproducing against a shar
 
 It always keeps the worktree and prints its path + branch at the end; remove it
 with `git worktree remove <path>` when done.
+
+### CI real turns
+
+The scheduled CI caller adds `--ci-real-turns` to make the reproduction capable
+of driving real Claude Code, Codex, and OpenAI Agents turns. The driver writes an
+isolated dual-family provider config whose credential is an
+`env:LLM_API_KEY` reference; the token is never persisted in the config. It also
+fails before creating a worktree when a credential, model, or native CLI is
+missing. There is no silent mock fallback in this mode.
+
+The runner setup is:
+
+```bash
+uv sync --extra all --group test
+npm --prefix .github/ci-deps install --ignore-scripts
+node .github/ci-deps/node_modules/@anthropic-ai/claude-code/install.cjs
+export PATH="$PWD/.github/ci-deps/node_modules/.bin:$PATH"
+
+uv run python dev/repro.py "$BUG_URL" --ci-real-turns
+```
+
+`GATEWAY_BASE_URL` and `LLM_API_KEY` come from repository secrets; the two
+model IDs come from repository variables. GitHub Actions callers should mask
+the token and scan the agent output and authored artifacts before upload. This
+is a self-contained runner lane and cannot be combined with `--server`; a remote
+host has its own filesystem and credential boundary.
 
 ## What it does
 

--- a/dev/repro-agent/config.yaml
+++ b/dev/repro-agent/config.yaml
@@ -27,6 +27,10 @@
 # (`omnigent setup` — an Anthropic key, a Claude subscription, an
 # OpenAI-compatible gateway, or a Databricks workspace). It drives the app via
 # the framework browser tools (auto-registered) and sys_session_* / HTTP.
+# Scheduled CI uses `python dev/repro.py <bug> --ci-real-turns`, which writes an
+# isolated dual-family gateway provider for the brain and for real Claude Code,
+# Codex, and OpenAI Agents reproduction turns. Missing CI credentials fail
+# closed; the agent must not replace those turns with the mock LLM.
 
 spec_version: 1
 name: repro_agent

--- a/dev/repro.py
+++ b/dev/repro.py
@@ -22,6 +22,7 @@ Usage (from the repo root):
   python dev/repro.py https://github.com/omnigent-ai/omnigent/issues/1234
   python dev/repro.py OMNI-1234 --server http://localhost:6767
   python dev/repro.py <bug_url> --public  # share the session public-read at start
+  python dev/repro.py <bug_url> --ci-real-turns  # CI gateway; no mock fallback
 
 Reproducing runs against whatever server ``omnigent run`` uses (the local server
 it spins up by default, or the one you pass with ``--server``).
@@ -30,17 +31,30 @@ it spins up by default, or the one you pass with ``--server``).
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
+import urllib.parse
+from collections.abc import Mapping
 from pathlib import Path
 from typing import NoReturn
 
 # dev/repro.py → repo root is the parent of dev/.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _AGENT_REL = "dev/repro-agent"
+
+_CI_GATEWAY_ENV_VARS = (
+    "GATEWAY_BASE_URL",
+    "LLM_API_KEY",
+    "OMNIGENT_CI_ANTHROPIC_MODEL",
+    "OMNIGENT_CI_OPENAI_MODEL",
+)
+_CI_REAL_TURNS_ENV_VAR = "REPRO_AGENT_REAL_TURNS"
 
 
 def _die(msg: str) -> NoReturn:
@@ -79,6 +93,82 @@ def _launch_env(bug_url: str) -> dict[str, str]:
         names.append("DATABRICKS_LINEAR_API_KEY")
     env["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] = ",".join(names)
     return env
+
+
+def build_ci_provider_config(env: Mapping[str, str]) -> dict[str, object]:
+    """Build the dual-family provider used by CI repro runs.
+
+    The repository's CI gateway serves Claude over its Anthropic surface and
+    Codex / OpenAI Agents over its Responses surface. The token stays in the
+    process environment: the config contains only ``env:LLM_API_KEY`` so it can
+    be forwarded to runner children without being written to disk.
+
+    :param env: Environment containing the CI gateway URL, token, and models.
+    :returns: An Omnigent ``config.yaml`` mapping.
+    :raises ValueError: If a required value is absent or the URL is invalid.
+    """
+    missing = [name for name in _CI_GATEWAY_ENV_VARS if not env.get(name, "").strip()]
+    if missing:
+        raise ValueError(f"missing CI real-turn environment: {', '.join(missing)}")
+
+    gateway = env["GATEWAY_BASE_URL"].strip().rstrip("/")
+    parsed = urllib.parse.urlparse(gateway)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError("GATEWAY_BASE_URL must be an absolute http(s) URL")
+    gateway_host = gateway.removesuffix("/serving-endpoints")
+
+    return {
+        "providers": {
+            "repro-ci-gateway": {
+                "kind": "gateway",
+                "default": ["anthropic", "openai"],
+                "anthropic": {
+                    "base_url": f"{gateway}/anthropic",
+                    "api_key_ref": "env:LLM_API_KEY",
+                    "models": {"default": env["OMNIGENT_CI_ANTHROPIC_MODEL"].strip()},
+                },
+                "openai": {
+                    "base_url": f"{gateway_host}/ai-gateway/codex/v1",
+                    "api_key_ref": "env:LLM_API_KEY",
+                    "wire_api": "responses",
+                    "models": {"default": env["OMNIGENT_CI_OPENAI_MODEL"].strip()},
+                },
+            }
+        }
+    }
+
+
+def configure_ci_real_turns(env: dict[str, str], config_home: Path) -> None:
+    """Write an isolated CI provider config and mark the repro run as live.
+
+    ``OMNIGENT_RUNNER_ENV_PASSTHROUGH`` carries the mode marker to the agent's
+    runner. ``LLM_API_KEY`` itself is discovered from the provider's env ref and
+    forwarded by the normal provider credential path.
+
+    :param env: Child environment mutated for the repro-agent launch.
+    :param config_home: Empty temporary config directory owned by this run.
+    """
+    config = build_ci_provider_config(env)
+    config_home.mkdir(parents=True, exist_ok=True)
+    config_path = config_home / "config.yaml"
+    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    config_path.chmod(0o600)
+
+    env["OMNIGENT_CONFIG_HOME"] = str(config_home)
+    env[_CI_REAL_TURNS_ENV_VAR] = "1"
+    passthrough = [
+        name.strip()
+        for name in env.get("OMNIGENT_RUNNER_ENV_PASSTHROUGH", "").split(",")
+        if name.strip()
+    ]
+    if _CI_REAL_TURNS_ENV_VAR not in passthrough:
+        passthrough.append(_CI_REAL_TURNS_ENV_VAR)
+    env["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] = ",".join(passthrough)
+
+
+def missing_ci_harness_clis() -> list[str]:
+    """Return native harness CLIs the all-surface CI repro lane is missing."""
+    return [name for name in ("claude", "codex") if shutil.which(name) is None]
 
 
 def _slug_from_bug_url(bug_url: str) -> str:
@@ -151,6 +241,14 @@ def _parse_args() -> argparse.Namespace:
         "the server) right after it starts. Off by default — useful when "
         "watching a live run or reproducing against a shared --server.",
     )
+    p.add_argument(
+        "--ci-real-turns",
+        action="store_true",
+        help="Configure the repository CI gateway for real Claude Code, Codex, "
+        "and OpenAI Agents turns. Requires GATEWAY_BASE_URL, LLM_API_KEY, "
+        "OMNIGENT_CI_ANTHROPIC_MODEL, OMNIGENT_CI_OPENAI_MODEL, and the "
+        "claude/codex CLIs; never falls back to mock turns.",
+    )
     return p.parse_args()
 
 
@@ -168,6 +266,26 @@ def main() -> None:
     bug_url = args.bug_url or input("Bug URL (GitHub issue or Linear ticket): ").strip()
     if not bug_url:
         _die("no bug URL given")
+
+    # Validate the live lane before creating a worktree: a missing secret or
+    # binary is CI setup failure and must not leave an empty repro branch behind.
+    if args.ci_real_turns:
+        if args.server is not None:
+            _die(
+                "--ci-real-turns is the self-contained CI-runner lane and cannot "
+                "be combined with --server; configure the remote host separately"
+            )
+        try:
+            build_ci_provider_config(os.environ)
+        except ValueError as exc:
+            _die(str(exc))
+        missing_clis = missing_ci_harness_clis()
+        if missing_clis:
+            _die(
+                "--ci-real-turns requires the native harness CLIs: "
+                + ", ".join(missing_clis)
+                + ". Install the pinned packages from .github/ci-deps first."
+            )
 
     # The agent's input contract is the bug URL (it always reproduces against the
     # running build, so there's no version to pass), plus an optional `public`
@@ -210,10 +328,26 @@ def main() -> None:
         cmd += ["--server", args.server]
 
     env = _launch_env(bug_url)
-    print(f"→ running: {' '.join(cmd)}")
-    print(f"→ cwd:     {worktree}\n")
+    config_context: contextlib.AbstractContextManager[str | None]
+    if args.ci_real_turns:
+        config_context = tempfile.TemporaryDirectory(prefix="omnigent-repro-ci-")
+    else:
+        config_context = contextlib.nullcontext(None)
 
-    result = subprocess.run(cmd, cwd=str(worktree), env=env, check=False)
+    with config_context as config_dir:
+        if config_dir is not None:
+            try:
+                configure_ci_real_turns(env, Path(config_dir))
+            except ValueError as exc:
+                _die(str(exc))
+            if os.environ.get("GITHUB_ACTIONS") == "true":
+                # GitHub consumes this command before rendering the line and
+                # masks the value in all subsequent logs.
+                print(f"::add-mask::{env['LLM_API_KEY']}")
+
+        print(f"→ running: {' '.join(cmd)}")
+        print(f"→ cwd:     {worktree}\n")
+        result = subprocess.run(cmd, cwd=str(worktree), env=env, check=False)
 
     # Always keep the worktree; the authored test (if any) lives on its branch.
     print(

--- a/tests/dev/test_repro.py
+++ b/tests/dev/test_repro.py
@@ -1,0 +1,144 @@
+"""Tests for the repro-agent driver's CI real-turn setup (``dev/repro.py``)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+import dev.repro as repro
+from dev.repro import build_ci_provider_config, configure_ci_real_turns
+from omnigent.onboarding.provider_config import default_provider_for_harness, load_config
+
+
+def _ci_env() -> dict[str, str]:
+    return {
+        "GATEWAY_BASE_URL": "https://workspace.example.com/serving-endpoints",
+        "LLM_API_KEY": "secret-repro-token",
+        "OMNIGENT_CI_ANTHROPIC_MODEL": "databricks-claude-sonnet",
+        "OMNIGENT_CI_OPENAI_MODEL": "databricks-gpt",
+    }
+
+
+def test_build_ci_provider_config_routes_all_repro_harness_families() -> None:
+    config = build_ci_provider_config(_ci_env())
+
+    provider = config["providers"]["repro-ci-gateway"]  # type: ignore[index]
+    assert provider["default"] == ["anthropic", "openai"]
+    assert provider["anthropic"] == {
+        "base_url": "https://workspace.example.com/serving-endpoints/anthropic",
+        "api_key_ref": "env:LLM_API_KEY",
+        "models": {"default": "databricks-claude-sonnet"},
+    }
+    assert provider["openai"] == {
+        "base_url": "https://workspace.example.com/ai-gateway/codex/v1",
+        "api_key_ref": "env:LLM_API_KEY",
+        "wire_api": "responses",
+        "models": {"default": "databricks-gpt"},
+    }
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        "GATEWAY_BASE_URL",
+        "LLM_API_KEY",
+        "OMNIGENT_CI_ANTHROPIC_MODEL",
+        "OMNIGENT_CI_OPENAI_MODEL",
+    ],
+)
+def test_build_ci_provider_config_fails_closed_when_credential_is_missing(
+    missing: str,
+) -> None:
+    env = _ci_env()
+    env[missing] = ""
+
+    with pytest.raises(ValueError, match=missing):
+        build_ci_provider_config(env)
+
+
+@pytest.mark.parametrize("gateway", ["workspace.example.com", "file:///tmp/gateway", ""])
+def test_build_ci_provider_config_rejects_invalid_gateway_url(gateway: str) -> None:
+    env = _ci_env()
+    env["GATEWAY_BASE_URL"] = gateway
+
+    with pytest.raises(ValueError, match="GATEWAY_BASE_URL"):
+        build_ci_provider_config(env)
+
+
+def test_configure_ci_real_turns_keeps_token_out_of_config(tmp_path: Path) -> None:
+    env = _ci_env()
+    env["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] = "DATABRICKS_LINEAR_API_KEY"
+
+    configure_ci_real_turns(env, tmp_path)
+
+    config_text = (tmp_path / "config.yaml").read_text(encoding="utf-8")
+    assert "secret-repro-token" not in config_text
+    assert json.loads(config_text) == build_ci_provider_config(env)
+    assert env["OMNIGENT_CONFIG_HOME"] == str(tmp_path)
+    assert env["REPRO_AGENT_REAL_TURNS"] == "1"
+    assert env["OMNIGENT_RUNNER_ENV_PASSTHROUGH"].split(",") == [
+        "DATABRICKS_LINEAR_API_KEY",
+        "REPRO_AGENT_REAL_TURNS",
+    ]
+
+
+def test_configure_ci_real_turns_does_not_duplicate_passthrough_marker(
+    tmp_path: Path,
+) -> None:
+    env = _ci_env()
+    env["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] = "REPRO_AGENT_REAL_TURNS"
+
+    configure_ci_real_turns(env, tmp_path)
+
+    assert env["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] == "REPRO_AGENT_REAL_TURNS"
+
+
+def test_ci_real_turns_rejects_remote_server_before_creating_worktree(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        repro,
+        "_parse_args",
+        lambda: argparse.Namespace(
+            bug_url="OMNI-4278",
+            server="https://remote.example.com",
+            public=False,
+            ci_real_turns=True,
+        ),
+    )
+
+    with pytest.raises(SystemExit, match="1"):
+        repro.main()
+
+    assert "cannot be combined with --server" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("harness", "family"),
+    [
+        ("claude-native", "anthropic"),
+        ("codex-native", "openai"),
+        ("openai-agents", "openai"),
+    ],
+)
+def test_ci_config_resolves_for_each_real_turn_harness(
+    harness: str,
+    family: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env = _ci_env()
+    configure_ci_real_turns(env, tmp_path)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+
+    provider = default_provider_for_harness(load_config(), harness)
+
+    assert provider is not None
+    resolved = provider.family(family)
+    assert resolved is not None
+    assert resolved.api_key == "secret-repro-token"


### PR DESCRIPTION
## Related issue

https://linear.app/omnigent/issue/OMNI-4278/repro-agent-credential-setup-for-claude-codex

## Summary

- Add a self-contained `--ci-real-turns` mode that writes an isolated dual-family gateway config for Claude Code, Codex, and OpenAI Agents without persisting the token.
- Fail before creating a worktree when credentials, models, native CLIs, or the local-run requirement are not satisfied; never silently fall back to mock turns.
- Teach repro-agent to require a real affected-harness turn in this lane, while retaining controlled mocks for deliberate fault injection.

ELI5: the repro bot now gets temporary, scoped credentials for the same real coding-agent paths users exercise, independently of managed sandbox infrastructure.

```mermaid
flowchart LR
    CI[CI runner] --> Driver[dev/repro.py --ci-real-turns]
    Driver --> Config[Temporary provider config]
    Config --> Claude[Anthropic gateway / Claude Code]
    Config --> OpenAI[Responses gateway / Codex + OpenAI Agents]
```

## Test Plan

- `uv run pytest tests/dev/test_repro.py -q` — 14 passed.
- `uv run ruff check dev/repro.py tests/dev/test_repro.py`
- `uv run ruff format --check dev/repro.py tests/dev/test_repro.py`
- `pnpm --filter omnigent-vscode run type-check`
- `uv run --no-sync pre-commit run --all-files`
- Manually verified missing CI credentials fail before creating a repro worktree.

## Demo

N/A — non-visual CI and agent-instruction change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the fail-closed preflight and confirmed it leaves no empty repro branch. A live gateway turn was not run locally because repository gateway secrets and model variables are available only to CI.
