### PR TITLE
Session CUJ timing

### DIFF
--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -25,6 +25,7 @@ import {
   type QueryClient,
 } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
+import { startTimedInteraction } from "@/lib/analyticsEmit";
 import {
   filtersFromConversationQueryKey,
   mergeItemsIntoPages,
@@ -404,6 +405,13 @@ async function fetchConversationsPage({
  * distinct four-element key that refetches when the picker changes. Used by
  * the Archived settings view's project filter.
  */
+// Latch so the list_sessions CUJ times only the first full-list fetch per app
+// load. `useConversations` is observed by several components sharing one query
+// cache, and it also refetches on a background poll / WS reconcile / pagination —
+// none of which are the user "open the list" action. A module-scoped flag times
+// exactly one fetch regardless of observer count, then stays latched.
+let initialListLoadTimed = false;
+
 export function useConversations(
   searchQuery = "",
   includeArchived = false,
@@ -426,13 +434,29 @@ export function useConversations(
     queryKey: project
       ? ["conversations", searchQuery, includeArchived, project]
       : ["conversations", searchQuery, includeArchived],
-    queryFn: ({ pageParam }) =>
-      fetchConversationsPage({
-        after: pageParam as string | undefined,
-        searchQuery,
-        includeArchived,
-        project,
-      }),
+    queryFn: async ({ pageParam }) => {
+      const fetchPage = () =>
+        fetchConversationsPage({
+          after: pageParam as string | undefined,
+          searchQuery,
+          includeArchived,
+          project,
+        });
+      // Time the first full-list load per app session; skip pagination
+      // (pageParam set) and every later fetch (poll / reconcile / invalidation).
+      if (initialListLoadTimed || pageParam !== undefined) return fetchPage();
+      initialListLoadTimed = true;
+      const interaction = startTimedInteraction("list_sessions");
+      try {
+        const page = await fetchPage();
+        interaction.complete();
+        return page;
+      } catch (error) {
+        interaction.fail();
+        throw error;
+      }
+    },
+
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) =>
       lastPage.has_more ? (lastPage.last_id ?? undefined) : undefined,

--- a/web/src/lib/analytics.test.tsx
+++ b/web/src/lib/analytics.test.tsx
@@ -10,6 +10,7 @@ import {
   useOmnigentAnalytics,
   useOmnigentPageView,
 } from "@/lib/analytics";
+import { startTimedInteraction } from "@/lib/analyticsEmit";
 
 afterEach(() => {
   // Reset the module-singleton host config between tests. The empty-config
@@ -85,6 +86,86 @@ describe("emitInteractionPhase", () => {
       status: "success",
       durationMs: 1234,
     });
+  });
+});
+
+describe("startTimedInteraction", () => {
+  it("emits start immediately, then complete(success) with duration on complete()", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+
+    const interaction = startTimedInteraction("get_session", "sess_1");
+    expect(analytics).toHaveBeenCalledExactlyOnceWith({
+      type: "interaction_phase",
+      interactionId: "sess_1",
+      interactionKind: "get_session",
+      phase: "start",
+    });
+
+    interaction.complete();
+    expect(analytics).toHaveBeenLastCalledWith({
+      type: "interaction_phase",
+      interactionId: "sess_1",
+      interactionKind: "get_session",
+      phase: "complete",
+      status: "success",
+      durationMs: expect.any(Number),
+    });
+  });
+
+  it("fail() completes with a failure status", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+
+    startTimedInteraction("create_session", "sess_2").fail();
+
+    expect(analytics).toHaveBeenLastCalledWith({
+      type: "interaction_phase",
+      interactionId: "sess_2",
+      interactionKind: "create_session",
+      phase: "complete",
+      status: "failure",
+      durationMs: expect.any(Number),
+    });
+  });
+
+  it("is idempotent — only the first settle emits a complete", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+
+    const interaction = startTimedInteraction("list_sessions", "l1");
+    interaction.complete();
+    interaction.fail(); // ignored
+    interaction.complete(); // ignored
+
+    // Exactly one start + one complete.
+    expect(analytics).toHaveBeenCalledTimes(2);
+    expect(analytics).toHaveBeenLastCalledWith(
+      expect.objectContaining({ phase: "complete", status: "success" }),
+    );
+  });
+
+  it("generates one correlation id shared by start and complete when none is given", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+
+    startTimedInteraction("list_sessions").complete();
+
+    const phases = analytics.mock.calls.map(
+      (c) => c[0] as { interactionId: string; phase: string },
+    );
+    expect(phases[0]?.interactionId).toBe(phases[1]?.interactionId);
+    expect(phases[0]?.interactionId).toEqual(expect.any(String));
+  });
+
+  it("never throws even when the host sink throws (telemetry can't break the caller)", () => {
+    setOmnigentHostConfig({
+      analytics: () => {
+        throw new Error("host sink blew up");
+      },
+    });
+
+    expect(() => startTimedInteraction("get_session", "s").complete()).not.toThrow();
   });
 });
 

--- a/web/src/lib/analyticsEmit.ts
+++ b/web/src/lib/analyticsEmit.ts
@@ -57,6 +57,63 @@ export function emitInteractionPhase(args: InteractionPhaseArgs): void {
   emitOmnigentAnalytics({ type: "interaction_phase", ...args });
 }
 
+// A random correlation id for a timed interaction that has no natural subject id
+// (creating a session, loading the list). Guarded so a missing `crypto.randomUUID`
+// can never throw into the wrapped operation.
+function newInteractionId(): string {
+  try {
+    if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
+  } catch {
+    // fall through to the timestamp fallback
+  }
+  return `iid-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** Handle for an in-flight timed interaction opened by `startTimedInteraction`. */
+export interface TimedInteraction {
+  /**
+   * Report the terminal outcome and elapsed `durationMs` (defaults to
+   * "success"). Idempotent: only the first settle emits, so a double-settle
+   * (e.g. a catch after a partial success) can never double-count.
+   */
+  complete: (status?: OmnigentInteractionStatus) => void;
+  /** Shorthand for `complete("failure")`. */
+  fail: () => void;
+}
+
+/**
+ * Begin a timed interaction: emit its `start` phase now and return a handle
+ * whose `complete()` / `fail()` emits the `complete` phase with the elapsed
+ * `durationMs`. Detached — `start` and the terminal call may live in different
+ * scopes, and the caller keeps control of its own operation (the handle never
+ * wraps or touches it). Emitting never throws (`emitInteractionPhase` no-ops
+ * with no host sink and swallows sink errors). Pass an `interactionId` for a
+ * natural subject (e.g. a session id); omit it for a generated correlation id.
+ *
+ *   const interaction = startTimedInteraction("get_session", sessionId);
+ *   try { await load(); interaction.complete(); } catch (e) { interaction.fail(); throw e; }
+ */
+export function startTimedInteraction(
+  interactionKind: OmnigentInteractionKind,
+  interactionId: string = newInteractionId(),
+): TimedInteraction {
+  const startedAt = Date.now();
+  let settled = false;
+  emitInteractionPhase({ interactionId, interactionKind, phase: "start" });
+  const complete = (status: OmnigentInteractionStatus = "success"): void => {
+    if (settled) return;
+    settled = true;
+    emitInteractionPhase({
+      interactionId,
+      interactionKind,
+      phase: "complete",
+      status,
+      durationMs: Date.now() - startedAt,
+    });
+  };
+  return { complete, fail: () => complete("failure") };
+}
+
 export interface TrackValueChangeOptions {
   /**
    * Set true ONLY when the value is known non-PII (e.g. a selection from a

--- a/web/src/lib/host.ts
+++ b/web/src/lib/host.ts
@@ -33,13 +33,17 @@ export type OmnigentComponentKind =
   "button" | "link" | "input" | "textarea" | "checkbox" | "toggle" | "select" | "tabs";
 
 /**
- * A multi-phase interaction whose *outcome* matters — not just that a control was
- * clicked. Host-agnostic; the host maps each onto its own taxonomy.
- *   - `agent_run`  — one user prompt → model run.
- *   - `tool_call`  — a single tool / skill / MCP invocation within a run.
- *   - `approval`   — a human-in-the-loop permission decision.
+ * A multi-phase interaction whose *outcome* or *latency* matters — not just that a
+ * control was clicked. Host-agnostic; the host maps each onto its own taxonomy.
+ *   - `agent_run`      — one user prompt → model run.
+ *   - `tool_call`      — a single tool / skill / MCP invocation within a run.
+ *   - `approval`       — a human-in-the-loop permission decision.
+ *   - `list_sessions`  — loading the session list (user-initiated; not background polls).
+ *   - `get_session`    — loading a single session the user opened / switched to.
+ *   - `create_session` — creating a new session.
  */
-export type OmnigentInteractionKind = "agent_run" | "tool_call" | "approval";
+export type OmnigentInteractionKind =
+  "agent_run" | "tool_call" | "approval" | "list_sessions" | "get_session" | "create_session";
 
 /** Terminal outcome of an interaction, set on the `complete` phase. */
 export type OmnigentInteractionStatus = "success" | "failure" | "cancelled" | "timed_out";
@@ -65,9 +69,10 @@ export type OmnigentAnalyticsEvent =
   | { type: "page_view"; pageId: string }
   | {
       /**
-       * Start or end of an interaction whose outcome matters (agent run, tool
-       * call, approval). `interactionId` correlates the `start` and `complete`
-       * of one interaction; `status` and `durationMs` are set on `complete`.
+       * Start or end of a timed interaction whose outcome or latency matters
+       * (see `OmnigentInteractionKind`). `interactionId` correlates the `start`
+       * and `complete` of one interaction; `status` and `durationMs` are set on
+       * `complete`.
        */
       type: "interaction_phase";
       interactionId: string;

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -116,7 +116,7 @@ import { getCurrentAuthorId } from "@/lib/identity";
 import { getOmnigentHostConfig, type OmnigentInteractionStatus } from "@/lib/host";
 // Routing-free emit primitive (not "@/lib/analytics", which pulls in useLocation
 // and would form a routing↔store import cycle).
-import { emitInteractionPhase } from "@/lib/analyticsEmit";
+import { emitInteractionPhase, startTimedInteraction } from "@/lib/analyticsEmit";
 import { getSessionHost } from "@/lib/sessionHost";
 import { isSystemUserContent } from "@/lib/systemMessage";
 import { isNativeWrapper } from "@/lib/nativeCodingAgents";
@@ -2016,8 +2016,20 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
 
     // Cold entry: bind its stream and hydrate history. `hydratePending` replays
     // the snapshot's un-consumed native messages — correct here because a fresh
-    // entry has no live optimistic bubbles to overwrite.
-    await bindStream(conversationId, entrySetter(entry), entryGetter(entry), true);
+    // entry has no live optimistic bubbles to overwrite. This is the only path
+    // that loads a session on switch (a live/current one paints instantly and
+    // returned above), so time it as the get_session CUJ.
+    const getInteraction = startTimedInteraction("get_session", conversationId);
+    try {
+      await bindStream(conversationId, entrySetter(entry), entryGetter(entry), true);
+      // bindStream catches a snapshot failure into `conversationLoadError`
+      // instead of throwing, so read it to report the real outcome.
+      if (entry.getState().conversationLoadError !== null) getInteraction.fail();
+      else getInteraction.complete();
+    } catch (error) {
+      getInteraction.fail();
+      throw error;
+    }
   },
 
   submitApproval: async (elicitationId, action, content) => {
@@ -2754,7 +2766,15 @@ async function ensureBoundSession(
     // initial_items dispatch synchronously inside create_session,
     // before we can subscribe to /stream, so early events can be
     // missed). Bind the stream FIRST, then post the first message.
-    const session = await createSession(agentId, []);
+    const createInteraction = startTimedInteraction("create_session");
+    let session: Session;
+    try {
+      session = await createSession(agentId, []);
+      createInteraction.complete();
+    } catch (error) {
+      createInteraction.fail();
+      throw error;
+    }
     sessionId = session.id;
     // Claim the send chain for this id NOW, while it is still private to this
     // call. Everything below publishes it (the store write, the navigate


### PR DESCRIPTION
## Related issue

N/A — no dedicated OSS issue. Client instrumentation supporting the hosted-Omnigent UI analytics effort (latency for the core session CUJs).

## Summary

Adds latency instrumentation for three session CUJs so we can measure how long each takes end to end:

- **List Sessions** — the first full session-list load per app session
- **Get Session** — loading a session when the user opens / switches to it
- **Create Session** — creating a new session

Each is reported as an `interaction_phase` **start → complete** pair (with `durationMs` and a success/failure `status`) through the existing host analytics sink. A new detached handle API, `startTimedInteraction(kind, id?)`, opens the span on the user action and settles it with `.complete()` / `.fail()`. It's idempotent and never throws, so it can't disturb the operation it measures, and in standalone OSS (no host analytics sink) every emit is a no-op.

Three new `OmnigentInteractionKind`s (`list_sessions`, `get_session`, `create_session`) join the existing `agent_run` / `tool_call` / `approval`. The emit is host-agnostic; the host maps each kind onto its own taxonomy.

**Seams (user-initiated only — background refetches/polls excluded):**

- `create_session` — around `createSession()` in the send path (`chatStore`).
- `get_session` — around the cold bind in `switchTo()` (`chatStore`); a live/current session paints instantly and isn't timed. Reads `conversationLoadError` to report the real outcome, since `bindStream` records a snapshot failure in state rather than throwing.
- `list_sessions` — the first full-list fetch in `useConversations`, gated by a module latch so pagination and background poll/reconcile fetches aren't counted.

<details><summary>ELI5 + flow</summary>

We put a stopwatch around three things the user does with sessions. When the action starts we note the time; when the data is ready (or it failed) we send how long it took and whether it succeeded. If nobody is listening (standalone OSS), it does nothing.

```mermaid
sequenceDiagram
  participant U as User
  participant App as omnigent web
  participant Sink as Host analytics sink
  U->>App: open / switch / create session
  App->>Sink: interaction_phase { phase: start }
  App->>App: await fetch / bind
  App->>Sink: interaction_phase { phase: complete, status, durationMs }
```

</details>

## Test Plan

Frontend-only; no server or wire changes. Verified with:

- `pnpm test src/lib/analytics.test.tsx src/hooks/useConversations.test.ts src/store/chatStore.test.ts` — green (new `startTimedInteraction` cases plus the existing session-load and list suites).
- `pnpm type-check` (`tsc -b`), `oxlint --deny-warnings`, `prettier --check` — clean.

No visible UI change: the instrumentation is a no-op unless a host wires an analytics sink, and it never alters the wrapped operation's result or errors.

## Demo

N/A — no visible UI change (instrumentation only).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the `startTimedInteraction` handle: `start` on open, `complete(success)` / `fail()` with a measured `durationMs`, idempotent settling, a generated correlation id when none is passed, and that a throwing host sink can't break the caller. The wrapped operations keep their existing coverage — the `useConversations` and `chatStore` suites still pass unchanged.

---
This pull request and its description were written by Isaac.
