### PR TITLE
Retry native startup and policy evaluation after HTTP 429

### DIFF
--- a/omnigent/_http_retry.py
+++ b/omnigent/_http_retry.py
@@ -1,0 +1,34 @@
+"""Shared helpers for bounded HTTP retry delays."""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+
+import httpx
+
+
+def bounded_retry_after_seconds(
+    response: httpx.Response,
+    *,
+    fallback: float,
+    max_delay: float,
+) -> float:
+    """Return a bounded ``Retry-After`` delay, or the fallback."""
+    value = response.headers.get("retry-after")
+    if value is None:
+        return fallback
+    try:
+        delay = float(value)
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError, OverflowError):
+            return fallback
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=UTC)
+        delay = (retry_at - datetime.now(UTC)).total_seconds()
+    if not math.isfinite(delay) or delay < 0:
+        return fallback
+    return min(delay, max_delay)

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -93,6 +93,7 @@ from omnigent.native_terminal import (
 from omnigent.native_terminal import (
     normalize_extra_args as _normalize_extra_args,
 )
+from omnigent.native_terminal import request_with_429_retry
 from omnigent.native_terminal import (
     terminal_attach_url as _attach_url,
 )
@@ -1644,11 +1645,13 @@ async def _create_codex_session(
     }
     if terminal_launch_args:
         metadata["terminal_launch_args"] = terminal_launch_args
-    resp = await client.post(
-        "/v1/sessions",
-        data={"metadata": json.dumps(metadata)},
-        files={"bundle": ("codex-native-ui.tar.gz", bundle, "application/gzip")},
-        timeout=120.0,
+    resp = await request_with_429_retry(
+        lambda: client.post(
+            "/v1/sessions",
+            data={"metadata": json.dumps(metadata)},
+            files={"bundle": ("codex-native-ui.tar.gz", bundle, "application/gzip")},
+            timeout=120.0,
+        )
     )
     if resp.status_code >= 400:
         raise click.ClickException(

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -31,13 +31,16 @@ from typing import NotRequired, TypedDict
 
 import httpx
 
-# How long to keep retrying transient 5xx / connect errors on the
+from omnigent._http_retry import bounded_retry_after_seconds
+
+# How long to keep retrying transient 429 / 5xx / connect errors on the
 # policy evaluate POST before failing closed. Keeps the pre-execution
 # gate from blocking long on a sick server while still absorbing brief
-# DB hiccups on a hosted deployment.
+# hosted-deployment failures.
 _EVALUATE_POLICY_RETRY_BUDGET_S = 30.0
 _EVALUATE_POLICY_RETRY_INITIAL_BACKOFF_S = 1.0
 _EVALUATE_POLICY_RETRY_MAX_BACKOFF_S = 10.0
+_EVALUATE_POLICY_MAX_RETRY_AFTER_S = 10.0
 # Fast connect budget so an unreachable server fails into the retry
 # loop quickly rather than blocking on the day-long read timeout.
 _EVALUATE_POLICY_CONNECT_TIMEOUT_S = 5.0
@@ -531,23 +534,26 @@ def post_evaluate_with_retry(
     """
     POST to the Omnigent policy evaluate endpoint, retrying on transient errors.
 
-    Retries on 5xx HTTP responses and connection-level errors
+    Retries on explicit 429 and 5xx HTTP responses and connection-level errors
     (:class:`httpx.ConnectError`, :class:`httpx.ConnectTimeout`) within
     :data:`_EVALUATE_POLICY_RETRY_BUDGET_S`. Returns the successful response,
     or ``None`` if the budget is exhausted or a non-retryable error occurs.
+    A 429 ``Retry-After`` hint takes precedence over exponential backoff but
+    is capped by :data:`_EVALUATE_POLICY_MAX_RETRY_AFTER_S`.
 
     A stable ``_omnigent_elicitation_id`` is minted once and stamped on
     every attempt. When the server parks an ASK gate and the connection
-    drops (5xx or :class:`httpx.ConnectError`), the retry re-POSTs the
-    same id so the server re-attaches to the existing elicitation rather
-    than minting a new one — mirroring the ``_post_hook_with_reattach``
+    drops or rejects the request (429, 5xx, or :class:`httpx.ConnectError`),
+    each retry re-POSTs the same id so the server re-attaches to the existing
+    elicitation rather than minting a new one — mirroring the
+    ``_post_hook_with_reattach``
     idiom used by the ``PermissionRequest`` hook. This prevents a
     second approval card from appearing when the first was already
     published before the error.
 
-    4xx responses are final — a bad request won't succeed on retry. Other
-    mid-stream errors (e.g. :class:`httpx.ReadTimeout`) are also not retried:
-    a read timeout fires *after* the server received the request and may
+    Other 4xx responses are final — a bad request won't succeed on retry.
+    Other mid-stream errors (e.g. :class:`httpx.ReadTimeout`) are also not
+    retried: a read timeout fires *after* the server received the request and may
     mean the long-polling ASK gate was severed mid-wait; retrying with the
     same id will re-park the existing elicitation (no duplicate card), but
     the caller's fail-closed path is equivalent and simpler. The caller is
@@ -585,6 +591,7 @@ def post_evaluate_with_retry(
     reauthed = False
     last_error: str = "unknown error"
     while True:
+        retry_delay_s = backoff_s
         try:
             with httpx.Client(headers=headers, timeout=timeout) as client:
                 resp = client.post(url, json=request_body)
@@ -619,7 +626,17 @@ def post_evaluate_with_retry(
             last_error = f"server returned {status}" + (
                 f": {body_preview}" if body_preview else ""
             )
-            if status < 500:
+            if status == 429:
+                retry_delay_s = bounded_retry_after_seconds(
+                    exc.response,
+                    fallback=backoff_s,
+                    max_delay=_EVALUATE_POLICY_MAX_RETRY_AFTER_S,
+                )
+                print(
+                    f"omnigent {hook_label}: Omnigent returned 429; retrying",
+                    file=sys.stderr,
+                )
+            elif status < 500:
                 print(
                     f"omnigent {hook_label}: Omnigent returned {status}"
                     + (f": {body_preview}" if body_preview else ""),
@@ -646,12 +663,12 @@ def post_evaluate_with_retry(
                 file=sys.stderr,
             )
             return None, last_error
-        if time.monotonic() + backoff_s >= deadline:
+        if time.monotonic() + retry_delay_s >= deadline:
             print(
                 f"omnigent {hook_label}: retry budget exhausted",
                 file=sys.stderr,
             )
             return None, f"retry budget exhausted (last error: {last_error})"
         # Two-step backoff; not worth a retry library in this dependency-light hook.
-        time.sleep(backoff_s)
+        time.sleep(retry_delay_s)
         backoff_s = min(backoff_s * 2, _EVALUATE_POLICY_RETRY_MAX_BACKOFF_S)

--- a/omnigent/native_terminal.py
+++ b/omnigent/native_terminal.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import math
 import urllib.parse
 import warnings
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 
 import click
 import httpx
@@ -13,6 +18,49 @@ from omnigent.host.daemon_launch import error_text
 DAEMON_HOST_ONLINE_TIMEOUT_S = 30.0
 DAEMON_RUNNER_ONLINE_TIMEOUT_S = 60.0
 DAEMON_TERMINAL_READY_TIMEOUT_S = 60.0
+_HTTP_429_RETRY_DELAYS_S = (0.5, 1.0, 2.0, 4.0)
+_HTTP_429_MAX_RETRY_AFTER_S = 10.0
+_sleep = asyncio.sleep
+
+
+async def request_with_429_retry(
+    send: Callable[[], Awaitable[httpx.Response]],
+) -> httpx.Response:
+    """Send an HTTP request, retrying only explicit 429 responses.
+
+    The callable rebuilds the request for every attempt, which keeps multipart
+    session creation bodies replayable. ``Retry-After`` takes precedence over
+    the bounded exponential fallback schedule.
+
+    :param send: Callable that creates and sends one request attempt.
+    :returns: The first non-429 response, or the final 429 response.
+    """
+    for attempt in range(len(_HTTP_429_RETRY_DELAYS_S) + 1):
+        response = await send()
+        if response.status_code != 429 or attempt == len(_HTTP_429_RETRY_DELAYS_S):
+            return response
+        await _sleep(_retry_after_seconds(response, fallback=_HTTP_429_RETRY_DELAYS_S[attempt]))
+    raise AssertionError("unreachable")
+
+
+def _retry_after_seconds(response: httpx.Response, *, fallback: float) -> float:
+    """Return a bounded Retry-After delay, or the exponential fallback."""
+    value = response.headers.get("retry-after")
+    if value is None:
+        return fallback
+    try:
+        delay = float(value)
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError, OverflowError):
+            return fallback
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=UTC)
+        delay = (retry_at - datetime.now(UTC)).total_seconds()
+    if not math.isfinite(delay) or delay < 0:
+        return fallback
+    return min(delay, _HTTP_429_MAX_RETRY_AFTER_S)
 
 
 def normalize_extra_args(
@@ -96,9 +144,11 @@ async def bind_session_runner(
     :raises click.ClickException: If binding fails.
     """
     try:
-        resp = await client.patch(
-            f"/v1/sessions/{url_component(session_id)}",
-            json={"runner_id": runner_id},
+        resp = await request_with_429_retry(
+            lambda: client.patch(
+                f"/v1/sessions/{url_component(session_id)}",
+                json={"runner_id": runner_id},
+            )
         )
     except httpx.ConnectError as exc:
         # Connection refused/reset or DNS failure: the server was never reached.

--- a/omnigent/native_terminal.py
+++ b/omnigent/native_terminal.py
@@ -3,16 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-import math
 import urllib.parse
 import warnings
 from collections.abc import Awaitable, Callable
-from datetime import UTC, datetime
-from email.utils import parsedate_to_datetime
 
 import click
 import httpx
 
+from omnigent._http_retry import bounded_retry_after_seconds
 from omnigent.host.daemon_launch import error_text
 
 DAEMON_HOST_ONLINE_TIMEOUT_S = 30.0
@@ -39,28 +37,14 @@ async def request_with_429_retry(
         response = await send()
         if response.status_code != 429 or attempt == len(_HTTP_429_RETRY_DELAYS_S):
             return response
-        await _sleep(_retry_after_seconds(response, fallback=_HTTP_429_RETRY_DELAYS_S[attempt]))
+        await _sleep(
+            bounded_retry_after_seconds(
+                response,
+                fallback=_HTTP_429_RETRY_DELAYS_S[attempt],
+                max_delay=_HTTP_429_MAX_RETRY_AFTER_S,
+            )
+        )
     raise AssertionError("unreachable")
-
-
-def _retry_after_seconds(response: httpx.Response, *, fallback: float) -> float:
-    """Return a bounded Retry-After delay, or the exponential fallback."""
-    value = response.headers.get("retry-after")
-    if value is None:
-        return fallback
-    try:
-        delay = float(value)
-    except ValueError:
-        try:
-            retry_at = parsedate_to_datetime(value)
-        except (TypeError, ValueError, OverflowError):
-            return fallback
-        if retry_at.tzinfo is None:
-            retry_at = retry_at.replace(tzinfo=UTC)
-        delay = (retry_at - datetime.now(UTC)).total_seconds()
-    if not math.isfinite(delay) or delay < 0:
-        return fallback
-    return min(delay, _HTTP_429_MAX_RETRY_AFTER_S)
 
 
 def normalize_extra_args(

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -7819,6 +7819,41 @@ def test_wrapper_spec_raw_instructions_resolves_prompt(tmp_path: Path) -> None:
     assert "Codex is running in the session terminal" in result
 
 
+@pytest.mark.asyncio
+async def test_create_codex_session_retries_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fresh Codex session creation retries an explicit rate-limit response."""
+    attempts = 0
+    request_bodies: list[bytes] = []
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        request_bodies.append(await request.aread())
+        if attempts == 1:
+            return httpx.Response(429, request=request)
+        return httpx.Response(201, json={"session_id": "conv_new"}, request=request)
+
+    async def _fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("omnigent.native_terminal._sleep", _fake_sleep)
+    async with httpx.AsyncClient(
+        base_url="https://example.databricks.com",
+        transport=httpx.MockTransport(_handler),
+    ) as client:
+        session_id = await codex_native._create_codex_session(
+            client,
+            b"bundle",
+            bridge_id=None,
+            terminal_launch_args=["--config", "approval_policy=on-request"],
+        )
+
+    assert session_id == "conv_new"
+    assert attempts == 2
+    assert all(b"bundle" in body for body in request_bodies)
+    assert all(b"approval_policy=on-request" in body for body in request_bodies)
+
+
 def test_wrapper_spec_raw_instructions_degrades_on_malformed_spec(tmp_path: Path) -> None:
     """A malformed wrapper spec must not block the terminal launch."""
     bad_spec = tmp_path / "bad.yaml"

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -436,6 +436,145 @@ def _make_redirect_then_ok_client(
     return _Client
 
 
+def _make_sequence_client(
+    responses: list[httpx.Response],
+    request_bodies: list[dict[str, object]],
+) -> type:
+    """Build an httpx.Client stub that returns responses in order."""
+
+    class _Client:
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del headers, timeout
+
+        def __enter__(self) -> _Client:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: dict[str, object]) -> httpx.Response:
+            del url
+            request_bodies.append(dict(json))
+            index = min(len(request_bodies) - 1, len(responses) - 1)
+            return responses[index]
+
+    return _Client
+
+
+def test_post_evaluate_with_retry_recovers_from_429_with_stable_elicitation_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient 429 retries the same logical policy evaluation."""
+    request = httpx.Request("POST", "https://ap/x")
+    responses = [
+        httpx.Response(429, text="rate limited", request=request),
+        httpx.Response(200, json={"result": "POLICY_ACTION_ALLOW"}, request=request),
+    ]
+    request_bodies: list[dict[str, object]] = []
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        native_policy_hook.httpx,
+        "Client",
+        _make_sequence_client(responses, request_bodies),
+    )
+    monkeypatch.setattr(native_policy_hook.time, "sleep", sleeps.append)
+
+    resp, error = post_evaluate_with_retry(
+        "https://ap/x", {}, {"event": {"type": "PHASE_REQUEST"}}, 5.0, "policy hook"
+    )
+
+    assert resp is responses[1]
+    assert error is None
+    assert sleeps == [1.0]
+    assert len(request_bodies) == 2
+    elicitation_id = request_bodies[0]["_omnigent_elicitation_id"]
+    assert isinstance(elicitation_id, str)
+    assert elicitation_id.startswith("elicit_evaluate_")
+    assert all(body["_omnigent_elicitation_id"] == elicitation_id for body in request_bodies)
+
+
+def test_post_evaluate_with_retry_bounds_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 429 honors ``Retry-After`` without exceeding the delay cap."""
+    request = httpx.Request("POST", "https://ap/x")
+    responses = [
+        httpx.Response(429, headers={"Retry-After": "30"}, request=request),
+        httpx.Response(200, json={"result": "POLICY_ACTION_ALLOW"}, request=request),
+    ]
+    request_bodies: list[dict[str, object]] = []
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        native_policy_hook.httpx,
+        "Client",
+        _make_sequence_client(responses, request_bodies),
+    )
+    monkeypatch.setattr(native_policy_hook.time, "sleep", sleeps.append)
+
+    resp, error = post_evaluate_with_retry("https://ap/x", {}, {"event": {}}, 5.0, "hook")
+
+    assert resp is responses[1]
+    assert error is None
+    assert sleeps == [10.0]
+
+
+def test_post_evaluate_with_retry_fails_closed_after_repeated_429(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated 429s stop at the existing retry budget and fail closed."""
+    request = httpx.Request("POST", "https://ap/x")
+    responses = [httpx.Response(429, text="rate limited", request=request)]
+    request_bodies: list[dict[str, object]] = []
+    now = 0.0
+    sleeps: list[float] = []
+
+    def _sleep(delay: float) -> None:
+        nonlocal now
+        sleeps.append(delay)
+        now += delay
+
+    monkeypatch.setattr(
+        native_policy_hook.httpx,
+        "Client",
+        _make_sequence_client(responses, request_bodies),
+    )
+    monkeypatch.setattr(native_policy_hook.time, "monotonic", lambda: now)
+    monkeypatch.setattr(native_policy_hook.time, "sleep", _sleep)
+
+    resp, error = post_evaluate_with_retry("https://ap/x", {}, {"event": {}}, 5.0, "hook")
+
+    assert resp is None
+    assert error is not None
+    assert "retry budget exhausted" in error
+    assert "server returned 429" in error
+    assert sleeps == [1.0, 2.0, 4.0, 8.0, 10.0]
+    assert len(request_bodies) == 6
+    assert len({body["_omnigent_elicitation_id"] for body in request_bodies}) == 1
+
+
+def test_post_evaluate_with_retry_keeps_non_429_4xx_single_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-rate-limit 4xx remains final without sleeping or retrying."""
+    request = httpx.Request("POST", "https://ap/x")
+    responses = [httpx.Response(422, text="invalid request", request=request)]
+    request_bodies: list[dict[str, object]] = []
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        native_policy_hook.httpx,
+        "Client",
+        _make_sequence_client(responses, request_bodies),
+    )
+    monkeypatch.setattr(native_policy_hook.time, "sleep", sleeps.append)
+
+    resp, error = post_evaluate_with_retry("https://ap/x", {}, {"event": {}}, 5.0, "hook")
+
+    assert resp is None
+    assert error == "server returned 422: invalid request"
+    assert sleeps == []
+    assert len(request_bodies) == 1
+
+
 def test_post_evaluate_with_retry_reauths_on_login_redirect(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_native_terminal.py
+++ b/tests/test_native_terminal.py
@@ -45,6 +45,68 @@ async def test_bind_session_runner_patches_encoded_session_path() -> None:
 
 
 @pytest.mark.asyncio
+async def test_bind_session_runner_retries_429_with_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runner binding retries rate limits and honors ``Retry-After``."""
+    attempts = 0
+    sleeps: list[float] = []
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        """Rate limit two attempts before accepting the binding."""
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(429, headers={"Retry-After": "30"}, request=request)
+        if attempts == 2:
+            return httpx.Response(429, request=request)
+        return httpx.Response(200, json={}, request=request)
+
+    async def _fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(native_terminal, "_sleep", _fake_sleep)
+    async with httpx.AsyncClient(
+        base_url="https://example.databricks.com",
+        transport=httpx.MockTransport(_handler),
+    ) as client:
+        await native_terminal.bind_session_runner(client, "conv_abc", "runner_abc")
+
+    assert attempts == 3
+    assert sleeps == [10.0, 1.0]
+
+
+@pytest.mark.asyncio
+async def test_bind_session_runner_surfaces_429_after_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The final rate-limit response remains user-facing after the retry budget."""
+    attempts = 0
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(
+            429,
+            json={"error_code": "RESOURCE_EXHAUSTED"},
+            request=request,
+        )
+
+    async def _fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(native_terminal, "_sleep", _fake_sleep)
+    async with httpx.AsyncClient(
+        base_url="https://example.databricks.com",
+        transport=httpx.MockTransport(_handler),
+    ) as client:
+        with pytest.raises(click.ClickException, match="RESOURCE_EXHAUSTED"):
+            await native_terminal.bind_session_runner(client, "conv_abc", "runner_abc")
+
+    assert attempts == 5
+
+
+@pytest.mark.asyncio
 async def test_bind_session_runner_raises_click_exception_on_http_error() -> None:
     """
     HTTP failures surface as ClickException with server detail.
@@ -52,6 +114,8 @@ async def test_bind_session_runner_raises_click_exception_on_http_error() -> Non
     Native wrappers call this during CLI setup, so the failure must be
     user-facing instead of leaking a raw ``httpx.Response`` shape.
     """
+
+    attempts = 0
 
     async def _handler(request: httpx.Request) -> httpx.Response:
         """
@@ -61,6 +125,8 @@ async def test_bind_session_runner_raises_click_exception_on_http_error() -> Non
             :func:`native_terminal.bind_session_runner`.
         :returns: HTTP 409 response with JSON error detail.
         """
+        nonlocal attempts
+        attempts += 1
         return httpx.Response(
             409,
             json={"detail": "runner already bound"},
@@ -73,6 +139,8 @@ async def test_bind_session_runner_raises_click_exception_on_http_error() -> Non
     ) as client:
         with pytest.raises(click.ClickException, match="runner already bound"):
             await native_terminal.bind_session_runner(client, "conv_abc", "runner_abc")
+
+    assert attempts == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Closes #5659

## Summary

- Retry only explicit HTTP 429 responses during fresh Codex session creation, native runner binding, and native policy evaluation.
- Use bounded exponential backoff and honor `Retry-After` up to 10 seconds.
- Preserve a stable `_omnigent_elicitation_id` across policy-evaluation attempts so ASK replays reattach safely.
- Keep all other 4xx responses final; preserve existing transport-error handling and policy fail-closed behavior after retry exhaustion.
- Leave `/events` unchanged; batching and backpressure there require separate analysis.

ELI5: a temporary “too many requests” response now makes native startup or a policy check pause briefly and try again instead of immediately failing.

```text
native request
      |
      v
 HTTP response -- non-429 --> existing handling
      |
     429
      |
      v
bounded wait --> retry --> success or existing final failure behavior
```

## Test Plan

- `uv run --frozen pytest tests/test_native_policy_hook.py tests/test_native_terminal.py tests/test_codex_native.py` (304 passed)
- `uv run --frozen ruff check omnigent/_http_retry.py omnigent/native_terminal.py omnigent/native_policy_hook.py tests/test_native_policy_hook.py`
- `uv run --frozen ruff format --check omnigent/_http_retry.py omnigent/native_terminal.py omnigent/native_policy_hook.py tests/test_native_terminal.py tests/test_native_policy_hook.py tests/test_codex_native.py`
- `uv run --frozen pyrefly check omnigent/_http_retry.py omnigent/native_terminal.py omnigent/native_policy_hook.py` (0 errors)
- Verified 429 recovery, bounded `Retry-After`, exhausted retries, stable elicitation replay IDs, replayable multipart session creation, and non-429 4xx single-attempt behavior.

## Demo

N/A — non-visual CLI behavior.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover all three affected native request paths and confirm non-429 behavior remains unchanged.

## Changelog

Native startup and policy evaluation now retry temporary HTTP 429 responses before surfacing or failing closed.