### PR TITLE
fix(host): drop ProcessType=Background from the macOS launchd plist

### DIFF
--- a/omnigent/host/service.py
+++ b/omnigent/host/service.py
@@ -94,7 +94,8 @@ def _launchd_payload(
         "ThrottleInterval": 10,
         "StandardOutPath": str(service.log_path),
         "StandardErrorPath": str(service.log_path),
-        "ProcessType": "Background",
+        # No ProcessType: the default (Standard) keeps runner/harness children
+        # out of the background QoS band, which would starve their deadlines.
     }
     return plistlib.dumps(payload, fmt=plistlib.FMT_XML, sort_keys=True)
 

--- a/tests/host/test_service.py
+++ b/tests/host/test_service.py
@@ -51,6 +51,7 @@ def test_enable_launchd_user_service(tmp_path: Path, monkeypatch: pytest.MonkeyP
     ]
     assert payload["EnvironmentVariables"]["PATH"] == "/usr/bin:/bin"
     assert payload["KeepAlive"] == {"SuccessfulExit": False}
+    assert "ProcessType" not in payload
     assert calls == [
         ["launchctl", "bootout", "gui/501/ai.omnigent.host"],
         [


### PR DESCRIPTION

## Related issue

Closes #5563

## Summary

- `omni host enable` rendered the launchd user-agent plist with `ProcessType=Background`, which puts the host and every descendant (runners, harness CLIs, catalog probes, `git` subprocesses) into the darwin background QoS band with throttled I/O.
- Under load this starved the whole harness tree: catalog refreshes timed out at 100%, and sessions failed to start or resume (`did not bind its endpoint within 30s`).
- Drop the key so launchd defaults to `Standard` — matching `omnigent host` run from a terminal, and matching the Linux systemd unit, which sets no CPU/IO weight. launchd offers no per-child escape hatch, so `Standard` for the whole tree is the practical answer.

## Test Plan

- `uv run pytest tests/host/test_service.py` — 7 passed, including a new assertion that `ProcessType` is absent from the rendered plist.
- Manual: reinstall the service (`omni host disable && omni host enable`), then `launchctl bootout gui/$UID/ai.omnigent.host && launchctl bootstrap gui/$UID ~/Library/LaunchAgents/ai.omnigent.host.plist` (kickstart alone keeps launchd's cached definition) and confirm `ps -o pri -p <host-pid>` is ~20+ rather than 4 (darwin-bg).

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

## Changelog

Fix macOS host service running in background QoS, which starved agent sessions under load and made Claude sessions fail to start or resume