### PR TITLE
feat(cli): announce the session URL as soon as the session is created

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -47,7 +47,10 @@ from omnigent._wrapper_labels import (
     WRAPPER_LABEL_KEY as _CLAUDE_NATIVE_WRAPPER_LABEL_KEY,
 )
 from omnigent.cli_invocation import cli_invocation
-from omnigent.conversation_browser import open_conversation_link_if_enabled
+from omnigent.conversation_browser import (
+    announce_conversation_url,
+    open_conversation_link_if_enabled,
+)
 from omnigent.errors import OmnigentError
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.inner import _proc
@@ -259,6 +262,36 @@ class _SessionToolAdapter:
             iteration=0,
         )
         return self.tool_handler.execute(legacy_info)
+
+
+def _on_session_known(
+    *,
+    base_url: str,
+    session_id: str,
+    auto_open_conversation: bool,
+) -> None:
+    """Announce (and optionally open) the conversation URL at session start.
+
+    Called the moment the session id is known — before the turn runs — so a
+    headless wrapper can surface the session link immediately. Always prints
+    the stable ``Omnigent session: <url>`` line; additionally opens the
+    browser when the user opted in.
+
+    :param base_url: Omnigent server base URL.
+    :param session_id: The freshly created/resumed conversation id.
+    :param auto_open_conversation: Whether to also open the browser link.
+    """
+    announce_conversation_url(
+        base_url=base_url,
+        conversation_id=session_id,
+        echo=lambda message: click.echo(message, err=True),
+    )
+    open_conversation_link_if_enabled(
+        base_url=base_url,
+        conversation_id=session_id,
+        enabled=auto_open_conversation,
+        warn=lambda message: click.echo(message, err=True),
+    )
 
 
 def run_chat(
@@ -4026,11 +4059,10 @@ def _run_repl(
                 used_families=used_families,
                 attach_only=attach_only,
                 on_session_start=(
-                    lambda session_id: open_conversation_link_if_enabled(
+                    lambda session_id: _on_session_known(
                         base_url=base_url,
-                        conversation_id=session_id,
-                        enabled=auto_open_conversation,
-                        warn=lambda message: click.echo(message, err=True),
+                        session_id=session_id,
+                        auto_open_conversation=auto_open_conversation,
                     )
                 ),
             )
@@ -4093,11 +4125,10 @@ def _run_one_shot(
                 runner_id=runner_id,
                 resume_conversation_id=resume_conversation_id,
                 on_session_ready=(
-                    lambda session_id: open_conversation_link_if_enabled(
+                    lambda session_id: _on_session_known(
                         base_url=base_url,
-                        conversation_id=session_id,
-                        enabled=auto_open_conversation,
-                        warn=lambda message: click.echo(message, err=True),
+                        session_id=session_id,
+                        auto_open_conversation=auto_open_conversation,
                     )
                 ),
             )

--- a/omnigent/conversation_browser.py
+++ b/omnigent/conversation_browser.py
@@ -104,6 +104,43 @@ def open_conversation_url(url: str) -> bool:
     return webbrowser.open(url)
 
 
+# Stable prefix for the "session created" announcement line. Emitted on a
+# line of its own so a wrapper (dev/resolve.py, dev/repro.py, or the CI
+# workflows that tee the run log) can grep the conversation URL the moment
+# the session exists — before the turn finishes — without polling the
+# sessions API. Keep this literal in sync with any log-scraping consumer.
+SESSION_URL_ANNOUNCE_PREFIX = "Omnigent session: "
+
+
+def announce_conversation_url(
+    *,
+    base_url: str,
+    conversation_id: str,
+    echo: Callable[[str], None] | None = None,
+) -> str:
+    """
+    Print the conversation URL on its own line as soon as the session exists.
+
+    Independent of the browser-open preference: this always emits a stable,
+    greppable ``"Omnigent session: <url>"`` line so headless callers (CI
+    wrappers) can surface the session link immediately, even when no browser
+    is opened. Returns the URL so callers can also use it programmatically.
+
+    :param base_url: Omnigent server base URL, e.g. ``"http://127.0.0.1:6767"``.
+    :param conversation_id: Conversation id, e.g. ``"conv_abc123"``.
+    :param echo: Output sink for the announcement line. Defaults to stderr
+        via ``print`` so it never intermixes with a one-shot's stdout answer.
+    :returns: The conversation URL that was announced.
+    """
+    url = conversation_url(base_url, conversation_id)
+    line = f"{SESSION_URL_ANNOUNCE_PREFIX}{url}"
+    if echo is not None:
+        echo(line)
+    else:
+        print(line, file=sys.stderr, flush=True)
+    return url
+
+
 def open_conversation_link_if_enabled(
     *,
     base_url: str,

--- a/tests/test_conversation_browser.py
+++ b/tests/test_conversation_browser.py
@@ -286,3 +286,44 @@ def test_strip_conversation_path_inverts_conversation_url(
     link = browser.conversation_url(base, "conv_abc123")
     assert link == f"{base}/c/conv_abc123"
     assert browser.strip_conversation_path(link) == base
+
+
+def test_announce_conversation_url_echo_sink() -> None:
+    """The announcement emits one stable, greppable line and returns the URL.
+
+    A headless CI wrapper scrapes this line to surface the session link the
+    moment the session exists (before the turn finishes), so the prefix and
+    the ``<prefix><url>`` shape are a contract with that scraper.
+
+    :returns: None.
+    """
+    captured: list[str] = []
+    url = browser.announce_conversation_url(
+        base_url="http://127.0.0.1:6767",
+        conversation_id="conv_abc123",
+        echo=captured.append,
+    )
+    assert url == "http://127.0.0.1:6767/c/conv_abc123"
+    assert captured == [
+        f"{browser.SESSION_URL_ANNOUNCE_PREFIX}http://127.0.0.1:6767/c/conv_abc123"
+    ]
+
+
+def test_announce_conversation_url_defaults_to_stderr(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """With no echo sink the line goes to stderr, never stdout.
+
+    A one-shot ``-p`` run prints only the final answer to stdout; the session
+    announcement must not intermix with it, so it defaults to stderr.
+
+    :param capsys: Pytest capture fixture.
+    :returns: None.
+    """
+    browser.announce_conversation_url(
+        base_url="http://127.0.0.1:6767",
+        conversation_id="x",
+    )
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err.strip() == f"{browser.SESSION_URL_ANNOUNCE_PREFIX}http://127.0.0.1:6767/c/x"


### PR DESCRIPTION
## Related issue

N/A — infrastructure for the repro/resolve agent pipeline (Feature).

## Summary

`omnigent run <agent> --server <url>` (the local-runner + remote-server topology `dev/resolve.py` and `dev/repro.py` use) created the session but only surfaced its URL when the user had browser-auto-open enabled. A **headless** caller — the CI wrappers that `tee` the run log — had no way to learn the session link until the turn finished and the sessions API could be polled. That's exactly why a resolve run that dies mid-turn (crash / harness turn-watchdog) left the Linear ticket with no session link.

This adds `announce_conversation_url()` in `omnigent/conversation_browser.py`, which **always** prints a stable, greppable line the moment the session id is known:

```
Omnigent session: https://<server>/c/<conversation_id>
```

- Independent of the browser-open preference (that behavior is unchanged — it still opens too when enabled).
- Defaults to **stderr** so it never intermixes with a one-shot `-p` run's stdout answer.
- Exposes a `SESSION_URL_ANNOUNCE_PREFIX` constant as the contract for log-scraping consumers.

Wired through a small `_on_session_known` helper in `run_chat`, replacing the two existing `open_conversation_link_if_enabled` callbacks — the interactive REPL's `on_session_start` (`_repl.py:1864`) and the one-shot's `on_session_ready` (`chat.py:2358`). Both already fire at session creation, so no new plumbing.

Follow-up (separate PRs): the CI workflows grep this line to comment the session URL on the ticket immediately — see omnigent-internal #108, which currently can only post the URL post-hoc after the Await step.

## Test Plan

- New unit tests in `tests/test_conversation_browser.py`: the echo-sink form emits exactly one `<prefix><url>` line and returns the URL; the default form writes to **stderr, not stdout** (so it can't corrupt a one-shot answer). Full file: **18 passed**.
- Verified both callbacks that now route through the announcement are actually invoked at session start (`_repl.py:1863-64`, `chat.py:2357-58`) — the exact paths `omnigent run --server -p` takes.
- Full `pre-commit` (ruff, format, pyrefly) clean on the changed files in a fresh worktree venv.

## Demo

N/A — CLI log-line change. Example line: `Omnigent session: http://127.0.0.1:6767/c/conv_abc123`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

Unit tests cover the announcement contract (prefix, URL shape, stderr routing). The callback wiring is exercised by the existing REPL/one-shot session-start paths; a full live `omnigent run` needs real gateway credentials, so it's verified by inspection of the invocation sites rather than an e2e test here.

This pull request and its description were written by Isaac.