### PR TITLE
fix(runner): report pi's per-family gateway URLs in the routing log

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -10741,7 +10741,9 @@ def _build_spawn_env_from_spec(
             "%s gateway routing: gateway=%s base_url=%s profile=%s model=%s",
             harness,
             env.get(f"{prefix}_GATEWAY"),
-            env.get(f"{prefix}_GATEWAY_BASE_URL"),
+            # A harness that carries per-family URLs (pi) sets only the plural
+            # ``_BASE_URLS`` JSON; without the fallback it logs base_url=None.
+            env.get(f"{prefix}_GATEWAY_BASE_URL") or env.get(f"{prefix}_GATEWAY_BASE_URLS"),
             env.get(f"{prefix}_DATABRICKS_PROFILE"),
             env.get(_HARNESS_MODEL_ENV_KEY.get(harness, f"{prefix}_MODEL")),
             extra={"session_id": session_id},

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -529,8 +529,9 @@ def test_pi_gateway_routing_log_reports_the_resolved_base_url(
     line = next(
         rec.getMessage() for rec in caplog.records if "gateway routing" in rec.getMessage()
     )
-    assert "base_url=None" not in line
-    assert "anthropic.example.com" in line
+    # Compare against the env value itself: the line must carry the plural
+    # key's URLs, not just some host substring.
+    assert f"base_url={env['HARNESS_PI_GATEWAY_BASE_URLS']}" in line
 
 
 def test_pi_threads_generic_openai_wire_api(config_home: Path) -> None:

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -20,6 +20,7 @@ subprocess spawn, no real CLI.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -502,6 +503,34 @@ def test_pi_uses_anthropic_global_default(config_home: Path) -> None:
     assert env["HARNESS_PI_GATEWAY_HOST"] == "https://anthropic.example.com"
     assert env["HARNESS_PI_GATEWAY_AUTH_COMMAND"] == "printf %s sk-ant-secret"
     assert env["HARNESS_PI_MODEL"] == "claude-default-model"
+
+
+def test_pi_gateway_routing_log_reports_the_resolved_base_url(
+    config_home: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """
+    The runner's routing log reports pi's plural ``_BASE_URLS`` key.
+
+    pi's generic-provider path emits only ``HARNESS_PI_GATEWAY_BASE_URLS``
+    (per-family JSON), so a log that reads just the singular
+    ``HARNESS_PI_GATEWAY_BASE_URL`` says ``base_url=None`` on a run that
+    routed fine. Failure means that fallback is gone and the line is
+    misleading again.
+    """
+    from omnigent.runner.app import _build_spawn_env_from_spec
+
+    _write_config(config_home, _anthropic_default_config())
+
+    with caplog.at_level(logging.INFO, logger="omnigent.runner.app"):
+        env = _build_spawn_env_from_spec(_make_spec(harness="pi"), "pi")
+
+    assert env is not None
+    assert "HARNESS_PI_GATEWAY_BASE_URL" not in env  # only the plural key is set
+    line = next(
+        rec.getMessage() for rec in caplog.records if "gateway routing" in rec.getMessage()
+    )
+    assert "base_url=None" not in line
+    assert "anthropic.example.com" in line
 
 
 def test_pi_threads_generic_openai_wire_api(config_home: Path) -> None:


### PR DESCRIPTION
## Related issue

Closes #5102

## Summary

- The runner's `gateway routing` log line read only the singular
  `HARNESS_<H>_GATEWAY_BASE_URL`. pi's generic-provider paths
  (`_apply_provider_to_pi`, `_apply_cli_config_databricks_to_pi`) emit only the
  plural `HARNESS_PI_GATEWAY_BASE_URLS` JSON, so every such run logged
  `base_url=None` even though routing had resolved fine. Cosmetic, but
  misleading exactly when someone is debugging a gateway problem (it reads as
  "no gateway was resolved").
- Fixed at the log site with a fallback to the plural key. The key is derived
  from the harness prefix, so any harness carrying per-family URLs is covered,
  not just pi.
- Deliberately *not* fixed by also writing the singular key on the provider
  path: both keys feed `PiExecutor` (`base_url_override` vs
  `base_urls_override`), so synthesizing the singular one would change routing
  behaviour to fix a log line. There are two plural-only writers and exactly
  one misreporting reader, so the reader is the root cause.

```
before:  pi gateway routing: gateway=true base_url=None profile=None model=<model>
after:   pi gateway routing: gateway=true base_url={"claude": "https://…/v1"} profile=None model=<model>
```

## Test Plan

- New unit test `test_pi_gateway_routing_log_reports_the_resolved_base_url`
  drives the real `_build_spawn_env_from_spec` for a pi spec against a
  configured provider and asserts the emitted log line, plus that only the
  plural key is present in the spawn env:

  ```
  pytest tests/runtime/test_provider_spawn_env.py -k pi_gateway_routing_log -v
  ```

- Confirmed the test reproduces the reported bug: reverting the one-line
  fallback turns it red with the issue's exact line,
  `pi gateway routing: gateway=true base_url=None profile=None model=claude-default-model`.
- `pytest tests/runtime/test_provider_spawn_env.py` and
  `pytest tests/runner/test_runner_dispatch.py -k "spawn_env or model_override"
  tests/test_acp_cli_harnesses.py` pass. One pre-existing failure in that file,
  `test_detected_ambient_key_routes_with_no_config`, reproduces on unmodified
  main in a separate checkout and asserts a claude-sdk var this diff does not
  touch.

## Demo

N/A (log-line change, no UI).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the before/after check above: the new test goes red on
the pre-fix code with the same `base_url=None` line the issue reports, and green
with the fallback in place.

## Changelog

The runner's pi gateway-routing log now shows the resolved gateway URL instead of `base_url=None`.
