### PR TITLE
feat(extensions): add contributed pages and primary navigation

### DIFF
--- a/omnigent/extensions/registry.py
+++ b/omnigent/extensions/registry.py
@@ -143,6 +143,8 @@ def _validate_relative_path(
         or len(path.parts) > _MAX_ASSET_DEPTH
     ):
         raise ExtensionValidationError(f"{field_name} {value!r} is not a safe relative path")
+    if route and len(path.parts) != 1:
+        raise ExtensionValidationError(f"{field_name} must contain exactly one segment")
     segment_pattern = _ROUTE_SEGMENT_RE if route else _ASSET_SEGMENT_RE
     if any(not segment_pattern.fullmatch(part) for part in path.parts):
         if route:

--- a/tests/extensions/test_registry.py
+++ b/tests/extensions/test_registry.py
@@ -465,12 +465,20 @@ def test_requires_css_suffix_for_browser_styles(monkeypatch: pytest.MonkeyPatch)
     )
 
 
+def test_rejects_multi_segment_page_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    page = replace(_manifest().pages[0], route="reports/daily")
+    manifest = replace(_manifest(), pages=(page,))
+    _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
+
+    assert "exactly one segment" in registry.plugin_state().load_errors["review"]
+
+
 def test_rejects_unsafe_or_dynamic_route(monkeypatch: pytest.MonkeyPatch) -> None:
     page = replace(_manifest().pages[0], route="dashboard/:section")
     manifest = replace(_manifest(), pages=(page,))
     _install_entry_points(monkeypatch, _EntryPoint("review", manifest))
 
-    assert "unsupported route segment" in registry.plugin_state().load_errors["review"]
+    assert "exactly one segment" in registry.plugin_state().load_errors["review"]
 
 
 def test_rejects_contribution_outside_extension_namespace(

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -22,6 +22,36 @@ vi.mock("@/pages/SettingsPage", async () => {
     SettingsPage: () => <div data-testid="settings-location">{useLocation().pathname}</div>,
   };
 });
+vi.mock("@/extensions/ExtensionProvider", () => ({
+  useExtensions: () => [
+    {
+      object: "extension",
+      id: "acme.review",
+      display_name: "Acme Review",
+      distribution: "acme-review",
+      version: "1.0.0",
+      extension_api: 1,
+      status: "enabled",
+      permissions: [],
+      pages: [
+        {
+          id: "acme.review.dashboard",
+          title: "Review dashboard",
+          route: "dashboard",
+          view: "review-dashboard",
+        },
+      ],
+      primary_navigation: [],
+      browser: {
+        declared: true,
+        has_styles: false,
+        digest: "digest",
+        script_url: "/script",
+        style_url: null,
+      },
+    },
+  ],
+}));
 
 import App from "./App";
 
@@ -48,6 +78,44 @@ function renderRoute(path: string) {
     </CapabilitiesProvider>,
   );
 }
+
+describe("Extension page routes", () => {
+  it("renders a catalog-owned namespaced page", async () => {
+    render(
+      <CapabilitiesProvider info={FALLBACK_SERVER_INFO}>
+        <MemoryRouter initialEntries={["/extensions/acme.review/dashboard"]}>
+          <App />
+        </MemoryRouter>
+      </CapabilitiesProvider>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Review dashboard" })).toBeInTheDocument();
+  });
+
+  it("matches extension pages under an embedded basename", async () => {
+    render(
+      <CapabilitiesProvider info={FALLBACK_SERVER_INFO}>
+        <MemoryRouter initialEntries={["/mount/extensions/acme.review/dashboard"]}>
+          <App basename="/mount" />
+        </MemoryRouter>
+      </CapabilitiesProvider>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Review dashboard" })).toBeInTheDocument();
+  });
+
+  it("rejects unknown extension pages", async () => {
+    render(
+      <CapabilitiesProvider info={FALLBACK_SERVER_INFO}>
+        <MemoryRouter initialEntries={["/extensions/acme.review/missing"]}>
+          <App />
+        </MemoryRouter>
+      </CapabilitiesProvider>,
+    );
+
+    expect(await screen.findByText("not found")).toBeInTheDocument();
+  });
+});
 
 describe("Usage release feature route", () => {
   it("does not register /usage while the feature is off", async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { useOmnigentPageView } from "@/lib/analytics";
 import { isFeatureEnabled } from "@/lib/capabilities";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { AppShell } from "@/shell/AppShell";
+import { ExtensionPageRoute } from "@/extensions/ExtensionPageRoute";
 
 // Bind a page component to its analytics page-view id. Declaring the id here,
 // beside the component, keeps the route table clean and means no route ships
@@ -167,6 +168,7 @@ function App({ basename }: AppProps = {}) {
             element={<Navigate to={`${prefix}/settings/general`} replace />}
           />
           <Route path={`${prefix}/settings/:section`} element={<SettingsPage />} />
+          <Route path={`${prefix}/extensions/:extensionId/*`} element={<ExtensionPageRoute />} />
           {/* Members / Policies are now settings sub-categories
               (/settings/members, /settings/policies) so entering them
               keeps the settings sidebar nav instead of dropping back to

--- a/web/src/embed.tsx
+++ b/web/src/embed.tsx
@@ -60,6 +60,7 @@ import "katex/dist/katex.min.css";
 import "streamdown/styles.css";
 import "./index.css";
 import { QueueFlushProvider } from "./hooks/QueueFlushProvider";
+import { ExtensionProvider } from "./extensions/ExtensionProvider";
 import { SessionUpdatesProvider } from "./hooks/SessionUpdatesProvider";
 
 export type { OmnigentHostConfig } from "./lib/host";
@@ -282,7 +283,9 @@ export function OmnigentApp({
   // reads it back via `useQueryClient()` under this provider.
   return (
     <QueryClientProvider client={queryClient}>
-      <OmnigentProviders routing={routingApi} basename={basename} isDarkMode={isDarkMode} />
+      <ExtensionProvider>
+        <OmnigentProviders routing={routingApi} basename={basename} isDarkMode={isDarkMode} />
+      </ExtensionProvider>
     </QueryClientProvider>
   );
 }

--- a/web/src/extensions/ExtensionPageRoute.tsx
+++ b/web/src/extensions/ExtensionPageRoute.tsx
@@ -1,0 +1,26 @@
+import { NotFoundPage } from "@/pages/NotFoundPage";
+import { useParams } from "@/lib/routing";
+import { resolveExtensionPage } from "./catalog";
+import { useExtensions } from "./ExtensionProvider";
+
+export function ExtensionPageRoute() {
+  const params = useParams<{ extensionId: string; "*": string }>();
+  const route = params["*"]?.split("/")[0];
+  const resolved = resolveExtensionPage(useExtensions(), params.extensionId, route);
+
+  if (!resolved) return <NotFoundPage />;
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 items-center justify-center p-6">
+      <section className="max-w-md rounded-lg border bg-card p-6 text-center shadow-sm">
+        <h1 className="text-lg font-semibold">{resolved.page.title}</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          The extension runtime will be available in the next framework layer.
+        </p>
+        <p className="mt-3 font-mono text-xs text-muted-foreground">
+          {resolved.extension.id} · {resolved.page.view}
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/web/src/extensions/ExtensionPrimaryNavigation.test.tsx
+++ b/web/src/extensions/ExtensionPrimaryNavigation.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+const extensions = [
+  {
+    object: "extension" as const,
+    id: "acme.review",
+    display_name: "Acme Review",
+    distribution: "acme-review",
+    version: "1.0.0",
+    extension_api: 1,
+    status: "enabled" as const,
+    permissions: [],
+    pages: [
+      { id: "acme.review.second", title: "Second", route: "second", view: "second" },
+      { id: "acme.review.first", title: "First", route: "first", view: "first" },
+    ],
+    primary_navigation: [
+      {
+        id: "acme.review.second-nav",
+        label: "Second",
+        page: "acme.review.second",
+        icon: null,
+        order: 500,
+        when: null,
+      },
+      {
+        id: "acme.review.first-nav",
+        label: "First",
+        page: "acme.review.first",
+        icon: "unknown-icon",
+        order: 300,
+        when: null,
+      },
+    ],
+    browser: { declared: true, has_styles: false, digest: "x", script_url: "/x", style_url: null },
+  },
+];
+
+vi.mock("./ExtensionProvider", () => ({ useExtensions: () => extensions }));
+
+import { ExtensionPrimaryNavigation } from "./ExtensionPrimaryNavigation";
+
+describe("ExtensionPrimaryNavigation", () => {
+  it("orders entries, falls back unknown icons, and marks the active page", () => {
+    const onNavigate = vi.fn();
+    render(
+      <MemoryRouter>
+        <ExtensionPrimaryNavigation activePageId="acme.review.first" onNavigate={onNavigate} />
+      </MemoryRouter>,
+    );
+
+    const links = screen.getAllByRole("link");
+    expect(links.map((link) => link.textContent)).toEqual(["First", "Second"]);
+    expect(links[0]).toHaveAttribute("href", "/extensions/acme.review/first");
+    expect(links[0]).toHaveAttribute("aria-current", "page");
+    expect(links[0].querySelector("svg")).not.toBeNull();
+
+    fireEvent.click(links[0]);
+    expect(onNavigate).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/extensions/ExtensionPrimaryNavigation.tsx
+++ b/web/src/extensions/ExtensionPrimaryNavigation.tsx
@@ -1,0 +1,54 @@
+import {
+  LayoutDashboardIcon,
+  PanelsTopLeftIcon,
+  PuzzleIcon,
+  SearchIcon,
+  type LucideIcon,
+} from "lucide-react";
+import type { MouseEvent } from "react";
+import { PrimaryNavLink } from "@/shell/PrimaryNavLink";
+import { useExtensions } from "./ExtensionProvider";
+
+const ICONS: Record<string, LucideIcon> = {
+  dashboard: LayoutDashboardIcon,
+  "panels-top-left": PanelsTopLeftIcon,
+  puzzle: PuzzleIcon,
+  search: SearchIcon,
+};
+
+export function ExtensionPrimaryNavigation({
+  activePageId,
+  onNavigate,
+}: {
+  activePageId: string | null;
+  onNavigate: (event: MouseEvent<HTMLAnchorElement>) => void;
+}) {
+  // V1 owns one slot between Inbox and Usage. `order` is deterministic within
+  // that extension-owned slot; it does not reorder core navigation rows.
+  const entries = useExtensions()
+    .flatMap((extension) =>
+      extension.primary_navigation.map((navigation) => ({ extension, navigation })),
+    )
+    .sort(
+      (left, right) =>
+        left.navigation.order - right.navigation.order ||
+        left.navigation.id.localeCompare(right.navigation.id),
+    );
+
+  return entries.map(({ extension, navigation }) => {
+    const page = extension.pages.find((item) => item.id === navigation.page);
+    if (!page) return null;
+    return (
+      <PrimaryNavLink
+        key={navigation.id}
+        to={`/extensions/${extension.id}/${page.route}`}
+        label={navigation.label}
+        icon={ICONS[navigation.icon ?? ""] ?? PuzzleIcon}
+        active={activePageId === page.id}
+        onClick={onNavigate}
+        componentId={`sidebar.extension.${navigation.id}`}
+        testId={`extension-nav-${navigation.id}`}
+      />
+    );
+  });
+}

--- a/web/src/extensions/ExtensionProvider.test.tsx
+++ b/web/src/extensions/ExtensionProvider.test.tsx
@@ -1,0 +1,49 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchExtensionCatalog } from "./catalog";
+import { ExtensionProvider, loadExtensionCatalog, useExtensions } from "./ExtensionProvider";
+
+vi.mock("./catalog", () => ({
+  EXTENSIONS_QUERY_KEY: ["extensions"],
+  fetchExtensionCatalog: vi.fn(),
+}));
+
+function Consumer() {
+  return <span>extensions:{useExtensions().length}</span>;
+}
+
+function renderProvider() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <ExtensionProvider>
+        <Consumer />
+      </ExtensionProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => vi.mocked(fetchExtensionCatalog).mockReset());
+
+describe("ExtensionProvider", () => {
+  it("publishes the loaded catalog", async () => {
+    vi.mocked(fetchExtensionCatalog).mockResolvedValue([]);
+    renderProvider();
+
+    expect(await screen.findByText("extensions:0")).toBeInTheDocument();
+    await waitFor(() => expect(fetchExtensionCatalog).toHaveBeenCalledOnce());
+  });
+
+  it("degrades a catalog failure once without unmounting the app", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const failingFetcher = vi.fn(async () => {
+      throw new Error("offline");
+    });
+
+    await expect(loadExtensionCatalog(undefined, failingFetcher)).resolves.toEqual([]);
+
+    expect(failingFetcher).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/extensions/ExtensionProvider.tsx
+++ b/web/src/extensions/ExtensionProvider.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, type ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { EXTENSIONS_QUERY_KEY, fetchExtensionCatalog } from "./catalog";
+import type { ExtensionCatalogItem } from "./types";
+
+const EMPTY_EXTENSIONS: ExtensionCatalogItem[] = [];
+const ExtensionContext = createContext<ExtensionCatalogItem[]>(EMPTY_EXTENSIONS);
+
+export async function loadExtensionCatalog(
+  signal?: AbortSignal,
+  fetcher: typeof fetchExtensionCatalog = fetchExtensionCatalog,
+): Promise<ExtensionCatalogItem[]> {
+  try {
+    return await fetcher(signal);
+  } catch {
+    console.warn("Extension catalog is unavailable");
+    return EMPTY_EXTENSIONS;
+  }
+}
+
+export function ExtensionCatalogProvider({
+  extensions,
+  children,
+}: {
+  extensions: ExtensionCatalogItem[];
+  children: ReactNode;
+}) {
+  return <ExtensionContext.Provider value={extensions}>{children}</ExtensionContext.Provider>;
+}
+
+export function ExtensionProvider({ children }: { children: ReactNode }) {
+  const query = useQuery({
+    queryKey: EXTENSIONS_QUERY_KEY,
+    queryFn: ({ signal }) => loadExtensionCatalog(signal),
+    retry: false,
+    staleTime: Infinity,
+  });
+
+  return (
+    <ExtensionContext.Provider value={query.data ?? EMPTY_EXTENSIONS}>
+      {children}
+    </ExtensionContext.Provider>
+  );
+}
+
+export function useExtensions(): ExtensionCatalogItem[] {
+  return useContext(ExtensionContext);
+}

--- a/web/src/extensions/catalog.test.ts
+++ b/web/src/extensions/catalog.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authenticatedFetch } from "@/lib/identity";
+import { fetchExtensionCatalog, resolveExtensionPageFromPath } from "./catalog";
+import type { ExtensionCatalogItem } from "./types";
+
+vi.mock("@/lib/identity", () => ({ authenticatedFetch: vi.fn() }));
+
+const extension: ExtensionCatalogItem = {
+  object: "extension",
+  id: "acme.review",
+  display_name: "Review",
+  distribution: "acme-review",
+  version: "1.0.0",
+  extension_api: 1,
+  status: "enabled",
+  permissions: [],
+  pages: [
+    {
+      id: "acme.review.dashboard",
+      title: "Dashboard",
+      route: "dashboard",
+      view: "dashboard",
+    },
+  ],
+  primary_navigation: [],
+  browser: {
+    declared: true,
+    has_styles: false,
+    digest: "abc",
+    script_url: "/script",
+    style_url: null,
+  },
+};
+
+beforeEach(() => vi.mocked(authenticatedFetch).mockReset());
+
+describe("fetchExtensionCatalog", () => {
+  it("keeps enabled extensions and suppresses unavailable ones", async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          object: "list",
+          data: [extension, { ...extension, id: "acme.broken", status: "unavailable" }],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(fetchExtensionCatalog()).resolves.toEqual([extension]);
+  });
+
+  it("rejects failed and malformed responses", async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce(new Response("", { status: 500 }));
+    await expect(fetchExtensionCatalog()).rejects.toThrow("Failed to load extensions (500)");
+
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ object: "wrong", data: [] }), { status: 200 }),
+    );
+    await expect(fetchExtensionCatalog()).rejects.toThrow("Invalid extension catalog response");
+  });
+});
+
+describe("resolveExtensionPageFromPath", () => {
+  it("resolves standalone and embedded paths", () => {
+    expect(
+      resolveExtensionPageFromPath([extension], "/extensions/acme.review/dashboard")?.page.id,
+    ).toBe("acme.review.dashboard");
+    expect(
+      resolveExtensionPageFromPath([extension], "/mount/extensions/acme.review/dashboard")?.page.id,
+    ).toBe("acme.review.dashboard");
+  });
+
+  it("rejects unknown pages", () => {
+    expect(resolveExtensionPageFromPath([extension], "/extensions/acme.review/missing")).toBeNull();
+  });
+});

--- a/web/src/extensions/catalog.ts
+++ b/web/src/extensions/catalog.ts
@@ -1,0 +1,56 @@
+import { authenticatedFetch } from "@/lib/identity";
+import type {
+  ExtensionCatalogItem,
+  ExtensionCatalogResponse,
+  ResolvedExtensionPage,
+} from "./types";
+
+export const EXTENSIONS_QUERY_KEY = ["extensions"] as const;
+
+function isCatalogResponse(value: unknown): value is ExtensionCatalogResponse {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<ExtensionCatalogResponse>;
+  return candidate.object === "list" && Array.isArray(candidate.data);
+}
+
+export async function fetchExtensionCatalog(signal?: AbortSignal): Promise<ExtensionCatalogItem[]> {
+  const response = await authenticatedFetch("/v1/extensions", { signal });
+  if (!response.ok) throw new Error(`Failed to load extensions (${response.status})`);
+  const payload: unknown = await response.json();
+  if (!isCatalogResponse(payload)) throw new Error("Invalid extension catalog response");
+  return payload.data.filter((extension) => extension.status === "enabled");
+}
+
+export function extensionPathParts(
+  pathname: string,
+): { extensionId: string; route: string } | null {
+  const marker = "/extensions/";
+  const markerIndex = pathname.lastIndexOf(marker);
+  if (markerIndex < 0) return null;
+  const parts = pathname
+    .slice(markerIndex + marker.length)
+    .split("/")
+    .filter(Boolean);
+  if (parts.length !== 2 || !parts[0].includes(".")) return null;
+  return { extensionId: parts[0], route: parts[1] };
+}
+
+export function resolveExtensionPageFromPath(
+  extensions: ExtensionCatalogItem[],
+  pathname: string,
+): ResolvedExtensionPage | null {
+  const parts = extensionPathParts(pathname);
+  return parts ? resolveExtensionPage(extensions, parts.extensionId, parts.route) : null;
+}
+
+export function resolveExtensionPage(
+  extensions: ExtensionCatalogItem[],
+  extensionId: string | undefined,
+  route: string | undefined,
+): ResolvedExtensionPage | null {
+  if (!extensionId || !route) return null;
+  const extension = extensions.find((item) => item.id === extensionId);
+  if (!extension) return null;
+  const page = extension.pages.find((item) => item.route === route);
+  return page ? { extension, page } : null;
+}

--- a/web/src/extensions/types.ts
+++ b/web/src/extensions/types.ts
@@ -1,0 +1,47 @@
+export interface ExtensionPage {
+  id: string;
+  title: string;
+  route: string;
+  view: string;
+}
+
+export interface ExtensionPrimaryNavigation {
+  id: string;
+  label: string;
+  page: string;
+  icon: string | null;
+  order: number;
+  when: string | null;
+}
+
+export interface ExtensionBrowserBundle {
+  declared: boolean;
+  has_styles: boolean;
+  digest: string | null;
+  script_url: string | null;
+  style_url: string | null;
+}
+
+export interface ExtensionCatalogItem {
+  object: "extension";
+  id: string;
+  display_name: string;
+  distribution: string;
+  version: string;
+  extension_api: number;
+  status: "enabled" | "unavailable";
+  permissions: string[];
+  pages: ExtensionPage[];
+  primary_navigation: ExtensionPrimaryNavigation[];
+  browser: ExtensionBrowserBundle;
+}
+
+export interface ExtensionCatalogResponse {
+  object: "list";
+  data: ExtensionCatalogItem[];
+}
+
+export interface ResolvedExtensionPage {
+  extension: ExtensionCatalogItem;
+  page: ExtensionPage;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -11,6 +11,7 @@ import { QueueFlushProvider } from "./hooks/QueueFlushProvider";
 import { SessionUpdatesProvider } from "./hooks/SessionUpdatesProvider";
 import { resolveServerInfo, type ServerInfo } from "./lib/capabilities";
 import { CapabilitiesProvider } from "./lib/CapabilitiesContext";
+import { ExtensionProvider } from "./extensions/ExtensionProvider";
 import { createBootServerInfo, withBootTimeout } from "./lib/bootCapabilities";
 import { isLoginRedirectPending, resolveIdentity } from "./lib/identity";
 import { hideNativeChatTerminalBar } from "./lib/nativeChatTerminalBar";
@@ -134,21 +135,23 @@ function RootApp({ initialInfo }: { initialInfo: ServerInfo }) {
   return (
     <CapabilitiesProvider info={info}>
       <QueryClientProvider client={queryClient}>
-        <ThemeProvider>
-          <TooltipProvider>
-            <ImageLightboxProvider>
-              <BrowserRouter>
-                <SessionUpdatesProvider>
-                  <RunnerHealthProvider>
-                    <QueueFlushProvider>
-                      <App />
-                    </QueueFlushProvider>
-                  </RunnerHealthProvider>
-                </SessionUpdatesProvider>
-              </BrowserRouter>
-            </ImageLightboxProvider>
-          </TooltipProvider>
-        </ThemeProvider>
+        <ExtensionProvider>
+          <ThemeProvider>
+            <TooltipProvider>
+              <ImageLightboxProvider>
+                <BrowserRouter>
+                  <SessionUpdatesProvider>
+                    <RunnerHealthProvider>
+                      <QueueFlushProvider>
+                        <App />
+                      </QueueFlushProvider>
+                    </RunnerHealthProvider>
+                  </SessionUpdatesProvider>
+                </BrowserRouter>
+              </ImageLightboxProvider>
+            </TooltipProvider>
+          </ThemeProvider>
+        </ExtensionProvider>
       </QueryClientProvider>
     </CapabilitiesProvider>
   );

--- a/web/src/shell/PrimaryNavLink.tsx
+++ b/web/src/shell/PrimaryNavLink.tsx
@@ -1,0 +1,62 @@
+import type { MouseEvent, ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Link } from "@/lib/routing";
+import { cn } from "@/lib/utils";
+import { SIDEBAR_ROW } from "./sidebarStyles";
+
+const HOVER_HIGHLIGHT = "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50";
+const ACTIVE_HIGHLIGHT =
+  "bg-[var(--sidebar-active)] text-[var(--sidebar-active-foreground)] hover:bg-[var(--sidebar-active)] hover:text-[var(--sidebar-active-foreground)] dark:hover:bg-[var(--sidebar-active)] dark:hover:text-[var(--sidebar-active-foreground)]";
+
+export interface PrimaryNavLinkProps {
+  to: string;
+  label: string;
+  icon: LucideIcon;
+  active: boolean;
+  componentId: string;
+  testId?: string;
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+  trailing?: ReactNode;
+}
+
+export function PrimaryNavLink({
+  to,
+  label,
+  icon: Icon,
+  active,
+  componentId,
+  testId,
+  onClick,
+  trailing,
+}: PrimaryNavLinkProps) {
+  return (
+    <Button
+      asChild
+      variant="ghost"
+      className={cn(
+        SIDEBAR_ROW,
+        "w-full justify-start border-0 font-normal",
+        HOVER_HIGHLIGHT,
+        active && ACTIVE_HIGHLIGHT,
+      )}
+      data-testid={testId}
+    >
+      <Link
+        to={to}
+        onClick={onClick}
+        componentId={componentId}
+        aria-current={active ? "page" : undefined}
+      >
+        <Icon
+          className={cn(
+            "ui-icon",
+            active ? "text-[var(--sidebar-active-foreground)]" : "text-muted-foreground",
+          )}
+        />
+        {label}
+        {trailing}
+      </Link>
+    </Button>
+  );
+}

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -16,6 +16,8 @@ import { FALLBACK_SERVER_INFO, type ServerInfo } from "@/lib/capabilities";
 import { clearOptimisticTitles, recordOptimisticTitle } from "@/lib/optimisticTitles";
 import { clearSessionDrafts, setSessionDraft } from "@/lib/sessionDrafts";
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
+import { ExtensionCatalogProvider } from "@/extensions/ExtensionProvider";
+import type { ExtensionCatalogItem } from "@/extensions/types";
 
 // Project mocks are declared via vi.hoisted so they exist before the hoisted
 // vi.mock factory runs. projectsMock is mutated per-test to drive project
@@ -224,16 +226,20 @@ function renderSidebar(
   initialEntry = "/",
   onOpenSearch?: () => void,
   info?: ServerInfo,
+  extensions: ExtensionCatalogItem[] = [],
+  onClose = vi.fn(),
 ) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  const sidebar = <Sidebar open={open} onClose={vi.fn()} onOpenSearch={onOpenSearch} />;
+  const sidebar = <Sidebar open={open} onClose={onClose} onOpenSearch={onOpenSearch} />;
   return render(
     <QueryClientProvider client={qc}>
-      <TooltipProvider>
-        <MemoryRouter initialEntries={[initialEntry]}>
-          {info ? <CapabilitiesProvider info={info}>{sidebar}</CapabilitiesProvider> : sidebar}
-        </MemoryRouter>
-      </TooltipProvider>
+      <ExtensionCatalogProvider extensions={extensions}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={[initialEntry]}>
+            {info ? <CapabilitiesProvider info={info}>{sidebar}</CapabilitiesProvider> : sidebar}
+          </MemoryRouter>
+        </TooltipProvider>
+      </ExtensionCatalogProvider>
     </QueryClientProvider>,
   );
 }
@@ -294,6 +300,42 @@ function seedPins(ids: string[]) {
   pinnedIdsRef.current = ids;
 }
 afterEach(cleanup);
+
+const TEST_EXTENSION: ExtensionCatalogItem = {
+  object: "extension",
+  id: "acme.review",
+  display_name: "Review",
+  distribution: "acme-review",
+  version: "1.0.0",
+  extension_api: 1,
+  status: "enabled",
+  permissions: [],
+  pages: [
+    {
+      id: "acme.review.inbox-page",
+      title: "Extension Inbox",
+      route: "inbox",
+      view: "inbox",
+    },
+  ],
+  primary_navigation: [
+    {
+      id: "acme.review.primary-nav",
+      label: "Extension Inbox",
+      page: "acme.review.inbox-page",
+      icon: "puzzle",
+      order: 500,
+      when: null,
+    },
+  ],
+  browser: {
+    declared: true,
+    has_styles: false,
+    digest: "digest",
+    script_url: "/script",
+    style_url: null,
+  },
+};
 
 describe("Sidebar session list", () => {
   it("uses the interface text token for the empty session-list state", () => {
@@ -811,6 +853,37 @@ describe("Sidebar session list", () => {
       "dark:hover:bg-[var(--sidebar-active)]",
       "dark:hover:text-[var(--sidebar-active-foreground)]",
     );
+  });
+
+  it("renders and activates an extension nav row without activating core rows", () => {
+    mockConversations(THREE_TYPE_CONVERSATIONS);
+    renderSidebar(true, "/extensions/acme.review/inbox", undefined, undefined, [TEST_EXTENSION]);
+
+    const extension = screen.getByTestId("extension-nav-acme.review.primary-nav");
+    expect(extension).toHaveAttribute("href", "/extensions/acme.review/inbox");
+    expect(extension).toHaveAttribute("aria-current", "page");
+    expect(screen.getByTestId("new-chat-button")).not.toHaveAttribute("aria-current");
+    expect(screen.getByTestId("inbox-button")).not.toHaveAttribute("aria-current");
+  });
+
+  it("closes the mobile sidebar when an extension nav row is selected", () => {
+    mockConversations(THREE_TYPE_CONVERSATIONS);
+    const onClose = vi.fn();
+    renderSidebar(true, "/", undefined, undefined, [TEST_EXTENSION], onClose);
+
+    fireEvent.click(screen.getByTestId("extension-nav-acme.review.primary-nav"));
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("leaves the primary nav unchanged for an empty extension catalog", () => {
+    mockConversations(THREE_TYPE_CONVERSATIONS);
+    renderSidebar();
+
+    expect(screen.queryByTestId(/^extension-nav-/)).toBeNull();
+    expect(screen.getByTestId("new-chat-button")).toBeInTheDocument();
+    expect(screen.getByTestId("scheduled-tasks-nav")).toBeInTheDocument();
+    expect(screen.getByTestId("inbox-button")).toBeInTheDocument();
   });
 
   it("does NOT close the sidebar when the footer Settings is tapped", () => {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -172,6 +172,9 @@ import {
   readSessionFilter,
   writeSessionFilter,
 } from "@/lib/sessionFilterPreferences";
+import { ExtensionPrimaryNavigation } from "@/extensions/ExtensionPrimaryNavigation";
+import { useExtensions } from "@/extensions/ExtensionProvider";
+import { extensionPathParts, resolveExtensionPageFromPath } from "@/extensions/catalog";
 import { NewProjectButton } from "./NewProjectButton";
 import { SettingsSidebarBody, useSettingsRoute, useTrackSettingsReturn } from "./settingsNav";
 import {
@@ -329,25 +332,41 @@ function useActiveNavItem(): {
   isInboxPage: boolean;
   isTasksPage: boolean;
   isUsagePage: boolean;
+  activeExtensionPageId: string | null;
   newSessionProjectName: string | null;
 } {
   const { conversationId: activeConversationId } = useParams<{ conversationId: string }>();
   const location = useLocation();
+  const extensions = useExtensions();
   const leaf = location.pathname.split("/").filter(Boolean).at(-1);
-  const isInboxPage = leaf === "inbox";
-  const isTasksPage = leaf === "tasks";
-  const isUsagePage = leaf === "usage";
+  const isExtensionRoute = extensionPathParts(location.pathname) !== null;
+  const isInboxPage = !isExtensionRoute && leaf === "inbox";
+  const isTasksPage = !isExtensionRoute && leaf === "tasks";
+  const isUsagePage = !isExtensionRoute && leaf === "usage";
+  const activeExtensionPageId =
+    resolveExtensionPageFromPath(extensions, location.pathname)?.page.id ?? null;
   const isNewSessionRoute =
-    activeConversationId == null && !isInboxPage && !isTasksPage && !isUsagePage;
+    activeConversationId == null &&
+    !isInboxPage &&
+    !isTasksPage &&
+    !isUsagePage &&
+    !isExtensionRoute;
   const requestedProject = isNewSessionRoute
     ? new URLSearchParams(location.search).get("project")
     : null;
   const newSessionProjectName = requestedProject || null;
-  // Exclude inbox/tasks/usage: they also have no `:conversationId`, so they
+  // Exclude non-composer routes: they also have no `:conversationId`, so they
   // would otherwise light up the "New session" button. A project-prefilled
   // new session belongs to that project row instead of the global nav item.
   const isNewChatPage = isNewSessionRoute && newSessionProjectName == null;
-  return { isNewChatPage, isInboxPage, isTasksPage, isUsagePage, newSessionProjectName };
+  return {
+    isNewChatPage,
+    isInboxPage,
+    isTasksPage,
+    isUsagePage,
+    activeExtensionPageId,
+    newSessionProjectName,
+  };
 }
 
 /**
@@ -623,8 +642,14 @@ export function Sidebar({
   }
 
   // Which top-level nav button to highlight for the current route.
-  const { isNewChatPage, isInboxPage, isTasksPage, isUsagePage, newSessionProjectName } =
-    useActiveNavItem();
+  const {
+    isNewChatPage,
+    isInboxPage,
+    isTasksPage,
+    isUsagePage,
+    activeExtensionPageId,
+    newSessionProjectName,
+  } = useActiveNavItem();
 
   // On /settings the card keeps its chrome but swaps the conversation list
   // for the settings section nav (see settingsNav.tsx) — entering settings
@@ -1007,6 +1032,10 @@ export function Sidebar({
                   )}
                 </Link>
               </Button>
+              <ExtensionPrimaryNavigation
+                activePageId={activeExtensionPageId}
+                onNavigate={onNavClick}
+              />
               {usagePageEnabled && (
                 <Button
                   asChild


### PR DESCRIPTION
## Related issue

N/A — maintainer architecture work.

## Summary

- Load the extension catalog once in standalone and embedded apps, degrading failures to an empty extension set without disrupting core UI.
- Add one namespaced extension route and validate page ownership before rendering a placeholder runtime surface.
- Render contributed primary-nav entries in a deterministic slot between Inbox and Usage, sharing the same accessible row component and mobile navigation behavior as core entries.

**ELI5:** installed extensions can now add a sidebar link and claim their own page URL, but their JavaScript still does not run until the next PR adds the isolated iframe host.

```text
GET /v1/extensions -> ExtensionProvider
                           |-> primary nav rows
                           +-> /extensions/:id/:page
```

This is **PR 4 of the extension-framework stack** and is based on PR #5613. Review only the single commit added by this branch.

V1 provides one extension-owned slot between Inbox and Usage. `order` sorts entries within that slot; it never reorders core navigation.

## Test Plan

- `pnpm --dir web exec vitest run src/extensions src/App.test.tsx src/shell/Sidebar.test.tsx src/lib/routing.test.tsx`
- `pnpm --dir web type-check`
- `pnpm --dir web lint`
- `uv run pytest tests/extensions/test_registry.py`
- `pre-commit run --all-files`

## Demo

The contributed page is intentionally a placeholder until the isolated runtime lands in the next PR. Component tests cover desktop/mobile navigation and active states.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover catalog success/failure, unavailable-extension filtering, page ownership, embedded basenames, nav ordering, icon fallback, core-row active-state isolation, mobile close behavior, and empty-catalog compatibility.
