### PR TITLE
fix(cli): derive the correct Databricks re-login 

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3388,7 +3388,10 @@ def _ensure_databricks_server_auth(server: str, *, non_interactive: bool = False
             f"HTTP {probe.status_code}). Run `{login_cmd}` and retry."
         )
     click.echo(f"Not signed in to {display} — running `{login_cmd}` first.")
-    _databricks_login(server, workspace_host, org_id=org_id)
+    # Login selector comes from the URL, not the stored org_id used above: on a
+    # single-tenant host a replayed ?o= makes `databricks auth login --host` skip
+    # workspace_id resolution, so the grant isn't workspace-bound (matches `login`).
+    _databricks_login(server, workspace_host, org_id=_org_id_from_url(server))
 
 
 def _ensure_backend(server: str | None) -> str:


### PR DESCRIPTION
## Related issue

_No tracking issue._

## Summary

The connect-path pre-flight (`_ensure_databricks_server_auth`) used the wrong host on login. On a single-tenant workspace host the bare host *is* the workspace. In the current model, the workspace rejects the token, surfacing as a re-login loop on connect.

Fix: derive the login selector from the URL via `server_url.org_id_from_url`, matching what the `login` command already passes to `_databricks_login`. The stored org_id still routes the verify probe and request headers above, where `?o=` is needed for multi-workspace host. 


## Test Plan

Reproduced by invalidating a workspace OAuth grant: the pre-flight opened the wrong url on the re-login and failed (grant not workspace-bound); with the fix it opens the correct host, the grant binds correctly, and connect succeeds.  python -m py_compile omnigent/cli.py passes.

## Demo

N/A (non-visual)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified against a live  server (repro + fix). No unit test added — the behavior hinges on the CLI resolving `workspace_id` from host metadata, which isn't exercised in unit tests.

## Changelog

Fix a re-login loop when connecting to a single-tenant Databricks workspace-hosted server.