### PR TITLE
Widen prose on ultra-wide displays

### DIFF
--- a/tests/e2e_ui/chat/test_chat_responsive_width.py
+++ b/tests/e2e_ui/chat/test_chat_responsive_width.py
@@ -17,7 +17,7 @@ _TABLE_MARKER = "Responsive table width marker"
     [
         pytest.param(1920, 768, 736, id="desktop"),
         pytest.param(2400, 896, 768, id="wide-desktop"),
-        pytest.param(3440, 1376, 963.2, id="ultrawide"),
+        pytest.param(3440, 1376, 1024, id="ultrawide"),
         pytest.param(4096, 1600, 1024, id="4k"),
     ],
 )

--- a/tests/e2e_ui/chat/test_chat_responsive_width.py
+++ b/tests/e2e_ui/chat/test_chat_responsive_width.py
@@ -17,7 +17,7 @@ _TABLE_MARKER = "Responsive table width marker"
     [
         pytest.param(1920, 768, 736, id="desktop"),
         pytest.param(2400, 896, 768, id="wide-desktop"),
-        pytest.param(3440, 1376, 1024, id="ultrawide"),
+        pytest.param(3200, 1280, 960, id="fluid-ultrawide"),
         pytest.param(4096, 1600, 1024, id="4k"),
     ],
 )

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -358,7 +358,7 @@ describe("BubbleView dispatch", () => {
     // under an answered turn.
     render(<BubbleView bubble={foldOnlyBubble([toolItem("c4")])} />);
     const bubble = screen.getByTestId("message-bubble");
-    expect(bubble).toHaveClass("max-w-3xl", "min-[2561px]:max-w-[clamp(56rem,28vw,64rem)]");
+    expect(bubble).toHaveClass("max-w-3xl", "min-[2561px]:max-w-[clamp(56rem,30vw,64rem)]");
     expect(bubble.firstElementChild).toHaveClass("w-full");
     expect(bubble.firstElementChild).not.toHaveClass("w-fit");
   });

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3950,7 +3950,7 @@ function AssistantBubble({
         data-testid="message-bubble"
         data-role="assistant"
         className={
-          spansFullColumn ? "max-w-full" : "max-w-3xl min-[2561px]:max-w-[clamp(56rem,28vw,64rem)]"
+          spansFullColumn ? "max-w-full" : "max-w-3xl min-[2561px]:max-w-[clamp(56rem,30vw,64rem)]"
         }
       >
         {/* A fold-only bubble takes w-full at the ordinary max-w-3xl cap


### PR DESCRIPTION
## Related issue

Follow-up to #5502.

## Summary

- Increase the ultra-wide ordinary-prose target from `28vw` to `30vw`.
- Keep the existing 896px minimum and 1024px maximum, so narrower layouts and 4K remain unchanged.

This makes prose use more of the widened chat frame at intermediate ultra-wide resolutions. At the reported ~3329px CSS viewport, prose grows from about 932px to 999px; at 3440px it reaches the still-readable 1024px ceiling.

## Test Plan

- `pnpm --dir web exec vitest run src/pages/ChatPage.indicators.test.tsx`
- `uv run pytest tests/e2e_ui/chat/test_chat_responsive_width.py -q`
- `pre-commit run --all-files`

The Playwright matrix includes a 3200px viewport where `30vw` resolves to 960px, explicitly exercising the fluid value below the 1024px ceiling.

## Demo

Rendered geometry in CSS pixels:

| Viewport | Chat frame | Prose before | Prose after |
| ---: | ---: | ---: | ---: |
| 3200px | 1280px | 896px | 960px |
| ~3329px | ~1332px | ~932px | ~999px |
| 3440px | 1376px | 963.2px | 1024px |
| 4096px | 1600px | 1024px | 1024px |

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test pins the responsive class, and Playwright measures real prose geometry at 1920px, 2400px, 3200px, and 4096px while ensuring wide tables still span the inner chat frame.

## Changelog

Assistant prose uses more available space on ultra-wide displays.
