### PR TITLE
feat(sessions): select model/effort/permission mode when forking

### DIFF
--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -185,6 +185,9 @@ from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.comment_store import CommentStore
 from omnigent.stores.conversation_store import (
+    CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY as _CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY,
+)
+from omnigent.stores.conversation_store import (
     PINNED_LABEL_KEY,
     PROJECT_LABEL_KEY,
     ConversationNotFoundError,
@@ -2129,6 +2132,17 @@ def register_core_routes(
         from the truncated items instead of resuming the source's full
         native transcript.
 
+        The dialog's run-config picks (``body.model_override``,
+        ``body.reasoning_effort``, ``body.terminal_launch_args`` — the
+        permission-/approval-mode selector) override what the fork would
+        otherwise inherit. Each is opt-in: a field omitted from the request
+        keeps the inherited value (model/effort within the same provider
+        family; launch args on a same-agent fork), while a field present
+        wins — a clear alias (``"default"``) resets to the bound agent's
+        default, and an explicit launch-args list also drops the source's
+        copied permission-mode / codex-bypass labels so they can't shadow
+        the freshly chosen mode.
+
         A sub-agent source is allowed, which is how a sub-agent is
         promoted to a session of its own: the fork is always a fresh
         top-level conversation (no parent, its own spawn-tree root, its
@@ -2210,6 +2224,76 @@ def register_core_routes(
                 _same_provider_family, source_agent, base_agent
             )
 
+        # Explicit run-config overrides from the fork dialog. Each field is
+        # opt-in: a field the client OMITS (not in model_fields_set) inherits
+        # the source per the copy rules above; a field the client SENDS wins,
+        # overriding the inheritance (a clear alias like "default" resets to
+        # the bound agent's default). Validated before any row exists — the
+        # persisted values reach a native CLI as --model / --effort argv at
+        # terminal launch, so a bad value must never create an orphan fork.
+        fields_set = body.model_fields_set
+        model_override_set = "model_override" in fields_set
+        effort_set = "reasoning_effort" in fields_set
+        launch_args_set = "terminal_launch_args" in fields_set
+
+        override_model: str | None = None
+        clear_override_model = False
+        if model_override_set:
+            raw_model = body.model_override
+            if isinstance(raw_model, str) and raw_model.strip().lower() in EFFORT_CLEAR_VALUES:
+                clear_override_model = True
+            elif raw_model is not None:
+                try:
+                    override_model = validate_model_override(raw_model)
+                except ValueError as exc:
+                    raise OmnigentError(
+                        f"invalid model_override: {exc}",
+                        code=ErrorCode.INVALID_INPUT,
+                    ) from exc
+            else:
+                # Explicit JSON null clears the override (matches the clear
+                # aliases), so the fork falls back to the bound agent default.
+                clear_override_model = True
+
+        override_effort: str | None = None
+        clear_override_effort = False
+        if effort_set:
+            raw_effort = body.reasoning_effort
+            if raw_effort is None or raw_effort in EFFORT_CLEAR_VALUES:
+                clear_override_effort = True
+            else:
+                try:
+                    override_effort = validate_effort(raw_effort, "fork", EFFORT_VALUES)
+                except ValueError as exc:
+                    raise OmnigentError(
+                        f"invalid reasoning_effort: {exc}",
+                        code=ErrorCode.INVALID_INPUT,
+                    ) from exc
+
+        override_launch_args: list[str] | None = None
+        if launch_args_set:
+            try:
+                override_launch_args = _validate_terminal_launch_args(body.terminal_launch_args)
+            except ValueError as exc:
+                raise OmnigentError(
+                    f"invalid terminal_launch_args: {exc}",
+                    code=ErrorCode.INVALID_INPUT,
+                ) from exc
+
+        # Permission mode lives BOTH in launch args (``--permission-mode``) and
+        # as a copied label — and the label wins when both are present. So when
+        # the dialog picks explicit launch args, drop the source's mode-derived
+        # labels from the fork; otherwise the copied label would shadow the
+        # freshly chosen mode. Only on an explicit pick: an untouched picker
+        # sends no launch args and the label carries over as before.
+        dropped_label_keys: frozenset[str] = (
+            frozenset(
+                {_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY, _CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY}
+            )
+            if launch_args_set
+            else frozenset()
+        )
+
         # When the fork binds a NATIVE target, the native CLI won't replay
         # the copied Omnigent transcript on its own — mark the fork so the
         # runner carries history into the native harness. Same-family: clone
@@ -2276,11 +2360,23 @@ def register_core_routes(
                 cloned_agent_bundle_location=base_agent.bundle_location,
                 cloned_agent_description=base_agent.description,
                 copy_model_settings=copy_model_settings,
+                # Explicit run-config picks from the fork dialog. Each rides a
+                # (value, set-flag) pair so the store can tell "override to
+                # None / clear" from "not chosen — inherit". When unset, the
+                # store falls back to copy_model_settings / copy_terminal_launch_args.
+                override_model_override=None if clear_override_model else override_model,
+                override_model_override_set=model_override_set,
+                override_reasoning_effort=None if clear_override_effort else override_effort,
+                override_reasoning_effort_set=effort_set,
+                override_terminal_launch_args=override_launch_args,
+                override_terminal_launch_args_set=launch_args_set,
+                dropped_label_keys=dropped_label_keys,
                 # Launch flags are CLI-specific. On an agent switch the fork may
                 # bind a different CLI (e.g. claude-code → pi), whose flag set
                 # differs — Claude Code's ``--permission-mode`` makes pi exit at
                 # launch (unknown option → ``required_terminal_exited``). Only
-                # carry the source's launch args on a same-agent fork.
+                # carry the source's launch args on a same-agent fork. An
+                # explicit override above supersedes this.
                 copy_terminal_launch_args=not switching_agent,
                 carry_history_into_native=carry_history_into_native,
                 resume_source_native_session=resume_source_native_session,

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -122,6 +122,7 @@ from omnigent.server.routes._sessions.helpers import (
     _get_runner_client,
     _invalidate_runner_backed_snapshot_state,
     _multipart_missing_detail,
+    _native_coding_agent_for_agent,
     _notify_runner_of_bundled_child,
     _parse_session_create_metadata,
     _permission_level_from_grants,
@@ -2300,6 +2301,23 @@ def register_core_routes(
             dropped_label_keys_set.add(_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY)
         dropped_label_keys: frozenset[str] = frozenset(dropped_label_keys_set)
 
+        # DANGEROUS codex full-bypass. The source's bypass label is always
+        # dropped above (instance-scoped), so a bypass-armed source never
+        # silently re-arms its clone. The ONLY way a fork enables bypass is an
+        # explicit, banner-gated opt-in from the dialog — and only when the
+        # bound target is actually codex-native (the label is inert elsewhere,
+        # so refuse to stamp it on a non-Codex fork). Stamped via extra_labels,
+        # which the store applies AFTER the drop so the opt-in wins.
+        extra_labels: dict[str, str] = {}
+        if body.codex_bypass_sandbox:
+            target_native = await asyncio.to_thread(_native_coding_agent_for_agent, base_agent)
+            if target_native is None or target_native.harness != "codex-native":
+                raise OmnigentError(
+                    "codex_bypass_sandbox is only valid for a codex-native fork target",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            extra_labels[_CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY] = "1"
+
         # When the fork binds a NATIVE target, the native CLI won't replay
         # the copied Omnigent transcript on its own — mark the fork so the
         # runner carries history into the native harness. Same-family: clone
@@ -2377,6 +2395,7 @@ def register_core_routes(
                 override_terminal_launch_args=override_launch_args,
                 override_terminal_launch_args_set=launch_args_set,
                 dropped_label_keys=dropped_label_keys,
+                extra_labels=extra_labels,
                 # Launch flags are CLI-specific. On an agent switch the fork may
                 # bind a different CLI (e.g. claude-code → pi), whose flag set
                 # differs — Claude Code's ``--permission-mode`` makes pi exit at

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -2286,13 +2286,19 @@ def register_core_routes(
         # labels from the fork; otherwise the copied label would shadow the
         # freshly chosen mode. Only on an explicit pick: an untouched picker
         # sends no launch args and the label carries over as before.
-        dropped_label_keys: frozenset[str] = (
-            frozenset(
-                {_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY, _CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY}
-            )
-            if launch_args_set
-            else frozenset()
-        )
+        dropped_label_keys_set: set[str] = set()
+        if launch_args_set:
+            dropped_label_keys_set |= {
+                _CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY,
+                _CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY,
+            }
+        # The claude-native permission-mode label is Claude-specific; on an
+        # agent switch (which already drops the source's launch args) it would
+        # otherwise ride along as stale metadata that could hydrate a wrong mode
+        # in generic native-wrapper UI state. Drop it whenever the agent changes.
+        if switching_agent:
+            dropped_label_keys_set.add(_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY)
+        dropped_label_keys: frozenset[str] = frozenset(dropped_label_keys_set)
 
         # When the fork binds a NATIVE target, the native CLI won't replay
         # the copied Omnigent transcript on its own — mark the fork so the

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2369,6 +2369,15 @@ class SessionForkRequest(BaseModel):
         are carried on a same-agent fork and dropped on an agent switch. A
         list (including ``[]``, which clears them) replaces them wholesale.
         Bounds (count / length) are validated server-side.
+    :param codex_bypass_sandbox: Opt-in for the DANGEROUS codex-native
+        full-bypass (``--dangerously-bypass-approvals-and-sandbox``) on the
+        fork. The source's bypass label is ALWAYS dropped on a fork (a
+        bypass-armed source can never silently re-arm its clone), so this is
+        the only way a fork enables it — an explicit, banner-gated opt-in
+        from the dialog, mirroring the new-session approval selector. ``True``
+        stamps ``omnigent.codex_native.bypass_sandbox`` on the fork; ``False``
+        / omitted leaves the fork in Codex's normal approval/sandbox stance.
+        Only meaningful for a codex-native target; ignored otherwise.
     """
 
     title: str | None = None
@@ -2377,6 +2386,7 @@ class SessionForkRequest(BaseModel):
     model_override: str | None = None
     reasoning_effort: str | None = None
     terminal_launch_args: list[str] | None = None
+    codex_bypass_sandbox: bool = False
 
     model_config = ConfigDict(extra="forbid")
 

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2349,11 +2349,34 @@ class SessionForkRequest(BaseModel):
         the last item of that response are copied — items after it are
         dropped from the fork. When ``None`` (default), the full history
         is copied.
+    :param model_override: Per-session LLM model override to apply to the
+        fork, e.g. ``"claude-opus-4-7"``. **Omitting** the field inherits
+        the source's model (same as today, within the same provider
+        family); an explicit value overrides it, and a clear alias
+        (``"default"``, ``"off"``, ``"reset"``) resets the fork to the
+        bound agent's default. Validated against a conservative model-id
+        charset. Set by the web fork dialog's model picker.
+    :param reasoning_effort: Per-session reasoning-effort override to apply
+        to the fork, e.g. ``"high"``. **Omitting** the field inherits the
+        source's effort; an explicit value overrides it, and a clear alias
+        (``"default"``, ``"off"``, ``"reset"``) resets it. Validated
+        against the shared effort vocabulary; provider support is enforced
+        at launch. Set by the web fork dialog's effort picker.
+    :param terminal_launch_args: Per-session native-terminal pass-through
+        args to apply to the fork, e.g. ``["--permission-mode", "auto"]``
+        (the fork dialog's permission-/approval-mode selector).
+        **Omitting** the field keeps today's behavior — the source's args
+        are carried on a same-agent fork and dropped on an agent switch. A
+        list (including ``[]``, which clears them) replaces them wholesale.
+        Bounds (count / length) are validated server-side.
     """
 
     title: str | None = None
     agent_id: str | None = None
     up_to_response_id: str | None = None
+    model_override: str | None = None
+    reasoning_effort: str | None = None
+    terminal_launch_args: list[str] | None = None
 
     model_config = ConfigDict(extra="forbid")
 

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1510,6 +1510,7 @@ class ConversationStore(ABC):
         override_terminal_launch_args: list[str] | None = None,
         override_terminal_launch_args_set: bool = False,
         dropped_label_keys: frozenset[str] = frozenset(),
+        extra_labels: dict[str, str] | None = None,
         carry_history_into_native: bool = False,
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
@@ -1579,6 +1580,10 @@ class ConversationStore(ABC):
             permission-mode / codex-bypass label keys when the dialog picks
             explicit launch args, so a stale copied label can't shadow the
             freshly chosen mode).
+        :param extra_labels: Labels stamped on the fork AFTER copy/drop, so a
+            deliberate opt-in beats the always-drop rule — e.g. the fork
+            dialog re-arming the DANGEROUS ``codex_native.bypass_sandbox``
+            label (the only path that sets it; the source's is always dropped).
         :param carry_history_into_native: When ``True``, stamp
             :data:`FORK_CARRY_HISTORY_LABEL_KEY` on the fork so a native
             target harness rebuilds its transcript (clone the source's

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1503,6 +1503,13 @@ class ConversationStore(ABC):
         cloned_agent_description: str | None = None,
         copy_model_settings: bool = True,
         copy_terminal_launch_args: bool = True,
+        override_model_override: str | None = None,
+        override_model_override_set: bool = False,
+        override_reasoning_effort: str | None = None,
+        override_reasoning_effort_set: bool = False,
+        override_terminal_launch_args: list[str] | None = None,
+        override_terminal_launch_args_set: bool = False,
+        dropped_label_keys: frozenset[str] = frozenset(),
         carry_history_into_native: bool = False,
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
@@ -1552,6 +1559,26 @@ class ConversationStore(ABC):
             with none — used when the fork switches to a different CLI, where
             the source's flags are meaningless or rejected (e.g. Claude Code's
             ``--permission-mode`` would make ``pi`` exit at launch).
+        :param override_model_override: Explicit ``model_override`` for the
+            fork, applied only when ``override_model_override_set`` — then it
+            supersedes the ``copy_model_settings`` copy.
+        :param override_model_override_set: Whether the caller chose an
+            explicit ``model_override`` (fork dialog's model picker).
+        :param override_reasoning_effort: Explicit ``reasoning_effort`` for
+            the fork, applied only when ``override_reasoning_effort_set``.
+        :param override_reasoning_effort_set: Whether the caller chose an
+            explicit ``reasoning_effort``.
+        :param override_terminal_launch_args: Explicit
+            ``terminal_launch_args`` for the fork (the permission-mode
+            selector), applied only when ``override_terminal_launch_args_set``
+            — then it supersedes the ``copy_terminal_launch_args`` copy.
+        :param override_terminal_launch_args_set: Whether the caller chose
+            explicit launch args.
+        :param dropped_label_keys: Source labels to NOT copy onto the fork,
+            beyond the always-dropped instance-scoped set (e.g. the
+            permission-mode / codex-bypass label keys when the dialog picks
+            explicit launch args, so a stale copied label can't shadow the
+            freshly chosen mode).
         :param carry_history_into_native: When ``True``, stamp
             :data:`FORK_CARRY_HISTORY_LABEL_KEY` on the fork so a native
             target harness rebuilds its transcript (clone the source's

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3445,6 +3445,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         override_terminal_launch_args: list[str] | None = None,
         override_terminal_launch_args_set: bool = False,
         dropped_label_keys: frozenset[str] = frozenset(),
+        extra_labels: dict[str, str] | None = None,
         carry_history_into_native: bool = False,
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
@@ -3528,6 +3529,12 @@ class SqlAlchemyConversationStore(ConversationStore):
             passes the permission-mode / codex-bypass label keys here when
             the dialog picks explicit launch args, so the stale copied label
             can't shadow the freshly chosen mode.
+        :param extra_labels: Labels to stamp on the fork AFTER the copy /
+            drop / presentation-label logic, so a deliberate opt-in wins over
+            the always-drop rule. The fork route passes the DANGEROUS
+            ``codex_native.bypass_sandbox`` label here when the dialog's
+            approval selector explicitly re-arms bypass — the only path that
+            sets it, since the source's own bypass label is always dropped.
         :param carry_history_into_native: When ``True``, stamp
             :data:`FORK_CARRY_HISTORY_LABEL_KEY` on the fork so a native
             target harness rebuilds its transcript instead of starting
@@ -3586,6 +3593,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             override_terminal_launch_args=override_terminal_launch_args,
             override_terminal_launch_args_set=override_terminal_launch_args_set,
             dropped_label_keys=dropped_label_keys,
+            extra_labels=extra_labels,
             carry_history_into_native=carry_history_into_native,
             resume_source_native_session=resume_source_native_session,
             presentation_labels=presentation_labels,
@@ -3612,6 +3620,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         override_terminal_launch_args: list[str] | None = None,
         override_terminal_launch_args_set: bool = False,
         dropped_label_keys: frozenset[str] = frozenset(),
+        extra_labels: dict[str, str] | None = None,
         carry_history_into_native: bool = False,
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
@@ -3879,6 +3888,13 @@ class SqlAlchemyConversationStore(ConversationStore):
                 for _pkey in (UI_MODE_LABEL_KEY, WRAPPER_LABEL_KEY):
                     fork_labels.pop(_pkey, None)
                 fork_labels.update(presentation_labels)
+            # Caller-supplied labels stamped LAST so a deliberate opt-in beats
+            # both the copy and the always-drop rules — e.g. the fork dialog
+            # re-arming the DANGEROUS codex bypass. The source's own bypass
+            # label was already dropped (it's instance-scoped), so this is the
+            # only path that sets it, and only from an explicit request field.
+            if extra_labels:
+                fork_labels.update(extra_labels)
             if fork_labels:
                 _upsert_labels(session, new_conv.id, fork_labels, now)
 

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3438,6 +3438,13 @@ class SqlAlchemyConversationStore(ConversationStore):
         cloned_agent_description: str | None = None,
         copy_model_settings: bool = True,
         copy_terminal_launch_args: bool = True,
+        override_model_override: str | None = None,
+        override_model_override_set: bool = False,
+        override_reasoning_effort: str | None = None,
+        override_reasoning_effort_set: bool = False,
+        override_terminal_launch_args: list[str] | None = None,
+        override_terminal_launch_args_set: bool = False,
+        dropped_label_keys: frozenset[str] = frozenset(),
         carry_history_into_native: bool = False,
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
@@ -3494,6 +3501,33 @@ class SqlAlchemyConversationStore(ConversationStore):
             the bound agent's defaults — used when the fork switches to
             an agent in a different provider family, where the source's
             model id is meaningless (a model is provider-bound).
+        :param override_model_override: Explicit ``model_override`` for the
+            fork, applied only when ``override_model_override_set`` is
+            ``True`` — then it supersedes the ``copy_model_settings`` copy
+            (a value pins that model; ``None`` clears to the agent default).
+        :param override_model_override_set: Whether the caller chose an
+            explicit ``model_override`` (the fork dialog's model picker).
+            ``False`` (default) inherits per ``copy_model_settings``.
+        :param override_reasoning_effort: Explicit ``reasoning_effort`` for
+            the fork, applied only when ``override_reasoning_effort_set`` is
+            ``True``.
+        :param override_reasoning_effort_set: Whether the caller chose an
+            explicit ``reasoning_effort``. ``False`` (default) inherits per
+            ``copy_model_settings``.
+        :param override_terminal_launch_args: Explicit
+            ``terminal_launch_args`` for the fork (e.g. the permission-mode
+            selector's ``["--permission-mode", "auto"]``), applied only when
+            ``override_terminal_launch_args_set`` is ``True`` — then it
+            supersedes the ``copy_terminal_launch_args`` copy (``[]`` clears
+            them, ``None`` also clears).
+        :param override_terminal_launch_args_set: Whether the caller chose
+            explicit launch args. ``False`` (default) inherits per
+            ``copy_terminal_launch_args``.
+        :param dropped_label_keys: Source labels to NOT copy onto the fork,
+            beyond the always-dropped instance-scoped set. The fork route
+            passes the permission-mode / codex-bypass label keys here when
+            the dialog picks explicit launch args, so the stale copied label
+            can't shadow the freshly chosen mode.
         :param carry_history_into_native: When ``True``, stamp
             :data:`FORK_CARRY_HISTORY_LABEL_KEY` on the fork so a native
             target harness rebuilds its transcript instead of starting
@@ -3545,6 +3579,13 @@ class SqlAlchemyConversationStore(ConversationStore):
             cloned_agent_description=cloned_agent_description,
             copy_model_settings=copy_model_settings,
             copy_terminal_launch_args=copy_terminal_launch_args,
+            override_model_override=override_model_override,
+            override_model_override_set=override_model_override_set,
+            override_reasoning_effort=override_reasoning_effort,
+            override_reasoning_effort_set=override_reasoning_effort_set,
+            override_terminal_launch_args=override_terminal_launch_args,
+            override_terminal_launch_args_set=override_terminal_launch_args_set,
+            dropped_label_keys=dropped_label_keys,
             carry_history_into_native=carry_history_into_native,
             resume_source_native_session=resume_source_native_session,
             presentation_labels=presentation_labels,
@@ -3564,6 +3605,13 @@ class SqlAlchemyConversationStore(ConversationStore):
         cloned_agent_description: str | None = None,
         copy_model_settings: bool = True,
         copy_terminal_launch_args: bool = True,
+        override_model_override: str | None = None,
+        override_model_override_set: bool = False,
+        override_reasoning_effort: str | None = None,
+        override_reasoning_effort_set: bool = False,
+        override_terminal_launch_args: list[str] | None = None,
+        override_terminal_launch_args_set: bool = False,
+        dropped_label_keys: frozenset[str] = frozenset(),
         carry_history_into_native: bool = False,
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
@@ -3604,14 +3652,23 @@ class SqlAlchemyConversationStore(ConversationStore):
             # — same gate — harness_override) copy only when copy_model_settings.
             # The routing switches (cost_control_mode_override,
             # subagent_routing_override) are intentionally never carried onto a fork.
+            # An explicit dialog pick (override_*_set) supersedes the inherited
+            # value — the fork dialog seeds the picker from the source, so an
+            # untouched picker sends nothing and inheritance stands.
+            fork_effort = (
+                override_reasoning_effort
+                if override_reasoning_effort_set
+                else (source_overrides["reasoning_effort"] if copy_model_settings else None)
+            )
+            fork_model = (
+                override_model_override
+                if override_model_override_set
+                else (source_overrides["model_override"] if copy_model_settings else None)
+            )
             fork_overrides = _encode_session_overrides(
                 {
-                    "reasoning_effort": (
-                        source_overrides["reasoning_effort"] if copy_model_settings else None
-                    ),
-                    "model_override": (
-                        source_overrides["model_override"] if copy_model_settings else None
-                    ),
+                    "reasoning_effort": fork_effort,
+                    "model_override": fork_model,
                     "harness_override": (
                         source_overrides["harness_override"] if copy_model_settings else None
                     ),
@@ -3755,7 +3812,12 @@ class SqlAlchemyConversationStore(ConversationStore):
             fork_labels = {
                 key: value
                 for key, value in _fetch_labels(session, source_conversation_id).items()
-                if key not in (_INSTANCE_SCOPED_LABEL_KEYS | _FORK_ONLY_DROPPED_LABEL_KEYS)
+                if key
+                not in (
+                    _INSTANCE_SCOPED_LABEL_KEYS
+                    | _FORK_ONLY_DROPPED_LABEL_KEYS
+                    | dropped_label_keys
+                )
                 and not key.startswith(f"{PINNED_LABEL_KEY}.")
             }
             source_workspace = source_meta_ref.workspace if source_meta_ref else None
@@ -3766,10 +3828,24 @@ class SqlAlchemyConversationStore(ConversationStore):
             # CLI — Claude Code's ``--permission-mode auto`` makes ``pi`` exit 1
             # at launch (unknown option), which surfaces as
             # ``required_terminal_exited``. Drop them on a switching fork.
+            # An explicit dialog pick (the permission-/approval-mode selector)
+            # supersedes the inherited launch args; an untouched picker sends
+            # nothing, so the same-agent copy / switch-drop rule stands. The
+            # metadata column stores the JSON-encoded string, so the copy path
+            # reuses the source's already-encoded value while an override list
+            # is encoded here (matching create_conversation).
             source_terminal_args = (
-                source_meta_ref.terminal_launch_args
-                if source_meta_ref and copy_terminal_launch_args
-                else None
+                (
+                    json.dumps(override_terminal_launch_args)
+                    if override_terminal_launch_args is not None
+                    else None
+                )
+                if override_terminal_launch_args_set
+                else (
+                    source_meta_ref.terminal_launch_args
+                    if source_meta_ref and copy_terminal_launch_args
+                    else None
+                )
             )
             if source_workspace is not None:
                 fork_labels[FORK_SOURCE_LABEL_KEY] = source_conversation_id

--- a/openapi.json
+++ b/openapi.json
@@ -4525,6 +4525,12 @@
             "description": "Built-in agent to bind the fork to, switching it away from the source's agent/harness (e.g. fork a Claude session into a Codex one, or a Claude-SDK session into Claude Code). When `None`, the fork keeps the source's agent. Must be a built-in agent (one listed by `GET /v1/agents`).",
             "title": "Agent Id"
           },
+          "codex_bypass_sandbox": {
+            "default": false,
+            "description": "Opt-in for the DANGEROUS codex-native full-bypass (`--dangerously-bypass-approvals-and-sandbox`) on the fork. The source's bypass label is ALWAYS dropped on a fork (a bypass-armed source can never silently re-arm its clone), so this is the only way a fork enables it \u2014 an explicit, banner-gated opt-in from the dialog, mirroring the new-session approval selector. `True` stamps `omnigent.codex_native.bypass_sandbox` on the fork; `False` / omitted leaves the fork in Codex's normal approval/sandbox stance. Only meaningful for a codex-native target; ignored otherwise.",
+            "title": "Codex Bypass Sandbox",
+            "type": "boolean"
+          },
           "model_override": {
             "anyOf": [
               {

--- a/openapi.json
+++ b/openapi.json
@@ -4525,6 +4525,45 @@
             "description": "Built-in agent to bind the fork to, switching it away from the source's agent/harness (e.g. fork a Claude session into a Codex one, or a Claude-SDK session into Claude Code). When `None`, the fork keeps the source's agent. Must be a built-in agent (one listed by `GET /v1/agents`).",
             "title": "Agent Id"
           },
+          "model_override": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-session LLM model override to apply to the fork, e.g. `\"claude-opus-4-7\"`. **Omitting** the field inherits the source's model (same as today, within the same provider family); an explicit value overrides it, and a clear alias (`\"default\"`, `\"off\"`, `\"reset\"`) resets the fork to the bound agent's default. Validated against a conservative model-id charset. Set by the web fork dialog's model picker.",
+            "title": "Model Override"
+          },
+          "reasoning_effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-session reasoning-effort override to apply to the fork, e.g. `\"high\"`. **Omitting** the field inherits the source's effort; an explicit value overrides it, and a clear alias (`\"default\"`, `\"off\"`, `\"reset\"`) resets it. Validated against the shared effort vocabulary; provider support is enforced at launch. Set by the web fork dialog's effort picker.",
+            "title": "Reasoning Effort"
+          },
+          "terminal_launch_args": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-session native-terminal pass-through args to apply to the fork, e.g. `[\"--permission-mode\", \"auto\"]` (the fork dialog's permission-/approval-mode selector). **Omitting** the field keeps today's behavior \u2014 the source's args are carried on a same-agent fork and dropped on an agent switch. A list (including `[]`, which clears them) replaces them wholesale. Bounds (count / length) are validated server-side.",
+            "title": "Terminal Launch Args"
+          },
           "title": {
             "anyOf": [
               {
@@ -13317,7 +13356,7 @@
     },
     "/v1/sessions/{source_id}/fork": {
       "post": {
-        "description": "Fork an existing session into a new session.\n\nDeep-copies the source session's conversation items and\nclones the agent into a new session. When `body.agent_id`\nis set, the fork binds that built-in agent instead of the\nsource's \u2014 switching harness (e.g. Claude-SDK \u2192 Claude Code,\nor Claude \u2192 Codex). The source's model settings carry over\nonly within the same provider family; a same-family native\ntarget also carries conversation history (the runner rebuilds\nits transcript). The REPL/CLI binds the fork to its runner via\n`PATCH /v1/sessions/{id}` after creation.\n\nWhen `body.up_to_response_id` is set, only history up to and\nincluding that response is copied into the fork (a \"fork from\nthis response\"); a native target then rebuilds its transcript\nfrom the truncated items instead of resuming the source's full\nnative transcript.\n\nA sub-agent source is allowed, which is how a sub-agent is\npromoted to a session of its own: the fork is always a fresh\ntop-level conversation (no parent, its own spawn-tree root, its\nown owner grant), so it appears in the sidebar and outlives the\nparent. The source keeps running under its parent untouched,\nand the fork does not adopt the source's own children.\n\n**Parameters**\n\n- `body` \u2014 The validated `SessionForkRequest`.\n\n**Returns:** A `SessionResponse` describing the newly created fork (status `\"idle\"`).\n\n**Raises**\n\n- `OmnigentError` \u2014 404 if *source_id* does not exist or `body.agent_id` is not a bindable built-in agent; 403 if the caller lacks read access; 400 if the source has no agent binding, or `body.up_to_response_id` names no response in the source session.",
+        "description": "Fork an existing session into a new session.\n\nDeep-copies the source session's conversation items and\nclones the agent into a new session. When `body.agent_id`\nis set, the fork binds that built-in agent instead of the\nsource's \u2014 switching harness (e.g. Claude-SDK \u2192 Claude Code,\nor Claude \u2192 Codex). The source's model settings carry over\nonly within the same provider family; a same-family native\ntarget also carries conversation history (the runner rebuilds\nits transcript). The REPL/CLI binds the fork to its runner via\n`PATCH /v1/sessions/{id}` after creation.\n\nWhen `body.up_to_response_id` is set, only history up to and\nincluding that response is copied into the fork (a \"fork from\nthis response\"); a native target then rebuilds its transcript\nfrom the truncated items instead of resuming the source's full\nnative transcript.\n\nThe dialog's run-config picks (`body.model_override`,\n`body.reasoning_effort`, `body.terminal_launch_args` \u2014 the\npermission-/approval-mode selector) override what the fork would\notherwise inherit. Each is opt-in: a field omitted from the request\nkeeps the inherited value (model/effort within the same provider\nfamily; launch args on a same-agent fork), while a field present\nwins \u2014 a clear alias (`\"default\"`) resets to the bound agent's\ndefault, and an explicit launch-args list also drops the source's\ncopied permission-mode / codex-bypass labels so they can't shadow\nthe freshly chosen mode.\n\nA sub-agent source is allowed, which is how a sub-agent is\npromoted to a session of its own: the fork is always a fresh\ntop-level conversation (no parent, its own spawn-tree root, its\nown owner grant), so it appears in the sidebar and outlives the\nparent. The source keeps running under its parent untouched,\nand the fork does not adopt the source's own children.\n\n**Parameters**\n\n- `body` \u2014 The validated `SessionForkRequest`.\n\n**Returns:** A `SessionResponse` describing the newly created fork (status `\"idle\"`).\n\n**Raises**\n\n- `OmnigentError` \u2014 404 if *source_id* does not exist or `body.agent_id` is not a bindable built-in agent; 403 if the caller lacks read access; 400 if the source has no agent binding, or `body.up_to_response_id` names no response in the source session.",
         "operationId": "fork_session_v1_sessions__source_id__fork_post",
         "parameters": [
           {

--- a/tests/e2e/test_sessions_fork_e2e.py
+++ b/tests/e2e/test_sessions_fork_e2e.py
@@ -265,6 +265,76 @@ def test_full_fork_replays_whole_history(
     )
 
 
+# Per-session run-config overrides on fork are new server-side behavior — an
+# older server ignores the new request fields and copies the source's settings
+# verbatim, so these assertions can't hold there.
+@pytest.mark.min_server_version("0.12.0")
+def test_fork_run_config_overrides_persist_on_clone(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    mock_llm_server_url: str,
+) -> None:
+    """The fork dialog's model / effort / launch-arg picks land on the clone.
+
+    Drives exactly what the Web UI's clone dialog sends — ``model_override``,
+    ``reasoning_effort``, and ``terminal_launch_args`` in the fork body — and
+    reads them back off the clone's ``SessionResponse``.
+
+    **What breaks if wrong:**
+
+    - The route drops the new fields → the clone inherits the source's model
+      settings instead of the picks (first block).
+    - A cleared model/effort (``"default"``) isn't treated as a reset → the
+      clone keeps the source's override (second block).
+    - Omitting the fields no longer inherits → a plain fork silently loses the
+      source's settings (third block, guarding the old contract).
+    """
+    reset_mock_llm(mock_llm_server_url)
+    agent_name, model = _register_mock_fork_agent(http_client, mock_llm_server_url, prefix="cfg")
+    configure_mock_llm(mock_llm_server_url, [{"text": "OK"}, {"text": "OK"}], key=model)
+    source_id = _seed_two_codeword_turns(
+        http_client, agent_name=agent_name, runner_id=live_runner_id
+    )
+    # Give the source its own model settings so "inherit" is observable — a
+    # plain fork must carry these, an override must replace them.
+    patched = http_client.patch(
+        f"/v1/sessions/{source_id}",
+        json={"model_override": "source-model", "reasoning_effort": "low"},
+    )
+    patched.raise_for_status()
+
+    # Explicit picks win over the source's settings.
+    overridden = _fork_session(
+        http_client,
+        source_id,
+        runner_id=live_runner_id,
+        body={
+            "model_override": "picked-model",
+            "reasoning_effort": "high",
+            "terminal_launch_args": ["--permission-mode", "plan"],
+        },
+    )
+    assert overridden["model_override"] == "picked-model"
+    assert overridden["reasoning_effort"] == "high"
+    assert overridden["terminal_launch_args"] == ["--permission-mode", "plan"]
+
+    # A "default" clear alias resets model/effort to the agent default even
+    # though a same-agent fork would otherwise copy the source's.
+    cleared = _fork_session(
+        http_client,
+        source_id,
+        runner_id=live_runner_id,
+        body={"model_override": "default", "reasoning_effort": "default"},
+    )
+    assert cleared["model_override"] is None
+    assert cleared["reasoning_effort"] is None
+
+    # Omitting the fields keeps the pre-existing inherit behavior.
+    inherited = _fork_session(http_client, source_id, runner_id=live_runner_id)
+    assert inherited["model_override"] == "source-model"
+    assert inherited["reasoning_effort"] == "low"
+
+
 # Compaction-cursor remapping is server-side behavior introduced after v0.11.
 # A new runner paired with an old server must skip this new-server contract.
 @pytest.mark.compat_smoke

--- a/tests/e2e_ui/sessions/test_clone_session.py
+++ b/tests/e2e_ui/sessions/test_clone_session.py
@@ -196,6 +196,17 @@ def test_clone_dialog_offers_cross_family_native_target_and_forks(
     option = page.get_by_test_id(f"fork-session-agent-option-{claude_native['id']}")
     expect(option).to_be_visible()
     option.click()
+
+    # Switching to claude-native reveals the run-config section (Model /
+    # Effort / Permissions). Pick a non-default permission mode so the fork
+    # carries the selector's ``--permission-mode`` launch args — the picker is
+    # seeded to the target harness's defaults on a cross-harness switch, so
+    # this is a deliberate change the fork body must transport.
+    perm = page.get_by_test_id("fork-session-config-permission")
+    expect(perm).to_be_visible()
+    perm.click()
+    page.get_by_role("option", name="Plan", exact=True).click()
+
     page.get_by_test_id("fork-session-submit").click()
 
     # The fork succeeds and navigates to a NEW session id.
@@ -222,6 +233,12 @@ def test_clone_dialog_offers_cross_family_native_target_and_forks(
     )
     assert labels.get("omnigent.wrapper") == "claude-code-native-ui", (
         f"fork must present as the TARGET (claude-native) harness, got {labels!r}"
+    )
+    # The run-config section's permission pick rode the fork body as launch
+    # args and persisted on the clone (the whole point of the picker).
+    assert snap.json().get("terminal_launch_args") == ["--permission-mode", "plan"], (
+        f"fork must carry the picked permission mode as launch args, "
+        f"got {snap.json().get('terminal_launch_args')!r}"
     )
 
 

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -875,6 +875,57 @@ async def test_fork_switch_binds_target_agent_bundle() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fork_switch_drops_claude_permission_mode_label() -> None:
+    """An agent switch drops the source's claude-native permission-mode label.
+
+    That label is Claude-specific and rides alongside launch args, which a
+    switching fork already drops. Carrying the label onto a switched fork would
+    leave stale mode metadata that could hydrate a wrong mode in native-wrapper
+    UI state, so the route lists it in ``dropped_label_keys`` whenever the agent
+    changes — independent of whether the dialog sent explicit launch args.
+    """
+    conv = _make_conversation()
+    conv_store = _ConversationStore(
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv},
+        items_by_conv={
+            "e9f8f58523cec9a57d3bdf93be543e8c": [
+                _make_item("9980c8a9248139f14f4165e5d53088aa", "Hello")
+            ]
+        },
+    )
+    client = TestClient(_build_app(conv_store, agent_store=_switch_agent_store()))
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"agent_id": "44b4151dd6cdfed6ee19430832398e05"},
+    )
+
+    assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
+    dropped = conv_store.fork_calls[0]["dropped_label_keys"]
+    assert "omnigent.claude_native.permission_mode" in dropped, (
+        f"agent switch must drop the claude permission-mode label, got {dropped!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fork_same_agent_keeps_permission_mode_label() -> None:
+    """A same-agent fork with no explicit launch args drops NO mode labels.
+
+    The permission-mode label is Claude-specific but valid for a same-agent
+    fork (same CLI), so it must carry over — the drop is gated on an agent
+    switch or an explicit launch-args pick, neither of which applies here.
+    """
+    conv = _make_conversation()
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    client = TestClient(_build_app(conv_store))
+
+    resp = client.post("/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork", json={})
+
+    assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
+    assert conv_store.fork_calls[0]["dropped_label_keys"] == frozenset()
+
+
+@pytest.mark.asyncio
 async def test_fork_switch_404_session_scoped_target() -> None:
     """Switching to a session-scoped agent is rejected with 404.
 

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -138,6 +138,7 @@ class _ConversationStore:
         override_terminal_launch_args: list[str] | None = None,
         override_terminal_launch_args_set: bool = False,
         dropped_label_keys: frozenset[str] = frozenset(),
+        extra_labels: dict[str, str] | None = None,
         carry_history_into_native: bool = False,
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
@@ -198,6 +199,7 @@ class _ConversationStore:
                 "override_terminal_launch_args": override_terminal_launch_args,
                 "override_terminal_launch_args_set": override_terminal_launch_args_set,
                 "dropped_label_keys": dropped_label_keys,
+                "extra_labels": extra_labels,
                 "carry_history_into_native": carry_history_into_native,
                 "resume_source_native_session": resume_source_native_session,
                 "presentation_labels": presentation_labels,
@@ -923,6 +925,88 @@ async def test_fork_same_agent_keeps_permission_mode_label() -> None:
 
     assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
     assert conv_store.fork_calls[0]["dropped_label_keys"] == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_fork_codex_bypass_stamps_label_on_codex_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bypass opt-in stamps the codex label via ``extra_labels``.
+
+    The source's own bypass label is always dropped (instance-scoped), so this
+    explicit, banner-gated request field is the ONLY path that arms bypass on a
+    fork — and the store applies ``extra_labels`` AFTER the drop, so the opt-in
+    wins. Gated on the target actually being codex-native.
+    """
+    conv = _make_conversation()
+    conv_store = _ConversationStore(
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv},
+        items_by_conv={
+            "e9f8f58523cec9a57d3bdf93be543e8c": [
+                _make_item("9980c8a9248139f14f4165e5d53088aa", "Hi")
+            ]
+        },
+    )
+    # The codex target (44b4…) must report codex-native so the route stamps.
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.get_agent_cache",
+        lambda: _StubAgentCache(
+            {
+                "087b7cb7ac30abf4debfaa578d052ec6": "claude_sdk",
+                "44b4151dd6cdfed6ee19430832398e05": "codex-native",
+            }
+        ),
+    )
+    client = TestClient(_build_app(conv_store, agent_store=_switch_agent_store()))
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"agent_id": "44b4151dd6cdfed6ee19430832398e05", "codex_bypass_sandbox": True},
+    )
+
+    assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
+    extra = conv_store.fork_calls[0]["extra_labels"]
+    assert extra == {"omnigent.codex_native.bypass_sandbox": "1"}, (
+        f"bypass opt-in must stamp the codex bypass label, got {extra!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fork_codex_bypass_rejected_on_non_codex_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Arming bypass for a non-codex target is a 400 (the label is inert there).
+
+    Refusing rather than silently ignoring keeps the dangerous flag from being
+    set on a fork it can't apply to — the request is a client bug.
+    """
+    conv = _make_conversation()
+    conv_store = _ConversationStore(
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv},
+        items_by_conv={
+            "e9f8f58523cec9a57d3bdf93be543e8c": [
+                _make_item("9980c8a9248139f14f4165e5d53088aa", "Hi")
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.get_agent_cache",
+        lambda: _StubAgentCache(
+            {
+                "087b7cb7ac30abf4debfaa578d052ec6": "claude_sdk",
+                "280d725b404d2915f9e9d6cccce91303": "claude-native",
+            }
+        ),
+    )
+    client = TestClient(_build_app(conv_store, agent_store=_switch_agent_store()))
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"agent_id": "280d725b404d2915f9e9d6cccce91303", "codex_bypass_sandbox": True},
+    )
+
+    assert resp.status_code == 400, f"got {resp.status_code}: {resp.text}"
+    assert conv_store.fork_calls == [], "no fork should happen on an invalid bypass opt-in"
 
 
 @pytest.mark.asyncio

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -131,6 +131,13 @@ class _ConversationStore:
         cloned_agent_description: str | None = None,
         copy_model_settings: bool = True,
         copy_terminal_launch_args: bool = True,
+        override_model_override: str | None = None,
+        override_model_override_set: bool = False,
+        override_reasoning_effort: str | None = None,
+        override_reasoning_effort_set: bool = False,
+        override_terminal_launch_args: list[str] | None = None,
+        override_terminal_launch_args_set: bool = False,
+        dropped_label_keys: frozenset[str] = frozenset(),
         carry_history_into_native: bool = False,
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
@@ -184,6 +191,13 @@ class _ConversationStore:
                 "cloned_agent_description": cloned_agent_description,
                 "copy_model_settings": copy_model_settings,
                 "copy_terminal_launch_args": copy_terminal_launch_args,
+                "override_model_override": override_model_override,
+                "override_model_override_set": override_model_override_set,
+                "override_reasoning_effort": override_reasoning_effort,
+                "override_reasoning_effort_set": override_reasoning_effort_set,
+                "override_terminal_launch_args": override_terminal_launch_args,
+                "override_terminal_launch_args_set": override_terminal_launch_args_set,
+                "dropped_label_keys": dropped_label_keys,
                 "carry_history_into_native": carry_history_into_native,
                 "resume_source_native_session": resume_source_native_session,
                 "presentation_labels": presentation_labels,
@@ -449,6 +463,98 @@ async def test_fork_session_happy_path() -> None:
     assert fork_call["agent_id"] == body["agent_id"], (
         "Fork must bind the same cloned agent id it asked the store to create"
     )
+
+
+@pytest.mark.asyncio
+async def test_fork_session_run_config_overrides_pass_through() -> None:
+    """The dialog's model / effort / launch-args picks reach the store as
+    explicit overrides with their set-flags on.
+
+    Omitting these fields must leave the store on the inherit path
+    (``override_*_set=False``), so the flags gate on the request having sent
+    each field — a regression here would either drop a user's pick or clobber
+    an inherited value the user never touched.
+    """
+    conv = _make_conversation()
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    client = TestClient(_build_app(conv_store))
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={
+            "model_override": "opus",
+            "reasoning_effort": "high",
+            "terminal_launch_args": ["--permission-mode", "auto"],
+        },
+    )
+
+    assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
+    fork_call = conv_store.fork_calls[0]
+    assert fork_call["override_model_override_set"] is True
+    assert fork_call["override_model_override"] == "opus"
+    assert fork_call["override_reasoning_effort_set"] is True
+    assert fork_call["override_reasoning_effort"] == "high"
+    assert fork_call["override_terminal_launch_args_set"] is True
+    assert fork_call["override_terminal_launch_args"] == ["--permission-mode", "auto"]
+    # Explicit launch args ⇒ drop the source's copied mode labels so a stale
+    # permission-mode label can't shadow the freshly chosen mode.
+    assert "omnigent.claude_native.permission_mode" in fork_call["dropped_label_keys"]
+
+
+@pytest.mark.asyncio
+async def test_fork_session_run_config_omitted_inherits() -> None:
+    """A fork with no run-config fields leaves every override unset, so the
+    store keeps today's inherit behavior (and drops no mode labels)."""
+    conv = _make_conversation()
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    client = TestClient(_build_app(conv_store))
+
+    resp = client.post("/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork", json={})
+
+    assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
+    fork_call = conv_store.fork_calls[0]
+    assert fork_call["override_model_override_set"] is False
+    assert fork_call["override_reasoning_effort_set"] is False
+    assert fork_call["override_terminal_launch_args_set"] is False
+    assert fork_call["dropped_label_keys"] == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_fork_session_run_config_clear_aliases() -> None:
+    """A "default" model/effort (the picker's Default row) reaches the store as
+    a cleared override — set-flag on, value None — resetting the fork to the
+    bound agent's default rather than inheriting the source's."""
+    conv = _make_conversation()
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    client = TestClient(_build_app(conv_store))
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"model_override": "default", "reasoning_effort": "default"},
+    )
+
+    assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
+    fork_call = conv_store.fork_calls[0]
+    assert fork_call["override_model_override_set"] is True
+    assert fork_call["override_model_override"] is None
+    assert fork_call["override_reasoning_effort_set"] is True
+    assert fork_call["override_reasoning_effort"] is None
+
+
+@pytest.mark.asyncio
+async def test_fork_session_400_invalid_model_override() -> None:
+    """A shell-/flag-shaped model id is rejected before any fork happens."""
+    conv = _make_conversation()
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    client = TestClient(_build_app(conv_store))
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"model_override": "--rm -rf"},
+    )
+
+    assert resp.status_code == 400, f"got {resp.status_code}: {resp.text}"
+    assert conv_store.fork_calls == [], "No fork should happen on a bad model override"
 
 
 @pytest.mark.asyncio

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -3860,6 +3860,40 @@ def test_fork_conversation_drops_instance_scoped_labels(
     )
 
 
+def test_fork_extra_labels_rearm_bypass_over_the_always_drop(
+    conversation_store: SqlAlchemyConversationStore,
+    agent_store: SqlAlchemyAgentStore,
+) -> None:
+    """``extra_labels`` stamps AFTER the drop, so a deliberate opt-in wins.
+
+    The source's own bypass label is always dropped (instance-scoped), so a
+    bypass-armed source can't silently re-arm its clone. But when the fork
+    dialog explicitly re-arms bypass, the route passes it via ``extra_labels``,
+    which the store applies last — the fork ends up armed even though the
+    source's identical label was dropped on the same fork.
+    """
+    agent_store.create(
+        agent_id="c1a2b3c4d5e6f7081920314253647586",
+        name="fork-bypass",
+        bundle_location="c1a2b3c4d5e6f7081920314253647586/fakehash",
+    )
+    source = conversation_store.create_conversation(agent_id="c1a2b3c4d5e6f7081920314253647586")
+    conversation_store.set_labels(source.id, {"omnigent.codex_native.bypass_sandbox": "1"})
+
+    # Same-agent fork WITHOUT the opt-in: the source's label is dropped.
+    plain = conversation_store.fork_conversation(source.id)
+    assert "omnigent.codex_native.bypass_sandbox" not in plain.labels
+
+    # WITH the opt-in via extra_labels: armed on the fork despite the drop.
+    armed = conversation_store.fork_conversation(
+        source.id,
+        extra_labels={"omnigent.codex_native.bypass_sandbox": "1"},
+    )
+    assert armed.labels.get("omnigent.codex_native.bypass_sandbox") == "1", (
+        f"extra_labels must re-arm bypass over the always-drop, got {armed.labels!r}"
+    )
+
+
 def test_fork_conversation_stamps_source_external_session_id(
     conversation_store: SqlAlchemyConversationStore,
     agent_store: SqlAlchemyAgentStore,

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -3610,6 +3610,72 @@ def test_fork_copies_terminal_launch_args_by_default(
     assert fetched.terminal_launch_args == ["--permission-mode", "auto"]
 
 
+def test_fork_override_terminal_launch_args_supersedes_copy(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """An explicit launch-args override replaces the copied source args.
+
+    The fork dialog's permission-mode picker sends its own
+    ``terminal_launch_args``; the override must win over the same-agent copy,
+    and an empty list must clear the source's flags entirely.
+    """
+    source = conversation_store.create_conversation(
+        terminal_launch_args=["--permission-mode", "auto"],
+    )
+    picked = conversation_store.fork_conversation(
+        source.id,
+        override_terminal_launch_args=["--permission-mode", "plan"],
+        override_terminal_launch_args_set=True,
+    )
+    fetched = conversation_store.get_conversation(picked.id)
+    assert fetched is not None
+    assert fetched.terminal_launch_args == ["--permission-mode", "plan"]
+
+    cleared = conversation_store.fork_conversation(
+        source.id,
+        override_terminal_launch_args=[],
+        override_terminal_launch_args_set=True,
+    )
+    fetched_cleared = conversation_store.get_conversation(cleared.id)
+    assert fetched_cleared is not None
+    assert fetched_cleared.terminal_launch_args == []
+
+
+def test_fork_override_model_and_effort_supersede_inherit(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """An explicit model/effort override wins over the source's copied values,
+    and a cleared override (set-flag on, value None) resets to the agent
+    default even on a same-agent fork that would otherwise copy them."""
+    source = conversation_store.create_conversation()
+    conversation_store.update_conversation(
+        source.id, model_override="sonnet", reasoning_effort="low"
+    )
+
+    overridden = conversation_store.fork_conversation(
+        source.id,
+        override_model_override="opus",
+        override_model_override_set=True,
+        override_reasoning_effort="high",
+        override_reasoning_effort_set=True,
+    )
+    fetched = conversation_store.get_conversation(overridden.id)
+    assert fetched is not None
+    assert fetched.model_override == "opus"
+    assert fetched.reasoning_effort == "high"
+
+    cleared = conversation_store.fork_conversation(
+        source.id,
+        override_model_override=None,
+        override_model_override_set=True,
+    )
+    fetched_cleared = conversation_store.get_conversation(cleared.id)
+    assert fetched_cleared is not None
+    assert fetched_cleared.model_override is None
+    # Effort NOT overridden ⇒ same-agent fork still copies the source's value.
+    assert fetched_cleared.reasoning_effort == "low"
+
+
 def test_fork_drops_terminal_launch_args_when_switching_agent(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:

--- a/web/src/lib/nativeHarnessModes.ts
+++ b/web/src/lib/nativeHarnessModes.ts
@@ -1,0 +1,135 @@
+// Native-harness permission / approval / execution mode tables, shared by the
+// new-session dialog and the fork dialog so the option lists, CLI-flag
+// mappings, and default values can't drift between the two surfaces.
+//
+// Each entry's `args` are the `terminal_launch_args` the runner passes to the
+// native CLI; a mode whose `args` are empty sends no flags (the CLI keeps its
+// own configured default). Keep in sync with each CLI's `--help`.
+
+import { CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE } from "@/lib/claudePermissionMode";
+
+/** One selectable mode: value + label + blurb + the CLI flags it maps to. */
+export interface NativeHarnessMode {
+  value: string;
+  label: string;
+  description: string;
+  args: string[];
+}
+
+// Antigravity (agy) permission control. agy exposes exactly ONE pre-emptive
+// knob — `--dangerously-skip-permissions`, an all-or-nothing bypass — with no
+// per-tool equivalent of acceptEdits/plan, so this is a two-value toggle rather
+// than Claude's graded selector. "default" sends no flags and leaves agy's own
+// request-review prompt in place. Keep in sync with `agy --help`.
+export const AGY_NATIVE_DEFAULT_SKIP_MODE = "default";
+export const AGY_NATIVE_SKIP_VALUE = "skip";
+export const AGY_NATIVE_SKIP_MODES: NativeHarnessMode[] = [
+  {
+    value: AGY_NATIVE_DEFAULT_SKIP_MODE,
+    label: "Ask every time",
+    description: "Prompts before each tool runs",
+    args: [],
+  },
+  {
+    value: AGY_NATIVE_SKIP_VALUE,
+    label: "Skip permissions",
+    description: "Runs everything; no prompts or safety checks",
+    args: ["--dangerously-skip-permissions"],
+  },
+];
+
+// The Auto Harness's Permissions vocabulary: Default only. No cross-harness
+// permission mapping exists, so the row stays locked and the create call sends
+// no override — each CLI keeps the machine's own configuration.
+export const AUTO_PERMISSION_MODE = {
+  value: CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE,
+  label: "Default",
+  description: "The picked harness keeps its own configured permissions",
+} as const;
+export const AUTO_PERMISSION_MODE_OPTIONS = [AUTO_PERMISSION_MODE] as const;
+
+// Cursor execution modes. "default" sends no flags; other values map to CLI
+// args passed via terminal_launch_args. Keep in sync with `cursor-agent --help`.
+export const CURSOR_NATIVE_DEFAULT_EXEC_MODE = "default";
+export const CURSOR_NATIVE_EXEC_MODES: NativeHarnessMode[] = [
+  {
+    value: "default",
+    label: "Default",
+    description: "Normal agent mode; prompts before running commands",
+    args: [],
+  },
+  {
+    value: "auto-review",
+    label: "Auto-review",
+    description: "Smart Auto: auto-runs safe tool calls and prompts for the rest",
+    args: ["--auto-review"],
+  },
+  {
+    value: "plan",
+    label: "Plan",
+    description: "Read-only planning; analyzes and proposes plans, no edits",
+    args: ["--mode", "plan"],
+  },
+  {
+    value: "ask",
+    label: "Ask",
+    description: "Q&A style; explains and answers questions (read-only)",
+    args: ["--mode", "ask"],
+  },
+  {
+    value: "yolo",
+    label: "Yolo",
+    description: "Runs everything without prompts or safety checks",
+    args: ["--yolo"],
+  },
+];
+
+// Codex approval presets matching the `/permissions` TUI popup.
+// Each preset bundles a sandbox profile + approval policy, mirroring
+// codex-rs/utils/approval-presets/src/lib.rs. "default" is the auto
+// preset (workspace-write + on-request) and sends no flags so the
+// runner uses Codex's built-in default.
+// Keep in sync with `codex --help` and
+// https://developers.openai.com/codex/agent-approvals-security
+export const CODEX_NATIVE_DEFAULT_APPROVAL_MODE = "default";
+export const CODEX_NATIVE_APPROVAL_MODES: NativeHarnessMode[] = [
+  {
+    value: "default",
+    label: "Default",
+    description: "Read/edit/run in workspace; approval for external edits or network",
+    args: [],
+  },
+  {
+    value: "full-access",
+    label: "Full access",
+    description: "Edit any file and access the internet without approval",
+    args: ["--sandbox", "danger-full-access", "--ask-for-approval", "never"],
+  },
+  {
+    value: "read-only",
+    label: "Read only",
+    description: "Read files only; approval required for edits, commands, or network",
+    args: ["--sandbox", "read-only", "--ask-for-approval", "on-request"],
+  },
+];
+
+// Conversation-label key for the DANGEROUS codex full-bypass opt-in. When
+// set to "1" the runner launches Codex with
+// `--dangerously-bypass-approvals-and-sandbox` (no approval prompts, no
+// command sandbox) — see omnigent.stores.conversation_store
+// CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY. Stored as a label (cheap thread
+// metadata) so it survives reload. Mutually exclusive in spirit with the
+// approval-mode presets above: when bypass is on the runner strips any
+// `--sandbox` / `--ask-for-approval` flags those presets would emit.
+export const CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY = "omnigent.codex_native.bypass_sandbox";
+// Bypass is the most-permissive Codex approval stance — presented as a 4th
+// option in the Codex approval dropdown (Codex only; OpenCode shares the
+// presets above but has no bypass). It rides as a conversation label, not
+// terminal_launch_args, so its `args` are empty and it's handled specially.
+export const CODEX_NATIVE_BYPASS_APPROVAL_VALUE = "bypass";
+export const CODEX_NATIVE_BYPASS_APPROVAL_OPTION: NativeHarnessMode = {
+  value: CODEX_NATIVE_BYPASS_APPROVAL_VALUE,
+  label: "Bypass approvals & sandbox",
+  description: "Runs Codex with no approval prompts and no command sandbox",
+  args: [],
+};

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -306,6 +306,47 @@ describe("forkSession", () => {
     expect(JSON.parse(init.body as string)).toEqual({ title: "My clone" });
   });
 
+  it("forwards run-config overrides (model / effort / launch args)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        id: "conv_fork",
+        agent_id: "agent_clone",
+        status: "idle",
+        created_at: 1704067200,
+      }),
+    );
+
+    await forkSession("conv_src", undefined, undefined, undefined, {
+      modelOverride: "opus",
+      reasoningEffort: "high",
+      terminalLaunchArgs: ["--permission-mode", "auto"],
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      model_override: "opus",
+      reasoning_effort: "high",
+      terminal_launch_args: ["--permission-mode", "auto"],
+    });
+  });
+
+  it("omits run-config fields left undefined so the fork inherits them", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        id: "conv_fork",
+        agent_id: "agent_clone",
+        status: "idle",
+        created_at: 1704067200,
+      }),
+    );
+
+    // An empty config object (non-native target) sends no run overrides.
+    await forkSession("conv_src", undefined, undefined, undefined, {});
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({});
+  });
+
   it("surfaces a non-ok response as a thrown error (e.g. 403 no access)", async () => {
     fetchMock.mockResolvedValueOnce(mockJsonResponse({}, { ok: false, status: 403 }));
     await expect(forkSession("conv_src")).rejects.toThrow(/403/);

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -614,6 +614,8 @@ export async function createBundledSession(
  *   same provider family), while a sent field overrides it. The
  *   permission-/approval-mode selector rides `terminalLaunchArgs` (e.g.
  *   `["--permission-mode", "auto"]`); `[]` clears the source's launch args.
+ *   `codexBypassSandbox: true` (Codex only) arms the dangerous full-bypass on
+ *   the fork — sent only on an explicit, banner-gated pick.
  */
 export async function forkSession(
   sourceId: string,
@@ -624,6 +626,7 @@ export async function forkSession(
     modelOverride?: string;
     reasoningEffort?: string;
     terminalLaunchArgs?: string[];
+    codexBypassSandbox?: boolean;
   },
 ): Promise<Session> {
   const body: {
@@ -633,6 +636,7 @@ export async function forkSession(
     model_override?: string;
     reasoning_effort?: string;
     terminal_launch_args?: string[];
+    codex_bypass_sandbox?: boolean;
   } = {};
   if (title !== undefined) {
     body.title = title;
@@ -651,6 +655,11 @@ export async function forkSession(
   }
   if (config?.terminalLaunchArgs !== undefined) {
     body.terminal_launch_args = config.terminalLaunchArgs;
+  }
+  // Only send the dangerous bypass opt-in when explicitly true; omitting it
+  // otherwise keeps the request minimal and the server default (no bypass).
+  if (config?.codexBypassSandbox) {
+    body.codex_bypass_sandbox = true;
   }
   const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(sourceId)}/fork`, {
     method: "POST",

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -608,14 +608,32 @@ export async function createBundledSession(
  * @param upToResponseId - Optional truncation point, e.g. "resp_abc". When
  *   set, the fork copies history only up to and including that response
  *   ("fork from here"); omitted, the full history is copied.
+ * @param config - Optional run-config overrides from the fork dialog's
+ *   model / effort / permission-mode pickers. Each field is opt-in: a field
+ *   left `undefined` inherits the source (model settings carry within the
+ *   same provider family), while a sent field overrides it. The
+ *   permission-/approval-mode selector rides `terminalLaunchArgs` (e.g.
+ *   `["--permission-mode", "auto"]`); `[]` clears the source's launch args.
  */
 export async function forkSession(
   sourceId: string,
   title?: string,
   agentId?: string,
   upToResponseId?: string,
+  config?: {
+    modelOverride?: string;
+    reasoningEffort?: string;
+    terminalLaunchArgs?: string[];
+  },
 ): Promise<Session> {
-  const body: { title?: string; agent_id?: string; up_to_response_id?: string } = {};
+  const body: {
+    title?: string;
+    agent_id?: string;
+    up_to_response_id?: string;
+    model_override?: string;
+    reasoning_effort?: string;
+    terminal_launch_args?: string[];
+  } = {};
   if (title !== undefined) {
     body.title = title;
   }
@@ -624,6 +642,15 @@ export async function forkSession(
   }
   if (upToResponseId !== undefined) {
     body.up_to_response_id = upToResponseId;
+  }
+  if (config?.modelOverride !== undefined) {
+    body.model_override = config.modelOverride;
+  }
+  if (config?.reasoningEffort !== undefined) {
+    body.reasoning_effort = config.reasoningEffort;
+  }
+  if (config?.terminalLaunchArgs !== undefined) {
+    body.terminal_launch_args = config.terminalLaunchArgs;
   }
   const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(sourceId)}/fork`, {
     method: "POST",

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -540,19 +540,44 @@ describe("ForkSessionDialog", () => {
     // Switching to a same-family native target forwards agent_id so the
     // server clones that agent and marks the fork for native rebuild. The
     // name was left blank (optional) → undefined so the server derives it.
-    // Switching to a native target reveals the run-config section; untouched,
-    // it reports the target harness's defaults — Default model/effort (clear
-    // alias "default") and the default permission mode (empty launch args).
+    // Switching reveals the run-config section, but no control was touched, so
+    // it emits `{}` — the server inherits/resets per its own family rule
+    // rather than the dialog racing the async model catalog and sending an
+    // explicit "default" that would clear the source's model.
     expect(forkSessionMock).toHaveBeenCalledWith(
       "conv_src",
       undefined,
       "ag_claude_native",
       undefined,
-      {
-        modelOverride: "default",
-        reasoningEffort: "default",
-        terminalLaunchArgs: [],
-      },
+      {},
+    );
+  });
+
+  it("emits only the run-config fields the user actually changed", async () => {
+    forkSessionMock.mockResolvedValue({
+      id: "conv_fork",
+    } as unknown as Awaited<ReturnType<typeof forkSession>>);
+    renderDialog();
+
+    // Switch to claude-native so the run-config section renders.
+    openAgentSelect();
+    fireEvent.click(screen.getByTestId("fork-session-agent-option-ag_claude_native"));
+
+    // Touch ONLY the permission control (pick "Plan"); leave model + effort
+    // untouched. The fork must carry the permission launch args and NOTHING
+    // for model/effort — so the server inherits those instead of the dialog
+    // sending a catalog-racing "default" that clears them.
+    fireEvent.click(screen.getByTestId("fork-session-config-permission"));
+    fireEvent.click(screen.getByRole("option", { name: "Plan" }));
+    fireEvent.click(screen.getByTestId("fork-session-submit"));
+
+    await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
+    expect(forkSessionMock).toHaveBeenCalledWith(
+      "conv_src",
+      undefined,
+      "ag_claude_native",
+      undefined,
+      { terminalLaunchArgs: ["--permission-mode", "plan"] },
     );
   });
 

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -581,6 +581,38 @@ describe("ForkSessionDialog", () => {
     );
   });
 
+  it("arms Codex bypass only on an explicit pick, with a danger banner", async () => {
+    forkSessionMock.mockResolvedValue({
+      id: "conv_fork",
+    } as unknown as Awaited<ReturnType<typeof forkSession>>);
+    renderDialog();
+
+    // Switch to codex-native so the Approval row (with the 4th bypass option)
+    // renders. No banner until the dangerous option is actually chosen.
+    openAgentSelect();
+    fireEvent.click(screen.getByTestId("fork-session-agent-option-ag_codex_native"));
+    expect(screen.queryByTestId("fork-session-codex-bypass-banner")).not.toBeInTheDocument();
+
+    // Pick "Bypass approvals & sandbox" → danger banner appears and the fork
+    // carries the dedicated opt-in (as a label server-side), NOT launch args.
+    fireEvent.click(screen.getByTestId("fork-session-config-approval"));
+    fireEvent.click(screen.getByRole("option", { name: "Bypass approvals & sandbox" }));
+    expect(screen.getByTestId("fork-session-codex-bypass-banner")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("fork-session-submit"));
+
+    await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
+    expect(forkSessionMock).toHaveBeenCalledWith(
+      "conv_src",
+      undefined,
+      "ag_codex_native",
+      undefined,
+      {
+        terminalLaunchArgs: [],
+        codexBypassSandbox: true,
+      },
+    );
+  });
+
   it("labels the keep-current option with the source agent's name, not generic text", () => {
     // The source is bound to the claude-sdk built-in ("Claude"). The
     // keep-current option reads "<agent> (same as original session)" so the

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -15,7 +15,8 @@ import {
   type AvailableAgent,
 } from "@/hooks/useAvailableAgents";
 import { useSessionAgent } from "@/hooks/useAgents";
-import { useHosts, type Host } from "@/hooks/useHosts";
+import { useSession } from "@/hooks/useSession";
+import { useHosts, useHostModelOptions, type Host } from "@/hooks/useHosts";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import { checkHostDirectory, useHostFilesystem } from "@/hooks/useHostFilesystem";
@@ -31,7 +32,8 @@ vi.mock("@/hooks/useAvailableAgents", () => ({
   prefetchAvailableAgentDetails: vi.fn(),
 }));
 vi.mock("@/hooks/useAgents", () => ({ useSessionAgent: vi.fn() }));
-vi.mock("@/hooks/useHosts", () => ({ useHosts: vi.fn() }));
+vi.mock("@/hooks/useSession", () => ({ useSession: vi.fn() }));
+vi.mock("@/hooks/useHosts", () => ({ useHosts: vi.fn(), useHostModelOptions: vi.fn() }));
 vi.mock("@/hooks/useDirectorySessions", () => ({ useDirectorySessions: vi.fn() }));
 vi.mock("@/hooks/RunnerHealthProvider", () => ({ useRunnerHealthRegistration: vi.fn() }));
 vi.mock("@/hooks/useHostFilesystem", () => ({
@@ -55,6 +57,8 @@ const launchRunnerMock = vi.mocked(launchRunner);
 const useAvailableAgentsMock = vi.mocked(useAvailableAgents);
 const useSessionAgentMock = vi.mocked(useSessionAgent);
 const useHostsMock = vi.mocked(useHosts);
+const useHostModelOptionsMock = vi.mocked(useHostModelOptions);
+const useSessionMock = vi.mocked(useSession);
 const useDirectorySessionsMock = vi.mocked(useDirectorySessions);
 const useRunnerHealthMock = vi.mocked(useRunnerHealthRegistration);
 const useHostFilesystemMock = vi.mocked(useHostFilesystem);
@@ -176,6 +180,20 @@ beforeEach(() => {
   checkHostDirectoryMock.mockResolvedValue(null);
   prefetchAvailableAgentDetailsMock.mockReset();
   setAgents(AVAILABLE_AGENTS, "claude-sdk");
+  // The run-config section reads the source snapshot (to seed a same-harness
+  // fork) and, for a native target, the host model catalog. Default both to
+  // empty so the section renders nothing for the SDK source these tests use
+  // and stays inert until a test opts into a native switch.
+  useSessionMock.mockReturnValue({
+    session: null,
+    isLoading: false,
+    error: null,
+  } as unknown as ReturnType<typeof useSession>);
+  useHostModelOptionsMock.mockReturnValue({
+    data: [],
+    isLoading: false,
+    error: null,
+  } as unknown as ReturnType<typeof useHostModelOptions>);
   // Defaults for the coding-fork wiring; the non-coding tests don't render
   // these fields but the hooks still run (with isCodingSource false).
   setHosts([host()]);
@@ -226,7 +244,9 @@ describe("ForkSessionDialog", () => {
     await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
     // No agent switch → agent_id omitted (undefined) so the server keeps
     // the source's agent.
-    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", "My clone", undefined, undefined);
+    // A non-native (SDK) source with no agent switch renders no run-config
+    // section, so the config arg is an empty object (no run overrides sent).
+    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", "My clone", undefined, undefined, {});
     // Session list refreshed so the fork shows in the sidebar, then navigated.
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
     // A fork inherits the source's project, so the project-folder lists must
@@ -273,7 +293,7 @@ describe("ForkSessionDialog", () => {
     await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
     // The 4th arg is the truncation point — undefined here would mean the
     // dialog dropped it and the fork silently copied the full history.
-    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", undefined, undefined, "resp_cut");
+    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", undefined, undefined, "resp_cut", {});
   });
 
   it("omits the title (server derives it) when the field is cleared", async () => {
@@ -290,7 +310,7 @@ describe("ForkSessionDialog", () => {
 
     await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
     // Whitespace-only → undefined so the server applies "Fork of <title>".
-    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", undefined, undefined, undefined);
+    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", undefined, undefined, undefined, {});
   });
 
   it("pressing Enter in the title input submits the fork", async () => {
@@ -520,11 +540,19 @@ describe("ForkSessionDialog", () => {
     // Switching to a same-family native target forwards agent_id so the
     // server clones that agent and marks the fork for native rebuild. The
     // name was left blank (optional) → undefined so the server derives it.
+    // Switching to a native target reveals the run-config section; untouched,
+    // it reports the target harness's defaults — Default model/effort (clear
+    // alias "default") and the default permission mode (empty launch args).
     expect(forkSessionMock).toHaveBeenCalledWith(
       "conv_src",
       undefined,
       "ag_claude_native",
       undefined,
+      {
+        modelOverride: "default",
+        reasoningEffort: "default",
+        terminalLaunchArgs: [],
+      },
     );
   });
 
@@ -630,7 +658,8 @@ describe("ForkSessionDialog", () => {
 
       await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
       // Name left blank (optional) → undefined so the server derives it.
-      expect(forkSessionMock).toHaveBeenCalledWith("conv_src", undefined, undefined, undefined);
+      // Coding SDK source, no agent switch → no run-config section, empty config.
+      expect(forkSessionMock).toHaveBeenCalledWith("conv_src", undefined, undefined, undefined, {});
       // Navigation happens even though the launch promise is still pending.
       await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_fork"));
       // The launch was kicked off (in the background) on the prefilled host/dir.

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -52,6 +52,8 @@ import {
   AGY_NATIVE_SKIP_MODES,
   AGY_NATIVE_SKIP_VALUE,
   CODEX_NATIVE_APPROVAL_MODES,
+  CODEX_NATIVE_BYPASS_APPROVAL_OPTION,
+  CODEX_NATIVE_BYPASS_APPROVAL_VALUE,
   CODEX_NATIVE_DEFAULT_APPROVAL_MODE,
   CURSOR_NATIVE_DEFAULT_EXEC_MODE,
   CURSOR_NATIVE_EXEC_MODES,
@@ -70,7 +72,7 @@ import {
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
-import { agentRootName, forkTargetCarriesHistory } from "@/lib/forkHarness";
+import { agentRootName, forkTargetCarriesHistory, harnessFamily } from "@/lib/forkHarness";
 import { checkHostDirectory } from "@/hooks/useHostFilesystem";
 import { getCliServerUrl } from "@/lib/host";
 import { WorkspacePicker, isNavigablePath } from "./WorkspacePicker";
@@ -154,6 +156,14 @@ export interface ForkRunConfigValue {
   modelOverride?: string;
   reasoningEffort?: string;
   terminalLaunchArgs?: string[];
+  /**
+   * DANGEROUS codex full-bypass opt-in. Only emitted (as `true`) when the
+   * user explicitly picks "Bypass approvals & sandbox" for a codex target;
+   * the fork request carries it as `codex_bypass_sandbox` and the server
+   * stamps the bypass label. Absent otherwise — the source's own bypass is
+   * always dropped, so a fork is never silently armed.
+   */
+  codexBypassSandbox?: boolean;
 }
 
 /**
@@ -162,25 +172,27 @@ export interface ForkRunConfigValue {
  * harness (Claude Code / Codex / Pi / Cursor / Antigravity) — SDK and non-coding
  * targets have no per-session run knobs the fork can express.
  *
- * Seeding follows the source's harness: forking to the SAME harness seeds the
- * pickers from the source session's current model / effort / permission mode
- * (so an untouched fork continues where the original left off); switching to a
- * DIFFERENT harness seeds the target harness's own defaults (an unselected
- * model/effort and the harness's default permission mode), exactly like starting
- * a fresh session on that harness.
+ * Seeding mirrors the two backend carry rules so the displayed value always
+ * matches what the fork will do: model/effort seed from the source when the
+ * target is in the same PROVIDER FAMILY (`sameFamilyAsSource`), and the
+ * permission/approval/mode pickers seed from the source only on a same-AGENT
+ * fork (`sameAgentAsSource`); otherwise each seeds the target's default. See
+ * the parent for how those two flags are derived from the backend's
+ * `copy_model_settings` / `copy_terminal_launch_args` gates.
  *
- * The section is authoritative: whatever the pickers show is sent explicitly on
- * submit (a "Default" model/effort rides the clear alias; the permission /
- * approval / cursor / agy mode rides `terminalLaunchArgs`, `[]` clearing the
- * source's launch flags). An untouched same-harness fork therefore re-sends the
- * source's values, which yields the identical result as inheriting them.
+ * Emission is opt-in per control: a field is sent ONLY when the user actually
+ * changed that control (see `touched`). An untouched control omits its field,
+ * so the fork request carries nothing for it and the server's own
+ * inherit / reset-by-family path decides — which is exactly the seeded meaning.
+ * This is what keeps the section honest against the async model catalog: a
+ * submit before the catalog resolves can't emit a spurious `model_override`.
  *
  * @param targetHarness - Effective target harness key (e.g. "claude-native"),
  *   or null for a non-native target (the section renders nothing).
  * @param targetAgent - The `{ name, harness }` the fork will bind, for
  *   capability detection.
  * @param sourceSession - Source session, read to seed the pickers.
- * @param sameHarnessAsSource - Whether the fork keeps the source's harness
+ * @param sameFamilyAsSource - Whether the fork keeps the source's harness
  *   family; seeds model + effort (which the backend carries within a family).
  * @param sameAgentAsSource - Whether the fork keeps the source's exact agent;
  *   seeds the launch-arg pickers (permission / approval / mode), which the
@@ -193,7 +205,7 @@ function ForkRunConfig({
   targetHarness,
   targetAgent,
   sourceSession,
-  sameHarnessAsSource,
+  sameFamilyAsSource,
   sameAgentAsSource,
   selectedHostId,
   onChange,
@@ -201,7 +213,7 @@ function ForkRunConfig({
   targetHarness: string | null;
   targetAgent: Pick<AvailableAgent, "name" | "harness">;
   sourceSession: Session | null;
-  sameHarnessAsSource: boolean;
+  sameFamilyAsSource: boolean;
   sameAgentAsSource: boolean;
   selectedHostId: string | null;
   onChange: (value: ForkRunConfigValue) => void;
@@ -246,18 +258,18 @@ function ForkRunConfig({
     // Seed the source's model only once the catalog confirms it: a model id
     // absent from the loaded options has no Select item to land on and would
     // blank the trigger. Until the catalog resolves, Default holds.
-    const picked = sameHarnessAsSource ? sourceSession?.modelOverride : null;
+    const picked = sameFamilyAsSource ? sourceSession?.modelOverride : null;
     return picked && modelOptions.some((m) => m.id === picked) ? picked : MODEL_SELECT_DEFAULT;
-  }, [sameHarnessAsSource, sourceSession, modelOptions]);
+  }, [sameFamilyAsSource, sourceSession, modelOptions]);
   const seededEffort = useMemo(() => {
     // Seed only an effort the picker can display; a source value outside the
     // offered vocabulary (e.g. "minimal") falls back to Default rather than
     // leaving the Select on an empty, unselectable value.
-    const effort = sameHarnessAsSource ? sourceSession?.reasoningEffort : null;
+    const effort = sameFamilyAsSource ? sourceSession?.reasoningEffort : null;
     return effort && CLAUDE_NATIVE_EFFORTS.some((e) => e.value === effort)
       ? effort
       : EFFORT_SELECT_NONE;
-  }, [sameHarnessAsSource, sourceSession]);
+  }, [sameFamilyAsSource, sourceSession]);
   const seededPermission = useMemo(() => {
     // Permission mode rides terminal_launch_args, which the backend copies
     // ONLY on a same-AGENT fork (copy_terminal_launch_args = not switching).
@@ -286,13 +298,24 @@ function ForkRunConfig({
       : hasCursor
         ? CURSOR_NATIVE_DEFAULT_EXEC_MODE
         : AGY_NATIVE_DEFAULT_SKIP_MODE;
+    // Codex bypass rides a LABEL, not launch args, so match it first: a
+    // same-agent fork of a bypass-armed codex source seeds the bypass option.
+    // (The source label is still dropped server-side; re-selecting here is the
+    // explicit opt-in that re-arms it — never automatic.)
+    if (
+      isCodex &&
+      sameAgentAsSource &&
+      sourceSession?.labels?.["omnigent.codex_native.bypass_sandbox"] === "1"
+    ) {
+      return CODEX_NATIVE_BYPASS_APPROVAL_VALUE;
+    }
     // Match the source's launch args against the mode table (longest args first
     // so "--mode plan" isn't shadowed by an empty-args default).
     const match = [...table]
       .sort((a, b) => b.args.length - a.args.length)
       .find((m) => m.args.length > 0 && m.args.every((arg) => source.includes(arg)));
     return match?.value ?? dflt;
-  }, [sameAgentAsSource, sourceSession, hasApproval, hasCursor, hasAgySkip]);
+  }, [isCodex, sameAgentAsSource, sourceSession, hasApproval, hasCursor, hasAgySkip]);
 
   const [model, setModel] = useState(seededModel);
   const [effort, setEffort] = useState(seededEffort);
@@ -369,8 +392,15 @@ function ForkRunConfig({
             : ["--permission-mode", permission];
       }
     } else if (hasApproval && touched.mode) {
-      value.terminalLaunchArgs =
-        CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === mode)?.args ?? [];
+      if (isCodex && mode === CODEX_NATIVE_BYPASS_APPROVAL_VALUE) {
+        // Bypass is a LABEL, not launch args: clear any preset flags and set
+        // the dedicated opt-in the server turns into the bypass label.
+        value.terminalLaunchArgs = [];
+        value.codexBypassSandbox = true;
+      } else {
+        value.terminalLaunchArgs =
+          CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === mode)?.args ?? [];
+      }
     } else if (hasCursor && touched.mode) {
       value.terminalLaunchArgs = CURSOR_NATIVE_EXEC_MODES.find((m) => m.value === mode)?.args ?? [];
     } else if (hasAgySkip && touched.mode) {
@@ -383,6 +413,7 @@ function ForkRunConfig({
     hasApproval,
     hasCursor,
     hasAgySkip,
+    isCodex,
     model,
     effort,
     permission,
@@ -464,16 +495,39 @@ function ForkRunConfig({
       )}
 
       {hasApproval && (
-        <ConfigRow label="Approval" description="What the agent can do without asking">
-          <DescribedSelect
-            value={mode}
-            onValueChange={changeMode}
-            options={CODEX_NATIVE_APPROVAL_MODES}
-            testId="fork-session-config-approval"
-            ariaLabel="Approval"
-            componentId="fork_session.config.approval"
-          />
-        </ConfigRow>
+        <>
+          <ConfigRow label="Approval" description="What the agent can do without asking">
+            <DescribedSelect
+              value={mode}
+              onValueChange={changeMode}
+              // Codex offers the DANGEROUS full-bypass as a 4th option, exactly
+              // as the new-session dialog does; other approval harnesses list
+              // only the three presets. Selecting it arms bypass on the fork
+              // (a fresh, deliberate opt-in — the source's is always dropped).
+              options={
+                isCodex
+                  ? [...CODEX_NATIVE_APPROVAL_MODES, CODEX_NATIVE_BYPASS_APPROVAL_OPTION]
+                  : CODEX_NATIVE_APPROVAL_MODES
+              }
+              testId="fork-session-config-approval"
+              ariaLabel="Approval"
+              componentId="fork_session.config.approval"
+            />
+          </ConfigRow>
+          {isCodex && mode === CODEX_NATIVE_BYPASS_APPROVAL_VALUE && (
+            <div
+              role="alert"
+              data-testid="fork-session-codex-bypass-banner"
+              className="flex items-start gap-1.5 rounded-md border border-destructive bg-destructive/10 px-2 py-1.5 text-xs font-medium leading-relaxed text-destructive"
+            >
+              <TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0" />
+              <span>
+                Danger: this fork runs Codex with approvals and the command sandbox disabled. It can
+                edit any file and run any command without asking.
+              </span>
+            </div>
+          )}
+        </>
       )}
 
       {hasCursor && (
@@ -755,14 +809,21 @@ export function ForkSessionForm({
     if (!switching) return nativeCodingAgentForSession(sourceSession)?.harness ?? null;
     return null;
   }, [targetAgent, switching, sourceSession]);
-  // Model / effort carry over within the same provider FAMILY (backend
-  // copy_model_settings), so seed those from same-harness. Launch args
-  // (permission / approval / mode) carry over only on a same-AGENT fork
-  // (backend copy_terminal_launch_args = not switching_agent), so those seed
-  // from same-agent — the two rules differ for a same-harness/different-agent
-  // switch, and matching each keeps the displayed value honest.
-  const sourceHarness = nativeCodingAgentForSession(sourceSession)?.harness ?? null;
-  const sameHarnessAsSource = !switching || targetHarness === sourceHarness;
+  // The two backend carry rules the pickers must mirror so the displayed value
+  // matches what the fork actually does:
+  //
+  //  • Model / effort carry over within the same provider FAMILY (backend
+  //    `copy_model_settings = !switching || _same_provider_family`). Keyed on
+  //    provider family, NOT native-harness identity — otherwise a same-family
+  //    switch (e.g. Claude-SDK → Claude Code, whose SDK source has no native
+  //    wrapper) would seed "Default" while the backend silently inherits the
+  //    source's model/effort. Use each side's EFFECTIVE harness
+  //    (`sourceSession.harness`, non-null for SDK sources) → `harnessFamily`.
+  //  • Launch args (permission / approval / mode) carry over only on a
+  //    same-AGENT fork (`copy_terminal_launch_args = not switching_agent`).
+  const sourceFamily = harnessFamily(sourceSession?.harness);
+  const targetFamily = harnessFamily(targetHarness);
+  const sameFamilyAsSource = !switching || (sourceFamily !== null && sourceFamily === targetFamily);
   const sameAgentAsSource = !switching;
 
   // Default the host = source host (when online) else the first online
@@ -1136,7 +1197,7 @@ export function ForkSessionForm({
             targetHarness={targetHarness}
             targetAgent={targetAgent}
             sourceSession={sourceSession}
-            sameHarnessAsSource={sameHarnessAsSource}
+            sameFamilyAsSource={sameFamilyAsSource}
             sameAgentAsSource={sameAgentAsSource}
             selectedHostId={isCodingSource ? selectedHostId : (sourceHostId ?? null)}
             onChange={setRunConfig}

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -179,8 +179,12 @@ export interface ForkRunConfigValue {
  *   or null for a non-native target (the section renders nothing).
  * @param targetAgent - The `{ name, harness }` the fork will bind, for
  *   capability detection.
- * @param sourceSession - Source session, read to seed a same-harness fork.
- * @param sameHarnessAsSource - Whether the fork keeps the source's harness.
+ * @param sourceSession - Source session, read to seed the pickers.
+ * @param sameHarnessAsSource - Whether the fork keeps the source's harness
+ *   family; seeds model + effort (which the backend carries within a family).
+ * @param sameAgentAsSource - Whether the fork keeps the source's exact agent;
+ *   seeds the launch-arg pickers (permission / approval / mode), which the
+ *   backend carries only on a same-agent fork.
  * @param selectedHostId - Host whose model catalog feeds the model picker; null
  *   leaves it on Default until a host is chosen.
  * @param onChange - Reports the ready-to-send value on every change.
@@ -190,6 +194,7 @@ function ForkRunConfig({
   targetAgent,
   sourceSession,
   sameHarnessAsSource,
+  sameAgentAsSource,
   selectedHostId,
   onChange,
 }: {
@@ -197,6 +202,7 @@ function ForkRunConfig({
   targetAgent: Pick<AvailableAgent, "name" | "harness">;
   sourceSession: Session | null;
   sameHarnessAsSource: boolean;
+  sameAgentAsSource: boolean;
   selectedHostId: string | null;
   onChange: (value: ForkRunConfigValue) => void;
 }) {
@@ -253,17 +259,21 @@ function ForkRunConfig({
       : EFFORT_SELECT_NONE;
   }, [sameHarnessAsSource, sourceSession]);
   const seededPermission = useMemo(() => {
-    if (sameHarnessAsSource) {
+    // Permission mode rides terminal_launch_args, which the backend copies
+    // ONLY on a same-AGENT fork (copy_terminal_launch_args = not switching).
+    // Seed on the same rule (not harness equality) so the displayed mode can't
+    // diverge from what a same-harness/different-agent fork actually launches.
+    if (sameAgentAsSource) {
       return (
         claudePermissionModeFromSession(sourceSession) ?? CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
       );
     }
     return CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE;
-  }, [sameHarnessAsSource, sourceSession]);
+  }, [sameAgentAsSource, sourceSession]);
   const seededModeValue = useMemo(() => {
-    // A same-harness fork of a source launched with a known mode seeds that
-    // mode by matching its launch args; otherwise the harness's default.
-    const source = sameHarnessAsSource ? (sourceSession?.terminalLaunchArgs ?? []) : [];
+    // Same as permission: launch args carry over only on a same-agent fork, so
+    // seed the mode from the source only then; otherwise the harness's default.
+    const source = sameAgentAsSource ? (sourceSession?.terminalLaunchArgs ?? []) : [];
     const table: NativeHarnessMode[] = hasApproval
       ? CODEX_NATIVE_APPROVAL_MODES
       : hasCursor
@@ -282,7 +292,7 @@ function ForkRunConfig({
       .sort((a, b) => b.args.length - a.args.length)
       .find((m) => m.args.length > 0 && m.args.every((arg) => source.includes(arg)));
     return match?.value ?? dflt;
-  }, [sameHarnessAsSource, sourceSession, hasApproval, hasCursor, hasAgySkip]);
+  }, [sameAgentAsSource, sourceSession, hasApproval, hasCursor, hasAgySkip]);
 
   const [model, setModel] = useState(seededModel);
   const [effort, setEffort] = useState(seededEffort);
@@ -745,10 +755,15 @@ export function ForkSessionForm({
     if (!switching) return nativeCodingAgentForSession(sourceSession)?.harness ?? null;
     return null;
   }, [targetAgent, switching, sourceSession]);
-  // Same-harness fork → seed pickers from the source; a switch to a different
-  // native harness → seed the target's own defaults.
+  // Model / effort carry over within the same provider FAMILY (backend
+  // copy_model_settings), so seed those from same-harness. Launch args
+  // (permission / approval / mode) carry over only on a same-AGENT fork
+  // (backend copy_terminal_launch_args = not switching_agent), so those seed
+  // from same-agent — the two rules differ for a same-harness/different-agent
+  // switch, and matching each keeps the displayed value honest.
   const sourceHarness = nativeCodingAgentForSession(sourceSession)?.harness ?? null;
   const sameHarnessAsSource = !switching || targetHarness === sourceHarness;
+  const sameAgentAsSource = !switching;
 
   // Default the host = source host (when online) else the first online
   // host, once hosts have loaded. Only fills an empty slot so an explicit
@@ -1110,13 +1125,19 @@ export function ForkSessionForm({
 
         {/* Run config (native targets only): model / effort / permission mode.
               Seeds from the source on a same-harness fork, else from the target
-              harness's defaults. Renders nothing for a non-native target. */}
+              harness's defaults. Renders nothing for a non-native target.
+              key=agentChoice remounts on any agent switch so the pickers'
+              touched-state and values reset and re-seed from scratch — otherwise
+              a model picked for one harness would leak onto the next and defeat
+              the backend's cross-family reset. */}
         {targetAgent !== null && (
           <ForkRunConfig
+            key={agentChoice}
             targetHarness={targetHarness}
             targetAgent={targetAgent}
             sourceSession={sourceSession}
             sameHarnessAsSource={sameHarnessAsSource}
+            sameAgentAsSource={sameAgentAsSource}
             selectedHostId={isCodingSource ? selectedHostId : (sourceHostId ?? null)}
             onChange={setRunConfig}
           />

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -289,33 +289,81 @@ function ForkRunConfig({
   const [permission, setPermission] = useState(seededPermission);
   const [mode, setMode] = useState(seededModeValue);
 
-  // Re-seed whenever the seeding basis changes (agent switch, source load).
-  useEffect(() => setModel(seededModel), [seededModel]);
-  useEffect(() => setEffort(seededEffort), [seededEffort]);
-  useEffect(() => setPermission(seededPermission), [seededPermission]);
-  useEffect(() => setMode(seededModeValue), [seededModeValue]);
+  // Which controls the user has actually changed. An UNTOUCHED control omits
+  // its field from the emitted config, so the fork request never carries it
+  // and the server's inherit / reset-by-family path decides — which is exactly
+  // the seeded meaning (same-harness → inherit the source; switch → the
+  // target's default). This is what makes the section safe against the async
+  // model catalog: a submit before `useHostModelOptions` resolves (or a source
+  // model absent from the host's catalog) leaves the Model row on its "Default"
+  // placeholder, but because it's untouched we send NOTHING rather than
+  // `model_override: "default"` — so a fast clone can't silently reset the
+  // source's model. Only a deliberate pick emits an explicit value (including
+  // an explicit "Default", which then means clear-to-agent-default).
+  const [touched, setTouched] = useState({
+    model: false,
+    effort: false,
+    permission: false,
+    mode: false,
+  });
+  const changeModel = (v: string) => {
+    setTouched((t) => ({ ...t, model: true }));
+    setModel(v);
+  };
+  const changeEffort = (v: string) => {
+    setTouched((t) => ({ ...t, effort: true }));
+    setEffort(v);
+  };
+  const changePermission = (v: string) => {
+    setTouched((t) => ({ ...t, permission: true }));
+    setPermission(v);
+  };
+  const changeMode = (v: string) => {
+    setTouched((t) => ({ ...t, mode: true }));
+    setMode(v);
+  };
 
-  // Report the ready-to-send value on every change. The section is
-  // authoritative, so it always emits explicit values (clear aliases for an
-  // unselected model/effort; `[]` for a default mode) rather than relying on
-  // the server's inherit path.
+  // Re-seed whenever the seeding basis changes (agent switch, source load), but
+  // never clobber a control the user already touched — a catalog refetch that
+  // recomputes `seededModel` must not overwrite a manual pick.
+  useEffect(() => {
+    if (!touched.model) setModel(seededModel);
+  }, [seededModel, touched.model]);
+  useEffect(() => {
+    if (!touched.effort) setEffort(seededEffort);
+  }, [seededEffort, touched.effort]);
+  useEffect(() => {
+    if (!touched.permission) setPermission(seededPermission);
+  }, [seededPermission, touched.permission]);
+  useEffect(() => {
+    if (!touched.mode) setMode(seededModeValue);
+  }, [seededModeValue, touched.mode]);
+
+  // Report the ready-to-send value on every change. Each field is included
+  // ONLY when its control was touched (see `touched` above); an untouched
+  // section therefore emits `{}` and the server inherits/resets as it would
+  // for a fork that sent no run-config at all.
   useEffect(() => {
     const value: ForkRunConfigValue = {};
-    if (showModel) {
+    if (showModel && touched.model) {
       value.modelOverride = model === MODEL_SELECT_DEFAULT ? "default" : model;
     }
     if (hasPermission) {
-      value.reasoningEffort = effort === EFFORT_SELECT_NONE ? "default" : effort;
-      value.terminalLaunchArgs =
-        permission === CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
-          ? []
-          : ["--permission-mode", permission];
-    } else if (hasApproval) {
+      if (touched.effort) {
+        value.reasoningEffort = effort === EFFORT_SELECT_NONE ? "default" : effort;
+      }
+      if (touched.permission) {
+        value.terminalLaunchArgs =
+          permission === CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
+            ? []
+            : ["--permission-mode", permission];
+      }
+    } else if (hasApproval && touched.mode) {
       value.terminalLaunchArgs =
         CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === mode)?.args ?? [];
-    } else if (hasCursor) {
+    } else if (hasCursor && touched.mode) {
       value.terminalLaunchArgs = CURSOR_NATIVE_EXEC_MODES.find((m) => m.value === mode)?.args ?? [];
-    } else if (hasAgySkip) {
+    } else if (hasAgySkip && touched.mode) {
       value.terminalLaunchArgs = AGY_NATIVE_SKIP_MODES.find((m) => m.value === mode)?.args ?? [];
     }
     onChange(value);
@@ -329,6 +377,7 @@ function ForkRunConfig({
     effort,
     permission,
     mode,
+    touched,
     onChange,
   ]);
 
@@ -345,7 +394,7 @@ function ForkRunConfig({
         <ConfigRow label="Model" description="Underlying LLM">
           <RoutingModelSelect
             value={model}
-            onValueChange={setModel}
+            onValueChange={changeModel}
             offerSmartRouting={false}
             testId="fork-session-config-model"
             models={modelSelectOptions}
@@ -369,7 +418,7 @@ function ForkRunConfig({
           <ConfigRow label="Effort" description="Reasoning depth vs. speed">
             <Select
               value={effort}
-              onValueChange={setEffort}
+              onValueChange={changeEffort}
               componentId="fork_session.config.effort"
               valueHasNoPii
             >
@@ -394,7 +443,7 @@ function ForkRunConfig({
           <ConfigRow label="Permissions" description="What the agent can do without asking">
             <DescribedSelect
               value={permission}
-              onValueChange={setPermission}
+              onValueChange={changePermission}
               options={CLAUDE_NATIVE_PERMISSION_MODES}
               testId="fork-session-config-permission"
               ariaLabel="Permissions"
@@ -408,7 +457,7 @@ function ForkRunConfig({
         <ConfigRow label="Approval" description="What the agent can do without asking">
           <DescribedSelect
             value={mode}
-            onValueChange={setMode}
+            onValueChange={changeMode}
             options={CODEX_NATIVE_APPROVAL_MODES}
             testId="fork-session-config-approval"
             ariaLabel="Approval"
@@ -421,7 +470,7 @@ function ForkRunConfig({
         <ConfigRow label="Mode" description="How Cursor runs commands">
           <DescribedSelect
             value={mode}
-            onValueChange={setMode}
+            onValueChange={changeMode}
             options={CURSOR_NATIVE_EXEC_MODES}
             testId="fork-session-config-cursor-mode"
             ariaLabel="Mode"
@@ -435,7 +484,7 @@ function ForkRunConfig({
           <ConfigRow label="Permissions" description="What the agent can do without asking">
             <DescribedSelect
               value={mode}
-              onValueChange={setMode}
+              onValueChange={changeMode}
               options={AGY_NATIVE_SKIP_MODES}
               testId="fork-session-config-agy-skip"
               ariaLabel="Permissions"

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -9,6 +9,7 @@ import {
   GitBranchIcon,
   InfoIcon,
   MonitorIcon,
+  TriangleAlertIcon,
 } from "lucide-react";
 import {
   Dialog,
@@ -30,9 +31,42 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { forkSession, launchRunner } from "@/lib/sessionsApi";
 import { useAvailableAgents, prefetchAvailableAgentDetails } from "@/hooks/useAvailableAgents";
+import type { AvailableAgent } from "@/hooks/useAvailableAgents";
 import { partitionAgentsByKind } from "@/lib/agentGrouping";
 import { useSessionAgent } from "@/hooks/useAgents";
-import { useHosts, type Host } from "@/hooks/useHosts";
+import { useSession } from "@/hooks/useSession";
+import type { Session } from "@/lib/types";
+import { useHosts, useHostModelOptions, type Host } from "@/hooks/useHosts";
+import {
+  nativeAgentHasCapability,
+  nativeCodingAgentForAvailableAgent,
+  nativeCodingAgentForSession,
+} from "@/lib/nativeCodingAgents";
+import {
+  CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE,
+  CLAUDE_NATIVE_PERMISSION_MODES,
+  claudePermissionModeFromSession,
+} from "@/lib/claudePermissionMode";
+import {
+  AGY_NATIVE_DEFAULT_SKIP_MODE,
+  AGY_NATIVE_SKIP_MODES,
+  AGY_NATIVE_SKIP_VALUE,
+  CODEX_NATIVE_APPROVAL_MODES,
+  CODEX_NATIVE_DEFAULT_APPROVAL_MODE,
+  CURSOR_NATIVE_DEFAULT_EXEC_MODE,
+  CURSOR_NATIVE_EXEC_MODES,
+  type NativeHarnessMode,
+} from "@/lib/nativeHarnessModes";
+import {
+  CLAUDE_NATIVE_EFFORTS,
+  ConfigRow,
+  DescribedSelect,
+  EFFORT_SELECT_NONE,
+  MODEL_SELECT_DEFAULT,
+  RoutingModelSelect,
+  defaultModelLabel,
+  nativeModelLabel,
+} from "@/components/HarnessConfigControls";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
@@ -109,6 +143,322 @@ function splitWorktreePath(workspace: string): { repo: string; branchDir: string
 function defaultForkTitle(sourceTitle: string | null | undefined): string {
   const trimmed = sourceTitle?.trim();
   return trimmed ? `Fork of ${trimmed}` : "";
+}
+
+/**
+ * Ready-to-send run-config overrides from the fork dialog's pickers. An
+ * undefined field is omitted from the fork request; the section reports the
+ * whole value on every change so the form can read it back at submit.
+ */
+export interface ForkRunConfigValue {
+  modelOverride?: string;
+  reasoningEffort?: string;
+  terminalLaunchArgs?: string[];
+}
+
+/**
+ * Model / effort / permission-mode pickers for a fork, mirroring the
+ * new-session dialog's harness-config rows. Only rendered for a NATIVE target
+ * harness (Claude Code / Codex / Pi / Cursor / Antigravity) — SDK and non-coding
+ * targets have no per-session run knobs the fork can express.
+ *
+ * Seeding follows the source's harness: forking to the SAME harness seeds the
+ * pickers from the source session's current model / effort / permission mode
+ * (so an untouched fork continues where the original left off); switching to a
+ * DIFFERENT harness seeds the target harness's own defaults (an unselected
+ * model/effort and the harness's default permission mode), exactly like starting
+ * a fresh session on that harness.
+ *
+ * The section is authoritative: whatever the pickers show is sent explicitly on
+ * submit (a "Default" model/effort rides the clear alias; the permission /
+ * approval / cursor / agy mode rides `terminalLaunchArgs`, `[]` clearing the
+ * source's launch flags). An untouched same-harness fork therefore re-sends the
+ * source's values, which yields the identical result as inheriting them.
+ *
+ * @param targetHarness - Effective target harness key (e.g. "claude-native"),
+ *   or null for a non-native target (the section renders nothing).
+ * @param targetAgent - The `{ name, harness }` the fork will bind, for
+ *   capability detection.
+ * @param sourceSession - Source session, read to seed a same-harness fork.
+ * @param sameHarnessAsSource - Whether the fork keeps the source's harness.
+ * @param selectedHostId - Host whose model catalog feeds the model picker; null
+ *   leaves it on Default until a host is chosen.
+ * @param onChange - Reports the ready-to-send value on every change.
+ */
+function ForkRunConfig({
+  targetHarness,
+  targetAgent,
+  sourceSession,
+  sameHarnessAsSource,
+  selectedHostId,
+  onChange,
+}: {
+  targetHarness: string | null;
+  targetAgent: Pick<AvailableAgent, "name" | "harness">;
+  sourceSession: Session | null;
+  sameHarnessAsSource: boolean;
+  selectedHostId: string | null;
+  onChange: (value: ForkRunConfigValue) => void;
+}) {
+  const hasPermission = nativeAgentHasCapability(targetAgent, "permissionMode");
+  const hasApproval = nativeAgentHasCapability(targetAgent, "approvalMode");
+  const hasCursor = nativeAgentHasCapability(targetAgent, "cursorMode");
+  const hasAgySkip = nativeAgentHasCapability(targetAgent, "skipPermissions");
+  const hasModelPicker = nativeAgentHasCapability(targetAgent, "modelPicker");
+  // Codex resolves its own catalog, so it gets a model row even though it lacks
+  // the modelPicker capability (mirrors the new-session dialog).
+  const isCodex = targetHarness === "codex-native";
+  const showModel = hasModelPicker || isCodex;
+
+  // Live model catalog for the target harness on the picked host. Only the
+  // native harnesses that expose a picker resolve a catalog; others pass a
+  // harmless unused harness key with the query disabled.
+  const catalogHarness = showModel && targetHarness ? targetHarness : "claude-native";
+  const { data: hostModelOptions, isLoading: modelsLoading } = useHostModelOptions(
+    selectedHostId,
+    catalogHarness,
+    showModel && selectedHostId !== null,
+  );
+  const modelOptions = useMemo(
+    () =>
+      (hostModelOptions ?? []).map((option) => ({
+        id: option.id,
+        displayName: option.displayName ?? option.id,
+        isDefault: option.isDefault,
+      })),
+    [hostModelOptions],
+  );
+  const modelSelectOptions = useMemo(
+    () => modelOptions.map((m) => ({ id: m.id, label: nativeModelLabel(m) })),
+    [modelOptions],
+  );
+
+  // Seed each picker: same-harness → the source's current value; switched →
+  // the target harness's default. Recomputed when the target or seeding basis
+  // changes so switching agents re-seeds correctly.
+  const seededModel = useMemo(() => {
+    // Seed the source's model only once the catalog confirms it: a model id
+    // absent from the loaded options has no Select item to land on and would
+    // blank the trigger. Until the catalog resolves, Default holds.
+    const picked = sameHarnessAsSource ? sourceSession?.modelOverride : null;
+    return picked && modelOptions.some((m) => m.id === picked) ? picked : MODEL_SELECT_DEFAULT;
+  }, [sameHarnessAsSource, sourceSession, modelOptions]);
+  const seededEffort = useMemo(() => {
+    // Seed only an effort the picker can display; a source value outside the
+    // offered vocabulary (e.g. "minimal") falls back to Default rather than
+    // leaving the Select on an empty, unselectable value.
+    const effort = sameHarnessAsSource ? sourceSession?.reasoningEffort : null;
+    return effort && CLAUDE_NATIVE_EFFORTS.some((e) => e.value === effort)
+      ? effort
+      : EFFORT_SELECT_NONE;
+  }, [sameHarnessAsSource, sourceSession]);
+  const seededPermission = useMemo(() => {
+    if (sameHarnessAsSource) {
+      return (
+        claudePermissionModeFromSession(sourceSession) ?? CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
+      );
+    }
+    return CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE;
+  }, [sameHarnessAsSource, sourceSession]);
+  const seededModeValue = useMemo(() => {
+    // A same-harness fork of a source launched with a known mode seeds that
+    // mode by matching its launch args; otherwise the harness's default.
+    const source = sameHarnessAsSource ? (sourceSession?.terminalLaunchArgs ?? []) : [];
+    const table: NativeHarnessMode[] = hasApproval
+      ? CODEX_NATIVE_APPROVAL_MODES
+      : hasCursor
+        ? CURSOR_NATIVE_EXEC_MODES
+        : hasAgySkip
+          ? AGY_NATIVE_SKIP_MODES
+          : [];
+    const dflt = hasApproval
+      ? CODEX_NATIVE_DEFAULT_APPROVAL_MODE
+      : hasCursor
+        ? CURSOR_NATIVE_DEFAULT_EXEC_MODE
+        : AGY_NATIVE_DEFAULT_SKIP_MODE;
+    // Match the source's launch args against the mode table (longest args first
+    // so "--mode plan" isn't shadowed by an empty-args default).
+    const match = [...table]
+      .sort((a, b) => b.args.length - a.args.length)
+      .find((m) => m.args.length > 0 && m.args.every((arg) => source.includes(arg)));
+    return match?.value ?? dflt;
+  }, [sameHarnessAsSource, sourceSession, hasApproval, hasCursor, hasAgySkip]);
+
+  const [model, setModel] = useState(seededModel);
+  const [effort, setEffort] = useState(seededEffort);
+  const [permission, setPermission] = useState(seededPermission);
+  const [mode, setMode] = useState(seededModeValue);
+
+  // Re-seed whenever the seeding basis changes (agent switch, source load).
+  useEffect(() => setModel(seededModel), [seededModel]);
+  useEffect(() => setEffort(seededEffort), [seededEffort]);
+  useEffect(() => setPermission(seededPermission), [seededPermission]);
+  useEffect(() => setMode(seededModeValue), [seededModeValue]);
+
+  // Report the ready-to-send value on every change. The section is
+  // authoritative, so it always emits explicit values (clear aliases for an
+  // unselected model/effort; `[]` for a default mode) rather than relying on
+  // the server's inherit path.
+  useEffect(() => {
+    const value: ForkRunConfigValue = {};
+    if (showModel) {
+      value.modelOverride = model === MODEL_SELECT_DEFAULT ? "default" : model;
+    }
+    if (hasPermission) {
+      value.reasoningEffort = effort === EFFORT_SELECT_NONE ? "default" : effort;
+      value.terminalLaunchArgs =
+        permission === CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
+          ? []
+          : ["--permission-mode", permission];
+    } else if (hasApproval) {
+      value.terminalLaunchArgs =
+        CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === mode)?.args ?? [];
+    } else if (hasCursor) {
+      value.terminalLaunchArgs = CURSOR_NATIVE_EXEC_MODES.find((m) => m.value === mode)?.args ?? [];
+    } else if (hasAgySkip) {
+      value.terminalLaunchArgs = AGY_NATIVE_SKIP_MODES.find((m) => m.value === mode)?.args ?? [];
+    }
+    onChange(value);
+  }, [
+    showModel,
+    hasPermission,
+    hasApproval,
+    hasCursor,
+    hasAgySkip,
+    model,
+    effort,
+    permission,
+    mode,
+    onChange,
+  ]);
+
+  if (
+    targetHarness === null ||
+    (!showModel && !hasPermission && !hasApproval && !hasCursor && !hasAgySkip)
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="fork-session-run-config">
+      {showModel && (
+        <ConfigRow label="Model" description="Underlying LLM">
+          <RoutingModelSelect
+            value={model}
+            onValueChange={setModel}
+            offerSmartRouting={false}
+            testId="fork-session-config-model"
+            models={modelSelectOptions}
+            defaultLabel={defaultModelLabel(modelOptions)}
+            componentId="fork_session.config.model"
+          >
+            {modelsLoading && (
+              <div className="px-2.5 py-1 text-sm text-muted-foreground">Loading models…</div>
+            )}
+            {!modelsLoading && modelOptions.length === 0 && (
+              <div className="px-2.5 py-1 text-sm text-muted-foreground">
+                {selectedHostId === null ? "Select a host to list models" : "Models unavailable"}
+              </div>
+            )}
+          </RoutingModelSelect>
+        </ConfigRow>
+      )}
+
+      {hasPermission && (
+        <>
+          <ConfigRow label="Effort" description="Reasoning depth vs. speed">
+            <Select
+              value={effort}
+              onValueChange={setEffort}
+              componentId="fork_session.config.effort"
+              valueHasNoPii
+            >
+              <SelectTrigger
+                className="w-full cursor-pointer"
+                data-testid="fork-session-config-effort"
+                aria-label="Reasoning effort"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent position="popper" align="start">
+                <SelectItem value={EFFORT_SELECT_NONE}>Default</SelectItem>
+                {CLAUDE_NATIVE_EFFORTS.map((e) => (
+                  <SelectItem key={e.value} value={e.value}>
+                    {e.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </ConfigRow>
+
+          <ConfigRow label="Permissions" description="What the agent can do without asking">
+            <DescribedSelect
+              value={permission}
+              onValueChange={setPermission}
+              options={CLAUDE_NATIVE_PERMISSION_MODES}
+              testId="fork-session-config-permission"
+              ariaLabel="Permissions"
+              componentId="fork_session.config.permission"
+            />
+          </ConfigRow>
+        </>
+      )}
+
+      {hasApproval && (
+        <ConfigRow label="Approval" description="What the agent can do without asking">
+          <DescribedSelect
+            value={mode}
+            onValueChange={setMode}
+            options={CODEX_NATIVE_APPROVAL_MODES}
+            testId="fork-session-config-approval"
+            ariaLabel="Approval"
+            componentId="fork_session.config.approval"
+          />
+        </ConfigRow>
+      )}
+
+      {hasCursor && (
+        <ConfigRow label="Mode" description="How Cursor runs commands">
+          <DescribedSelect
+            value={mode}
+            onValueChange={setMode}
+            options={CURSOR_NATIVE_EXEC_MODES}
+            testId="fork-session-config-cursor-mode"
+            ariaLabel="Mode"
+            componentId="fork_session.config.cursor_mode"
+          />
+        </ConfigRow>
+      )}
+
+      {hasAgySkip && (
+        <>
+          <ConfigRow label="Permissions" description="What the agent can do without asking">
+            <DescribedSelect
+              value={mode}
+              onValueChange={setMode}
+              options={AGY_NATIVE_SKIP_MODES}
+              testId="fork-session-config-agy-skip"
+              ariaLabel="Permissions"
+              componentId="fork_session.config.permission"
+            />
+          </ConfigRow>
+          {mode === AGY_NATIVE_SKIP_VALUE && (
+            <div
+              role="alert"
+              data-testid="fork-session-agy-skip-banner"
+              className="flex items-start gap-1.5 rounded-md border border-destructive bg-destructive/10 px-2 py-1.5 text-xs font-medium leading-relaxed text-destructive"
+            >
+              <TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0" />
+              <span>
+                Danger: this session runs Antigravity with all tool permission prompts disabled. It
+                can edit any file and run any command without asking.
+              </span>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
 }
 
 /**
@@ -191,6 +541,10 @@ export function ForkSessionForm({
   const [agentChoice, setAgentChoice] = useState<string>(SAME_AS_SOURCE);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Ready-to-send model/effort/permission overrides from the run-config
+  // section. Empty until that section (rendered only for a native target)
+  // reports its seeded value.
+  const [runConfig, setRunConfig] = useState<ForkRunConfigValue>({});
   // Working directory + git worktree live behind "Advanced settings",
   // collapsed by default (they prefill sensibly from the source, so the
   // common "clone & start in the same place" path needs no input).
@@ -319,6 +673,33 @@ export function ForkSessionForm({
   );
 
   const switching = agentChoice !== SAME_AS_SOURCE;
+
+  // Source session snapshot — seeds the run-config pickers on a same-harness
+  // fork (its current model / effort / permission mode). Cheap: the chat page
+  // already holds this in the shared ["session", id] cache.
+  const { session: sourceSession } = useSession(sourceSessionId);
+
+  // The agent the fork will bind: the switched-to target, else the source's
+  // own agent. Its harness drives the run-config section (shown only for a
+  // native target) and whether the pickers seed from the source.
+  const targetAgent = useMemo<Pick<AvailableAgent, "name" | "harness"> | null>(() => {
+    if (switching) return switchableAgents.find((a) => a.id === agentChoice) ?? null;
+    if (sourceAgent) return { name: sourceAgent.name, harness: sourceAgent.harness ?? null };
+    return null;
+  }, [switching, switchableAgents, agentChoice, sourceAgent]);
+  // Effective target harness key, resolved from the target agent (or the
+  // source session's wrapper label when keeping the source's agent — a UI
+  // session's bound agent may report a null harness).
+  const targetHarness = useMemo(() => {
+    const fromAgent = nativeCodingAgentForAvailableAgent(targetAgent)?.harness;
+    if (fromAgent) return fromAgent;
+    if (!switching) return nativeCodingAgentForSession(sourceSession)?.harness ?? null;
+    return null;
+  }, [targetAgent, switching, sourceSession]);
+  // Same-harness fork → seed pickers from the source; a switch to a different
+  // native harness → seed the target's own defaults.
+  const sourceHarness = nativeCodingAgentForSession(sourceSession)?.harness ?? null;
+  const sameHarnessAsSource = !switching || targetHarness === sourceHarness;
 
   // Default the host = source host (when online) else the first online
   // host, once hosts have loaded. Only fills an empty slot so an explicit
@@ -461,11 +842,14 @@ export function ForkSessionForm({
       }
       const trimmed = title.trim();
       // Empty title → omit so the server derives "Fork of <source title>".
+      // The run-config section (native targets only) reports its ready-to-send
+      // value; an empty object (non-native target) sends no run overrides.
       const fork = await forkSession(
         sourceSessionId,
         trimmed === "" ? undefined : trimmed,
         switching ? agentChoice : undefined,
         upToResponseId ?? undefined,
+        runConfig,
       );
       // Coding fork: launch the runner in the BACKGROUND, then navigate
       // into the (already-created, unbound) clone immediately — awaiting the
@@ -674,6 +1058,20 @@ export function ForkSessionForm({
             </SelectContent>
           </Select>
         </div>
+
+        {/* Run config (native targets only): model / effort / permission mode.
+              Seeds from the source on a same-harness fork, else from the target
+              harness's defaults. Renders nothing for a non-native target. */}
+        {targetAgent !== null && (
+          <ForkRunConfig
+            targetHarness={targetHarness}
+            targetAgent={targetAgent}
+            sourceSession={sourceSession}
+            sameHarnessAsSource={sameHarnessAsSource}
+            selectedHostId={isCodingSource ? selectedHostId : (sourceHostId ?? null)}
+            onChange={setRunConfig}
+          />
+        )}
 
         {/* Indicator: by default the clone reuses the source's working
               directory; changing it lives under Advanced settings. */}

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useNavigate } from "@/lib/routing";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -61,7 +61,6 @@ import {
 } from "@/lib/nativeHarnessModes";
 import {
   CLAUDE_NATIVE_EFFORTS,
-  ConfigRow,
   DescribedSelect,
   EFFORT_SELECT_NONE,
   MODEL_SELECT_DEFAULT,
@@ -145,6 +144,22 @@ function splitWorktreePath(workspace: string): { repo: string; branchDir: string
 function defaultForkTitle(sourceTitle: string | null | undefined): string {
   const trimmed = sourceTitle?.trim();
   return trimmed ? `Fork of ${trimmed}` : "";
+}
+
+/**
+ * A run-config field row that matches the dialog's "Agent" field: a stacked
+ * `text-sm` muted label above a full-width control. Deliberately NOT the
+ * `ConfigRow` used inside the "Configure …" modal (bigger `text-ui` label +
+ * side-by-side sub-description) — those rows would read visually inconsistent
+ * next to the Agent select in this same form.
+ */
+function ForkConfigRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-sm font-medium text-muted-foreground">{label}</span>
+      {children}
+    </div>
+  );
 }
 
 /**
@@ -432,7 +447,7 @@ function ForkRunConfig({
   return (
     <div className="flex flex-col gap-4" data-testid="fork-session-run-config">
       {showModel && (
-        <ConfigRow label="Model" description="Underlying LLM">
+        <ForkConfigRow label="Model">
           <RoutingModelSelect
             value={model}
             onValueChange={changeModel}
@@ -451,12 +466,12 @@ function ForkRunConfig({
               </div>
             )}
           </RoutingModelSelect>
-        </ConfigRow>
+        </ForkConfigRow>
       )}
 
       {hasPermission && (
         <>
-          <ConfigRow label="Effort" description="Reasoning depth vs. speed">
+          <ForkConfigRow label="Effort">
             <Select
               value={effort}
               onValueChange={changeEffort}
@@ -479,9 +494,9 @@ function ForkRunConfig({
                 ))}
               </SelectContent>
             </Select>
-          </ConfigRow>
+          </ForkConfigRow>
 
-          <ConfigRow label="Permissions" description="What the agent can do without asking">
+          <ForkConfigRow label="Permissions">
             <DescribedSelect
               value={permission}
               onValueChange={changePermission}
@@ -490,13 +505,13 @@ function ForkRunConfig({
               ariaLabel="Permissions"
               componentId="fork_session.config.permission"
             />
-          </ConfigRow>
+          </ForkConfigRow>
         </>
       )}
 
       {hasApproval && (
         <>
-          <ConfigRow label="Approval" description="What the agent can do without asking">
+          <ForkConfigRow label="Approval">
             <DescribedSelect
               value={mode}
               onValueChange={changeMode}
@@ -513,7 +528,7 @@ function ForkRunConfig({
               ariaLabel="Approval"
               componentId="fork_session.config.approval"
             />
-          </ConfigRow>
+          </ForkConfigRow>
           {isCodex && mode === CODEX_NATIVE_BYPASS_APPROVAL_VALUE && (
             <div
               role="alert"
@@ -531,7 +546,7 @@ function ForkRunConfig({
       )}
 
       {hasCursor && (
-        <ConfigRow label="Mode" description="How Cursor runs commands">
+        <ForkConfigRow label="Mode">
           <DescribedSelect
             value={mode}
             onValueChange={changeMode}
@@ -540,12 +555,12 @@ function ForkRunConfig({
             ariaLabel="Mode"
             componentId="fork_session.config.cursor_mode"
           />
-        </ConfigRow>
+        </ForkConfigRow>
       )}
 
       {hasAgySkip && (
         <>
-          <ConfigRow label="Permissions" description="What the agent can do without asking">
+          <ForkConfigRow label="Permissions">
             <DescribedSelect
               value={mode}
               onValueChange={changeMode}
@@ -554,7 +569,7 @@ function ForkRunConfig({
               ariaLabel="Permissions"
               componentId="fork_session.config.permission"
             />
-          </ConfigRow>
+          </ForkConfigRow>
           {mode === AGY_NATIVE_SKIP_VALUE && (
             <div
               role="alert"

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -165,6 +165,20 @@ import {
   CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE,
   CLAUDE_NATIVE_PERMISSION_MODES,
 } from "@/lib/claudePermissionMode";
+import {
+  AGY_NATIVE_DEFAULT_SKIP_MODE,
+  AGY_NATIVE_SKIP_MODES,
+  AGY_NATIVE_SKIP_VALUE,
+  AUTO_PERMISSION_MODE,
+  AUTO_PERMISSION_MODE_OPTIONS,
+  CODEX_NATIVE_APPROVAL_MODES,
+  CODEX_NATIVE_BYPASS_APPROVAL_OPTION,
+  CODEX_NATIVE_BYPASS_APPROVAL_VALUE,
+  CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY,
+  CODEX_NATIVE_DEFAULT_APPROVAL_MODE,
+  CURSOR_NATIVE_DEFAULT_EXEC_MODE,
+  CURSOR_NATIVE_EXEC_MODES,
+} from "@/lib/nativeHarnessModes";
 import { useHostModelOptions, useHosts, type Host } from "@/hooks/useHosts";
 import {
   controlHost,
@@ -242,139 +256,6 @@ const AGENT_PICKER_DESCRIPTIONS: Record<string, string> = {
 // landing composer. Deliberately an allowlist while the pattern proves
 // out — other agents keep the "/" menu as the only skill surface.
 const SKILL_PILL_AGENTS = new Set(["polly", "debby"]);
-
-// Antigravity (agy) permission control. agy exposes exactly ONE pre-emptive
-// knob — `--dangerously-skip-permissions`, an all-or-nothing bypass — with no
-// per-tool equivalent of acceptEdits/plan, so this is a two-value toggle rather
-// than Claude's graded selector. "default" sends no flags and leaves agy's own
-// request-review prompt in place. Keep in sync with `agy --help`.
-const AGY_NATIVE_DEFAULT_SKIP_MODE = "default";
-const AGY_NATIVE_SKIP_VALUE = "skip";
-const AGY_NATIVE_SKIP_MODES: {
-  value: string;
-  label: string;
-  description: string;
-  args: string[];
-}[] = [
-  {
-    value: AGY_NATIVE_DEFAULT_SKIP_MODE,
-    label: "Ask every time",
-    description: "Prompts before each tool runs",
-    args: [],
-  },
-  {
-    value: AGY_NATIVE_SKIP_VALUE,
-    label: "Skip permissions",
-    description: "Runs everything; no prompts or safety checks",
-    args: ["--dangerously-skip-permissions"],
-  },
-];
-
-// The Auto Harness's Permissions vocabulary: Default only. No cross-harness
-// permission mapping exists, so the row stays locked and the create call sends
-// no override — each CLI keeps the machine's own configuration.
-const AUTO_PERMISSION_MODE = {
-  value: CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE,
-  label: "Default",
-  description: "The picked harness keeps its own configured permissions",
-} as const;
-const AUTO_PERMISSION_MODE_OPTIONS = [AUTO_PERMISSION_MODE] as const;
-
-// Cursor execution modes. "default" sends no flags; other values map to CLI
-// args passed via terminal_launch_args. Keep in sync with `cursor-agent --help`.
-const CURSOR_NATIVE_DEFAULT_EXEC_MODE = "default";
-const CURSOR_NATIVE_EXEC_MODES: {
-  value: string;
-  label: string;
-  description: string;
-  args: string[];
-}[] = [
-  {
-    value: "default",
-    label: "Default",
-    description: "Normal agent mode; prompts before running commands",
-    args: [],
-  },
-  {
-    value: "auto-review",
-    label: "Auto-review",
-    description: "Smart Auto: auto-runs safe tool calls and prompts for the rest",
-    args: ["--auto-review"],
-  },
-  {
-    value: "plan",
-    label: "Plan",
-    description: "Read-only planning; analyzes and proposes plans, no edits",
-    args: ["--mode", "plan"],
-  },
-  {
-    value: "ask",
-    label: "Ask",
-    description: "Q&A style; explains and answers questions (read-only)",
-    args: ["--mode", "ask"],
-  },
-  {
-    value: "yolo",
-    label: "Yolo",
-    description: "Runs everything without prompts or safety checks",
-    args: ["--yolo"],
-  },
-];
-
-// Codex approval presets matching the `/permissions` TUI popup.
-// Each preset bundles a sandbox profile + approval policy, mirroring
-// codex-rs/utils/approval-presets/src/lib.rs. "default" is the auto
-// preset (workspace-write + on-request) and sends no flags so the
-// runner uses Codex's built-in default.
-// Keep in sync with `codex --help` and
-// https://developers.openai.com/codex/agent-approvals-security
-const CODEX_NATIVE_DEFAULT_APPROVAL_MODE = "default";
-const CODEX_NATIVE_APPROVAL_MODES: {
-  value: string;
-  label: string;
-  description: string;
-  args: string[];
-}[] = [
-  {
-    value: "default",
-    label: "Default",
-    description: "Read/edit/run in workspace; approval for external edits or network",
-    args: [],
-  },
-  {
-    value: "full-access",
-    label: "Full access",
-    description: "Edit any file and access the internet without approval",
-    args: ["--sandbox", "danger-full-access", "--ask-for-approval", "never"],
-  },
-  {
-    value: "read-only",
-    label: "Read only",
-    description: "Read files only; approval required for edits, commands, or network",
-    args: ["--sandbox", "read-only", "--ask-for-approval", "on-request"],
-  },
-];
-
-// Conversation-label key for the DANGEROUS codex full-bypass opt-in. When
-// set to "1" the runner launches Codex with
-// `--dangerously-bypass-approvals-and-sandbox` (no approval prompts, no
-// command sandbox) — see omnigent.stores.conversation_store
-// CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY. Stored as a label (cheap thread
-// metadata) so it survives reload. Mutually exclusive in spirit with the
-// approval-mode presets above: when bypass is on the runner strips any
-// `--sandbox` / `--ask-for-approval` flags those presets would emit.
-const CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY = "omnigent.codex_native.bypass_sandbox";
-// Bypass is the most-permissive Codex approval stance — presented as a 4th
-// option in the Codex approval dropdown (Codex only; OpenCode shares the
-// presets above but has no bypass). It rides as a conversation label, not
-// terminal_launch_args, so its `args` are empty and it's handled specially.
-const CODEX_NATIVE_BYPASS_APPROVAL_VALUE = "bypass";
-const CODEX_NATIVE_BYPASS_APPROVAL_OPTION = {
-  value: CODEX_NATIVE_BYPASS_APPROVAL_VALUE,
-  label: "Bypass approvals & sandbox",
-  description: "Runs Codex with no approval prompts and no command sandbox",
-  args: [] as string[],
-};
 
 function createdHarnessOptions({
   harness,


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- The clone/fork dialog previously **inherited** the source session's model, reasoning effort, and permission mode with no way to change them. This adds a run-config section to the fork dialog so you can pick them at clone time.
- Rows are harness-aware: **model / effort / permissions** for Claude, **model + approval** for Codex, **mode** for Cursor, **permissions** for Antigravity. They render only for a native target (SDK/non-coding targets have no per-session knobs).
- Seeding matches the new-session dialog: a **same-harness** fork seeds the pickers from the source session's current values; a **cross-harness** switch seeds the target harness's defaults.

Backend: `SessionForkRequest` gains `model_override`, `reasoning_effort`, `terminal_launch_args`. The fork route validates each exactly like session-create; each is opt-in via `model_fields_set`, so an omitted field inherits (today's behavior) and a sent field overrides (a `"default"` clear alias resets to the agent default). When explicit launch args are chosen, the source's copied permission-mode / codex-bypass labels are dropped so a stale label can't shadow the freshly chosen mode. `fork_conversation` gains `override_*` params (with set-flags) and `dropped_label_keys`.

Frontend: `forkSession` takes an optional `config`; a shared `nativeHarnessModes.ts` module holds the codex/cursor/agy mode tables (extracted from `NewChatDialog` so both dialogs share one source of truth); a `ForkRunConfig` component renders the pickers.

## Test Plan

- **Backend unit** (`test_sessions_fork.py`): route override pass-through, omit-inherits, `"default"` clear-aliases, invalid-model rejection.
- **Store unit** (`test_conversation_store.py`): explicit override supersedes the inherited copy (incl. `[]` clearing launch args) and the cleared-with-flag semantics.
- **API-level e2e** (`test_sessions_fork_e2e.py::test_fork_run_config_overrides_persist_on_clone`): drives the real fork endpoint and asserts the overrides persist on the clone, `"default"` clears, and omission inherits. ✅ passes against a live mock stack.
- **UI e2e** (`test_clone_session.py`): the cross-family clone test now picks a Plan permission mode and asserts the fork carries `["--permission-mode", "plan"]`.
- **Web unit** (`sessionsApi.test.ts`, `ForkSessionDialog.test.tsx`): config forwarding + the seeded-defaults call shape.
- `pre-commit run --all-files` clean; `web` build + `tsc` green.

## Demo

_Please see the `ui-preview` deploy for the new Model / Effort / Permissions rows in the Clone dialog._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — automated coverage added at the route, store, API-e2e, UI-e2e, and web-unit layers.

## Changelog

The Clone session dialog now lets you pick the model, reasoning effort, and permission/approval mode for the fork.

This pull request and its description were written by Isaac.