### PR TITLE
feat(ci): let the issue-link sweep reach PRs older than a day

### DIFF
--- a/.github/workflows/demo-check.yml
+++ b/.github/workflows/demo-check.yml
@@ -16,11 +16,31 @@ name: PR Hygiene
 # issue-link check closes only over its own label, only past the deadline the nudge
 # announced, and reversibly via `/reopen`. Never checks out or runs PR code -- they
 # read PR metadata via the API using only the default-branch script.
+#
+# Two dispatch inputs exist for one-off runs: `scan_hours` widens the issue-link
+# window so PRs older than a day can be brought into the rule (hand-labeling them
+# instead would skip the nudge and start a clock nobody was warned about), and
+# `enforce: false` dry-runs the whole sweep into the step summary. Both are empty
+# on the schedule, so cron behaviour is unchanged.
 
 on:
   schedule:
     - cron: "0 * * * *"
   workflow_dispatch:
+    inputs:
+      scan_hours:
+        description: >
+          Issue-link check only: widen the scan window, in hours, for a one-off
+          backfill over PRs older than a day. The effective date still floors it.
+          Leave blank for the usual 24 hours.
+        required: false
+      enforce:
+        description: >
+          Set to "false" to dry-run the whole sweep: every verdict lands in the
+          step summary and nothing is commented, labeled, or closed. Use this to
+          review a backfill before it touches anyone.
+        required: false
+        default: "true"
 
 defaults:
   run:
@@ -48,7 +68,10 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           sparse-checkout: .github
+      # demo-check.js has no dry-run mode, so a dry run skips it rather than pass a
+      # flag it ignores. Nothing in the sweep writes when enforce is "false".
       - name: Demo check
+        if: inputs.enforce != 'false'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           retries: 3
@@ -70,7 +93,10 @@ jobs:
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
-          ENFORCE: "true"
+          # Inputs are empty on the cron schedule, so both fall back to the
+          # scheduled behaviour: enforcing, over the usual 24-hour window.
+          ENFORCE: ${{ inputs.enforce || 'true' }}
+          SCAN_HOURS: ${{ inputs.scan_hours }}
           CLOSE_ENFORCE: "false"
           LIMIT: "25"
         with:
@@ -86,7 +112,7 @@ jobs:
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
-          ENFORCE: "true"
+          ENFORCE: ${{ inputs.enforce || 'true' }}
         with:
           retries: 3
           script: |

--- a/.github/workflows/pr-issue-link.js
+++ b/.github/workflows/pr-issue-link.js
@@ -291,6 +291,21 @@ module.exports = async ({ context, github, core }) => {
       }
     }
 
+    // Widens the sweep's window for a one-off manual run, so PRs older than a day
+    // can be brought into the rule without hand-labeling them (which would skip
+    // the nudge and start a clock nobody was warned about). EFFECTIVE_FROM still
+    // floors it, so this can never reach the pre-rule backlog.
+    let scanHours = HOURS_TO_SCAN;
+    const rawScanHours = process.env.SCAN_HOURS;
+    if (rawScanHours !== undefined && rawScanHours !== "") {
+      const parsed = Number(rawScanHours);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        scanHours = parsed;
+      } else {
+        core.warning(`SCAN_HOURS=${rawScanHours} is not a positive number; using ${HOURS_TO_SCAN}.`);
+      }
+    }
+
     // One PR when an event names it, the whole window on the cron sweep. Only the
     // fetch differs: every decision below runs identically either way, so the
     // instant path and the sweep can never reach different verdicts.
@@ -312,7 +327,7 @@ module.exports = async ({ context, github, core }) => {
       }
       console.log(`Checking #${single} (enforce=${enforce})`);
     } else {
-      const windowStart = new Date(Date.now() - HOURS_TO_SCAN * MS_PER_HOUR);
+      const windowStart = new Date(Date.now() - scanHours * MS_PER_HOUR);
       // Never look further back than the effective date, whichever is later.
       const cutoff = new Date(
         Math.max(windowStart.getTime(), new Date(EFFECTIVE_FROM).getTime())

--- a/.github/workflows/pr-issue-link.test.js
+++ b/.github/workflows/pr-issue-link.test.js
@@ -295,6 +295,26 @@ for (const tracked of ["Bug fix", "Feature", "UI / frontend change"]) {
     assert.ok(asked >= floor, "scan cutoff never predates the effective date");
   }
 
+  // SCAN_HOURS widens the window for a one-off backfill, but never past the
+  // effective date: the pre-rule backlog stays unreachable however wide it is set.
+  {
+    const { queries } = await run([pr({ number: 190 })], { env: { SCAN_HOURS: "100000" } });
+    const floor = new Date(script.EFFECTIVE_FROM).getTime();
+    const asked = new Date(/created:>(\S+)/.exec(queries[0])[1]).getTime();
+    assert.strictEqual(asked, floor, "a wide window clamps to the effective date");
+  }
+
+  // A malformed SCAN_HOURS falls back to the default window rather than widening.
+  {
+    const { queries, warnings } = await run([pr({ number: 191 })], {
+      env: { SCAN_HOURS: "lots" },
+    });
+    const dayAgo = Date.now() - 25 * 60 * 60 * 1000;
+    const asked = new Date(/created:>(\S+)/.exec(queries[0])[1]).getTime();
+    assert.ok(asked > dayAgo, "malformed SCAN_HOURS keeps the 24-hour window");
+    assert.ok(warnings.some((w) => /SCAN_HOURS=lots/.test(w)));
+  }
+
   // Dry run (the default) must not comment or label.
   {
     const { commented, labeled } = await run([pr({ number: 20 })]);


### PR DESCRIPTION
## Related issue

No issue: `Test / CI` change (see *Type of change*). Follow-up to #5661, enabling the
backfill that PR's rollout assumed.

## Summary

**ELI5:** #5661 made the bot label unlinked PRs and close them 7 days later, but the
sweep only looks at PRs opened in the last 24 hours. The 32 PRs that need the new
treatment are all older than that, so nothing can reach them. This adds a knob to
widen the window for one manual run.

**Hand-applying `needs-issue` would have been the wrong backfill.** The loop checks
for the label *before* the nudge:

```
unlinked ─→ labeled? ─ no ──→ comment (states the deadline) + label
                 └─ yes ─→ age >= 7d ──→ close
```

So a hand-labeled PR skips the comment entirely and lands in the close branch. Those
32 PRs would then be closed having only ever seen the old comment, which said
"_No action is taken beyond this comment._" That is precisely the broken promise
#5661 was built to avoid. `pull_request_target` has no `labeled` trigger either, so
the live path would not rescue them.

The fix is to give them the real nudge path, which means letting the sweep see them:

- **`SCAN_HOURS`** overrides the 24-hour window. `EFFECTIVE_FROM` still floors the
  cutoff, so no value can reach the pre-rule backlog, and a malformed value falls
  back to 24 hours rather than widening.
- **`scan_hours` dispatch input** feeds it, plus an **`enforce` input** so the
  backfill can be dry-run into the step summary before it touches anyone. Both are
  empty on the cron schedule, so scheduled behaviour is unchanged.
- `enforce: false` **skips the demo-check step** rather than passing it a flag
  `demo-check.js` does not read. Without that, a "dry run" would still have let the
  demo check comment and label. The ready-for-review gate is wired to the input too,
  so a dry run writes nothing anywhere in the sweep.

Everything else is reused as-is: exemptions, the authoritative per-PR link check,
`LIMIT`, the comment text, and `CLOSE_ENFORCE` still `"false"`.

## Test Plan

```bash
node .github/workflows/pr-issue-link.test.js
```

Two new assertions: a very wide `SCAN_HOURS` clamps the search cutoff exactly to
`EFFECTIVE_FROM` (the backlog stays unreachable however wide it is set), and a
malformed value keeps the 24-hour window and warns.

Workflow shape verified by parsing the YAML: `scan_hours` and `enforce` are declared,
`Demo check` carries `if: inputs.enforce != 'false'`, and both scripted steps read
`ENFORCE: ${{ inputs.enforce || 'true' }}`.

**The backfill run itself, after merge, in two steps:**

1. Dispatch **PR Hygiene** with `scan_hours: 600`, `enforce: false`. Writes nothing.
   Read the *Issue-link check* summary and confirm roughly 32 `FLAG` rows, zero
   `CLOSED`, and that `#4363`, `#4731`, `#4647`, `#5233` still read `exempt`/`ok`
   (declared `Test / CI`, declared `Docs`, `Part of #4327`, and a
   `.github/MAINTAINER` author). Those four are the false-positive canaries.
2. Only if that table is right, dispatch again with `scan_hours: 600` and `enforce`
   left at `true`. `LIMIT: 25` means 25 PRs get nudged and labeled on the first run
   and the rest on the second.

## Demo

N/A, no UI surface.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the two things unit tests cannot: that the merged loop
really does check the label before the nudge (so hand-labeling skips the warning),
and that `pull_request_target` in `pr-hygiene-live.yml` has no `labeled` trigger, so
labeling by hand produces no event either. Both are why this knob exists rather than
a bulk `gh label` loop.

The dispatch inputs themselves are only exercised by a real run, which is why the
plan above is a dry run first. No PR was written to while preparing this.
