### PR TITLE
fix(sessions): persist claude-native permission mode into launch args

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -2487,6 +2487,18 @@ async def _persist_external_permission_mode_change(
             f"{sorted(_CLAUDE_NATIVE_PERMISSION_MODES)}; got {mode!r}",
             code=ErrorCode.INVALID_INPUT,
         )
+    # Reflect the switch into terminal_launch_args so a relaunch reopens in this
+    # mode — the launcher reads the mode from launch args, while the label below
+    # is only the web UI's read-back. Rewrites an existing --permission-mode only
+    # (a no-op for a session launched without one); kept ahead of the label
+    # short-circuit so a stale launch arg is fixed even when the label matches.
+    merged_args = _merge_claude_permission_launch_args(conv.terminal_launch_args, mode)
+    if conv.terminal_launch_args != merged_args:
+        await asyncio.to_thread(
+            conversation_store.update_conversation,
+            session_id,
+            terminal_launch_args=merged_args,
+        )
     if conv.labels.get(_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY) == mode:
         return
     await asyncio.to_thread(
@@ -2571,6 +2583,45 @@ def _merge_codex_permission_launch_args(
         merged.append(arg)
         index += 1
     return [*merged, *permission_args]
+
+
+def _merge_claude_permission_launch_args(
+    existing_args: list[str] | None,
+    mode: str,
+) -> list[str] | None:
+    """Rewrite an existing ``--permission-mode`` in Claude launch args to ``mode``.
+
+    A runtime mode switch (shift+tab or PATCH) must survive relaunch, and the
+    launcher restores the mode from ``terminal_launch_args`` — not the label.
+    Rewrite the existing ``--permission-mode`` entry (space- or ``=``-joined) to
+    the current mode, preserving other args in order, so a cold resume reopens
+    in the mode the user last chose.
+
+    Returns ``existing_args`` unchanged when they carry no ``--permission-mode``:
+    a session launched without the flag (manual, or a ``settings.json``
+    ``defaultMode``) must NOT be pinned to an explicit mode by a footer report —
+    the forwarder posts the launch mode on its first poll (see
+    ``claude_native_forwarder``), and pinning it would override the session's
+    settings default on relaunch. Those sessions surface the live mode through
+    the permission-mode label instead.
+    """
+    args = list(existing_args or ())
+    if not any(a == "--permission-mode" or a.startswith("--permission-mode=") for a in args):
+        return existing_args
+    merged: list[str] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--permission-mode":
+            index += 2  # drop the flag and its separate value token
+            continue
+        if arg.startswith("--permission-mode="):
+            index += 1
+            continue
+        merged.append(arg)
+        index += 1
+    merged.extend(("--permission-mode", mode))
+    return merged
 
 
 def _handle_external_session_todos(
@@ -9906,6 +9957,7 @@ __all__ = [
     "_mcp_input_required_response",
     "_mcp_ok_response",
     "_mcp_tool_result",
+    "_merge_claude_permission_launch_args",
     "_merge_pending_file_blocks",
     "_message_text",
     "_model_options_from_wire",

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -121,6 +121,7 @@ from omnigent.server.routes._sessions.helpers import (
     _forward_session_change_to_runner,
     _get_runner_client,
     _invalidate_runner_backed_snapshot_state,
+    _merge_claude_permission_launch_args,
     _multipart_missing_detail,
     _notify_runner_of_bundled_child,
     _parse_session_create_metadata,
@@ -1975,13 +1976,28 @@ def register_core_routes(
             )
             # Raises unless the runner confirms the switch, so the label can
             # never claim a mode Claude isn't in. Stores the mode it reached.
-            labels_to_set[_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY] = (
-                _require_permission_mode_forward(
-                    session_id,
-                    requested_claude_permission_mode,
-                    _mode_result,
-                )
+            _confirmed_permission_mode = _require_permission_mode_forward(
+                session_id,
+                requested_claude_permission_mode,
+                _mode_result,
             )
+            labels_to_set[_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY] = _confirmed_permission_mode
+            # The launcher restores the mode from terminal_launch_args, not the
+            # label above, so reflect the confirmed mode there too — otherwise a
+            # relaunch reverts to the launch --permission-mode. Merge against
+            # ``updated`` (the post-write row), not the pre-update snapshot, so a
+            # combined PATCH that also set terminal_launch_args keeps those. Only
+            # rewrites an existing --permission-mode; mirrors the shift+tab path.
+            _merged_permission_args = _merge_claude_permission_launch_args(
+                updated.terminal_launch_args,
+                _confirmed_permission_mode,
+            )
+            if updated.terminal_launch_args != _merged_permission_args:
+                await asyncio.to_thread(
+                    conversation_store.update_conversation,
+                    session_id,
+                    terminal_launch_args=_merged_permission_args,
+                )
         # Some labels are cleared by DELETE, not by upserting an empty value:
         # the project membership (empty = "remove from project") and the pinned
         # flag (empty = "unpin"). Split any empty-valued clear keys out before

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -6624,6 +6624,46 @@ async def test_post_external_permission_mode_change_persists_label_and_publishes
     assert published[0][1]["permission_mode"] == "auto"
     snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
     assert snapshot["labels"]["omnigent.claude_native.permission_mode"] == "auto"
+    # This session launched without an explicit --permission-mode, so the footer
+    # report must NOT pin one (that would override its settings default on
+    # relaunch); the label alone carries the mode for the web picker.
+    assert snapshot["terminal_launch_args"] is None
+
+
+async def test_post_external_permission_mode_change_rewrites_launch_arg(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    A pane switch replaces the create-time ``--permission-mode`` launch arg.
+
+    A session created in one mode keeps that mode in ``terminal_launch_args``;
+    when the user cycles to another mode with shift+tab, the stored launch args
+    must carry the NEW mode (other args untouched) so a cold resume reopens in
+    it rather than the create-time mode.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(
+        client,
+        agent["id"],
+        terminal_launch_args=["--model", "opus", "--permission-mode", "plan"],
+    )
+
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={
+            "type": "external_permission_mode_change",
+            "data": {"permission_mode": "acceptEdits"},
+        },
+    )
+
+    assert resp.status_code == 202, resp.text
+    snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
+    assert snapshot["terminal_launch_args"] == [
+        "--model",
+        "opus",
+        "--permission-mode",
+        "acceptEdits",
+    ]
 
 
 async def test_post_external_permission_mode_change_is_quiet_when_unchanged(
@@ -8407,9 +8447,73 @@ async def test_patch_permission_mode_persists_label_and_forwards_event(
 
     assert resp.status_code == 200, resp.text
     assert resp.json()["labels"]["omnigent.claude_native.permission_mode"] == "auto"
+    # No launch --permission-mode to rewrite, so none is fabricated (see the
+    # rewrite-existing test below for the persist-to-launch-args case).
+    assert resp.json()["terminal_launch_args"] is None
     forwards = [f for f in captured if f.url.endswith(f"/v1/sessions/{session['id']}/events")]
     assert len(forwards) == 1, f"Expected one runner forward, got {captured!r}"
     assert forwards[0].body == {"type": "permission_mode_change", "permission_mode": "auto"}
+
+
+async def test_patch_permission_mode_rewrites_launch_arg_and_keeps_other_args(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    A combined PATCH rewrites the launch --permission-mode and keeps other args.
+
+    Guards two things: the confirmed mode replaces an existing launch
+    ``--permission-mode`` (so a relaunch reopens in it), and merging against the
+    freshly written row — not the pre-update snapshot — means a PATCH that also
+    sets ``terminal_launch_args`` keeps the caller's other args (here
+    ``--model sonnet``) rather than reverting to the pre-PATCH launch args.
+    """
+    from omnigent.runtime import set_runner_client
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Echo the switched mode like the claude-native runner handler."""
+        if request.method != "POST":
+            return httpx.Response(204)
+        return httpx.Response(200, json={"permission_mode": "acceptEdits"})
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://runner",
+    )
+    set_runner_client(fake_runner)
+    try:
+        agent = await create_test_agent(client)
+        session = await _create_session(
+            client,
+            agent["id"],
+            labels={
+                "omnigent.ui": "terminal",
+                "omnigent.wrapper": "claude-code-native-ui",
+            },
+            terminal_launch_args=["--model", "opus", "--permission-mode", "plan"],
+        )
+
+        resp = await client.patch(
+            f"/v1/sessions/{session['id']}",
+            json={
+                "permission_mode": "acceptEdits",
+                # Same request also replaces the launch args wholesale.
+                "terminal_launch_args": ["--model", "sonnet", "--permission-mode", "plan"],
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+        set_runner_client(None)
+
+    assert resp.status_code == 200, resp.text
+    # The PATCH's --model sonnet survives, and --permission-mode is rewritten to
+    # the runner-confirmed mode (not the pre-PATCH --model opus / plan).
+    assert resp.json()["terminal_launch_args"] == [
+        "--model",
+        "sonnet",
+        "--permission-mode",
+        "acceptEdits",
+    ]
+    assert resp.json()["labels"]["omnigent.claude_native.permission_mode"] == "acceptEdits"
 
 
 @pytest.mark.parametrize("runner_status", [None, 503], ids=["no_runner", "runner_rejects"])


### PR DESCRIPTION
## Related issue

No tracking issue yet (draft). Bug fix for claude-native permission-mode persistence.

Closes #

## Summary

- A runtime permission-mode switch on a claude-native session (shift+tab in the TUI, or a `PATCH /v1/sessions/{id}` with `permission_mode`) only updated the `omnigent.claude_native.permission_mode` label and the live SSE stream.
- The native launcher restores the mode from `terminal_launch_args`, not the label, so on a runner restart / cold resume the session reverted to the create-time `--permission-mode`, silently discarding the mode the user last chose.
- This reflects the switched mode into `terminal_launch_args` too (replacing any prior `--permission-mode` entry, preserving other args), on both the external shift+tab event path and the PATCH path. It mirrors how codex approval mode already merges into `terminal_launch_args`. The label + SSE publish are unchanged, so the web UI still reads the label back.

### ELI5

Creating a session lets you pick a permission mode, and that choice was written into the launch command so it stuck. But flipping the mode mid-session only wrote it to a "current mode" sticky note the web UI reads. The thing that actually relaunches Claude reads the launch command, not the sticky note, so after a restart it went back to the mode you started with. Now a mid-session flip updates the launch command too.

```
create   permission_mode -> terminal_launch_args (--permission-mode) -> consumed at launch  [survives]
before   shift+tab/PATCH  -> label + SSE only                                                [lost on relaunch]
after    shift+tab/PATCH  -> label + SSE + terminal_launch_args (--permission-mode)           [survives]
```

## Test Plan

- `uv run pytest tests/server/integration/test_sessions_endpoints.py -k permission_mode` (15 passed)
- `uv run pytest tests/server/routes/test_sessions_yolo_launch_args.py` (33 passed, no regressions in launch-arg derivation)
- `ruff check` / `ruff format --check` / `pyrefly check` clean on the changed files.

Added a test asserting the external shift+tab path rewrites an existing `--permission-mode` launch arg while preserving other args, and extended the existing external + PATCH tests to assert `terminal_launch_args` carries the new mode.

E2E tested, and resuming now persists changed permission modes.

## Demo

N/A (server-side behavior, no UI change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Covered by integration tests against `POST /v1/sessions/{id}/events` (the shift+tab path) and `PATCH /v1/sessions/{id}` (the user-initiated path), asserting both the label and `terminal_launch_args` reflect the switched mode.

## Changelog

Claude-native permission-mode changes made mid-session now survive a session relaunch.

This pull request and its description were written by Isaac.
