### PR TITLE
Update create session measurement

### DIFF
--- a/web/src/lib/analytics.test.tsx
+++ b/web/src/lib/analytics.test.tsx
@@ -117,12 +117,12 @@ describe("startTimedInteraction", () => {
     const analytics = vi.fn();
     setOmnigentHostConfig({ analytics });
 
-    startTimedInteraction("create_session", "sess_2").fail();
+    startTimedInteraction("create_session_sandbox", "sess_2").fail();
 
     expect(analytics).toHaveBeenLastCalledWith({
       type: "interaction_phase",
       interactionId: "sess_2",
-      interactionKind: "create_session",
+      interactionKind: "create_session_sandbox",
       phase: "complete",
       status: "failure",
       durationMs: expect.any(Number),

--- a/web/src/lib/analyticsEmit.ts
+++ b/web/src/lib/analyticsEmit.ts
@@ -92,14 +92,19 @@ export interface TimedInteraction {
  *
  *   const interaction = startTimedInteraction("get_session", sessionId);
  *   try { await load(); interaction.complete(); } catch (e) { interaction.fail(); throw e; }
+ *
+ * `name` is an optional bounded, non-PII label (e.g. a tool name) carried on both
+ * phases; never user content.
  */
 export function startTimedInteraction(
   interactionKind: OmnigentInteractionKind,
   interactionId: string = newInteractionId(),
+  name?: string,
 ): TimedInteraction {
   const startedAt = Date.now();
   let settled = false;
-  emitInteractionPhase({ interactionId, interactionKind, phase: "start" });
+  const label = name ? { name } : {};
+  emitInteractionPhase({ interactionId, interactionKind, phase: "start", ...label });
   const complete = (status: OmnigentInteractionStatus = "success"): void => {
     if (settled) return;
     settled = true;
@@ -108,6 +113,7 @@ export function startTimedInteraction(
       interactionKind,
       phase: "complete",
       status,
+      ...label,
       durationMs: Date.now() - startedAt,
     });
   };

--- a/web/src/lib/analyticsEmit.ts
+++ b/web/src/lib/analyticsEmit.ts
@@ -73,10 +73,12 @@ function newInteractionId(): string {
 export interface TimedInteraction {
   /**
    * Report the terminal outcome and elapsed `durationMs` (defaults to
-   * "success"). Idempotent: only the first settle emits, so a double-settle
-   * (e.g. a catch after a partial success) can never double-count.
+   * "success"; pass `null` to omit status entirely — for interactions with no
+   * reliable outcome signal, such as tool calls). Idempotent: only the first
+   * settle emits, so a double-settle (e.g. a catch after a partial success)
+   * can never double-count.
    */
-  complete: (status?: OmnigentInteractionStatus) => void;
+  complete: (status?: OmnigentInteractionStatus | null) => void;
   /** Shorthand for `complete("failure")`. */
   fail: () => void;
 }
@@ -105,14 +107,16 @@ export function startTimedInteraction(
   let settled = false;
   const label = name ? { name } : {};
   emitInteractionPhase({ interactionId, interactionKind, phase: "start", ...label });
-  const complete = (status: OmnigentInteractionStatus = "success"): void => {
+  const complete = (status: OmnigentInteractionStatus | null = "success"): void => {
     if (settled) return;
     settled = true;
     emitInteractionPhase({
       interactionId,
       interactionKind,
       phase: "complete",
-      status,
+      // `null` omits status: an interaction with no reliable outcome signal
+      // (a tool call) must not report a fabricated success/failure.
+      ...(status !== null ? { status } : {}),
       ...label,
       durationMs: Date.now() - startedAt,
     });

--- a/web/src/lib/host.ts
+++ b/web/src/lib/host.ts
@@ -40,10 +40,19 @@ export type OmnigentComponentKind =
  *   - `approval`       — a human-in-the-loop permission decision.
  *   - `list_sessions`  — loading the session list (user-initiated; not background polls).
  *   - `get_session`    — loading a single session the user opened / switched to.
- *   - `create_session` — creating a new session.
+ *   - `create_session_sandbox` / `create_session_computer` — a brand-new chat from
+ *     send to the first AI message, split by where the session runs (managed
+ *     sandbox vs the user's computer host); host kind is baked into the kind so
+ *     the host can name/segment the two without a queryable sub-dimension.
  */
 export type OmnigentInteractionKind =
-  "agent_run" | "tool_call" | "approval" | "list_sessions" | "get_session" | "create_session";
+  | "agent_run"
+  | "tool_call"
+  | "approval"
+  | "list_sessions"
+  | "get_session"
+  | "create_session_sandbox"
+  | "create_session_computer";
 
 /** Terminal outcome of an interaction, set on the `complete` phase. */
 export type OmnigentInteractionStatus = "success" | "failure" | "cancelled" | "timed_out";

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -101,7 +101,8 @@ import {
   rankedSlashCommandNames,
   SlashCommandMenu,
 } from "@/components/SlashCommandMenu";
-import { beginCreateSessionTiming, setPendingInitialPrompt } from "@/store/chatStore";
+import { setPendingInitialPrompt } from "@/store/chatStore";
+import { markSessionCreated } from "@/store/interactionTelemetry";
 import { appendPromptHistoryEntry } from "@/hooks/usePromptHistory";
 import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
@@ -4045,10 +4046,10 @@ export function NewChatLandingScreen() {
           bundle,
           metadata as Parameters<typeof createBundledSession>[1],
         );
-        // Time create_session for the custom-agent (bundled) path too — otherwise
-        // both sandbox and computer bundled creates emit nothing. Split by the
-        // picked host; the stream pump completes/settles the span.
-        beginCreateSessionTiming(data.id, sandboxSelected ? "sandbox" : "computer");
+        // Register create_session for the custom-agent (bundled) path too —
+        // otherwise both sandbox and computer bundled creates emit nothing. Split
+        // by the picked host; interactionTelemetry completes/settles the span.
+        markSessionCreated(data.id, sandboxSelected ? "sandbox" : "computer");
         // Launch the runner on the selected host. The multipart create
         // only stores DB rows — launchRunner binds + starts the runner.
         if (!sandboxSelected && selectedHostId && workspaceTrimmed) {
@@ -4204,10 +4205,10 @@ export function NewChatLandingScreen() {
           return;
         }
         data = { id: created.id };
-        // Time create_session (created → first AI message), split by host. New
-        // Chat is the only create path that can produce a managed sandbox; the
-        // stream pump completes/settles the span once the session runs.
-        beginCreateSessionTiming(created.id, sandboxSelected ? "sandbox" : "computer");
+        // Register create_session (created → first AI activity), split by host.
+        // New Chat is the only create path that can produce a managed sandbox;
+        // interactionTelemetry completes/settles the span once the session runs.
+        markSessionCreated(created.id, sandboxSelected ? "sandbox" : "computer");
       }
       // Persist the configuration that actually launched. Modal Save updates
       // storage eagerly so an immediate Send cannot observe stale state; this

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -4045,6 +4045,10 @@ export function NewChatLandingScreen() {
           bundle,
           metadata as Parameters<typeof createBundledSession>[1],
         );
+        // Time create_session for the custom-agent (bundled) path too — otherwise
+        // both sandbox and computer bundled creates emit nothing. Split by the
+        // picked host; the stream pump completes/settles the span.
+        beginCreateSessionTiming(data.id, sandboxSelected ? "sandbox" : "computer");
         // Launch the runner on the selected host. The multipart create
         // only stores DB rows — launchRunner binds + starts the runner.
         if (!sandboxSelected && selectedHostId && workspaceTrimmed) {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -101,7 +101,7 @@ import {
   rankedSlashCommandNames,
   SlashCommandMenu,
 } from "@/components/SlashCommandMenu";
-import { setPendingInitialPrompt } from "@/store/chatStore";
+import { beginCreateSessionTiming, setPendingInitialPrompt } from "@/store/chatStore";
 import { appendPromptHistoryEntry } from "@/hooks/usePromptHistory";
 import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
@@ -4200,6 +4200,10 @@ export function NewChatLandingScreen() {
           return;
         }
         data = { id: created.id };
+        // Time create_session (created → first AI message), split by host. New
+        // Chat is the only create path that can produce a managed sandbox; the
+        // stream pump completes/settles the span once the session runs.
+        beginCreateSessionTiming(created.id, sandboxSelected ? "sandbox" : "computer");
       }
       // Persist the configuration that actually launched. Modal Save updates
       // storage eagerly so an immediate Send cannot observe stale state; this

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -70,6 +70,7 @@ import {
   releaseConversation,
 } from "./chatStore";
 import { conversationRegistry } from "./conversationRegistry";
+import { resetInteractionTelemetryForTests } from "./interactionTelemetry";
 import {
   resetStreamSlotManager,
   setStreamSlotManagerForTest,
@@ -11567,6 +11568,9 @@ describe("chatStore — interaction_phase analytics", () => {
   let events: OmnigentAnalyticsEvent[];
 
   beforeEach(() => {
+    // The projector is a module singleton; clear its in-flight tracking so an
+    // un-terminated run from a prior case can't be swept (as "cancelled") here.
+    resetInteractionTelemetryForTests();
     events = [];
     setOmnigentHostConfig({ analytics: (e) => events.push(e) });
   });

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -70,7 +70,7 @@ import {
   releaseConversation,
 } from "./chatStore";
 import { conversationRegistry } from "./conversationRegistry";
-import { resetInteractionTelemetryForTests } from "./interactionTelemetry";
+import { markSessionCreated, resetInteractionTelemetryForTests } from "./interactionTelemetry";
 import {
   resetStreamSlotManager,
   setStreamSlotManagerForTest,
@@ -11714,6 +11714,43 @@ describe("chatStore — interaction_phase analytics", () => {
       name: "shell",
     });
     expect(typeof tools[1]!.durationMs).toBe("number");
+    // No reliable success/failure signal on a tool result — the completion must
+    // carry no status rather than a fabricated one.
+    expect(tools[1]).not.toHaveProperty("status");
+
+    controller.abort();
+  });
+
+  it("completes create_session on the first live activity, not on response.created alone", async () => {
+    markSessionCreated("conv_ip_create", "computer");
+    useChatStore.setState({ conversationId: "conv_ip_create", blocks: [] });
+    const sink = pushableStream();
+    const controller = new AbortController();
+    void pumpStreamEvents("conv_ip_create", sink.stream, controller, setState, getState, immediate);
+
+    sink.push(sse("response.created", { id: "resp_ip_c", status: "in_progress", output: [] }));
+    await tick();
+    // The turn started but produced no assistant output yet — span stays open.
+    expect(phases("create_session_computer").some((e) => e.phase === "complete")).toBe(false);
+
+    sink.push(
+      sse("response.output_item.done", {
+        item: {
+          id: "fc_ip_c",
+          type: "function_call",
+          response_id: "resp_ip_c",
+          call_id: "call_ip_c",
+          name: "shell",
+          arguments: "{}",
+          status: "in_progress",
+        },
+      }),
+    );
+    await tick();
+
+    const create = phases("create_session_computer");
+    expect(create[0]).toMatchObject({ phase: "start" });
+    expect(create.at(-1)).toMatchObject({ phase: "complete", status: "success" });
 
     controller.abort();
   });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -113,14 +113,11 @@ import { supportsEffortControl } from "@/lib/sessionCapabilities";
 import { claudePermissionModeFromSession } from "@/lib/claudePermissionMode";
 import { codexPlanModeFromSession } from "@/lib/codexPlanMode";
 import { getCurrentAuthorId } from "@/lib/identity";
-import { getOmnigentHostConfig, type OmnigentInteractionStatus } from "@/lib/host";
+import { getOmnigentHostConfig } from "@/lib/host";
 // Routing-free emit primitive (not "@/lib/analytics", which pulls in useLocation
 // and would form a routing↔store import cycle).
-import {
-  emitInteractionPhase,
-  startTimedInteraction,
-  type TimedInteraction,
-} from "@/lib/analyticsEmit";
+import { emitInteractionPhase, startTimedInteraction } from "@/lib/analyticsEmit";
+import { markSessionCreated } from "./interactionTelemetry";
 import { getSessionHost } from "@/lib/sessionHost";
 import { isSystemUserContent } from "@/lib/systemMessage";
 import { isNativeWrapper } from "@/lib/nativeCodingAgents";
@@ -2772,11 +2769,11 @@ async function ensureBoundSession(
     // missed). Bind the stream FIRST, then post the first message.
     const session = await createSession(agentId, []);
     sessionId = session.id;
-    // Open the create_session CUJ span (see `beginCreateSessionTiming`); the pump
-    // completes it on the session's first AI message. This path sends no host
-    // params, so the server always makes an external ("computer") session —
-    // managed sandboxes are created by the New Chat dialog, which times itself.
-    beginCreateSessionTiming(sessionId, "computer");
+    // Register the create_session span (see interactionTelemetry). This path
+    // sends no host params, so the server always makes an external ("computer")
+    // session — managed sandboxes are created by the New Chat dialog, which
+    // registers itself.
+    markSessionCreated(sessionId, "computer");
     // Claim the send chain for this id NOW, while it is still private to this
     // call. Everything below publishes it (the store write, the navigate
     // callback, the sidebar invalidation) and awaits network work, so a send
@@ -4194,16 +4191,6 @@ export async function startStreamPump(
     if (get().abortController === controller) {
       set({ abortController: null });
     }
-    // The session's streaming is over (aborted / switched away / gave up).
-    // Reconnects stay inside the loop above, so reaching here is a true terminal.
-    // If a create_session span is still open, its first AI message never arrived —
-    // settle it as a failure so it neither leaks nor is completed later as a stale,
-    // inflated success.
-    const pendingCreate = createSessionPending.get(id);
-    if (pendingCreate) {
-      createSessionPending.delete(id);
-      pendingCreate.fail();
-    }
   }
   /* eslint-enable no-await-in-loop */
 }
@@ -4561,58 +4548,11 @@ function revivePendingElicitationBlock(set: Setter, elicitationId: string): void
   });
 }
 
-// Product-analytics interaction tracking (agent runs, tool calls). START stamps
-// a timestamp keyed by the run/tool id; COMPLETE reads-and-deletes it, so each
-// interaction emits start/complete exactly once (guarding SSE re-delivery on
-// reconnect) and carries a duration. Only the LIVE pump below writes these —
-// history hydration goes through `reduceSync`, which never runs this loop, so
-// reopening an old conversation never re-emits.
-const runStartTimes = new Map<string, number>();
-const toolStartTimes = new Map<string, number>();
-// create_session CUJ: an open interaction per brand-new session, keyed by session
-// id. Opened at create time (see `beginCreateSessionTiming`), completed on that
-// session's FIRST painted assistant content in the pump below ("first AI message"),
-// and settled as a failure on pump exit if that content never arrives. The span is
-// "session created → first AI message", the part that varies by host (bind / sandbox
-// launch / time-to-first-token); the create POST itself is excluded (small and
-// measurable from backend traces).
-const createSessionPending = new Map<string, TimedInteraction>();
-
-/**
- * Open the create_session span for a brand-new session, keyed by `sessionId`.
- * Called from both create paths: the send/landing-composer path (always a
- * `"computer"` external session) and the New Chat dialog (`"sandbox"` when the
- * user picked a managed sandbox, else `"computer"`). Host kind is baked into the
- * interaction kind so the host can segment sandbox vs computer without a queryable
- * sub-dimension. The pump settles it (complete on first content, fail on exit).
- */
-export function beginCreateSessionTiming(
-  sessionId: string,
-  hostKind: "sandbox" | "computer",
-): void {
-  createSessionPending.set(
-    sessionId,
-    startTimedInteraction(
-      hostKind === "sandbox" ? "create_session_sandbox" : "create_session_computer",
-      sessionId,
-    ),
-  );
-}
-
-function mapRunStatus(state: string): OmnigentInteractionStatus {
-  switch (state) {
-    case "completed":
-      return "success";
-    case "failed":
-      return "failure";
-    // "incomplete"/"cancelled" are both a stopped turn from the user's view.
-    case "incomplete":
-    case "cancelled":
-      return "cancelled";
-    default:
-      return "failure";
-  }
-}
+// agent_run / tool_call / create_session telemetry is DERIVED from committed
+// conversation state by the projector in `interactionTelemetry.ts` (subscribed to
+// `conversationRegistry`), not emitted from this pump. Create sites call
+// `markSessionCreated`; the projector owns the rest. `approval` above stays a
+// direct emit — it has no stream lifecycle to derive.
 
 export async function pumpStreamEvents(
   id: string,
@@ -4694,37 +4634,16 @@ export async function pumpStreamEvents(
       if (controller.signal.aborted) return "aborted";
       if (isConversationDisposed(id)) return "switched";
 
-      // First genuine assistant output for a brand-new session ends the
-      // create_session CUJ ("first AI message"). Gate on assistant text/reasoning
-      // specifically — NOT "first painted block", which also covers the pre-
-      // `response_end` `error` block (would log a failed create as success) and a
-      // slash/skill `user_message` echo (would complete on the user's own command).
-      // `id` is this pump's session id; the delete makes it fire once, so later
-      // responses and duplicate chunks on reconnect find nothing.
-      if (block.type === "text_chunk" || block.type === "reasoning_chunk") {
-        const pendingCreate = createSessionPending.get(id);
-        if (pendingCreate) {
-          createSessionPending.delete(id);
-          pendingCreate.complete();
-        }
-      }
-
       if (block.type === "response_start") {
         // New response: force-flush whatever is buffered, then land the
         // marker + lifecycle in one commit. Reset the first-paint latch.
+        // (agent_run / create_session telemetry is derived from this
+        // activeResponse transition by interactionTelemetry.ts, not emitted here.)
         paintedFirstContent = false;
         flush(block, {
           activeResponse: { responseId: block.responseId, state: "streaming", error: null },
           status: "streaming",
         });
-        if (block.responseId && !runStartTimes.has(block.responseId)) {
-          runStartTimes.set(block.responseId, Date.now());
-          emitInteractionPhase({
-            interactionId: block.responseId,
-            interactionKind: "agent_run",
-            phase: "start",
-          });
-        }
         continue;
       }
 
@@ -4866,27 +4785,8 @@ export async function pumpStreamEvents(
           const errorMsg = block.response?.error?.message ?? null;
           finalizeActive(set, block.status as ActiveResponse["state"], errorMsg);
         }
-        const runStart = runStartTimes.get(endedId);
-        if (endedId && runStart !== undefined) {
-          runStartTimes.delete(endedId);
-          emitInteractionPhase({
-            interactionId: endedId,
-            interactionKind: "agent_run",
-            phase: "complete",
-            status:
-              active?.state === "cancelled" ? "cancelled" : mapRunStatus(String(block.status)),
-            durationMs: Date.now() - runStart,
-          });
-        }
-        // A create_session span still open at a response terminal means this
-        // response ended without ever painting content — no "first AI message" —
-        // so settle it as a failure (and clear it so a later turn can't complete a
-        // stale span). The success path already deleted it at first content.
-        const pendingCreate = createSessionPending.get(id);
-        if (pendingCreate) {
-          createSessionPending.delete(id);
-          pendingCreate.fail();
-        }
+        // agent_run complete + create_session settle are derived from the
+        // finalized activeResponse by interactionTelemetry.ts, not emitted here.
         // Turn over: drop any provisional preview never finalized by a
         // committed item (e.g. an interrupt where the partial item lands
         // after this event, or a stream drop). Normal messages already
@@ -4911,35 +4811,8 @@ export async function pumpStreamEvents(
         continue;
       }
 
-      // Tool-call analytics (live only). No reliable success/failure signal on
-      // the result block — tool errors surface as separate error events — so we
-      // report invocation + duration + tool name, not an outcome status.
-      if (block.type === "tool_group") {
-        for (const ex of block.executions) {
-          if (ex.callId && !toolStartTimes.has(ex.callId)) {
-            toolStartTimes.set(ex.callId, Date.now());
-            emitInteractionPhase({
-              interactionId: ex.callId,
-              interactionKind: "tool_call",
-              phase: "start",
-              name: ex.name,
-            });
-          }
-        }
-      } else if (block.type === "tool_result") {
-        const toolStart = toolStartTimes.get(block.callId);
-        if (block.callId && toolStart !== undefined) {
-          toolStartTimes.delete(block.callId);
-          emitInteractionPhase({
-            interactionId: block.callId,
-            interactionKind: "tool_call",
-            phase: "complete",
-            name: block.name,
-            durationMs: Date.now() - toolStart,
-          });
-        }
-      }
-
+      // tool_call telemetry is derived from tool_group / tool_result blocks in
+      // the committed transcript by interactionTelemetry.ts, not emitted here.
       buffer.push(block);
       if (!paintedFirstContent) {
         // First content of the response — paint it immediately so the

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -117,7 +117,12 @@ import { getOmnigentHostConfig } from "@/lib/host";
 // Routing-free emit primitive (not "@/lib/analytics", which pulls in useLocation
 // and would form a routing↔store import cycle).
 import { emitInteractionPhase, startTimedInteraction } from "@/lib/analyticsEmit";
-import { markSessionCreated } from "./interactionTelemetry";
+import {
+  markSessionCreated,
+  onLiveBlock,
+  onResponseEnd,
+  onResponseStart,
+} from "./interactionTelemetry";
 import { getSessionHost } from "@/lib/sessionHost";
 import { isSystemUserContent } from "@/lib/systemMessage";
 import { isNativeWrapper } from "@/lib/nativeCodingAgents";
@@ -4548,11 +4553,11 @@ function revivePendingElicitationBlock(set: Setter, elicitationId: string): void
   });
 }
 
-// agent_run / tool_call / create_session telemetry is DERIVED from committed
-// conversation state by the projector in `interactionTelemetry.ts` (subscribed to
-// `conversationRegistry`), not emitted from this pump. Create sites call
-// `markSessionCreated`; the projector owns the rest. `approval` above stays a
-// direct emit — it has no stream lifecycle to derive.
+// agent_run / tool_call / create_session telemetry is emitted from this pump's
+// live reduce-loop (see `onResponseStart` / `onResponseEnd` / `onLiveBlock` in
+// `interactionTelemetry.ts`) — the one place each stream frame is seen once,
+// live, in order. Create sites call `markSessionCreated`. `approval` above stays
+// a direct emit — it has no stream lifecycle.
 
 export async function pumpStreamEvents(
   id: string,
@@ -4637,9 +4642,10 @@ export async function pumpStreamEvents(
       if (block.type === "response_start") {
         // New response: force-flush whatever is buffered, then land the
         // marker + lifecycle in one commit. Reset the first-paint latch.
-        // (agent_run / create_session telemetry is derived from this
-        // activeResponse transition by interactionTelemetry.ts, not emitted here.)
         paintedFirstContent = false;
+        // agent_run start. This is the live turn edge — a revive reopens the
+        // turn via `set()` and emits no `response_start`, so it never double-opens.
+        onResponseStart(id, block.responseId);
         flush(block, {
           activeResponse: { responseId: block.responseId, state: "streaming", error: null },
           status: "streaming",
@@ -4785,8 +4791,9 @@ export async function pumpStreamEvents(
           const errorMsg = block.response?.error?.message ?? null;
           finalizeActive(set, block.status as ActiveResponse["state"], errorMsg);
         }
-        // agent_run complete + create_session settle are derived from the
-        // finalized activeResponse by interactionTelemetry.ts, not emitted here.
+        // agent_run complete + create_session settle. Read the finalized state so
+        // a `session.interrupted` cancelled (kept above) wins over block.status.
+        onResponseEnd(id, endedId, get().activeResponse?.state ?? block.status);
         // Turn over: drop any provisional preview never finalized by a
         // committed item (e.g. an interrupt where the partial item lands
         // after this event, or a stream drop). Normal messages already
@@ -4811,8 +4818,10 @@ export async function pumpStreamEvents(
         continue;
       }
 
-      // tool_call telemetry is derived from tool_group / tool_result blocks in
-      // the committed transcript by interactionTelemetry.ts, not emitted here.
+      // tool_call boundaries + create_session first-activity, from live blocks.
+      // Only fresh (non-deduped) blocks reach here, so each is observed once;
+      // history hydration takes the `reduceSync` path and never runs this loop.
+      onLiveBlock(id, block);
       buffer.push(block);
       if (!paintedFirstContent) {
         // First content of the response — paint it immediately so the

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -116,7 +116,11 @@ import { getCurrentAuthorId } from "@/lib/identity";
 import { getOmnigentHostConfig, type OmnigentInteractionStatus } from "@/lib/host";
 // Routing-free emit primitive (not "@/lib/analytics", which pulls in useLocation
 // and would form a routing↔store import cycle).
-import { emitInteractionPhase, startTimedInteraction } from "@/lib/analyticsEmit";
+import {
+  emitInteractionPhase,
+  startTimedInteraction,
+  type TimedInteraction,
+} from "@/lib/analyticsEmit";
 import { getSessionHost } from "@/lib/sessionHost";
 import { isSystemUserContent } from "@/lib/systemMessage";
 import { isNativeWrapper } from "@/lib/nativeCodingAgents";
@@ -2766,16 +2770,20 @@ async function ensureBoundSession(
     // initial_items dispatch synchronously inside create_session,
     // before we can subscribe to /stream, so early events can be
     // missed). Bind the stream FIRST, then post the first message.
-    const createInteraction = startTimedInteraction("create_session");
-    let session: Session;
-    try {
-      session = await createSession(agentId, []);
-      createInteraction.complete();
-    } catch (error) {
-      createInteraction.fail();
-      throw error;
-    }
+    const session = await createSession(agentId, []);
     sessionId = session.id;
+    // Open the create_session CUJ span now (session just created) and complete it
+    // on this session's first `response_start` (see the pump below): the span is
+    // "created → first AI message". Host kind is baked into the interaction kind so
+    // the host names/segments sandbox vs computer without a queryable sub-dimension.
+    const createHostKind = session.sandboxStatus != null ? "sandbox" : "computer";
+    createSessionPending.set(
+      sessionId,
+      startTimedInteraction(
+        createHostKind === "sandbox" ? "create_session_sandbox" : "create_session_computer",
+        sessionId,
+      ),
+    );
     // Claim the send chain for this id NOW, while it is still private to this
     // call. Everything below publishes it (the store write, the navigate
     // callback, the sidebar invalidation) and awaits network work, so a send
@@ -4558,6 +4566,13 @@ function revivePendingElicitationBlock(set: Setter, elicitationId: string): void
 // reopening an old conversation never re-emits.
 const runStartTimes = new Map<string, number>();
 const toolStartTimes = new Map<string, number>();
+// create_session CUJ: an open interaction per brand-new session, keyed by
+// session id. Opened right after the session is created (in `ensureBoundSession`)
+// and completed on that session's FIRST `response_start` below — i.e. the span is
+// "session created → first AI message", the part that varies by host (bind /
+// sandbox launch / time-to-first-token). The create POST itself is excluded (it's
+// small and measurable from backend traces).
+const createSessionPending = new Map<string, TimedInteraction>();
 
 function mapRunStatus(state: string): OmnigentInteractionStatus {
   switch (state) {
@@ -4669,6 +4684,14 @@ export async function pumpStreamEvents(
             interactionKind: "agent_run",
             phase: "start",
           });
+        }
+        // First response for a brand-new session = the create_session CUJ's end
+        // ("first AI message"). `id` is this pump's session id; the map only holds
+        // freshly-created sessions, and the delete makes this fire once.
+        const pendingCreate = createSessionPending.get(id);
+        if (pendingCreate) {
+          createSessionPending.delete(id);
+          pendingCreate.complete();
         }
         continue;
       }

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -4694,6 +4694,21 @@ export async function pumpStreamEvents(
       if (controller.signal.aborted) return "aborted";
       if (isConversationDisposed(id)) return "switched";
 
+      // First genuine assistant output for a brand-new session ends the
+      // create_session CUJ ("first AI message"). Gate on assistant text/reasoning
+      // specifically — NOT "first painted block", which also covers the pre-
+      // `response_end` `error` block (would log a failed create as success) and a
+      // slash/skill `user_message` echo (would complete on the user's own command).
+      // `id` is this pump's session id; the delete makes it fire once, so later
+      // responses and duplicate chunks on reconnect find nothing.
+      if (block.type === "text_chunk" || block.type === "reasoning_chunk") {
+        const pendingCreate = createSessionPending.get(id);
+        if (pendingCreate) {
+          createSessionPending.delete(id);
+          pendingCreate.complete();
+        }
+      }
+
       if (block.type === "response_start") {
         // New response: force-flush whatever is buffered, then land the
         // marker + lifecycle in one commit. Reset the first-paint latch.
@@ -4931,16 +4946,6 @@ export async function pumpStreamEvents(
         // user sees the first token without waiting a frame.
         paintedFirstContent = true;
         flush();
-        // First painted content of a brand-new session = the "first AI message"
-        // that ends the create_session CUJ (`response_start` above is only run
-        // acknowledgement, before any output). `id` is this pump's session id; the
-        // map holds only freshly-created sessions and the delete makes this fire
-        // once — later responses find nothing.
-        const pendingCreate = createSessionPending.get(id);
-        if (pendingCreate) {
-          createSessionPending.delete(id);
-          pendingCreate.complete();
-        }
       } else {
         scheduler.schedule(() => flush());
       }

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -2772,18 +2772,11 @@ async function ensureBoundSession(
     // missed). Bind the stream FIRST, then post the first message.
     const session = await createSession(agentId, []);
     sessionId = session.id;
-    // Open the create_session CUJ span now (session just created) and complete it
-    // on this session's first `response_start` (see the pump below): the span is
-    // "created → first AI message". Host kind is baked into the interaction kind so
-    // the host names/segments sandbox vs computer without a queryable sub-dimension.
-    const createHostKind = session.sandboxStatus != null ? "sandbox" : "computer";
-    createSessionPending.set(
-      sessionId,
-      startTimedInteraction(
-        createHostKind === "sandbox" ? "create_session_sandbox" : "create_session_computer",
-        sessionId,
-      ),
-    );
+    // Open the create_session CUJ span (see `beginCreateSessionTiming`); the pump
+    // completes it on the session's first AI message. This path sends no host
+    // params, so the server always makes an external ("computer") session —
+    // managed sandboxes are created by the New Chat dialog, which times itself.
+    beginCreateSessionTiming(sessionId, "computer");
     // Claim the send chain for this id NOW, while it is still private to this
     // call. Everything below publishes it (the store write, the navigate
     // callback, the sidebar invalidation) and awaits network work, so a send
@@ -4201,6 +4194,16 @@ export async function startStreamPump(
     if (get().abortController === controller) {
       set({ abortController: null });
     }
+    // The session's streaming is over (aborted / switched away / gave up).
+    // Reconnects stay inside the loop above, so reaching here is a true terminal.
+    // If a create_session span is still open, its first AI message never arrived —
+    // settle it as a failure so it neither leaks nor is completed later as a stale,
+    // inflated success.
+    const pendingCreate = createSessionPending.get(id);
+    if (pendingCreate) {
+      createSessionPending.delete(id);
+      pendingCreate.fail();
+    }
   }
   /* eslint-enable no-await-in-loop */
 }
@@ -4566,13 +4569,35 @@ function revivePendingElicitationBlock(set: Setter, elicitationId: string): void
 // reopening an old conversation never re-emits.
 const runStartTimes = new Map<string, number>();
 const toolStartTimes = new Map<string, number>();
-// create_session CUJ: an open interaction per brand-new session, keyed by
-// session id. Opened right after the session is created (in `ensureBoundSession`)
-// and completed on that session's FIRST `response_start` below — i.e. the span is
-// "session created → first AI message", the part that varies by host (bind /
-// sandbox launch / time-to-first-token). The create POST itself is excluded (it's
-// small and measurable from backend traces).
+// create_session CUJ: an open interaction per brand-new session, keyed by session
+// id. Opened at create time (see `beginCreateSessionTiming`), completed on that
+// session's FIRST painted assistant content in the pump below ("first AI message"),
+// and settled as a failure on pump exit if that content never arrives. The span is
+// "session created → first AI message", the part that varies by host (bind / sandbox
+// launch / time-to-first-token); the create POST itself is excluded (small and
+// measurable from backend traces).
 const createSessionPending = new Map<string, TimedInteraction>();
+
+/**
+ * Open the create_session span for a brand-new session, keyed by `sessionId`.
+ * Called from both create paths: the send/landing-composer path (always a
+ * `"computer"` external session) and the New Chat dialog (`"sandbox"` when the
+ * user picked a managed sandbox, else `"computer"`). Host kind is baked into the
+ * interaction kind so the host can segment sandbox vs computer without a queryable
+ * sub-dimension. The pump settles it (complete on first content, fail on exit).
+ */
+export function beginCreateSessionTiming(
+  sessionId: string,
+  hostKind: "sandbox" | "computer",
+): void {
+  createSessionPending.set(
+    sessionId,
+    startTimedInteraction(
+      hostKind === "sandbox" ? "create_session_sandbox" : "create_session_computer",
+      sessionId,
+    ),
+  );
+}
 
 function mapRunStatus(state: string): OmnigentInteractionStatus {
   switch (state) {
@@ -4684,14 +4709,6 @@ export async function pumpStreamEvents(
             interactionKind: "agent_run",
             phase: "start",
           });
-        }
-        // First response for a brand-new session = the create_session CUJ's end
-        // ("first AI message"). `id` is this pump's session id; the map only holds
-        // freshly-created sessions, and the delete makes this fire once.
-        const pendingCreate = createSessionPending.get(id);
-        if (pendingCreate) {
-          createSessionPending.delete(id);
-          pendingCreate.complete();
         }
         continue;
       }
@@ -4846,6 +4863,15 @@ export async function pumpStreamEvents(
             durationMs: Date.now() - runStart,
           });
         }
+        // A create_session span still open at a response terminal means this
+        // response ended without ever painting content — no "first AI message" —
+        // so settle it as a failure (and clear it so a later turn can't complete a
+        // stale span). The success path already deleted it at first content.
+        const pendingCreate = createSessionPending.get(id);
+        if (pendingCreate) {
+          createSessionPending.delete(id);
+          pendingCreate.fail();
+        }
         // Turn over: drop any provisional preview never finalized by a
         // committed item (e.g. an interrupt where the partial item lands
         // after this event, or a stream drop). Normal messages already
@@ -4905,6 +4931,16 @@ export async function pumpStreamEvents(
         // user sees the first token without waiting a frame.
         paintedFirstContent = true;
         flush();
+        // First painted content of a brand-new session = the "first AI message"
+        // that ends the create_session CUJ (`response_start` above is only run
+        // acknowledgement, before any output). `id` is this pump's session id; the
+        // map holds only freshly-created sessions and the delete makes this fire
+        // once — later responses find nothing.
+        const pendingCreate = createSessionPending.get(id);
+        if (pendingCreate) {
+          createSessionPending.delete(id);
+          pendingCreate.complete();
+        }
       } else {
         scheduler.schedule(() => flush());
       }

--- a/web/src/store/conversationRegistry.ts
+++ b/web/src/store/conversationRegistry.ts
@@ -88,6 +88,9 @@ export type ConversationGetter = () => ConversationState;
 /** Notified whenever an entry's state changes, so the root store can mirror it. */
 type ChangeListener = (id: string) => void;
 
+/** Notified when an entry is disposed (released, evicted, or cleared). */
+type DisposeListener = (id: string) => void;
+
 /**
  * One conversation's live state and stream.
  *
@@ -115,6 +118,7 @@ export interface ConversationEntry {
 export class ConversationRegistry {
   private readonly entries = new Map<string, ConversationEntry>();
   private readonly listeners = new Set<ChangeListener>();
+  private readonly disposeListeners = new Set<DisposeListener>();
   /** Conversation currently on screen; exempt from eviction. */
   private activeId: string | null = null;
 
@@ -127,6 +131,17 @@ export class ConversationRegistry {
   subscribe(listener: ChangeListener): () => void {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
+  }
+
+  /**
+   * Subscribe to entry disposal (release / eviction / clear). Disposal is not a
+   * state change and never reaches `subscribe`, so anything that must run when a
+   * conversation goes away — settling its live telemetry spans — hooks here.
+   * Returns an unsubscribe function.
+   */
+  subscribeDisposed(listener: DisposeListener): () => void {
+    this.disposeListeners.add(listener);
+    return () => this.disposeListeners.delete(listener);
   }
 
   /** The entry for `id`, or `undefined` when not live. */
@@ -277,6 +292,7 @@ export class ConversationRegistry {
         entry.disposed = true;
         // Ends the reconnect loop and cancels the in-flight fetch.
         state.abortController?.abort();
+        for (const listener of this.disposeListeners) listener(id);
       },
     };
     return entry;

--- a/web/src/store/interactionTelemetry.test.ts
+++ b/web/src/store/interactionTelemetry.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setOmnigentHostConfig } from "@/lib/host";
+import type { AnyBlock } from "@/lib/blocks";
+
+import { conversationRegistry } from "./conversationRegistry";
+import { markSessionCreated, resetInteractionTelemetryForTests } from "./interactionTelemetry";
+
+// The projector subscribes to `conversationRegistry` on import (above) and derives
+// interaction-phase events from committed conversation state. We drive real
+// registry entries and assert what it emits to the host analytics sink.
+
+const analytics = vi.fn();
+
+beforeEach(() => {
+  resetInteractionTelemetryForTests();
+  analytics.mockClear();
+  setOmnigentHostConfig({ analytics });
+});
+
+afterEach(() => {
+  conversationRegistry.clear();
+  setOmnigentHostConfig({});
+});
+
+// Minimal block fixtures — only the fields the projector reads. Cast once here so
+// the tests stay readable; the projector only ever inspects `type` (+ tool ids).
+function ctx() {
+  return { agent: null, depth: 0, turn: 0, timestamp: 0, responseId: "resp", itemId: null };
+}
+const textChunk = { type: "text_chunk", ctx: ctx(), text: "hi" };
+const errorBlock = { type: "error", ctx: ctx(), message: "boom", source: "llm", code: "x" };
+const userEcho = { type: "user_message", ctx: ctx(), content: [] };
+function toolGroup(callId: string, name = "shell") {
+  return {
+    type: "tool_group",
+    ctx: ctx(),
+    iteration: 0,
+    executions: [
+      { name, arguments: {}, argsSummary: "", callId, agentName: "a", source: "client" },
+    ],
+  };
+}
+function toolResult(callId: string, name = "shell") {
+  return { type: "tool_result", ctx: ctx(), name, callId, agentName: "a", output: "ok" };
+}
+function blocks(...bs: unknown[]): AnyBlock[] {
+  return bs as AnyBlock[];
+}
+
+function set(id: string, patch: Record<string, unknown>) {
+  conversationRegistry.acquire(id).setState(patch);
+}
+
+/** interaction_phase events emitted for a given interactionId, in order. */
+function phasesFor(interactionId: string) {
+  return analytics.mock.calls
+    .map(
+      (c) =>
+        c[0] as {
+          type: string;
+          interactionId: string;
+          phase: string;
+          status?: string;
+          interactionKind: string;
+        },
+    )
+    .filter((e) => e.type === "interaction_phase" && e.interactionId === interactionId);
+}
+
+describe("interaction telemetry projector", () => {
+  describe("create_session", () => {
+    it("completes on the first assistant text (first AI message)", () => {
+      markSessionCreated("s1", "sandbox");
+      set("s1", { blocks: blocks(userEcho, textChunk) });
+
+      const p = phasesFor("s1");
+      expect(p[0]).toMatchObject({ interactionKind: "create_session_sandbox", phase: "start" });
+      expect(p.at(-1)).toMatchObject({ phase: "complete", status: "success" });
+    });
+
+    it("completes on a tool call as first AI activity", () => {
+      markSessionCreated("s2", "computer");
+      set("s2", { blocks: blocks(toolGroup("c1")) });
+
+      expect(phasesFor("s2").at(-1)).toMatchObject({
+        interactionKind: "create_session_computer",
+        phase: "complete",
+        status: "success",
+      });
+    });
+
+    it("does NOT complete on an error block, and fails when the first turn ends without activity", () => {
+      markSessionCreated("s3", "sandbox");
+      // error block precedes the terminal — must not be read as a success.
+      set("s3", {
+        blocks: blocks(errorBlock),
+        activeResponse: { responseId: "r", state: "failed", error: "e" },
+      });
+
+      const p = phasesFor("s3");
+      expect(p.at(-1)).toMatchObject({ phase: "complete", status: "failure" });
+      expect(p.some((e) => e.phase === "complete" && e.status === "success")).toBe(false);
+    });
+
+    it("does NOT complete on the user_message echo of a slash/skill prompt", () => {
+      markSessionCreated("s4", "computer");
+      set("s4", { blocks: blocks(userEcho) });
+
+      expect(phasesFor("s4").some((e) => e.phase === "complete")).toBe(false);
+    });
+
+    it("bounds the span to the first turn: a later turn's activity cannot complete a stale span", () => {
+      markSessionCreated("s5", "sandbox");
+      // First response streams then terminates with no activity → fail.
+      set("s5", { activeResponse: { responseId: "r1", state: "streaming", error: null } });
+      set("s5", { activeResponse: { responseId: "r1", state: "failed", error: "e" } });
+      // A second turn produces content — must NOT flip the settled span to success.
+      set("s5", {
+        blocks: blocks(textChunk),
+        activeResponse: { responseId: "r2", state: "streaming", error: null },
+      });
+
+      const p = phasesFor("s5");
+      expect(p.filter((e) => e.phase === "complete")).toHaveLength(1);
+      expect(p.at(-1)).toMatchObject({ phase: "complete", status: "failure" });
+    });
+  });
+
+  describe("agent_run", () => {
+    it("starts on streaming and completes with the mapped outcome", () => {
+      set("a1", { activeResponse: { responseId: "run1", state: "streaming", error: null } });
+      set("a1", { activeResponse: { responseId: "run1", state: "completed", error: null } });
+
+      const p = phasesFor("run1");
+      expect(p[0]).toMatchObject({ interactionKind: "agent_run", phase: "start" });
+      expect(p.at(-1)).toMatchObject({ phase: "complete", status: "success" });
+    });
+
+    it("maps a failed response to a failure outcome", () => {
+      set("a2", { activeResponse: { responseId: "run2", state: "streaming", error: null } });
+      set("a2", { activeResponse: { responseId: "run2", state: "failed", error: "e" } });
+
+      expect(phasesFor("run2").at(-1)).toMatchObject({ phase: "complete", status: "failure" });
+    });
+  });
+
+  describe("tool_call", () => {
+    it("starts on tool_group and completes on the matching tool_result", () => {
+      set("t1", { blocks: blocks(toolGroup("call_9", "web_search")) });
+      set("t1", {
+        blocks: blocks(toolGroup("call_9", "web_search"), toolResult("call_9", "web_search")),
+      });
+
+      const p = phasesFor("call_9");
+      expect(p[0]).toMatchObject({
+        interactionKind: "tool_call",
+        phase: "start",
+        name: "web_search",
+      });
+      expect(p.at(-1)).toMatchObject({ phase: "complete" });
+    });
+  });
+});

--- a/web/src/store/interactionTelemetry.test.ts
+++ b/web/src/store/interactionTelemetry.test.ts
@@ -4,11 +4,17 @@ import { setOmnigentHostConfig } from "@/lib/host";
 import type { AnyBlock } from "@/lib/blocks";
 
 import { conversationRegistry } from "./conversationRegistry";
-import { markSessionCreated, resetInteractionTelemetryForTests } from "./interactionTelemetry";
+import {
+  markSessionCreated,
+  onLiveBlock,
+  onResponseEnd,
+  onResponseStart,
+  resetInteractionTelemetryForTests,
+} from "./interactionTelemetry";
 
-// The projector subscribes to `conversationRegistry` on import (above) and derives
-// interaction-phase events from committed conversation state. We drive real
-// registry entries and assert what it emits to the host analytics sink.
+// The telemetry functions are called by the pump's live reduce-loop. Here we
+// call them directly and assert what they emit to the host analytics sink —
+// covering the paths the committed-state projector kept mismeasuring.
 
 const analytics = vi.fn();
 
@@ -23,68 +29,54 @@ afterEach(() => {
   setOmnigentHostConfig({});
 });
 
-// Minimal block fixtures — only the fields the projector reads. Cast once here so
-// the tests stay readable; the projector only ever inspects `type` (+ tool ids).
+// Minimal block fixtures — only the fields the functions read. `block` widens
+// through `unknown` so the literals aren't excess-property-checked against the
+// full block interfaces.
 function ctx() {
   return { agent: null, depth: 0, turn: 0, timestamp: 0, responseId: "resp", itemId: null };
 }
-const textChunk = { type: "text_chunk", ctx: ctx(), text: "hi" };
-// The native-harness path (common new-chat case) commits assistant text as
-// `text_done`, never `text_chunk` — the block the real first-activity check sees.
-const textDone = { type: "text_done", ctx: ctx(), fullText: "hi", hasCodeBlocks: false };
-const errorBlock = { type: "error", ctx: ctx(), message: "boom", source: "llm", code: "x" };
-const userEcho = { type: "user_message", ctx: ctx(), content: [] };
-function toolGroup(callId: string, name = "shell") {
-  return {
+function block(b: unknown): AnyBlock {
+  return b as AnyBlock;
+}
+const textDone = block({ type: "text_done", ctx: ctx(), fullText: "hi", hasCodeBlocks: false });
+const errorBlock = block({ type: "error", ctx: ctx(), message: "boom", source: "llm", code: "x" });
+const userEcho = block({ type: "user_message", ctx: ctx(), content: [] });
+function toolGroup(callId: string, name = "shell"): AnyBlock {
+  return block({
     type: "tool_group",
     ctx: ctx(),
     iteration: 0,
     executions: [
       { name, arguments: {}, argsSummary: "", callId, agentName: "a", source: "client" },
     ],
-  };
+  });
 }
-function toolResult(callId: string, name = "shell") {
-  return { type: "tool_result", ctx: ctx(), name, callId, agentName: "a", output: "ok" };
-}
-function blocks(...bs: unknown[]): AnyBlock[] {
-  return bs as AnyBlock[];
-}
-
-function set(id: string, patch: Record<string, unknown>) {
-  conversationRegistry.acquire(id).setState(patch);
+function toolResult(callId: string, name = "shell"): AnyBlock {
+  return block({ type: "tool_result", ctx: ctx(), name, callId, agentName: "a", output: "ok" });
 }
 
 /** interaction_phase events emitted for a given interactionId, in order. */
 function phasesFor(interactionId: string) {
   return analytics.mock.calls
-    .map(
-      (c) =>
-        c[0] as {
-          type: string;
-          interactionId: string;
-          phase: string;
-          status?: string;
-          interactionKind: string;
-        },
-    )
+    .map((c) => c[0] as Record<string, unknown>)
     .filter((e) => e.type === "interaction_phase" && e.interactionId === interactionId);
 }
 
-describe("interaction telemetry projector", () => {
+describe("interaction telemetry", () => {
   describe("create_session", () => {
-    it("completes on the first assistant text — committed as text_done on the native path", () => {
+    it("completes on the first assistant text (text_done on the native path)", () => {
       markSessionCreated("s1", "sandbox");
-      set("s1", { blocks: blocks(userEcho, textDone) });
+      onLiveBlock("s1", userEcho);
+      onLiveBlock("s1", textDone);
 
       const p = phasesFor("s1");
       expect(p[0]).toMatchObject({ interactionKind: "create_session_sandbox", phase: "start" });
       expect(p.at(-1)).toMatchObject({ phase: "complete", status: "success" });
     });
 
-    it("completes on a tool call as first AI activity", () => {
+    it("completes on a tool call as first activity", () => {
       markSessionCreated("s2", "computer");
-      set("s2", { blocks: blocks(toolGroup("c1")) });
+      onLiveBlock("s2", toolGroup("c1"));
 
       expect(phasesFor("s2").at(-1)).toMatchObject({
         interactionKind: "create_session_computer",
@@ -93,67 +85,79 @@ describe("interaction telemetry projector", () => {
       });
     });
 
-    it("does NOT complete on an error block, and fails when the first turn ends without activity", () => {
+    it("does NOT complete on a user echo or an error block", () => {
       markSessionCreated("s3", "sandbox");
-      // error block precedes the terminal — must not be read as a success.
-      set("s3", {
-        blocks: blocks(errorBlock),
-        activeResponse: { responseId: "r", state: "failed", error: "e" },
-      });
+      onLiveBlock("s3", userEcho);
+      onLiveBlock("s3", errorBlock);
 
-      const p = phasesFor("s3");
-      expect(p.at(-1)).toMatchObject({ phase: "complete", status: "failure" });
-      expect(p.some((e) => e.phase === "complete" && e.status === "success")).toBe(false);
+      expect(phasesFor("s3").some((e) => e.phase === "complete")).toBe(false);
     });
 
-    it("does NOT complete on the user_message echo of a slash/skill prompt", () => {
-      markSessionCreated("s4", "computer");
-      set("s4", { blocks: blocks(userEcho) });
+    it("fails on a genuine failure terminal with no activity", () => {
+      markSessionCreated("s4", "sandbox");
+      onResponseEnd("s4", "r1", "failed");
 
-      expect(phasesFor("s4").some((e) => e.phase === "complete")).toBe(false);
+      expect(phasesFor("s4").at(-1)).toMatchObject({ phase: "complete", status: "failure" });
     });
 
-    it("bounds the span to the first turn: a later turn's activity cannot complete a stale span", () => {
-      markSessionCreated("s5", "sandbox");
-      // First response streams then terminates with no activity → fail.
-      set("s5", { activeResponse: { responseId: "r1", state: "streaming", error: null } });
-      set("s5", { activeResponse: { responseId: "r1", state: "failed", error: "e" } });
-      // A second turn produces content — must NOT flip the settled span to success.
-      set("s5", {
-        blocks: blocks(textChunk),
-        activeResponse: { responseId: "r2", state: "streaming", error: null },
-      });
+    it("does NOT fail on a stray `completed` terminal that revive can reopen (B2)", () => {
+      markSessionCreated("s5", "computer");
+      onResponseStart("s5", "r1");
+      onResponseEnd("s5", "r1", "completed"); // stray idle edge — no activity yet
+      // reviveStrayCompletedResponse reopens the turn (no block); late content lands:
+      onLiveBlock("s5", textDone);
 
-      const p = phasesFor("s5");
-      expect(p.filter((e) => e.phase === "complete")).toHaveLength(1);
-      expect(p.at(-1)).toMatchObject({ phase: "complete", status: "failure" });
+      const completes = phasesFor("s5").filter((e) => e.phase === "complete");
+      expect(completes).toHaveLength(1);
+      expect(completes[0]).toMatchObject({ phase: "complete", status: "success" });
     });
   });
 
   describe("agent_run", () => {
-    it("starts on streaming and completes with the mapped outcome", () => {
-      set("a1", { activeResponse: { responseId: "run1", state: "streaming", error: null } });
-      set("a1", { activeResponse: { responseId: "run1", state: "completed", error: null } });
+    it("starts on response_start and completes with the mapped outcome", () => {
+      onResponseStart("a1", "run1");
+      onResponseEnd("a1", "run1", "completed");
 
       const p = phasesFor("run1");
       expect(p[0]).toMatchObject({ interactionKind: "agent_run", phase: "start" });
       expect(p.at(-1)).toMatchObject({ phase: "complete", status: "success" });
     });
 
-    it("maps a failed response to a failure outcome", () => {
-      set("a2", { activeResponse: { responseId: "run2", state: "streaming", error: null } });
-      set("a2", { activeResponse: { responseId: "run2", state: "failed", error: "e" } });
+    it("maps failed / incomplete terminals", () => {
+      onResponseStart("a2", "run2");
+      onResponseEnd("a2", "run2", "failed");
+      onResponseStart("a3", "run3");
+      onResponseEnd("a3", "run3", "incomplete");
 
-      expect(phasesFor("run2").at(-1)).toMatchObject({ phase: "complete", status: "failure" });
+      expect(phasesFor("run2").at(-1)).toMatchObject({ status: "failure" });
+      expect(phasesFor("run3").at(-1)).toMatchObject({ status: "cancelled" });
+    });
+
+    it("does not double-start on a re-delivered response.created", () => {
+      onResponseStart("a4", "run4");
+      onResponseStart("a4", "run4"); // reconnect re-delivery
+      onResponseEnd("a4", "run4", "completed");
+
+      const starts = phasesFor("run4").filter((e) => e.phase === "start");
+      expect(starts).toHaveLength(1);
+    });
+
+    it("emits exactly one span across a revive (stray completed → reopen → real end) (B3)", () => {
+      onResponseStart("a5", "run5");
+      onResponseEnd("a5", "run5", "completed"); // stray terminal
+      // revive emits no response_start; the real terminal arrives later for the same id:
+      onResponseEnd("a5", "run5", "completed");
+
+      const p = phasesFor("run5");
+      expect(p.filter((e) => e.phase === "start")).toHaveLength(1);
+      expect(p.filter((e) => e.phase === "complete")).toHaveLength(1);
     });
   });
 
   describe("tool_call", () => {
-    it("starts on tool_group and completes on the matching tool_result", () => {
-      set("t1", { blocks: blocks(toolGroup("call_9", "web_search")) });
-      set("t1", {
-        blocks: blocks(toolGroup("call_9", "web_search"), toolResult("call_9", "web_search")),
-      });
+    it("starts on tool_group and completes on the result — with NO status (B4)", () => {
+      onLiveBlock("t1", toolGroup("call_9", "web_search"));
+      onLiveBlock("t1", toolResult("call_9", "web_search"));
 
       const p = phasesFor("call_9");
       expect(p[0]).toMatchObject({
@@ -161,15 +165,31 @@ describe("interaction telemetry projector", () => {
         phase: "start",
         name: "web_search",
       });
-      expect(p.at(-1)).toMatchObject({ phase: "complete" });
+      const complete = p.at(-1)!;
+      expect(complete.phase).toBe("complete");
+      expect(complete).not.toHaveProperty("status");
     });
 
-    it("does NOT re-emit for a tool call hydrated from history", () => {
-      // Reopening a past conversation lands the group + result together in one
-      // snapshot scan; a call already complete on first sight was never live.
-      set("t2", { blocks: blocks(toolGroup("hist_1", "shell"), toolResult("hist_1", "shell")) });
+    it("closes an unresulted tool (no status) when its run ends", () => {
+      onResponseStart("t2", "run_t2");
+      onLiveBlock("t2", toolGroup("call_x"));
+      onResponseEnd("t2", "run_t2", "failed");
 
-      expect(phasesFor("hist_1")).toHaveLength(0);
+      const complete = phasesFor("call_x").find((e) => e.phase === "complete");
+      expect(complete).toBeDefined();
+      expect(complete).not.toHaveProperty("status");
+    });
+  });
+
+  describe("disposal (B1)", () => {
+    it("settles open spans when the conversation is disposed", () => {
+      markSessionCreated("d1", "sandbox");
+      onResponseStart("d1", "run_d1");
+      conversationRegistry.acquire("d1");
+      conversationRegistry.release("d1"); // fires the dispose notification
+
+      expect(phasesFor("d1").at(-1)).toMatchObject({ phase: "complete", status: "cancelled" });
+      expect(phasesFor("run_d1").at(-1)).toMatchObject({ phase: "complete", status: "cancelled" });
     });
   });
 });

--- a/web/src/store/interactionTelemetry.test.ts
+++ b/web/src/store/interactionTelemetry.test.ts
@@ -29,6 +29,9 @@ function ctx() {
   return { agent: null, depth: 0, turn: 0, timestamp: 0, responseId: "resp", itemId: null };
 }
 const textChunk = { type: "text_chunk", ctx: ctx(), text: "hi" };
+// The native-harness path (common new-chat case) commits assistant text as
+// `text_done`, never `text_chunk` — the block the real first-activity check sees.
+const textDone = { type: "text_done", ctx: ctx(), fullText: "hi", hasCodeBlocks: false };
 const errorBlock = { type: "error", ctx: ctx(), message: "boom", source: "llm", code: "x" };
 const userEcho = { type: "user_message", ctx: ctx(), content: [] };
 function toolGroup(callId: string, name = "shell") {
@@ -70,9 +73,9 @@ function phasesFor(interactionId: string) {
 
 describe("interaction telemetry projector", () => {
   describe("create_session", () => {
-    it("completes on the first assistant text (first AI message)", () => {
+    it("completes on the first assistant text — committed as text_done on the native path", () => {
       markSessionCreated("s1", "sandbox");
-      set("s1", { blocks: blocks(userEcho, textChunk) });
+      set("s1", { blocks: blocks(userEcho, textDone) });
 
       const p = phasesFor("s1");
       expect(p[0]).toMatchObject({ interactionKind: "create_session_sandbox", phase: "start" });
@@ -159,6 +162,14 @@ describe("interaction telemetry projector", () => {
         name: "web_search",
       });
       expect(p.at(-1)).toMatchObject({ phase: "complete" });
+    });
+
+    it("does NOT re-emit for a tool call hydrated from history", () => {
+      // Reopening a past conversation lands the group + result together in one
+      // snapshot scan; a call already complete on first sight was never live.
+      set("t2", { blocks: blocks(toolGroup("hist_1", "shell"), toolResult("hist_1", "shell")) });
+
+      expect(phasesFor("hist_1")).toHaveLength(0);
     });
   });
 });

--- a/web/src/store/interactionTelemetry.ts
+++ b/web/src/store/interactionTelemetry.ts
@@ -1,0 +1,200 @@
+// Client interaction telemetry, DERIVED from the store's authoritative,
+// reconnect-reconciled per-conversation state — not hooked onto raw SSE blocks.
+//
+// One subscriber owns the whole lifecycle for every live conversation:
+//   - agent_run      — from `activeResponse.state` (streaming → terminal).
+//   - tool_call      — from `tool_group` / `tool_result` blocks in the transcript.
+//   - create_session — a brand-new session's "created → first AI activity",
+//     registered by the create sites via `markSessionCreated` (they alone know
+//     the host kind); completed on first assistant activity, failed if the first
+//     turn ends without any.
+//
+// Why derive from state instead of hooking blocks: `blocks` and `activeResponse`
+// are the committed, deduplicated, snapshot-reconciled truth the UI renders, so
+// they survive reconnects and dropped stream frames (a lost `response_start` /
+// `response_end` / tool block does not). And it keeps every emit in ONE testable
+// place rather than scattered through the pump, where each un-handled block type
+// (error, user-echo, …) was a fresh mis-attribution bug. `approval` stays a direct
+// emit on the user action (chatStore.submitApproval) — it has no stream lifecycle.
+
+import { startTimedInteraction, type TimedInteraction } from "@/lib/analyticsEmit";
+import { conversationRegistry } from "./conversationRegistry";
+
+type HostKind = "sandbox" | "computer";
+
+interface ConvTracking {
+  create?: { handle: TimedInteraction; settled: boolean };
+  run?: { responseId: string; handle: TimedInteraction };
+  tools: Map<string, TimedInteraction>;
+  toolSeen: Set<string>;
+  toolDone: Set<string>;
+  // Ref of the last-scanned blocks array, so a state change that didn't touch
+  // the transcript (e.g. an activeResponse-only update) skips the block scan.
+  lastBlocks?: unknown;
+}
+
+const tracked = new Map<string, ConvTracking>();
+
+/**
+ * Drop all in-flight tracking without settling. Test-only: the projector is a
+ * module singleton, so tests that drive shared state must reset it between cases
+ * or one case's open spans leak into the next.
+ */
+export function resetInteractionTelemetryForTests(): void {
+  tracked.clear();
+}
+
+function trackingFor(id: string): ConvTracking {
+  let t = tracked.get(id);
+  if (t === undefined) {
+    t = { tools: new Map(), toolSeen: new Set(), toolDone: new Set() };
+    tracked.set(id, t);
+  }
+  return t;
+}
+
+/**
+ * Register a brand-new session for create_session timing. Called by the create
+ * sites (the send/landing path and the New Chat dialog) — the only places that
+ * know the host kind. Opens the span now; the subscriber completes it on the
+ * session's first AI activity, or fails it if the first turn ends without any.
+ * Idempotent per session id.
+ */
+export function markSessionCreated(sessionId: string, hostKind: HostKind): void {
+  const t = trackingFor(sessionId);
+  if (t.create !== undefined) return;
+  t.create = {
+    handle: startTimedInteraction(
+      hostKind === "sandbox" ? "create_session_sandbox" : "create_session_computer",
+      sessionId,
+    ),
+    settled: false,
+  };
+}
+
+const TERMINAL_STATES = new Set(["completed", "failed", "cancelled", "incomplete"]);
+
+function runStatus(state: string): "success" | "failure" | "cancelled" {
+  if (state === "completed") return "success";
+  if (state === "failed") return "failure";
+  return "cancelled"; // cancelled / incomplete (interrupted)
+}
+
+// "First AI activity" = the first assistant output the user perceives: streamed
+// text, streamed reasoning, or a tool call. NOT the `user_message` echo or an
+// `error` block (those aren't assistant activity and must not complete the span).
+function isActivityBlock(type: string): boolean {
+  return type === "text_chunk" || type === "reasoning_chunk" || type === "tool_group";
+}
+
+function process(id: string): void {
+  const entry = conversationRegistry.peek(id);
+  if (entry === undefined || entry.disposed) {
+    const existing = tracked.get(id);
+    if (existing !== undefined) settleDead(id, existing);
+    return;
+  }
+  const t = trackingFor(id);
+  const state = entry.getState();
+  const ar = state.activeResponse;
+
+  // agent_run — from the active response lifecycle (at most one at a time).
+  // `runSettled` records that a response for this session just ended (terminal or
+  // superseded), which also bounds the create_session span below.
+  let runSettled = false;
+  if (ar !== null && ar.state === "streaming") {
+    if (t.run === undefined || t.run.responseId !== ar.responseId) {
+      if (t.run !== undefined) {
+        t.run.handle.complete("cancelled"); // superseded before a terminal
+        runSettled = true;
+      }
+      t.run = {
+        responseId: ar.responseId,
+        handle: startTimedInteraction("agent_run", ar.responseId),
+      };
+    }
+  } else if (t.run !== undefined) {
+    if (ar !== null && ar.responseId === t.run.responseId && TERMINAL_STATES.has(ar.state)) {
+      t.run.handle.complete(runStatus(ar.state));
+    } else {
+      t.run.handle.complete("cancelled"); // cleared or replaced without a matching terminal
+    }
+    t.run = undefined;
+    runSettled = true;
+  }
+
+  // tool_call — from the committed transcript. Re-scan only when it changed; the
+  // seen/done sets make it emit once per callId across scans.
+  if (state.blocks !== t.lastBlocks) {
+    t.lastBlocks = state.blocks;
+    for (const block of state.blocks) {
+      if (block.type === "tool_group") {
+        for (const ex of block.executions) {
+          if (ex.callId && !t.toolSeen.has(ex.callId)) {
+            t.toolSeen.add(ex.callId);
+            t.tools.set(ex.callId, startTimedInteraction("tool_call", ex.callId, ex.name));
+          }
+        }
+      } else if (block.type === "tool_result") {
+        const open = t.tools.get(block.callId);
+        if (open !== undefined && !t.toolDone.has(block.callId)) {
+          t.toolDone.add(block.callId);
+          t.tools.delete(block.callId);
+          open.complete();
+        }
+      }
+    }
+  }
+
+  // create_session — first assistant activity completes it. Otherwise it's failed
+  // once its first response ends without any (`runSettled`, or a terminal
+  // activeResponse) — bounding the span to the first turn so a *later* turn's
+  // activity can never complete a stale span as an inflated success.
+  const create = t.create;
+  if (create !== undefined && !create.settled) {
+    if (state.blocks.some((b) => isActivityBlock(b.type))) {
+      create.handle.complete("success");
+      create.settled = true;
+    } else if (runSettled || (ar !== null && TERMINAL_STATES.has(ar.state))) {
+      create.handle.fail();
+      create.settled = true;
+    }
+  }
+}
+
+// A conversation that went away (evicted / released / switched-away-and-disposed)
+// never delivers more state, so settle whatever it left open and drop tracking.
+function settleDead(id: string, t: ConvTracking): void {
+  if (t.run !== undefined) {
+    t.run.handle.complete("cancelled");
+    t.run = undefined;
+  }
+  for (const handle of t.tools.values()) handle.complete("cancelled");
+  t.tools.clear();
+  if (t.create !== undefined && !t.create.settled) {
+    t.create.handle.fail();
+    t.create.settled = true;
+  }
+  tracked.delete(id);
+}
+
+// Subscribe once. `subscribe` fires on every entry state change (with the changed
+// id) but NOT on dispose, so after handling the change also sweep tracked
+// conversations whose entry is now gone/disposed.
+conversationRegistry.subscribe((id) => {
+  try {
+    process(id);
+  } catch {
+    // Telemetry must never break the app.
+  }
+  for (const [tid, t] of [...tracked]) {
+    const entry = conversationRegistry.peek(tid);
+    if (entry === undefined || entry.disposed) {
+      try {
+        settleDead(tid, t);
+      } catch {
+        // ignore
+      }
+    }
+  }
+});

--- a/web/src/store/interactionTelemetry.ts
+++ b/web/src/store/interactionTelemetry.ts
@@ -80,11 +80,23 @@ function runStatus(state: string): "success" | "failure" | "cancelled" {
   return "cancelled"; // cancelled / incomplete (interrupted)
 }
 
-// "First AI activity" = the first assistant output the user perceives: streamed
-// text, streamed reasoning, or a tool call. NOT the `user_message` echo or an
-// `error` block (those aren't assistant activity and must not complete the span).
+// "First AI activity" = the first assistant output the user perceives, in either
+// its streaming or its committed/hydrated form: the native-harness path (the
+// common new-chat case) commits assistant text as `text_done` — never
+// `text_chunk` — and reasoning as `reasoning_block`, so matching only the
+// streaming chunk types would record a successful text-first session as a
+// failure. NOT the `user_message` echo or an `error` block — those aren't
+// assistant activity and must not complete the span.
+const ACTIVITY_BLOCKS = new Set([
+  "text_chunk",
+  "text_done",
+  "reasoning_chunk",
+  "reasoning_block",
+  "tool_group",
+  "native_tool",
+]);
 function isActivityBlock(type: string): boolean {
-  return type === "text_chunk" || type === "reasoning_chunk" || type === "tool_group";
+  return ACTIVITY_BLOCKS.has(type);
 }
 
 function process(id: string): void {
@@ -124,15 +136,28 @@ function process(id: string): void {
   }
 
   // tool_call — from the committed transcript. Re-scan only when it changed; the
-  // seen/done sets make it emit once per callId across scans.
+  // seen/done sets make it emit once per callId across scans. A call whose result
+  // is ALREADY present the first time we see it was hydrated from history or
+  // reconnect-reconciled (its `tool_group` and `tool_result` arrive together in
+  // one snapshot), never observed executing live — so record it settled WITHOUT
+  // emitting. Otherwise reopening a past conversation would replay a phantom
+  // ~0ms start+complete for every historical tool call.
   if (state.blocks !== t.lastBlocks) {
     t.lastBlocks = state.blocks;
+    const haveResult = new Set<string>();
+    for (const block of state.blocks) {
+      if (block.type === "tool_result") haveResult.add(block.callId);
+    }
     for (const block of state.blocks) {
       if (block.type === "tool_group") {
         for (const ex of block.executions) {
           if (ex.callId && !t.toolSeen.has(ex.callId)) {
             t.toolSeen.add(ex.callId);
-            t.tools.set(ex.callId, startTimedInteraction("tool_call", ex.callId, ex.name));
+            if (haveResult.has(ex.callId)) {
+              t.toolDone.add(ex.callId); // already complete on first sight → hydrated
+            } else {
+              t.tools.set(ex.callId, startTimedInteraction("tool_call", ex.callId, ex.name));
+            }
           }
         }
       } else if (block.type === "tool_result") {

--- a/web/src/store/interactionTelemetry.ts
+++ b/web/src/store/interactionTelemetry.ts
@@ -1,225 +1,173 @@
-// Client interaction telemetry, DERIVED from the store's authoritative,
-// reconnect-reconciled per-conversation state — not hooked onto raw SSE blocks.
+// Live interaction telemetry, emitted from the pump's SSE reduce-loop in
+// chatStore.ts — the one place that sees each stream frame ONCE, live, in order.
+// It is NOT derived from committed conversation state: that state is built for
+// rendering and erases what telemetry needs (live-vs-history, an edge vs. a
+// revived level transition, a real outcome), which mismeasured on every
+// reconnect / revive / reopen. History hydration takes the `reduceSync` path,
+// not this loop, so reopening a conversation never re-emits.
 //
-// One subscriber owns the whole lifecycle for every live conversation:
-//   - agent_run      — from `activeResponse.state` (streaming → terminal).
-//   - tool_call      — from `tool_group` / `tool_result` blocks in the transcript.
-//   - create_session — a brand-new session's "created → first AI activity",
-//     registered by the create sites via `markSessionCreated` (they alone know
-//     the host kind); completed on first assistant activity, failed if the first
-//     turn ends without any.
+//   - agent_run      — onResponseStart / onResponseEnd (mapped terminal status).
+//                      Revive reopens a turn via `set()` and emits neither block,
+//                      so it never double-opens a run.
+//   - tool_call      — onLiveBlock: start on a live tool_group; complete (NO
+//                      status — none is reliable) on its result or when its run ends.
+//   - create_session — markSessionCreated (create sites; they alone know the host
+//                      kind) → onLiveBlock on first activity, else onResponseEnd fail.
 //
-// Why derive from state instead of hooking blocks: `blocks` and `activeResponse`
-// are the committed, deduplicated, snapshot-reconciled truth the UI renders, so
-// they survive reconnects and dropped stream frames (a lost `response_start` /
-// `response_end` / tool block does not). And it keeps every emit in ONE testable
-// place rather than scattered through the pump, where each un-handled block type
-// (error, user-echo, …) was a fresh mis-attribution bug. `approval` stays a direct
-// emit on the user action (chatStore.submitApproval) — it has no stream lifecycle.
+// Spans still open when a conversation is disposed are settled by
+// onConversationDisposed (wired to the registry's dispose notification).
 
 import { startTimedInteraction, type TimedInteraction } from "@/lib/analyticsEmit";
+import type { AnyBlock } from "@/lib/blocks";
 import { conversationRegistry } from "./conversationRegistry";
 
 type HostKind = "sandbox" | "computer";
 
-interface ConvTracking {
-  create?: { handle: TimedInteraction; settled: boolean };
+interface ConvSpans {
+  create?: TimedInteraction;
   run?: { responseId: string; handle: TimedInteraction };
+  /** Open tool calls by callId (removed on their result). */
   tools: Map<string, TimedInteraction>;
-  toolSeen: Set<string>;
-  toolDone: Set<string>;
-  // Ref of the last-scanned blocks array, so a state change that didn't touch
-  // the transcript (e.g. an activeResponse-only update) skips the block scan.
-  lastBlocks?: unknown;
 }
 
-const tracked = new Map<string, ConvTracking>();
+const spans = new Map<string, ConvSpans>();
 
-/**
- * Drop all in-flight tracking without settling. Test-only: the projector is a
- * module singleton, so tests that drive shared state must reset it between cases
- * or one case's open spans leak into the next.
- */
-export function resetInteractionTelemetryForTests(): void {
-  tracked.clear();
-}
-
-function trackingFor(id: string): ConvTracking {
-  let t = tracked.get(id);
-  if (t === undefined) {
-    t = { tools: new Map(), toolSeen: new Set(), toolDone: new Set() };
-    tracked.set(id, t);
+function spansFor(id: string): ConvSpans {
+  let s = spans.get(id);
+  if (s === undefined) {
+    s = { tools: new Map() };
+    spans.set(id, s);
   }
-  return t;
+  return s;
 }
 
-/**
- * Register a brand-new session for create_session timing. Called by the create
- * sites (the send/landing path and the New Chat dialog) — the only places that
- * know the host kind. Opens the span now; the subscriber completes it on the
- * session's first AI activity, or fails it if the first turn ends without any.
- * Idempotent per session id.
- */
-export function markSessionCreated(sessionId: string, hostKind: HostKind): void {
-  const t = trackingFor(sessionId);
-  if (t.create !== undefined) return;
-  t.create = {
-    handle: startTimedInteraction(
-      hostKind === "sandbox" ? "create_session_sandbox" : "create_session_computer",
-      sessionId,
-    ),
-    settled: false,
-  };
-}
+// Map a response's terminal status to an interaction outcome.
+const TERMINAL_OUTCOME: Record<string, "success" | "failure" | "cancelled"> = {
+  completed: "success",
+  failed: "failure",
+  cancelled: "cancelled",
+  incomplete: "cancelled", // interrupted / hit a limit
+};
 
-const TERMINAL_STATES = new Set(["completed", "failed", "cancelled", "incomplete"]);
-
-function runStatus(state: string): "success" | "failure" | "cancelled" {
-  if (state === "completed") return "success";
-  if (state === "failed") return "failure";
-  return "cancelled"; // cancelled / incomplete (interrupted)
-}
-
-// "First AI activity" = the first assistant output the user perceives, in either
-// its streaming or its committed/hydrated form: the native-harness path (the
-// common new-chat case) commits assistant text as `text_done` — never
-// `text_chunk` — and reasoning as `reasoning_block`, so matching only the
-// streaming chunk types would record a successful text-first session as a
-// failure. NOT the `user_message` echo or an `error` block — those aren't
-// assistant activity and must not complete the span.
-const ACTIVITY_BLOCKS = new Set([
+// The first assistant output the user perceives — in streaming or committed
+// form (the native-harness path commits text as `text_done`, reasoning as
+// `reasoning_block`). NOT the `user_message` echo or an `error` block.
+const ACTIVITY_TYPES = new Set([
   "text_chunk",
   "text_done",
   "reasoning_chunk",
   "reasoning_block",
   "tool_group",
   "native_tool",
+  "file",
 ]);
-function isActivityBlock(type: string): boolean {
-  return ACTIVITY_BLOCKS.has(type);
+
+/**
+ * Register a brand-new session for create_session timing. Called by the create
+ * sites (the send/landing path and the New Chat dialog) — the only places that
+ * know the host kind. Opens the span now; the pump completes it on the session's
+ * first assistant activity, or settles it if the first turn fails without any.
+ * Idempotent per session id.
+ */
+export function markSessionCreated(sessionId: string, hostKind: HostKind): void {
+  const s = spansFor(sessionId);
+  if (s.create !== undefined) return;
+  s.create = startTimedInteraction(
+    hostKind === "sandbox" ? "create_session_sandbox" : "create_session_computer",
+    sessionId,
+  );
 }
 
-function process(id: string): void {
-  const entry = conversationRegistry.peek(id);
-  if (entry === undefined || entry.disposed) {
-    const existing = tracked.get(id);
-    if (existing !== undefined) settleDead(id, existing);
+/** A response turn started (the `response_start` block). Opens an agent_run. */
+export function onResponseStart(conversationId: string, responseId: string): void {
+  const s = spansFor(conversationId);
+  if (s.run !== undefined) {
+    if (s.run.responseId === responseId) return; // re-delivered response.created on reconnect
+    s.run.handle.complete("cancelled"); // a prior run never saw its terminal
+  }
+  s.run = { responseId, handle: startTimedInteraction("agent_run", responseId) };
+}
+
+/**
+ * A response turn reached a terminal (the `response_end` block). Completes its
+ * agent_run and closes any tool left open by it. Settles a pending
+ * create_session only on a genuine failure terminal: a `completed` edge can be a
+ * stray idle that `reviveStrayCompletedResponse` reopens, and late content would
+ * then complete the span correctly — failing on it would misreport a healthy
+ * session as a failed create.
+ */
+export function onResponseEnd(conversationId: string, responseId: string, status: string): void {
+  const s = spans.get(conversationId);
+  if (s === undefined) return;
+  const outcome = TERMINAL_OUTCOME[status] ?? "cancelled";
+
+  if (s.run !== undefined && s.run.responseId === responseId) {
+    s.run.handle.complete(outcome);
+    s.run = undefined;
+  }
+  // A tool that never delivered a result before its run ended was abandoned by
+  // that turn — close it (no status) rather than leak it.
+  for (const handle of s.tools.values()) handle.complete(null);
+  s.tools.clear();
+  if (s.create !== undefined && outcome !== "success") {
+    s.create.complete(outcome);
+    s.create = undefined;
+  }
+}
+
+/**
+ * A block committed live to the transcript. Drives tool_call boundaries and
+ * completes a pending create_session on the first assistant activity.
+ */
+export function onLiveBlock(conversationId: string, block: AnyBlock): void {
+  if (block.type === "tool_group") {
+    const s = spansFor(conversationId);
+    for (const ex of block.executions) {
+      if (ex.callId && !s.tools.has(ex.callId)) {
+        s.tools.set(ex.callId, startTimedInteraction("tool_call", ex.callId, ex.name));
+      }
+    }
+    completeCreateIfOpen(s); // a tool call is first activity too
     return;
   }
-  const t = trackingFor(id);
-  const state = entry.getState();
-  const ar = state.activeResponse;
 
-  // agent_run — from the active response lifecycle (at most one at a time).
-  // `runSettled` records that a response for this session just ended (terminal or
-  // superseded), which also bounds the create_session span below.
-  let runSettled = false;
-  if (ar !== null && ar.state === "streaming") {
-    if (t.run === undefined || t.run.responseId !== ar.responseId) {
-      if (t.run !== undefined) {
-        t.run.handle.complete("cancelled"); // superseded before a terminal
-        runSettled = true;
-      }
-      t.run = {
-        responseId: ar.responseId,
-        handle: startTimedInteraction("agent_run", ar.responseId),
-      };
-    }
-  } else if (t.run !== undefined) {
-    if (ar !== null && ar.responseId === t.run.responseId && TERMINAL_STATES.has(ar.state)) {
-      t.run.handle.complete(runStatus(ar.state));
-    } else {
-      t.run.handle.complete("cancelled"); // cleared or replaced without a matching terminal
-    }
-    t.run = undefined;
-    runSettled = true;
-  }
+  const s = spans.get(conversationId);
+  if (s === undefined) return;
 
-  // tool_call — from the committed transcript. Re-scan only when it changed; the
-  // seen/done sets make it emit once per callId across scans. A call whose result
-  // is ALREADY present the first time we see it was hydrated from history or
-  // reconnect-reconciled (its `tool_group` and `tool_result` arrive together in
-  // one snapshot), never observed executing live — so record it settled WITHOUT
-  // emitting. Otherwise reopening a past conversation would replay a phantom
-  // ~0ms start+complete for every historical tool call.
-  if (state.blocks !== t.lastBlocks) {
-    t.lastBlocks = state.blocks;
-    const haveResult = new Set<string>();
-    for (const block of state.blocks) {
-      if (block.type === "tool_result") haveResult.add(block.callId);
+  if (block.type === "tool_result") {
+    const open = s.tools.get(block.callId);
+    if (open !== undefined) {
+      s.tools.delete(block.callId);
+      open.complete(null); // no reliable success/failure signal on a tool result
     }
-    for (const block of state.blocks) {
-      if (block.type === "tool_group") {
-        for (const ex of block.executions) {
-          if (ex.callId && !t.toolSeen.has(ex.callId)) {
-            t.toolSeen.add(ex.callId);
-            if (haveResult.has(ex.callId)) {
-              t.toolDone.add(ex.callId); // already complete on first sight → hydrated
-            } else {
-              t.tools.set(ex.callId, startTimedInteraction("tool_call", ex.callId, ex.name));
-            }
-          }
-        }
-      } else if (block.type === "tool_result") {
-        const open = t.tools.get(block.callId);
-        if (open !== undefined && !t.toolDone.has(block.callId)) {
-          t.toolDone.add(block.callId);
-          t.tools.delete(block.callId);
-          open.complete();
-        }
-      }
-    }
+    return;
   }
-
-  // create_session — first assistant activity completes it. Otherwise it's failed
-  // once its first response ends without any (`runSettled`, or a terminal
-  // activeResponse) — bounding the span to the first turn so a *later* turn's
-  // activity can never complete a stale span as an inflated success.
-  const create = t.create;
-  if (create !== undefined && !create.settled) {
-    if (state.blocks.some((b) => isActivityBlock(b.type))) {
-      create.handle.complete("success");
-      create.settled = true;
-    } else if (runSettled || (ar !== null && TERMINAL_STATES.has(ar.state))) {
-      create.handle.fail();
-      create.settled = true;
-    }
-  }
+  if (ACTIVITY_TYPES.has(block.type)) completeCreateIfOpen(s);
 }
 
-// A conversation that went away (evicted / released / switched-away-and-disposed)
-// never delivers more state, so settle whatever it left open and drop tracking.
-function settleDead(id: string, t: ConvTracking): void {
-  if (t.run !== undefined) {
-    t.run.handle.complete("cancelled");
-    t.run = undefined;
-  }
-  for (const handle of t.tools.values()) handle.complete("cancelled");
-  t.tools.clear();
-  if (t.create !== undefined && !t.create.settled) {
-    t.create.handle.fail();
-    t.create.settled = true;
-  }
-  tracked.delete(id);
+function completeCreateIfOpen(s: ConvSpans): void {
+  if (s.create === undefined) return;
+  s.create.complete("success");
+  s.create = undefined;
 }
 
-// Subscribe once. `subscribe` fires on every entry state change (with the changed
-// id) but NOT on dispose, so after handling the change also sweep tracked
-// conversations whose entry is now gone/disposed.
-conversationRegistry.subscribe((id) => {
-  try {
-    process(id);
-  } catch {
-    // Telemetry must never break the app.
-  }
-  for (const [tid, t] of [...tracked]) {
-    const entry = conversationRegistry.peek(tid);
-    if (entry === undefined || entry.disposed) {
-      try {
-        settleDead(tid, t);
-      } catch {
-        // ignore
-      }
-    }
-  }
-});
+// A disposed conversation delivers no more frames, so settle whatever it left
+// open. Wired to the registry's dispose notification (release / evict / clear).
+function onConversationDisposed(conversationId: string): void {
+  const s = spans.get(conversationId);
+  if (s === undefined) return;
+  spans.delete(conversationId);
+  if (s.run !== undefined) s.run.handle.complete("cancelled");
+  for (const handle of s.tools.values()) handle.complete(null);
+  if (s.create !== undefined) s.create.complete("cancelled");
+}
+
+conversationRegistry.subscribeDisposed(onConversationDisposed);
+
+/**
+ * Drop all in-flight tracking. Test-only: the span map is a module singleton, so
+ * tests that drive the pump must reset it between cases.
+ */
+export function resetInteractionTelemetryForTests(): void {
+  spans.clear();
+}


### PR DESCRIPTION
## Related issue

N/A — no dedicated OSS issue. Refines the `create_session` CUJ introduced in #5619, part of the hosted-Omnigent UI analytics effort.

## Summary

Redefines the **`create_session`** latency CUJ from "create POST latency" to **"session created → first AI message"** — the part of a brand-new chat that actually varies by where the session runs (stream bind + managed-sandbox launch + time-to-first-token). The bare `createSession` POST is dropped from the metric: it's small and already measurable from backend/HTTP traces.

The span is also **split by host kind**, encoded into the interaction name so the dashboard can segment it without a queryable sub-dimension (RIT tags go to the metrics system, not the UI-observability table; span attributes only reach the raw log):

- `create_session_sandbox` — session runs on a managed sandbox
- `create_session_computer` — session runs on the user's own host

**Seams** (`web/src/store/chatStore.ts`):
- **Start** — right after `createSession()` returns in the new-chat path (`ensureBoundSession`). Host kind = `session.sandboxStatus != null ? "sandbox" : "computer"`. The open interaction is stored in a module `Map` keyed by session id.
- **Complete** — on that session's **first `response_start`** in the stream pump (correlated by the pump's session `id`; the map delete makes it fire once).

Why not reuse `agent_run`? It starts at `response_start` too, so it measures response-start → response-end and misses the entire pre-response wait — exactly the part this CUJ is about.

<details><summary>ELI5 + flow</summary>

For a brand-new chat, we time from "the session exists" to "the agent's first message shows up" — the wait a user feels after hitting send on a fresh chat. We tag it sandbox vs computer because a managed sandbox has to launch first.

```mermaid
sequenceDiagram
  participant U as User
  participant App as omnigent web
  participant Sink as Host analytics sink
  U->>App: send (brand-new chat)
  App->>App: createSession()  — POST, excluded from the span
  App->>Sink: create_session_{sandbox|computer} · start
  App->>App: bind + sandbox launch + post first message
  App-->>App: first response_start  (first AI message)
  App->>Sink: create_session_{…} · complete (status, durationMs)
```

</details>

**Notes for reviewers**
- Host kind uses `session.sandboxStatus` (the best session-local signal, read while a managed sandbox's launch is in flight). If it proves unreliable at scale, the firmer signal is the host's `sandbox_provider` (needs a lookup).
- A session that's created but never produces a first response leaves one open interaction (missing measurement, not corruption) — same pattern as the existing `agent_run` timing.

## Test Plan

Frontend-only; no server or wire changes. Verified with:

- `pnpm test src/lib/analytics.test.tsx src/store/chatStore.test.ts src/hooks/useConversations.test.ts` — green.
- `pnpm type-check` (`tsc -b`), `oxlint --deny-warnings`, `prettier --check` — clean.

No visible UI change: the emit is a no-op unless a host wires an analytics sink, and never alters the wrapped flow's result or errors.

## Demo

N/A — no visible UI change (instrumentation only).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`analytics.test.tsx` covers the `startTimedInteraction` handle (start on open, `complete`/`fail` with a measured `durationMs`, idempotent settle, generated id, never-throws) with the new kind name. The new send→first-message correlation rides the existing `chatStore` stream-pump path, whose suite (`chatStore.test.ts`) still passes unchanged.

---
This pull request and its description were written by Isaac.
