### PR TITLE
ci(e2e-ui): retry transient test failures once

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -299,9 +299,12 @@ jobs:
           # --durations surfaces the slowest test phases (setup/call/teardown)
           # at the end of each shard's log so we can see where the wall-clock
           # goes and rebalance; the 1s floor keeps trivial phases out.
+          # Retry every otherwise-unmarked failure once for transient CI races;
+          # per-test @pytest.mark.flaky settings still take precedence.
           uv run pytest tests/e2e_ui \
             -v --tb=long --showlocals --log-level=INFO -r a \
             --durations=25 --durations-min=1.0 \
+            --reruns=1 --reruns-delay=5 \
             --ui-skip-build \
             --splits="$NUM_SHARDS" \
             --group="$((SHARD_ID + 1))" \


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Reduce intermittent E2E UI CI failures caused by transient timing races.
- Retry otherwise-unmarked UI tests once after a five-second delay while preserving per-test `@pytest.mark.flaky` settings.

## Test Plan

- `actionlint .github/workflows/e2e-ui.yml`
- `git diff --check`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Validated the updated workflow with actionlint and checked the diff for whitespace errors. The E2E UI workflow itself will exercise the retry behavior in CI.
