### PR TITLE
feat(acp): route a sub-agent's tool calls into its child transcript

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -61,7 +61,7 @@ from typing import Any, Protocol, TypeAlias
 
 from omnigent.inner._acp_omnigent_mcp import OmnigentAcpMcp
 from omnigent.inner.acp_extension import NO_ACP_EXTENSION, AcpExtension
-from omnigent.inner.acp_subagents import SubAgentStart, read_subagent_events
+from omnigent.inner.acp_subagents import SubAgentActivity, SubAgentStart, read_subagent_events
 from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import (
@@ -73,6 +73,7 @@ from omnigent.inner.executor import (
     ReasoningChunk,
     SubAgentCompleted,
     SubAgentStarted,
+    SubAgentToolCall,
     TextChunk,
     ToolCallComplete,
     ToolCallRequest,
@@ -1187,6 +1188,36 @@ class AcpExecutor(Executor):
         update_type = update.get("sessionUpdate", "")
         events: list[ExecutorEvent] = []
 
+        # Sub-agent frames ride a per-agent dialect (Devin: cognition.ai/* on the
+        # ``_meta``); a source claims them. When one does, the frame belongs to a
+        # *child* session, not the parent stream — so emit the child-directed
+        # events and stop. The tool-card branches below would otherwise render the
+        # sub-agent's own work in the parent, and a lifecycle ``tool_call_update``
+        # (whose id was never an originating ``tool_call``) would close a spurious
+        # "tool" card there. Empty for a generic ACP agent (no sources), so this
+        # is a no-op for every non-Devin harness.
+        sub_events = read_subagent_events(update, self._extension.subagent_sources)
+        if sub_events:
+            for sub in sub_events:
+                if isinstance(sub, SubAgentStart):
+                    events.append(
+                        SubAgentStarted(child_key=sub.child_key, title=sub.title, task=sub.task)
+                    )
+                elif isinstance(sub, SubAgentActivity):
+                    events.append(
+                        SubAgentToolCall(
+                            child_key=sub.child_key,
+                            call_id=sub.call_id,
+                            name=sub.name,
+                            args=dict(sub.args),
+                        )
+                    )
+                else:  # SubAgentEnd
+                    events.append(
+                        SubAgentCompleted(child_key=sub.child_key, ok=sub.ok, summary=sub.summary)
+                    )
+            return events
+
         if update_type == _UPDATE_AGENT_MESSAGE_CHUNK:
             content = update.get("content", {})
             text = content.get("text", "") if isinstance(content, dict) else ""
@@ -1236,20 +1267,6 @@ class AcpExecutor(Executor):
 
         elif update_type == _UPDATE_CONFIG_OPTION:
             self._note_config_options(update.get("configOptions"))
-
-        # Sub-agent lifecycle rides on these updates in a per-agent dialect, so
-        # only the sources this agent's extension supplies can recognize it —
-        # none for a generic ACP agent. The runner mints a child session per
-        # start so the "Subagents" panel lists it.
-        for sub in read_subagent_events(update, self._extension.subagent_sources):
-            if isinstance(sub, SubAgentStart):
-                events.append(
-                    SubAgentStarted(child_key=sub.child_key, title=sub.title, task=sub.task)
-                )
-            else:
-                events.append(
-                    SubAgentCompleted(child_key=sub.child_key, ok=sub.ok, summary=sub.summary)
-                )
 
         return events
 

--- a/omnigent/inner/acp_subagents.py
+++ b/omnigent/inner/acp_subagents.py
@@ -6,14 +6,16 @@ child ``sessionId``, but no shipping agent emits that yet, so an agent that
 spawns sub-agents reports them in its own dialect.
 
 This module owns only the **generic** half: a small normalized lifecycle
-(:class:`SubAgentStart` / :class:`SubAgentEnd`) and the
-:class:`AcpSubAgentSource` protocol that maps one dialect onto it. It reads no
-vendor field and names no vendor;
+(:class:`SubAgentStart` / :class:`SubAgentEnd`, plus :class:`SubAgentActivity`
+for a tool call the sub-agent ran) and the :class:`AcpSubAgentSource` protocol
+that maps one dialect onto it. It reads no vendor field and names no vendor;
 :class:`~omnigent.inner.acp_executor.AcpExecutor` runs whatever sources its
-:class:`~omnigent.inner.acp_extension.AcpExtension` supplies and emits
-:class:`~omnigent.inner.executor.SubAgentStarted` /
-:class:`~omnigent.inner.executor.SubAgentCompleted`, which the runner turns into
-Omnigent child sessions so the web "Subagents" panel lists one row per child.
+:class:`~omnigent.inner.acp_extension.AcpExtension` supplies and emits the
+matching :class:`~omnigent.inner.executor.SubAgentStarted` /
+:class:`~omnigent.inner.executor.SubAgentCompleted` /
+:class:`~omnigent.inner.executor.SubAgentToolCall`, which the runner turns into
+an Omnigent child session and its transcript so the web "Subagents" panel lists
+one row per child with the work it did.
 
 A vendor's dialect lives with that vendor — see
 :class:`omnigent.inner.devin.subagents.DevinSubAgentSource` for the worked
@@ -26,7 +28,7 @@ compliant agent at once, and can ship here rather than per-vendor.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
 
@@ -60,7 +62,29 @@ class SubAgentEnd:
     summary: str = ""
 
 
-SubAgentEvent = SubAgentStart | SubAgentEnd
+@dataclass(frozen=True)
+class SubAgentActivity:
+    """A tool call a sub-agent ran, to route into its child transcript.
+
+    Distinct from the parent's own tool calls: this is a call the sub-agent made
+    *inside* its delegated work, which belongs in the child session's chat rather
+    than the parent stream. A source emits one only for frames it can attribute to
+    a specific sub-agent (Devin tags them with the owning ``parentAgentId``).
+
+    :param child_key: The owning sub-agent — matches the originating
+        :attr:`SubAgentStart.child_key`, so the runner can address the child.
+    :param call_id: The tool call's id, used as the child item's ``call_id``.
+    :param name: Human tool label for the card, e.g. ``"Wrote mathutils.py"``.
+    :param args: The tool's raw input, rendered as the call's arguments.
+    """
+
+    child_key: str
+    call_id: str
+    name: str
+    args: Mapping[str, Any] = field(default_factory=dict)
+
+
+SubAgentEvent = SubAgentStart | SubAgentEnd | SubAgentActivity
 
 
 @runtime_checkable

--- a/omnigent/inner/devin/subagents.py
+++ b/omnigent/inner/devin/subagents.py
@@ -7,9 +7,10 @@ three sub-agents (2026-08-25): no ``kind: "subagent"``, no ``childSessionId``,
 one session, and the whole lifecycle on a ``tool_call_update`` whose
 ``toolCallId`` is the sub-agent's ``agentId``::
 
-    _meta["cognition.ai/subagent_started"]   = {agentId, title, task}
-    _meta["cognition.ai/subagent_completed"] = {agentId, success, summary}
-    _meta["cognition.ai/subagent_context"]   = {parentAgentId}   # provenance only
+    _meta["cognition.ai/subagent_started"]   = {agentId, title, task}       # tool_call_update
+    _meta["cognition.ai/subagent_completed"] = {agentId, success, summary}  # tool_call_update
+    _meta["cognition.ai/subagent_context"]   = {parentAgentId}              # on the sub-agent's
+                                                                            # own tool_call frames
 
 Reading vendor ``_meta`` is not a shortcut here — it is the only structured
 sub-agent signal Devin emits, so there is no generic field to prefer. Confining
@@ -30,12 +31,20 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from omnigent.inner.acp_subagents import SubAgentEnd, SubAgentEvent, SubAgentStart
+from omnigent.inner.acp_subagents import (
+    SubAgentActivity,
+    SubAgentEnd,
+    SubAgentEvent,
+    SubAgentStart,
+)
 
 # Devin conveys the sub-agent lifecycle only through these vendor ``_meta`` keys;
-# the sub-agent's ``agentId`` is the stable key across both edges.
+# the sub-agent's ``agentId`` is the stable key across both edges. ``context``
+# tags the sub-agent's *own* tool calls with the owning agent, so they can be
+# routed into that sub-agent's child transcript instead of the parent stream.
 _STARTED = "cognition.ai/subagent_started"
 _COMPLETED = "cognition.ai/subagent_completed"
+_CONTEXT = "cognition.ai/subagent_context"
 
 
 class DevinSubAgentSource:
@@ -47,15 +56,40 @@ class DevinSubAgentSource:
     """
 
     def read(self, update: Mapping[str, Any]) -> Sequence[SubAgentEvent]:
-        """Return the sub-agent lifecycle events carried by one ``session/update``.
+        """Return the sub-agent events carried by one ``session/update``.
 
         :param update: The ACP ``params.update`` object.
-        :returns: Normalized start/end events, empty for a non-Devin frame.
+        :returns: Normalized start / end / activity events, empty for a non-Devin
+            frame. At most one applies per frame (the lifecycle keys ride
+            ``tool_call_update``; ``subagent_context`` rides the sub-agent's own
+            ``tool_call``).
         """
         meta = update.get("_meta")
         if not isinstance(meta, Mapping):
             return ()
         events: list[SubAgentEvent] = []
+
+        # The sub-agent's own tool call — route it to that sub-agent's child.
+        context = meta.get(_CONTEXT)
+        if isinstance(context, Mapping) and update.get("sessionUpdate") == "tool_call":
+            parent_agent_id = context.get("parentAgentId")
+            call_id = update.get("toolCallId")
+            if (
+                isinstance(parent_agent_id, str)
+                and parent_agent_id
+                and isinstance(call_id, str)
+                and call_id
+            ):
+                raw_input = update.get("rawInput")
+                events.append(
+                    SubAgentActivity(
+                        child_key=parent_agent_id,
+                        call_id=call_id,
+                        name=str(update.get("title") or update.get("kind") or "tool"),
+                        args=raw_input if isinstance(raw_input, Mapping) else {},
+                    )
+                )
+
         started = meta.get(_STARTED)
         if isinstance(started, Mapping):
             agent_id = started.get("agentId")

--- a/omnigent/inner/executor.py
+++ b/omnigent/inner/executor.py
@@ -298,6 +298,27 @@ class SubAgentCompleted(ExecutorEvent):
 
 
 @dataclass
+class SubAgentToolCall(ExecutorEvent):
+    """A tool call an ACP sub-agent ran, to append to its child transcript.
+
+    Distinct from :class:`ToolCallRequest`, which renders in the *parent* stream:
+    this is a call the sub-agent made inside its delegated work, routed to the
+    sub-agent's own child session by :attr:`child_key`. See
+    :mod:`omnigent.inner.acp_subagents`.
+
+    :param child_key: Matches the owning :attr:`SubAgentStarted.child_key`.
+    :param call_id: The tool call's id, used as the child item's ``call_id``.
+    :param name: Human tool label for the card, e.g. ``"Wrote mathutils.py"``.
+    :param args: The tool's arguments (its raw input).
+    """
+
+    child_key: str
+    call_id: str
+    name: str
+    args: ToolArgs = field(default_factory=dict)
+
+
+@dataclass
 class TurnCancelled(ExecutorEvent):
     """The current assistant turn was cancelled before completion."""
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -822,6 +822,92 @@ async def _complete_acp_subagent_child(
         )
 
 
+async def _post_acp_subagent_tool_call(
+    client: httpx.AsyncClient,
+    *,
+    child_key: str,
+    call_id: str,
+    name: str,
+    arguments: str,
+    child_id_future: asyncio.Future[str],
+    title: str = "",
+) -> None:
+    """Append one of a sub-agent's own tool calls to its child transcript.
+
+    Renders as a ``function_call`` card in the child's chat (the same shape the
+    parent uses for an observed tool call), so opening a sub-agent shows the work
+    it did, not just the task and summary. Shares the ``response_id`` the task and
+    summary messages use, so the card groups into the same turn.
+
+    Waits (bounded) for the start edge to mint the child. Best-effort: a missing
+    or failed mint is logged and skipped, never raised into the turn.
+
+    :param client: Omnigent HTTP client for the runner subprocess.
+    :param child_key: Stable sub-agent id, matching the start edge.
+    :param call_id: The tool call's id (the child item's ``call_id``).
+    :param name: Human tool label, e.g. ``"Wrote mathutils.py"``.
+    :param arguments: JSON-encoded arguments string (the tool's raw input).
+    :param child_id_future: Future the start edge resolves with the child id.
+    :param title: The sub-agent's display name, used as the item's author; falls
+        back to *child_key* when empty.
+    """
+    try:
+        child_id = await asyncio.wait_for(
+            asyncio.shield(child_id_future), timeout=_SUBAGENT_MINT_WAIT_S
+        )
+    except Exception as exc:  # noqa: BLE001 — includes the start edge's own mint failure
+        _logger.warning(
+            "acp sub-agent child unavailable for tool call (child_key=%s): %s", child_key, exc
+        )
+        return
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{child_id}/events",
+            json={
+                "type": "external_conversation_item",
+                "data": {
+                    "item_type": "function_call",
+                    "item_data": {
+                        # FunctionCallData.agent (validated by name, serialized as "model").
+                        "agent": title or child_key,
+                        "name": name,
+                        "arguments": arguments or "{}",
+                        "call_id": call_id,
+                    },
+                    "response_id": f"resp_acpsub_{child_key}",
+                },
+            },
+        )
+        resp.raise_for_status()
+    except Exception as exc:  # noqa: BLE001 — a transcript item must not break the turn
+        _logger.warning("acp sub-agent tool-call item failed (child_key=%s): %s", child_key, exc)
+
+
+def _chain_acp_subagent_post(
+    prev: asyncio.Task[object] | None, coro: Awaitable[None]
+) -> asyncio.Task[object]:
+    """Serialize a child's transcript posts so its items land in stream order.
+
+    The start/tool-call/completion edges for one sub-agent are dispatched as
+    independent tasks; without ordering, the summary could race ahead of a tool
+    card. Each post is chained after the child's previous one (mint → tool calls
+    → summary), and the stream is never blocked because chaining only schedules a
+    task. A failure in *prev* is suppressed so one bad post can't strand the rest.
+
+    :param prev: The child's previous post task, or ``None`` for the first.
+    :param coro: The post coroutine to run after *prev* completes.
+    :returns: The new tail task for this child.
+    """
+
+    async def _run() -> None:
+        if prev is not None:
+            with contextlib.suppress(Exception):
+                await prev
+        await coro
+
+    return asyncio.create_task(_run())
+
+
 def _response_body_preview(resp: object, *, limit: int = 500) -> str:
     """
     Return a short response-body preview for diagnostics.
@@ -6961,6 +7047,10 @@ def create_runner_app(
                     # Sub-agent start edge → its title, so the completion edge can
                     # author the summary message (assistant messages need one).
                     _subagent_titles: dict[str, str] = {}
+                    # Sub-agent child_key → its latest transcript-post task, so the
+                    # mint / tool-call / completion posts for one child land in
+                    # order instead of racing.
+                    _subagent_post_chains: dict[str, _asyncio.Task[object]] = {}
                     _text_acc: list[str] = []
                     _stream_failed_error: _JsonObject | None = None
                     async for chunk in harness_resp.aiter_text():
@@ -7216,6 +7306,8 @@ def create_runner_app(
                                     # A harness reported spawning a sub-agent; mint
                                     # a child session so it shows in the Subagents
                                     # panel. Swallowed (never relayed to clients).
+                                    # The mint task heads the child's post chain, so
+                                    # its tool calls and summary land after it.
                                     _sa_key = event.get("child_key", "")
                                     if isinstance(_sa_key, str) and _sa_key:
                                         _sa_start_future: _asyncio.Future[str] = (
@@ -7223,18 +7315,45 @@ def create_runner_app(
                                         )
                                         _subagent_child_futures[_sa_key] = _sa_start_future
                                         _subagent_titles[_sa_key] = event.get("title", "")
-                                        _dispatch_tasks.append(
-                                            _asyncio.create_task(
-                                                _mint_acp_subagent_child(
-                                                    server_client,
-                                                    parent_id=conv_id,
-                                                    child_key=_sa_key,
-                                                    title=event.get("title", ""),
-                                                    task=event.get("task", ""),
-                                                    child_id_future=_sa_start_future,
-                                                )
+                                        _sa_mint_task = _asyncio.create_task(
+                                            _mint_acp_subagent_child(
+                                                server_client,
+                                                parent_id=conv_id,
+                                                child_key=_sa_key,
+                                                title=event.get("title", ""),
+                                                task=event.get("task", ""),
+                                                child_id_future=_sa_start_future,
                                             )
                                         )
+                                        _subagent_post_chains[_sa_key] = _sa_mint_task
+                                        _dispatch_tasks.append(_sa_mint_task)
+                                    continue
+
+                                if _evt_type == "subagent.tool_call":
+                                    # A tool call the sub-agent ran; append it to the
+                                    # child's transcript, chained after the child's
+                                    # previous post so it stays ordered.
+                                    _sa_tc_key = event.get("child_key", "")
+                                    _sa_tc_future = (
+                                        _subagent_child_futures.get(_sa_tc_key)
+                                        if isinstance(_sa_tc_key, str)
+                                        else None
+                                    )
+                                    if _sa_tc_future is not None:
+                                        _sa_tc_task = _chain_acp_subagent_post(
+                                            _subagent_post_chains.get(_sa_tc_key),
+                                            _post_acp_subagent_tool_call(
+                                                server_client,
+                                                child_key=_sa_tc_key,
+                                                call_id=event.get("call_id", ""),
+                                                name=event.get("name", "tool"),
+                                                arguments=event.get("arguments", ""),
+                                                child_id_future=_sa_tc_future,
+                                                title=_subagent_titles.get(_sa_tc_key, ""),
+                                            ),
+                                        )
+                                        _subagent_post_chains[_sa_tc_key] = _sa_tc_task
+                                        _dispatch_tasks.append(_sa_tc_task)
                                     continue
 
                                 if _evt_type == "subagent.completed":
@@ -7245,18 +7364,19 @@ def create_runner_app(
                                         else None
                                     )
                                     if _sa_done_future is not None:
-                                        _dispatch_tasks.append(
-                                            _asyncio.create_task(
-                                                _complete_acp_subagent_child(
-                                                    server_client,
-                                                    child_key=_sa_done_key,
-                                                    ok=bool(event.get("ok", True)),
-                                                    summary=event.get("summary", ""),
-                                                    child_id_future=_sa_done_future,
-                                                    title=_subagent_titles.get(_sa_done_key, ""),
-                                                )
-                                            )
+                                        _sa_done_task = _chain_acp_subagent_post(
+                                            _subagent_post_chains.get(_sa_done_key),
+                                            _complete_acp_subagent_child(
+                                                server_client,
+                                                child_key=_sa_done_key,
+                                                ok=bool(event.get("ok", True)),
+                                                summary=event.get("summary", ""),
+                                                child_id_future=_sa_done_future,
+                                                title=_subagent_titles.get(_sa_done_key, ""),
+                                            ),
                                         )
+                                        _subagent_post_chains[_sa_done_key] = _sa_done_task
+                                        _dispatch_tasks.append(_sa_done_task)
                                     continue
 
                             if event is None:

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -33,6 +33,7 @@ from omnigent.inner.executor import (
     ReasoningChunk,
     SubAgentCompleted,
     SubAgentStarted,
+    SubAgentToolCall,
     TextChunk,
     ToolCallComplete,
     ToolCallRequest,
@@ -798,6 +799,18 @@ class ExecutorAdapter(HarnessApp):
                     child_key=event.child_key,
                     ok=event.ok,
                     summary=event.summary,
+                )
+            )
+        elif isinstance(event, SubAgentToolCall):
+            from omnigent.server.schemas import SubagentToolCallEvent
+
+            ctx.emit(
+                SubagentToolCallEvent(
+                    type="subagent.tool_call",
+                    child_key=event.child_key,
+                    call_id=event.call_id,
+                    name=event.name,
+                    arguments=_serialize_args(event.args),
                 )
             )
         # ExecutorError handled by the caller (re-raises so the

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -4580,12 +4580,38 @@ class SubagentCompletedEvent(_SSEEventBase):
     summary: str = ""
 
 
+class SubagentToolCallEvent(_SSEEventBase):
+    """
+    Runner-internal marker: an ACP sub-agent ran a tool call.
+
+    Emitted by the adapter from a
+    :class:`~omnigent.inner.executor.SubAgentToolCall` — a call the sub-agent
+    made inside its delegated work, which belongs in the child's transcript, not
+    the parent stream. The runner appends it as a ``function_call`` conversation
+    item on the child session minted for the matching ``child_key``. **Never**
+    relayed to external clients.
+
+    :param type: Always ``"subagent.tool_call"``.
+    :param child_key: Matches the :attr:`SubagentStartedEvent.child_key`.
+    :param call_id: The tool call's id, used as the child item's ``call_id``.
+    :param name: Human tool label for the card, e.g. ``"Wrote mathutils.py"``.
+    :param arguments: JSON-encoded arguments string (the tool's raw input).
+    """
+
+    type: Literal["subagent.tool_call"]
+    child_key: str
+    call_id: str
+    name: str
+    arguments: str = ""
+
+
 HarnessStreamEvent = (
     ServerStreamEvent
     | InjectionConsumedEvent
     | PolicyEvaluationRequestEvent
     | SubagentStartedEvent
     | SubagentCompletedEvent
+    | SubagentToolCallEvent
 )
 
 

--- a/tests/inner/devin/test_devin_subagents.py
+++ b/tests/inner/devin/test_devin_subagents.py
@@ -9,7 +9,7 @@ against what Devin actually emits, not a paraphrase.
 
 from __future__ import annotations
 
-from omnigent.inner.acp_subagents import SubAgentEnd, SubAgentStart
+from omnigent.inner.acp_subagents import SubAgentActivity, SubAgentEnd, SubAgentStart
 from omnigent.inner.devin import DEVIN_ACP_EXTENSION, DevinSubAgentSource
 
 # --- real captured frames (params.update objects) -----------------------------
@@ -40,11 +40,14 @@ _DEVIN_COMPLETED = {
     },
 }
 
-# A nested tool call the sub-agent made — marks provenance, NOT a lifecycle edge.
+# A nested tool call the sub-agent made — tagged with the owning agentId so it
+# can be routed into that sub-agent's child transcript.
 _DEVIN_CONTEXT = {
     "sessionUpdate": "tool_call",
     "toolCallId": "toolu_bdrk_01Ha8UacTecWfxbxgERXdGtN",
-    "title": "Wrote mathutils.py",
+    "title": "Wrote /tmp/x/mathutils.py",
+    "kind": "edit",
+    "rawInput": {"file_path": "/tmp/x/mathutils.py", "content": "def add(a, b): ..."},
     "_meta": {"cognition.ai/subagent_context": {"parentAgentId": "a0ac9364"}},
 }
 
@@ -77,13 +80,66 @@ def test_devin_source_reads_a_completion() -> None:
     )
 
 
-def test_devin_source_ignores_context_marker() -> None:
-    """``subagent_context`` marks a nested call's provenance — not a lifecycle edge.
+def test_devin_source_reads_context_as_activity() -> None:
+    """``subagent_context`` on a ``tool_call`` → a ``SubAgentActivity`` for the child.
 
-    Treating it as a start/end would mint or close a phantom child on every tool
-    call the sub-agent makes.
+    **What breaks if this fails**: the sub-agent's own work (its file writes,
+    commands) never reaches its child transcript — the child chat shows only the
+    task and summary. ``parentAgentId`` is the child_key, so the runner can route
+    the card to the right sub-agent.
     """
-    assert DevinSubAgentSource().read(_DEVIN_CONTEXT) == ()
+    events = DevinSubAgentSource().read(_DEVIN_CONTEXT)
+    assert events == (
+        SubAgentActivity(
+            child_key="a0ac9364",
+            call_id="toolu_bdrk_01Ha8UacTecWfxbxgERXdGtN",
+            name="Wrote /tmp/x/mathutils.py",
+            args={"file_path": "/tmp/x/mathutils.py", "content": "def add(a, b): ..."},
+        ),
+    )
+
+
+def test_devin_source_ignores_context_on_a_non_tool_call() -> None:
+    """A ``subagent_context`` marker off a ``tool_call`` frame is not an activity.
+
+    Only the sub-agent's own ``tool_call`` frames are its work; the same marker on
+    another update kind is not a tool card, so it is left alone (and not routed).
+    """
+    assert (
+        DevinSubAgentSource().read(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "toolu_x",
+                "status": "in_progress",
+                "_meta": {"cognition.ai/subagent_context": {"parentAgentId": "a0ac9364"}},
+            }
+        )
+        == ()
+    )
+
+
+def test_devin_source_skips_context_with_a_blank_parent_or_call_id() -> None:
+    """Activity needs both a parent agent id and a call id to be addressable."""
+    source = DevinSubAgentSource()
+    assert (
+        source.read(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "c1",
+                "_meta": {"cognition.ai/subagent_context": {}},
+            }
+        )
+        == ()
+    )
+    assert (
+        source.read(
+            {
+                "sessionUpdate": "tool_call",
+                "_meta": {"cognition.ai/subagent_context": {"parentAgentId": "a0"}},
+            }
+        )
+        == ()
+    )
 
 
 def test_devin_source_self_gates_on_plain_frames() -> None:
@@ -138,10 +194,16 @@ def test_devin_dialect_reaches_the_executor_through_the_extension() -> None:
     a rename on either side of the seam fails here rather than silently.
     """
     from omnigent.inner.acp_executor import AcpAgentConfig, AcpExecutor
-    from omnigent.inner.executor import SubAgentCompleted, SubAgentStarted
+    from omnigent.inner.executor import (
+        SubAgentCompleted,
+        SubAgentStarted,
+        SubAgentToolCall,
+        ToolCallComplete,
+    )
 
     ex = AcpExecutor(AcpAgentConfig(command="devin acp"), extension=DEVIN_ACP_EXTENSION)
     started = ex._handle_session_update(_DEVIN_STARTED)
+    activity = ex._handle_session_update(_DEVIN_CONTEXT)
     completed = ex._handle_session_update(_DEVIN_COMPLETED)
 
     assert [e for e in started if isinstance(e, SubAgentStarted)] == [
@@ -151,6 +213,14 @@ def test_devin_dialect_reaches_the_executor_through_the_extension() -> None:
             task="In the directory /tmp/x create mathutils.py with add/sub/mul and tests.",
         )
     ]
+    assert [e for e in activity if isinstance(e, SubAgentToolCall)] == [
+        SubAgentToolCall(
+            child_key="a0ac9364",
+            call_id="toolu_bdrk_01Ha8UacTecWfxbxgERXdGtN",
+            name="Wrote /tmp/x/mathutils.py",
+            args={"file_path": "/tmp/x/mathutils.py", "content": "def add(a, b): ..."},
+        )
+    ]
     assert [e for e in completed if isinstance(e, SubAgentCompleted)] == [
         SubAgentCompleted(
             child_key="a0ac9364",
@@ -158,3 +228,7 @@ def test_devin_dialect_reaches_the_executor_through_the_extension() -> None:
             summary="Created mathutils.py and test_mathutils.py; 3 tests pass.",
         )
     ]
+    # The sub-agent's frames never leak into the parent stream as tool cards —
+    # in particular the completed lifecycle frame must not close a spurious
+    # "tool" card (its toolCallId was never an originating tool_call).
+    assert not any(isinstance(e, ToolCallComplete) for e in completed)

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -32,6 +32,7 @@ from omnigent.inner.executor import (
     ReasoningChunk,
     SubAgentCompleted,
     SubAgentStarted,
+    SubAgentToolCall,
     TextChunk,
     ToolCallComplete,
     ToolCallRequest,
@@ -364,11 +365,17 @@ class _FakeSubAgentDialect:
     """An invented dialect, so this generic suite names no vendor."""
 
     def read(self, update: dict[str, object]) -> tuple[object, ...]:
-        """Return a start/end for ``acme.dev/spawn`` / ``acme.dev/done``."""
-        from omnigent.inner.acp_subagents import SubAgentEnd, SubAgentStart
+        """Return start / activity / end for ``acme.dev/{spawn,work,done}``."""
+        from omnigent.inner.acp_subagents import SubAgentActivity, SubAgentEnd, SubAgentStart
 
         if isinstance(update.get("acme.dev/spawn"), dict):
             return (SubAgentStart(child_key="w1", title="worker", task="do a thing"),)
+        if isinstance(update.get("acme.dev/work"), dict):
+            return (
+                SubAgentActivity(
+                    child_key="w1", call_id="c9", name="Wrote out.txt", args={"path": "out.txt"}
+                ),
+            )
         if isinstance(update.get("acme.dev/done"), dict):
             return (SubAgentEnd(child_key="w1", ok=True, summary="done"),)
         return ()
@@ -427,11 +434,44 @@ def test_generic_executor_does_no_subagent_scanning() -> None:
 
 
 def test_tool_cards_still_render_alongside_the_scan() -> None:
-    """The scan is additive — an ordinary tool_call still produces its card."""
+    """An ordinary (unclaimed) tool_call still produces a parent card."""
     events = _extended_executor()._handle_session_update(
         {"sessionUpdate": "tool_call", "toolCallId": "c1", "title": "Ran ls", "kind": "execute"}
     )
     assert [type(e) for e in events] == [ToolCallRequest]
+
+
+def test_handle_session_update_routes_activity_to_the_child() -> None:
+    """A claimed tool call becomes a ``SubAgentToolCall``, not a parent card.
+
+    **What breaks if this fails**: the sub-agent's own work renders in the parent
+    stream (or nowhere) instead of the child transcript — the exact gap this
+    change closes.
+    """
+    events = _extended_executor()._handle_session_update(
+        {"sessionUpdate": "tool_call", "toolCallId": "c9", "acme.dev/work": {"any": 1}}
+    )
+    assert events == [
+        SubAgentToolCall(
+            child_key="w1", call_id="c9", name="Wrote out.txt", args={"path": "out.txt"}
+        )
+    ]
+    # The frame is claimed, so it does NOT also emit a parent tool card.
+    assert not any(isinstance(e, ToolCallRequest) for e in events)
+
+
+def test_claimed_completion_frame_emits_no_spurious_parent_card() -> None:
+    """A claimed ``tool_call_update`` doesn't also close a parent tool card.
+
+    The sub-agent's completion rides a ``tool_call_update`` whose id was never an
+    originating ``tool_call``; without the short-circuit the terminal-status
+    branch would emit a stray ``ToolCallComplete(name="tool")`` in the parent.
+    """
+    events = _extended_executor()._handle_session_update(
+        {"sessionUpdate": "tool_call_update", "status": "completed", "acme.dev/done": {"id": "w1"}}
+    )
+    assert [type(e) for e in events] == [SubAgentCompleted]
+    assert not any(isinstance(e, ToolCallComplete) for e in events)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/runner/test_acp_subagent_forwarding.py
+++ b/tests/runner/test_acp_subagent_forwarding.py
@@ -302,3 +302,104 @@ async def test_transcript_failure_does_not_break_the_turn() -> None:
         child_id_future=fut,
     )
     assert fut.result() == "child_abc", "the child id must survive a transcript failure"
+
+
+@pytest.mark.asyncio
+async def test_post_tool_call_appends_a_function_call_to_the_child() -> None:
+    """A sub-agent's own tool call lands in the child as a ``function_call`` card.
+
+    **What breaks if this fails**: the child chat shows only the task and summary,
+    never the work the sub-agent did — the gap this fix closes. The item must
+    carry the FunctionCallData fields (agent/name/arguments/call_id) or the server
+    rejects it, and share the messages' ``response_id`` so it groups into the turn.
+    """
+    child_url = "/v1/sessions/child_abc/events"
+    client = _RecordingServerClient([_ok(child_url)])
+    fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    fut.set_result("child_abc")
+
+    await runner_app_mod._post_acp_subagent_tool_call(
+        client,  # type: ignore[arg-type]
+        child_key="a0ac9364",
+        call_id="toolu_01",
+        name="Wrote mathutils.py",
+        arguments='{"file_path": "mathutils.py"}',
+        child_id_future=fut,
+        title="mathutils",
+    )
+
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    assert call.url == child_url
+    assert call.body["type"] == "external_conversation_item"
+    assert call.body["data"]["item_type"] == "function_call"
+    assert call.body["data"]["item_data"] == {
+        "agent": "mathutils",
+        "name": "Wrote mathutils.py",
+        "arguments": '{"file_path": "mathutils.py"}',
+        "call_id": "toolu_01",
+    }
+    assert call.body["data"]["response_id"] == "resp_acpsub_a0ac9364"
+
+
+@pytest.mark.asyncio
+async def test_post_tool_call_skips_when_mint_failed() -> None:
+    """If the start edge's mint failed, a tool-call post logs and skips — no POST."""
+    client = _RecordingServerClient([])  # any POST would fail loudly (empty queue)
+    fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    fut.set_exception(RuntimeError("mint failed"))
+
+    await runner_app_mod._post_acp_subagent_tool_call(
+        client,  # type: ignore[arg-type]
+        child_key="a0ac9364",
+        call_id="toolu_01",
+        name="Wrote x",
+        arguments="{}",
+        child_id_future=fut,
+    )
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_post_tool_call_defaults_agent_to_child_key() -> None:
+    """With no title, the card's author falls back to the child_key (never blank)."""
+    child_url = "/v1/sessions/c/events"
+    client = _RecordingServerClient([_ok(child_url)])
+    fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    fut.set_result("c")
+    await runner_app_mod._post_acp_subagent_tool_call(
+        client,  # type: ignore[arg-type]
+        child_key="k1",
+        call_id="t1",
+        name="Ran ls",
+        arguments="{}",
+        child_id_future=fut,
+    )
+    assert client.calls[0].body["data"]["item_data"]["agent"] == "k1"
+
+
+@pytest.mark.asyncio
+async def test_chain_orders_posts_and_survives_a_failure() -> None:
+    """The per-child chain runs posts in dispatch order, tolerating a bad one.
+
+    Ordering is the whole point: without it a sub-agent's summary could land before
+    a tool card. The chain must also not let one failed post strand the rest.
+    """
+    order: list[str] = []
+
+    async def _append(tag: str) -> None:
+        order.append(tag)
+
+    async def _boom() -> None:
+        order.append("boom")
+        raise RuntimeError("post failed")
+
+    # mint (no prev) -> tool1 -> failing tool2 -> summary, each chained on the last.
+    t = runner_app_mod._chain_acp_subagent_post(None, _append("mint"))
+    t = runner_app_mod._chain_acp_subagent_post(t, _append("tool1"))
+    t = runner_app_mod._chain_acp_subagent_post(t, _boom())
+    t = runner_app_mod._chain_acp_subagent_post(t, _append("summary"))
+    await t
+
+    # Order preserved, and the failing post did not stop the summary from running.
+    assert order == ["mint", "tool1", "boom", "summary"]

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -2211,3 +2211,36 @@ def test_translate_event_emits_subagent_completed() -> None:
         True,
         "3 tests pass",
     )
+
+
+def test_translate_event_emits_subagent_tool_call() -> None:
+    """A ``SubAgentToolCall`` becomes ``subagent.tool_call`` with JSON arguments.
+
+    The runner appends this to the child transcript as a ``function_call`` card,
+    so ``arguments`` must be the JSON-encoded string the item expects.
+    """
+    from omnigent.inner.executor import SubAgentToolCall
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.server.schemas import SubagentToolCallEvent
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    ctx = _RecordingTurnContext(response_id="resp_sa")
+    adapter._translate_event(
+        SubAgentToolCall(
+            child_key="a0ac9364",
+            call_id="toolu_01",
+            name="Wrote mathutils.py",
+            args={"file_path": "mathutils.py"},
+        ),
+        ctx,  # type: ignore[arg-type]
+    )
+    assert len(ctx.emitted) == 1
+    ev = ctx.emitted[0]
+    assert isinstance(ev, SubagentToolCallEvent)
+    assert (ev.type, ev.child_key, ev.call_id, ev.name) == (
+        "subagent.tool_call",
+        "a0ac9364",
+        "toolu_01",
+        "Wrote mathutils.py",
+    )
+    assert json.loads(ev.arguments) == {"file_path": "mathutils.py"}

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -1051,6 +1051,53 @@ async def test_acp_subagent_summary_needs_an_agent_to_persist(
     )
 
 
+async def test_acp_subagent_tool_call_persists_into_the_child(
+    client: httpx.AsyncClient,
+) -> None:
+    """A sub-agent's own tool call persists into its child as a ``function_call``.
+
+    The transcript-depth path: the runner appends each of the sub-agent's tool
+    calls to its child as a ``function_call`` item so opening the row shows the
+    work it did, not just the task and summary. ``FunctionCallData`` requires
+    ``agent`` / ``name`` / ``arguments`` / ``call_id``, so this pins that the
+    exact shape the runner sends is accepted and appears in the child's items.
+    """
+    import json
+
+    agent = await create_test_agent(client)
+    parent = await _create_session(client, agent["id"])
+    mint = await client.post(
+        f"/v1/sessions/{parent['id']}/events",
+        json={
+            "type": "external_acp_subagent_start",
+            "data": {"subagent_id": "a0ac9364", "title": "mathutils", "description": "t"},
+        },
+    )
+    child_id = mint.json()["child_session_id"]
+
+    resp = await client.post(
+        f"/v1/sessions/{child_id}/events",
+        json={
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "function_call",
+                "item_data": {
+                    "agent": "mathutils",
+                    "name": "Wrote mathutils.py",
+                    "arguments": '{"file_path": "mathutils.py"}',
+                    "call_id": "toolu_01",
+                },
+                "response_id": "resp_acpsub_a0ac9364",
+            },
+        },
+    )
+    assert resp.status_code in (200, 202), resp.text
+
+    items = (await client.get(f"/v1/sessions/{child_id}/items")).json()["data"]
+    assert any(it.get("type") == "function_call" for it in items), items
+    assert "Wrote mathutils.py" in json.dumps(items)
+
+
 async def test_external_subagent_start_handles_duplicate_agent_type_and_description(
     client: httpx.AsyncClient,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #5574

## Summary

An ACP sub-agent's child session (from #5489) showed only the **task** and the
**summary** — the tool calls it actually ran rendered in the *parent* stream, so
opening a sub-agent row didn't show its work. This routes them into the child.

Devin tags a sub-agent's own tool calls with the owning agent via
`_meta["cognition.ai/subagent_context"].parentAgentId` — which is the child_key
from the start edge — so each can be addressed to the right child.

| | Before | After |
|---|---|---|
| Child chat | task + summary only | task + **its tool cards** + summary |
| Parent stream | the sub-agent's writes **+ a stray `tool` card per sub-agent** | just the delegation cards |

<details>
<summary>ELI5 + the flow</summary>

Each helper agent's file writes were showing up on the boss's transcript, not the
helper's own page — and the boss's page also grew a blank "tool" card every time a
helper finished. Now each helper's work lands on the helper's page, and the blank
cards are gone.

```
Devin tool_call (_meta cognition.ai/subagent_context.parentAgentId = a0ac9364)
  └─ DevinSubAgentSource → SubAgentActivity(child_key=a0ac9364, call_id, name, args)
       └─ AcpExecutor → SubAgentToolCall     (parent tool-card branch short-circuited)
            └─ adapter → subagent.tool_call   (runner-internal SSE, never sent to client)
                 └─ runner → external_conversation_item (function_call) on the child
```
</details>

The seam gains a third normalized event, `SubAgentActivity`, beside start/end. The
executor now **scans sub-agent events first and short-circuits** when a source
claims a frame — the frame belongs to a child, not the parent. That also fixes a
**latent bug**: a sub-agent's completion rides a `tool_call_update status=completed`
whose `toolCallId` (the agentId) was never an originating `tool_call`, so the
terminal-status branch was closing a spurious `ToolCallComplete(name="tool")` card
in the parent — one per sub-agent. The short-circuit removes it.

Per-child posts (mint → tool calls → summary) are serialized through an ordered
chain so the child transcript can't render the summary ahead of a tool card,
without blocking the stream.

**Generic and additive.** A source that claims no frames — every non-Devin ACP
agent — leaves the parent path exactly as it was. No new server code: the child
item goes through the existing `external_conversation_item` (`function_call`) path.

## Test Plan

Verified end-to-end by replaying the **real captured turn** (three sub-agents)
through the executor with Devin's extension:

```
SubAgentToolCall  : 21   routed to 3 children (6 / 9 / 6)
parent ToolCallRequest: 23  (delegation cards kept: "Ran general subagent …")
spurious 'tool' ToolCallComplete in parent: 0   (was 3 before this change)
```

New tests across the layers:

- `tests/inner/devin/test_devin_subagents.py` — `subagent_context` on a `tool_call`
  → `SubAgentActivity` (real frame); not claimed off a non-`tool_call`; blank
  parent/call id guarded; and the dialect→executor path emits `SubAgentToolCall`
  and no spurious parent completion.
- `tests/inner/test_acp_executor.py` (vendor-free) — a claimed activity frame emits
  `SubAgentToolCall` and **no** parent card; a claimed completed frame emits **no**
  `ToolCallComplete`; an unclaimed `tool_call` still renders a parent card.
- `tests/runtime/harnesses/test_executor_adapter.py` — `SubAgentToolCall` →
  `subagent.tool_call` with JSON-encoded arguments.
- `tests/runner/test_acp_subagent_forwarding.py` — the poster appends the right
  `function_call` item (agent/name/arguments/call_id, child response_id), awaits
  the mint, skips on mint failure; and the chain runs posts **in order** and
  survives a failing post.
- `tests/server/integration/test_sessions_endpoints.py` — over real HTTP, a
  `function_call` item persists into the child and appears in its `/items`.

**Suites** — `tests/inner/devin/`, `test_acp_subagents.py`, `test_acp_executor.py`,
`test_executor_adapter.py`, `test_acp_subagent_forwarding.py`, goose/qwen executors
→ **338 passed**; server ACP-subagent integration → **23 passed**; schemas +
`test_app_sessions_native_wake_forwarders` + `test_runner_policy` → **127 passed**.
`pyrefly` 0 errors, `ruff` clean, full `pre-commit` on the changed files passes,
`uv.lock` untouched.

## Demo

N/A — no frontend change. The Subagents panel already renders a child's
conversation items; this makes the runner mint the tool-call items. The exact item
shape and its persistence are asserted in the runner and server-integration tests
above.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the real-capture replay above (21 tool calls routed, stray
parent cards 3 → 0). What is not automated is the final pixels — seeing the tool
cards render inside a sub-agent row in the web UI — which needs a live Devin turn,
the same limitation as #5489. Every link up to the persisted child item is covered
(dialect → executor → adapter → runner POST → server `/items`).

## Changelog

ACP sub-agents (e.g. Devin) now show the tool calls they ran inside their own
Subagents-panel chat, instead of only the task and final summary
