### PR TITLE
fix(web): use reactive viewerId in archived bulk actions

### DIFF
--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -213,6 +213,34 @@ const SharingPage = lazy(() =>
 );
 
 /**
+ * The current viewer's user id, resolved reactively. Uses `getCurrentUserId`
+ * (NOT `getCurrentAuthorId`): ownership compares against the session's `owner`
+ * grant, which in single-user mode is the reserved `"local"` id — and
+ * `getCurrentAuthorId` nulls `"local"` out (it's for author labels), which
+ * would make the viewer's own sessions read as shared and vanish from the
+ * default "My sessions" tab. `getCurrentUserId` keeps `"local"` and is the
+ * identical real email in multi-user mode. It is synchronous (populated once
+ * `resolveIdentity` has run — which `main.tsx` kicks off at boot), but on a
+ * cold mount it can still be null for a tick, so we also await
+ * `resolveIdentity()` and re-render when it lands. Keeping this reactive
+ * (rather than a bare module read) means the My/Shared split settles correctly
+ * the moment identity is known, without a manual refresh.
+ */
+function useViewerId(): string | null {
+  const [viewerId, setViewerId] = useState<string | null>(() => getCurrentUserId());
+  useEffect(() => {
+    let cancelled = false;
+    void resolveIdentity().then(() => {
+      if (!cancelled) setViewerId(getCurrentUserId());
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return viewerId;
+}
+
+/**
  * Settings content panel. The section nav lives in the sidebar card
  * (SettingsSidebarBody); this renders only the selected section into the
  * AppShell main outlet. The active section is read from the URL so the two
@@ -2088,7 +2116,7 @@ function ArchivedBulkActionBar({
 }) {
   const bulkArchive = useBulkArchiveConversations();
   const bulkDelete = useBulkDeleteConversations();
-  const [viewerId] = useState(() => getCurrentUserId());
+  const viewerId = useViewerId();
 
   const ownedSelected = useMemo(() => {
     return allArchived.filter((c) => {


### PR DESCRIPTION
## Related issue

N/A

## Summary

Fixes the blocking issue identified in the Polly AI review on #3625: the `ArchivedBulkActionBar` component was capturing `viewerId` once at mount via `useState(() => getCurrentUserId())`, which meant it would stay `null` if the user's identity hadn't resolved yet from the `/v1/me` probe. This caused bulk delete/unarchive actions to be permanently disabled for the user's own sessions.

The fix switches to a reactive `useViewerId()` hook (matching the pattern already used in `Sidebar.tsx`) that:
- Seeds from `getCurrentUserId()` at mount
- Reactively updates after `resolveIdentity()` settles
- Ensures bulk actions become enabled once identity is known

## Test Plan

1. Navigate to Settings > Archived sessions (after archiving a few sessions you own)
2. Click "Select" to enter selection mode
3. Select one or more sessions
4. Verify the "Delete N" and "Unarchive N" buttons are enabled (not stuck at 0)
5. Click "Unarchive N" and verify sessions are restored
6. Click "Delete N" and confirm deletion works

The fix ensures that even if identity hasn't loaded when the page first renders, bulk action controls will become enabled once identity resolves.

## Demo

N/A (bug fix for internal state management)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification completed: tested the bulk selection flow in archived sessions with sessions owned by the current user. The existing test fixtures in `SettingsPage.test.tsx` use the `conv()` helper which omits `owner` by default, so all test rows are ownerless and don't exercise the ownership filtering path where this bug manifested.

## Changelog

Fixed bulk delete and unarchive being permanently disabled in archived sessions settings when identity loads slowly.