### PR TITLE
fix(harness): persist observed tool-call cards so they survive reload

### DIFF
--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -145,6 +145,14 @@ class ExecutorAdapter(HarnessApp):
         # dispatch_tool emits the function_call_output, so ToolCallComplete for these ids
         # must be suppressed in _translate_event to avoid duplicates.
         self._dispatched_call_ids: set[str] = set()
+        # Observed (harness-run) tool calls → (name, arguments) from the inline
+        # ToolCallRequest, so the matching ToolCallComplete can re-emit a *completed*
+        # function_call. The initial observed emission is status "in_progress", which
+        # the turn-persist filter drops (only completed function_calls are durable), so
+        # without the re-emission an observed tool card renders live but vanishes on
+        # reload. Dispatched calls never reach this — their ToolCallComplete
+        # short-circuits — so it is observed-only.
+        self._observed_tool_calls: dict[str, tuple[str, str]] = {}
 
     async def run_turn(self, request: CreateResponseRequest, ctx: TurnContext) -> None:
         """Drive the inner executor for one turn, translating its events to Omnigent SSE.
@@ -196,6 +204,7 @@ class ExecutorAdapter(HarnessApp):
         # bounded interrupt only on abnormal exits (CancelledError, ExecutorError, etc.).
         clean_exit = False
         self._dispatched_call_ids.clear()
+        self._observed_tool_calls.clear()
 
         tracing = is_tracing_enabled()
         from omnigent.runtime.telemetry import current_session_id, session_scope
@@ -724,11 +733,22 @@ class ExecutorAdapter(HarnessApp):
                 self._pending_mcp_call_ids.append(tool_use_id)
             call_id = tool_use_id or f"call_{uuid.uuid4().hex[:12]}"
             bare_name = _strip_mcp_tool_prefix(event.name)
-            status = (
-                _COMPLETED_TOOL_CALL_STATUS
-                if event.metadata.get("observed_call_completed") is True
-                else _OBSERVED_TOOL_CALL_STATUS
-            )
+            arguments_json = _serialize_args(event.args)
+            if event.metadata.get("observed_call_completed") is True:
+                # The executor already emits this call's durable completed form
+                # itself (e.g. a codex built-in re-emitted at completion). Emit it
+                # completed in one shot and drop any live entry cached from an
+                # earlier in_progress emit of the same call, so the ToolCallComplete
+                # below does not re-emit a second, duplicate completed card.
+                status = _COMPLETED_TOOL_CALL_STATUS
+                self._observed_tool_calls.pop(call_id, None)
+            else:
+                # A live observation. The turn-persist filter drops "in_progress",
+                # so remember name/args; the matching ToolCallComplete re-emits it as
+                # a durable completed function_call (see that branch) — which is what
+                # keeps an observed card from vanishing on reload.
+                status = _OBSERVED_TOOL_CALL_STATUS
+                self._observed_tool_calls[call_id] = (bare_name, arguments_json)
             ctx.emit(
                 OutputItemDoneEvent(
                     type="response.output_item.done",
@@ -737,7 +757,7 @@ class ExecutorAdapter(HarnessApp):
                         "type": "function_call",
                         "status": status,
                         "name": bare_name,
-                        "arguments": _serialize_args(event.args),
+                        "arguments": arguments_json,
                         "call_id": call_id,
                         "agent": ctx.response_id,
                     },
@@ -750,6 +770,31 @@ class ExecutorAdapter(HarnessApp):
             call_id = _call_id_from_metadata(getattr(event, "metadata", None)) or ""
             if not call_id or call_id in self._dispatched_call_ids:
                 return
+            # A live observed call cached at ToolCallRequest is re-emitted here as a
+            # durable COMPLETED function_call so it survives reload — the in_progress
+            # one is dropped by the turn-persist filter. Same call_id → the web dedupes
+            # this with the live render into one card. A call already emitted completed
+            # (observed_call_completed) was never cached, so it is not re-emitted — that
+            # is what prevents a duplicate card. This mirrors how a dispatched call
+            # re-emits completed once its dispatch resolves.
+            observed = self._observed_tool_calls.pop(call_id, None)
+            if observed is not None:
+                observed_name, observed_args = observed
+                ctx.emit(
+                    OutputItemDoneEvent(
+                        type="response.output_item.done",
+                        item={
+                            "id": f"fc_{uuid.uuid4().hex[:12]}",
+                            "type": "function_call",
+                            "status": _COMPLETED_TOOL_CALL_STATUS,
+                            "name": observed_name,
+                            "arguments": observed_args,
+                            "call_id": call_id,
+                            "agent": ctx.response_id,
+                        },
+                    )
+                )
+            raw_args = getattr(event, "metadata", {}).get("arguments")
             item: dict[str, Any] = {
                 "id": f"fco_{uuid.uuid4().hex[:12]}",
                 "type": "function_call_output",
@@ -757,7 +802,6 @@ class ExecutorAdapter(HarnessApp):
                 # Cap the mirror; the inner SDK already consumed the full result.
                 "output": cap_tool_output(_serialize_tool_result(event)),
             }
-            raw_args = getattr(event, "metadata", {}).get("arguments")
             if isinstance(raw_args, dict):
                 item["arguments"] = raw_args
             ctx.emit(OutputItemDoneEvent(type="response.output_item.done", item=item))

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -1090,6 +1090,152 @@ def test_tool_call_complete_suppressed_for_dispatched_executor() -> None:
     assert ctx.emitted == []
 
 
+def _fc_items(ctx: _RecordingTurnContext) -> list[dict[str, Any]]:
+    """The ``item`` dicts of the OutputItemDoneEvents ``ctx`` recorded."""
+    return [e.item for e in ctx.emitted if getattr(e, "item", None) is not None]
+
+
+def test_observed_tool_call_reemits_a_completed_function_call() -> None:
+    """An observed tool call's completion re-emits a durable ``completed`` card.
+
+    **What breaks if this fails**: the inline ToolCallRequest emits status
+    ``"in_progress"``, which the turn-persist filter drops — so the card renders
+    live but disappears on refresh (the reported bug for generic-ACP harnesses).
+    On completion the adapter re-emits the same call as a ``completed``
+    function_call (which persists), then the function_call_output. Same call_id →
+    the web dedupes the live in_progress render and this one into a single card.
+    """
+    from omnigent.inner.executor import ToolCallComplete, ToolCallRequest, ToolCallStatus
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    ctx = _RecordingTurnContext(response_id="resp_obs")
+    adapter._current_ctx = ctx  # type: ignore[assignment]
+
+    adapter._translate_event(  # type: ignore[arg-type]
+        ToolCallRequest(name="Ran command", args={"command": "ls"}, metadata={"call_id": "c1"}),
+        ctx,
+    )
+    adapter._translate_event(  # type: ignore[arg-type]
+        ToolCallComplete(
+            name="Ran command",
+            status=ToolCallStatus.SUCCESS,
+            result="a.txt",
+            metadata={"call_id": "c1"},
+        ),
+        ctx,
+    )
+
+    items = _fc_items(ctx)
+    assert [(i["type"], i.get("status")) for i in items] == [
+        ("function_call", "in_progress"),  # live-only; dropped by the persist filter
+        ("function_call", "completed"),  # durable — survives reload
+        ("function_call_output", None),
+    ]
+    completed = items[1]
+    assert completed["call_id"] == "c1", "same call_id → dedupes with the live card"
+    assert completed["name"] == "Ran command"
+    assert completed["arguments"] == '{"command": "ls"}', "args carried from the request"
+
+
+def test_uncached_completion_reemits_no_function_call() -> None:
+    """A completion with no cached in_progress request re-emits no card.
+
+    The re-emission is gated on the request having been cached (an in_progress
+    observation). A ToolCallComplete for a call the adapter never saw start emits
+    only the function_call_output — never a synthesized completed card. That gate
+    is what keeps the re-emission from firing for a call whose durable completed
+    form some other path already produced (see the observed_call_completed test).
+    """
+    from omnigent.inner.executor import ToolCallComplete, ToolCallStatus
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    ctx = _RecordingTurnContext(response_id="resp_obs")
+    adapter._current_ctx = ctx  # type: ignore[assignment]
+
+    adapter._translate_event(  # type: ignore[arg-type]
+        ToolCallComplete(
+            name="grep", status=ToolCallStatus.SUCCESS, result="hit", metadata={"call_id": "c9"}
+        ),
+        ctx,
+    )
+    items = _fc_items(ctx)
+    assert [(i["type"], i.get("status")) for i in items] == [
+        ("function_call_output", None),
+    ]
+
+
+def test_observed_call_completed_request_is_not_reemitted_at_completion() -> None:
+    """An executor that self-emits a durable completed card is not doubled.
+
+    Codex built-ins re-emit their own completed function_call at completion (via
+    ``observed_call_completed`` on the ToolCallRequest) because the relay persists
+    only completed calls. That request is emitted completed in one shot AND drops
+    the cache entry, so the ToolCallComplete that follows must NOT re-emit a second
+    completed card. Regression guard: without the cache pop, this observed call
+    would render (and persist) two identical completed cards.
+    """
+    from omnigent.inner.executor import ToolCallComplete, ToolCallRequest, ToolCallStatus
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    ctx = _RecordingTurnContext(response_id="resp_obs")
+    adapter._current_ctx = ctx  # type: ignore[assignment]
+
+    # Live start (in_progress), then codex's own completed re-emit + the completion.
+    adapter._translate_event(  # type: ignore[arg-type]
+        ToolCallRequest(name="shell", args={"command": "ls"}, metadata={"call_id": "cb"}),
+        ctx,
+    )
+    adapter._translate_event(  # type: ignore[arg-type]
+        ToolCallRequest(
+            name="shell",
+            args={"command": "ls"},
+            metadata={"call_id": "cb", "observed_call_completed": True},
+        ),
+        ctx,
+    )
+    adapter._translate_event(  # type: ignore[arg-type]
+        ToolCallComplete(
+            name="shell", status=ToolCallStatus.SUCCESS, result="a.txt", metadata={"call_id": "cb"}
+        ),
+        ctx,
+    )
+
+    items = _fc_items(ctx)
+    assert [(i["type"], i.get("status")) for i in items] == [
+        ("function_call", "in_progress"),  # live-only; dropped by the persist filter
+        ("function_call", "completed"),  # the executor's own durable re-emit
+        ("function_call_output", None),  # completion emits only the output — no 2nd card
+    ]
+    assert sum(i["type"] == "function_call" and i.get("status") == "completed" for i in items) == 1
+
+
+def test_dispatched_call_does_not_reemit_a_completed_function_call() -> None:
+    """A dispatched tool's completion stays suppressed — no duplicate card.
+
+    Dispatched (runner-side) tools already persist their own completed
+    function_call via dispatch_tool, so the ToolCallComplete short-circuits before
+    the re-emission. Re-emitting here would double the card.
+    """
+    from omnigent.inner.executor import ToolCallComplete, ToolCallStatus
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    ctx = _RecordingTurnContext()
+    adapter._current_ctx = ctx  # type: ignore[assignment]
+    adapter._dispatched_call_ids.add("d1")
+
+    adapter._translate_event(  # type: ignore[arg-type]
+        ToolCallComplete(
+            name="x", status=ToolCallStatus.SUCCESS, result="out", metadata={"call_id": "d1"}
+        ),
+        ctx,
+    )
+    assert ctx.emitted == []
+
+
 def test_translate_event_mcp_request_queues_tool_use_id_for_dispatch() -> None:
     """
     A ``ToolCallRequest`` with an MCP-prefixed name pushes the
@@ -1212,9 +1358,12 @@ def test_internally_executed_tool_bypasses_dispatch_correlation_queue() -> None:
     )
 
     assert list(adapter._pending_mcp_call_ids) == []
-    assert [event.item["type"] for event in ctx.emitted] == [
-        "function_call",
-        "function_call_output",
+    # The live in_progress card is cached and re-emitted completed at completion so
+    # it survives reload; the queue bypass asserted above is orthogonal to that.
+    assert [(e.item["type"], e.item.get("status")) for e in ctx.emitted] == [
+        ("function_call", "in_progress"),
+        ("function_call", "completed"),
+        ("function_call_output", None),
     ]
 
 

--- a/tests/server/routes/test_persistent_item_from_sse.py
+++ b/tests/server/routes/test_persistent_item_from_sse.py
@@ -1,0 +1,76 @@
+"""Tests for the turn-persist filter (``_extract_persistent_item_from_sse``).
+
+This is the gate that decides which streamed ``response.output_item.done`` items
+become durable conversation items. It is the other half of the observed-tool-card
+persistence fix: the adapter re-emits an observed tool call as a ``completed``
+function_call precisely because this filter keeps ``completed`` ones and drops
+``in_progress`` ones. These tests pin that contract so a change to either side
+can't silently reopen the "tool cards vanish on refresh" bug.
+"""
+
+from __future__ import annotations
+
+from omnigent.server.routes._sessions.helpers import _extract_persistent_item_from_sse
+
+
+def _output_item_done(item: dict[str, object]) -> dict[str, object]:
+    """Wrap an item as a ``response.output_item.done`` SSE event."""
+    return {"type": "response.output_item.done", "item": item}
+
+
+def test_completed_function_call_is_persisted() -> None:
+    """A ``completed`` function_call becomes a durable item — this is what the
+    adapter re-emits for an observed tool call so it survives reload."""
+    result = _extract_persistent_item_from_sse(
+        _output_item_done(
+            {
+                "id": "fc_1",
+                "type": "function_call",
+                "status": "completed",
+                "name": "Ran command",
+                "arguments": '{"command": "ls"}',
+                "call_id": "c1",
+                "agent": "resp_1",
+            }
+        )
+    )
+    assert result is not None
+    assert result.type == "function_call"
+
+
+def test_in_progress_function_call_is_dropped() -> None:
+    """The live-only observed emission (``in_progress``) is NOT persisted.
+
+    Persisting it would leave an orphan card whose spinner never resolves; the
+    durable copy is the ``completed`` re-emission asserted above.
+    """
+    result = _extract_persistent_item_from_sse(
+        _output_item_done(
+            {
+                "id": "fc_1",
+                "type": "function_call",
+                "status": "in_progress",
+                "name": "Ran command",
+                "arguments": '{"command": "ls"}',
+                "call_id": "c1",
+                "agent": "resp_1",
+            }
+        )
+    )
+    assert result is None
+
+
+def test_function_call_output_is_persisted() -> None:
+    """The paired output persists too, so the reloaded card shows its result."""
+    result = _extract_persistent_item_from_sse(
+        _output_item_done(
+            {
+                "id": "fco_1",
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": "a.txt",
+            }
+        )
+    )
+    assert result is not None
+    assert result.type == "function_call_output"


### PR DESCRIPTION
## Related issue

Closes #5581

## Summary

A generic-ACP agent's parent-chat tool cards (Devin, Grok, kilocode — any harness
that runs tools internally) rendered live but **vanished on refresh**. You caught
this while testing #5575, and noted the tell precisely: the sub-agent cards (which
#5575 writes as real `external_conversation_item`s) persist, while the parent's do
not.

**Root cause.** An observed tool call is emitted once as a `function_call` with
`status="in_progress"` (`_executor_adapter.py`). The turn-persist filter
(`helpers.py`) drops any `function_call` that isn't `"completed"` — only completed
ones are durable. So the observed card is never written; the reloaded chat, rebuilt
from stored items, has nothing. Dispatched tools (the omnigent MCP relay) survive
because the scaffold re-emits them as `completed` after the dispatch Future resolves
— the re-emission an observed call never had.

| Tool kind | Emitted | Persists? |
|---|---|---|
| Dispatched (MCP relay) | `action_required` → **`completed`** (after Future) | ✓ |
| Observed (ACP/Devin, goose, qwen, …) — **before** | `in_progress` only | ✗ dropped |
| Observed — **after this PR** | `in_progress` (live) → **`completed`** (on completion) | ✓ |

**Fix.** Give the observed path the same shape as the dispatched one, in the
executor adapter: cache each observed `in_progress` request by `call_id`, and on its
`ToolCallComplete` re-emit it as a `completed` function_call (which the existing
filter keeps) before the function_call_output. Same `call_id`, so the web dedupes
the live `in_progress` render and this one into a single card; on reload only the
completed pair remains and renders. No server-filter change — the fix makes the
observed path emit exactly what the existing filter already keeps.

**Why at completion, not at request time — interaction with #5200.** `main` grew
`observed_call_completed` (#5200) while this was in flight: codex built-ins set it on
the `ToolCallRequest` to emit `completed` in one shot. That request-time flag can't
drive ACP. An ACP agent emits a `session/update tool_call` frame for *every* tool,
and only the dispatched subset later emits `session/request_permission` — so at
request-emission time we don't yet know whether a card is observed or dispatched
(verified against captured Devin frames: the 3 permission-gated ids were a strict
subset of the 44 tool-call frame ids). The observed-vs-dispatched split is only known
at **completion** (`_dispatched_call_ids`, populated by the dispatch that ran in
between), which is exactly where this re-emit sits. The two mechanisms coexist: a
request already emitted `completed` via `observed_call_completed` is **not** cached —
and drops any live cache entry for its `call_id` — so the `ToolCallComplete` that
follows does not re-emit a second, duplicate card.

<details>
<summary>Why this is safe for SDK/native harnesses</summary>

Every harness shares `ExecutorAdapter`, so the change is in shared code. Three guards
keep it correct:

- The `ToolCallComplete` branch already **short-circuits for dispatched call ids**
  (`call_id in self._dispatched_call_ids`), and the re-emit sits after that return —
  so it never fires for dispatched / MCP-relay tools.
- The re-emit is **gated on a cached `in_progress` request**; a completion the
  adapter never saw start emits only its output, no synthesized card.
- A request emitted `completed` in one shot (`observed_call_completed`, e.g. codex
  built-ins) is **not** cached and **pops** any prior live entry, so its completion
  can't double the card.

Observed executors that emit a plain `in_progress` request + completion (goose, qwen,
copilot, antigravity, cursor, kimi, …) now get their cards persisted too — the same
beneficial fix, not a regression.
</details>

## Test Plan

New / updated unit tests, both sides of the gap:

- `tests/runtime/harnesses/test_executor_adapter.py`
  - `..._observed_tool_call_reemits_a_completed_function_call` — a request→complete
    pair emits `[function_call in_progress, function_call completed, function_call_output]`,
    the completed one carrying the same `call_id` and the request's name/args.
  - `..._observed_call_completed_request_is_not_reemitted_at_completion` — the #5200
    codex path: a self-completed request emits exactly one `completed` card; the
    following completion adds only the output, never a duplicate. (Regression guard
    against double-firing.)
  - `..._uncached_completion_reemits_no_function_call` — a completion with no cached
    request emits only the function_call_output (no synthesized card).
  - `..._dispatched_call_does_not_reemit...` — a dispatched call id stays suppressed.
  - `..._internally_executed_tool_bypasses_dispatch_correlation_queue` — updated: an
    internally-executed `in_progress` card is now cached and re-emitted completed
    (persistence is orthogonal to the queue-bypass this test asserts).
- `tests/server/routes/test_persistent_item_from_sse.py` (new) — closes the loop on
  the filter: `completed` function_call persists, `in_progress` is dropped,
  function_call_output persists. So the re-emitted item is exactly what survives.

**Rebased onto `main`** (now carrying #5575 and #5200); resolved the one
`_executor_adapter.py` overlap by merging #5200's `observed_call_completed` status
logic with this cache/re-emit (they are complementary). Blast-radius re-run:

- Focused: `test_executor_adapter.py` + `test_persistent_item_from_sse.py` +
  `test_codex_executor.py` + `test_acp_executor.py` → **265 passed**.
- Shared adapter (broad): all of `tests/runtime/harnesses/` + the observed executors
  (goose, qwen, copilot, antigravity, cursor, kimi, claude-native) → **655 passed**.
  The one red, `test_runner_subprocess_exits_when_spawning_parent_exits`, is a
  pre-existing macOS spawn-timeout flake (process-manager parent-death test, red on a
  clean tree) — unrelated to tool-card emission.

`pyrefly` 0 errors, `ruff`/`ruff format` clean, `pre-commit` green, `uv.lock`
untouched.

## Demo

N/A — no frontend change; the web already renders persisted `function_call` items.
The fix makes the observed path emit a durable one. The emission sequence and the
persist-filter contract are asserted directly in the tests above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the persist-filter unit test that proves the exact item the
adapter now emits (`completed` function_call) is the one the filter keeps, plus the
adapter test proving it's emitted with the right call_id/name/args. What is **not**
automated is the final browser check — refreshing a live Devin chat and seeing the
cards remain — which needs a live turn + UI, the same limitation as #5489/#5575. The
persist→reload→render chain is covered up to the persisted item; `itemsToBlocks.ts`
already renders that shape.

## Changelog

Tool-call cards from ACP agents (Devin, Grok, …) now stay in the chat after a
refresh, instead of disappearing once the turn ends.
