### PR TITLE
chore(governance): add Leemoonsoo to the maintainer allowlist

### DIFF
--- a/.github/MAINTAINER
+++ b/.github/MAINTAINER
@@ -28,3 +28,4 @@ ajayalfred
 yaoharry
 marktai
 arthivjkumar
+Leemoonsoo


### PR DESCRIPTION
## Related issue

N/A — governance/config change (`Refactor / chore`).

## Summary

Moon is a maintainer but was missing from `.github/MAINTAINER`, so both
author-is-maintainer paths treated his contributions as a community
contributor's:

- **Issues** — `issue-triage.yml:736` assigns a maintainer-filed issue to its
  author and sets `maintainer_assigned=true`, skipping the least-loaded-owner
  round-robin. Without the entry his issues were routed to someone else
  (#5391 is an example: it landed on another maintainer's queue).
- **PRs** — `auto-assign-reviewer.js:76` skips maintainer-authored PRs
  entirely ("authors pick their own reviewers"); assignment is scoped to fork
  PRs from non-maintainers. Without the entry his PRs were in scope.

One line, and it fixes both.

### Casing is load-bearing

`issue-triage.yml` matches with `grep -qxF`, which is case-**sensitive**, so
the entry must be `Leemoonsoo` exactly as GitHub reports the login (verified
against `GET /users/leemoonsoo` → `login: Leemoonsoo`, and against the author
field on #5391). The reviewer path lowercases both sides, so a lower-cased
entry would have fixed PRs and silently left issues routing to others, with no
error.

### Scope note for reviewers

`.github/MAINTAINER` feeds ~20 workflows, so this is not only an assignment
change. It also grants: maintainer approval, merge-ready waivers,
`skip-e2e-ui-test`, security-scan bypass, `/regen`, and the demo-check /
ready-for-review exemptions. That is correct for an actual maintainer, but
worth stating explicitly rather than merging as "one line, no risk".

**Deliberately not** added to `.github/areas.json` owners. That is the opposite
direction — it would make him a *candidate* for other people's issues and PRs.
`areas.test.js` requires MAINTAINER membership first, so that remains available
as a separate decision.

## Test Plan

Verified the entry is picked up by each of the three real parsers, rather than
only by eye:

```bash
# 1. issue path — issue-triage.yml:736, case-sensitive exact match
grep -qxF 'Leemoonsoo' .github/MAINTAINER   # match
grep -qxF 'leemoonsoo' .github/MAINTAINER   # no match (the trap above)

# 2. PR path — auto-assign-reviewer.yml lowercased set
sed 's/#.*//' .github/MAINTAINER | tr -d '[:blank:]' | tr 'A-Z' 'a-z' | grep -qx 'leemoonsoo'

# 3. maintainer-approval.yml whitespace-split list
sed -E 's/#.*$//' .github/MAINTAINER | tr -s '[:space:]' '\n' | grep -v '^$' | grep -cx 'Leemoonsoo'
```

Both integrity suites that read this file pass:

```bash
node .github/workflows/areas.test.js              # All areas.json integrity checks passed
node .github/workflows/auto-assign-reviewer.test.js  # all PASS
```

`pre-commit run --files .github/MAINTAINER` passes.

## Demo

N/A — no user-visible surface.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`areas.test.js` and `auto-assign-reviewer.test.js` both read the real
`.github/MAINTAINER`, so the existing suites exercise this file directly and
pass with the entry present. Manual verification was running each of the three
production parsers against the file (commands above), including the negative
case that proves the case-sensitive path would reject a lower-cased entry.

No new test is added: a test asserting one login is in an allowlist would
restate the file rather than check behavior, and the parser-level coverage
already exists.
