### PR TITLE
Fix harness session auto-compaction on context overflow

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1121,6 +1121,8 @@ class TurnDispatch:
     agent_version: int | None = None
     spawn_env: dict[str, str] | None = None
     client_side_tool_names: frozenset[str] = frozenset()
+    compaction_model: str | None = None
+    context_overflow_retry_attempted: bool = False
 
 
 def _wrap_as_message_event(body: _JsonObject) -> _JsonObject:
@@ -6530,12 +6532,23 @@ def create_runner_app(
         _model_override = msg_body.get("model_override")
         if isinstance(_model_override, str) and _model_override:
             harness_body["model_override"] = _model_override
+            ctx.compaction_model = _model_override
             _logger.info(
                 "_run_turn_bg: conv=%s received model_override=%s (forwarding to harness)",
                 conv,
                 _model_override,
                 extra={"session_id": conv},
             )
+        elif cached_spec is not None:
+            if cached_spec.llm is not None:
+                ctx.compaction_model = cached_spec.llm.model
+            elif cached_spec.executor.model is not None:
+                ctx.compaction_model = cached_spec.executor.model
+            elif spawn_env is not None and harness_name is not None:
+                model_key = _HARNESS_MODEL_ENV_KEY.get(harness_name)
+                env_model = spawn_env.get(model_key) if model_key is not None else None
+                if env_model:
+                    ctx.compaction_model = env_model
         # Resolve the effort for this turn — an explicit per-event value, else
         # the session's remembered one — then deliver only what this harness can
         # accept. The persisted effort is validated at create against the union
@@ -6802,6 +6815,46 @@ def create_runner_app(
                     "message": f"background turn drain failed: {exc}",
                 },
             )
+
+    async def _compact_after_context_overflow(
+        conv_id: str,
+        dispatch: TurnDispatch,
+    ) -> bool:
+        """
+        Ask the AP server to compact after a harness context overflow.
+
+        :param conv_id: Session/conversation identifier.
+        :param dispatch: Current turn dispatch state.
+        :returns: ``True`` when compaction completed and history was reloaded.
+        """
+        data: _JsonObject = {"context_overflow_retry": True}
+        if dispatch.compaction_model:
+            data["model"] = dispatch.compaction_model
+        try:
+            resp = await server_client.post(
+                f"/v1/sessions/{conv_id}/events",
+                json={"type": "compact", "data": data},
+                timeout=120.0,
+            )
+        except (httpx.HTTPError, RuntimeError):
+            _logger.warning(
+                "Context-overflow compaction request failed for session=%s",
+                conv_id,
+                exc_info=True,
+                extra={"session_id": conv_id},
+            )
+            return False
+        if resp.status_code >= 400:
+            _logger.warning(
+                "Context-overflow compaction rejected for session=%s status=%s body=%s",
+                conv_id,
+                resp.status_code,
+                _response_body_preview(resp),
+                extra={"session_id": conv_id},
+            )
+            return False
+        _session_histories[conv_id] = await _load_history_as_input(conv_id)
+        return True
 
     async def _stream_message_to_harness(
         body: _JsonObject,
@@ -7412,6 +7465,29 @@ def create_runner_app(
                     )
 
             except _ContextWindowOverflow as overflow:
+                if (
+                    dispatch is not None
+                    and not dispatch.context_overflow_retry_attempted
+                    and server_client is not None
+                ):
+                    dispatch.context_overflow_retry_attempted = True
+                    _release_live_turn_markers(conv_id)
+                    if await _compact_after_context_overflow(conv_id, dispatch):
+                        body["content"] = _session_histories.get(conv_id, [])
+                        retry_response = await _stream_message_to_harness(
+                            body,
+                            conv_id,
+                            dispatch=dispatch,
+                        )
+                        if isinstance(retry_response, StreamingResponse):
+                            async for retry_chunk in retry_response.body_iterator:
+                                if isinstance(retry_chunk, str):
+                                    yield retry_chunk.encode("utf-8")
+                                elif isinstance(retry_chunk, memoryview):
+                                    yield retry_chunk.tobytes()
+                                else:
+                                    yield retry_chunk
+                            return
                 _error = {
                     "code": "context_length_exceeded",
                     "message": (
@@ -7426,7 +7502,7 @@ def create_runner_app(
                     "error": _error,
                 }
                 _publish_event(conv_id, _overflow_fail)
-                _on_proxy_stream_end(conv_id, error=_error, owner_response_id=_response_id)
+                _on_proxy_stream_end(conv_id, error=_error)
                 yield _response_failed_event(_error)
 
             except (httpx.HTTPError, RuntimeError) as exc:

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -6969,6 +6969,9 @@ async def _run_compact_locked(
     conv: Conversation,
     agent_store: AgentStore,
     agent_cache: AgentCache | None,
+    *,
+    model: str | None = None,
+    allow_running: bool = False,
 ) -> None:
     """
     Run explicit compaction while holding the per-session compact lock.
@@ -6977,6 +6980,10 @@ async def _run_compact_locked(
     :param conv: Conversation row.
     :param agent_store: Agent store for spec lookup.
     :param agent_cache: Agent cache for bundle loading.
+    :param model: Optional effective turn model supplied by the runner or
+        caller. Used when the spec does not declare a server-visible model.
+    :param allow_running: Permit compaction while the session is marked
+        running. Reserved for runner-initiated context-overflow recovery.
     """
     lock = _compact_lock(session_id)
     async with lock:
@@ -6988,7 +6995,7 @@ async def _run_compact_locked(
                 code=ErrorCode.INTERNAL_ERROR,
             )
         # Recheck after acquiring — a turn may have started while waiting.
-        if _session_status_cache.get(session_id) in ("running", "waiting"):
+        if not allow_running and _session_status_cache.get(session_id) in ("running", "waiting"):
             raise OmnigentError(
                 "Cannot compact while a turn is running; cancel or wait for it to finish first",
                 code=ErrorCode.CONFLICT,
@@ -7003,12 +7010,20 @@ async def _run_compact_locked(
             agent.id, agent.bundle_location, expand_env=agent.session_id is None
         )
         spec = loaded.spec
+        effective_model = model or conv.model_override
         if spec.llm is not None:
             llm_config = spec.llm
+            model_override = effective_model
         elif spec.executor.model is not None:
             from omnigent.spec.types import LLMConfig
 
             llm_config = LLMConfig(model=spec.executor.model, connection=spec.executor.connection)
+            model_override = effective_model
+        elif effective_model is not None:
+            from omnigent.spec.types import LLMConfig
+
+            llm_config = LLMConfig(model=effective_model, connection=spec.executor.connection)
+            model_override = None
         else:
             harness = spec.executor.harness_kind
             raise OmnigentError(
@@ -7034,6 +7049,7 @@ async def _run_compact_locked(
                 spec=spec,
                 llm_config=llm_config,
                 tool_schemas=[],
+                model_override=model_override,
                 preserve_recent_window=1,
             )
         except Exception as exc:

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -91,7 +91,13 @@ from omnigent.runtime.policies.builder import (
     load_session_usage,
 )
 from omnigent.runtime.policies.engine import PolicyEngine
-from omnigent.runtime.workflow import _find_spec_by_name
+from omnigent.runtime.workflow import (
+    _CompactionState,
+    _find_spec_by_name,
+    _load_initial_history,
+    _prepare_messages,
+    count_tokens,
+)
 from omnigent.server import session_live_state, shutdown_state
 from omnigent.server._elicitation_registry import (
     _harness_elicitation_owners,
@@ -331,6 +337,7 @@ from omnigent.session_lifecycle import (
 )
 from omnigent.spec.types import (
     AgentSpec,
+    LLMConfig,
     Phase,
     PolicyAction,
 )
@@ -4688,6 +4695,119 @@ def _runner_reject_detail(response: httpx.Response) -> str:
     return f"{code}: {detail}" if code else detail
 
 
+def _compaction_llm_config_for_turn(
+    spec: AgentSpec,
+    *,
+    model_override: str | None,
+) -> tuple[LLMConfig | None, str | None]:
+    """
+    Resolve the LLM config and effective override used for turn compaction.
+
+    :param spec: Agent spec bound to the session.
+    :param model_override: Per-event or persisted session model override.
+    :returns: ``(llm_config, model_override_for_workflow)``. The second value
+        is passed to ``compact_conversation_now`` when the base config still
+        needs the override applied.
+    """
+    if spec.llm is not None:
+        return spec.llm, model_override
+    if spec.executor.model is not None:
+        return (
+            LLMConfig(model=spec.executor.model, connection=spec.executor.connection),
+            model_override,
+        )
+    if model_override is not None:
+        return LLMConfig(model=model_override, connection=spec.executor.connection), None
+    return None, None
+
+
+async def _maybe_compact_before_runner_turn(
+    session_id: str,
+    body: SessionEventInput,
+    conversation_store: ConversationStore,
+    spec: AgentSpec | None,
+    *,
+    model_override: str | None,
+) -> None:
+    """
+    Proactively compact a non-native user turn before it reaches the runner.
+
+    The message has already been persisted but no ``session.status=running``
+    edge has been published yet, so server-side compaction can safely summarize
+    history and the runner's cold-history load will replay the compacted view.
+
+    :param session_id: Conversation being dispatched.
+    :param body: Client event that starts the runner turn.
+    :param conversation_store: Store containing the just-persisted item.
+    :param spec: Resolved agent spec, or ``None`` when unavailable.
+    :param model_override: Effective turn model override after routing.
+    """
+    if spec is None or body.type != "message" or body.data.get("role") != "user":
+        return
+    llm_config, workflow_model_override = _compaction_llm_config_for_turn(
+        spec,
+        model_override=model_override,
+    )
+    if llm_config is None:
+        return
+    effective_model = workflow_model_override or llm_config.model
+    try:
+        context_window = await asyncio.to_thread(
+            resolve_effective_context_window,
+            spec.executor.context_window,
+            llm_config.model,
+            model_override=workflow_model_override,
+        )
+        if context_window is None:
+            return
+        loaded = await asyncio.to_thread(
+            _load_initial_history,
+            conversation_store,
+            session_id,
+        )
+        compaction_state = _CompactionState(
+            context_window=None,
+            last_summary=None,
+            config=spec.compaction,
+            model=effective_model,
+            connection=llm_config.connection,
+            conversation_id=session_id,
+        )
+        _sys_instructions, messages, sys_tokens = await asyncio.to_thread(
+            _prepare_messages,
+            spec,
+            llm_config,
+            loaded.items,
+            None,
+            [],
+            compaction_state,
+            {},
+            conversation_id=session_id,
+        )
+        del _sys_instructions
+        trigger_threshold = spec.compaction.trigger_threshold if spec.compaction else 0.8
+        budget = int(context_window * trigger_threshold) - sys_tokens
+        if count_tokens(messages, effective_model) <= budget:
+            return
+        from omnigent.runtime import workflow as _workflow
+
+        await _workflow.compact_conversation_now(
+            task_id=f"compact_{int(time.time() * 1000)}",
+            conversation_id=session_id,
+            spec=spec,
+            llm_config=llm_config,
+            tool_schemas=[],
+            model_override=workflow_model_override,
+        )
+    except Exception:  # noqa: BLE001 - proactive compaction must never break a turn.
+        _logger.warning(
+            "Proactive compaction failed open for session=%s",
+            session_id,
+            exc_info=True,
+            extra={"session_id": session_id},
+        )
+
+
 async def _forward_event_to_runner(
     session_id: str,
     conv: Conversation,
@@ -4700,6 +4820,7 @@ async def _forward_event_to_runner(
     has_mcp_servers: bool = False,
     created_by: str | None = None,
     host_store: HostStore | None = None,
+    agent_spec: AgentSpec | None = None,
 ) -> str:
     """
     Persist a user event and forward it to the runner.
@@ -4731,6 +4852,8 @@ async def _forward_event_to_runner(
     :param host_store: Host registrations, read only to learn whether this
         session's harness is AI-Gateway-backed (which router may route it).
         ``None`` reads as unknown, which counts as backed.
+    :param agent_spec: Resolved agent spec for this session, when the caller
+        already loaded it for dispatch metadata.
     :returns: The store-assigned id of the persisted item.
     """
     import uuid
@@ -5150,6 +5273,13 @@ async def _forward_event_to_runner(
     _effective_harness = _routed_harness or conv.harness_override
     if _effective_harness is not None and _effective_harness != "auto":
         runner_body["harness_override"] = _effective_harness
+    await _maybe_compact_before_runner_turn(
+        session_id,
+        body,
+        conversation_store,
+        agent_spec,
+        model_override=effective_runner_override,
+    )
 
     # The runner's sessions-native POST returns 202 immediately
     # and starts the turn as a background task. No streaming
@@ -5412,6 +5542,7 @@ async def _dispatch_session_event_to_runner_impl(
     runner_router: RunnerRouter | None = None,
     native_terminal_ready: bool = False,
     host_store: HostStore | None = None,
+    agent_spec: AgentSpec | None = None,
 ) -> _SessionEventDispatchResult:
     """
     Forward an item-event to the runner with harness-aware dispatch.
@@ -5484,6 +5615,8 @@ async def _dispatch_session_event_to_runner_impl(
         session's harness is AI-Gateway-backed (which router may route it).
         ``None`` reads as unknown, which counts as backed — the same posture
         an older host row gets.
+    :param agent_spec: Resolved agent spec for this session, when already
+        loaded by the route.
     :returns: A :class:`_SessionEventDispatchResult` carrying the
         persisted item id (non-native) or the pending-input id
         (claude-native message bypass).
@@ -5711,6 +5844,7 @@ async def _dispatch_session_event_to_runner_impl(
         has_mcp_servers=has_mcp_servers,
         created_by=created_by,
         host_store=host_store,
+        agent_spec=agent_spec,
     )
     return _SessionEventDispatchResult(item_id=item_id, pending_id=None)
 

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -1034,10 +1034,23 @@ def register_events_routes(
             # drives a delivery-verified slash-command inject, and a timeout
             # here falls through to AP-side compaction on top of the
             # terminal's own still-running /compact.
+            raw_compact_model = body.data.get("model")
+            compact_model = (
+                raw_compact_model.strip()
+                if isinstance(raw_compact_model, str) and raw_compact_model.strip()
+                else None
+            )
+            compact_data = {"model": compact_model} if compact_model is not None else {}
+            compact_runner_body: dict[str, Any] = {"type": _COMPACT_TYPE}
+            if compact_data:
+                compact_runner_body["data"] = compact_data
+            allow_running_compact = body.data.get(
+                "context_overflow_retry"
+            ) is True and _has_runner_created_by_authority(request, conv)
             runner_result = await _forward_session_change_to_runner(
                 session_id,
                 runner_router,
-                {"type": _COMPACT_TYPE},
+                compact_runner_body,
                 timeout_s=_TUI_INJECT_FORWARD_TIMEOUT_S,
             )
             if runner_result is not None and runner_result.status_code == 200:
@@ -1067,7 +1080,7 @@ def register_events_routes(
                     runner_result = await _forward_session_change_to_runner(
                         session_id,
                         runner_router,
-                        {"type": _COMPACT_TYPE},
+                        compact_runner_body,
                         timeout_s=_TUI_INJECT_FORWARD_TIMEOUT_S,
                     )
                     if runner_result is not None and runner_result.status_code == 200:
@@ -1093,6 +1106,8 @@ def register_events_routes(
                 conv,
                 agent_store,
                 agent_cache,
+                model=compact_model,
+                allow_running=allow_running_compact,
             )
             return {"queued": False}
         if body.type == "compaction":
@@ -1860,6 +1875,7 @@ def register_events_routes(
         # asyncio.to_thread wrapper covers the rare cold-cache path
         # where the bundle is extracted from disk for the first time.
         _has_mcp_servers = False
+        _agent_spec = None
         if _agent is not None and agent_cache is not None and _agent.bundle_location:
             try:
                 _loaded_agent = await asyncio.to_thread(
@@ -1867,7 +1883,8 @@ def register_events_routes(
                     _agent.id,
                     _agent.bundle_location,
                 )
-                _has_mcp_servers = bool(_loaded_agent.spec.mcp_servers)
+                _agent_spec = _loaded_agent.spec
+                _has_mcp_servers = bool(_agent_spec.mcp_servers)
             except Exception:
                 _logger.warning(
                     "Failed to load agent spec for MCP hint for session=%s",
@@ -1931,6 +1948,7 @@ def register_events_routes(
             # Read only for the gateway-backing check that decides which router
             # serves this turn; absent, routing keeps its default posture.
             host_store=getattr(request.app.state, "host_store", None),
+            agent_spec=_agent_spec,
         )
         if pending_background_title is not None:
             pending_background_title.schedule()

--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import copy
 import dataclasses
 import json
 import logging
@@ -350,6 +351,7 @@ async def test_launch_adapters_forward_expected_kwarg_subset(
     adapter = native_dispatch.resolve_hook_for_key(
         harness.removesuffix("-native"), "auto_create_terminal"
     )
+    assert adapter is not None
     ctx = _launch_ctx()
     await adapter(ctx)
 
@@ -524,14 +526,15 @@ async def test_launch_native_terminal_resolves_spec_lazily_only_on_create(
 
     seen_spec: dict[str, Any] = {}
     resolver_calls = {"n": 0}
+    spec = AgentSpec(spec_version=1, name="resolved-spec")
 
     async def _fake_launch_pi(ctx: NativeLaunchContext) -> object:
         seen_spec["spec"] = ctx.agent_spec
         return object()
 
-    async def _resolver() -> str:
+    async def _resolver() -> AgentSpec:
         resolver_calls["n"] += 1
-        return "resolved-spec"
+        return spec
 
     monkeypatch.setattr("omnigent.runner.native._launch_pi", _fake_launch_pi)
 
@@ -540,7 +543,7 @@ async def test_launch_native_terminal_resolves_spec_lazily_only_on_create(
         "pi-native", _launch_ctx(), ensure_locks={}, resolve_agent_spec=_resolver
     )
     assert resolver_calls["n"] == 1
-    assert seen_spec["spec"] == "resolved-spec"
+    assert seen_spec["spec"] is spec
 
     # Existing terminal: resolver must NOT run.
     await _launch_native_terminal(
@@ -1550,6 +1553,349 @@ async def test_sessions_native_clears_in_flight_on_context_overflow_live_stream(
         f"in-flight marker never cleared on live-stream context overflow "
         f"(got {pm.cleared_in_flight}) -- the reaper would skip this "
         f"conversation's harness forever"
+    )
+
+
+class _SequentialHarnessClient(_ScriptedHarnessClient):
+    """Harness client that returns a different scripted stream per turn."""
+
+    def __init__(self, frame_batches: list[list[str]]) -> None:
+        """Store one frame batch per expected harness stream call."""
+        super().__init__([])
+        self._frame_batches = list(frame_batches)
+
+    def stream(self, method: str, url: str, *, json: dict[str, Any], timeout: Any) -> Any:
+        """Capture body and stream the next scripted frame batch."""
+        del method, url, timeout
+        self.posted_bodies.append(copy.deepcopy(json))
+        frames = self._frame_batches.pop(0) if self._frame_batches else []
+
+        class _StreamCtx:
+            status_code = 200
+
+            async def __aenter__(self) -> _ScriptedHarnessClient._StreamHandle:
+                return _ScriptedHarnessClient._StreamHandle(frames, None)
+
+            async def __aexit__(self, *_: Any) -> None:
+                return None
+
+        return _StreamCtx()
+
+
+class _ContextOverflowRetryServerClient:
+    """Server client that swaps history after runner-triggered compaction."""
+
+    def __init__(
+        self,
+        *,
+        before_items: list[dict[str, Any]],
+        after_items: list[dict[str, Any]],
+    ) -> None:
+        """Capture requests and serve compacted history after compact POST."""
+        self.before_items = before_items
+        self.after_items = after_items
+        self.compacted = False
+        self.get_calls: list[tuple[str, dict[str, Any]]] = []
+        self.post_calls: list[tuple[str, dict[str, Any]]] = []
+
+    class _Response:
+        """Minimal HTTP response for runner tests."""
+
+        def __init__(self, status_code: int = 200, payload: dict[str, Any] | None = None) -> None:
+            self.status_code = status_code
+            self._payload = payload or {}
+            self.headers: dict[str, str] = {}
+            self.content = b"{}"
+            self.text = "{}"
+
+        def json(self) -> dict[str, Any]:
+            """Return the configured JSON payload."""
+            return self._payload
+
+        def raise_for_status(self) -> None:
+            """No-op for successful fake responses."""
+
+    async def get(self, url: str, **kwargs: Any) -> _Response:
+        """Return current history for item loads; otherwise return empty 200."""
+        self.get_calls.append((url, kwargs))
+        if url.endswith("/items"):
+            items = self.after_items if self.compacted else self.before_items
+            return self._Response(payload={"data": items, "has_more": False})
+        return self._Response()
+
+    async def post(self, url: str, **kwargs: Any) -> _Response:
+        """Record compaction requests and mark future history as compacted."""
+        self.post_calls.append((url, kwargs))
+        payload = kwargs.get("json")
+        if (
+            url.endswith("/events")
+            and isinstance(payload, dict)
+            and payload.get("type") == "compact"
+        ):
+            self.compacted = True
+        return self._Response(status_code=202)
+
+
+async def _wait_until(predicate: Any, *, timeout_s: float = 5.0) -> None:
+    """Wait until *predicate* returns truthy, failing if it never does."""
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while not predicate():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError("condition was not met before timeout")
+        await asyncio.sleep(0.05)
+
+
+def _drain_runner_events(app: Any, session_id: str) -> list[dict[str, Any]]:
+    """Collect queued runner events without opening an SSE stream."""
+    queue = app.state.session_event_queues.get(session_id)
+    events: list[dict[str, Any]] = []
+    if queue is None:
+        return events
+    while not queue.empty():
+        item = queue.get_nowait()
+        if item is not None:
+            events.append(item)
+    return events
+
+
+@pytest.mark.asyncio
+async def test_sessions_native_context_overflow_compacts_and_retries() -> None:
+    """A background SDK turn compacts and retries once after context overflow."""
+    old_history_text = "oversized history before compaction"
+    compacted_summary_text = "short summary after compaction"
+    conv_id = "e583be6f6f0f4f22ad9f85a4be356c24"
+    before_items = [
+        {
+            "id": "item_old_user",
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": old_history_text}],
+        }
+    ]
+    after_items = [
+        {
+            "id": "item_compact",
+            "type": "compaction",
+            "compacted_messages": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": compacted_summary_text}],
+                }
+            ],
+        },
+        {
+            "id": "item_current_user",
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue"}],
+        },
+    ]
+    harness_client = _SequentialHarnessClient(
+        [
+            [
+                _sse({"type": "response.created", "response": {"id": "resp_overflow"}}),
+                _sse(
+                    {
+                        "type": "response.failed",
+                        "error": {
+                            "message": (
+                                "context_length_exceeded: 5000 tokens > 4096 "
+                                "maximum context length"
+                            ),
+                            "code": "context_length_exceeded",
+                        },
+                    }
+                ),
+            ],
+            [
+                _sse({"type": "response.created", "response": {"id": "resp_retry"}}),
+                _sse({"type": "response.output_text.delta", "delta": "recovered"}),
+                _sse({"type": "response.completed", "response": {"id": "resp_retry"}}),
+            ],
+        ]
+    )
+    pm = _FakeProcessManager(harness_client)
+    server_client = _ContextOverflowRetryServerClient(
+        before_items=before_items,
+        after_items=after_items,
+    )
+    spec = AgentSpec(
+        spec_version=1,
+        name="plain-agent",
+        executor=ExecutorSpec(
+            type="omnigent",
+            model="databricks-gpt-5-4-mini",
+            config={"harness": "codex"},
+        ),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=server_client,  # type: ignore[arg-type]
+    )
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "9ec9ab9af477e4cf897ae37c4a98ed05",
+                "model": "plain-agent",
+                "content": [{"type": "input_text", "text": "continue"}],
+                "harness": "codex",
+            },
+        )
+        assert resp.status_code == 202
+        await _wait_until(lambda: len(harness_client.posted_bodies) == 2)
+        await _wait_until(lambda: len(pm.cleared_in_flight) >= 2)
+
+    compact_posts = [
+        body
+        for url, kwargs in server_client.post_calls
+        if url == f"/v1/sessions/{conv_id}/events"
+        for body in [kwargs.get("json")]
+    ]
+    assert compact_posts == [
+        {
+            "type": "compact",
+            "data": {
+                "context_overflow_retry": True,
+                "model": "databricks-gpt-5-4-mini",
+            },
+        }
+    ]
+    assert len(harness_client.posted_bodies) == 2
+    first_content = harness_client.posted_bodies[0]["content"]
+    retry_content = harness_client.posted_bodies[1]["content"]
+    assert first_content == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": old_history_text}],
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue"}],
+        },
+    ]
+    assert retry_content == [
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": compacted_summary_text}],
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue"}],
+        },
+    ]
+    events = _drain_runner_events(app, conv_id)
+    assert [event.get("type") for event in events].count("response.failed") == 0
+    assert any(event.get("type") == "response.completed" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_sessions_native_context_overflow_retry_fails_once() -> None:
+    """A second overflow after compaction surfaces one context-length failure."""
+    conv_id = "af06bdc9a1374ffcab21f911c19dd48d"
+    before_items = [
+        {
+            "id": "item_old_user",
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "oversized history"}],
+        }
+    ]
+    after_items = [
+        {
+            "id": "item_compact",
+            "type": "compaction",
+            "summary": "still too large",
+        }
+    ]
+    overflow_frames = [
+        _sse({"type": "response.created", "response": {"id": "resp_overflow"}}),
+        _sse(
+            {
+                "type": "response.failed",
+                "error": {
+                    "message": (
+                        "context_length_exceeded: 5000 tokens > 4096 maximum context length"
+                    ),
+                    "code": "context_length_exceeded",
+                },
+            }
+        ),
+    ]
+    harness_client = _SequentialHarnessClient([overflow_frames, overflow_frames])
+    pm = _FakeProcessManager(harness_client)
+    server_client = _ContextOverflowRetryServerClient(
+        before_items=before_items,
+        after_items=after_items,
+    )
+    spec = AgentSpec(
+        spec_version=1,
+        name="plain-agent",
+        executor=ExecutorSpec(
+            type="omnigent",
+            model="databricks-gpt-5-4-mini",
+            config={"harness": "codex"},
+        ),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=server_client,  # type: ignore[arg-type]
+    )
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "9ec9ab9af477e4cf897ae37c4a98ed05",
+                "model": "plain-agent",
+                "content": [{"type": "input_text", "text": "continue"}],
+                "harness": "codex",
+            },
+        )
+        assert resp.status_code == 202
+        await _wait_until(lambda: len(harness_client.posted_bodies) == 2)
+        await _wait_until(
+            lambda: any(
+                event.get("type") == "session.status" and event.get("status") == "failed"
+                for event in list(app.state.session_event_queues[conv_id]._queue)
+                if event is not None
+            )
+        )
+
+    events = _drain_runner_events(app, conv_id)
+    failed = [event for event in events if event.get("type") == "response.failed"]
+    assert len(failed) == 1
+    assert failed[0]["error"]["code"] == "context_length_exceeded"
+    assert (
+        len(
+            [
+                kwargs
+                for url, kwargs in server_client.post_calls
+                if url == f"/v1/sessions/{conv_id}/events"
+                and (kwargs.get("json") or {}).get("type") == "compact"
+            ]
+        )
+        == 1
     )
 
 

--- a/tests/server/integration/test_sessions_compact.py
+++ b/tests/server/integration/test_sessions_compact.py
@@ -206,6 +206,124 @@ async def test_compact_runs_omnigent_compaction_when_runner_noops(
     )
 
 
+async def test_compact_model_less_sdk_harness_uses_event_model(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runner-supplied compact model unblocks model-less SDK agents."""
+    from omnigent.runtime import set_runner_client
+
+    calls: list[dict[str, Any]] = []
+
+    async def _record(**kwargs: Any) -> CompactionResult:
+        calls.append(kwargs)
+        return CompactionResult(messages=[], summary_metadata=None, total_tokens=1)
+
+    monkeypatch.setattr("omnigent.runtime.workflow.compact_conversation_now", _record)
+
+    runner, captured = _fake_runner_returning(204)
+    set_runner_client(runner)
+    try:
+        agent = await create_test_agent(
+            client,
+            name="model-less-event-compact",
+            executor={"type": "omnigent", "config": {"harness": "openai-agents"}},
+            include_llm=False,
+        )
+        sid = await _create_session(client, agent["id"])
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={"type": "compact", "data": {"model": "claude-sonnet-5"}},
+        )
+    finally:
+        await runner.aclose()
+        set_runner_client(None)
+
+    assert resp.status_code == 202, resp.text
+    assert captured == [{"type": "compact", "data": {"model": "claude-sonnet-5"}}]
+    assert len(calls) == 1
+    assert calls[0]["llm_config"].model == "claude-sonnet-5"
+    assert calls[0]["model_override"] is None
+
+
+async def test_message_proactively_compacts_before_runner_forward(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Oversized non-native history compacts before the runner sees the turn."""
+    from omnigent.server.routes import sessions as sessions_mod
+
+    sequence: list[str] = []
+    compact_calls: list[dict[str, Any]] = []
+    forwarded: list[dict[str, Any]] = []
+
+    def _count_tokens(messages: list[dict[str, Any]], model: str) -> int:
+        del model
+        if messages and messages[0].get("role") == "system":
+            return 0
+        return 90
+
+    async def _compact(**kwargs: Any) -> CompactionResult:
+        sequence.append("compact")
+        compact_calls.append(kwargs)
+        return CompactionResult(messages=[], summary_metadata=None, total_tokens=40)
+
+    class _CaptureRunner:
+        async def post(self, path: str, *, json: dict[str, Any], **_: Any) -> Any:
+            del path
+            if json.get("type") == "message":
+                sequence.append("forward")
+                forwarded.append(json)
+
+            class _Resp:
+                status_code = 202
+                headers: dict[str, str] = {}
+                text = ""
+
+            return _Resp()
+
+    async def _runner_client(*_: Any, **__: Any) -> _CaptureRunner:
+        return _CaptureRunner()
+
+    monkeypatch.setattr("omnigent.runtime.workflow.count_tokens", _count_tokens)
+    monkeypatch.setattr(
+        "omnigent.server.routes._sessions.orchestration.count_tokens",
+        _count_tokens,
+    )
+    monkeypatch.setattr("omnigent.runtime.workflow.compact_conversation_now", _compact)
+    monkeypatch.setattr(sessions_mod, "_get_runner_client", _runner_client)
+
+    agent = await create_test_agent(
+        client,
+        name="proactive-compact",
+        executor={
+            "type": "omnigent",
+            "model": "openai/gpt-4o",
+            "context_window": 100,
+            "config": {"harness": "openai-agents"},
+        },
+        include_llm=False,
+    )
+    sid = await _create_session(client, agent["id"])
+    resp = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={
+            "type": "message",
+            "data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "fill the window"}],
+            },
+        },
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert sequence == ["compact", "forward"]
+    assert len(compact_calls) == 1
+    assert compact_calls[0]["conversation_id"] == sid
+    assert compact_calls[0]["llm_config"].model == "openai/gpt-4o"
+    assert forwarded and forwarded[0]["type"] == "message"
+
+
 async def test_compact_model_less_sdk_harness_returns_clear_unavailable_message(
     client: httpx.AsyncClient,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #2967

## Summary

- Let compact events carry the effective model so model-less SDK/harness agents can still run server-side compaction.
- Add a proactive pre-runner compaction guard for oversized non-native turns, using the resolved turn model and the agent compaction threshold.
- Add a runner-side one-shot context-overflow recovery path that asks the server to compact, reloads compacted history, and retries before surfacing `context_length_exceeded`.

ELI5: when a harness session gets too long, Omnigent now tries to summarize the old parts before sending the next prompt. If the harness still says the prompt is too long, the runner asks the server to compact once and tries that turn again.

```mermaid
flowchart TD
    A[User message persisted] --> B{History above threshold?}
    B -- yes --> C[Server compacts before runner forward]
    B -- no --> D[Forward to runner]
    C --> D
    D --> E{Harness context overflow?}
    E -- no --> F[Normal completion]
    E -- first overflow --> G[Runner POSTs compact with effective model]
    G --> H[Reload compacted history]
    H --> D
    E -- overflow after retry --> I[Surface context_length_exceeded]
```

## Test Plan

- `ruff check omnigent/runner/app.py omnigent/server/routes/_sessions/helpers.py omnigent/server/routes/_sessions/orchestration.py omnigent/server/routes/sessions/routes_events.py tests/server/integration/test_sessions_compact.py tests/runner/test_app_sessions_native_workflow_init.py`
- `.venv/bin/pyrefly check omnigent/runner/app.py omnigent/server/routes/_sessions/helpers.py omnigent/server/routes/_sessions/orchestration.py omnigent/server/routes/sessions/routes_events.py tests/server/integration/test_sessions_compact.py tests/runner/test_app_sessions_native_workflow_init.py`
- `pytest tests/server/integration/test_sessions_compact.py -q`
- `pytest tests/runner/test_app_sessions_native_workflow_init.py::test_sessions_native_clears_in_flight_on_context_overflow_live_stream tests/runner/test_app_sessions_native_workflow_init.py::test_sessions_native_context_overflow_compacts_and_retries tests/runner/test_app_sessions_native_workflow_init.py::test_sessions_native_context_overflow_retry_fails_once -q`
- `pre-commit run --files omnigent/runner/app.py omnigent/server/routes/_sessions/helpers.py omnigent/server/routes/_sessions/orchestration.py omnigent/server/routes/sessions/routes_events.py tests/server/integration/test_sessions_compact.py tests/runner/test_app_sessions_native_workflow_init.py` partially ran: `ruff-format` updated files and `ruff check` passed; the project-wide `pyrefly` hook failed because this worktree uses a symlinked `.venv` whose editable SDK paths point at the main checkout, producing unrelated SDK missing-import errors. Direct Pyrefly on the touched files passed after formatting.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage exercises model-less compaction, proactive pre-runner compaction, successful runner overflow compact-and-retry, and the bounded retry failure path.

## Changelog

Harness sessions auto-compact and retry instead of getting stuck when replayed history fills the model context window.
