### PR TITLE
Price AWS Bedrock Anthropic model ids from the shared catalog

### DIFF
--- a/omnigent/onboarding/providers/__init__.py
+++ b/omnigent/onboarding/providers/__init__.py
@@ -618,6 +618,12 @@ def _inferred_catalog_provider(model: str) -> str | None:
     return None
 
 
+_BEDROCK_ANTHROPIC_PATTERN = re.compile(
+    r"^(?:[a-z0-9-]{2,8}\.)?anthropic\.(?P<model>claude-.+?)(?:-v\d+)?$",
+    re.IGNORECASE,
+)
+
+
 def _catalog_lookup_targets(model: str) -> list[tuple[str, str]]:
     """Return bounded provider/id pairs for a model catalog lookup."""
     normalized = model.split(":", 1)[0].strip()
@@ -627,6 +633,14 @@ def _catalog_lookup_targets(model: str) -> list[tuple[str, str]]:
     def _add(provider: str | None, model_id: str) -> None:
         if provider is not None and (provider, model_id) not in targets:
             targets.append((provider, model_id))
+
+    bedrock = _BEDROCK_ANTHROPIC_PATTERN.match(normalized)
+    if bedrock:
+        bare = bedrock.group("model")
+        _add("anthropic", bare)
+        _add(_inferred_catalog_provider(bare), bare)
+        _add("openrouter", normalized)
+        return targets
 
     if "/" in normalized:
         namespace, bare = normalized.split("/", 1)

--- a/tests/onboarding/test_providers.py
+++ b/tests/onboarding/test_providers.py
@@ -246,6 +246,9 @@ def test_get_models_preserves_context_and_cache_pricing_metadata() -> None:
         ("databricks-claude-opus-4-8", "anthropic", "claude-opus-4-8"),
         ("databricks/databricks-claude-opus-4-8", "anthropic", "claude-opus-4-8"),
         ("DATABRICKS-CLAUDE-OPUS-4-8", "anthropic", "claude-opus-4-8"),
+        ("anthropic.claude-opus-4-8-v1:0", "anthropic", "claude-opus-4-8"),
+        ("us.anthropic.claude-opus-4-8-v1:0", "anthropic", "claude-opus-4-8"),
+        ("anthropic.claude-opus-4-8", "anthropic", "claude-opus-4-8"),
     ],
 )
 def test_find_catalog_models_resolves_provider_and_vendor_namespaces(


### PR DESCRIPTION
## Related issue

Closes #5663

## Summary

- Bedrock model ids are dot-namespaced with a version segment (`[<region>.]anthropic.claude-…-vN[:M]`). `_catalog_lookup_targets` only recognised `/`-qualified and `databricks-` ids, so a Bedrock id missed the catalog entirely and the turn was left **unpriced** — token counts showed but `total_cost_usd` stayed absent — even though the same model prices fine under its plain `claude-…` id.
- Normalize the Bedrock form to the bare `claude-…` id (anthropic provider) before catalog lookup, so pricing (and the catalog context window) resolve just like the plain id. Fixed at the shared resolver, so both `fetch_model_pricing` and `get_model_context_window` benefit.

## Test Plan

Added three Bedrock cases (region-less, cross-region `us.`, and no-version) to the existing offline `find_catalog_models` parametrization in `tests/onboarding/test_providers.py`.

- **Before** the source change, the three new cases fail (`find_catalog_models(...)` → `[]`).
- **After**, all pass:

```
uv run --no-sync pytest tests/onboarding/test_providers.py::test_find_catalog_models_resolves_provider_and_vendor_namespaces -q
# 11 passed
```

## Demo

N/A (non-visual change).

## Type of change

- [x] Bug fix

## Test coverage

- [x] This PR adds or updates tests

## Coverage notes

Extends the existing offline parametrization (mocked catalog fixture) with a failing-before / passing-after regression case for the Bedrock id form.

---
This pull request and its description were written by Isaac.
