### PR TITLE
Elect one host daemon per target

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -56,6 +56,12 @@ from omnigent.config import (
 )
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.host.daemon_lifecycle import (
+    DAEMON_CONFIG_SIG_ENV_VAR,
+)
+from omnigent.host.daemon_lifecycle import (
+    HostDaemonRecord as _HostDaemonRecord,
+)
+from omnigent.host.daemon_lifecycle import (
     daemon_record_path as _daemon_record_path_for,
 )
 from omnigent.host.daemon_lifecycle import (
@@ -67,6 +73,7 @@ from omnigent.host.daemon_lifecycle import (
 from omnigent.host.daemon_lifecycle import (
     record_flock_is_held as _record_flock_is_held,
 )
+from omnigent.host.daemon_lifecycle import write_daemon_record as _write_daemon_record_impl
 from omnigent.host.local_server import (
     _DEFAULT_LOCAL_PORT,
     _pid_alive,
@@ -2388,46 +2395,6 @@ def _is_local_server_request(server: str | None) -> bool:
 
 
 @dataclass(frozen=True)
-class _HostDaemonRecord:
-    """
-    Local registry record for one background host daemon.
-
-    :param pid: Process id of the background daemon, e.g. ``4242``.
-    :param target: Normalized daemon target, e.g.
-        ``"https://example.databricksapps.com"`` or ``"local"``.
-    :param mode: Launch mode, either ``"server"`` or ``"local"``.
-    :param server_url: Normalized requested server URL for ``"server"``
-        mode, e.g. ``"https://example.databricksapps.com"``. ``None``
-        for local mode.
-    :param log_path: Daemon log file path, e.g.
-        ``"/Users/me/.omnigent/logs/host/host-abc.log"``.
-    :param started_at: Unix epoch seconds when the daemon was spawned,
-        e.g. ``1710000000``.
-    :param host_id: Local host id advertised to Omnigent servers, e.g.
-        ``"host_abc123"``. ``None`` for legacy records.
-    :param resolved_server_url: Concrete local server URL discovered for
-        local mode, e.g. ``"http://127.0.0.1:8123"``. ``None`` until
-        discovery succeeds or for remote mode.
-    :param config_sig: Signature of the server-affecting config (resolved
-        auth source) the daemon was spawned under, e.g.
-        ``"3f9a1c2b4d5e6f70"`` (see :func:`_server_config_signature`).
-        ``None`` for legacy records written before config-signature
-        tracking existed; a ``None`` signature is never treated as a
-        config mismatch (we can't know what it was started with).
-    """
-
-    pid: int
-    target: str
-    mode: str
-    server_url: str | None
-    log_path: str | None
-    started_at: int
-    host_id: str | None = None
-    resolved_server_url: str | None = None
-    config_sig: str | None = None
-
-
-@dataclass(frozen=True)
 class _HostHttpResult:
     """
     Decoded Omnigent management HTTP response.
@@ -2666,9 +2633,7 @@ def _write_daemon_record(record: _HostDaemonRecord) -> None:
     :param record: Record to write, e.g. a local daemon record with
         ``target == "local"``.
     """
-    path = _daemon_record_path(record.target)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(asdict(record), indent=2, sort_keys=True) + "\n")
+    _write_daemon_record_impl(record, base_dir=_HOST_PID_PATH.parent)
 
 
 def _delete_daemon_record(record: _HostDaemonRecord) -> None:
@@ -3024,34 +2989,26 @@ def _spawn_host_daemon_process(
     return _SpawnedDaemonProcess(pid=proc.pid, log_path=str(log_path))
 
 
-def _persist_spawned_daemon(
-    *,
+_DAEMON_CLAIM_TIMEOUT_S = 10.0
+
+
+def _wait_for_daemon_claim(
     target: str,
     spawned: _SpawnedDaemonProcess,
-    config_sig: str,
-) -> None:
-    """
-    Persist registry and legacy pidfile entries for a spawned daemon.
-
-    :param target: Normalized daemon target, e.g. ``"local"``.
-    :param spawned: Spawned process metadata.
-    :param config_sig: Config signature this daemon was spawned under,
-        e.g. ``"3f9a1c2b4d5e6f70"`` (see :func:`server_config_signature`).
-    """
-    mode = "local" if target == _LOCAL_DAEMON_MARKER else "server"
-    _write_daemon_record(
-        _HostDaemonRecord(
-            pid=spawned.pid,
-            target=target,
-            mode=mode,
-            server_url=None if mode == "local" else target,
-            log_path=spawned.log_path,
-            started_at=int(time.time()),
-            host_id=_load_existing_host_id(),
-            config_sig=config_sig,
-        )
-    )
-    _HOST_PID_PATH.write_text(f"{spawned.pid}\n{target}\n")
+    *,
+    timeout_s: float = _DAEMON_CLAIM_TIMEOUT_S,
+) -> _HostDaemonRecord | None:
+    """Wait for a spawned daemon (or its concurrent winner) to claim *target*."""
+    deadline = time.monotonic() + timeout_s
+    while True:
+        record = _find_daemon_record(target)
+        if record is not None and _daemon_owner_is_live(record, target):
+            return record
+        if time.monotonic() >= deadline:
+            return None
+        # A losing child exits promptly, but the winner's process may still be
+        # importing and writing the shared record from a concurrent launcher.
+        time.sleep(0.02 if _pid_alive(spawned.pid) else 0.05)
 
 
 def _foreground_daemon_record(
@@ -3208,17 +3165,13 @@ def _ensure_host_daemon(server_url: str | None) -> bool:
     _HOST_PID_PATH.parent.mkdir(parents=True, exist_ok=True)
     mode_args = ["--local"] if not server_url else ["--server", server_url]
     args = [sys.executable, "-m", "omnigent.host._daemon_entry", *mode_args]
-    spawned = _spawn_host_daemon_process(
-        args=args,
-        env=_build_host_daemon_env(server_url=server_url),
-    )
+    config_sig = server_config_signature(include_features=not server_url)
+    daemon_env = _build_host_daemon_env(server_url=server_url)
+    daemon_env[DAEMON_CONFIG_SIG_ENV_VAR] = config_sig
+    spawned = _spawn_host_daemon_process(args=args, env=daemon_env)
     if spawned is None:
         return False
-    _persist_spawned_daemon(
-        target=target,
-        spawned=spawned,
-        config_sig=server_config_signature(include_features=not server_url),
-    )
+    _wait_for_daemon_claim(target, spawned)
     return decision.config_changed
 
 

--- a/omnigent/host/_daemon_entry.py
+++ b/omnigent/host/_daemon_entry.py
@@ -15,6 +15,9 @@ Two modes:
 from __future__ import annotations
 
 import argparse
+import logging
+import os
+import time
 
 
 def main() -> None:
@@ -45,27 +48,63 @@ def main() -> None:
 
     from omnigent.process_logging import configure_process_logging
 
-    configure_process_logging("host", force=True)
+    log_path = configure_process_logging("host", force=True)
 
     if args.local == bool(args.server):
         # Both or neither — the CLI always passes exactly one; fail loud.
         parser.error("exactly one of --server <url> or --local is required")
 
-    from omnigent.host.daemon_lifecycle import normalize_daemon_target
+    from omnigent.host.daemon_lifecycle import (
+        DAEMON_CONFIG_SIG_ENV_VAR,
+        DaemonLifecycleLock,
+        HostDaemonRecord,
+        normalize_daemon_target,
+        write_daemon_record,
+    )
 
-    if args.local:
-        # The daemon owns the local server: start/reuse it, then connect.
-        from omnigent.host.local_server import ensure_local_omnigent_server
+    daemon_target = normalize_daemon_target(None if args.local else args.server)
+    lifecycle_lock = DaemonLifecycleLock.for_target(daemon_target)
+    claim = lifecycle_lock.try_acquire()
+    if claim is False:
+        logging.getLogger(__name__).info(
+            "Another host daemon already claimed target %s; exiting", daemon_target
+        )
+        return
 
-        server_url = ensure_local_omnigent_server().url
-        daemon_target = normalize_daemon_target(None)
-    else:
-        server_url = args.server
-        daemon_target = normalize_daemon_target(args.server)
+    try:
+        from omnigent.host.identity import CONFIG_PATH, load_or_create_host_identity
 
-    from omnigent.host.connect import run_host_process
+        identity = load_or_create_host_identity(CONFIG_PATH)
+        mode = "local" if args.local else "server"
+        record = HostDaemonRecord(
+            pid=os.getpid(),
+            target=daemon_target,
+            mode=mode,
+            server_url=None if args.local else daemon_target,
+            log_path=str(log_path),
+            started_at=int(time.time()),
+            host_id=identity.host_id,
+            config_sig=os.environ.get(DAEMON_CONFIG_SIG_ENV_VAR),
+        )
+        write_daemon_record(record, update_legacy_pidfile=True)
 
-    run_host_process(server_url=server_url, daemon_target=daemon_target)
+        if args.local:
+            # The daemon owns the local server: start/reuse it, then connect.
+            from omnigent.host.local_server import ensure_local_omnigent_server
+
+            server_url = ensure_local_omnigent_server().url
+        else:
+            server_url = args.server
+
+        from omnigent.host.connect import run_host_process
+
+        run_host_process(
+            server_url=server_url,
+            daemon_target=daemon_target,
+            lifecycle_lock=lifecycle_lock,
+        )
+    finally:
+        lifecycle_lock.release()
 
 
 if __name__ == "__main__":

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -3565,6 +3565,7 @@ def run_host_process(
     config_path: Path | None = None,
     *,
     daemon_target: str | None = None,
+    lifecycle_lock: DaemonLifecycleLock | None = None,
 ) -> None:
     """Entry point for ``omnigent host``.
 
@@ -3579,6 +3580,9 @@ def run_host_process(
         ``"local"`` or a server URL. When given, the daemon binds its lifetime
         to that record (flock + self-terminate on delete/reassign). ``None``
         (the historical default) runs without the lifecycle guard.
+    :param lifecycle_lock: A lock already acquired by an auto-launched daemon
+        before it claimed the registry record. When provided, it is retained
+        for the host process lifetime instead of acquiring another handle.
     :raises SystemExit: With :data:`HOST_FATAL_EXIT_CODE` when the tunnel
         fails permanently (auth / authorization / outdated server, or a
         loopback server that is gone). The actionable cause is printed
@@ -3613,9 +3617,8 @@ def run_host_process(
     if _cli_log is not None and _cli_log != host_log_path:
         print(f"CLI diagnostics: {display_log_path(_cli_log)}")
 
-    lifecycle_lock = (
-        DaemonLifecycleLock.for_target(daemon_target) if daemon_target is not None else None
-    )
+    if lifecycle_lock is None and daemon_target is not None:
+        lifecycle_lock = DaemonLifecycleLock.for_target(daemon_target)
     host = HostProcess(identity, server_url, lifecycle_lock=lifecycle_lock)
     try:
         asyncio.run(host.run())

--- a/omnigent/host/daemon_lifecycle.py
+++ b/omnigent/host/daemon_lifecycle.py
@@ -11,10 +11,9 @@ it is stale and terminates itself.
 The flock also serves reuse: :func:`record_flock_is_held` probes it so a
 spin-up can tell a live daemon (reuse it) from a dead one (reap + respawn),
 with a PID check as the fallback when the lock is free or unprobeable. This
-relies on the record being rewritten in place (``Path.write_text``, see
-``cli._write_daemon_record``): an atomic-rename write would swap the inode and
-strand the daemon's flock on the old one, so takeover must keep modifying the
-existing file.
+relies on the record being rewritten in place (see :func:`write_daemon_record`):
+an atomic-rename write would swap the inode and strand the daemon's flock on
+the old one, so takeover must keep modifying the existing file.
 """
 
 from __future__ import annotations
@@ -24,6 +23,7 @@ import hashlib
 import json
 import logging
 import os
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from omnigent.process_logging import data_dir
@@ -36,6 +36,33 @@ except ImportError:  # pragma: no cover - Windows has no flock.
 _logger = logging.getLogger(__name__)
 
 _LOCAL_DAEMON_MARKER = "local"
+DAEMON_CONFIG_SIG_ENV_VAR = "OMNIGENT_HOST_DAEMON_CONFIG_SIG"
+
+
+@dataclass(frozen=True)
+class HostDaemonRecord:
+    """Registry metadata for one host daemon process.
+
+    :param pid: Process id of the daemon.
+    :param target: Normalized server URL or ``"local"``.
+    :param mode: Launch mode, either ``"server"`` or ``"local"``.
+    :param server_url: Requested URL in server mode; ``None`` in local mode.
+    :param log_path: Captured daemon log, or ``None`` for foreground hosts.
+    :param started_at: Unix epoch seconds when the daemon started.
+    :param host_id: Stable host id advertised to the server.
+    :param resolved_server_url: Concrete URL owned by a local-mode daemon.
+    :param config_sig: Signature of server-affecting launch configuration.
+    """
+
+    pid: int
+    target: str
+    mode: str
+    server_url: str | None
+    log_path: str | None
+    started_at: int
+    host_id: str | None = None
+    resolved_server_url: str | None = None
+    config_sig: str | None = None
 
 
 def normalize_daemon_target(server_url: str | None) -> str:
@@ -68,6 +95,21 @@ def daemon_record_path(target: str, *, base_dir: Path | None = None) -> Path:
     :returns: JSON record path.
     """
     return daemon_registry_dir(base_dir) / f"{_target_digest(target)}.json"
+
+
+def write_daemon_record(
+    record: HostDaemonRecord,
+    *,
+    base_dir: Path | None = None,
+    update_legacy_pidfile: bool = False,
+) -> None:
+    """Persist *record* in place while preserving its lifecycle-lock inode."""
+    root = base_dir if base_dir is not None else data_dir()
+    path = daemon_record_path(record.target, base_dir=root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(asdict(record), indent=2, sort_keys=True) + "\n")
+    if update_legacy_pidfile:
+        (root / "host.pid").write_text(f"{record.pid}\n{record.target}\n")
 
 
 def record_flock_is_held(record_path: Path) -> bool | None:
@@ -158,15 +200,24 @@ class DaemonLifecycleLock:
         """Take the exclusive lifetime lock on the record file.
 
         Best-effort: a failure (no ``fcntl``, contended lock, IO error) is
-        logged and reported, never raised — the record-based ownership check
-        still guards the daemon even without a held lock. The record's content
-        is owned by the CLI, so we only open + lock it, never truncate or write
-        (that would clobber the record the launching CLI wrote).
+        reported, never raised. The lock handle only opens the file; the
+        elected daemon persists its metadata separately after claiming it.
 
         :returns: ``True`` if the flock is now held by this process.
         """
+        return self.try_acquire() is True
+
+    def try_acquire(self) -> bool | None:
+        """Try to claim this target, distinguishing contention from no support.
+
+        :returns: ``True`` when acquired, ``False`` when another daemon owns
+            the target, or ``None`` when locking is unavailable so callers can
+            retain the historical best-effort fallback.
+        """
+        if self._fd is not None:
+            return True
         if fcntl is None:
-            return False
+            return None
         fd: int | None = None
         try:
             self._record_path.parent.mkdir(parents=True, exist_ok=True)
@@ -176,6 +227,11 @@ class DaemonLifecycleLock:
                 0o600,
             )
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            if fd is not None:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+            return False
         except OSError:
             _logger.warning(
                 "daemon lifecycle lock acquire failed for %s", self._target, exc_info=True
@@ -183,7 +239,7 @@ class DaemonLifecycleLock:
             if fd is not None:
                 with contextlib.suppress(OSError):
                     os.close(fd)
-            return False
+            return None
         self._fd = fd
         return True
 

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -15,6 +15,7 @@ import io
 import json
 import re
 import sys
+import threading
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -88,6 +89,30 @@ def _patch_daemon_spawn(
         return proc
 
     monkeypatch.setattr(cli.subprocess, "Popen", _popen)
+
+    def _claim(
+        target: str,
+        spawned: cli._SpawnedDaemonProcess,
+        **_kwargs: object,
+    ) -> cli._HostDaemonRecord | None:
+        env = captured["env"]
+        assert isinstance(env, dict)
+        mode = "local" if target == "local" else "server"
+        cli._write_daemon_record(
+            cli._HostDaemonRecord(
+                pid=spawned.pid,
+                target=target,
+                mode=mode,
+                server_url=None if mode == "local" else target,
+                log_path=spawned.log_path,
+                started_at=int(cli.time.time()),
+                config_sig=str(env[cli.DAEMON_CONFIG_SIG_ENV_VAR]),
+            )
+        )
+        cli._HOST_PID_PATH.write_text(f"{spawned.pid}\n{target}\n")
+        return cli._find_daemon_record(target)
+
+    monkeypatch.setattr(cli, "_wait_for_daemon_claim", _claim)
 
 
 def _write_daemon_registry_record(
@@ -542,6 +567,68 @@ def test_ensure_host_daemon_young_offline_daemon_not_torn_down(
 
     assert torn_down == []
     assert "args" not in captured  # reused despite being offline (still connecting)
+
+
+def test_concurrent_ensure_host_daemon_elects_one_daemon(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Concurrent launchers may spawn, but only one daemon claims the target."""
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    monkeypatch.setattr(cli, "_build_host_daemon_env", lambda **_kw: {})
+    monkeypatch.setattr(cli, "server_config_signature", lambda **_kw: "sig")
+    live_pids: set[int] = set()
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: pid in live_pids)
+
+    both_spawned = threading.Barrier(2)
+    spawn_count = 0
+    count_lock = threading.Lock()
+
+    def _spawn(**_kw: object) -> cli._SpawnedDaemonProcess:
+        nonlocal spawn_count
+        with count_lock:
+            spawn_count += 1
+            count = spawn_count
+        pid = 4241 + count
+        both_spawned.wait(timeout=5)
+        if count == 1:
+            live_pids.add(pid)
+            target = "https://server.example.com"
+            cli._write_daemon_record(
+                cli._HostDaemonRecord(
+                    pid=pid,
+                    target=target,
+                    mode="server",
+                    server_url=target,
+                    log_path=str(tmp_path / "host.log"),
+                    started_at=int(cli.time.time()),
+                    config_sig="sig",
+                )
+            )
+        return cli._SpawnedDaemonProcess(pid=pid, log_path=str(tmp_path / "host.log"))
+
+    monkeypatch.setattr(cli, "_spawn_host_daemon_process", _spawn)
+    errors: list[BaseException] = []
+
+    def _ensure() -> None:
+        try:
+            _ensure_host_daemon("https://server.example.com")
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    first = threading.Thread(target=_ensure)
+    second = threading.Thread(target=_ensure)
+    first.start()
+    second.start()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert spawn_count == 2
+    record = cli._find_daemon_record("https://server.example.com")
+    assert record is not None
+    assert record.pid == 4242
 
 
 def _online_record() -> cli._HostDaemonRecord:

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -43,6 +43,31 @@ class _HostRun:
     server_url: str
 
 
+def _persist_fake_daemon_claim(
+    target: str,
+    spawned: object,
+    **_kwargs: object,
+) -> object:
+    """Simulate the child-side registry claim for patched daemon spawns."""
+    import omnigent.cli as cli_module
+
+    assert isinstance(spawned, cli_module._SpawnedDaemonProcess)
+    mode = "local" if target == "local" else "server"
+    cli_module._write_daemon_record(
+        cli_module._HostDaemonRecord(
+            pid=spawned.pid,
+            target=target,
+            mode=mode,
+            server_url=None if mode == "local" else target,
+            log_path=spawned.log_path,
+            started_at=int(time.time()),
+            config_sig="test-config-signature",
+        )
+    )
+    cli_module._HOST_PID_PATH.write_text(f"{spawned.pid}\n{target}\n")
+    return cli_module._find_daemon_record(target)
+
+
 def test_host_pid_path_honors_data_dir_at_import(tmp_path: Path) -> None:
     env = {**os.environ, "OMNIGENT_DATA_DIR": str(tmp_path / "data")}
     result = subprocess.run(
@@ -470,6 +495,7 @@ def test_ensure_host_daemon_writes_pid_file(
     with (
         patch("omnigent.cli._HOST_PID_PATH", pid_path),
         patch("omnigent.cli.subprocess.Popen", side_effect=_fake_popen),
+        patch("omnigent.cli._wait_for_daemon_claim", side_effect=_persist_fake_daemon_claim),
     ):
         _ensure_host_daemon("http://localhost:8000")
 
@@ -523,6 +549,7 @@ def test_ensure_host_daemon_keeps_old_for_different_server(
         patch("omnigent.cli._pid_alive", lambda pid: pid in {4242, 4243}),
         patch("omnigent.cli.os.kill", lambda pid, sig: killed.append(pid)),
         patch("omnigent.cli.subprocess.Popen", side_effect=_fake_popen),
+        patch("omnigent.cli._wait_for_daemon_claim", side_effect=_persist_fake_daemon_claim),
     ):
         _ensure_host_daemon("http://old-server:8000")
         _ensure_host_daemon("http://new-server:9000")
@@ -814,6 +841,7 @@ def _patch_background_host_spawn(
         return _SpawnedDaemonProcess(pid=pid, log_path=str(log_path))
 
     monkeypatch.setattr("omnigent.cli._spawn_host_daemon_process", _fake_spawn)
+    monkeypatch.setattr("omnigent.cli._wait_for_daemon_claim", _persist_fake_daemon_claim)
     return spawned_args, log_path
 
 

--- a/tests/host/test_daemon_lifecycle.py
+++ b/tests/host/test_daemon_lifecycle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -71,12 +72,23 @@ def test_acquire_flocks_the_record_and_preserves_content(tmp_path: Path) -> None
 
 
 def test_acquire_creates_record_when_absent(tmp_path: Path) -> None:
-    # Auto-spawn can start the daemon before the launching CLI writes the
-    # record, so acquire() must create + flock the file rather than fail.
+    # The elected child locks before writing its metadata, so acquire() must
+    # create + flock the record file rather than fail when it is absent.
     lock = DaemonLifecycleLock.for_target("local", base_dir=tmp_path, pid=7)
     assert lock.acquire() is True
     assert daemon_record_path("local", base_dir=tmp_path).exists()
     lock.release()
+
+
+def test_different_targets_can_be_claimed_concurrently(tmp_path: Path) -> None:
+    first = DaemonLifecycleLock.for_target("https://one.example.com", base_dir=tmp_path)
+    second = DaemonLifecycleLock.for_target("https://two.example.com", base_dir=tmp_path)
+    assert first.acquire() is True
+    try:
+        assert second.acquire() is True
+    finally:
+        first.release()
+        second.release()
 
 
 def test_still_owner_delete_and_mismatch(tmp_path: Path) -> None:
@@ -115,6 +127,76 @@ def test_record_flock_is_held_states(tmp_path: Path) -> None:
     assert record_flock_is_held(record) is True
     lock.release()
     assert record_flock_is_held(record) is False
+
+
+def test_background_daemon_claims_record_before_connecting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The elected child owns and records the target before opening a tunnel."""
+    from omnigent.host import _daemon_entry
+    from omnigent.host import identity as identity_module
+    from omnigent.process_logging import DATA_DIR_ENV_VAR
+
+    target = "https://server.example.com"
+    log_path = tmp_path / "host.log"
+    monkeypatch.setenv(DATA_DIR_ENV_VAR, str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_HOST_DAEMON_CONFIG_SIG", "config-signature")
+    monkeypatch.setattr(sys, "argv", ["omnigent.host._daemon_entry", "--server", target])
+    monkeypatch.setattr(
+        "omnigent.process_logging.configure_process_logging", lambda *_a, **_kw: log_path
+    )
+    monkeypatch.setattr(
+        identity_module,
+        "load_or_create_host_identity",
+        lambda _path: HostIdentity(host_id="host_elected", name="elected"),
+    )
+
+    connected: list[str] = []
+
+    def _run(*, server_url: str, daemon_target: str, lifecycle_lock: object) -> None:
+        assert record_flock_is_held(daemon_record_path(target, base_dir=tmp_path)) is True
+        assert lifecycle_lock is not None
+        connected.append(f"{server_url}|{daemon_target}")
+
+    monkeypatch.setattr("omnigent.host.connect.run_host_process", _run)
+
+    _daemon_entry.main()
+
+    payload = json.loads(daemon_record_path(target, base_dir=tmp_path).read_text())
+    assert payload["pid"] == os.getpid()
+    assert payload["host_id"] == "host_elected"
+    assert payload["config_sig"] == "config-signature"
+    assert connected == [f"{target}|{target}"]
+    assert record_flock_is_held(daemon_record_path(target, base_dir=tmp_path)) is False
+
+
+def test_background_daemon_loser_exits_before_connecting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second child for one target exits without replacing the live owner."""
+    from omnigent.host import _daemon_entry
+    from omnigent.process_logging import DATA_DIR_ENV_VAR
+
+    target = "https://server.example.com"
+    monkeypatch.setenv(DATA_DIR_ENV_VAR, str(tmp_path))
+    monkeypatch.setattr(sys, "argv", ["omnigent.host._daemon_entry", "--server", target])
+    monkeypatch.setattr(
+        "omnigent.process_logging.configure_process_logging",
+        lambda *_a, **_kw: tmp_path / "loser.log",
+    )
+    monkeypatch.setattr(
+        "omnigent.host.connect.run_host_process",
+        lambda **_kw: pytest.fail("losing daemon must not connect"),
+    )
+    owner = DaemonLifecycleLock.for_target(target, base_dir=tmp_path, pid=4242)
+    assert owner.acquire() is True
+    try:
+        _write_record(daemon_record_path(target, base_dir=tmp_path), 4242)
+        before = daemon_record_path(target, base_dir=tmp_path).read_text()
+        _daemon_entry.main()
+        assert daemon_record_path(target, base_dir=tmp_path).read_text() == before
+    finally:
+        owner.release()
 
 
 def _record(target: str, pid: int) -> object:


### PR DESCRIPTION
## Related issue

Closes #5560

## Summary

- Let concurrent launchers spawn daemon candidates, but require each child to atomically claim its per-target registry record before connecting.
- The winner writes the authoritative record and retains its lifecycle lock; same-target losers exit cleanly.
- Different server targets remain fully concurrent, and no additional lock file is created.

**ELI5:** Multiple candidates may start, but only the one holding that server target's key may connect.

```text
launcher A -> daemon A ─┐
                        ├─> per-target record claim -> winner connects
launcher B -> daemon B ─┘                         └-> loser exits

different target -> different record -> proceeds concurrently
```

## Test Plan

- `uv run --frozen --extra tracing --group dev pytest -q tests/cli/test_backend.py tests/host/test_daemon_lifecycle.py tests/host/test_cli_host.py` — 136 passed.
- `uv run --frozen --extra tracing --group dev pre-commit run --files omnigent/cli.py omnigent/host/_daemon_entry.py omnigent/host/connect.py omnigent/host/daemon_lifecycle.py tests/cli/test_backend.py tests/host/test_cli_host.py tests/host/test_daemon_lifecycle.py` — all hooks passed.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests verify that the winning child claims and publishes the per-target record before connecting, a same-target loser exits without connecting or overwriting the record, different targets can claim concurrently, and concurrent CLI launches converge on one authoritative daemon.

## Changelog

Concurrent native launches now elect one host daemon per server target instead of creating competing tunnels.