### PR TITLE
fix(homebrew): pin pillow to an upstream wheel

### DIFF
--- a/.github/scripts/homebrew/generate_formula.py
+++ b/.github/scripts/homebrew/generate_formula.py
@@ -111,6 +111,7 @@ PREFER_WHEEL = {
     "grpcio",
     "httptools",
     "markupsafe",
+    "pillow",
     "protobuf",
     "pyyaml",
     "regex",


### PR DESCRIPTION
## Related issue

Closes #5120

## Summary

- `pillow>=12.2,<13` became a dependency in 0.10.0, added for white-label UI branding (#2857).
- The Homebrew tap's formula generator (`.github/scripts/homebrew/generate_formula.py`) pins
  select compiled packages to prebuilt PyPI wheels through the `PREFER_WHEEL` set. `pillow` was
  never added, so it ships as an sdist `resource` instead.
- Homebrew builds sdist resources with `pip install --no-binary=:all:` inside a sandbox that only
  exposes headers for libraries the formula declares in `depends_on`. No `jpeg-turbo` header is
  present, so Pillow's source build fails with `RequiredDependencyException: The headers or
  library files could not be found for jpeg`, and the whole keg install is abandoned.
- The fix adds `"pillow"` to `PREFER_WHEEL`, the same mechanism PR #4080 used for this class of
  bug (grpcio, uvloop, protobuf, and others). `omnigent-ai/homebrew-tap#16` hit the identical
  failure one release earlier, for `google-re2`'s sdist, and was fixed the same way.

omnigent-ai/homebrew-tap#31 is the same bug on the tap side. Closing keywords don't work across
repos, so it needs a maintainer to close by hand.

`depends_on "jpeg-turbo"` (suggested and confirmed working on `homebrew-tap#31`) is smaller, but
`omnigent.rb.template` pins every compiled extension to an upstream wheel instead, to keep
`cc`/`rustc` off the bottle builder. Pillow shipping as an sdist was the bug, not an exception to
that rule.

## Test Plan

1. Generated the 0.11.0 formula from unmodified `main`, then again from this one-line change,
   with identical flags (`generate_formula.py --version 0.11.0 --out ...`). The only diff between
   the two outputs is the `pillow` resource turning from a single-URL sdist stanza into an
   `on_arm`/`on_intel` wheel block, the same shape as the existing `markupsafe`/`pyyaml` entries.
2. Manually patched that exact wheel stanza into tap PR #32's 0.11.0 formula on my machine and ran
   a real `brew upgrade omnigent-ai/tap/omnigent`: 0.9.0 → 0.11.0 completed successfully (previously
   failed on Pillow's sdist build, see #5120).
3. Confirmed the bundled libjpeg survives Homebrew's keg relocation, the check the
   `PREFER_WHEEL` comment prescribes:
   `python -c "from PIL import Image, features; print(features.check('jpg'), features.check('zlib'))"`
   → `True True`.
4. Ran the formula's other smoke checks post-upgrade: `omnigent --help` and
   `python -c "import certifi, cryptography, pydantic, rpds, re2, celpy"`. Both pass.

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed

## Coverage notes

No test suite covers `.github/scripts/` (`testpaths = ["tests"]`). Verified manually instead: the
generator before/after diff (item 1 above) and a real end-to-end `brew` install of 0.11.0 with the
wheel-pinned Pillow (items 2-4 above).

## Changelog

`brew install omnigent` no longer fails building Pillow from source on macOS.
