### PR TITLE
fix(runtime): exclude "any" sentinel from model-change respawn guard

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -803,10 +803,26 @@ class HarnessProcessManager:
                 await self._close_entry(entry)
                 entry = None
                 respawn_reason = "harness_respawn_agent_switch"
-            if entry is not None and harness not in _LIVE_MODEL_CONFIG_HARNESSES:
+            if (
+                entry is not None
+                and harness != "any"
+                and harness not in _LIVE_MODEL_CONFIG_HARNESSES
+            ):
                 # Most harnesses bake the model into the subprocess env. A
                 # later concrete model change must respawn them; ACP harnesses
                 # in the live-config set instead apply the request in-session.
+                #
+                # ``harness != "any"`` mirrors the harness-mismatch guard
+                # above: ``"any"`` is the harness-agnostic sentinel steering /
+                # cancel / interrupt callers pass to reach the live
+                # subprocess, not a real harness. Today ``_model_env_key("any")``
+                # resolves to a key no spawn-env builder ever sets, so
+                # ``requested_model`` is always ``None`` and this branch is a
+                # no-op for ``"any"`` by accident. Guard explicitly so a
+                # future change to the lookup key (e.g. resolving through
+                # ``entry.harness``) can't turn a harmless steering call into
+                # a respawn — or, past the ``entry is None`` check below, a
+                # ``NoLiveHarnessError`` crash.
                 requested_model = (env or {}).get(_model_env_key(harness))
                 if requested_model is not None and requested_model != entry.model:
                     _logger.info(

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -512,6 +512,44 @@ async def test_get_client_respawns_on_model_change(
         await manager.shutdown()
 
 
+async def test_get_client_any_harness_sentinel_ignores_model_change(
+    manager: HarnessProcessManager,
+) -> None:
+    """``get_client(conv, "any", env={...})`` never respawns on a model change.
+
+    Combines the two branches ``test_get_client_respawns_on_model_change`` and
+    ``test_get_client_any_harness_sentinel_reuses_subprocess`` each cover
+    alone: a steering/cancel/interrupt call passes ``"any"`` *and* its own
+    env, which may carry a ``HARNESS_<H>_MODEL`` key that differs from the
+    model the live subprocess was spawned with. ``"any"`` has no real
+    harness of its own to respawn into, so this must stay a no-op — a
+    respawn here would tear down an in-flight turn, and (per the
+    ``entry is None`` fallback) a mismatch with no entry to reuse would raise
+    ``NoLiveHarnessError`` instead, turning a harmless call into a crash.
+    """
+    await manager.start()
+    try:
+        client_first = await manager.get_client(
+            "conv_a",
+            _TEST_HARNESS_NAME,
+            env={"HARNESS_TEST_MODEL": "model-a"},
+        )
+        pid_first = (await client_first.get("/pid")).json()["pid"]
+
+        # "any" sentinel with a DIFFERENT model in env → must still reuse.
+        client_any = await manager.get_client(
+            "conv_a",
+            "any",
+            env={"HARNESS_TEST_MODEL": "model-b"},
+        )
+        pid_any = (await client_any.get("/pid")).json()["pid"]
+        # Same PID proves the model-change branch didn't trip for "any".
+        assert pid_any == pid_first
+        assert _pid_alive(pid_first)
+    finally:
+        await manager.shutdown()
+
+
 async def test_get_client_any_harness_sentinel_reuses_subprocess(
     manager: HarnessProcessManager,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #2224

## Summary

- `get_client`'s harness-mismatch check already excludes the `"any"` harness-agnostic sentinel — the value steering/cancel/interrupt callers pass to reach an already-running subprocess without naming its real harness. The model-change respawn check directly below it does **not** apply that same exclusion.
- Today this is a no-op only by accident: `_model_env_key("any")` resolves to `HARNESS_ANY_MODEL`, a key no spawn-env builder ever sets, so `requested_model` is always `None` for `"any"` calls. `"any"` has no real harness of its own to respawn into, so a future change to that lookup (e.g. resolving through `entry.harness`, a reasonable-looking "fix") could wrongly tear down and respawn an in-flight turn mid-response, or — past the entry-recreation branch — raise `NoLiveHarnessError`, turning a harmless steering call into a crash.
- Fix: add the same `harness != "any"` guard to the model-change branch, mirroring the harness-mismatch check's existing exclusion, with a comment explaining why (matches the fix suggested in the issue).

No observable behavior changes today — this is a defense-in-depth fix that makes the safety explicit instead of incidental.

## Test Plan

```
uv run pytest tests/runtime/harnesses/test_process_manager.py -q      # 41 passed
uv run pytest tests/runtime/test_process_manager.py -q                 # 4 passed
uv run pytest tests/runtime/ -q --ignore=tests/runtime/test_telemetry.py --ignore=tests/runtime/test_telemetry_logs.py
  # 1204 passed; the only failures/errors are pre-existing and unrelated
  # (test_provider_spawn_env.py / test_openai_agents_sdk_spawn_env.py shadowed
  # by a locally running Ollama — see #5449 — and test_databricks.py needing a
  # real Databricks CLI/config not present in this sandbox; reproduced
  # identically on unmodified main via git stash)
uv run ruff format --check omnigent/runtime/harnesses/process_manager.py tests/runtime/harnesses/test_process_manager.py
uv run ruff check omnigent/runtime/harnesses/process_manager.py tests/runtime/harnesses/test_process_manager.py
```

Also verified the new test is a real regression guard, not a tautology: reverted just the source fix (`git stash` on `process_manager.py` only) and confirmed `test_get_client_any_harness_sentinel_ignores_model_change` still passes today (proving the current "safe by accident" behavior), while walking through the exact regression the issue describes (pointing the lookup at `entry.harness` instead of `harness`) shows the same test would then fail — either a PID change (wrongful respawn) or a raised `NoLiveHarnessError`.

## Demo

Backend-only change (no UI surface). This is a latent-bug guard rather than a fix for an actively-observable bug today, so instead of a screenshot: the new regression test `test_get_client_any_harness_sentinel_ignores_model_change` passes both with and without the source fix right now (proving today'''s behavior is merely *safe by accident*, exactly as the issue describes) — verified by temporarily reverting just `process_manager.py` to its pre-fix content and re-running the new test in isolation:

```
$ uv run pytest tests/runtime/harnesses/test_process_manager.py::test_get_client_any_harness_sentinel_ignores_model_change -q
# with the fix:    1 passed
# without the fix: 1 passed   (confirms today'''s accidental safety; guards the future regression the issue warns about)
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added `test_get_client_any_harness_sentinel_ignores_model_change` in `tests/runtime/harnesses/test_process_manager.py`, combining the two scenarios the existing suite covered separately (`test_get_client_respawns_on_model_change` and `test_get_client_any_harness_sentinel_reuses_subprocess`): a `get_client(conv, "any", env={...})` call whose env carries a *different* model than the live subprocess was spawned with must still reuse the cached subprocess, not respawn.

