### PR TITLE
docs(resolve-agent): require a real Polly review before approving a fork PR; make the recorder env-strip mandatory

### DIFF
--- a/dev/recording-lanes.md
+++ b/dev/recording-lanes.md
@@ -57,11 +57,14 @@ like an environment failure but is really the build starving the boot. So
 **always build the SPA first as its own step**, then run the recorder.
 
 When you are yourself running inside a server-spawned runner (the `--server`
-path), also **strip the ambient runner/host env vars** so the fixture's own runner
-starts clean. Those vars (`OMNIGENT_RUNNER_ZYGOTE*` FDs, `OMNIGENT_RUNNER_ID`,
-tunnel/host tokens) leak into the spawned child, make it take the zygote-fork path
-and block on control FDs it doesn't have, so it hangs with an empty `runner.log`
-and stays `online: false`. Strip them with `env -u`:
+path — check with `echo "$OMNIGENT_RUNNER_ID"`, which is set there), you **must
+strip the ambient runner/host env vars** so the fixture's own runner starts clean.
+This is not optional: those vars (`OMNIGENT_RUNNER_ZYGOTE*` FDs,
+`OMNIGENT_RUNNER_ID`, tunnel/host tokens) leak into the spawned child, make it take
+the zygote-fork path and block on control FDs it doesn't have, so it hangs with an
+empty `runner.log` and stays `online: false`. A bare `pytest`/`uv run pytest` with
+`OMNIGENT_RUNNER_ID` still set is the single most common way the after-clip
+silently fails to record. Strip them with `env -u`:
 
 ```bash
 # Point npm/pnpm at the Databricks registry proxy first (see
@@ -77,13 +80,18 @@ env -u OMNIGENT_RUNNER_ID -u OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN \
     pytest <test_path> --screenshot on --output recordings/<slug>
 ```
 
-If the spawned runner still doesn't reach `online: true` within the fixture's
-timeout *after* the SPA is built and the env is stripped, capture the tail of the
-fixture's `runner.log`, treat that lane as genuinely unreachable here, keep
-`recordings: []` for it, and say plainly **"recorder's test server did not come
-online in time"** with the `runner.log` tail — noting whether the log was empty
-(the leaked-env/zygote hang) or showed a later failure, so the cause is named from
-what you observed rather than guessed.
+Only *after* the SPA is built and the env is stripped is an `online: false` a
+real environment limit. If you see `online: false` and you have **not** stripped
+the leaked vars (`OMNIGENT_RUNNER_ID` was set in your shell), that failure is your
+own un-stripped env, not the harness — re-run with the `env -u` prefix before
+concluding anything; do **not** file it as an environmental blocker or a "runner
+not coming online" env problem. Once the SPA is built, the env is stripped, and the
+spawned runner still doesn't reach `online: true` within the fixture's timeout,
+capture the tail of the fixture's `runner.log`, treat that lane as genuinely
+unreachable here, keep `recordings: []` for it, and say plainly **"recorder's test
+server did not come online in time"** with the `runner.log` tail — noting whether
+the log was empty (the leaked-env/zygote hang) or showed a later failure, so the
+cause is named from what you observed rather than guessed.
 
 ## `web` facets
 

--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -272,8 +272,11 @@ reproduction test is your objective instrument.
    through **and** produce the after; when it carries none, still produce the
    after and note the missing before. Only omit the after clip when it is
    genuinely unobtainable (recorder tooling missing, or the fixture can't come
-   online after the SPA build) — say so explicitly in your review comment and in
-   `evidence`, naming the blocker. A missing upstream before-clip is never that
+   online after the SPA build **and** the leaked runner env is stripped) — say so
+   explicitly in your review comment and in `evidence`, naming the blocker. An
+   `online: false` seen while `OMNIGENT_RUNNER_ID` is still set is your own
+   un-stripped env, not a blocker: re-run with the `env -u` prefix from
+   `dev/recording-lanes.md` first. A missing upstream before-clip is never that
    blocker. Never drop it silently.
 4. **Review the diff** for quality, not just green: does it address the **root
    cause** or only mask the symptom? Does it miss facets or obvious adjacent edge
@@ -302,6 +305,14 @@ reproduction test is your objective instrument.
      --body '…'`. A genuine independent verification — the "someone checked it, take
      your pass" signal a maintainer wants. Note in the body that it's an automated
      reviewer's approval and a maintainer's approval is still required to merge.
+     **"Polly clean" here means a real Polly review actually ran and came back
+     clean** — a fresh `<!-- polly-review-bot -->` comment for the current head,
+     every finding fixed or justified (4.3), **not** a green check. If you could not
+     get a real Polly review to run (the dispatch failed, no comment ever landed,
+     or you only ever saw the phantom green check on a fork PR), you have **not**
+     verified this precondition: do **not** approve. Leave a `--comment` review
+     that states the fail→pass evidence *and* that a Polly review could not be
+     obtained, and let a maintainer take over the review from there.
    - **`not_fixed` / `partially_fixed`** → `gh pr review <pr> --request-changes
      --body '…'` naming what still fails.
    - **You pushed fixes to this PR** (in-repo branch) **or took it over** (fork) →
@@ -317,7 +328,10 @@ reproduction test is your objective instrument.
    **fork PR** you can't push to *and it needs a fix*, take over by opening your
    own PR that carries their commits + your fix (crediting them). If the fork PR
    needs no fix, keep it as-is. Either way you **do** iterate CI and Polly, rather
-   than triggering one review and stopping. Record `mode: "reviewed_existing_pr"`
+   than triggering one review and stopping — and on a fork PR you must actually
+   dispatch Polly and wait for its comment, because the automatic check reports a
+   green `pass` there without ever running (see 4.3). Record
+   `mode: "reviewed_existing_pr"`
    and its `pr_url` when you keep it; if a fork takeover made you open your own,
    record `mode: "authored_fix"` with the fork PR in `reviewed_pr_url`.
 
@@ -488,7 +502,12 @@ produces*:
   and the handoff (`recordings`). Omit it **only** for the genuine environmental
   blockers named in `dev/recording-lanes.md` (tooling missing, server won't come
   online, `api`-surface facet with nothing to film) — and then say which, with the
-  evidence; never report an after-clip you didn't actually produce.
+  evidence; never report an after-clip you didn't actually produce. When you run
+  inside a server-spawned runner (`OMNIGENT_RUNNER_ID` is set), a recorder
+  `online: false` is **not** an environmental blocker until you have stripped the
+  leaked runner/host env vars per `dev/recording-lanes.md`; an un-stripped
+  `online: false` is your own env and must be re-run with the `env -u` prefix, not
+  filed as "runner won't come online."
 
 ### 2B.6 — Get an independent cross-vendor review before you open the PR
 
@@ -923,20 +942,37 @@ gh pr view <pr> --json comments \
   --jq '[.comments[] | select(.body | startswith("<!-- polly-review-bot -->"))] | last | .body'
 ```
 
+**A green "Polly AI Review" check is not proof Polly reviewed anything.** On a
+**fork PR** the automatic `pull_request` run has no LLM credentials (GitHub
+withholds secrets from fork events), so the workflow's credentials gate skips every
+real step and the check still reports `pass` in a few seconds — a green check with
+no review behind it. Never read the check status as "Polly is clean." The **only**
+evidence of a real review is a fresh `<!-- polly-review-bot -->` **comment** for
+the current head; if the query above returns empty, Polly has **not** reviewed this
+head, no matter what `gh pr checks` says.
+
 Polly runs automatically when the PR first becomes ready, but on a **reviewed PR**
-that already opened before you arrived it may not have run for the current head —
-so kick off the first review yourself. **Trigger it via the workflow's
+that already opened before you arrived — and on **every fork PR**, where the
+automatic run always skips — it will not have posted a real review for the current
+head, so you must kick one off yourself. **Trigger it via the workflow's
 `workflow_dispatch` entry point, not a `/review` comment**: Polly's comment handler
 **ignores `/review` from `[bot]` accounts, and you are one** (`omni-resolve-agent[bot]`),
 so a `/review` comment you post is silently dropped. `workflow_dispatch` has no
-bot/association gate:
+bot/association gate, and it reviews a prefetched diff so it works even for a fork
+PR whose automatic run skipped:
 
 ```
 gh workflow run polly-review.yml -R omnigent-ai/omnigent -f pr=<pr>
 ```
 
-Wait for the review to land (a few minutes), then **triage every finding — under
-*all* headings, not just Blocking/Security**. Polly's bucketing is a hint, not a
+Your App token carries `actions: write`, so this dispatch is expected to succeed;
+a `403` means the App lost that permission — record `polly_review` as "could not
+dispatch — App lacks actions:write" and flag it, rather than falling back to the
+green check as if the review were clean.
+
+Wait for a **new** `<!-- polly-review-bot -->` comment to land (a few minutes) —
+never treat the review as done on the green check alone — then **triage every
+finding under *all* headings, not just Blocking/Security**. Polly's bucketing is a hint, not a
 verdict: a real defect regularly lands under **Non-blocking notes** (a missed edge
 case, a subtly wrong condition, a dropped error path), and "non-blocking" is not a
 licence to ignore it. Go through the newest comment finding by finding — Blocking
@@ -1237,10 +1273,13 @@ Field meanings:
   a fix and you took over into your own PR, this reflects **your** PR's checks.
   Empty when `skip_push` was set or you stopped before there was a PR to land.
 - `polly_review` — the result of the Step 4.3 automated-review loop: `clean` (every
-  finding on the newest review addressed — blocking, security, **and** non-blocking)
-  with how many review rounds it took, what you fixed, and which non-blocking notes
-  you fixed vs. justified skipping; or the unresolved findings if you hit the round
-  cap. Empty when no PR was opened.
+  finding on the newest **real review comment** addressed — blocking, security, **and**
+  non-blocking) with how many review rounds it took, what you fixed, and which
+  non-blocking notes you fixed vs. justified skipping; or the unresolved findings if
+  you hit the round cap. If a real review never ran — the dispatch failed or no
+  `<!-- polly-review-bot -->` comment ever landed (a phantom green check does not
+  count) — say so here explicitly; that state also blocks an approving review (see
+  the review-verdict step). Empty when no PR was opened.
 - `ui_preview` — the result of Step 4.1 (run on every PR, not just frontend fixes):
   the **preview URL** (verbatim, so the ticket write-back can surface it and a
   reviewer can `omnigent claude -p '<prompt>' --server <url>`), or why it failed to


### PR DESCRIPTION
## Related issue

Closes #

<!-- Docs change — no issue required. -->

## Summary

While diagnosing why a resolve-agent run approved fork PR #5081 without a real Polly review, we found two silent gaps of the same kind — the agent treating a *non-result* as a verified result:

- **Phantom Polly pass.** On a fork PR the automatic `Polly AI Review` check reports a green `pass` in ~5s: GitHub withholds secrets from fork `pull_request` events, so the workflow's credentials gate skips every real step and the job still succeeds. The agent read that green check as "Polly clean," never dispatched a review, and **approved on a review that never ran** (`polly_review: "clean"` was false; #5081 has zero Polly review comments).
- **Un-stripped-env recording failure.** A run inside a server-spawned runner filmed no after-clip because it invoked the recorder with `OMNIGENT_RUNNER_ID` still set (`online: false`), then filed it as an environment limit. The `env -u` workaround was already documented but read as advisory.

This PR closes both by making the docs refuse to accept the non-result:

- **4.3** — a green check is not proof of a review; the only evidence is a fresh `<!-- polly-review-bot -->` comment for the current head. Dispatch via `workflow_dispatch` (the App token has `actions: write`) and wait for the comment; a `403` is a flagged permission regression, not a fallback to the green check.
- **Review verdict** — "Polly clean" as an approval precondition now means a real review ran and came back clean. If no real review could be obtained → **do not approve**; leave a comment review and hand off to a maintainer.
- **`polly_review` handoff field** — "review never ran" is a first-class recorded state that also blocks approval.
- **Recording** — the `--server` env-strip is now mandatory; an un-stripped `online: false` is the agent's own env and must be re-run with the `env -u` prefix before it can be called a blocker.

No `polly-review.yml` or GitHub App permission changes: the `/review` comment gate stays locked down as designed, and `workflow_dispatch` already works for the bot.

## Test Plan

Docs-only. Verified the two changed files pass `pre-commit run --files dev/resolve-agent/AGENTS.md dev/recording-lanes.md`, and that the guidance is anchored to the current post-#5692 wording (the phantom-check text was confirmed absent from `origin/main` before this change). No code paths affected.

## Demo

N/A — documentation only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only change to agent-guidance files (`dev/resolve-agent/AGENTS.md`, `dev/recording-lanes.md`). No runtime code is affected, so automated test coverage does not apply; verified via pre-commit and by re-anchoring the edits against the current `origin/main`.

This pull request and its description were written by Isaac.