### PR TITLE
docs: document response and inactivity policies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,8 @@ and [`areas.json`](.github/areas.json).
 ## Response times and inactive issues
 
 Priority determines the order in which maintainers consider work; it does not
-set a response, review, or resolution deadline. We do not currently guarantee a
+set a response, review, or resolution deadline. We are working toward published
+response targets, but they are not yet an SLA. For now, we do not guarantee a
 specific response time for issues or pull requests.
 
 Issues with no activity for 30 days are marked `stale` and close after another

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,23 @@ The scoring configuration and component map are public in
 [`default_scoring.json`](.github/triage_v2/src/issue_prioritization/default_scoring.json)
 and [`areas.json`](.github/areas.json).
 
+## Response times and inactive issues
+
+Priority determines the order in which maintainers consider work; it does not
+set a response, review, or resolution deadline. We do not currently guarantee a
+specific response time for issues or pull requests.
+
+Issues with no activity for 30 days are marked `stale` and close after another
+14 days without activity. New activity restarts that inactivity window. Issues
+labeled `pinned`, `security`, or `bug` are exempt.
+
+If an issue is labeled `needs-info`, a comment from its author clears the label
+and triggers another triage pass. Without an author response, the normal stale
+policy applies unless the issue also has one of the exempt labels above.
+
+Pull requests waiting for an author response follow the separate 7-day policy
+described under [Review state labels](#review-state-labels).
+
 ## Development setup
 
 This is a Python package with an optional frontend under `web/`. Use


### PR DESCRIPTION
## Related issue

N/A — documentation-only change.

## Summary

- Clarifies that priority controls ordering but does not currently guarantee a maintainer response, review, or resolution deadline.
- Documents the active 30-day stale and 14-day close policy, including label exemptions.
- Explains how author responses retrigger triage for `needs-info` issues and links to the existing 7-day PR-author policy.

## Test Plan

- `pre-commit run --files CONTRIBUTING.md`
- `git diff --check`
- Reviewed the Markdown heading, policy values, exemptions, and anchor link against the active workflows.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only policy clarification; no executable behavior changed. The relevant Markdown and repository hygiene checks pass.
