### PR TITLE
Show project emoji icons in Move session picker

### DIFF
--- a/web/src/shell/HeaderConversationMenu.test.tsx
+++ b/web/src/shell/HeaderConversationMenu.test.tsx
@@ -10,7 +10,11 @@ import { HeaderConversationMenu } from "./HeaderConversationMenu";
 
 const mocks = vi.hoisted(() => ({
   isMobile: false,
-  projects: [{ id: "project-1", name: "Sprint 42" }],
+  projects: [{ id: "project-1", name: "Sprint 42" }] as {
+    id: string | null;
+    name: string;
+    icon?: string | null;
+  }[],
   togglePinned: vi.fn(),
   rename: vi.fn(),
   moveToProject: vi.fn(),
@@ -194,6 +198,29 @@ describe("HeaderConversationMenu", () => {
     expect(screen.getByRole("textbox", { name: "Search projects" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("menuitem", { name: "Sprint 42" }));
     expect(mocks.moveToProject).toHaveBeenCalledWith({ id: "conv-1", project: "Sprint 42" });
+  });
+
+  it("shows decorative project icons and a folder fallback in the picker", () => {
+    mocks.isMobile = true;
+    mocks.projects = [
+      { id: "project-1", name: "Sprint 42", icon: "🚀" },
+      { id: null, name: "Legacy project" },
+    ];
+    renderMenu({ currentProject: "Sprint 42" });
+    openMenu();
+    fireEvent.click(screen.getByTestId("header-move-to-project"));
+
+    const iconRow = screen.getByRole("menuitem", { name: "Sprint 42" });
+    const emoji = iconRow.querySelector('span[aria-hidden="true"]');
+    expect(emoji).toHaveTextContent("🚀");
+    expect(emoji).toHaveClass("shrink-0", "text-[14px]", "leading-none");
+
+    const fallback = screen.getByRole("menuitem", { name: "Legacy project" }).querySelector("svg");
+    expect(fallback).toHaveClass("lucide-folder", "size-3.5", "shrink-0");
+    expect(fallback).toHaveAttribute("aria-hidden", "true");
+
+    const removeItem = screen.getByRole("menuitem", { name: "Remove from Sprint 42" });
+    expect(removeItem.querySelector('span[aria-hidden="true"]')).toHaveTextContent("🚀");
   });
 
   it("closes and resets Rename when the conversation id changes", async () => {

--- a/web/src/shell/HeaderConversationMenu.test.tsx
+++ b/web/src/shell/HeaderConversationMenu.test.tsx
@@ -200,7 +200,7 @@ describe("HeaderConversationMenu", () => {
     expect(mocks.moveToProject).toHaveBeenCalledWith({ id: "conv-1", project: "Sprint 42" });
   });
 
-  it("shows decorative project icons and a folder fallback in the picker", () => {
+  it("orders decorative project icons and a folder fallback before their names", () => {
     mocks.isMobile = true;
     mocks.projects = [
       { id: "project-1", name: "Sprint 42", icon: "🚀" },
@@ -211,16 +211,56 @@ describe("HeaderConversationMenu", () => {
     fireEvent.click(screen.getByTestId("header-move-to-project"));
 
     const iconRow = screen.getByRole("menuitem", { name: "Sprint 42" });
-    const emoji = iconRow.querySelector('span[aria-hidden="true"]');
+    const emoji = iconRow.firstElementChild;
+    expect(emoji).toHaveAttribute("data-testid", "project-icon");
+    expect(emoji).toHaveAttribute("aria-hidden", "true");
     expect(emoji).toHaveTextContent("🚀");
-    expect(emoji).toHaveClass("shrink-0", "text-[14px]", "leading-none");
+    expect(emoji?.nextElementSibling).toHaveTextContent("Sprint 42");
 
-    const fallback = screen.getByRole("menuitem", { name: "Legacy project" }).querySelector("svg");
-    expect(fallback).toHaveClass("lucide-folder", "size-3.5", "shrink-0");
+    const fallback = screen.getByRole("menuitem", { name: "Legacy project" }).firstElementChild;
+    expect(fallback?.tagName.toLowerCase()).toBe("svg");
     expect(fallback).toHaveAttribute("aria-hidden", "true");
+    expect(fallback?.nextElementSibling).toHaveTextContent("Legacy project");
 
     const removeItem = screen.getByRole("menuitem", { name: "Remove from Sprint 42" });
-    expect(removeItem.querySelector('span[aria-hidden="true"]')).toHaveTextContent("🚀");
+    expect(removeItem.firstElementChild).toHaveAttribute("data-testid", "project-icon");
+    expect(removeItem.firstElementChild).toHaveTextContent("🚀");
+  });
+
+  it("uses project names and the Remove label for desktop picker typeahead", async () => {
+    mocks.projects = [
+      { id: null, name: "Alpha" },
+      { id: "project-1", name: "Sprint 42", icon: "🚀" },
+    ];
+    const view = renderMenu({ currentProject: "Sprint 42" });
+    openMenu();
+    const moveTrigger = screen.getByTestId("header-move-to-project");
+    moveTrigger.focus();
+    fireEvent.keyDown(moveTrigger, { key: "ArrowRight" });
+
+    const alphaRow = await screen.findByRole("menuitem", { name: "Alpha" });
+    const sprintRow = screen.getByRole("menuitem", { name: "Sprint 42" });
+    expect(alphaRow.firstElementChild?.tagName.toLowerCase()).toBe("svg");
+    expect(alphaRow.firstElementChild).toHaveAttribute("aria-hidden", "true");
+    expect(alphaRow.firstElementChild?.nextElementSibling).toHaveTextContent("Alpha");
+    expect(sprintRow.firstElementChild).toHaveAttribute("data-testid", "project-icon");
+    expect(sprintRow.firstElementChild?.nextElementSibling).toHaveTextContent("Sprint 42");
+    await waitFor(() => expect(alphaRow).toHaveFocus());
+    fireEvent.keyDown(alphaRow, { key: "s" });
+    await waitFor(() => expect(sprintRow).toHaveFocus());
+
+    view.unmount();
+    renderMenu({ currentProject: "Sprint 42" });
+    openMenu();
+    const freshMoveTrigger = screen.getByTestId("header-move-to-project");
+    freshMoveTrigger.focus();
+    fireEvent.keyDown(freshMoveTrigger, { key: "ArrowRight" });
+
+    const freshAlphaRow = await screen.findByRole("menuitem", { name: "Alpha" });
+    const removeItem = screen.getByRole("menuitem", { name: "Remove from Sprint 42" });
+    await waitFor(() => expect(freshAlphaRow).toHaveFocus());
+    fireEvent.keyDown(freshAlphaRow, { key: "r" });
+    await waitFor(() => expect(removeItem).toHaveFocus());
   });
 
   it("closes and resets Rename when the conversation id changes", async () => {

--- a/web/src/shell/HeaderConversationMenu.tsx
+++ b/web/src/shell/HeaderConversationMenu.tsx
@@ -11,6 +11,7 @@ import {
   CheckIcon,
   ChevronLeftIcon,
   EllipsisIcon,
+  FolderIcon,
   FolderInputIcon,
   GitBranchIcon,
   InfoIcon,
@@ -101,6 +102,7 @@ function ProjectPicker({
   const filtered = search
     ? projects.filter((project) => project.name.toLowerCase().includes(search.toLowerCase()))
     : projects;
+  const currentProjectIcon = projects.find((project) => project.name === currentProject)?.icon;
 
   return (
     <>
@@ -122,6 +124,13 @@ function ProjectPicker({
             className="px-2 py-1"
             onSelect={() => onSelect(project.name)}
           >
+            {project.icon ? (
+              <span aria-hidden="true" className="shrink-0 text-[14px] leading-none">
+                {project.icon}
+              </span>
+            ) : (
+              <FolderIcon aria-hidden="true" className="size-3.5 shrink-0 text-muted-foreground" />
+            )}
             <span className="flex-1 truncate text-left">{project.name}</span>
             {currentProject === project.name && (
               <CheckIcon className="size-3.5 shrink-0 text-primary" />
@@ -135,6 +144,13 @@ function ProjectPicker({
       {currentProject && (
         <div className="border-t pt-1">
           <DropdownMenuItem className="px-2 py-1" onSelect={() => onSelect("")}>
+            {currentProjectIcon ? (
+              <span aria-hidden="true" className="shrink-0 text-[14px] leading-none">
+                {currentProjectIcon}
+              </span>
+            ) : (
+              <FolderIcon aria-hidden="true" className="size-3.5 shrink-0 text-muted-foreground" />
+            )}
             Remove from{" "}
             <span className="rounded bg-muted px-1 py-0.5 font-mono text-[0.95em]">
               {currentProject}

--- a/web/src/shell/HeaderConversationMenu.tsx
+++ b/web/src/shell/HeaderConversationMenu.tsx
@@ -122,10 +122,15 @@ function ProjectPicker({
           <DropdownMenuItem
             key={project.name}
             className="px-2 py-1"
+            textValue={project.name}
             onSelect={() => onSelect(project.name)}
           >
             {project.icon ? (
-              <span aria-hidden="true" className="shrink-0 text-[14px] leading-none">
+              <span
+                aria-hidden="true"
+                className="shrink-0 text-[14px] leading-none"
+                data-testid="project-icon"
+              >
                 {project.icon}
               </span>
             ) : (
@@ -143,9 +148,17 @@ function ProjectPicker({
       </div>
       {currentProject && (
         <div className="border-t pt-1">
-          <DropdownMenuItem className="px-2 py-1" onSelect={() => onSelect("")}>
+          <DropdownMenuItem
+            className="px-2 py-1"
+            textValue={`Remove from ${currentProject}`}
+            onSelect={() => onSelect("")}
+          >
             {currentProjectIcon ? (
-              <span aria-hidden="true" className="shrink-0 text-[14px] leading-none">
+              <span
+                aria-hidden="true"
+                className="shrink-0 text-[14px] leading-none"
+                data-testid="project-icon"
+              >
                 {currentProjectIcon}
               </span>
             ) : (

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -52,6 +52,7 @@ const mocks = vi.hoisted(() => {
     // Projects surfaced by the picker + the move-to-project mutation, so the
     // mobile in-place project view test can assert both the list and the pick.
     projects: [] as string[],
+    projectIcons: {} as Record<string, string | null | undefined>,
     moveToProject: { mutate: vi.fn() },
     leave: { mutate: vi.fn(), isPending: false },
     // The signed-in viewer. Rows with no `owner` read as owned by them; a row
@@ -106,7 +107,13 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkMoveToProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => ({ mutate: vi.fn() }),
-  useProjects: () => ({ data: mocks.projects.map((name: string) => ({ id: `p_${name}`, name })) }),
+  useProjects: () => ({
+    data: mocks.projects.map((name: string) => ({
+      id: `p_${name}`,
+      name,
+      icon: mocks.projectIcons[name],
+    })),
+  }),
   // A non-empty `useProjects` renders a project folder, which queries its
   // sessions — return the collapsed (disabled) shape so the folder is inert
   // (this suite keeps its test row unfiled; the picker only needs the name).
@@ -257,6 +264,7 @@ beforeEach(() => {
   mocks.moveToProject.mutate.mockReset();
   mocks.leave.mutate.mockReset();
   mocks.projects = [];
+  mocks.projectIcons = {};
   // Default every test to the desktop viewport; the mobile flyout test opts in.
   mocks.isMobile = false;
   useConvMock.mockReset();
@@ -874,6 +882,30 @@ describe("mobile in-place project picker", () => {
       id: "conv_1",
       project: "Sprint 42",
     });
+  });
+
+  it("shows decorative project icons and a folder fallback in the picker", () => {
+    mocks.isMobile = true;
+    mocks.projects = ["Sprint 42", "Legacy project"];
+    mocks.projectIcons = { "Sprint 42": "🚀" };
+    mockConversations([{ ...CONV, labels: { omni_project: "Sprint 42" } }]);
+    mocks.pinnedStore.set([CONV.id]);
+    renderSidebar();
+
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+    fireEvent.click(screen.getByTestId("move-to-project"));
+
+    const iconRow = screen.getByRole("menuitem", { name: "Sprint 42" });
+    const emoji = iconRow.querySelector('span[aria-hidden="true"]');
+    expect(emoji).toHaveTextContent("🚀");
+    expect(emoji).toHaveClass("shrink-0", "text-[14px]", "leading-none");
+
+    const fallback = screen.getByRole("menuitem", { name: "Legacy project" }).querySelector("svg");
+    expect(fallback).toHaveClass("lucide-folder", "size-3.5", "shrink-0");
+    expect(fallback).toHaveAttribute("aria-hidden", "true");
+
+    const removeItem = screen.getByRole("menuitem", { name: "Remove from Sprint 42" });
+    expect(removeItem.querySelector('span[aria-hidden="true"]')).toHaveTextContent("🚀");
   });
 
   it("keeps the desktop side-flyout submenu (no in-place swap)", () => {

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -8,7 +8,7 @@
 
 import { useSyncExternalStore } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -884,7 +884,7 @@ describe("mobile in-place project picker", () => {
     });
   });
 
-  it("shows decorative project icons and a folder fallback in the picker", () => {
+  it("orders decorative project icons and a folder fallback before their names", () => {
     mocks.isMobile = true;
     mocks.projects = ["Sprint 42", "Legacy project"];
     mocks.projectIcons = { "Sprint 42": "🚀" };
@@ -896,16 +896,57 @@ describe("mobile in-place project picker", () => {
     fireEvent.click(screen.getByTestId("move-to-project"));
 
     const iconRow = screen.getByRole("menuitem", { name: "Sprint 42" });
-    const emoji = iconRow.querySelector('span[aria-hidden="true"]');
+    const emoji = iconRow.firstElementChild;
+    expect(emoji).toHaveAttribute("data-testid", "project-icon");
+    expect(emoji).toHaveAttribute("aria-hidden", "true");
     expect(emoji).toHaveTextContent("🚀");
-    expect(emoji).toHaveClass("shrink-0", "text-[14px]", "leading-none");
+    expect(emoji?.nextElementSibling).toHaveTextContent("Sprint 42");
 
-    const fallback = screen.getByRole("menuitem", { name: "Legacy project" }).querySelector("svg");
-    expect(fallback).toHaveClass("lucide-folder", "size-3.5", "shrink-0");
+    const fallback = screen.getByRole("menuitem", { name: "Legacy project" }).firstElementChild;
+    expect(fallback?.tagName.toLowerCase()).toBe("svg");
     expect(fallback).toHaveAttribute("aria-hidden", "true");
+    expect(fallback?.nextElementSibling).toHaveTextContent("Legacy project");
 
     const removeItem = screen.getByRole("menuitem", { name: "Remove from Sprint 42" });
-    expect(removeItem.querySelector('span[aria-hidden="true"]')).toHaveTextContent("🚀");
+    expect(removeItem.firstElementChild).toHaveAttribute("data-testid", "project-icon");
+    expect(removeItem.firstElementChild).toHaveTextContent("🚀");
+  });
+
+  it("uses project names and the Remove label for desktop picker typeahead", async () => {
+    mocks.projects = ["Alpha", "Sprint 42"];
+    mocks.projectIcons = { "Sprint 42": "🚀" };
+    mockConversations([{ ...CONV, labels: { omni_project: "Sprint 42" } }]);
+    mocks.pinnedStore.set([CONV.id]);
+    const view = renderSidebar();
+
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+    const moveTrigger = screen.getByTestId("move-to-project");
+    moveTrigger.focus();
+    fireEvent.keyDown(moveTrigger, { key: "ArrowRight" });
+
+    const alphaRow = await screen.findByRole("menuitem", { name: "Alpha" });
+    const sprintRow = screen.getByRole("menuitem", { name: "Sprint 42" });
+    expect(alphaRow.firstElementChild?.tagName.toLowerCase()).toBe("svg");
+    expect(alphaRow.firstElementChild).toHaveAttribute("aria-hidden", "true");
+    expect(alphaRow.firstElementChild?.nextElementSibling).toHaveTextContent("Alpha");
+    expect(sprintRow.firstElementChild).toHaveAttribute("data-testid", "project-icon");
+    expect(sprintRow.firstElementChild?.nextElementSibling).toHaveTextContent("Sprint 42");
+    await waitFor(() => expect(alphaRow).toHaveFocus());
+    fireEvent.keyDown(alphaRow, { key: "s" });
+    await waitFor(() => expect(sprintRow).toHaveFocus());
+
+    view.unmount();
+    renderSidebar();
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+    const freshMoveTrigger = screen.getByTestId("move-to-project");
+    freshMoveTrigger.focus();
+    fireEvent.keyDown(freshMoveTrigger, { key: "ArrowRight" });
+
+    const freshAlphaRow = await screen.findByRole("menuitem", { name: "Alpha" });
+    const removeItem = screen.getByRole("menuitem", { name: "Remove from Sprint 42" });
+    await waitFor(() => expect(freshAlphaRow).toHaveFocus());
+    fireEvent.keyDown(freshAlphaRow, { key: "r" });
+    await waitFor(() => expect(removeItem).toHaveFocus());
   });
 
   it("keeps the desktop side-flyout submenu (no in-place swap)", () => {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -4465,6 +4465,7 @@ function ProjectPickerMenu({
   const filtered = search
     ? projects.filter((p) => p.name.toLowerCase().includes(search.toLowerCase()))
     : projects;
+  const currentProjectIcon = projects.find((p) => p.name === currentProject)?.icon;
 
   // Keep keystrokes inside the inputs from reaching the menu's typeahead /
   // navigation handlers (which would otherwise steal letters and arrows).
@@ -4487,6 +4488,13 @@ function ProjectPickerMenu({
       <div className="max-h-48 overflow-y-auto">
         {filtered.map((p) => (
           <C.Item key={p.name} className="px-2 py-1" onSelect={() => onSelect(p.name)}>
+            {p.icon ? (
+              <span aria-hidden="true" className="shrink-0 text-[14px] leading-none">
+                {p.icon}
+              </span>
+            ) : (
+              <FolderIcon aria-hidden="true" className="size-3.5 shrink-0 text-muted-foreground" />
+            )}
             <span className="flex-1 truncate text-left">{p.name}</span>
             {currentProject === p.name && (
               <CheckMarkIcon className="size-3.5 shrink-0 text-primary" />
@@ -4500,6 +4508,13 @@ function ProjectPickerMenu({
       {currentProject && (
         <div className="border-t pt-1">
           <C.Item className="px-2 py-1" onSelect={() => onSelect("")}>
+            {currentProjectIcon ? (
+              <span aria-hidden="true" className="shrink-0 text-[14px] leading-none">
+                {currentProjectIcon}
+              </span>
+            ) : (
+              <FolderIcon aria-hidden="true" className="size-3.5 shrink-0 text-muted-foreground" />
+            )}
             Remove from{" "}
             <span className="rounded bg-muted px-1 py-0.5 font-mono text-[0.95em]">
               {currentProject}

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -2709,6 +2709,7 @@ interface MenuItemProps {
   children?: ReactNode;
   className?: string;
   disabled?: boolean;
+  textValue?: string;
   variant?: "default" | "destructive";
   // Radix's menu `onSelect` receives a native Event in both families.
   onSelect?: (event: Event) => void;
@@ -4487,9 +4488,18 @@ function ProjectPickerMenu({
       </div>
       <div className="max-h-48 overflow-y-auto">
         {filtered.map((p) => (
-          <C.Item key={p.name} className="px-2 py-1" onSelect={() => onSelect(p.name)}>
+          <C.Item
+            key={p.name}
+            className="px-2 py-1"
+            textValue={p.name}
+            onSelect={() => onSelect(p.name)}
+          >
             {p.icon ? (
-              <span aria-hidden="true" className="shrink-0 text-[14px] leading-none">
+              <span
+                aria-hidden="true"
+                className="shrink-0 text-[14px] leading-none"
+                data-testid="project-icon"
+              >
                 {p.icon}
               </span>
             ) : (
@@ -4507,9 +4517,17 @@ function ProjectPickerMenu({
       </div>
       {currentProject && (
         <div className="border-t pt-1">
-          <C.Item className="px-2 py-1" onSelect={() => onSelect("")}>
+          <C.Item
+            className="px-2 py-1"
+            textValue={`Remove from ${currentProject}`}
+            onSelect={() => onSelect("")}
+          >
             {currentProjectIcon ? (
-              <span aria-hidden="true" className="shrink-0 text-[14px] leading-none">
+              <span
+                aria-hidden="true"
+                className="shrink-0 text-[14px] leading-none"
+                data-testid="project-icon"
+              >
                 {currentProjectIcon}
               </span>
             ) : (


### PR DESCRIPTION
## Related issue

Closes #5556

## Summary

- Show each project's configured emoji in the Move session picker across the sidebar row/context menus and active-session header menu, with the folder glyph as the fallback.
- Show the current project's icon in the Remove from footer while keeping icons decorative so accessible names and name-only search remain unchanged.
- Preserve Radix keyboard typeahead by supplying the visible project and Remove action labels as explicit menu-item text values.

## Test Plan

- [x] `NODE_OPTIONS="--no-experimental-webstorage" ./node_modules/.bin/vitest run src/shell/HeaderConversationMenu.test.tsx src/shell/Sidebar.rowActions.test.tsx` — 2 files passed, 65 tests passed.
- [x] Full web unit suite via `./node_modules/.bin/vitest run` with `NODE_OPTIONS="--no-experimental-webstorage"` plus a worker-only jsdom Linux user-agent preload for the macOS test environment — 306 files passed, 1 skipped; 6,097 tests passed, 3 expected failures, 1 skipped.
- [x] `pnpm run lint` — passed with no warnings.
- [x] `pnpm run type-check` — passed.
- [x] `pnpm run format:check` — all matched files use Prettier style.
- [x] `pnpm run build` — passed; 6,977 modules transformed (existing CSS pseudo-element and chunk-size warnings only).
- [x] `uv run --no-sync pre-commit run --all-files` — all hooks passed.
- [x] Mutation checks — removing row `textValue` left focus on Alpha instead of Sprint 42 in both picker tests; removing footer `textValue` left focus on Alpha instead of Remove from Sprint 42; moving icons after names failed both ordering tests at the expected leading-icon assertion.

## Demo

No screenshot or recording is attached because this isolated worktree does not have a configured live backend with saved project-icon data.

To view the change manually:

1. Run `just dev` and open the web app.
2. Create one project with an emoji icon and one without an icon.
3. Open a session-row kebab or right-click menu, choose Move session, and confirm the emoji/folder icons in the picker and the current-project icon in the Remove from footer.
4. Open the active session header menu, choose Move session, and confirm the same behavior there.
5. On desktop, type the first letter of an icon-bearing project's name and confirm focus jumps to that project; type `r` and confirm focus jumps to the Remove action.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage exercises both duplicated picker renderers, mobile in-place and desktop flyout behavior, emoji and folder fallback ordering, current-project footer icons, unchanged exact accessible names, and keyboard typeahead for icon-bearing rows and Remove actions.

## Changelog

Project emoji icons now appear in Move session pickers and their Remove from project action.
