### PR TITLE
feat(extensions): serve content-addressed browser bundles

### DIFF
--- a/omnigent/extensions/api.py
+++ b/omnigent/extensions/api.py
@@ -82,7 +82,12 @@ class ExtensionPluginState:
 
     manifests: tuple[ExtensionManifest, ...]
     load_errors: dict[str, str] = field(default_factory=dict)
+    asset_packages: dict[str, str] = field(default_factory=dict)
 
     def get(self, extension_id: str) -> ExtensionManifest | None:
         """Return one accepted manifest by ID."""
         return next((item for item in self.manifests if item.id == extension_id), None)
+
+    def asset_package(self, extension_id: str) -> str | None:
+        """Return the verified package holding an extension's browser assets."""
+        return self.asset_packages.get(extension_id)

--- a/omnigent/extensions/assets.py
+++ b/omnigent/extensions/assets.py
@@ -1,0 +1,207 @@
+"""Resolve immutable browser bundles from installed extension packages.
+
+Bundle digests provide cache keys and torn catalog/bundle detection. They are
+not an integrity boundary: catalog and assets come from the same trusted server.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.resources
+import importlib.util
+import logging
+import re
+import stat
+from collections.abc import Mapping
+from dataclasses import dataclass
+from importlib.resources.abc import Traversable
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+
+from omnigent.extensions.api import ExtensionManifest, ExtensionPluginState
+
+ASSET_SCRIPT = "extension.js"
+ASSET_STYLES = "extension.css"
+ASSET_MEDIA_TYPES = {
+    ASSET_SCRIPT: "text/javascript; charset=utf-8",
+    ASSET_STYLES: "text/css; charset=utf-8",
+}
+MAX_ASSET_BYTES = 4 * 1024 * 1024
+
+_logger = logging.getLogger(__name__)
+_SAFE_PART = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
+
+
+class ExtensionAssetError(ValueError):
+    """An extension browser bundle could not be resolved safely."""
+
+
+@dataclass(frozen=True)
+class ResolvedAsset:
+    """One in-memory asset from a validated extension bundle."""
+
+    name: str
+    media_type: str
+    content: bytes
+    sha256: str
+
+
+@dataclass(frozen=True)
+class ResolvedBundle:
+    """A complete browser bundle and its content-addressed URL key."""
+
+    extension_id: str
+    digest: str
+    assets: Mapping[str, ResolvedAsset]
+
+    def url(self, name: str) -> str:
+        """Return the server-relative URL for one logical asset."""
+        if name not in self.assets:
+            raise KeyError(name)
+        return f"/v1/extensions/{self.extension_id}/assets/{self.digest}/{name}"
+
+
+def _safe_parts(declared: str) -> tuple[str, ...]:
+    """Validate an already-declared resource path again at the I/O boundary."""
+    if not isinstance(declared, str) or not declared.isprintable():
+        raise ExtensionAssetError("extension asset path is invalid")
+    path = PurePosixPath(declared)
+    if (
+        path.is_absolute()
+        or declared.startswith("./")
+        or declared != path.as_posix()
+        or len(path.parts) > 16
+        or any(not _SAFE_PART.fullmatch(part) for part in path.parts)
+    ):
+        raise ExtensionAssetError(f"unsafe extension asset path {declared!r}")
+    return path.parts
+
+
+def _read_filesystem_asset(root: Path, parts: tuple[str, ...], max_bytes: int) -> bytes:
+    resolved_root = root.resolve(strict=True)
+    target = root.joinpath(*parts)
+    resolved_target = target.resolve(strict=True)
+    if not resolved_target.is_relative_to(resolved_root):
+        raise ExtensionAssetError("extension asset escapes its package root")
+    file_stat = resolved_target.stat()
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise ExtensionAssetError("extension asset is not a regular file")
+    with resolved_target.open("rb") as stream:
+        content = stream.read(max_bytes + 1)
+    if len(content) > max_bytes:
+        raise ExtensionAssetError(f"extension asset exceeds {max_bytes} bytes")
+    return content
+
+
+def _read_traversable_asset(root: Traversable, parts: tuple[str, ...], max_bytes: int) -> bytes:
+    target = root.joinpath(*parts)
+    if not target.is_file():
+        raise ExtensionAssetError("extension asset is not a regular file")
+    with target.open("rb") as stream:
+        content = stream.read(max_bytes + 1)
+    if len(content) > max_bytes:
+        raise ExtensionAssetError(f"extension asset exceeds {max_bytes} bytes")
+    return content
+
+
+def _resource_root(package: str) -> Traversable:
+    try:
+        spec = importlib.util.find_spec(package)
+        if spec is None or spec.origin is None:
+            raise ExtensionAssetError("extension asset root must be a regular package")
+        root = importlib.resources.files(package)
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise ExtensionAssetError(f"extension asset package {package!r} is unavailable") from exc
+    return root
+
+
+def _read_asset(root: Traversable, declared: str, max_bytes: int) -> bytes:
+    parts = _safe_parts(declared)
+    if isinstance(root, Path):
+        return _read_filesystem_asset(root, parts, max_bytes)
+    return _read_traversable_asset(root, parts, max_bytes)
+
+
+def resolve_bundle(
+    manifest: ExtensionManifest,
+    *,
+    package: str | None = None,
+    root_override: Path | None = None,
+    max_bytes: int = MAX_ASSET_BYTES,
+) -> ResolvedBundle:
+    """Read, bound, and hash one extension's declared browser bundle."""
+    if manifest.entrypoints.browser is None:
+        raise ExtensionAssetError(f"extension {manifest.id!r} has no browser bundle")
+    if package is None and root_override is None:
+        raise ExtensionAssetError(f"extension {manifest.id!r} has no verified asset package")
+    if package is not None and root_override is not None:
+        raise ExtensionAssetError("asset package and development override are mutually exclusive")
+    if manifest.entrypoints.browser != "dist/extension.js":
+        raise ExtensionAssetError("browser entrypoint must be dist/extension.js")
+    if manifest.entrypoints.browser_css not in {None, "dist/extension.css"}:
+        raise ExtensionAssetError("browser CSS entrypoint must be dist/extension.css")
+    if root_override is not None:
+        root: Traversable = root_override
+    else:
+        assert package is not None
+        root = _resource_root(package)
+
+    declarations = {ASSET_SCRIPT: manifest.entrypoints.browser}
+    if manifest.entrypoints.browser_css is not None:
+        declarations[ASSET_STYLES] = manifest.entrypoints.browser_css
+
+    assets: dict[str, ResolvedAsset] = {}
+    for name, declared in declarations.items():
+        try:
+            content = _read_asset(root, declared, max_bytes)
+        except FileNotFoundError as exc:
+            raise ExtensionAssetError(f"declared extension asset {declared!r} is missing") from exc
+        digest = hashlib.sha256(content).hexdigest()
+        assets[name] = ResolvedAsset(
+            name=name,
+            media_type=ASSET_MEDIA_TYPES[name],
+            content=content,
+            sha256=digest,
+        )
+
+    digest_input = b"omnigent-extension-bundle/1\n" + b"".join(
+        f"{name} {asset.sha256}\n".encode() for name, asset in sorted(assets.items())
+    )
+    bundle_digest = hashlib.sha256(digest_input).hexdigest()
+    return ResolvedBundle(
+        extension_id=manifest.id,
+        digest=bundle_digest,
+        assets=MappingProxyType(assets),
+    )
+
+
+def build_asset_index(
+    state: ExtensionPluginState,
+    *,
+    overrides: Mapping[str, Path] | None = None,
+    max_bytes: int = MAX_ASSET_BYTES,
+) -> tuple[dict[str, ResolvedBundle], dict[str, str]]:
+    """Resolve all declared bundles, isolating failures by extension."""
+    bundles: dict[str, ResolvedBundle] = {}
+    errors: dict[str, str] = {}
+    override_paths = overrides or {}
+    for manifest in state.manifests:
+        if manifest.entrypoints.browser is None:
+            continue
+        try:
+            override = override_paths.get(manifest.id)
+            bundles[manifest.id] = resolve_bundle(
+                manifest,
+                package=None if override is not None else state.asset_package(manifest.id),
+                root_override=override,
+                max_bytes=max_bytes,
+            )
+        except Exception as exc:  # noqa: BLE001
+            errors[manifest.id] = str(exc)
+            _logger.warning(
+                "could not resolve browser bundle for extension %s (%s)",
+                manifest.id,
+                exc,
+                exc_info=True,
+            )
+    return dict(sorted(bundles.items())), dict(sorted(errors.items()))

--- a/omnigent/extensions/registry.py
+++ b/omnigent/extensions/registry.py
@@ -275,8 +275,10 @@ def validate_manifest(manifest: ExtensionManifest) -> None:
         _validate_relative_path(
             manifest.entrypoints.browser,
             "browser entrypoint",
-            suffixes=frozenset({".js", ".mjs"}),
+            suffixes=frozenset({".js"}),
         )
+        if manifest.entrypoints.browser != "dist/extension.js":
+            raise ExtensionValidationError("browser entrypoint must be dist/extension.js")
     if manifest.entrypoints.browser_css is not None:
         if manifest.entrypoints.browser is None:
             raise ExtensionValidationError(
@@ -287,6 +289,8 @@ def validate_manifest(manifest: ExtensionManifest) -> None:
             "browser CSS entrypoint",
             suffixes=frozenset({".css"}),
         )
+        if manifest.entrypoints.browser_css != "dist/extension.css":
+            raise ExtensionValidationError("browser CSS entrypoint must be dist/extension.css")
 
     invalid_permissions = sorted(
         repr(permission)
@@ -390,8 +394,30 @@ def _diagnostic_key(entry_point: Any, used: set[str]) -> str:
     return key
 
 
-def _load_community_manifests() -> tuple[list[tuple[str, ExtensionManifest]], dict[str, str]]:
-    candidates: list[tuple[str, ExtensionManifest]] = []
+def _entry_point_asset_package(entry_point: Any) -> str | None:
+    """Return the top-level package when its declaring distribution owns it."""
+    module = getattr(entry_point, "module", None)
+    if not isinstance(module, str) or not module:
+        value = getattr(entry_point, "value", None)
+        if not isinstance(value, str) or not value:
+            return None
+        module = value.partition(":")[0]
+    package = module.split(".", 1)[0]
+    if package == "omnigent":
+        return None
+
+    dist = getattr(entry_point, "dist", None)
+    files = getattr(dist, "files", None)
+    if files is None:
+        return None
+    owned_packages = {str(file).replace("\\", "/").split("/", 1)[0] for file in files}
+    return package if package in owned_packages else None
+
+
+def _load_community_manifests() -> tuple[
+    list[tuple[str, ExtensionManifest, str | None]], dict[str, str]
+]:
+    candidates: list[tuple[str, ExtensionManifest, str | None]] = []
     errors: dict[str, str] = {}
     used_keys: set[str] = set()
     for entry_point in _entry_points():
@@ -405,7 +431,7 @@ def _load_community_manifests() -> tuple[list[tuple[str, ExtensionManifest]], di
                 )
             validate_manifest(manifest)
             _validate_distribution_metadata(entry_point, manifest)
-            candidates.append((key, manifest))
+            candidates.append((key, manifest, _entry_point_asset_package(entry_point)))
         # Entry points are an external package boundary: one plugin may raise
         # any exception, and must not prevent healthy extensions from loading.
         except Exception as exc:  # noqa: BLE001
@@ -433,7 +459,7 @@ def _validate_builtin_collisions(builtins: tuple[ExtensionManifest, ...]) -> Non
 
 def _collision_errors(
     builtins: tuple[ExtensionManifest, ...],
-    candidates: list[tuple[str, ExtensionManifest]],
+    candidates: list[tuple[str, ExtensionManifest, str | None]],
 ) -> dict[str, str]:
     builtin_claims: dict[str, str] = {}
     for manifest in builtins:
@@ -441,7 +467,7 @@ def _collision_errors(
             builtin_claims[claim] = manifest.id
 
     community_claims: dict[str, list[str]] = defaultdict(list)
-    for owner, manifest in candidates:
+    for owner, manifest, _asset_package in candidates:
         for claim in _manifest_claims(manifest):
             community_claims[claim].append(owner)
 
@@ -476,11 +502,23 @@ def _build_plugin_state() -> ExtensionPluginState:
         load_errors[owner] = error
         _logger.warning("could not register extension entry point %s (%s)", owner, error)
 
-    accepted = [manifest for owner, manifest in candidates if owner not in collisions]
-    manifests = tuple(sorted((*builtins, *accepted), key=lambda item: item.id))
+    accepted = [
+        (manifest, asset_package)
+        for owner, manifest, asset_package in candidates
+        if owner not in collisions
+    ]
+    manifests = tuple(
+        sorted((*builtins, *(item[0] for item in accepted)), key=lambda item: item.id)
+    )
+    asset_packages = {
+        manifest.id: asset_package
+        for manifest, asset_package in accepted
+        if asset_package is not None
+    }
     return ExtensionPluginState(
         manifests=manifests,
         load_errors=dict(sorted(load_errors.items())),
+        asset_packages=dict(sorted(asset_packages.items())),
     )
 
 

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -38,6 +38,7 @@ from omnigent.debug_logging import (
 )
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.extensions import ExtensionPluginState
+from omnigent.extensions.assets import ResolvedBundle, build_asset_index
 from omnigent.extensions.registry import plugin_state as load_extension_plugin_state
 from omnigent.harness_plugins import (
     NativeHarnessProvider,
@@ -76,6 +77,7 @@ from omnigent.server.routes.builtin_agents import create_builtin_agents_router
 from omnigent.server.routes.comments import create_comments_router
 from omnigent.server.routes.default_policies import create_default_policies_router
 from omnigent.server.routes.dictation import create_dictation_router
+from omnigent.server.routes.extension_assets import create_extension_assets_router
 from omnigent.server.routes.extensions import create_extensions_router
 from omnigent.server.routes.harnesses import create_harnesses_router
 from omnigent.server.routes.imports import create_imports_router
@@ -169,6 +171,17 @@ def _resolve_extension_state(
     except Exception as exc:  # noqa: BLE001
         _logger.warning("could not discover installed extensions (%s)", exc, exc_info=True)
         return ExtensionPluginState(manifests=(), load_errors={"registry": str(exc)})
+
+
+def _resolve_extension_assets(
+    state: ExtensionPluginState,
+) -> tuple[dict[str, ResolvedBundle], dict[str, str]]:
+    """Resolve bundle snapshots without allowing asset failures to stop the server."""
+    try:
+        return build_asset_index(state)
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("could not build extension asset index (%s)", exc, exc_info=True)
+        return {}, {"registry": str(exc)}
 
 
 def _server_version() -> str:
@@ -1200,6 +1213,7 @@ def create_app(
     title_instructions = session_title_instructions(resolved_server_config)
     resolved_feature_flags = feature_flags or resolve_feature_flags()
     resolved_extension_state = _resolve_extension_state(extension_state)
+    extension_bundles, extension_asset_errors = _resolve_extension_assets(resolved_extension_state)
 
     # First-boot admin bootstrap for the accounts auth provider.
     # Runs before any route is mounted so the login page is never
@@ -2572,8 +2586,18 @@ def create_app(
     app.include_router(
         create_extensions_router(
             resolved_extension_state,
+            bundles=extension_bundles,
+            asset_errors=extension_asset_errors,
             auth_provider=auth_provider,
             permission_store=permission_store,
+        ),
+        prefix="/v1",
+        tags=["extensions"],
+    )
+    app.include_router(
+        create_extension_assets_router(
+            extension_bundles,
+            auth_provider=auth_provider,
         ),
         prefix="/v1",
         tags=["extensions"],

--- a/omnigent/server/routes/extension_assets.py
+++ b/omnigent/server/routes/extension_assets.py
@@ -1,0 +1,80 @@
+"""Content-addressed delivery for installed extension browser bundles."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from fastapi import APIRouter, Request
+from fastapi.responses import Response
+
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.extensions.assets import ASSET_MEDIA_TYPES, ResolvedBundle
+from omnigent.server.auth import AuthProvider
+from omnigent.server.routes._auth_helpers import require_user
+
+_CACHE_CONTROL = "private, max-age=31536000, immutable"
+
+
+def _not_found() -> OmnigentError:
+    return OmnigentError("Extension asset not found", code=ErrorCode.NOT_FOUND)
+
+
+def _etag_matches(header: str | None, etag: str) -> bool:
+    if header is None:
+        return False
+    candidates = (item.strip().removeprefix("W/") for item in header.split(","))
+    return any(item in {etag, "*"} for item in candidates)
+
+
+def create_extension_assets_router(
+    bundles: Mapping[str, ResolvedBundle],
+    *,
+    auth_provider: AuthProvider | None = None,
+) -> APIRouter:
+    """Build the authenticated extension asset router, mounted under ``/v1``."""
+    router = APIRouter()
+
+    @router.get(
+        "/extensions/{extension_id}/assets/{digest}/{asset_name}",
+        response_model=None,
+        responses={
+            200: {
+                "description": "Extension JavaScript or CSS asset",
+                "content": {
+                    "text/javascript": {"schema": {"type": "string", "format": "binary"}},
+                    "text/css": {"schema": {"type": "string", "format": "binary"}},
+                },
+            },
+            404: {"description": "Extension asset not found"},
+        },
+    )
+    async def get_extension_asset(
+        request: Request,
+        extension_id: str,
+        digest: str,
+        asset_name: str,
+    ) -> Response:
+        """Return a declared asset only when its bundle digest still matches."""
+        require_user(request, auth_provider)
+        if asset_name not in ASSET_MEDIA_TYPES:
+            raise _not_found()
+        bundle = bundles.get(extension_id)
+        if bundle is None or bundle.digest != digest:
+            raise _not_found()
+        asset = bundle.assets.get(asset_name)
+        if asset is None:
+            raise _not_found()
+
+        etag = f'"{bundle.digest}-{asset.name}"'
+        headers = {
+            "Cache-Control": _CACHE_CONTROL,
+            "Content-Disposition": "inline",
+            "Content-Security-Policy": "default-src 'none'; sandbox",
+            "ETag": etag,
+            "X-Content-Type-Options": "nosniff",
+        }
+        if _etag_matches(request.headers.get("if-none-match"), etag):
+            return Response(status_code=304, headers=headers)
+        return Response(content=asset.content, media_type=asset.media_type, headers=headers)
+
+    return router

--- a/omnigent/server/routes/extensions.py
+++ b/omnigent/server/routes/extensions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 from typing import Literal
 
 from fastapi import APIRouter, Request
@@ -10,6 +11,7 @@ from pydantic import BaseModel
 
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.extensions import ExtensionManifest, ExtensionPluginState
+from omnigent.extensions.assets import ASSET_SCRIPT, ASSET_STYLES, ResolvedBundle
 from omnigent.server.auth import AuthProvider
 from omnigent.server.routes._auth_helpers import require_user
 from omnigent.stores.permission_store import PermissionStore
@@ -36,12 +38,7 @@ class ExtensionPrimaryNavigationResponse(BaseModel):
 
 
 class ExtensionBrowserBundleResponse(BaseModel):
-    """Opaque browser-bundle availability metadata.
-
-    Asset URLs and content digests are populated by the asset-serving layer in
-    the next stack PR. A declared bundle is not runnable until those fields are
-    present.
-    """
+    """Opaque browser-bundle availability and content-addressed asset URLs."""
 
     declared: bool
     has_styles: bool
@@ -59,7 +56,7 @@ class ExtensionResponse(BaseModel):
     distribution: str
     version: str
     extension_api: int
-    status: Literal["enabled"] = "enabled"
+    status: Literal["enabled", "unavailable"]
     permissions: list[str]
     pages: list[ExtensionPageResponse]
     primary_navigation: list[ExtensionPrimaryNavigationResponse]
@@ -81,43 +78,72 @@ class ExtensionLoadErrorResponse(BaseModel):
     error: str
 
 
+class ExtensionAssetErrorResponse(BaseModel):
+    """Concise diagnostic for one unresolved browser bundle."""
+
+    extension_id: str
+    status: Literal["unresolved"] = "unresolved"
+    error: str
+
+
 class ExtensionDiagnosticsResponse(BaseModel):
     """Administrator view of accepted and rejected extensions."""
 
     object: Literal["extension_diagnostics"] = "extension_diagnostics"
     extensions: list[ExtensionResponse]
     load_errors: list[ExtensionLoadErrorResponse]
+    asset_errors: list[ExtensionAssetErrorResponse]
 
 
-def _serialize_manifest(manifest: ExtensionManifest) -> ExtensionResponse:
+def _serialize_manifest(
+    manifest: ExtensionManifest,
+    bundle: ResolvedBundle | None = None,
+) -> ExtensionResponse:
     """Convert a validated manifest into stable JSON-safe catalog metadata."""
-    pages = [
-        ExtensionPageResponse(id=page.id, title=page.title, route=page.route, view=page.view)
-        for page in sorted(manifest.pages, key=lambda item: item.id)
-    ]
-    navigation = [
-        ExtensionPrimaryNavigationResponse(
-            id=item.id,
-            label=item.label,
-            page=item.page,
-            icon=item.icon,
-            order=item.order,
-            when=item.when,
-        )
-        for item in sorted(manifest.primary_navigation, key=lambda item: (item.order, item.id))
-    ]
+    unavailable = manifest.entrypoints.browser is not None and bundle is None
+    pages = (
+        []
+        if unavailable
+        else [
+            ExtensionPageResponse(id=page.id, title=page.title, route=page.route, view=page.view)
+            for page in sorted(manifest.pages, key=lambda item: item.id)
+        ]
+    )
+    navigation = (
+        []
+        if unavailable
+        else [
+            ExtensionPrimaryNavigationResponse(
+                id=item.id,
+                label=item.label,
+                page=item.page,
+                icon=item.icon,
+                order=item.order,
+                when=item.when,
+            )
+            for item in sorted(manifest.primary_navigation, key=lambda item: (item.order, item.id))
+        ]
+    )
     return ExtensionResponse(
         id=manifest.id,
         display_name=manifest.display_name,
         distribution=manifest.distribution,
         version=manifest.version,
         extension_api=manifest.extension_api,
+        status="unavailable" if unavailable else "enabled",
         permissions=sorted(permission.value for permission in manifest.permissions),
         pages=pages,
         primary_navigation=navigation,
         browser=ExtensionBrowserBundleResponse(
             declared=manifest.entrypoints.browser is not None,
             has_styles=manifest.entrypoints.browser_css is not None,
+            digest=bundle.digest if bundle is not None else None,
+            script_url=bundle.url(ASSET_SCRIPT) if bundle is not None else None,
+            style_url=(
+                bundle.url(ASSET_STYLES)
+                if bundle is not None and ASSET_STYLES in bundle.assets
+                else None
+            ),
         ),
     )
 
@@ -150,19 +176,26 @@ def _diagnostic_message(error: str) -> str:
 def create_extensions_router(
     state: ExtensionPluginState,
     *,
+    bundles: Mapping[str, ResolvedBundle] | None = None,
+    asset_errors: Mapping[str, str] | None = None,
     auth_provider: AuthProvider | None = None,
     permission_store: PermissionStore | None = None,
 ) -> APIRouter:
     """Build the installed-extension catalog router, mounted under ``/v1``."""
     router = APIRouter()
+    resolved_bundles = bundles or {}
     catalog = tuple(
-        _serialize_manifest(manifest)
+        _serialize_manifest(manifest, resolved_bundles.get(manifest.id))
         for manifest in sorted(state.manifests, key=lambda item: item.id)
     )
     by_id = {item.id: item for item in catalog}
     diagnostics = tuple(
         ExtensionLoadErrorResponse(entry_point=entry_point, error=_diagnostic_message(error))
         for entry_point, error in sorted(state.load_errors.items())
+    )
+    asset_diagnostics = tuple(
+        ExtensionAssetErrorResponse(extension_id=extension_id, error=_diagnostic_message(error))
+        for extension_id, error in sorted((asset_errors or {}).items())
     )
 
     @router.get("/extensions", response_model=ExtensionListResponse)
@@ -184,6 +217,7 @@ def create_extensions_router(
         return ExtensionDiagnosticsResponse(
             extensions=list(catalog),
             load_errors=list(diagnostics),
+            asset_errors=list(asset_diagnostics),
         )
 
     @router.get("/extensions/{extension_id}", response_model=ExtensionResponse)

--- a/openapi.json
+++ b/openapi.json
@@ -1867,8 +1867,33 @@
         "title": "ErrorEvent",
         "type": "object"
       },
+      "ExtensionAssetErrorResponse": {
+        "description": "Concise diagnostic for one unresolved browser bundle.",
+        "properties": {
+          "error": {
+            "title": "Error",
+            "type": "string"
+          },
+          "extension_id": {
+            "title": "Extension Id",
+            "type": "string"
+          },
+          "status": {
+            "const": "unresolved",
+            "default": "unresolved",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "extension_id",
+          "error"
+        ],
+        "title": "ExtensionAssetErrorResponse",
+        "type": "object"
+      },
       "ExtensionBrowserBundleResponse": {
-        "description": "Opaque browser-bundle availability metadata.\n\nAsset URLs and content digests are populated by the asset-serving layer in\nthe next stack PR. A declared bundle is not runnable until those fields are\npresent.",
+        "description": "Opaque browser-bundle availability and content-addressed asset URLs.",
         "properties": {
           "declared": {
             "title": "Declared",
@@ -1922,6 +1947,13 @@
       "ExtensionDiagnosticsResponse": {
         "description": "Administrator view of accepted and rejected extensions.",
         "properties": {
+          "asset_errors": {
+            "items": {
+              "$ref": "#/components/schemas/ExtensionAssetErrorResponse"
+            },
+            "title": "Asset Errors",
+            "type": "array"
+          },
           "extensions": {
             "items": {
               "$ref": "#/components/schemas/ExtensionResponse"
@@ -1945,7 +1977,8 @@
         },
         "required": [
           "extensions",
-          "load_errors"
+          "load_errors",
+          "asset_errors"
         ],
         "title": "ExtensionDiagnosticsResponse",
         "type": "object"
@@ -2132,8 +2165,10 @@
             "type": "array"
           },
           "status": {
-            "const": "enabled",
-            "default": "enabled",
+            "enum": [
+              "enabled",
+              "unavailable"
+            ],
             "title": "Status",
             "type": "string"
           },
@@ -2148,6 +2183,7 @@
           "distribution",
           "version",
           "extension_api",
+          "status",
           "permissions",
           "pages",
           "primary_navigation",
@@ -8740,6 +8776,80 @@
           }
         },
         "summary": "Get Extension",
+        "tags": [
+          "extensions"
+        ]
+      }
+    },
+    "/v1/extensions/{extension_id}/assets/{digest}/{asset_name}": {
+      "get": {
+        "description": "Return a declared asset only when its bundle digest still matches.",
+        "operationId": "get_extension_asset_v1_extensions__extension_id__assets__digest___asset_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "extension_id",
+            "required": true,
+            "schema": {
+              "title": "Extension Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "digest",
+            "required": true,
+            "schema": {
+              "title": "Digest",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "asset_name",
+            "required": true,
+            "schema": {
+              "title": "Asset Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "text/css": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "text/javascript": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Extension JavaScript or CSS asset"
+          },
+          "404": {
+            "description": "Extension asset not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Extension Asset",
         "tags": [
           "extensions"
         ]

--- a/tests/extensions/test_assets.py
+++ b/tests/extensions/test_assets.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import hashlib
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+from omnigent.extensions import EXTENSION_API_VERSION, ExtensionEntrypoints, ExtensionManifest
+from omnigent.extensions.api import ExtensionPluginState
+from omnigent.extensions.assets import (
+    ASSET_SCRIPT,
+    ASSET_STYLES,
+    ExtensionAssetError,
+    build_asset_index,
+    resolve_bundle,
+)
+
+
+def _manifest(
+    extension_id: str = "acme.assets",
+    *,
+    browser: str = "dist/extension.js",
+    css: str | None = "dist/extension.css",
+) -> ExtensionManifest:
+    return ExtensionManifest(
+        id=extension_id,
+        display_name="Assets",
+        distribution="acme-assets",
+        version="1.0.0",
+        requires_omnigent=">=0.11,<1",
+        extension_api=EXTENSION_API_VERSION,
+        entrypoints=ExtensionEntrypoints(browser=browser, browser_css=css),
+    )
+
+
+def _package(
+    tmp_path: Path,
+    name: str,
+    *,
+    js: bytes = b"console.log('ok')",
+    css: bytes = b"body{}",
+) -> Path:
+    root = tmp_path / name
+    (root / "dist").mkdir(parents=True)
+    (root / "__init__.py").write_text("", encoding="utf-8")
+    (root / "dist" / "extension.js").write_bytes(js)
+    (root / "dist" / "extension.css").write_bytes(css)
+    return root
+
+
+def test_resolves_and_hashes_complete_bundle(tmp_path: Path) -> None:
+    root = _package(tmp_path, "acme_ext")
+
+    bundle = resolve_bundle(_manifest(), root_override=root)
+
+    assert bundle.assets[ASSET_SCRIPT].content == b"console.log('ok')"
+    assert bundle.assets[ASSET_STYLES].content == b"body{}"
+    assert bundle.assets[ASSET_SCRIPT].sha256 == hashlib.sha256(b"console.log('ok')").hexdigest()
+    assert len(bundle.digest) == 64
+    assert bundle.url(ASSET_SCRIPT).endswith(f"/{bundle.digest}/extension.js")
+
+
+def test_css_change_changes_whole_bundle_digest(tmp_path: Path) -> None:
+    root = _package(tmp_path, "acme_ext")
+    first = resolve_bundle(_manifest(), root_override=root)
+    (root / "dist" / "extension.css").write_bytes(b"body{color:red}")
+
+    second = resolve_bundle(_manifest(), root_override=root)
+
+    assert first.digest != second.digest
+
+
+def test_missing_and_oversized_assets_fail(tmp_path: Path) -> None:
+    root = _package(tmp_path, "acme_ext", js=b"12345")
+    (root / "dist" / "extension.css").unlink()
+
+    with pytest.raises(ExtensionAssetError, match="missing"):
+        resolve_bundle(_manifest(), root_override=root)
+    with pytest.raises(ExtensionAssetError, match="exceeds"):
+        resolve_bundle(_manifest(css=None), root_override=root, max_bytes=4)
+
+
+def test_rejects_symlink_escape(tmp_path: Path) -> None:
+    root = _package(tmp_path, "acme_ext")
+    outside = tmp_path / "outside.js"
+    outside.write_text("secret", encoding="utf-8")
+    (root / "dist" / "extension.js").unlink()
+    (root / "dist" / "extension.js").symlink_to(outside)
+
+    with pytest.raises(ExtensionAssetError, match="escapes"):
+        resolve_bundle(_manifest(css=None), root_override=root)
+
+
+@pytest.mark.parametrize("path", ["../../etc/passwd.js", "dist\\..\\escape.js", "/tmp/x.js"])
+def test_revalidates_paths_at_io_boundary(tmp_path: Path, path: str) -> None:
+    root = _package(tmp_path, "acme_ext")
+
+    with pytest.raises(ExtensionAssetError):
+        resolve_bundle(_manifest(browser=path, css=None), root_override=root)
+
+
+def test_rejects_directory_target(tmp_path: Path) -> None:
+    root = _package(tmp_path, "acme_ext")
+    (root / "dist" / "extension.js").unlink()
+    (root / "dist" / "extension.js").mkdir()
+
+    with pytest.raises(ExtensionAssetError, match="regular file"):
+        resolve_bundle(_manifest(css=None), root_override=root)
+
+
+def test_rejects_namespace_package_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    package = "extension_namespace_fixture"
+    roots = [tmp_path / "one", tmp_path / "two"]
+    for root in roots:
+        (root / package).mkdir(parents=True)
+        monkeypatch.syspath_prepend(str(root))
+    importlib.invalidate_caches()
+    sys.modules.pop(package, None)
+
+    with pytest.raises(ExtensionAssetError, match="regular package"):
+        resolve_bundle(_manifest(css=None), package=package)
+
+
+def test_asset_index_isolates_broken_extension(tmp_path: Path) -> None:
+    healthy_root = _package(tmp_path, "healthy")
+    broken_root = _package(tmp_path, "broken")
+    (broken_root / "dist" / "extension.js").unlink()
+    healthy = _manifest("acme.healthy", css=None)
+    broken = _manifest("acme.broken", css=None)
+    state = ExtensionPluginState(manifests=(broken, healthy))
+
+    bundles, errors = build_asset_index(
+        state,
+        overrides={healthy.id: healthy_root, broken.id: broken_root},
+    )
+
+    assert set(bundles) == {"acme.healthy"}
+    assert set(errors) == {"acme.broken"}

--- a/tests/extensions/test_registry.py
+++ b/tests/extensions/test_registry.py
@@ -21,9 +21,15 @@ from omnigent.extensions import (
 
 
 class _Distribution:
-    def __init__(self, name: str, version: str | None = None) -> None:
+    def __init__(
+        self,
+        name: str,
+        version: str | None = None,
+        files: tuple[str, ...] | None = None,
+    ) -> None:
         self.name = name
         self.version = version
+        self.files = files
 
 
 class _EntryPoint:
@@ -34,10 +40,14 @@ class _EntryPoint:
         *,
         distribution: str | None = None,
         version: str | None = None,
+        module: str | None = None,
+        files: tuple[str, ...] | None = None,
     ) -> None:
         self.name = name
         self._loader = loader
-        self.dist = _Distribution(distribution, version) if distribution else None
+        self.module = module
+        self.value = f"{module}:get_manifest" if module else ""
+        self.dist = _Distribution(distribution, version, files) if distribution else None
 
     def load(self) -> Callable[[], ExtensionManifest] | object:
         return self._loader
@@ -183,6 +193,54 @@ def test_accepts_manifest_object_without_factory(monkeypatch: pytest.MonkeyPatch
     _install_entry_points(monkeypatch, _EntryPoint("review", _manifest()))
 
     assert registry.extension_manifests() == (_manifest(),)
+
+
+def test_records_verified_asset_package(monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _manifest()
+    _install_entry_points(
+        monkeypatch,
+        _EntryPoint(
+            "review",
+            manifest,
+            distribution=manifest.distribution,
+            version=manifest.version,
+            module="acme_review.plugin",
+            files=("acme_review/__init__.py", "acme_review/dist/extension.js"),
+        ),
+    )
+
+    state = registry.plugin_state()
+
+    assert state.asset_package(manifest.id) == "acme_review"
+
+
+def test_does_not_record_unverified_or_core_asset_package(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unverified = _manifest("acme.unverified")
+    core = _manifest("acme.core")
+    _install_entry_points(
+        monkeypatch,
+        _EntryPoint(
+            "unverified",
+            unverified,
+            distribution=unverified.distribution,
+            module="not_owned.plugin",
+            files=("different_package/__init__.py",),
+        ),
+        _EntryPoint(
+            "core",
+            core,
+            distribution=core.distribution,
+            module="omnigent.extensions",
+            files=("omnigent/__init__.py",),
+        ),
+    )
+
+    state = registry.plugin_state()
+
+    assert state.asset_package(unverified.id) is None
+    assert state.asset_package(core.id) is None
 
 
 def test_records_bad_return_type_without_breaking_healthy_extension(
@@ -377,9 +435,18 @@ def test_requires_javascript_suffix_for_browser_entrypoint(
     _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
 
     assert (
-        "browser entrypoint must use one of: .js, .mjs"
-        in registry.plugin_state().load_errors["review"]
+        "browser entrypoint must use one of: .js" in registry.plugin_state().load_errors["review"]
     )
+
+
+def test_requires_fixed_browser_bundle_location(monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = replace(
+        _manifest(),
+        entrypoints=ExtensionEntrypoints(browser="other/extension.js"),
+    )
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "must be dist/extension.js" in registry.plugin_state().load_errors["review"]
 
 
 def test_requires_css_suffix_for_browser_styles(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/server/routes/test_extension_assets_routes.py
+++ b/tests/server/routes/test_extension_assets_routes.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from omnigent.errors import OmnigentError
+from omnigent.extensions import EXTENSION_API_VERSION, ExtensionEntrypoints, ExtensionManifest
+from omnigent.extensions.api import ExtensionPluginState
+from omnigent.extensions.assets import ASSET_SCRIPT, ASSET_STYLES, resolve_bundle
+from omnigent.server.auth import UnifiedAuthProvider
+from omnigent.server.routes.extension_assets import create_extension_assets_router
+from omnigent.server.routes.extensions import create_extensions_router
+
+
+def _manifest(css: bool = True) -> ExtensionManifest:
+    return ExtensionManifest(
+        id="acme.assets",
+        display_name="Assets",
+        distribution="acme-assets",
+        version="1.0.0",
+        requires_omnigent=">=0.11,<1",
+        extension_api=EXTENSION_API_VERSION,
+        entrypoints=ExtensionEntrypoints(
+            browser="dist/extension.js",
+            browser_css="dist/extension.css" if css else None,
+        ),
+    )
+
+
+def _bundle(tmp_path: Path, *, js: bytes = b"console.log('ok')", css: bool = True):
+    root = tmp_path / "package"
+    (root / "dist").mkdir(parents=True, exist_ok=True)
+    (root / "dist" / "extension.js").write_bytes(js)
+    if css:
+        (root / "dist" / "extension.css").write_bytes(b"body{}")
+    return resolve_bundle(_manifest(css), root_override=root)
+
+
+def _app(bundle, *, auth=False) -> FastAPI:
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def handle_error(_request: Request, exc: OmnigentError) -> JSONResponse:
+        return JSONResponse(status_code=exc.http_status, content={"error": exc.message})
+
+    provider = UnifiedAuthProvider(source="header", local_single_user=False) if auth else None
+    app.include_router(
+        create_extensions_router(
+            ExtensionPluginState(manifests=(_manifest(ASSET_STYLES in bundle.assets),)),
+            bundles={bundle.extension_id: bundle},
+            auth_provider=provider,
+        ),
+        prefix="/v1",
+    )
+    app.include_router(
+        create_extension_assets_router(
+            {bundle.extension_id: bundle},
+            auth_provider=provider,
+        ),
+        prefix="/v1",
+    )
+    return app
+
+
+def _client(app: FastAPI, *, authenticated: bool = False) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"X-Forwarded-Email": "user@example.com"} if authenticated else {},
+    )
+
+
+async def test_catalog_exposes_digest_urls_without_package_paths(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    async with _client(_app(bundle)) as client:
+        response = await client.get("/v1/extensions")
+
+    browser = response.json()["data"][0]["browser"]
+    assert browser == {
+        "declared": True,
+        "has_styles": True,
+        "digest": bundle.digest,
+        "script_url": bundle.url(ASSET_SCRIPT),
+        "style_url": bundle.url(ASSET_STYLES),
+    }
+    assert str(tmp_path) not in response.text
+    assert "dist/extension" not in response.text
+
+
+async def test_serves_script_css_and_conditional_cache(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    async with _client(_app(bundle)) as client:
+        script = await client.get(bundle.url(ASSET_SCRIPT))
+        styles = await client.get(bundle.url(ASSET_STYLES))
+        cached = await client.get(
+            bundle.url(ASSET_SCRIPT), headers={"If-None-Match": script.headers["etag"]}
+        )
+        weak_cached = await client.get(
+            bundle.url(ASSET_SCRIPT), headers={"If-None-Match": f"W/{script.headers['etag']}"}
+        )
+
+    assert script.status_code == 200
+    assert script.content == b"console.log('ok')"
+    assert script.headers["content-type"] == "text/javascript; charset=utf-8"
+    assert script.headers["cache-control"] == "private, max-age=31536000, immutable"
+    assert script.headers["x-content-type-options"] == "nosniff"
+    assert script.headers["content-security-policy"] == "default-src 'none'; sandbox"
+    assert styles.headers["content-type"] == "text/css; charset=utf-8"
+    assert cached.status_code == 304
+    assert cached.content == b""
+    assert cached.headers["etag"] == script.headers["etag"]
+    assert weak_cached.status_code == 304
+
+
+async def test_all_unknown_asset_variants_are_not_found(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path, css=False)
+    base = f"/v1/extensions/{bundle.extension_id}/assets"
+    paths = [
+        f"{base}/{'0' * 64}/extension.js",
+        f"{base}/{bundle.digest}/extension.css",
+        f"{base}/{bundle.digest}/extension.js.map",
+        f"/v1/extensions/missing.extension/assets/{bundle.digest}/extension.js",
+    ]
+    async with _client(_app(bundle)) as client:
+        responses = [await client.get(path) for path in paths]
+
+    assert {response.status_code for response in responses} == {404}
+    assert {response.json()["error"] for response in responses} == {"Extension asset not found"}
+
+
+async def test_rejected_extension_has_no_asset_surface(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    state = ExtensionPluginState(
+        manifests=(),
+        load_errors={"acme-assets:entry": "invalid manifest"},
+    )
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def handle_error(_request: Request, exc: OmnigentError) -> JSONResponse:
+        return JSONResponse(status_code=exc.http_status, content={"error": exc.message})
+
+    app.include_router(create_extension_assets_router({}), prefix="/v1")
+    app.include_router(create_extensions_router(state), prefix="/v1")
+
+    async with _client(app) as client:
+        asset = await client.get(bundle.url(ASSET_SCRIPT))
+        diagnostics = await client.get("/v1/extensions/diagnostics")
+
+    assert asset.status_code == 404
+    assert diagnostics.json()["load_errors"][0]["status"] == "rejected"
+
+
+async def test_old_digest_is_rejected_after_bundle_change(tmp_path: Path) -> None:
+    old = _bundle(tmp_path, js=b"old")
+    new = _bundle(tmp_path, js=b"new")
+    async with _client(_app(new)) as client:
+        stale = await client.get(old.url(ASSET_SCRIPT))
+        current = await client.get(new.url(ASSET_SCRIPT))
+
+    assert stale.status_code == 404
+    assert current.status_code == 200
+    assert current.content == b"new"
+
+
+async def test_asset_requires_authentication_in_multi_user_mode(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    app = _app(bundle, auth=True)
+    async with _client(app) as anonymous:
+        denied = await anonymous.get(bundle.url(ASSET_SCRIPT))
+    async with _client(app, authenticated=True) as authenticated:
+        allowed = await authenticated.get(bundle.url(ASSET_SCRIPT))
+
+    assert denied.status_code == 401
+    assert allowed.status_code == 200

--- a/tests/server/routes/test_extensions_routes.py
+++ b/tests/server/routes/test_extensions_routes.py
@@ -136,26 +136,10 @@ async def test_catalog_serializes_only_public_v1_contributions(catalog_app: Fast
                 "distribution": "omnigent-acme-review",
                 "version": "1.2.0",
                 "extension_api": 1,
-                "status": "enabled",
+                "status": "unavailable",
                 "permissions": ["navigation", "storage.user"],
-                "pages": [
-                    {
-                        "id": "acme.review.dashboard",
-                        "title": "Review dashboard",
-                        "route": "dashboard",
-                        "view": "review-dashboard",
-                    }
-                ],
-                "primary_navigation": [
-                    {
-                        "id": "acme.review.primary-nav",
-                        "label": "Code Review",
-                        "page": "acme.review.dashboard",
-                        "icon": "search",
-                        "order": 350,
-                        "when": None,
-                    }
-                ],
+                "pages": [],
+                "primary_navigation": [],
                 "browser": {
                     "declared": True,
                     "has_styles": True,
@@ -186,7 +170,7 @@ async def test_empty_catalog_on_core_only_install(db_uri: str, tmp_path: Path) -
 
 
 async def test_catalog_order_is_stable(db_uri: str, tmp_path: Path) -> None:
-    zeta = _manifest("zeta.review")
+    zeta = replace(_manifest("zeta.review"), entrypoints=ExtensionEntrypoints())
     alpha_page = PageContribution(
         id="acme.review.alpha",
         title="Alpha",
@@ -201,6 +185,7 @@ async def test_catalog_order_is_stable(db_uri: str, tmp_path: Path) -> None:
     )
     alpha = replace(
         _manifest(),
+        entrypoints=ExtensionEntrypoints(),
         pages=(*_manifest().pages, alpha_page),
         primary_navigation=(*_manifest().primary_navigation, alpha_nav),
     )
@@ -244,6 +229,13 @@ async def test_diagnostics_allows_single_user_mode(catalog_app: FastAPI) -> None
             "entry_point": "broken:entry",
             "status": "rejected",
             "error": "extension import failed",
+        }
+    ]
+    assert response.json()["asset_errors"] == [
+        {
+            "extension_id": "acme.review",
+            "status": "unresolved",
+            "error": "extension 'acme.review' has no verified asset package",
         }
     ]
 
@@ -375,6 +367,7 @@ def test_extension_routes_are_mounted_before_spa_fallback(
         "/v1/extensions",
         "/v1/extensions/diagnostics",
         "/v1/extensions/{extension_id}",
+        "/v1/extensions/{extension_id}/assets/{digest}/{asset_name}",
     }
     assert expected <= set(paths)
     spa_index = next(index for index, path in enumerate(paths) if path == "")


### PR DESCRIPTION
## Related issue

N/A — maintainer architecture work.

## Summary

- Resolve declared browser bundles from their owning extension package, enforce fixed self-contained JS/CSS locations, and isolate missing or unsafe bundles without stopping the server.
- Publish content-addressed asset URLs and serve authenticated, bounded in-memory snapshots with immutable private caching, ETags, pinned MIME types, and indistinguishable 404s.
- Mark extensions with unresolved bundles unavailable and suppress their page/navigation contributions while exposing concise asset diagnostics to administrators.

**ELI5:** Omnigent now safely finds each extension's packaged web files, gives them versioned URLs, and refuses to advertise a page if its files cannot be loaded.

```text
installed package -> validate root/path -> read + hash once
                                           |
                 catalog digest URLs <-----+-----> authenticated assets
```

This is **PR 3 of the extension-framework stack** and is based on PR #5609. Review only the single commit added by this branch.

Bundle digests are cache keys and torn catalog/bundle detection across restarts, not an independent integrity control. V1 assets use fixed `dist/extension.js` and optional `dist/extension.css` paths. The explicit override seam is intentionally unwired until the loud dev-only configuration in PR 7.

## Test Plan

- `uv run pytest tests/extensions/test_registry.py tests/extensions/test_assets.py tests/server/routes/test_extensions_routes.py tests/server/routes/test_extension_assets_routes.py`
- `uv run ruff check omnigent/extensions omnigent/server/routes/extensions.py omnigent/server/routes/extension_assets.py omnigent/server/app.py tests/extensions tests/server/routes/test_extensions_routes.py tests/server/routes/test_extension_assets_routes.py scripts/dump_openapi.py`
- `uv run pyrefly check omnigent/extensions omnigent/server/routes/extensions.py omnigent/server/routes/extension_assets.py`
- `uv run python scripts/dump_openapi.py --check`
- `pre-commit run --all-files`

## Demo

N/A — this PR adds bundle delivery APIs with no rendered extension page yet.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused tests cover package ownership, digest stability, CSS drift, traversal and symlink escape, namespace packages, size limits, failure isolation, authenticated delivery, cache validators, stale digests, unavailable catalog entries, and diagnostics.
