### PR TITLE
feat(triage): add v2 needs-info lifecycle

### DIFF
--- a/.github/triage_v2/README.md
+++ b/.github/triage_v2/README.md
@@ -86,6 +86,14 @@ a reproduction heading when it contains an intermittent observation, controlled
 test, diagnostics, or concrete code-path analysis. These fields are diagnostic;
 by themselves they do not add `needs-info` or close an issue.
 
+On the event path, V2 uses the assessment to keep the Bug, Feature, or Docs
+label aligned with the classified content. An incomplete bug receives
+`needs-info` and the bot-owned triage comment becomes a request for the specific
+missing categories with a seven-day deadline. Author comments and issue-body
+edits run the classifier again; sufficient evidence removes `needs-info` and
+restores the normal assessment comment. Security issues are excluded from this
+lifecycle. V2 does not close issues; expiry is a separate rollout gate.
+
 ## Databricks dry-run
 
 The bundle defines a paused trigger on updates to `github_issues_bronze`. It

--- a/.github/triage_v2/src/issue_prioritization/bronze.py
+++ b/.github/triage_v2/src/issue_prioritization/bronze.py
@@ -57,6 +57,7 @@ class BronzeIssue:
             area_keys=classification.area_keys,
             component_labels=classification.component_labels,
             classification_reasoning=classification.reasoning,
+            classification_content_hash=classification.content_hash,
             reported_type=classification.reported_type,
             evidence_kind=classification.evidence_kind,
             information_status=classification.information_status,

--- a/.github/triage_v2/src/issue_prioritization/comments.py
+++ b/.github/triage_v2/src/issue_prioritization/comments.py
@@ -2,28 +2,64 @@ from __future__ import annotations
 
 import json
 import re
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 from issue_prioritization.artifacts import RankedIssue
-from issue_prioritization.domain import Priority
+from issue_prioritization.domain import (
+    EvidenceKind,
+    InformationStatus,
+    MissingInformation,
+    Priority,
+)
 from issue_prioritization.mutations import MutationPlan
 
 COMMENT_MARKER = "omnigent-issue-prioritization-v2"
+NEEDS_INFO_DAYS = 7
 _SPACE = re.compile(r"\s+")
+_MISSING_INFORMATION_TEXT = {
+    MissingInformation.TRIGGER: "the exact action, input, or sequence that triggers the problem",
+    MissingInformation.EXPECTED_BEHAVIOR: "what you expected to happen",
+    MissingInformation.OBSERVED_BEHAVIOR: "what happened instead, including the exact error",
+    MissingInformation.VERSION_OR_ENVIRONMENT: (
+        "the Omnigent version and relevant environment details"
+    ),
+    MissingInformation.DIAGNOSTIC_EVIDENCE: (
+        "logs, screenshots, or session IDs that show the failure"
+    ),
+}
+_EVIDENCE_TEXT = {
+    EvidenceKind.DIRECT_STEPS: "direct reproduction steps",
+    EvidenceKind.OBSERVED_INTERMITTENT: "a concrete intermittent observation",
+    EvidenceKind.CONTROLLED_TEST: "a controlled test",
+    EvidenceKind.DIAGNOSTIC_EVIDENCE: "diagnostic evidence",
+    EvidenceKind.CODE_ANALYSIS: "concrete code-path analysis",
+}
 
 
 def build_triage_comment(
     item: RankedIssue,
     plan: MutationPlan,
     labels_after: tuple[str, ...],
+    evaluated_at: datetime | None = None,
 ) -> str:
+    needs_info = item.issue.information_status == InformationStatus.NEEDS_INFO and not any(
+        value.startswith("needs_info_") for value in plan.blocked
+    )
+    deadline = (
+        evaluated_at + timedelta(days=NEEDS_INFO_DAYS) if needs_info and evaluated_at else None
+    )
     metadata = {
-        "schema_version": 1,
+        "schema_version": 2,
         "base_score": float(_base_score(item)),
+        "content_hash": item.issue.classification_content_hash,
+        "information_status": item.issue.information_status.value,
+        "needs_info_deadline": deadline.date().isoformat() if deadline else None,
     }
     marker = f"<!-- {COMMENT_MARKER} {json.dumps(metadata, separators=(',', ':'))} -->"
     priority_lines = _priority_lines(item, plan, labels_after)
     reasoning = _safe_reasoning(item.issue.classification_reasoning)
+    information_lines = _information_lines(item, deadline)
     return "\n".join(
         (
             marker,
@@ -31,12 +67,71 @@ def build_triage_comment(
             "",
             f"- **Bot assessment:** {item.issue.impact.label} impact",
             *priority_lines,
+            *information_lines,
             f"- **Why:** {reasoning}",
             "",
             "This automated assessment uses the issue content and repository signals. "
             "Maintainers can override the priority label.",
         )
     )
+
+
+def preserve_needs_info_deadline(body: str, existing_body: str) -> str:
+    metadata = _comment_metadata(body)
+    existing_metadata = _comment_metadata(existing_body)
+    if not metadata or not existing_metadata:
+        return body
+    if (
+        metadata.get("information_status") != InformationStatus.NEEDS_INFO
+        or existing_metadata.get("information_status") != InformationStatus.NEEDS_INFO
+        or not existing_metadata.get("needs_info_deadline")
+    ):
+        return body
+
+    new_deadline = str(metadata.get("needs_info_deadline") or "")
+    existing_deadline = str(existing_metadata["needs_info_deadline"])
+    metadata["needs_info_deadline"] = existing_deadline
+    lines = body.splitlines()
+    lines[0] = f"<!-- {COMMENT_MARKER} {json.dumps(metadata, separators=(',', ':'))} -->"
+    rendered = "\n".join(lines)
+    if new_deadline:
+        rendered = rendered.replace(f"**{new_deadline}**", f"**{existing_deadline}**", 1)
+    return rendered
+
+
+def _comment_metadata(body: str) -> dict[str, object] | None:
+    first_line = body.splitlines()[0] if body else ""
+    prefix = f"<!-- {COMMENT_MARKER} "
+    if not first_line.startswith(prefix) or not first_line.endswith(" -->"):
+        return None
+    try:
+        value = json.loads(first_line[len(prefix) : -4])
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _information_lines(item: RankedIssue, deadline: datetime | None) -> tuple[str, ...]:
+    issue = item.issue
+    if issue.information_status == InformationStatus.NEEDS_INFO and deadline:
+        requests = tuple(
+            f"  - [ ] {_MISSING_INFORMATION_TEXT[value]}" for value in issue.missing_information
+        )
+        return (
+            "- **Information status:** More information needed",
+            "",
+            "Please add the following details so this bug can be investigated:",
+            *requests,
+            "",
+            f"Please update the issue by **{deadline.date().isoformat()}** "
+            f"(within {NEEDS_INFO_DAYS} "
+            "days). A comment or body edit will trigger another review; if the report is still "
+            "missing this information after the deadline, it may be closed automatically.",
+            "",
+        )
+    if evidence := _EVIDENCE_TEXT.get(issue.evidence_kind):
+        return (f"- **Evidence:** {evidence}",)
+    return ()
 
 
 def _base_score(item: RankedIssue) -> Decimal:

--- a/.github/triage_v2/src/issue_prioritization/databricks_io.py
+++ b/.github/triage_v2/src/issue_prioritization/databricks_io.py
@@ -215,6 +215,8 @@ class VolumeArtifactSink:
                 "target": {
                     "priority": plan.target.priority,
                     "components": list(plan.target.components),
+                    "issue_type": plan.target.issue_type,
+                    "needs_info": plan.target.needs_info,
                 },
                 "labels_add": list(plan.labels_add),
                 "labels_remove": list(plan.labels_remove),
@@ -227,6 +229,7 @@ class VolumeArtifactSink:
                     ranked[plan.target.issue_number],
                     plan,
                     _planned_labels_after(ranked[plan.target.issue_number], plan),
+                    run.scored_at,
                 ),
             }
             for plan in run.mutations

--- a/.github/triage_v2/src/issue_prioritization/domain.py
+++ b/.github/triage_v2/src/issue_prioritization/domain.py
@@ -135,6 +135,7 @@ class Issue:
     area_keys: tuple[str, ...] = ()
     component_labels: tuple[str, ...] = ()
     classification_reasoning: str = ""
+    classification_content_hash: str = ""
     reported_type: IssueType | None = None
     evidence_kind: EvidenceKind = EvidenceKind.NONE
     information_status: InformationStatus = InformationStatus.NOT_APPLICABLE
@@ -160,6 +161,7 @@ class Issue:
             classification_reasoning=str(
                 value.get("classification_reasoning", value.get("reasoning", ""))
             ),
+            classification_content_hash=str(value.get("classification_content_hash", "")),
             reported_type=(
                 IssueType.parse(value["reported_type"]) if value.get("reported_type") else None
             ),

--- a/.github/triage_v2/src/issue_prioritization/event.py
+++ b/.github/triage_v2/src/issue_prioritization/event.py
@@ -170,6 +170,7 @@ def write_event_status(
                 decision,
                 plan,
                 labels_after if labels_after is not None else _planned_labels_after(decision, plan),
+                run.scored_at,
             )
         },
         "applied_bot_state": (
@@ -218,6 +219,8 @@ def _mutation_payload(plan: MutationPlan) -> dict[str, object]:
         "target": {
             "priority": plan.target.priority,
             "components": list(plan.target.components),
+            "issue_type": plan.target.issue_type,
+            "needs_info": plan.target.needs_info,
         },
         "labels_add": list(plan.labels_add),
         "labels_remove": list(plan.labels_remove),

--- a/.github/triage_v2/src/issue_prioritization/github.py
+++ b/.github/triage_v2/src/issue_prioritization/github.py
@@ -8,7 +8,11 @@ from urllib.parse import quote
 from urllib.request import Request, urlopen
 
 from issue_prioritization.bronze import BronzeIssue
-from issue_prioritization.comments import COMMENT_MARKER, build_triage_comment
+from issue_prioritization.comments import (
+    COMMENT_MARKER,
+    build_triage_comment,
+    preserve_needs_info_deadline,
+)
 from issue_prioritization.labels import LabelManifest
 from issue_prioritization.mutations import (
     BotState,
@@ -82,7 +86,42 @@ class GitHubClient:
             raise ValueError("GitHub issue response must be an object")
         if value.get("state") != "open" or "pull_request" in value:
             return None
+        author = value.get("user")
+        author_login = str(author.get("login", "")) if isinstance(author, dict) else ""
+        comments = self._author_comments(issue_number, author_login)
+        if comments:
+            original_body = str(value.get("body") or "")
+            value = {
+                **value,
+                "body": "Author follow-up comments (newest first):\n\n"
+                + "\n\n---\n\n".join(reversed(comments))
+                + "\n\nOriginal issue body:\n\n"
+                + original_body,
+            }
         return BronzeIssue.from_mapping(value)
+
+    def _author_comments(self, issue_number: int, author_login: str) -> tuple[str, ...]:
+        if not author_login:
+            return ()
+        comments = []
+        page = 1
+        while True:
+            value = self.transport(
+                "GET", f"/issues/{issue_number}/comments?per_page=100&page={page}", None
+            )
+            if not isinstance(value, list):
+                raise ValueError("GitHub issue comments response must be an array")
+            for comment in value:
+                if not isinstance(comment, dict):
+                    continue
+                user = comment.get("user")
+                login = str(user.get("login", "")) if isinstance(user, dict) else ""
+                body = str(comment.get("body") or "").strip()
+                if login.casefold() == author_login.casefold() and body:
+                    comments.append(body[:4000])
+            if len(value) < 100:
+                return tuple(comments[-5:])
+            page += 1
 
     def apply_labels(
         self,
@@ -115,7 +154,9 @@ class GitHubClient:
                 ):
                     continue
                 comment_id = int(comment["id"])
-                if comment.get("body") != body:
+                existing_body = str(comment.get("body", ""))
+                body = preserve_needs_info_deadline(body, existing_body)
+                if existing_body != body:
                     self.transport("PATCH", f"/issues/comments/{comment_id}", {"body": body})
                 return comment_id
             if len(value) < 100:
@@ -261,7 +302,7 @@ class GitHubMutationSink:
                 if item := ranked.get(issue_number):
                     self.client.upsert_issue_comment(
                         issue_number,
-                        build_triage_comment(item, plan, labels_after),
+                        build_triage_comment(item, plan, labels_after, run.scored_at),
                     )
         finally:
             self.states.upsert(updated)

--- a/.github/triage_v2/src/issue_prioritization/mutations.py
+++ b/.github/triage_v2/src/issue_prioritization/mutations.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from issue_prioritization.artifacts import RankedIssue
-from issue_prioritization.domain import Priority
+from issue_prioritization.domain import InformationStatus, Priority
 from issue_prioritization.labels import LEGACY_SEVERITY_LABELS, LabelManifest
 
 
@@ -34,6 +34,8 @@ class MutationTarget:
     issue_number: int
     priority: str
     components: tuple[str, ...]
+    issue_type: str | None = None
+    needs_info: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -101,6 +103,28 @@ class MutationPlanner:
         labels_remove = existing & LEGACY_SEVERITY_LABELS
         blocked: list[str] = []
 
+        if target.issue_type is not None:
+            type_labels = {"Bug", "Feature", "Docs"}
+            current_types = existing & type_labels
+            if target.issue_type not in current_types:
+                labels_add.add(target.issue_type)
+            labels_remove.update(current_types - {target.issue_type})
+
+        if target.needs_info is True:
+            lifecycle_labels = {label.casefold() for label in existing}
+            exemption = next(
+                (label for label in ("security", "duplicate") if label in lifecycle_labels),
+                None,
+            )
+            if exemption:
+                blocked.append(f"needs_info_{exemption}_exempt")
+                if "needs-info" in existing:
+                    labels_remove.add("needs-info")
+            elif "needs-info" not in existing:
+                labels_add.add("needs-info")
+        elif target.needs_info is False and "needs-info" in existing:
+            labels_remove.add("needs-info")
+
         current_priorities = existing & self.priority_labels
         current_priority = next(iter(current_priorities)) if len(current_priorities) == 1 else None
         priority_written = False
@@ -149,6 +173,8 @@ def target_from_ranked(item: RankedIssue) -> MutationTarget:
         issue_number=item.issue.number,
         priority=item.result.priority.value,
         components=item.issue.component_labels,
+        issue_type=item.issue.issue_type.label,
+        needs_info=item.issue.information_status == InformationStatus.NEEDS_INFO,
     )
 
 

--- a/.github/triage_v2/tests/test_comments.py
+++ b/.github/triage_v2/tests/test_comments.py
@@ -1,14 +1,31 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from decimal import Decimal
 
 from issue_prioritization.artifacts import RankedIssue
-from issue_prioritization.comments import build_triage_comment
-from issue_prioritization.domain import Impact, Issue, IssueType, Priority, ScoreResult, ScoreStep
+from issue_prioritization.comments import build_triage_comment, preserve_needs_info_deadline
+from issue_prioritization.domain import (
+    EvidenceKind,
+    Impact,
+    InformationStatus,
+    Issue,
+    IssueType,
+    MissingInformation,
+    Priority,
+    ScoreResult,
+    ScoreStep,
+)
 from issue_prioritization.mutations import BotState, MutationPlan, MutationTarget
 
 
-def _ranked(current_priority: Priority | None = None) -> RankedIssue:
+def _ranked(
+    current_priority: Priority | None = None,
+    *,
+    information_status: InformationStatus = InformationStatus.NOT_APPLICABLE,
+    evidence_kind: EvidenceKind = EvidenceKind.NONE,
+    missing_information: tuple[MissingInformation, ...] = (),
+) -> RankedIssue:
     issue = Issue(
         7,
         "Session fails",
@@ -16,6 +33,10 @@ def _ranked(current_priority: Priority | None = None) -> RankedIssue:
         IssueType.BUG,
         Impact.HIGH,
         classification_reasoning="Blocks @team session startup. <unsafe>",
+        classification_content_hash="content-v1",
+        information_status=information_status,
+        evidence_kind=evidence_kind,
+        missing_information=missing_information,
         current_priority=current_priority,
     )
     result = ScoreResult(
@@ -74,3 +95,125 @@ def test_comment_respects_a_human_removed_priority() -> None:
 
     assert "**Priority:** None (human override retained)" in body
     assert "**Automated recommendation:** `P1-high`" in body
+
+
+def test_comment_requests_specific_information_with_seven_day_deadline() -> None:
+    plan = MutationPlan(
+        MutationTarget(7, "P1-high", (), "Bug", True),
+        ("needs-info",),
+        (),
+        (),
+        BotState(7, None, ()),
+    )
+    ranked = _ranked(
+        information_status=InformationStatus.NEEDS_INFO,
+        missing_information=(
+            MissingInformation.TRIGGER,
+            MissingInformation.VERSION_OR_ENVIRONMENT,
+        ),
+    )
+
+    body = build_triage_comment(
+        ranked,
+        plan,
+        ("needs-info",),
+        datetime(2026, 8, 28, 12, tzinfo=UTC),
+    )
+
+    assert '"needs_info_deadline":"2026-09-04"' in body.splitlines()[0]
+    assert "exact action, input, or sequence" in body
+    assert "Omnigent version and relevant environment" in body
+    assert "what you expected" not in body
+    assert "within 7 days" in body
+
+
+def test_comment_records_usable_code_analysis_without_requesting_steps() -> None:
+    plan = MutationPlan(
+        MutationTarget(7, "P1-high", (), "Bug", False),
+        (),
+        (),
+        (),
+        BotState(7, None, ()),
+    )
+
+    body = build_triage_comment(
+        _ranked(
+            information_status=InformationStatus.SUFFICIENT,
+            evidence_kind=EvidenceKind.CODE_ANALYSIS,
+        ),
+        plan,
+        (),
+    )
+
+    assert "**Evidence:** concrete code-path analysis" in body
+    assert "More information needed" not in body
+
+
+def test_continuous_needs_info_keeps_deadline_after_content_changes() -> None:
+    plan = MutationPlan(
+        MutationTarget(7, "P1-high", (), "Bug", True),
+        ("needs-info",),
+        (),
+        (),
+        BotState(7, None, ()),
+    )
+    ranked = _ranked(
+        information_status=InformationStatus.NEEDS_INFO,
+        missing_information=(MissingInformation.TRIGGER,),
+    )
+    original = build_triage_comment(
+        ranked,
+        plan,
+        ("needs-info",),
+        datetime(2026, 8, 28, tzinfo=UTC),
+    )
+    refreshed = build_triage_comment(
+        ranked,
+        plan,
+        ("needs-info",),
+        datetime(2026, 8, 30, tzinfo=UTC),
+    )
+    refreshed = refreshed.replace('"content_hash":"content-v1"', '"content_hash":"content-v2"')
+
+    preserved = preserve_needs_info_deadline(refreshed, original)
+
+    assert '"needs_info_deadline":"2026-09-04"' in preserved.splitlines()[0]
+    assert '"content_hash":"content-v2"' in preserved.splitlines()[0]
+    assert "**2026-09-04**" in preserved
+
+
+def test_new_needs_info_transition_starts_a_new_deadline() -> None:
+    sufficient_plan = MutationPlan(
+        MutationTarget(7, "P1-high", (), "Bug", False),
+        (),
+        (),
+        (),
+        BotState(7, None, ()),
+    )
+    needs_info_plan = MutationPlan(
+        MutationTarget(7, "P1-high", (), "Bug", True),
+        ("needs-info",),
+        (),
+        (),
+        BotState(7, None, ()),
+    )
+    original = build_triage_comment(
+        _ranked(information_status=InformationStatus.SUFFICIENT),
+        sufficient_plan,
+        (),
+        datetime(2026, 8, 28, tzinfo=UTC),
+    )
+    refreshed = build_triage_comment(
+        _ranked(
+            information_status=InformationStatus.NEEDS_INFO,
+            missing_information=(MissingInformation.TRIGGER,),
+        ),
+        needs_info_plan,
+        ("needs-info",),
+        datetime(2026, 8, 30, tzinfo=UTC),
+    )
+
+    preserved = preserve_needs_info_deadline(refreshed, original)
+
+    assert '"needs_info_deadline":"2026-09-06"' in preserved.splitlines()[0]
+    assert "**2026-09-06**" in preserved

--- a/.github/triage_v2/tests/test_databricks_io.py
+++ b/.github/triage_v2/tests/test_databricks_io.py
@@ -72,7 +72,12 @@ def test_dry_run_artifact_contains_complete_mutation_plan(tmp_path) -> None:
     VolumeArtifactSink(str(tmp_path), ScoringConfig.default()).write(run)
 
     payload = json.loads((tmp_path / "preview" / "mutations.json").read_text())
-    assert payload[0]["target"] == {"priority": "P1-high", "components": ["comp:db"]}
+    assert payload[0]["target"] == {
+        "priority": "P1-high",
+        "components": ["comp:db"],
+        "issue_type": None,
+        "needs_info": None,
+    }
     assert payload[0]["labels_add"] == ["P1-high", "comp:db"]
     assert payload[0]["labels_remove"] == ["P2-medium", "severity:S2"]
     assert "<!-- omnigent-issue-prioritization-v2" in payload[0]["comment"]

--- a/.github/triage_v2/tests/test_event.py
+++ b/.github/triage_v2/tests/test_event.py
@@ -70,6 +70,7 @@ def test_event_grades_and_plans_labels_for_one_issue() -> None:
     assert classification.impact == Impact.HIGH
     assert run.ranked[0].result.score == Decimal("72.00")
     assert set(run.mutations[0].labels_add) == {
+        "Bug",
         "P1-high",
         "comp:db",
     }
@@ -88,7 +89,7 @@ def test_event_preserves_human_priority_and_retires_severity_label() -> None:
 
     assert run.ranked[0].issue.impact == Impact.HIGH
     assert run.ranked[0].result.priority.value == "P1-high"
-    assert run.mutations[0].labels_add == ("comp:db",)
+    assert run.mutations[0].labels_add == ("Bug", "comp:db")
     assert run.mutations[0].labels_remove == ("severity:S3",)
     assert run.mutations[0].blocked == ("priority_human_override",)
 
@@ -127,6 +128,8 @@ def test_event_artifact_contains_classification_and_mutation(tmp_path) -> None:
     assert payload["classification"]["missing_information"] == []
     assert payload["score"]["score"] == 72.0
     assert payload["mutation"]["target"]["priority"] == "P1-high"
+    assert payload["mutation"]["target"]["issue_type"] == "Bug"
+    assert payload["mutation"]["target"]["needs_info"] is False
     assert payload["model_endpoint"] == "test-endpoint"
     assert payload["source_revision"] == "abc123"
     assert "<!-- omnigent-issue-prioritization-v2" in payload["comment"]["body"]

--- a/.github/triage_v2/tests/test_github.py
+++ b/.github/triage_v2/tests/test_github.py
@@ -274,7 +274,11 @@ def test_client_loads_a_live_open_issue() -> None:
         "reactions": {"+1": 3},
         "state": "open",
     }
-    client = GitHubClient("token", "org/repo", lambda method, path, body: payload)
+
+    def transport(method, path, body):
+        return [] if "/comments" in path else payload
+
+    client = GitHubClient("token", "org/repo", transport)
 
     issue = client.open_issue(7)
 
@@ -283,6 +287,33 @@ def test_client_loads_a_live_open_issue() -> None:
     assert issue.author == "community"
     assert issue.labels == ("bug",)
     assert issue.upvote_count == 3
+
+
+def test_client_includes_only_author_follow_up_comments() -> None:
+    payload = {
+        "number": 7,
+        "title": "Session fails",
+        "body": "Original report",
+        "html_url": "https://github.com/org/repo/issues/7",
+        "user": {"login": "community"},
+        "labels": [{"name": "Bug"}],
+        "created_at": "2026-08-06T00:00:00Z",
+        "state": "open",
+    }
+    comments = [
+        {"user": {"login": "maintainer"}, "body": "Could you share logs?"},
+        {"user": {"login": "community"}, "body": "The session ID is abc-123."},
+    ]
+
+    def transport(method, path, body):
+        return comments if "/comments" in path else payload
+
+    issue = GitHubClient("token", "org/repo", transport).open_issue(7)
+
+    assert issue is not None
+    assert "The session ID is abc-123." in issue.body
+    assert "Could you share logs?" not in issue.body
+    assert "Original report" in issue.body
 
 
 def test_client_ignores_closed_issues_and_pull_requests() -> None:

--- a/.github/triage_v2/tests/test_mutations.py
+++ b/.github/triage_v2/tests/test_mutations.py
@@ -172,3 +172,42 @@ def test_legacy_human_priority_is_not_adopted() -> None:
     )
 
     assert planner.resolve_state(1, ("P2-medium",), None) is None
+
+
+def test_classification_corrects_type_and_requests_missing_information() -> None:
+    planner = MutationPlanner(_manifest(), FakeStates())
+    target = MutationTarget(1, "P1-high", ("comp:db",), "Bug", True)
+
+    plan = planner.plan_one(target, ("Feature",), None)
+
+    assert set(plan.labels_add) == {"Bug", "P1-high", "comp:db", "needs-info"}
+    assert plan.labels_remove == ("Feature",)
+
+
+def test_sufficient_reassessment_removes_needs_info() -> None:
+    planner = MutationPlanner(_manifest(), FakeStates())
+    target = MutationTarget(1, "P1-high", ("comp:db",), "Bug", False)
+
+    plan = planner.plan_one(target, ("Bug", "needs-info"), None)
+
+    assert "needs-info" in plan.labels_remove
+
+
+def test_security_issue_is_exempt_from_needs_info_lifecycle() -> None:
+    planner = MutationPlanner(_manifest(), FakeStates())
+    target = MutationTarget(1, "P1-high", ("comp:db",), "Bug", True)
+
+    plan = planner.plan_one(target, ("Bug", "security"), None)
+
+    assert "needs-info" not in plan.labels_add
+    assert "needs_info_security_exempt" in plan.blocked
+
+
+def test_duplicate_is_exempt_and_drops_stale_needs_info() -> None:
+    planner = MutationPlanner(_manifest(), FakeStates())
+    target = MutationTarget(1, "P1-high", ("comp:db",), "Bug", True)
+
+    plan = planner.plan_one(target, ("Bug", "duplicate", "needs-info"), None)
+
+    assert "needs-info" in plan.labels_remove
+    assert "needs_info_duplicate_exempt" in plan.blocked

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -32,7 +32,7 @@ name: Issue Triage
 
 on:
   issues:
-    types: [opened]
+    types: [opened, edited]
   workflow_call:
     inputs:
       issue_number:
@@ -819,14 +819,22 @@ jobs:
           if-no-files-found: ignore
 
   prioritize-v2:
-    name: Prioritize new issue with v2
+    name: Classify and prioritize issue with v2
     needs: triage
     if: >-
-      needs.triage.result == 'success' &&
-      github.event_name == 'issues' &&
-      github.event.action == 'opened' &&
+      always() &&
       vars.ISSUE_PRIORITIZATION_V2_ENABLED == 'true' &&
-      !endsWith(github.event.issue.user.login, '[bot]')
+      (
+        (
+          github.event_name == 'issues' &&
+          !endsWith(github.event.issue.user.login, '[bot]') &&
+          (
+            (github.event.action == 'opened' && needs.triage.result == 'success') ||
+            github.event.action == 'edited'
+          )
+        ) ||
+        (inputs.retriage && needs.triage.result == 'success')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -860,7 +868,7 @@ jobs:
           : "${DATABRICKS_CLIENT_SECRET:?Set the DATABRICKS_CLIENT_SECRET repository secret}"
           : "${MODEL_ENDPOINT:?Set the ISSUE_PRIORITIZATION_V2_MODEL_ENDPOINT repository variable}"
           uv run --frozen --project .github/triage_v2 issue-priority-event \
-            --issue-number "${{ github.event.issue.number }}" \
+            --issue-number "${{ github.event.issue.number || inputs.issue_number }}" \
             --github-repo "${{ github.repository }}" \
             --model-endpoint "$MODEL_ENDPOINT" \
             --areas .github/areas.json \
@@ -874,7 +882,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: issue-priority-v2-${{ github.event.issue.number }}-${{ github.run_id }}
+          name: issue-priority-v2-${{ github.event.issue.number || inputs.issue_number }}-${{ github.run_id }}
           path: /tmp/issue-priority-v2
           retention-days: 30
           if-no-files-found: warn


### PR DESCRIPTION
## Related issue

[OMNI-4269](https://linear.app/omnigent/issue/OMNI-4269/make-sure-issues-contain-valid-steps-to-reproduce)

## Summary

- Convert PR 1's information assessment into reversible V2 mutations: correct the type label, add needs-info only to incomplete bugs, and remove it when the report becomes sufficient.
- Update the bot-owned triage comment with the specific missing categories and a seven-day deadline.
- Re-evaluate issue-body edits and author comments, including follow-up comments in the model context.
- Keep a deadline stable while classified content is unchanged; refresh it only after content changes and another review.
- Exempt security and duplicate issues. This PR does not close anything.

ELI5: V2 now asks a focused follow-up question and checks the answer. The label is a temporary state, not a verdict.

```text
incomplete bug
     |
     v
needs-info + focused request
     |
 author comment or body edit
     |
     v
 V2 re-evaluation
   /         \
enough      still missing
  |              |
remove label   refresh request
```

Stack: #5653 -> #5654 (this PR) -> #5656. Review only this PR's diff for the lifecycle behavior.

## Test Plan

- Ran: uv run --isolated --frozen --project .github/triage_v2 pytest .github/triage_v2/tests
- Result: 89 tests passed on this branch.
- Ran the repository-wide pre-commit hooks on the completed stack.

## Demo

N/A — non-visual triage automation.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Covers type correction, needs-info add/remove behavior, security and duplicate exemptions, author-comment ingestion, focused request copy, and stable deadline handling.

## Changelog

Incomplete bug reports now receive a focused seven-day information request and are re-evaluated when the author responds.

