### PR TITLE
fix(spec): discover skills grouped in namespace folders under skills/

### DIFF
--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -2274,16 +2274,24 @@ def discover_host_skills(
     return skills
 
 
+# How many grouping levels ``_discover_skills`` descends below ``skills/``:
+# ``skills/<namespace>/<skill>/SKILL.md`` is found, deeper nesting is not.
+_SKILL_NAMESPACE_MAX_DEPTH = 1
+
+
 def _discover_skills(
     skills_dir: Path,
     *,
     skipped: list[str] | None = None,
+    _depth: int = 0,
 ) -> list[SkillSpec]:
     """
     Discover and parse all skills under the ``skills/`` directory.
 
     Each subdirectory containing a ``SKILL.md`` file is parsed via
-    :func:`_parse_skill`.
+    :func:`_parse_skill`. A subdirectory without one is a namespace
+    folder and is scanned one level deeper, so
+    ``skills/<namespace>/<skill>/SKILL.md`` is discovered too.
 
     :param skills_dir: Path to the ``skills/`` directory, e.g.
         ``root / "skills"``.
@@ -2316,6 +2324,10 @@ def _discover_skills(
             continue
         skill_md = skill_dir / "SKILL.md"
         if not skill_md.exists():
+            # Namespace folder: group skills one level deeper. Dot-dirs
+            # (``.git`` in a cloned skill pack) stay opaque.
+            if _depth < _SKILL_NAMESPACE_MAX_DEPTH and not skill_dir.name.startswith("."):
+                skills.extend(_discover_skills(skill_dir, skipped=skipped, _depth=_depth + 1))
             continue
         try:
             skill = _parse_skill(skill_md)

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -2302,7 +2302,10 @@ def _discover_skills(
         Pass ``None`` (the default) to fail loud on the first
         error — used for bundled skills that the agent author
         controls.
-    :returns: A sorted list of parsed :class:`SkillSpec` objects.
+    Namespace folders only group skills; they do not alter the skill name
+    declared in ``SKILL.md``.
+
+    :returns: Parsed :class:`SkillSpec` objects in deterministic path order.
         Returns an empty list if *skills_dir* does not exist.
     """
     if not skills_dir.is_dir():
@@ -2320,13 +2323,12 @@ def _discover_skills(
         return []
     skills: list[SkillSpec] = []
     for skill_dir in entries:
-        if not skill_dir.is_dir():
+        if not skill_dir.is_dir() or skill_dir.name.startswith("."):
             continue
         skill_md = skill_dir / "SKILL.md"
         if not skill_md.exists():
-            # Namespace folder: group skills one level deeper. Dot-dirs
-            # (``.git`` in a cloned skill pack) stay opaque.
-            if _depth < _SKILL_NAMESPACE_MAX_DEPTH and not skill_dir.name.startswith("."):
+            # Namespace folder: group skills one level deeper.
+            if _depth < _SKILL_NAMESPACE_MAX_DEPTH:
                 skills.extend(_discover_skills(skill_dir, skipped=skipped, _depth=_depth + 1))
             continue
         try:

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -773,6 +773,39 @@ def test_discover_host_skills_skips_unreadable_skill_file(
     assert "could not be read" in msg
 
 
+def _write_skill(skill_dir: Path, name: str) -> None:
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\ndescription: d\n---\nBody.")
+
+
+def test_discover_skills_in_namespace_directories(agent_dir: Path) -> None:
+    """
+    A folder under ``skills/`` without its own ``SKILL.md`` groups
+    skills one level deeper: ``skills/<ns>/<skill>/SKILL.md`` must be
+    discovered alongside flat ``skills/<skill>/SKILL.md`` entries.
+    """
+    skills = agent_dir / "skills"
+    _write_skill(skills / "flat", "flat")
+    _write_skill(skills / "ops" / "deploy", "deploy")
+    _write_skill(skills / "ops" / "rollback", "rollback")
+
+    assert [s.name for s in parse(agent_dir).skills] == ["flat", "deploy", "rollback"]
+
+
+def test_discover_skills_namespace_depth_is_bounded(agent_dir: Path) -> None:
+    """
+    Namespace descent stops after one level and never enters dot-dirs,
+    so a cloned skill pack's ``.git`` tree or a deeply nested layout
+    cannot be walked (host skill dirs are user-managed).
+    """
+    skills = agent_dir / "skills"
+    _write_skill(skills / "ops" / "deploy", "deploy")
+    _write_skill(skills / "ops" / "too" / "deep", "deep")
+    _write_skill(skills / ".git" / "hidden", "hidden")
+
+    assert [s.name for s in parse(agent_dir).skills] == ["deploy"]
+
+
 # ── top-level ``skills:`` field (host-skill filter) ──────────────
 
 

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -802,6 +802,8 @@ def test_discover_skills_namespace_depth_is_bounded(agent_dir: Path) -> None:
     _write_skill(skills / "ops" / "deploy", "deploy")
     _write_skill(skills / "ops" / "too" / "deep", "deep")
     _write_skill(skills / ".git" / "hidden", "hidden")
+    _write_skill(skills / ".direct-hidden", "direct-hidden")
+    _write_skill(skills / "ops" / ".nested-hidden", "nested-hidden")
 
     assert [s.name for s in parse(agent_dir).skills] == ["deploy"]
 


### PR DESCRIPTION
## Related issue

Closes #5636

## Summary

- `_discover_skills` only scanned one level below `skills/`, so `skills/<namespace>/<skill>/SKILL.md` was silently ignored — missing from the slash picker, unreachable via `load_skill`.
- A folder without its own `SKILL.md` is now treated as a namespace and scanned one level deeper. Descent is bounded to that single level and never enters dot-dirs (`.git` in a cloned skill pack) — host skill dirs are user-managed, so unbounded recursion is a footgun.
- Applies uniformly to every caller: bundle skills, host `~/.claude/skills`, plugin install paths, onboarding skills.

```
skills/
├── flat/SKILL.md              # before: found   after: found
└── ops/                       # no SKILL.md → namespace
    ├── deploy/SKILL.md        # before: ignored after: found
    └── too/deep/SKILL.md      # ignored (depth bound)
```

## Test Plan

`uv run pytest tests/spec/test_parser.py tests/spec/test_skill_sources.py -q` — 296 passed.

New tests:
- `test_discover_skills_in_namespace_directories` — flat + namespaced skills are all discovered, in sorted order.
- `test_discover_skills_namespace_depth_is_bounded` — two-level nesting and `.git/…` are not walked.

## Demo

N/A — backend-only (spec parsing).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two new tests in `tests/spec/test_parser.py` (above). No existing tests adjusted — flat-layout behaviour is unchanged.

## Changelog

Skills grouped in a subfolder (`skills/<namespace>/<skill>/SKILL.md`) are now discovered
