### PR TITLE
fix(web): settle approvals resolved before frame flush

### DIFF
--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -7518,6 +7518,58 @@ describe("chatStore — pumpStreamEvents frame batching", () => {
     controller.abort();
   });
 
+  it("settles an approval resolved before its buffered card reaches the store", async () => {
+    useChatStore.setState({ conversationId: "conv_fast_elicitation", blocks: [] });
+    const sink = pushableStream();
+    const controller = new AbortController();
+    const manual = manualScheduler();
+    void pumpStreamEvents(
+      "conv_fast_elicitation",
+      sink.stream,
+      controller,
+      setState,
+      getState,
+      manual.scheduler,
+    );
+
+    sink.push(sse("response.created", { id: "resp_fast", status: "in_progress", output: [] }));
+    sink.push(delta("A"));
+    await tick();
+
+    sink.push(
+      sse("response.elicitation_request", {
+        elicitation_id: "elic_fast",
+        params: {
+          mode: "form",
+          message: "Approve fast operation?",
+          phase: "codex_mcp_elicitation",
+          policy_name: "codex_native_mcp_elicitation",
+          content_preview: "",
+        },
+      }),
+    );
+    sink.push(
+      sse("response.elicitation_resolved", {
+        elicitation_id: "elic_fast",
+      }),
+    );
+    await tick();
+
+    expect(manual.pending()).toBe(true);
+    manual.fire();
+
+    const card = useChatStore
+      .getState()
+      .blocks.find(
+        (block): block is ElicitationBlock =>
+          block.type === "elicitation" && block.elicitationId === "elic_fast",
+      );
+    expect(card?.status).toBe("responded");
+    expect(card?.response).toEqual({ action: "auto_resolved" });
+
+    controller.abort();
+  });
+
   it("appends live command output to the running tool card", async () => {
     useChatStore.setState({ conversationId: "conv_tool_delta", blocks: [] });
     const sink = pushableStream();

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -4528,6 +4528,11 @@ export async function pumpStreamEvents(
   const stream = new BlockStream();
   const sseResult: SseStreamResult = { sawDone: false };
   const rawEvents = parseSseStream(body, sseResult);
+  // Blocks awaiting their coalesced flush; `seenItemIds` dedupes against
+  // both committed and still-buffered blocks. Lives for the whole stream
+  // (one SSE connection); bounded by item count like `blocks` itself.
+  const buffer: AnyBlock[] = [];
+  const seenItemIds = new Set<string>();
   // Tap the raw event stream for `session.*` side effects (sessionStatus,
   // pending-message promotion, interrupted decoration) before handing it
   // to the BlockStream reducer. The reducer is intentionally pure
@@ -4536,13 +4541,31 @@ export async function pumpStreamEvents(
   // A scheduled wake can stream before its new turn id arrives. Ignore the
   // rest of that message so it cannot attach to the completed prior turn.
   const ignoredWakeMessages = new Set<string>();
-  const events = tapLiveDeltas(tapSessionEvents(rawEvents, id), id, ignoredWakeMessages, set, get);
-
-  // Blocks awaiting their coalesced flush; `seenItemIds` dedupes against
-  // both committed and still-buffered blocks. Lives for the whole stream
-  // (one SSE connection); bounded by item count like `blocks` itself.
-  const buffer: AnyBlock[] = [];
-  const seenItemIds = new Set<string>();
+  const events = tapLiveDeltas(
+    tapSessionEvents(rawEvents, id, (elicitationId) => {
+      // A fast native approval can resolve in the few milliseconds between
+      // the reducer yielding its card and the next animation-frame flush.
+      // `handleSessionEvent` can only update committed blocks, so settle the
+      // buffered copy here instead of dropping that resolved edge.
+      const at = buffer.findIndex(
+        (block) =>
+          block.type === "elicitation" &&
+          block.elicitationId === elicitationId &&
+          block.status === "pending",
+      );
+      if (at === -1) return;
+      const target = buffer[at] as ElicitationBlock;
+      buffer[at] = {
+        ...target,
+        status: "responded",
+        response: { action: "auto_resolved" },
+      };
+    }),
+    id,
+    ignoredWakeMessages,
+    set,
+    get,
+  );
   // First content block of each response flushes synchronously (snappy
   // first-token paint); the rest batch.
   let paintedFirstContent = false;
@@ -6059,9 +6082,13 @@ function applyChildSessionUpdated(
 async function* tapSessionEvents(
   events: AsyncIterable<StreamEvent>,
   conversationId: string,
+  onElicitationResolved?: (elicitationId: string) => void,
 ): AsyncIterable<StreamEvent> {
   for await (const event of events) {
     handleSessionEvent(event, conversationId);
+    if (event.type === "elicitation_resolved") {
+      onElicitationResolved?.(event.elicitationId);
+    }
     pushSseEvent(conversationId, event);
     yield event;
   }


### PR DESCRIPTION
## Related issue

Closes #5611

## Summary

- Settle an elicitation that resolves while its card is still waiting in the animation-frame buffer.
- Keep the existing committed-card resolution path unchanged.
- Add a deterministic frame-scheduler regression test for the request → resolved-before-flush ordering observed with native Codex auto-approval.

ELI5: Web batches transcript updates until the next paint. A very fast approval could finish before its card was painted, so the "finished" signal could not find the card and the next paint showed it as still waiting. The stream pump now also settles the buffered copy.

```text
response.elicitation_request -> reducer buffer
                                  |
response.elicitation_resolved ----+-> mark buffered card responded
                                  |
next animation frame -------------+-> commit Resolved elsewhere
```

## Test Plan

```text
pnpm --dir web exec vitest run src/store/chatStore.test.ts -t 'settles an approval resolved before its buffered card reaches the store'
pnpm --dir web exec vitest run src/store/chatStore.test.ts
pnpm --dir web run type-check
pnpm --dir web exec oxlint --deny-warnings --report-unused-disable-directives src/store/chatStore.ts src/store/chatStore.test.ts
uvx pre-commit run --files web/src/store/chatStore.ts web/src/store/chatStore.test.ts
```

The focused regression failed before the fix with `expected 'pending' to be 'responded'` and passes after it. The full chat store suite passes 371/371.

## Demo

### Before

Web could retain several actionable approval cards after the native Codex client had already resolved them. The screenshot is cropped and redacted; session and turn identifiers are intentionally hidden.

![Four stale MCP approval cards stacked in Omnigent Web](https://raw.githubusercontent.com/guanbear/omnigent/6aa48403cc88a37ab9bf5feecb0069d3f6060625/omnigent-pr-5612-before-redacted.jpg)

After refresh, these stale cards disappeared because the server reported no pending elicitations. With this PR, the buffered copies are settled before the next animation-frame flush, so they commit as `Resolved elsewhere` instead of remaining actionable.

The deterministic regression test pins the same request → resolved-before-flush ordering without relying on timing-sensitive manual reproduction.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the live symptom across the native Codex terminal, `GET /v1/sessions/{id}`, and Web before refresh. The new unit test pins the race deterministically with a manual frame scheduler; the existing chat store tests cover committed-card resolution, reconnect reconciliation, duplicate prompts, and re-parking.

## Changelog

Fast approvals resolved in another client no longer leave Web blocked on a stale approval card.
