### PR TITLE
fix(web): keep remembered host through list gaps

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -1212,22 +1212,21 @@ async def _drive_remembers_last_picked_host(base_url: str, session_id: str) -> N
             await browser.close()
 
 
-def test_start_session_waits_for_refreshed_remembered_host(
+def test_start_session_preserves_unavailable_remembered_host(
     seeded_session: tuple[str, str],
 ) -> None:
-    """Cached Mac-only hosts do not displace a remembered VM during refresh."""
+    """Mac-only host snapshots do not displace a remembered VM."""
     base_url, session_id = seeded_session
-    _run_in_fresh_loop(_drive_waits_for_refreshed_remembered_host(base_url, session_id))
+    _run_in_fresh_loop(_drive_preserves_unavailable_remembered_host(base_url, session_id))
 
 
-async def _drive_waits_for_refreshed_remembered_host(base_url: str, session_id: str) -> None:
+async def _drive_preserves_unavailable_remembered_host(base_url: str, session_id: str) -> None:
     alpha_id, _alpha_name = _HOST_ALPHA
     beta_id, beta_name = _HOST_BETA
     async with async_playwright() as pw:
         browser = await pw.chromium.launch()
         page = await browser.new_page()
-        release_refresh = asyncio.Event()
-        route_state = {"delay_refresh": False, "initial_requests": 0}
+        route_state = {"include_remembered": False, "requests": 0}
         try:
             create_bodies: list[dict[str, Any]] = []
             await _register_common_routes(
@@ -1235,12 +1234,11 @@ async def _drive_waits_for_refreshed_remembered_host(base_url: str, session_id: 
             )
 
             async def handle_hosts(route: Route) -> None:
-                if route_state["delay_refresh"]:
-                    await release_refresh.wait()
-                    body = _two_hosts_body()
-                else:
-                    route_state["initial_requests"] += 1
-                    body = json.dumps(
+                route_state["requests"] += 1
+                body = (
+                    _two_hosts_body()
+                    if route_state["include_remembered"]
+                    else json.dumps(
                         {
                             "hosts": [
                                 {
@@ -1252,6 +1250,7 @@ async def _drive_waits_for_refreshed_remembered_host(base_url: str, session_id: 
                             ]
                         }
                     )
+                )
                 await route.fulfill(status=200, content_type="application/json", body=body)
 
             # Registered after the common route so this stateful handler wins.
@@ -1267,19 +1266,25 @@ async def _drive_waits_for_refreshed_remembered_host(base_url: str, session_id: 
             # stub exposes only the Mac. No landing draft exists on this path.
             await page.goto(f"{base_url}/c/{session_id}")
             await page.get_by_test_id("new-chat-button").wait_for(state="visible", timeout=30_000)
-            await _wait_until(lambda: route_state["initial_requests"] >= 2)
+            await _wait_until(lambda: route_state["requests"] >= 2)
 
-            # NewChat mounts with cached Mac-only data and immediately starts a
-            # fresh request. Hold it so the intermediate choice is observable.
-            route_state["delay_refresh"] = True
+            # NewChat mounts with cached Mac-only data and completes another
+            # Mac-only request. Neither snapshot may silently replace the saved
+            # VM with the local default.
+            requests_before_open = route_state["requests"]
             await page.get_by_test_id("new-chat-button").click()
             chip = page.get_by_test_id("new-chat-landing-host-chip")
+            await _wait_until(lambda: route_state["requests"] > requests_before_open)
             await expect(chip).to_contain_text("Choose host")
 
-            release_refresh.set()
+            # A later host refresh reports the continuously preferred VM again.
+            # The empty slot lets that saved choice heal automatically.
+            route_state["include_remembered"] = True
+            requests_before_focus = route_state["requests"]
+            await page.evaluate("window.dispatchEvent(new Event('visibilitychange'))")
+            await _wait_until(lambda: route_state["requests"] > requests_before_focus)
             await expect(chip).to_contain_text(beta_name)
         finally:
-            release_refresh.set()
             await browser.close()
 
 

--- a/web/src/lib/hostPreferences.ts
+++ b/web/src/lib/hostPreferences.ts
@@ -6,9 +6,10 @@
 // snapshot it when the user explicitly picks a host (or the managed sandbox),
 // so the next visit starts from the last choice instead of the auto-picked
 // default — the sandbox in managed deployments, the first online host in OSS.
-// The consumer still validates a stored host id against the live host list. It
-// waits for any active host-list refresh before falling back when that host is
-// gone or offline.
+// The consumer still validates a stored host id against the live host list. An
+// unavailable stored host is never silently replaced with the automatic
+// default: the picker waits for it to reappear, or for the user to explicitly
+// choose another host.
 
 const STORAGE_KEY = "omnigent:last-host-choice";
 const SANDBOX_PROVIDER_KEY = "omnigent:last-sandbox-provider";

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -990,13 +990,23 @@ describe("NewChatLandingScreen", () => {
     await waitFor(() => expect(chip).toHaveTextContent("machine-2"));
   });
 
-  it("falls back after a fresh host list confirms the remembered host is gone", async () => {
+  it("does not silently replace an unavailable remembered host", async () => {
     localStorage.setItem("omnigent:last-host-choice", "host_2");
     mockHosts([host("online", 1)], { isFetching: false });
     renderLanding();
 
     await waitFor(() =>
-      expect(screen.getByTestId("new-chat-landing-host-chip")).not.toHaveTextContent("Choose host"),
+      expect(screen.getByTestId("new-chat-landing-host-chip")).toHaveTextContent("Choose host"),
+    );
+  });
+
+  it("does not replace an unavailable remembered host with the managed sandbox", async () => {
+    localStorage.setItem("omnigent:last-host-choice", "host_2");
+    mockHosts([host("online", 1)], { isFetching: false });
+    renderLanding({ managed_sandboxes_enabled: true });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip")).toHaveTextContent("Choose host"),
     );
   });
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2136,11 +2136,7 @@ export function NewChatLandingScreen() {
   const { data: agents } = useAvailableAgents();
   // refetchOnFocus: returning from a terminal `omni setup` must clear the
   // readiness badge even if the live push was missed while the tab was hidden.
-  const {
-    data: hosts,
-    isLoading: hostsLoading,
-    isFetching: hostsFetching,
-  } = useHosts({ refetchOnFocus: true });
+  const { data: hosts, isLoading: hostsLoading } = useHosts({ refetchOnFocus: true });
 
   // Offer an import affordance on the empty landing: a brand-new user with no
   // Omnigent sessions can pull in their existing local CLI history. Same query
@@ -2758,11 +2754,9 @@ export function NewChatLandingScreen() {
         setSelectedHostId(stored.host_id);
         return;
       }
-      // Cached data can omit the remembered host while a fresh list is already
-      // in flight. Let that refresh settle before using the normal fallback.
-      if (hostsFetching) return;
-      // The fresh list confirms the stored host is gone or offline — fall
-      // through to the default.
+      // A transient host-list gap must not replace the saved VM with the local
+      // or sandbox default. Leave the slot empty until it returns or the user picks again.
+      return;
     }
 
     if (managedSandboxesEnabled) {
@@ -2775,7 +2769,6 @@ export function NewChatLandingScreen() {
   }, [
     hosts,
     hostsLoading,
-    hostsFetching,
     selectedHostId,
     sandboxSelected,
     managedSandboxesEnabled,


### PR DESCRIPTION
## Related issue

Follow-up to #5490

## Summary

- Keep an explicitly saved host authoritative when the current `/v1/hosts` snapshot temporarily omits it or marks it unavailable.
- Do not silently replace that saved host with `This Mac` or `Databricks Sandbox`; leave the picker on `Choose host` until the host reappears or the user explicitly chooses another option.
- Allow a later host refresh to restore the saved host automatically.

**ELI5:** The saved VM preference was not being lost. A rare host-list response could briefly contain only the Mac (or omit the VM), and the picker treated that response as permission to choose the normal default. Once it chose the fallback, later refreshes could not heal it. This change keeps the slot empty instead of silently switching machines.

```text
stored preference: VM
host snapshot:     Mac only          -> Choose host (keep VM preference)
later snapshot:    Mac + VM          -> select VM
explicit user pick: Mac or sandbox   -> replace saved preference
```

## Test Plan

- `pnpm --dir web test src/shell/NewChatDialog.test.tsx src/lib/hostPreferences.test.ts` (288 passed)
- `pnpm --dir web build`
- `env -u OMNIGENT -u OMNIGENT_PROCESS_LOG_FILE -u OMNIGENT_RUNNER_DELEGATED_AUTH -u OMNIGENT_RUNNER_ID -u OMNIGENT_RUNNER_PARENT_PID -u OMNIGENT_RUNNER_WORKSPACE -u OMNIGENT_RUNNER_ZYGOTE_HARNESS_FD -u RUNNER_SERVER_URL uv run --no-sync pytest tests/e2e_ui/start_session/test_start_session.py::test_start_session_remembers_last_picked_host tests/e2e_ui/start_session/test_start_session.py::test_start_session_preserves_unavailable_remembered_host -q -p no:randomly --ui-skip-build` (2 passed)
- `web/node_modules/.bin/prettier --check web/src/lib/hostPreferences.ts web/src/shell/NewChatDialog.tsx web/src/shell/NewChatDialog.test.tsx`
- `(cd web && node_modules/.bin/oxlint --deny-warnings --report-unused-disable-directives .)`
- `(cd web && node_modules/.bin/tsc -b)`
- `.venv/bin/python -m ruff format --check --force-exclude tests/e2e_ui/start_session/test_start_session.py`
- `.venv/bin/python -m ruff check --force-exclude tests/e2e_ui/start_session/test_start_session.py`
- `git diff --cached --check`

## Demo

N/A — this changes asynchronous host restoration rather than static visuals. The Playwright regression completes both a cached and fresh Mac-only host response, verifies the picker stays on `Choose host`, then returns the VM in a later response and verifies it heals to the saved VM.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage verifies that an unavailable saved host is not replaced by either the first online host or the managed sandbox. Playwright coverage verifies the full cache/fresh-response race and automatic recovery when the saved VM returns.

## Changelog

The new-session picker no longer silently switches from your remembered host to the local machine or managed sandbox during a transient host-list gap.
