### PR TITLE
Fix project settings preserving emoji icon

### DIFF
--- a/tests/e2e_ui/sessions/test_project_settings_dialog.py
+++ b/tests/e2e_ui/sessions/test_project_settings_dialog.py
@@ -50,10 +50,9 @@ def _get_project_config(base_url: str, project_id: str) -> dict:
 
 def _open_project_settings(page: Page, project: str) -> None:
     """Open the folder kebab → "Project settings" for *project*."""
-    header = page.get_by_role("button", name=project, exact=True)
-    expect(header).to_be_visible()
-    header.hover()
-    page.get_by_role("button", name=f"Project actions for {project}").click()
+    actions = page.get_by_role("button", name=f"Project actions for {project}", exact=True)
+    expect(actions).to_be_visible()
+    actions.click()
     page.get_by_test_id("project-settings").click()
     # The dialog's Save button confirms the editor mounted + the config fetch
     # settled (Save is disabled while loading).

--- a/tests/e2e_ui/sessions/test_project_settings_dialog.py
+++ b/tests/e2e_ui/sessions/test_project_settings_dialog.py
@@ -41,6 +41,13 @@ def _set_project_config(base_url: str, project_id: str, config: dict) -> None:
     resp.raise_for_status()
 
 
+def _get_project_config(base_url: str, project_id: str) -> dict:
+    """Read a project's stored config via ``GET /v1/projects/{id}``."""
+    resp = httpx.get(f"{base_url}/v1/projects/{project_id}", timeout=10.0)
+    resp.raise_for_status()
+    return resp.json()["config"]
+
+
 def _open_project_settings(page: Page, project: str) -> None:
     """Open the folder kebab → "Project settings" for *project*."""
     header = page.get_by_role("button", name=project, exact=True)
@@ -122,6 +129,28 @@ def test_project_settings_clears_worktree_toggle(
     expect(page.get_by_test_id("project-settings-worktree")).to_have_attribute(
         "data-state", "unchecked"
     )
+
+
+def test_project_settings_preserves_icon_on_save(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Saving settings preserves config keys owned by other project dialogs."""
+    base_url, session_id = seeded_session
+    project = f"Project {uuid.uuid4().hex[:6]}"
+    project_id = _create_project(base_url, project)
+    _set_project_config(base_url, project_id, {"icon": "🔥", "use_worktree": True})
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    _open_project_settings(page, project)
+    expect(page.get_by_test_id("project-settings-worktree")).to_have_attribute(
+        "data-state", "checked"
+    )
+    page.get_by_test_id("project-settings-save").click()
+    expect(page.get_by_test_id("project-settings-save")).to_have_count(0)
+
+    assert _get_project_config(base_url, project_id) == {"icon": "🔥", "use_worktree": True}
 
 
 def test_project_settings_base_branch_persists(

--- a/web/src/shell/ProjectSettingsDialog.test.tsx
+++ b/web/src/shell/ProjectSettingsDialog.test.tsx
@@ -117,6 +117,27 @@ describe("ProjectSettingsDialog", () => {
     expect(updateMock).toHaveBeenCalledWith("p_1", { use_worktree: true });
   });
 
+  it("preserves the project icon when saving settings", async () => {
+    getProjectMock.mockResolvedValue({
+      id: "p_1",
+      name: "Work",
+      config: { icon: "🔥", use_worktree: true },
+    });
+    renderDialog();
+    await waitFor(() =>
+      expect(screen.getByTestId("project-settings-worktree")).toHaveAttribute(
+        "data-state",
+        "checked",
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("project-settings-save"));
+
+    await waitFor(() =>
+      expect(updateMock).toHaveBeenCalledWith("p_1", { icon: "🔥", use_worktree: true }),
+    );
+  });
+
   it("stores nothing for the worktree toggle when left at its default (OFF)", async () => {
     getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
     renderDialog();

--- a/web/src/shell/ProjectSettingsDialog.tsx
+++ b/web/src/shell/ProjectSettingsDialog.tsx
@@ -184,27 +184,31 @@ export function ProjectSettingsDialog({
     // Guard against submitting a blank draft seeded from a failed load, which
     // the server would read as "clear the stored defaults".
     if (loadFailed) return;
-    // Build the config from set fields only — an unset slot is an absent key,
-    // so the whole object is `{}` when nothing is configured (the server treats
-    // that as "clear the stored defaults").
-    const config: ProjectConfig = {};
+    // Preserve config keys owned by other dialogs, then replace only the fields
+    // this form edits.
+    const config: ProjectConfig = { ...(stored ?? {}) };
     if (hostId !== NONE) config.host_id = hostId;
+    else delete config.host_id;
     // A workspace is host-relative and only meaningful with a concrete host —
     // don't persist a stale path from a since-cleared host, and drop it for the
     // sandbox (a sandbox create provisions its own workspace and ignores this).
     const ws =
       hostId !== NONE && hostId !== SANDBOX_HOST_CHOICE ? trimOrUndef(workspace) : undefined;
     if (ws) config.workspace = ws;
+    else delete config.workspace;
     if (agentId) config.agent_id = agentId;
+    else delete config.agent_id;
     // Store the worktree choice only when it overrides the user-global default;
     // while it matches, leave the key unset so the project keeps inheriting
     // (and an all-default dialog still clears to {}).
     if (useWorktree !== readAlwaysUseWorktree()) config.use_worktree = useWorktree;
+    else delete config.use_worktree;
     // A base branch only forks a worktree, so it's only meaningful when the
     // worktree default is on — drop it otherwise so it can't linger as a stale,
     // invisible default after the toggle is turned off.
     const base = useWorktree ? trimOrUndef(baseBranch) : undefined;
     if (base) config.base_branch = base;
+    else delete config.base_branch;
 
     updateConfig.mutate(
       { id: projectId, name: projectName, config },


### PR DESCRIPTION
## Related issue

Closes #5551

## Summary

- Preserve non-settings project config keys when saving from `ProjectSettingsDialog`.
- Replace or delete only the fields owned by the settings form, so `config.icon` survives a settings-only save.
- Add regression coverage for saving settings on a project that already has an emoji icon.

ELI5: the settings dialog now starts from the current project config instead of an empty config, then only edits its own fields.

```text
stored config { icon, settings }
        |
settings dialog save
        |
keep icon + rewrite settings-owned keys only
```

## Test Plan

- `pnpm --dir web exec vitest run src/shell/ProjectSettingsDialog.test.tsx` — 11 passed
- `pnpm --dir web exec prettier --check src/shell/ProjectSettingsDialog.tsx src/shell/ProjectSettingsDialog.test.tsx` — passed
- `pnpm --dir web exec oxlint --deny-warnings --report-unused-disable-directives src/shell/ProjectSettingsDialog.tsx src/shell/ProjectSettingsDialog.test.tsx` — passed
- `pnpm --dir web exec tsc -b` — passed

## Demo

The project below was created with `config.icon = "🌊"`. I opened Project settings, saved without changing the icon, and captured this state after the save. The sidebar still shows `🌊 Icon persistence demo`.

<img width="1920" height="963" alt="Project sidebar retaining the wave emoji after saving project settings" src="https://github.com/user-attachments/assets/f545d99a-7315-4af4-bfc4-a85e74e42208" />

A read-back through `GET /v1/projects/<id>` also still returned `{"config":{"icon":"🌊"}}`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Risk boundary: this only changes `ProjectSettingsDialog` config payload construction. Server PATCH replacement semantics are unchanged, and the icon picker flow is untouched.

## Changelog

Saving project settings no longer clears a project's emoji icon.