### PR TITLE
fix(web): inset the mobile pill for the Chat/Terminal toggle

### DIFF
--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -454,6 +454,20 @@ describe("ChatHeader — floating mobile controls", () => {
     expect(toggle).toHaveClass("size-10");
   });
 
+  it("insets the pill's leading edge for the Chat/Terminal track", () => {
+    // The track paints its own background to its edge, so with the pill's
+    // zero padding it sat flush against the border while an icon-only
+    // neighbour cleared it by the slack in its 40px box. The inset is
+    // conditional: a lone kebab must stay the 40px circle asserted above.
+    isMobileMock.mockReturnValue(true);
+    renderHeaderWithSession(makeTerminalFirstCtx());
+
+    const cluster = screen.getByTestId("view-mode-toggle").parentElement;
+    expect(cluster).toHaveClass("max-md:has-data-[slot=view-mode-toggle]:pl-1.5");
+    // The guard keys off the track's own data-slot, so it has to be present.
+    expect(screen.getByTestId("view-mode-toggle")).toHaveAttribute("data-slot", "view-mode-toggle");
+  });
+
   it("rounds the kebab's own background so no square shows inside the pill", () => {
     // The ghost button paints `aria-expanded:bg-muted` at its rounded-lg
     // radius, which showed as a square behind the round pill once open.

--- a/web/src/shell/ViewModeToggle.tsx
+++ b/web/src/shell/ViewModeToggle.tsx
@@ -30,6 +30,9 @@ export function ViewModeToggle() {
       role="group"
       aria-label="Switch between chat and terminal"
       data-testid="view-mode-toggle"
+      // Lets the mobile header pill inset itself only when this segmented
+      // track is present — see MOBILE_GLASS_PILL.
+      data-slot="view-mode-toggle"
       // Inset track: p-0.5 around two size-6 segments lands the control at
       // 32px tall, matching the header's other controls.
       className="flex items-center gap-0.5 rounded-[var(--radius-lg)] bg-muted/60 p-0.5"

--- a/web/src/shell/mobileGlass.ts
+++ b/web/src/shell/mobileGlass.ts
@@ -14,5 +14,11 @@ export const MOBILE_GLASS_SURFACE =
  * A control cluster's floating pill. No padding of its own so a single
  * ``size="icon"`` child stays exactly 40px — the sidebar toggle and the
  * session kebab must read as the same size.
+ *
+ * The exception is the Chat/Terminal track (ViewModeToggle): it paints its
+ * own background out to its edge, so with no padding it collides with the
+ * pill's border while an icon-only neighbour still clears it by the slack
+ * inside its 40px box. Inset the leading edge by that slack — only when the
+ * track is present — so ink sits 12px from either end.
  */
-export const MOBILE_GLASS_PILL = `${MOBILE_GLASS_SURFACE} max-md:rounded-full`;
+export const MOBILE_GLASS_PILL = `${MOBILE_GLASS_SURFACE} max-md:rounded-full max-md:has-data-[slot=view-mode-toggle]:pl-1.5`;

--- a/web/src/shell/mobileGlass.ts
+++ b/web/src/shell/mobileGlass.ts
@@ -19,6 +19,8 @@ export const MOBILE_GLASS_SURFACE =
  * own background out to its edge, so with no padding it collides with the
  * pill's border while an icon-only neighbour still clears it by the slack
  * inside its 40px box. Inset the leading edge by that slack — only when the
- * track is present — so ink sits 12px from either end.
+ * track is present — so ink sits 12px from either end. Assumes the track is
+ * the cluster's leading child on mobile; a control added ahead of it would
+ * take the inset instead.
  */
 export const MOBILE_GLASS_PILL = `${MOBILE_GLASS_SURFACE} max-md:rounded-full max-md:has-data-[slot=view-mode-toggle]:pl-1.5`;


### PR DESCRIPTION
## Related issue

Closes #5577

## Summary

- The mobile header pill carries `padding: 0` on purpose, so a lone `size="icon"`
  child stays exactly 40px and matches the sidebar toggle across the header. That
  holds for icon-only children — a 40px box around a `size-4` glyph self-clears
  ~12px — but `ViewModeToggle` paints its own `bg-muted/60` track out to its edge,
  so the track collided with the pill's left border while the kebab beside it
  cleared the right border.
- Inset the pill's leading edge by the 6px of slack an icon child gets for free,
  gated on `has-data-[slot=view-mode-toggle]` so the inset applies **only** when
  the segmented track is present. A lone-kebab pill stays the 40px circle
  `ChatHeader.test.tsx` already asserts.
- `ViewModeToggle` grows a `data-slot="view-mode-toggle"` hook for that variant,
  matching the `data-slot` convention the `ui/` primitives use for `has-`
  targeting rather than keying styling off `data-testid`.

ELI5: the pill has no inner padding, which looks fine when its contents are
round icons floating in roomy boxes, but the Chat/Terminal switcher is a solid
rectangle that reaches its own edge — so it touched the pill's rim. Now the pill
adds a sliver of padding, but only when that rectangle is inside it.

```text
before                                  after
┌──────────────────────────┐            ┌────────────────────────────┐
│▛▀▀▀▀▀▀▀▜   ·             │            │  ▛▀▀▀▀▀▀▀▜   ·             │
│▌ 💬  > ▐   ·             │            │  ▌ 💬  > ▐   ·             │
│▙▄▄▄▄▄▄▄▟   ·             │            │  ▙▄▄▄▄▄▄▄▟   ·             │
└──────────────────────────┘            └────────────────────────────┘
 ↑0px track flush to border               ↑6px pad → 12px ink, both ends
 6px ink left / 12px right                12px ink left / 12px right
```

## Test Plan

- `pnpm --filter web test src/shell` — 96 files / 2052 tests pass.
- `pnpm --filter web run type-check` (`tsc -b`) clean; `oxlint --deny-warnings`
  and `prettier --check` clean on the three changed files.
- Added a colocated regression test in `ChatHeader.test.tsx`, and **confirmed it
  fails when the fix is reverted** — not merely that it passes with it.
- Picked the 6px value by measurement rather than by eye: rendered `pl-1` /
  `pl-1.5` / `pl-2` in headless Chromium at 402pt / DPR 3 (the reporter's
  viewport) and measured pill inner edge → nearest painted glyph on both sides.
  `pl-1.5` is the only candidate that lands even:

  | candidate | pill width | left ink | right ink | Δ |
  | --- | --- | --- | --- | --- |
  | current (none) | 96px | 6px | 12px | **6.0px** |
  | `pl-1` | 100px | 10px | 12px | 2.0px |
  | **`pl-1.5`** | 102px | **12px** | **12px** | **0.0px** |
  | `pl-2` | 104px | 14px | 12px | 2.0px |

- Verified the two invariants the guard exists to protect: a lone-kebab pill
  still computes `padding-left: 0px` and stays a 40px circle, and the sidebar
  toggle on the left is byte-for-byte unchanged at 40×40.
- Confirmed the committed visual baselines are unaffected: every
  `tests/e2e_ui/visual` snapshot renders at 1280px (one at 1024px), both above
  the 768px `md` breakpoint, and this change is `max-md:`-scoped. No story covers
  `ChatHeader` / `ViewModeToggle`.

## Demo

Before / after at the reported viewport (402pt, DPR 3):

![Chat/Terminal pill before and after](https://raw.githubusercontent.com/omnigent-ai/omnigent/demo-assets/pill-margin-5577/pill-compare.png)

The full header row after the fix — the sidebar toggle on the left is unchanged,
confirming the two pills still read as the same size:

![Full mobile header row after the fix](https://raw.githubusercontent.com/omnigent-ai/omnigent/demo-assets/pill-margin-5577/pill-after-full.png)

> Caveat for reviewers: these render the real components against real compiled
> Tailwind at the reported viewport, but in a throwaway harness under headless
> Chromium — not a live session on iOS Safari, so the glass blur behind the pill
> won't match a device pixel-for-pixel. The geometry is the point. Screenshots
> are hosted on the parentless `demo-assets/pill-margin-5577` branch so no
> binaries land in this diff or on `main`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed

## Coverage notes

Colocated Vitest coverage is added in `ChatHeader.test.tsx` (verified to fail
without the fix). No `tests/e2e_ui/` test is added: this is a styling-only change
with no behaviour change — the toggle's flows, gating, and accessible names are
untouched, and the only new attribute is a CSS targeting hook — which
`CONTRIBUTING.md` exempts from the `E2E UI Required` gate. The margin itself is
geometry Playwright would assert less precisely than the measurements above.
Happy to add an e2e case, or apply `skip-e2e-ui-test`, if a maintainer would
rather the gate be satisfied explicitly.
