### PR TITLE
feat(tools): add Serply backend to web_search

### DIFF
--- a/omnigent/spec/AGENTSPEC.md
+++ b/omnigent/spec/AGENTSPEC.md
@@ -143,6 +143,10 @@ tools:
       search_provider: nimble
       api_key: ${NIMBLE_API_KEY}
       # optional: max_results (1-100, default 5); search_depth (lite | deep)
+    - name: web_search                     # dict — explicit Serply
+      search_provider: serply
+      api_key: ${SERPLY_API_KEY}
+      # optional: max_results (1-10, default 5); search_type (web | news | scholar)
 ```
 
 Keys can be hardcoded or use `${ENV_VAR}` references (resolved at deploy time
@@ -160,6 +164,11 @@ by the client, not at runtime by the server — the spec is self-contained).
   URLs, and snippets from Nimble's AI search API. Requires `api_key`; optional
   `max_results` (1-100, default 5) and `search_depth` (`lite` default, or
   `deep`). Works with any non-OpenAI model.
+- **Serply** (`search_provider: serply`): returns Google web results (title,
+  URL, snippet) from the [Serply](https://serply.io) API; set `search_type` to
+  `news` or `scholar` to get Google News or Google Scholar results with the same
+  key. Requires `api_key`; optional `max_results` (1-10, default 5). API
+  reference: https://serply.io/docs. Works with any non-OpenAI model.
 
 **`web_fetch` — zero-config web research:** Spawns an internal sub-agent with
 `terminal_run` to search the web and fetch pages using plain HTTP. No API keys

--- a/omnigent/tools/builtins/web_search.py
+++ b/omnigent/tools/builtins/web_search.py
@@ -337,6 +337,26 @@ def _run_keenable(query: str, config: dict[str, str]) -> str:
     return _search_keenable(query, config)
 
 
+def _run_serply(query: str, config: dict[str, str]) -> str:
+    """
+    Run a Serply web search query using spec config credentials.
+
+    :param query: The search query.
+    :param config: Must contain ``api_key``; may contain ``search_type``
+        (``web`` default, ``news``, or ``scholar``) and ``max_results``.
+    :returns: Formatted results or an error message.
+    """
+    from omnigent.tools.builtins.web_search_serply import (
+        _search_serply,
+    )
+
+    api_key = config.get("api_key")
+    if not api_key:
+        return "Serply web search requires api_key in the web_search config."
+
+    return _search_serply(query, config)
+
+
 # Single source of truth for the selectable backends. To add an engine, write
 # its ``_run_*`` above and add one row here — the dispatch in ``_search`` and
 # the error hint below both derive from this map, so nothing else needs editing.
@@ -348,6 +368,7 @@ _BACKENDS: dict[str, _Backend] = {
     "perplexity": _Backend(_run_perplexity, keyless=False),
     "nimble": _Backend(_run_nimble, keyless=False),
     "tavily": _Backend(_run_tavily, keyless=False),
+    "serply": _Backend(_run_serply, keyless=False),
 }
 
 

--- a/omnigent/tools/builtins/web_search_serply.py
+++ b/omnigent/tools/builtins/web_search_serply.py
@@ -1,0 +1,174 @@
+"""Built-in tool: Serply web search.
+
+Uses Serply's Google search API (``GET /v1/search/``) to return a list of
+grounded results (title, URL, snippet). The same key also serves Google News
+(``GET /v1/news/``) and Google Scholar (``GET /v1/scholar/``), selected with
+the optional ``search_type`` setting. Good for non-OpenAI models (Llama, Mistral,
+Databricks-hosted, etc.) that cannot use OpenAI's native
+``web_search_preview``.
+
+Configured in the agent spec::
+
+    tools:
+      builtins:
+        - name: web_search
+          search_provider: serply
+          api_key: ${SERPLY_API_KEY}
+          # optional:
+          # max_results: 5            # 1-10 (default 5)
+          # search_type: web          # web (default), news, or scholar
+
+See https://serply.io/docs (API reference) and https://serply.io.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import os
+import re
+
+# Any: Serply's JSON response is a heterogeneous dict with string keys
+# and mixed value types (str, int, list, dict, None).
+from typing import Any
+
+import httpx
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_SERPLY_URL = "https://api.serply.io/v1"
+
+# Default number of results when the spec does not set ``max_results``.
+# One Serply page holds at most 10 results; larger values are ignored server-side.
+_DEFAULT_MAX_RESULTS: int = 5
+_MAX_PAGE_SIZE: int = 10
+
+# Supported search verticals, mapped to their API path segment. Non-default
+# values are validated against this allowlist so a misconfigured spec gets a
+# clear error rather than an opaque API failure.
+_DEFAULT_SEARCH_TYPE = "web"
+_ENDPOINTS: dict[str, str] = {
+    "web": "search",
+    "news": "news",
+    "scholar": "scholar",
+}
+
+# Identifies this integration to Serply via the ``User-Agent`` header so
+# traffic from the Omnigent provider is attributable.
+_CLIENT_SOURCE = "omnigent-web-search"
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _serply_base_url() -> str:
+    """Resolve the Serply base URL; ``OMNIGENT_SERPLY_BASE_URL`` overrides for tests."""
+    return os.environ.get("OMNIGENT_SERPLY_BASE_URL", _DEFAULT_SERPLY_URL).rstrip("/")
+
+
+def _resolve_max_results(config: dict[str, str]) -> int:
+    """
+    Read ``max_results`` from spec config, clamped to Serply's 1-10 page range.
+
+    :param config: Spec-level config; ``max_results`` may be a str or int.
+    :returns: A valid result count, or the default on missing/invalid input.
+    """
+    raw = config.get("max_results")
+    if raw is None:
+        return _DEFAULT_MAX_RESULTS
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_RESULTS
+    return max(1, min(value, _MAX_PAGE_SIZE))
+
+
+def _search_serply(
+    query: str,
+    config: dict[str, str],
+) -> str:
+    """
+    Call the Serply search API and format the results.
+
+    :param query: The search query string.
+    :param config: Spec-level config; checked for ``api_key`` (required),
+        ``search_type`` and ``max_results`` (optional).
+    :returns: Formatted results or an error message.
+    """
+    api_key = config.get("api_key")
+    if not api_key:
+        return "Error: api_key must be provided in the web_search config in config.yaml."
+    search_type = config.get("search_type", _DEFAULT_SEARCH_TYPE)
+    endpoint = _ENDPOINTS.get(search_type)
+    if endpoint is None:
+        return (
+            f"Error: unsupported search_type {search_type!r}. "
+            f"Use one of: {', '.join(sorted(_ENDPOINTS))}."
+        )
+    max_results = _resolve_max_results(config)
+    try:
+        resp = httpx.get(
+            f"{_serply_base_url()}/{endpoint}/",
+            headers={
+                "X-Api-Key": api_key,
+                "Accept": "application/json",
+                "User-Agent": _CLIENT_SOURCE,
+            },
+            params={"q": query, "num": max_results},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        return f"Serply search error: HTTP {exc.response.status_code}"
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        return f"Serply search error: {exc}"
+
+    return _format_results(resp.json(), search_type, max_results)
+
+
+def _clean_text(value: object) -> str:
+    """Strip HTML tags and entities from a snippet and collapse whitespace."""
+    if not isinstance(value, str):
+        return ""
+    return " ".join(html.unescape(_TAG_RE.sub("", value)).split())
+
+
+def _format_results(data: dict[str, Any], search_type: str, max_results: int) -> str:
+    """
+    Format a Serply JSON response into readable text.
+
+    Web search returns ``{"results": [{"title", "link", "description", ...}]}``,
+    news returns ``{"entries": [{"title", "link", "summary", "source", ...}]}``
+    (RSS-shaped, ``summary`` is HTML and ``num`` is ignored server-side), and
+    scholar returns ``{"articles": [{"title", "link", "description", "extras",
+    ...}]}``. The list is sliced to ``max_results`` and rendered as numbered
+    entries.
+
+    :param data: The parsed JSON response from Serply.
+    :param search_type: One of the ``_ENDPOINTS`` keys; picks the result list.
+    :param max_results: Maximum number of results to render.
+    :returns: Numbered results, or a "no results" message.
+    """
+    list_key = {"web": "results", "news": "entries", "scholar": "articles"}[search_type]
+    results = data.get(list_key) if isinstance(data, dict) else None
+    if not isinstance(results, list) or not results:
+        return "No results found."
+
+    formatted: list[str] = []
+    for i, item in enumerate(results[:max_results]):
+        if not isinstance(item, dict):
+            continue
+        title = _clean_text(item.get("title"))
+        url = item.get("link") or ""
+        if search_type == "news":
+            source = item.get("source") if isinstance(item.get("source"), dict) else {}
+            snippet = _clean_text(item.get("summary")) or _clean_text(source.get("title"))
+        else:
+            snippet = _clean_text(item.get("description"))
+            if search_type == "scholar":
+                extras = item.get("extras") if isinstance(item.get("extras"), dict) else {}
+                citations = extras.get("citations") if isinstance(extras, dict) else None
+                count = citations.get("count") if isinstance(citations, dict) else None
+                if isinstance(count, int) and count > 0:
+                    snippet = f"{snippet} (cited by {count})".strip()
+        formatted.append(f"{i + 1}. {title}\n   {url}\n   {snippet}")
+    return "\n\n".join(formatted) if formatted else "No results found."

--- a/tests/tools/builtins/test_web_search.py
+++ b/tests/tools/builtins/test_web_search.py
@@ -15,6 +15,9 @@ from omnigent.tools.builtins.web_search_keenable import (
     _resolve_max_results as _resolve_max_results_keenable,
 )
 from omnigent.tools.builtins.web_search_nimble import _resolve_max_results
+from omnigent.tools.builtins.web_search_serply import (
+    _resolve_max_results as _resolve_max_results_serply,
+)
 from omnigent.tools.builtins.web_search_tavily import (
     _resolve_max_results as _resolve_max_results_tavily,
 )
@@ -598,6 +601,7 @@ def test_no_search_provider_fails_loudly(
     assert "nimble" in result.lower()
     assert "tavily" in result.lower()
     assert "keenable" in result.lower()
+    assert "serply" in result.lower()
 
 
 # ── search_provider: keenable ────────────────────────
@@ -756,6 +760,222 @@ def test_keenable_max_results_clamped() -> None:
     assert _resolve_max_results_keenable({"max_results": "0"}) == 1  # below min → clamped up
     assert _resolve_max_results_keenable({"max_results": "500"}) == 20  # above max → clamped down
     assert _resolve_max_results_keenable({"max_results": "abc"}) == 5  # non-numeric → default
+
+
+# ── search_provider: serply ──────────────────────────
+
+
+def test_serply_backend_via_spec_config(tool_ctx: ToolContext) -> None:
+    """
+    With search_provider=serply and api_key in spec config,
+    the tool delegates to Serply web search.
+    """
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "results": [
+            {
+                "title": "Serply Docs",
+                "link": "https://serply.io/docs",
+                "description": "Google search API for agents.",
+                "position": 1,
+            },
+        ],
+    }
+
+    tool = WebSearchTool(
+        config={
+            "search_provider": "serply",
+            "api_key": "spec-serply-key",
+        },
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_serply.httpx.get") as mock_get:
+        mock_get.return_value = fake_response
+        result = tool.invoke(json.dumps({"query": "serply"}), tool_ctx)
+
+    # Serply result list made it through the unified tool pipeline.
+    assert "1. Serply Docs" in result
+    assert "https://serply.io/docs" in result
+    assert "Google search API for agents." in result
+
+
+def test_serply_missing_key_returns_error(tool_ctx: ToolContext) -> None:
+    """With search_provider=serply but no api_key, returns error."""
+    tool = WebSearchTool(
+        config={"search_provider": "serply"},
+        llm_provider="anthropic",
+    )
+    result = tool.invoke(json.dumps({"query": "test"}), tool_ctx)
+    assert "api_key" in result
+
+
+def test_serply_spec_config_used_in_http_call(tool_ctx: ToolContext) -> None:
+    """
+    api_key from spec config is sent as the X-Api-Key header, the web
+    endpoint is used by default, and the query string carries q / num.
+    """
+    fake_response = MagicMock()
+    fake_response.json.return_value = {"results": []}
+
+    tool = WebSearchTool(
+        config={
+            "search_provider": "serply",
+            "api_key": "spec-serply",
+            "max_results": "7",
+        },
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_serply.httpx.get") as mock_get:
+        mock_get.return_value = fake_response
+        tool.invoke(json.dumps({"query": "hello"}), tool_ctx)
+
+    _, kwargs = mock_get.call_args
+    assert mock_get.call_args.args[0].endswith("/v1/search/")
+    assert kwargs["headers"]["X-Api-Key"] == "spec-serply"
+    assert kwargs["headers"]["User-Agent"] == "omnigent-web-search"
+    assert kwargs["params"] == {"q": "hello", "num": 7}
+
+
+def test_serply_http_error_returns_error_string(tool_ctx: ToolContext) -> None:
+    """A non-2xx response surfaces as a readable error, not an exception."""
+    fake_response = MagicMock()
+    fake_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "boom", request=MagicMock(), response=MagicMock(status_code=401)
+    )
+
+    tool = WebSearchTool(
+        config={"search_provider": "serply", "api_key": "bad"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_serply.httpx.get") as mock_get:
+        mock_get.return_value = fake_response
+        result = tool.invoke(json.dumps({"query": "test"}), tool_ctx)
+
+    assert result == "Serply search error: HTTP 401"
+
+
+def test_serply_empty_results_returns_no_results(tool_ctx: ToolContext) -> None:
+    """An empty result list yields the 'No results found.' message."""
+    fake_response = MagicMock()
+    fake_response.json.return_value = {"results": []}
+
+    tool = WebSearchTool(
+        config={"search_provider": "serply", "api_key": "k"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_serply.httpx.get") as mock_get:
+        mock_get.return_value = fake_response
+        result = tool.invoke(json.dumps({"query": "test"}), tool_ctx)
+
+    assert result == "No results found."
+
+
+def test_serply_news_strips_html_and_slices(tool_ctx: ToolContext) -> None:
+    """
+    search_type=news hits the news endpoint; RSS-style HTML summaries are
+    flattened to text and the list is cut to ``max_results`` client-side
+    (the news endpoint ignores ``num``).
+    """
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "entries": [
+            {
+                "title": f"Story {i}",
+                "link": f"https://news.example/{i}",
+                "published": "Wed, 26 Aug 2026 09:00:09 GMT",
+                "source": {"href": "https://example.com", "title": "Example"},
+                "summary": '<a href="https://x">Story</a>&nbsp;&nbsp;text',
+            }
+            for i in range(20)
+        ],
+    }
+
+    tool = WebSearchTool(
+        config={
+            "search_provider": "serply",
+            "api_key": "k",
+            "search_type": "news",
+            "max_results": "3",
+        },
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_serply.httpx.get") as mock_get:
+        mock_get.return_value = fake_response
+        result = tool.invoke(json.dumps({"query": "quantum"}), tool_ctx)
+
+    assert mock_get.call_args.args[0].endswith("/v1/news/")
+    assert "1. Story 0\n   https://news.example/0\n   Story text" in result
+    assert "3. Story 2" in result
+    assert "Story 3" not in result
+
+
+def test_serply_scholar_formats_articles(tool_ctx: ToolContext) -> None:
+    """search_type=scholar hits the scholar endpoint and appends citation counts."""
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "articles": [
+            {
+                "title": "Quantum Computing in the NISQ era",
+                "link": "https://doi.org/10.22331/q-2018-08-06-79",
+                "description": "John Preskill - Quantum, 2018",
+                "author": {"names": "John Preskill - Quantum, 2018", "authors": []},
+                "extras": {"citations": {"count": 8592, "link": "https://example.org"}},
+                "doc": {"link": "https://example.org/paper.pdf", "type": "PDF"},
+            }
+        ],
+    }
+
+    tool = WebSearchTool(
+        config={"search_provider": "serply", "api_key": "k", "search_type": "scholar"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_serply.httpx.get") as mock_get:
+        mock_get.return_value = fake_response
+        result = tool.invoke(json.dumps({"query": "quantum computing"}), tool_ctx)
+
+    assert mock_get.call_args.args[0].endswith("/v1/scholar/")
+    assert "1. Quantum Computing in the NISQ era" in result
+    assert "https://doi.org/10.22331/q-2018-08-06-79" in result
+    assert "John Preskill - Quantum, 2018 (cited by 8592)" in result
+
+
+def test_serply_unsupported_search_type_rejected(tool_ctx: ToolContext) -> None:
+    """An unknown ``search_type`` is rejected before any HTTP call is made."""
+    tool = WebSearchTool(
+        config={"search_provider": "serply", "api_key": "k", "search_type": "images"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_serply.httpx.get") as mock_get:
+        result = tool.invoke(json.dumps({"query": "test"}), tool_ctx)
+
+    mock_get.assert_not_called()
+    assert "unsupported search_type" in result
+    assert "news, scholar, web" in result
+
+
+def test_serply_max_results_clamped() -> None:
+    """``max_results`` is coerced + clamped to a 1-10 range; junk falls back to the default."""
+    assert _resolve_max_results_serply({}) == 5  # missing: default
+    assert _resolve_max_results_serply({"max_results": "0"}) == 1  # below min: clamped up
+    assert _resolve_max_results_serply({"max_results": "500"}) == 10  # above max: clamped down
+    assert _resolve_max_results_serply({"max_results": "abc"}) == 5  # non-numeric: default
+
+
+def test_serply_base_url_override(tool_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``OMNIGENT_SERPLY_BASE_URL`` redirects requests (used by stub-server tests)."""
+    monkeypatch.setenv("OMNIGENT_SERPLY_BASE_URL", "http://127.0.0.1:9/v1/")
+    fake_response = MagicMock()
+    fake_response.json.return_value = {"results": []}
+
+    tool = WebSearchTool(
+        config={"search_provider": "serply", "api_key": "k"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_serply.httpx.get") as mock_get:
+        mock_get.return_value = fake_response
+        tool.invoke(json.dumps({"query": "test"}), tool_ctx)
+
+    assert mock_get.call_args.args[0] == "http://127.0.0.1:9/v1/search/"
 
 
 # ── Spec config passed through ───────────────────────


### PR DESCRIPTION
## Related issue

Closes #5685

## Summary

- Adds `search_provider: serply` to the built-in `web_search` tool, backed by the [Serply](https://serply.io) Google search API. Configure it in the agent spec with `api_key: ${SERPLY_API_KEY}`; optional `max_results` (1-10, default 5) and `search_type` (`web` default, `news`, or `scholar`) select the Google web, Google News, or Google Scholar vertical with the same key.
- New module `omnigent/tools/builtins/web_search_serply.py` mirrors the Tavily and Keenable backends: `httpx`, `OMNIGENT_SERPLY_BASE_URL` override for stub-server tests, `_resolve_max_results` clamp, errors returned as strings (`Serply search error: HTTP 401`), numbered `title / url / snippet` output. Registered in `_BACKENDS` in `web_search.py` (so the no-provider hint lists it automatically) and documented in `AGENTSPEC.md`.
- Nothing changes for specs that do not set `search_provider: serply`.

ELI5: same `web_search` tool, one more engine to pick from; this one can also answer "what does the news say" and "what do the papers say" without a second key.

```
WebSearchTool._BACKENDS["serply"]
  -> _run_serply(query, config)             # web_search.py: api_key presence check
     -> _search_serply(query, config)       # web_search_serply.py
        GET {base}/v1/{search|news|scholar}/?q=...&num=N   X-Api-Key: <key>
        -> _format_results(json, search_type, N)           "1. title\n   url\n   snippet"
```

## Test Plan

- `uv run pytest tests/tools/builtins/test_web_search.py tests/runner/test_web_search_local_dispatch.py tests/spec -q`: 646 passed (10 new Serply tests; `test_no_search_provider_fails_loudly` now also asserts `serply` is in the hint).
- `pre-commit run --files <the 4 changed files>`: ruff format / ruff check pass; the pyrefly hook reports the same 23 pre-existing `missing-import` errors (optional `opentelemetry` modules) on a clean `main`, none in the changed files.
- Live check with a real key against `api.serply.io`: `web`, `news`, and `scholar` each return formatted results; an invalid key returns `Serply search error: HTTP 401`; `search_type: images` is rejected before any HTTP call.

To try it yourself, add to an agent spec:

```yaml
tools:
  builtins:
    - name: web_search
      search_provider: serply
      api_key: ${SERPLY_API_KEY}
      search_type: scholar   # or news, or leave out for web
```

then ask the agent something like "find recent papers on quantum error correction" and check the tool result lists numbered title / URL / snippet lines with citation counts.

## Demo

Web UI run of a demo agent (`openai-agents` harness, model served through an OpenAI-compatible gateway, so `web_search` takes the function-tool path) with the built-in `web_search` configured as `search_provider: serply` and the default `search_type: web`. The agent issued ten `web_search` calls, each answered by Serply (`GET https://api.serply.io/v1/search/` in the runner log), and cited the result URLs:

![omnigent web UI: serply-research agent answering a news question from Serply web_search results](https://raw.githubusercontent.com/googio/omnigent/serply-demo-assets/serply-web-search-ui.png)

Terminal run of the same tool, once with the default `search_type: web` and once with `search_type: scholar` (same key, same query). The `(cited by N)` suffix comes from Google Scholar's citation counts:

![omnigent web_search with search_provider: serply, web and scholar results for the same query](https://raw.githubusercontent.com/googio/omnigent/serply-demo-assets/serply-web-search-demo.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests mock `httpx.get` and cover: backend selection via spec config, missing key error, header and query-string contract (`X-Api-Key`, `User-Agent`, `q`, `num`), HTTP error string, empty results, news HTML stripping plus client-side slicing (the news endpoint ignores `num` server-side), scholar citation formatting, unsupported `search_type` short-circuit, `max_results` clamping, and the base URL override. The live contract (response shapes for the three endpoints) was verified manually against the real API, the same approach the Tavily and Keenable backends took; happy to add a stub-server e2e in the `tests/e2e` style if you would like one.

Size note: 4 files / +424, about half of it tests. The backend itself is the same size as `web_search_tavily.py`.

Disclosure: I work with Serply. API reference: https://serply.io/docs. Happy to adjust naming, defaults, or the result format to whatever you prefer.

## Changelog

`web_search` supports `search_provider: serply` with optional `search_type: news | scholar`
