### PR TITLE
[Stack B] feat(extensions): define runner tool contributions

### DIFF
--- a/docs/extending/extension_manifest.md
+++ b/docs/extending/extension_manifest.md
@@ -14,14 +14,17 @@ import runtime or UI implementation modules.
 ```python
 from omnigent.extensions import (
     EXTENSION_API_VERSION,
+    EnablementScope,
     ExtensionEntrypoints,
     ExtensionManifest,
     ExtensionPermission,
     PageContribution,
     PrimaryNavigationContribution,
+    RunnerPermission,
     SlotId,
     SlotItemContribution,
     SlotItemKind,
+    ToolContribution,
 )
 
 
@@ -36,6 +39,7 @@ def get_manifest() -> ExtensionManifest:
         entrypoints=ExtensionEntrypoints(
             browser="dist/extension.js",
             browser_css="dist/extension.css",
+            runner="acme_review.runner:activate",
         ),
         permissions=frozenset({ExtensionPermission.NAVIGATION}),
         pages=(
@@ -64,6 +68,17 @@ def get_manifest() -> ExtensionManifest:
                 page="acme.review.dashboard",
             ),
         ),
+        tools=(
+            ToolContribution(
+                id="acme.review.review-tool",
+                tool_name="ext__acme_d_review__review",
+                title="Review workspace",
+                description="Review files in the current workspace.",
+                input_schema={"type": "object"},
+                runner_permissions=frozenset({RunnerPermission.FILESYSTEM_READ}),
+                enablement=EnablementScope.AGENT,
+            ),
+        ),
     )
 ```
 
@@ -76,6 +91,11 @@ def get_manifest() -> ExtensionManifest:
 - `requires_omnigent` is a PEP 440 release-line range.
 - Browser paths are fixed to `dist/extension.js` and optional
   `dist/extension.css` inside the entry point's verified import package.
+- Runner entrypoints use `package.module:factory`, live in the manifest entry
+  point's verified package, and are declared together with tools.
+- Tool names use the reserved injective `ext__...__tool` namespace, schemas are
+  JSON objects, and permissions/enablement use closed enums. See
+  [Extension tools](extension_tools.md).
 - Slot items use a supported slot/kind pairing, reference a page owned by the
   same extension, and cannot reorder core UI. See
   [Extension UI slots](extension_ui_slots.md).

--- a/docs/extending/extension_tools.md
+++ b/docs/extending/extension_tools.md
@@ -1,0 +1,73 @@
+# Extension tools
+
+Extension packages may declare runner-hosted tool schemas. Declaration is
+separate from execution: schemas are validated and visible in the extension
+catalog, while runner activation and `ToolManager` wiring are applied only when
+the tool is enabled.
+
+```python
+from omnigent.extensions import (
+    EnablementScope,
+    RunnerPermission,
+    ToolContribution,
+)
+
+ToolContribution(
+    id="acme.review.review-tool",
+    tool_name="ext__acme_d_review__review",
+    title="Review workspace",
+    description="Review files in the current workspace.",
+    input_schema={
+        "type": "object",
+        "properties": {"path": {"type": "string"}},
+        "required": ["path"],
+    },
+    runner_permissions=frozenset({RunnerPermission.FILESYSTEM_READ}),
+    enablement=EnablementScope.AGENT,
+)
+```
+
+The manifest must also declare a runner factory:
+
+```python
+ExtensionEntrypoints(runner="acme_review.runner:activate")
+```
+
+The runner module must live in the same verified Python package as the manifest
+entry point. A manifest must declare both the runner entrypoint and at least one
+tool, or neither.
+
+## Names
+
+Tool names use an injective, reserved namespace derived from the extension ID.
+Dots become `_d_`, hyphens become `_h_`, and `ext__` reserves the source from
+MCP and local tools:
+
+```text
+acme.review       -> ext__acme_d_review__review
+acme.foo-bar      -> ext__acme_d_foo_h_bar__run
+```
+
+The local suffix is lowercase snake case. MCP server and agent-local tool names
+cannot begin with `ext__`.
+
+## Permissions and enablement
+
+Runner permissions are declarative and start with a deliberately small set:
+`process.spawn`, `fs.read`, and `net.http`. They describe requested authority;
+a subprocess alone is not an OS sandbox.
+
+Every tool requires deployment allowlisting. A tool whose minimum enablement is
+`user`, `agent`, or `session` additionally requires its name in that exact
+scope's allowlist. Broader-scope approval does not imply a narrower scope. This
+explicit intersection prevents an extension from widening its own availability.
+
+```bash
+omni extensions tools
+omni extensions doctor acme.review
+```
+
+The catalog and these commands are declarative; they do not activate runner
+code merely to display schemas. For an extension that contributes both UI and
+tools, a broken browser bundle suppresses only its pages/slots; runner tool
+metadata remains available because it has an independent execution boundary.

--- a/docs/extending/extensions.md
+++ b/docs/extending/extensions.md
@@ -30,17 +30,20 @@ trusted Python package -> validated manifest -> server catalog
   Inbox and Usage. `order` sorts only within that slot.
 - `slot_items`: core-rendered, page-backed links in four semantic UI locations.
   See [Extension UI slots](extension_ui_slots.md).
+- `tools`: runner-side tool schemas with explicit permissions and enablement.
+  See [Extension tools](extension_tools.md).
 
 Command metadata, activation events, and `when` expressions are validated and
 reserved but are not executed or evaluated in V1. Arbitrary React components,
-DOM selectors, FastAPI routers, runner tools, and user-installed marketplace
-packages are not supported.
+DOM selectors, FastAPI routers, in-process server plugins, and user-installed
+marketplace packages are not supported.
 
 ## Installation and diagnostics
 
 Declare an `omnigent.extensions` entry point, install the wheel in the server's
-Python environment, and restart the server. Installation implies enablement for
-V1; there is no separate enable switch.
+Python environment, and restart the server. Installation enables page and UI
+contributions. Tools additionally require the deployment and declared-scope
+allowlists described in [Extension tools](extension_tools.md).
 
 ```bash
 omni extensions list
@@ -55,5 +58,6 @@ load and asset errors through `doctor` or `/v1/extensions/diagnostics`.
 
 See [Extension manifest](extension_manifest.md),
 [Browser extensions](browser_extensions.md),
-[Extension UI slots](extension_ui_slots.md), and the
+[Extension UI slots](extension_ui_slots.md),
+[Extension tools](extension_tools.md), and the
 [Hello Page example](../../examples/extensions/hello-page/README.md).

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4614,6 +4614,23 @@ def extensions_list() -> None:
         click.echo(f"{len(state.load_errors)} rejected extension entry point(s)", err=True)
 
 
+@extensions_cli.command("tools")
+def extensions_tools() -> None:
+    """List declarative extension tool schemas without activating runners."""
+    from omnigent.extensions import plugin_state
+
+    tools = sorted(
+        ((manifest.id, tool) for manifest in plugin_state().manifests for tool in manifest.tools),
+        key=lambda item: (item[0], item[1].tool_name),
+    )
+    if not tools:
+        click.echo("No extension tools installed.")
+        return
+    for extension_id, tool in tools:
+        permissions = ",".join(sorted(item.value for item in tool.runner_permissions)) or "none"
+        click.echo(f"{tool.tool_name}\t{extension_id}\t{tool.enablement.value}\t{permissions}")
+
+
 @extensions_cli.command("doctor")
 @click.argument("extension_id")
 def extensions_doctor(extension_id: str) -> None:
@@ -4637,8 +4654,16 @@ def extensions_doctor(extension_id: str) -> None:
     click.echo(f"id: {manifest.id}")
     click.echo(f"distribution: {manifest.distribution} {manifest.version}")
     click.echo(f"extension API: {manifest.extension_api}")
+    if manifest.entrypoints.runner is not None:
+        click.echo(
+            f"runner: {manifest.entrypoints.runner} "
+            f"(package: {state.asset_package(extension_id) or 'unverified'})"
+        )
     for item in manifest.slot_items:
         click.echo(f"UI slot: {item.slot.value} -> {item.page} ({item.label})")
+    for tool in manifest.tools:
+        permissions = ", ".join(sorted(item.value for item in tool.runner_permissions)) or "none"
+        click.echo(f"tool: {tool.tool_name} ({tool.enablement.value}; permissions: {permissions})")
     if manifest.entrypoints.browser is None:
         click.echo("browser bundle: not declared")
         return

--- a/omnigent/extensions/__init__.py
+++ b/omnigent/extensions/__init__.py
@@ -3,15 +3,18 @@
 from omnigent.extensions.api import (
     EXTENSION_API_VERSION,
     CommandContribution,
+    EnablementScope,
     ExtensionEntrypoints,
     ExtensionManifest,
     ExtensionPermission,
     ExtensionPluginState,
     PageContribution,
     PrimaryNavigationContribution,
+    RunnerPermission,
     SlotId,
     SlotItemContribution,
     SlotItemKind,
+    ToolContribution,
 )
 from omnigent.extensions.conformance import check_extension_package
 from omnigent.extensions.registry import (
@@ -29,6 +32,7 @@ __all__ = [
     "EXTENSION_API_VERSION",
     "SUPPORTED_EXTENSION_API_VERSIONS",
     "CommandContribution",
+    "EnablementScope",
     "ExtensionEntrypoints",
     "ExtensionManifest",
     "ExtensionPermission",
@@ -36,9 +40,11 @@ __all__ = [
     "ExtensionValidationError",
     "PageContribution",
     "PrimaryNavigationContribution",
+    "RunnerPermission",
     "SlotId",
     "SlotItemContribution",
     "SlotItemKind",
+    "ToolContribution",
     "check_extension_package",
     "extension_manifest",
     "extension_manifests",

--- a/omnigent/extensions/api.py
+++ b/omnigent/extensions/api.py
@@ -30,6 +30,23 @@ class SlotItemKind(StrEnum):
     SECTION = "section"
 
 
+class RunnerPermission(StrEnum):
+    """Runner capabilities requested by an extension tool."""
+
+    PROCESS_SPAWN = "process.spawn"
+    FILESYSTEM_READ = "fs.read"
+    NETWORK_HTTP = "net.http"
+
+
+class EnablementScope(StrEnum):
+    """Narrowest scope at which a contributed tool may be enabled."""
+
+    DEPLOYMENT = "deployment"
+    USER = "user"
+    AGENT = "agent"
+    SESSION = "session"
+
+
 class ExtensionPermission(StrEnum):
     """Host capabilities an extension may request."""
 
@@ -43,6 +60,7 @@ class ExtensionEntrypoints:
 
     browser: str | None = None
     browser_css: str | None = None
+    runner: str | None = None
 
 
 @dataclass(frozen=True)
@@ -82,6 +100,20 @@ class SlotItemContribution:
 
 
 @dataclass(frozen=True)
+class ToolContribution:
+    """Declarative schema for a tool implemented by the runner entrypoint."""
+
+    id: str
+    tool_name: str
+    title: str
+    description: str
+    input_schema: dict[str, object]
+    runner_permissions: frozenset[RunnerPermission] = frozenset()
+    enablement: EnablementScope = EnablementScope.DEPLOYMENT
+    is_async: bool = False
+
+
+@dataclass(frozen=True)
 class CommandContribution:
     """Reserved command metadata; V1 does not execute contributed commands."""
 
@@ -105,6 +137,7 @@ class ExtensionManifest:
     pages: tuple[PageContribution, ...] = ()
     primary_navigation: tuple[PrimaryNavigationContribution, ...] = ()
     slot_items: tuple[SlotItemContribution, ...] = ()
+    tools: tuple[ToolContribution, ...] = ()
     commands: tuple[CommandContribution, ...] = ()
 
 

--- a/omnigent/extensions/conformance.py
+++ b/omnigent/extensions/conformance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.metadata
+import importlib.util
 from pathlib import Path
 
 import tomllib
@@ -42,6 +43,28 @@ def _validate_installed_metadata(manifest: ExtensionManifest, package: str) -> N
         raise ExtensionAssetError("asset package is not owned by the manifest distribution")
 
 
+def _validate_runner_entrypoint(
+    manifest: ExtensionManifest,
+    *,
+    package: str | None,
+    package_root: Path | None,
+) -> None:
+    runner = manifest.entrypoints.runner
+    if runner is None:
+        return
+    module, _separator, _factory = runner.partition(":")
+    runner_package = module.split(".", 1)[0]
+    expected_package = package or (package_root.name if package_root is not None else None)
+    if expected_package is None or runner_package != expected_package:
+        raise ExtensionAssetError("runner entrypoint is not owned by the extension package")
+    if package is not None and importlib.util.find_spec(module) is None:
+        raise ExtensionAssetError(f"runner module {module!r} is unavailable")
+    if package_root is not None:
+        target = package_root.joinpath(*module.split(".")[1:])
+        if not target.with_suffix(".py").is_file() and not (target / "__init__.py").is_file():
+            raise ExtensionAssetError(f"runner module {module!r} is unavailable")
+
+
 def check_extension_package(
     manifest: ExtensionManifest,
     *,
@@ -57,6 +80,7 @@ def check_extension_package(
         _validate_project_metadata(manifest, project_root)
     elif package is not None:
         _validate_installed_metadata(manifest, package)
+    _validate_runner_entrypoint(manifest, package=package, package_root=package_root)
     if manifest.entrypoints.browser is None:
         return None
     return resolve_bundle(manifest, package=package, root_override=package_root)

--- a/omnigent/extensions/enablement.py
+++ b/omnigent/extensions/enablement.py
@@ -1,0 +1,35 @@
+"""Pure enablement resolution for extension-contributed tools."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from omnigent.extensions.api import EnablementScope, ExtensionManifest
+
+
+def resolve_enabled_tools(
+    manifests: Iterable[ExtensionManifest],
+    *,
+    deployment_allow: Iterable[str],
+    user_allow: Iterable[str] = (),
+    agent_allow: Iterable[str] = (),
+    session_allow: Iterable[str] = (),
+) -> frozenset[str]:
+    """Resolve enabled tool names from deployment and scope-specific allowlists.
+
+    The deployment allowlist is always required. Tools narrower than deployment
+    additionally require approval at their declared minimum scope.
+    """
+    deployment = frozenset(deployment_allow)
+    scope_allows = {
+        EnablementScope.DEPLOYMENT: deployment,
+        EnablementScope.USER: frozenset(user_allow),
+        EnablementScope.AGENT: frozenset(agent_allow),
+        EnablementScope.SESSION: frozenset(session_allow),
+    }
+    return frozenset(
+        tool.tool_name
+        for manifest in manifests
+        for tool in manifest.tools
+        if tool.tool_name in deployment and tool.tool_name in scope_allows[tool.enablement]
+    )

--- a/omnigent/extensions/registry.py
+++ b/omnigent/extensions/registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.metadata
+import json
 import logging
 import re
 import threading
@@ -18,16 +19,20 @@ from packaging.version import InvalidVersion, Version
 from omnigent.extensions.api import (
     EXTENSION_API_VERSION,
     CommandContribution,
+    EnablementScope,
     ExtensionEntrypoints,
     ExtensionManifest,
     ExtensionPermission,
     ExtensionPluginState,
     PageContribution,
     PrimaryNavigationContribution,
+    RunnerPermission,
     SlotId,
     SlotItemContribution,
     SlotItemKind,
+    ToolContribution,
 )
+from omnigent.extensions.tool_names import extension_tool_prefix, validate_extension_tool_name
 from omnigent.version import VERSION
 
 ENTRY_POINT_GROUP = "omnigent.extensions"
@@ -45,6 +50,7 @@ _ROUTE_SEGMENT_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$")
 _ASSET_SEGMENT_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
 _SYMBOL_RE = _ASSET_SEGMENT_RE
 _ACTIVATION_EVENT_RE = re.compile(r"^(onPage|onCommand):(.+)$")
+_RUNNER_ENTRYPOINT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*:[A-Za-z_][A-Za-z0-9_]*$")
 _MAX_TEXT_LENGTH = 512
 _MAX_ASSET_DEPTH = 16
 
@@ -229,6 +235,35 @@ def _validate_slot_item(
         raise ExtensionValidationError(f"slot item {item.id!r} order must be an integer")
 
 
+def _validate_tool(extension_id: str, tool: ToolContribution) -> None:
+    _validate_contribution_id(extension_id, tool.id, "tool")
+    _require_text(tool.tool_name, f"tool {tool.id!r} name")
+    if error := validate_extension_tool_name(extension_id, tool.tool_name):
+        raise ExtensionValidationError(f"tool {tool.id!r} {error}")
+    _require_text(tool.title, f"tool {tool.id!r} title")
+    _require_text(tool.description, f"tool {tool.id!r} description")
+    if not isinstance(tool.input_schema, dict):
+        raise ExtensionValidationError(f"tool {tool.id!r} input_schema must be an object")
+    try:
+        serialized_schema = json.dumps(tool.input_schema)
+    except (TypeError, ValueError) as exc:
+        raise ExtensionValidationError(
+            f"tool {tool.id!r} input_schema must be JSON serializable"
+        ) from exc
+    if len(serialized_schema.encode()) > 64 * 1024:
+        raise ExtensionValidationError(f"tool {tool.id!r} input_schema exceeds 64 KB")
+    if tool.input_schema.get("type") not in {None, "object"}:
+        raise ExtensionValidationError(f"tool {tool.id!r} input_schema type must be 'object'")
+    if not isinstance(tool.runner_permissions, frozenset) or any(
+        not isinstance(permission, RunnerPermission) for permission in tool.runner_permissions
+    ):
+        raise ExtensionValidationError(f"tool {tool.id!r} has unsupported runner permissions")
+    if not isinstance(tool.enablement, EnablementScope):
+        raise ExtensionValidationError(f"tool {tool.id!r} has unsupported enablement scope")
+    if not isinstance(tool.is_async, bool):
+        raise ExtensionValidationError(f"tool {tool.id!r} is_async must be a boolean")
+
+
 def _validate_command(extension_id: str, command: CommandContribution) -> None:
     _validate_contribution_id(extension_id, command.id, "command")
     _require_text(command.title, f"command {command.id!r} title")
@@ -254,6 +289,7 @@ def validate_manifest(manifest: ExtensionManifest) -> None:
         "pages",
         "primary_navigation",
         "slot_items",
+        "tools",
         "commands",
         "activation_events",
     ):
@@ -265,6 +301,7 @@ def validate_manifest(manifest: ExtensionManifest) -> None:
         ("pages", manifest.pages, PageContribution),
         ("primary_navigation", manifest.primary_navigation, PrimaryNavigationContribution),
         ("slot_items", manifest.slot_items, SlotItemContribution),
+        ("tools", manifest.tools, ToolContribution),
         ("commands", manifest.commands, CommandContribution),
     ):
         invalid = [
@@ -342,6 +379,16 @@ def validate_manifest(manifest: ExtensionManifest) -> None:
         )
         if manifest.entrypoints.browser_css != "dist/extension.css":
             raise ExtensionValidationError("browser CSS entrypoint must be dist/extension.css")
+    if manifest.entrypoints.runner is not None:
+        _require_text(manifest.entrypoints.runner, "runner entrypoint")
+        if not _RUNNER_ENTRYPOINT_RE.fullmatch(manifest.entrypoints.runner):
+            raise ExtensionValidationError(
+                "runner entrypoint must use 'package.module:factory' syntax"
+            )
+    if bool(manifest.tools) != bool(manifest.entrypoints.runner):
+        raise ExtensionValidationError(
+            "runner entrypoint and tool contributions must be declared together"
+        )
 
     invalid_permissions = sorted(
         repr(permission)
@@ -358,6 +405,8 @@ def validate_manifest(manifest: ExtensionManifest) -> None:
         _validate_page(manifest.id, page)
     for command in manifest.commands:
         _validate_command(manifest.id, command)
+    for tool in manifest.tools:
+        _validate_tool(manifest.id, tool)
 
     page_ids = {page.id for page in manifest.pages}
     command_ids = {command.id for command in manifest.commands}
@@ -367,6 +416,7 @@ def validate_manifest(manifest: ExtensionManifest) -> None:
     for item in manifest.slot_items:
         _validate_slot_item(manifest.id, item, page_ids=page_ids)
     slot_item_ids = {item.id for item in manifest.slot_items}
+    tool_ids = {tool.id for tool in manifest.tools}
 
     _reject_duplicates((page.id for page in manifest.pages), "page ids")
     _reject_duplicates((page.route for page in manifest.pages), "page routes")
@@ -376,8 +426,10 @@ def validate_manifest(manifest: ExtensionManifest) -> None:
         "primary navigation ids",
     )
     _reject_duplicates((item.id for item in manifest.slot_items), "slot item ids")
+    _reject_duplicates((tool.id for tool in manifest.tools), "tool ids")
+    _reject_duplicates((tool.tool_name for tool in manifest.tools), "tool names")
     _reject_duplicates(
-        (*page_ids, *command_ids, *navigation_ids, *slot_item_ids),
+        (*page_ids, *command_ids, *navigation_ids, *slot_item_ids, *tool_ids),
         "contribution ids",
     )
 
@@ -430,10 +482,13 @@ def _manifest_claims(manifest: ExtensionManifest) -> tuple[str, ...]:
         *(command.id for command in manifest.commands),
         *(item.id for item in manifest.primary_navigation),
         *(item.id for item in manifest.slot_items),
+        *(tool.id for tool in manifest.tools),
     )
     return (
         f"extension:{manifest.id}",
+        *((f"tool-prefix:{extension_tool_prefix(manifest.id)}",) if manifest.tools else ()),
         *(f"contribution:{item}" for item in contribution_ids),
+        *(f"tool-name:{tool.tool_name}" for tool in manifest.tools),
         *(f"route:{manifest.id}/{page.route}" for page in manifest.pages),
     )
 
@@ -494,7 +549,14 @@ def _load_community_manifests() -> tuple[
                 )
             validate_manifest(manifest)
             _validate_distribution_metadata(entry_point, manifest)
-            candidates.append((key, manifest, _entry_point_asset_package(entry_point)))
+            package = _entry_point_asset_package(entry_point)
+            if manifest.entrypoints.runner is not None:
+                runner_package = manifest.entrypoints.runner.partition(":")[0].split(".", 1)[0]
+                if package is None or runner_package != package:
+                    raise ExtensionValidationError(
+                        "runner entrypoint must live in the extension entry point package"
+                    )
+            candidates.append((key, manifest, package))
         # Entry points are an external package boundary: one plugin may raise
         # any exception, and must not prevent healthy extensions from loading.
         except Exception as exc:  # noqa: BLE001

--- a/omnigent/extensions/tool_names.py
+++ b/omnigent/extensions/tool_names.py
@@ -1,0 +1,29 @@
+"""Import-light naming rules for extension-contributed tools."""
+
+from __future__ import annotations
+
+import re
+
+from omnigent.tool_namespaces import EXTENSION_TOOL_MARKER
+
+TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,256}$")
+_LOCAL_TOOL_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_]*[a-z0-9])?$")
+
+
+def extension_tool_prefix(extension_id: str) -> str:
+    """Return an injective, reserved tool prefix derived from an extension ID."""
+    encoded = extension_id.replace("-", "_h_").replace(".", "_d_")
+    return f"{EXTENSION_TOOL_MARKER}{encoded}__"
+
+
+def validate_extension_tool_name(extension_id: str, tool_name: str) -> str | None:
+    """Return an error for a malformed/non-namespaced tool name."""
+    if not TOOL_NAME_RE.fullmatch(tool_name):
+        return "tool name must match ^[a-zA-Z0-9_-]{1,256}$"
+    prefix = extension_tool_prefix(extension_id)
+    if not tool_name.startswith(prefix):
+        return f"tool name must start with {prefix!r}"
+    local_name = tool_name[len(prefix) :]
+    if not _LOCAL_TOOL_NAME_RE.fullmatch(local_name):
+        return "extension-local tool name must be lowercase snake_case"
+    return None

--- a/omnigent/server/routes/extensions.py
+++ b/omnigent/server/routes/extensions.py
@@ -55,6 +55,19 @@ class ExtensionSlotItemResponse(BaseModel):
     when: str | None
 
 
+class ExtensionToolResponse(BaseModel):
+    """Declarative metadata for one runner-hosted extension tool."""
+
+    id: str
+    tool_name: str
+    title: str
+    description: str
+    input_schema: dict[str, object]
+    runner_permissions: list[str]
+    enablement: str
+    is_async: bool
+
+
 class ExtensionBrowserBundleResponse(BaseModel):
     """Opaque browser-bundle availability and content-addressed asset URLs."""
 
@@ -79,6 +92,7 @@ class ExtensionResponse(BaseModel):
     pages: list[ExtensionPageResponse]
     primary_navigation: list[ExtensionPrimaryNavigationResponse]
     slot_items: list[ExtensionSlotItemResponse]
+    tools: list[ExtensionToolResponse]
     browser: ExtensionBrowserBundleResponse
 
 
@@ -163,6 +177,19 @@ def _serialize_manifest(
             )
         ]
     )
+    tools = [
+        ExtensionToolResponse(
+            id=tool.id,
+            tool_name=tool.tool_name,
+            title=tool.title,
+            description=tool.description,
+            input_schema=tool.input_schema,
+            runner_permissions=sorted(permission.value for permission in tool.runner_permissions),
+            enablement=tool.enablement.value,
+            is_async=tool.is_async,
+        )
+        for tool in sorted(manifest.tools, key=lambda tool: tool.tool_name)
+    ]
     return ExtensionResponse(
         id=manifest.id,
         display_name=manifest.display_name,
@@ -174,6 +201,7 @@ def _serialize_manifest(
         pages=pages,
         primary_navigation=navigation,
         slot_items=slot_items,
+        tools=tools,
         browser=ExtensionBrowserBundleResponse(
             declared=manifest.entrypoints.browser is not None,
             has_styles=manifest.entrypoints.browser_css is not None,

--- a/omnigent/spec/validator.py
+++ b/omnigent/spec/validator.py
@@ -340,6 +340,7 @@ def _validate_local_tools(spec: AgentSpec, result: ValidationResult) -> None:
     # Lazy import to avoid pulling the tools package during
     # spec load (the validator runs from ``omnigent.spec``,
     # which is a lower layer than ``omnigent.tools``).
+    from omnigent.tool_namespaces import EXTENSION_TOOL_MARKER
     from omnigent.tools.builtins import BUILTIN_NAMES
 
     # Collect everything the agent declares and cross-check
@@ -347,6 +348,11 @@ def _validate_local_tools(spec: AgentSpec, result: ValidationResult) -> None:
     # also used for duplicate-name detection across sources.
     all_tool_names: set[str] = set()
     for i, mcp in enumerate(spec.mcp_servers):
+        if mcp.name.startswith(EXTENSION_TOOL_MARKER):
+            result.add(
+                f"mcp_servers[{i}].name",
+                f"tool name prefix {EXTENSION_TOOL_MARKER!r} is reserved for extension tools",
+            )
         if mcp.name in BUILTIN_NAMES:
             result.add(
                 f"mcp_servers[{i}].name",
@@ -355,6 +361,11 @@ def _validate_local_tools(spec: AgentSpec, result: ValidationResult) -> None:
             )
         all_tool_names.add(mcp.name)
     for i, tool in enumerate(spec.local_tools):
+        if tool.name.startswith(EXTENSION_TOOL_MARKER):
+            result.add(
+                f"local_tools[{i}].name",
+                f"tool name prefix {EXTENSION_TOOL_MARKER!r} is reserved for extension tools",
+            )
         if tool.name in BUILTIN_NAMES:
             result.add(
                 f"local_tools[{i}].name",

--- a/omnigent/tool_namespaces.py
+++ b/omnigent/tool_namespaces.py
@@ -1,0 +1,3 @@
+"""Reserved cross-source tool namespaces."""
+
+EXTENSION_TOOL_MARKER = "ext__"

--- a/omnigent/tools/client_specified/__init__.py
+++ b/omnigent/tools/client_specified/__init__.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from omnigent.tool_namespaces import EXTENSION_TOOL_MARKER
 from omnigent.tools.base import Tool, ToolContext, is_valid_tool_name
 
 
@@ -163,6 +164,11 @@ def parse_client_side_tool_spec(raw: dict[str, Any]) -> ClientSideToolSpec:
 
     if not is_valid_tool_name(name):
         raise ValueError(f"Invalid tool name {name!r}: must match [a-zA-Z0-9_-]{{1,256}}")
+    if name.startswith(EXTENSION_TOOL_MARKER):
+        raise ValueError(
+            f"Invalid tool name {name!r}: prefix {EXTENSION_TOOL_MARKER!r} "
+            "is reserved for extension tools"
+        )
 
     return ClientSideToolSpec(name=name, schema=raw)
 

--- a/openapi.json
+++ b/openapi.json
@@ -2112,6 +2112,13 @@
             "title": "Status",
             "type": "string"
           },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/ExtensionToolResponse"
+            },
+            "title": "Tools",
+            "type": "array"
+          },
           "version": {
             "title": "Version",
             "type": "string"
@@ -2128,6 +2135,7 @@
           "pages",
           "primary_navigation",
           "slot_items",
+          "tools",
           "browser"
         ],
         "title": "ExtensionResponse",
@@ -2192,6 +2200,59 @@
           "when"
         ],
         "title": "ExtensionSlotItemResponse",
+        "type": "object"
+      },
+      "ExtensionToolResponse": {
+        "description": "Declarative metadata for one runner-hosted extension tool.",
+        "properties": {
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "enablement": {
+            "title": "Enablement",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "input_schema": {
+            "additionalProperties": true,
+            "title": "Input Schema",
+            "type": "object"
+          },
+          "is_async": {
+            "title": "Is Async",
+            "type": "boolean"
+          },
+          "runner_permissions": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Runner Permissions",
+            "type": "array"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "tool_name": {
+            "title": "Tool Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "tool_name",
+          "title",
+          "description",
+          "input_schema",
+          "runner_permissions",
+          "enablement",
+          "is_async"
+        ],
+        "title": "ExtensionToolResponse",
         "type": "object"
       },
       "FailedEvent": {

--- a/tests/extensions/test_cli.py
+++ b/tests/extensions/test_cli.py
@@ -13,6 +13,7 @@ from omnigent.extensions import (
     ExtensionEntrypoints,
     ExtensionManifest,
     ExtensionPluginState,
+    ToolContribution,
 )
 from omnigent.extensions.assets import ResolvedBundle
 
@@ -39,6 +40,36 @@ def test_extensions_list(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert "acme.review\t1.0.0\tReview" in result.output
+
+
+def test_extensions_tools_lists_declarative_metadata(monkeypatch) -> None:
+    tool = ToolContribution(
+        id="acme.review.echo-tool",
+        tool_name="ext__acme_d_review__echo",
+        title="Echo",
+        description="Echo text.",
+        input_schema={"type": "object"},
+    )
+    manifest = replace(
+        _manifest(),
+        entrypoints=ExtensionEntrypoints(runner="acme_review.runner:activate"),
+        tools=(tool,),
+    )
+    monkeypatch.setattr(
+        extensions_api,
+        "plugin_state",
+        lambda: ExtensionPluginState(manifests=(manifest,)),
+    )
+
+    result = CliRunner().invoke(cli, ["extensions", "tools"])
+
+    assert result.exit_code == 0
+    assert "ext__acme_d_review__echo\tacme.review\tdeployment\tnone" in result.output
+
+    doctor = CliRunner().invoke(cli, ["extensions", "doctor", manifest.id])
+    assert doctor.exit_code == 0
+    assert "runner: acme_review.runner:activate" in doctor.output
+    assert "tool: ext__acme_d_review__echo" in doctor.output
 
 
 def test_extensions_doctor_reports_resolved_bundle(monkeypatch) -> None:

--- a/tests/extensions/test_registry.py
+++ b/tests/extensions/test_registry.py
@@ -20,6 +20,7 @@ from omnigent.extensions import (
     SlotId,
     SlotItemContribution,
     SlotItemKind,
+    ToolContribution,
 )
 
 
@@ -271,6 +272,43 @@ def test_does_not_record_unverified_or_core_asset_package(
 
     assert state.asset_package(unverified.id) is None
     assert state.asset_package(core.id) is None
+
+
+def test_rejects_runner_entrypoint_outside_verified_plugin_package(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = replace(
+        _manifest(),
+        entrypoints=replace(
+            _manifest().entrypoints,
+            runner="other.runner:activate",
+        ),
+        tools=(
+            ToolContribution(
+                id="acme.review.run-tool",
+                tool_name="ext__acme_d_review__run",
+                title="Run",
+                description="Run a task.",
+                input_schema={"type": "object"},
+            ),
+        ),
+    )
+    _install_entry_points(
+        monkeypatch,
+        _EntryPoint(
+            "review",
+            manifest,
+            distribution=manifest.distribution,
+            version=manifest.version,
+            module="acme_review.plugin",
+            top_level="acme_review\n",
+        ),
+    )
+
+    assert (
+        "must live in the extension entry point package"
+        in registry.plugin_state().load_errors[f"{manifest.distribution}:review"]
+    )
 
 
 def test_records_bad_return_type_without_breaking_healthy_extension(

--- a/tests/extensions/test_tool_contract.py
+++ b/tests/extensions/test_tool_contract.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+import omnigent.extensions.registry as registry
+from omnigent.extensions import (
+    EXTENSION_API_VERSION,
+    EnablementScope,
+    ExtensionEntrypoints,
+    ExtensionManifest,
+    RunnerPermission,
+    ToolContribution,
+    check_extension_package,
+)
+from omnigent.extensions.assets import ExtensionAssetError
+from omnigent.extensions.enablement import resolve_enabled_tools
+from omnigent.extensions.tool_names import TOOL_NAME_RE, extension_tool_prefix
+from omnigent.tool_namespaces import EXTENSION_TOOL_MARKER
+from omnigent.tools.base import TOOL_NAME_RE as RUNTIME_TOOL_NAME_RE
+from omnigent.tools.builtins import BUILTIN_NAMES
+
+_ACME_PREFIX = extension_tool_prefix("acme.review")
+
+
+def _tool(
+    extension_id: str = "acme.review",
+    *,
+    tool_name: str | None = None,
+    enablement: EnablementScope = EnablementScope.DEPLOYMENT,
+) -> ToolContribution:
+    return ToolContribution(
+        id=f"{extension_id}.review-tool",
+        tool_name=tool_name or f"{extension_tool_prefix(extension_id)}review",
+        title="Review",
+        description="Review the current workspace.",
+        input_schema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+        runner_permissions=frozenset({RunnerPermission.FILESYSTEM_READ}),
+        enablement=enablement,
+    )
+
+
+def _manifest(
+    extension_id: str = "acme.review",
+    *,
+    tool: ToolContribution | None = None,
+) -> ExtensionManifest:
+    return ExtensionManifest(
+        id=extension_id,
+        display_name="Review",
+        distribution=f"{extension_id}-distribution",
+        version="1.0.0",
+        requires_omnigent=">=0.11,<1",
+        extension_api=EXTENSION_API_VERSION,
+        entrypoints=ExtensionEntrypoints(runner="acme_review.runner:activate"),
+        tools=(tool or _tool(extension_id),),
+    )
+
+
+def test_accepts_namespaced_tool_contract() -> None:
+    registry.validate_manifest(_manifest())
+
+
+@pytest.mark.parametrize(
+    ("tool", "message"),
+    [
+        (_tool(tool_name="review"), f"must start with '{_ACME_PREFIX}'"),
+        (_tool(tool_name="acme.review.tool"), "must match"),
+        (
+            replace(_tool(), input_schema=[]),  # type: ignore[arg-type]
+            "input_schema must be an object",
+        ),
+        (
+            replace(_tool(), input_schema={"type": "array"}),
+            "input_schema type must be 'object'",
+        ),
+        (
+            replace(_tool(), runner_permissions=frozenset({"root"})),  # type: ignore[arg-type]
+            "unsupported runner permissions",
+        ),
+        (
+            replace(_tool(), enablement="global"),  # type: ignore[arg-type]
+            "unsupported enablement scope",
+        ),
+    ],
+)
+def test_rejects_invalid_tool_contract(tool: ToolContribution, message: str) -> None:
+    with pytest.raises(registry.ExtensionValidationError, match=message):
+        registry.validate_manifest(_manifest(tool=tool))
+
+
+def test_requires_runner_entrypoint_and_tools_together() -> None:
+    with pytest.raises(registry.ExtensionValidationError, match="declared together"):
+        registry.validate_manifest(replace(_manifest(), entrypoints=ExtensionEntrypoints()))
+    with pytest.raises(registry.ExtensionValidationError, match="declared together"):
+        registry.validate_manifest(
+            replace(
+                _manifest(),
+                tools=(),
+                entrypoints=ExtensionEntrypoints(runner="acme_review.runner:activate"),
+            )
+        )
+
+
+def test_rejects_invalid_runner_entrypoint() -> None:
+    with pytest.raises(registry.ExtensionValidationError, match=r"package\.module:factory"):
+        registry.validate_manifest(
+            replace(_manifest(), entrypoints=ExtensionEntrypoints(runner="shell command"))
+        )
+
+
+def test_tool_prefix_encoding_is_injective_and_claimed() -> None:
+    first_id = "acme.foo-bar"
+    second_id = "acme.foo.bar"
+    assert extension_tool_prefix(first_id) != extension_tool_prefix(second_id)
+    first = _manifest(first_id)
+    second = _manifest(second_id)
+    registry.validate_manifest(first)
+    registry.validate_manifest(second)
+
+    assert registry._collision_errors((), [("first", first, None), ("second", second, None)]) == {}
+    assert f"tool-prefix:{extension_tool_prefix(first_id)}" in registry._manifest_claims(first)
+
+
+def test_enablement_requires_deployment_and_declared_scope_allowlists() -> None:
+    tools = (
+        _tool(enablement=EnablementScope.DEPLOYMENT),
+        replace(
+            _tool(),
+            id="acme.review.user-tool",
+            tool_name=f"{_ACME_PREFIX}user",
+            enablement=EnablementScope.USER,
+        ),
+        replace(
+            _tool(),
+            id="acme.review.agent-tool",
+            tool_name=f"{_ACME_PREFIX}agent",
+            enablement=EnablementScope.AGENT,
+        ),
+        replace(
+            _tool(),
+            id="acme.review.session-tool",
+            tool_name=f"{_ACME_PREFIX}session",
+            enablement=EnablementScope.SESSION,
+        ),
+    )
+    manifest = replace(_manifest(), tools=tools)
+    deployment = {tool.tool_name for tool in tools}
+
+    assert resolve_enabled_tools(
+        [manifest],
+        deployment_allow=deployment,
+        user_allow={f"{_ACME_PREFIX}user"},
+        agent_allow={f"{_ACME_PREFIX}agent"},
+        session_allow={f"{_ACME_PREFIX}session"},
+    ) == frozenset(deployment)
+    assert resolve_enabled_tools([manifest], deployment_allow=deployment) == frozenset(
+        {f"{_ACME_PREFIX}review"}
+    )
+    assert resolve_enabled_tools([manifest], deployment_allow=()) == frozenset()
+
+
+def test_source_conformance_checks_runner_module_ownership(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    package_root = project_root / "acme_review"
+    package_root.mkdir(parents=True)
+    (project_root / "pyproject.toml").write_text(
+        '[project]\nname="acme.review-distribution"\nversion="1.0.0"\n',
+        encoding="utf-8",
+    )
+    (package_root / "runner.py").write_text("def activate(): pass\n", encoding="utf-8")
+
+    assert (
+        check_extension_package(
+            _manifest(),
+            package_root=package_root,
+            project_root=project_root,
+        )
+        is None
+    )
+    wrong = replace(
+        _manifest(),
+        entrypoints=ExtensionEntrypoints(runner="other.runner:activate"),
+    )
+    with pytest.raises(ExtensionAssetError, match="not owned"):
+        check_extension_package(
+            wrong,
+            package_root=package_root,
+            project_root=project_root,
+        )
+
+
+def test_extension_tool_name_contract_stays_disjoint_from_runtime_builtins() -> None:
+    assert TOOL_NAME_RE.pattern == RUNTIME_TOOL_NAME_RE.pattern
+    assert not any(name.startswith(EXTENSION_TOOL_MARKER) for name in BUILTIN_NAMES)
+    assert extension_tool_prefix("acme.review") == "ext__acme_d_review__"

--- a/tests/server/routes/test_extensions_routes.py
+++ b/tests/server/routes/test_extensions_routes.py
@@ -21,6 +21,7 @@ from omnigent.extensions import (
     SlotId,
     SlotItemContribution,
     SlotItemKind,
+    ToolContribution,
 )
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server.app import create_app
@@ -144,6 +145,7 @@ async def test_catalog_serializes_only_public_v1_contributions(catalog_app: Fast
                 "pages": [],
                 "primary_navigation": [],
                 "slot_items": [],
+                "tools": [],
                 "browser": {
                     "declared": True,
                     "has_styles": True,
@@ -189,7 +191,7 @@ async def test_catalog_order_is_stable(db_uri: str, tmp_path: Path) -> None:
     )
     alpha = replace(
         _manifest(),
-        entrypoints=ExtensionEntrypoints(),
+        entrypoints=ExtensionEntrypoints(runner="acme_review.runner:activate"),
         pages=(*_manifest().pages, alpha_page),
         primary_navigation=(*_manifest().primary_navigation, alpha_nav),
         slot_items=(
@@ -199,6 +201,15 @@ async def test_catalog_order_is_stable(db_uri: str, tmp_path: Path) -> None:
                 kind=SlotItemKind.ACTION,
                 label="Review",
                 page="acme.review.dashboard",
+            ),
+        ),
+        tools=(
+            ToolContribution(
+                id="acme.review.review-tool",
+                tool_name="ext__acme_d_review__review",
+                title="Review",
+                description="Review a workspace.",
+                input_schema={"type": "object"},
             ),
         ),
     )
@@ -220,6 +231,18 @@ async def test_catalog_order_is_stable(db_uri: str, tmp_path: Path) -> None:
         "acme.review.alpha-nav",
         "acme.review.primary-nav",
     ]
+    assert data[0]["tools"] == [
+        {
+            "id": "acme.review.review-tool",
+            "tool_name": "ext__acme_d_review__review",
+            "title": "Review",
+            "description": "Review a workspace.",
+            "input_schema": {"type": "object"},
+            "runner_permissions": [],
+            "enablement": "deployment",
+            "is_async": False,
+        }
+    ]
     assert data[0]["slot_items"] == [
         {
             "id": "acme.review.header-action",
@@ -232,6 +255,39 @@ async def test_catalog_order_is_stable(db_uri: str, tmp_path: Path) -> None:
             "when": None,
         }
     ]
+
+
+async def test_runner_tools_remain_visible_when_only_browser_bundle_is_unavailable(
+    db_uri: str,
+    tmp_path: Path,
+) -> None:
+    tool = ToolContribution(
+        id="acme.review.review-tool",
+        tool_name="ext__acme_d_review__review",
+        title="Review",
+        description="Review a workspace.",
+        input_schema={"type": "object"},
+    )
+    manifest = replace(
+        _manifest(),
+        entrypoints=replace(
+            _manifest().entrypoints,
+            runner="acme_review.runner:activate",
+        ),
+        tools=(tool,),
+    )
+    app = _build_app(
+        db_uri,
+        tmp_path,
+        extension_state=ExtensionPluginState(manifests=(manifest,)),
+    )
+
+    async with _client(app) as client:
+        item = (await client.get("/v1/extensions")).json()["data"][0]
+
+    assert item["status"] == "unavailable"
+    assert item["pages"] == []
+    assert [entry["tool_name"] for entry in item["tools"]] == [tool.tool_name]
 
 
 async def test_extension_detail_and_unknown_id(catalog_app: FastAPI) -> None:

--- a/tests/spec/test_validator.py
+++ b/tests/spec/test_validator.py
@@ -203,6 +203,23 @@ def test_duplicate_tool_names_across_mcp_and_local() -> None:
     assert any("duplicate tool name" in e.message for e in result.errors)
 
 
+@pytest.mark.parametrize("source", ["mcp", "local"])
+def test_extension_tool_prefix_is_reserved_from_agent_tool_sources(source: str) -> None:
+    name = "ext__acme_d_review__run"
+    spec = (
+        _minimal_spec(mcp_servers=[MCPServerConfig(name=name, url="http://localhost:9000")])
+        if source == "mcp"
+        else _minimal_spec(
+            local_tools=[LocalToolInfo(name=name, path="tools/python/run.py", language="python")]
+        )
+    )
+
+    result = validate(spec)
+
+    assert not result.valid
+    assert any("reserved for extension tools" in error.message for error in result.errors)
+
+
 def test_sub_agent_reference_valid() -> None:
     sub = _minimal_spec(
         name="helper",

--- a/tests/tools/client_specified/test_client_specified.py
+++ b/tests/tools/client_specified/test_client_specified.py
@@ -268,6 +268,20 @@ def test_parse_rejects_invalid_tool_name(name: str) -> None:
         parse_client_side_tool_spec(raw)
 
 
+def test_parse_rejects_reserved_extension_tool_prefix() -> None:
+    raw = {
+        "type": "function",
+        "function": {
+            "name": "ext__acme_d_review__run",
+            "description": "A tool.",
+            "parameters": {},
+        },
+    }
+
+    with pytest.raises(ValueError, match="reserved for extension tools"):
+        parse_client_side_tool_spec(raw)
+
+
 @pytest.mark.parametrize(
     "name",
     [

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -51,6 +51,7 @@ vi.mock("@/extensions/ExtensionProvider", () => ({
       ],
       primary_navigation: [],
       slot_items: [],
+      tools: [],
       browser: {
         declared: true,
         has_styles: false,

--- a/web/src/extensions/ExtensionPrimaryNavigation.test.tsx
+++ b/web/src/extensions/ExtensionPrimaryNavigation.test.tsx
@@ -17,6 +17,7 @@ const extensions = [
       { id: "acme.review.first", title: "First", route: "first", view: "first" },
     ],
     slot_items: [],
+    tools: [],
     primary_navigation: [
       {
         id: "acme.review.second-nav",

--- a/web/src/extensions/ExtensionSlot.test.tsx
+++ b/web/src/extensions/ExtensionSlot.test.tsx
@@ -61,6 +61,7 @@ const extension: ExtensionCatalogItem = {
       when: null,
     },
   ],
+  tools: [],
   browser: {
     declared: true,
     has_styles: false,

--- a/web/src/extensions/catalog.test.ts
+++ b/web/src/extensions/catalog.test.ts
@@ -24,6 +24,7 @@ const extension: ExtensionCatalogItem = {
   ],
   primary_navigation: [],
   slot_items: [],
+  tools: [],
   browser: {
     declared: true,
     has_styles: false,

--- a/web/src/extensions/rpc/host.test.ts
+++ b/web/src/extensions/rpc/host.test.ts
@@ -28,6 +28,7 @@ const extension: ExtensionCatalogItem = {
   pages: [page],
   primary_navigation: [],
   slot_items: [],
+  tools: [],
   browser: {
     declared: true,
     has_styles: true,

--- a/web/src/extensions/services/useExtensionHostServices.test.tsx
+++ b/web/src/extensions/services/useExtensionHostServices.test.tsx
@@ -36,6 +36,7 @@ const extension: ExtensionCatalogItem = {
   ],
   primary_navigation: [],
   slot_items: [],
+  tools: [],
   browser: {
     declared: true,
     has_styles: false,

--- a/web/src/extensions/slots.test.ts
+++ b/web/src/extensions/slots.test.ts
@@ -38,6 +38,7 @@ const extension: ExtensionCatalogItem = {
       when: null,
     },
   ],
+  tools: [],
   browser: {
     declared: true,
     has_styles: false,

--- a/web/src/extensions/types.ts
+++ b/web/src/extensions/types.ts
@@ -28,6 +28,17 @@ export interface ExtensionSlotItem {
   when: string | null;
 }
 
+export interface ExtensionTool {
+  id: string;
+  tool_name: string;
+  title: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+  runner_permissions: string[];
+  enablement: "deployment" | "user" | "agent" | "session";
+  is_async: boolean;
+}
+
 export interface ExtensionBrowserBundle {
   declared: boolean;
   has_styles: boolean;
@@ -48,6 +59,7 @@ export interface ExtensionCatalogItem {
   pages: ExtensionPage[];
   primary_navigation: ExtensionPrimaryNavigation[];
   slot_items: ExtensionSlotItem[];
+  tools: ExtensionTool[];
   browser: ExtensionBrowserBundle;
 }
 

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -311,6 +311,7 @@ const TEST_EXTENSION: ExtensionCatalogItem = {
     },
   ],
   slot_items: [],
+  tools: [],
   primary_navigation: [
     {
       id: "acme.review.primary-nav",

--- a/web/src/shell/settingsNav.test.tsx
+++ b/web/src/shell/settingsNav.test.tsx
@@ -162,6 +162,7 @@ const SETTINGS_EXTENSION: ExtensionCatalogItem = {
       when: null,
     },
   ],
+  tools: [],
   browser: {
     declared: true,
     has_styles: false,


### PR DESCRIPTION
## Related issue

N/A — maintainer architecture work.

## Summary

- Add declarative runner tool schemas, runner entrypoints, requested permissions, and deployment/user/agent/session enablement scopes to extension manifests and the catalog.
- Reserve an injective `ext__...__` namespace across extension, MCP, agent-local, and request-supplied tools, with deterministic prefix/name collisions and package-owned runner entrypoints.
- Add pure allowlist resolution, CLI inspection, source conformance checks, OpenAPI/web contracts, and author documentation without activating or registering any tool runtime.

**ELI5:** extensions can now describe tools and the permissions they need, but this PR only checks and displays those descriptions. No extension process starts yet.

```text
manifest tool -> validate namespace/schema/permissions -> catalog + CLI
                                                     (no execution)
```

This is **Stack B PR 2** and is based on PR #5660. Review only the single commit added by this branch.

## Test Plan

- `uv run pytest tests/extensions/test_tool_contract.py tests/extensions/test_registry.py tests/extensions/test_cli.py tests/server/routes/test_extensions_routes.py tests/spec/test_validator.py tests/tools/client_specified/test_client_specified.py`
- `uv run ruff check omnigent/extensions omnigent/tool_namespaces.py omnigent/spec/validator.py omnigent/tools/client_specified omnigent/server/routes/extensions.py omnigent/cli.py tests/extensions tests/server/routes/test_extensions_routes.py tests/spec/test_validator.py tests/tools/client_specified`
- `uv run pyrefly check omnigent/extensions omnigent/tool_namespaces.py omnigent/spec/validator.py omnigent/tools/client_specified omnigent/server/routes/extensions.py`
- `pnpm --dir web type-check && pnpm --dir web lint`
- `uv run python scripts/dump_openapi.py --check`
- `pre-commit run --all-files`

## Demo

N/A — this PR is a declarative contract and intentionally does not execute tools.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover injective names, reserved namespaces across every tool source, schema and enum validation, runner package ownership, deterministic claims, scope intersections, catalog behavior when UI is unavailable, CLI output, and conformance checks.
