### PR TITLE
docs(agents): address every Polly finding + Databricks registry proxies (shared env doc)

### DIFF
--- a/dev/agent-environment.md
+++ b/dev/agent-environment.md
@@ -1,0 +1,39 @@
+# Agent environment — general notes for repro-agent and resolve-agent
+
+Shared reference for both agents. These apply to **everything you run in your
+session's shell**, regardless of the task — not just recording.
+
+## Package installs go through the Databricks registry proxies
+
+You run inside a **Databricks-network session**, where **direct access to the
+public npm and PyPI registries is blocked** (a supply-chain security control). So
+any command that fetches from `registry.npmjs.org` or `pypi.org` — `npm`/`pnpm`/
+`npx`/`yarn install`, `pip install`, `uv pip install`, `uv sync`, `pytest`/
+`playwright`/`vhs`/`electron` installs — fails with an **auth/connection error**
+that looks like your command is wrong but is really the registry being
+unreachable. Point the tools at the internal proxies **once, up front, before any
+install**:
+
+```bash
+# npm / pnpm / npx / yarn — writes ~/.npmrc, so all of them pick it up
+npm config set registry https://npm-proxy.cloud.databricks.com/
+# pip
+pip3 config set global.index-url https://pypi-proxy.cloud.databricks.com/simple
+# uv — pass the index explicitly (don't bake the proxy into uv.lock)
+uv pip install --default-index https://pypi-proxy.cloud.databricks.com/simple/ <pkg>
+uv sync --index-url https://pypi-proxy.cloud.databricks.com/simple/
+```
+
+Notes:
+
+- **Never commit the proxy URL into a lockfile.** `uv sync` records the index it
+  resolved against into `uv.lock`; passing `--index-url` on the CLI keeps it out
+  of the committed lockfile (the proxy isn't reachable from GitHub-hosted CI, and
+  it must not leak into a public repo). If an install step writes a lockfile,
+  revert that lockfile change unless it's genuinely part of the fix.
+- The proxies **embargo package versions newer than 7 days**; if an install fails
+  only for a just-published version, that's the age filter, not a misconfig —
+  note it rather than trying to bypass the block.
+- If an install still fails **after** pointing at the proxy, treat that tooling as
+  unavailable for the task at hand and say so plainly — **do not** attempt to
+  reach the public registry directly (the block is deliberate).

--- a/dev/recording-lanes.md
+++ b/dev/recording-lanes.md
@@ -36,6 +36,40 @@ a concrete reason, never a silent skip. Never let recording block or distort the
 work itself, and never fabricate a hollow journey that doesn't reach the failure
 just to produce a video.
 
+## Package installs must go through the Databricks registry proxies
+
+You run inside a Databricks-network session, where **direct access to the public
+npm and PyPI registries is blocked** (a supply-chain security control). So a bare
+`pnpm install`, `pip install`, `uv pip install`, or `npx <pkg>` — anything that
+fetches from `registry.npmjs.org` or `pypi.org` — fails with an auth/connection
+error, *not* because your command is wrong but because the registry is unreachable.
+This bites the install steps below (the SPA build's `pnpm install`, Playwright,
+`vhs`, any `uv`/`pip` install). Point the tools at the internal proxies first:
+
+```bash
+# npm / pnpm / npx / yarn — writes ~/.npmrc, so all of them pick it up
+npm config set registry https://npm-proxy.cloud.databricks.com/
+# pip
+pip3 config set global.index-url https://pypi-proxy.cloud.databricks.com/simple
+# uv — pass the index explicitly (don't bake the proxy into uv.lock)
+uv pip install --default-index https://pypi-proxy.cloud.databricks.com/simple/ <pkg>
+uv sync --index-url https://pypi-proxy.cloud.databricks.com/simple/
+```
+
+Do this **once, up front**, before any install command in this doc. Notes:
+
+- **Never commit the proxy URL into a lockfile.** `uv sync` records the index it
+  resolved against into `uv.lock`; passing `--index-url` on the CLI keeps it out
+  of the committed lockfile (the proxy isn't reachable from GitHub-hosted CI, and
+  it must not leak into a public repo). If a build step writes a lockfile, revert
+  that lockfile change unless it's genuinely part of the fix.
+- The proxies embargo package versions **newer than 7 days**; if an install fails
+  only for a just-published version, that's the age filter, not a misconfig — note
+  it rather than trying to bypass the block.
+- If an install still fails **after** pointing at the proxy, treat that lane's
+  tooling as unavailable per the best-effort rule (keep `recordings: []` and name
+  the blocker) — do not attempt to reach the public registry directly.
+
 ## The recorder needs its own local server
 
 A `web`/`terminal` recording runs the `tests/e2e_ui/` suite, which drives a live
@@ -64,6 +98,8 @@ and block on control FDs it doesn't have, so it hangs with an empty `runner.log`
 and stays `online: false`. Strip them with `env -u`:
 
 ```bash
+# Point npm/pnpm at the proxy first (see "Package installs must go through the
+# Databricks registry proxies" above) or this install fails with an auth error.
 pnpm --filter web install && pnpm --filter web run build   # once, up front
 env -u OMNIGENT_RUNNER_ID -u OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN \
     -u OMNIGENT_RUNNER_TUNNEL_TOKEN -u OMNIGENT_RUNNER_PARENT_PID \

--- a/dev/recording-lanes.md
+++ b/dev/recording-lanes.md
@@ -36,40 +36,6 @@ a concrete reason, never a silent skip. Never let recording block or distort the
 work itself, and never fabricate a hollow journey that doesn't reach the failure
 just to produce a video.
 
-## Package installs must go through the Databricks registry proxies
-
-You run inside a Databricks-network session, where **direct access to the public
-npm and PyPI registries is blocked** (a supply-chain security control). So a bare
-`pnpm install`, `pip install`, `uv pip install`, or `npx <pkg>` — anything that
-fetches from `registry.npmjs.org` or `pypi.org` — fails with an auth/connection
-error, *not* because your command is wrong but because the registry is unreachable.
-This bites the install steps below (the SPA build's `pnpm install`, Playwright,
-`vhs`, any `uv`/`pip` install). Point the tools at the internal proxies first:
-
-```bash
-# npm / pnpm / npx / yarn — writes ~/.npmrc, so all of them pick it up
-npm config set registry https://npm-proxy.cloud.databricks.com/
-# pip
-pip3 config set global.index-url https://pypi-proxy.cloud.databricks.com/simple
-# uv — pass the index explicitly (don't bake the proxy into uv.lock)
-uv pip install --default-index https://pypi-proxy.cloud.databricks.com/simple/ <pkg>
-uv sync --index-url https://pypi-proxy.cloud.databricks.com/simple/
-```
-
-Do this **once, up front**, before any install command in this doc. Notes:
-
-- **Never commit the proxy URL into a lockfile.** `uv sync` records the index it
-  resolved against into `uv.lock`; passing `--index-url` on the CLI keeps it out
-  of the committed lockfile (the proxy isn't reachable from GitHub-hosted CI, and
-  it must not leak into a public repo). If a build step writes a lockfile, revert
-  that lockfile change unless it's genuinely part of the fix.
-- The proxies embargo package versions **newer than 7 days**; if an install fails
-  only for a just-published version, that's the age filter, not a misconfig — note
-  it rather than trying to bypass the block.
-- If an install still fails **after** pointing at the proxy, treat that lane's
-  tooling as unavailable per the best-effort rule (keep `recordings: []` and name
-  the blocker) — do not attempt to reach the public registry directly.
-
 ## The recorder needs its own local server
 
 A `web`/`terminal` recording runs the `tests/e2e_ui/` suite, which drives a live
@@ -98,8 +64,8 @@ and block on control FDs it doesn't have, so it hangs with an empty `runner.log`
 and stays `online: false`. Strip them with `env -u`:
 
 ```bash
-# Point npm/pnpm at the proxy first (see "Package installs must go through the
-# Databricks registry proxies" above) or this install fails with an auth error.
+# Point npm/pnpm at the Databricks registry proxy first (see
+# dev/agent-environment.md) or this install fails with an auth error.
 pnpm --filter web install && pnpm --filter web run build   # once, up front
 env -u OMNIGENT_RUNNER_ID -u OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN \
     -u OMNIGENT_RUNNER_TUNNEL_TOKEN -u OMNIGENT_RUNNER_PARENT_PID \

--- a/dev/repro-agent/AGENTS.md
+++ b/dev/repro-agent/AGENTS.md
@@ -13,6 +13,12 @@ against** — the local server `omnigent run` spins up, or a server passed with
 reproduce in — reproducing on the running app **is** the reproduction. Your
 whole session is browsable in that app afterward.
 
+**Environment note:** when you run under `--server` you're inside a
+Databricks-network session where the public npm/PyPI registries are blocked —
+point package installs at the internal proxies. See
+[`dev/agent-environment.md`](../agent-environment.md) before running any
+`npm`/`pnpm`/`pip`/`uv` install.
+
 You do **not** fix the bug. Finding the root cause and implementing a fix — and
 proving the fix with a before/after test transition — is a separate step; it
 consumes your session (the reconstructed journey, the e2e test, and your notes)

--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -514,10 +514,12 @@ server and runner you already run on; no new infrastructure.
    PR bots later catch a new recurring class, add a line to that checklist so the
    next run catches it up front.
 3. **Read the review back** (`sys_session_get_history` on the child) and **act on
-   it**: fix any blocking/security finding it surfaces, re-run the deliverable
+   every finding it surfaces — not only the blocking/security ones**: address each
+   (fix it at the root, or record why it's not actionable), re-run the deliverable
    (back through 2B.5) so it stays green, and — because the diff changed — refresh
-   the review or note why a finding was left. Do not open the PR with an
-   unaddressed blocking finding.
+   the review or note why a finding was left. Treat a non-blocking note the same way
+   you will treat Polly's in 4.3: judge it by whether it's correct, not by its
+   label. Do not open the PR with an unaddressed finding of any severity.
 4. **If no different-vendor bundle is reachable** (e.g. codex isn't configured in
    this environment), do **not** silently fall back to reviewing your own work as
    if it were independent. Skip the spawn and record `cross_review: "skipped: no
@@ -927,25 +929,37 @@ bot/association gate:
 gh workflow run polly-review.yml -R omnigent-ai/omnigent -f pr=<pr>
 ```
 
-Wait for the review to land (a few minutes), then triage the newest comment:
+Wait for the review to land (a few minutes), then **triage every finding — under
+*all* headings, not just Blocking/Security**. Polly's bucketing is a hint, not a
+verdict: a real defect regularly lands under **Non-blocking notes** (a missed edge
+case, a subtly wrong condition, a dropped error path), and "non-blocking" is not a
+licence to ignore it. Go through the newest comment finding by finding — Blocking
+issues, Security vulnerabilities, **and** Non-blocking notes — and for each one do
+exactly one of:
 
-- **Critical findings present** — anything under **Blocking issues** or **Security
-  vulnerabilities** that is a real defect in the PR's diff. Fix each one at the root
-  (same fail→pass discipline as Step 2B — add/adjust a targeted test where it
-  makes sense), re-run the affected tests, then land the fix per the
-  **push-or-take-over rule**: `git commit` + `git push` when you can push to the
-  branch; on a **fork PR** you can't push to, take over into your own PR (Step 4
-  preamble) and continue on it.
-  - After **pushing** a fix (to your PR or an in-repo branch), **re-trigger the
-    review** the same way — another `gh workflow run polly-review.yml -f pr=<pr>`
-    (again: not a `/review` comment from you). Then poll for a **new**
-    `<!-- polly-review-bot -->` comment and triage again.
-- **No critical findings** — only non-blocking notes or a clean summary → the
-  review is clean; you're done with this loop. You may address cheap non-blocking
-  notes if they're clearly right, but they don't gate.
+- **Fix it** — the default for anything that is, or might be, a real defect or a
+  cheap correctness/robustness win. Fix at the root (same fail→pass discipline as
+  Step 2B — add/adjust a targeted test where it makes sense), re-run the affected
+  tests, then land the fix per the **push-or-take-over rule**: `git commit` +
+  `git push` when you can push to the branch; on a **fork PR** you can't push to,
+  take over into your own PR (Step 4 preamble) and continue on it. **Re-assess a
+  non-blocking note as if it were blocking** — decide by whether it's *correct*,
+  not by which heading Polly filed it under.
+- **Justify skipping it** — only when it is genuinely not actionable in this PR: a
+  false positive, purely stylistic/subjective, or out of scope (a pre-existing
+  issue your diff didn't introduce). State *which* finding and *why* — in a PR
+  reply to Polly's comment and in the handoff (`polly_review`). Never skip a
+  finding silently, and never skip one merely because it's labelled non-blocking.
 
-Repeat push → re-trigger → re-read within the round cap until no critical Polly
-findings remain. Record the final state in the handoff (`polly_review`). If a
+After **pushing** any fix (to your PR or an in-repo branch), **re-trigger the
+review** — another `gh workflow run polly-review.yml -f pr=<pr>` (again: not a
+`/review` comment from you) — then poll for a **new** `<!-- polly-review-bot -->`
+comment and triage it again the same way.
+
+Repeat push → re-trigger → re-read within the round cap until **every** finding on
+the newest review is either fixed or has a recorded justification — no unaddressed
+notes of any severity remain. Record the final state in the handoff
+(`polly_review`), including which non-blocking notes you fixed vs. justified. If a
 recurring class of bug shows up here, add a one-line check to
 `dev/resolve-agent/review-checklist.md` so the pre-PR reviewer catches it next
 time.
@@ -1216,10 +1230,11 @@ Field meanings:
   and whether each was diff-caused vs pre-existing/flaky/infra. If a fork PR needed
   a fix and you took over into your own PR, this reflects **your** PR's checks.
   Empty when `skip_push` was set or you stopped before there was a PR to land.
-- `polly_review` — the result of the Step 4.3 automated-review loop: `clean` (no
-  blocking/security findings) with how many review rounds it took and what you
-  fixed, or the unresolved critical findings if you hit the round cap. Empty when
-  no PR was opened.
+- `polly_review` — the result of the Step 4.3 automated-review loop: `clean` (every
+  finding on the newest review addressed — blocking, security, **and** non-blocking)
+  with how many review rounds it took, what you fixed, and which non-blocking notes
+  you fixed vs. justified skipping; or the unresolved findings if you hit the round
+  cap. Empty when no PR was opened.
 - `ui_preview` — the result of Step 4.1 (run on every PR, not just frontend fixes):
   the **preview URL** (verbatim, so the ticket write-back can surface it and a
   reviewer can `omnigent claude -p '<prompt>' --server <url>`), or why it failed to

--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -23,6 +23,12 @@ against**. Your working directory is an `omnigent-ai/omnigent` checkout — the
 product repo where the bug lives, the code you may change, and where the tests
 belong.
 
+**Environment note:** when you run under `--server` you're inside a
+Databricks-network session where the public npm/PyPI registries are blocked —
+point package installs at the internal proxies. See
+[`dev/agent-environment.md`](../agent-environment.md) before running any
+`npm`/`pnpm`/`pip`/`uv` install.
+
 ## Input contract
 
 You are invoked with a **pointer to a completed repro run** — not the bug report


### PR DESCRIPTION
## Related issue

N/A — hardening the repro/resolve agent specs (Docs / prompt).

## Summary

Two agent-spec fixes:

### 1. Address every Polly review finding, not just blocking (`dev/resolve-agent/AGENTS.md`)
Polly's Blocking / Security / Non-blocking bucketing is a hint, not a verdict — a real defect (a missed edge case, a subtly wrong condition, a dropped error path) regularly lands under **Non-blocking notes**. §4.3 previously said non-blocking notes "don't gate" and were optional, so the agent could ship a PR leaving a genuine bug unaddressed just because Polly mislabelled it.

- **§4.3** rewritten: triage every finding under *all* headings; for each, either **fix it** (re-assessing a non-blocking note as if blocking — judged by correctness, not label) or **record a justification** for skipping (false positive / purely stylistic / out of scope) in a PR reply to Polly and in the handoff. The loop ends only when every finding is fixed or justified.
- **§2B.6** (cross-vendor pre-PR review) updated to the same discipline.
- **`polly_review`** handoff field updated to match.

### 2. Package installs go through the Databricks registry proxies (new `dev/agent-environment.md`)
The agents run inside a Databricks-network session where **direct access to public npm/PyPI is blocked** (supply-chain control), so a bare `pnpm`/`pip`/`uv`/`npx` install fails with an auth/connection error — the npm and PyPI auth failures seen on repro/resolve runs.

This is **general environment behavior both agents must follow for any package install**, not something recording-specific — so it lives in a new shared **`dev/agent-environment.md`**, referenced from both agent preambles ("before running any npm/pnpm/pip/uv install"). It covers npm/pnpm/npx via `~/.npmrc` (`https://npm-proxy.cloud.databricks.com/`) and pip/uv index (`https://pypi-proxy.cloud.databricks.com/simple`), warns against baking the proxy URL into a committed `uv.lock`, and notes the 7-day version embargo. `dev/recording-lanes.md` keeps a one-line pointer at its SPA-build step.

**Why omnigent (not omnigent-internal):** the CI wrappers run on GitHub-hosted `ubuntu-latest` (normal public-registry access); the block only hits the *agent's own shell* inside the Databricks-network session, which is where these installs run.

## Test Plan

Prompt-only changes (`dev/resolve-agent/AGENTS.md`, `dev/repro-agent/AGENTS.md`, `dev/agent-environment.md`, `dev/recording-lanes.md`). `pre-commit` passes. Behavioural verification on the next runs — Polly: a non-blocking note is fixed or justified in a reply + `polly_review`; proxies: SPA build / recorder / any install succeeds inside the session.

## Demo

N/A — non-visual (agent spec).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Agent-spec prose has no automated coverage; verified by pre-commit and by reading the composed 4.3 / 2B.6 / preamble flow. Behavioural check happens on the next resolve/repro run.

## Changelog

N/A

This pull request and its description were written by Isaac.
