### PR TITLE
feat(extensions): add the versioned extension manifest registry

### DIFF
--- a/omnigent/extensions/__init__.py
+++ b/omnigent/extensions/__init__.py
@@ -1,0 +1,39 @@
+"""Public API for installed Omnigent extensions."""
+
+from omnigent.extensions.api import (
+    EXTENSION_API_VERSION,
+    CommandContribution,
+    ExtensionEntrypoints,
+    ExtensionManifest,
+    ExtensionPermission,
+    ExtensionPluginState,
+    PageContribution,
+    PrimaryNavigationContribution,
+)
+from omnigent.extensions.registry import (
+    ENTRY_POINT_GROUP,
+    SUPPORTED_EXTENSION_API_VERSIONS,
+    ExtensionValidationError,
+    extension_manifest,
+    extension_manifests,
+    plugin_state,
+    validate_manifest,
+)
+
+__all__ = [
+    "ENTRY_POINT_GROUP",
+    "EXTENSION_API_VERSION",
+    "SUPPORTED_EXTENSION_API_VERSIONS",
+    "CommandContribution",
+    "ExtensionEntrypoints",
+    "ExtensionManifest",
+    "ExtensionPermission",
+    "ExtensionPluginState",
+    "ExtensionValidationError",
+    "PageContribution",
+    "PrimaryNavigationContribution",
+    "extension_manifest",
+    "extension_manifests",
+    "plugin_state",
+    "validate_manifest",
+]

--- a/omnigent/extensions/api.py
+++ b/omnigent/extensions/api.py
@@ -1,0 +1,88 @@
+"""Public manifest types for installed Omnigent extensions.
+
+The extension API is versioned independently from the Omnigent package. Entry
+points should return these lightweight, declarative values without importing
+extension runtime implementations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+EXTENSION_API_VERSION = 1
+
+
+class ExtensionPermission(StrEnum):
+    """Host capabilities an extension may request."""
+
+    NAVIGATION = "navigation"
+    STORAGE_USER = "storage.user"
+
+
+@dataclass(frozen=True)
+class ExtensionEntrypoints:
+    """Lazy runtime assets declared by an extension."""
+
+    browser: str | None = None
+    browser_css: str | None = None
+
+
+@dataclass(frozen=True)
+class PageContribution:
+    """A page rendered below the extension's namespaced route."""
+
+    id: str
+    title: str
+    route: str
+    view: str
+
+
+@dataclass(frozen=True)
+class PrimaryNavigationContribution:
+    """A link contributed to the application's primary sidebar navigation."""
+
+    id: str
+    label: str
+    page: str
+    icon: str | None = None
+    order: int = 500
+    when: str | None = None
+
+
+@dataclass(frozen=True)
+class CommandContribution:
+    """Reserved command metadata; V1 does not execute contributed commands."""
+
+    id: str
+    title: str
+
+
+@dataclass(frozen=True)
+class ExtensionManifest:
+    """One installed package's declarative extension contribution."""
+
+    id: str
+    display_name: str
+    distribution: str
+    version: str
+    requires_omnigent: str
+    extension_api: int
+    entrypoints: ExtensionEntrypoints = field(default_factory=ExtensionEntrypoints)
+    permissions: frozenset[ExtensionPermission] = frozenset()
+    activation_events: tuple[str, ...] = ()
+    pages: tuple[PageContribution, ...] = ()
+    primary_navigation: tuple[PrimaryNavigationContribution, ...] = ()
+    commands: tuple[CommandContribution, ...] = ()
+
+
+@dataclass(frozen=True)
+class ExtensionPluginState:
+    """Validated manifests plus non-fatal discovery errors."""
+
+    manifests: tuple[ExtensionManifest, ...]
+    load_errors: dict[str, str] = field(default_factory=dict)
+
+    def get(self, extension_id: str) -> ExtensionManifest | None:
+        """Return one accepted manifest by ID."""
+        return next((item for item in self.manifests if item.id == extension_id), None)

--- a/omnigent/extensions/registry.py
+++ b/omnigent/extensions/registry.py
@@ -1,0 +1,533 @@
+"""Discovery and deterministic validation for installed extensions."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+import re
+import threading
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import PurePosixPath
+from typing import Any
+
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
+
+from omnigent.extensions.api import (
+    EXTENSION_API_VERSION,
+    CommandContribution,
+    ExtensionEntrypoints,
+    ExtensionManifest,
+    ExtensionPermission,
+    ExtensionPluginState,
+    PageContribution,
+    PrimaryNavigationContribution,
+)
+from omnigent.version import VERSION
+
+ENTRY_POINT_GROUP = "omnigent.extensions"
+SUPPORTED_EXTENSION_API_VERSIONS = frozenset({EXTENSION_API_VERSION})
+
+_logger = logging.getLogger(__name__)
+_state: ExtensionPluginState | None = None
+_state_condition = threading.Condition()
+_building_thread_id: int | None = None
+
+_ID_SEGMENT = r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+_EXTENSION_ID_RE = re.compile(rf"^{_ID_SEGMENT}(?:\.{_ID_SEGMENT})+$")
+_CONTRIBUTION_ID_RE = re.compile(rf"^{_ID_SEGMENT}(?:[.-]{_ID_SEGMENT})+$")
+_ROUTE_SEGMENT_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$")
+_ASSET_SEGMENT_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
+_SYMBOL_RE = _ASSET_SEGMENT_RE
+_ACTIVATION_EVENT_RE = re.compile(r"^(onPage|onCommand):(.+)$")
+_MAX_TEXT_LENGTH = 512
+_MAX_ASSET_DEPTH = 16
+
+
+class ExtensionValidationError(ValueError):
+    """An extension manifest is structurally invalid or incompatible."""
+
+
+def _entry_point_distribution_name(entry_point: Any) -> str | None:
+    """Return an entry point's installed distribution name when available."""
+    dist = getattr(entry_point, "dist", None)
+    if dist is None:
+        return None
+    name = getattr(dist, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    metadata = getattr(dist, "metadata", None)
+    if metadata is not None:
+        metadata_name = metadata.get("Name")
+        if isinstance(metadata_name, str) and metadata_name:
+            return metadata_name
+    return None
+
+
+def _entry_points() -> tuple[importlib.metadata.EntryPoint, ...]:
+    """Return installed extension entry points in deterministic order."""
+    discovered = importlib.metadata.entry_points(group=ENTRY_POINT_GROUP)
+    return tuple(
+        sorted(
+            discovered,
+            key=lambda item: (
+                _entry_point_distribution_name(item) or "",
+                item.name,
+                getattr(item, "value", ""),
+            ),
+        )
+    )
+
+
+def _builtin_manifests() -> tuple[ExtensionManifest, ...]:
+    """Return core-owned manifests routed through the public validation path."""
+    return ()
+
+
+def _require_text(value: object, field_name: str) -> None:
+    if not isinstance(value, str):
+        raise ExtensionValidationError(f"{field_name} must be a string")
+    if not value or value != value.strip():
+        raise ExtensionValidationError(f"{field_name} must be non-empty and trimmed")
+    if len(value) > _MAX_TEXT_LENGTH:
+        raise ExtensionValidationError(
+            f"{field_name} must be at most {_MAX_TEXT_LENGTH} characters"
+        )
+    if not value.isprintable():
+        raise ExtensionValidationError(f"{field_name} contains non-printable characters")
+
+
+def _require_symbol(value: str, field_name: str) -> None:
+    _require_text(value, field_name)
+    if not _SYMBOL_RE.fullmatch(value):
+        raise ExtensionValidationError(
+            f"{field_name} must contain only letters, digits, dots, underscores, and hyphens"
+        )
+
+
+def _validate_extension_id(extension_id: str) -> None:
+    _require_text(extension_id, "extension id")
+    if not _EXTENSION_ID_RE.fullmatch(extension_id):
+        raise ExtensionValidationError(
+            f"extension id {extension_id!r} must be a lowercase, publisher-qualified id"
+        )
+
+
+def _validate_contribution_id(extension_id: str, contribution_id: str, kind: str) -> None:
+    _require_text(contribution_id, f"{kind} id")
+    if not _CONTRIBUTION_ID_RE.fullmatch(contribution_id):
+        raise ExtensionValidationError(
+            f"{kind} id {contribution_id!r} must contain only lowercase namespaced segments"
+        )
+    if not contribution_id.startswith(f"{extension_id}."):
+        raise ExtensionValidationError(
+            f"{kind} id {contribution_id!r} must be namespaced under {extension_id!r}"
+        )
+
+
+def _validate_relative_path(
+    value: str,
+    field_name: str,
+    *,
+    route: bool = False,
+    suffixes: frozenset[str] | None = None,
+) -> None:
+    _require_text(value, field_name)
+    path = PurePosixPath(value)
+    if (
+        path.is_absolute()
+        or value.startswith("./")
+        or value != path.as_posix()
+        or len(path.parts) > _MAX_ASSET_DEPTH
+    ):
+        raise ExtensionValidationError(f"{field_name} {value!r} is not a safe relative path")
+    segment_pattern = _ROUTE_SEGMENT_RE if route else _ASSET_SEGMENT_RE
+    if any(not segment_pattern.fullmatch(part) for part in path.parts):
+        if route:
+            raise ExtensionValidationError(
+                f"{field_name} {value!r} contains an unsupported route segment"
+            )
+        raise ExtensionValidationError(f"{field_name} {value!r} is not a safe relative path")
+    if suffixes is not None and path.suffix.lower() not in suffixes:
+        expected = ", ".join(sorted(suffixes))
+        raise ExtensionValidationError(f"{field_name} must use one of: {expected}")
+
+
+def _validate_page(extension_id: str, page: PageContribution) -> None:
+    _validate_contribution_id(extension_id, page.id, "page")
+    _require_text(page.title, f"page {page.id!r} title")
+    _validate_relative_path(page.route, f"page {page.id!r} route", route=True)
+    _require_symbol(page.view, f"page {page.id!r} view")
+
+
+def _validate_navigation(
+    extension_id: str,
+    navigation: PrimaryNavigationContribution,
+    *,
+    page_ids: set[str],
+) -> None:
+    _validate_contribution_id(extension_id, navigation.id, "primary navigation")
+    _require_text(navigation.label, f"primary navigation {navigation.id!r} label")
+    _require_text(navigation.page, f"primary navigation {navigation.id!r} page")
+    if navigation.page not in page_ids:
+        raise ExtensionValidationError(
+            f"primary navigation {navigation.id!r} references unknown page {navigation.page!r}"
+        )
+    if navigation.icon is not None:
+        _require_symbol(navigation.icon, f"primary navigation {navigation.id!r} icon")
+    if navigation.when is not None:
+        _require_text(navigation.when, f"primary navigation {navigation.id!r} when")
+    if isinstance(navigation.order, bool) or not isinstance(navigation.order, int):
+        raise ExtensionValidationError(
+            f"primary navigation {navigation.id!r} order must be an integer"
+        )
+
+
+def _validate_command(extension_id: str, command: CommandContribution) -> None:
+    _validate_contribution_id(extension_id, command.id, "command")
+    _require_text(command.title, f"command {command.id!r} title")
+
+
+def _reject_duplicates(values: Iterable[str], kind: str) -> None:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for value in values:
+        if value in seen:
+            duplicates.add(value)
+        seen.add(value)
+    if duplicates:
+        rendered = ", ".join(repr(item) for item in sorted(duplicates))
+        raise ExtensionValidationError(f"duplicate {kind}: {rendered}")
+
+
+def validate_manifest(manifest: ExtensionManifest) -> None:
+    """Validate one manifest independently of other installed extensions."""
+    if not isinstance(manifest.entrypoints, ExtensionEntrypoints):
+        raise ExtensionValidationError("entrypoints must be ExtensionEntrypoints")
+    for field_name in ("pages", "primary_navigation", "commands", "activation_events"):
+        if not isinstance(getattr(manifest, field_name), tuple):
+            raise ExtensionValidationError(f"{field_name} must be a tuple")
+    if not isinstance(manifest.permissions, frozenset):
+        raise ExtensionValidationError("permissions must be a frozenset")
+    for field_name, values, expected_type in (
+        ("pages", manifest.pages, PageContribution),
+        ("primary_navigation", manifest.primary_navigation, PrimaryNavigationContribution),
+        ("commands", manifest.commands, CommandContribution),
+    ):
+        invalid = [
+            type(value).__name__ for value in values if not isinstance(value, expected_type)
+        ]
+        if invalid:
+            raise ExtensionValidationError(
+                f"{field_name} contains invalid contribution types: " + ", ".join(invalid)
+            )
+
+    _validate_extension_id(manifest.id)
+    _require_text(manifest.display_name, "display_name")
+    _require_text(manifest.distribution, "distribution")
+    _require_text(manifest.version, "version")
+    _require_text(manifest.requires_omnigent, "requires_omnigent")
+
+    try:
+        Version(manifest.version)
+    except InvalidVersion as exc:
+        raise ExtensionValidationError(
+            f"extension {manifest.id!r} has invalid version {manifest.version!r}"
+        ) from exc
+
+    if (
+        isinstance(manifest.extension_api, bool)
+        or not isinstance(manifest.extension_api, int)
+        or manifest.extension_api not in SUPPORTED_EXTENSION_API_VERSIONS
+    ):
+        supported = ", ".join(str(item) for item in sorted(SUPPORTED_EXTENSION_API_VERSIONS))
+        raise ExtensionValidationError(
+            f"extension {manifest.id!r} targets unsupported extension API "
+            f"{manifest.extension_api!r}; supported versions: {supported}"
+        )
+
+    try:
+        core_range = SpecifierSet(manifest.requires_omnigent)
+    except InvalidSpecifier as exc:
+        raise ExtensionValidationError(
+            f"extension {manifest.id!r} has invalid Omnigent requirement "
+            f"{manifest.requires_omnigent!r}"
+        ) from exc
+    try:
+        # Compatibility ranges target a release line. Treat a local dev/RC build
+        # as its base release so normal ranges also work in development and CI.
+        compatibility_version = Version(Version(VERSION).base_version)
+    except InvalidVersion as exc:
+        raise ExtensionValidationError(f"Omnigent has invalid version {VERSION!r}") from exc
+    if not core_range.contains(compatibility_version):
+        raise ExtensionValidationError(
+            f"extension {manifest.id!r} requires Omnigent {manifest.requires_omnigent}; "
+            f"running version is {VERSION}"
+        )
+
+    if manifest.pages and manifest.entrypoints.browser is None:
+        raise ExtensionValidationError(
+            f"extension {manifest.id!r} contributes pages but has no browser entrypoint"
+        )
+    if manifest.entrypoints.browser is not None:
+        _validate_relative_path(
+            manifest.entrypoints.browser,
+            "browser entrypoint",
+            suffixes=frozenset({".js", ".mjs"}),
+        )
+    if manifest.entrypoints.browser_css is not None:
+        if manifest.entrypoints.browser is None:
+            raise ExtensionValidationError(
+                f"extension {manifest.id!r} has browser CSS but no browser entrypoint"
+            )
+        _validate_relative_path(
+            manifest.entrypoints.browser_css,
+            "browser CSS entrypoint",
+            suffixes=frozenset({".css"}),
+        )
+
+    invalid_permissions = sorted(
+        repr(permission)
+        for permission in manifest.permissions
+        if not isinstance(permission, ExtensionPermission)
+    )
+    if invalid_permissions:
+        raise ExtensionValidationError(
+            f"extension {manifest.id!r} requests unsupported permissions: "
+            + ", ".join(invalid_permissions)
+        )
+
+    for page in manifest.pages:
+        _validate_page(manifest.id, page)
+    for command in manifest.commands:
+        _validate_command(manifest.id, command)
+
+    page_ids = {page.id for page in manifest.pages}
+    command_ids = {command.id for command in manifest.commands}
+    for navigation in manifest.primary_navigation:
+        _validate_navigation(manifest.id, navigation, page_ids=page_ids)
+    navigation_ids = {navigation.id for navigation in manifest.primary_navigation}
+
+    _reject_duplicates((page.id for page in manifest.pages), "page ids")
+    _reject_duplicates((page.route for page in manifest.pages), "page routes")
+    _reject_duplicates((command.id for command in manifest.commands), "command ids")
+    _reject_duplicates(
+        (navigation.id for navigation in manifest.primary_navigation),
+        "primary navigation ids",
+    )
+    _reject_duplicates(
+        (*page_ids, *command_ids, *navigation_ids),
+        "contribution ids",
+    )
+
+    for event in manifest.activation_events:
+        _require_text(event, "activation event")
+    _reject_duplicates(manifest.activation_events, "activation events")
+    for event in manifest.activation_events:
+        match = _ACTIVATION_EVENT_RE.fullmatch(event)
+        if match is None:
+            raise ExtensionValidationError(f"unsupported activation event {event!r}")
+        kind, target = match.groups()
+        known = page_ids if kind == "onPage" else command_ids
+        if target not in known:
+            raise ExtensionValidationError(
+                f"activation event {event!r} references an unknown contribution"
+            )
+
+
+def _validate_distribution_metadata(entry_point: Any, manifest: ExtensionManifest) -> None:
+    """Ensure a manifest describes the distribution that registered it."""
+    installed_name = _entry_point_distribution_name(entry_point)
+    if installed_name is not None and canonicalize_name(installed_name) != canonicalize_name(
+        manifest.distribution
+    ):
+        raise ExtensionValidationError(
+            f"manifest distribution {manifest.distribution!r} does not match installed "
+            f"distribution {installed_name!r}"
+        )
+
+    dist = getattr(entry_point, "dist", None)
+    installed_version = getattr(dist, "version", None)
+    if isinstance(installed_version, str) and installed_version:
+        try:
+            versions_match = Version(installed_version) == Version(manifest.version)
+        except InvalidVersion as exc:
+            raise ExtensionValidationError(
+                f"installed distribution {installed_name or manifest.distribution!r} has "
+                f"invalid version {installed_version!r}"
+            ) from exc
+        if not versions_match:
+            raise ExtensionValidationError(
+                f"manifest version {manifest.version!r} does not match installed "
+                f"distribution version {installed_version!r}"
+            )
+
+
+def _manifest_claims(manifest: ExtensionManifest) -> tuple[str, ...]:
+    contribution_ids = (
+        *(page.id for page in manifest.pages),
+        *(command.id for command in manifest.commands),
+        *(item.id for item in manifest.primary_navigation),
+    )
+    return (
+        f"extension:{manifest.id}",
+        *(f"contribution:{item}" for item in contribution_ids),
+        *(f"route:{manifest.id}/{page.route}" for page in manifest.pages),
+    )
+
+
+def _diagnostic_key(entry_point: Any, used: set[str]) -> str:
+    dist_name = _entry_point_distribution_name(entry_point)
+    base = f"{dist_name}:{entry_point.name}" if dist_name else entry_point.name
+    key = base
+    suffix = 2
+    while key in used:
+        key = f"{base}#{suffix}"
+        suffix += 1
+    used.add(key)
+    return key
+
+
+def _load_community_manifests() -> tuple[list[tuple[str, ExtensionManifest]], dict[str, str]]:
+    candidates: list[tuple[str, ExtensionManifest]] = []
+    errors: dict[str, str] = {}
+    used_keys: set[str] = set()
+    for entry_point in _entry_points():
+        key = _diagnostic_key(entry_point, used_keys)
+        try:
+            loaded = entry_point.load()
+            manifest = loaded() if callable(loaded) else loaded
+            if not isinstance(manifest, ExtensionManifest):
+                raise TypeError(
+                    f"entry point returned {type(manifest).__name__}, expected ExtensionManifest"
+                )
+            validate_manifest(manifest)
+            _validate_distribution_metadata(entry_point, manifest)
+            candidates.append((key, manifest))
+        # Entry points are an external package boundary: one plugin may raise
+        # any exception, and must not prevent healthy extensions from loading.
+        except Exception as exc:  # noqa: BLE001
+            errors[key] = str(exc)
+            _logger.warning(
+                "could not load extension entry point %s (%s)",
+                key,
+                exc,
+                exc_info=True,
+            )
+    return candidates, errors
+
+
+def _validate_builtin_collisions(builtins: tuple[ExtensionManifest, ...]) -> None:
+    claims: dict[str, str] = {}
+    for manifest in builtins:
+        for claim in _manifest_claims(manifest):
+            previous = claims.get(claim)
+            if previous is not None:
+                raise RuntimeError(
+                    f"built-in extensions {previous!r} and {manifest.id!r} both claim {claim}"
+                )
+            claims[claim] = manifest.id
+
+
+def _collision_errors(
+    builtins: tuple[ExtensionManifest, ...],
+    candidates: list[tuple[str, ExtensionManifest]],
+) -> dict[str, str]:
+    builtin_claims: dict[str, str] = {}
+    for manifest in builtins:
+        for claim in _manifest_claims(manifest):
+            builtin_claims[claim] = manifest.id
+
+    community_claims: dict[str, list[str]] = defaultdict(list)
+    for owner, manifest in candidates:
+        for claim in _manifest_claims(manifest):
+            community_claims[claim].append(owner)
+
+    conflicts: dict[str, list[str]] = defaultdict(list)
+    for claim, owners in community_claims.items():
+        if claim in builtin_claims:
+            for owner in owners:
+                conflicts[owner].append(
+                    f"{claim} is reserved by built-in extension {builtin_claims[claim]!r}"
+                )
+        if len(owners) > 1:
+            rendered_owners = ", ".join(repr(item) for item in sorted(owners))
+            for owner in owners:
+                conflicts[owner].append(f"{claim} is claimed by {rendered_owners}")
+
+    return {
+        owner: "extension contribution collision: " + "; ".join(sorted(messages))
+        for owner, messages in conflicts.items()
+    }
+
+
+def _build_plugin_state() -> ExtensionPluginState:
+    """Discover and validate a fresh extension registry state."""
+    builtins = tuple(sorted(_builtin_manifests(), key=lambda item: item.id))
+    for manifest in builtins:
+        validate_manifest(manifest)
+    _validate_builtin_collisions(builtins)
+
+    candidates, load_errors = _load_community_manifests()
+    collisions = _collision_errors(builtins, candidates)
+    for owner, error in collisions.items():
+        load_errors[owner] = error
+        _logger.warning("could not register extension entry point %s (%s)", owner, error)
+
+    accepted = [manifest for owner, manifest in candidates if owner not in collisions]
+    manifests = tuple(sorted((*builtins, *accepted), key=lambda item: item.id))
+    return ExtensionPluginState(
+        manifests=manifests,
+        load_errors=dict(sorted(load_errors.items())),
+    )
+
+
+def plugin_state() -> ExtensionPluginState:
+    """Return the process-cached built-in and installed extension registry."""
+    global _building_thread_id, _state
+    current_thread_id = threading.get_ident()
+    with _state_condition:
+        while _state is None and _building_thread_id is not None:
+            if _building_thread_id == current_thread_id:
+                raise RuntimeError("extension registry cannot be read during discovery")
+            _state_condition.wait()
+        if _state is not None:
+            return _state
+        _building_thread_id = current_thread_id
+
+    try:
+        built = _build_plugin_state()
+    except BaseException:
+        with _state_condition:
+            _building_thread_id = None
+            _state_condition.notify_all()
+        raise
+
+    with _state_condition:
+        _state = built
+        _building_thread_id = None
+        _state_condition.notify_all()
+        return _state
+
+
+def extension_manifests() -> tuple[ExtensionManifest, ...]:
+    """Return all accepted extension manifests in stable ID order."""
+    return plugin_state().manifests
+
+
+def extension_manifest(extension_id: str) -> ExtensionManifest | None:
+    """Return one accepted extension manifest by ID."""
+    return plugin_state().get(extension_id)
+
+
+def reset_plugin_state_for_tests() -> None:
+    """Clear the process-cached registry state."""
+    global _state
+    with _state_condition:
+        if _building_thread_id == threading.get_ident():
+            raise RuntimeError("extension registry cannot be reset during discovery")
+        while _building_thread_id is not None:
+            _state_condition.wait()
+        _state = None

--- a/tests/extensions/__init__.py
+++ b/tests/extensions/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for installed extension discovery and contracts."""

--- a/tests/extensions/test_registry.py
+++ b/tests/extensions/test_registry.py
@@ -1,0 +1,662 @@
+from __future__ import annotations
+
+import importlib.metadata
+import time
+from collections.abc import Callable, Iterator
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+
+import pytest
+
+import omnigent.extensions.registry as registry
+from omnigent.extensions import (
+    EXTENSION_API_VERSION,
+    CommandContribution,
+    ExtensionEntrypoints,
+    ExtensionManifest,
+    ExtensionPermission,
+    PageContribution,
+    PrimaryNavigationContribution,
+)
+
+
+class _Distribution:
+    def __init__(self, name: str, version: str | None = None) -> None:
+        self.name = name
+        self.version = version
+
+
+class _EntryPoint:
+    def __init__(
+        self,
+        name: str,
+        loader: Callable[[], ExtensionManifest] | object,
+        *,
+        distribution: str | None = None,
+        version: str | None = None,
+    ) -> None:
+        self.name = name
+        self._loader = loader
+        self.dist = _Distribution(distribution, version) if distribution else None
+
+    def load(self) -> Callable[[], ExtensionManifest] | object:
+        return self._loader
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    registry.reset_plugin_state_for_tests()
+    monkeypatch.setattr(registry, "_builtin_manifests", lambda: ())
+    monkeypatch.setattr(registry, "VERSION", "0.11.0.dev0")
+    yield
+    registry.reset_plugin_state_for_tests()
+
+
+def _manifest(
+    extension_id: str = "acme.review",
+    *,
+    page_suffix: str = "dashboard",
+    command_suffix: str = "open",
+) -> ExtensionManifest:
+    page_id = f"{extension_id}.{page_suffix}"
+    command_id = f"{extension_id}.{command_suffix}"
+    return ExtensionManifest(
+        id=extension_id,
+        display_name="Acme Review",
+        distribution=f"omnigent-{extension_id.replace('.', '-')}",
+        version="1.2.0",
+        extension_api=EXTENSION_API_VERSION,
+        requires_omnigent=">=0.11,<1",
+        entrypoints=ExtensionEntrypoints(
+            browser="dist/extension.js",
+            browser_css="dist/extension.css",
+        ),
+        permissions=frozenset({ExtensionPermission.NAVIGATION, ExtensionPermission.STORAGE_USER}),
+        activation_events=(f"onPage:{page_id}", f"onCommand:{command_id}"),
+        pages=(
+            PageContribution(
+                id=page_id,
+                title="Review dashboard",
+                route=page_suffix,
+                view="review-dashboard",
+            ),
+        ),
+        primary_navigation=(
+            PrimaryNavigationContribution(
+                id=f"{extension_id}.primary-nav",
+                label="Code Review",
+                page=page_id,
+                icon="search",
+                order=350,
+            ),
+        ),
+        commands=(CommandContribution(id=command_id, title="Open review"),),
+    )
+
+
+def _install_entry_points(
+    monkeypatch: pytest.MonkeyPatch,
+    *entry_points: _EntryPoint,
+) -> None:
+    monkeypatch.setattr(registry, "_entry_points", lambda: entry_points)
+
+
+def test_modern_entry_point_discovery_selects_extension_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = importlib.metadata.EntryPoint(
+        name="review",
+        value="acme_review.plugin:get_manifest",
+        group=registry.ENTRY_POINT_GROUP,
+    )
+    ignored = importlib.metadata.EntryPoint(
+        name="other",
+        value="other.plugin:get_manifest",
+        group="other.group",
+    )
+    discovered = importlib.metadata.EntryPoints((ignored, expected))
+
+    def entry_points(**kwargs: str) -> importlib.metadata.EntryPoints:
+        assert kwargs == {"group": registry.ENTRY_POINT_GROUP}
+        return discovered.select(**kwargs)
+
+    monkeypatch.setattr(registry.importlib.metadata, "entry_points", entry_points)
+
+    assert registry._entry_points() == (expected,)
+
+
+def test_discovers_and_caches_valid_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def contribution() -> ExtensionManifest:
+        nonlocal calls
+        calls += 1
+        return _manifest()
+
+    _install_entry_points(monkeypatch, _EntryPoint("review", contribution))
+
+    first = registry.plugin_state()
+    second = registry.plugin_state()
+
+    assert first is second
+    assert calls == 1
+    assert first.manifests == (_manifest(),)
+    assert first.load_errors == {}
+    assert registry.extension_manifest("acme.review") == _manifest()
+    assert registry.extension_manifest("missing.extension") is None
+
+
+def test_plugin_state_initializes_once_across_threads(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def contribution() -> ExtensionManifest:
+        nonlocal calls
+        calls += 1
+        time.sleep(0.02)
+        return _manifest()
+
+    _install_entry_points(monkeypatch, _EntryPoint("review", contribution))
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        states = list(executor.map(lambda _index: registry.plugin_state(), range(16)))
+
+    assert calls == 1
+    assert all(state is states[0] for state in states)
+
+
+def test_reentrant_registry_read_rejects_plugin_without_hanging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def contribution() -> ExtensionManifest:
+        registry.plugin_state()
+        return _manifest()
+
+    _install_entry_points(monkeypatch, _EntryPoint("review", contribution))
+
+    state = registry.plugin_state()
+
+    assert state.manifests == ()
+    assert "cannot be read during discovery" in state.load_errors["review"]
+
+
+def test_accepts_manifest_object_without_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_entry_points(monkeypatch, _EntryPoint("review", _manifest()))
+
+    assert registry.extension_manifests() == (_manifest(),)
+
+
+def test_records_bad_return_type_without_breaking_healthy_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_entry_points(
+        monkeypatch,
+        _EntryPoint("bad", lambda: object()),
+        _EntryPoint("review", _manifest),
+    )
+
+    state = registry.plugin_state()
+
+    assert state.manifests == (_manifest(),)
+    assert "expected ExtensionManifest" in state.load_errors["bad"]
+
+
+def test_records_raising_entry_point(monkeypatch: pytest.MonkeyPatch) -> None:
+    def broken() -> ExtensionManifest:
+        raise RuntimeError("extension import failed")
+
+    _install_entry_points(monkeypatch, _EntryPoint("broken", broken))
+
+    state = registry.plugin_state()
+
+    assert state.manifests == ()
+    assert state.load_errors["broken"] == "extension import failed"
+
+
+@pytest.mark.parametrize(
+    ("change", "message"),
+    [
+        ({"id": "review"}, "publisher-qualified"),
+        ({"id": "Acme.Review"}, "publisher-qualified"),
+        ({"display_name": ""}, "display_name"),
+        ({"distribution": " omnigent-review"}, "distribution"),
+        ({"version": "not a version"}, "invalid version"),
+        ({"extension_api": EXTENSION_API_VERSION + 1}, "extension API"),
+        ({"extension_api": True}, "extension API"),
+        ({"requires_omnigent": "definitely-not-a-range"}, "invalid Omnigent requirement"),
+        ({"requires_omnigent": "<0"}, "requires Omnigent"),
+    ],
+)
+def test_rejects_invalid_manifest_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    change: dict[str, object],
+    message: str,
+) -> None:
+    manifest = replace(_manifest(), **change)
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    state = registry.plugin_state()
+
+    assert state.manifests == ()
+    assert message in state.load_errors["review"]
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"id": None},
+        {"display_name": 123},
+        {"version": b"1.0"},
+        {"requires_omnigent": None},
+    ],
+)
+def test_non_string_manifest_fields_raise_typed_error(change: dict[str, object]) -> None:
+    with pytest.raises(registry.ExtensionValidationError, match="must be a string"):
+        registry.validate_manifest(replace(_manifest(), **change))
+
+
+def test_non_string_contribution_field_raises_typed_error() -> None:
+    page = replace(_manifest().pages[0], title=None)  # type: ignore[arg-type]
+
+    with pytest.raises(registry.ExtensionValidationError, match="must be a string"):
+        registry.validate_manifest(replace(_manifest(), pages=(page,)))
+
+
+@pytest.mark.parametrize("value", ["line\nbreak", "nul\x00byte", "bidi\u202eoverride"])
+def test_rejects_non_printable_display_text(value: str) -> None:
+    with pytest.raises(registry.ExtensionValidationError, match="non-printable"):
+        registry.validate_manifest(replace(_manifest(), display_name=value))
+
+
+@pytest.mark.parametrize("value", ["../../secret", "view name", "view<script>"])
+def test_rejects_unsafe_view_symbol(value: str) -> None:
+    page = replace(_manifest().pages[0], view=value)
+
+    with pytest.raises(registry.ExtensionValidationError, match="letters, digits"):
+        registry.validate_manifest(replace(_manifest(), pages=(page,)))
+
+
+def test_rejects_unsafe_icon_symbol() -> None:
+    navigation = replace(_manifest().primary_navigation[0], icon="icon\x00name")
+
+    with pytest.raises(registry.ExtensionValidationError, match="non-printable"):
+        registry.validate_manifest(replace(_manifest(), primary_navigation=(navigation,)))
+
+
+def test_rejects_mutable_contribution_collections(monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = replace(_manifest(), pages=list(_manifest().pages))  # type: ignore[arg-type]
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "pages must be a tuple" in registry.plugin_state().load_errors["review"]
+
+
+def test_rejects_wrong_contribution_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = replace(_manifest(), commands=(object(),))  # type: ignore[arg-type]
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert (
+        "commands contains invalid contribution types"
+        in registry.plugin_state().load_errors["review"]
+    )
+
+
+def test_requires_browser_entrypoint_for_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = replace(_manifest(), entrypoints=ExtensionEntrypoints())
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "has no browser entrypoint" in registry.plugin_state().load_errors["review"]
+
+
+def test_rejects_browser_css_without_browser_entrypoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = replace(
+        _manifest(),
+        pages=(),
+        primary_navigation=(),
+        activation_events=("onCommand:acme.review.open",),
+        entrypoints=ExtensionEntrypoints(browser_css="dist/extension.css"),
+    )
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "browser CSS but no browser entrypoint" in registry.plugin_state().load_errors["review"]
+
+
+def test_rejects_unknown_permission(monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = replace(
+        _manifest(),
+        permissions=frozenset({"sessions.delete"}),  # type: ignore[arg-type]
+    )
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "unsupported permissions" in registry.plugin_state().load_errors["review"]
+
+
+def test_rejects_non_integer_navigation_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    nav = replace(_manifest().primary_navigation[0], order=3.5)  # type: ignore[arg-type]
+    manifest = replace(_manifest(), primary_navigation=(nav,))
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "order must be an integer" in registry.plugin_state().load_errors["review"]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/dist/extension.js",
+        "../extension.js",
+        "dist/../extension.js",
+        "dist\\extension.js",
+        "dist/extension.js?raw=1",
+        "./dist/extension.js",
+        "%2e%2e/extension.js",
+        "dist/ext\x00ension.js",
+        "dist/ext ension.js",
+        "C:/extension.js",
+    ],
+)
+def test_rejects_unsafe_browser_entrypoint(
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+) -> None:
+    manifest = replace(
+        _manifest(),
+        entrypoints=ExtensionEntrypoints(browser=path),
+    )
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "browser entrypoint" in registry.plugin_state().load_errors["review"]
+
+
+def test_requires_javascript_suffix_for_browser_entrypoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = replace(
+        _manifest(),
+        entrypoints=ExtensionEntrypoints(browser="dist/extension.txt"),
+    )
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert (
+        "browser entrypoint must use one of: .js, .mjs"
+        in registry.plugin_state().load_errors["review"]
+    )
+
+
+def test_requires_css_suffix_for_browser_styles(monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = replace(
+        _manifest(),
+        entrypoints=ExtensionEntrypoints(
+            browser="dist/extension.js",
+            browser_css="dist/extension.txt",
+        ),
+    )
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert (
+        "browser CSS entrypoint must use one of: .css"
+        in registry.plugin_state().load_errors["review"]
+    )
+
+
+def test_rejects_unsafe_or_dynamic_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    page = replace(_manifest().pages[0], route="dashboard/:section")
+    manifest = replace(_manifest(), pages=(page,))
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "unsupported route segment" in registry.plugin_state().load_errors["review"]
+
+
+def test_rejects_contribution_outside_extension_namespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page = replace(_manifest().pages[0], id="other.publisher.dashboard")
+    manifest = replace(_manifest(), pages=(page,))
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "must be namespaced" in registry.plugin_state().load_errors["review"]
+
+
+def test_rejects_navigation_reference_to_unknown_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nav = replace(_manifest().primary_navigation[0], page="acme.review.missing")
+    manifest = replace(_manifest(), primary_navigation=(nav,))
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "references unknown page" in registry.plugin_state().load_errors["review"]
+
+
+def test_rejects_activation_reference_to_unknown_contribution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = replace(_manifest(), activation_events=("onCommand:acme.review.missing",))
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "unknown contribution" in registry.plugin_state().load_errors["review"]
+
+
+def test_rejects_duplicate_page_routes(monkeypatch: pytest.MonkeyPatch) -> None:
+    second = PageContribution(
+        id="acme.review.other",
+        title="Other",
+        route="dashboard",
+        view="other",
+    )
+    manifest = replace(_manifest(), pages=(*_manifest().pages, second))
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "duplicate page routes" in registry.plugin_state().load_errors["review"]
+
+
+def test_rejects_duplicate_ids_across_contribution_kinds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = CommandContribution(id="acme.review.dashboard", title="Dashboard")
+    manifest = replace(
+        _manifest(),
+        commands=(command,),
+        activation_events=("onPage:acme.review.dashboard",),
+    )
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "duplicate contribution ids" in registry.plugin_state().load_errors["review"]
+
+
+def test_rejects_installed_distribution_metadata_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_entry_points(
+        monkeypatch,
+        _EntryPoint(
+            "review",
+            _manifest(),
+            distribution="different-package",
+            version="9.0.0",
+        ),
+    )
+
+    error = registry.plugin_state().load_errors["different-package:review"]
+    assert "does not match installed distribution" in error
+
+
+def test_rejects_installed_distribution_version_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest()
+    _install_entry_points(
+        monkeypatch,
+        _EntryPoint(
+            "review",
+            manifest,
+            distribution=manifest.distribution.replace("-", "_"),
+            version="9.0.0",
+        ),
+    )
+
+    error = registry.plugin_state().load_errors[
+        f"{manifest.distribution.replace('-', '_')}:review"
+    ]
+    assert "does not match installed distribution version" in error
+
+
+@pytest.mark.parametrize(
+    ("running_version", "requirement", "accepted"),
+    [
+        ("0.11.0.dev0", ">=0.11,<1", True),
+        ("0.11.9", ">=0.12", False),
+        ("1.0.0rc1", "<1", False),
+        ("0.11.0.dev0", "==0.11.0.dev0", False),
+    ],
+)
+def test_core_compatibility_uses_release_line(
+    monkeypatch: pytest.MonkeyPatch,
+    running_version: str,
+    requirement: str,
+    accepted: bool,
+) -> None:
+    monkeypatch.setattr(registry, "VERSION", running_version)
+    manifest = replace(_manifest(), requires_omnigent=requirement)
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    state = registry.plugin_state()
+
+    assert bool(state.manifests) is accepted
+
+
+def test_invalid_running_core_version_has_typed_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(registry, "VERSION", "invalid")
+
+    with pytest.raises(registry.ExtensionValidationError, match="Omnigent has invalid version"):
+        registry.validate_manifest(_manifest())
+
+
+def test_accepts_multiple_extensions_in_stable_id_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = replace(_manifest("zeta.review"), distribution="shared-package")
+    second = replace(_manifest("acme.notes"), distribution="shared-package")
+    _install_entry_points(
+        monkeypatch,
+        _EntryPoint("zeta", first),
+        _EntryPoint("acme", second),
+    )
+
+    state = registry.plugin_state()
+
+    assert [manifest.id for manifest in state.manifests] == ["acme.notes", "zeta.review"]
+    assert state.load_errors == {}
+
+
+def test_rejects_cross_extension_contribution_collision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = _manifest("acme.review")
+    second = _manifest("acme.review.sub")
+    second = replace(
+        second,
+        commands=(CommandContribution(id="acme.review.sub.open", title="Open"),),
+    )
+    first = replace(
+        first,
+        commands=(CommandContribution(id="acme.review.sub.open", title="Open tools"),),
+        activation_events=("onPage:acme.review.dashboard",),
+    )
+    _install_entry_points(
+        monkeypatch,
+        _EntryPoint("review", first),
+        _EntryPoint("tools", second),
+    )
+
+    state = registry.plugin_state()
+
+    assert state.manifests == ()
+    assert "contribution:acme.review.sub.open" in state.load_errors["review"]
+    assert "contribution:acme.review.sub.open" in state.load_errors["tools"]
+
+
+def test_rejects_all_community_extensions_in_collision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = _manifest()
+    second = replace(first, distribution="other-review", version="2.0.0")
+    _install_entry_points(
+        monkeypatch,
+        _EntryPoint("z-review", second),
+        _EntryPoint("a-review", first),
+    )
+
+    state = registry.plugin_state()
+
+    assert state.manifests == ()
+    assert "extension:acme.review" in state.load_errors["a-review"]
+    assert "extension:acme.review" in state.load_errors["z-review"]
+    assert "'a-review', 'z-review'" in state.load_errors["a-review"]
+
+
+def test_rejects_community_collision_with_builtin(monkeypatch: pytest.MonkeyPatch) -> None:
+    builtin = _manifest()
+    monkeypatch.setattr(registry, "_builtin_manifests", lambda: (builtin,))
+    community = replace(builtin, distribution="community-review")
+    _install_entry_points(monkeypatch, _EntryPoint("review", community))
+
+    state = registry.plugin_state()
+
+    assert state.manifests == (builtin,)
+    assert "reserved by built-in extension 'acme.review'" in state.load_errors["review"]
+
+
+def test_accepts_multiple_builtins_from_core_distribution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = replace(_manifest("zeta.review"), distribution="omnigent")
+    second = replace(_manifest("acme.notes"), distribution="omnigent")
+    monkeypatch.setattr(registry, "_builtin_manifests", lambda: (first, second))
+    _install_entry_points(monkeypatch)
+
+    assert [manifest.id for manifest in registry.extension_manifests()] == [
+        "acme.notes",
+        "zeta.review",
+    ]
+
+
+def test_rejects_colliding_builtin_manifests(monkeypatch: pytest.MonkeyPatch) -> None:
+    first = _manifest()
+    second = replace(first, display_name="Other built-in")
+    monkeypatch.setattr(registry, "_builtin_manifests", lambda: (first, second))
+    _install_entry_points(monkeypatch)
+
+    with pytest.raises(RuntimeError, match=r"both claim extension:acme\.review"):
+        registry.plugin_state()
+
+
+def test_uses_distribution_in_diagnostics_and_disambiguates_duplicates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_entry_points(
+        monkeypatch,
+        _EntryPoint("plugin", lambda: object(), distribution="first-dist"),
+        _EntryPoint("plugin", lambda: object(), distribution="first-dist"),
+    )
+
+    assert set(registry.plugin_state().load_errors) == {
+        "first-dist:plugin",
+        "first-dist:plugin#2",
+    }
+
+
+def test_public_validate_manifest_raises_typed_error() -> None:
+    with pytest.raises(registry.ExtensionValidationError, match="publisher-qualified"):
+        registry.validate_manifest(replace(_manifest(), id="invalid"))
+
+
+def test_load_errors_are_a_stably_ordered_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_entry_points(
+        monkeypatch,
+        _EntryPoint("z-bad", lambda: object()),
+        _EntryPoint("a-bad", lambda: object()),
+    )
+
+    errors = registry.plugin_state().load_errors
+
+    assert isinstance(errors, dict)
+    assert list(errors) == ["a-bad", "z-bad"]


### PR DESCRIPTION
## Related issue

N/A — maintainer architecture work.

## Summary

- Introduce versioned contracts for extension pages, primary navigation, permissions, browser entrypoints, and reserved command metadata.
- Discover installed `omnigent.extensions` entry points, validate compatibility and package metadata, and reject malformed or conflicting contributions atomically without breaking healthy plugins.
- Make first-load caching thread-safe and expose deterministic diagnostics for optional plugin failures. Command execution, activation events, and `when` evaluation remain explicitly deferred from V1.

**ELI5:** extension packages can now hand Omnigent a checked list of the pages and navigation they want to add. Omnigent records valid lists and sets bad or conflicting ones aside before any extension UI runs.

```text
installed entry points
        |
        v
load lightweight manifests
        |
        v
validate + find all collisions
        |
        v
accepted registry + diagnostics
```

This is **PR 1 of the extension-framework stack**. PR #5606 adds the server catalog and diagnostics API on top of this contract.

## Test Plan

- `uv run pytest tests/extensions/test_registry.py`
- `uv run ruff check omnigent/extensions tests/extensions`
- `uv run pyrefly check omnigent/extensions`
- `git diff --check`
- `pre-commit run --all-files`

## Demo

N/A — this PR adds a backend contract and registry with no visual surface.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused registry suite covers discovery, compatibility, validation, deterministic collisions, package metadata, concurrency, and failure isolation.
