### PR TITLE
fix(codex): bridge remote-MCP OAuth credentials into the private CODEX_HOME

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -130,8 +130,10 @@ _STDERR_CHUNK_LIMIT = 65536
 _STREAM_READ_CHUNK_SIZE = 65536
 # Files symlinked from the real CODEX_HOME into the per-session temp home.
 # Symlinks (not copies) so credential refreshes in the real home propagate
-# to running sessions without any action from Omnigent.
-_CODEX_HOME_SYMLINK_FILES = ("auth.json",)
+# to running sessions without any action from Omnigent. ``.credentials.json``
+# is codex's OAuth store for remote (``url =``) MCP servers; without it a
+# private home starts those servers unauthenticated while stdio ones work.
+_CODEX_HOME_SYMLINK_FILES = ("auth.json", ".credentials.json")
 _CODEX_HOME_GLOBAL_INSTRUCTION_FILES = ("AGENTS.md", "AGENTS.override.md", "hooks.json")
 # Name of the hooks file inside a CODEX_HOME. Symlinked from the user's home
 # by default; generated as a merged regular file when subagent routing is on.
@@ -149,7 +151,12 @@ _CODEX_HOME_COPY_FILES = ("config.toml",)
 # otherwise re-materialize tens of MB into every private home. Sharing the
 # one real cache dedupes it across sessions; codex's own writes land in the
 # shared cache exactly as they would without the private home.
-_CODEX_HOME_SYMLINK_DIRS = (Path("plugins") / "cache",)
+_CODEX_HOME_SYMLINK_DIRS = (
+    Path("plugins") / "cache",
+    # Cross-process lock guarding ``.credentials.json``; shared so a token
+    # refresh in one session cannot race another into a stale refresh token.
+    Path("mcp-oauth-locks"),
+)
 _CODEX_MINIMAL_CONFIG_ENV = "HARNESS_CODEX_MINIMAL_CONFIG"
 _CODEX_PROVIDER_CONFIG_PREFIX = "model_providers."
 

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -2475,6 +2475,34 @@ def test_populate_codex_home_config_symlinks_auth_and_config(tmp_path: Path) -> 
     assert (target / "config.toml").read_text() == '[default]\nmodel = "gpt-5.4"'
 
 
+def test_populate_codex_home_config_symlinks_remote_mcp_oauth(tmp_path: Path) -> None:
+    """``.credentials.json`` and its lock dir are symlinked, not left behind.
+
+    Codex keeps OAuth tokens for remote (``url =``) MCP servers in
+    ``.credentials.json``, guarded across processes by
+    ``mcp-oauth-locks/``. A private home missing them starts those servers
+    unauthenticated while ``command =`` (stdio) servers still work.
+    """
+    from omnigent.inner.codex_executor import _populate_codex_home_config
+
+    source = tmp_path / "real_codex_home"
+    source.mkdir()
+    (source / "config.toml").write_text('[mcp_servers.linear]\nurl = "https://x/mcp"')
+    (source / ".credentials.json").write_text('{"linear|abc": {"access_token": "t"}}')
+    (source / "mcp-oauth-locks").mkdir()
+    (source / "mcp-oauth-locks" / "file-store.lock").write_text("")
+    target = tmp_path / "temp_codex_home"
+    target.mkdir()
+
+    _populate_codex_home_config(target, source)
+
+    # Symlinked (not copied) so a refresh in either direction is shared.
+    assert (target / ".credentials.json").is_symlink()
+    assert (target / ".credentials.json").read_text() == '{"linear|abc": {"access_token": "t"}}'
+    assert (target / "mcp-oauth-locks").is_symlink()
+    assert (target / "mcp-oauth-locks" / "file-store.lock").is_file()
+
+
 def test_populate_codex_home_config_symlinks_plugins_cache(tmp_path: Path) -> None:
     """``plugins/cache`` is symlinked to the shared home to dedupe it.
 


### PR DESCRIPTION
## Related issue

None filed. Discovered while debugging why every MCP server appeared to fail under
`omni codex` but worked under a bare `codex`. Happy to open a tracking issue if
maintainers want one on record for a bug fix.

## Summary

Native codex sessions run in a **per-session private `CODEX_HOME`** that bridges only
`auth.json` (symlink) and `config.toml` (copy) from the user's real home. But codex keeps
OAuth tokens for **remote** MCP servers (declared `url = ...` rather than `command = ...`)
in a *second* credential store, `.credentials.json`, which was never bridged.

Result: remote MCP servers start unauthenticated under `omni codex` while stdio servers
work normally. The failure is **silent** so it misreads as "MCP is broken under omni":

- no error on any surface
- the server is simply *absent* from the session's `mcp_startup.json`
- every `command =` server in the same config still reports `ready`

ELI5: codex has two credential files. We were copying the door key but not the mailbox key,
so anything that needed the mailbox quietly got nothing.

```
  ~/.codex/                          <hash>/codex-home/   (private, per session)
  ├── auth.json .................... ├── auth.json         symlink   ok
  ├── config.toml (mcp_servers) .... ├── config.toml       copy      ok
  ├── .credentials.json ............ └──  (absent)                   <-- remote MCP OAuth
  └── mcp-oauth-locks/                                               <-- lock for that store
```

The fix adds both to the existing bridge lists:

- `.credentials.json` is **symlinked**, not copied, matching `auth.json`. These tokens
  expire and carry a `refresh_token`, so a copy would strand the refresh inside a throwaway
  session home and force a re-auth every session.
- `mcp-oauth-locks/` is shared too. It holds `file-store.lock`, the cross-process lock
  guarding that credential store. Sharing the file without its lock would let two concurrent
  sessions refresh at once and rotate each other into a stale `refresh_token`.

## Test Plan

- `pytest tests/inner/test_codex_executor.py` — 116 passed, including a new
  `test_populate_codex_home_config_symlinks_remote_mcp_oauth`.
- `pytest tests/inner/test_codex_hooks_generation.py tests/test_codex_native_app_server.py`
  — 93 passed. These cover `_private_codex_home_config_source`, which iterates the same
  `_CODEX_HOME_SYMLINK_FILES` tuple for nested-session resolution, so it was the main
  regression risk.
- Ran `_populate_codex_home_config` against a real `~/.codex` with a `url =` server
  configured: both `.credentials.json` and `mcp-oauth-locks` resolve as symlinks, and the
  server's token is readable through the private home.
- Confirmed the pre-fix diagnosis on a real session: `mcp_startup.json` listed 17 stdio
  servers as `ready` and omitted the one `url =` server entirely.
- `ruff format --check` / `ruff check` clean.

**Not verified:** the concurrent-refresh path the shared lock dir guards. That needs two
simultaneous sessions racing a token expiry, which I could not stage locally. The lock dir
is shared on the same reasoning codex itself uses it, but it is untested here.

## Demo

N/A (non-visual).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test covers the bridge itself (both entries land as symlinks and read through to
the source). Manual verification was needed for the parts a unit test cannot reach: that a
real `url =` server is the one that fails, and that its token becomes visible through the
private home. The concurrent token-refresh race is called out as unverified above.

## Changelog

Remote MCP servers configured with `url =` now authenticate correctly under `omni codex`
