### PR TITLE
feat(extensions): add permission-checked browser host APIs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,9 @@ importers:
       ai-elements:
         specifier: ^1.9.0
         version: 1.9.0
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)(canvas@3.2.3)
@@ -5780,6 +5783,10 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -15333,6 +15340,8 @@ snapshots:
       is-extendable: 1.0.1
 
   extend@3.0.2: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fast-deep-equal@3.1.3: {}
 

--- a/sdks/web-extension/src/index.ts
+++ b/sdks/web-extension/src/index.ts
@@ -1,19 +1,61 @@
 import {
   EXTENSION_RPC_SOURCE,
   EXTENSION_RPC_VERSION,
+  type ExtensionCancelMessage,
   type ExtensionDisposeMessage,
   type ExtensionErrorMessage,
+  type ExtensionEventMessage,
   type ExtensionIdentity,
   type ExtensionIncompatibleMessage,
   type ExtensionInitMessage,
   type ExtensionReadyMessage,
+  type ExtensionRequestMessage,
+  type ExtensionResponseMessage,
 } from "./protocol";
+
+export interface Disposable {
+  dispose(): void;
+}
+
+export interface ThemeInfo {
+  theme: "light" | "dark";
+}
+
+export class ExtensionApiError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ExtensionApiError";
+  }
+}
 
 export interface ExtensionContext {
   extensionId: string;
   pageId: string;
   view: string;
   apiVersion: number;
+  capabilities: readonly string[];
+  navigation: {
+    openPage(
+      pageId: string,
+      params?: Record<string, string | number | boolean>,
+    ): Promise<void>;
+    openSession(sessionId: string): Promise<void>;
+    openNewSession(): Promise<void>;
+  };
+  theme: {
+    getCurrent(): Promise<ThemeInfo>;
+    subscribe(listener: (theme: ThemeInfo) => void): Promise<Disposable>;
+  };
+  storage: {
+    user: {
+      get<T = unknown>(key: string): Promise<T | null>;
+      set(key: string, value: unknown): Promise<void>;
+      delete(key: string): Promise<void>;
+    };
+  };
 }
 
 export interface ExtensionLifecycle {
@@ -21,17 +63,21 @@ export interface ExtensionLifecycle {
   deactivate?(): void | Promise<void>;
 }
 
+interface PendingRequest {
+  resolve(value: unknown): void;
+  reject(reason: unknown): void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
 declare global {
   var __OMNIGENT_EXTENSION__: ExtensionIdentity | undefined;
 }
 
 function matchesIdentity(
-  message: ExtensionInitMessage,
+  message: Partial<ExtensionIdentity>,
   identity: ExtensionIdentity,
 ): boolean {
   return (
-    message.source === EXTENSION_RPC_SOURCE &&
-    message.type === "init" &&
     message.extensionId === identity.extensionId &&
     message.pageId === identity.pageId &&
     message.view === identity.view &&
@@ -45,32 +91,171 @@ export function defineExtension(lifecycle: ExtensionLifecycle): void {
   if (!identity) throw new Error("Omnigent extension bootstrap is missing");
   let active = false;
   let port: MessagePort | null = null;
+  let requestSequence = 0;
+  const pending = new Map<string, PendingRequest>();
+  const listeners = new Map<string, Set<(value: unknown) => void>>();
+  let grantedCapabilities = new Set<string>();
+
+  const rejectPending = () => {
+    for (const request of pending.values()) {
+      clearTimeout(request.timeout);
+      request.reject(
+        new ExtensionApiError("Disposed", "Extension host was disposed"),
+      );
+    }
+    pending.clear();
+  };
 
   const deactivate = () => {
     if (!active) return;
     active = false;
+    rejectPending();
     void lifecycle.deactivate?.();
     port?.close();
     port = null;
   };
+
+  const request = <T>(method: string, params: unknown): Promise<T> => {
+    if (!active || !port) {
+      return Promise.reject(
+        new ExtensionApiError("NotActive", "Extension is not active"),
+      );
+    }
+    if (!grantedCapabilities.has(method)) {
+      return Promise.reject(
+        new ExtensionApiError(
+          "Unsupported",
+          `Host method ${method} is not granted`,
+        ),
+      );
+    }
+    const requestId = `${identity.nonce}-${++requestSequence}`;
+    const message: ExtensionRequestMessage = {
+      ...identity,
+      source: EXTENSION_RPC_SOURCE,
+      type: "request",
+      requestId,
+      method,
+      params,
+    };
+    return new Promise<T>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (!pending.delete(requestId)) return;
+        const cancel: ExtensionCancelMessage = {
+          ...identity,
+          source: EXTENSION_RPC_SOURCE,
+          type: "cancel",
+          requestId,
+        };
+        port?.postMessage(cancel);
+        reject(
+          new ExtensionApiError("Timeout", `Host method ${method} timed out`),
+        );
+      }, 10_000);
+      pending.set(requestId, {
+        resolve: (value) => resolve(value as T),
+        reject,
+        timeout,
+      });
+      port?.postMessage(message);
+    });
+  };
+
+  const createContext = (): ExtensionContext => ({
+    extensionId: identity.extensionId,
+    pageId: identity.pageId,
+    view: identity.view,
+    apiVersion: identity.apiVersion,
+    capabilities: [...grantedCapabilities].sort(),
+    navigation: {
+      async openPage(pageId, params) {
+        await request("navigation.openPage", { pageId, params });
+      },
+      async openSession(sessionId) {
+        await request("navigation.openSession", { sessionId });
+      },
+      async openNewSession() {
+        await request("navigation.openNewSession", {});
+      },
+    },
+    theme: {
+      getCurrent: () => request<ThemeInfo>("theme.getCurrent", {}),
+      async subscribe(listener) {
+        const initial = await request<ThemeInfo>("theme.subscribe", {});
+        let handlers = listeners.get("theme.changed");
+        if (!handlers) {
+          handlers = new Set();
+          listeners.set("theme.changed", handlers);
+        }
+        const handler = listener as (value: unknown) => void;
+        handlers.add(handler);
+        listener(initial);
+        return { dispose: () => handlers?.delete(handler) };
+      },
+    },
+    storage: {
+      user: {
+        get: <T>(key: string) => request<T | null>("storage.user.get", { key }),
+        async set(key, value) {
+          await request("storage.user.set", { key, value });
+        },
+        async delete(key) {
+          await request("storage.user.delete", { key });
+        },
+      },
+    },
+  });
 
   const handleInit = (event: MessageEvent<unknown>) => {
     if (active || event.source !== window.parent || event.ports.length !== 1)
       return;
     if (!event.data || typeof event.data !== "object") return;
     const init = event.data as ExtensionInitMessage;
-    if (!matchesIdentity(init, identity)) return;
+    if (
+      init.source !== EXTENSION_RPC_SOURCE ||
+      init.type !== "init" ||
+      !matchesIdentity(init, identity) ||
+      !Array.isArray(init.capabilities) ||
+      !init.capabilities.every((item) => typeof item === "string")
+    ) {
+      return;
+    }
     port = event.ports[0];
+    grantedCapabilities = new Set(init.capabilities);
     active = true;
     window.removeEventListener("message", handleInit);
     port.onmessage = (portEvent: MessageEvent<unknown>) => {
-      const message = portEvent.data as Partial<ExtensionDisposeMessage> | null;
+      if (!portEvent.data || typeof portEvent.data !== "object") return;
+      const message = portEvent.data as
+        | ExtensionDisposeMessage
+        | ExtensionResponseMessage
+        | ExtensionEventMessage;
       if (
-        message?.source === EXTENSION_RPC_SOURCE &&
-        message.type === "dispose" &&
-        message.nonce === identity.nonce
-      ) {
+        message.source !== EXTENSION_RPC_SOURCE ||
+        !matchesIdentity(message, identity)
+      )
+        return;
+      if (message.type === "dispose") {
         deactivate();
+        return;
+      }
+      if (message.type === "response") {
+        const requestState = pending.get(message.requestId);
+        if (!requestState) return;
+        pending.delete(message.requestId);
+        clearTimeout(requestState.timeout);
+        if (message.error) {
+          requestState.reject(
+            new ExtensionApiError(message.error.code, message.error.message),
+          );
+        } else {
+          requestState.resolve(message.result);
+        }
+        return;
+      }
+      if (message.type === "event") {
+        for (const listener of listeners.get(message.event) ?? [])
+          listener(message.value);
       }
     };
     port.start();
@@ -84,13 +269,7 @@ export function defineExtension(lifecycle: ExtensionLifecycle): void {
       port.postMessage(incompatible);
       return;
     }
-    const context: ExtensionContext = {
-      extensionId: identity.extensionId,
-      pageId: identity.pageId,
-      view: identity.view,
-      apiVersion: identity.apiVersion,
-    };
-    void Promise.resolve(lifecycle.activate(context)).then(
+    void Promise.resolve(lifecycle.activate(createContext())).then(
       () => {
         const ready: ExtensionReadyMessage = {
           ...identity,

--- a/sdks/web-extension/src/protocol.ts
+++ b/sdks/web-extension/src/protocol.ts
@@ -12,6 +12,7 @@ export interface ExtensionIdentity {
 export interface ExtensionInitMessage extends ExtensionIdentity {
   source: typeof EXTENSION_RPC_SOURCE;
   type: "init";
+  capabilities: string[];
 }
 
 export interface ExtensionReadyMessage extends ExtensionIdentity {
@@ -29,6 +30,35 @@ export interface ExtensionErrorMessage extends ExtensionIdentity {
   source: typeof EXTENSION_RPC_SOURCE;
   type: "error";
   message: string;
+}
+
+export interface ExtensionRequestMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "request";
+  requestId: string;
+  method: string;
+  params: unknown;
+}
+
+export interface ExtensionCancelMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "cancel";
+  requestId: string;
+}
+
+export interface ExtensionResponseMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "response";
+  requestId: string;
+  result?: unknown;
+  error?: { code: string; message: string };
+}
+
+export interface ExtensionEventMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "event";
+  event: string;
+  value: unknown;
 }
 
 export interface ExtensionDisposeMessage extends ExtensionIdentity {

--- a/web/package.json
+++ b/web/package.json
@@ -119,6 +119,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "ai": "^6.0.169",
     "ai-elements": "^1.9.0",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.1",
     "lightningcss": "^1.29.1",
     "oxlint": "^1.62.0",

--- a/web/src/extensions/ExtensionPageHost.tsx
+++ b/web/src/extensions/ExtensionPageHost.tsx
@@ -1,10 +1,18 @@
 import type { ResolvedExtensionPage } from "./types";
 import { useRefreshExtensions } from "./ExtensionProvider";
 import { ExtensionViewHost } from "./ExtensionViewHost";
+import { useExtensionHostServices } from "./services/useExtensionHostServices";
 
 export function ExtensionPageHost({ resolved }: { resolved: ResolvedExtensionPage }) {
   const refresh = useRefreshExtensions();
+  const { methods, events } = useExtensionHostServices(resolved.extension);
   return (
-    <ExtensionViewHost extension={resolved.extension} page={resolved.page} refresh={refresh} />
+    <ExtensionViewHost
+      extension={resolved.extension}
+      page={resolved.page}
+      refresh={refresh}
+      methods={methods}
+      events={events}
+    />
   );
 }

--- a/web/src/extensions/ExtensionViewHost.test.tsx
+++ b/web/src/extensions/ExtensionViewHost.test.tsx
@@ -125,6 +125,78 @@ describe("ExtensionViewHost", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("activation timed out");
   });
 
+  it("rejects prototype properties that are not registered host methods", async () => {
+    render(<ExtensionViewHost extension={extension} page={page} refresh={refresh} />);
+    await screen.findByTitle("Dashboard");
+    await waitFor(() => expect(FakeMessageChannel.latest).not.toBeNull());
+
+    act(() => {
+      FakeMessageChannel.latest!.port1.onmessage?.({
+        data: {
+          ...identity,
+          source: EXTENSION_RPC_SOURCE,
+          type: "request",
+          requestId: "prototype",
+          method: "constructor",
+          params: {},
+        },
+      } as MessageEvent<unknown>);
+    });
+
+    expect(FakeMessageChannel.latest!.port1.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: "prototype",
+        error: { code: "MethodNotFound", message: "Host method is not available" },
+      }),
+    );
+  });
+
+  it("dispatches through the latest host method implementation", async () => {
+    const light = vi.fn(() => ({ theme: "light" }));
+    const dark = vi.fn(() => ({ theme: "dark" }));
+    const rendered = render(
+      <ExtensionViewHost
+        extension={extension}
+        page={page}
+        refresh={refresh}
+        methods={{ "theme.getCurrent": light }}
+      />,
+    );
+    await screen.findByTitle("Dashboard");
+    await waitFor(() => expect(FakeMessageChannel.latest).not.toBeNull());
+    rendered.rerender(
+      <ExtensionViewHost
+        extension={extension}
+        page={page}
+        refresh={refresh}
+        methods={{ "theme.getCurrent": dark }}
+      />,
+    );
+
+    act(() => {
+      FakeMessageChannel.latest!.port1.onmessage?.({
+        data: {
+          ...identity,
+          source: EXTENSION_RPC_SOURCE,
+          type: "request",
+          requestId: "theme",
+          method: "theme.getCurrent",
+          params: {},
+        },
+      } as MessageEvent<unknown>);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(light).not.toHaveBeenCalled();
+    expect(dark).toHaveBeenCalledOnce();
+    expect(FakeMessageChannel.latest!.port1.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: "theme", result: { theme: "dark" } }),
+    );
+  });
+
   it("cancels outstanding host calls and sends dispose on unmount", async () => {
     const captured: { signal?: AbortSignal } = {};
     const pending = vi.fn((_params: unknown, signal: AbortSignal) => {
@@ -152,6 +224,9 @@ describe("ExtensionViewHost", () => {
           params: {},
         },
       } as MessageEvent<unknown>);
+    });
+    await act(async () => {
+      await Promise.resolve();
     });
     expect(pending).toHaveBeenCalledOnce();
 

--- a/web/src/extensions/ExtensionViewHost.tsx
+++ b/web/src/extensions/ExtensionViewHost.tsx
@@ -4,17 +4,20 @@ import { buildExtensionDocument, createExtensionNonce, loadExtensionBundle } fro
 import {
   EXTENSION_RPC_SOURCE,
   type ExtensionDisposeMessage,
+  type ExtensionEventMessage,
   type ExtensionIdentity,
   type ExtensionInitMessage,
   type ExtensionResponseMessage,
 } from "./rpc/protocol";
 import { isExtensionInboundMessage, isExtensionPayloadWithinBudget } from "./rpc/validation";
+import { ExtensionHostServiceError } from "./services/errors";
 
 const ACTIVATION_TIMEOUT_MS = 10_000;
 const REQUEST_TIMEOUT_MS = 10_000;
 
 type HostMethod = (params: unknown, signal: AbortSignal) => unknown | Promise<unknown>;
 const NO_HOST_METHODS: Readonly<Record<string, HostMethod>> = {};
+const NO_HOST_EVENTS: Readonly<Record<string, unknown>> = {};
 interface PendingRequest {
   controller: AbortController;
   timeout: ReturnType<typeof setTimeout>;
@@ -30,11 +33,13 @@ export function ExtensionViewHost({
   page,
   refresh,
   methods = NO_HOST_METHODS,
+  events = NO_HOST_EVENTS,
 }: {
   extension: ExtensionCatalogItem;
   page: ExtensionPage;
   refresh: () => Promise<ExtensionCatalogItem[]>;
   methods?: Readonly<Record<string, HostMethod>>;
+  events?: Readonly<Record<string, unknown>>;
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const portRef = useRef<MessagePort | null>(null);
@@ -43,6 +48,7 @@ export function ExtensionViewHost({
   const handshakeDoneRef = useRef(false);
   const staleRetryDoneRef = useRef(false);
   const pendingRef = useRef(new Map<string, PendingRequest>());
+  const methodsRef = useRef(methods);
   const [frameDocument, setFrameDocument] = useState<DocumentState | null>(null);
   const [status, setStatus] = useState<"loading" | "activating" | "ready" | "error">("loading");
   const [error, setError] = useState<string | null>(null);
@@ -71,6 +77,10 @@ export function ExtensionViewHost({
     portRef.current = null;
     identityRef.current = null;
   }, []);
+
+  useEffect(() => {
+    methodsRef.current = methods;
+  }, [methods]);
 
   useEffect(() => {
     staleRetryDoneRef.current = false;
@@ -110,6 +120,22 @@ export function ExtensionViewHost({
       closeRuntime();
     };
   }, [closeRuntime, extension, page, refresh, retryKey]);
+
+  useEffect(() => {
+    const port = portRef.current;
+    const identity = identityRef.current;
+    if (status !== "ready" || !port || !identity) return;
+    for (const [event, value] of Object.entries(events)) {
+      const message: ExtensionEventMessage = {
+        ...identity,
+        source: EXTENSION_RPC_SOURCE,
+        type: "event",
+        event,
+        value,
+      };
+      if (isExtensionPayloadWithinBudget(message)) port.postMessage(message);
+    }
+  }, [events, status]);
 
   const handleLoad = useCallback(() => {
     if (!frameDocument || !iframeRef.current?.contentWindow) return;
@@ -161,7 +187,10 @@ export function ExtensionViewHost({
         type: "response",
         requestId: message.requestId,
       };
-      const method = methods[message.method];
+      const currentMethods = methodsRef.current;
+      const method = Object.hasOwn(currentMethods, message.method)
+        ? currentMethods[message.method]
+        : undefined;
       if (!method) {
         response.error = { code: "MethodNotFound", message: "Host method is not available" };
         channel.port1.postMessage(response);
@@ -182,44 +211,53 @@ export function ExtensionViewHost({
         });
       }, REQUEST_TIMEOUT_MS);
       pendingRef.current.set(message.requestId, { controller, timeout: requestTimeout });
-      void Promise.resolve(method(message.params, controller.signal)).then(
-        (result) => {
-          const pending = pendingRef.current.get(message.requestId);
-          if (!pending || !pendingRef.current.delete(message.requestId)) return;
-          clearTimeout(pending.timeout);
-          if (!isExtensionPayloadWithinBudget(result)) {
+      void Promise.resolve()
+        .then(() => method(message.params, controller.signal))
+        .then(
+          (result) => {
+            const pending = pendingRef.current.get(message.requestId);
+            if (!pending || !pendingRef.current.delete(message.requestId)) return;
+            clearTimeout(pending.timeout);
+            if (!isExtensionPayloadWithinBudget(result)) {
+              channel.port1.postMessage({
+                ...response,
+                error: { code: "ResponseTooLarge", message: "Host response exceeds the limit" },
+              });
+              return;
+            }
+            channel.port1.postMessage({ ...response, result });
+          },
+          (reason: unknown) => {
+            const pending = pendingRef.current.get(message.requestId);
+            if (!pending || !pendingRef.current.delete(message.requestId)) return;
+            clearTimeout(pending.timeout);
             channel.port1.postMessage({
               ...response,
-              error: { code: "ResponseTooLarge", message: "Host response exceeds the limit" },
+              error: {
+                code:
+                  reason instanceof ExtensionHostServiceError
+                    ? reason.code
+                    : controller.signal.aborted
+                      ? "Cancelled"
+                      : "HostError",
+                message:
+                  reason instanceof Error ? reason.message.slice(0, 512) : "Host call failed",
+              },
             });
-            return;
-          }
-          channel.port1.postMessage({ ...response, result });
-        },
-        (reason: unknown) => {
-          const pending = pendingRef.current.get(message.requestId);
-          if (!pending || !pendingRef.current.delete(message.requestId)) return;
-          clearTimeout(pending.timeout);
-          channel.port1.postMessage({
-            ...response,
-            error: {
-              code: controller.signal.aborted ? "Cancelled" : "HostError",
-              message: reason instanceof Error ? reason.message.slice(0, 512) : "Host call failed",
-            },
-          });
-        },
-      );
+          },
+        );
     };
     channel.port1.start();
     const init: ExtensionInitMessage = {
       ...frameDocument.identity,
       source: EXTENSION_RPC_SOURCE,
       type: "init",
+      capabilities: Object.keys(methodsRef.current).sort(),
     };
     // A srcdoc frame has opaque origin "null"; the per-mount nonce and the
     // transferred port are the spoofing boundary, so targetOrigin must be "*".
     iframeRef.current.contentWindow.postMessage(init, "*", [channel.port2]);
-  }, [closeRuntime, frameDocument, methods]);
+  }, [closeRuntime, frameDocument]);
 
   if (status === "error") {
     return (

--- a/web/src/extensions/rpc/protocol.ts
+++ b/web/src/extensions/rpc/protocol.ts
@@ -13,6 +13,7 @@ export interface ExtensionIdentity {
 export interface ExtensionInitMessage extends ExtensionIdentity {
   source: typeof EXTENSION_RPC_SOURCE;
   type: "init";
+  capabilities: string[];
 }
 
 export interface ExtensionReadyMessage extends ExtensionIdentity {
@@ -52,6 +53,13 @@ export type ExtensionInboundMessage =
   | ExtensionErrorMessage
   | ExtensionRequestMessage
   | ExtensionCancelMessage;
+
+export interface ExtensionEventMessage extends ExtensionIdentity {
+  source: typeof EXTENSION_RPC_SOURCE;
+  type: "event";
+  event: string;
+  value: unknown;
+}
 
 export interface ExtensionDisposeMessage extends ExtensionIdentity {
   source: typeof EXTENSION_RPC_SOURCE;

--- a/web/src/extensions/services/errors.ts
+++ b/web/src/extensions/services/errors.ts
@@ -1,0 +1,9 @@
+export class ExtensionHostServiceError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "ExtensionHostServiceError";
+  }
+}

--- a/web/src/extensions/services/registry.ts
+++ b/web/src/extensions/services/registry.ts
@@ -1,0 +1,29 @@
+import type { ExtensionCatalogItem } from "../types";
+
+export const HOST_METHOD_PERMISSIONS = {
+  "navigation.openPage": "navigation",
+  "navigation.openSession": "navigation",
+  "navigation.openNewSession": "navigation",
+  "theme.getCurrent": null,
+  "theme.subscribe": null,
+  "storage.user.get": "storage.user",
+  "storage.user.set": "storage.user",
+  "storage.user.delete": "storage.user",
+} as const satisfies Record<string, string | null>;
+
+export function grantedHostMethods<T extends Record<string, unknown>>(
+  extension: ExtensionCatalogItem,
+  implementations: T,
+): Partial<T> {
+  const granted: Partial<T> = {};
+  for (const [method, implementation] of Object.entries(implementations)) {
+    if (!Object.hasOwn(HOST_METHOD_PERMISSIONS, method)) {
+      throw new Error(`Host method ${method} has no permission declaration`);
+    }
+    const permission = HOST_METHOD_PERMISSIONS[method as keyof typeof HOST_METHOD_PERMISSIONS];
+    if (permission === null || extension.permissions.includes(permission)) {
+      granted[method as keyof T] = implementation as T[keyof T];
+    }
+  }
+  return granted;
+}

--- a/web/src/extensions/services/storage.test.ts
+++ b/web/src/extensions/services/storage.test.ts
@@ -1,0 +1,90 @@
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ExtensionStorageError,
+  ExtensionStorageWriteLimiter,
+  ExtensionUserStorage,
+  resetExtensionStorageForTests,
+} from "./storage";
+
+beforeEach(() => resetExtensionStorageForTests());
+afterEach(() => vi.useRealTimers());
+
+describe("ExtensionStorageWriteLimiter", () => {
+  it("paces writes and rejects work cancelled in the queue", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const limiter = new ExtensionStorageWriteLimiter();
+    await limiter.run(new AbortController().signal, async () => "first");
+    const operation = vi.fn(async () => "second");
+    const controller = new AbortController();
+    const second = limiter.run(controller.signal, operation);
+    await Promise.resolve();
+    expect(operation).not.toHaveBeenCalled();
+    controller.abort();
+    vi.advanceTimersByTime(25);
+
+    await expect(second).rejects.toThrow("cancelled");
+    expect(operation).not.toHaveBeenCalled();
+  });
+});
+
+describe("ExtensionUserStorage", () => {
+  it("stores JSON values without touching core localStorage", async () => {
+    localStorage.setItem("omnigent:theme", "dark");
+    const storage = new ExtensionUserStorage("server-a", "user-a", "acme.one");
+
+    await storage.set("layout.v1", { x: 1, y: 2 });
+    expect(await storage.get("layout.v1")).toEqual({ x: 1, y: 2 });
+    expect(localStorage.getItem("omnigent:theme")).toBe("dark");
+
+    await storage.delete("layout.v1");
+    expect(await storage.get("layout.v1")).toBeNull();
+  });
+
+  it("scopes values by server, user, and extension", async () => {
+    const original = new ExtensionUserStorage("server-a", "user-a", "acme.one");
+    const otherServer = new ExtensionUserStorage("server-b", "user-a", "acme.one");
+    const otherUser = new ExtensionUserStorage("server-a", "user-b", "acme.one");
+    const otherExtension = new ExtensionUserStorage("server-a", "user-a", "acme.two");
+    await original.set("key", "secret");
+
+    await expect(otherServer.get("key")).resolves.toBeNull();
+    await expect(otherUser.get("key")).resolves.toBeNull();
+    await expect(otherExtension.get("key")).resolves.toBeNull();
+  });
+
+  it("rejects invalid keys and non-JSON values with typed errors", async () => {
+    const storage = new ExtensionUserStorage("server", "user", "acme.one");
+
+    await expect(storage.set("../escape", 1)).rejects.toMatchObject({ code: "InvalidKey" });
+    await expect(storage.set("value", BigInt(1))).rejects.toMatchObject({ code: "InvalidValue" });
+  });
+
+  it("rejects per-value and aggregate quota overflow without eviction", async () => {
+    const storage = new ExtensionUserStorage("server", "user", "acme.quota");
+    await expect(storage.set("large", "x".repeat(33 * 1024))).rejects.toMatchObject({
+      code: "QuotaExceeded",
+    });
+
+    await Promise.all(
+      Array.from({ length: 8 }, (_, index) => storage.set(`value-${index}`, "x".repeat(32_000))),
+    );
+    const error = await storage.set("overflow", "x".repeat(32_000)).catch((reason) => reason);
+    expect(error).toBeInstanceOf(ExtensionStorageError);
+    expect(error).toMatchObject({ code: "QuotaExceeded" });
+    await expect(storage.get("value-0")).resolves.toBe("x".repeat(32_000));
+    await expect(storage.get("overflow")).resolves.toBeNull();
+    localStorage.setItem("omnigent:after-extension-quota", "still-works");
+    expect(localStorage.getItem("omnigent:after-extension-quota")).toBe("still-works");
+  });
+
+  it("enforces the key-count cap independently of the byte cap", async () => {
+    const storage = new ExtensionUserStorage("server", "user", "acme.keys");
+    await Promise.all(Array.from({ length: 128 }, (_, index) => storage.set(`key-${index}`, null)));
+
+    await expect(storage.set("key-128", null)).rejects.toMatchObject({
+      code: "QuotaExceeded",
+    });
+  });
+});

--- a/web/src/extensions/services/storage.ts
+++ b/web/src/extensions/services/storage.ts
@@ -1,0 +1,200 @@
+export const EXTENSION_STORAGE_DATABASE = "omnigent-extensions";
+export const EXTENSION_STORAGE_STORE = "values";
+export const EXTENSION_STORAGE_MAX_BYTES = 256 * 1024;
+export const EXTENSION_STORAGE_MAX_VALUE_BYTES = 32 * 1024;
+export const EXTENSION_STORAGE_MAX_KEYS = 128;
+export const EXTENSION_STORAGE_WRITE_INTERVAL_MS = 25;
+
+interface StoredValue {
+  id: string;
+  namespace: string;
+  key: string;
+  json: string;
+  size: number;
+}
+
+export class ExtensionStorageError extends Error {
+  readonly code: "InvalidKey" | "InvalidValue" | "QuotaExceeded" | "Unavailable";
+
+  constructor(
+    code: "InvalidKey" | "InvalidValue" | "QuotaExceeded" | "Unavailable",
+    message: string,
+  ) {
+    super(message);
+    this.code = code;
+    this.name = "ExtensionStorageError";
+  }
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
+  });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error ?? new Error("IndexedDB failed"));
+    transaction.onabort = () => reject(transaction.error ?? new Error("IndexedDB aborted"));
+  });
+}
+
+let databasePromise: Promise<IDBDatabase> | null = null;
+
+function database(): Promise<IDBDatabase> {
+  if (!globalThis.indexedDB) {
+    return Promise.reject(new ExtensionStorageError("Unavailable", "IndexedDB is unavailable"));
+  }
+  databasePromise ??= new Promise((resolve, reject) => {
+    const request = indexedDB.open(EXTENSION_STORAGE_DATABASE, 1);
+    request.onupgradeneeded = () => {
+      const store = request.result.createObjectStore(EXTENSION_STORAGE_STORE, { keyPath: "id" });
+      store.createIndex("namespace", "namespace", { unique: false });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("Could not open extension storage"));
+  });
+  return databasePromise;
+}
+
+function validateKey(key: unknown): asserts key is string {
+  if (
+    typeof key !== "string" ||
+    key.length < 1 ||
+    key.length > 128 ||
+    !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(key)
+  ) {
+    throw new ExtensionStorageError("InvalidKey", "Storage key is invalid");
+  }
+}
+
+function serializeValue(value: unknown): { json: string; size: number } {
+  let json: string | undefined;
+  try {
+    json = JSON.stringify(value);
+  } catch {
+    throw new ExtensionStorageError("InvalidValue", "Storage value must be JSON serializable");
+  }
+  if (json === undefined) {
+    throw new ExtensionStorageError("InvalidValue", "Storage value must be JSON serializable");
+  }
+  const size = new TextEncoder().encode(json).byteLength;
+  if (size > EXTENSION_STORAGE_MAX_VALUE_BYTES) {
+    throw new ExtensionStorageError("QuotaExceeded", "Storage value exceeds 32 KB");
+  }
+  return { json, size };
+}
+
+function namespace(serverIdentity: string, userId: string, extensionId: string): string {
+  return `v1/${encodeURIComponent(serverIdentity)}/${encodeURIComponent(userId)}/${encodeURIComponent(extensionId)}`;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new DOMException("Storage operation cancelled", "AbortError");
+}
+
+export class ExtensionStorageWriteLimiter {
+  private tail: Promise<void> = Promise.resolve();
+  private lastWriteAt = 0;
+
+  run<T>(signal: AbortSignal, operation: () => Promise<T>): Promise<T> {
+    const execute = async () => {
+      throwIfAborted(signal);
+      const waitMs = Math.max(
+        0,
+        EXTENSION_STORAGE_WRITE_INTERVAL_MS - (Date.now() - this.lastWriteAt),
+      );
+      if (waitMs > 0) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, waitMs);
+        });
+      }
+      throwIfAborted(signal);
+      const result = await operation();
+      this.lastWriteAt = Date.now();
+      return result;
+    };
+    const result = this.tail.then(execute, execute);
+    this.tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}
+
+export class ExtensionUserStorage {
+  readonly namespace: string;
+
+  constructor(serverIdentity: string, userId: string, extensionId: string) {
+    this.namespace = namespace(serverIdentity, userId, extensionId);
+  }
+
+  private id(key: string): string {
+    return `${this.namespace}/${encodeURIComponent(key)}`;
+  }
+
+  async get(key: unknown, signal?: AbortSignal): Promise<unknown> {
+    validateKey(key);
+    throwIfAborted(signal);
+    const db = await database();
+    throwIfAborted(signal);
+    const transaction = db.transaction(EXTENSION_STORAGE_STORE, "readonly");
+    const record = await requestResult<StoredValue | undefined>(
+      transaction.objectStore(EXTENSION_STORAGE_STORE).get(this.id(key)),
+    );
+    throwIfAborted(signal);
+    return record ? JSON.parse(record.json) : null;
+  }
+
+  async set(key: unknown, value: unknown, signal?: AbortSignal): Promise<void> {
+    validateKey(key);
+    throwIfAborted(signal);
+    const serialized = serializeValue(value);
+    const db = await database();
+    throwIfAborted(signal);
+    const transaction = db.transaction(EXTENSION_STORAGE_STORE, "readwrite");
+    const store = transaction.objectStore(EXTENSION_STORAGE_STORE);
+    const existing = await requestResult<StoredValue[]>(
+      store.index("namespace").getAll(this.namespace),
+    );
+    throwIfAborted(signal);
+    const previous = existing.find((record) => record.key === key);
+    const nextBytes =
+      existing.reduce((total, record) => total + record.size, 0) -
+      (previous?.size ?? 0) +
+      serialized.size;
+    const nextKeys = existing.length + (previous ? 0 : 1);
+    if (nextBytes > EXTENSION_STORAGE_MAX_BYTES || nextKeys > EXTENSION_STORAGE_MAX_KEYS) {
+      transaction.abort();
+      throw new ExtensionStorageError("QuotaExceeded", "Extension storage quota exceeded");
+    }
+    store.put({
+      id: this.id(key),
+      namespace: this.namespace,
+      key,
+      json: serialized.json,
+      size: serialized.size,
+    } satisfies StoredValue);
+    await transactionDone(transaction);
+  }
+
+  async delete(key: unknown, signal?: AbortSignal): Promise<void> {
+    validateKey(key);
+    throwIfAborted(signal);
+    const db = await database();
+    throwIfAborted(signal);
+    const transaction = db.transaction(EXTENSION_STORAGE_STORE, "readwrite");
+    transaction.objectStore(EXTENSION_STORAGE_STORE).delete(this.id(key));
+    await transactionDone(transaction);
+  }
+}
+
+export async function resetExtensionStorageForTests(): Promise<void> {
+  if (databasePromise) (await databasePromise).close();
+  databasePromise = null;
+  if (!globalThis.indexedDB) return;
+  await requestResult(indexedDB.deleteDatabase(EXTENSION_STORAGE_DATABASE));
+}

--- a/web/src/extensions/services/useExtensionHostServices.test.tsx
+++ b/web/src/extensions/services/useExtensionHostServices.test.tsx
@@ -1,0 +1,129 @@
+import "fake-indexeddb/auto";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionCatalogItem } from "../types";
+import { HOST_METHOD_PERMISSIONS } from "./registry";
+import { resetExtensionStorageForTests } from "./storage";
+
+const { navigate, identityRef, serverRef } = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  identityRef: { current: "user@example.com" as string | null },
+  serverRef: { current: "server-a" as string | null },
+}));
+vi.mock("@/lib/routing", () => ({ useNavigate: () => navigate }));
+vi.mock("@/lib/identity", () => ({ resolveIdentity: async () => identityRef.current }));
+vi.mock("@/lib/host", () => ({ getOmnigentServerIdentity: () => serverRef.current }));
+vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
+
+import { useExtensionHostServices } from "./useExtensionHostServices";
+
+const extension: ExtensionCatalogItem = {
+  object: "extension",
+  id: "acme.review",
+  display_name: "Review",
+  distribution: "acme-review",
+  version: "1.0.0",
+  extension_api: 1,
+  status: "enabled",
+  permissions: ["navigation", "storage.user"],
+  pages: [
+    {
+      id: "acme.review.dashboard",
+      title: "Dashboard",
+      route: "dashboard",
+      view: "dashboard",
+    },
+  ],
+  primary_navigation: [],
+  browser: {
+    declared: true,
+    has_styles: false,
+    digest: "digest",
+    script_url: "/script",
+    style_url: null,
+  },
+};
+const signal = () => new AbortController().signal;
+
+beforeEach(async () => {
+  navigate.mockReset();
+  identityRef.current = "user@example.com";
+  serverRef.current = "server-a";
+  await resetExtensionStorageForTests();
+});
+
+describe("useExtensionHostServices", () => {
+  it("declares a permission rule for every exposed host method", () => {
+    const { result } = renderHook(() => useExtensionHostServices(extension));
+    expect(Object.keys(result.current.methods).sort()).toEqual(
+      Object.keys(HOST_METHOD_PERMISSIONS).sort(),
+    );
+  });
+
+  it("routes only to pages owned by the extension and preserves params", () => {
+    const { result } = renderHook(() => useExtensionHostServices(extension));
+    act(() => {
+      result.current.methods["navigation.openPage"]?.(
+        { pageId: "acme.review.dashboard", params: { tab: "files" } },
+        signal(),
+      );
+    });
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: "/extensions/acme.review/dashboard",
+      search: "?tab=files",
+    });
+
+    expect(() =>
+      result.current.methods["navigation.openPage"]?.({ pageId: "other.page" }, signal()),
+    ).toThrow("Page is not owned by extension");
+  });
+
+  it("opens sessions and the new-session page through parent routing", () => {
+    const { result } = renderHook(() => useExtensionHostServices(extension));
+    act(() => {
+      result.current.methods["navigation.openSession"]?.({ sessionId: "conv_123" }, signal());
+      result.current.methods["navigation.openNewSession"]?.({}, signal());
+    });
+
+    expect(navigate).toHaveBeenNthCalledWith(1, "/c/conv_123");
+    expect(navigate).toHaveBeenNthCalledWith(2, "/");
+  });
+
+  it("returns theme snapshots and emits theme state", () => {
+    const { result } = renderHook(() => useExtensionHostServices(extension));
+
+    expect(result.current.methods["theme.getCurrent"]?.({}, signal())).toEqual({ theme: "dark" });
+    expect(result.current.events).toEqual({ "theme.changed": { theme: "dark" } });
+  });
+
+  it("omits methods whose permissions were not granted", () => {
+    const denied = { ...extension, permissions: [] };
+    const { result } = renderHook(() => useExtensionHostServices(denied));
+
+    expect(Object.keys(result.current.methods).sort()).toEqual([
+      "theme.getCurrent",
+      "theme.subscribe",
+    ]);
+  });
+
+  it("refuses storage until both user and server identities resolve", async () => {
+    identityRef.current = null;
+    serverRef.current = null;
+    const { result } = renderHook(() => useExtensionHostServices(extension));
+
+    await expect(
+      result.current.methods["storage.user.get"]?.({ key: "layout" }, signal()),
+    ).rejects.toMatchObject({ code: "Unavailable" });
+  });
+
+  it("persists extension-scoped values through the storage service", async () => {
+    const { result } = renderHook(() => useExtensionHostServices(extension));
+    await act(() =>
+      result.current.methods["storage.user.set"]?.({ key: "layout", value: { x: 1 } }, signal()),
+    );
+
+    await expect(
+      result.current.methods["storage.user.get"]?.({ key: "layout" }, signal()),
+    ).resolves.toEqual({ x: 1 });
+  });
+});

--- a/web/src/extensions/services/useExtensionHostServices.ts
+++ b/web/src/extensions/services/useExtensionHostServices.ts
@@ -1,0 +1,136 @@
+import { useMemo } from "react";
+import { useTheme } from "next-themes";
+import { resolveIdentity } from "@/lib/identity";
+import { getOmnigentServerIdentity } from "@/lib/host";
+import { useNavigate } from "@/lib/routing";
+import type { ExtensionCatalogItem } from "../types";
+import { ExtensionHostServiceError } from "./errors";
+import { grantedHostMethods } from "./registry";
+import {
+  ExtensionStorageError,
+  ExtensionStorageWriteLimiter,
+  ExtensionUserStorage,
+} from "./storage";
+
+function objectParams(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ExtensionHostServiceError("InvalidParams", "Expected an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw new DOMException("Host operation cancelled", "AbortError");
+}
+
+async function mapStorageErrors<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof ExtensionStorageError) {
+      throw new ExtensionHostServiceError(error.code, error.message);
+    }
+    throw error;
+  }
+}
+
+async function storageFor(extensionId: string): Promise<ExtensionUserStorage> {
+  const [userId, serverIdentity] = await Promise.all([
+    resolveIdentity(),
+    Promise.resolve(getOmnigentServerIdentity()),
+  ]);
+  if (!userId || !serverIdentity) {
+    throw new ExtensionHostServiceError(
+      "Unavailable",
+      "Extension storage requires resolved user and server identities",
+    );
+  }
+  return new ExtensionUserStorage(serverIdentity, userId, extensionId);
+}
+
+function pageSearch(value: unknown): string {
+  if (value === undefined) return "";
+  const params = objectParams(value);
+  const search = new URLSearchParams();
+  for (const key of Object.keys(params).sort()) {
+    const item = params[key];
+    if (typeof item !== "string" && typeof item !== "number" && typeof item !== "boolean") {
+      throw new ExtensionHostServiceError("InvalidParams", `Page parameter ${key} is invalid`);
+    }
+    search.set(key, String(item));
+  }
+  const serialized = search.toString();
+  return serialized ? `?${serialized}` : "";
+}
+
+export function useExtensionHostServices(extension: ExtensionCatalogItem) {
+  const navigate = useNavigate();
+  const { resolvedTheme } = useTheme();
+  const theme = resolvedTheme === "dark" ? "dark" : "light";
+  const writeLimiter = useMemo(() => new ExtensionStorageWriteLimiter(), []);
+
+  const methods = useMemo(() => {
+    const implementations = {
+      "navigation.openPage": (params: unknown, signal: AbortSignal) => {
+        throwIfAborted(signal);
+        const input = objectParams(params);
+        const pageId = input.pageId;
+        if (typeof pageId !== "string") {
+          throw new ExtensionHostServiceError("InvalidParams", "pageId is required");
+        }
+        const page = extension.pages.find((item) => item.id === pageId);
+        if (!page) {
+          throw new ExtensionHostServiceError("PermissionDenied", "Page is not owned by extension");
+        }
+        navigate({
+          pathname: `/extensions/${extension.id}/${page.route}`,
+          search: pageSearch(input.params),
+        });
+        return null;
+      },
+      "navigation.openSession": (params: unknown, signal: AbortSignal) => {
+        throwIfAborted(signal);
+        const sessionId = objectParams(params).sessionId;
+        if (typeof sessionId !== "string" || !sessionId || sessionId.length > 256) {
+          throw new ExtensionHostServiceError("InvalidParams", "sessionId is invalid");
+        }
+        navigate(`/c/${encodeURIComponent(sessionId)}`);
+        return null;
+      },
+      "navigation.openNewSession": (_params: unknown, signal: AbortSignal) => {
+        throwIfAborted(signal);
+        navigate("/");
+        return null;
+      },
+      "theme.getCurrent": (_params: unknown, signal: AbortSignal) => {
+        throwIfAborted(signal);
+        return { theme };
+      },
+      "theme.subscribe": (_params: unknown, signal: AbortSignal) => {
+        throwIfAborted(signal);
+        return { theme };
+      },
+      "storage.user.get": async (params: unknown, signal: AbortSignal) => {
+        const storage = await storageFor(extension.id);
+        return mapStorageErrors(() => storage.get(objectParams(params).key, signal));
+      },
+      "storage.user.set": async (params: unknown, signal: AbortSignal) => {
+        const input = objectParams(params);
+        return writeLimiter.run(signal, async () => {
+          const storage = await storageFor(extension.id);
+          await mapStorageErrors(() => storage.set(input.key, input.value, signal));
+          return null;
+        });
+      },
+      "storage.user.delete": async (params: unknown, signal: AbortSignal) =>
+        writeLimiter.run(signal, async () => {
+          const storage = await storageFor(extension.id);
+          await mapStorageErrors(() => storage.delete(objectParams(params).key, signal));
+          return null;
+        }),
+    };
+    return grantedHostMethods(extension, implementations);
+  }, [extension, navigate, theme, writeLimiter]);
+  const events = useMemo(() => ({ "theme.changed": { theme } }), [theme]);
+  return { methods, events };
+}

--- a/web/src/lib/host.ts
+++ b/web/src/lib/host.ts
@@ -93,6 +93,8 @@ export type OmnigentAnalyticsEvent =
     };
 
 export interface OmnigentHostConfig {
+  /** Stable server/workspace identity used to scope browser-local extension storage. */
+  serverIdentity?: string;
   /**
    * Maps an web API path (always starting with `/v1`, `/health`, or
    * `/api/...`) to a `Response`. The host implementation is responsible for
@@ -169,6 +171,14 @@ let hostConfig: OmnigentHostConfig = {};
 let hostConfigGeneration = 0;
 let embedRoot: HTMLElement | null = null;
 let embedScopeRoot: HTMLElement | null = null;
+
+export function getOmnigentServerIdentity(): string | null {
+  if (hostConfig.serverIdentity?.trim()) return hostConfig.serverIdentity.trim();
+  // Standalone has one same-origin server. Embedded hosts can proxy many
+  // backends behind one origin and must provide an explicit stable identity.
+  if (hostConfig.fetcher) return null;
+  return typeof window === "undefined" ? "server" : window.location.origin;
+}
 
 export function setOmnigentHostConfig(config: OmnigentHostConfig): void {
   // Guard: never clobber an already-installed fetcher with an empty config.


### PR DESCRIPTION
## Related issue

N/A — maintainer architecture work.

## Summary

- Broker a declarative allowlist of navigation, theme, and user-storage methods over the extension MessageChannel, advertising only granted capabilities to the SDK.
- Add parent-owned navigation with page ownership checks and query params, live theme snapshots/events, typed service errors, cancellation, request/response limits, and current-method dispatch.
- Add IndexedDB storage scoped by server, user, and extension with explicit identity gating, per-value/aggregate/key quotas, paced writes, and no eviction or impact on core localStorage.

**ELI5:** extension pages can now ask the parent app to navigate, follow the theme, or save a small amount of data. The parent checks every method and permission instead of giving the extension direct access.

```text
extension SDK request
        |
capability + method allowlist
        |
 navigation | theme | scoped IndexedDB
```

This is **PR 6 of the extension-framework stack** and is based on PR #5617. Review only the single commit added by this branch.

Embedded hosts must supply an explicit `serverIdentity` to enable storage; the standalone app uses its same-origin server identity. Storage remains browser-local and is never automatically pruned when an extension is removed.

## Test Plan

- `pnpm --dir web exec vitest run src/extensions src/App.test.tsx src/shell/Sidebar.test.tsx src/lib/host.test.ts`
- `pnpm --dir web type-check`
- `pnpm --dir web lint`
- `pnpm --dir sdks/web-extension type-check`
- `pre-commit run --all-files`

## Demo

The reference extension in PR 7 provides the visual demonstration. Component tests exercise the broker and storage boundaries directly.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover method declaration completeness, prototype-property rejection, capability filtering, page ownership and params, current theme dispatch, events, cancellation, request timeout, identity availability, IndexedDB isolation, quotas, key limits, paced writes, and core localStorage independence.
