### PR TITLE
feat(web): add separate Default and Manual Claude permission modes

### DIFF
--- a/omnigent/server/routes/_session_create_validation.py
+++ b/omnigent/server/routes/_session_create_validation.py
@@ -28,7 +28,8 @@ _logger = logging.getLogger(__name__)
 # accepts at start, not just the shift+tab-switchable subset. ``dontAsk`` and
 # ``bypassPermissions`` are launch-only (rejected on a running-session PATCH),
 # but a scheduled task launches a fresh session each fire, so all of them are
-# valid here. Mirrors the frontend's ``CLAUDE_NATIVE_PERMISSION_MODES``.
+# valid here. Does not include ``"inherit"`` (the frontend-only no-flag
+# sentinel) — that value is never sent to the server.
 CLAUDE_NATIVE_LAUNCH_PERMISSION_MODES: frozenset[str] = frozenset(
     {"default", "auto", "acceptEdits", "plan", "dontAsk", "bypassPermissions"}
 )

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -578,11 +578,12 @@ async def _drive_permission_mode(base_url: str, session_id: str) -> None:
             # Claude Code auto-selects (only built-in, ranked first); its config
             # (model / effort / permission mode) lives in the gear-icon modal.
             await _open_entry_config(page, "ag_claude_e2e")
-            # The permission select offers all six Claude permission modes.
+            # The permission select offers all seven Claude permission modes.
             perm = page.get_by_test_id("new-chat-landing-config-permission")
             await expect(perm).to_be_visible()
             await perm.click()
             perm_labels = (
+                "Default",
                 "Manual",
                 "Auto",
                 "Accept edits",

--- a/web/src/components/scheduled/ModelEffortFields.tsx
+++ b/web/src/components/scheduled/ModelEffortFields.tsx
@@ -158,7 +158,7 @@ export function ModelEffortFields({
             className="w-(--radix-select-trigger-width)"
           >
             <SelectItem value={PERMISSION_SELECT_DEFAULT}>Default</SelectItem>
-            {CLAUDE_NATIVE_PERMISSION_MODES.map((m) => (
+            {CLAUDE_NATIVE_PERMISSION_MODES.filter((m) => m.value !== "inherit").map((m) => (
               <SelectItem key={m.value} value={m.value}>
                 {m.label}
               </SelectItem>

--- a/web/src/lib/claudePermissionMode.test.ts
+++ b/web/src/lib/claudePermissionMode.test.ts
@@ -26,13 +26,15 @@ describe("claudePermissionMode", () => {
     // The start-session picker passes --permission-mode, which accepts modes
     // the live switcher can't reach; that vocabulary must stay wider.
     const startup = CLAUDE_NATIVE_PERMISSION_MODES.map((m) => m.value);
+    expect(startup).toContain("inherit");
     expect(startup).toContain("dontAsk");
     expect(startup).toContain("bypassPermissions");
   });
 
-  it("labels the prompting mode the way Claude Code does", () => {
-    // Claude's own TUI renders "manual mode on" for the `default` value, so
-    // the web label matches what users see in the pane.
+  it("labels inherit as Default and the prompting mode as Manual", () => {
+    // "inherit" = no flag, uses the user's configured mode → labelled "Default".
+    // "default" = --permission-mode default, explicit prompting → labelled "Manual".
+    expect(claudePermissionModeLabel("inherit")).toBe("Default");
     expect(claudePermissionModeLabel("default")).toBe("Manual");
     expect(claudePermissionModeLabel("auto")).toBe("Auto");
   });

--- a/web/src/lib/claudePermissionMode.ts
+++ b/web/src/lib/claudePermissionMode.ts
@@ -23,12 +23,19 @@ export interface ClaudePermissionModeOption {
   description: string;
 }
 
-export const CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE = "default";
+// "inherit" is a web-UI sentinel: no --permission-mode flag is passed, so
+// Claude Code uses whatever the user has configured in their settings file.
+export const CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE = "inherit";
 
 // Claude Code's `claude --permission-mode` choices (v2.1). Keep in sync
-// with `claude --help`. The prompting mode is spelled `default` on the
-// wire and labelled "Manual" in Claude's own UI, which this mirrors.
+// with `claude --help`. "inherit" is prepended as the no-flag default; the
+// rest map 1:1 to --permission-mode values sent on session create.
 export const CLAUDE_NATIVE_PERMISSION_MODES: ClaudePermissionModeOption[] = [
+  {
+    value: "inherit",
+    label: "Default",
+    description: "Uses your configured Claude Code permission mode",
+  },
   { value: "default", label: "Manual", description: "Prompts before edits and commands" },
   {
     value: "auto",
@@ -50,6 +57,8 @@ export const CLAUDE_NATIVE_PERMISSION_MODES: ClaudePermissionModeOption[] = [
 ];
 
 /** Modes a running session can be switched to (shift+tab-reachable). */
+// "inherit" is launch-only — there is no --permission-mode flag that means
+// "use my settings", so it cannot be sent as a mid-session switch.
 export const CLAUDE_NATIVE_SWITCHABLE_PERMISSION_MODES: ClaudePermissionModeOption[] =
   CLAUDE_NATIVE_PERMISSION_MODES.filter((mode) =>
     ["default", "acceptEdits", "plan", "auto"].includes(mode.value),
@@ -72,8 +81,8 @@ export function claudePermissionModeLabel(mode: string | null | undefined): stri
  * Prefers the label the server stamps after a confirmed switch, then the
  * launch flag. Returns `null` rather than assuming Claude's default: a
  * `permissions.defaultMode` in a settings file boots the session into a mode
- * that never appears in `terminal_launch_args`, so guessing "Manual" would
- * display a mode the session isn't in. Callers hide the picker on `null`.
+ * that never appears in `terminal_launch_args`, so guessing would display a
+ * mode the session isn't in. Callers hide the picker on `null`.
  */
 export function claudePermissionModeFromSession(
   session:

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -914,11 +914,11 @@ describe("NewChatLandingScreen create flow", () => {
     // in — the permission select sits at its Default.
     openAgentConfig("ag_native");
     expect(screen.queryByTestId("new-chat-landing-config-approval")).toBeNull();
-    // The permission select's trigger displays its current value — "Manual"
-    // (Claude's own label for the prompting `default` mode), not Codex's
-    // stored "full-access" (which isn't even a valid value here).
+    // The permission select's trigger displays its current value — "Default"
+    // (the "inherit" no-flag mode), not Codex's stored "full-access"
+    // (which isn't even a valid value here).
     expect(screen.getByTestId("new-chat-landing-config-permission").textContent).toContain(
-      "Manual",
+      "Default",
     );
   });
 

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -3192,9 +3192,9 @@ describe("NewChatLandingScreen agent picker + config gear", () => {
     renderLanding();
     openAgentConfig("a1");
     openSelect("new-chat-landing-config-permission");
-    // The footer starts on the selected (Default) mode's blurb...
+    // The footer starts on the selected (Default/inherit) mode's blurb...
     const detail = screen.getByTestId("new-chat-landing-config-permission-detail");
-    expect(detail.textContent).toContain("Prompts before edits and commands");
+    expect(detail.textContent).toContain("Uses your configured Claude Code permission mode");
     // ...then follows the hovered option.
     fireEvent.pointerEnter(screen.getByRole("option", { name: "Plan" }));
     expect(detail.textContent).toContain("Plans only; makes no edits");
@@ -3210,10 +3210,10 @@ describe("NewChatLandingScreen agent picker + config gear", () => {
     fireEvent.click(screen.getByTestId("new-chat-landing-config-cancel"));
     expect(screen.queryByTestId("new-chat-landing-config-modal")).toBeNull();
     fireEvent.click(screen.getByTestId("new-chat-landing-config-gear"));
-    // Reopened: Plan was discarded, the permission select is back at Manual
-    // (Claude's label for the prompting `default` mode).
+    // Reopened: Plan was discarded, the permission select is back at Default
+    // (the "inherit" no-flag mode).
     expect(screen.getByTestId("new-chat-landing-config-permission").textContent).toContain(
-      "Manual",
+      "Default",
     );
   });
 
@@ -4265,13 +4265,14 @@ describe("NewChatLandingScreen Smart Routing harness row", () => {
     expect(permission.textContent).toContain("Default");
     expect(permission.textContent).not.toContain("Plan");
     // Reads the state behind the locked row, not the row's own constant: the
-    // wrapper's full modal is back and shows the reset value.
+    // wrapper's full modal is back and shows the reset value (Default, since
+    // Smart Routing cleared the remembered "plan").
     fireEvent.click(screen.getByTestId("new-chat-landing-config-cancel"));
     selectAgent("a1");
     fireEvent.click(screen.getByTestId("new-chat-landing-config-gear"));
-    expect(screen.getByTestId("new-chat-landing-config-permission").textContent).toContain(
-      "Manual",
-    );
+    const reopened = screen.getByTestId("new-chat-landing-config-permission");
+    expect(reopened.textContent).toContain("Default");
+    expect(reopened.textContent).not.toContain("Plan");
   });
 
   it("leaves Smart Routing by re-picking a harness row", () => {


### PR DESCRIPTION
## Related issue


## Summary

The New Chat permission picker had a single entry — wire value `"default"`, labelled "Manual" — that sent **no** `--permission-mode` flag, so Claude Code fell through to whatever the user configured in their settings file. Users who selected "Manual" expecting prompts-before-edits behavior were surprised to land in their configured mode (e.g. `dontAsk`).

This introduces a proper two-mode split:

| Picker label | Wire value | Flag sent to Claude Code | What it does |
|---|---|---|---|
| **Default** | `"inherit"` (new sentinel) | *(none sent)* | Claude Code uses `permissions.defaultMode` from the user's `~/.claude/settings.json` — whatever they configured. Pre-selected. |
| **Manual** | `"default"` (unchanged) | `--permission-mode default` | Claude Code always prompts before edits and commands, regardless of user settings. |

**Why `"default"` for Manual and `"inherit"` for Default?**

Claude Code's internal name for "prompt before every edit/command" mode is `default` (visible in `claude --help`). Omnigent calls it **Manual** to distinguish it from the new **Default** entry — but the wire value on session create stays `"default"` and the flag sent is `--permission-mode default`.

The new **Default** entry uses the Omnigent-only sentinel `"inherit"` meaning "send no flag, let the user's settings decide." There is no `--permission-mode` value that expresses this, so `"inherit"` is excluded from `CLAUDE_NATIVE_SWITCHABLE_PERMISSION_MODES` and cannot be sent as a mid-session switch.

The `terminal_launch_args` condition in `NewChatDialog.tsx` already reads:
```ts
permissionMode !== CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
  ? ["--permission-mode", permissionMode]   // sends the flag
  : undefined                                // omits the flag
Changing CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE from "default" to "inherit" makes this correct without touching NewChatDialog.tsx.

Supersedes #5245, which was a label-only rename with no behavior fix.

Test Plan

1. Start a new Claude session with Default selected → confirm no --permission-mode in terminal_launch_args; Claude Code starts in your configured mode.
2. Start a new Claude session with Manual selected → confirm terminal_launch_args contains ["--permission-mode", "default"]; Claude Code prompts before edits and commands even if settings say dontAsk.
3. Confirm Default is pre-selected when opening New Chat.
4. Confirm Default does not appear in the mid-session permission switcher (shift+tab).

Unit tests: pnpm test src/lib/claudePermissionMode.test.ts

Demo

N/A — picker gains a "Default" entry above "Manual" with description "Uses your configured Claude Code permission mode".

Type of change

- [x] Bug fix
- [x] UI / frontend change

Test coverage

- [x] Unit tests added / updated
- [x] Manual verification completed

Coverage notes

Unit tests cover: "inherit" excluded from switchable modes, "inherit" producing no --permission-mode flag in terminal_launch_args, "default" producing the correct flag, and picker ordering. Manual: terminal_launch_args contents verified for both modes via session create payload.

Changelog

The permission picker now has separate Default (inherits your Claude Code settings) and Manual (always prompts before edits and commands) entries, fixing the bug where "Manual" silently used your configured mode instead of enabling prompts.