### PR TITLE
feat(ci): close PRs that reference no issue after 7 days

### DIFF
--- a/.github/workflows/demo-check.yml
+++ b/.github/workflows/demo-check.yml
@@ -5,15 +5,17 @@ name: PR Hygiene
 #   1. Demo check -- comment on PRs that check "Bug fix" / "Feature" /
 #      "UI / frontend change" but provide no demo (screenshot / video).
 #      See demo-check.js.
-#   2. Issue-link check -- comment on PRs that reference no issue. Forward-only:
+#   2. Issue-link check -- comment on PRs that reference no issue and label them
+#      `needs-issue`, then close one still unlinked 7 days later. Forward-only:
 #      nothing opened before its effective date is considered, so the backlog is
-#      untouched. Enforcing, capped at LIMIT comments per run. See
-#      pr-issue-link.js.
+#      untouched. Enforcing, capped at LIMIT comments and LIMIT closures per run.
+#      See pr-issue-link.js.
 #
-# Both skip drafts and PRs they've already flagged -- the demo check dedupes on
-# its `needs-demo` label, the issue-link check on a marker in its own comment.
-# Neither ever closes anything. Never checks out or runs PR code -- they read
-# PR metadata via the API using only the default-branch script.
+# Both skip drafts and PRs they've already flagged, each deduping on its own label
+# (`needs-demo`, `needs-issue`). The demo check never closes anything; the
+# issue-link check closes only over its own label, only past the deadline the nudge
+# announced, and reversibly via `/reopen`. Never checks out or runs PR code -- they
+# read PR metadata via the API using only the default-branch script.
 
 on:
   schedule:
@@ -53,15 +55,23 @@ jobs:
           script: |
             const script = require(".github/workflows/demo-check.js");
             await script({ context, github, core });
-      # LIMIT bounds how many contributors a single run may comment on, so a
-      # mistake in the wording or the predicate cannot reach the whole queue in one
-      # sweep. Setting ENFORCE back to "false" returns to a dry run, which
+      # LIMIT bounds how many contributors a single run may comment on or close, so
+      # a mistake in the wording or the predicate cannot reach the whole queue in
+      # one sweep. Setting ENFORCE back to "false" returns to a dry run, which
       # enumerates every verdict into the step summary and writes nothing.
+      #
+      # CLOSE_ENFORCE gates only the close half, so the nudge stays live while the
+      # closes are a dry run: the step summary lists every WOULD CLOSE verdict for
+      # review first. Flip it to "true" to start closing. Nothing can be closed
+      # before it has carried `needs-issue` for the full window, and every PR
+      # already nudged under the old wording (which promised no action would be
+      # taken) is re-nudged with the deadline before its clock starts.
       - name: Issue-link check
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           ENFORCE: "true"
+          CLOSE_ENFORCE: "false"
           LIMIT: "25"
         with:
           retries: 3

--- a/.github/workflows/pr-hygiene-live.yml
+++ b/.github/workflows/pr-hygiene-live.yml
@@ -50,6 +50,9 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ENFORCE: "true"
+          # Keep in step with the sweep in demo-check.yml: the two paths run the
+          # same script and must never reach different verdicts.
+          CLOSE_ENFORCE: "false"
           # One PR per run, so the sweep's LIMIT (which bounds a batch) does not apply.
           PR_NUMBER: ${{ github.event.pull_request.number }}
         with:

--- a/.github/workflows/pr-issue-link.js
+++ b/.github/workflows/pr-issue-link.js
@@ -1,8 +1,18 @@
 // Scan PRs opened in the last 24 hours and flag any that don't link an issue.
 // Runs hourly from the demo-check sweep; the 24-hour window ensures every new PR
-// is checked even if it was opened just before a cron tick. A flagged PR gets one
-// comment and nothing else: no label (it would only add noise to the queue
-// maintainers filter) and no close.
+// is checked even if it was opened just before a cron tick.
+//
+// A flagged PR gets one comment and the `needs-issue` label. The label is the
+// whole state machine: it dedupes the comment, it is how a later sweep finds the
+// PR again (the 24-hour window cannot, and GitHub search cannot match a marker
+// hidden in a comment body), and its application time is the clock. A PR still
+// unlinked CLOSE_AFTER_DAYS after the label went on is closed, reversibly, with a
+// pointer at `/reopen`.
+//
+// The label is derived state, recomputed every run: a PR that should be flagged
+// gets it, a PR that should not has it removed. So linking the issue, ticking a
+// chore box, or converting to draft all clear it, and a PR that becomes flaggable
+// again starts a fresh clock rather than inheriting a stale one.
 //
 // Forward-only: nothing opened before EFFECTIVE_FROM is ever considered, so the
 // existing backlog is untouched no matter how the scan window is set.
@@ -30,15 +40,23 @@
 //     and a maintainer may hold write access without being listed in the file.
 
 const MS_PER_HOUR = 60 * 60 * 1000;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
 const HOURS_TO_SCAN = 24;
+// Days a PR may sit labeled `needs-issue` before it is closed. Matches the
+// `waiting-on-author` window so contributors have one number to learn, and the
+// same `/reopen` escape hatch applies.
+const CLOSE_AFTER_DAYS = 7;
 // The rule applies going forward only. PRs opened before this date are the
 // backlog's problem, cleared by hand, and must never be flagged -- so the floor
 // is a constant here rather than something a wider scan window could reach past.
 const EFFECTIVE_FROM = "2026-08-05T00:00:00Z";
-// Dedupe on a hidden marker in the bot's own comment rather than a label: the
-// nudge is a one-shot message, and a label on top of it would add queue noise
-// maintainers have to filter past (same approach as reopen-notice.js).
+// Stamped on the bot's own comment for provenance (same approach as
+// reopen-notice.js). Dedupe is the label's job, not this marker's.
 const MARKER = "<!-- pr-issue-link -->";
+// Dedupe, search key, and close clock in one. See the header.
+const NEEDS_ISSUE_LABEL = "needs-issue";
+// The only unconditional opt-out, and it needs write access. Removing
+// `needs-issue` is not one: that label is recomputed every run.
 const OVERRIDE_LABEL = "skip-issue-check";
 // Same threshold pr-size.js uses for size/XS.
 const TRIVIAL_LINES = 9;
@@ -200,12 +218,26 @@ The only exceptions are changes with no user-visible behaviour: pure **Refactor 
 
 See [CONTRIBUTING.md](https://github.com/omnigent-ai/omnigent/blob/main/CONTRIBUTING.md#every-pr-needs-an-issue) for the full policy.
 
-_No action is taken beyond this comment._`;
+This PR is now labeled \`${NEEDS_ISSUE_LABEL}\`. **If no issue is referenced within ${CLOSE_AFTER_DAYS} days, it will be closed automatically** to keep the review queue readable. That is not a judgement on the change, and it is reversible: comment \`/reopen\` and the PR comes back. Referencing an issue clears the label, and the countdown with it.`;
+
+const closeMessage = (labeledAt) =>
+  `Closing this PR because it has been labeled \`${NEEDS_ISSUE_LABEL}\` for ${CLOSE_AFTER_DAYS} days without an issue reference.
+
+The label was applied on ${labeledAt}. This isn't a judgement on the merit of the PR -- it's how we keep the review queue readable.
+
+To continue: add \`Closes #123\` or \`Part of #123\` to the description, then comment \`/reopen\` and this PR comes back, as long as its source branch still exists. If the branch is gone, push it again and open a fresh PR referencing this one.
+
+See [CONTRIBUTING.md](https://github.com/omnigent-ai/omnigent/blob/main/CONTRIBUTING.md#every-pr-needs-an-issue) for the full policy.`;
 
 module.exports = async ({ context, github, core }) => {
   const { owner, repo } = context.repo;
   // Default to a dry run: enforcement is opt-in via the workflow env.
   const enforce = process.env.ENFORCE === "true";
+  // Closing is gated separately from commenting, so the close half can ship in a
+  // dry run (verdicts in the step summary, nothing touched) while the nudge stays
+  // live. Implies ENFORCE: nothing may be closed over a label a dry run only
+  // pretended to apply.
+  const closeEnforce = enforce && process.env.CLOSE_ENFORCE === "true";
   // Unset means unlimited; an explicit LIMIT=0 means flag nothing. A malformed
   // value flags nothing rather than everything -- this bounds how many
   // contributors one run may comment on, so the safe default is the low one.
@@ -240,6 +272,25 @@ module.exports = async ({ context, github, core }) => {
       core.warning(`Could not load .github/MAINTAINER: ${err.message}`);
     }
 
+    // Ensure the label exists before applying it, the same way demo-check.js does
+    // for needs-demo. Only when enforcing: a dry run creates nothing.
+    if (enforce) {
+      try {
+        await github.rest.issues.createLabel({
+          owner,
+          repo,
+          name: NEEDS_ISSUE_LABEL,
+          color: "d93f0b",
+          description: `PR references no issue; closed after ${CLOSE_AFTER_DAYS} days`,
+        });
+      } catch (err) {
+        // 422 = already exists; anything else is unexpected.
+        if (err.status !== 422) {
+          core.warning(`Could not create label '${NEEDS_ISSUE_LABEL}': ${err.message}`);
+        }
+      }
+    }
+
     // One PR when an event names it, the whole window on the cron sweep. Only the
     // fetch differs: every decision below runs identically either way, so the
     // instant path and the sweep can never reach different verdicts.
@@ -266,31 +317,86 @@ module.exports = async ({ context, github, core }) => {
       const cutoff = new Date(
         Math.max(windowStart.getTime(), new Date(EFFECTIVE_FROM).getTime())
       );
-      const cutoffString = cutoff.toISOString().replace(/\.\d{3}Z$/, "Z");
-      const searchQuery = `repo:${owner}/${repo} is:pr is:open created:>${cutoffString}`;
-      console.log(`Scanning PRs: ${searchQuery} (enforce=${enforce})`);
-
-      let cursor = null;
-      let hasNextPage = true;
-      while (hasNextPage) {
-        const response = await github.graphql(QUERY, { cursor, searchQuery });
-        const { remaining, resetAt } = response.rateLimit;
-        console.log(`Rate limit: ${remaining} remaining, resets at ${resetAt}`);
-        const { nodes, pageInfo } = response.search;
-        hasNextPage = pageInfo.hasNextPage;
-        cursor = pageInfo.endCursor;
-        allPRs.push(...nodes);
+      const stamp = (d) => d.toISOString().replace(/\.\d{3}Z$/, "Z");
+      const search = async (searchQuery) => {
+        console.log(`Scanning PRs: ${searchQuery} (enforce=${enforce})`);
+        const found = [];
+        let cursor = null;
+        let hasNextPage = true;
+        while (hasNextPage) {
+          const response = await github.graphql(QUERY, { cursor, searchQuery });
+          const { remaining, resetAt } = response.rateLimit;
+          console.log(`Rate limit: ${remaining} remaining, resets at ${resetAt}`);
+          const { nodes, pageInfo } = response.search;
+          hasNextPage = pageInfo.hasNextPage;
+          cursor = pageInfo.endCursor;
+          found.push(...nodes);
+        }
+        return found;
+      };
+      // Two passes: PRs new enough to flag, then every PR already flagged. The
+      // second is the only route back to a PR older than the window, which is what
+      // the close clock needs. The effective date still floors both.
+      const seen = new Set();
+      for (const searchQuery of [
+        `repo:${owner}/${repo} is:pr is:open created:>${stamp(cutoff)}`,
+        `repo:${owner}/${repo} is:pr is:open label:${NEEDS_ISSUE_LABEL} created:>${stamp(new Date(EFFECTIVE_FROM))}`,
+      ]) {
+        for (const pr of await search(searchQuery)) {
+          if (seen.has(pr.number)) continue;
+          seen.add(pr.number);
+          allPRs.push(pr);
+        }
       }
-      console.log(`Found ${allPRs.length} open PRs from the last ${HOURS_TO_SCAN} hours`);
+      console.log(`Found ${allPRs.length} open PRs to check`);
     }
+
+    const hasNeedsIssue = (pr) =>
+      (pr.labels?.nodes ?? []).some((l) => l.name === NEEDS_ISSUE_LABEL);
+
+    // The label is derived state, so drop it the moment a PR stops being flaggable.
+    // Returns the reason string, annotated with what it did, for the summary.
+    const clearLabel = async (pr, why) => {
+      if (!hasNeedsIssue(pr)) return why;
+      if (!enforce) return `${why}; would clear ${NEEDS_ISSUE_LABEL}`;
+      try {
+        await github.rest.issues.removeLabel({
+          owner,
+          repo,
+          issue_number: pr.number,
+          name: NEEDS_ISSUE_LABEL,
+        });
+        return `${why}; cleared ${NEEDS_ISSUE_LABEL}`;
+      } catch (err) {
+        core.warning(`Could not clear ${NEEDS_ISSUE_LABEL} from #${pr.number}: ${err.message}`);
+        return why;
+      }
+    };
+
+    // When the label last went on, which is when the clock started. Null when no
+    // such event exists: unverifiable is not grounds to close.
+    const labeledAt = async (number) => {
+      const events = await github.paginate(github.rest.issues.listEvents, {
+        owner,
+        repo,
+        issue_number: number,
+        per_page: 100,
+      });
+      const stamps = events
+        .filter((e) => e.event === "labeled" && e.label?.name === NEEDS_ISSUE_LABEL)
+        .map((e) => e.created_at)
+        .sort();
+      return stamps.length ? stamps[stamps.length - 1] : null;
+    };
 
     const verdicts = [];
     let flagged = 0;
+    let closed = 0;
 
     for (const pr of allPRs) {
       const exempt = exemptReason(pr, maintainers);
       if (exempt) {
-        verdicts.push({ pr: pr.number, verdict: "exempt", reason: exempt });
+        verdicts.push({ pr: pr.number, verdict: "exempt", reason: await clearLabel(pr, exempt) });
         continue;
       }
 
@@ -308,7 +414,8 @@ module.exports = async ({ context, github, core }) => {
         continue;
       }
       if (linkCount > 0) {
-        verdicts.push({ pr: pr.number, verdict: "ok", reason: `${linkCount} linked` });
+        const reason = await clearLabel(pr, `${linkCount} linked`);
+        verdicts.push({ pr: pr.number, verdict: "ok", reason });
         continue;
       }
 
@@ -323,11 +430,61 @@ module.exports = async ({ context, github, core }) => {
         }
       }
       if (tracked) {
-        verdicts.push({ pr: pr.number, verdict: "ok", reason: `references #${tracked}` });
+        const reason = await clearLabel(pr, `references #${tracked}`);
+        verdicts.push({ pr: pr.number, verdict: "ok", reason });
         continue;
       }
 
       const author = pr.author?.login ?? "contributor";
+
+      // Already flagged. Only these PRs pay for the timeline lookup, and the label
+      // is what dedupes the nudge, so an unflagged PR costs nothing extra.
+      if (hasNeedsIssue(pr)) {
+        const since = await labeledAt(pr.number);
+        if (!since) {
+          core.warning(
+            `#${pr.number} has ${NEEDS_ISSUE_LABEL} but no labeled event; not closing.`
+          );
+          verdicts.push({ pr: pr.number, verdict: "skip", reason: "no label timestamp" });
+          continue;
+        }
+        const days = Math.floor((Date.now() - new Date(since).getTime()) / MS_PER_DAY);
+        if (days < CLOSE_AFTER_DAYS) {
+          verdicts.push({
+            pr: pr.number,
+            verdict: "waiting",
+            reason: `day ${days} of ${CLOSE_AFTER_DAYS}`,
+          });
+          continue;
+        }
+        const overdue = `labeled ${days}d ago`;
+        if (!closeEnforce) {
+          verdicts.push({ pr: pr.number, verdict: "WOULD CLOSE", reason: overdue });
+          continue;
+        }
+        // LIMIT bounds closures the same way it bounds nudges: a mistake in the
+        // predicate must not reach the whole queue in one sweep.
+        if (closed >= limit) {
+          verdicts.push({ pr: pr.number, verdict: "deferred", reason: "close limit reached" });
+          continue;
+        }
+        verdicts.push({ pr: pr.number, verdict: "CLOSED", reason: overdue });
+        closed++;
+        // Comment first, so the explanation is already there when it closes.
+        await github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: pr.number,
+          body: closeMessage(since.slice(0, 10)),
+        });
+        await github.rest.issues.update({
+          owner,
+          repo,
+          issue_number: pr.number,
+          state: "closed",
+        });
+        continue;
+      }
 
       // A dry run enumerates every verdict -- that's its whole point, so LIMIT
       // (which bounds how many contributors one enforcing run may touch) must
@@ -342,19 +499,6 @@ module.exports = async ({ context, github, core }) => {
         continue;
       }
 
-      // Only PRs about to be nudged pay for the comment lookup. Checked here
-      // rather than up front so the dry run doesn't spend a request per PR.
-      const comments = await github.paginate(github.rest.issues.listComments, {
-        owner,
-        repo,
-        issue_number: pr.number,
-        per_page: 100,
-      });
-      if (comments.some((c) => c.body?.includes(MARKER))) {
-        verdicts.push({ pr: pr.number, verdict: "skip", reason: "already nudged" });
-        continue;
-      }
-
       verdicts.push({ pr: pr.number, verdict: "FLAG", reason: `@${author}` });
       flagged++;
       await github.rest.issues.createComment({
@@ -363,6 +507,19 @@ module.exports = async ({ context, github, core }) => {
         issue_number: pr.number,
         body: `${MARKER}\n${message(author)}`,
       });
+      // The label is the clock, so it has to go on with the comment. Applied after
+      // it, so a failure here leaves an unflagged PR that the next run retries
+      // rather than a silent clock with no warning attached.
+      try {
+        await github.rest.issues.addLabels({
+          owner,
+          repo,
+          issue_number: pr.number,
+          labels: [NEEDS_ISSUE_LABEL],
+        });
+      } catch (err) {
+        core.warning(`Could not label #${pr.number} ${NEEDS_ISSUE_LABEL}: ${err.message}`);
+      }
     }
 
     const counts = verdicts.reduce((acc, v) => {
@@ -403,3 +560,5 @@ module.exports.assertedText = assertedText;
 module.exports.resolvesToOpenIssue = resolvesToOpenIssue;
 module.exports.MARKER = MARKER;
 module.exports.EFFECTIVE_FROM = EFFECTIVE_FROM;
+module.exports.NEEDS_ISSUE_LABEL = NEEDS_ISSUE_LABEL;
+module.exports.CLOSE_AFTER_DAYS = CLOSE_AFTER_DAYS;

--- a/.github/workflows/pr-issue-link.test.js
+++ b/.github/workflows/pr-issue-link.test.js
@@ -1,6 +1,7 @@
 // Local unit test for pr-issue-link.js -- mocks the GitHub client and runs the
 // real decision logic. No network. Covers the exemption predicates, the
-// authoritative per-PR link lookup, dedupe, and that a dry run touches nothing.
+// authoritative per-PR link lookup, the needs-issue label as dedupe and close
+// clock, and that a dry run touches nothing.
 
 const assert = require("assert");
 const path = require("path");
@@ -32,8 +33,15 @@ function pr({
   };
 }
 
+// Days ago as an ISO stamp, for the label clock.
+function daysAgo(n) {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+}
+
 // Run the script over PR nodes. `linked` maps PR number -> closing-issue count.
-// `env` overrides process.env for the run.
+// `env` overrides process.env for the run. `labelNodes` are served to the
+// second (label:needs-issue) search pass; `labelEvents` maps PR number -> when
+// the label went on, which is the close clock.
 async function run(
   nodes,
   {
@@ -41,14 +49,18 @@ async function run(
     env = {},
     linkError = false,
     maintainers = [],
-    existingComments = {},
+    labelNodes = [],
+    labelEvents = {},
     issues = {},
   } = {}
 ) {
   const commented = [];
   const labeled = [];
+  const unlabeled = [];
+  const updated = [];
+  const createdLabels = [];
   const queries = [];
-  let searchCalls = 0;
+  const pages = {};
   const github = {
     repos: {},
     graphql: async (query, vars) => {
@@ -76,17 +88,26 @@ async function run(
           },
         };
       }
-      const done = searchCalls++ > 0;
+      // Two passes run per sweep: the 24-hour window, then label:needs-issue.
+      // Each serves its nodes on page 1 and an empty page 2, to exercise paging.
+      const pass = /label:/.test(vars.searchQuery ?? "") ? "label" : "window";
+      pages[pass] = (pages[pass] ?? 0) + 1;
+      const first = pages[pass] === 1;
       return {
         rateLimit: { remaining: 4999, resetAt: "n/a" },
         search: {
-          pageInfo: { hasNextPage: !done, endCursor: "c" },
-          nodes: done ? [] : nodes,
+          pageInfo: { hasNextPage: first, endCursor: "c" },
+          nodes: first ? (pass === "label" ? labelNodes : nodes) : [],
         },
       };
     },
-    paginate: async (_fn, { issue_number }) =>
-      (existingComments[issue_number] ?? []).map((body) => ({ body })),
+    paginate: async (fn, { issue_number }) => {
+      if (fn !== "listEvents") return [];
+      const at = labelEvents[issue_number];
+      return at
+        ? [{ event: "labeled", label: { name: script.NEEDS_ISSUE_LABEL }, created_at: at }]
+        : [];
+    },
     rest: {
       repos: {
         getContent: async () => ({
@@ -95,8 +116,12 @@ async function run(
       },
       issues: {
         listComments: "listComments",
+        listEvents: "listEvents",
         createComment: async ({ issue_number, body }) => commented.push({ issue_number, body }),
         addLabels: async ({ issue_number, labels: ls }) => labeled.push({ issue_number, labels: ls }),
+        removeLabel: async ({ issue_number, name }) => unlabeled.push({ issue_number, name }),
+        update: async ({ issue_number, state }) => updated.push({ issue_number, state }),
+        createLabel: async ({ name }) => createdLabels.push(name),
         // `issues` maps number -> "issue" | "pr" | undefined (404).
         get: async ({ issue_number }) => {
           const kind = issues[issue_number];
@@ -140,7 +165,7 @@ async function run(
     for (const k of Object.keys(env)) delete process.env[k];
     Object.assign(process.env, saved);
   }
-  return { commented, labeled, warnings, rows, queries };
+  return { commented, labeled, unlabeled, updated, createdLabels, warnings, rows, queries };
 }
 
 const ENFORCE = { ENFORCE: "true" };
@@ -284,13 +309,21 @@ for (const tracked of ["Bug fix", "Feature", "UI / frontend change"]) {
     assert.strictEqual(commented[0].issue_number, 21);
     assert.match(commented[0].body, /@alice/);
     assert.match(commented[0].body, /Closes #123/);
-    assert.ok(commented[0].body.startsWith(script.MARKER), "comment carries the dedupe marker");
+    assert.ok(commented[0].body.startsWith(script.MARKER), "comment carries the provenance marker");
     // House style: no em dashes in anything a contributor reads.
     assert.ok(!commented[0].body.includes("—"), "no em dashes in the nudge");
     // The exemption must not read as a free opt-out.
     assert.match(commented[0].body, /require an issue for every PR/);
     assert.match(commented[0].body, /even when it also touches docs or tests/);
-    assert.deepStrictEqual(labeled, [], "no label is applied");
+    // The close is a promise the comment has to make before the clock can run.
+    assert.match(commented[0].body, /will be closed automatically/);
+    assert.match(commented[0].body, new RegExp(`${script.CLOSE_AFTER_DAYS} days`));
+    assert.match(commented[0].body, /\/reopen/);
+    assert.deepStrictEqual(
+      labeled,
+      [{ issue_number: 21, labels: [script.NEEDS_ISSUE_LABEL] }],
+      "the nudge starts the clock by labeling"
+    );
   }
 
   // A non-closing reference to a real ISSUE satisfies the rule: a PR that only
@@ -413,23 +446,124 @@ for (const tracked of ["Bug fix", "Feature", "UI / frontend change"]) {
     assert.strictEqual(labeled.length, 0);
   }
 
-  // An already-nudged PR is never commented on twice: the hidden marker in the
-  // bot's own earlier comment is the dedupe.
+  // An already-labeled PR is never nudged twice: the label is the dedupe.
   {
-    const { commented } = await run([pr({ number: 23 })], {
+    const flagged = pr({ number: 23, labels: [script.NEEDS_ISSUE_LABEL] });
+    const { commented } = await run([flagged], {
       env: ENFORCE,
-      existingComments: { 23: [`${script.MARKER}\nplease link an issue`] },
+      labelEvents: { 23: daysAgo(1) },
     });
-    assert.strictEqual(commented.length, 0, "marker dedupes repeat runs");
+    assert.strictEqual(commented.length, 0, "the label dedupes repeat runs");
   }
 
-  // An unrelated human comment must not be mistaken for the nudge.
+  // Inside the window the PR is left alone, with the countdown reported.
   {
-    const { commented } = await run([pr({ number: 231 })], {
-      env: ENFORCE,
-      existingComments: { 231: ["lgtm"] },
+    const flagged = pr({ number: 230, labels: [script.NEEDS_ISSUE_LABEL] });
+    const { commented, updated, rows } = await run([flagged], {
+      env: { ...ENFORCE, CLOSE_ENFORCE: "true" },
+      labelEvents: { 230: daysAgo(script.CLOSE_AFTER_DAYS - 1) },
     });
-    assert.strictEqual(commented.length, 1, "only the marker suppresses the nudge");
+    assert.strictEqual(commented.length, 0, "not yet due");
+    assert.strictEqual(updated.length, 0, "not yet due");
+    assert.match(rows.find((r) => r[0] === "#230")[1], /waiting/);
+  }
+
+  // Past the window, CLOSE_ENFORCE off is a dry run: it reports, changes nothing.
+  {
+    const flagged = pr({ number: 232, labels: [script.NEEDS_ISSUE_LABEL] });
+    const { commented, updated, rows } = await run([flagged], {
+      env: ENFORCE,
+      labelEvents: { 232: daysAgo(script.CLOSE_AFTER_DAYS + 3) },
+    });
+    assert.strictEqual(updated.length, 0, "CLOSE_ENFORCE off must not close");
+    assert.strictEqual(commented.length, 0, "CLOSE_ENFORCE off must not comment");
+    assert.strictEqual(rows.find((r) => r[0] === "#232")[1], "WOULD CLOSE");
+  }
+
+  // Past the window with CLOSE_ENFORCE on: comment, then close.
+  {
+    const flagged = pr({ number: 233, labels: [script.NEEDS_ISSUE_LABEL] });
+    const { commented, updated } = await run([flagged], {
+      env: { ...ENFORCE, CLOSE_ENFORCE: "true" },
+      labelEvents: { 233: daysAgo(script.CLOSE_AFTER_DAYS) },
+    });
+    assert.deepStrictEqual(updated, [{ issue_number: 233, state: "closed" }]);
+    assert.strictEqual(commented.length, 1);
+    assert.match(commented[0].body, /\/reopen/, "the close is reversible, and says so");
+    assert.ok(!commented[0].body.includes("\u2014"), "no em dashes in the close notice");
+  }
+
+  // CLOSE_ENFORCE alone must never close: it only unlocks the enforcing path.
+  {
+    const flagged = pr({ number: 234, labels: [script.NEEDS_ISSUE_LABEL] });
+    const { updated, commented } = await run([flagged], {
+      env: { CLOSE_ENFORCE: "true" },
+      labelEvents: { 234: daysAgo(30) },
+    });
+    assert.strictEqual(updated.length, 0, "CLOSE_ENFORCE without ENFORCE is still a dry run");
+    assert.strictEqual(commented.length, 0);
+  }
+
+  // A label with no timestamp in the timeline must fail closed, never close.
+  {
+    const flagged = pr({ number: 235, labels: [script.NEEDS_ISSUE_LABEL] });
+    const { updated, warnings } = await run([flagged], {
+      env: { ...ENFORCE, CLOSE_ENFORCE: "true" },
+    });
+    assert.strictEqual(updated.length, 0, "no label timestamp is not grounds to close");
+    assert.ok(warnings.some((w) => /#235 has needs-issue but no labeled event/.test(w)));
+  }
+
+  // The label is derived state: linking the issue clears it and the countdown.
+  {
+    const flagged = pr({ number: 236, labels: [script.NEEDS_ISSUE_LABEL] });
+    const { unlabeled, updated } = await run([flagged], {
+      linked: { 236: 1 },
+      env: { ...ENFORCE, CLOSE_ENFORCE: "true" },
+      labelEvents: { 236: daysAgo(30) },
+    });
+    assert.deepStrictEqual(unlabeled, [
+      { issue_number: 236, name: script.NEEDS_ISSUE_LABEL },
+    ]);
+    assert.strictEqual(updated.length, 0, "a linked PR is never closed");
+  }
+
+  // Becoming exempt also clears it, so a draft's clock does not keep running.
+  {
+    const flagged = pr({ number: 237, draft: true, labels: [script.NEEDS_ISSUE_LABEL] });
+    const { unlabeled, updated } = await run([flagged], {
+      env: { ...ENFORCE, CLOSE_ENFORCE: "true" },
+      labelEvents: { 237: daysAgo(30) },
+    });
+    assert.deepStrictEqual(unlabeled, [
+      { issue_number: 237, name: script.NEEDS_ISSUE_LABEL },
+    ]);
+    assert.strictEqual(updated.length, 0, "an exempt PR is never closed");
+  }
+
+  // The label pass is what reaches a PR older than the 24-hour window.
+  {
+    const stale = pr({ number: 238, labels: [script.NEEDS_ISSUE_LABEL] });
+    const { updated, queries } = await run([], {
+      labelNodes: [stale],
+      env: { ...ENFORCE, CLOSE_ENFORCE: "true" },
+      labelEvents: { 238: daysAgo(20) },
+    });
+    assert.ok(
+      queries.some((q) => q.includes(`label:${script.NEEDS_ISSUE_LABEL}`)),
+      "a second search pass looks for already-flagged PRs"
+    );
+    assert.deepStrictEqual(updated, [{ issue_number: 238, state: "closed" }]);
+  }
+
+  // LIMIT caps closures the same way it caps nudges.
+  {
+    const overdue = [239, 240, 241].map((n) => pr({ number: n, labels: [script.NEEDS_ISSUE_LABEL] }));
+    const { updated } = await run(overdue, {
+      env: { ...ENFORCE, CLOSE_ENFORCE: "true", LIMIT: "2" },
+      labelEvents: { 239: daysAgo(10), 240: daysAgo(10), 241: daysAgo(10) },
+    });
+    assert.strictEqual(updated.length, 2, "LIMIT bounds closures per run");
   }
 
   // A failed link lookup must fail closed (skip), never flag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -367,7 +367,12 @@ your PR is, check that box under *Type of change* and no issue is needed.
 Anything that fixes a bug, adds a feature, or changes the UI needs an issue,
 even when it also touches docs or tests.
 
-A bot comments once on PRs that reference no issue. It never closes anything.
+A bot comments once on PRs that reference no issue and labels them `needs-issue`.
+Reference an issue and the label clears automatically. A PR still labeled
+`needs-issue` after **7 days** is closed, the same way and for the same reason as
+`waiting-on-author` below: to keep the review queue readable, not as a judgement
+on the change. It is reversible, so comment `/reopen` once you have added the
+reference.
 
 ### Review state labels
 
@@ -378,6 +383,10 @@ need to apply them.
 | --- | --- |
 | `waiting-on-author` | A maintainer has left feedback. The PR is in your court. |
 | `waiting-for-review` | You have responded. It is back in the reviewer's queue. |
+
+A third label, `needs-issue`, is separate from these two: it says the PR
+references no issue, not that anyone is waiting on a reply. See [Every PR needs an
+issue](#every-pr-needs-an-issue).
 
 A maintainer reviewing or commenting on your PR sets `waiting-on-author`. When
 you push a commit, comment, or reply to a review, that clears automatically and


### PR DESCRIPTION
## Related issue

No issue: this is a `Test / CI` + `Docs` change (see *Type of change*), so none is
required. Requested in Slack after ~40 PRs were spotted still open with no issue
reference. Happy to file a tracking issue if reviewers prefer one.

## Summary

**ELI5:** the bot that says "please link an issue" only ever said it. Nothing
followed up, so a PR could ignore it forever. Now the bot also puts a
`needs-issue` label on, and if the label is still there 7 days later the PR is
closed, reversibly, with `/reopen`.

The nudge in `pr-issue-link.js` commented and stopped there by design: no label,
no close. Since the 5 August effective date, **32 open PRs still reference no
issue, 22 of them nudged between 9 and 21 days ago.** Detection is fine (of the
50 that look unlinked, the other 18 are correctly exempt: bots, declared
chore/docs/test, `Part of #N`, and a maintainer in `.github/MAINTAINER`). Only
enforcement was missing.

**Why not route it into `waiting-on-author`, which already closes at 7 days.**
Two reasons, both fatal:

1. Its only entrance (`waiting_on_author.py`, `apply_waiting_on_maintainer_activity`)
   requires a **non-bot** actor with write access leaving a review, so a bot nudge
   cannot reach it.
2. Its clear conditions are a comment, review reply, or new commit. The nudge asks
   the author to *edit the description* or *link from the sidebar*, and neither is
   author activity (the sidebar link fires no webhook at all). A contributor who did
   exactly what the bot asked would still be closed on day 7.

So the nudge gets its own deadline on its own label. `needs-issue` is dedupe,
search key, and clock in one:

```
                        ┌─ exempt / linked ──→ clear the label, done
open PR ─→ check link ──┤
                        └─ unlinked ─→ labeled? ─ no ──→ comment + label (clock starts)
                                            └─ yes ─→ label age < 7d ──→ leave it
                                                          age >= 7d ──→ comment + close
```

The label is **derived state, recomputed every run**, which is what keeps the
clock honest: converting to draft clears it, so a PR that becomes flaggable again
starts a fresh 7 days instead of inheriting a stale one. `skip-issue-check`
remains the only opt-out (it needs write access; removing `needs-issue` is not an
opt-out, since the label comes back).

Two structural bits:

- **A second search pass** over `label:needs-issue` (floored at the effective
  date). The 24-hour window can never reach a PR nudged 8 days ago, and GitHub
  search cannot match a marker hidden in a comment body, so this is the only route
  back. `MARKER` is now provenance only.
- **The per-PR comment scan is gone**, since the label dedupes. Net new API cost is
  one `listEvents` per already-labeled PR, which is roughly the set that was paying
  for a comment list anyway.

**`CLOSE_ENFORCE` ships `"false"`.** It gates only the close half and implies
`ENFORCE`, so the nudge stays live while closes are a dry run that lists every
`WOULD CLOSE` verdict in the step summary for review. `LIMIT` bounds closures the
way it already bounds nudges. Set on both callers (`demo-check.yml` sweep and
`pr-hygiene-live.yml` per-PR) so the two paths cannot disagree.

**No broken promises.** The 32 already-nudged PRs were told "_No action is taken
beyond this comment._", and `CONTRIBUTING.md` said the bot "never closes
anything". They carry no label, so the first enforcing run re-nudges them with
wording that states the deadline, and the clock starts there. Both texts are
updated in this PR.

## Test Plan

```bash
node .github/workflows/pr-issue-link.test.js    # 13 new assertions
node .github/workflows/ready-for-review.test.js # unaffected sibling, still green
pre-commit run --files .github/workflows/pr-issue-link.js .github/workflows/pr-issue-link.test.js \
  .github/workflows/demo-check.yml .github/workflows/pr-hygiene-live.yml CONTRIBUTING.md
```

New unit coverage, all with a mocked client and no network: the label dedupes the
nudge; inside the window nothing happens and the countdown is reported; past the
window with `CLOSE_ENFORCE` off it reports `WOULD CLOSE` and writes nothing; with
it on, comment then close; `CLOSE_ENFORCE` without `ENFORCE` is still a dry run; a
label with no timeline event fails closed rather than closing; linking or becoming
exempt clears the label and cancels the close; the label pass is what reaches a PR
older than the window; and `LIMIT` caps closures.

Live dry-run check before enabling anything (writes nothing): dispatch **PR
Hygiene** on this branch and read the *Issue-link check* step summary. Expect ~32
`FLAG` rows (25 plus `deferred` under `LIMIT: 25`), zero `CLOSED`, and `#4363`,
`#4731`, `#4647`, `#5233` still `exempt`/`ok`. Those four are the false-positive
canaries: declared `Test / CI`, declared `Docs`, `Part of #4327`, and a
`.github/MAINTAINER` author.

## Demo

N/A, no UI surface.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was read-only against the live repo: enumerated every open PR
created since the effective date, cross-checked each apparently-unlinked one
against the script's exemption rules, and confirmed the nudge/label/close history
on #4446 (nudged 19 days ago, never labeled) and #4846 (nudged, then labeled
`waiting-on-author` 11 days later by a maintainer review, not by the nudge). That
pair is what shows the nudge never reached the existing 7-day close.

The close path itself is exercised only by the unit tests, deliberately: it is
gated behind `CLOSE_ENFORCE: "false"` in this PR, so the live proof is the dry-run
step summary above rather than a real closure.
