### PR TITLE
fix(runner): bind local tools to the session workspace

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7433,17 +7433,14 @@ def create_runner_app(
                                                 {"message": _err_msg, "type": _err_type}
                                             )
                                             return
-                                        _dispatch_workdir = (
-                                            _resolved_workdir_for_spec(
-                                                _spec_for_dispatch_entry,
-                                                runner_workspace,
-                                            )
-                                            if _is_spec_local
-                                            else runner_workspace
+                                        _local_tool_workdir = _resolved_workdir_for_spec(
+                                            _spec_for_dispatch_entry,
+                                            runner_workspace,
                                         )
                                         _spec_for_dispatch = _unwrap_resolved_spec(
                                             _spec_for_dispatch_entry
                                         )
+                                        _dispatch_workspace = await _session_runtime_cwd(conv_id)
                                         event[_RUNNER_DISPATCHED_FIELD] = True
                                         raw_sse_bytes = _encode_sse_event(event)
                                         _agent_id_for_dispatch = cast(
@@ -7470,7 +7467,8 @@ def create_runner_app(
                                                     task_id=_omnigent_task_id or _response_id,
                                                     agent_id=_agent_id_for_dispatch,
                                                     agent_name=cast(str | None, body.get("model")),
-                                                    runner_workspace=_dispatch_workdir,
+                                                    runner_workspace=_dispatch_workspace,
+                                                    local_tool_workdir=_local_tool_workdir,
                                                     mcp_manager=cast(
                                                         "RunnerMcpManager", _dispatch_mcp
                                                     ),
@@ -10195,15 +10193,8 @@ def create_runner_app(
                     except (OmnigentError, httpx.HTTPError, RuntimeError):
                         pass
                 _agent_id_local = _session_agent_ids.get(session_id)
-                dispatch_workspace = (
-                    # A resolved entry with no bundle dir gets no workspace at
-                    # all: widening that to the runner workspace would hand a
-                    # sub-agent the tool tree its own bundle does not contain.
-                    spec_workdir
-                    if _is_spec_local_native_python_tool(spec, tool_name)
-                    else runner_workspace
-                )
                 try:
+                    dispatch_workspace = await _session_runtime_cwd(session_id)
                     output = await execute_tool(
                         tool_name=tool_name,
                         arguments=_json.dumps(arguments),
@@ -10216,6 +10207,7 @@ def create_runner_app(
                         agent_id=_agent_id_local,
                         agent_name=getattr(spec, "name", None),
                         runner_workspace=dispatch_workspace,
+                        local_tool_workdir=spec_workdir,
                         mcp_manager=None,
                         session_inbox=_session_inboxes.get(session_id),
                         session_async_tasks=_session_async_tasks.get(session_id),

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -118,6 +118,13 @@ _logger = logging.getLogger(__name__)
 _EventPublisher = Callable[[str, _JsonObject], None]
 
 
+class _UnsetLocalToolWorkdir:
+    """Sentinel distinguishing legacy fallback from an explicit no-bundle root."""
+
+
+_UNSET_LOCAL_TOOL_WORKDIR = _UnsetLocalToolWorkdir()
+
+
 class _DynamicCallable(Protocol):
     """Callable loaded from an agent spec's dotted Python path."""
 
@@ -939,19 +946,16 @@ async def _execute_local_python_tool(
     task_id: str | None,
     agent_id: str | None,
     runner_workspace: Path | None,
+    local_tool_workdir: Path | None,
 ) -> str:
     if agent_spec is None:
         return f"Error: {tool_name} not in local dispatch table (no agent spec)"
-    manager = ToolManager(agent_spec, workdir=runner_workspace)
+    manager = ToolManager(agent_spec, workdir=local_tool_workdir)
     try:
-        workspace = None
-        if runner_workspace is not None and conversation_id is not None:
-            workspace = runner_workspace / conversation_id
-            workspace.mkdir(parents=True, exist_ok=True)
         ctx = ToolContext(
             task_id=task_id or conversation_id or "runner-local-tool",
             agent_id=agent_id or agent_spec.name or "runner-agent",
-            workspace=workspace,
+            workspace=runner_workspace,
             conversation_id=conversation_id,
         )
         return await asyncio.to_thread(manager.call_tool, tool_name, args, ctx)
@@ -5635,6 +5639,7 @@ async def execute_tool(
     agent_id: str | None = None,
     agent_name: str | None = None,
     runner_workspace: Path | None = None,
+    local_tool_workdir: Path | None | _UnsetLocalToolWorkdir = _UNSET_LOCAL_TOOL_WORKDIR,
     mcp_manager: RunnerMcpManager | None = None,
     session_inbox: asyncio.Queue[_JsonObject] | None = None,
     session_async_tasks: dict[str, tuple[asyncio.Task[str], asyncio.Event]] | None = None,
@@ -5672,7 +5677,6 @@ async def execute_tool(
     if error is not None:
         return json.dumps({"error": error})
     assert args is not None
-
     try:
         if mcp_manager is not None:
             # All MCP tool calls are routed through the AP server's
@@ -5738,6 +5742,7 @@ async def execute_tool(
                 agent_id=agent_id,
                 agent_name=agent_name,
                 runner_workspace=runner_workspace,
+                local_tool_workdir=local_tool_workdir,
                 mcp_manager=mcp_manager,
                 filesystem_registry=filesystem_registry,
             )
@@ -5889,6 +5894,11 @@ async def execute_tool(
                 task_id=task_id,
                 agent_id=agent_id,
                 runner_workspace=runner_workspace,
+                local_tool_workdir=(
+                    runner_workspace
+                    if local_tool_workdir is _UNSET_LOCAL_TOOL_WORKDIR
+                    else cast(Path | None, local_tool_workdir)
+                ),
             )
         elif _is_uc_function_tool(tool_name, agent_spec):
             output = await _execute_uc_function_tool(tool_name, args, agent_spec=agent_spec)
@@ -5976,6 +5986,7 @@ async def dispatch_tool_locally(
     agent_id: str | None = None,
     agent_name: str | None = None,
     runner_workspace: Path | None = None,
+    local_tool_workdir: Path | None | _UnsetLocalToolWorkdir = _UNSET_LOCAL_TOOL_WORKDIR,
     mcp_manager: RunnerMcpManager | None = None,
     session_inbox: asyncio.Queue[_JsonObject] | None = None,
     session_async_tasks: dict[str, tuple[asyncio.Task[str], asyncio.Event]] | None = None,
@@ -6016,6 +6027,7 @@ async def dispatch_tool_locally(
         agent_id=agent_id,
         agent_name=agent_name,
         runner_workspace=runner_workspace,
+        local_tool_workdir=local_tool_workdir,
         mcp_manager=mcp_manager,
         session_inbox=session_inbox,
         session_async_tasks=session_async_tasks,
@@ -6836,6 +6848,7 @@ async def _execute_async_inbox_tool(
     agent_id: str | None,
     agent_name: str | None,
     runner_workspace: Path | None,
+    local_tool_workdir: Path | None | _UnsetLocalToolWorkdir,
     mcp_manager: RunnerMcpManager | None,
     filesystem_registry: FilesystemRegistry | None = None,
     harness_client: httpx.AsyncClient | None = None,
@@ -6882,6 +6895,7 @@ async def _execute_async_inbox_tool(
             agent_id=agent_id,
             agent_name=agent_name,
             runner_workspace=runner_workspace,
+            local_tool_workdir=local_tool_workdir,
             mcp_manager=mcp_manager,
             filesystem_registry=filesystem_registry,
         )
@@ -7336,6 +7350,7 @@ def _spawn_async_tool(
     runner_workspace: Path | None,
     mcp_manager: RunnerMcpManager | None,
     filesystem_registry: FilesystemRegistry | None = None,
+    local_tool_workdir: Path | None | _UnsetLocalToolWorkdir = _UNSET_LOCAL_TOOL_WORKDIR,
 ) -> str:
     """
     Spawn a tool as a background asyncio.Task.
@@ -7420,6 +7435,7 @@ def _spawn_async_tool(
                 agent_id=agent_id,
                 agent_name=agent_name,
                 runner_workspace=runner_workspace,
+                local_tool_workdir=local_tool_workdir,
                 mcp_manager=mcp_manager,
                 session_inbox=session_inbox if target_tool in _TERMINAL_TOOLS else None,
                 filesystem_registry=filesystem_registry,

--- a/omnigent/tools/local.py
+++ b/omnigent/tools/local.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import contextlib
 import importlib.util
+import inspect
 import json
 import logging
 import os
@@ -108,6 +109,7 @@ class LocalPythonTool(Tool):
         srt_available: bool,
         uv_available: bool,
         sandbox_enabled: bool = True,
+        uses_tool_state: bool = False,
     ) -> None:
         """
         Initialize from a discovered ``@tool`` function.
@@ -130,6 +132,7 @@ class LocalPythonTool(Tool):
         self._sandbox_enabled = sandbox_enabled
         self._srt_available = srt_available
         self._uv_available = uv_available
+        self._uses_tool_state = uses_tool_state
         # Live subprocesses from any in-flight ``invoke()`` — tracked
         # as a set guarded by a lock so ``cancel()`` can kill all of
         # them at once. A single ``self._proc`` would race when the
@@ -226,7 +229,7 @@ class LocalPythonTool(Tool):
         # the runner then refuses to inject and raises a clear error
         # if the tool asked for tool_state). See designs/TOOL_STATE.md.
         state_root: str | None = None
-        if ctx.workspace is not None:
+        if self._uses_tool_state and ctx.workspace is not None:
             state_dir = ctx.workspace / ".tool_state" / ctx.agent_id
             state_dir.mkdir(parents=True, exist_ok=True)
             state_root = str(state_dir)
@@ -692,7 +695,7 @@ def load_local_python_tools(
             module=module,
         )
 
-        for tool_name, metadata in functions:
+        for tool_name, metadata, uses_tool_state in functions:
             # Detect collision with another custom tool already discovered.
             existing = discovered.get(tool_name)
             if existing is not None:
@@ -715,6 +718,7 @@ def load_local_python_tools(
                 info=info,
                 metadata=metadata,
                 module_path=tool_path.resolve(),
+                uses_tool_state=uses_tool_state,
             )
 
     return [
@@ -726,6 +730,7 @@ def load_local_python_tools(
             srt_available=effective_srt,
             uv_available=effective_uv,
             sandbox_enabled=sandbox_enabled,
+            uses_tool_state=disc.uses_tool_state,
         )
         for disc in discovered.values()
     ]
@@ -745,17 +750,19 @@ class _DiscoveredTool:
     :param module_path: Resolved absolute path to the source file.
     """
 
-    __slots__ = ("info", "metadata", "module_path")
+    __slots__ = ("info", "metadata", "module_path", "uses_tool_state")
 
     def __init__(
         self,
         info: LocalToolInfo,
         metadata: ToolMetadata,
         module_path: Path,
+        uses_tool_state: bool,
     ) -> None:
         self.info = info
         self.metadata = metadata
         self.module_path = module_path
+        self.uses_tool_state = uses_tool_state
 
 
 def _scan_inline_metadata(info: LocalToolInfo, path: Path) -> None:
@@ -818,7 +825,7 @@ def _extract_decorated_functions(
     agent_name: str,
     tool_path: Path,
     module: ModuleType,
-) -> list[tuple[str, ToolMetadata]]:
+) -> list[tuple[str, ToolMetadata, bool]]:
     """
     Find every ``@tool``-decorated function defined in ``module``.
 
@@ -837,7 +844,7 @@ def _extract_decorated_functions(
     :raises LocalToolLoadError: If the module exports no
         ``@tool``-decorated functions.
     """
-    found: list[tuple[str, ToolMetadata]] = []
+    found: list[tuple[str, ToolMetadata, bool]] = []
     for value in module.__dict__.values():
         # Only consider objects defined in THIS module (not imports).
         # Re-imported decorated functions would otherwise be doubly
@@ -849,7 +856,8 @@ def _extract_decorated_functions(
         metadata = get_tool_metadata(value)
         if metadata is None:
             continue
-        found.append((metadata.name, metadata))
+        uses_tool_state = "tool_state" in inspect.signature(value).parameters
+        found.append((metadata.name, metadata, uses_tool_state))
 
     if found:
         return found

--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -1242,9 +1242,8 @@ async def test_sessions_native_dispatches_native_tool_with_bundle_workdir(
 
     End-to-end through ``POST /v1/sessions/{conv}/events`` (no live LLM):
     the scripted harness emits an ``action_required`` for a spec-declared
-    python tool, and the runner must dispatch it locally with
-    ``runner_workspace`` set to the resolved ``ResolvedSpec.workdir`` (the
-    bundle dir), not the generic CLI ``runner_workspace``. This is the
+    python tool, and the runner must dispatch it locally with the session
+    workspace kept separate from the resolved ``ResolvedSpec.workdir``. This is the
     dispatch-time counterpart to
     :func:`test_runner_session_tool_schemas_use_resolved_bundle_workdir`,
     which only proved schema generation used the bundle workdir.
@@ -1260,6 +1259,8 @@ async def test_sessions_native_dispatches_native_tool_with_bundle_workdir(
     )
     workspace = tmp_path / "workspace"
     workspace.mkdir()
+    session_workspace = tmp_path / "session-worktree"
+    session_workspace.mkdir()
     spec = AgentSpec(
         spec_version=1,
         name="bundle-agent",
@@ -1272,10 +1273,15 @@ async def test_sessions_native_dispatches_native_tool_with_bundle_workdir(
         ],
     )
 
-    captured_workspaces: list[Path | None] = []
+    captured_workspaces: list[tuple[Path | None, Path | None]] = []
 
-    async def _fake_dispatch(*, runner_workspace: Path | None = None, **kwargs: Any) -> str:
-        captured_workspaces.append(runner_workspace)
+    async def _fake_dispatch(
+        *,
+        runner_workspace: Path | None = None,
+        local_tool_workdir: Path | None = None,
+        **kwargs: Any,
+    ) -> str:
+        captured_workspaces.append((runner_workspace, local_tool_workdir))
         return "ok"
 
     monkeypatch.setattr(_tool_dispatch, "dispatch_tool_locally", _fake_dispatch)
@@ -1303,10 +1309,23 @@ async def test_sessions_native_dispatches_native_tool_with_bundle_workdir(
         del agent_id, session_id
         return ResolvedSpec(spec=spec, workdir=bundle_dir)
 
+    class _WorkspaceServerClient(NullServerClient):
+        class _WorkspaceResponse(NullServerClient._Response):
+            def json(self) -> dict[str, Any]:
+                return {
+                    "workspace": str(session_workspace),
+                    "agent_id": "31ebfedf721b44dabd76f662cb70a400",
+                }
+
+        async def get(self, url: str, **kwargs: Any) -> NullServerClient._Response:
+            if url.startswith("/v1/sessions/"):
+                return self._WorkspaceResponse()
+            return await super().get(url, **kwargs)
+
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]
         spec_resolver=_resolver,
-        server_client=NullServerClient(),  # type: ignore[arg-type]
+        server_client=_WorkspaceServerClient(),  # type: ignore[arg-type]
         runner_workspace=workspace,
     )
     async with _runner_client(app) as client:
@@ -1328,10 +1347,7 @@ async def test_sessions_native_dispatches_native_tool_with_bundle_workdir(
             await asyncio.sleep(0.05)
 
     assert captured_workspaces, "native tool must be dispatched locally"
-    assert captured_workspaces[0] == bundle_dir, (
-        "dispatch must use the resolved bundle workdir, not runner_workspace "
-        f"({workspace!r}); got {captured_workspaces[0]!r}"
-    )
+    assert captured_workspaces[0] == (session_workspace.resolve(), bundle_dir)
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_local_tool_workspace_binding.py
+++ b/tests/runner/test_local_tool_workspace_binding.py
@@ -1,0 +1,159 @@
+"""Regression tests for local-tool bundle and session workspace separation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from omnigent.runner.tool_dispatch import execute_tool
+from omnigent.spec.types import AgentSpec, LocalToolInfo
+
+
+def _probe_spec(bundle: Path, *, agent_name: str = "probe") -> AgentSpec:
+    """Create a bundle tool that reports its code root and execution workspace."""
+    tool_path = bundle / "tools" / "python" / "workspace_probe.py"
+    tool_path.parent.mkdir(parents=True)
+    tool_path.write_text(
+        "from pathlib import Path\n"
+        "import os\n"
+        "from omnigent_client import tool\n\n"
+        "@tool\n"
+        "def workspace_probe(value: str) -> str:\n"
+        "    return f'{os.environ.get(\"_AP_WORKSPACE\")}|{Path(__file__).resolve()}'\n"
+    )
+    return AgentSpec(
+        spec_version=1,
+        name=agent_name,
+        local_tools=[
+            LocalToolInfo(
+                name="workspace_probe",
+                path="tools/python/workspace_probe.py",
+                language="python",
+            )
+        ],
+    )
+
+
+async def _run_probe(spec: AgentSpec, bundle: Path, workspace: Path, session_id: str) -> str:
+    return await execute_tool(
+        tool_name="workspace_probe",
+        arguments=json.dumps({"value": "ignored"}),
+        agent_spec=spec,
+        conversation_id=session_id,
+        agent_id="ag_probe",
+        runner_workspace=workspace,
+        local_tool_workdir=bundle,
+    )
+
+
+@pytest.mark.asyncio
+async def test_local_tool_import_root_is_separate_from_exact_session_workspace(
+    tmp_path: Path,
+) -> None:
+    """Tool code loads from the bundle while ``_AP_WORKSPACE`` is the worktree."""
+    bundle = tmp_path / "bundle"
+    workspace = tmp_path / "worktree"
+    workspace.mkdir()
+    spec = _probe_spec(bundle)
+
+    result = await _run_probe(spec, bundle, workspace, "child-session")
+
+    assert result == f"{workspace}|{(bundle / 'tools/python/workspace_probe.py').resolve()}"
+    assert not (workspace / "child-session").exists()
+    assert not (workspace / ".tool_state").exists()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sessions_do_not_cross_bind_execution_workspaces(tmp_path: Path) -> None:
+    """Concurrent children keep their own `_AP_WORKSPACE` values."""
+    bundle = tmp_path / "bundle"
+    first_workspace = tmp_path / "first-worktree"
+    second_workspace = tmp_path / "second-worktree"
+    first_workspace.mkdir()
+    second_workspace.mkdir()
+    spec = _probe_spec(bundle)
+
+    first, second = await asyncio.gather(
+        _run_probe(spec, bundle, first_workspace, "child-a"),
+        _run_probe(spec, bundle, second_workspace, "child-b"),
+    )
+
+    module_path = (bundle / "tools/python/workspace_probe.py").resolve()
+    assert first == f"{first_workspace}|{module_path}"
+    assert second == f"{second_workspace}|{module_path}"
+
+
+@pytest.mark.asyncio
+async def test_sibling_bundle_roots_remain_isolated_from_shared_workspace(tmp_path: Path) -> None:
+    """Siblings may share a runner root without sharing bundle imports."""
+    workspace = tmp_path / "shared-worktree"
+    first_bundle = tmp_path / "first-bundle"
+    second_bundle = tmp_path / "second-bundle"
+    workspace.mkdir()
+    first_spec = _probe_spec(first_bundle, agent_name="first")
+    second_spec = _probe_spec(second_bundle, agent_name="second")
+
+    first, second = await asyncio.gather(
+        _run_probe(first_spec, first_bundle, workspace, "first-child"),
+        _run_probe(second_spec, second_bundle, workspace, "second-child"),
+    )
+
+    assert first == f"{workspace}|{(first_bundle / 'tools/python/workspace_probe.py').resolve()}"
+    assert second == f"{workspace}|{(second_bundle / 'tools/python/workspace_probe.py').resolve()}"
+
+
+@pytest.mark.asyncio
+async def test_async_custom_tool_keeps_bundle_root_and_session_workspace(tmp_path: Path) -> None:
+    """A builtin ``sys_call_async`` still threads both roots to its custom target."""
+    bundle = tmp_path / "bundle"
+    workspace = tmp_path / "worktree"
+    workspace.mkdir()
+    spec = _probe_spec(bundle)
+    inbox: asyncio.Queue[dict[str, object]] = asyncio.Queue()
+    tasks: dict[str, tuple[asyncio.Task[str], asyncio.Event]] = {}
+
+    raw_handle = await execute_tool(
+        tool_name="sys_call_async",
+        arguments=json.dumps(
+            {"tool": "workspace_probe", "args": json.dumps({"value": "ignored"})}
+        ),
+        agent_spec=spec,
+        conversation_id="async-child",
+        agent_id="ag_probe",
+        runner_workspace=workspace,
+        local_tool_workdir=bundle,
+        session_inbox=inbox,
+        session_async_tasks=tasks,
+    )
+    handle_id = json.loads(raw_handle)["handle_id"]
+    await tasks[handle_id][0]
+    completion = await inbox.get()
+
+    expected = f"{workspace}|{(bundle / 'tools/python/workspace_probe.py').resolve()}"
+    assert completion["status"] == "completed"
+    assert completion["output"] == expected
+
+
+@pytest.mark.asyncio
+async def test_explicit_missing_bundle_never_falls_back_to_session_workspace(
+    tmp_path: Path,
+) -> None:
+    """A resolved no-bundle verdict cannot load tools from the worktree."""
+    workspace = tmp_path / "worktree"
+    workspace.mkdir()
+    spec = _probe_spec(workspace)
+
+    result = await execute_tool(
+        tool_name="workspace_probe",
+        arguments=json.dumps({"value": "ignored"}),
+        agent_spec=spec,
+        conversation_id="no-bundle-child",
+        runner_workspace=workspace,
+        local_tool_workdir=None,
+    )
+
+    assert result.startswith("Error:")
+    assert str(workspace / "tools/python/workspace_probe.py") not in result

--- a/tests/runner/test_sub_agent_bundle_isolation.py
+++ b/tests/runner/test_sub_agent_bundle_isolation.py
@@ -509,11 +509,16 @@ async def test_top_level_bare_spec_still_dispatches_in_runner_workspace(
     _write_python_tool(workspace, "tools/python/bundle_tool.py")
     spec = _python_tool_spec("plain-agent", "tools/python/bundle_tool.py")
 
-    captured: list[Path | None] = []
+    captured: list[tuple[Path | None, Path | None]] = []
 
-    async def _fake_dispatch(*, runner_workspace: Path | None = None, **kwargs: Any) -> str:
+    async def _fake_dispatch(
+        *,
+        runner_workspace: Path | None = None,
+        local_tool_workdir: Path | None = None,
+        **kwargs: Any,
+    ) -> str:
         del kwargs
-        captured.append(runner_workspace)
+        captured.append((runner_workspace, local_tool_workdir))
         return "ok"
 
     monkeypatch.setattr(_tool_dispatch, "dispatch_tool_locally", _fake_dispatch)
@@ -568,11 +573,7 @@ async def test_top_level_bare_spec_still_dispatches_in_runner_workspace(
             await asyncio.sleep(0.05)
 
     assert captured, "the local tool was never dispatched"
-    assert captured[0] == workspace, (
-        f"a top-level bare spec dispatched against {captured[0]!r}; expected the "
-        f"runner workspace {workspace!r}. None here means the spec cache wrapped a "
-        "spec that never carried bundle information, so the fallback was lost."
-    )
+    assert captured[0] == (workspace, workspace)
 
 
 # ── /mcp/execute (sibling site) ───────────────────────────────
@@ -637,15 +638,22 @@ async def test_mcp_execute_spec_local_tool_honours_resolved_workdir(
     bundle_dir.mkdir()
     workspace = tmp_path / "workspace"
     workspace.mkdir()
+    session_workspace = tmp_path / "session-worktree"
+    session_workspace.mkdir()
     _write_python_tool(bundle_dir, "tools/python/bundle_tool.py")
     _write_python_tool(workspace, "tools/python/bundle_tool.py")
     spec = _python_tool_spec("probe-agent", "tools/python/bundle_tool.py")
 
-    captured: list[Path | None] = []
+    captured: list[tuple[Path | None, Path | None]] = []
 
-    async def _fake_execute_tool(*, runner_workspace: Path | None = None, **kwargs: Any) -> str:
+    async def _fake_execute_tool(
+        *,
+        runner_workspace: Path | None = None,
+        local_tool_workdir: Path | None = None,
+        **kwargs: Any,
+    ) -> str:
         del kwargs
-        captured.append(runner_workspace)
+        captured.append((runner_workspace, local_tool_workdir))
         return "ok"
 
     monkeypatch.setattr(_tool_dispatch, "execute_tool", _fake_execute_tool)
@@ -654,13 +662,26 @@ async def test_mcp_execute_spec_local_tool_honours_resolved_workdir(
         del agent_id, session_id
         return ResolvedSpec(spec=spec, workdir=bundle_dir if wrap_workdir else None)
 
+    class _WorkspaceServerClient(NullServerClient):
+        class _WorkspaceResponse(NullServerClient._Response):
+            def json(self) -> dict[str, Any]:
+                return {
+                    "workspace": str(session_workspace),
+                    "agent_id": "31ebfedf721b44dabd76f662cb70a400",
+                }
+
+        async def get(self, url: str, **kwargs: Any) -> NullServerClient._Response:
+            if url.startswith("/v1/sessions/"):
+                return self._WorkspaceResponse()
+            return await super().get(url, **kwargs)
+
     harness_client = _ScriptedHarnessClient(
         [_sse({"type": "response.completed", "response": {"id": "resp_1"}})]
     )
     app = create_runner_app(
         process_manager=_FakeProcessManager(harness_client),  # type: ignore[arg-type]
         spec_resolver=_resolver,
-        server_client=NullServerClient(),  # type: ignore[arg-type]
+        server_client=_WorkspaceServerClient(),  # type: ignore[arg-type]
         runner_workspace=workspace,
     )
 
@@ -669,8 +690,4 @@ async def test_mcp_execute_spec_local_tool_honours_resolved_workdir(
     assert resp.status_code == 200, resp.text
     assert captured, "the spec-local tool was never dispatched"
     expected = bundle_dir if wrap_workdir else None
-    assert captured[0] == expected, (
-        f"/mcp/execute dispatched the spec-local tool against {captured[0]!r}; "
-        f"expected {expected!r}. The runner workspace {workspace!r} means the "
-        "endpoint still falls back instead of honouring the resolved workdir."
-    )
+    assert captured[0] == (session_workspace.resolve(), expected)

--- a/tests/tools/test_local.py
+++ b/tests/tools/test_local.py
@@ -127,6 +127,49 @@ def test_invoke_subprocess_success(tmp_path: Path, tool_ctx: ToolContext) -> Non
     assert "result:" in result
 
 
+def test_stateless_tool_does_not_create_tool_state_directory(tmp_path: Path) -> None:
+    """A stateless custom tool must not dirty its execution workspace."""
+    py_dir = tmp_path / "bundle" / "tools" / "python"
+    _write_decorated_tool(py_dir, "echo_tool.py", func_name="echo_tool")
+    info = LocalToolInfo(name="echo_tool", path="tools/python/echo_tool.py", language="python")
+    tools = load_local_python_tools([info], tmp_path / "bundle")
+    workspace = tmp_path / "worktree"
+    workspace.mkdir()
+    ctx = ToolContext(task_id="task_test", agent_id="ag_test", workspace=workspace)
+
+    assert "hello" in tools[0].invoke(json.dumps({"value": "hello"}), ctx)
+    assert not (workspace / ".tool_state").exists()
+
+
+def test_stateful_tool_receives_isolated_state_root(tmp_path: Path) -> None:
+    """Only a reserved ``tool_state`` parameter enables persistent state."""
+    bundle = tmp_path / "bundle"
+    py_dir = bundle / "tools" / "python"
+    py_dir.mkdir(parents=True)
+    (py_dir / "stateful.py").write_text(
+        "from omnigent_client.tools import ToolState, tool\n\n"
+        "@tool\n"
+        "def stateful(value: str, tool_state: ToolState) -> str:\n"
+        "    prior = tool_state.get('value')\n"
+        "    tool_state.set('value', value)\n"
+        "    return f'{prior}|{value}'\n"
+    )
+    info = LocalToolInfo(name="stateful", path="tools/python/stateful.py", language="python")
+    tool = load_local_python_tools([info], bundle)[0]
+    first_workspace = tmp_path / "first"
+    second_workspace = tmp_path / "second"
+    first_workspace.mkdir()
+    second_workspace.mkdir()
+    first_ctx = ToolContext(task_id="first", agent_id="ag_test", workspace=first_workspace)
+    second_ctx = ToolContext(task_id="second", agent_id="ag_test", workspace=second_workspace)
+
+    assert tool.invoke(json.dumps({"value": "one"}), first_ctx) == "None|one"
+    assert tool.invoke(json.dumps({"value": "two"}), first_ctx) == "one|two"
+    assert tool.invoke(json.dumps({"value": "other"}), second_ctx) == "None|other"
+    assert (first_workspace / ".tool_state" / "ag_test").is_dir()
+    assert (second_workspace / ".tool_state" / "ag_test").is_dir()
+
+
 def test_invoke_subprocess_strips_runner_binding_token(
     tmp_path: Path,
     tool_ctx: ToolContext,


### PR DESCRIPTION
## Related issue

Closes #5634

## Summary

- Separate the local tool bundle/import root from the trusted session execution workspace.
- Bind `ToolContext.workspace` and `_AP_WORKSPACE` to the persisted session workspace exactly, without a conversation-ID suffix.
- Avoid creating `.tool_state` for stateless tools while preserving isolated state for tools that declare it.

ELI5: the tool's code can live in Omnigent's cache, but the tool must work in the task's real checkout. This patch keeps those two folders separate.

```text
agent bundle ──> imports and assets
session worktree ──> ToolContext.workspace / _AP_WORKSPACE
```

## Test Plan

- `uv run pytest -q tests/runner/test_local_tool_workspace_binding.py tests/runner/test_app_sessions_native_workflow_init.py tests/runner/test_sub_agent_bundle_isolation.py tests/tools/test_local.py` — 131 passed.
- Added `/mcp/execute` coverage proving a persisted workspace is delivered to a bundled local tool.
- Covered persisted-workspace precedence, runner-root fallback, direct and async dispatch, sibling/concurrent isolation, explicit `None`, and stateless/stateful tool-state behavior.
- Built and installed the full wheel locally; `omnigent --version` reported commit `e6ebc7bc` and the wheel contained the runner, tool, and web UI assets.

## Demo

N/A — runner-only behavior with no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification built the production wheel and installed it in an isolated `uv` tool directory. The reported version included the reviewed commit, and the wheel contained the changed runner/tool modules plus the web UI bundle.

## Changelog

Bundled local tools now operate in the session's persisted workspace while continuing to load code from their isolated agent bundle.
