### PR TITLE
docs(resolve-agent): recover the write token from the git extraheader, not /proc

### DIFF
--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -535,34 +535,45 @@ then goes straight to Step 4 to land it.) Once the set is genuinely green:
 
 Any write to GitHub — `git push`, `gh pr create`, `gh pr edit --add-reviewer`,
 `gh pr comment`, `gh pr close` — needs the resolve-agent App installation token
-(`omni-resolve-agent[bot]`, `contents`+`pull_requests` write). **The CI wrapper
-holds it, but your shell does not inherit it**: you run inside the session's
-runner process, not the wrapper's, so `$GH_TOKEN` in your shell is empty and a
-bare `git push` fails with a 403 / permission error. This is **not** a
-missing/expired/read-only token — it is present on the host, just not exported to
-you. Recover it before any GitHub write:
+(`omni-resolve-agent[bot]`, `contents`+`pull_requests` write on
+`omnigent-ai/omnigent`). **Your shell does not inherit it in a usable env var**:
+you run inside the session's runner process (a different process, often a
+different machine when hosted on `--server`), so `$GH_TOKEN` in your shell is
+empty and a bare `git push` fails with a 403 / permission error. This is **not**
+a missing/expired/read-only token — the write credential IS on this machine, in
+the git config of your checkout. Recover it before any GitHub write.
+
+**The reliable source is the checkout's persisted `http.extraheader`.**
+`actions/checkout` bakes the App installation token into your repo's git config
+as an `AUTHORIZATION: basic <base64>` header (git worktrees share it via the
+common config, so it's readable from your fix worktree too). Decode it and export
+it as `GH_TOKEN`:
 
 ```bash
-# The wrapper (dev/resolve.py) runs with GH_TOKEN set. Find that process and read
-# the token out of its environment — robust to the exact PID and independent of
-# the git credential helper. Export it for git + gh in your current shell.
-export GH_TOKEN="$(
-  for p in /proc/[0-9]*/environ; do
-    tr '\0' '\n' < "$p" 2>/dev/null | sed -n 's/^GH_TOKEN=//p'
-  done | grep . | head -n1
-)"
-[ -n "$GH_TOKEN" ] || echo "GH_TOKEN not found in any /proc/*/environ"
+# Run from anywhere inside your checkout / fix worktree. The extraheader value is
+# base64("x-access-token:<token>"), so strip the prefix, base64 -d, take the part
+# after the colon.
+export GH_TOKEN="$(git config --get http.https://github.com/.extraheader \
+  | sed 's/^AUTHORIZATION: basic //' | base64 -d | cut -d: -f2-)"
+[ -n "$GH_TOKEN" ] || echo "no extraheader token found in git config"
 gh auth setup-git   # route git pushes through gh's credential helper with this token
 ```
 
 - Do this **once** at the start of Step 3 (and again in Step 4 if a later
   `gh`/`git push` call reports it lost auth). Then push, open the PR, request the
-  reviewer, and comment normally — all of them use this token.
-- If the scan genuinely finds **no** `GH_TOKEN` anywhere (rare — e.g. a
-  `skip_push` run, or the wrapper never set it), report that exact fact in
-  `maintainer_review` with the command output. **Never** substitute a guess like
-  "token expired" or "PAT is read-only" — those are false and drop the hand-off
-  silently. Only a real, quoted failure goes in `maintainer_review`.
+  reviewer, and comment normally — all of them use this token. Confirm it works
+  and is write-scoped with `gh auth status` / a cheap `gh api /repos/omnigent-ai/omnigent`
+  before relying on it.
+- **Do not go hunting elsewhere first.** The token is **not** reachable via
+  `/proc/*/environ` (that is denied in the session sandbox), and the ambient
+  `github-actions[bot]` credential is read-only on `omnigent-ai/omnigent` (it's
+  scoped to `omnigent-internal`) — both are dead ends that waste the turn. The
+  extraheader above is the one that works.
+- If the extraheader is genuinely absent (rare — e.g. a `skip_push` run, or the
+  checkout didn't persist it), report that exact fact in `maintainer_review` with
+  the command output. **Never** substitute a guess like "token expired" or "PAT
+  is read-only" — those are false and drop the hand-off silently. Only a real,
+  quoted failure goes in `maintainer_review`.
 
 Once the set is genuinely green:
 


### PR DESCRIPTION
## Related issue

N/A — process/docs fix for the resolve-agent spec (Bug fix). Corrects #5548.

## Summary

#5548 told the agent to recover its GitHub write token by scanning `/proc/*/environ` for `GH_TOKEN`. Two live session transcripts prove that **never works** in the remote `--server` session sandbox — `/proc` of other processes is `Permission denied` (×260 on the OMNI-3766 run). The agent then fell back to the `github-actions[bot]` token (read-only on `omnigent-ai/omnigent` → "Resource not accessible by integration") and gave up with no PR.

The method that **actually works** — and did, on the successful #5511 / OMNI-2812 run — is decoding the `http.extraheader` that `actions/checkout` persists into the checkout's git config: an App installation token scoped to `omnigent-ai/omnigent` (write). git worktrees share the common config, so it's reachable from the fix worktree.

This rewrites the **"Get the GitHub write token"** step to:
- Prescribe the **extraheader decode** as the reliable method (`git config --get http.https://github.com/.extraheader | sed … | base64 -d | cut -d: -f2-`), then `gh auth setup-git`.
- Explicitly name the two **dead ends** so the agent doesn't waste the turn: `/proc` is denied in-session; the ambient `github-actions[bot]` token is read-only on omnigent (scoped to omnigent-internal).

## Test Plan

Spec-only change. Grounded in two transcripts: the successful #5511 run used exactly this extraheader decode to push + open the PR + tag the reviewer; the failed OMNI-3766 run tried `/proc` (denied) and the read-only bot token, matching what #5548's instruction produced.

Pairs with **omnigent-internal #110**, which stops unsetting that extraheader (a regression from #105) and instead refreshes it with a fresh full-TTL App token — so the credential this instruction reads is present and unexpired.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI

## Test coverage

- [x] Not applicable

## Coverage notes

Prompt/spec text; exercised by resolve-agent CI runs. Verified against the #5511-worked / OMNI-3766-failed transcripts.

This pull request and its description were written by Isaac.