### PR TITLE
feat(sessions): restart a session in place on the latest agent version

### DIFF
--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -994,6 +994,29 @@ def delete_fts_by_conversation(session: Session, conversation_id: str) -> None:
         )
 
 
+def delete_fts_by_item_ids(session: Session, item_ids: list[str]) -> None:
+    """
+    Remove FTS rows for a list of conversation items in a single query.
+
+    No-op when ``item_ids`` is empty or the dialect lacks FTS5. Used when
+    individual items are removed (truncation) rather than a whole
+    conversation being deleted.
+
+    :param session: An active SQLAlchemy session.
+    :param item_ids: Conversation-item IDs whose FTS rows should be
+        removed, e.g. ``["msg_a1b2c3d4..."]``.
+    """
+    if not item_ids:
+        return
+    if session.bind and _supports_fts5(session.bind.dialect.name):
+        placeholders = ", ".join(f":iid{i}" for i in range(len(item_ids)))
+        params = {f"iid{i}": iid for i, iid in enumerate(item_ids)}
+        session.execute(
+            text(f"DELETE FROM {_FTS_TABLE} WHERE item_id IN ({placeholders})"),
+            params,
+        )
+
+
 def delete_fts_by_conversation_ids(session: Session, conv_ids: list[str]) -> None:
     """
     Remove all FTS rows for a list of conversations in a single query.

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -7331,6 +7331,28 @@ def _presentation_labels_for_agent(*args: Any, **kwargs: Any) -> dict[str, str]:
     return _facade._presentation_labels_for_agent(*args, **kwargs)
 
 
+_CLONE_NAME_SUFFIX_RE = re.compile(r" \((?:fork|switch) [^)]+\)$")
+
+
+def _agent_clone_root_name(name: str) -> str:
+    """Return the root agent name behind fork/switch clone suffixes.
+
+    Clone rows are named ``"<name>"`` (fork) or ``"<name> (switch <id>)"``
+    (switch), and a clone of a clone stacks suffixes. Peeling every layer
+    lets a restart match a session-scoped clone back to the built-in it
+    derives from by name. Mirrors the web client's ``agentRootName``.
+
+    :param name: An agent name, possibly with nested clone suffixes.
+    :returns: The name with every clone suffix removed.
+    """
+    prev = None
+    cur = name
+    while cur != prev:
+        prev = cur
+        cur = _CLONE_NAME_SUFFIX_RE.sub("", cur)
+    return cur
+
+
 def _presentation_labels_for_agent_impl(agent: Agent) -> dict[str, str]:
     """Return the Web UI presentation labels for an agent's harness.
 

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -347,6 +347,7 @@ from omnigent.server.routes._sessions.helpers import (
     _add_model_usage_delta as _add_model_usage_delta,
     _agent_carries_cursor_fork_history as _agent_carries_cursor_fork_history,
     _agent_carries_native_fork_history_impl as _agent_carries_native_fork_history_impl,
+    _agent_clone_root_name as _agent_clone_root_name,
     _agent_is_native_impl as _agent_is_native_impl,
     _agent_provider_family as _agent_provider_family,
     _allow_all_edits_eligible as _allow_all_edits_eligible,
@@ -739,6 +740,7 @@ from omnigent.tools.client_specified import parse_client_side_tool_specs
 if TYPE_CHECKING:
     __all__ = [
         "_agent_carries_native_fork_history",
+        "_agent_clone_root_name",
         "_agent_is_native",
         "_build_policy_engine_from_spec",
         "_dispatch_session_event_to_runner",

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -36,6 +36,7 @@ from omnigent.entities import (
     Conversation,
     synthesize_conversation_title,
 )
+from omnigent.entities.agent import Agent
 from omnigent.entities.permission import SessionPermission
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.model_override import validate_model_override
@@ -113,6 +114,7 @@ from omnigent.server.routes._sessions.helpers import (
     SessionLiveness,
     _agent_carries_cursor_fork_history,
     _agent_carries_native_fork_history,
+    _agent_clone_root_name,
     _announce_session_added,
     _apply_liveness_to_items,
     _authorize_bundled_parent_and_inherit_runner,
@@ -142,6 +144,8 @@ from omnigent.server.routes._sessions.helpers import (
     _same_provider_family,
     _session_status_from_cache,
     _set_read_state,
+    _stop_session_host_runner,
+    _stop_session_via_runner,
     _surface_model_change_forward_failure,
     _title_content_from_item,
     _validate_terminal_launch_args,
@@ -154,7 +158,9 @@ from omnigent.server.routes._sessions.orchestration import (
     _build_session_response,
     _create_session_from_bundle,
     _create_session_from_existing_agent,
+    _ensure_native_terminal_ready,
     _ensure_runner_relay_ready,
+    _ensure_runner_session_initialized,
     _get_session_snapshot,
     _is_native_terminal_session,
     _labels_for_viewer,
@@ -162,6 +168,7 @@ from omnigent.server.routes._sessions.orchestration import (
     _publish_runner_recovered_status,
     _run_managed_launch,
     _spawn_archive_stop,
+    ensure_runner_connected,
 )
 from omnigent.server.schemas import (
     AutomaticSessionRenameRequest,
@@ -178,6 +185,7 @@ from omnigent.server.schemas import (
     SessionListItem,
     SessionProjectSummary,
     SessionResponse,
+    SessionRestartRequest,
     SessionSwitchAgentRequest,
     UpdateSessionRequest,
 )
@@ -2751,4 +2759,302 @@ def register_core_routes(
             permission_level=level,
             last_task_error=None,
             agent_name=target_agent.name,
+        )
+
+    # ── POST /sessions/{session_id}/restart ──────────────────────
+
+    @router.post(
+        "/sessions/{session_id}/restart",
+        # response_model=None keeps FastAPI from re-validating/serializing
+        # the handler's SessionResponse; responses= still advertises the
+        # body schema to docs/SDK tooling.
+        response_model=None,
+        responses={200: {"model": SessionResponse}},
+    )
+    async def restart_session(
+        request: Request,
+        session_id: str,
+        body: SessionRestartRequest,
+    ) -> SessionResponse:
+        """
+        Restart a session's harness execution in place.
+
+        The current harness is stopped and a fresh one is started from the
+        latest installed agent version/configuration, keeping the SAME
+        session — transcript, title, pin state, project, comments, files,
+        host, and workspace are untouched. When the session is bound to a
+        session-scoped clone whose origin built-in was refreshed after the
+        clone was made (matched by root name), the clone is re-created from
+        the built-in's current bundle so the restart picks up the update;
+        a session bound directly to a built-in already tracks its latest
+        bundle. Unlike fork, no new session is created; unlike retry, the
+        harness is replaced even when the runner is still connected.
+
+        With ``up_to_response_id`` the session is first restored to that
+        conversation point — later items are removed and the restarted
+        harness rebuilds its context from the remaining items (the stored
+        native session id is cleared since its transcript no longer
+        matches). Without it, the restarted harness resumes from the
+        session's latest state.
+
+        :param request: The incoming FastAPI request (for auth).
+        :param session_id: Session/conversation identifier to restart,
+            e.g. ``"conv_abc123"``.
+        :param body: The validated :class:`SessionRestartRequest`.
+        :returns: A :class:`SessionResponse` describing the session after
+            the restart (status ``"idle"``).
+        :raises OmnigentError: 404 if the session or its agent does not
+            exist; 403 if the caller lacks edit access; 400 if the
+            session is a sub-agent, has no agent binding, the agent
+            bundle can't be loaded, or ``up_to_response_id`` names no
+            response in the session; 409 if a turn is currently running;
+            503 if the old execution was stopped but no replacement
+            harness could be started (the session is intact — retry the
+            restart once the host is reachable).
+        """
+        user_id = _get_user_id(request, auth_provider)
+        access = await _require_access_and_level(
+            user_id, session_id, LEVEL_EDIT, permission_store, conversation_store
+        )
+        session = access.conversation
+        if session is None:
+            session = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+            if session is None:
+                raise OmnigentError(
+                    f"Session not found: {session_id!r}",
+                    code=ErrorCode.NOT_FOUND,
+                )
+        if session.kind == "sub_agent":
+            raise OmnigentError(
+                "Cannot restart a sub-agent session — only top-level sessions can be restarted.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        if session.agent_id is None:
+            raise OmnigentError(
+                "Session has no agent binding — cannot restart.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+
+        # Restarting mid-turn would tear the running harness subprocess out
+        # from under an active stream. Reject; the caller retries when idle.
+        if _session_status_from_cache(session_id, session.live_status) == "running":
+            raise OmnigentError(
+                "Session is busy — wait for the current turn to finish before restarting.",
+                code=ErrorCode.CONFLICT,
+            )
+
+        current_agent = await asyncio.to_thread(agent_store.get, session.agent_id)
+        if current_agent is None:
+            raise OmnigentError(
+                f"Current agent not found: {session.agent_id!r}",
+                code=ErrorCode.NOT_FOUND,
+            )
+
+        # Resolve the refresh source for a session-scoped clone: the
+        # built-in whose name matches the clone's root name and whose
+        # bundle drifted since the clone was made. A session bound
+        # directly to a built-in already tracks its latest bundle; a
+        # clone with no matching built-in keeps its pinned bundle.
+        refresh_source: Agent | None = None
+        if current_agent.session_id is not None:
+            root_name = _agent_clone_root_name(current_agent.name)
+            candidate = await asyncio.to_thread(agent_store.get_by_name, root_name)
+            if (
+                candidate is not None
+                and candidate.session_id is None
+                and candidate.bundle_location != current_agent.bundle_location
+            ):
+                refresh_source = candidate
+        spec_source = refresh_source or current_agent
+
+        # Load the spec BEFORE committing — an unloadable bundle fails the
+        # request with zero mutation, and the truncation point is validated
+        # before the old execution is stopped.
+        try:
+            from omnigent.server.routes import sessions as _sessions_facade
+
+            await asyncio.to_thread(
+                _sessions_facade.get_agent_cache().load,
+                spec_source.id,
+                spec_source.bundle_location,
+                expand_env=spec_source.session_id is None,
+            )
+        except Exception as exc:
+            raise OmnigentError(
+                "The agent bundle for this session could not be loaded — cannot restart.",
+                code=ErrorCode.INVALID_INPUT,
+            ) from exc
+        if body.up_to_response_id is not None:
+            precheck_items = await asyncio.to_thread(
+                conversation_store.list_items, session_id, limit=100000
+            )
+            if not any(
+                item.response_id == body.up_to_response_id
+                for item in precheck_items.data
+                if item.response_id is not None
+            ):
+                raise OmnigentError(
+                    f"Response id {body.up_to_response_id!r} not found in session items.",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+
+        presentation_labels = await asyncio.to_thread(_presentation_labels_for_agent, spec_source)
+        # A truncated restart rebuilds context from the remaining items:
+        # claude/codex/pi native rebuild their resumable session file,
+        # cursor/opencode replay prior turns as a preamble, and SDK
+        # harnesses replay the transcript as context.
+        carry_history_into_native = body.up_to_response_id is not None and (
+            await asyncio.to_thread(_agent_carries_native_fork_history, spec_source)
+            or await asyncio.to_thread(_agent_carries_cursor_fork_history, spec_source)
+        )
+
+        # Stop the current execution before mutating so no live harness can
+        # write after a truncation. Best-effort: a wedged runner is the
+        # target use case — the replacement runner supersedes it.
+        with contextlib.suppress(OmnigentError):
+            await _stop_session_via_runner(session_id, runner_router)
+        if session.host_id and session.runner_id and host_registry is not None:
+            await _stop_session_host_runner(
+                session_id, session.host_id, session.runner_id, host_registry
+            )
+
+        restart_agent_id: str | None = None
+        restart_agent_name: str | None = None
+        restart_agent_bundle: str | None = None
+        restart_agent_description: str | None = None
+        if refresh_source is not None:
+            restart_agent_id = generate_agent_id()
+            restart_agent_name = refresh_source.name
+            restart_agent_bundle = refresh_source.bundle_location
+            restart_agent_description = refresh_source.description
+        try:
+            updated = await asyncio.to_thread(
+                conversation_store.restart_conversation,
+                session_id,
+                new_agent_id=restart_agent_id,
+                new_agent_name=restart_agent_name,
+                new_agent_bundle_location=restart_agent_bundle,
+                new_agent_description=restart_agent_description,
+                presentation_labels=presentation_labels,
+                up_to_response_id=body.up_to_response_id,
+                carry_history_into_native=carry_history_into_native,
+            )
+        except LookupError as exc:
+            raise OmnigentError(
+                f"Session not found: {session_id!r}",
+                code=ErrorCode.NOT_FOUND,
+            ) from exc
+        except ValueError as exc:
+            # Store raises ValueError when up_to_response_id names no
+            # response in the conversation (raced the route precheck).
+            raise OmnigentError(
+                str(exc),
+                code=ErrorCode.INVALID_INPUT,
+            ) from exc
+
+        # Runner-derived caches (skills, routing catalog) belong to the old
+        # execution — drop them so the next snapshot re-fetches from the
+        # replacement runner. The model catalog stays: the agent family is
+        # unchanged, and it must outlive runner death for the offline picker.
+        _invalidate_runner_backed_snapshot_state(
+            session_id, cancel_inflight=True, drop_model_options=False
+        )
+
+        # Start the replacement execution. A runner that survived the stop
+        # (in-process or CLI-owned) keeps serving: reset its cached
+        # spec/terminal state so it re-resolves the refreshed agent, then
+        # respawn the native pane eagerly. A runner that is gone (host-bound
+        # and killed above, or dead) is relaunched via the same ladder the
+        # retry path uses.
+        runner_client = await _get_runner_client(session_id, runner_router, conversation=updated)
+        if runner_client is not None:
+            await _reset_runner_resources_after_switch(session_id)
+            if _is_native_terminal_session(updated):
+                terminal_outcome = await _ensure_native_terminal_ready(
+                    runner_client,
+                    session_id,
+                    updated,
+                    persist_resource_event=False,
+                )
+                if terminal_outcome.error is not None:
+                    raise OmnigentError(
+                        terminal_outcome.error.message,
+                        code=ErrorCode.RUNNER_UNAVAILABLE,
+                    )
+                await _ensure_runner_relay_ready(
+                    session_id,
+                    updated.runner_id,
+                    runner_client,
+                    conversation_store,
+                )
+        elif updated.host_id:
+            runner_client, updated = await ensure_runner_connected(
+                session_id=session_id,
+                conv=updated,
+                app_state=request.app.state,
+                conversation_store=conversation_store,
+                runner_router=runner_router,
+                raise_host_refusal=True,
+            )
+            if runner_client is None:
+                raise OmnigentError(
+                    "The session was restarted but no replacement runner could be started — "
+                    "retry the restart once the host is reachable.",
+                    code=ErrorCode.RUNNER_UNAVAILABLE,
+                )
+            terminal_ready_from_init = await _ensure_runner_session_initialized(
+                session_id,
+                updated,
+                runner_client,
+                conversation_store,
+                initializer=getattr(request.app.state, "runner_session_initializer", None),
+                suppress_recovery_turn=False,
+                require_success=True,
+            )
+            if _is_native_terminal_session(updated):
+                if not terminal_ready_from_init:
+                    terminal_outcome = await _ensure_native_terminal_ready(
+                        runner_client,
+                        session_id,
+                        updated,
+                        persist_resource_event=False,
+                    )
+                    if terminal_outcome.error is not None:
+                        raise OmnigentError(
+                            terminal_outcome.error.message,
+                            code=ErrorCode.RUNNER_UNAVAILABLE,
+                        )
+                await _ensure_runner_relay_ready(
+                    session_id,
+                    updated.runner_id,
+                    runner_client,
+                    conversation_store,
+                )
+        # else: a CLI-owned runner is offline — nothing to relaunch
+        # server-side; the next CLI connect resolves the refreshed agent.
+
+        if refresh_source is not None:
+            # Tell connected clients the binding changed so they re-derive
+            # session state (presentation labels, bound agent) from a fresh
+            # snapshot.
+            assert restart_agent_id is not None
+            restart_event = SessionAgentChangedEvent(
+                type="session.agent_changed",
+                conversation_id=session_id,
+                agent_id=restart_agent_id,
+                agent_name=refresh_source.name,
+            )
+            from omnigent.server.routes import sessions as _sessions_facade
+
+            _sessions_facade.session_stream.publish(session_id, restart_event.model_dump())
+
+        items = await asyncio.to_thread(conversation_store.list_items, session_id, limit=10000)
+        level = await _get_permission_level(user_id, session_id, permission_store)
+        return _build_session_response(
+            updated,
+            items.data,
+            "idle",
+            permission_level=level,
+            last_task_error=None,
+            agent_name=spec_source.name,
         )

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2506,6 +2506,29 @@ class SessionSwitchAgentRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class SessionRestartRequest(BaseModel):
+    """
+    Request body for ``POST /v1/sessions/{id}/restart``.
+
+    Replaces the session's harness execution in place — the current
+    harness is stopped and a fresh one is started from the latest
+    installed agent version/configuration — while keeping the same
+    session (transcript, title, pin state, project, comments, files,
+    workspace). Unlike fork, no new session is created.
+
+    :param up_to_response_id: Restore the session from a selected
+        conversation point, e.g. ``"resp_abc123"``. When set, items
+        after that response are removed and the restarted harness
+        rebuilds its context from the remaining items. When ``None``
+        (default), the restarted harness resumes from the session's
+        latest state.
+    """
+
+    up_to_response_id: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class SessionListItem(BaseModel):
     """
     Lightweight session summary for ``GET /v1/sessions`` list responses.

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1775,3 +1775,83 @@ class ConversationStore(ABC):
             ``False`` otherwise.
         """
         ...
+
+    @abstractmethod
+    def restart_conversation(
+        self,
+        conversation_id: str,
+        *,
+        new_agent_id: str | None,
+        new_agent_name: str | None,
+        new_agent_bundle_location: str | None,
+        new_agent_description: str | None,
+        presentation_labels: dict[str, str] | None,
+        up_to_response_id: str | None,
+        carry_history_into_native: bool,
+    ) -> Conversation:
+        """
+        Restart a session in place, refreshing its agent binding.
+
+        The backing store must:
+
+        1. Verify the conversation exists.
+        2. When ``new_agent_id`` is not ``None``: create a NEW
+           session-scoped agent row (fresh id ``new_agent_id``) cloned
+           from the refresh source (``new_agent_name`` /
+           ``new_agent_bundle_location`` / ``new_agent_description``),
+           point the conversation at it, and delete the old agent row
+           when it was itself session-scoped. When ``new_agent_id`` is
+           ``None``: keep the conversation's current agent binding
+           untouched (a session bound directly to a built-in already
+           tracks that built-in's latest bundle).
+        3. Keep the model settings (``llm_model``,
+           ``llm_context_window``, ``harness_override``,
+           ``terminal_launch_args``) — a restart never changes the
+           agent family, so the session's choices stay valid.
+        4. When ``up_to_response_id`` is not ``None``: resolve the
+           truncation point (the highest position of any item carrying
+           that response id) and remove every item after it, including
+           their FTS rows; raise :class:`ValueError` when no item
+           carries that response id. Also clear
+           ``external_session_id`` — the native transcript no longer
+           matches the truncated items — plus the fork-source labels
+           (the native transcript they point at is likewise stale), and
+           stamp :data:`FORK_CARRY_HISTORY_LABEL_KEY` when
+           ``carry_history_into_native`` so the restarted harness
+           rebuilds its context from the remaining items; remove the
+           marker otherwise.
+        5. When ``up_to_response_id`` is ``None``: keep
+           ``external_session_id`` so the restarted harness resumes
+           from the session's latest native state.
+        6. Drop the instance-scoped labels in
+           ``_INSTANCE_SCOPED_LABEL_KEYS`` (runtime status, runner
+           workspace, schedule links, etc. describe the replaced
+           execution, not the session).
+        7. Refresh presentation labels: drop the existing wrapper/ui
+           keys, then apply ``presentation_labels`` when given.
+        8. Update ``updated_at``.
+
+        :param conversation_id: Conversation to restart,
+            e.g. ``"conv_abc123"``.
+        :param new_agent_id: Fresh id for the replacement session-scoped
+            agent row, or ``None`` to keep the current binding.
+        :param new_agent_name: Name for the replacement agent row.
+        :param new_agent_bundle_location: Bundle directory for the
+            replacement agent row.
+        :param new_agent_description: Description for the replacement
+            agent row.
+        :param presentation_labels: Fresh wrapper/ui labels derived
+            from the refresh source; ``None``/empty drops the keys
+            (plain chat presentation).
+        :param up_to_response_id: Response id to truncate after, or
+            ``None`` to keep the full history.
+        :param carry_history_into_native: Whether the restarted harness
+            can rebuild its context from the remaining items after a
+            truncation.
+        :returns: The updated conversation.
+        :raises ConversationNotFoundError: If no conversation exists
+            with the given id.
+        :raises ValueError: If ``up_to_response_id`` matches no item in
+            the conversation.
+        """
+        ...

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -4122,6 +4122,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 )
                 is not None
             )
+
     def restart_conversation(
         self,
         conversation_id: str,

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -56,6 +56,7 @@ from omnigent.db.utils import (
     _supports_fts5,
     build_search_snippet,
     delete_fts_by_conversation_ids,
+    delete_fts_by_item_ids,
     ensure_fts_table,
     extract_search_text,
     generate_conversation_id,
@@ -4121,6 +4122,129 @@ class SqlAlchemyConversationStore(ConversationStore):
                 )
                 is not None
             )
+    def restart_conversation(
+        self,
+        conversation_id: str,
+        *,
+        new_agent_id: str | None,
+        new_agent_name: str | None,
+        new_agent_bundle_location: str | None,
+        new_agent_description: str | None,
+        presentation_labels: dict[str, str] | None,
+        up_to_response_id: str | None,
+        carry_history_into_native: bool,
+    ) -> Conversation:
+        """
+        Restart a session in place, refreshing its agent binding.
+
+        See :meth:`ConversationStore.restart_conversation` for the full
+        contract. Unlike switch-agent, the model settings and
+        ``terminal_launch_args`` are kept — a restart stays on the same
+        agent family, so the session's choices stay valid.
+        """
+        now = now_epoch()
+        # Agent Platform side: conversation row (agent rebinding, updated_at),
+        # item truncation, and label drops/upserts.
+        with self._conv_session("restart_conversation") as ap_sess:
+            row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
+            if row is None:
+                raise LookupError(f"conversation not found: {conversation_id!r}")
+            old_agent_id = row.agent_id
+            if new_agent_id is not None:
+                row.agent_id = new_agent_id
+            row.updated_at = now
+
+            if up_to_response_id is not None:
+                cutoff = ap_sess.execute(
+                    select(func.max(SqlConversationItem.position)).where(
+                        SqlConversationItem.workspace_id == current_workspace_id(),
+                        SqlConversationItem.conversation_id == conversation_id,
+                        SqlConversationItem.response_id == up_to_response_id,
+                    )
+                ).scalar_one()
+                if cutoff is None:
+                    raise ValueError(
+                        f"response_id {up_to_response_id!r} not found in conversation"
+                    )
+                doomed = list(
+                    ap_sess.execute(
+                        select(SqlConversationItem.id).where(
+                            SqlConversationItem.workspace_id == current_workspace_id(),
+                            SqlConversationItem.conversation_id == conversation_id,
+                            SqlConversationItem.position > cutoff,
+                        )
+                    ).scalars()
+                )
+                if doomed:
+                    ap_sess.execute(
+                        delete(SqlConversationItem).where(SqlConversationItem.id.in_(doomed))
+                    )
+                    delete_fts_by_item_ids(ap_sess, doomed)
+
+            existing = _fetch_labels(ap_sess, conversation_id)
+            drop_keys = {
+                WRAPPER_LABEL_KEY,
+                UI_MODE_LABEL_KEY,
+                *_INSTANCE_SCOPED_LABEL_KEYS,
+            }
+            upserts: dict[str, str] = dict(presentation_labels or {})
+            if up_to_response_id is not None:
+                # The source native transcript no longer matches the
+                # truncated items; cloning it would replay the dropped
+                # tail. Rebuild from items instead. A carry marker left
+                # by an earlier fork is stale for the same reason —
+                # re-stamp it only when the current harness can rebuild.
+                drop_keys.add(FORK_SOURCE_LABEL_KEY)
+                drop_keys.add(FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY)
+                drop_keys.add(FORK_CARRY_HISTORY_LABEL_KEY)
+                if carry_history_into_native:
+                    upserts[FORK_CARRY_HISTORY_LABEL_KEY] = "1"
+            present_drop = [key for key in drop_keys if key in existing]
+            if present_drop:
+                ap_sess.execute(
+                    delete(SqlConversationLabel).where(
+                        SqlConversationLabel.workspace_id == current_workspace_id(),
+                        SqlConversationLabel.conversation_id == conversation_id,
+                        SqlConversationLabel.key.in_(present_drop),
+                    )
+                )
+            if upserts:
+                _upsert_labels(ap_sess, conversation_id, upserts, now)
+
+        # Omnigent side: agent rows + metadata. The rebind swaps the old
+        # session-scoped clone for a fresh row in one transaction, so a
+        # failure leaves the original binding intact; clones orphaned by
+        # an earlier crash are swept at startup.
+        with self._session("restart_conversation") as session:
+            if new_agent_id is not None:
+                # The route resolves all-or-none rebind params; a clone
+                # without name/bundle is a caller bug, not a state to
+                # persist.
+                assert new_agent_name is not None
+                assert new_agent_bundle_location is not None
+                if old_agent_id is not None:
+                    old_agent = session.get(SqlAgent, (current_workspace_id(), old_agent_id))
+                    if old_agent is not None and old_agent.kind == encode_agent_kind("session"):
+                        session.delete(old_agent)
+                        session.flush()
+                session.add(
+                    _new_session_agent_row(
+                        agent_id=new_agent_id,
+                        agent_name=new_agent_name,
+                        agent_bundle_location=new_agent_bundle_location,
+                        agent_description=new_agent_description,
+                        now=now,
+                    )
+                )
+
+            meta = session.get(SqlConversationMetadata, (current_workspace_id(), conversation_id))
+            if meta is not None and up_to_response_id is not None:
+                meta.external_session_id = None
+
+        conv = self.get_conversation(conversation_id)
+        if conv is None:
+            raise LookupError(f"conversation not found: {conversation_id!r}")
+        return conv
 
     async def delete_conversation(self, conversation_id: str) -> bool:
         """

--- a/openapi.json
+++ b/openapi.json
@@ -6278,6 +6278,26 @@
         "title": "SessionResponse",
         "type": "object"
       },
+      "SessionRestartRequest": {
+        "additionalProperties": false,
+        "description": "Request body for `POST /v1/sessions/{id}/restart`.\n\nReplaces the session's harness execution in place \u2014 the current\nharness is stopped and a fresh one is started from the latest\ninstalled agent version/configuration \u2014 while keeping the same\nsession (transcript, title, pin state, project, comments, files,\nworkspace). Unlike fork, no new session is created.",
+        "properties": {
+          "up_to_response_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Restore the session from a selected conversation point, e.g. `\"resp_abc123\"`. When set, items after that response are removed and the restarted harness rebuilds its context from the remaining items. When `None` (default), the restarted harness resumes from the session's latest state.",
+            "title": "Up To Response Id"
+          }
+        },
+        "title": "SessionRestartRequest",
+        "type": "object"
+      },
       "SessionSandboxStatusEvent": {
         "description": "Managed-sandbox launch progress for a `host_type=\"managed\"` session.\n\nA managed create returns before its sandbox exists; the Omnigent\nserver emits this event as the background launch pipeline advances\nso the Web UI can show live provisioning progress on the session\npage instead of a silent dead chat: sandbox provision \u2192 repository\nclone \u2192 host startup \u2192 runner connect \u2192 ready, or a terminal\nfailure with the reason.",
         "properties": {
@@ -13396,6 +13416,60 @@
         "summary": "Get Session Resource",
         "tags": [
           "session_resources"
+        ]
+      }
+    },
+    "/v1/sessions/{session_id}/restart": {
+      "post": {
+        "description": "Restart a session's harness execution in place.\n\nThe current harness is stopped and a fresh one is started from the\nlatest installed agent version/configuration, keeping the SAME\nsession \u2014 transcript, title, pin state, project, comments, files,\nhost, and workspace are untouched. When the session is bound to a\nsession-scoped clone whose origin built-in was refreshed after the\nclone was made (matched by root name), the clone is re-created from\nthe built-in's current bundle so the restart picks up the update;\na session bound directly to a built-in already tracks its latest\nbundle. Unlike fork, no new session is created; unlike retry, the\nharness is replaced even when the runner is still connected.\n\nWith `up_to_response_id` the session is first restored to that\nconversation point \u2014 later items are removed and the restarted\nharness rebuilds its context from the remaining items (the stored\nnative session id is cleared since its transcript no longer\nmatches). Without it, the restarted harness resumes from the\nsession's latest state.\n\n**Parameters**\n\n- `body` \u2014 The validated `SessionRestartRequest`.\n\n**Returns:** A `SessionResponse` describing the session after the restart (status `\"idle\"`).\n\n**Raises**\n\n- `OmnigentError` \u2014 404 if the session or its agent does not exist; 403 if the caller lacks edit access; 400 if the session is a sub-agent, has no agent binding, the agent bundle can't be loaded, or `up_to_response_id` names no response in the session; 409 if a turn is currently running; 503 if the old execution was stopped but no replacement harness could be started (the session is intact \u2014 retry the restart once the host is reachable).",
+        "operationId": "restart_session_v1_sessions__session_id__restart_post",
+        "parameters": [
+          {
+            "description": "Session/conversation identifier to restart, e.g. `\"conv_abc123\"`.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SessionRestartRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restart Session",
+        "tags": [
+          "sessions"
         ]
       }
     },

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -1129,6 +1129,51 @@ class SessionsNamespace:
             f"POST /v1/sessions/{source_session_id}/fork",
         )
 
+    async def restart(
+        self,
+        session_id: str,
+        *,
+        up_to_response_id: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Restart a session's harness execution in place.
+
+        Calls ``POST /v1/sessions/{session_id}/restart``. The current
+        harness is stopped and a fresh one is started from the latest
+        installed agent version/configuration, keeping the same
+        session identity (transcript, title, pin state, project,
+        workspace).
+
+        :param session_id: ID of the session to restart, e.g.
+            ``"conv_abc123"``.
+        :param up_to_response_id: Optional restore point, e.g.
+            ``"resp_abc123"``. When set, items after that response are
+            removed and the restarted harness rebuilds its context
+            from the remaining items; ``None`` (default) resumes from
+            the session's latest state.
+        :returns: Raw response dict matching the ``SessionResponse``
+            shape: ``id``, ``agent_id``, ``status``, ``created_at``,
+            ``title``, ``labels``, ``reasoning_effort``, and
+            ``items``.
+        :raises OmnigentError: 404 if *session_id* does not exist;
+            400 if the session has no agent binding or
+            *up_to_response_id* names no response in the session;
+            409 if a turn is running; 503 if no replacement harness
+            could be started.
+        """
+        body: dict[str, Any] = {}
+        if up_to_response_id is not None:
+            body["up_to_response_id"] = up_to_response_id
+        resp = await self._http.post(
+            f"{self._base}/v1/sessions/{session_id}/restart",
+            json=body,
+        )
+        raise_for_status(resp.status_code, response_body(resp))
+        return require_json_object(
+            resp,
+            f"POST /v1/sessions/{session_id}/restart",
+        )
+
     async def compact(self, session_id: str) -> None:
         """
         Request explicit context compaction for a session.

--- a/tests/db/test_utils_extended.py
+++ b/tests/db/test_utils_extended.py
@@ -27,6 +27,7 @@ from omnigent.db.utils import (
     _ITEM_TYPES,
     clear_engine_cache,
     delete_fts_by_conversation,
+    delete_fts_by_item_ids,
     ensure_fts_table,
     generate_conversation_id,
     generate_file_id,
@@ -285,6 +286,47 @@ class TestFtsHelpers:
             ).fetchall()
             assert len(rows) == 1
             assert rows[0][0] == "9980c8a9248139f14f4165e5d53088aa"
+
+    def test_delete_fts_by_item_ids(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        if engine.dialect.name != "sqlite":
+            pytest.skip("FTS5 virtual table is SQLite-only; no-op on other backends")
+        ensure_fts_table(engine)
+        managed = make_managed_session_maker(engine)
+
+        with managed() as session:
+            insert_fts(
+                session,
+                "11cd574b729d39c61cf72d568188531a",
+                "223a265445caf1cdb034abe0b449485d",
+                "searchable text",
+            )
+            insert_fts(
+                session,
+                "3317d69fc9d16f420210e37ed3ef5f31",
+                "223a265445caf1cdb034abe0b449485d",
+                "also searchable",
+            )
+
+        with managed() as session:
+            delete_fts_by_item_ids(session, ["11cd574b729d39c61cf72d568188531a"])
+
+        with managed() as session:
+            deleted = session.execute(
+                text(
+                    "SELECT item_id FROM conversation_items_fts"
+                    " WHERE item_id = '11cd574b729d39c61cf72d568188531a'"
+                )
+            ).fetchall()
+            assert len(deleted) == 0
+
+            kept = session.execute(
+                text(
+                    "SELECT item_id FROM conversation_items_fts "
+                    "WHERE item_id = '3317d69fc9d16f420210e37ed3ef5f31'"
+                )
+            ).fetchall()
+            assert len(kept) == 1
 
     def test_delete_fts_by_conversation(self, db_uri: str) -> None:
         engine = get_or_create_engine(db_uri)

--- a/tests/e2e/test_restart_session_e2e.py
+++ b/tests/e2e/test_restart_session_e2e.py
@@ -1,0 +1,255 @@
+"""E2E tests for restart-in-place — ``POST /v1/sessions/{id}/restart``.
+
+Real server + runner + LLM (or mock LLM). Restart stops the session's current
+harness execution and starts a fresh one on the SAME session id, from the
+latest installed agent version, optionally rewinding the transcript to a
+selected conversation point (``up_to_response_id``). The guarantees under
+test:
+
+* the session id, transcript, and metadata survive the restart, and the
+  relaunched agent still recalls a code word planted before it;
+* a truncation restart removes later items and keeps earlier ones.
+
+The built-in version-refresh rebind (re-cloning a drifted fork/switch clone)
+is covered by the route unit tests — an e2e server has no second built-in
+bundle version to drift against.
+
+In mock mode the source is an inline ``openai-agents`` agent pointed at the
+mock LLM server; the recall queue is claimed by a token unique to the recall
+turn (content-routing ``match``) so a stray request cannot drain it.
+
+Usage::
+
+    pytest tests/e2e/test_restart_session_e2e.py -v --timeout=60
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    create_runner_bound_session,
+    poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
+    send_user_message_to_session,
+    set_fallback_mock_llm,
+)
+from tests.e2e.helpers import final_assistant_text
+
+
+def _bound_agent(client: httpx.Client, session_id: str) -> dict[str, str]:
+    """Return the session's currently-bound agent object.
+
+    :param client: HTTP client pointed at the test server.
+    :param session_id: Session/conversation id.
+    :returns: The agent object (``{id, name, harness, ...}``).
+    """
+    resp = client.get(f"/v1/sessions/{session_id}/agent")
+    resp.raise_for_status()
+    return resp.json()
+
+
+def test_restart_session_in_place_recalls_history(
+    http_client: httpx.Client,
+    claude_coder_agent: str,
+    live_runner_id: str,
+    using_mock_llm: bool,
+    mock_llm_server_url: str,
+) -> None:
+    """A restarted session recalls a code word planted before the restart.
+
+    Plants a marker on a source session, restarts the session IN PLACE, then
+    asks the relaunched agent to recall it. In mock mode the source agent is
+    named like a fork of the ``sdk-chat-builtin`` built-in, so the restart
+    also exercises the version refresh: the binding must move to a fresh
+    clone of the current built-in bundle (agent id changes, root name stays).
+
+    :param http_client: HTTP client pointed at the live server.
+    :param claude_coder_agent: The uploaded claude-sdk source agent name
+        (used only in real-LLM mode).
+    :param live_runner_id: The server fixture's runner id.
+    :param using_mock_llm: Whether mock LLM is active.
+    :param mock_llm_server_url: Mock LLM server URL.
+    :returns: None.
+    """
+    marker = f"RESTARTWORD_{uuid.uuid4().hex[:6].upper()}"
+
+    if using_mock_llm:
+        uid = uuid.uuid4().hex[:6]
+        source_model = f"mock-restart-src-{uid}"
+        source_agent = register_inline_agent(
+            http_client,
+            name=f"restart-src-{uid}",
+            harness="openai-agents",
+            model=source_model,
+            profile="",
+            prompt="You are a terse assistant.",
+            mock_llm_base_url=f"{mock_llm_server_url}/v1",
+        )
+        recall_token = f"recall-{uid}"
+        recall_key = f"restart-tgt-{uid}"
+        reset_mock_llm(mock_llm_server_url)
+        configure_mock_llm(
+            mock_llm_server_url,
+            [{"text": "ACK"}],
+            key=source_model,
+        )
+        configure_mock_llm(
+            mock_llm_server_url,
+            [{"text": marker}],
+            key=recall_key,
+            match=recall_token,
+        )
+        set_fallback_mock_llm(mock_llm_server_url, key=recall_key, text=marker)
+    else:
+        source_agent = claude_coder_agent
+
+    # 1. Source session on the server's runner; plant a word.
+    session_id = create_runner_bound_session(
+        http_client, agent_name=source_agent, runner_id=live_runner_id
+    )
+    original_agent_id = _bound_agent(http_client, session_id)["id"]
+    rid_1 = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content=(f"Remember this code word for later: {marker}. Reply with exactly one word: ACK"),
+    )
+    body_1 = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=rid_1, timeout=180
+    )
+    assert body_1["status"] == "completed", f"plant turn failed: {body_1.get('error')}"
+    pre_restart_item_ids = {
+        item["id"] for item in http_client.get(f"/v1/sessions/{session_id}").json()["items"]
+    }
+
+    # 2. Restart the SAME session in place.
+    resp = http_client.post(f"/v1/sessions/{session_id}/restart", json={})
+    assert resp.status_code == 200, f"restart failed: {resp.status_code} {resp.text}"
+    restarted = resp.json()
+    # Same session — restart must not branch into a new conversation.
+    assert restarted["id"] == session_id, "restart must keep the same session id"
+    # Every pre-restart item survives. (Superset, not equality: the
+    # relaunched runner appends its own init/resource items
+    # asynchronously, so a later read can legitimately see MORE items.)
+    restarted_item_ids = {item["id"] for item in restarted["items"]}
+    assert pre_restart_item_ids <= restarted_item_ids, (
+        "restart must not drop transcript items: "
+        f"missing {sorted(pre_restart_item_ids - restarted_item_ids)}"
+    )
+    # A custom agent with no matching built-in keeps its binding (the
+    # built-in refresh rebind is unit-tested at the route).
+    assert restarted["agent_id"] == original_agent_id
+
+    # 3. Recall on the SAME session after the relaunch. Only possible if the
+    # in-place transcript was replayed as context to the restarted agent.
+    recall_prompt = (
+        "Earlier in this conversation I gave you a code word to remember. "
+        "Reply with exactly that code word and nothing else."
+    )
+    if using_mock_llm:
+        recall_prompt = f"{recall_prompt} ({recall_token})"
+    rid_2 = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content=recall_prompt,
+    )
+    body_2 = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=rid_2, timeout=180
+    )
+    assert body_2["status"] == "completed", f"recall turn failed: {body_2.get('error')}"
+    text = final_assistant_text(body_2).upper()
+    assert marker in text, (
+        f"restarted agent did not recall {marker!r} (got {text!r}) — the transcript "
+        "was not preserved or the relaunched agent was not rebuilt from it"
+    )
+
+
+def test_restart_session_truncates_to_response_point(
+    http_client: httpx.Client,
+    claude_coder_agent: str,
+    live_runner_id: str,
+    using_mock_llm: bool,
+    mock_llm_server_url: str,
+) -> None:
+    """A restart with ``up_to_response_id`` rewinds the transcript.
+
+    Plants two turns, then restarts the session up to the FIRST turn's
+    response id. The restart response must list only the first turn's items —
+    the later turn is gone from the Omnigent transcript the relaunched agent
+    rebuilds from.
+
+    :param http_client: HTTP client pointed at the live server.
+    :param claude_coder_agent: The uploaded claude-sdk source agent name
+        (used only in real-LLM mode).
+    :param live_runner_id: The server fixture's runner id.
+    :param using_mock_llm: Whether mock LLM is active.
+    :param mock_llm_server_url: Mock LLM server URL.
+    :returns: None.
+    """
+    if using_mock_llm:
+        uid = uuid.uuid4().hex[:6]
+        source_model = f"mock-restart-trunc-{uid}"
+        source_agent = register_inline_agent(
+            http_client,
+            name=f"restart-trunc-{uid}",
+            harness="openai-agents",
+            model=source_model,
+            profile="",
+            prompt="You are a terse assistant.",
+            mock_llm_base_url=f"{mock_llm_server_url}/v1",
+        )
+        reset_mock_llm(mock_llm_server_url)
+        configure_mock_llm(
+            mock_llm_server_url,
+            [{"text": "ACK"}, {"text": "ACK"}],
+            key=source_model,
+        )
+    else:
+        source_agent = claude_coder_agent
+
+    session_id = create_runner_bound_session(
+        http_client, agent_name=source_agent, runner_id=live_runner_id
+    )
+    rid_1 = send_user_message_to_session(
+        http_client, session_id=session_id, content="First turn. Reply with exactly: ACK"
+    )
+    body_1 = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=rid_1, timeout=180
+    )
+    assert body_1["status"] == "completed", f"first turn failed: {body_1.get('error')}"
+    items_after_turn_1 = http_client.get(f"/v1/sessions/{session_id}").json()["items"]
+    # Turn-grouping response ids attach to the user message; assistant
+    # output carries its own, so the restore point is the response id of
+    # the LAST item of the first turn (what the UI passes when a user
+    # picks that message).
+    restore_point = next(
+        item["response_id"] for item in reversed(items_after_turn_1) if item["response_id"]
+    )
+
+    rid_2 = send_user_message_to_session(
+        http_client, session_id=session_id, content="Second turn. Reply with exactly: ACK"
+    )
+    body_2 = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=rid_2, timeout=180
+    )
+    assert body_2["status"] == "completed", f"second turn failed: {body_2.get('error')}"
+    items_after_turn_2 = http_client.get(f"/v1/sessions/{session_id}").json()["items"]
+    turn_1_item_ids = {item["id"] for item in items_after_turn_1}
+    turn_2_item_ids = {item["id"] for item in items_after_turn_2} - turn_1_item_ids
+    assert turn_2_item_ids, "second turn must append items"
+
+    # Rewind to the end of the first turn.
+    resp = http_client.post(
+        f"/v1/sessions/{session_id}/restart",
+        json={"up_to_response_id": restore_point},
+    )
+    assert resp.status_code == 200, f"restart failed: {resp.status_code} {resp.text}"
+    restarted = resp.json()
+    assert restarted["id"] == session_id, "restart must keep the same session id"
+    restarted_item_ids = {item["id"] for item in restarted["items"]}
+    assert turn_1_item_ids <= restarted_item_ids, "truncation must keep the first turn"
+    assert not (turn_2_item_ids & restarted_item_ids), "truncation must drop the second turn"

--- a/tests/e2e_ui/sessions/test_header_session_menu.py
+++ b/tests/e2e_ui/sessions/test_header_session_menu.py
@@ -54,12 +54,13 @@ def test_header_session_menu_renames_owner_and_hides_for_subagent(
         # shortcuts. "Add to project" is a submenu trigger, so its label carries
         # the flyout's own items; match only the leading action label.
         menu_items = page.get_by_role("menuitem")
-        expect(menu_items).to_have_count(6)
+        expect(menu_items).to_have_count(7)
         labels = [text.split("\n")[0] for text in menu_items.all_inner_texts()]
         assert labels == [
             "Pin",
             "Rename",
             "Mark as unread",
+            "Restart session…",
             "Add to project",
             "Archive",
             "Delete",

--- a/tests/e2e_ui/sessions/test_restart_session.py
+++ b/tests/e2e_ui/sessions/test_restart_session.py
@@ -1,0 +1,58 @@
+"""E2E coverage for the header menu's "Restart session…" action.
+
+Drives the real UI: open the session actions menu, confirm the restart
+dialog, and verify the session reloads in place — same URL, transcript
+intact, agent binding refreshed from the latest installed version.
+"""
+
+from __future__ import annotations
+
+import httpx
+from playwright.sync_api import Page, expect
+
+
+def test_header_menu_restarts_session_in_place(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Restart via the header menu keeps the session and reloads it fresh."""
+    base_url, session_id = seeded_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+    trigger = page.get_by_test_id("header-conversation-actions")
+    expect(trigger).to_be_visible(timeout=30_000)
+    trigger.click()
+
+    restart_item = page.get_by_role("menuitem", name="Restart session…")
+    expect(restart_item).to_be_visible()
+    restart_item.click()
+
+    # The confirm dialog guards the action; cancelling changes nothing.
+    dialog = page.get_by_role("dialog")
+    expect(dialog.get_by_role("heading", name="Restart session?")).to_be_visible()
+    dialog.get_by_role("button", name="Cancel").click()
+    expect(dialog).to_have_count(0)
+
+    trigger.click()
+    page.get_by_role("menuitem", name="Restart session…").click()
+    page.get_by_test_id("header-restart-confirm").click()
+
+    # The dialog closes on success and the session reloads in place.
+    expect(page.get_by_role("dialog")).to_have_count(0, timeout=30_000)
+    expect(page).to_have_url(f"{base_url}/c/{session_id}")
+    expect(trigger).to_be_visible(timeout=30_000)
+
+    after = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+    after.raise_for_status()
+    body = after.json()
+    assert body["id"] == session_id, "restart must keep the same session id"
+    assert body["status"] == "idle", f"restarted session should be idle, got {body['status']}"
+    # The session still resolves to a working agent of the same family. When
+    # the fixture's binding is a drifted clone the restart rebinds to a fresh
+    # clone of the current built-in (agent id changes); an up-to-date or
+    # built-in-bound session keeps its id. Either shape is a valid restart.
+    agent_after = httpx.get(f"{base_url}/v1/sessions/{session_id}/agent", timeout=10.0)
+    agent_after.raise_for_status()
+    assert "hello_world" in str(agent_after.json()["name"]), (
+        f"restart must keep the session on the hello_world agent, got {agent_after.json()}"
+    )

--- a/tests/server/routes/test_sessions_restart.py
+++ b/tests/server/routes/test_sessions_restart.py
@@ -1,0 +1,592 @@
+"""Tests for ``POST /v1/sessions/{id}/restart``.
+
+Exercises the restart-in-place endpoint: validation (404 missing session,
+400 sub-agent / no binding / unknown truncation point / unloadable bundle,
+409 while busy) and the happy-path wiring (stop → store restart → relaunch
+→ event). Real-type store stubs — no MagicMock.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from starlette.testclient import TestClient
+
+from omnigent.entities import Agent, Conversation, ConversationItem, MessageData, PagedList
+from omnigent.errors import OmnigentError
+from omnigent.server.routes import sessions as sessions_mod
+from omnigent.server.routes.sessions import create_sessions_router
+from omnigent.server.routes.sessions import routes_core as routes_core_mod
+
+# ── Stubs ────────────────────────────────────────────────────────
+
+
+class _AgentStore:
+    """Agent store stub: get + list for the restart route.
+
+    :param agents: Pre-populated map of agent_id → Agent.
+    """
+
+    def __init__(self, agents: dict[str, Agent]) -> None:
+        self._agents = dict(agents)
+
+    def get(self, agent_id: str) -> Agent | None:
+        """:returns: The agent if present, else None."""
+        return self._agents.get(agent_id)
+
+    def get_by_name(self, name: str) -> Agent | None:
+        """:returns: The first agent with this name, else None."""
+        return next((a for a in self._agents.values() if a.name == name), None)
+
+    def list(
+        self,
+        limit: int = 20,
+        after: str | None = None,
+        before: str | None = None,
+        order: str = "desc",
+    ) -> PagedList[Agent]:
+        """Return the built-in (session_id is None) agents.
+
+        :param limit: Max agents (ignored — stubs are small).
+        :returns: A PagedList of the template agents.
+        """
+        del after, before, order
+        builtins = [a for a in self._agents.values() if a.session_id is None][:limit]
+        return PagedList(data=builtins, first_id=None, last_id=None, has_more=False)
+
+
+class _ConversationStore:
+    """Conversation store stub for the restart route.
+
+    :param conversations: Map of id → Conversation.
+    :param items_by_conv: Map of conv_id → items.
+    """
+
+    def __init__(
+        self,
+        conversations: dict[str, Conversation],
+        items_by_conv: dict[str, list[ConversationItem]] | None = None,
+    ) -> None:
+        self._convs = conversations
+        self._items = items_by_conv or {}
+        self.restart_calls: list[dict[str, Any]] = []
+
+    def get_conversation(self, conversation_id: str) -> Conversation | None:
+        """:returns: The conversation if present, else None."""
+        return self._convs.get(conversation_id)
+
+    def restart_conversation(
+        self,
+        conversation_id: str,
+        *,
+        new_agent_id: str | None,
+        new_agent_name: str | None,
+        new_agent_bundle_location: str | None,
+        new_agent_description: str | None,
+        presentation_labels: dict[str, str] | None,
+        up_to_response_id: str | None,
+        carry_history_into_native: bool,
+    ) -> Conversation:
+        """Record the call and return the restarted conversation.
+
+        :param conversation_id: Session being restarted.
+        :param new_agent_id: Refreshed clone id, or None to keep the binding.
+        :param new_agent_name: Clone name.
+        :param new_agent_bundle_location: Fresh bundle key.
+        :param new_agent_description: Fresh description.
+        :param presentation_labels: ui/wrapper labels from the refresh source.
+        :param up_to_response_id: Truncation point, or None.
+        :param carry_history_into_native: Rebuild directive flag.
+        :returns: The conversation, rebound when ``new_agent_id`` is set.
+        :raises LookupError: If the conversation is unknown.
+        """
+        self.restart_calls.append(
+            {
+                "conversation_id": conversation_id,
+                "new_agent_id": new_agent_id,
+                "new_agent_name": new_agent_name,
+                "new_agent_bundle_location": new_agent_bundle_location,
+                "new_agent_description": new_agent_description,
+                "presentation_labels": presentation_labels,
+                "up_to_response_id": up_to_response_id,
+                "carry_history_into_native": carry_history_into_native,
+            }
+        )
+        src = self._convs.get(conversation_id)
+        if src is None:
+            raise LookupError(conversation_id)
+        return Conversation(
+            id=conversation_id,
+            created_at=src.created_at,
+            updated_at=200,
+            root_conversation_id=conversation_id,
+            agent_id=new_agent_id or src.agent_id,
+            title=src.title,
+            kind=src.kind,
+            host_id=src.host_id,
+        )
+
+    def list_items(
+        self,
+        conversation_id: str,
+        limit: int = 100,
+        after: str | None = None,
+        before: str | None = None,
+        order: str = "asc",
+        type: str | None = None,
+    ) -> PagedList[ConversationItem]:
+        """:returns: A PagedList of the conversation's items."""
+        del limit, after, before, order, type
+        items = self._items.get(conversation_id, [])
+        return PagedList(
+            data=items,
+            first_id=items[0].id if items else None,
+            last_id=items[-1].id if items else None,
+            has_more=False,
+        )
+
+
+class _AgentCacheStub:
+    """Stub for ``get_agent_cache()`` — controls the bundle precheck.
+
+    :param raise_on_load: When True, ``load`` raises to simulate an
+        unloadable refresh-source bundle (the route maps this to 400).
+    """
+
+    def __init__(self, raise_on_load: bool = False) -> None:
+        self._raise = raise_on_load
+
+    def load(
+        self,
+        agent_id: str,
+        bundle_location: str,
+        *,
+        expand_env: bool = False,
+    ) -> object:
+        """Pretend to load a bundle.
+
+        :param agent_id: Agent id (unused).
+        :param bundle_location: Bundle key (unused).
+        :param expand_env: Accepted to match the real ``AgentCache.load``.
+        :returns: A sentinel object (the route ignores the value).
+        :raises RuntimeError: When configured to fail.
+        """
+        del agent_id, bundle_location, expand_env
+        if self._raise:
+            raise RuntimeError("bundle missing")
+        return object()
+
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+_SESSION_ID = "e9f8f58523cec9a57d3bdf93be543e8c"
+_CLONE_ID = "a98bb825ebd41391c19637c58fe3c0b7"
+_BUILTIN_ID = "c1030c25bd9d756e4aef6c4e96a7e126"
+
+
+def _conv(
+    conv_id: str = _SESSION_ID,
+    agent_id: str | None = _CLONE_ID,
+    kind: str = "default",
+    host_id: str | None = None,
+) -> Conversation:
+    """Build a Conversation entity.
+
+    :param conv_id: Conversation id.
+    :param agent_id: Bound agent id, or None.
+    :param kind: ``"default"`` or ``"sub_agent"``.
+    :param host_id: Connected-host id, or None.
+    :returns: A Conversation.
+    """
+    return Conversation(
+        id=conv_id,
+        created_at=1,
+        updated_at=1,
+        root_conversation_id=conv_id,
+        agent_id=agent_id,
+        title="Source",
+        kind=kind,
+        host_id=host_id,
+    )
+
+
+def _agent(agent_id: str, name: str, bundle: str, session_id: str | None) -> Agent:
+    """Build an Agent entity.
+
+    :param agent_id: Agent id.
+    :param name: Agent name.
+    :param bundle: Bundle location.
+    :param session_id: Owning session id (None for a built-in).
+    :returns: An Agent.
+    """
+    return Agent(
+        id=agent_id,
+        created_at=1,
+        name=name,
+        bundle_location=bundle,
+        version=1,
+        session_id=session_id,
+    )
+
+
+def _item(item_id: str, response_id: str) -> ConversationItem:
+    """Build a user-message item.
+
+    :param item_id: Item id.
+    :param response_id: Turn response id.
+    :returns: A ConversationItem.
+    """
+    return ConversationItem(
+        id=item_id,
+        type="message",
+        status="completed",
+        response_id=response_id,
+        created_at=1,
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+    )
+
+
+def _build_app(conv_store: _ConversationStore, agent_store: _AgentStore) -> FastAPI:
+    """Build a FastAPI app mounting the sessions router + error handler.
+
+    :param conv_store: Conversation store stub.
+    :param agent_store: Agent store stub.
+    :returns: A configured FastAPI app.
+    """
+    router = create_sessions_router(
+        conversation_store=conv_store,  # type: ignore[arg-type]
+        agent_store=agent_store,  # type: ignore[arg-type]
+    )
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def _handle(request: Request, exc: OmnigentError) -> JSONResponse:
+        del request
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    app.include_router(router, prefix="/v1")
+    return app
+
+
+def _patch_restart_helpers(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[str]]:
+    """Stub the bundle/labels/stop helpers so the route runs hermetically.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: A dict with the ordered stop/relaunch call log.
+    """
+    calls: dict[str, list[str]] = {"stopped": [], "reset": []}
+    monkeypatch.setattr(sessions_mod, "get_agent_cache", lambda: _AgentCacheStub())
+    monkeypatch.setattr(sessions_mod, "_agent_carries_native_fork_history", lambda a: False)
+    monkeypatch.setattr(sessions_mod, "_agent_carries_cursor_fork_history", lambda a: False)
+    monkeypatch.setattr(sessions_mod, "_presentation_labels_for_agent", lambda a: {})
+
+    async def _stop(session_id: str, runner_router: Any) -> bool:
+        del runner_router
+        calls["stopped"].append(session_id)
+        return True
+
+    monkeypatch.setattr(sessions_mod, "_stop_session_via_runner", _stop)
+
+    async def _reset(request: Any, conversation: Any) -> None:
+        del request
+        calls["reset"].append(conversation.id)
+
+    monkeypatch.setattr(sessions_mod, "_reset_runner_resources_after_switch", _reset)
+
+    # Runner is gone after the stop → the relaunch ladder takes the
+    # CLI-offline branch (no-op) for a hostless session.
+    async def _no_client(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        return
+
+    monkeypatch.setattr(sessions_mod, "_get_runner_client", _no_client)
+    return calls
+
+
+# The session's currently-bound agent is a session-scoped clone of the
+# claude built-in — exactly the fork/switch shape a restart must refresh.
+_CLONE_STALE = _agent(_CLONE_ID, "claude (switch ag_old)", "bundle/old", _SESSION_ID)
+_CLONE_CURRENT = _agent(_CLONE_ID, "claude (switch ag_old)", "bundle/new", _SESSION_ID)
+_BUILTIN_STALE = _agent(_BUILTIN_ID, "claude", "bundle/new", None)
+
+
+# ── Tests ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_restart_reclones_from_refreshed_builtin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A restart of a session-scoped clone whose bundle drifted from the
+    current built-in rebinds to a fresh clone of the latest bundle.
+    """
+    conv_store = _ConversationStore(conversations={_SESSION_ID: _conv()})
+    agent_store = _AgentStore({_CLONE_ID: _CLONE_STALE, _BUILTIN_ID: _BUILTIN_STALE})
+    calls = _patch_restart_helpers(monkeypatch)
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(f"/v1/sessions/{_SESSION_ID}/restart", json={})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "idle"
+    assert body["id"] == _SESSION_ID, "restart must keep the session id"
+    assert len(body["agent_id"]) == 32 and body["agent_id"] != _CLONE_ID, (
+        "restart must bind a freshly cloned session-scoped agent"
+    )
+
+    assert len(conv_store.restart_calls) == 1, "route must call restart exactly once"
+    call = conv_store.restart_calls[0]
+    assert call["conversation_id"] == _SESSION_ID
+    assert call["new_agent_bundle_location"] == "bundle/new", "must clone the latest bundle"
+    assert call["up_to_response_id"] is None
+    assert call["carry_history_into_native"] is False
+    # The old execution was stopped before the store mutation.
+    assert calls["stopped"] == [_SESSION_ID]
+
+
+@pytest.mark.asyncio
+async def test_restart_keeps_binding_when_bundle_current(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A clone already on the built-in's bundle restarts in place without a
+    rebind — same agent id before and after.
+    """
+    conv_store = _ConversationStore(conversations={_SESSION_ID: _conv()})
+    agent_store = _AgentStore({_CLONE_ID: _CLONE_CURRENT, _BUILTIN_ID: _BUILTIN_STALE})
+    _patch_restart_helpers(monkeypatch)
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(f"/v1/sessions/{_SESSION_ID}/restart", json={})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agent_id"] == _CLONE_ID
+    call = conv_store.restart_calls[0]
+    assert call["new_agent_id"] is None, "no drift → keep the current binding"
+
+
+@pytest.mark.asyncio
+async def test_restart_keeps_builtin_binding_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session bound directly to a built-in keeps that binding: built-in
+    rows already track the latest bundle, and pinning them as clones would
+    lose future refreshes.
+    """
+    conv_store = _ConversationStore(conversations={_SESSION_ID: _conv(agent_id=_BUILTIN_ID)})
+    agent_store = _AgentStore({_BUILTIN_ID: _agent(_BUILTIN_ID, "claude", "bundle/old", None)})
+    _patch_restart_helpers(monkeypatch)
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(f"/v1/sessions/{_SESSION_ID}/restart", json={})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agent_id"] == _BUILTIN_ID
+    assert conv_store.restart_calls[0]["new_agent_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_restart_keeps_custom_clone_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A clone with no matching built-in (custom upload) restarts on its
+    own bundle.
+    """
+    custom = _agent(_CLONE_ID, "my-uploaded-agent", "bundle/custom", _SESSION_ID)
+    conv_store = _ConversationStore(conversations={_SESSION_ID: _conv()})
+    agent_store = _AgentStore({_CLONE_ID: custom, _BUILTIN_ID: _BUILTIN_STALE})
+    _patch_restart_helpers(monkeypatch)
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(f"/v1/sessions/{_SESSION_ID}/restart", json={})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agent_id"] == _CLONE_ID
+    call = conv_store.restart_calls[0]
+    assert call["new_agent_id"] is None
+    assert call["new_agent_bundle_location"] is None
+
+
+@pytest.mark.asyncio
+async def test_restart_truncates_to_response_point(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``up_to_response_id`` forwards the truncation to the store."""
+    conv_store = _ConversationStore(
+        conversations={_SESSION_ID: _conv()},
+        items_by_conv={_SESSION_ID: [_item("9980c8a9248139f14f4165e5d53088aa", "resp_1")]},
+    )
+    agent_store = _AgentStore({_CLONE_ID: _CLONE_CURRENT, _BUILTIN_ID: _BUILTIN_STALE})
+    _patch_restart_helpers(monkeypatch)
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(
+        f"/v1/sessions/{_SESSION_ID}/restart",
+        json={"up_to_response_id": "resp_1"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    call = conv_store.restart_calls[0]
+    assert call["up_to_response_id"] == "resp_1"
+
+
+@pytest.mark.asyncio
+async def test_restart_400_unknown_response_point(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ``up_to_response_id`` that appears in no item is rejected before
+    anything is stopped or mutated.
+    """
+    conv_store = _ConversationStore(
+        conversations={_SESSION_ID: _conv()},
+        items_by_conv={_SESSION_ID: [_item("9980c8a9248139f14f4165e5d53088aa", "resp_1")]},
+    )
+    agent_store = _AgentStore({_CLONE_ID: _CLONE_CURRENT, _BUILTIN_ID: _BUILTIN_STALE})
+    calls = _patch_restart_helpers(monkeypatch)
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(
+        f"/v1/sessions/{_SESSION_ID}/restart",
+        json={"up_to_response_id": "resp_missing"},
+    )
+
+    assert resp.status_code == 400, resp.text
+    assert conv_store.restart_calls == []
+    assert calls["stopped"] == [], "validation must happen before the stop"
+
+
+@pytest.mark.asyncio
+async def test_restart_404_missing_session() -> None:
+    """Restarting an unknown session returns 404."""
+    conv_store = _ConversationStore(conversations={})
+    agent_store = _AgentStore({})
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(f"/v1/sessions/{_SESSION_ID}/restart", json={})
+
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_restart_400_sub_agent() -> None:
+    """Sub-agent sessions cannot be restarted."""
+    conv_store = _ConversationStore(conversations={_SESSION_ID: _conv(kind="sub_agent")})
+    agent_store = _AgentStore({_CLONE_ID: _CLONE_STALE})
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(f"/v1/sessions/{_SESSION_ID}/restart", json={})
+
+    assert resp.status_code == 400, resp.text
+
+
+@pytest.mark.asyncio
+async def test_restart_400_no_agent_binding() -> None:
+    """A session with no bound agent has nothing to relaunch."""
+    conv_store = _ConversationStore(conversations={_SESSION_ID: _conv(agent_id=None)})
+    agent_store = _AgentStore({})
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(f"/v1/sessions/{_SESSION_ID}/restart", json={})
+
+    assert resp.status_code == 400, resp.text
+
+
+@pytest.mark.asyncio
+async def test_restart_409_when_busy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restart refuses to run while the session is mid-turn."""
+    conv_store = _ConversationStore(conversations={_SESSION_ID: _conv()})
+    agent_store = _AgentStore({_CLONE_ID: _CLONE_STALE, _BUILTIN_ID: _BUILTIN_STALE})
+    # Mark the session as running in the relay status cache.
+    monkeypatch.setitem(sessions_mod._session_status_cache, _SESSION_ID, "running")
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(f"/v1/sessions/{_SESSION_ID}/restart", json={})
+
+    assert resp.status_code == 409, resp.text
+    assert conv_store.restart_calls == []
+
+
+@pytest.mark.asyncio
+async def test_restart_400_unloadable_refresh_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unloadable refresh-source bundle is rejected before the stop so a
+    failed restart never leaves a session without its execution.
+    """
+    conv_store = _ConversationStore(conversations={_SESSION_ID: _conv()})
+    agent_store = _AgentStore({_CLONE_ID: _CLONE_STALE, _BUILTIN_ID: _BUILTIN_STALE})
+    monkeypatch.setattr(
+        sessions_mod, "get_agent_cache", lambda: _AgentCacheStub(raise_on_load=True)
+    )
+    monkeypatch.setattr(sessions_mod, "_agent_carries_native_fork_history", lambda a: False)
+    monkeypatch.setattr(sessions_mod, "_agent_carries_cursor_fork_history", lambda a: False)
+    monkeypatch.setattr(sessions_mod, "_presentation_labels_for_agent", lambda a: {})
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(f"/v1/sessions/{_SESSION_ID}/restart", json={})
+
+    assert resp.status_code == 400, resp.text
+    assert conv_store.restart_calls == []
+
+
+@pytest.mark.asyncio
+async def test_restart_publishes_agent_changed_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rebound restart publishes ``session_agent_changed`` so open
+    frontends re-render the agent badge.
+    """
+
+    class _RecordingStream:
+        @staticmethod
+        def publish(session_id: str, payload: dict[str, Any]) -> None:
+            _RecordingStream.events.append((session_id, payload))
+
+        events: list[tuple[str, dict[str, Any]]] = []
+
+    monkeypatch.setattr(sessions_mod, "session_stream", _RecordingStream)
+    conv_store = _ConversationStore(conversations={_SESSION_ID: _conv()})
+    agent_store = _AgentStore({_CLONE_ID: _CLONE_STALE, _BUILTIN_ID: _BUILTIN_STALE})
+    _patch_restart_helpers(monkeypatch)
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(f"/v1/sessions/{_SESSION_ID}/restart", json={})
+
+    assert resp.status_code == 200, resp.text
+    assert len(_RecordingStream.events) == 1
+    stream_session_id, payload = _RecordingStream.events[0]
+    assert stream_session_id == _SESSION_ID
+    assert payload["agent_id"] == resp.json()["agent_id"]
+
+
+@pytest.mark.asyncio
+async def test_restart_503_when_connected_host_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a connected host, a runner that can't be woken after the stop
+    fails with 503 — the session itself is intact and the call is retryable.
+    """
+    conv_store = _ConversationStore(conversations={_SESSION_ID: _conv(host_id="host_1")})
+    agent_store = _AgentStore({_CLONE_ID: _CLONE_CURRENT, _BUILTIN_ID: _BUILTIN_STALE})
+    _patch_restart_helpers(monkeypatch)
+
+    async def _offline(**kwargs: Any) -> tuple[None, Any]:
+        return None, kwargs["conv"]
+
+    # The relaunch ladder imports these directly from orchestration, so
+    # patch the route module's references.
+    monkeypatch.setattr(routes_core_mod, "ensure_runner_connected", _offline)
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post(f"/v1/sessions/{_SESSION_ID}/restart", json={})
+
+    assert resp.status_code == 503, resp.text
+    # The store mutation already happened — the restart is durable and the
+    # 503 only reports the relaunch failure (retry picks up from there).
+    assert len(conv_store.restart_calls) == 1

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -4587,6 +4587,361 @@ def test_switch_conversation_agent_same_family_keeps_model_settings(
     assert SWITCH_PREVIOUS_BUILTIN_LABEL_KEY not in updated.labels
 
 
+def test_restart_conversation_rebind_keeps_settings_and_native_state(
+    conversation_store: SqlAlchemyConversationStore,
+    agent_store: SqlAlchemyAgentStore,
+) -> None:
+    """A restart that re-clones from a refreshed built-in replaces the
+    session-scoped agent but keeps the model settings, launch args, items,
+    and — in latest-state mode — the native session id.
+    """
+    from omnigent._wrapper_labels import (
+        UI_MODE_LABEL_KEY,
+        UI_MODE_TERMINAL_VALUE,
+        WRAPPER_LABEL_KEY,
+    )
+
+    instance_label = "omnigent.last_context_tokens"
+    created = conversation_store.create_session_with_agent(
+        agent_id="af75a9579488e3520ba6842699e43323",
+        agent_name="claude",
+        agent_bundle_location="af75a9579488e3520ba6842699e43323/oldhash",
+        agent_description="old",
+        title="keep me",
+    )
+    conv_id = created.conversation.id
+    conversation_store.update_conversation(
+        conv_id,
+        model_override="claude-opus-4-7",
+        reasoning_effort="high",
+        harness_override="pi",
+        terminal_launch_args=["--verbose"],
+    )
+    conversation_store.set_external_session_id(conv_id, "native-uuid-1")
+    conversation_store.set_labels(
+        conv_id,
+        {
+            instance_label: "1",
+            UI_MODE_LABEL_KEY: UI_MODE_TERMINAL_VALUE,
+            WRAPPER_LABEL_KEY: "claude-code-native-ui",
+            "omnigent.pinned": "1",
+        },
+    )
+    conversation_store.append(
+        conv_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_1",
+                data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+            )
+        ],
+    )
+
+    updated = conversation_store.restart_conversation(
+        conv_id,
+        new_agent_id="9d2c8d5e342b7da390dc38351c49fb72",
+        new_agent_name="claude",
+        new_agent_bundle_location="builtin-id/newhash",
+        new_agent_description="new",
+        presentation_labels={
+            UI_MODE_LABEL_KEY: UI_MODE_TERMINAL_VALUE,
+            WRAPPER_LABEL_KEY: "claude-code-native-ui",
+        },
+        up_to_response_id=None,
+        carry_history_into_native=False,
+    )
+
+    # Rebound to the fresh clone; the stale clone row is deleted.
+    assert updated.agent_id == "9d2c8d5e342b7da390dc38351c49fb72"
+    assert agent_store.get("af75a9579488e3520ba6842699e43323") is None
+    new_agent = agent_store.get("9d2c8d5e342b7da390dc38351c49fb72")
+    assert new_agent is not None and new_agent.session_id == conv_id
+    assert new_agent.bundle_location == "builtin-id/newhash"
+    # Same agent family → every per-session setting survives.
+    assert updated.model_override == "claude-opus-4-7"
+    assert updated.reasoning_effort == "high"
+    assert updated.harness_override == "pi"
+    assert updated.terminal_launch_args == ["--verbose"]
+    # Latest-state mode keeps the native session id so the relaunch resumes.
+    assert updated.external_session_id == "native-uuid-1"
+    # Identity + non-instance labels untouched; instance-scoped dropped.
+    assert updated.title == "keep me"
+    assert updated.labels["omnigent.pinned"] == "1"
+    assert instance_label not in updated.labels
+    assert updated.labels[WRAPPER_LABEL_KEY] == "claude-code-native-ui"
+    # Transcript untouched.
+    assert len(conversation_store.list_items(conv_id).data) == 1
+
+
+def test_restart_conversation_without_rebind_keeps_agent_binding(
+    conversation_store: SqlAlchemyConversationStore,
+    agent_store: SqlAlchemyAgentStore,
+) -> None:
+    """``new_agent_id=None`` keeps the current binding — the shape used for
+    sessions bound directly to a built-in (which already tracks the latest
+    bundle) — while still refreshing labels.
+    """
+    from omnigent._wrapper_labels import UI_MODE_LABEL_KEY, WRAPPER_LABEL_KEY
+
+    agent_store.create(
+        agent_id="6239422fb5e1335506bb6dedf0f5e8cb",
+        name="builtin-agent",
+        bundle_location="6239422fb5e1335506bb6dedf0f5e8cb/hash",
+    )
+    conv = conversation_store.create_conversation(agent_id="6239422fb5e1335506bb6dedf0f5e8cb")
+    conversation_store.set_labels(
+        conv.id,
+        {
+            WRAPPER_LABEL_KEY: "claude-code-native-ui",
+            UI_MODE_LABEL_KEY: "terminal",
+            "omnigent.last_context_tokens": "1",
+        },
+    )
+
+    updated = conversation_store.restart_conversation(
+        conv.id,
+        new_agent_id=None,
+        new_agent_name=None,
+        new_agent_bundle_location=None,
+        new_agent_description=None,
+        presentation_labels={},  # refresh source resolves to plain chat
+        up_to_response_id=None,
+        carry_history_into_native=False,
+    )
+
+    assert updated.agent_id == "6239422fb5e1335506bb6dedf0f5e8cb"
+    assert agent_store.get("6239422fb5e1335506bb6dedf0f5e8cb") is not None
+    assert WRAPPER_LABEL_KEY not in updated.labels
+    assert UI_MODE_LABEL_KEY not in updated.labels
+    assert "omnigent.last_context_tokens" not in updated.labels
+
+
+def test_restart_conversation_truncates_and_clears_native_state(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A restart with ``up_to_response_id`` removes later items (and their
+    FTS rows), clears the native session id, drops fork-source directives,
+    and stamps carry-history so the harness rebuilds from the kept items.
+    """
+    from omnigent.stores.conversation_store import (
+        FORK_CARRY_HISTORY_LABEL_KEY,
+        FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY,
+        FORK_SOURCE_LABEL_KEY,
+    )
+
+    created = conversation_store.create_session_with_agent(
+        agent_id="06efca8dd5c2e87b8cfed1aae99cc239",
+        agent_name="claude-native-ui",
+        agent_bundle_location="06efca8dd5c2e87b8cfed1aae99cc239/hash",
+        agent_description=None,
+    )
+    conv_id = created.conversation.id
+    conversation_store.set_external_session_id(conv_id, "native-uuid-2")
+    conversation_store.set_labels(
+        conv_id,
+        {
+            FORK_SOURCE_LABEL_KEY: "conv_source",
+            FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY: "source-native-uuid",
+            FORK_CARRY_HISTORY_LABEL_KEY: "1",
+        },
+    )
+    conversation_store.append(
+        conv_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_1",
+                data=MessageData(role="user", content=[{"type": "input_text", "text": "first"}]),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id="resp_1",
+                data=MessageData(role="user", content=[{"type": "input_text", "text": "reply"}]),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id="resp_2",
+                data=MessageData(role="user", content=[{"type": "input_text", "text": "second"}]),
+            ),
+        ],
+    )
+
+    updated = conversation_store.restart_conversation(
+        conv_id,
+        new_agent_id=None,
+        new_agent_name=None,
+        new_agent_bundle_location=None,
+        new_agent_description=None,
+        presentation_labels=None,
+        up_to_response_id="resp_1",
+        carry_history_into_native=True,
+    )
+
+    items = conversation_store.list_items(conv_id).data
+    assert [item.response_id for item in items] == ["resp_1", "resp_1"]
+    # The native transcript no longer matches → cleared + rebuild directive.
+    assert updated.external_session_id is None
+    assert FORK_SOURCE_LABEL_KEY not in updated.labels
+    assert FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY not in updated.labels
+    assert updated.labels[FORK_CARRY_HISTORY_LABEL_KEY] == "1"
+
+
+def test_restart_conversation_truncation_drops_stale_carry_marker(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """When the harness cannot rebuild from items (carry=False), a carry
+    marker left by an earlier fork must not survive the truncation.
+    """
+    from omnigent.stores.conversation_store import FORK_CARRY_HISTORY_LABEL_KEY
+
+    created = conversation_store.create_session_with_agent(
+        agent_id="b5f73b57f0e44bd3a3c16c988d8b2e9a",
+        agent_name="cursor-agent",
+        agent_bundle_location="b5f73b57f0e44bd3a3c16c988d8b2e9a/hash",
+        agent_description=None,
+    )
+    conv_id = created.conversation.id
+    conversation_store.set_labels(conv_id, {FORK_CARRY_HISTORY_LABEL_KEY: "1"})
+    conversation_store.append(
+        conv_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_1",
+                data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id="resp_2",
+                data=MessageData(role="user", content=[{"type": "input_text", "text": "later"}]),
+            ),
+        ],
+    )
+
+    updated = conversation_store.restart_conversation(
+        conv_id,
+        new_agent_id=None,
+        new_agent_name=None,
+        new_agent_bundle_location=None,
+        new_agent_description=None,
+        presentation_labels=None,
+        up_to_response_id="resp_1",
+        carry_history_into_native=False,
+    )
+
+    assert FORK_CARRY_HISTORY_LABEL_KEY not in updated.labels
+    assert len(conversation_store.list_items(conv_id).data) == 1
+
+
+def test_restart_conversation_unknown_response_id_raises_without_mutation(
+    conversation_store: SqlAlchemyConversationStore,
+    agent_store: SqlAlchemyAgentStore,
+) -> None:
+    """An unknown ``up_to_response_id`` raises ValueError and must leave the
+    session — including the agent binding — untouched.
+    """
+    created = conversation_store.create_session_with_agent(
+        agent_id="c7a1c41b0d2f4b6b9d0d9a75c0f5a111",
+        agent_name="claude",
+        agent_bundle_location="c7a1c41b0d2f4b6b9d0d9a75c0f5a111/hash",
+        agent_description=None,
+    )
+    conv_id = created.conversation.id
+    conversation_store.append(
+        conv_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_1",
+                data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="resp_missing"):
+        conversation_store.restart_conversation(
+            conv_id,
+            new_agent_id="9d2c8d5e342b7da390dc38351c49fb72",
+            new_agent_name="claude",
+            new_agent_bundle_location="builtin/newhash",
+            new_agent_description=None,
+            presentation_labels=None,
+            up_to_response_id="resp_missing",
+            carry_history_into_native=False,
+        )
+
+    conv = conversation_store.get_conversation(conv_id)
+    assert conv is not None and conv.agent_id == "c7a1c41b0d2f4b6b9d0d9a75c0f5a111"
+    assert agent_store.get("c7a1c41b0d2f4b6b9d0d9a75c0f5a111") is not None
+    assert agent_store.get("9d2c8d5e342b7da390dc38351c49fb72") is None
+    assert len(conversation_store.list_items(conv_id).data) == 1
+
+
+def test_restart_conversation_missing_conversation_raises(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A restart of a conversation that does not exist raises LookupError."""
+    with pytest.raises(LookupError):
+        conversation_store.restart_conversation(
+            "f0e1d2c3b4a5968778695a4b3c2d1e0f",
+            new_agent_id=None,
+            new_agent_name=None,
+            new_agent_bundle_location=None,
+            new_agent_description=None,
+            presentation_labels=None,
+            up_to_response_id=None,
+            carry_history_into_native=False,
+        )
+
+
+def test_restart_conversation_split_db_truncates_across_databases(
+    split_db_conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Under a split-DB deployment the truncation lands in the AP database
+    while the native-session-id clear lands in the Omnigent database.
+    """
+    conversation_store = split_db_conversation_store
+    created = conversation_store.create_session_with_agent(
+        agent_id="d3b5c91e2f0a4c5b8d7e6f5a4b3c2d1e",
+        agent_name="claude",
+        agent_bundle_location="d3b5c91e2f0a4c5b8d7e6f5a4b3c2d1e/hash",
+        agent_description=None,
+    )
+    conv_id = created.conversation.id
+    conversation_store.set_external_session_id(conv_id, "native-uuid-3")
+    conversation_store.append(
+        conv_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_1",
+                data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id="resp_2",
+                data=MessageData(role="user", content=[{"type": "input_text", "text": "later"}]),
+            ),
+        ],
+    )
+
+    updated = conversation_store.restart_conversation(
+        conv_id,
+        new_agent_id="e4c6da2f3a1b5d6c9e8f7a6b5c4d3e2f",
+        new_agent_name="claude",
+        new_agent_bundle_location="builtin/newhash",
+        new_agent_description=None,
+        presentation_labels=None,
+        up_to_response_id="resp_1",
+        carry_history_into_native=False,
+    )
+
+    assert updated.agent_id == "e4c6da2f3a1b5d6c9e8f7a6b5c4d3e2f"
+    assert updated.external_session_id is None
+    assert len(conversation_store.list_items(conv_id).data) == 1
+
+
 def test_get_session_connectivity_batches_runner_and_host(
     conversation_store: SqlAlchemyConversationStore,
     db_uri: str,

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -41,7 +41,7 @@ import {
 import { showToast } from "@/components/ui/toast";
 import { revokePermission } from "@/lib/permissionsApi";
 import { conversationDisplayLabel, setLegacyPinnedConversationId } from "@/shell/sidebarNav";
-import { stopSession } from "@/lib/sessionsApi";
+import { restartSession, stopSession } from "@/lib/sessionsApi";
 import { setSessionHost } from "@/lib/sessionHost";
 import {
   createProject as apiCreateProject,
@@ -961,6 +961,26 @@ export function useStopSession() {
     onSuccess: (_data, id) => {
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });
       void queryClient.invalidateQueries({ queryKey: ["session", id] });
+    },
+  });
+}
+
+/**
+ * Restart a session's harness execution in place via
+ * `POST /v1/sessions/{id}/restart`.
+ *
+ * Invalidates the session snapshot (`["session", id]`), its bound-agent
+ * query (`["session-agent", id]` — a refresh rebind changes it), and the
+ * conversations list so the header/sidebar reflect the restarted state.
+ */
+export function useRestartConversation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => restartSession(id),
+    onSuccess: (_data, id) => {
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      void queryClient.invalidateQueries({ queryKey: ["session", id] });
+      void queryClient.invalidateQueries({ queryKey: ["session-agent", id] });
     },
   });
 }

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -700,6 +700,39 @@ export async function switchSessionAgent(sessionId: string, agentId: string): Pr
 }
 
 /**
+ * Restart a session's harness execution in place:
+ * ``POST /v1/sessions/{id}/restart``.
+ *
+ * Stops the current harness and starts a fresh one from the latest
+ * installed agent version/configuration, keeping the SAME session
+ * (transcript, title, pin, project, comments, files, workspace). With
+ * ``upToResponseId`` the transcript is first rewound to that conversation
+ * point (later items are removed) so the relaunched harness restores from
+ * the selected message. Only valid while the session is idle (a running
+ * turn → 409).
+ *
+ * @param sessionId - The session to restart, e.g. ``"conv_abc123"``.
+ * @param upToResponseId - Optional response id to rewind the transcript
+ *   to before relaunching (restore-from-point).
+ * @returns The session as it stands after the restart.
+ * @throws Error carrying the server's failure detail (e.g. 409 when a
+ *   turn is running, 503 when the runner can't be relaunched) so the
+ *   caller can surface it inline.
+ */
+export async function restartSession(sessionId: string, upToResponseId?: string): Promise<Session> {
+  const body: { up_to_response_id?: string } = {};
+  if (upToResponseId !== undefined) {
+    body.up_to_response_id = upToResponseId;
+  }
+  const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(sessionId)}/restart`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return sessionFromWire(await readJsonOrThrow<SessionResponseWire>(res));
+}
+
+/**
  * Bind an existing (unbound) session to a host + working directory and
  * launch its runner: ``POST /v1/hosts/{hostId}/runners``.
  *

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -653,6 +653,7 @@ describe("ChatHeader — title-adjacent conversation actions", () => {
       "Pin",
       "Rename",
       "Mark as unread",
+      "Restart session…",
       "Add to project",
       "Files",
       "Changes",

--- a/web/src/shell/HeaderConversationMenu.test.tsx
+++ b/web/src/shell/HeaderConversationMenu.test.tsx
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   moveToProject: vi.fn(),
   archive: vi.fn(),
   deleteConversation: vi.fn(),
+  restart: vi.fn(),
   markUnread: vi.fn(),
 }));
 
@@ -41,6 +42,7 @@ vi.mock("@/hooks/useConversations", async (importOriginal) => {
       mutate: mocks.deleteConversation,
       isPending: false,
     }),
+    useRestartConversation: () => ({ mutate: mocks.restart, isPending: false }),
   };
 });
 
@@ -120,6 +122,7 @@ describe("HeaderConversationMenu", () => {
       "Share",
       "Rename",
       "Mark as unread",
+      "Restart session…",
       "Add to project",
       "Archive",
       "Delete",
@@ -184,6 +187,27 @@ describe("HeaderConversationMenu", () => {
       id: "conv-1",
       deleteBranch: true,
     });
+  });
+
+  it("restarts the session only after the confirm dialog", () => {
+    renderMenu();
+
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Restart session…" }));
+    expect(screen.getByRole("heading", { name: "Restart session?" })).toBeInTheDocument();
+    expect(mocks.restart).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("heading", { name: "Restart session?" })).toBeNull();
+    expect(mocks.restart).not.toHaveBeenCalled();
+
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Restart session…" }));
+    fireEvent.click(screen.getByTestId("header-restart-confirm"));
+    expect(mocks.restart).toHaveBeenCalledWith(
+      "conv-1",
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
   });
 
   it("labels project actions for filed and unfiled sessions", () => {
@@ -394,6 +418,7 @@ describe("HeaderConversationMenu", () => {
       "Share",
       "Rename",
       "Mark as unread",
+      "Restart session…",
       "Add to project",
       "Archive",
       "Delete",
@@ -414,6 +439,7 @@ describe("HeaderConversationMenu", () => {
       "Share",
       "Rename",
       "Mark as unread",
+      "Restart session…",
       "Add to project",
       "Files",
       "Archive",

--- a/web/src/shell/HeaderConversationMenu.tsx
+++ b/web/src/shell/HeaderConversationMenu.tsx
@@ -17,6 +17,7 @@ import {
   PencilIcon,
   PinIcon,
   PinOffIcon,
+  RefreshCwIcon,
   ShareIcon,
   Trash2Icon,
 } from "lucide-react";
@@ -46,6 +47,7 @@ import {
   useArchiveConversation,
   useMoveToProject,
   useRenameConversation,
+  useRestartConversation,
   useStopAndDeleteConversation,
   useTogglePinnedConversation,
 } from "@/hooks/useConversations";
@@ -107,10 +109,13 @@ export function HeaderConversationMenu({
   const moveToProject = useMoveToProject();
   const archive = useArchiveConversation();
   const deleteConversation = useStopAndDeleteConversation();
+  const restart = useRestartConversation();
   const [menuOpen, setMenuOpen] = useState(false);
   const [projectPickerOpen, setProjectPickerOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
   const [renameTitle, setRenameTitle] = useState(conversation.title ?? "");
+  const [restartOpen, setRestartOpen] = useState(false);
+  const [restartError, setRestartError] = useState<string | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteBranch, setDeleteBranch] = useState(false);
   const previousConversationId = useRef(conversation.id);
@@ -138,6 +143,8 @@ export function HeaderConversationMenu({
     setProjectPickerOpen(false);
     setRenameOpen(false);
     setRenameTitle(conversation.title ?? "");
+    setRestartOpen(false);
+    setRestartError(null);
     setDeleteOpen(false);
     setDeleteBranch(false);
   }, [conversation.id, conversation.title]);
@@ -168,6 +175,19 @@ export function HeaderConversationMenu({
     deleteConversation.mutate({
       id: conversation.id,
       deleteBranch: gitBranch !== null && deleteBranch,
+    });
+  };
+
+  const confirmRestart = () => {
+    setRestartError(null);
+    restart.mutate(conversation.id, {
+      onSuccess: () => {
+        setRestartOpen(false);
+        showToast("Session restarted — running the latest agent version.");
+      },
+      onError: (error) => {
+        setRestartError(error instanceof Error ? error.message : "Restart failed.");
+      },
     });
   };
 
@@ -245,6 +265,14 @@ export function HeaderConversationMenu({
       >
         <MailIcon className="size-3.5" />
         Mark as unread
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        data-testid="header-restart-conversation"
+        className={itemClass}
+        onSelect={() => setRestartOpen(true)}
+      >
+        <RefreshCwIcon className="size-3.5" />
+        Restart session…
       </DropdownMenuItem>
       {/* Move to project is also reachable on desktop via the breadcrumb's
           folder tag (HeaderProjectTag); on mobile the native shells hide the
@@ -393,6 +421,48 @@ export function HeaderConversationMenu({
               </Button>
             </DialogFooter>
           </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={restartOpen}
+        onOpenChange={(open) => {
+          setRestartOpen(open);
+          if (!open) setRestartError(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Restart session?</DialogTitle>
+            <DialogDescription>
+              Stops the current harness and starts a fresh one from the latest installed agent
+              version. The session — transcript, files, comments, and workspace — stays exactly
+              where it is.
+            </DialogDescription>
+          </DialogHeader>
+          {restartError !== null && (
+            <p data-testid="header-restart-error" className="text-sm text-destructive">
+              {restartError}
+            </p>
+          )}
+          <DialogFooter className="border-t-0 bg-transparent">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setRestartOpen(false)}
+              disabled={restart.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              data-testid="header-restart-confirm"
+              onClick={confirmRestart}
+              disabled={restart.isPending}
+            >
+              {restart.isPending ? "Restarting…" : "Restart"}
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 


### PR DESCRIPTION
## Related issue

Closes #5537

## Summary

Adds **Restart session…**: a long-lived session can now be restarted in place — its harness execution is torn down and relaunched at the currently installed agent version/config, while session identity (id, title, pin, project, workspace/worktree, metadata) is preserved. The transcript and forked-conversation history stay intact by default; an optional `up_to_response_id` rewinds the session to a chosen conversation point (clearing the native harness state) for a restore-style restart.

- **Backend** — `POST /v1/sessions/{id}/restart` plus a `restart_conversation` store operation. When the session is bound to a session-scoped clone of a built-in agent whose bundle has drifted from the installed built-in (matched by clone root name), restart re-clones from the installed bundle; sessions bound directly to a built-in or to a custom uploaded agent keep their binding. Guards: 404 unknown session/agent, 403 without edit access, 400 sub-agent / no binding / unloadable bundle / unknown restore point (validated *before* anything is stopped or mutated), 409 mid-turn, 503 when the old execution stopped but no replacement harness could start (session intact — retry once the host is reachable). Stop is best-effort (a wedged runner is the target use case); relaunch reuses the retry-path runner ladder after invalidating runner-backed snapshot caches.
- **Web** — "Restart session…" action in the header session menu with a confirm dialog, inline error on failure, toast on success.
- **SDK** — `omnigent_client.sessions.restart(session_id, up_to_response_id=...)`.

**ELI5:** "Restart" is like turning an agent session off and on again. The chat, its name, its files, and its place in your projects all stay exactly where they were — but the agent process behind it starts fresh, running the newest version of the agent you have installed. You can also choose to roll the conversation back to an earlier message and restart from there.

```mermaid
flowchart LR
    A[Restart clicked] --> B{session busy?}
    B -- yes --> X[409]
    B -- no --> C{up_to_response_id valid?}
    C -- no --> Y[400 - nothing stopped]
    C -- yes --> D[stop harness execution - best-effort]
    D --> E{clone of drifted built-in?}
    E -- yes --> F[re-clone from installed built-in bundle]
    E -- no --> G[keep binding]
    F --> H[relaunch fresh execution - same session id]
    G --> H
    H --> I[session idle - transcript preserved]
```

## Test Plan

All run on macOS, Python 3.12, Node 22 / pnpm 11 (final commit `f6b79a6` — the second commit is a test-only fix folding the new menu item into the `ChatHeader` mobile-kebab order assertion, caught by CI's `web test`):

- `uv run --no-sync pytest tests/server/routes/test_sessions_restart.py tests/stores/test_conversation_store.py tests/db/test_utils_extended.py tests/server/routes/test_sessions_switch_agent.py tests/server/test_openapi_drift.py -q` → **258 passed, 1 skipped** (13 new route tests: rebind-from-refreshed-built-in, keep-binding ×3, truncation, 400 unknown point before stop, 404, 400 sub-agent, 400 no binding, 409 busy, 400 unloadable bundle, event publish, 503 host unreachable; 7 new store tests incl. split-DB truncation + FTS cleanup).
- `uv run --no-sync pytest tests/server/routes/ -q -k session` → **602 passed** (no regressions in neighbouring session routes).
- `uv run --no-sync pytest tests/e2e/test_restart_session_e2e.py --timeout=240 --timeout-method=thread -q` → **2 passed** (mock-LLM e2e: restart-in-place recalls history after relaunch — same id, transcript intact, custom-agent binding kept; restart with `up_to_response_id` keeps turn 1 and drops turn 2). Rerun 4× consecutively to verify the assertions are race-free against asynchronous runner-init items.
- `uv run --no-sync pytest tests/e2e_ui/sessions/test_restart_session.py tests/e2e_ui/sessions/test_header_session_menu.py --timeout=300 -q` → **3 passed** (Playwright/Chromium: real UI menu → confirm dialog → restart → session reloads in place at the same URL, idle, binding refreshed from the installed built-in live; header menu order/count updated for the new item).
- `uv run --no-sync ruff check` + `ruff format --check` on changed files → clean (repo-wide `ruff check .` reports only pre-existing `web/src/shell/__fixtures__/*.ipynb` fixture findings, untouched by this PR).
- `uv run --no-sync pyrefly check` → **0 errors**.
- `uv run --no-sync pre-commit run --all-files` → **all hooks pass** (incl. web oxlint, web `tsc -b`, VS Code ext `tsc`, uv.lock registry normalization).
- `cd web && pnpm run lint && pnpm run type-check && pnpm run build` → all pass (`✓ built`); Vitest `npx vitest run src/shell/ChatHeader.test.tsx src/shell/HeaderConversationMenu.test.tsx` → **51 passed** (incl. new restart-confirm-flow test).
- OpenAPI snapshot regenerated via the repo's drift test (`tests/server/test_openapi_drift.py` passes).

## Demo

Full flow — header menu → "Restart session…" → confirm dialog → session reloads in place, idle:

![Restart session flow](https://raw.githubusercontent.com/randypitcherii/omnigent/demo-assets-5537/demo-assets/restart-demo.gif)

Stills of the same flow:

| Menu item (after "Mark as unread") | Confirm dialog | After restart — same session, idle |
| --- | --- | --- |
| ![menu](https://raw.githubusercontent.com/randypitcherii/omnigent/demo-assets-5537/demo-assets/restart-demo-1-menu.png) | ![dialog](https://raw.githubusercontent.com/randypitcherii/omnigent/demo-assets-5537/demo-assets/restart-demo-2-dialog.png) | ![after](https://raw.githubusercontent.com/randypitcherii/omnigent/demo-assets-5537/demo-assets/restart-demo-3-after.png) |

(Recorded by driving the real app — spawned server + built web UI — in Chromium via Playwright. Artifacts live on the `demo-assets-5537` branch of the fork purely as image hosting and are not part of this PR's diff.)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: drove the real app (spawned server + built web UI) through the full flow in Chromium via Playwright — open header menu → "Restart session…" → confirm dialog → session reloads in place at the same URL, status returns to `idle`, transcript intact, and the binding refreshed from the installed built-in when the session's clone had drifted (agent id updated live, verified via `GET /v1/sessions/{id}/agent`). Cancel path in the dialog verified to leave the session untouched. Demo recording and stills above.

## Changelog

Restart a session in place from the header menu to pick up the latest installed agent version, optionally rolling back to an earlier point in the conversation
