### PR TITLE
fix(web): de-translucent dark-mode dropdowns in project settings

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -468,6 +468,7 @@ aside[aria-label="Workspace"][data-maximized] {
 
 /* Popovers/menus — same glass treatment */
 .dark [data-slot="popover-content"],
+.dark [data-slot="select-content"],
 .dark [role="menu"],
 .dark [data-radix-popper-content-wrapper] > * {
   /* -webkit- before unprefixed — see comment on the bg-card rule above. */

--- a/web/src/shell/ProjectSettingsDialog.tsx
+++ b/web/src/shell/ProjectSettingsDialog.tsx
@@ -339,7 +339,7 @@ export function ProjectSettingsDialog({
                       className="fixed inset-0 z-10 cursor-default"
                       onClick={() => setWorkspaceOpen(false)}
                     />
-                    <div className="absolute top-full right-0 left-0 z-20 mt-1 rounded-[12px] border border-border bg-popover p-2 shadow-menu [&>[data-testid=workspace-picker]]:border-0">
+                    <div className="absolute top-full right-0 left-0 z-20 mt-1 rounded-[12px] border border-border bg-popover p-2 shadow-menu dark:border-white/10 dark:backdrop-blur-xl dark:backdrop-saturate-150 [&>[data-testid=workspace-picker]]:border-0">
                       <WorkspacePicker
                         hostId={browsableHostId}
                         initialPath={isNavigablePath(workspace) ? workspace : undefined}


### PR DESCRIPTION
## Related issue

<!-- Refactor / chore-adjacent UI fix; no tracking issue. -->

Closes https://linear.app/omnigent/issue/OMNI-5587/file-dropdown-shouldnt-be-translucent

## Summary

In dark mode, two dropdowns in the Project Settings modal rendered with the translucent `--popover` background (`rgba(26,33,41,0.8)`) but **without** the compensating backdrop blur, so their contents were hard to read:

- **Host** ("Where new sessions run by default") — a Radix `Select` (item-aligned) whose content carries `data-slot="select-content"`.
- **Working directory** ("Browse the host or type a path") — a plain `<div>` overlay anchored to its trigger.

The shared dark "glass" rule in `index.css` only matched `[data-slot="popover-content"]`, `[role="menu"]`, and Radix popper wrappers — so neither dropdown got the `backdrop-filter: blur(24px) saturate(150%)` that makes the frosted menus (e.g. the Agent / harness picker, a `DropdownMenu` → `role="menu"`) readable.

Fix:
- Add `[data-slot="select-content"]` to the shared `.dark` glass rule — repairs the Host dropdown **and every other Radix `Select`** in the app in one line.
- Apply the same blur utilities (`dark:backdrop-blur-xl dark:backdrop-saturate-150 dark:border-white/10`) directly to the workspace dropdown `<div>`, which has no matching slot.

The generated `themePalettes.generated.css` was intentionally left untouched — `--popover` is a shared token and the translucency + blur is a deliberate app-wide glass treatment; the gap was in the selector coverage, not the token.

## Test Plan

Manual, in dark mode, in the Project Settings modal:

1. Open **Host** dropdown ("Where new sessions run by default") → contents now render over frosted glass and are readable.
2. Open **Working directory** dropdown ("Browse the host or type a path") → same frosted-glass treatment, matching the Agent dropdown.
3. Toggle to light mode → both unchanged (fixes are `dark:` / `.dark`-scoped).

`npx tsc --noEmit` clean; `web-prettier` pre-commit hook passes on both files.

## Demo

<!-- TODO: attach a before/after screenshot of the dark-mode dropdowns. -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

CSS-class-only change with no logic; verified manually in dark mode that both dropdowns now render the frosted-glass blur and remain readable, and that light mode is unchanged. No unit test added — the behavior is purely visual (backdrop-filter compositing) and not meaningfully assertable in jsdom.

## Changelog

[UI] Dark-mode Host and working-directory dropdowns in project settings are no longer translucent and hard to read