### PR TITLE
ci(e2e_ui): raise E2E UI Tests job timeout 20m -> 25m

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -148,7 +148,7 @@ jobs:
     # `ready_for_review` re-fires when a draft is converted.
     needs: [setup, build-sidecar]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       # One red shard shouldn't cancel siblings -- we want every shard's signal.
       fail-fast: false


### PR DESCRIPTION
## Related issue

<!-- Test / CI change — no issue required. -->

N/A — Test / CI change.

## Summary

- The `E2E UI Tests` job in `.github/workflows/e2e-ui.yml` was capped at `timeout-minutes: 20`, and the sharded suite was bumping that cap and getting killed mid-run.
- Raise the job timeout to `25` minutes to give the shards enough headroom to finish.

## Test Plan

- Config-only change to a GitHub Actions workflow. Verified the edit is the single `E2E UI Tests` job cap (`grep -n "timeout-minutes" .github/workflows/e2e-ui.yml` → line 151 now reads `25`).
- The change takes effect when this workflow runs; the `E2E UI Tests` job in this PR's CI will show the 25-minute cap.

## Demo

N/A — no UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

CI workflow configuration change (a job timeout value). There is no code path to
unit/integration test; the new cap is exercised the next time the `E2E UI Tests`
job runs.
