### PR TITLE
Copyable cli error commands

### DIFF
--- a/web/src/shell/CliCommandBlock.test.tsx
+++ b/web/src/shell/CliCommandBlock.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { renderTextWithInlineCode } from "./CliCommandBlock";
+
+describe("renderTextWithInlineCode", () => {
+  it("renders backtick spans as copyable code and leaves plain text selectable", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    render(
+      <div>
+        {renderTextWithInlineCode(
+          "Run `omnigent login https://x` and retry, or run `omnigent setup`.",
+        )}
+      </div>,
+    );
+
+    // Both commands render as <code>.
+    expect(screen.getByText("omnigent login https://x").tagName).toBe("CODE");
+    expect(screen.getByText("omnigent setup").tagName).toBe("CODE");
+    // Plain text between them is preserved.
+    expect(screen.getByText(/and retry, or run/)).toBeInTheDocument();
+
+    // Copy button copies just its command.
+    fireEvent.click(screen.getAllByRole("button", { name: "Copy command" })[1]!);
+    expect(writeText).toHaveBeenCalledWith("omnigent setup");
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/web/src/shell/CliCommandBlock.tsx
+++ b/web/src/shell/CliCommandBlock.tsx
@@ -1,6 +1,38 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Copy `text` to the clipboard and flash a "copied" state for 2s.
+ * Shared by the block and inline CLI-command surfaces.
+ */
+function useCopy(text: string) {
+  const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current !== null) {
+        window.clearTimeout(copyTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const copy = useCallback(async () => {
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) return;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      return;
+    }
+    setCopied(true);
+    if (copyTimeoutRef.current !== null) window.clearTimeout(copyTimeoutRef.current);
+    copyTimeoutRef.current = window.setTimeout(() => setCopied(false), 2000);
+  }, [text]);
+
+  return { copied, copy };
+}
 
 /**
  * Code box with a copy-to-clipboard button — used by every "go run
@@ -18,28 +50,7 @@ export function CliCommandBlock({
   command: string;
   testIdPrefix: string;
 }) {
-  const [copied, setCopied] = useState(false);
-  const copyTimeoutRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (copyTimeoutRef.current !== null) {
-        window.clearTimeout(copyTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  async function copyCommand() {
-    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) return;
-    try {
-      await navigator.clipboard.writeText(command);
-    } catch {
-      return;
-    }
-    setCopied(true);
-    if (copyTimeoutRef.current !== null) window.clearTimeout(copyTimeoutRef.current);
-    copyTimeoutRef.current = window.setTimeout(() => setCopied(false), 2000);
-  }
+  const { copied, copy } = useCopy(command);
 
   return (
     // items-start: copy button anchors to top-right next to the first
@@ -61,11 +72,48 @@ export function CliCommandBlock({
         size="icon-sm"
         aria-label={copied ? "Copied" : "Copy command"}
         data-testid={`${testIdPrefix}-copy`}
-        onClick={copyCommand}
+        onClick={() => void copy()}
         className="shrink-0"
       >
         {copied ? <CheckIcon className="size-3.5" /> : <CopyIcon className="size-3.5" />}
       </Button>
     </div>
   );
+}
+
+/**
+ * Inline `<code>` with a small copy button, for CLI commands mentioned
+ * mid-sentence (e.g. inside an error message). Selectable text plus a
+ * one-click copy, without the full block treatment.
+ */
+export function InlineCliCode({ command }: { command: string }) {
+  const { copied, copy } = useCopy(command);
+
+  return (
+    <span className="inline-flex items-baseline gap-1 rounded bg-muted px-1 align-baseline font-mono">
+      <code className="select-text break-all [font-variant-ligatures:none] [font-feature-settings:'liga'_0,'calt'_0]">
+        {command}
+      </code>
+      <button
+        type="button"
+        aria-label={copied ? "Copied" : "Copy command"}
+        onClick={() => void copy()}
+        className={cn("shrink-0 self-center opacity-70 hover:opacity-100", copied && "opacity-100")}
+      >
+        {copied ? <CheckIcon className="size-3" /> : <CopyIcon className="size-3" />}
+      </button>
+    </span>
+  );
+}
+
+/**
+ * Render `text`, turning `` `backtick` ``-wrapped spans into
+ * {@link InlineCliCode}. Odd segments of the split are the code spans.
+ */
+export function renderTextWithInlineCode(text: string) {
+  return text
+    .split("`")
+    .map((segment, i) =>
+      i % 2 === 1 ? <InlineCliCode key={i} command={segment} /> : <span key={i}>{segment}</span>,
+    );
 }

--- a/web/src/shell/CliCommandBlock.tsx
+++ b/web/src/shell/CliCommandBlock.tsx
@@ -111,9 +111,14 @@ export function InlineCliCode({ command }: { command: string }) {
  * {@link InlineCliCode}. Odd segments of the split are the code spans.
  */
 export function renderTextWithInlineCode(text: string) {
-  return text
-    .split("`")
-    .map((segment, i) =>
-      i % 2 === 1 ? <InlineCliCode key={i} command={segment} /> : <span key={i}>{segment}</span>,
+  return text.split("`").map((segment, i) => {
+    // Static text → keys are stable across renders; index disambiguates
+    // repeated segments (e.g. the same command mentioned twice).
+    const key = `${i}:${segment}`;
+    return i % 2 === 1 ? (
+      <InlineCliCode key={key} command={segment} />
+    ) : (
+      <span key={key}>{segment}</span>
     );
+  });
 }

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -105,7 +105,7 @@ import { setPendingInitialPrompt } from "@/store/chatStore";
 import { appendPromptHistoryEntry } from "@/hooks/usePromptHistory";
 import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
-import { CliCommandBlock } from "./CliCommandBlock";
+import { CliCommandBlock, renderTextWithInlineCode } from "./CliCommandBlock";
 import { WorkspacePicker, isNavigablePath } from "./WorkspacePicker";
 import {
   initialPrefillState,
@@ -5352,10 +5352,10 @@ export function NewChatLandingScreen() {
 
           {connectError && (
             <p
-              className="flex flex-wrap items-center gap-x-1.5 text-sm text-destructive"
+              className="flex flex-wrap items-center gap-x-1.5 text-sm text-destructive select-text"
               data-testid="new-chat-landing-connect-error"
             >
-              <span>{connectError}</span>
+              <span>{renderTextWithInlineCode(connectError)}</span>
               <button
                 type="button"
                 className="underline underline-offset-2 hover:no-underline disabled:opacity-60"


### PR DESCRIPTION
## Related issue

Closes https://linear.app/omnigent/issue/OMNI-5628/make-terminal-commands-copyable-in-session-error-message

## Summary

The connect-error message on the new-chat landing screen suggests CLI commands
(`omnigent login …`, `omnigent setup`) but rendered them as plain text you
couldn't cleanly select or copy. This makes those commands first-class:

- Backtick-wrapped spans in the error now render as inline `<code>` with a small
  one-click copy button (icon flips to a checkmark for 2s on copy).
- The whole message is explicitly selectable (`select-text`).
- The copy logic already living in `CliCommandBlock` was extracted into a shared
  `useCopy` hook and reused by the new `InlineCliCode`, so there's no new
  clipboard machinery — just an inline variant plus a small
  `renderTextWithInlineCode` parser that splits on backticks.

## Test Plan

- `npx vitest run src/shell/CliCommandBlock.test.tsx` — new test covers the
  parser (backtick spans → `<code>`, plain text preserved) and that a copy
  button copies only its own command.
- Manual: forced the landing connect-error to render, confirmed the
  `omnigent …` commands appear as inline code chips with a working copy icon,
  and that the message text is now drag-selectable.

## Demo

<img width="860" height="409" alt="Screenshot 2026-08-27 at 10 46 37" src="https://github.com/user-attachments/assets/c10d4a80-8ddf-4b7a-8c34-f1c8a7c14057" />

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a unit test for the backtick parser and per-command copy. Manually
verified in the browser that the connect-error commands render as selectable
inline code with a working copy button.

## Changelog

CLI commands suggested in the new-chat connect-error message are now selectable and copyable inline
