### PR TITLE
[Stack B] feat(extensions): isolate runner extensions in subprocesses

### DIFF
--- a/omnigent/extensions/__init__.py
+++ b/omnigent/extensions/__init__.py
@@ -26,6 +26,11 @@ from omnigent.extensions.registry import (
     plugin_state,
     validate_manifest,
 )
+from omnigent.extensions.runner_api import (
+    RunnerExtension,
+    RunnerExtensionContext,
+    RunnerToolCallContext,
+)
 
 __all__ = [
     "ENTRY_POINT_GROUP",
@@ -40,7 +45,10 @@ __all__ = [
     "ExtensionValidationError",
     "PageContribution",
     "PrimaryNavigationContribution",
+    "RunnerExtension",
+    "RunnerExtensionContext",
     "RunnerPermission",
+    "RunnerToolCallContext",
     "SlotId",
     "SlotItemContribution",
     "SlotItemKind",

--- a/omnigent/extensions/runner_api.py
+++ b/omnigent/extensions/runner_api.py
@@ -1,0 +1,47 @@
+"""Public runtime values for out-of-process extension runners.
+
+The worker subprocess improves lifecycle and crash isolation. It is not an OS
+sandbox and has the same operating-system authority as the runner process.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class RunnerExtensionContext:
+    """Activation context supplied once inside the extension worker."""
+
+    extension_id: str
+    declared_tools: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RunnerToolCallContext:
+    """Per-invocation context supplied to an extension tool handler."""
+
+    extension_id: str
+    tool_name: str
+    request_id: str
+
+
+class RunnerToolHandler(Protocol):
+    def __call__(
+        self,
+        arguments: dict[str, Any],
+        context: RunnerToolCallContext,
+    ) -> Any:
+        """Execute a tool; async callables are also accepted at runtime."""
+        ...
+
+
+@dataclass
+class RunnerExtension:
+    """Activated extension runtime returned by a runner entrypoint factory."""
+
+    tools: Mapping[str, Callable[..., Any]]
+    shutdown: Callable[[], Any] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/omnigent/extensions/runner_protocol.py
+++ b/omnigent/extensions/runner_protocol.py
@@ -1,0 +1,100 @@
+"""Versioned JSON-lines protocol for runner extension subprocesses."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+RUNNER_EXTENSION_PROTOCOL_VERSION = 1
+MAX_RUNNER_EXTENSION_FRAME_BYTES = 1024 * 1024
+
+
+class RunnerExtensionProtocolError(ValueError):
+    """A runner extension frame is malformed or incompatible."""
+
+
+@dataclass(frozen=True)
+class RunnerRequest:
+    request_id: str
+    generation: str
+    method: str
+    params: dict[str, Any]
+    version: int = RUNNER_EXTENSION_PROTOCOL_VERSION
+
+
+@dataclass(frozen=True)
+class RunnerResponse:
+    request_id: str
+    generation: str
+    result: Any = None
+    error: dict[str, str] | None = None
+    version: int = RUNNER_EXTENSION_PROTOCOL_VERSION
+
+
+def encode_frame(value: RunnerRequest | RunnerResponse) -> bytes:
+    """Encode one bounded protocol frame including its line terminator."""
+    payload = json.dumps(value.__dict__, separators=(",", ":"), ensure_ascii=False).encode()
+    if len(payload) > MAX_RUNNER_EXTENSION_FRAME_BYTES:
+        raise RunnerExtensionProtocolError("runner extension frame exceeds 1 MB")
+    return payload + b"\n"
+
+
+def decode_request(line: bytes, *, allow_version_mismatch: bool = False) -> RunnerRequest:
+    """Decode and validate one host-to-worker request."""
+    raw = _decode_object(line)
+    _validate_common(raw, check_version=not allow_version_mismatch)
+    method = raw.get("method")
+    params = raw.get("params")
+    if not isinstance(method, str) or not isinstance(params, dict):
+        raise RunnerExtensionProtocolError("runner extension request is malformed")
+    return RunnerRequest(
+        request_id=raw["request_id"],
+        generation=raw["generation"],
+        method=method,
+        params=params,
+        version=raw["version"],
+    )
+
+
+def decode_response(line: bytes) -> RunnerResponse:
+    """Decode and validate one worker-to-host response."""
+    raw = _decode_object(line)
+    _validate_common(raw, check_version=True)
+    error = raw.get("error")
+    if error is not None and (
+        not isinstance(error, dict)
+        or not isinstance(error.get("code"), str)
+        or not isinstance(error.get("message"), str)
+    ):
+        raise RunnerExtensionProtocolError("runner extension error envelope is malformed")
+    return RunnerResponse(
+        request_id=raw["request_id"],
+        generation=raw["generation"],
+        result=raw.get("result"),
+        error=error,
+        version=raw["version"],
+    )
+
+
+def _decode_object(line: bytes) -> dict[str, Any]:
+    if len(line) > MAX_RUNNER_EXTENSION_FRAME_BYTES + 1:
+        raise RunnerExtensionProtocolError("runner extension frame exceeds 1 MB")
+    try:
+        raw = json.loads(line)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise RunnerExtensionProtocolError("runner extension frame is not valid JSON") from exc
+    if not isinstance(raw, dict):
+        raise RunnerExtensionProtocolError("runner extension frame must be an object")
+    return raw
+
+
+def _validate_common(raw: dict[str, Any], *, check_version: bool) -> None:
+    if check_version and raw.get("version") != RUNNER_EXTENSION_PROTOCOL_VERSION:
+        raise RunnerExtensionProtocolError(
+            f"unsupported runner extension protocol version {raw.get('version')!r}"
+        )
+    if not isinstance(raw.get("version"), int):
+        raise RunnerExtensionProtocolError("runner extension protocol version is malformed")
+    if not isinstance(raw.get("request_id"), str) or not isinstance(raw.get("generation"), str):
+        raise RunnerExtensionProtocolError("runner extension frame identity is malformed")

--- a/omnigent/runner/extension_host.py
+++ b/omnigent/runner/extension_host.py
@@ -1,0 +1,417 @@
+"""Supervisor for runner-side extension subprocesses.
+
+Each extension runs in one lazily started subprocess per runner. This isolates
+imports, lifecycle failures, and crashes; it is not an OS security sandbox.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import sys
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from omnigent.extensions.api import ExtensionManifest
+from omnigent.extensions.runner_protocol import (
+    MAX_RUNNER_EXTENSION_FRAME_BYTES,
+    RUNNER_EXTENSION_PROTOCOL_VERSION,
+    RunnerExtensionProtocolError,
+    RunnerRequest,
+    decode_response,
+    encode_frame,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class RunnerExtensionHostError(RuntimeError):
+    """A typed activation, transport, or tool failure from an extension host."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass
+class _ProcessEntry:
+    manifest: ExtensionManifest
+    process: asyncio.subprocess.Process
+    generation: str
+    pending: dict[str, asyncio.Future[Any]] = field(default_factory=dict)
+    tools: frozenset[str] = frozenset()
+    activated: bool = False
+    close_when_idle: bool = False
+    write_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    reader_task: asyncio.Task[None] | None = None
+    stderr_task: asyncio.Task[None] | None = None
+    owners: set[str] = field(default_factory=set)
+
+
+class RunnerExtensionHost:
+    """Lazily activate and invoke installed runner extensions over JSON lines."""
+
+    def __init__(
+        self,
+        *,
+        activation_timeout: float = 10.0,
+        invocation_timeout: float = 60.0,
+        env: dict[str, str] | None = None,
+        protocol_version: int = RUNNER_EXTENSION_PROTOCOL_VERSION,
+    ) -> None:
+        self.activation_timeout = activation_timeout
+        self.invocation_timeout = invocation_timeout
+        self.env = env
+        self.protocol_version = protocol_version
+        self._entries: dict[str, _ProcessEntry] = {}
+        self._spawn_order: list[str] = []
+        self._entry_locks: dict[str, asyncio.Lock] = {}
+        self._closed = False
+        self._background_tasks: set[asyncio.Task[Any]] = set()
+
+    async def _spawn(self, manifest: ExtensionManifest) -> _ProcessEntry:
+        runner = manifest.entrypoints.runner
+        if runner is None:
+            raise RunnerExtensionHostError("NoRunner", "extension has no runner entrypoint")
+        generation = uuid.uuid4().hex
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            "omnigent.runner.extension_worker",
+            "--entrypoint",
+            runner,
+            "--extension-id",
+            manifest.id,
+            "--generation",
+            generation,
+            "--parent-pid",
+            str(os.getpid()),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=self.env or os.environ.copy(),
+            limit=MAX_RUNNER_EXTENSION_FRAME_BYTES + 1024,
+        )
+        entry = _ProcessEntry(manifest=manifest, process=process, generation=generation)
+        self._entries[manifest.id] = entry
+        if manifest.id in self._spawn_order:
+            self._spawn_order.remove(manifest.id)
+        self._spawn_order.append(manifest.id)
+        entry.reader_task = asyncio.create_task(
+            self._read_responses(entry),
+            name=f"extension-reader:{manifest.id}",
+        )
+        entry.stderr_task = asyncio.create_task(
+            self._drain_stderr(entry),
+            name=f"extension-stderr:{manifest.id}",
+        )
+        return entry
+
+    async def _ensure_entry(self, manifest: ExtensionManifest) -> _ProcessEntry:
+        if self._closed:
+            raise RunnerExtensionHostError("HostClosed", "runner extension host is closed")
+        lock = self._entry_locks.setdefault(manifest.id, asyncio.Lock())
+        async with lock:
+            entry = self._entries.get(manifest.id)
+            if entry is not None and entry.process.returncode is None and entry.activated:
+                return entry
+            if entry is not None:
+                await self._close_entry(entry)
+            entry = await self._spawn(manifest)
+            try:
+                result = await self._request(
+                    entry,
+                    "activate",
+                    {
+                        "extension_id": manifest.id,
+                        "tools": sorted(tool.tool_name for tool in manifest.tools),
+                    },
+                    timeout=self.activation_timeout,
+                )
+                tools = result.get("tools") if isinstance(result, dict) else None
+                worker_version = (
+                    result.get("protocol_version") if isinstance(result, dict) else None
+                )
+                if worker_version != self.protocol_version:
+                    raise RunnerExtensionHostError(
+                        "ProtocolMismatch",
+                        f"worker protocol {worker_version!r} does not match host protocol "
+                        f"{self.protocol_version}",
+                    )
+                if not isinstance(tools, list) or not all(isinstance(name, str) for name in tools):
+                    raise RunnerExtensionHostError(
+                        "InvalidActivation",
+                        "extension activation returned an invalid tool list",
+                    )
+                declared = {tool.tool_name for tool in manifest.tools}
+                if set(tools) != declared:
+                    mismatch = (
+                        f"runtime tools {sorted(tools)!r} do not match "
+                        f"manifest {sorted(declared)!r}"
+                    )
+                    raise RunnerExtensionHostError("ToolMismatch", mismatch)
+                entry.tools = frozenset(tools)
+                entry.activated = True
+                return entry
+            except BaseException:
+                await self._close_entry(entry)
+                raise
+
+    async def _request(
+        self,
+        entry: _ProcessEntry,
+        method: str,
+        params: dict[str, Any],
+        *,
+        timeout: float,
+        request_id: str | None = None,
+    ) -> Any:
+        if entry.process.returncode is not None or entry.process.stdin is None:
+            raise RunnerExtensionHostError("WorkerExited", "extension worker is not running")
+        request_id = request_id or uuid.uuid4().hex
+        if request_id in entry.pending:
+            raise RunnerExtensionHostError("DuplicateRequest", "request id is already active")
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[Any] = loop.create_future()
+        entry.pending[request_id] = future
+        try:
+            frame = encode_frame(
+                RunnerRequest(
+                    request_id=request_id,
+                    generation=entry.generation,
+                    method=method,
+                    params=params,
+                    version=self.protocol_version,
+                )
+            )
+            async with entry.write_lock:
+                entry.process.stdin.write(frame)
+                await entry.process.stdin.drain()
+            return await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
+        except (RunnerExtensionProtocolError, TypeError, ValueError) as exc:
+            entry.pending.pop(request_id, None)
+            raise RunnerExtensionHostError("ProtocolError", str(exc)) from exc
+        except asyncio.CancelledError:
+            entry.pending.pop(request_id, None)
+            if method == "invoke":
+                cancel_task = asyncio.create_task(self._cancel_best_effort(entry, request_id))
+                self._background_tasks.add(cancel_task)
+                cancel_task.add_done_callback(self._background_tasks.discard)
+            raise
+        except TimeoutError as exc:
+            entry.pending.pop(request_id, None)
+            if method == "invoke":
+                cancel_task = asyncio.create_task(self._cancel_best_effort(entry, request_id))
+                self._background_tasks.add(cancel_task)
+                cancel_task.add_done_callback(self._background_tasks.discard)
+            raise RunnerExtensionHostError(
+                "Timeout",
+                f"extension worker method {method!r} timed out",
+            ) from exc
+        except (BrokenPipeError, ConnectionError) as exc:
+            entry.pending.pop(request_id, None)
+            raise RunnerExtensionHostError("WorkerExited", "extension worker pipe closed") from exc
+        finally:
+            if future.cancelled():
+                entry.pending.pop(request_id, None)
+            if entry.close_when_idle and not entry.pending and not entry.owners:
+                close_task = asyncio.create_task(self._close_if_idle(entry))
+                self._background_tasks.add(close_task)
+                close_task.add_done_callback(self._background_tasks.discard)
+
+    async def _close_if_idle(self, entry: _ProcessEntry) -> None:
+        lock = self._entry_locks.setdefault(entry.manifest.id, asyncio.Lock())
+        async with lock:
+            if (
+                self._entries.get(entry.manifest.id) is entry
+                and entry.close_when_idle
+                and not entry.pending
+                and not entry.owners
+            ):
+                await self._close_entry(entry)
+
+    async def _cancel_best_effort(self, entry: _ProcessEntry, request_id: str) -> None:
+        with contextlib.suppress(Exception):
+            await self._request(
+                entry,
+                "cancel",
+                {"request_id": request_id, "generation": entry.generation},
+                timeout=1.0,
+            )
+
+    async def _read_responses(self, entry: _ProcessEntry) -> None:
+        stdout = entry.process.stdout
+        assert stdout is not None
+        failure: RunnerExtensionHostError | None = None
+        try:
+            while line := await stdout.readline():
+                response = decode_response(line)
+                if response.generation != entry.generation:
+                    continue
+                future = entry.pending.pop(response.request_id, None)
+                if future is None or future.done():
+                    continue
+                if response.error is not None:
+                    future.set_exception(
+                        RunnerExtensionHostError(
+                            response.error["code"],
+                            response.error["message"],
+                        )
+                    )
+                else:
+                    future.set_result(response.result)
+        except (RunnerExtensionProtocolError, ValueError) as exc:
+            failure = RunnerExtensionHostError("ProtocolError", str(exc))
+        except asyncio.CancelledError:
+            return
+        finally:
+            if failure is None and not self._closed:
+                failure = RunnerExtensionHostError(
+                    "WorkerExited",
+                    f"extension worker exited with status {entry.process.returncode}",
+                )
+            if failure is not None:
+                if entry.process.returncode is None:
+                    with contextlib.suppress(ProcessLookupError):
+                        entry.process.terminate()
+                    try:
+                        await asyncio.wait_for(entry.process.wait(), timeout=1.0)
+                    except TimeoutError:
+                        entry.process.kill()
+                        await entry.process.wait()
+                for future in entry.pending.values():
+                    if not future.done():
+                        future.set_exception(failure)
+                entry.pending.clear()
+            if self._entries.get(entry.manifest.id) is entry:
+                self._entries.pop(entry.manifest.id, None)
+
+    async def _drain_stderr(self, entry: _ProcessEntry) -> None:
+        stderr = entry.process.stderr
+        assert stderr is not None
+        try:
+            while chunk := await stderr.read(64 * 1024):
+                _logger.warning(
+                    "extension %s stderr: %s",
+                    entry.manifest.id,
+                    chunk.decode(errors="replace").rstrip()[:4096],
+                )
+        except asyncio.CancelledError:
+            return
+
+    async def list_tools(self, manifest: ExtensionManifest) -> frozenset[str]:
+        """Activate lazily and return the runtime-verified tool names."""
+        return (await self._ensure_entry(manifest)).tools
+
+    async def invoke(
+        self,
+        manifest: ExtensionManifest,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        request_id: str | None = None,
+        timeout: float | None = None,
+    ) -> Any:
+        """Invoke one declared tool in its extension subprocess."""
+        entry = await self._ensure_entry(manifest)
+        if tool_name not in entry.tools:
+            raise RunnerExtensionHostError("UnknownTool", f"unknown extension tool {tool_name!r}")
+        return await self._request(
+            entry,
+            "invoke",
+            {"tool_name": tool_name, "arguments": arguments},
+            timeout=self.invocation_timeout if timeout is None else timeout,
+            request_id=request_id,
+        )
+
+    async def cancel(self, extension_id: str, request_id: str) -> bool:
+        """Cancel one in-flight invocation in the current worker generation."""
+        entry = self._entries.get(extension_id)
+        if entry is None or request_id not in entry.pending:
+            return False
+        result = await self._request(
+            entry,
+            "cancel",
+            {"request_id": request_id, "generation": entry.generation},
+            timeout=1.0,
+        )
+        return bool(isinstance(result, dict) and result.get("cancelled"))
+
+    async def acquire(self, manifest: ExtensionManifest, owner: str) -> None:
+        """Hold a session-scoped reference to an extension worker."""
+        entry = await self._ensure_entry(manifest)
+        entry.owners.add(owner)
+
+    async def release(self, extension_id: str, owner: str) -> None:
+        """Release a session reference and close the now-unowned worker."""
+        lock = self._entry_locks.setdefault(extension_id, asyncio.Lock())
+        async with lock:
+            entry = self._entries.get(extension_id)
+            if entry is None:
+                return
+            entry.owners.discard(owner)
+            if entry.owners:
+                return
+            if entry.pending:
+                entry.close_when_idle = True
+                return
+            await self._close_entry(entry)
+
+    async def _close_entry(self, entry: _ProcessEntry) -> None:
+        if entry.process.returncode is None:
+            with contextlib.suppress(Exception):
+                await self._request(entry, "shutdown", {}, timeout=2.0)
+        if entry.process.stdin is not None:
+            with contextlib.suppress(BrokenPipeError, ConnectionError):
+                entry.process.stdin.close()
+        try:
+            await asyncio.wait_for(entry.process.wait(), timeout=2.0)
+        except TimeoutError:
+            entry.process.kill()
+            await entry.process.wait()
+        current = asyncio.current_task()
+        cleanup_tasks = []
+        for task in (entry.reader_task, entry.stderr_task):
+            if task is not None and task is not current and not task.done():
+                task.cancel()
+                cleanup_tasks.append(task)
+        if cleanup_tasks:
+            await asyncio.gather(*cleanup_tasks, return_exceptions=True)
+        for future in entry.pending.values():
+            if not future.done():
+                future.set_exception(
+                    RunnerExtensionHostError("WorkerClosed", "extension worker was closed")
+                )
+        entry.pending.clear()
+        if self._entries.get(entry.manifest.id) is entry:
+            self._entries.pop(entry.manifest.id, None)
+
+    def status_snapshot(self) -> dict[str, dict[str, Any]]:
+        """Return JSON-safe worker diagnostics without activating extensions."""
+        return {
+            extension_id: {
+                "pid": entry.process.pid,
+                "generation": entry.generation,
+                "running": entry.process.returncode is None,
+                "tools": sorted(entry.tools),
+                "owners": sorted(entry.owners),
+            }
+            for extension_id, entry in sorted(self._entries.items())
+        }
+
+    async def shutdown(self) -> None:
+        """Close workers in reverse spawn order; repeated calls are harmless."""
+        if self._closed:
+            return
+        self._closed = True
+        for extension_id in reversed(self._spawn_order):
+            entry = self._entries.get(extension_id)
+            if entry is not None:
+                await self._close_entry(entry)
+        self._spawn_order.clear()
+        if self._background_tasks:
+            await asyncio.gather(*self._background_tasks, return_exceptions=True)
+        self._background_tasks.clear()

--- a/omnigent/runner/extension_worker.py
+++ b/omnigent/runner/extension_worker.py
@@ -1,0 +1,297 @@
+"""Child process for one runner-side extension.
+
+The module speaks bounded JSON lines over stdin/stdout. Extension imports and
+handlers run here rather than in the runner, but this process is not sandboxed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import inspect
+import os
+import sys
+from collections.abc import Callable, Mapping
+from typing import Any, BinaryIO
+
+from omnigent.extensions.runner_api import (
+    RunnerExtension,
+    RunnerExtensionContext,
+    RunnerToolCallContext,
+)
+from omnigent.extensions.runner_protocol import (
+    RUNNER_EXTENSION_PROTOCOL_VERSION,
+    RunnerExtensionProtocolError,
+    RunnerRequest,
+    RunnerResponse,
+    decode_request,
+    encode_frame,
+)
+
+
+class ExtensionWorker:
+    def __init__(
+        self,
+        entrypoint: str,
+        extension_id: str,
+        generation: str,
+        protocol_output: BinaryIO,
+    ) -> None:
+        self.entrypoint = entrypoint
+        self.extension_id = extension_id
+        self.generation = generation
+        self.runtime: RunnerExtension | None = None
+        self.protocol_output = protocol_output
+        self.tasks: dict[str, asyncio.Task[None]] = {}
+        self._write_lock = asyncio.Lock()
+        self._shutdown_called = False
+
+    async def respond(
+        self,
+        request: RunnerRequest,
+        *,
+        result: Any = None,
+        code: str | None = None,
+        message: str | None = None,
+    ) -> None:
+        error = {"code": code, "message": message or code} if code is not None else None
+        response = RunnerResponse(
+            request_id=request.request_id,
+            generation=self.generation,
+            result=result,
+            error=error,
+        )
+        try:
+            frame = encode_frame(response)
+        except (RunnerExtensionProtocolError, TypeError, ValueError):
+            frame = encode_frame(
+                RunnerResponse(
+                    request_id=request.request_id,
+                    generation=self.generation,
+                    error={"code": "SerializationError", "message": "result is not serializable"},
+                )
+            )
+        async with self._write_lock:
+            await asyncio.to_thread(self._write, frame)
+
+    def _write(self, frame: bytes) -> None:
+        self.protocol_output.write(frame)
+        self.protocol_output.flush()
+
+    async def activate(self, request: RunnerRequest) -> None:
+        if self.runtime is not None:
+            await self.respond(
+                request,
+                result={
+                    "tools": sorted(self.runtime.tools),
+                    "protocol_version": RUNNER_EXTENSION_PROTOCOL_VERSION,
+                },
+            )
+            return
+        try:
+            factory = _load_object(self.entrypoint)
+            declared_tools = request.params.get("tools")
+            if not isinstance(declared_tools, list) or not all(
+                isinstance(name, str) for name in declared_tools
+            ):
+                raise TypeError("activation must provide declared tool names")
+            context = RunnerExtensionContext(
+                extension_id=self.extension_id,
+                declared_tools=tuple(declared_tools),
+            )
+            runtime = factory(context)
+            if inspect.isawaitable(runtime):
+                runtime = await runtime
+            if isinstance(runtime, Mapping):
+                runtime = RunnerExtension(tools=runtime)
+            if not isinstance(runtime, RunnerExtension):
+                raise TypeError("runner factory must return RunnerExtension or a tool mapping")
+            if not all(
+                isinstance(name, str) and callable(handler)
+                for name, handler in runtime.tools.items()
+            ):
+                raise TypeError(
+                    "runner tool mapping must contain string names and callable handlers"
+                )
+            self.runtime = runtime
+            await self.respond(
+                request,
+                result={
+                    "tools": sorted(runtime.tools),
+                    "protocol_version": RUNNER_EXTENSION_PROTOCOL_VERSION,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            await self.respond(request, code="ActivationError", message=str(exc)[:512])
+
+    async def handle(self, request: RunnerRequest) -> None:
+        if request.version != RUNNER_EXTENSION_PROTOCOL_VERSION:
+            await self.respond(
+                request,
+                code="ProtocolMismatch",
+                message=(
+                    f"worker protocol {RUNNER_EXTENSION_PROTOCOL_VERSION} does not support "
+                    f"host protocol {request.version}"
+                ),
+            )
+            return
+        if request.generation != self.generation:
+            await self.respond(
+                request, code="StaleGeneration", message="worker generation changed"
+            )
+            return
+        if request.method == "activate":
+            await self.activate(request)
+            return
+        if request.method == "list_tools":
+            if self.runtime is None:
+                await self.respond(request, code="NotActive", message="extension is not active")
+            else:
+                await self.respond(request, result={"tools": sorted(self.runtime.tools)})
+            return
+        if request.method == "invoke":
+            await self.invoke(request)
+            return
+        if request.method == "cancel":
+            target = request.params.get("request_id")
+            target_generation = request.params.get("generation")
+            task = (
+                self.tasks.get(target)
+                if isinstance(target, str) and target_generation == self.generation
+                else None
+            )
+            if task is not None:
+                task.cancel()
+            await self.respond(request, result={"cancelled": task is not None})
+            return
+        if request.method == "shutdown":
+            await self.shutdown()
+            await self.respond(request, result={"shutdown": True})
+            return
+        await self.respond(
+            request, code="MethodNotFound", message="unknown extension worker method"
+        )
+
+    async def invoke(self, request: RunnerRequest) -> None:
+        if self.runtime is None:
+            await self.respond(request, code="NotActive", message="extension is not active")
+            return
+        tool_name = request.params.get("tool_name")
+        arguments = request.params.get("arguments")
+        if not isinstance(tool_name, str) or not isinstance(arguments, dict):
+            await self.respond(
+                request, code="InvalidParams", message="invoke parameters are invalid"
+            )
+            return
+        handler = self.runtime.tools.get(tool_name)
+        if handler is None:
+            await self.respond(request, code="UnknownTool", message=f"unknown tool {tool_name!r}")
+            return
+        context = RunnerToolCallContext(
+            extension_id=self.extension_id,
+            tool_name=tool_name,
+            request_id=request.request_id,
+        )
+        try:
+            if inspect.iscoroutinefunction(handler):
+                result = await handler(arguments, context)
+            else:
+                result = await asyncio.to_thread(handler, arguments, context)
+            await self.respond(request, result=result)
+        except asyncio.CancelledError:
+            await self.respond(request, code="Cancelled", message="tool invocation cancelled")
+            raise
+        except Exception as exc:  # noqa: BLE001
+            await self.respond(request, code="ToolError", message=str(exc)[:512])
+
+    async def shutdown(self) -> None:
+        if self._shutdown_called:
+            return
+        self._shutdown_called = True
+        for task in tuple(self.tasks.values()):
+            if task is not asyncio.current_task():
+                task.cancel()
+        if self.runtime is not None and self.runtime.shutdown is not None:
+            result = self.runtime.shutdown()
+            if inspect.isawaitable(result):
+                await result
+
+
+def _load_object(import_path: str) -> Callable[..., Any]:
+    module_name, separator, attribute = import_path.partition(":")
+    if not separator:
+        raise ValueError("runner entrypoint must use module:attribute syntax")
+    module = importlib.import_module(module_name)
+    value = getattr(module, attribute)
+    if not callable(value):
+        raise TypeError("runner entrypoint is not callable")
+    return value
+
+
+async def _watch_parent(parent_pid: int) -> None:
+    while True:
+        await asyncio.sleep(1)
+        if os.getppid() != parent_pid:
+            os._exit(1)
+
+
+async def run_worker(
+    entrypoint: str,
+    extension_id: str,
+    generation: str,
+    parent_pid: int,
+) -> int:
+    # Preserve the original stdout pipe exclusively for protocol frames, then
+    # redirect extension prints to stderr so debug output cannot corrupt RPC.
+    protocol_output = os.fdopen(os.dup(sys.stdout.fileno()), "wb", buffering=0)
+    os.dup2(sys.stderr.fileno(), sys.stdout.fileno())
+    sys.stdout = sys.stderr
+    worker = ExtensionWorker(entrypoint, extension_id, generation, protocol_output)
+    parent_watchdog = asyncio.create_task(_watch_parent(parent_pid))
+    try:
+        while True:
+            line = await asyncio.to_thread(sys.stdin.buffer.readline)
+            if not line:
+                break
+            try:
+                request = decode_request(line, allow_version_mismatch=True)
+            except RunnerExtensionProtocolError as exc:
+                print(f"invalid runner extension frame: {exc}", file=sys.stderr, flush=True)
+                continue
+            if request.method in {"activate", "cancel", "shutdown"}:
+                await worker.handle(request)
+                if request.method == "shutdown":
+                    break
+                continue
+            task = asyncio.create_task(worker.handle(request))
+            worker.tasks[request.request_id] = task
+            task.add_done_callback(
+                lambda _task, request_id=request.request_id: worker.tasks.pop(request_id, None)
+            )
+    finally:
+        parent_watchdog.cancel()
+        await asyncio.gather(parent_watchdog, return_exceptions=True)
+        await worker.shutdown()
+        if worker.tasks:
+            _done, pending = await asyncio.wait(tuple(worker.tasks.values()), timeout=1.0)
+            if pending:
+                os._exit(1)
+        protocol_output.close()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--entrypoint", required=True)
+    parser.add_argument("--extension-id", required=True)
+    parser.add_argument("--generation", required=True)
+    parser.add_argument("--parent-pid", required=True, type=int)
+    args = parser.parse_args()
+    return asyncio.run(
+        run_worker(args.entrypoint, args.extension_id, args.generation, args.parent_pid)
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/extensions/fixtures/__init__.py
+++ b/tests/extensions/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Subprocess fixtures for runner extension host tests."""

--- a/tests/extensions/fixtures/runner_extension.py
+++ b/tests/extensions/fixtures/runner_extension.py
@@ -1,0 +1,76 @@
+"""Real child-process extension used by runner host tests."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from omnigent.extensions.runner_api import (
+    RunnerExtension,
+    RunnerExtensionContext,
+    RunnerToolCallContext,
+)
+
+
+def activate(context: RunnerExtensionContext) -> RunnerExtension:
+    if "slow-activation" in context.extension_id:
+        time.sleep(0.5)
+    if "activation-crash" in context.extension_id:
+        os._exit(19)
+    if "activation-fail" in context.extension_id:
+        raise RuntimeError("fixture activation failed")
+
+    async def echo(arguments: dict[str, Any], _call: RunnerToolCallContext) -> Any:
+        return {"echo": arguments}
+
+    async def sleep_tool(arguments: dict[str, Any], _call: RunnerToolCallContext) -> Any:
+        await asyncio.sleep(float(arguments.get("seconds", 60)))
+        return {"slept": True}
+
+    def crash(_arguments: dict[str, Any], _call: RunnerToolCallContext) -> Any:
+        os._exit(17)
+
+    def badstdout(_arguments: dict[str, Any], _call: RunnerToolCallContext) -> Any:
+        sys.stdout.write("not-json\n")
+        sys.stdout.flush()
+        return {"unreachable": True}
+
+    def stderr_blob(arguments: dict[str, Any], _call: RunnerToolCallContext) -> Any:
+        size = int(arguments.get("size", 2 * 1024 * 1024))
+        sys.stderr.write("x" * size)
+        sys.stderr.flush()
+        return {"bytes": size}
+
+    def stderr_tool(arguments: dict[str, Any], _call: RunnerToolCallContext) -> Any:
+        count = int(arguments.get("count", 100))
+        for index in range(count):
+            print(f"fixture stderr line {index}", file=sys.stderr, flush=True)
+        return {"lines": count}
+
+    available = {
+        "echo": echo,
+        "sleep": sleep_tool,
+        "crash": crash,
+        "badstdout": badstdout,
+        "stderr_blob": stderr_blob,
+        "stderr": stderr_tool,
+    }
+    tools = {
+        name: available[name.rsplit("__", 1)[-1]]
+        for name in context.declared_tools
+        if name.rsplit("__", 1)[-1] in available
+    }
+    if "mismatch" in context.extension_id and tools:
+        tools.pop(next(iter(tools)))
+
+    def shutdown() -> None:
+        path = os.environ.get("EXTENSION_SHUTDOWN_LOG")
+        if path:
+            with Path(path).open("a", encoding="utf-8") as stream:
+                stream.write(f"{context.extension_id}\n")
+
+    return RunnerExtension(tools=tools, shutdown=shutdown)

--- a/tests/extensions/test_runner_extension_host.py
+++ b/tests/extensions/test_runner_extension_host.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from omnigent.extensions import (
+    EXTENSION_API_VERSION,
+    ExtensionEntrypoints,
+    ExtensionManifest,
+    ToolContribution,
+)
+from omnigent.extensions.runner_protocol import (
+    RUNNER_EXTENSION_PROTOCOL_VERSION,
+    RunnerExtensionProtocolError,
+    decode_response,
+)
+from omnigent.extensions.tool_names import extension_tool_prefix
+from omnigent.runner.extension_host import RunnerExtensionHost, RunnerExtensionHostError
+
+_ENTRYPOINT = "tests.extensions.fixtures.runner_extension:activate"
+
+
+def _manifest(extension_id: str = "tests.runner", *suffixes: str) -> ExtensionManifest:
+    suffixes = suffixes or ("echo",)
+    prefix = extension_tool_prefix(extension_id)
+    return ExtensionManifest(
+        id=extension_id,
+        display_name="Runner fixture",
+        distribution="tests-runner-extension",
+        version="1.0.0",
+        requires_omnigent=">=0.11,<1",
+        extension_api=EXTENSION_API_VERSION,
+        entrypoints=ExtensionEntrypoints(runner=_ENTRYPOINT),
+        tools=tuple(
+            ToolContribution(
+                id=f"{extension_id}.{suffix.replace('_', '-')}-tool",
+                tool_name=f"{prefix}{suffix}",
+                title=suffix.title(),
+                description=f"Fixture {suffix} tool.",
+                input_schema={"type": "object"},
+            )
+            for suffix in suffixes
+        ),
+    )
+
+
+async def test_lazily_activates_lists_and_invokes_tool() -> None:
+    host = RunnerExtensionHost()
+    manifest = _manifest()
+    assert host.status_snapshot() == {}
+    try:
+        names = await host.list_tools(manifest)
+        first_status = host.status_snapshot()[manifest.id]
+        assert names == frozenset({f"{extension_tool_prefix(manifest.id)}echo"})
+        assert await host.list_tools(manifest) == names
+        assert host.status_snapshot()[manifest.id]["pid"] == first_status["pid"]
+        result = await host.invoke(manifest, next(iter(names)), {"text": "hello"})
+        assert result == {"echo": {"text": "hello"}}
+    finally:
+        await host.shutdown()
+    assert host.status_snapshot() == {}
+
+
+async def test_zero_tool_runtime_reuses_activated_process() -> None:
+    host = RunnerExtensionHost()
+    manifest = replace(_manifest(), tools=())
+    try:
+        assert await host.list_tools(manifest) == frozenset()
+        pid = host.status_snapshot()[manifest.id]["pid"]
+        assert await host.list_tools(manifest) == frozenset()
+        assert host.status_snapshot()[manifest.id]["pid"] == pid
+    finally:
+        await host.shutdown()
+
+
+async def test_rejects_protocol_and_runtime_tool_mismatches() -> None:
+    incompatible = RunnerExtensionHost(protocol_version=RUNNER_EXTENSION_PROTOCOL_VERSION + 1)
+    with pytest.raises(RunnerExtensionHostError, match="does not support") as protocol_error:
+        await incompatible.list_tools(_manifest())
+    assert protocol_error.value.code == "ProtocolMismatch"
+    await incompatible.shutdown()
+
+    mismatch = RunnerExtensionHost()
+    with pytest.raises(RunnerExtensionHostError, match="do not match") as tool_error:
+        await mismatch.list_tools(_manifest("tests.mismatch", "echo"))
+    assert tool_error.value.code == "ToolMismatch"
+    await mismatch.shutdown()
+
+
+async def test_slow_activation_does_not_block_other_extensions() -> None:
+    host = RunnerExtensionHost()
+    slow = _manifest("tests.slow-activation", "echo")
+    fast = _manifest("tests.fast-activation", "echo")
+    slow_task = asyncio.create_task(host.list_tools(slow))
+    await asyncio.sleep(0.03)
+
+    assert await host.list_tools(fast)
+    assert not slow_task.done()
+    assert await slow_task
+    await host.shutdown()
+
+
+async def test_activation_process_crash_is_typed_and_restartable() -> None:
+    host = RunnerExtensionHost()
+    crashing = _manifest("tests.activation-crash", "echo")
+    with pytest.raises(RunnerExtensionHostError) as error:
+        await host.list_tools(crashing)
+    assert error.value.code == "WorkerExited"
+    assert host.status_snapshot() == {}
+
+    healthy = _manifest("tests.activation-healthy", "echo")
+    assert await host.list_tools(healthy)
+    await host.shutdown()
+
+
+async def test_activation_failure_isolated_and_no_process_left() -> None:
+    host = RunnerExtensionHost()
+    manifest = _manifest("tests.activation-fail", "echo")
+    with pytest.raises(RunnerExtensionHostError, match="fixture activation failed") as error:
+        await host.list_tools(manifest)
+    assert error.value.code == "ActivationError"
+    assert host.status_snapshot() == {}
+    await host.shutdown()
+
+
+async def test_cancel_midflight_then_worker_remains_usable() -> None:
+    host = RunnerExtensionHost()
+    manifest = _manifest("tests.cancel", "echo", "sleep")
+    sleep_name = f"{extension_tool_prefix(manifest.id)}sleep"
+    echo_name = f"{extension_tool_prefix(manifest.id)}echo"
+    try:
+        await host.list_tools(manifest)
+        invocation = asyncio.create_task(
+            host.invoke(
+                manifest,
+                sleep_name,
+                {"seconds": 30},
+                request_id="sleep-request",
+            )
+        )
+        await asyncio.sleep(0.05)
+        assert await host.cancel(manifest.id, "sleep-request") is True
+        with pytest.raises(RunnerExtensionHostError) as cancelled:
+            await invocation
+        assert cancelled.value.code == "Cancelled"
+        assert await host.invoke(manifest, echo_name, {"ok": True}) == {"echo": {"ok": True}}
+    finally:
+        await host.shutdown()
+
+
+async def test_caller_task_cancellation_propagates_to_worker() -> None:
+    host = RunnerExtensionHost()
+    manifest = _manifest("tests.task-cancel", "echo", "sleep")
+    try:
+        invocation = asyncio.create_task(
+            host.invoke(
+                manifest,
+                f"{extension_tool_prefix(manifest.id)}sleep",
+                {"seconds": 30},
+                request_id="caller-cancel",
+            )
+        )
+        await asyncio.sleep(0.05)
+        invocation.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await invocation
+        await asyncio.sleep(0.05)
+        assert await host.invoke(
+            manifest,
+            f"{extension_tool_prefix(manifest.id)}echo",
+            {},
+        ) == {"echo": {}}
+    finally:
+        await host.shutdown()
+
+
+async def test_invocation_timeout_cancels_without_poisoning_host() -> None:
+    host = RunnerExtensionHost(invocation_timeout=0.05)
+    manifest = _manifest("tests.timeout", "echo", "sleep")
+    try:
+        with pytest.raises(RunnerExtensionHostError) as timeout:
+            await host.invoke(
+                manifest,
+                f"{extension_tool_prefix(manifest.id)}sleep",
+                {"seconds": 30},
+            )
+        assert timeout.value.code == "Timeout"
+        await asyncio.sleep(0.05)
+        assert await host.invoke(
+            manifest,
+            f"{extension_tool_prefix(manifest.id)}echo",
+            {},
+        ) == {"echo": {}}
+    finally:
+        await host.shutdown()
+
+
+async def test_crash_fails_one_worker_and_restarts_on_next_call() -> None:
+    host = RunnerExtensionHost()
+    crashing = _manifest("tests.crasher", "crash", "echo")
+    healthy = _manifest("tests.healthy", "echo")
+    try:
+        await host.list_tools(crashing)
+        old_pid = host.status_snapshot()[crashing.id]["pid"]
+        await host.list_tools(healthy)
+        with pytest.raises(RunnerExtensionHostError) as crash:
+            await host.invoke(crashing, f"{extension_tool_prefix(crashing.id)}crash", {})
+        assert crash.value.code == "WorkerExited"
+        assert await host.invoke(
+            healthy,
+            f"{extension_tool_prefix(healthy.id)}echo",
+            {"healthy": True},
+        ) == {"echo": {"healthy": True}}
+        await host.list_tools(crashing)
+        assert host.status_snapshot()[crashing.id]["pid"] != old_pid
+    finally:
+        await host.shutdown()
+
+
+async def test_oversized_frame_and_unknown_tool_are_typed_errors() -> None:
+    host = RunnerExtensionHost()
+    manifest = _manifest()
+    try:
+        with pytest.raises(RunnerExtensionHostError) as oversized:
+            await host.invoke(
+                manifest,
+                f"{extension_tool_prefix(manifest.id)}echo",
+                {"value": "x" * (1024 * 1024)},
+            )
+        assert oversized.value.code == "ProtocolError"
+        with pytest.raises(RunnerExtensionHostError) as unknown:
+            await host.invoke(manifest, "missing", {})
+        assert unknown.value.code == "UnknownTool"
+    finally:
+        await host.shutdown()
+
+
+async def test_extension_stdout_is_redirected_without_corrupting_protocol() -> None:
+    host = RunnerExtensionHost()
+    manifest = _manifest("tests.badstdout", "badstdout", "echo")
+    try:
+        assert await host.invoke(
+            manifest,
+            f"{extension_tool_prefix(manifest.id)}badstdout",
+            {},
+        ) == {"unreachable": True}
+        assert await host.invoke(
+            manifest,
+            f"{extension_tool_prefix(manifest.id)}echo",
+            {},
+        ) == {"echo": {}}
+    finally:
+        await host.shutdown()
+
+
+async def test_unknown_worker_method_is_rejected() -> None:
+    host = RunnerExtensionHost()
+    manifest = _manifest()
+    try:
+        await host.list_tools(manifest)
+        entry = host._entries[manifest.id]
+        with pytest.raises(RunnerExtensionHostError) as error:
+            await host._request(entry, "unknown", {}, timeout=1)
+        assert error.value.code == "MethodNotFound"
+    finally:
+        await host.shutdown()
+
+
+async def test_stderr_is_drained_without_deadlock() -> None:
+    host = RunnerExtensionHost(invocation_timeout=5)
+    manifest = _manifest("tests.stderr", "stderr", "stderr_blob", "echo")
+    try:
+        result = await host.invoke(
+            manifest,
+            f"{extension_tool_prefix(manifest.id)}stderr",
+            {"count": 2_000},
+        )
+        assert result == {"lines": 2_000}
+        assert await host.invoke(
+            manifest,
+            f"{extension_tool_prefix(manifest.id)}stderr_blob",
+            {"size": 2 * 1024 * 1024},
+        ) == {"bytes": 2 * 1024 * 1024}
+        assert await host.invoke(
+            manifest,
+            f"{extension_tool_prefix(manifest.id)}echo",
+            {},
+        ) == {"echo": {}}
+    finally:
+        await host.shutdown()
+
+
+async def test_release_waits_for_inflight_invocation() -> None:
+    host = RunnerExtensionHost()
+    manifest = _manifest("tests.release-active", "sleep")
+    await host.acquire(manifest, "session-a")
+    invocation = asyncio.create_task(
+        host.invoke(
+            manifest,
+            f"{extension_tool_prefix(manifest.id)}sleep",
+            {"seconds": 0.1},
+            request_id="active-request",
+        )
+    )
+    await asyncio.sleep(0.03)
+    await host.release(manifest.id, "session-a")
+
+    assert await invocation == {"slept": True}
+    for _ in range(20):
+        if manifest.id not in host.status_snapshot():
+            break
+        await asyncio.sleep(0.02)
+    assert manifest.id not in host.status_snapshot()
+    await host.shutdown()
+
+
+async def test_release_refcounts_and_reverse_shutdown_order(tmp_path: Path) -> None:
+    shutdown_log = tmp_path / "shutdown.log"
+    env = os.environ.copy()
+    env["EXTENSION_SHUTDOWN_LOG"] = str(shutdown_log)
+    host = RunnerExtensionHost(env=env)
+    first = _manifest("tests.first", "echo")
+    second = _manifest("tests.second", "echo")
+    await host.acquire(first, "session-a")
+    await host.acquire(first, "session-b")
+    await host.release(first.id, "session-a")
+    assert first.id in host.status_snapshot()
+    await host.acquire(second, "session-a")
+    await host.shutdown()
+
+    assert shutdown_log.read_text(encoding="utf-8").splitlines() == [second.id, first.id]
+
+
+async def test_parent_watchdog_exits_when_runner_parent_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent.runner import extension_worker
+
+    monkeypatch.setattr(extension_worker.os, "getppid", lambda: 999)
+
+    def exit_process(code: int) -> None:
+        raise RuntimeError(f"exit {code}")
+
+    monkeypatch.setattr(extension_worker.os, "_exit", exit_process)
+    with pytest.raises(RuntimeError, match="exit 1"):
+        await asyncio.wait_for(extension_worker._watch_parent(123), timeout=2)
+
+
+def test_malformed_response_frame_is_rejected() -> None:
+    with pytest.raises(RunnerExtensionProtocolError, match="valid JSON"):
+        decode_response(b"not-json\n")
+
+
+def test_manifest_helper_is_valid() -> None:
+    # Guard fixture names against future contract changes before subprocess tests
+    # turn a validation regression into an opaque activation failure.
+    from omnigent.extensions.registry import validate_manifest
+
+    validate_manifest(
+        _manifest(
+            "tests.fixture",
+            "echo",
+            "sleep",
+            "crash",
+            "badstdout",
+            "stderr",
+            "stderr_blob",
+        )
+    )
+    assert replace(_manifest(), display_name="Other").id == "tests.runner"


### PR DESCRIPTION
## Related issue

N/A — maintainer architecture work.

## Summary

- Add a versioned, bounded JSON-lines protocol and public runner runtime contract for extension activation, tool listing, invocation, cancellation, and shutdown.
- Add a lazy one-process-per-extension runner supervisor with per-extension activation locks, tool-list verification, request timeouts, caller cancellation, refcounted ownership, crash/protocol recovery, stderr draining, parent-death monitoring, and reverse-order cleanup.
- Fence extension stdout away from the protocol channel and keep all ToolManager integration intentionally deferred to the next stack PR.

**ELI5:** extension Python code now runs in a separate helper process. If one crashes, hangs, or prints debugging output, it does not corrupt the runner or another extension.

```text
runner host -> bounded RPC -> extension worker -> handlers
      |                         (not an OS sandbox)
      + one process per extension
```

This is **Stack B PR 3** and is based on PR #5665. Review only the single commit added by this branch.

## Test Plan

- `uv run pytest tests/extensions/test_runner_extension_host.py`
- `uv run ruff check omnigent/extensions/runner_api.py omnigent/extensions/runner_protocol.py omnigent/runner/extension_host.py omnigent/runner/extension_worker.py tests/extensions/fixtures tests/extensions/test_runner_extension_host.py`
- `uv run pyrefly check omnigent/extensions/runner_api.py omnigent/extensions/runner_protocol.py omnigent/runner/extension_host.py omnigent/runner/extension_worker.py`
- `pre-commit run --all-files`

## Demo

N/A — this PR adds runner process infrastructure without exposing tools to agents yet.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Real subprocess tests cover lazy activation and caching, explicit protocol mismatch, zero-tool activation, activation errors/crashes, cancellation and timeout, worker restart, cross-extension isolation and parallel activation, bounded frames, stdout fencing, large stderr output, unknown methods/tools, in-flight release, parent watchdog behavior, refcounts, and reverse shutdown.
