### PR TITLE
fix(runner): retry the primary model-stream relay on a dead channel before output

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -426,6 +426,19 @@ _WAKE_POST_RETRY_MAX_DELAY_S = 4.0
 # classification): everything else in 4xx is a permanent client-side rejection.
 _WAKE_POST_TRANSIENT_4XX = frozenset({408, 409, 425, 429})
 
+# Bounded retry budget for the primary model-stream relay (``proxy_stream``).
+# A dead-channel drop (see ``_DEAD_HARNESS_CHANNEL_ERRORS``) on the harness
+# response stream — e.g. an ``httpx.ReadError`` seconds into a turn — otherwise
+# terminates the turn as failed with the generic "Harness stream connection
+# error" and no retry, even though the gateway serves the same stream fine to a
+# fresh client. Re-drive the turn, but ONLY while it has produced no observable
+# output yet (no ``response.created``, no locally dispatched work): once the
+# model has started emitting, a re-POST would double the response, so we fail as
+# before. Mirrors the policy-verdict-delivery path's dead-channel retry.
+_STREAM_RELAY_MAX_ATTEMPTS = 3
+_STREAM_RELAY_RETRY_BASE_DELAY_S = 0.5
+_STREAM_RELAY_RETRY_MAX_DELAY_S = 4.0
+
 # Cadence for ``session.heartbeat`` keepalive events on the runner's
 # ``GET /v1/sessions/{id}/stream`` endpoint. Between turns the event
 # queue is idle — without periodic bytes, an intermediate proxy (e.g.
@@ -7007,7 +7020,16 @@ def create_runner_app(
             event_body = _wrap_as_message_event(body)
             _inject_mcp_schemas(event_body, _mcp_schemas)
             _response_id: str | None = None
-            try:
+            # Hoisted so the terminal handler can gate the dead-channel retry:
+            # a re-POST is only safe before ``response.created``, before any
+            # locally dispatched work (tool calls, policy evals), and before any
+            # byte has been yielded downstream — re-driving must never duplicate
+            # frames the client already saw.
+            _dispatch_tasks: list[_asyncio.Task[object]] = []
+            _yielded_any = False
+
+            async def _run_stream_attempt() -> AsyncIterator[bytes]:
+                nonlocal _response_id, _dispatch_tasks, _yielded_any
                 async with client.stream(
                     "POST",
                     f"/v1/sessions/{conv_id}/events",
@@ -7040,7 +7062,7 @@ def create_runner_app(
 
                     _omnigent_task_id = cast(str | None, body.get("task_id"))
                     _buffer = ""
-                    _dispatch_tasks: list[_asyncio.Task[object]] = []
+                    _dispatch_tasks = []
                     # Sub-agent start edge → minted child id, so the completion
                     # edge can address the child it created. Per-stream.
                     _subagent_child_futures: dict[str, _asyncio.Future[str]] = {}
@@ -7380,6 +7402,7 @@ def create_runner_app(
                                     continue
 
                             if event is None:
+                                _yielded_any = True
                                 yield raw_sse_bytes
                                 continue
                             if not _defer_publish and event.get("type") != "response.created":
@@ -7387,6 +7410,7 @@ def create_runner_app(
                             if dispatch is not None and event.get(_RUNNER_DISPATCHED_FIELD):
                                 pass
                             else:
+                                _yielded_any = True
                                 yield raw_sse_bytes
 
                     if _dispatch_tasks:
@@ -7396,44 +7420,84 @@ def create_runner_app(
                         conv_id, error=_stream_failed_error, owner_response_id=_response_id
                     )
 
-            except _ContextWindowOverflow as overflow:
-                _error = {
-                    "code": "context_length_exceeded",
-                    "message": (
-                        f"Context window exceeded: {overflow.actual_tokens} tokens "
-                        f"> {overflow.max_tokens} max"
-                    ),
-                    "type": "_ContextWindowOverflow",
-                }
-                _overflow_fail = {
-                    "type": "response.failed",
-                    "response": {"status": "failed", "error": _error},
-                    "error": _error,
-                }
-                _publish_event(conv_id, _overflow_fail)
-                _on_proxy_stream_end(conv_id, error=_error, owner_response_id=_response_id)
-                yield _response_failed_event(_error)
+            for _attempt in range(_STREAM_RELAY_MAX_ATTEMPTS):
+                _response_id = None
+                _dispatch_tasks = []
+                _yielded_any = False
+                try:
+                    async for _out in _run_stream_attempt():
+                        yield _out
+                    return
 
-            except (httpx.HTTPError, RuntimeError) as exc:
-                _logger.exception(
-                    "proxy stream connection error for %s: %s",
-                    conv_id,
-                    exc,
-                    extra={"session_id": conv_id},
-                )
-                _error = {
-                    "code": "connection_error",
-                    "message": "Harness stream connection error.",
-                    "type": type(exc).__name__,
-                }
-                _http_fail = {
-                    "type": "response.failed",
-                    "response": {"status": "failed", "error": _error},
-                    "error": _error,
-                }
-                _publish_event(conv_id, _http_fail)
-                _on_proxy_stream_end(conv_id, error=_error, owner_response_id=_response_id)
-                yield _response_failed_event(_error)
+                except _ContextWindowOverflow as overflow:
+                    _error = {
+                        "code": "context_length_exceeded",
+                        "message": (
+                            f"Context window exceeded: {overflow.actual_tokens} tokens "
+                            f"> {overflow.max_tokens} max"
+                        ),
+                        "type": "_ContextWindowOverflow",
+                    }
+                    _overflow_fail = {
+                        "type": "response.failed",
+                        "response": {"status": "failed", "error": _error},
+                        "error": _error,
+                    }
+                    _publish_event(conv_id, _overflow_fail)
+                    _on_proxy_stream_end(conv_id, error=_error, owner_response_id=_response_id)
+                    yield _response_failed_event(_error)
+                    return
+
+                except (httpx.HTTPError, RuntimeError) as exc:
+                    # A dead harness channel (e.g. httpx.ReadError) that drops the
+                    # stream before the turn produced any output is safe to
+                    # re-drive: no response.created was seen and no local dispatch
+                    # is pending, so a re-POST cannot double the response. Retry
+                    # within budget; on exhaustion or once output has started,
+                    # fail with the generic connection error as before.
+                    if (
+                        isinstance(exc, _DEAD_HARNESS_CHANNEL_ERRORS)
+                        and _response_id is None
+                        and not _dispatch_tasks
+                        and not _yielded_any
+                        and _attempt + 1 < _STREAM_RELAY_MAX_ATTEMPTS
+                    ):
+                        _logger.warning(
+                            "proxy stream dead channel before first output for %s "
+                            "(attempt %d/%d); re-driving turn: %s",
+                            conv_id,
+                            _attempt + 1,
+                            _STREAM_RELAY_MAX_ATTEMPTS,
+                            exc,
+                            extra={"session_id": conv_id},
+                        )
+                        await _asyncio.sleep(
+                            min(
+                                _STREAM_RELAY_RETRY_BASE_DELAY_S * (2**_attempt),
+                                _STREAM_RELAY_RETRY_MAX_DELAY_S,
+                            )
+                        )
+                        continue
+                    _logger.exception(
+                        "proxy stream connection error for %s: %s",
+                        conv_id,
+                        exc,
+                        extra={"session_id": conv_id},
+                    )
+                    _error = {
+                        "code": "connection_error",
+                        "message": "Harness stream connection error.",
+                        "type": type(exc).__name__,
+                    }
+                    _http_fail = {
+                        "type": "response.failed",
+                        "response": {"status": "failed", "error": _error},
+                        "error": _error,
+                    }
+                    _publish_event(conv_id, _http_fail)
+                    _on_proxy_stream_end(conv_id, error=_error, owner_response_id=_response_id)
+                    yield _response_failed_event(_error)
+                    return
 
         return StreamingResponse(
             proxy_stream(),

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -5047,6 +5047,223 @@ async def test_scaffold_subagent_defers_terminal_delivery_while_continuation_buf
     assert entry.delivered is True
 
 
+class _MaybeFailingHarnessStream:
+    """Fake harness stream that can drop mid-``aiter_text`` with a dead-channel error.
+
+    Yields the first ``fail_after`` scripted chunks, then either raises
+    ``httpx.ReadError`` (simulating the gateway relay dropping the SSE
+    connection) or streams the remaining chunks to completion.
+
+    :param chunks: SSE chunks to stream when the attempt succeeds.
+    :param should_fail: Whether this attempt raises instead of finishing.
+    :param fail_after: Number of leading chunks to emit before raising.
+    """
+
+    def __init__(self, chunks: list[str], should_fail: bool, fail_after: int) -> None:
+        """Store the per-attempt script and failure shape.
+
+        :param chunks: SSE chunks to stream when the attempt succeeds.
+        :param should_fail: Whether this attempt raises instead of finishing.
+        :param fail_after: Number of leading chunks to emit before raising.
+        """
+        self._chunks = chunks
+        self._should_fail = should_fail
+        self._fail_after = fail_after
+        self.status_code = 200
+
+    async def __aenter__(self) -> _MaybeFailingHarnessStream:
+        """Enter the stream context.
+
+        :returns: This stream.
+        """
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Exit without suppressing exceptions.
+
+        :param exc_type: Exception type from the context, if any.
+        :param exc: Exception value from the context, if any.
+        :param tb: Traceback from the context, if any.
+        :returns: None.
+        """
+        del exc_type, exc, tb
+
+    async def aiter_text(self) -> AsyncIterator[str]:
+        """Stream chunks, optionally dropping the channel mid-flight.
+
+        :returns: Async iterator of SSE chunks.
+        :raises httpx.ReadError: When this attempt is scripted to fail.
+        """
+        for index, chunk in enumerate(self._chunks):
+            if self._should_fail and index >= self._fail_after:
+                raise httpx.ReadError("harness stream dropped")
+            yield chunk
+        if self._should_fail:
+            raise httpx.ReadError("harness stream dropped")
+
+
+class _DeadChannelThenOkClient:
+    """Harness client whose first N stream attempts drop, then succeed.
+
+    Records ``attempts`` so a test can assert whether the runner re-drove
+    the turn. Each attempt that is scripted to fail raises ``httpx.ReadError``
+    from ``aiter_text`` after emitting ``fail_after`` chunks.
+
+    :param chunks: SSE chunks streamed on a successful attempt.
+    :param fail_times: Number of leading attempts that drop the channel.
+    :param fail_after: Chunks emitted before a failing attempt raises.
+    """
+
+    def __init__(self, chunks: list[str], fail_times: int, fail_after: int = 0) -> None:
+        """Store the script and how many attempts drop.
+
+        :param chunks: SSE chunks streamed on a successful attempt.
+        :param fail_times: Number of leading attempts that drop the channel.
+        :param fail_after: Chunks emitted before a failing attempt raises.
+        """
+        self._chunks = chunks
+        self._fail_times = fail_times
+        self._fail_after = fail_after
+        self.attempts = 0
+
+    def stream(
+        self,
+        method: str,
+        url: str,
+        *,
+        json: dict[str, object],
+        timeout: float | None,
+    ) -> _MaybeFailingHarnessStream:
+        """Return the next attempt's stream, failing the first ``fail_times``.
+
+        :param method: HTTP method (ignored).
+        :param url: Harness endpoint path (ignored).
+        :param json: JSON body (ignored).
+        :param timeout: Request timeout (ignored).
+        :returns: A maybe-failing stream for this attempt.
+        """
+        del method, url, json, timeout
+        self.attempts += 1
+        should_fail = self.attempts <= self._fail_times
+        return _MaybeFailingHarnessStream(self._chunks, should_fail, self._fail_after)
+
+
+@pytest.mark.asyncio
+async def test_proxy_stream_retries_dead_channel_before_any_output() -> None:
+    """A dead-channel drop before ``response.created`` re-drives the turn.
+
+    Reproduces the ``Harness stream connection error`` failure: the harness
+    response stream raises ``httpx.ReadError`` seconds into the turn, before
+    any model output, and the turn used to terminate as failed with no retry.
+    The first attempt drops immediately; the runner must re-POST and stream the
+    second attempt's turn to a clean ``response.completed`` — no
+    ``connection_error`` reaches the client.
+    """
+    client = _DeadChannelThenOkClient(_sse_text_turn("RECOVERED"), fail_times=1)
+    app = create_runner_app(
+        process_manager=cast(HarnessProcessManager, _FakeProcessManager(client)),
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_test_client(app) as http:
+        response = await http.post(
+            "/v1/sessions/conv_dead_channel_retry/events?stream=true",
+            json={
+                "type": "message",
+                "role": "user",
+                "harness": _TEST_HARNESS_NAME,
+                "agent_id": "ag_retry",
+                "model": "x",
+                "content": [{"type": "input_text", "text": "hi"}],
+            },
+        )
+
+    assert response.status_code == 200
+    # The turn re-drove: attempt 1 dropped, attempt 2 streamed the real turn.
+    assert client.attempts == 2
+    assert "event: response.completed" in response.text
+    assert "RECOVERED" in response.text
+    # The generic terminal failure must NOT be surfaced — the retry absorbed it.
+    assert "connection_error" not in response.text
+    assert "Harness stream connection error" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_proxy_stream_no_retry_after_output_started() -> None:
+    """A dead-channel drop AFTER ``response.created`` fails without re-driving.
+
+    Once the model turn has begun emitting, a re-POST would double the
+    response, so the retry gate must not fire: the runner surfaces the generic
+    ``connection_error`` failure and calls the harness exactly once.
+    """
+    # fail_after=1 → emit response.created (sets _response_id) then drop.
+    client = _DeadChannelThenOkClient(
+        _sse_text_turn("SHOULD_NOT_REPLAY"), fail_times=1, fail_after=1
+    )
+    app = create_runner_app(
+        process_manager=cast(HarnessProcessManager, _FakeProcessManager(client)),
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_test_client(app) as http:
+        response = await http.post(
+            "/v1/sessions/conv_dead_channel_no_retry/events?stream=true",
+            json={
+                "type": "message",
+                "role": "user",
+                "harness": _TEST_HARNESS_NAME,
+                "agent_id": "ag_no_retry",
+                "model": "x",
+                "content": [{"type": "input_text", "text": "hi"}],
+            },
+        )
+
+    assert response.status_code == 200
+    # No re-drive once output started: the harness was invoked exactly once.
+    assert client.attempts == 1
+    assert "event: response.created" in response.text
+    assert "connection_error" in response.text
+    # The second attempt's script must never have replayed.
+    assert "SHOULD_NOT_REPLAY" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_proxy_stream_fails_after_retry_budget_exhausted() -> None:
+    """Persistent dead-channel drops fail with the generic error after the budget.
+
+    Every attempt drops before any output, so the runner exhausts
+    ``_STREAM_RELAY_MAX_ATTEMPTS`` and then surfaces the generic
+    ``connection_error`` failure rather than retrying forever.
+    """
+    from omnigent.runner import app as runner_app
+
+    client = _DeadChannelThenOkClient(_sse_text_turn("NEVER"), fail_times=99)
+    app = create_runner_app(
+        process_manager=cast(HarnessProcessManager, _FakeProcessManager(client)),
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_test_client(app) as http:
+        response = await http.post(
+            "/v1/sessions/conv_dead_channel_exhausted/events?stream=true",
+            json={
+                "type": "message",
+                "role": "user",
+                "harness": _TEST_HARNESS_NAME,
+                "agent_id": "ag_exhausted",
+                "model": "x",
+                "content": [{"type": "input_text", "text": "hi"}],
+            },
+        )
+
+    assert response.status_code == 200
+    assert client.attempts == runner_app._STREAM_RELAY_MAX_ATTEMPTS
+    assert "connection_error" in response.text
+    assert "NEVER" not in response.text
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("status", "policy_response", "expected_output", "blocked_output"),


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

Closes #5558 

## Summary

Every claude-native sub-agent dispatch was failing with the generic `Harness stream connection error`. The runner's `proxy_stream` relay (`omnigent/runner/app.py`) reads the harness's streamed model response via `harness_resp.aiter_text()`. When that channel dropped with an `httpx.ReadError` **before the turn produced any output** (only `resource_event`s, no `response.created`), the error fell into the broad `except (httpx.HTTPError, RuntimeError)` handler, which terminated the turn as failed **with no retry** — even though `httpx.ReadError`/`httpcore.ReadError` are already in `_DEAD_HARNESS_CHANNEL_ERRORS` and the policy-verdict-delivery path already recovers from dead channels. That recovery was scoped to the ASK-gate verdict delivery, not the primary model-stream relay.

This adds the same bounded dead-channel retry to the primary stream:

- New retry budget `_STREAM_RELAY_MAX_ATTEMPTS = 3` with exponential backoff (0.5s → 4s), alongside the existing wake-post retry constants.
- The streaming body is refactored into a nested generator `_run_stream_attempt()` wrapped in a retry loop. On a dead-channel error the turn is **re-driven only while it is provably safe**: no `response.created` seen (`_response_id is None`), no locally dispatched work (`not _dispatch_tasks`), and nothing yet yielded downstream (`not _yielded_any`). Once the model has started emitting, a re-POST would double the response, so it fails exactly as before. Context-overflow and non-dead-channel errors are unchanged.

Re-POSTing the turn is safe because `resource_event`s flow through a **separate** persist path (`_publish_and_persist_resource_event`), not this stream, so a retry cannot duplicate them.

**Scope note:** this closes the *recovery* gap the issue localized (the primary stream lacked the retry the policy path had). The underlying *trigger* — why the relay's httpx client drops the long-lived SSE ~20s in when a fresh direct client does not (candidate: http2 / keep-alive / pool-reuse config) — is not addressed here and is worth a follow-up if retries also fail against the gateway.

## Test Plan

- `python -m pytest tests/runner/test_runner_dispatch.py` — **217 passed, 1 skipped** (includes 3 new regression tests):
  - `test_proxy_stream_retries_dead_channel_before_any_output` — drop before output → re-drives, streams `response.completed`, no `connection_error`.
  - `test_proxy_stream_no_retry_after_output_started` — drop after `response.created` → single attempt, generic failure, no replay.
  - `test_proxy_stream_fails_after_retry_budget_exhausted` — persistent drops → exhausts the budget, then fails.
- Native workflow / schema-injection / supervision suites: **124 passed**.
- `pre-commit run --files omnigent/runner/app.py tests/runner/test_runner_dispatch.py`  — ruff check, ruff format, and all substantive hooks pass (pyrefly skipped locally: executable not installed).

To verify against a live gateway: re-run a claude-native fan-out that dispatches sub-agents. A ~20s `httpx.ReadError` before first output should now log `proxy stream dead channel before first output for <id> (attempt 1/3); re-driving turn` and complete on retry, instead of surfacing `Harness stream connection error`.

## Demo

N/A

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [X] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable
