### PR TITLE
fix(cli): point host and server log diagnostics at the configured data dir

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -60,6 +60,7 @@ from omnigent.process_logging import (
     child_logging_popen_kwargs,
     logs_root,
     open_process_log_file,
+    process_log_dir_reference,
 )
 from omnigent.spec import load as load_spec
 from omnigent.spec._omnigent_compat import OMNIGENT_EXECUTOR_TYPE
@@ -1535,7 +1536,7 @@ def _unreachable_server_message(base_url: str) -> str:
         return (
             f"Could not connect to the local Omnigent server at {base_url}. "
             "It may have stopped — run `omnigent stop`, then try again. "
-            "Server logs are under ~/.omnigent/logs/server/."
+            f"Server logs are under {process_log_dir_reference('server')}."
         )
     from omnigent.server_url import display_server_url
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -81,7 +81,13 @@ from omnigent.inner import _proc, ui
 from omnigent.integration_daemon import IntegrationDaemon
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.onboarding.sandboxes import available_providers as _sandbox_providers
-from omnigent.process_logging import LOG_LEVEL_ENV_VAR, LOG_TO_STDERR_ENV_VAR, data_dir, env_truthy
+from omnigent.process_logging import (
+    LOG_LEVEL_ENV_VAR,
+    LOG_TO_STDERR_ENV_VAR,
+    data_dir,
+    env_truthy,
+    process_log_dir_reference,
+)
 from omnigent.server_url import ServerUrl
 from omnigent.server_url import org_id_from_url as _org_id_from_url
 
@@ -3513,13 +3519,13 @@ def _discover_local_server_url(
         if not _host_daemon_alive():
             raise click.ClickException(
                 "The local daemon exited before its Omnigent server became ready. "
-                "See logs under ~/.omnigent/logs/host/ and "
-                "~/.omnigent/logs/server/."
+                f"See logs under {process_log_dir_reference('host')} and "
+                f"{process_log_dir_reference('server')}."
             )
         time.sleep(0.2)
     raise click.ClickException(
         f"Timed out after {timeout:.0f}s waiting for the local Omnigent server to "
-        "start. See ~/.omnigent/logs/server/ for details."
+        f"start. See {process_log_dir_reference('server')} for details."
     )
 
 
@@ -8248,7 +8254,8 @@ def _run_background_host(
                 click.echo(f"The local host daemon already serves {display_server_url(target)}.")
                 return
         raise click.ClickException(
-            "Could not spawn the background host daemon. See ~/.omnigent/logs/host/ for details."
+            "Could not spawn the background host daemon. "
+            f"See {process_log_dir_reference('host')} for details."
         )
     reused = previous is not None and previous.pid == record.pid
     try:

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -268,6 +268,22 @@ def current_process_log_path() -> Path | None:
     return _current_process_log_path or _process_log_file_from_env()
 
 
+def process_log_dir_reference(destination: str) -> str:
+    """Return a user-facing pointer to a process-log *directory*.
+
+    Resolved through :func:`process_log_dir`, so the path tracks
+    ``OMNIGENT_DATA_DIR`` instead of assuming the default tree. Use this
+    rather than :func:`process_log_reference` when the message is about a
+    different process than the caller. The CLI naming where the host daemon
+    logs must point at the host directory, not the CLI's own log file.
+
+    :param destination: Process-log destination, e.g. ``"host"``.
+    :returns: A display path with a trailing separator, e.g.
+        ``"~/.omnigent/logs/host/"``.
+    """
+    return f"{display_log_path(process_log_dir(destination))}/"
+
+
 def process_log_reference(destination: str) -> str:
     """Return a user-facing pointer to this process's log for error messages.
 
@@ -284,7 +300,7 @@ def process_log_reference(destination: str) -> str:
     path = current_process_log_path()
     if path is not None:
         return display_log_path(path)
-    return f"{display_log_path(process_log_dir(destination))}/"
+    return process_log_dir_reference(destination)
 
 
 def _terminal_stream() -> TextIO | None:

--- a/tests/cli/test_host_log_path_diagnostics.py
+++ b/tests/cli/test_host_log_path_diagnostics.py
@@ -1,0 +1,67 @@
+"""Diagnostics must name the configured data dir, not the default tree.
+
+Host and server state live under :func:`omnigent.process_logging.data_dir`,
+which honors ``OMNIGENT_DATA_DIR``. A failure message that hardcodes
+``~/.omnigent/logs/...`` sends a reader with a relocated data dir to an empty
+directory and hides the logs that would explain the failure.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from omnigent.process_logging import DATA_DIR_ENV_VAR
+
+# Every diagnostic that points a reader at a host or server log tree. Each is
+# checked for the hardcoded literal rather than exercised, because reaching
+# them needs a real daemon spawn.
+_LOG_TREE_DIAGNOSTICS = (
+    ("omnigent.cli", "_discover_local_server_url"),
+    ("omnigent.cli", "_run_background_host"),
+    ("omnigent.chat", "_unreachable_server_message"),
+)
+
+
+@pytest.mark.parametrize(("module_name", "func_name"), _LOG_TREE_DIAGNOSTICS)
+def test_diagnostic_does_not_hardcode_the_default_log_tree(
+    module_name: str,
+    func_name: str,
+) -> None:
+    """No log-tree diagnostic embeds the default ``~/.omnigent`` path.
+
+    :param module_name: Module holding the diagnostic, e.g. ``"omnigent.cli"``.
+    :param func_name: Function whose source is scanned.
+    """
+    import importlib
+
+    module = importlib.import_module(module_name)
+    source = inspect.getsource(getattr(module, func_name))
+
+    assert "~/.omnigent/logs/" not in source, (
+        f"{module_name}.{func_name} hardcodes the default log tree; "
+        "use process_log_dir_reference(destination) so the path follows "
+        f"${DATA_DIR_ENV_VAR}"
+    )
+
+
+def test_unreachable_local_server_message_names_the_relocated_log_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The loopback connection error points at the configured server log dir.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Pytest temp dir, used as the runtime data dir.
+    """
+    from omnigent.chat import _unreachable_server_message
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "elsewhere")
+    monkeypatch.setenv(DATA_DIR_ENV_VAR, str(tmp_path / "data"))
+
+    message = _unreachable_server_message("http://127.0.0.1:6767")
+
+    assert str(tmp_path / "data" / "logs" / "server") in message
+    assert "~/.omnigent" not in message

--- a/tests/test_process_logging.py
+++ b/tests/test_process_logging.py
@@ -23,6 +23,7 @@ from omnigent.process_logging import (
     child_logging_popen_kwargs,
     configure_process_logging,
     current_process_log_path,
+    process_log_dir_reference,
     process_log_reference,
     terminal_stream_handler,
     terminal_supports_color,
@@ -214,6 +215,29 @@ def test_process_log_reference_falls_back_to_the_destination_dir(
     monkeypatch.setenv(DATA_DIR_ENV_VAR, str(tmp_path / "data"))
 
     assert process_log_reference("runner") == f"{tmp_path / 'data' / 'logs' / 'runner'}/"
+
+
+def test_process_log_dir_reference_follows_the_data_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The directory pointer tracks ``OMNIGENT_DATA_DIR``.
+
+    Unlike :func:`process_log_reference` this never substitutes the caller's
+    own log file, so a message about another process names that process's
+    tree even when this one has a captured log.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Pytest temp dir, used as the runtime data dir.
+    """
+    monkeypatch.setattr(
+        "omnigent.process_logging._current_process_log_path",
+        tmp_path / "mine" / "cli.log",
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "elsewhere")
+    monkeypatch.setenv(DATA_DIR_ENV_VAR, str(tmp_path / "data"))
+
+    assert process_log_dir_reference("host") == f"{tmp_path / 'data' / 'logs' / 'host'}/"
 
 
 def test_configure_process_logging_publishes_its_log_path(


### PR DESCRIPTION
## Related issue

Closes #5541

## Summary

Host and server state moved to `data_dir()` (which honors `OMNIGENT_DATA_DIR`),
but four failure messages still spelled the default tree literally. With a
relocated data dir they sent the reader to an empty log directory and hid the
logs that would have explained the failure. That is worst exactly when it
matters most: the daemon did not come up, and its log is the only evidence.

`process_log_reference()` already composed the right pointer, but it prefers
*the calling process's own* log file. That is the wrong preference here: the
CLI reporting where the **host daemon** logs must name the host directory, not
the CLI's log. So this splits the composition it already contained into
`process_log_dir_reference()`, which always names the destination directory,
and has `process_log_reference()` call it. Net new logic: one line.

The issue names one call site. Four had the same literal, so all four are
fixed rather than just the reported one:

| Site | Message |
|---|---|
| `cli.py` `_run_background_host` | "Could not spawn the background host daemon" (the reported one) |
| `cli.py` `_discover_local_server_url` | local daemon exited before its server was ready |
| `cli.py` `_discover_local_server_url` | timed out waiting for the local server |
| `chat.py` `_unreachable_server_message` | could not connect to the local server |

**Deliberately left alone:** the `--log` help string (`cli.py`). It names
`logs_root()` rather than a process-log destination and is built at import
time for a Click decorator, so it is a different surface with a different
helper. Happy to fold it in if a reviewer wants it.

## Test Plan

```bash
pytest tests/cli/test_host_log_path_diagnostics.py tests/test_process_logging.py
# 17 passed
```

Verified the new tests actually fail on the unfixed code, rather than just
passing alongside it: restoring the old literal in `chat.py` turns both of the
relevant tests red (`hardcodes the default log tree`, and the rendered message
missing the relocated path), and re-applying the fix turns them green.

Manual check of the reported path:

```bash
OMNIGENT_DATA_DIR=/tmp/omni-relocated omnigent host start
# error now names /tmp/omni-relocated/logs/host/ instead of ~/.omnigent/logs/host/
```

Ran `pre-commit` on the touched files: `ruff format`, `ruff check`, and the
custom hooks all pass. One pre-existing failure in
`tests/cli/test_server_lifecycle.py::test_server_start_alias_warns_on_stderr_only`
reproduces on clean `main` without this change and is unrelated.

## Demo

N/A — the change is a path inside two CLI error strings; the before/after is in
the Test Plan above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two unit tests, plus a parametrized source-level guard.

`process_log_dir_reference` gets a direct test that it follows
`OMNIGENT_DATA_DIR` **even when the calling process has its own captured log
file** — that case is the whole reason it exists separately from
`process_log_reference`, and a test that omitted it would pass against the
buggy version.

For the call sites, `_unreachable_server_message` is a pure function, so it is
called directly and asserted to contain the relocated directory and no
`~/.omnigent`. The two `cli.py` sites need a real daemon spawn to reach, so
instead of mocking one they are covered by a parametrized `inspect.getsource`
guard asserting no log-tree diagnostic embeds `~/.omnigent/logs/`. That is a
cheaper and broader guard: it also catches a *new* hardcoded site added later.
This follows existing precedent in the repo (`tests/repl/test_context_command.py`,
`tests/inner/test_codex_model_catalog.py`).

Manual verification was the `OMNIGENT_DATA_DIR` run above.

## Changelog

Host and server startup failures now point at your configured `OMNIGENT_DATA_DIR` log directory instead of always `~/.omnigent/logs/`
