### PR TITLE
feat(extensions): expose the installed extension catalog

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -29,6 +29,8 @@ from omnigent._platform import resolve_repo_symlink
 from omnigent.db.db_models import InvalidUuidError
 from omnigent.debug_logging import set_current_user_id
 from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.extensions import ExtensionPluginState
+from omnigent.extensions.registry import plugin_state as load_extension_plugin_state
 from omnigent.harness_plugins import (
     NativeHarnessProvider,
     native_provider_for_key,
@@ -66,6 +68,7 @@ from omnigent.server.routes.builtin_agents import create_builtin_agents_router
 from omnigent.server.routes.comments import create_comments_router
 from omnigent.server.routes.default_policies import create_default_policies_router
 from omnigent.server.routes.dictation import create_dictation_router
+from omnigent.server.routes.extensions import create_extensions_router
 from omnigent.server.routes.harnesses import create_harnesses_router
 from omnigent.server.routes.imports import create_imports_router
 from omnigent.server.routes.policy_registry import create_policy_registry_router
@@ -141,6 +144,22 @@ class ServerInfoResponse(BaseModel):
     installable_harnesses: list[str]
     dictation_available: bool
     branding: BrandingInfo
+
+
+def _resolve_extension_state(
+    provided: ExtensionPluginState | None,
+) -> ExtensionPluginState:
+    """Resolve extensions without allowing catalog discovery to stop the server."""
+    if provided is not None:
+        return provided
+    try:
+        return load_extension_plugin_state()
+    # Distribution metadata is an external installation boundary. Preserve the
+    # rest of the server if global discovery itself fails before per-plugin
+    # failure isolation can apply.
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("could not discover installed extensions (%s)", exc, exc_info=True)
+        return ExtensionPluginState(manifests=(), load_errors={"registry": str(exc)})
 
 
 def _server_version() -> str:
@@ -926,6 +945,7 @@ def create_app(
     public_sharing: bool | Callable[[], bool] | None = None,
     server_config: dict[str, Any] | None = None,
     feature_flags: FeatureFlags | None = None,
+    extension_state: ExtensionPluginState | None = None,
 ) -> FastAPI:
     """
     Build and return the FastAPI application with all routes mounted.
@@ -1019,6 +1039,9 @@ def create_app(
     :param feature_flags: Optional immutable release-feature snapshot.
         When omitted, resolves the comma-separated ``OMNIGENT_FEATURES``
         enabled set once at application construction.
+    :param extension_state: Optional pre-resolved installed-extension registry.
+        When omitted, entry points are discovered once at application
+        construction and the process-cached state is reused thereafter.
     :param public_sharing: Whether public (anyone-with-the-link) read
         access may be granted — i.e. whether the ``__public__`` grant is
         allowed. Orthogonal to ``sharing_mode``: a server can keep normal
@@ -1042,6 +1065,7 @@ def create_app(
 
     branding_snapshot = load_branding_snapshot(server_config)
     resolved_feature_flags = feature_flags or resolve_feature_flags()
+    resolved_extension_state = _resolve_extension_state(extension_state)
 
     # First-boot admin bootstrap for the accounts auth provider.
     # Runs before any route is mounted so the login page is never
@@ -2268,6 +2292,15 @@ def create_app(
         create_harnesses_router(auth_provider=auth_provider),
         prefix="/v1",
         tags=["harnesses"],
+    )
+    app.include_router(
+        create_extensions_router(
+            resolved_extension_state,
+            auth_provider=auth_provider,
+            permission_store=permission_store,
+        ),
+        prefix="/v1",
+        tags=["extensions"],
     )
     # Server-side speech-to-text behind the composer mic button
     # (designs/server-dictation.md). Availability is probed lazily, so

--- a/omnigent/server/routes/extensions.py
+++ b/omnigent/server/routes/extensions.py
@@ -1,0 +1,198 @@
+"""Read-only catalog and diagnostics for installed extensions."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Literal
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.extensions import ExtensionManifest, ExtensionPluginState
+from omnigent.server.auth import AuthProvider
+from omnigent.server.routes._auth_helpers import require_user
+from omnigent.stores.permission_store import PermissionStore
+
+
+class ExtensionPageResponse(BaseModel):
+    """One namespaced page contribution."""
+
+    id: str
+    title: str
+    route: str
+    view: str
+
+
+class ExtensionPrimaryNavigationResponse(BaseModel):
+    """One primary-sidebar navigation contribution."""
+
+    id: str
+    label: str
+    page: str
+    icon: str | None
+    order: int
+    when: str | None
+
+
+class ExtensionBrowserBundleResponse(BaseModel):
+    """Opaque browser-bundle availability metadata.
+
+    Asset URLs and content digests are populated by the asset-serving layer in
+    the next stack PR. A declared bundle is not runnable until those fields are
+    present.
+    """
+
+    declared: bool
+    has_styles: bool
+    digest: str | None = None
+    script_url: str | None = None
+    style_url: str | None = None
+
+
+class ExtensionResponse(BaseModel):
+    """Public metadata for one accepted extension."""
+
+    object: Literal["extension"] = "extension"
+    id: str
+    display_name: str
+    distribution: str
+    version: str
+    extension_api: int
+    status: Literal["enabled"] = "enabled"
+    permissions: list[str]
+    pages: list[ExtensionPageResponse]
+    primary_navigation: list[ExtensionPrimaryNavigationResponse]
+    browser: ExtensionBrowserBundleResponse
+
+
+class ExtensionListResponse(BaseModel):
+    """Public catalog of accepted extensions."""
+
+    object: Literal["list"] = "list"
+    data: list[ExtensionResponse]
+
+
+class ExtensionLoadErrorResponse(BaseModel):
+    """Concise diagnostic for one rejected entry point."""
+
+    entry_point: str
+    status: Literal["rejected"] = "rejected"
+    error: str
+
+
+class ExtensionDiagnosticsResponse(BaseModel):
+    """Administrator view of accepted and rejected extensions."""
+
+    object: Literal["extension_diagnostics"] = "extension_diagnostics"
+    extensions: list[ExtensionResponse]
+    load_errors: list[ExtensionLoadErrorResponse]
+
+
+def _serialize_manifest(manifest: ExtensionManifest) -> ExtensionResponse:
+    """Convert a validated manifest into stable JSON-safe catalog metadata."""
+    pages = [
+        ExtensionPageResponse(id=page.id, title=page.title, route=page.route, view=page.view)
+        for page in sorted(manifest.pages, key=lambda item: item.id)
+    ]
+    navigation = [
+        ExtensionPrimaryNavigationResponse(
+            id=item.id,
+            label=item.label,
+            page=item.page,
+            icon=item.icon,
+            order=item.order,
+            when=item.when,
+        )
+        for item in sorted(manifest.primary_navigation, key=lambda item: (item.order, item.id))
+    ]
+    return ExtensionResponse(
+        id=manifest.id,
+        display_name=manifest.display_name,
+        distribution=manifest.distribution,
+        version=manifest.version,
+        extension_api=manifest.extension_api,
+        permissions=sorted(permission.value for permission in manifest.permissions),
+        pages=pages,
+        primary_navigation=navigation,
+        browser=ExtensionBrowserBundleResponse(
+            declared=manifest.entrypoints.browser is not None,
+            has_styles=manifest.entrypoints.browser_css is not None,
+        ),
+    )
+
+
+async def _require_admin(
+    request: Request,
+    auth_provider: AuthProvider | None,
+    permission_store: PermissionStore | None,
+) -> None:
+    """Require an administrator in multi-user mode."""
+    user_id = require_user(request, auth_provider)
+    if permission_store is None:
+        return
+    if user_id is None:
+        raise OmnigentError("Authentication required", code=ErrorCode.UNAUTHORIZED)
+    is_admin = await asyncio.to_thread(permission_store.is_admin, user_id)
+    if not is_admin:
+        raise OmnigentError(
+            "Admin privileges required to inspect extension diagnostics",
+            code=ErrorCode.FORBIDDEN,
+        )
+
+
+def _diagnostic_message(error: str) -> str:
+    """Bound and flatten plugin errors before returning them through the API."""
+    printable = "".join(character if character.isprintable() else " " for character in error)
+    return " ".join(printable.split())[:512]
+
+
+def create_extensions_router(
+    state: ExtensionPluginState,
+    *,
+    auth_provider: AuthProvider | None = None,
+    permission_store: PermissionStore | None = None,
+) -> APIRouter:
+    """Build the installed-extension catalog router, mounted under ``/v1``."""
+    router = APIRouter()
+    catalog = tuple(
+        _serialize_manifest(manifest)
+        for manifest in sorted(state.manifests, key=lambda item: item.id)
+    )
+    by_id = {item.id: item for item in catalog}
+    diagnostics = tuple(
+        ExtensionLoadErrorResponse(entry_point=entry_point, error=_diagnostic_message(error))
+        for entry_point, error in sorted(state.load_errors.items())
+    )
+
+    @router.get("/extensions", response_model=ExtensionListResponse)
+    async def list_extensions(request: Request) -> ExtensionListResponse:
+        """List extensions installed and enabled when the server started.
+
+        V1 treats operator installation as enablement. Installing, removing, or
+        upgrading a package requires a server restart to refresh this snapshot.
+        """
+        require_user(request, auth_provider)
+        return ExtensionListResponse(data=list(catalog))
+
+    # Keep this static path above ``/{extension_id}`` so it cannot be consumed
+    # as an extension identifier.
+    @router.get("/extensions/diagnostics", response_model=ExtensionDiagnosticsResponse)
+    async def extension_diagnostics(request: Request) -> ExtensionDiagnosticsResponse:
+        """Show accepted extensions and concise discovery failures to administrators."""
+        await _require_admin(request, auth_provider, permission_store)
+        return ExtensionDiagnosticsResponse(
+            extensions=list(catalog),
+            load_errors=list(diagnostics),
+        )
+
+    @router.get("/extensions/{extension_id}", response_model=ExtensionResponse)
+    async def get_extension(request: Request, extension_id: str) -> ExtensionResponse:
+        """Return one installed extension's public contribution metadata."""
+        require_user(request, auth_provider)
+        extension = by_id.get(extension_id)
+        if extension is None:
+            raise OmnigentError("Extension not found", code=ErrorCode.NOT_FOUND)
+        return extension
+
+    return router

--- a/openapi.json
+++ b/openapi.json
@@ -1802,6 +1802,293 @@
         "title": "ErrorEvent",
         "type": "object"
       },
+      "ExtensionBrowserBundleResponse": {
+        "description": "Opaque browser-bundle availability metadata.\n\nAsset URLs and content digests are populated by the asset-serving layer in\nthe next stack PR. A declared bundle is not runnable until those fields are\npresent.",
+        "properties": {
+          "declared": {
+            "title": "Declared",
+            "type": "boolean"
+          },
+          "digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Digest"
+          },
+          "has_styles": {
+            "title": "Has Styles",
+            "type": "boolean"
+          },
+          "script_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Script Url"
+          },
+          "style_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Style Url"
+          }
+        },
+        "required": [
+          "declared",
+          "has_styles"
+        ],
+        "title": "ExtensionBrowserBundleResponse",
+        "type": "object"
+      },
+      "ExtensionDiagnosticsResponse": {
+        "description": "Administrator view of accepted and rejected extensions.",
+        "properties": {
+          "extensions": {
+            "items": {
+              "$ref": "#/components/schemas/ExtensionResponse"
+            },
+            "title": "Extensions",
+            "type": "array"
+          },
+          "load_errors": {
+            "items": {
+              "$ref": "#/components/schemas/ExtensionLoadErrorResponse"
+            },
+            "title": "Load Errors",
+            "type": "array"
+          },
+          "object": {
+            "const": "extension_diagnostics",
+            "default": "extension_diagnostics",
+            "title": "Object",
+            "type": "string"
+          }
+        },
+        "required": [
+          "extensions",
+          "load_errors"
+        ],
+        "title": "ExtensionDiagnosticsResponse",
+        "type": "object"
+      },
+      "ExtensionListResponse": {
+        "description": "Public catalog of accepted extensions.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ExtensionResponse"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "object": {
+            "const": "list",
+            "default": "list",
+            "title": "Object",
+            "type": "string"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "ExtensionListResponse",
+        "type": "object"
+      },
+      "ExtensionLoadErrorResponse": {
+        "description": "Concise diagnostic for one rejected entry point.",
+        "properties": {
+          "entry_point": {
+            "title": "Entry Point",
+            "type": "string"
+          },
+          "error": {
+            "title": "Error",
+            "type": "string"
+          },
+          "status": {
+            "const": "rejected",
+            "default": "rejected",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "entry_point",
+          "error"
+        ],
+        "title": "ExtensionLoadErrorResponse",
+        "type": "object"
+      },
+      "ExtensionPageResponse": {
+        "description": "One namespaced page contribution.",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "route": {
+            "title": "Route",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "view": {
+            "title": "View",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "route",
+          "view"
+        ],
+        "title": "ExtensionPageResponse",
+        "type": "object"
+      },
+      "ExtensionPrimaryNavigationResponse": {
+        "description": "One primary-sidebar navigation contribution.",
+        "properties": {
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "order": {
+            "title": "Order",
+            "type": "integer"
+          },
+          "page": {
+            "title": "Page",
+            "type": "string"
+          },
+          "when": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "When"
+          }
+        },
+        "required": [
+          "id",
+          "label",
+          "page",
+          "icon",
+          "order",
+          "when"
+        ],
+        "title": "ExtensionPrimaryNavigationResponse",
+        "type": "object"
+      },
+      "ExtensionResponse": {
+        "description": "Public metadata for one accepted extension.",
+        "properties": {
+          "browser": {
+            "$ref": "#/components/schemas/ExtensionBrowserBundleResponse"
+          },
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "distribution": {
+            "title": "Distribution",
+            "type": "string"
+          },
+          "extension_api": {
+            "title": "Extension Api",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "object": {
+            "const": "extension",
+            "default": "extension",
+            "title": "Object",
+            "type": "string"
+          },
+          "pages": {
+            "items": {
+              "$ref": "#/components/schemas/ExtensionPageResponse"
+            },
+            "title": "Pages",
+            "type": "array"
+          },
+          "permissions": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Permissions",
+            "type": "array"
+          },
+          "primary_navigation": {
+            "items": {
+              "$ref": "#/components/schemas/ExtensionPrimaryNavigationResponse"
+            },
+            "title": "Primary Navigation",
+            "type": "array"
+          },
+          "status": {
+            "const": "enabled",
+            "default": "enabled",
+            "title": "Status",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "display_name",
+          "distribution",
+          "version",
+          "extension_api",
+          "permissions",
+          "pages",
+          "primary_navigation",
+          "browser"
+        ],
+        "title": "ExtensionResponse",
+        "type": "object"
+      },
       "FailedEvent": {
         "description": "Terminal event for a turn that ended with an error.\n\nCarries a `omnigent.server.schemas.FailedResponseObject`\nwhose `error` field describes the failure. Response metadata may\nbe absent when the failure occurs before response allocation.",
         "properties": {
@@ -8005,6 +8292,93 @@
         "summary": "Branding Logo"
       }
     },
+    "/v1/extensions": {
+      "get": {
+        "description": "List extensions installed and enabled when the server started.\n\nV1 treats operator installation as enablement. Installing, removing, or\nupgrading a package requires a server restart to refresh this snapshot.",
+        "operationId": "list_extensions_v1_extensions_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Extensions",
+        "tags": [
+          "extensions"
+        ]
+      }
+    },
+    "/v1/extensions/diagnostics": {
+      "get": {
+        "description": "Show accepted extensions and concise discovery failures to administrators.",
+        "operationId": "extension_diagnostics_v1_extensions_diagnostics_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionDiagnosticsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Extension Diagnostics",
+        "tags": [
+          "extensions"
+        ]
+      }
+    },
+    "/v1/extensions/{extension_id}": {
+      "get": {
+        "description": "Return one installed extension's public contribution metadata.",
+        "operationId": "get_extension_v1_extensions__extension_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "extension_id",
+            "required": true,
+            "schema": {
+              "title": "Extension Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Extension",
+        "tags": [
+          "extensions"
+        ]
+      }
+    },
     "/v1/harnesses": {
       "get": {
         "operationId": "list_harnesses_v1_harnesses_get",
@@ -13312,6 +13686,11 @@
       "description": "Discover the built-in agents available to bind to a session.",
       "name": "agents",
       "x-displayName": "Agents"
+    },
+    {
+      "description": "Inspect installed extension pages and navigation contributions.",
+      "name": "extensions",
+      "x-displayName": "Extensions"
     },
     {
       "description": "Hosts that can launch runners. Browse the host filesystem and create directories.",

--- a/scripts/dump_openapi.py
+++ b/scripts/dump_openapi.py
@@ -236,6 +236,11 @@ _TAGS: list[dict[str, str]] = [
         "description": "Discover the built-in agents available to bind to a session.",
     },
     {
+        "name": "extensions",
+        "x-displayName": "Extensions",
+        "description": "Inspect installed extension pages and navigation contributions.",
+    },
+    {
         "name": "hosts",
         "x-displayName": "Hosts",
         "description": (

--- a/tests/server/routes/test_extensions_routes.py
+++ b/tests/server/routes/test_extensions_routes.py
@@ -1,0 +1,381 @@
+"""Tests for the installed-extension catalog and diagnostics routes."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+import omnigent.server.app as app_module
+from omnigent.extensions import (
+    EXTENSION_API_VERSION,
+    ExtensionEntrypoints,
+    ExtensionManifest,
+    ExtensionPermission,
+    ExtensionPluginState,
+    PageContribution,
+    PrimaryNavigationContribution,
+)
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.app import create_app
+from omnigent.server.auth import AuthProvider, UnifiedAuthProvider
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+
+_ADMIN = "admin@extensions.test"
+_USER = "user@extensions.test"
+
+
+def _manifest(extension_id: str = "acme.review") -> ExtensionManifest:
+    page_id = f"{extension_id}.dashboard"
+    return ExtensionManifest(
+        id=extension_id,
+        display_name="Acme Review",
+        distribution="omnigent-acme-review",
+        version="1.2.0",
+        requires_omnigent=">=0.11,<1",
+        extension_api=EXTENSION_API_VERSION,
+        entrypoints=ExtensionEntrypoints(
+            browser="dist/extension.js",
+            browser_css="dist/extension.css",
+        ),
+        permissions=frozenset({ExtensionPermission.NAVIGATION, ExtensionPermission.STORAGE_USER}),
+        pages=(
+            PageContribution(
+                id=page_id,
+                title="Review dashboard",
+                route="dashboard",
+                view="review-dashboard",
+            ),
+        ),
+        primary_navigation=(
+            PrimaryNavigationContribution(
+                id=f"{extension_id}.primary-nav",
+                label="Code Review",
+                page=page_id,
+                icon="search",
+                order=350,
+            ),
+        ),
+    )
+
+
+def _state() -> ExtensionPluginState:
+    return ExtensionPluginState(
+        manifests=(_manifest(),),
+        load_errors={"broken:entry": "extension import failed"},
+    )
+
+
+def _build_app(
+    db_uri: str,
+    tmp_path: Path,
+    *,
+    extension_state: ExtensionPluginState | None = None,
+    permission_store: SqlAlchemyPermissionStore | None = None,
+    auth_provider: AuthProvider | None = None,
+) -> FastAPI:
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    return create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(artifact_store=artifact_store, cache_dir=tmp_path / "cache"),
+        permission_store=permission_store,
+        auth_provider=auth_provider,
+        extension_state=extension_state,
+    )
+
+
+def _client(app: FastAPI, email: str | None = None) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"X-Forwarded-Email": email} if email else {},
+    )
+
+
+@pytest.fixture
+def catalog_app(db_uri: str, tmp_path: Path) -> FastAPI:
+    return _build_app(db_uri, tmp_path, extension_state=_state())
+
+
+@pytest.fixture
+def multi_user_app(db_uri: str, tmp_path: Path) -> FastAPI:
+    permission_store = SqlAlchemyPermissionStore(db_uri)
+    permission_store.ensure_user(_ADMIN, is_admin=True)
+    permission_store.ensure_user(_USER)
+    return _build_app(
+        db_uri,
+        tmp_path,
+        extension_state=_state(),
+        permission_store=permission_store,
+        auth_provider=UnifiedAuthProvider(source="header", local_single_user=False),
+    )
+
+
+async def test_catalog_serializes_only_public_v1_contributions(catalog_app: FastAPI) -> None:
+    async with _client(catalog_app) as client:
+        response = await client.get("/v1/extensions")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "object": "list",
+        "data": [
+            {
+                "object": "extension",
+                "id": "acme.review",
+                "display_name": "Acme Review",
+                "distribution": "omnigent-acme-review",
+                "version": "1.2.0",
+                "extension_api": 1,
+                "status": "enabled",
+                "permissions": ["navigation", "storage.user"],
+                "pages": [
+                    {
+                        "id": "acme.review.dashboard",
+                        "title": "Review dashboard",
+                        "route": "dashboard",
+                        "view": "review-dashboard",
+                    }
+                ],
+                "primary_navigation": [
+                    {
+                        "id": "acme.review.primary-nav",
+                        "label": "Code Review",
+                        "page": "acme.review.dashboard",
+                        "icon": "search",
+                        "order": 350,
+                        "when": None,
+                    }
+                ],
+                "browser": {
+                    "declared": True,
+                    "has_styles": True,
+                    "digest": None,
+                    "script_url": None,
+                    "style_url": None,
+                },
+            }
+        ],
+    }
+    assert "commands" not in response.text
+    assert "dist/extension.js" not in response.text
+    assert "extension import failed" not in response.text
+
+
+async def test_empty_catalog_on_core_only_install(db_uri: str, tmp_path: Path) -> None:
+    app = _build_app(
+        db_uri,
+        tmp_path,
+        extension_state=ExtensionPluginState(manifests=(), load_errors={}),
+    )
+
+    async with _client(app) as client:
+        response = await client.get("/v1/extensions")
+
+    assert response.status_code == 200
+    assert response.json() == {"object": "list", "data": []}
+
+
+async def test_catalog_order_is_stable(db_uri: str, tmp_path: Path) -> None:
+    zeta = _manifest("zeta.review")
+    alpha_page = PageContribution(
+        id="acme.review.alpha",
+        title="Alpha",
+        route="alpha",
+        view="alpha",
+    )
+    alpha_nav = PrimaryNavigationContribution(
+        id="acme.review.alpha-nav",
+        label="Alpha",
+        page=alpha_page.id,
+        order=350,
+    )
+    alpha = replace(
+        _manifest(),
+        pages=(*_manifest().pages, alpha_page),
+        primary_navigation=(*_manifest().primary_navigation, alpha_nav),
+    )
+    app = _build_app(
+        db_uri,
+        tmp_path,
+        extension_state=ExtensionPluginState(manifests=(zeta, alpha), load_errors={}),
+    )
+
+    async with _client(app) as client:
+        data = (await client.get("/v1/extensions")).json()["data"]
+
+    assert [item["id"] for item in data] == ["acme.review", "zeta.review"]
+    assert [item["id"] for item in data[0]["pages"]] == [
+        "acme.review.alpha",
+        "acme.review.dashboard",
+    ]
+    assert [item["id"] for item in data[0]["primary_navigation"]] == [
+        "acme.review.alpha-nav",
+        "acme.review.primary-nav",
+    ]
+
+
+async def test_extension_detail_and_unknown_id(catalog_app: FastAPI) -> None:
+    async with _client(catalog_app) as client:
+        found = await client.get("/v1/extensions/acme.review")
+        missing = await client.get("/v1/extensions/missing.extension")
+
+    assert found.status_code == 200
+    assert found.json()["id"] == "acme.review"
+    assert missing.status_code == 404
+
+
+async def test_diagnostics_allows_single_user_mode(catalog_app: FastAPI) -> None:
+    async with _client(catalog_app) as client:
+        response = await client.get("/v1/extensions/diagnostics")
+
+    assert response.status_code == 200
+    assert response.json()["load_errors"] == [
+        {
+            "entry_point": "broken:entry",
+            "status": "rejected",
+            "error": "extension import failed",
+        }
+    ]
+
+
+async def test_public_catalog_requires_authentication(multi_user_app: FastAPI) -> None:
+    async with _client(multi_user_app) as client:
+        listing = await client.get("/v1/extensions")
+        detail = await client.get("/v1/extensions/acme.review")
+
+    assert listing.status_code == 401
+    assert detail.status_code == 401
+
+
+async def test_diagnostics_requires_auth_without_permission_store(
+    db_uri: str,
+    tmp_path: Path,
+) -> None:
+    app = _build_app(
+        db_uri,
+        tmp_path,
+        extension_state=_state(),
+        auth_provider=UnifiedAuthProvider(source="header", local_single_user=False),
+    )
+
+    async with _client(app) as client:
+        response = await client.get("/v1/extensions/diagnostics")
+
+    assert response.status_code == 401
+
+
+async def test_diagnostics_sanitizes_and_bounds_plugin_errors(
+    db_uri: str,
+    tmp_path: Path,
+) -> None:
+    error = "bad\npath\x00" + "x" * 600
+    app = _build_app(
+        db_uri,
+        tmp_path,
+        extension_state=ExtensionPluginState(manifests=(), load_errors={"bad": error}),
+    )
+
+    async with _client(app) as client:
+        response = await client.get("/v1/extensions/diagnostics")
+
+    returned = response.json()["load_errors"][0]["error"]
+    assert returned.startswith("bad path ")
+    assert len(returned) == 512
+    assert "\n" not in returned
+    assert "\x00" not in returned
+
+
+async def test_diagnostics_allows_admin(multi_user_app: FastAPI) -> None:
+    async with _client(multi_user_app, _ADMIN) as client:
+        response = await client.get("/v1/extensions/diagnostics")
+
+    assert response.status_code == 200
+
+
+async def test_diagnostics_forbids_non_admin(multi_user_app: FastAPI) -> None:
+    async with _client(multi_user_app, _USER) as client:
+        response = await client.get("/v1/extensions/diagnostics")
+
+    assert response.status_code == 403
+
+
+async def test_diagnostics_requires_authentication(multi_user_app: FastAPI) -> None:
+    async with _client(multi_user_app) as client:
+        response = await client.get("/v1/extensions/diagnostics")
+
+    assert response.status_code == 401
+
+
+async def test_registry_is_resolved_once_at_app_construction(
+    db_uri: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def load_state() -> ExtensionPluginState:
+        nonlocal calls
+        calls += 1
+        return _state()
+
+    monkeypatch.setattr(app_module, "load_extension_plugin_state", load_state)
+    app = _build_app(db_uri, tmp_path)
+
+    async with _client(app) as client:
+        assert (await client.get("/v1/extensions")).status_code == 200
+        assert (await client.get("/v1/extensions")).status_code == 200
+
+    assert calls == 1
+
+
+async def test_global_discovery_failure_does_not_stop_server(
+    db_uri: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_discovery() -> ExtensionPluginState:
+        raise RuntimeError("broken distribution metadata")
+
+    monkeypatch.setattr(app_module, "load_extension_plugin_state", fail_discovery)
+    app = _build_app(db_uri, tmp_path)
+
+    async with _client(app) as client:
+        version = await client.get("/api/version")
+        extensions = await client.get("/v1/extensions")
+        diagnostics = await client.get("/v1/extensions/diagnostics")
+
+    assert version.status_code == 200
+    assert extensions.json() == {"object": "list", "data": []}
+    assert diagnostics.json()["load_errors"][0]["error"] == "broken distribution metadata"
+
+
+def test_extension_routes_are_mounted_before_spa_fallback(
+    db_uri: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    web_dist = tmp_path / "web-ui"
+    web_dist.mkdir()
+    (web_dist / "index.html").write_text("<html></html>", encoding="utf-8")
+    monkeypatch.setattr(app_module, "_WEB_UI_DIST", web_dist)
+    app = _build_app(db_uri, tmp_path, extension_state=_state())
+    paths = [route.path for route in app.routes if hasattr(route, "path")]
+
+    expected = {
+        "/v1/extensions",
+        "/v1/extensions/diagnostics",
+        "/v1/extensions/{extension_id}",
+    }
+    assert expected <= set(paths)
+    spa_index = next(index for index, path in enumerate(paths) if path == "")
+    assert all(paths.index(path) < spa_index for path in expected)


### PR DESCRIPTION
## Related issue

N/A — maintainer architecture work.

## Summary

- Add authenticated extension list/detail endpoints and admin-only diagnostics for rejected entry points.
- Resolve the extension registry once during app construction, degrade global discovery failures without taking down unrelated routes, and keep operator-installed extensions enabled until restart.
- Publish stable page/navigation metadata while keeping command metadata and package asset paths private; reserve digest URLs for the asset-serving PR.

**ELI5:** the server can now tell the UI which extension pages are installed, while keeping broken extensions out of the usable list and showing concise failure reasons only to administrators.

```text
validated registry
      |
      v
server snapshot ----> GET /v1/extensions
      |
      +-------------> admin diagnostics
```

This is **PR 2 of the extension-framework stack** and is based on PR #5605. Review only the single commit added by this branch.

## Test Plan

- `uv run pytest tests/server/routes/test_extensions_routes.py`
- `uv run ruff check omnigent/server/routes/extensions.py omnigent/server/app.py tests/server/routes/test_extensions_routes.py scripts/dump_openapi.py`
- `uv run pyrefly check omnigent/server/routes/extensions.py`
- `uv run python scripts/dump_openapi.py --check`
- `pre-commit run --all-files`

## Demo

N/A — this PR adds server APIs with no visual surface.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused route tests cover empty and populated catalogs, stable serialization, authentication, admin diagnostics, failure isolation, one-time resolution, sanitization, and route ordering before the SPA fallback.
