### PR TITLE
Reject unsafe download_file path inputs

### DIFF
--- a/omnigent/tools/builtins/download_file.py
+++ b/omnigent/tools/builtins/download_file.py
@@ -62,6 +62,7 @@ class DownloadFileTool(Tool):
                         },
                     },
                     "required": ["file_id"],
+                    "additionalProperties": False,
                 },
             },
         }
@@ -77,6 +78,11 @@ class DownloadFileTool(Tool):
         if error is not None:
             return json.dumps({"error": error})
         assert args is not None
+
+        unsupported = sorted(set(args) - {"file_id"})
+        if unsupported:
+            names = ", ".join(repr(name) for name in unsupported)
+            return json.dumps({"error": f"unsupported argument(s): {names}"})
 
         file_id = args.get("file_id")
         if file_id is None or file_id == "":
@@ -136,17 +142,22 @@ def _resolve_destination(
     """
     Resolve the save path for a downloaded file.
 
-    The stored ``filename`` is untrusted metadata (it originates from
-    whoever uploaded the file and is persisted verbatim). It is reduced
-    to its bare basename and confined to the workspace via
-    :func:`safe_resolve`, so a malicious name such as ``../../escape``
-    or an absolute path cannot cause a write outside the workspace.
+    The stored ``filename`` is untrusted metadata. Path-bearing names are
+    rejected, and valid names are confined via :func:`safe_resolve`.
 
     :param filename: The file's original filename from the store.
     :param workspace: The agent's workspace directory, or ``None``.
     :returns: Absolute path to save the file, confined to ``workspace``.
-    :raises ValueError: If the resolved path escapes the workspace.
+    :raises ValueError: If the filename contains path components or the
+        resolved path escapes the workspace.
     """
     base = workspace or Path.cwd()
-    name = Path(filename).name or "downloaded.bin"
-    return safe_resolve(name, base)
+    if (
+        not filename
+        or filename in {".", ".."}
+        or Path(filename).name != filename
+        or "/" in filename
+        or "\\" in filename
+    ):
+        raise ValueError("Stored filename must be a single path component.")
+    return safe_resolve(filename, base)

--- a/tests/tools/builtins/test_file_tools.py
+++ b/tests/tools/builtins/test_file_tools.py
@@ -422,27 +422,60 @@ def test_download_file_saves_to_workspace(
 
 
 @pytest.mark.parametrize(
+    "destination",
+    [
+        "/root/.ssh/authorized_keys",
+        "../../etc/cron.d/x",
+    ],
+)
+def test_download_file_rejects_unsupported_destination(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_ctx: ToolContext,
+    destination: str,
+) -> None:
+    """
+    A removed ``destination`` argument is rejected before any write.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tool_ctx: Tool execution context.
+    :param destination: Absolute or traversing destination to reject.
+    """
+
+    def fail_on_write(path: Path, _data: bytes) -> int:
+        pytest.fail(f"unexpected write to {path}")
+
+    monkeypatch.setattr(Path, "write_bytes", fail_on_write)
+
+    tool = DownloadFileTool()
+    assert tool.get_schema()["function"]["parameters"]["additionalProperties"] is False
+    result = json.loads(
+        tool.invoke(
+            json.dumps({"file_id": "file_evil", "destination": destination}),
+            tool_ctx,
+        )
+    )
+
+    assert result == {"error": "unsupported argument(s): 'destination'"}
+
+
+@pytest.mark.parametrize(
     "malicious_filename",
     [
         "../escape.txt",
         "../../escape.txt",
-        "foo/../../bar.txt",
+        "../../etc/cron.d/x",
+        "nested/file.txt",
+        r"nested\file.txt",
         "/etc/passwd",
-        "/tmp/abs-escape.txt",
     ],
 )
-def test_download_file_confines_untrusted_filename_to_workspace(
+def test_download_file_rejects_path_bearing_store_filename(
     monkeypatch: pytest.MonkeyPatch,
     tool_ctx: ToolContext,
     malicious_filename: str,
 ) -> None:
     """
-    A malicious stored filename cannot write outside the workspace.
-
-    The stored filename is untrusted metadata (persisted verbatim from
-    whoever uploaded the file). Traversal sequences and absolute paths
-    must be reduced to a basename and confined to the workspace, never
-    escaping it.
+    A path-bearing stored filename is rejected before any write.
 
     :param monkeypatch: Pytest monkeypatch fixture.
     :param tool_ctx: Tool execution context.
@@ -469,60 +502,15 @@ def test_download_file_confines_untrusted_filename_to_workspace(
         lambda: _FakeArtifactStore({"file_evil": content}),
     )
 
+    def fail_on_write(path: Path, _data: bytes) -> int:
+        pytest.fail(f"unexpected write to {path}")
+
+    monkeypatch.setattr(Path, "write_bytes", fail_on_write)
+
     tool = DownloadFileTool()
     result = json.loads(tool.invoke('{"file_id": "file_evil"}', tool_ctx))
 
-    # The write must land strictly inside the workspace.
-    saved = Path(result["path"])
-    workspace = tool_ctx.workspace
-    assert workspace is not None
-    assert saved.resolve().is_relative_to(workspace.resolve())
-    # Nothing was written outside the workspace.
-    assert not Path("/etc/passwd").is_symlink()
-    assert saved.exists()
-    assert saved.read_bytes() == content
-
-
-def test_download_file_basenames_store_filename(
-    monkeypatch: pytest.MonkeyPatch,
-    tool_ctx: ToolContext,
-) -> None:
-    """
-    A filename with leading directory components is saved by basename.
-
-    :param monkeypatch: Pytest monkeypatch fixture.
-    :param tool_ctx: Tool execution context.
-    """
-    content = b"report-bytes"
-    monkeypatch.setattr(
-        "omnigent.runtime.get_file_store",
-        lambda: _FakeFileStore(
-            [
-                _FakeFile(
-                    "file_nested",
-                    "reports/2026/q2.csv",
-                    len(content),
-                    "text/csv",
-                    1000,
-                    session_id="conv_alice",
-                ),
-            ]
-        ),
-    )
-    monkeypatch.setattr(
-        "omnigent.runtime.get_artifact_store",
-        lambda: _FakeArtifactStore({"file_nested": content}),
-    )
-
-    tool = DownloadFileTool()
-    result = json.loads(tool.invoke('{"file_id": "file_nested"}', tool_ctx))
-
-    saved = Path(result["path"])
-    workspace = tool_ctx.workspace
-    assert workspace is not None
-    assert saved.name == "q2.csv"
-    assert saved.parent.resolve() == workspace.resolve()
-    assert saved.read_bytes() == content
+    assert result == {"error": "Stored filename must be a single path component."}
 
 
 def test_download_file_not_found(


### PR DESCRIPTION
## Summary

Fail closed on untrusted path inputs to `download_file`. The tool now rejects the removed `destination` argument instead of silently ignoring it, closes the LLM-facing schema to unknown properties, and rejects stored filenames containing path components before `write_bytes()` can run. Valid single-component filenames still pass through `safe_resolve()` for workspace containment.

This intentionally changes malformed-record behavior: stored filenames such as `reports/2026/q2.csv` now return an error instead of being silently reduced to `q2.csv`. Normal `upload_file` records are unaffected because that path already stores only `resolved.name`.

**ELI5:** callers may choose which stored file to download, but neither callers nor stored metadata may choose a filesystem path.

```text
tool arguments -> reject unknown keys -> load record -> reject path-bearing filename -> safe_resolve -> write
```

## Test Plan

- `uv run --frozen pytest tests/tools/builtins/test_file_tools.py -q`
- `uv run --frozen pytest tests/tools/builtins/test_registry_unified.py -q`
- `pre-commit run --all-files`

The regression tests use the reported `/root/.ssh/authorized_keys` and `../../etc/cron.d/x` destinations and patch `Path.write_bytes` to fail if either rejected path reaches a write.

## Demo

N/A — non-visual security fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Unit coverage asserts that absolute and traversing `destination` values return an error without any write, path-bearing stored filenames using POSIX or Windows separators also fail before any write, and ordinary workspace downloads continue to succeed. The complete repository pre-commit suite passes.
