### PR TITLE
fix(web): use full isNativeTerminalSession check for live-preview dedup

### DIFF
--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -119,7 +119,7 @@ import { getOmnigentHostConfig, type OmnigentInteractionStatus } from "@/lib/hos
 import { emitInteractionPhase } from "@/lib/analyticsEmit";
 import { getSessionHost } from "@/lib/sessionHost";
 import { isSystemUserContent } from "@/lib/systemMessage";
-import { isNativeWrapper } from "@/lib/nativeCodingAgents";
+import { isNativeTerminalSession as isNativeTerminalSessionFn, isNativeWrapper } from "@/lib/nativeCodingAgents";
 
 export interface SendOptions {
   /**
@@ -2940,7 +2940,7 @@ function sessionBindingPatch(
 > {
   const wrapper = session.labels?.["omnigent.wrapper"];
   return {
-    isNativeTerminalSession: isNativeWrapper(wrapper),
+    isNativeTerminalSession: isNativeTerminalSessionFn(session),
     // Native wrapper whose model lives in the vendor TUI (no Omnigent picker):
     // qwen/goose/cursor/pi/opencode. nativeModelFamilyForSession is non-null
     // only for claude-/codex-native, which keep the composer model label.

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -119,7 +119,10 @@ import { getOmnigentHostConfig, type OmnigentInteractionStatus } from "@/lib/hos
 import { emitInteractionPhase } from "@/lib/analyticsEmit";
 import { getSessionHost } from "@/lib/sessionHost";
 import { isSystemUserContent } from "@/lib/systemMessage";
-import { isNativeTerminalSession as isNativeTerminalSessionFn, isNativeWrapper } from "@/lib/nativeCodingAgents";
+import {
+  isNativeTerminalSession as isNativeTerminalSessionFn,
+  isNativeWrapper,
+} from "@/lib/nativeCodingAgents";
 
 export interface SendOptions {
   /**

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -119,10 +119,7 @@ import { getOmnigentHostConfig, type OmnigentInteractionStatus } from "@/lib/hos
 import { emitInteractionPhase } from "@/lib/analyticsEmit";
 import { getSessionHost } from "@/lib/sessionHost";
 import { isSystemUserContent } from "@/lib/systemMessage";
-import {
-  isNativeTerminalSession as isNativeTerminalSessionFn,
-  isNativeWrapper,
-} from "@/lib/nativeCodingAgents";
+import { isNativeTerminalSession as isNativeTerminalSessionFn } from "@/lib/nativeCodingAgents";
 
 export interface SendOptions {
   /**
@@ -2948,7 +2945,7 @@ function sessionBindingPatch(
     // qwen/goose/cursor/pi/opencode. nativeModelFamilyForSession is non-null
     // only for claude-/codex-native, which keep the composer model label.
     nativeVendorOwnsModel:
-      isNativeWrapper(wrapper) && nativeModelFamilyForSession(session) === null,
+      isNativeTerminalSessionFn(session) && nativeModelFamilyForSession(session) === null,
     boundAgentId: session.agentId,
     boundAgentName: session.agentName,
     llmModel: session.llmModel ?? null,
@@ -2959,7 +2956,7 @@ function sessionBindingPatch(
     costControlModeOverride: session.costControlModeOverride ?? null,
     subagentRoutingOverride: session.subagentRoutingOverride ?? null,
     codexPlanMode: codexPlanModeFromSession(session),
-    claudePermissionMode: isNativeWrapper(wrapper)
+    claudePermissionMode: isNativeTerminalSessionFn(session)
       ? (claudePermissionModeFromSession(session) ?? "")
       : "",
     contextWindow: session.contextWindow ?? null,

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -2938,7 +2938,6 @@ function sessionBindingPatch(
   | "sandboxStatus"
   | "mcpStartup"
 > {
-  const wrapper = session.labels?.["omnigent.wrapper"];
   return {
     isNativeTerminalSession: isNativeTerminalSessionFn(session),
     // Native wrapper whose model lives in the vendor TUI (no Omnigent picker):


### PR DESCRIPTION
## Summary

Custom agents with `executor: {harness: claude-native}` (e.g. launched via `omni run`) show the assistant response twice in the live view but correctly once after reload.

**Root cause:** `sessionBindingPatch` in `chatStore.ts` set `isNativeTerminalSession` using `isNativeWrapper(label)` which only checks the `omnigent.wrapper` session label. Built-in native wrapper sessions (the `claude` agent, `codex` agent, etc.) have this label. Custom bundled agents bound to `claude-native` harness do **not** — they have `session.harness = "claude-native"` but no wrapper label.

The dedup path at chatStore.ts ~line 4752 removes the live provisional streaming block when `response.output_item.done` arrives, but is gated on `isNativeTerminalSession`. With it `false` for custom agents, both the streaming preview (from `response.output_text.delta`) and the persisted item (from `response.output_item.done`) rendered as separate messages.

**Fix:** Replace `isNativeWrapper(wrapper)` with the full `isNativeTerminalSession(session)` which falls back to `nativeCodingAgentForHarness(session.harness)` when no wrapper label is set. This function already existed in `nativeCodingAgents.ts` and handles both signals correctly.

## Test Plan

1. Start the server and runner
2. Run `omni run /tmp/test-agent.yaml` where the YAML has `executor: {harness: claude-native}`
3. Send two messages to the session in the web UI
4. **Before fix:** second message response appears doubled in live view (fixed on reload)
5. **After fix:** response appears once, matching reload behavior

## Demo

before
<img width="718" height="230" alt="image" src="https://github.com/user-attachments/assets/7ea37b49-a98f-4973-9dd0-16407b89f921" />

after
<img width="746" height="116" alt="image" src="https://github.com/user-attachments/assets/505fa214-56ec-4f8d-8666-c348ae9a630f" />


## Type of change
- [x] Bug fix

## Test coverage
- [x] Manual verification completed

## Coverage notes
Verified manually with `omni run` bundled claude-native session. The `isNativeTerminalSession` function in `nativeCodingAgents.ts` already had the correct dual-signal logic; chatStore was just not using it.