### PR TITLE
feat(logging): populate workspace_id and app_name on debug-log rows

### DIFF
--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import atexit
 import contextlib
+import functools
 import json
 import logging
 import os
@@ -56,6 +57,16 @@ PRIMARY_SESSION_ID_ENV_VAR = "OMNIGENT_RUNNER_PRIMARY_SESSION_ID"
 # because a ContextVar set at startup is invisible to run_in_executor threads).
 USER_ID_ENV_VAR = "OMNIGENT_USER_ID"
 _user_id_var: ContextVar[str | None] = ContextVar("omnigent_debug_user_id", default=None)
+
+# Origin deployment identity for the workspace_id/app_name columns. The
+# multi-tenant managed service stamps a per-request ``record.workspace_id`` (via
+# its logging ContextFilter), so the sink prefers that; the values below are the
+# process-constant fallback for single-tenant deployments -- the DATABRICKS_* env
+# a Databricks App injects, else parsed from the server URL a runner/host
+# connected to an App carries. All absent on OSS/local (columns stay null).
+ORIGIN_WORKSPACE_ID_ENV_VAR = "DATABRICKS_WORKSPACE_ID"
+APP_NAME_ENV_VAR = "DATABRICKS_APP_NAME"
+SERVER_URL_ENV_VAR = "RUNNER_SERVER_URL"
 
 # Batching / delivery defaults.
 _BATCH_MAX_RECORDS = 100
@@ -223,6 +234,55 @@ def current_user_id() -> str | None:
     return _user_id_var.get() or os.environ.get(USER_ID_ENV_VAR) or None
 
 
+def _clean(value: object) -> str | None:
+    """Coerce a missing/blank record attribute to ``None`` so a fallback engages.
+
+    The managed service's logging filter sets ``record.workspace_id`` to ``""``
+    (present-but-empty) for records emitted outside a workspace-bound request, so
+    an empty value must fall through to the process-constant fallback, not win.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _parse_databricks_app_host(url: str | None) -> tuple[str | None, str | None]:
+    """Parse ``(app_name, workspace_id)`` from a Databricks Apps server URL.
+
+    Apps URLs are ``https://<app_name>-<workspace_id>.<region>.databricksapps.com``;
+    the app name may itself contain hyphens, so split on the last one and require a
+    numeric workspace-id suffix. ``(None, None)`` for any non-Apps URL -- the
+    managed service (``dbc-<hash>...``), localhost, or a custom domain.
+    """
+    if not url:
+        return None, None
+    host = urllib.parse.urlparse(url).hostname or ""
+    if not host.endswith(".databricksapps.com"):
+        return None, None
+    label = host.split(".", 1)[0]
+    app_name, sep, workspace_id = label.rpartition("-")
+    if not sep or not app_name or not workspace_id.isdigit():
+        return None, None
+    return app_name, workspace_id
+
+
+@functools.lru_cache(maxsize=1)
+def _process_identity() -> tuple[str | None, str | None]:
+    """Process-constant ``(workspace_id, app_name)`` for single-tenant deployments.
+
+    The fallback the sink applies when a record carries no per-request identity:
+    the ``DATABRICKS_*`` env a Databricks App injects, else the values parsed from
+    the server URL a runner/host connected to an App carries. ``(None, None)`` on
+    the managed service (which supplies identity per-record) and on OSS/local.
+    Cached: the environment is fixed for the process's life.
+    """
+    url_app, url_ws = _parse_databricks_app_host(os.environ.get(SERVER_URL_ENV_VAR))
+    workspace_id = _clean(os.environ.get(ORIGIN_WORKSPACE_ID_ENV_VAR)) or url_ws
+    app_name = _clean(os.environ.get(APP_NAME_ENV_VAR)) or url_app
+    return workspace_id, app_name
+
+
 def debug_event(
     event_name: str,
     *,
@@ -278,7 +338,14 @@ def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
     ``client_time`` is epoch microseconds and ``attributes`` a plain object --
     the two shapes the ZeroBus JSON path requires for the ``TIMESTAMP`` and
     ``MAP<STRING,STRING>`` columns respectively.
+
+    ``workspace_id``/``app_name`` describe the record's origin deployment: the
+    managed service stamps ``record.workspace_id`` per request (so it wins),
+    while single-tenant deployments fall back to the process-constant
+    :func:`_process_identity`. ``app_name`` has no per-request source, so it is
+    null on the managed service.
     """
+    workspace_id, app_name = _process_identity()
     return {
         "session_id": getattr(record, "session_id", None),
         "turn_id": getattr(record, "turn_id", None),
@@ -295,6 +362,8 @@ def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
         "attributes": _attributes(record),
         "log_id": uuid.uuid4().hex,
         "user_id": getattr(record, "user_id", None) or current_user_id(),
+        "workspace_id": _clean(getattr(record, "workspace_id", None)) or workspace_id,
+        "app_name": _clean(getattr(record, "app_name", None)) or app_name,
     }
 
 

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import atexit
 import contextlib
-import functools
 import json
 import logging
 import os
@@ -267,15 +266,16 @@ def _parse_databricks_app_host(url: str | None) -> tuple[str | None, str | None]
     return app_name, workspace_id
 
 
-@functools.lru_cache(maxsize=1)
 def _process_identity() -> tuple[str | None, str | None]:
-    """Process-constant ``(workspace_id, app_name)`` for single-tenant deployments.
+    """Best-available ``(workspace_id, app_name)`` for single-tenant deployments.
 
     The fallback the sink applies when a record carries no per-request identity:
-    the ``DATABRICKS_*`` env a Databricks App injects, else the values parsed from
-    the server URL a runner/host connected to an App carries. ``(None, None)`` on
-    the managed service (which supplies identity per-record) and on OSS/local.
-    Cached: the environment is fixed for the process's life.
+    the ``DATABRICKS_*`` env (a Databricks App injects it; a host connected to a
+    managed service resolves its workspace id and publishes it there, and injects
+    it into each runner it spawns), else the values parsed from the server URL a
+    runner/host connected to an App carries. ``(None, None)`` on the managed
+    service (which supplies identity per-record) and on OSS/local. Read fresh per
+    call, not cached: the host resolves and sets the env after import.
     """
     url_app, url_ws = _parse_databricks_app_host(os.environ.get(SERVER_URL_ENV_VAR))
     workspace_id = _clean(os.environ.get(ORIGIN_WORKSPACE_ID_ENV_VAR)) or url_ws

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -58,15 +58,12 @@ PRIMARY_SESSION_ID_ENV_VAR = "OMNIGENT_RUNNER_PRIMARY_SESSION_ID"
 USER_ID_ENV_VAR = "OMNIGENT_USER_ID"
 _user_id_var: ContextVar[str | None] = ContextVar("omnigent_debug_user_id", default=None)
 
-# Origin deployment identity for the workspace_id/app_name columns. The
-# multi-tenant managed service stamps a per-request ``record.workspace_id`` (via
-# its logging ContextFilter), so the sink prefers that; the values below are the
-# process-constant fallback for single-tenant deployments -- the DATABRICKS_* env
-# a Databricks App injects, else parsed from the server URL a runner/host
-# connected to an App carries. All absent on OSS/local (columns stay null).
-ORIGIN_WORKSPACE_ID_ENV_VAR = "DATABRICKS_WORKSPACE_ID"
-APP_NAME_ENV_VAR = "DATABRICKS_APP_NAME"
-SERVER_URL_ENV_VAR = "RUNNER_SERVER_URL"
+# Origin deployment: the Omnigent server URL this process is bound to, logged so
+# an error dashboard can group by deployment. On Databricks Apps the URL already
+# embeds the workspace id + app name, so those can be split out at query time.
+# Read from the runner's ``RUNNER_SERVER_URL`` or a harness subprocess's
+# ``_OMNIGENT_SERVER_URL``; null on the server process itself and on OSS/local.
+SERVER_URL_ENVS = ("RUNNER_SERVER_URL", "_OMNIGENT_SERVER_URL")
 
 # Batching / delivery defaults.
 _BATCH_MAX_RECORDS = 100
@@ -234,53 +231,19 @@ def current_user_id() -> str | None:
     return _user_id_var.get() or os.environ.get(USER_ID_ENV_VAR) or None
 
 
-def _clean(value: object) -> str | None:
-    """Coerce a missing/blank record attribute to ``None`` so a fallback engages.
-
-    The managed service's logging filter sets ``record.workspace_id`` to ``""``
-    (present-but-empty) for records emitted outside a workspace-bound request, so
-    an empty value must fall through to the process-constant fallback, not win.
-    """
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None
-
-
-def _parse_databricks_app_host(url: str | None) -> tuple[str | None, str | None]:
-    """Parse ``(app_name, workspace_id)`` from a Databricks Apps server URL.
-
-    Apps URLs are ``https://<app_name>-<workspace_id>.<region>.databricksapps.com``;
-    the app name may itself contain hyphens, so split on the last one and require a
-    numeric workspace-id suffix. ``(None, None)`` for any non-Apps URL -- the
-    managed service (``dbc-<hash>...``), localhost, or a custom domain.
-    """
-    if not url:
-        return None, None
-    host = urllib.parse.urlparse(url).hostname or ""
-    if not host.endswith(".databricksapps.com"):
-        return None, None
-    label = host.split(".", 1)[0]
-    app_name, sep, workspace_id = label.rpartition("-")
-    if not sep or not app_name or not workspace_id.isdigit():
-        return None, None
-    return app_name, workspace_id
-
-
 @functools.lru_cache(maxsize=1)
-def _process_identity() -> tuple[str | None, str | None]:
-    """Process-constant ``(workspace_id, app_name)`` for single-tenant deployments.
+def _server_url() -> str | None:
+    """The Omnigent server URL this process is bound to, or ``None``.
 
-    The fallback the sink applies when a record carries no per-request identity:
-    the ``DATABRICKS_*`` env a Databricks App injects, else the values parsed from
-    the server URL a runner/host connected to an App carries. ``(None, None)`` on
-    the managed service (which supplies identity per-record) and on OSS/local.
-    Cached: the environment is fixed for the process's life.
+    A process constant: the runner sets ``RUNNER_SERVER_URL`` and harness
+    subprocesses ``_OMNIGENT_SERVER_URL``. Null on the server process itself and
+    on OSS/local. Cached -- the environment is fixed for the process's life.
     """
-    url_app, url_ws = _parse_databricks_app_host(os.environ.get(SERVER_URL_ENV_VAR))
-    workspace_id = _clean(os.environ.get(ORIGIN_WORKSPACE_ID_ENV_VAR)) or url_ws
-    app_name = _clean(os.environ.get(APP_NAME_ENV_VAR)) or url_app
-    return workspace_id, app_name
+    for name in SERVER_URL_ENVS:
+        value = os.environ.get(name)
+        if value and value.strip():
+            return value.strip()
+    return None
 
 
 def debug_event(
@@ -339,13 +302,10 @@ def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
     the two shapes the ZeroBus JSON path requires for the ``TIMESTAMP`` and
     ``MAP<STRING,STRING>`` columns respectively.
 
-    ``workspace_id``/``app_name`` describe the record's origin deployment: the
-    managed service stamps ``record.workspace_id`` per request (so it wins),
-    while single-tenant deployments fall back to the process-constant
-    :func:`_process_identity`. ``app_name`` has no per-request source, so it is
-    null on the managed service.
+    ``server_url`` is the deployment the record originated from (see
+    :func:`_server_url`); on Databricks Apps that URL embeds the workspace id and
+    app name, so grouping or splitting can happen at query time.
     """
-    workspace_id, app_name = _process_identity()
     return {
         "session_id": getattr(record, "session_id", None),
         "turn_id": getattr(record, "turn_id", None),
@@ -362,8 +322,7 @@ def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
         "attributes": _attributes(record),
         "log_id": uuid.uuid4().hex,
         "user_id": getattr(record, "user_id", None) or current_user_id(),
-        "workspace_id": _clean(getattr(record, "workspace_id", None)) or workspace_id,
-        "app_name": _clean(getattr(record, "app_name", None)) or app_name,
+        "server_url": _server_url(),
     }
 
 

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -58,12 +58,15 @@ PRIMARY_SESSION_ID_ENV_VAR = "OMNIGENT_RUNNER_PRIMARY_SESSION_ID"
 USER_ID_ENV_VAR = "OMNIGENT_USER_ID"
 _user_id_var: ContextVar[str | None] = ContextVar("omnigent_debug_user_id", default=None)
 
-# Origin deployment: the Omnigent server URL this process is bound to, logged so
-# an error dashboard can group by deployment. On Databricks Apps the URL already
-# embeds the workspace id + app name, so those can be split out at query time.
-# Read from the runner's ``RUNNER_SERVER_URL`` or a harness subprocess's
-# ``_OMNIGENT_SERVER_URL``; null on the server process itself and on OSS/local.
-SERVER_URL_ENVS = ("RUNNER_SERVER_URL", "_OMNIGENT_SERVER_URL")
+# Origin deployment identity for the workspace_id/app_name columns. The
+# multi-tenant managed service stamps a per-request ``record.workspace_id`` (via
+# its logging ContextFilter), so the sink prefers that; the values below are the
+# process-constant fallback for single-tenant deployments -- the DATABRICKS_* env
+# a Databricks App injects, else parsed from the server URL a runner/host
+# connected to an App carries. All absent on OSS/local (columns stay null).
+ORIGIN_WORKSPACE_ID_ENV_VAR = "DATABRICKS_WORKSPACE_ID"
+APP_NAME_ENV_VAR = "DATABRICKS_APP_NAME"
+SERVER_URL_ENV_VAR = "RUNNER_SERVER_URL"
 
 # Batching / delivery defaults.
 _BATCH_MAX_RECORDS = 100
@@ -231,19 +234,53 @@ def current_user_id() -> str | None:
     return _user_id_var.get() or os.environ.get(USER_ID_ENV_VAR) or None
 
 
-@functools.lru_cache(maxsize=1)
-def _server_url() -> str | None:
-    """The Omnigent server URL this process is bound to, or ``None``.
+def _clean(value: object) -> str | None:
+    """Coerce a missing/blank record attribute to ``None`` so a fallback engages.
 
-    A process constant: the runner sets ``RUNNER_SERVER_URL`` and harness
-    subprocesses ``_OMNIGENT_SERVER_URL``. Null on the server process itself and
-    on OSS/local. Cached -- the environment is fixed for the process's life.
+    The managed service's logging filter sets ``record.workspace_id`` to ``""``
+    (present-but-empty) for records emitted outside a workspace-bound request, so
+    an empty value must fall through to the process-constant fallback, not win.
     """
-    for name in SERVER_URL_ENVS:
-        value = os.environ.get(name)
-        if value and value.strip():
-            return value.strip()
-    return None
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _parse_databricks_app_host(url: str | None) -> tuple[str | None, str | None]:
+    """Parse ``(app_name, workspace_id)`` from a Databricks Apps server URL.
+
+    Apps URLs are ``https://<app_name>-<workspace_id>.<region>.databricksapps.com``;
+    the app name may itself contain hyphens, so split on the last one and require a
+    numeric workspace-id suffix. ``(None, None)`` for any non-Apps URL -- the
+    managed service (``dbc-<hash>...``), localhost, or a custom domain.
+    """
+    if not url:
+        return None, None
+    host = urllib.parse.urlparse(url).hostname or ""
+    if not host.endswith(".databricksapps.com"):
+        return None, None
+    label = host.split(".", 1)[0]
+    app_name, sep, workspace_id = label.rpartition("-")
+    if not sep or not app_name or not workspace_id.isdigit():
+        return None, None
+    return app_name, workspace_id
+
+
+@functools.lru_cache(maxsize=1)
+def _process_identity() -> tuple[str | None, str | None]:
+    """Process-constant ``(workspace_id, app_name)`` for single-tenant deployments.
+
+    The fallback the sink applies when a record carries no per-request identity:
+    the ``DATABRICKS_*`` env a Databricks App injects, else the values parsed from
+    the server URL a runner/host connected to an App carries. ``(None, None)`` on
+    the managed service (which supplies identity per-record) and on OSS/local.
+    Cached: the environment is fixed for the process's life.
+    """
+    url_app, url_ws = _parse_databricks_app_host(os.environ.get(SERVER_URL_ENV_VAR))
+    workspace_id = _clean(os.environ.get(ORIGIN_WORKSPACE_ID_ENV_VAR)) or url_ws
+    app_name = _clean(os.environ.get(APP_NAME_ENV_VAR)) or url_app
+    return workspace_id, app_name
 
 
 def debug_event(
@@ -302,10 +339,13 @@ def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
     the two shapes the ZeroBus JSON path requires for the ``TIMESTAMP`` and
     ``MAP<STRING,STRING>`` columns respectively.
 
-    ``server_url`` is the deployment the record originated from (see
-    :func:`_server_url`); on Databricks Apps that URL embeds the workspace id and
-    app name, so grouping or splitting can happen at query time.
+    ``workspace_id``/``app_name`` describe the record's origin deployment: the
+    managed service stamps ``record.workspace_id`` per request (so it wins),
+    while single-tenant deployments fall back to the process-constant
+    :func:`_process_identity`. ``app_name`` has no per-request source, so it is
+    null on the managed service.
     """
+    workspace_id, app_name = _process_identity()
     return {
         "session_id": getattr(record, "session_id", None),
         "turn_id": getattr(record, "turn_id", None),
@@ -322,7 +362,8 @@ def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
         "attributes": _attributes(record),
         "log_id": uuid.uuid4().hex,
         "user_id": getattr(record, "user_id", None) or current_user_id(),
-        "server_url": _server_url(),
+        "workspace_id": _clean(getattr(record, "workspace_id", None)) or workspace_id,
+        "app_name": _clean(getattr(record, "app_name", None)) or app_name,
     }
 
 

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -28,7 +28,11 @@ from websockets.exceptions import ConnectionClosed, InvalidStatus, InvalidURI
 
 from omnigent._platform import IS_POSIX, WINDOWS_ENV_PASSTHROUGH
 from omnigent.cli_invocation import cli_invocation
-from omnigent.debug_logging import PRIMARY_SESSION_ID_ENV_VAR, USER_ID_ENV_VAR
+from omnigent.debug_logging import (
+    ORIGIN_WORKSPACE_ID_ENV_VAR,
+    PRIMARY_SESSION_ID_ENV_VAR,
+    USER_ID_ENV_VAR,
+)
 from omnigent.env_credentials import env_names_with_omnigent_prefix
 from omnigent.gateway_inference import gateway_inference_map
 from omnigent.harness_aliases import canonicalize_harness, is_claude_sdk_harness_name
@@ -880,6 +884,20 @@ class HostProcess:
         # to OMNIGENT_USER_ID so host/runner debug-log rows carry it. None until
         # resolved, or on a single-user server / managed host where it is absent.
         self._owner_user_id: str | None = None
+        # The fronting Databricks workspace id for this server, resolved once from
+        # the server URL (its ?o= selector or the stored login record) — the same
+        # resolution the display URL uses, no extra network. Published to
+        # DATABRICKS_WORKSPACE_ID for the host's own debug-log rows and injected
+        # into every runner this host spawns; None on a non-Databricks server.
+        self._origin_workspace_id: str | None = None
+        try:
+            from omnigent.server_url import ServerUrl
+
+            self._origin_workspace_id = ServerUrl.from_api_base(self._server_url).org_id
+        except Exception:  # noqa: BLE001 — attribution is best-effort
+            self._origin_workspace_id = None
+        if self._origin_workspace_id:
+            os.environ[ORIGIN_WORKSPACE_ID_ENV_VAR] = self._origin_workspace_id
         # Set on the first accepted WS upgrade. Distinguishes a host that
         # never authenticated (login redirects / 401 / 403 turn fatal) from a
         # live host hit by a transient failure — a server restart or a dropped
@@ -1480,6 +1498,10 @@ class HostProcess:
         # attribution of runner-level log records.
         if self._owner_user_id:
             env[USER_ID_ENV_VAR] = self._owner_user_id
+        # The workspace id is resolved from the same server URL the runner dials,
+        # so hand it the already-resolved value rather than making it re-derive.
+        if self._origin_workspace_id:
+            env[ORIGIN_WORKSPACE_ID_ENV_VAR] = self._origin_workspace_id
 
         # Embed the session id so operators can find all logs for a session
         # with `omnigent debug logs --session <id>`. Cap at 32 chars to keep

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -33,8 +33,14 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
         dl.ENDPOINT_ENV_VAR,
         dl.USER_ID_ENV_VAR,
         dl.PRIMARY_SESSION_ID_ENV_VAR,
+        dl.ORIGIN_WORKSPACE_ID_ENV_VAR,
+        dl.APP_NAME_ENV_VAR,
+        dl.SERVER_URL_ENV_VAR,
     ):
         monkeypatch.delenv(name, raising=False)
+    # _process_identity is a process constant and lru-cached; reset it between
+    # tests so one test's env can't leak through the cache into the next.
+    dl._process_identity.cache_clear()
 
 
 def test_disabled_without_env() -> None:
@@ -106,6 +112,8 @@ def test_record_to_row_shape_and_coercions() -> None:
         "attributes",
         "log_id",
         "user_id",
+        "workspace_id",
+        "app_name",
     }
 
 
@@ -324,3 +332,139 @@ def test_attach_suppresses_handler_init_failure(
     dl.attach_debug_log_sink([target], source="server", level=logging.INFO)
     assert target.handlers == []
     assert dl._active_sink is None
+
+
+# ── origin workspace_id / app_name resolution ───────────────────────────────
+
+
+def test_parse_app_host_basic() -> None:
+    assert dl._parse_databricks_app_host(
+        "https://omnigents-3272836215725701.aws.databricksapps.com/c/abc123"
+    ) == ("omnigents", "3272836215725701")
+
+
+def test_parse_app_host_hyphenated_app_name() -> None:
+    # The app name may contain hyphens; only the final numeric segment is the
+    # workspace id, so the split must be on the LAST hyphen.
+    assert dl._parse_databricks_app_host(
+        "https://my-cool-app-3272836215725701.aws.databricksapps.com"
+    ) == ("my-cool-app", "3272836215725701")
+
+
+def test_parse_app_host_non_apps_urls_yield_nothing() -> None:
+    # Managed service (dbc-<hash> host), localhost, a custom domain, and empty
+    # input carry no parseable Databricks Apps identity.
+    assert dl._parse_databricks_app_host(
+        "https://dbc-a5d4177a-49dc.cloud.databricks.com/omnigent"
+    ) == (None, None)
+    assert dl._parse_databricks_app_host("http://localhost:8000") == (None, None)
+    assert dl._parse_databricks_app_host("https://omnigent.example.com") == (None, None)
+    assert dl._parse_databricks_app_host(None) == (None, None)
+    assert dl._parse_databricks_app_host("") == (None, None)
+
+
+def test_parse_app_host_rejects_malformed_labels() -> None:
+    # A databricksapps host with no hyphen, or a non-numeric final segment, is
+    # not a valid <app_name>-<workspace_id> label.
+    assert dl._parse_databricks_app_host("https://noworkspaceid.aws.databricksapps.com") == (
+        None,
+        None,
+    )
+    assert dl._parse_databricks_app_host("https://app-notanumber.aws.databricksapps.com") == (
+        None,
+        None,
+    )
+
+
+def test_process_identity_from_databricks_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Databricks App: the platform-injected env is authoritative.
+    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "111222333")
+    monkeypatch.setenv(dl.APP_NAME_ENV_VAR, "omnigents")
+    dl._process_identity.cache_clear()
+    assert dl._process_identity() == ("111222333", "omnigents")
+
+
+def test_process_identity_from_server_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Runner/host connected to a Databricks App: both parsed from the server URL.
+    monkeypatch.setenv(
+        dl.SERVER_URL_ENV_VAR, "https://omnigents-3272836215725701.aws.databricksapps.com"
+    )
+    dl._process_identity.cache_clear()
+    assert dl._process_identity() == ("3272836215725701", "omnigents")
+
+
+def test_process_identity_env_beats_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Explicit DATABRICKS_* env wins over a (possibly divergent) URL parse.
+    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "999")
+    monkeypatch.setenv(dl.APP_NAME_ENV_VAR, "envapp")
+    monkeypatch.setenv(dl.SERVER_URL_ENV_VAR, "https://urlapp-111.aws.databricksapps.com")
+    dl._process_identity.cache_clear()
+    assert dl._process_identity() == ("999", "envapp")
+
+
+def test_process_identity_managed_service_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Managed service: no DATABRICKS_* env and the server URL is a dbc-<hash> host,
+    # not an Apps URL. Identity arrives per-record, so the process constant is empty.
+    monkeypatch.setenv(
+        dl.SERVER_URL_ENV_VAR, "https://dbc-a5d4177a-49dc.cloud.databricks.com/omnigent"
+    )
+    dl._process_identity.cache_clear()
+    assert dl._process_identity() == (None, None)
+
+
+def test_process_identity_unset_is_none() -> None:
+    # OSS / local: nothing set anywhere.
+    dl._process_identity.cache_clear()
+    assert dl._process_identity() == (None, None)
+
+
+def test_record_to_row_prefers_record_workspace_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The managed service stamps record.workspace_id per request; it wins over
+    # the process-constant fallback.
+    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "process999")
+    dl._process_identity.cache_clear()
+    record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
+    record.workspace_id = "perrequest111"
+    assert dl.record_to_row(record, source="server")["workspace_id"] == "perrequest111"
+
+
+def test_record_to_row_blank_record_workspace_id_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Outside a request the managed filter sets record.workspace_id = "" — an
+    # empty value must fall through to the process constant, not win.
+    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "process999")
+    dl._process_identity.cache_clear()
+    record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
+    record.workspace_id = ""
+    assert dl.record_to_row(record, source="server")["workspace_id"] == "process999"
+
+
+def test_record_to_row_origin_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Databricks App: both columns come from the process constant when the record
+    # carries none.
+    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "3272836215725701")
+    monkeypatch.setenv(dl.APP_NAME_ENV_VAR, "omnigents")
+    dl._process_identity.cache_clear()
+    record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
+    row = dl.record_to_row(record, source="server")
+    assert row["workspace_id"] == "3272836215725701"
+    assert row["app_name"] == "omnigents"
+
+
+def test_record_to_row_app_name_null_on_managed() -> None:
+    # Managed service: workspace_id arrives per-record, but there is no per-request
+    # app_name and no process constant, so app_name is null.
+    record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
+    record.workspace_id = "3272836215725701"
+    row = dl.record_to_row(record, source="server")
+    assert row["workspace_id"] == "3272836215725701"
+    assert row["app_name"] is None
+
+
+def test_record_to_row_origin_columns_null_on_oss() -> None:
+    # OSS / local: nothing set anywhere → both columns null.
+    record = logging.LogRecord("omnigent", logging.INFO, __file__, 1, "hi", (), None)
+    row = dl.record_to_row(record, source="host")
+    assert row["workspace_id"] is None
+    assert row["app_name"] is None

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -33,14 +33,12 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
         dl.ENDPOINT_ENV_VAR,
         dl.USER_ID_ENV_VAR,
         dl.PRIMARY_SESSION_ID_ENV_VAR,
-        dl.ORIGIN_WORKSPACE_ID_ENV_VAR,
-        dl.APP_NAME_ENV_VAR,
-        dl.SERVER_URL_ENV_VAR,
+        *dl.SERVER_URL_ENVS,
     ):
         monkeypatch.delenv(name, raising=False)
-    # _process_identity is a process constant and lru-cached; reset it between
-    # tests so one test's env can't leak through the cache into the next.
-    dl._process_identity.cache_clear()
+    # _server_url is a process constant and lru-cached; reset it between tests so
+    # one test's env can't leak through the cache into the next.
+    dl._server_url.cache_clear()
 
 
 def test_disabled_without_env() -> None:
@@ -112,8 +110,7 @@ def test_record_to_row_shape_and_coercions() -> None:
         "attributes",
         "log_id",
         "user_id",
-        "workspace_id",
-        "app_name",
+        "server_url",
     }
 
 
@@ -334,137 +331,59 @@ def test_attach_suppresses_handler_init_failure(
     assert dl._active_sink is None
 
 
-# ── origin workspace_id / app_name resolution ───────────────────────────────
+# ── server_url (origin deployment) resolution ────────────────────────────────
 
 
-def test_parse_app_host_basic() -> None:
-    assert dl._parse_databricks_app_host(
-        "https://omnigents-3272836215725701.aws.databricksapps.com/c/abc123"
-    ) == ("omnigents", "3272836215725701")
-
-
-def test_parse_app_host_hyphenated_app_name() -> None:
-    # The app name may contain hyphens; only the final numeric segment is the
-    # workspace id, so the split must be on the LAST hyphen.
-    assert dl._parse_databricks_app_host(
-        "https://my-cool-app-3272836215725701.aws.databricksapps.com"
-    ) == ("my-cool-app", "3272836215725701")
-
-
-def test_parse_app_host_non_apps_urls_yield_nothing() -> None:
-    # Managed service (dbc-<hash> host), localhost, a custom domain, and empty
-    # input carry no parseable Databricks Apps identity.
-    assert dl._parse_databricks_app_host(
-        "https://dbc-a5d4177a-49dc.cloud.databricks.com/omnigent"
-    ) == (None, None)
-    assert dl._parse_databricks_app_host("http://localhost:8000") == (None, None)
-    assert dl._parse_databricks_app_host("https://omnigent.example.com") == (None, None)
-    assert dl._parse_databricks_app_host(None) == (None, None)
-    assert dl._parse_databricks_app_host("") == (None, None)
-
-
-def test_parse_app_host_rejects_malformed_labels() -> None:
-    # A databricksapps host with no hyphen, or a non-numeric final segment, is
-    # not a valid <app_name>-<workspace_id> label.
-    assert dl._parse_databricks_app_host("https://noworkspaceid.aws.databricksapps.com") == (
-        None,
-        None,
-    )
-    assert dl._parse_databricks_app_host("https://app-notanumber.aws.databricksapps.com") == (
-        None,
-        None,
-    )
-
-
-def test_process_identity_from_databricks_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Databricks App: the platform-injected env is authoritative.
-    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "111222333")
-    monkeypatch.setenv(dl.APP_NAME_ENV_VAR, "omnigents")
-    dl._process_identity.cache_clear()
-    assert dl._process_identity() == ("111222333", "omnigents")
-
-
-def test_process_identity_from_server_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Runner/host connected to a Databricks App: both parsed from the server URL.
+def test_server_url_from_runner_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The runner sets RUNNER_SERVER_URL; it's read verbatim.
     monkeypatch.setenv(
-        dl.SERVER_URL_ENV_VAR, "https://omnigents-3272836215725701.aws.databricksapps.com"
+        "RUNNER_SERVER_URL", "https://omnigents-3272836215725701.aws.databricksapps.com"
     )
-    dl._process_identity.cache_clear()
-    assert dl._process_identity() == ("3272836215725701", "omnigents")
+    dl._server_url.cache_clear()
+    assert dl._server_url() == "https://omnigents-3272836215725701.aws.databricksapps.com"
 
 
-def test_process_identity_env_beats_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Explicit DATABRICKS_* env wins over a (possibly divergent) URL parse.
-    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "999")
-    monkeypatch.setenv(dl.APP_NAME_ENV_VAR, "envapp")
-    monkeypatch.setenv(dl.SERVER_URL_ENV_VAR, "https://urlapp-111.aws.databricksapps.com")
-    dl._process_identity.cache_clear()
-    assert dl._process_identity() == ("999", "envapp")
-
-
-def test_process_identity_managed_service_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Managed service: no DATABRICKS_* env and the server URL is a dbc-<hash> host,
-    # not an Apps URL. Identity arrives per-record, so the process constant is empty.
+def test_server_url_from_harness_hook_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Harness subprocesses see _OMNIGENT_SERVER_URL instead.
     monkeypatch.setenv(
-        dl.SERVER_URL_ENV_VAR, "https://dbc-a5d4177a-49dc.cloud.databricks.com/omnigent"
+        "_OMNIGENT_SERVER_URL", "https://dbc-a5d4177a-49dc.cloud.databricks.com/omnigent"
     )
-    dl._process_identity.cache_clear()
-    assert dl._process_identity() == (None, None)
+    dl._server_url.cache_clear()
+    assert dl._server_url() == "https://dbc-a5d4177a-49dc.cloud.databricks.com/omnigent"
 
 
-def test_process_identity_unset_is_none() -> None:
-    # OSS / local: nothing set anywhere.
-    dl._process_identity.cache_clear()
-    assert dl._process_identity() == (None, None)
+def test_server_url_prefers_runner_over_hook(monkeypatch: pytest.MonkeyPatch) -> None:
+    # RUNNER_SERVER_URL takes precedence when both are set.
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://runner.example.com")
+    monkeypatch.setenv("_OMNIGENT_SERVER_URL", "https://hook.example.com")
+    dl._server_url.cache_clear()
+    assert dl._server_url() == "https://runner.example.com"
 
 
-def test_record_to_row_prefers_record_workspace_id(monkeypatch: pytest.MonkeyPatch) -> None:
-    # The managed service stamps record.workspace_id per request; it wins over
-    # the process-constant fallback.
-    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "process999")
-    dl._process_identity.cache_clear()
-    record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
-    record.workspace_id = "perrequest111"
-    assert dl.record_to_row(record, source="server")["workspace_id"] == "perrequest111"
+def test_server_url_blank_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An empty/whitespace value is treated as unset (falls through to None).
+    monkeypatch.setenv("RUNNER_SERVER_URL", "   ")
+    dl._server_url.cache_clear()
+    assert dl._server_url() is None
 
 
-def test_record_to_row_blank_record_workspace_id_falls_back(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # Outside a request the managed filter sets record.workspace_id = "" — an
-    # empty value must fall through to the process constant, not win.
-    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "process999")
-    dl._process_identity.cache_clear()
-    record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
-    record.workspace_id = ""
-    assert dl.record_to_row(record, source="server")["workspace_id"] == "process999"
+def test_server_url_unset_is_none() -> None:
+    # Server process / OSS / local: nothing set → None.
+    dl._server_url.cache_clear()
+    assert dl._server_url() is None
 
 
-def test_record_to_row_origin_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Databricks App: both columns come from the process constant when the record
-    # carries none.
-    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "3272836215725701")
-    monkeypatch.setenv(dl.APP_NAME_ENV_VAR, "omnigents")
-    dl._process_identity.cache_clear()
-    record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
-    row = dl.record_to_row(record, source="server")
-    assert row["workspace_id"] == "3272836215725701"
-    assert row["app_name"] == "omnigents"
+def test_record_to_row_server_url_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "RUNNER_SERVER_URL", "https://omnigents-3272836215725701.aws.databricksapps.com"
+    )
+    dl._server_url.cache_clear()
+    record = logging.LogRecord("omnigent.runner", logging.INFO, __file__, 1, "hi", (), None)
+    row = dl.record_to_row(record, source="runner")
+    assert row["server_url"] == "https://omnigents-3272836215725701.aws.databricksapps.com"
 
 
-def test_record_to_row_app_name_null_on_managed() -> None:
-    # Managed service: workspace_id arrives per-record, but there is no per-request
-    # app_name and no process constant, so app_name is null.
-    record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
-    record.workspace_id = "3272836215725701"
-    row = dl.record_to_row(record, source="server")
-    assert row["workspace_id"] == "3272836215725701"
-    assert row["app_name"] is None
-
-
-def test_record_to_row_origin_columns_null_on_oss() -> None:
-    # OSS / local: nothing set anywhere → both columns null.
+def test_record_to_row_server_url_null_when_unset() -> None:
     record = logging.LogRecord("omnigent", logging.INFO, __file__, 1, "hi", (), None)
-    row = dl.record_to_row(record, source="host")
-    assert row["workspace_id"] is None
-    assert row["app_name"] is None
+    row = dl.record_to_row(record, source="server")
+    assert row["server_url"] is None

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -38,9 +38,6 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
         dl.SERVER_URL_ENV_VAR,
     ):
         monkeypatch.delenv(name, raising=False)
-    # _process_identity is a process constant and lru-cached; reset it between
-    # tests so one test's env can't leak through the cache into the next.
-    dl._process_identity.cache_clear()
 
 
 def test_disabled_without_env() -> None:
@@ -380,7 +377,6 @@ def test_process_identity_from_databricks_env(monkeypatch: pytest.MonkeyPatch) -
     # Databricks App: the platform-injected env is authoritative.
     monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "111222333")
     monkeypatch.setenv(dl.APP_NAME_ENV_VAR, "omnigents")
-    dl._process_identity.cache_clear()
     assert dl._process_identity() == ("111222333", "omnigents")
 
 
@@ -389,7 +385,6 @@ def test_process_identity_from_server_url(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setenv(
         dl.SERVER_URL_ENV_VAR, "https://omnigents-3272836215725701.aws.databricksapps.com"
     )
-    dl._process_identity.cache_clear()
     assert dl._process_identity() == ("3272836215725701", "omnigents")
 
 
@@ -398,7 +393,6 @@ def test_process_identity_env_beats_url(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "999")
     monkeypatch.setenv(dl.APP_NAME_ENV_VAR, "envapp")
     monkeypatch.setenv(dl.SERVER_URL_ENV_VAR, "https://urlapp-111.aws.databricksapps.com")
-    dl._process_identity.cache_clear()
     assert dl._process_identity() == ("999", "envapp")
 
 
@@ -408,13 +402,11 @@ def test_process_identity_managed_service_is_none(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setenv(
         dl.SERVER_URL_ENV_VAR, "https://dbc-a5d4177a-49dc.cloud.databricks.com/omnigent"
     )
-    dl._process_identity.cache_clear()
     assert dl._process_identity() == (None, None)
 
 
 def test_process_identity_unset_is_none() -> None:
     # OSS / local: nothing set anywhere.
-    dl._process_identity.cache_clear()
     assert dl._process_identity() == (None, None)
 
 
@@ -422,7 +414,6 @@ def test_record_to_row_prefers_record_workspace_id(monkeypatch: pytest.MonkeyPat
     # The managed service stamps record.workspace_id per request; it wins over
     # the process-constant fallback.
     monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "process999")
-    dl._process_identity.cache_clear()
     record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
     record.workspace_id = "perrequest111"
     assert dl.record_to_row(record, source="server")["workspace_id"] == "perrequest111"
@@ -434,7 +425,6 @@ def test_record_to_row_blank_record_workspace_id_falls_back(
     # Outside a request the managed filter sets record.workspace_id = "" — an
     # empty value must fall through to the process constant, not win.
     monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "process999")
-    dl._process_identity.cache_clear()
     record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
     record.workspace_id = ""
     assert dl.record_to_row(record, source="server")["workspace_id"] == "process999"
@@ -445,7 +435,6 @@ def test_record_to_row_origin_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     # carries none.
     monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "3272836215725701")
     monkeypatch.setenv(dl.APP_NAME_ENV_VAR, "omnigents")
-    dl._process_identity.cache_clear()
     record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
     row = dl.record_to_row(record, source="server")
     assert row["workspace_id"] == "3272836215725701"

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -33,12 +33,14 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
         dl.ENDPOINT_ENV_VAR,
         dl.USER_ID_ENV_VAR,
         dl.PRIMARY_SESSION_ID_ENV_VAR,
-        *dl.SERVER_URL_ENVS,
+        dl.ORIGIN_WORKSPACE_ID_ENV_VAR,
+        dl.APP_NAME_ENV_VAR,
+        dl.SERVER_URL_ENV_VAR,
     ):
         monkeypatch.delenv(name, raising=False)
-    # _server_url is a process constant and lru-cached; reset it between tests so
-    # one test's env can't leak through the cache into the next.
-    dl._server_url.cache_clear()
+    # _process_identity is a process constant and lru-cached; reset it between
+    # tests so one test's env can't leak through the cache into the next.
+    dl._process_identity.cache_clear()
 
 
 def test_disabled_without_env() -> None:
@@ -110,7 +112,8 @@ def test_record_to_row_shape_and_coercions() -> None:
         "attributes",
         "log_id",
         "user_id",
-        "server_url",
+        "workspace_id",
+        "app_name",
     }
 
 
@@ -331,59 +334,137 @@ def test_attach_suppresses_handler_init_failure(
     assert dl._active_sink is None
 
 
-# ── server_url (origin deployment) resolution ────────────────────────────────
+# ── origin workspace_id / app_name resolution ───────────────────────────────
 
 
-def test_server_url_from_runner_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    # The runner sets RUNNER_SERVER_URL; it's read verbatim.
-    monkeypatch.setenv(
-        "RUNNER_SERVER_URL", "https://omnigents-3272836215725701.aws.databricksapps.com"
+def test_parse_app_host_basic() -> None:
+    assert dl._parse_databricks_app_host(
+        "https://omnigents-3272836215725701.aws.databricksapps.com/c/abc123"
+    ) == ("omnigents", "3272836215725701")
+
+
+def test_parse_app_host_hyphenated_app_name() -> None:
+    # The app name may contain hyphens; only the final numeric segment is the
+    # workspace id, so the split must be on the LAST hyphen.
+    assert dl._parse_databricks_app_host(
+        "https://my-cool-app-3272836215725701.aws.databricksapps.com"
+    ) == ("my-cool-app", "3272836215725701")
+
+
+def test_parse_app_host_non_apps_urls_yield_nothing() -> None:
+    # Managed service (dbc-<hash> host), localhost, a custom domain, and empty
+    # input carry no parseable Databricks Apps identity.
+    assert dl._parse_databricks_app_host(
+        "https://dbc-a5d4177a-49dc.cloud.databricks.com/omnigent"
+    ) == (None, None)
+    assert dl._parse_databricks_app_host("http://localhost:8000") == (None, None)
+    assert dl._parse_databricks_app_host("https://omnigent.example.com") == (None, None)
+    assert dl._parse_databricks_app_host(None) == (None, None)
+    assert dl._parse_databricks_app_host("") == (None, None)
+
+
+def test_parse_app_host_rejects_malformed_labels() -> None:
+    # A databricksapps host with no hyphen, or a non-numeric final segment, is
+    # not a valid <app_name>-<workspace_id> label.
+    assert dl._parse_databricks_app_host("https://noworkspaceid.aws.databricksapps.com") == (
+        None,
+        None,
     )
-    dl._server_url.cache_clear()
-    assert dl._server_url() == "https://omnigents-3272836215725701.aws.databricksapps.com"
-
-
-def test_server_url_from_harness_hook_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Harness subprocesses see _OMNIGENT_SERVER_URL instead.
-    monkeypatch.setenv(
-        "_OMNIGENT_SERVER_URL", "https://dbc-a5d4177a-49dc.cloud.databricks.com/omnigent"
+    assert dl._parse_databricks_app_host("https://app-notanumber.aws.databricksapps.com") == (
+        None,
+        None,
     )
-    dl._server_url.cache_clear()
-    assert dl._server_url() == "https://dbc-a5d4177a-49dc.cloud.databricks.com/omnigent"
 
 
-def test_server_url_prefers_runner_over_hook(monkeypatch: pytest.MonkeyPatch) -> None:
-    # RUNNER_SERVER_URL takes precedence when both are set.
-    monkeypatch.setenv("RUNNER_SERVER_URL", "https://runner.example.com")
-    monkeypatch.setenv("_OMNIGENT_SERVER_URL", "https://hook.example.com")
-    dl._server_url.cache_clear()
-    assert dl._server_url() == "https://runner.example.com"
+def test_process_identity_from_databricks_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Databricks App: the platform-injected env is authoritative.
+    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "111222333")
+    monkeypatch.setenv(dl.APP_NAME_ENV_VAR, "omnigents")
+    dl._process_identity.cache_clear()
+    assert dl._process_identity() == ("111222333", "omnigents")
 
 
-def test_server_url_blank_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    # An empty/whitespace value is treated as unset (falls through to None).
-    monkeypatch.setenv("RUNNER_SERVER_URL", "   ")
-    dl._server_url.cache_clear()
-    assert dl._server_url() is None
-
-
-def test_server_url_unset_is_none() -> None:
-    # Server process / OSS / local: nothing set → None.
-    dl._server_url.cache_clear()
-    assert dl._server_url() is None
-
-
-def test_record_to_row_server_url_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_process_identity_from_server_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Runner/host connected to a Databricks App: both parsed from the server URL.
     monkeypatch.setenv(
-        "RUNNER_SERVER_URL", "https://omnigents-3272836215725701.aws.databricksapps.com"
+        dl.SERVER_URL_ENV_VAR, "https://omnigents-3272836215725701.aws.databricksapps.com"
     )
-    dl._server_url.cache_clear()
-    record = logging.LogRecord("omnigent.runner", logging.INFO, __file__, 1, "hi", (), None)
-    row = dl.record_to_row(record, source="runner")
-    assert row["server_url"] == "https://omnigents-3272836215725701.aws.databricksapps.com"
+    dl._process_identity.cache_clear()
+    assert dl._process_identity() == ("3272836215725701", "omnigents")
 
 
-def test_record_to_row_server_url_null_when_unset() -> None:
-    record = logging.LogRecord("omnigent", logging.INFO, __file__, 1, "hi", (), None)
+def test_process_identity_env_beats_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Explicit DATABRICKS_* env wins over a (possibly divergent) URL parse.
+    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "999")
+    monkeypatch.setenv(dl.APP_NAME_ENV_VAR, "envapp")
+    monkeypatch.setenv(dl.SERVER_URL_ENV_VAR, "https://urlapp-111.aws.databricksapps.com")
+    dl._process_identity.cache_clear()
+    assert dl._process_identity() == ("999", "envapp")
+
+
+def test_process_identity_managed_service_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Managed service: no DATABRICKS_* env and the server URL is a dbc-<hash> host,
+    # not an Apps URL. Identity arrives per-record, so the process constant is empty.
+    monkeypatch.setenv(
+        dl.SERVER_URL_ENV_VAR, "https://dbc-a5d4177a-49dc.cloud.databricks.com/omnigent"
+    )
+    dl._process_identity.cache_clear()
+    assert dl._process_identity() == (None, None)
+
+
+def test_process_identity_unset_is_none() -> None:
+    # OSS / local: nothing set anywhere.
+    dl._process_identity.cache_clear()
+    assert dl._process_identity() == (None, None)
+
+
+def test_record_to_row_prefers_record_workspace_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The managed service stamps record.workspace_id per request; it wins over
+    # the process-constant fallback.
+    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "process999")
+    dl._process_identity.cache_clear()
+    record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
+    record.workspace_id = "perrequest111"
+    assert dl.record_to_row(record, source="server")["workspace_id"] == "perrequest111"
+
+
+def test_record_to_row_blank_record_workspace_id_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Outside a request the managed filter sets record.workspace_id = "" — an
+    # empty value must fall through to the process constant, not win.
+    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "process999")
+    dl._process_identity.cache_clear()
+    record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
+    record.workspace_id = ""
+    assert dl.record_to_row(record, source="server")["workspace_id"] == "process999"
+
+
+def test_record_to_row_origin_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Databricks App: both columns come from the process constant when the record
+    # carries none.
+    monkeypatch.setenv(dl.ORIGIN_WORKSPACE_ID_ENV_VAR, "3272836215725701")
+    monkeypatch.setenv(dl.APP_NAME_ENV_VAR, "omnigents")
+    dl._process_identity.cache_clear()
+    record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
     row = dl.record_to_row(record, source="server")
-    assert row["server_url"] is None
+    assert row["workspace_id"] == "3272836215725701"
+    assert row["app_name"] == "omnigents"
+
+
+def test_record_to_row_app_name_null_on_managed() -> None:
+    # Managed service: workspace_id arrives per-record, but there is no per-request
+    # app_name and no process constant, so app_name is null.
+    record = logging.LogRecord("omnigent.server", logging.INFO, __file__, 1, "hi", (), None)
+    record.workspace_id = "3272836215725701"
+    row = dl.record_to_row(record, source="server")
+    assert row["workspace_id"] == "3272836215725701"
+    assert row["app_name"] is None
+
+
+def test_record_to_row_origin_columns_null_on_oss() -> None:
+    # OSS / local: nothing set anywhere → both columns null.
+    record = logging.LogRecord("omnigent", logging.INFO, __file__, 1, "hi", (), None)
+    row = dl.record_to_row(record, source="host")
+    assert row["workspace_id"] is None
+    assert row["app_name"] is None


### PR DESCRIPTION
## Related issue

N/A — follow-on to the debug-log sink work (OMNI-4198); no separate tracked issue.

## Summary

The debug-log table gained two columns — `workspace_id` and `app_name` — so an error-frequency dashboard can slice failures by the deployment they came from. This wires the sink to populate them, layered exactly like the existing `user_id` fallback:

- **`workspace_id`** — prefer `record.workspace_id` (the multi-tenant managed service stamps it **per request** via its logging `ContextFilter`), else fall back to a process constant.
- **Process constant** (`_process_identity`, cached) — `DATABRICKS_WORKSPACE_ID` / `DATABRICKS_APP_NAME` (a Databricks App injects these), else parsed from the `RUNNER_SERVER_URL` host a runner/host connected to an App carries: `https://<app_name>-<workspace_id>.<region>.databricksapps.com`. The app name may itself contain hyphens, so the split is on the **last** hyphen with a numeric-suffix check.
- **`app_name`** has no per-request source, so it is `NULL` on the managed service; both columns are `NULL` on OSS/local.

Why per-deployment matters: `DebugLogConfig.workspace_id` (parsed from the insert URL) is the *destination* table's workspace and is load-bearing for the ZeroBus token audience — it's constant once many deployments centralize into one table. The *origin* workspace is what a dashboard needs, so it's resolved separately as above.

**⚠️ Deploy ordering:** the sink now emits `workspace_id`/`app_name` on **every** row. ZeroBus rejects a record that carries any field the table lacks (a `null`-valued unknown field still counts), so the target table **must** have both columns before this ships — migrate the table first, then deploy. The ai-oss prototyping table already has them.

**Not included (universe-side follow-up):** for the managed service to actually populate `workspace_id`, its `ContextFilter` must be attached to the ZeroBus sink handler so `record.workspace_id` is stamped before the record is queued. This PR is the OSS-side consumer only; it reads a plain attribute that MAS populates, with no universe import.

**ELI5:** each debug-log row now records which workspace (and, on Databricks Apps, which app) it came from. On the shared managed service that's read per-request off the log record; on a single-tenant app/runner it's read once from env or the server URL.

## Test Plan

- `uv run --no-sync pytest tests/test_debug_logging.py -q` → **37 passed** (13 new).
- New unit tests cover: `_parse_databricks_app_host` (basic, hyphenated app name, non-Apps/managed/localhost/empty URLs, malformed labels); `_process_identity` (DATABRICKS_* env, server-URL parse, env-beats-URL precedence, managed `dbc-` host → `(None,None)`, unset → `(None,None)`); and the `record_to_row` layered resolution (record attr wins, blank record attr falls through, env fallback, `app_name` null on managed, both null on OSS).
- `ruff check` + `ruff format --check` clean on both files.
- The existing `test_record_to_row_shape_and_coercions` column-set assertion was updated to include the two new keys.

## Demo

N/A — non-visual (logging / observability).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The resolution logic (env/URL/record precedence, empty-string fall-through, the hyphenated-app-name split) is fully unit-tested. Two things are intentionally not unit-tested: the deploy-ordering requirement (the table must carry the columns first — an operational constraint, called out above) and the managed-service `ContextFilter`-on-sink-handler wiring (a universe-repo change). End-to-end population on a live managed deployment should be spot-checked once that wiring lands: drive a turn and confirm `workspace_id` is per-request and `app_name` is `NULL`; on a Databricks App deploy, confirm both come from the `DATABRICKS_*` env.

## Changelog

DELETE THIS WHOLE SECTION — internal observability plumbing, no user-facing change.

This pull request and its description were written by Isaac.
