### PR TITLE
fix(web): show a loading state while the terminal initializes

### DIFF
--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -8,7 +8,7 @@ and opening the new terminal as a rail tab (its xterm renders in the rail's
 content slot). None of this needs an LLM turn — the user, not the agent,
 launches the shell — so these tests never send a chat message.
 
-Three behaviors are covered:
+Five behaviors are covered:
 
 1. **"+" → Shell launches and opens a shell.** Picking Shell creates a
    ``zsh`` shell that opens as a rail tab (``zsh · u-…``): its xterm
@@ -28,14 +28,24 @@ Three behaviors are covered:
    beside the chat header at the 8px outer inset instead of clearing the
    header like the main-column surfaces.
 
-Both use the function-scoped ``terminal_session`` fixture (registers the
+4. **Terminal view startup vs. stopped states.** A starting terminal-first
+   session renders a passive "Starting up…" status with no actionable
+   control; a stopped one — PTY removed mid-session, or a genuine stop
+   followed by a hard reload inside the cold-boot window — renders the
+   stopped copy with an enabled Resume action and no startup status.
+
+All use the function-scoped ``terminal_session`` fixture (registers the
 ``zsh``-declaring agent and a runner-bound session), so each test gets an
 independent session.
 """
 
 from __future__ import annotations
 
+import json
+import os
 import re
+import signal
+import subprocess
 import time
 from pathlib import Path
 
@@ -61,6 +71,23 @@ def _open_new_shell(page: Page) -> None:
     # type launches the default directly.
     rail.get_by_role("button", name="Open new").click()
     page.get_by_role("menuitem", name=re.compile("Shell")).click()
+
+
+def _find_runner_pids() -> list[int]:
+    """PIDs of the runner entry point (``omnigent.runner._entry``).
+
+    Same drop-the-runner stand-in for "Stop session" as
+    ``sessions/test_sidebar_stop.py``: the harness's tunneled non-host
+    runner has no stop_session path, so a kill produces the identical
+    liveness chain. The ``terminal_session`` fixture respawns it for the
+    next test.
+    """
+    result = subprocess.run(
+        ["pgrep", "-f", "omnigent.runner._entry"], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        return []
+    return [int(line.strip()) for line in result.stdout.strip().splitlines() if line.strip()]
 
 
 def test_new_shell_launches_and_opens(page: Page, terminal_session: tuple[str, str]) -> None:
@@ -145,13 +172,115 @@ def test_new_shell_accepts_typed_command(page: Page, terminal_session: tuple[str
 def test_empty_terminal_view_remains_selectable_and_resumable(
     page: Page, terminal_session: tuple[str, str]
 ) -> None:
-    """A stopped terminal-first session exposes its resume state in Terminal."""
+    """A stopped terminal-first session is resumable, same mount and after reload.
+
+    Two phases, both inside the session's 45s cold-boot window:
+
+    1. Same mount: delete the real agent PTY through the resources API
+       (resource cleanup lands while the runner is still online, and the
+       live stream carries the removal). The view must flip to the
+       stopped-session UI with an enabled Resume action: the fresh-session
+       startup grace covers a PTY that has not arrived yet, never one
+       that was present and then removed.
+    2. Hard reload after a genuine stop (runner dropped, server observed
+       offline): a brand-new mount has no PTY observation, yet the stopped
+       UI — not the startup state — must own the view immediately.
+    """
     base_url, session_id = terminal_session
 
-    # Hide terminal resources and their live updates to model the observable
-    # state immediately after stopping a session. Resource cleanup can arrive
-    # before the health poll reports the runner offline, so the UI must infer
-    # that an empty, non-starting inventory is resumable on its own.
+    terminal_first = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"labels": {"omnigent.ui": "terminal"}},
+        timeout=10.0,
+    )
+    terminal_first.raise_for_status()
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    terminal_button = page.get_by_test_id("view-mode-terminal")
+    expect(terminal_button).to_be_enabled()
+    terminal_button.click()
+    expect(terminal_button).to_have_attribute("aria-pressed", "true")
+
+    # The real agent PTY connects before we remove it.
+    terminal_view = page.locator('[data-testid="main-terminal-view"][data-visible="true"]')
+    expect(terminal_view).to_be_visible()
+    expect(terminal_view.locator(".xterm")).to_be_visible()
+
+    # Delete the agent PTY the way a stop does: the resource goes away while
+    # the runner stays online, and the SSE delta prunes the client cache.
+    terminals = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/resources/terminals",
+        params={"order": "asc", "limit": 1000},
+        timeout=10.0,
+    )
+    terminals.raise_for_status()
+    agent_ids = [t["id"] for t in terminals.json()["data"] if t["id"].startswith("terminal_tui")]
+    assert agent_ids, f"no agent terminal in inventory: {terminals.json()['data']}"
+    for terminal_id in agent_ids:
+        deleted = httpx.delete(
+            f"{base_url}/v1/sessions/{session_id}/resources/terminals/{terminal_id}",
+            timeout=10.0,
+        )
+        deleted.raise_for_status()
+
+    # Stopped-session UI: no startup status, Resume offered and enabled.
+    expect(terminal_view.locator(".xterm")).to_have_count(0)
+    expect(terminal_view.get_by_role("status")).to_have_count(0)
+    expect(terminal_view).to_contain_text("The harness is not running.")
+    expect(terminal_view.get_by_role("button", name="Resume session")).to_be_enabled()
+
+    # Genuine stop + hard reload, still inside the 45s creation window:
+    # drop the runner, wait for the server to observe it offline, reload.
+    # The fresh-session startup grace must not mask the stopped UI.
+    runner_pids = _find_runner_pids()
+    assert runner_pids, "no runner process found to stop"
+    for pid in runner_pids:
+        os.kill(pid, signal.SIGKILL)
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        health = httpx.get(f"{base_url}/health", params={"session_ids": session_id}, timeout=5.0)
+        if (
+            health.status_code == 200
+            and not health.json()["sessions"][session_id]["runner_online"]
+        ):
+            break
+        time.sleep(0.5)
+    else:
+        raise AssertionError("server never observed the runner offline")
+
+    page.reload()
+
+    expect(terminal_button).to_be_enabled()
+    if terminal_button.get_attribute("aria-pressed") != "true":
+        terminal_button.click()
+    expect(terminal_button).to_have_attribute("aria-pressed", "true")
+    expect(terminal_view).to_be_visible()
+    expect(terminal_view).to_contain_text("The harness is not running.")
+    expect(terminal_view.get_by_role("button", name="Resume session")).to_be_enabled()
+    expect(terminal_view.get_by_role("status")).to_have_count(0)
+
+
+def test_starting_terminal_view_shows_loading_without_resume(
+    page: Page, terminal_session: tuple[str, str]
+) -> None:
+    """A starting terminal-first session shows a passive loading state, not Resume.
+
+    Models the cold boot of a brand-new terminal-first session: the PTY
+    inventory is still empty, the health poll reports the runner down
+    (the poll can beat the boot's registration), and the session snapshot
+    carries the runner's authoritative ``terminal_pending`` — the signal
+    that distinguishes a cold-booting session from a genuinely stopped
+    one (identical otherwise: fresh, runner down, empty inventory). The
+    view must render the passive startup status and must NOT offer the
+    stopped-session Resume action.
+    """
+    base_url, session_id = terminal_session
+
+    # Pin the cold-boot shape deterministically: freshly created (inside
+    # the startup grace) with the runner down on every liveness carrier.
+    created = int(time.time()) - 20
+
     terminal_list = re.compile(rf"/v1/sessions/{re.escape(session_id)}/resources/terminals\?.*")
     page.route(
         terminal_list,
@@ -161,7 +290,45 @@ def test_empty_terminal_view_remains_selectable_and_resumable(
             body='{"data":[],"first_id":null,"last_id":null,"has_more":false}',
         ),
     )
+    page.route(
+        re.compile(r"/health\?session_ids="),
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {"sessions": {session_id: {"runner_online": False, "host_online": True}}}
+            ),
+        ),
+    )
+    # Silence the two live channels (the real runner IS online with a real
+    # PTY): an open stream or socket push would leak it past the mocks.
     page.route(f"**/v1/sessions/{session_id}/stream*", lambda route: route.abort())
+    page.route_web_socket(re.compile(r"/v1/sessions/updates"), lambda ws: None)
+
+    # The sidebar list's HTTP rows also carry runner_online; rewrite this
+    # session's row so every liveness source agrees the runner is down.
+    def _patch_conversation_rows(route):
+        resp = route.fetch()
+        body = resp.json()
+        for row in body.get("data", []):
+            if row.get("id") == session_id:
+                row["runner_online"] = False
+                row["created_at"] = created
+        route.fulfill(response=resp, json=body)
+
+    page.route(re.compile(r"/v1/sessions\?"), _patch_conversation_rows)
+
+    # The single-session snapshot (a directly-opened /c/{id}) carries the
+    # cold-boot timestamp AND the runner's authoritative terminal_pending —
+    # the creating-the-PTY signal a loading terminal view keys on.
+    def _patch_snapshot(route):
+        resp = route.fetch()
+        body = resp.json()
+        body["created_at"] = created
+        body["terminal_pending"] = True
+        route.fulfill(response=resp, json=body)
+
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), _patch_snapshot)
 
     terminal_first = httpx.patch(
         f"{base_url}/v1/sessions/{session_id}",
@@ -179,8 +346,93 @@ def test_empty_terminal_view_remains_selectable_and_resumable(
 
     terminal_view = page.locator('[data-testid="main-terminal-view"][data-visible="true"]')
     expect(terminal_view).to_be_visible()
+    # The passive startup status is announced (role=status) and carries no
+    # actionable stopped-session UI: no "harness is not running", no Resume.
+    expect(terminal_view.get_by_role("status")).to_contain_text("Starting up…")
+    expect(terminal_view).not_to_contain_text("The harness is not running.")
+    expect(terminal_view.get_by_role("button", name="Resume session")).to_have_count(0)
+
+
+def test_stopped_terminal_view_keeps_resume(page: Page, terminal_session: tuple[str, str]) -> None:
+    """A genuinely stopped terminal-first session keeps its Resume action.
+
+    Mirror of the startup-gap test above — same offline modeling (empty PTY
+    inventory, runner down, live channels silenced) — but the session row
+    is OLDER than the 45s cold-boot grace, so nothing can read it as a
+    starting session: the stopped-session UI and its Resume action must
+    render, with no startup status.
+    """
+    base_url, session_id = terminal_session
+
+    # Outside the grace window (created an hour ago), runner down.
+    created = int(time.time()) - 3600
+
+    terminal_list = re.compile(rf"/v1/sessions/{re.escape(session_id)}/resources/terminals\?.*")
+    page.route(
+        terminal_list,
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"data":[],"first_id":null,"last_id":null,"has_more":false}',
+        ),
+    )
+    page.route(
+        re.compile(r"/health\?session_ids="),
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {"sessions": {session_id: {"runner_online": False, "host_online": True}}}
+            ),
+        ),
+    )
+    # Silence the same two live channels as the startup-gap test (see there
+    # for why each is needed).
+    page.route(f"**/v1/sessions/{session_id}/stream*", lambda route: route.abort())
+    page.route_web_socket(re.compile(r"/v1/sessions/updates"), lambda ws: None)
+
+    # Every liveness carrier agrees: runner offline, created long past the
+    # cold-boot grace.
+    def _patch_conversation_rows(route):
+        resp = route.fetch()
+        body = resp.json()
+        for row in body.get("data", []):
+            if row.get("id") == session_id:
+                row["runner_online"] = False
+                row["created_at"] = created
+        route.fulfill(response=resp, json=body)
+
+    page.route(re.compile(r"/v1/sessions\?"), _patch_conversation_rows)
+
+    def _patch_snapshot(route):
+        resp = route.fetch()
+        body = resp.json()
+        body["created_at"] = created
+        route.fulfill(response=resp, json=body)
+
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), _patch_snapshot)
+
+    terminal_first = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"labels": {"omnigent.ui": "terminal"}},
+        timeout=10.0,
+    )
+    terminal_first.raise_for_status()
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    terminal_button = page.get_by_test_id("view-mode-terminal")
+    expect(terminal_button).to_be_enabled()
+    terminal_button.click()
+    expect(terminal_button).to_have_attribute("aria-pressed", "true")
+
+    terminal_view = page.locator('[data-testid="main-terminal-view"][data-visible="true"]')
+    expect(terminal_view).to_be_visible()
+    # The stopped-session UI renders — no startup status, and the Resume
+    # action is present and enabled.
     expect(terminal_view).to_contain_text("The harness is not running.")
     expect(terminal_view.get_by_role("button", name="Resume session")).to_be_enabled()
+    expect(terminal_view.get_by_role("status")).to_have_count(0)
 
 
 def test_shell_wheel_scroll_reaches_mouse_tracking_program(

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -2,6 +2,7 @@ import type * as UseTerminalsModule from "@/hooks/useTerminals";
 import type * as UseChildSessionsModule from "@/hooks/useChildSessions";
 import type * as UseSessionModule from "@/hooks/useSession";
 import type * as UseConversationsModule from "@/hooks/useConversations";
+import type * as RunnerHealthModule from "@/hooks/RunnerHealthProvider";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
@@ -19,6 +20,18 @@ import type { ServerInfo } from "@/lib/capabilities";
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
 import { writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
 import { writeWorkspacePanelDefault } from "@/lib/workspacePanelPreferences";
+
+const runnerHealthState = vi.hoisted(() => ({
+  runnerOnline: undefined as boolean | undefined,
+}));
+
+vi.mock("@/hooks/RunnerHealthProvider", async (importOriginal) => ({
+  // Keep the real provider component — only the per-session readers are
+  // replaced so tests can pin runner/host liveness directly.
+  ...(await importOriginal<typeof RunnerHealthModule>()),
+  useSessionRunnerOnline: () => runnerHealthState.runnerOnline,
+  useSessionHostOnline: () => true,
+}));
 
 vi.mock("@/hooks/useConversations", async (importOriginal) => ({
   // Keep the real module (PROJECT_LABEL_KEY, the mutation hooks) — only the
@@ -438,6 +451,7 @@ function mockConversations(
     host_id?: string | null;
     runner_id?: string | null;
     workspace?: string | null;
+    created_at?: number;
   }[],
 ) {
   useConvMock.mockReturnValue({
@@ -448,7 +462,7 @@ function mockConversations(
             id: c.id,
             object: "conversation" as const,
             title: null,
-            created_at: 0,
+            created_at: c.created_at ?? 0,
             updated_at: 0,
             labels: c.labels ?? {},
             permission_level: c.permission_level,
@@ -484,6 +498,7 @@ function withWindowOrigin(origin: string, run: () => void) {
 }
 
 beforeEach(() => {
+  runnerHealthState.runnerOnline = undefined;
   useConvMock.mockReset();
   useTerminalsMock.mockReset();
   useTerminalsMock.mockReturnValue({
@@ -752,6 +767,8 @@ describe("AppShell header", () => {
     mockConversations([
       { id: "conv_terminal", permission_level: null, labels: { "omnigent.ui": "terminal" } },
     ]);
+    // terminalPending is only ever emitted by a live runner — model it.
+    runnerHealthState.runnerOnline = true;
     useChatStore.setState({ terminalPending: true, sessionStatus: "running" });
 
     renderShell("/c/conv_terminal");
@@ -783,11 +800,235 @@ describe("AppShell header", () => {
     mockConversations([
       { id: "conv_terminal", permission_level: null, labels: { "omnigent.ui": "terminal" } },
     ]);
+    runnerHealthState.runnerOnline = true;
     useChatStore.setState({ terminalPending: true, sessionStatus: "failed", status: "streaming" });
 
     renderShell("/c/conv_terminal");
 
     expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminal-starting-up", "true");
+  });
+
+  it("treats an unhydrated session row as startup so a fresh session never looks stopped", () => {
+    // Before the sidebar list or snapshot hydrates, a brand-new session is
+    // indistinguishable from a stopped one; the spinner must cover that
+    // gap or the Terminal view flashes Resume during startup.
+    useConvMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useConversations>);
+    useSessionMock.mockReturnValue({ session: null, isLoading: true, error: null });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const makeTree = () => (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_fresh"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <LocationDisplay />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(makeTree());
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminal-starting-up", "true");
+
+    // Partial hydration: the snapshot resolved (terminal_pending=true,
+    // fresh row) but the store bind hasn't applied pending and the list
+    // is still loading. The bridged snapshot pending must hold startup.
+    runnerHealthState.runnerOnline = false;
+    useSessionMock.mockReturnValue({
+      session: {
+        id: "conv_fresh",
+        agentId: "ag_fresh",
+        agentName: "developer",
+        runnerId: null,
+        status: "idle",
+        createdAt: Math.floor(Date.now() / 1000),
+        title: "Fresh session",
+        labels: { "omnigent.ui": "terminal" },
+        items: [],
+        pendingElicitations: [],
+        permissionLevel: null,
+        parentSessionId: null,
+        subAgentName: null,
+        kind: "default",
+        terminalPending: true,
+      },
+      isLoading: false,
+      error: null,
+    });
+    rerender(makeTree());
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminal-starting-up", "true");
+  });
+
+  it("does not spin for a hydrated stopped session — it stays resumable", () => {
+    // The genuine-stop-after-reload shape: fresh created_at, runner down,
+    // and NO terminal_pending — the stopped UI must own Resume here; the
+    // liveness cold-boot grace alone must not read it as startup.
+    runnerHealthState.runnerOnline = false;
+    mockConversations([
+      {
+        id: "conv_stopped",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal" },
+        created_at: Math.floor(Date.now() / 1000),
+      },
+    ]);
+
+    renderShell("/c/conv_stopped");
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminal-starting-up", "false");
+  });
+
+  it("holds startup while an online terminal-first runner's PTY is still arriving", () => {
+    // The runner can register online before its auto-created PTY reaches
+    // the inventory; a terminal-first session inside its cold-boot grace
+    // must keep the startup state (never Resume) through that gap.
+    runnerHealthState.runnerOnline = true;
+    const created = Math.floor(Date.now() / 1000);
+    mockConversations([
+      {
+        id: "conv_fresh_online",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal" },
+        created_at: created,
+      },
+    ]);
+
+    renderShell("/c/conv_fresh_online");
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminal-starting-up", "true");
+  });
+
+  it("releases startup when a fresh session's PTY disappears mid-mount", () => {
+    // A PTY present this mount and then vanished is a stop, not a startup
+    // gap: the grace must not pin the spinner over the Resume affordance.
+    runnerHealthState.runnerOnline = true;
+    const created = Math.floor(Date.now() / 1000);
+    mockConversations([
+      {
+        id: "conv_fresh_deleted",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal" },
+        created_at: created,
+      },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_tui_main", name: "tui", session: "main", running: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    // Stable QueryClient + fresh element per render so the rerender reads
+    // the updated mock (React bails on an identical element reference).
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const makeTree = () => (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_fresh_deleted"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <LocationDisplay />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(makeTree());
+
+    // The PTY disappears (runner stopped / terminal deleted): startup
+    // must release so the stopped UI can offer Resume.
+    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
+    rerender(makeTree());
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminal-starting-up", "false");
+  });
+
+  it("holds startup on a cross-session switch to a fresh terminal-first session", () => {
+    // Switching from a session WITH an agent PTY to a fresh terminal-first
+    // session must not leak the prior PTY observation into the grace.
+    runnerHealthState.runnerOnline = true;
+    const created = Math.floor(Date.now() / 1000);
+    mockConversations([
+      {
+        id: "conv_lived",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal" },
+        created_at: created - 3600,
+      },
+      {
+        id: "conv_new",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal" },
+        created_at: created,
+      },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_tui_main", name: "tui", session: "main", running: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_lived"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <SessionNavButton to="/c/conv_new" />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+
+    // Switch to the fresh session whose PTY has not arrived yet.
+    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
+    fireEvent.click(screen.getByTestId("nav-session"));
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminal-starting-up", "true");
+  });
+
+  it("does not hold startup for a fresh chat-first session with an online runner", () => {
+    // Same shape minus the terminal-first label: the grace is scoped to
+    // terminal-first sessions, so chat-first behavior is unchanged.
+    runnerHealthState.runnerOnline = true;
+    const created = Math.floor(Date.now() / 1000);
+    mockConversations([{ id: "conv_chat_fresh", permission_level: null, created_at: created }]);
+
+    renderShell("/c/conv_chat_fresh");
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminal-starting-up", "false");
   });
 });
 
@@ -1079,6 +1320,7 @@ describe("TerminalFirstContext", () => {
     ]);
     // terminalPending + a non-failed status makes terminalStartingUp true once
     // the list empties (see the startup-spinner tests above).
+    runnerHealthState.runnerOnline = true;
     useChatStore.setState({ terminalPending: true, sessionStatus: "running" });
     useTerminalsMock.mockReturnValue({
       terminals: [{ id: "terminal_claude_main", name: "claude", session: "main", running: true }],

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -407,7 +407,7 @@ export function AppShell() {
   const agentTerminal = useMemo(() => findAgentTerminal(terminals), [terminals]);
 
   const debugMode = useDebugMode();
-  const { data: conversationsData } = useConversations("", true);
+  const { data: conversationsData, isLoading: conversationsLoading } = useConversations("", true);
   // Surface sessions needing attention as OS notifications + a dock badge.
   // Mounted here (inside the Router) so it can navigate on click and knows
   // the active conversation id, which suppresses the notification/badge for
@@ -447,11 +447,11 @@ export function AppShell() {
   // Set when this client launches a runner outside the send path (a host
   // switch); extends the liveness startup grace so the move spins.
   const runnerLaunchedAt = useChatStore((s) => s.runnerLaunchedAt);
-  const liveness = useSessionLiveness(
-    conversationId ?? undefined,
-    activeConv ?? livenessRowFromSession(activeSession),
-    { turnActive: chatStatus === "streaming", launchedAt: runnerLaunchedAt },
-  );
+  const livenessRow = activeConv ?? livenessRowFromSession(activeSession);
+  const liveness = useSessionLiveness(conversationId ?? undefined, livenessRow, {
+    turnActive: chatStatus === "streaming",
+    launchedAt: runnerLaunchedAt,
+  });
   // Full agent object (mcp_servers + policies) for the header info icon.
   // react-query-cached, so this shares the fetch ChatPage's picker makes.
   const { data: boundAgent } = useSessionAgent(conversationId ?? null);
@@ -1608,10 +1608,41 @@ export function AppShell() {
   // the failed-suppression exactly like an in-flight send does.
   const launchPending =
     runnerLaunchedAt !== null && Date.now() - runnerLaunchedAt < STARTING_GRACE_S * 1000;
+  // Until the liveness row or session snapshot hydrates, a brand-new
+  // session is indistinguishable from a stopped one — treat the unobserved
+  // window as starting so the stopped UI can't flash during startup.
+  const livenessRowPending =
+    activeConv === null && activeSession === null && (conversationsLoading || sessionLoading);
+  // The runner can register online before its auto-created PTY reaches the
+  // inventory; hold startup through that gap inside the cold-boot grace. A
+  // PTY seen for THIS conversation and then removed is a stop, not a gap.
+  const createdAtS = livenessRow?.created_at;
+  const hadPtyForConvRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (agentTerminal) hadPtyForConvRef.current = conversationId ?? null;
+  }, [conversationId, agentTerminal]);
+  const freshOnlineGrace =
+    terminalFirst &&
+    liveness.kind === "online" &&
+    hadPtyForConvRef.current !== conversationId &&
+    typeof createdAtS === "number" &&
+    createdAtS > 0 &&
+    Date.now() / 1000 - createdAtS < STARTING_GRACE_S;
   const terminalStartingUp =
     !terminalsAvailable &&
     (sessionStatus !== "failed" || chatStatus === "streaming" || launchPending) &&
-    (liveness.kind === "starting" || terminalPending);
+    (livenessRowPending ||
+      launchPending ||
+      // terminal_pending is the runner's own "creating the PTY" signal,
+      // accurate in the snapshot after a reload; gate on an alive-ish
+      // liveness so a stale flag from a dead runner can't pin the spinner.
+      ((terminalPending || activeSession?.terminalPending === true) &&
+        (liveness.kind === "online" ||
+          liveness.kind === "starting" ||
+          liveness.kind === "unknown")) ||
+      // A send in flight is this client (re)launching the runner now.
+      (chatStatus === "streaming" && liveness.kind !== "online") ||
+      freshOnlineGrace);
   // A rail-opened shell (any open terminal key other than the agent's
   // own terminal) takes over the main view chrome-free:
   // ConnectionIndicator hides the Chat/Terminal pill while this is

--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -1,7 +1,7 @@
 import type * as UseTerminalsModule from "@/hooks/useTerminals";
 
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type TerminalInfo, useTerminals } from "@/hooks/useTerminals";
 import { MainTerminalView } from "./MainTerminalView";
@@ -90,6 +90,7 @@ const BASH_SHELL: TerminalInfo = {
 function makeCtx(
   isNativeWrapper: boolean,
   setView: (view: "chat" | "terminal") => void = () => {},
+  overrides: Partial<TerminalFirstContextValue> = {},
 ): TerminalFirstContextValue {
   return {
     isClaudeNative: isNativeWrapper,
@@ -101,10 +102,11 @@ function makeCtx(
     setView,
     terminalsAvailable: true,
     terminalStartingUp: false,
+    ...overrides,
   } as TerminalFirstContextValue;
 }
 
-function renderView({
+function viewTree({
   terminals,
   isNativeWrapper = false,
   initialTerminalKey = null,
@@ -113,6 +115,7 @@ function renderView({
   runnerOnline,
   onResume,
   setView,
+  terminalStartingUp = false,
 }: {
   terminals: TerminalInfo[];
   isNativeWrapper?: boolean;
@@ -122,10 +125,11 @@ function renderView({
   runnerOnline?: boolean;
   onResume?: () => void | Promise<void>;
   setView?: (view: "chat" | "terminal") => void;
+  terminalStartingUp?: boolean;
 }) {
   useTerminalsMock.mockReturnValue({ terminals, isLoading: false, error: null });
-  return render(
-    <TerminalFirstContextProvider value={makeCtx(isNativeWrapper, setView)}>
+  return (
+    <TerminalFirstContextProvider value={makeCtx(isNativeWrapper, setView, { terminalStartingUp })}>
       <MainTerminalView
         conversationId={conversationId}
         initialTerminalKey={initialTerminalKey}
@@ -133,8 +137,12 @@ function renderView({
         runnerOnline={runnerOnline}
         onResume={onResume}
       />
-    </TerminalFirstContextProvider>,
+    </TerminalFirstContextProvider>
   );
+}
+
+function renderView(args: Parameters<typeof viewTree>[0]) {
+  return render(viewTree(args));
 }
 
 beforeEach(() => {
@@ -237,6 +245,87 @@ describe("MainTerminalView — terminal-first SDK sessions", () => {
 
     expect(await screen.findByText("Couldn't resume session: host offline")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Resume session" })).toBeEnabled();
+  });
+});
+
+describe("MainTerminalView — terminal startup in progress", () => {
+  it("shows a passive loading status, never Resume, while a fresh session initializes", () => {
+    // The reported regression: a fresh terminal-first session with no PTY
+    // yet must render the passive startup state, never the actionable
+    // stopped-session UI — even when the poll reports the runner down.
+    const onResume = vi.fn().mockResolvedValue(undefined);
+    renderView({ terminals: [], runnerOnline: false, onResume, terminalStartingUp: true });
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent("Starting up…");
+    expect(screen.queryByText("The harness is not running.")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Resume session" })).toBeNull();
+    expect(onResume).not.toHaveBeenCalled();
+  });
+
+  it("keeps a genuinely stopped session resumable once startup has settled", () => {
+    // Guards the stopped-session behavior: an idle stopped session (not
+    // starting) keeps the Resume action for the same empty inventory.
+    const onResume = vi.fn().mockResolvedValue(undefined);
+    renderView({ terminals: [], runnerOnline: false, onResume, terminalStartingUp: false });
+
+    expect(screen.getByText("The harness is not running.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Resume session" })).toBeEnabled();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("replaces the loading state with the terminal once the PTY appears", () => {
+    const { rerender } = renderView({ terminals: [], terminalStartingUp: true });
+    expect(screen.getByRole("status")).toHaveTextContent("Starting up…");
+
+    rerender(viewTree({ terminals: [REPL_TERMINAL], terminalStartingUp: false }));
+
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.getByTestId("terminal-view")).toHaveAttribute(
+      "data-terminal-id",
+      "terminal_tui_main",
+    );
+  });
+
+  it("renders the arrived PTY in the same commit — no stopped/empty flash", () => {
+    // activeKey normalizes in a passive effect one commit after the PTY
+    // lands; a layout-effect probe captures each commit's DOM before it
+    // runs — the transient frame must be the terminal, never stopped/empty.
+    const commits: string[] = [];
+    function CommitProbe() {
+      useLayoutEffect(() => {
+        commits.push(
+          document.querySelector('[data-testid="main-terminal-view"]')?.textContent ?? "",
+        );
+      });
+      return null;
+    }
+    const onResume = vi.fn().mockResolvedValue(undefined);
+    const tree = (terminalStartingUp: boolean) => (
+      <TerminalFirstContextProvider value={makeCtx(false, () => {}, { terminalStartingUp })}>
+        <MainTerminalView conversationId="conv_sdk" runnerOnline={false} onResume={onResume} />
+        <CommitProbe />
+      </TerminalFirstContextProvider>
+    );
+    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
+    const { rerender } = render(tree(true));
+    expect(screen.getByRole("status")).toHaveTextContent("Starting up…");
+
+    useTerminalsMock.mockReturnValue({
+      terminals: [REPL_TERMINAL],
+      isLoading: false,
+      error: null,
+    });
+    rerender(tree(false));
+
+    expect(screen.getByTestId("terminal-view")).toHaveAttribute(
+      "data-terminal-id",
+      "terminal_tui_main",
+    );
+    expect(commits.some((text) => text.includes("The harness is not running."))).toBe(false);
+    expect(commits.some((text) => text.includes("Agent terminal unavailable."))).toBe(false);
+    expect(screen.queryByRole("button", { name: "Resume session" })).toBeNull();
+    expect(onResume).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -91,12 +91,15 @@ export function MainTerminalView({
   const [resumePending, setResumePending] = useState(false);
   const [resumeError, setResumeError] = useState<string | null>(null);
   const runnerOffline = runnerOnline === false;
+  // A session whose terminal is coming up (fresh cold boot, relaunch, or
+  // server-side PTY creation) must never read as stopped — the health poll
+  // can report the runner down before the boot registers.
+  const startingUp = terminalFirstCtx?.terminalStartingUp === true;
   // Resource cleanup can beat the health poll when a session is stopped. An
   // empty, non-starting inventory is therefore resumable even before liveness
   // has caught up and explicitly reported the runner offline.
   const resumeAvailable =
-    onResume !== undefined &&
-    (runnerOffline || (terminals.length === 0 && terminalFirstCtx?.terminalStartingUp !== true));
+    onResume !== undefined && !startingUp && (runnerOffline || terminals.length === 0);
   const handleResume = useCallback(async () => {
     if (!onResume) return;
     setResumeError(null);
@@ -145,7 +148,12 @@ export function MainTerminalView({
     setActiveKey(agentTerminal ? terminalTabKey(agentTerminal) : "");
   }, [visible, terminals, agentTerminal]);
 
-  const activeTerminal = terminals.find((t) => terminalTabKey(t) === activeKey) ?? null;
+  // Selection normalizes in the effect above one commit after the PTY
+  // lands; fall back to the agent terminal synchronously so that commit
+  // never reads as an empty/stopped inventory.
+  const activeTerminal =
+    terminals.find((t) => terminalTabKey(t) === activeKey) ??
+    (terminals.length > 0 ? agentTerminal : null);
   // A user shell opened from the rail takes over the pane chrome-free:
   // a single header row naming the shell plus a close X — no agent tab
   // (the shell is not the agent). The Chat/Terminal pill is hidden in
@@ -185,7 +193,25 @@ export function MainTerminalView({
     >
       <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden rounded-lg border border-border bg-card p-3 shadow-sm">
         {activeTerminal === null ? (
-          resumeAvailable ? (
+          startingUp ? (
+            // Passive startup state: same centered geometry as the stopped
+            // state so the swap doesn't jump, and nothing actionable — the
+            // terminal connects on its own. role=status announces the wait.
+            <div
+              role="status"
+              aria-live="polite"
+              data-testid="terminal-starting-up"
+              className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center"
+            >
+              <Loader2Icon className="size-7 animate-spin text-muted-foreground" aria-hidden />
+              <div className="space-y-1">
+                <p className="font-medium text-foreground text-ui">Starting up…</p>
+                <p className="text-muted-foreground text-sm">
+                  The terminal will connect automatically.
+                </p>
+              </div>
+            </div>
+          ) : resumeAvailable ? (
             <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
               <div className="space-y-1">
                 <p className="font-medium text-foreground text-ui">The harness is not running.</p>


### PR DESCRIPTION
## Related issue

[OMNI-5644 — Show loading state while TUI terminal initializes](https://linear.app/omnigent/issue/OMNI-5644/show-loading-state-while-tui-terminal-initializes)

## Summary

A fresh terminal-first session rendered the **stopped-session** UI — "The harness is not running." plus an actionable **Resume** button — from the moment the view opened until its PTY arrived, inviting a click that could only fail.

**ELI5:** while the terminal is still booting, the app now says "Starting up…" and waits; it only offers Resume once the session is genuinely stopped, and it swaps in the live terminal the moment it connects.

The fix classifies startup from **existing client signals only** — no new server contract:

```
no PTY in view
 ├─ rows still hydrating, send in flight, explicit relaunch,
 │   runner reports terminal_pending, or runner online inside the
 │   45s cold-boot grace (PTY never seen for this conversation)
 │     → passive "Starting up…" (role=status, nothing actionable)
 ├─ PTY seen for this conversation and then removed
 │     → stopped UI + Resume (same mount or after a hard reload)
 └─ PTY present
     → terminal (selected synchronously, so the arrival commit
       never reads as an empty/stopped inventory)
```

`terminal_pending` (already in the session snapshot) is the authoritative "runner is creating the PTY" signal; it is what separates a cold-booting session from a genuinely stopped one after a hard reload inside the 45s creation window (otherwise client-identical states). Genuine stopped Resume, chat-first, and already-running behavior are unchanged.

## Test Plan

**Unit (Vitest, 130 passed):**

```
cd web && npx vitest run src/shell/AppShell.test.tsx src/shell/MainTerminalView.test.tsx
# Test Files 2 passed, Tests 130 passed
```

Covers: loading shows role=status and never Resume during startup; stopped UI owns Resume; PTY arrival renders the terminal in the same commit (no one-frame stopped flash); fresh-online startup gap held; same-mount PTY removal releases to stopped; cross-session switch does not leak the prior session's PTY observation; fresh + runner-down + no `terminal_pending` (the genuine-stop-after-reload shape) is NOT startup; chat-first unaffected. A focused regression added 2026-08-28 drives the partial-hydration window directly — snapshot resolved with `terminalPending: true` on a fresh row while the store bind has not yet applied pending — and asserts startup still holds via the snapshot-pending bridge in `AppShell.tsx`.

**E2E (Playwright, 7 passed):**

```
python -m pytest tests/e2e_ui/shells/test_new_shell.py --ui-skip-build -q
# 7 passed
```

- `test_starting_terminal_view_shows_loading_without_resume` — cold boot (snapshot `terminal_pending`) shows passive loading, zero Resume.
- `test_empty_terminal_view_remains_selectable_and_resumable` — real PTY deleted mid-session (runner online) flips to stopped+Resume; then a **genuine stop (runner dropped) + hard reload inside the 45s creation window** shows Resume immediately, not loading.
- `test_stopped_terminal_view_keeps_resume` — stopped session past the grace keeps Resume, no startup status.

**Real-stack browser verification** (server + host + Vite dev server from this worktree, SP2K embedded browser, MutationObserver-sampled DOM, not screenshots alone):

- Fresh terminal-first create: passive loading from first terminal frame (~3.7s) until the PTY arrived; **zero Resume samples at any point**; xterm connected automatically.
- Genuine stop: single transition to the stopped UI with one enabled Resume; no loading frame.
- Stop 6s after creation → server observed runner offline → hard reload (well inside the 45s window): stopped UI + Resume on the first hydrated frame, no startup status.
- Resume click: zero duplicate/actionable Resume afterwards; xterm reconnected in ~1.7s.
- Loading-state DOM/a11y: `role="status"`, `aria-live="polite"`, "Starting up… / The terminal will connect automatically.", zero enabled controls, symmetric centered geometry; verified in light and dark themes.

**Checks:** `prettier --check`, `oxlint`, `tsc --noEmit`, `ruff check`/`ruff format`, `git diff --check`, and `pre-commit run --files <changed files>` all pass.

## Demo

Starting state (passive loading, nothing actionable):

![Starting — light](https://github.com/zhengwin/omnigent/blob/tmp-screenshots-omni-5644/omni5644-starting-light.png?raw=true)

![Starting — dark](https://github.com/zhengwin/omnigent/blob/tmp-screenshots-omni-5644/omni5644-starting-dark.png?raw=true)

Genuinely stopped state (Resume offered):

![Stopped — light](https://github.com/zhengwin/omnigent/blob/tmp-screenshots-omni-5644/omni5644-stopped-light.png?raw=true)

![Stopped — dark](https://github.com/zhengwin/omnigent/blob/tmp-screenshots-omni-5644/omni5644-stopped-dark.png?raw=true)

(The loading/stopped markup in this PR is byte-identical to these captures; the live DOM re-verified on this branch matches them, per Test Plan.)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used a real three-process local stack (server + host + Vite) driven through the actual browser: fresh terminal-first startup (zero Resume flashes, automatic terminal connect), genuine stop → Resume, stop within the 45s creation window followed by a hard reload → Resume immediately, Resume relaunch, and loading-state DOM/a11y/geometry in light and dark themes. **Final human browser sign-off 2026-08-28:** the user reopened the running app, validated the loading and stopped behavior end-to-end, and approved it. Known boundary: a stop inside the 45s cold-boot window is client-distinguishable from a cold boot only via `terminal_pending`/`streaming ; a reload in the seconds before the runner first registers can briefly show the stopped copy — the same tradeoff main already makes, bounded by the pending signal arriving.

## Changelog

Terminal sessions now show a "Starting up…" loading state while the terminal initializes instead of a premature "harness is not running" message

