### PR TITLE
fix(runner): a declined tool call must not cancel a native sub-agent dispatch

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -391,6 +391,8 @@ def _unwrap_spec_entry(entry: _SpecEntry | None) -> AgentSpec | None:
 
 _NO_BODY_STATUS_CODES = {204, 304}
 _SUBAGENT_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
+# A declined tool call aborts the turn only; it does not end the dispatch.
+_INTERRUPT_REASON_TOOL_DECLINED = "tool_declined"
 _SUBAGENT_DELIVERY_DELIVERED = "delivered"
 _SUBAGENT_DELIVERY_ALREADY_DELIVERED = "already_delivered"
 _SUBAGENT_DELIVERY_UNTRACKED = "untracked"
@@ -7840,7 +7842,13 @@ def create_runner_app(
 
         if body_type == "interrupt":
             _harness = _session_harness_name(conversation_id)
-            _interrupt_resp = await _native_interrupt_runner.interrupt(_harness, conversation_id)
+            _data = body.get("data") if isinstance(body, dict) else None
+            _reason = _data.get("reason") if isinstance(_data, dict) else None
+            _interrupt_resp = await _native_interrupt_runner.interrupt(
+                _harness,
+                conversation_id,
+                dispatch_terminal=_reason != _INTERRUPT_REASON_TOOL_DECLINED,
+            )
             if _interrupt_resp is not None:
                 return _interrupt_resp
             await _cancel_inprocess_turn(conversation_id)

--- a/omnigent/runner/native/interrupt.py
+++ b/omnigent/runner/native/interrupt.py
@@ -268,9 +268,20 @@ class NativeInterruptRunner:
         self._client_safe_error_detail = client_safe_error_detail
         self._logger = logger
 
-    async def interrupt(self, harness_name: str | None, conv_id: str) -> Response | None:
+    async def interrupt(
+        self,
+        harness_name: str | None,
+        conv_id: str,
+        *,
+        dispatch_terminal: bool = True,
+    ) -> Response | None:
         """Dispatch an interrupt to the harness's bridge.
 
+        :param dispatch_terminal: Whether this interrupt ends the sub-agent
+            dispatch. ``True`` for a user Stop. ``False`` when it merely aborts
+            the current turn (a declined tool call), where reporting the
+            dispatch ``cancelled`` would overwrite the real outcome the
+            harness reports moments later via ``external_session_status``.
         :returns: A response when this harness has an interrupt handler, else
             ``None`` so the caller falls through to the in-process turn cancel
             (antigravity/opencode).
@@ -280,13 +291,13 @@ class NativeInterruptRunner:
             return None
         key = agent.key
         if key == "claude":
-            return await self._claude_interrupt(conv_id)
+            return await self._claude_interrupt(conv_id, dispatch_terminal=dispatch_terminal)
         if key == "codex":
-            return await self._codex_interrupt(conv_id)
+            return await self._codex_interrupt(conv_id, dispatch_terminal=dispatch_terminal)
         spec = _UNIFORM_INTERRUPT.get(key)
         if spec is None:
             return None
-        return await self._uniform_interrupt(spec, conv_id)
+        return await self._uniform_interrupt(spec, conv_id, dispatch_terminal=dispatch_terminal)
 
     async def stop(self, harness_name: str | None, conv_id: str) -> Response | None:
         """Dispatch a stop_session to the harness's bridge.
@@ -310,7 +321,13 @@ class NativeInterruptRunner:
             return None
         return await self._uniform_stop(spec, conv_id)
 
-    def _wake_parent_after_native_interrupt(self, conv_id: str) -> None:
+    def _wake_parent_after_native_interrupt(
+        self, conv_id: str, *, dispatch_terminal: bool = True
+    ) -> None:
+        # A turn-only abort leaves the dispatch running; the harness's own
+        # external_session_status edge carries the real terminal outcome.
+        if not dispatch_terminal:
+            return
         delivery_ack = self._mark_subagent_terminal_and_wake(
             conv_id,
             status="cancelled",
@@ -354,7 +371,9 @@ class NativeInterruptRunner:
                 publish_event=self._publish_event,
             )
 
-    async def _uniform_interrupt(self, spec: _UniformInterrupt, conv_id: str) -> Response:
+    async def _uniform_interrupt(
+        self, spec: _UniformInterrupt, conv_id: str, *, dispatch_terminal: bool = True
+    ) -> Response:
         module = importlib.import_module(spec.module)
         bridge_dir = module.bridge_dir_for_session_id(conv_id)
         inject = getattr(module, spec.inject_fn)
@@ -375,7 +394,7 @@ class NativeInterruptRunner:
                     "detail": self._client_safe_error_detail(exc, context=spec.context),
                 },
             )
-        self._wake_parent_after_native_interrupt(conv_id)
+        self._wake_parent_after_native_interrupt(conv_id, dispatch_terminal=dispatch_terminal)
         return Response(status_code=204)
 
     async def _uniform_stop(self, spec: _UniformStop, conv_id: str) -> Response:
@@ -412,7 +431,7 @@ class NativeInterruptRunner:
             )
         return Response(status_code=204)
 
-    async def _claude_interrupt(self, conv_id: str) -> Response:
+    async def _claude_interrupt(self, conv_id: str, *, dispatch_terminal: bool = True) -> Response:
         from omnigent.claude_native_bridge import bridge_dir_for_bridge_id, inject_interrupt
 
         bridge_id = await _claude_native_bridge_id_for_session(
@@ -432,7 +451,7 @@ class NativeInterruptRunner:
                     ),
                 },
             )
-        self._wake_parent_after_native_interrupt(conv_id)
+        self._wake_parent_after_native_interrupt(conv_id, dispatch_terminal=dispatch_terminal)
         return Response(status_code=204)
 
     async def _claude_stop(self, conv_id: str) -> Response:
@@ -477,7 +496,7 @@ class NativeInterruptRunner:
             )
         return Response(status_code=204)
 
-    async def _codex_interrupt(self, conv_id: str) -> Response:
+    async def _codex_interrupt(self, conv_id: str, *, dispatch_terminal: bool = True) -> Response:
         from omnigent.codex_native_app_server import client_for_transport
         from omnigent.codex_native_bridge import (
             CODEX_NATIVE_BRIDGE_ID_LABEL_KEY,
@@ -570,5 +589,5 @@ class NativeInterruptRunner:
         finally:
             with contextlib.suppress(Exception):
                 await codex_client.close()
-        self._wake_parent_after_native_interrupt(conv_id)
+        self._wake_parent_after_native_interrupt(conv_id, dispatch_terminal=dispatch_terminal)
         return Response(status_code=204)

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -53,6 +53,10 @@ _logger = logging.getLogger("omnigent.server.routes.sessions")
 
 
 _INTERRUPT_TYPE: str = "interrupt"
+# ``data.reason`` marking an interrupt that aborts the current turn only.
+# A declined tool call does not end a sub-agent dispatch, so the runner must
+# not report the dispatch terminally cancelled for it.
+_INTERRUPT_REASON_TOOL_DECLINED: str = "tool_declined"
 
 
 _APPROVAL_TYPE: str = "approval"

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -59,6 +59,7 @@ from omnigent.server.routes._content_type import (
 )
 from omnigent.server.routes._sessions.common import (
     _EVALUATE_HOOK_ELICITATION_ID_RE,
+    _INTERRUPT_REASON_TOOL_DECLINED,
     _TURN_ACTOR_LABEL,
     _logger,
     get_server_runner_router,
@@ -880,7 +881,10 @@ def register_hooks_routes(
                             await _forward_session_change_to_runner(
                                 session_id,
                                 get_server_runner_router(),
-                                {"type": "interrupt"},
+                                {
+                                    "type": "interrupt",
+                                    "data": {"reason": _INTERRUPT_REASON_TOOL_DECLINED},
+                                },
                             )
                             decline_body = {
                                 "result": "POLICY_ACTION_DENY",
@@ -1014,7 +1018,10 @@ def register_hooks_routes(
             await _forward_session_change_to_runner(
                 session_id,
                 get_server_runner_router(),
-                {"type": "interrupt"},
+                {
+                    "type": "interrupt",
+                    "data": {"reason": _INTERRUPT_REASON_TOOL_DECLINED},
+                },
             )
         body = codex_request.build_response(result)
         return Response(
@@ -1118,7 +1125,10 @@ def register_hooks_routes(
             await _forward_session_change_to_runner(
                 session_id,
                 get_server_runner_router(),
-                {"type": "interrupt"},
+                {
+                    "type": "interrupt",
+                    "data": {"reason": _INTERRUPT_REASON_TOOL_DECLINED},
+                },
             )
         return Response(
             content=result.model_dump_json(),
@@ -1235,7 +1245,10 @@ def register_hooks_routes(
             await _forward_session_change_to_runner(
                 session_id,
                 get_server_runner_router(),
-                {"type": "interrupt"},
+                {
+                    "type": "interrupt",
+                    "data": {"reason": _INTERRUPT_REASON_TOOL_DECLINED},
+                },
             )
         return Response(
             content=json.dumps(result.model_dump(exclude_none=True)),
@@ -1345,7 +1358,10 @@ def register_hooks_routes(
             await _forward_session_change_to_runner(
                 session_id,
                 get_server_runner_router(),
-                {"type": "interrupt"},
+                {
+                    "type": "interrupt",
+                    "data": {"reason": _INTERRUPT_REASON_TOOL_DECLINED},
+                },
             )
         return Response(
             content=json.dumps(result.model_dump(exclude_none=True)),

--- a/tests/runner/test_app_sessions_native_supervision.py
+++ b/tests/runner/test_app_sessions_native_supervision.py
@@ -1037,6 +1037,153 @@ async def test_tracked_subagent_status_without_parent_inbox_returns_503() -> Non
     assert entry.delivered is False
 
 
+def _cursor_native_subagent_app() -> Any:
+    """Build a runner app whose sessions resolve to the cursor-native harness."""
+    spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "cursor-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    return create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.asyncio
+async def test_declined_tool_interrupt_keeps_dispatch_alive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A declined tool call must not report the sub-agent dispatch cancelled.
+
+    Declining one tool call makes the server post an ``interrupt`` carrying
+    ``data.reason = "tool_declined"``. That aborts the turn; it does not end the
+    dispatch. The native bridge only sends Escape into the tmux pane and cannot
+    confirm the agent stopped, so cursor-agent often finishes anyway (modelled
+    here by a no-op inject followed by a real ``idle`` edge).
+
+    Before the fix the interrupt fabricated a terminal ``"cancelled"``, which
+    delivered and drained the entry, so the genuine ``"completed"`` that
+    followed was dropped as ``already_delivered`` and the parent kept a
+    ``cancelled`` verdict for work that succeeded.
+    """
+    import omnigent.cursor_native_bridge as cursor_bridge
+    from omnigent.runner import app as runner_app
+    from omnigent.server.routes._sessions.common import _INTERRUPT_REASON_TOOL_DECLINED
+
+    # Escape is delivered, but cursor-agent keeps working.
+    monkeypatch.setattr(cursor_bridge, "inject_interrupt", lambda bridge_dir, *, timeout_s: None)
+
+    parent_id = "bb11bb22cc33dd44aa11bb22cc330101"
+    child_id = "bb11bb22cc33dd44aa11bb22cc330102"
+    session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async with _runner_client(_cursor_native_subagent_app()) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": child_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        runner_app.register_subagent_work(
+            parent_session_id=parent_id,
+            child_session_id=child_id,
+            agent="cursor-native",
+            title="research task",
+        )
+        runner_app._session_inboxes_ref[parent_id] = session_inbox
+        try:
+            declined_resp = await client.post(
+                f"/v1/sessions/{child_id}/events",
+                json={
+                    "type": "interrupt",
+                    "data": {"reason": _INTERRUPT_REASON_TOOL_DECLINED},
+                },
+            )
+            idle_resp = await client.post(
+                f"/v1/sessions/{child_id}/events",
+                json={
+                    "type": "external_session_status",
+                    "data": {"status": "idle", "output": "VERDICT: all 3 citations check out."},
+                },
+            )
+            delivered = []
+            while not session_inbox.empty():
+                delivered.append(session_inbox.get_nowait())
+        finally:
+            runner_app.unregister_subagent_work(child_id)
+            runner_app._session_inboxes_ref.pop(parent_id, None)
+            runner_app._drained_delivered_subagent_children.discard(child_id)
+
+    assert declined_resp.status_code == 204, declined_resp.text
+    assert idle_resp.status_code == 204, idle_resp.text
+    assert len(delivered) == 1, f"expected one parent-inbox result, got {delivered}"
+    assert delivered[0]["status"] == "completed", (
+        f"a declined tool call must not end the dispatch; parent got "
+        f"{delivered[0]['status']!r} for work that completed"
+    )
+    assert delivered[0]["output"] == "VERDICT: all 3 citations check out."
+
+
+@pytest.mark.asyncio
+async def test_bare_interrupt_still_cancels_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The web Stop button (a bare ``interrupt``) still reports cancelled.
+
+    Guards the other direction of
+    :func:`test_declined_tool_interrupt_keeps_dispatch_alive`: only a
+    ``tool_declined`` reason is turn-scoped. A reason-less interrupt is a user
+    cancel and must still deliver a terminal ``"cancelled"`` to the parent.
+    """
+    import omnigent.cursor_native_bridge as cursor_bridge
+    from omnigent.runner import app as runner_app
+
+    monkeypatch.setattr(cursor_bridge, "inject_interrupt", lambda bridge_dir, *, timeout_s: None)
+
+    parent_id = "bb11bb22cc33dd44aa11bb22cc330201"
+    child_id = "bb11bb22cc33dd44aa11bb22cc330202"
+    session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async with _runner_client(_cursor_native_subagent_app()) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": child_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        runner_app.register_subagent_work(
+            parent_session_id=parent_id,
+            child_session_id=child_id,
+            agent="cursor-native",
+            title="research task",
+        )
+        runner_app._session_inboxes_ref[parent_id] = session_inbox
+        try:
+            stop_resp = await client.post(
+                f"/v1/sessions/{child_id}/events",
+                json={"type": "interrupt"},
+            )
+            delivered = []
+            while not session_inbox.empty():
+                delivered.append(session_inbox.get_nowait())
+        finally:
+            runner_app.unregister_subagent_work(child_id)
+            runner_app._session_inboxes_ref.pop(parent_id, None)
+            runner_app._drained_delivered_subagent_children.discard(child_id)
+
+    assert stop_resp.status_code == 204, stop_resp.text
+    assert [m["status"] for m in delivered] == ["cancelled"], (
+        f"a user Stop must still cancel the dispatch; got {delivered}"
+    )
+
+
 def test_subagent_terminal_delivery_retry_uses_latest_undelivered_report() -> None:
     """
     Terminal retry delivers the latest report after the parent inbox reappears.


### PR DESCRIPTION
## Related issue

Refs #5559

Fixes the headline defect in that issue (a completed native sub-agent reported
`cancelled`). It deliberately does **not** claim to close #5559, which also
names a separate auto-accept fall-through defect: see *Deferred* below.

## Summary

A declined tool call and the web UI's Stop button both posted a bare
`{"type": "interrupt"}`, so the runner could not tell them apart and treated
both as ending the sub-agent dispatch.

That matters because the interrupt path reported a terminal `"cancelled"` to the
parent **optimistically**. `cursor_native_bridge.inject_interrupt` only sends
`Escape` into the tmux pane, raising solely if the tmux target is unadvertised
or `send-keys` itself fails. It never confirms the agent stopped. (Contrast
`stop_session`, which calls `kill_session`, so *its* `cancelled` is truthful.)

So when cursor-agent survived the Escape and finished normally, the parent
already held `cancelled`. The genuine `"completed"` that followed was dropped as
`already_delivered`, because delivery drains the work entry into
`_drained_delivered_subagent_children` and nothing can correct a delivered
status. Work that succeeded was reported as aborted, with its result discarded.

**Root cause:** declining one tool call is not ending the dispatch. The two
intents were indistinguishable on the wire.

**Fix:** mark the intent at the source. The five hook decline sites
(`routes_hooks.py`: claude, codex, antigravity, cursor, generic native) now send
`data.reason = "tool_declined"` on the interrupt they already post. The runner
reads it and passes `dispatch_terminal=False` into
`NativeInterruptRunner.interrupt`, which skips the parent wake so the harness's
own `external_session_status` edge carries the real terminal outcome. A
reason-less interrupt (user Stop) is unchanged.

`data` is the event schema's existing free-form payload for control events
(`SessionEventInput`: *"For `"interrupt"` this is typically `{}`"*), so this
adds no new wire field.

## Test Plan

Reproduced first, through the real runner HTTP path, before writing the fix.
Posting a `tool_declined` interrupt and then a genuine `external_session_status:
idle` to a cursor-native sub-agent session, with `inject_interrupt` stubbed to a
no-op (modelling "Escape delivered, agent kept working"):

```
before:  parent inbox got 1 message: status='cancelled'  output='[System: sub-agent interrupted]'
after:   parent inbox got 1 message: status='completed'  output='VERDICT: all 3 citations check out.'
```

Two tests in `tests/runner/test_app_sessions_native_supervision.py`:

- `test_declined_tool_interrupt_keeps_dispatch_alive` — the sequence above;
  asserts the parent receives `completed` with the real output intact.
- `test_bare_interrupt_still_cancels_dispatch` — a reason-less interrupt still
  delivers `cancelled`, so only `tool_declined` is turn-scoped.

The first test imports `_INTERRUPT_REASON_TOOL_DECLINED` from the **server's**
`common.py` and posts that value to the runner, so the constant is pinned across
the HTTP boundary: if the two sides ever drift, this test fails.

Suites run: `test_native_interrupt_runner.py` 13/13 (it covers the three
signatures changed here), and the supervision file's interrupt/subagent/delivery
selection 19 passed / 1 failed. That one failure,
`test_message_turn_lifecycle_status_suppressed_for_terminal_backed_harnesses[openai-agents-...]`,
is **pre-existing and environment-caused**: it fails identically on clean
`origin/main` (`d2157a72d`) because a local `~/.codex/config.toml` pins a codex
provider, so the `openai-agents` parametrization is rejected. Green in CI.

## Demo

N/A — runner-internal terminal-status routing, no UI change.

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

N/A — automated coverage added above.

## Deferred

- The `cancelled`-delivered-then-`completed` ordering stays uncorrectable by
  design: once delivered the entry is drained, and correcting it would need a
  second parent-inbox message, which changes the dispatch contract. This PR
  removes the main way a *spurious* `cancelled` got delivered in the first place.
- #5559's secondary defect is untouched: the yolo auto-accept budget
  (`_YOLO_ACCEPT_MAX_ATTEMPTS = 3` × `_YOLO_ACCEPT_RETRY_S = 2.0`, gated on
  `_ACCEPT_KEY_HINT_RE`, `cursor_native_permissions.py:335`) is what surfaces
  the cards whose declines trigger this path. Narrowing that is separate work.

## Changelog

Declining a single tool call in a native sub-agent session no longer reports the
whole sub-agent as `cancelled` to its parent; the sub-agent's real outcome
(`completed` / `failed`) is delivered instead.
