### PR TITLE
feat(codex): run codex-native under Omnigent's bwrap sandbox + egress

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -57,6 +57,16 @@ from .databricks_executor import (
     _databricks_gateway_host,
 )
 from .datamodel import OSEnvSandboxSpec, OSEnvSpec
+from .egress import EgressProxyHandle
+from .native_sandbox import bootstrap_native_egress
+from .sandbox import (
+    cleanup_private_tmpdir,
+    create_exec_launcher,
+    get_backend,
+    resolve_sandbox,
+    with_additional_read_roots,
+    with_additional_write_roots,
+)
 from .executor import (
     Executor,
     ExecutorConfig,
@@ -2236,6 +2246,13 @@ class _CodexAppServerSession:
         self._fatal_gateway_error: _CodexGatewayError | None = None
         self._recent_events: list[CodexMessage] = []
         self._process_cwd: Path | None = None
+        # Set True at spawn when Codex is successfully wrapped in Omnigent's
+        # bwrap sandbox; drives ``sandbox="danger-full-access"`` per turn so
+        # Codex trusts the outer jail instead of nesting its own sandbox.
+        self._omnigent_sandbox_active = False
+        # Live handle for the per-session L7 egress proxy, when egress_rules are
+        # configured. Torn down in ``close()``.
+        self._egress_handle: EgressProxyHandle | None = None
         # Private CODEX_HOME so the subprocess never writes to the user's ~/.codex/.
         self._codex_home_dir: Path | None = None
         # Most recent ``thread/tokenUsage/updated`` payload's ``last``
@@ -2325,8 +2342,64 @@ class _CodexAppServerSession:
         # history) in a private temp directory rather than the user's ~/.codex/.
         # This prevents subagent sessions from polluting the user's Codex history.
         proc_env = {**self._env, "CODEX_HOME": str(self._codex_home_dir)}
+        # Run Codex inside Omnigent's bwrap sandbox (+ L7 egress proxy when
+        # ``egress_rules`` are set) so ``os_env.sandbox`` actually governs it
+        # — Codex spawns its own shell rather than routing through the sys_os
+        # helper, so without this the sandbox/egress never reach it. The wrap
+        # engages whenever a sandbox is configured (``type != none``),
+        # independent of egress (egress may be enforced at the host level).
+        # Network posture follows Omnigent's convention: direct network unless
+        # ``allow_network: false`` or ``egress_rules`` are set. When wrapped,
+        # Codex's own nested sandbox is disabled per turn (see ``run_turn``) so
+        # Omnigent's jail is the sole boundary.
+        codex_bin = self._codex_path
+        launcher_bin = codex_bin
+        self._omnigent_sandbox_active = False
+        spec = self._os_env_spec
+        if spec is not None and spec.sandbox is not None and spec.sandbox.type != "none":
+            cwd_path = Path(self._cwd or os.getcwd())
+            try:
+                policy = resolve_sandbox(spec, cwd_path)
+                if policy.active:
+                    # Codex writes its state under the temp CODEX_HOME, and the
+                    # `codex` launcher (a node script) must be readable in the jail.
+                    if self._codex_home_dir is not None:
+                        policy = with_additional_write_roots(
+                            policy, [Path(self._codex_home_dir)]
+                        )
+                    policy = with_additional_read_roots(
+                        policy, [Path(codex_bin).resolve().parent]
+                    )
+                    if spec.sandbox.egress_rules:
+                        policy, self._egress_handle = bootstrap_native_egress(
+                            policy,
+                            proc_env,
+                            egress_rules=spec.sandbox.egress_rules,
+                            allow_private_destinations=(
+                                spec.sandbox.egress_allow_private_destinations
+                            ),
+                        )
+                    # Fail fast if the sandbox can't wrap this binary (mirrors
+                    # the Claude SDK path) instead of discovering it post-spawn.
+                    get_backend(policy.backend_type).wrap_launcher_argv(
+                        [codex_bin, "app-server"], policy, cwd_path, target=codex_bin
+                    )
+                    launcher_bin = create_exec_launcher(codex_bin, policy)
+                    self._omnigent_sandbox_active = True
+            except OSError as exc:
+                logger.warning(
+                    "Omnigent sandbox cannot wrap Codex at %s (%s); running "
+                    "Codex unwrapped under its own sandbox.",
+                    codex_bin,
+                    exc,
+                )
+                self._omnigent_sandbox_active = False
+                if self._egress_handle is not None:
+                    self._egress_handle.stop()
+                    self._egress_handle = None
+                launcher_bin = codex_bin
         try:
-            argv = [self._codex_path, "app-server"]
+            argv = [launcher_bin, "app-server"]
             for override in self._codex_config_overrides:
                 argv.extend(["-c", override])
             self._proc = await _create_subprocess_exec(
@@ -2372,6 +2445,18 @@ class _CodexAppServerSession:
             raise
 
     async def close(self) -> None:
+        # Tear down the per-session egress proxy (if we started one) and its
+        # scratch tmpdir. Safe to run on either close() path below.
+        if self._egress_handle is not None:
+            try:
+                self._egress_handle.stop()
+            except Exception:  # noqa: BLE001 — best-effort proxy shutdown
+                logger.debug("egress proxy stop failed", exc_info=True)
+            try:
+                cleanup_private_tmpdir(self._egress_handle.socket_path.parent)
+            except Exception:  # noqa: BLE001 — best-effort tmpdir cleanup
+                logger.debug("egress tmpdir cleanup failed", exc_info=True)
+            self._egress_handle = None
         current_loop = asyncio.get_running_loop()
         if self._loop is not None and self._loop is not current_loop:
             if self._proc is not None and self._proc.returncode is None:
@@ -3619,7 +3704,13 @@ class CodexExecutor(Executor):
             effective_cwd=effective_cwd,
         )
         sandbox_mode = _sandbox_mode(self._os_env_spec)
-        if tools and sandbox_mode == "read-only":
+        if self._omnigent_sandbox_active:
+            # Codex is wrapped in Omnigent's bwrap jail (the real boundary), so
+            # disable Codex's own nested sandbox: a nested landlock/seccomp
+            # sandbox would either fail for lack of privileges inside bwrap or
+            # block the loopback egress relay.
+            sandbox_mode = "danger-full-access"
+        elif tools and sandbox_mode == "read-only":
             sandbox_mode = "workspace-write"
 
         try:

--- a/omnigent/inner/native_sandbox.py
+++ b/omnigent/inner/native_sandbox.py
@@ -1,0 +1,86 @@
+"""Wrap a native (vendor) process in Omnigent's bwrap sandbox + optional egress.
+
+Native harnesses (Codex, and the tmux terminal) spawn a vendor binary directly
+rather than routing tool calls through the ``sys_os`` helper. That means the
+vendor process — and every shell command it runs — does NOT participate in the
+egress proxy the ``sys_os`` helper sets up, so ``os_env.sandbox.egress_rules``
+never governs it.
+
+This module holds the shared logic (previously inlined in
+:mod:`omnigent.inner.terminal`) for bootstrapping a parent-side L7 egress proxy
+for such a process and baking its relay port / socket path / CA bundle into the
+:class:`SandboxPolicy` + spawn env, so the process can be wrapped with
+:func:`create_exec_launcher` and reach the network only through the allow-list.
+
+``require_auth=False`` is used deliberately: a native vendor process has no
+out-of-band FD channel to receive the Proxy-Authorization token (embedding it in
+``HTTP_PROXY`` would leak it via ``ps -E`` to every shell child). The relay's
+other defenses — random ephemeral port, default-deny on private destinations,
+and the ``egress_rules`` allow-list — still apply. See the egress controller's
+docstring for the full trade-off discussion.
+"""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping, Sequence
+from dataclasses import replace
+
+from .egress import EgressProxyHandle, apply_egress_env, start_egress_proxy
+from .sandbox import (
+    SandboxPolicy,
+    create_private_tmpdir,
+    with_additional_write_roots,
+)
+
+
+def bootstrap_native_egress(
+    sandbox: SandboxPolicy,
+    env: MutableMapping[str, str],
+    *,
+    egress_rules: Sequence[str],
+    allow_private_destinations: bool = False,
+) -> tuple[SandboxPolicy, EgressProxyHandle]:
+    """Start a parent-side MITM egress proxy for a native process.
+
+    Mints a private scratch tmpdir (added to ``write_roots`` so bwrap
+    bind-mounts it into the namespace — the CA bundle and egress socket live
+    there), starts the proxy, injects ``HTTP_PROXY`` / ``HTTPS_PROXY`` / CA env
+    vars into ``env``, and returns a policy whose ``egress_relay_port`` /
+    ``egress_socket_path`` are populated for :func:`create_exec_launcher`.
+
+    The caller MUST use the returned policy for the launcher and is responsible
+    for the returned handle's lifecycle: call ``handle.stop()`` and
+    ``cleanup_private_tmpdir(handle.socket_path.parent)`` on teardown.
+
+    :param sandbox: Active sandbox policy (caller verified ``sandbox.active``).
+    :param env: Mutable spawn env; mutated in place with proxy + CA vars.
+    :param egress_rules: Non-empty allow-list of ``"METHODS host/path"`` rules.
+    :param allow_private_destinations: Passed through to the proxy; default
+        ``False`` blocks RFC1918 / loopback upstream (anti DNS-rebinding).
+    :returns: ``(updated_policy, egress_handle)``.
+    """
+    tmpdir = create_private_tmpdir()
+    # Add the scratch tmpdir to write_roots BEFORE encoding the policy into the
+    # launcher; otherwise bwrap won't bind it and the CA bundle / egress socket
+    # the launcher needs at activate time would be invisible in the namespace.
+    sandbox = with_additional_write_roots(sandbox, [tmpdir])
+    handle = start_egress_proxy(
+        rules=list(egress_rules),
+        tmpdir=tmpdir,
+        allow_private_destinations=allow_private_destinations,
+        require_auth=False,
+    )
+    apply_egress_env(
+        env,
+        relay_port=handle.relay_port,
+        ca_bundle_path=handle.ca_bundle_path,
+        auth_token=None,
+    )
+    return (
+        replace(
+            sandbox,
+            egress_relay_port=handle.relay_port,
+            egress_socket_path=str(handle.socket_path),
+        ),
+        handle,
+    )

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -27,7 +27,8 @@ from omnigent.runner.identity import strip_runner_auth_secrets
 
 from . import _proc
 from .datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
-from .egress import EgressProxyHandle, apply_egress_env, start_egress_proxy
+from .egress import EgressProxyHandle
+from .native_sandbox import bootstrap_native_egress
 from .os_env import (
     OSEnvironment,
     _copy_tree,
@@ -37,7 +38,6 @@ from .sandbox import (
     SandboxPolicy,
     cleanup_private_tmpdir,
     create_exec_launcher,
-    create_private_tmpdir,
     resolve_sandbox,
     with_additional_write_roots,
     with_denied_unix_sockets,
@@ -1236,39 +1236,16 @@ class TerminalInstance:
             bind-mounts it inside the namespace.
         """
         assert self.egress_rules, "caller checked self.egress_rules"
-        self._egress_tmpdir = create_private_tmpdir()
-        # Add the scratch tmpdir to write_roots BEFORE encoding the
-        # policy into the launcher. Without this, bwrap won't bind
-        # the tmpdir into the namespace and the CA bundle /
-        # egress socket the launcher needs at activate time would
-        # be invisible.
-        sandbox = with_additional_write_roots(sandbox, [self._egress_tmpdir])
-        self._egress_handle = start_egress_proxy(
-            rules=self.egress_rules,
-            tmpdir=self._egress_tmpdir,
-            allow_private_destinations=self.egress_allow_private_destinations,
-            # Terminal path uses ``require_auth=False``: tmux closes
-            # inherited FDs before exec, so we have no out-of-band
-            # channel for a Proxy-Authorization token. Embedding the
-            # token in HTTP_PROXY (the alternative) would leak it via
-            # ``ps -E`` on every shell child anyway. The relay's
-            # other defenses (random ephemeral port, default-deny on
-            # private destinations, allow-list per :attr:`egress_rules`)
-            # still apply; see the controller's docstring for the
-            # full trade-off discussion.
-            require_auth=False,
-        )
-        apply_egress_env(
-            env,
-            relay_port=self._egress_handle.relay_port,
-            ca_bundle_path=self._egress_handle.ca_bundle_path,
-            auth_token=None,
-        )
-        return replace(
+        sandbox, self._egress_handle = bootstrap_native_egress(
             sandbox,
-            egress_relay_port=self._egress_handle.relay_port,
-            egress_socket_path=str(self._egress_handle.socket_path),
+            env,
+            egress_rules=self.egress_rules,
+            allow_private_destinations=self.egress_allow_private_destinations,
         )
+        # Retain the scratch tmpdir (the parent of the egress socket that
+        # ``bootstrap_native_egress`` minted) so ``close()`` can remove it.
+        self._egress_tmpdir = self._egress_handle.socket_path.parent
+        return sandbox
 
     async def close(self) -> None:
         """Kill the tmux session and clean up."""


### PR DESCRIPTION
Fixes the gap described in #5693: the `codex` (codex-native) harness runs
outside Omnigent's sandbox machinery, so `os_env.sandbox` (bwrap filesystem
containment + L7 `egress_rules`) never governs it.

## Changes
- **New `inner/native_sandbox.py`** — `bootstrap_native_egress()`, a shared
  helper extracted from `terminal.py`'s inline egress bootstrap (mint scratch
  tmpdir → `start_egress_proxy(require_auth=False)` → `apply_egress_env` → stamp
  relay port / socket path onto the `SandboxPolicy`).
- **`inner/terminal.py`** — refactored `_bootstrap_egress_proxy` to call the
  shared helper (behavior-preserving; removed now-unused imports).
- **`inner/codex_executor.py`**:
  - When `os_env.sandbox` is configured (`type != none`), resolve the policy,
    add Codex's write root (temp `CODEX_HOME`) + read root (codex binary dir),
    start the egress proxy when `egress_rules` are set, and wrap the
    `codex app-server` spawn via `create_exec_launcher`.
  - Pass `sandbox="danger-full-access"` per turn when wrapped, so Codex's own
    nested sandbox doesn't fight (or fail inside) Omnigent's bwrap jail.
  - Network follows Omnigent's convention (direct unless `allow_network: false`
    or `egress_rules`).
  - Graceful fallback to the unwrapped spawn if the wrap can't be built.
  - Tear down the egress proxy in `close()`.

## Activation
- bwrap wrap: whenever `os_env.sandbox` is configured (decoupled from egress —
  egress may be enforced at the host level).
- egress network-namespace + proxy: only when `egress_rules` are set.

## Validation so far
- Modules compile and import cleanly; the `terminal.py` refactor is
  behavior-preserving.
- The JSON-RPC-over-stdio transport survives the bwrap launcher wrap (verified:
  a process wrapped via `create_exec_launcher` round-trips stdio through the
  `--unshare`/bwrap re-exec).
- Reuses the exact egress relay/proxy path the terminal already uses.

## Draft — not yet done
- A full end-to-end run of the modified harness under enforced egress
  (allow/deny + `git clone`/`push`) is not yet included; flagged for
  reviewer/CI. Opening as **draft** to get maintainer feedback on the approach
  and the open questions in #5693 first (per CONTRIBUTING).

This pull request and its description were written by Isaac.
