### PR TITLE
fix(spec): honor tools: allow-list on sidecar MCP servers

### DIFF
--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -2603,17 +2603,6 @@ def _parse_inline_mcp_servers(
                     code=ErrorCode.INVALID_INPUT,
                 )
             databricks_profile = str(raw_profile)
-        # Optional per-server tool allow-list (the YAML ``tools:`` whitelist) —
-        # only these tool names are exposed to the model; ``None`` exposes all.
-        # Mirrors ``MCPTool.tools`` and is filtered downstream in
-        # server/mcp_pool.py + runner/mcp_manager.py.
-        raw_allow = val.get("tools")
-        if raw_allow is not None and not isinstance(raw_allow, list):
-            raise OmnigentError(
-                f"Inline MCP server {name!r} 'tools' must be a list of tool names",
-                code=ErrorCode.INVALID_INPUT,
-            )
-        tool_allowlist = [str(t) for t in raw_allow] if raw_allow else None
         servers.append(
             MCPServerConfig(
                 name=name,
@@ -2628,10 +2617,43 @@ def _parse_inline_mcp_servers(
                 headers=headers,
                 env=env,
                 databricks_profile=databricks_profile,
-                tools=tool_allowlist,
+                tools=_parse_mcp_tool_allowlist(name, val, "inline MCP server"),
             )
         )
     return servers
+
+
+def _parse_mcp_tool_allowlist(
+    name: object,
+    raw: dict[str, object],
+    source: object,
+) -> list[str] | None:
+    """
+    Parse the optional per-server ``tools:`` allow-list.
+
+    Only these tool names are exposed to the model; ``None`` exposes
+    all. Mirrors ``MCPTool.tools`` and is filtered downstream in
+    ``server/mcp_pool.py`` + ``runner/mcp_manager.py``. Shared by the
+    inline (``config.yaml``) and sidecar (``tools/mcp/*.yaml``) MCP
+    parsers so both forms honour the same allow-list — a restriction
+    silently accepted in one form and dropped in the other would fail
+    open, granting more tools than the spec asked for.
+
+    :param name: The MCP server's ``name`` field, used in the error
+        message.
+    :param raw: Parsed YAML mapping for the MCP server.
+    :param source: Path (sidecar) or label (inline) identifying the
+        YAML source, used in the error message.
+    :returns: List of allowed tool names, or ``None`` to expose all.
+    :raises OmnigentError: If ``tools`` is present and not a list.
+    """
+    raw_allow = raw.get("tools")
+    if raw_allow is not None and not isinstance(raw_allow, list):
+        raise OmnigentError(
+            f"MCP server {name!r} 'tools' must be a list of tool names: {source}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    return [str(t) for t in raw_allow] if raw_allow else None
 
 
 def _discover_mcp_servers(
@@ -2750,6 +2772,7 @@ def _parse_http_mcp_server(
         url=url_str,
         headers=expand_env_vars(headers) if expand_env else headers,
         description=str(raw_description) if raw_description is not None else None,
+        tools=_parse_mcp_tool_allowlist(name, raw, yaml_file),
         timeout=(
             _parse_int_field(raw["timeout"], f"MCP server {name!r}.timeout")
             if "timeout" in raw
@@ -2848,6 +2871,7 @@ def _parse_stdio_mcp_server(
         args=[str(a) for a in raw_args],
         env=env,
         description=str(raw_description) if raw_description is not None else None,
+        tools=_parse_mcp_tool_allowlist(name, raw, yaml_file),
         timeout=(
             _parse_int_field(raw["timeout"], f"MCP server {name!r}.timeout")
             if "timeout" in raw

--- a/tests/e2e_ui/chat/test_sidecar_mcp_allowlist.py
+++ b/tests/e2e_ui/chat/test_sidecar_mcp_allowlist.py
@@ -1,0 +1,320 @@
+"""E2E: a sidecar ``tools/mcp/*.yaml`` per-server ``tools:`` allow-list
+must actually restrict the agent's tool surface.
+
+A per-server ``tools:`` allow-list is honoured when an MCP server is
+declared **inline** under ``tools:`` in ``config.yaml``, but was
+**silently ignored** when the same server is declared in a **sidecar**
+``tools/mcp/*.yaml`` file. The inline parser reads and validates the
+key; both sidecar parsers (``_parse_stdio_mcp_server`` /
+``_parse_http_mcp_server`` in ``omnigent/spec/parser.py``) build the
+``MCPServerConfig`` without ``tools=``, so the allow-list disappears
+before it reaches the enforcement seam. The failure is *open*: the
+agent gets MORE tools than the spec asked for, with no warning.
+
+Journey (all user-observable):
+
+1. A spec author writes an agent whose only tool is an MCP server
+   declared in the SIDECAR form (``tools/mcp/probe.yaml``), with a
+   restrictive ``tools:`` allow-list that excludes a destructive tool
+   (here ``danger``, standing in for the real ``sandbox_clear``).
+2. Deploy the agent and start a session on it.
+3. Drive a turn in which the model attempts the *excluded* ``danger``
+   tool.
+4. On the broken build the excluded tool is advertised to the model and
+   executes anyway (the chat shows ``danger-executed: ...``); the
+   allow-list was silently dropped. When the allow-list is honoured the
+   excluded tool is absent from the advertised surface and never runs.
+
+The mock LLM scripts the turn (call ``danger``, then a wrap-up
+sentence), so the only thing under test is which tools the sidecar
+allow-list exposes.
+
+Robustness: the guard reads the tool surface the harness advertises to
+the model (captured on the FIRST LLM request, before any tool dispatch),
+so it settles cleanly on both the broken and the fixed build regardless
+of how a filtered tool call is handled downstream.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json as _json
+import sys
+import tarfile
+import time
+import uuid
+from pathlib import Path
+
+import httpx
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import (
+    _bind_session_runner,
+    _ensure_runner_online,
+    _server_state,
+    configure_mock_llm,
+)
+
+# The two-tool stdio MCP fixture: a SAFE ``echo`` and a forbidden
+# ``danger`` that returns a distinctive marker when it runs.
+_ALLOWLIST_MCP_SERVER = (
+    Path(__file__).resolve().parents[3]
+    / "tests"
+    / "tools"
+    / "fixtures"
+    / "allowlist_stdio_mcp_server.py"
+)
+
+_PROBE = "sidecar-allowlist-probe"
+_DANGER_MARKER = f"danger-executed: {_PROBE}"
+_TURN_DONE = "sidecar-allowlist-turn-complete"
+
+_COMPOSER = "Send a message…"
+
+# Agent whose ONLY tool is the sidecar-declared MCP server. Note there is
+# NO inline ``tools:`` block here — the allow-list lives in the sidecar
+# ``tools/mcp/probe.yaml`` file, which is exactly the form that dropped it.
+_CONFIG_YAML = """\
+spec_version: 1
+name: {name}
+prompt: |
+  You are a deterministic tool assistant. When the user sends a turn you
+  MUST call the ``probe__danger`` tool once with the text they provide,
+  then reply with one short sentence.
+
+executor:
+  model: {model}
+  config:
+    harness: openai-agents
+"""
+
+# Sidecar MCP config with a restrictive allow-list: only ``echo`` is
+# permitted; ``danger`` must never be exposed. This is the file whose
+# ``tools:`` key was silently discarded.
+_SIDECAR_MCP_YAML = """\
+name: probe
+transport: stdio
+command: {python}
+args:
+  - {server}
+tools:
+  - echo
+"""
+
+
+def _create_sidecar_allowlist_session(
+    base_url: str,
+    runner_id: str,
+    *,
+    agent_name: str,
+    model: str,
+) -> str:
+    """Register + bind an agent whose sidecar MCP allow-lists only ``echo``.
+
+    Packages a bundle with ``config.yaml`` at the root and the sidecar
+    ``tools/mcp/probe.yaml`` beside it, then binds the created session to
+    *runner_id* so ``POST /v1/responses`` dispatches.
+
+    :param base_url: Spawned server base URL.
+    :param runner_id: Token-bound runner id to bind.
+    :param agent_name: Display name for the agent.
+    :param model: Model id baked into the spec (routes the mock queue).
+    :returns: The new session/conversation id.
+    """
+    assert _ALLOWLIST_MCP_SERVER.is_file(), (
+        f"Expected allow-list MCP fixture at {_ALLOWLIST_MCP_SERVER}; "
+        f"update _ALLOWLIST_MCP_SERVER if the file moved."
+    )
+    config = _CONFIG_YAML.format(name=agent_name, model=model).encode()
+    sidecar = _SIDECAR_MCP_YAML.format(
+        python=sys.executable,
+        server=str(_ALLOWLIST_MCP_SERVER),
+    ).encode()
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        cfg_info = tarfile.TarInfo("config.yaml")
+        cfg_info.size = len(config)
+        tar.addfile(cfg_info, io.BytesIO(config))
+        mcp_info = tarfile.TarInfo("tools/mcp/probe.yaml")
+        mcp_info.size = len(sidecar)
+        tar.addfile(mcp_info, io.BytesIO(sidecar))
+
+    create = httpx.post(
+        f"{base_url}/v1/sessions",
+        data={"metadata": _json.dumps({})},
+        files={"bundle": ("agent.tar.gz", buf.getvalue(), "application/gzip")},
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = str(create.json()["session_id"])
+    _bind_session_runner(base_url, session_id, runner_id)
+    return session_id
+
+
+def _advertised_tool_names(mock_url: str) -> set[str]:
+    """Collect every tool name the harness advertised to the model.
+
+    Reads the captured request bodies from the mock LLM and unions the
+    ``name`` of each entry in every request's ``tools`` array.
+
+    :param mock_url: Mock LLM base URL.
+    :returns: Set of advertised tool names (namespaced, e.g. ``probe__echo``).
+    """
+    resp = httpx.get(f"{mock_url}/mock/requests", timeout=10.0)
+    resp.raise_for_status()
+    names: set[str] = set()
+    for req in resp.json().get("requests", []):
+        if not isinstance(req, dict):
+            continue
+        for tool in req.get("tools") or []:
+            if not isinstance(tool, dict):
+                continue
+            # openai-agents Responses format: {"type": "function", "name": ...}
+            # or a nested {"function": {"name": ...}} chat-completions shape.
+            name = tool.get("name")
+            if name is None and isinstance(tool.get("function"), dict):
+                name = tool["function"].get("name")
+            if isinstance(name, str):
+                names.add(name)
+    return names
+
+
+def _wait_for_advertised_tools(mock_url: str, *, timeout: float = 60.0) -> set[str]:
+    """Poll the mock until a request carrying a tool surface is captured.
+
+    The harness sends the model's available tools on the FIRST LLM
+    request of the turn, before any tool is dispatched — so this settles
+    on both the broken and the fixed build (it does not depend on the
+    forbidden tool call succeeding).
+
+    :param mock_url: Mock LLM base URL.
+    :param timeout: Max seconds to wait.
+    :returns: The union of advertised tool names once any appear.
+    :raises AssertionError: If no tool surface is advertised in time.
+    """
+    deadline = time.monotonic() + timeout
+    names: set[str] = set()
+    while time.monotonic() < deadline:
+        names = _advertised_tool_names(mock_url)
+        if names:
+            return names
+        time.sleep(0.5)
+    raise AssertionError(
+        "The harness never advertised any tools to the model within "
+        f"{timeout:.0f}s — the turn did not reach the LLM."
+    )
+
+
+def _tool_call_outputs(base_url: str, session_id: str) -> list[str]:
+    """Return the raw outputs of every ``function_call_output`` item, in order.
+
+    :param base_url: Spawned server base URL.
+    :param session_id: Session whose items to read.
+    :returns: List of tool-output strings.
+    """
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}/items?limit=200", timeout=10.0)
+    resp.raise_for_status()
+    items = resp.json()["data"]
+    outputs: list[str] = []
+    for item in items:
+        data = item.get("data") or {}
+        if item.get("type") == "function_call_output":
+            outputs.append(str(item.get("output") or data.get("output") or ""))
+    return outputs
+
+
+def _send(page: Page, text: str) -> None:
+    """Type *text* into the composer and click Send."""
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill(text)
+    page.get_by_role("button", name="Send", exact=True).click()
+
+
+def test_sidecar_mcp_allowlist_excludes_forbidden_tool(
+    page: Page,
+    live_server: str,
+    mock_llm_server_url: str,
+    tmp_path_factory,
+) -> None:
+    """A sidecar ``tools:`` allow-list must exclude the forbidden tool.
+
+    On the broken build the sidecar parser drops the ``tools:`` key, so
+    ``probe__danger`` is advertised to the model and executes (the chat
+    shows ``danger-executed: ...``). When the allow-list is honoured the
+    excluded tool is absent from the advertised surface and never runs.
+    """
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+
+    session_id: str | None = None
+    try:
+        model = f"mcp-allowlist-{uuid.uuid4().hex[:8]}"
+        # Turn: the model calls the FORBIDDEN ``danger`` tool, then wraps up.
+        configure_mock_llm(
+            mock_llm_server_url,
+            [
+                {
+                    "tool_calls": [
+                        {
+                            "call_id": "call_danger_1",
+                            "name": "probe__danger",
+                            "arguments": _json.dumps({"text": _PROBE}),
+                        }
+                    ]
+                },
+                {"text": _TURN_DONE},
+            ],
+            key=model,
+        )
+
+        session_id = _create_sidecar_allowlist_session(
+            live_server,
+            runner_id,
+            agent_name=f"sidecar-allowlist-{uuid.uuid4().hex[:6]}",
+            model=model,
+        )
+
+        page.goto(f"{live_server}/c/{session_id}")
+
+        # Drive the turn: the model is scripted to attempt ``danger``.
+        _send(page, "Run the tool on this turn.")
+
+        # Best-effort: let the turn play out on screen so the recording
+        # shows the excluded tool executing on the broken build. Swallowed
+        # so a fixed build (where the excluded call is refused) can't hang.
+        with contextlib.suppress(Exception):
+            expect(page.get_by_text(_TURN_DONE)).to_be_visible(timeout=60_000)
+
+        # ── The exact reported symptom: the excluded tool is advertised ──
+        # Read the tool surface the harness sent the model (captured on the
+        # first LLM request, before any dispatch) — deterministic on both
+        # the broken and the fixed build.
+        advertised = _wait_for_advertised_tools(mock_llm_server_url, timeout=60.0)
+        assert "probe__echo" in advertised, (
+            f"Sanity check failed: the allow-listed ``echo`` tool should be "
+            f"advertised to the model, but the advertised tools were: {advertised!r}"
+        )
+        assert "probe__danger" not in advertised, (
+            "SIDECAR ALLOW-LIST IGNORED: the excluded ``danger`` tool was "
+            "advertised to the model. The sidecar tools/mcp/*.yaml ``tools:`` "
+            "allow-list ([echo]) was silently dropped by the sidecar parser, "
+            f"so the model saw the destructive tool. Advertised: {advertised!r}"
+        )
+
+        # ── And it must never actually run ──
+        outputs = _tool_call_outputs(live_server, session_id)
+        assert not any(_DANGER_MARKER in o for o in outputs), (
+            "SIDECAR ALLOW-LIST IGNORED: the excluded ``danger`` tool "
+            f"executed ({_DANGER_MARKER!r} appeared in a tool output). The "
+            "sidecar allow-list should have prevented it from being callable. "
+            f"Tool outputs: {outputs!r}"
+        )
+    finally:
+        if session_id is not None:
+            httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
+            respawned.wait(timeout=5)

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -2878,6 +2878,87 @@ def test_parse_mcp_http_rejects_stdio_fields(agent_dir: Path) -> None:
         parse(agent_dir)
 
 
+def test_parse_mcp_stdio_tools_whitelist(agent_dir: Path) -> None:
+    """A per-server ``tools:`` whitelist on a sidecar stdio MCP propagates to
+    ``MCPServerConfig.tools`` (regression: the sidecar parsers dropped the
+    key entirely, so a restrictive allow-list in ``tools/mcp/*.yaml`` was a
+    silent no-op — the agent got every tool despite the YAML on disk saying
+    otherwise. Same allow-list, same bug class as the inline form fixed in
+    ``test_parse_inline_mcp_tools_whitelist``.)
+
+    :param agent_dir: Temporary agent directory fixture.
+    """
+    mcp_dir = agent_dir / "tools" / "mcp"
+    mcp_dir.mkdir(parents=True)
+    mcp_config = {
+        "name": "github",
+        "transport": "stdio",
+        "command": "npx",
+        "tools": ["search_issues", "get_pull_request"],
+    }
+    (mcp_dir / "github.yaml").write_text(yaml.dump(mcp_config))
+    spec = parse(agent_dir)
+    mcp = spec.mcp_servers[0]
+    assert mcp.tools == ["search_issues", "get_pull_request"]
+
+
+def test_parse_mcp_http_tools_whitelist(agent_dir: Path) -> None:
+    """Same regression as ``test_parse_mcp_stdio_tools_whitelist``, for the
+    sidecar HTTP transport.
+
+    :param agent_dir: Temporary agent directory fixture.
+    """
+    mcp_dir = agent_dir / "tools" / "mcp"
+    mcp_dir.mkdir(parents=True)
+    mcp_config = {
+        "name": "docs",
+        "transport": "http",
+        "url": "https://mcp.example.com/sse",
+        "tools": ["search_docs"],
+    }
+    (mcp_dir / "docs.yaml").write_text(yaml.dump(mcp_config))
+    spec = parse(agent_dir)
+    mcp = spec.mcp_servers[0]
+    assert mcp.tools == ["search_docs"]
+
+
+def test_parse_mcp_sidecar_tools_absent_is_none(agent_dir: Path) -> None:
+    """Omitting ``tools:`` on a sidecar MCP leaves the allow-list as ``None``
+    (expose all) — mirrors ``test_parse_inline_mcp_tools_absent_is_none``.
+
+    :param agent_dir: Temporary agent directory fixture.
+    """
+    mcp_dir = agent_dir / "tools" / "mcp"
+    mcp_dir.mkdir(parents=True)
+    (mcp_dir / "github.yaml").write_text(
+        yaml.dump({"name": "github", "transport": "stdio", "command": "npx"})
+    )
+    mcp = parse(agent_dir).mcp_servers[0]
+    assert mcp.tools is None
+
+
+def test_parse_mcp_sidecar_tools_non_list_raises(agent_dir: Path) -> None:
+    """A non-list ``tools:`` value on a sidecar MCP is a clear error, not a
+    silent type bug — mirrors ``test_parse_inline_mcp_tools_non_list_raises``.
+
+    :param agent_dir: Temporary agent directory fixture.
+    """
+    mcp_dir = agent_dir / "tools" / "mcp"
+    mcp_dir.mkdir(parents=True)
+    (mcp_dir / "github.yaml").write_text(
+        yaml.dump(
+            {
+                "name": "github",
+                "transport": "stdio",
+                "command": "npx",
+                "tools": "search_issues",
+            }
+        )
+    )
+    with pytest.raises(OmnigentError, match=r"'tools' must be a list"):
+        parse(agent_dir)
+
+
 def test_parse_mcp_unknown_transport_raises(agent_dir: Path) -> None:
     """
     ``transport: grpc`` or any other value fails loud with a

--- a/tests/tools/fixtures/allowlist_stdio_mcp_server.py
+++ b/tests/tools/fixtures/allowlist_stdio_mcp_server.py
@@ -1,0 +1,54 @@
+"""Two-tool stdio MCP server for exercising a per-server ``tools:`` allow-list.
+
+Exposes a *safe* tool (``echo``) and a *dangerous* tool (``danger``).
+A spec that allow-lists only ``echo`` must never expose ``danger`` to
+the model. This fixture stands in for a real-world server mixing many
+read-only tools with one machine-global destructive tool (e.g.
+``sandbox_clear``) whose allow-list exists precisely to exclude the
+destructive tool.
+
+Kept deterministic and dependency-free (only ``mcp``) so the e2e test
+needs no external services, credentials, or network access.
+
+Usage::
+
+    python tests/tools/fixtures/allowlist_stdio_mcp_server.py
+
+``FastMCP.run()`` defaults to stdio transport, so the process
+reads/writes MCP protocol frames on stdin/stdout.
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("allowlist-test")
+
+
+@mcp.tool()
+def echo(text: str) -> str:
+    """
+    Return *text* verbatim, prefixed with ``"echo: "`` (the SAFE tool).
+
+    :param text: The string to echo back, e.g. ``"hello"``.
+    :returns: ``f"echo: {text}"``.
+    """
+    return f"echo: {text}"
+
+
+@mcp.tool()
+def danger(text: str) -> str:
+    """
+    The tool an allow-list is meant to EXCLUDE.
+
+    Returns a distinctive marker so a test can prove whether it ran.
+    Stands in for a destructive tool like ``sandbox_clear``.
+
+    :param text: An arbitrary string, echoed into the marker.
+    :returns: ``f"danger-executed: {text}"``.
+    """
+    return f"danger-executed: {text}"
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Related issue

Closes #5178

## Summary

- MCP servers declared inline under `config.yaml`'s `tools:` block already validated and applied a per-server `tools:` allow-list, but the same key was silently dropped for MCP servers declared as sidecar `tools/mcp/*.yaml` files — both `_parse_stdio_mcp_server` and `_parse_http_mcp_server` built `MCPServerConfig` without ever reading `tools`.
- The failure is **open**: a spec author who writes a restrictive allow-list in the sidecar form gets the full, unrestricted tool surface with no error, warning, or log line, because the allow-list is enforced by downstream filtering (`server/mcp_pool.py`, `runner/mcp_manager.py`), not at parse time.
- Fix: factor the allow-list parsing (including the existing "must be a list of tool names" validation) into one shared `_parse_mcp_tool_allowlist` helper, used by all three MCP parsers (inline, sidecar-stdio, sidecar-http) — matches option 1 from the issue and the intent already documented on `MCPServerConfig.tools` ("Applies to both transports").

## Test Plan

```
uv run pytest tests/spec/test_parser.py -k mcp -q   # 38 passed (4 new)
uv run pytest tests/spec/ -q                          # 587 passed
uv run ruff format --check omnigent/spec/parser.py tests/spec/test_parser.py
uv run ruff check omnigent/spec/parser.py tests/spec/test_parser.py
```

Also manually reproduced the issue's repro before the fix (a sidecar YAML with a `tools:` list parsed to `MCPServerConfig.tools == None`, i.e. "allow all") and confirmed it now parses to the declared allow-list, matching the inline form.

## Demo

Backend-only change (no UI surface), so here is a before/after repro transcript instead of a screenshot — same `tools/mcp/roteiro.yaml` sidecar file with a 2-name allow-list, parsed on `main` vs. on this branch:

```
=== BEFORE (main, unfixed) ===
sidecar MCP tools allow-list: None  <-- BUG: None means every tool the server exposes is granted; the declared allow-list was silently dropped

=== AFTER (this PR) ===
sidecar MCP tools allow-list: ['list_shows', 'get_show_details']
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added 4 regression tests in `tests/spec/test_parser.py` mirroring the existing inline-form tests (`test_parse_mcp_stdio_tools_whitelist`, `test_parse_mcp_http_tools_whitelist`, `test_parse_mcp_sidecar_tools_absent_is_none`, `test_parse_mcp_sidecar_tools_non_list_raises`), covering both sidecar transports, the "expose all" default, and the non-list error path.

## Changelog

Fixed: a `tools:` allow-list on a sidecar `tools/mcp/*.yaml` MCP server is now enforced (previously silently ignored, exposing every tool on that server regardless of the declared allow-list)

## Issues

Resolves [OMNI-4484](https://linear.app/omnigent/issue/OMNI-4484/bug-mcp-tools-allow-list-is-silently-ignored-in-sidecar-toolsmcpyaml)
