### PR TITLE
feat(extensions): run pages in an isolated browser host

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,6 +88,13 @@ repos:
         files: ^(editors/vscode/.*\.[cm]?[jt]sx?|editors/vscode/tsconfig\.json|editors/vscode/package\.json|pnpm-(?:lock|workspace)\.yaml)$
         pass_filenames: false
 
+      - id: web-extension-sdk-tsc
+        name: Web extension SDK TypeScript type check
+        language: system
+        entry: bash -c 'test -x sdks/web-extension/node_modules/.bin/tsc && cd sdks/web-extension && node_modules/.bin/tsc --noEmit'
+        files: ^(sdks/web-extension/.*\.[cm]?[jt]sx?|sdks/web-extension/tsconfig\.json|sdks/web-extension/package\.json|pnpm-(?:lock|workspace)\.yaml)$
+        pass_filenames: false
+
       # Android Kotlin formatting + linting via ktlint (config:
       # web/android/.editorconfig). The wrapper no-ops when ktlint is absent,
       # so local machines without ktlint installed skip cleanly. CI installs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,12 @@ importers:
         specifier: ^3.2.6
         version: 3.2.7(@types/debug@4.1.13)(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.3))(msw@2.15.0(@types/node@20.19.43)(typescript@5.9.3))(supports-color@10.2.2)(yaml@2.9.0)
 
+  sdks/web-extension:
+    devDependencies:
+      typescript:
+        specifier: ~6.0.2
+        version: 6.0.3
+
   web:
     dependencies:
       '@dnd-kit/core':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - '.github/ci-deps'
   - 'editors/vscode'
   - 'deploy/cloudflare'
+  - 'sdks/web-extension'
 
 settings:
   # 7-day dependency cooldown, mirroring the Python-side exclude-newer = "P7D" in uv.toml.

--- a/sdks/web-extension/package.json
+++ b/sdks/web-extension/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@omnigent/extension-sdk",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "type-check": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "~6.0.2"
+  }
+}

--- a/sdks/web-extension/src/index.ts
+++ b/sdks/web-extension/src/index.ts
@@ -1,0 +1,120 @@
+import {
+  EXTENSION_RPC_SOURCE,
+  EXTENSION_RPC_VERSION,
+  type ExtensionDisposeMessage,
+  type ExtensionErrorMessage,
+  type ExtensionIdentity,
+  type ExtensionIncompatibleMessage,
+  type ExtensionInitMessage,
+  type ExtensionReadyMessage,
+} from "./protocol";
+
+export interface ExtensionContext {
+  extensionId: string;
+  pageId: string;
+  view: string;
+  apiVersion: number;
+}
+
+export interface ExtensionLifecycle {
+  activate(context: ExtensionContext): void | Promise<void>;
+  deactivate?(): void | Promise<void>;
+}
+
+declare global {
+  var __OMNIGENT_EXTENSION__: ExtensionIdentity | undefined;
+}
+
+function matchesIdentity(
+  message: ExtensionInitMessage,
+  identity: ExtensionIdentity,
+): boolean {
+  return (
+    message.source === EXTENSION_RPC_SOURCE &&
+    message.type === "init" &&
+    message.extensionId === identity.extensionId &&
+    message.pageId === identity.pageId &&
+    message.view === identity.view &&
+    message.nonce === identity.nonce &&
+    message.apiVersion === identity.apiVersion
+  );
+}
+
+export function defineExtension(lifecycle: ExtensionLifecycle): void {
+  const identity = globalThis.__OMNIGENT_EXTENSION__;
+  if (!identity) throw new Error("Omnigent extension bootstrap is missing");
+  let active = false;
+  let port: MessagePort | null = null;
+
+  const deactivate = () => {
+    if (!active) return;
+    active = false;
+    void lifecycle.deactivate?.();
+    port?.close();
+    port = null;
+  };
+
+  const handleInit = (event: MessageEvent<unknown>) => {
+    if (active || event.source !== window.parent || event.ports.length !== 1)
+      return;
+    if (!event.data || typeof event.data !== "object") return;
+    const init = event.data as ExtensionInitMessage;
+    if (!matchesIdentity(init, identity)) return;
+    port = event.ports[0];
+    active = true;
+    window.removeEventListener("message", handleInit);
+    port.onmessage = (portEvent: MessageEvent<unknown>) => {
+      const message = portEvent.data as Partial<ExtensionDisposeMessage> | null;
+      if (
+        message?.source === EXTENSION_RPC_SOURCE &&
+        message.type === "dispose" &&
+        message.nonce === identity.nonce
+      ) {
+        deactivate();
+      }
+    };
+    port.start();
+    if (identity.apiVersion !== EXTENSION_RPC_VERSION) {
+      const incompatible: ExtensionIncompatibleMessage = {
+        ...identity,
+        source: EXTENSION_RPC_SOURCE,
+        type: "incompatible",
+        sdkApiVersion: EXTENSION_RPC_VERSION,
+      };
+      port.postMessage(incompatible);
+      return;
+    }
+    const context: ExtensionContext = {
+      extensionId: identity.extensionId,
+      pageId: identity.pageId,
+      view: identity.view,
+      apiVersion: identity.apiVersion,
+    };
+    void Promise.resolve(lifecycle.activate(context)).then(
+      () => {
+        const ready: ExtensionReadyMessage = {
+          ...identity,
+          source: EXTENSION_RPC_SOURCE,
+          type: "ready",
+        };
+        port?.postMessage(ready);
+      },
+      (reason: unknown) => {
+        const failed: ExtensionErrorMessage = {
+          ...identity,
+          source: EXTENSION_RPC_SOURCE,
+          type: "error",
+          message:
+            reason instanceof Error
+              ? reason.message.slice(0, 512)
+              : "Activation failed",
+        };
+        port?.postMessage(failed);
+      },
+    );
+  };
+  window.addEventListener("message", handleInit);
+  window.addEventListener("pagehide", deactivate, { once: true });
+}
+
+export { EXTENSION_RPC_VERSION } from "./protocol";

--- a/sdks/web-extension/src/protocol.ts
+++ b/sdks/web-extension/src/protocol.ts
@@ -1,0 +1,37 @@
+export const EXTENSION_RPC_SOURCE = "omnigent-extension";
+export const EXTENSION_RPC_VERSION = 1;
+
+export interface ExtensionIdentity {
+  extensionId: string;
+  pageId: string;
+  view: string;
+  nonce: string;
+  apiVersion: number;
+}
+
+export interface ExtensionInitMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "init";
+}
+
+export interface ExtensionReadyMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "ready";
+}
+
+export interface ExtensionIncompatibleMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "incompatible";
+  sdkApiVersion: number;
+}
+
+export interface ExtensionErrorMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "error";
+  message: string;
+}
+
+export interface ExtensionDisposeMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "dispose";
+}

--- a/sdks/web-extension/tsconfig.json
+++ b/sdks/web-extension/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "declaration": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -22,6 +22,11 @@ vi.mock("@/pages/SettingsPage", async () => {
     SettingsPage: () => <div data-testid="settings-location">{useLocation().pathname}</div>,
   };
 });
+vi.mock("@/extensions/ExtensionPageHost", () => ({
+  ExtensionPageHost: ({ resolved }: { resolved: { page: { title: string } } }) => (
+    <h1>{resolved.page.title}</h1>
+  ),
+}));
 vi.mock("@/extensions/ExtensionProvider", () => ({
   useExtensions: () => [
     {

--- a/web/src/extensions/ExtensionPageHost.tsx
+++ b/web/src/extensions/ExtensionPageHost.tsx
@@ -1,0 +1,10 @@
+import type { ResolvedExtensionPage } from "./types";
+import { useRefreshExtensions } from "./ExtensionProvider";
+import { ExtensionViewHost } from "./ExtensionViewHost";
+
+export function ExtensionPageHost({ resolved }: { resolved: ResolvedExtensionPage }) {
+  const refresh = useRefreshExtensions();
+  return (
+    <ExtensionViewHost extension={resolved.extension} page={resolved.page} refresh={refresh} />
+  );
+}

--- a/web/src/extensions/ExtensionPageRoute.tsx
+++ b/web/src/extensions/ExtensionPageRoute.tsx
@@ -2,6 +2,7 @@ import { NotFoundPage } from "@/pages/NotFoundPage";
 import { useParams } from "@/lib/routing";
 import { resolveExtensionPage } from "./catalog";
 import { useExtensions } from "./ExtensionProvider";
+import { ExtensionPageHost } from "./ExtensionPageHost";
 
 export function ExtensionPageRoute() {
   const params = useParams<{ extensionId: string; "*": string }>();
@@ -10,17 +11,5 @@ export function ExtensionPageRoute() {
 
   if (!resolved) return <NotFoundPage />;
 
-  return (
-    <div className="flex h-full min-h-0 flex-1 items-center justify-center p-6">
-      <section className="max-w-md rounded-lg border bg-card p-6 text-center shadow-sm">
-        <h1 className="text-lg font-semibold">{resolved.page.title}</h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          The extension runtime will be available in the next framework layer.
-        </p>
-        <p className="mt-3 font-mono text-xs text-muted-foreground">
-          {resolved.extension.id} · {resolved.page.view}
-        </p>
-      </section>
-    </div>
-  );
+  return <ExtensionPageHost resolved={resolved} />;
 }

--- a/web/src/extensions/ExtensionProvider.tsx
+++ b/web/src/extensions/ExtensionProvider.tsx
@@ -1,10 +1,18 @@
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { EXTENSIONS_QUERY_KEY, fetchExtensionCatalog } from "./catalog";
 import type { ExtensionCatalogItem } from "./types";
 
 const EMPTY_EXTENSIONS: ExtensionCatalogItem[] = [];
-const ExtensionContext = createContext<ExtensionCatalogItem[]>(EMPTY_EXTENSIONS);
+const NOOP_REFRESH = async () => EMPTY_EXTENSIONS;
+interface ExtensionContextValue {
+  extensions: ExtensionCatalogItem[];
+  refresh: () => Promise<ExtensionCatalogItem[]>;
+}
+const ExtensionContext = createContext<ExtensionContextValue>({
+  extensions: EMPTY_EXTENSIONS,
+  refresh: NOOP_REFRESH,
+});
 
 export async function loadExtensionCatalog(
   signal?: AbortSignal,
@@ -25,7 +33,11 @@ export function ExtensionCatalogProvider({
   extensions: ExtensionCatalogItem[];
   children: ReactNode;
 }) {
-  return <ExtensionContext.Provider value={extensions}>{children}</ExtensionContext.Provider>;
+  const value = useMemo<ExtensionContextValue>(
+    () => ({ extensions, refresh: async () => extensions }),
+    [extensions],
+  );
+  return <ExtensionContext.Provider value={value}>{children}</ExtensionContext.Provider>;
 }
 
 export function ExtensionProvider({ children }: { children: ReactNode }) {
@@ -36,13 +48,17 @@ export function ExtensionProvider({ children }: { children: ReactNode }) {
     staleTime: Infinity,
   });
 
-  return (
-    <ExtensionContext.Provider value={query.data ?? EMPTY_EXTENSIONS}>
-      {children}
-    </ExtensionContext.Provider>
-  );
+  const extensions = query.data ?? EMPTY_EXTENSIONS;
+  const { refetch } = query;
+  const refresh = useCallback(async () => (await refetch()).data ?? EMPTY_EXTENSIONS, [refetch]);
+  const value = useMemo(() => ({ extensions, refresh }), [extensions, refresh]);
+  return <ExtensionContext.Provider value={value}>{children}</ExtensionContext.Provider>;
 }
 
 export function useExtensions(): ExtensionCatalogItem[] {
-  return useContext(ExtensionContext);
+  return useContext(ExtensionContext).extensions;
+}
+
+export function useRefreshExtensions(): () => Promise<ExtensionCatalogItem[]> {
+  return useContext(ExtensionContext).refresh;
 }

--- a/web/src/extensions/ExtensionViewHost.test.tsx
+++ b/web/src/extensions/ExtensionViewHost.test.tsx
@@ -1,0 +1,242 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EXTENSION_RPC_SOURCE, EXTENSION_RPC_VERSION } from "./rpc/protocol";
+import type { ExtensionCatalogItem, ExtensionPage } from "./types";
+
+const { loadBundleMock, buildDocumentMock } = vi.hoisted(() => ({
+  loadBundleMock: vi.fn(),
+  buildDocumentMock: vi.fn(),
+}));
+
+vi.mock("./rpc/host", () => ({
+  createExtensionNonce: () => "nonce",
+  loadExtensionBundle: loadBundleMock,
+  buildExtensionDocument: buildDocumentMock,
+}));
+
+import { ExtensionViewHost } from "./ExtensionViewHost";
+
+const page: ExtensionPage = {
+  id: "acme.review.dashboard",
+  title: "Dashboard",
+  route: "dashboard",
+  view: "dashboard",
+};
+const extension = {
+  id: "acme.review",
+  browser: { digest: "digest", script_url: "/script" },
+} as ExtensionCatalogItem;
+const identity = {
+  extensionId: extension.id,
+  pageId: page.id,
+  view: page.view,
+  nonce: "nonce",
+  apiVersion: EXTENSION_RPC_VERSION,
+};
+
+class FakePort {
+  onmessage: ((event: MessageEvent<unknown>) => void) | null = null;
+  postMessage = vi.fn();
+  start = vi.fn();
+  close = vi.fn();
+}
+
+class FakeMessageChannel {
+  static latest: FakeMessageChannel | null = null;
+  port1 = new FakePort();
+  port2 = new FakePort();
+
+  constructor() {
+    FakeMessageChannel.latest = this;
+  }
+}
+
+const refresh = vi.fn(async () => [extension]);
+
+beforeEach(() => {
+  vi.stubGlobal("MessageChannel", FakeMessageChannel);
+  loadBundleMock.mockReset().mockResolvedValue({ extension, script: "", styles: "" });
+  buildDocumentMock.mockReset().mockReturnValue({ srcDoc: "<html></html>", identity });
+  refresh.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("ExtensionViewHost", () => {
+  it("uses an opaque sandbox and becomes ready only after the nonce-bound handshake", async () => {
+    render(<ExtensionViewHost extension={extension} page={page} refresh={refresh} />);
+    const iframe = await screen.findByTitle("Dashboard");
+    expect(iframe).toHaveAttribute("sandbox", "allow-scripts");
+    expect(iframe).toHaveAttribute("allow", "");
+    expect(screen.getByRole("status")).toHaveTextContent("Starting extension");
+    await waitFor(() => expect(FakeMessageChannel.latest).not.toBeNull());
+    act(() => {
+      FakeMessageChannel.latest!.port1.onmessage?.({
+        data: { ...identity, source: EXTENSION_RPC_SOURCE, type: "ready" },
+      } as MessageEvent<unknown>);
+    });
+    await waitFor(() => expect(screen.queryByRole("status")).toBeNull());
+  });
+
+  it("rejects an incompatible extension SDK explicitly", async () => {
+    render(<ExtensionViewHost extension={extension} page={page} refresh={refresh} />);
+    await screen.findByTitle("Dashboard");
+    await waitFor(() => expect(FakeMessageChannel.latest).not.toBeNull());
+
+    act(() => {
+      FakeMessageChannel.latest!.port1.onmessage?.({
+        data: {
+          ...identity,
+          source: EXTENSION_RPC_SOURCE,
+          type: "incompatible",
+          sdkApiVersion: 2,
+        },
+      } as MessageEvent<unknown>);
+    });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "SDK API 2 is incompatible with host API 1",
+    );
+  });
+
+  it("rejects a second load instead of handing out another port", async () => {
+    render(<ExtensionViewHost extension={extension} page={page} refresh={refresh} />);
+    const iframe = await screen.findByTitle("Dashboard");
+    fireEvent.load(iframe);
+    fireEvent.load(iframe);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("reloaded during activation");
+  });
+
+  it("times out even when the iframe never finishes loading", async () => {
+    vi.useFakeTimers();
+    render(<ExtensionViewHost extension={extension} page={page} refresh={refresh} />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByTitle("Dashboard")).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(10_000));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("activation timed out");
+  });
+
+  it("cancels outstanding host calls and sends dispose on unmount", async () => {
+    const captured: { signal?: AbortSignal } = {};
+    const pending = vi.fn((_params: unknown, signal: AbortSignal) => {
+      captured.signal = signal;
+      return new Promise<void>(() => {});
+    });
+    const rendered = render(
+      <ExtensionViewHost
+        extension={extension}
+        page={page}
+        refresh={refresh}
+        methods={{ "test.pending": pending }}
+      />,
+    );
+    await screen.findByTitle("Dashboard");
+    await waitFor(() => expect(FakeMessageChannel.latest).not.toBeNull());
+    act(() => {
+      FakeMessageChannel.latest!.port1.onmessage?.({
+        data: {
+          ...identity,
+          source: EXTENSION_RPC_SOURCE,
+          type: "request",
+          requestId: "request-1",
+          method: "test.pending",
+          params: {},
+        },
+      } as MessageEvent<unknown>);
+    });
+    expect(pending).toHaveBeenCalledOnce();
+
+    rendered.unmount();
+
+    expect(captured.signal?.aborted).toBe(true);
+    expect(FakeMessageChannel.latest!.port1.postMessage).toHaveBeenCalledWith({
+      ...identity,
+      source: EXTENSION_RPC_SOURCE,
+      type: "dispose",
+    });
+    expect(FakeMessageChannel.latest!.port1.close).toHaveBeenCalledOnce();
+    expect(FakeMessageChannel.latest!.port1.onmessage).toBeNull();
+  });
+
+  it("times out an unfinished host request", async () => {
+    vi.useFakeTimers();
+    const pending = vi.fn(() => new Promise<void>(() => {}));
+    render(
+      <ExtensionViewHost
+        extension={extension}
+        page={page}
+        refresh={refresh}
+        methods={{ "test.pending": pending }}
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    act(() => {
+      FakeMessageChannel.latest!.port1.onmessage?.({
+        data: { ...identity, source: EXTENSION_RPC_SOURCE, type: "ready" },
+      } as MessageEvent<unknown>);
+      FakeMessageChannel.latest!.port1.onmessage?.({
+        data: {
+          ...identity,
+          source: EXTENSION_RPC_SOURCE,
+          type: "request",
+          requestId: "request-1",
+          method: "test.pending",
+          params: {},
+        },
+      } as MessageEvent<unknown>);
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(FakeMessageChannel.latest!.port1.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "response",
+        requestId: "request-1",
+        error: { code: "RequestTimeout", message: "Host request timed out" },
+      }),
+    );
+  });
+
+  it("does not let one failed extension prevent another from mounting", async () => {
+    const healthy = { ...extension, id: "acme.healthy" };
+    const healthyIdentity = { ...identity, extensionId: healthy.id };
+    loadBundleMock.mockImplementation((item: ExtensionCatalogItem) =>
+      item.id === extension.id
+        ? Promise.reject(new Error("bundle missing"))
+        : Promise.resolve({ extension: healthy, script: "", styles: "" }),
+    );
+    buildDocumentMock.mockImplementation((_bundle: unknown, mountedPage: ExtensionPage) => ({
+      srcDoc: "<html></html>",
+      identity: { ...healthyIdentity, pageId: mountedPage.id },
+    }));
+
+    render(
+      <>
+        <ExtensionViewHost extension={extension} page={page} refresh={refresh} />
+        <ExtensionViewHost extension={healthy} page={page} refresh={refresh} />
+      </>,
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("bundle missing");
+    expect(await screen.findByTitle("Dashboard")).toBeInTheDocument();
+  });
+
+  it("isolates bundle load failures behind an extension-local error", async () => {
+    loadBundleMock.mockRejectedValue(new Error("bundle missing"));
+
+    render(<ExtensionViewHost extension={extension} page={page} refresh={refresh} />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("bundle missing");
+  });
+});

--- a/web/src/extensions/ExtensionViewHost.tsx
+++ b/web/src/extensions/ExtensionViewHost.tsx
@@ -1,0 +1,269 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ExtensionCatalogItem, ExtensionPage } from "./types";
+import { buildExtensionDocument, createExtensionNonce, loadExtensionBundle } from "./rpc/host";
+import {
+  EXTENSION_RPC_SOURCE,
+  type ExtensionDisposeMessage,
+  type ExtensionIdentity,
+  type ExtensionInitMessage,
+  type ExtensionResponseMessage,
+} from "./rpc/protocol";
+import { isExtensionInboundMessage, isExtensionPayloadWithinBudget } from "./rpc/validation";
+
+const ACTIVATION_TIMEOUT_MS = 10_000;
+const REQUEST_TIMEOUT_MS = 10_000;
+
+type HostMethod = (params: unknown, signal: AbortSignal) => unknown | Promise<unknown>;
+const NO_HOST_METHODS: Readonly<Record<string, HostMethod>> = {};
+interface PendingRequest {
+  controller: AbortController;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+interface DocumentState {
+  srcDoc: string;
+  identity: ExtensionIdentity;
+}
+
+export function ExtensionViewHost({
+  extension,
+  page,
+  refresh,
+  methods = NO_HOST_METHODS,
+}: {
+  extension: ExtensionCatalogItem;
+  page: ExtensionPage;
+  refresh: () => Promise<ExtensionCatalogItem[]>;
+  methods?: Readonly<Record<string, HostMethod>>;
+}) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const portRef = useRef<MessagePort | null>(null);
+  const identityRef = useRef<ExtensionIdentity | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handshakeDoneRef = useRef(false);
+  const staleRetryDoneRef = useRef(false);
+  const pendingRef = useRef(new Map<string, PendingRequest>());
+  const [frameDocument, setFrameDocument] = useState<DocumentState | null>(null);
+  const [status, setStatus] = useState<"loading" | "activating" | "ready" | "error">("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
+
+  const closeRuntime = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = null;
+    for (const pending of pendingRef.current.values()) {
+      clearTimeout(pending.timeout);
+      pending.controller.abort();
+    }
+    pendingRef.current.clear();
+    const port = portRef.current;
+    const identity = identityRef.current;
+    if (port && identity) {
+      const dispose: ExtensionDisposeMessage = {
+        ...identity,
+        source: EXTENSION_RPC_SOURCE,
+        type: "dispose",
+      };
+      port.postMessage(dispose);
+      port.onmessage = null;
+      port.close();
+    }
+    portRef.current = null;
+    identityRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    staleRetryDoneRef.current = false;
+  }, [extension.id, page.id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    closeRuntime();
+    handshakeDoneRef.current = false;
+    setStatus("loading");
+    setError(null);
+    setFrameDocument(null);
+    const refreshOnce = async () => {
+      if (staleRetryDoneRef.current) return [];
+      staleRetryDoneRef.current = true;
+      return refresh();
+    };
+    void loadExtensionBundle(extension, refreshOnce)
+      .then((bundle) => {
+        if (cancelled) return;
+        const nextDocument = buildExtensionDocument(bundle, page, createExtensionNonce());
+        setFrameDocument(nextDocument);
+        setStatus("activating");
+        timeoutRef.current = setTimeout(() => {
+          closeRuntime();
+          setError("Extension activation timed out");
+          setStatus("error");
+        }, ACTIVATION_TIMEOUT_MS);
+      })
+      .catch((reason: unknown) => {
+        if (cancelled) return;
+        setError(reason instanceof Error ? reason.message : "Extension bundle failed to load");
+        setStatus("error");
+      });
+    return () => {
+      cancelled = true;
+      closeRuntime();
+    };
+  }, [closeRuntime, extension, page, refresh, retryKey]);
+
+  const handleLoad = useCallback(() => {
+    if (!frameDocument || !iframeRef.current?.contentWindow) return;
+    if (handshakeDoneRef.current) {
+      closeRuntime();
+      setError("Extension frame reloaded during activation");
+      setStatus("error");
+      return;
+    }
+    handshakeDoneRef.current = true;
+    const channel = new MessageChannel();
+    portRef.current = channel.port1;
+    identityRef.current = frameDocument.identity;
+    channel.port1.onmessage = (event: MessageEvent<unknown>) => {
+      if (!isExtensionInboundMessage(event.data, frameDocument.identity)) return;
+      const message = event.data;
+      if (message.type === "ready") {
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+        setStatus("ready");
+        return;
+      }
+      if (message.type === "incompatible") {
+        closeRuntime();
+        setError(
+          `Extension SDK API ${message.sdkApiVersion} is incompatible with host API ${message.apiVersion}`,
+        );
+        setStatus("error");
+        return;
+      }
+      if (message.type === "error") {
+        closeRuntime();
+        setError(message.message.slice(0, 512));
+        setStatus("error");
+        return;
+      }
+      if (message.type === "cancel") {
+        const pending = pendingRef.current.get(message.requestId);
+        if (pending) {
+          clearTimeout(pending.timeout);
+          pending.controller.abort();
+          pendingRef.current.delete(message.requestId);
+        }
+        return;
+      }
+      const response: ExtensionResponseMessage = {
+        ...frameDocument.identity,
+        source: EXTENSION_RPC_SOURCE,
+        type: "response",
+        requestId: message.requestId,
+      };
+      const method = methods[message.method];
+      if (!method) {
+        response.error = { code: "MethodNotFound", message: "Host method is not available" };
+        channel.port1.postMessage(response);
+        return;
+      }
+      if (pendingRef.current.has(message.requestId)) {
+        response.error = { code: "DuplicateRequest", message: "Request ID is already active" };
+        channel.port1.postMessage(response);
+        return;
+      }
+      const controller = new AbortController();
+      const requestTimeout = setTimeout(() => {
+        if (!pendingRef.current.delete(message.requestId)) return;
+        controller.abort();
+        channel.port1.postMessage({
+          ...response,
+          error: { code: "RequestTimeout", message: "Host request timed out" },
+        });
+      }, REQUEST_TIMEOUT_MS);
+      pendingRef.current.set(message.requestId, { controller, timeout: requestTimeout });
+      void Promise.resolve(method(message.params, controller.signal)).then(
+        (result) => {
+          const pending = pendingRef.current.get(message.requestId);
+          if (!pending || !pendingRef.current.delete(message.requestId)) return;
+          clearTimeout(pending.timeout);
+          if (!isExtensionPayloadWithinBudget(result)) {
+            channel.port1.postMessage({
+              ...response,
+              error: { code: "ResponseTooLarge", message: "Host response exceeds the limit" },
+            });
+            return;
+          }
+          channel.port1.postMessage({ ...response, result });
+        },
+        (reason: unknown) => {
+          const pending = pendingRef.current.get(message.requestId);
+          if (!pending || !pendingRef.current.delete(message.requestId)) return;
+          clearTimeout(pending.timeout);
+          channel.port1.postMessage({
+            ...response,
+            error: {
+              code: controller.signal.aborted ? "Cancelled" : "HostError",
+              message: reason instanceof Error ? reason.message.slice(0, 512) : "Host call failed",
+            },
+          });
+        },
+      );
+    };
+    channel.port1.start();
+    const init: ExtensionInitMessage = {
+      ...frameDocument.identity,
+      source: EXTENSION_RPC_SOURCE,
+      type: "init",
+    };
+    // A srcdoc frame has opaque origin "null"; the per-mount nonce and the
+    // transferred port are the spoofing boundary, so targetOrigin must be "*".
+    iframeRef.current.contentWindow.postMessage(init, "*", [channel.port2]);
+  }, [closeRuntime, frameDocument, methods]);
+
+  if (status === "error") {
+    return (
+      <div role="alert" className="flex h-full items-center justify-center p-6">
+        <div className="max-w-md rounded-lg border border-destructive/40 bg-card p-6 text-center">
+          <h1 className="font-semibold">{page.title} could not start</h1>
+          <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+          <button
+            type="button"
+            className="mt-4 rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+            onClick={() => {
+              staleRetryDoneRef.current = false;
+              setRetryKey((value) => value + 1);
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-full min-h-0 w-full overflow-hidden">
+      {frameDocument && (
+        <iframe
+          key={frameDocument.identity.nonce}
+          ref={iframeRef}
+          title={page.title}
+          sandbox="allow-scripts"
+          allow=""
+          srcDoc={frameDocument.srcDoc}
+          onLoad={handleLoad}
+          className="h-full w-full border-0 bg-background"
+        />
+      )}
+      {status !== "ready" && (
+        <div
+          role="status"
+          className="absolute inset-0 flex items-center justify-center bg-background text-sm text-muted-foreground"
+        >
+          {status === "loading" ? "Loading extension…" : "Starting extension…"}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/extensions/rpc/host.test.ts
+++ b/web/src/extensions/rpc/host.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authenticatedFetch } from "@/lib/identity";
+import type { ExtensionCatalogItem, ExtensionPage } from "../types";
+import { buildExtensionDocument, loadExtensionBundle } from "./host";
+import { EXTENSION_RPC_SOURCE, EXTENSION_RPC_VERSION } from "./protocol";
+import { isExtensionInboundMessage } from "./validation";
+
+vi.mock("@/lib/identity", () => ({ authenticatedFetch: vi.fn() }));
+
+const page: ExtensionPage = {
+  id: "acme.review.dashboard",
+  title: "Dashboard",
+  route: "dashboard",
+  view: "dashboard",
+};
+
+const extension: ExtensionCatalogItem = {
+  object: "extension",
+  id: "acme.review",
+  display_name: "Review",
+  distribution: "acme-review",
+  version: "1.0.0",
+  extension_api: 1,
+  status: "enabled",
+  permissions: [],
+  pages: [page],
+  primary_navigation: [],
+  browser: {
+    declared: true,
+    has_styles: true,
+    digest: "old",
+    script_url: "/old/extension.js",
+    style_url: "/old/extension.css",
+  },
+};
+
+beforeEach(() => vi.mocked(authenticatedFetch).mockReset());
+
+describe("loadExtensionBundle", () => {
+  it("refetches the catalog once after a stale digest 404", async () => {
+    const refreshed = {
+      ...extension,
+      browser: {
+        ...extension.browser,
+        digest: "new",
+        script_url: "/new/extension.js",
+        style_url: null,
+      },
+    };
+    vi.mocked(authenticatedFetch)
+      .mockResolvedValueOnce(new Response("", { status: 404 }))
+      .mockResolvedValueOnce(new Response("new script", { status: 200 }));
+    const refresh = vi.fn(async () => [refreshed]);
+
+    const bundle = await loadExtensionBundle(extension, refresh);
+
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(bundle.extension.browser.digest).toBe("new");
+    expect(bundle.script).toBe("new script");
+    expect(authenticatedFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not refresh non-404 failures", async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(new Response("", { status: 500 }));
+    const refresh = vi.fn(async () => [extension]);
+
+    await expect(loadExtensionBundle(extension, refresh)).rejects.toThrow("(500)");
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildExtensionDocument", () => {
+  it("builds an opaque-origin document with no network egress", () => {
+    const { srcDoc, identity } = buildExtensionDocument(
+      { extension, script: "globalThis.ok=true;</script>", styles: "body{color:red}</style>" },
+      page,
+      "nonce123",
+    );
+
+    expect(identity).toEqual({
+      extensionId: extension.id,
+      pageId: page.id,
+      view: page.view,
+      nonce: "nonce123",
+      apiVersion: EXTENSION_RPC_VERSION,
+    });
+    expect(srcDoc).toContain("default-src 'none'");
+    expect(srcDoc).toContain("connect-src 'none'");
+    expect(srcDoc).toContain("img-src data: blob:");
+    expect(srcDoc).toContain("form-action 'none'");
+    expect(srcDoc).toContain("base-uri 'none'");
+    expect(srcDoc).toContain("webrtc 'none'");
+    expect(srcDoc).toContain('nonce="nonce123"');
+    expect(srcDoc).toContain("atob(");
+    expect(srcDoc).not.toContain("globalThis.ok=true;</script>");
+    expect(srcDoc).not.toContain("body{color:red}</style>");
+  });
+});
+
+describe("protocol parity", () => {
+  it("pins the browser SDK to the host protocol constants", () => {
+    const sdkProtocol = readFileSync(
+      resolve(process.cwd(), "../sdks/web-extension/src/protocol.ts"),
+      "utf8",
+    );
+    expect(sdkProtocol).toContain(`EXTENSION_RPC_SOURCE = "${EXTENSION_RPC_SOURCE}"`);
+    expect(sdkProtocol).toContain(`EXTENSION_RPC_VERSION = ${EXTENSION_RPC_VERSION}`);
+  });
+});
+
+describe("isExtensionInboundMessage", () => {
+  const identity = {
+    extensionId: extension.id,
+    pageId: page.id,
+    view: page.view,
+    nonce: "nonce",
+    apiVersion: EXTENSION_RPC_VERSION,
+  };
+
+  it("accepts only bounded messages matching the mount identity", () => {
+    const ready = { ...identity, source: EXTENSION_RPC_SOURCE, type: "ready" };
+    expect(isExtensionInboundMessage(ready, identity)).toBe(true);
+    expect(isExtensionInboundMessage({ ...ready, nonce: "wrong" }, identity)).toBe(false);
+    expect(isExtensionInboundMessage({ ...ready, extra: "x".repeat(70_000) }, identity)).toBe(
+      false,
+    );
+  });
+});

--- a/web/src/extensions/rpc/host.ts
+++ b/web/src/extensions/rpc/host.ts
@@ -1,0 +1,97 @@
+import { authenticatedFetch } from "@/lib/identity";
+import type { ExtensionCatalogItem, ExtensionPage } from "../types";
+import { EXTENSION_RPC_VERSION, type ExtensionIdentity } from "./protocol";
+
+export interface LoadedExtensionBundle {
+  extension: ExtensionCatalogItem;
+  script: string;
+  styles: string;
+}
+
+export function createExtensionNonce(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join("");
+}
+
+async function fetchAsset(url: string): Promise<Response> {
+  return authenticatedFetch(url);
+}
+
+async function readBundle(extension: ExtensionCatalogItem): Promise<LoadedExtensionBundle> {
+  const scriptUrl = extension.browser.script_url;
+  if (!scriptUrl || !extension.browser.digest) throw new Error("Extension bundle is unavailable");
+  const scriptResponse = await fetchAsset(scriptUrl);
+  if (!scriptResponse.ok) {
+    const error = new Error(`Extension script failed to load (${scriptResponse.status})`);
+    Object.assign(error, { status: scriptResponse.status });
+    throw error;
+  }
+  let styles = "";
+  if (extension.browser.style_url) {
+    const styleResponse = await fetchAsset(extension.browser.style_url);
+    if (!styleResponse.ok) {
+      const error = new Error(`Extension styles failed to load (${styleResponse.status})`);
+      Object.assign(error, { status: styleResponse.status });
+      throw error;
+    }
+    styles = await styleResponse.text();
+  }
+  return { extension, script: await scriptResponse.text(), styles };
+}
+
+export async function loadExtensionBundle(
+  extension: ExtensionCatalogItem,
+  refresh: () => Promise<ExtensionCatalogItem[]>,
+): Promise<LoadedExtensionBundle> {
+  try {
+    return await readBundle(extension);
+  } catch (error) {
+    if (!(error instanceof Error) || (error as Error & { status?: number }).status !== 404) {
+      throw error;
+    }
+    const refreshed = (await refresh()).find((item) => item.id === extension.id);
+    if (!refreshed || refreshed.status !== "enabled") throw error;
+    return readBundle(refreshed);
+  }
+}
+
+function encodeBase64(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+export function buildExtensionDocument(
+  bundle: LoadedExtensionBundle,
+  page: ExtensionPage,
+  nonce: string,
+): { srcDoc: string; identity: ExtensionIdentity } {
+  const identity: ExtensionIdentity = {
+    extensionId: bundle.extension.id,
+    pageId: page.id,
+    view: page.view,
+    nonce,
+    apiVersion: EXTENSION_RPC_VERSION,
+  };
+  const serializedIdentity = JSON.stringify(identity).replaceAll("<", "\\u003c");
+  const encodedStyles = encodeBase64(bundle.styles);
+  const encodedScript = encodeBase64(bundle.script);
+  const bootstrap = `(()=>{const d=(s)=>new TextDecoder().decode(Uint8Array.from(atob(s),c=>c.charCodeAt(0)));globalThis.__OMNIGENT_EXTENSION__=${serializedIdentity};const style=document.createElement('style');style.textContent=d('${encodedStyles}');document.head.append(style);const script=document.createElement('script');script.nonce='${nonce}';script.textContent=d('${encodedScript}');document.body.append(script)})();`;
+  const csp = [
+    "default-src 'none'",
+    `script-src 'nonce-${nonce}'`,
+    "style-src 'unsafe-inline'",
+    "connect-src 'none'",
+    "img-src data: blob:",
+    "font-src data:",
+    "form-action 'none'",
+    "base-uri 'none'",
+    "webrtc 'none'",
+  ].join("; ");
+  return {
+    identity,
+    srcDoc: `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${csp}"><meta name="viewport" content="width=device-width,initial-scale=1"></head><body><div id="root"></div><script nonce="${nonce}">${bootstrap}</script></body></html>`,
+  };
+}

--- a/web/src/extensions/rpc/protocol.ts
+++ b/web/src/extensions/rpc/protocol.ts
@@ -1,0 +1,67 @@
+export const EXTENSION_RPC_SOURCE = "omnigent-extension";
+export const EXTENSION_RPC_VERSION = 1;
+export const MAX_EXTENSION_MESSAGE_BYTES = 64 * 1024;
+
+export interface ExtensionIdentity {
+  extensionId: string;
+  pageId: string;
+  view: string;
+  nonce: string;
+  apiVersion: number;
+}
+
+export interface ExtensionInitMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "init";
+}
+
+export interface ExtensionReadyMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "ready";
+}
+
+export interface ExtensionIncompatibleMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "incompatible";
+  sdkApiVersion: number;
+}
+
+export interface ExtensionErrorMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "error";
+  message: string;
+}
+
+export interface ExtensionRequestMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "request";
+  requestId: string;
+  method: string;
+  params: unknown;
+}
+
+export interface ExtensionCancelMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "cancel";
+  requestId: string;
+}
+
+export type ExtensionInboundMessage =
+  | ExtensionReadyMessage
+  | ExtensionIncompatibleMessage
+  | ExtensionErrorMessage
+  | ExtensionRequestMessage
+  | ExtensionCancelMessage;
+
+export interface ExtensionDisposeMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "dispose";
+}
+
+export interface ExtensionResponseMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "response";
+  requestId: string;
+  result?: unknown;
+  error?: { code: string; message: string };
+}

--- a/web/src/extensions/rpc/validation.ts
+++ b/web/src/extensions/rpc/validation.ts
@@ -1,0 +1,67 @@
+import {
+  EXTENSION_RPC_SOURCE,
+  MAX_EXTENSION_MESSAGE_BYTES,
+  type ExtensionIdentity,
+  type ExtensionInboundMessage,
+} from "./protocol";
+
+export function isExtensionPayloadWithinBudget(value: unknown): boolean {
+  let budget = MAX_EXTENSION_MESSAGE_BYTES;
+  let nodes = 0;
+  const seen = new WeakSet<object>();
+  const visit = (item: unknown, depth: number): boolean => {
+    if (depth > 20 || ++nodes > 5_000) return false;
+    if (item === null || typeof item === "boolean" || typeof item === "number") {
+      budget -= 8;
+      return budget >= 0;
+    }
+    if (typeof item === "string") {
+      budget -= item.length * 2;
+      return budget >= 0;
+    }
+    if (Array.isArray(item)) {
+      if (seen.has(item)) return false;
+      seen.add(item);
+      return item.every((entry) => visit(entry, depth + 1));
+    }
+    if (typeof item !== "object") return false;
+    if (ArrayBuffer.isView(item) || item instanceof ArrayBuffer || item instanceof Blob)
+      return false;
+    const prototype = Object.getPrototypeOf(item);
+    if (prototype !== Object.prototype && prototype !== null) return false;
+    if (seen.has(item)) return false;
+    seen.add(item);
+    const entries = Object.entries(item);
+    if (entries.length > 256) return false;
+    return entries.every(([key, entry]) => visit(key, depth + 1) && visit(entry, depth + 1));
+  };
+  return visit(value, 0);
+}
+
+export function isExtensionInboundMessage(
+  value: unknown,
+  identity: ExtensionIdentity,
+): value is ExtensionInboundMessage {
+  if (!value || typeof value !== "object") return false;
+  const message = value as Record<string, unknown>;
+  if (
+    message.source !== EXTENSION_RPC_SOURCE ||
+    message.extensionId !== identity.extensionId ||
+    message.pageId !== identity.pageId ||
+    message.view !== identity.view ||
+    message.nonce !== identity.nonce ||
+    message.apiVersion !== identity.apiVersion
+  ) {
+    return false;
+  }
+  if (!isExtensionPayloadWithinBudget(value)) return false;
+  if (message.type === "ready") return true;
+  if (message.type === "incompatible") return typeof message.sdkApiVersion === "number";
+  if (message.type === "error") return typeof message.message === "string";
+  if (message.type === "cancel") return typeof message.requestId === "string";
+  return (
+    message.type === "request" &&
+    typeof message.requestId === "string" &&
+    typeof message.method === "string"
+  );
+}


### PR DESCRIPTION
## Related issue

N/A — maintainer architecture work.

## Summary

- Load extension JS/CSS through authenticated digest URLs and execute it in an opaque-origin `srcdoc` iframe with strict CSP and no network egress.
- Add a nonce-bound, versioned MessageChannel protocol with activation and request timeouts, bounded JSON payloads, cancellation, explicit disposal, stale-frame rejection, and incompatible-SDK errors.
- Add the private `@omnigent/extension-sdk` workspace package and a pre-commit type-check gate so extension bundles can participate in the handshake without parent DOM or application-state access.

**ELI5:** extension pages now run in their own locked room. They can exchange checked messages through one handed-over channel, but cannot reach the app's cookies, React tree, network, or native bridges.

```text
catalog URLs -> authenticated fetch -> sandboxed srcdoc
                                          |
parent host <------ nonce MessagePort ----> SDK
```

This is **PR 5 of the extension-framework stack** and is based on PR #5615. Review only the single commit added by this branch.

## Test Plan

- `pnpm --dir web exec vitest run src/extensions src/App.test.tsx src/shell/Sidebar.test.tsx`
- `pnpm --dir web type-check`
- `pnpm --dir web lint`
- `pnpm --dir sdks/web-extension type-check`
- `uv run pytest tests/extensions/test_registry.py`
- `pre-commit run --all-files`

## Demo

The reference extension and end-to-end visual demo land in PR 7. This PR exercises successful, failed, timed-out, incompatible, and reloaded iframe lifecycles in component tests.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover stale-catalog retry, CSP construction, script/style parser safety, protocol parity, identity and size validation, opaque sandboxing, successful activation, incompatibility, timeout, duplicate loads, cancellation/disposal, request timeout, and extension-local failure isolation.
