### PR TITLE
fix(server): validate relay-reported token counts in session usage accumulation

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import math
 import re
 import secrets
 import time
@@ -2122,23 +2123,26 @@ def _coerce_cumulative_field(
 
     :param data: The ``external_session_usage`` event ``data`` dict.
     :param key: Field name, e.g. ``"cumulative_input_tokens"``.
-    :param numeric: When ``True`` accept any non-negative number (cost);
-        when ``False`` require a non-negative int (token counts).
+    :param numeric: When ``True`` accept any finite non-negative number
+        (cost); when ``False`` require a finite non-negative int (token
+        counts).
     :returns: The validated value, or ``None`` when the key is absent.
-    :raises OmnigentError: When present but the wrong type / negative.
+    :raises OmnigentError: When present but the wrong type / negative /
+        non-finite (``NaN`` / ``inf`` — which the monotonic ``max(old,
+        new)`` clamp downstream would otherwise latch permanently).
     """
     value = data.get(key)
     if value is None:
         return None
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise OmnigentError(
-            f"external_session_usage data.{key} must be a non-negative "
+            f"external_session_usage data.{key} must be a finite non-negative "
             f"{'number' if numeric else 'int'}",
             code=ErrorCode.INVALID_INPUT,
         )
-    if (not numeric and not isinstance(value, int)) or value < 0:
+    if (not numeric and not isinstance(value, int)) or not math.isfinite(value) or value < 0:
         raise OmnigentError(
-            f"external_session_usage data.{key} must be a non-negative "
+            f"external_session_usage data.{key} must be a finite non-negative "
             f"{'number' if numeric else 'int'}",
             code=ErrorCode.INVALID_INPUT,
         )

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -1163,6 +1163,32 @@ def _build_session_response(
     )
 
 
+def _sane_relay_token_count(value: object) -> int:
+    """
+    Coerce a runner-reported token count to a trusted non-negative int.
+
+    Relay usage frames are POSTed under the session owner's own bearer
+    token, so a forged negative or non-finite count must never reach the
+    additive :meth:`ConversationStore.increment_session_usage` delta: a
+    negative would claw back the session's cumulative ``total_cost_usd``
+    (the figure the relay cost-budget gate reads, since relay sessions
+    never post ``policy_cost_usd``) and a ``NaN`` / ``inf`` would poison
+    every downstream sum. Anything that is not a finite, non-negative,
+    non-bool number collapses to ``0``; the turn is then priced on
+    whatever counts survive.
+
+    :param value: Raw ``usage`` field from the harness response, e.g.
+        ``1200``, ``-1``, or ``float("nan")``.
+    :returns: The value as a non-negative ``int``, or ``0`` when it is
+        missing / the wrong type / negative / non-finite.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    if not math.isfinite(value) or value < 0:
+        return 0
+    return int(value)
+
+
 def _accumulate_session_usage(
     resp_obj: dict[str, Any],
     session_id: str,
@@ -1205,14 +1231,19 @@ def _accumulate_session_usage(
     usage_obj = resp_obj.get("usage")
     if not isinstance(usage_obj, dict):
         return None
-    input_tokens = usage_obj.get("input_tokens", 0)
-    output_tokens = usage_obj.get("output_tokens", 0)
-    total_tokens = usage_obj.get("total_tokens", 0)
+    # Sanitize every runner-reported count: a forged negative / non-finite
+    # value here would otherwise flow into both the additive token counters
+    # and (via the catalog-pricing branch below) the additive cost delta.
+    input_tokens = _sane_relay_token_count(usage_obj.get("input_tokens", 0))
+    output_tokens = _sane_relay_token_count(usage_obj.get("output_tokens", 0))
+    total_tokens = _sane_relay_token_count(usage_obj.get("total_tokens", 0))
     if not any((input_tokens, output_tokens, total_tokens)):
         return None
 
-    cache_read_input_tokens = usage_obj.get("cache_read_input_tokens", 0)
-    cache_creation_input_tokens = usage_obj.get("cache_creation_input_tokens", 0)
+    cache_read_input_tokens = _sane_relay_token_count(usage_obj.get("cache_read_input_tokens", 0))
+    cache_creation_input_tokens = _sane_relay_token_count(
+        usage_obj.get("cache_creation_input_tokens", 0)
+    )
 
     # Load conversation metadata for pricing only (NOT for reading session_usage —
     # the atomic increment_session_usage call below handles that separately to
@@ -1271,10 +1302,20 @@ def _accumulate_session_usage(
             )
             priced = pricing is not None
             if pricing is not None:
-                # Cache-aware: usage_obj carries cache_read/cache_creation
-                # token counts when the harness reports them; compute_llm_cost
-                # prices them at their own (cheaper read / pricier write) rates.
-                cost_delta = compute_llm_cost(usage_obj, pricing)
+                # Cache-aware: price the sanitized cache-read / cache-creation
+                # token counts at their own (cheaper read / pricier write)
+                # rates. Pass the validated locals, not the raw response usage
+                # — a forged negative / non-finite count must not reach the
+                # cost sum (compute_llm_cost multiplies without a lower bound).
+                cost_delta = compute_llm_cost(
+                    {
+                        "input_tokens": input_tokens,
+                        "output_tokens": output_tokens,
+                        "cache_read_input_tokens": cache_read_input_tokens,
+                        "cache_creation_input_tokens": cache_creation_input_tokens,
+                    },
+                    pricing,
+                )
 
     # Build the delta dict and atomically apply it to the persisted
     # session_usage in a single DB transaction (SELECT FOR UPDATE on

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1,6 +1,7 @@
 """Conversation store — manages conversations and their items."""
 
 import hashlib
+import math
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -285,6 +286,26 @@ class NameAlreadyExistsError(Exception):
     """
 
 
+def _is_addable_usage_increment(value: Any) -> bool:
+    """
+    Return whether *value* is a safe additive ``session_usage`` increment.
+
+    Every production caller (the relay ``_accumulate_session_usage`` path)
+    only ever adds a finite, non-negative count or cost. A negative or
+    non-finite increment is therefore corruption — applied additively it
+    would drive a cumulative counter backwards or poison it with ``NaN`` /
+    ``inf``, and the relay cost-budget gate reads these very totals — so
+    :func:`apply_session_usage_delta` drops it rather than merging it.
+
+    :param value: A flat or ``by_model`` sub-key increment from a delta.
+    :returns: ``True`` when *value* is a finite, non-negative, non-bool
+        number; ``False`` otherwise.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    return math.isfinite(value) and value >= 0
+
+
 def apply_session_usage_delta(current: dict[str, Any], delta: dict[str, Any]) -> None:
     """
     Apply a usage *delta* to *current* in place (add semantics, nested-aware).
@@ -293,6 +314,11 @@ def apply_session_usage_delta(current: dict[str, Any], delta: dict[str, Any]) ->
     model id, summing each model's sub-keys independently. Used by
     :meth:`ConversationStore.increment_session_usage` implementations to
     keep the merge logic in one place.
+
+    Negative and non-finite increments are dropped (see
+    :func:`_is_addable_usage_increment`): they can only come from a forged
+    runner usage frame and would corrupt the cumulative totals the relay
+    cost-budget gate enforces on.
 
     :param current: Existing ``session_usage`` dict (mutated in place).
     :param delta: Increments to apply (same layout as ``session_usage``).
@@ -303,8 +329,10 @@ def apply_session_usage_delta(current: dict[str, Any], delta: dict[str, Any]) ->
             for model_id, model_delta in value.items():
                 bucket = by_model.setdefault(model_id, {})
                 for sub_key, sub_value in model_delta.items():
+                    if not _is_addable_usage_increment(sub_value):
+                        continue
                     bucket[sub_key] = bucket.get(sub_key, 0) + sub_value
-        else:
+        elif _is_addable_usage_increment(value):
             current[key] = current.get(key, 0) + value
 
 

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -5499,6 +5499,132 @@ async def test_accumulate_session_usage_rejects_non_finite_provider_cost(
     assert math.isfinite(usage["total_cost_usd"])
 
 
+async def test_accumulate_session_usage_rejects_negative_token_count(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A forged negative ``input_tokens`` is coerced to 0, not priced as a negative.
+
+    The ``cost_usd`` guard only covers the harness-reported-cost fast path; the
+    catalog-pricing branch derives the cost delta from the token counts in the
+    same forgeable frame. ``compute_llm_cost`` multiplies without a lower bound,
+    so an unsanitised negative count would make the additive ``total_cost_usd``
+    delta negative — clawing back the running total the relay cost-budget gate
+    reads. The count must collapse to 0 and the turn price on what survives.
+    """
+    from omnigent.server.routes import sessions as sessions_routes
+
+    monkeypatch.setattr(
+        "omnigent.llms.context_window.fetch_model_pricing",
+        lambda model: ModelPricing(input_per_token=1e-3, output_per_token=2e-3),
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    sessions_routes._accumulate_session_usage(
+        {
+            "usage": {
+                "input_tokens": -100_000_000,
+                "output_tokens": 500,
+                "model": "harness-model",
+            }
+        },
+        session["id"],
+        SqlAlchemyConversationStore(db_uri),
+    )
+    usage = _read_session_usage(db_uri, session["id"])
+    # input collapses to 0; catalog charges only 500*2e-3 = 1.0 (never negative).
+    assert usage.get("total_cost_usd") == pytest.approx(1.0)
+    assert usage["by_model"]["harness-model"]["total_cost_usd"] == pytest.approx(1.0)
+    # The forged count is not persisted as a negative cumulative counter.
+    assert usage["input_tokens"] == 0
+    assert usage["output_tokens"] == 500
+
+
+async def test_accumulate_session_usage_negative_tokens_cannot_reset_running_total(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A forged negative token count can't subtract from a prior running total."""
+    from omnigent.server.routes import sessions as sessions_routes
+
+    store = SqlAlchemyConversationStore(db_uri)
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    # An honest priced turn establishes a positive running total.
+    monkeypatch.setattr(
+        "omnigent.llms.context_window.fetch_model_pricing",
+        lambda model: ModelPricing(input_per_token=1e-3, output_per_token=2e-3),
+    )
+    sessions_routes._accumulate_session_usage(
+        {"usage": {"input_tokens": 1000, "output_tokens": 500, "model": "grok-4.3"}},
+        session["id"],
+        store,
+    )
+    assert _read_session_usage(db_uri, session["id"]).get("total_cost_usd") == pytest.approx(2.0)
+
+    # A forged negative report must not drive the running total (or the token
+    # counters) down.
+    sessions_routes._accumulate_session_usage(
+        {
+            "usage": {
+                "input_tokens": -1_000_000_000,
+                "output_tokens": 0,
+                "model": "grok-4.3",
+            }
+        },
+        session["id"],
+        store,
+    )
+    usage = _read_session_usage(db_uri, session["id"])
+    assert usage.get("total_cost_usd") == pytest.approx(2.0)
+    assert usage["input_tokens"] == 1000
+
+
+async def test_accumulate_session_usage_rejects_non_finite_token_count(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A NaN / infinite token count never reaches the cost sum or the counters.
+
+    ``json.loads`` accepts bare ``NaN`` / ``Infinity``, so a runner can send a
+    non-finite token count. Left unsanitised it poisons ``total_cost_usd``
+    permanently (every ``cost > cap`` comparison is then ``False``) and the
+    stored token counters.
+    """
+    from omnigent.server.routes import sessions as sessions_routes
+
+    monkeypatch.setattr(
+        "omnigent.llms.context_window.fetch_model_pricing",
+        lambda model: ModelPricing(input_per_token=1e-3, output_per_token=2e-3),
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    for bad_tokens in (float("nan"), float("inf"), float("-inf")):
+        sessions_routes._accumulate_session_usage(
+            {
+                "usage": {
+                    "input_tokens": bad_tokens,
+                    "output_tokens": 500,
+                    "model": "harness-model",
+                }
+            },
+            session["id"],
+            SqlAlchemyConversationStore(db_uri),
+        )
+    usage = _read_session_usage(db_uri, session["id"])
+    # Three turns, each priced only on the finite 500 output tokens (1.0 each).
+    assert usage.get("total_cost_usd") == pytest.approx(3.0)
+    assert math.isfinite(usage["total_cost_usd"])
+    assert usage["input_tokens"] == 0
+    assert math.isfinite(usage["input_tokens"])
+
+
 async def test_accumulate_session_usage_unpriced_without_usage_model(
     client: httpx.AsyncClient,
     db_uri: str,

--- a/tests/stores/test_conversation_store_split_db.py
+++ b/tests/stores/test_conversation_store_split_db.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -278,6 +279,43 @@ def test_increment_session_usage(store: SqlAlchemyConversationStore) -> None:
     assert result["input_tokens"] == 100
     result2 = store.increment_session_usage(conv.id, {"input_tokens": 50})
     assert result2["input_tokens"] == 150
+
+
+def test_apply_session_usage_delta_drops_negative_and_non_finite_increments() -> None:
+    """A forged usage frame can't drive a cumulative counter backwards or poison it.
+
+    ``apply_session_usage_delta`` is the single merge point for the relay
+    ``increment_session_usage`` path, whose totals the cost-budget gate
+    enforces on. Negative and non-finite increments — flat or nested under
+    ``by_model`` — are dropped rather than applied; well-formed non-negative
+    increments still merge.
+    """
+    from omnigent.stores.conversation_store import apply_session_usage_delta
+
+    current: dict[str, Any] = {
+        "input_tokens": 100,
+        "total_cost_usd": 1.0,
+        "by_model": {"m": {"input_tokens": 100, "total_cost_usd": 1.0}},
+    }
+    apply_session_usage_delta(
+        current,
+        {
+            "input_tokens": -1_000_000,
+            "output_tokens": float("nan"),
+            "total_cost_usd": float("-inf"),
+            "by_model": {"m": {"input_tokens": -50, "total_cost_usd": float("inf")}},
+        },
+    )
+    assert current["input_tokens"] == 100
+    assert "output_tokens" not in current
+    assert current["total_cost_usd"] == 1.0
+    assert current["by_model"]["m"] == {"input_tokens": 100, "total_cost_usd": 1.0}
+
+    apply_session_usage_delta(
+        current, {"input_tokens": 25, "by_model": {"m": {"input_tokens": 25}}}
+    )
+    assert current["input_tokens"] == 125
+    assert current["by_model"]["m"]["input_tokens"] == 125
 
 
 def test_set_external_session_id(store: SqlAlchemyConversationStore) -> None:


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

Closes #5645

## Summary

- Sanitize every runner-reported token count in `_accumulate_session_usage`
  (coerce a finite, non-negative, non-bool number to `int`; otherwise `0`) and
  price the turn from the sanitized values, not the raw `usage` dict.
- `apply_session_usage_delta` now drops negative / non-finite increments (flat and
  `by_model`) instead of adding them.
- `_coerce_cumulative_field` (native path) also rejects `NaN` / `inf`.

## Test Plan

- New integration tests (tests/server/integration/test_sessions_endpoints.py),
  mirroring #4827's three but via the token vector: a forged negative / NaN /
  inf input_tokens falls through to a non-negative catalog estimate, can't
  claw back a prior running total, and can't make total_cost_usd non-finite.
- New unit test (tests/stores/test_conversation_store_split_db.py):
  apply_session_usage_delta drops negative / non-finite increments (flat and
  by_model) while still merging well-formed ones.
- Before/after check: reverted only the source (kept the new tests), and all 4
  fail on main (total_cost_usd observed as -99999.0, -999998.0, nan; a counter
  driven to -999900). Restored the fix, and all pass.
- Regression: test_sessions_endpoints.py -k "usage or cost or budget" + both
  conversation_store test files + tests/runtime/policies/ -k "cost or budget or
  usage or daily" gives 78 passed, 0 failed (plus targeted runs of
  accumulate_session_usage 14, external_session_usage 37, policy cost/budget 26,
  all green).
- pre-commit run (ruff-format, ruff-check) pass; pyrefly check on the three
  source files: 0 errors.

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

`N/A`

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [X] Unit tests added / updated
- [X] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`N/A`

## Changelog

Relay sessions can no longer be pushed under their spend cap by a forged token
count in a harness usage report.