### PR TITLE
perf(e2e-ui): shorten long UI timers in slow tests

### DIFF
--- a/tests/e2e_ui/chat/test_stale_stream.py
+++ b/tests/e2e_ui/chat/test_stale_stream.py
@@ -25,7 +25,13 @@ import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
-from tests.e2e_ui.conftest import _server_state, configure_mock_llm
+from tests.e2e_ui.conftest import _server_state, configure_mock_llm, test_timer_init_script
+
+# Shorten the client's 45 s SSE stall guard so the self-heal assertion does not
+# sit idle waiting it out. 5 s is well clear of the 3 s heartbeat cadence (so a
+# healthy stream never trips it) yet proves the same recover-from-byte-silence
+# behaviour the production window does.
+_STALL_GUARD_MS = 5_000
 
 
 def _find_runner_pids() -> list[int]:
@@ -173,6 +179,7 @@ def test_silent_stream_stall_self_heals(
         lambda msg: stall_warnings.append(msg.text) if "no stream bytes" in msg.text else None,
     )
 
+    page.add_init_script(test_timer_init_script(sseStallMs=_STALL_GUARD_MS))
     page.goto(f"{live_server}/c/{session_id}")
     expect(page.get_by_placeholder("Ask the agent anything…")).to_be_visible()
     for _ in range(100):
@@ -186,19 +193,19 @@ def test_silent_stream_stall_self_heals(
     server_pid = int(_server_state["pid"])
     os.kill(server_pid, signal.SIGSTOP)
     try:
-        # The stall guard trips after 45 s of silence; poll to 70 s.
-        # wait_for_timeout (not time.sleep) keeps dispatching this
-        # page's console/request callbacks while we wait.
-        for _ in range(700):
+        # The stall guard trips after _STALL_GUARD_MS of silence; poll to a
+        # generous multiple of that. wait_for_timeout (not time.sleep) keeps
+        # dispatching this page's console/request callbacks while we wait.
+        for _ in range(int(_STALL_GUARD_MS / 100) + 150):
             if stall_warnings:
                 break
             page.wait_for_timeout(100)
     finally:
         os.kill(server_pid, signal.SIGCONT)
     assert stall_warnings, (
-        "the client never declared the byte-silent stream dead within 70s -- "
-        "without the stall guard it blocks in reader.read() forever and the "
-        "transcript freezes until a manual reload"
+        "the client never declared the byte-silent stream dead -- without the "
+        "stall guard it blocks in reader.read() forever and the transcript "
+        "freezes until a manual reload"
     )
 
     # The recycle issues a fresh /stream open (it may have been pending

--- a/tests/e2e_ui/collaboration/test_collab_realtime.py
+++ b/tests/e2e_ui/collaboration/test_collab_realtime.py
@@ -35,6 +35,13 @@ import uuid
 import httpx
 from playwright.sync_api import Browser, expect
 
+from tests.e2e_ui.conftest import test_timer_init_script
+
+# Shorten the SPA's 30 s hidden-tab debounce so the idle-greying assertion does
+# not wait it out. 3 s still proves the debounce (a visible tab never greys)
+# without the full production dwell.
+_PRESENCE_IDLE_MS = 3_000
+
 
 def test_two_browser_contexts_sync_message_realtime(
     browser: Browser,
@@ -248,6 +255,8 @@ def test_presence_idle_greys_backgrounded_viewer(
 
     alice_ctx = browser.new_context(extra_http_headers={"X-Forwarded-Email": alice_email})
     bob_ctx = browser.new_context(extra_http_headers={"X-Forwarded-Email": bob_email})
+    # Only Bob's tab goes idle, so only his SPA needs the shortened debounce.
+    bob_ctx.add_init_script(test_timer_init_script(presenceIdleMs=_PRESENCE_IDLE_MS))
     try:
         alice = alice_ctx.new_page()
         bob = bob_ctx.new_page()
@@ -272,12 +281,12 @@ def test_presence_idle_greys_backgrounded_viewer(
             "}"
         )
 
-        # The grey lands only after the SPA's 30s hidden-debounce plus
-        # the reconnect/broadcast round trip — 60s bounds that without
-        # masking a stall. (An instant grey would ALSO be a bug — it
-        # would mean alt-tabs flicker — but that direction is pinned by
-        # the tracker unit tests, not re-asserted here.)
-        expect(bob_circle).to_have_class(re.compile(r"opacity-40"), timeout=60_000)
+        # The grey lands only after the SPA's hidden-debounce
+        # (_PRESENCE_IDLE_MS here) plus the reconnect/broadcast round trip;
+        # 15s bounds that without masking a stall. (An instant grey would ALSO
+        # be a bug — it would mean alt-tabs flicker — but that direction is
+        # pinned by the tracker unit tests, not re-asserted here.)
+        expect(bob_circle).to_have_class(re.compile(r"opacity-40"), timeout=15_000)
 
         # Restore visibility: un-greying skips the debounce, so it must
         # land within one reconnect round trip.

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -96,6 +96,26 @@ def fetch_with_retry(route: Route, *, attempts: int = 3) -> APIResponse:
     return route.fetch()
 
 
+def test_timer_init_script(**overrides_ms: int) -> str:
+    """Build an init script that shortens long UI timers for a test.
+
+    The SPA reads ``window.__omniTestTimers`` once at module load (see
+    ``web/src/lib/testTimers.ts``); setting it via ``page.add_init_script``
+    before ``goto`` lets a test trade a real wall-clock wait for a short one
+    without weakening the assertion (a 3 s stall guard proves the same
+    self-heal a 45 s one does). Keys mirror ``TestTimerOverrides``:
+    ``sseStallMs``, ``presenceIdleMs``, ``idleNotificationSettleMs``.
+
+    :param overrides_ms: Timer key → milliseconds. Only the passed keys are
+        set; every other timer keeps its production default.
+    :returns: A JS snippet for ``page.add_init_script`` /
+        ``context.add_init_script``.
+    """
+    import json as _json
+
+    return f"window.__omniTestTimers = {_json.dumps(overrides_ms)};"
+
+
 def open_right_rail(page: Page) -> None:
     """Expand the right "Workspace" rail if it is collapsed.
 

--- a/tests/e2e_ui/sessions/test_idle_notifications.py
+++ b/tests/e2e_ui/sessions/test_idle_notifications.py
@@ -35,6 +35,15 @@ from __future__ import annotations
 
 from playwright.sync_api import Page, expect
 
+from tests.e2e_ui.conftest import test_timer_init_script
+
+# Shorten the SPA's 10 s idle-notification settle window so these tests do not
+# wait it out before the cue fires. 5 s still proves the deferral: it stays
+# comfortably above the 3 s "not fired yet" probe in
+# test_idle_notification_deferred_until_settle (so that assertion holds) while
+# cutting the wait for the notification to land.
+_IDLE_SETTLE_MS = 5_000
+
 # Records constructed notifications and makes visibility/focus controllable
 # from the test via window.__hidden. Runs before any app script on every
 # navigation (add_init_script), so the SPA's feature detection and
@@ -146,7 +155,7 @@ Object.defineProperty(document, "hidden", {
   get() { return window.__hidden; },
 });
 document.hasFocus = function () { return !window.__hidden; };
-"""
+""" + test_timer_init_script(idleNotificationSettleMs=_IDLE_SETTLE_MS)
 
 # Kept deliberately tiny: these tests only need a real ``running`` ->
 # ``idle`` turn to observe, not a long generation. A short reply still

--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -98,7 +98,7 @@
       }
     },
     {
-      "files": ["src/lib/identity.ts", "src/lib/sessionHost.ts"],
+      "files": ["src/lib/identity.ts", "src/lib/sessionHost.ts", "src/lib/testTimers.ts"],
       "rules": {
         "no-underscore-dangle": "off"
       }

--- a/web/src/hooks/useIdleNotifications.ts
+++ b/web/src/hooks/useIdleNotifications.ts
@@ -51,6 +51,7 @@ import {
   setBadgeCount,
 } from "@/lib/nativeBridge";
 import { fetchLastAssistantText } from "@/lib/lastAssistantText";
+import { resolveTestTimer } from "@/lib/testTimers";
 import {
   buildElicitationMap,
   buildStatusMap,
@@ -69,7 +70,7 @@ const ELICITATION_BODY = "Agent is asking for your input.";
 // "actually done" and notified — long enough that an imminent next step (the
 // agent resuming to `running`) cancels the cue, so step-by-step agents don't
 // fire a notification per step.
-const IDLE_SETTLE_MS = 10_000;
+const IDLE_SETTLE_MS = resolveTestTimer("idleNotificationSettleMs", 10_000);
 
 /**
  * Attach a one-shot listener that requests notification permission on the

--- a/web/src/lib/presenceIdle.ts
+++ b/web/src/lib/presenceIdle.ts
@@ -6,10 +6,12 @@
 // the same abort-and-reopen the client already performs on the
 // ingress' ~5-min stream recycle. See `designs/UI/PRESENCE.md`.
 
+import { resolveTestTimer } from "./testTimers";
+
 /** Hidden-tab dwell before this tab reports itself idle. Long enough
  * that alt-tabbing to copy something never reaches the wire; short
  * enough that co-viewers' headers stay honest. */
-export const PRESENCE_IDLE_AFTER_MS = 30_000;
+export const PRESENCE_IDLE_AFTER_MS = resolveTestTimer("presenceIdleMs", 30_000);
 
 export interface PresenceIdleTracker {
   /**

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -70,6 +70,7 @@ import type {
 } from "./events";
 import { NATIVE_TOOL_TYPES } from "./events";
 import { routingExtrasFromWire } from "./routingDecision";
+import { resolveTestTimer } from "./testTimers";
 import type { BackgroundTaskInfo, ErrorInfo, ModelUsage, RememberScope, Response } from "./types";
 
 /**
@@ -88,7 +89,7 @@ export interface SseStreamResult {
 // a close) `reader.read()` blocks forever and the transcript silently
 // freezes. Three missed heartbeats in a row trip the guard; one late
 // heartbeat doesn't.
-export const SSE_STALL_TIMEOUT_MS = 45_000;
+export const SSE_STALL_TIMEOUT_MS = resolveTestTimer("sseStallMs", 45_000);
 
 /**
  * Wrap an SSE byte stream with a silence watchdog.

--- a/web/src/lib/testTimers.ts
+++ b/web/src/lib/testTimers.ts
@@ -1,0 +1,45 @@
+/**
+ * Test-only overrides for long UI timing constants.
+ *
+ * A handful of timers (the SSE stall guard, the presence-idle debounce, the
+ * idle-notification settle window) are tens of seconds long by design, so the
+ * e2e tests that assert their behaviour otherwise sit idle waiting them out. A
+ * Playwright test can shorten a timer by setting `window.__omniTestTimers`
+ * (via `add_init_script`, which runs before the bundle evaluates) — the value
+ * is read once at module init and each constant falls back to its production
+ * default when the global is absent.
+ *
+ * This is inert in production: nothing sets the global, so every timer resolves
+ * to its default. It is deliberately NOT wired to server config or `/v1/info`
+ * — it exists only to let tests trade a real wall-clock wait for a short one
+ * without weakening the assertion (a 3 s stall guard proves the same
+ * self-heal a 45 s one does).
+ */
+
+/** Timer keys a test may override. Values are milliseconds. */
+export interface TestTimerOverrides {
+  sseStallMs?: number;
+  presenceIdleMs?: number;
+  idleNotificationSettleMs?: number;
+}
+
+declare global {
+  interface Window {
+    __omniTestTimers?: TestTimerOverrides;
+  }
+}
+
+/**
+ * Resolve a timing constant, honouring a test override when present.
+ *
+ * @param key The override key a test would set on `window.__omniTestTimers`.
+ * @param defaultMs The production value used whenever no override is set.
+ * @returns The override (a finite, positive number) or `defaultMs`.
+ */
+export function resolveTestTimer(key: keyof TestTimerOverrides, defaultMs: number): number {
+  if (typeof window === "undefined") return defaultMs;
+  const override = window.__omniTestTimers?.[key];
+  return typeof override === "number" && Number.isFinite(override) && override > 0
+    ? override
+    : defaultMs;
+}


### PR DESCRIPTION
## Related issue

N/A — Test / CI performance change, no issue required.

## Summary

The slowest e2e_ui tests spend most of their wall-clock **waiting out client-side timing constants**, not doing work. The `--durations` data (from #5518) showed the worst offenders are timer-bound:

- `test_silent_stream_stall_self_heals` — 49s (45s SSE stall guard)
- `test_presence_idle_greys_backgrounded_viewer` — 33s (30s presence hidden-tab debounce)
- `test_idle_notification_*` (×4) — 14–18s each (10s idle-notification settle)

This adds a **test-only override seam** so those timers can be shortened without weakening the assertions:

- New `web/src/lib/testTimers.ts` reads `window.__omniTestTimers` (set by Playwright `add_init_script` before the bundle evaluates); each constant falls back to its production default when the global is absent. **Inert in production** — nothing sets the global, and it is deliberately *not* wired to server config / `/v1/info`.
- `sse.ts`, `presenceIdle.ts`, and `useIdleNotifications.ts` resolve their constants through it.
- Tests inject a short value via a new `test_timer_init_script` conftest helper.

Assertions stay valid: a 5s stall guard proves the same self-heal a 45s one does; the idle settle (5s) stays above the deferral test's 3s "not fired yet" probe so it still proves deferral.

## Test Plan

Measured locally (built SPA + `--ui-skip-build`):
- `test_presence_idle_greys_backgrounded_viewer`: **PASSES, 33s → 5s** call time — clean end-to-end proof the override reaches the SPA.
- `test_silent_stream_stall_self_heals`: call time **49s → ~21s**.
- `test_idle_notification_suppressed_when_foreground`: passes.

Two LLM-pipeline-dependent tests (`test_silent_stream_stall_self_heals`'s final recovery turn and `test_idle_notification_deferred_until_settle`) fail **identically on unmodified `main`** in my local sandbox — a pre-existing local-env issue with the real-LLM path, not caused by this change. This PR's CI (mock LLM) is the real validation for those.

- `npx tsc -b`, web oxlint, prettier, and ruff all pass.
- The 3 pre-existing `NewChatDialog.test.tsx` unit failures are unrelated (they fail on `main` too; this PR touches none of that code).

## Demo

N/A — no visual change; production behaviour is unchanged (timers keep their defaults).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change modifies how existing e2e_ui tests wait, plus a small production-inert config seam. Verified by running the affected tests locally against a built SPA (timings above) and by confirming the seam is a no-op without the injected global (production constants unchanged). No new product behaviour to add unit coverage for; the SPA modules keep their existing defaults and type check.

This pull request and its description were written by Isaac.