### PR TITLE
feat(web): move session to project from the title folder tag

### DIFF
--- a/tests/e2e_ui/sessions/test_header_move_to_project.py
+++ b/tests/e2e_ui/sessions/test_header_move_to_project.py
@@ -1,0 +1,136 @@
+"""Browser e2e for moving a session into a project from the chat header.
+
+The session title's leading folder icon is a Slack-style "Move session"
+shortcut (``data-testid="header-project-tag"``): clicking it opens a project
+picker whose search box doubles as a create field. Picking a project — or the
+"+ Create <name>" row for a typed name with no match — files the session via
+``PATCH /v1/sessions/{id}`` with ``{project_id}`` (creating the first-class
+``projects`` row on demand). Desktop-only; the kebab keeps the equivalent item
+on mobile.
+
+These drive the real chain the ``HeaderProjectTag`` / ``ProjectPicker`` unit
+tests mock out: the header tag → the PATCH → the committed ``project_id`` on
+``GET /v1/sessions/{id}``, and the sidebar regrouping the row into the project
+folder.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+import time
+import uuid
+
+import httpx
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import seed_committed_turn
+
+
+def _await_filed_under(base_url: str, session_id: str, *, timeout: float = 10.0) -> str | None:
+    """Poll ``GET /v1/sessions/{id}`` until it reports a ``project_id``.
+
+    The header paints the move optimistically, so the committed membership can
+    lag the click by a PATCH round-trip.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        snapshot = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+        snapshot.raise_for_status()
+        filed_under = snapshot.json().get("project_id")
+        if filed_under:
+            return filed_under
+        time.sleep(0.2)
+    return None
+
+
+def test_header_folder_tag_moves_session_into_existing_project(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The header folder tag files an unfiled session into a picked project."""
+    base_url, session_id = seeded_session
+    uniq = uuid.uuid4().hex[:6]
+    project_name = f"E2E Header Move {uniq}"
+    title = f"e2e-header-move-{uniq}"
+
+    httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        timeout=10.0,
+    ).raise_for_status()
+    project_id = httpx.post(
+        f"{base_url}/v1/projects",
+        json={"name": project_name},
+        timeout=10.0,
+    ).json()["id"]
+    # A committed turn settles the header title so the breadcrumb (and its
+    # folder tag) mounts.
+    seed_committed_turn(session_id, prompt="ping", reply="pong")
+
+    try:
+        page.goto(f"{base_url}/c/{session_id}")
+
+        # Unfiled → the tag reads "Add to project". Open it and pick the project.
+        tag = page.get_by_test_id("header-project-tag")
+        expect(tag).to_be_visible(timeout=30_000)
+        expect(tag).to_have_attribute("aria-label", "Add to project")
+        tag.click()
+        page.get_by_role("menuitem", name=project_name).click()
+
+        # It commits server-side…
+        assert _await_filed_under(base_url, session_id) == project_id
+        # …and the tag flips to the filed state (folder icon, project label).
+        expect(page.get_by_test_id("header-project-tag")).to_have_attribute(
+            "aria-label", f"Project: {project_name}"
+        )
+    finally:
+        with contextlib.suppress(httpx.HTTPError):
+            httpx.delete(f"{base_url}/v1/projects/{project_id}", timeout=10.0)
+
+
+def test_header_folder_tag_creates_project_from_typed_name(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Typing an unmatched name offers "+ Create", filing into a new project."""
+    base_url, session_id = seeded_session
+    uniq = uuid.uuid4().hex[:6]
+    project_name = f"E2E Header Create {uniq}"
+    title = f"e2e-header-create-{uniq}"
+
+    httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        timeout=10.0,
+    ).raise_for_status()
+    seed_committed_turn(session_id, prompt="ping", reply="pong")
+
+    created_project_id: str | None = None
+    try:
+        page.goto(f"{base_url}/c/{session_id}")
+
+        tag = page.get_by_test_id("header-project-tag")
+        expect(tag).to_be_visible(timeout=30_000)
+        tag.click()
+
+        # Type a name no existing project matches → the create row appears.
+        page.get_by_role("textbox", name="Search or create project").fill(project_name)
+        create_row = page.get_by_role(
+            "menuitem", name=re.compile(f"^Create {re.escape(project_name)}")
+        )
+        expect(create_row).to_be_visible()
+        create_row.click()
+
+        # The move creates the project on demand and files the session into it.
+        created_project_id = _await_filed_under(base_url, session_id)
+        assert created_project_id is not None
+        projects = httpx.get(f"{base_url}/v1/sessions/projects", timeout=10.0).json()
+        assert any(p["id"] == created_project_id and p["name"] == project_name for p in projects)
+        expect(page.get_by_test_id("header-project-tag")).to_have_attribute(
+            "aria-label", f"Project: {project_name}"
+        )
+    finally:
+        if created_project_id is not None:
+            with contextlib.suppress(httpx.HTTPError):
+                httpx.delete(f"{base_url}/v1/projects/{created_project_id}", timeout=10.0)

--- a/tests/e2e_ui/sessions/test_header_session_menu.py
+++ b/tests/e2e_ui/sessions/test_header_session_menu.py
@@ -49,13 +49,15 @@ def test_header_session_menu_renames_owner_and_hides_for_subagent(
         expect(trigger).to_be_visible(timeout=30_000)
         trigger.click()
 
+        # Desktop drops "Add to project" from the kebab — the breadcrumb's
+        # folder tag owns that shortcut now (see HeaderProjectTag). It stays in
+        # this menu only on mobile, where the native shells hide the breadcrumb.
         menu_items = page.get_by_role("menuitem")
-        expect(menu_items).to_have_count(6)
+        expect(menu_items).to_have_count(5)
         assert menu_items.all_inner_texts() == [
             "Pin",
             "Rename",
             "Mark as unread",
-            "Add to project",
             "Archive",
             "Delete",
         ]

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -24,6 +24,7 @@ import {
 import { AgentInfoButton } from "@/components/AgentInfo";
 import { ConversationBreadcrumb } from "./ConversationBreadcrumb";
 import { HeaderConversationMenu } from "./HeaderConversationMenu";
+import { HeaderProjectTag } from "./HeaderProjectTag";
 import { UNTITLED_CONVERSATION_LABEL } from "./sidebarNav";
 import { PresenceAvatars } from "@/components/PresenceAvatars";
 import type { Agent } from "@/hooks/useAgents";
@@ -171,7 +172,8 @@ interface ChatHeaderProps {
  * mask, index.css; chat reserves clearance via ``pt-20``,
  * terminal-first via ``pt-14``). Left slot: open-sidebar + a conversation
  * breadcrumb (``[folder] / <title> [/ <sub-agent>]``, with the session-actions
- * kebab on desktop). Right slot: desktop action buttons (Agent info ·
+ * kebab on desktop and a "Move to…" project picker on the folder tag). Right
+ * slot: desktop action buttons (Agent info ·
  * Share · right-panel toggle) and, on mobile, a **single** kebab holding both
  * the session actions (pin/share/rename/project/archive/delete) and the
  * workspace-rail entries that open Files · Agents · Shells as full-screen
@@ -342,6 +344,16 @@ export function ChatHeader({
       workspaceItems={isMobile ? workspaceItems : null}
     />
   ) : null;
+  // Slack-style "Move to…" shortcut on the breadcrumb's folder tag: click it to
+  // file/move/unfile the session without opening the kebab. Desktop-only (the
+  // tag is hidden on mobile; the mobile menu keeps its own move item) and only
+  // for the owner-managed top-level row — a sub-agent's folder stays static so
+  // the title keeps its back-to-parent role. `null` falls back to the static
+  // folder icon in the breadcrumb.
+  const projectTag =
+    !isMobile && actionConversation && !isChildSession ? (
+      <HeaderProjectTag conversationId={actionConversation.id} projectName={projectName} />
+    ) : null;
   return (
     <header
       className={cn(
@@ -418,6 +430,7 @@ export function ChatHeader({
           <ConversationBreadcrumb
             conversationTitle={conversationTitle ?? UNTITLED_CONVERSATION_LABEL}
             projectName={projectName}
+            projectTag={projectTag ?? undefined}
             titleLinkTo={titleLinkTo}
             isChildSession={isChildSession}
             boundAgent={boundAgent}

--- a/web/src/shell/ConversationBreadcrumb.tsx
+++ b/web/src/shell/ConversationBreadcrumb.tsx
@@ -24,6 +24,7 @@ import { cn } from "@/lib/utils";
 export function ConversationBreadcrumb({
   conversationTitle,
   projectName,
+  projectTag,
   titleLinkTo,
   isChildSession,
   boundAgent,
@@ -35,6 +36,13 @@ export function ConversationBreadcrumb({
   conversationTitle: string;
   /** Project the conversation is filed under, or `null` when unfiled. */
   projectName: string | null;
+  /**
+   * Leading folder segment. When set (the desktop title shortcut), it replaces
+   * the static folder icon with an interactive "Move to…" trigger and self-gates
+   * its own visibility. When omitted, a static folder renders iff `projectName`
+   * is set — the fallback for surfaces without the shortcut (e.g. sub-agents).
+   */
+  projectTag?: ReactNode;
   /** Parent-session route the title links to, or `undefined` for plain text. */
   titleLinkTo?: string;
   /** Whether the active session is a sub-agent (appends its identity). */
@@ -65,32 +73,33 @@ export function ConversationBreadcrumb({
       aria-label="Conversation"
       className={cn("conversation-breadcrumb flex min-w-0 items-center gap-1.5 text-ui", className)}
     >
-      {projectName && (
-        <div className="hidden md:flex min-w-0 items-center gap-1.5 text-ui shrink-0">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span
-                className="breadcrumb-folder flex shrink-0 items-center text-muted-foreground opacity-40 hover:opacity-100"
-                aria-label={`Project: ${projectName}`}
-              >
-                <FolderIcon className="size-4" />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" align="start">
-              <div>
-                <span className="font-semibold text-ui">{conversationTitle}</span>
-                <div className="flex gap-1 text-muted-foreground">
+      {projectTag ??
+        (projectName && (
+          <div className="hidden md:flex min-w-0 items-center gap-1.5 text-ui shrink-0">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="breadcrumb-folder flex shrink-0 items-center text-muted-foreground opacity-40 hover:opacity-100"
+                  aria-label={`Project: ${projectName}`}
+                >
                   <FolderIcon className="size-4" />
-                  {projectName}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" align="start">
+                <div>
+                  <span className="font-semibold text-ui">{conversationTitle}</span>
+                  <div className="flex gap-1 text-muted-foreground">
+                    <FolderIcon className="size-4" />
+                    {projectName}
+                  </div>
                 </div>
-              </div>
-            </TooltipContent>
-          </Tooltip>
-          <span aria-hidden className="shrink-0 text-muted-foreground opacity-40">
-            /
-          </span>
-        </div>
-      )}
+              </TooltipContent>
+            </Tooltip>
+            <span aria-hidden className="shrink-0 text-muted-foreground opacity-40">
+              /
+            </span>
+          </div>
+        ))}
       {titleLinkTo ? (
         <Link
           to={titleLinkTo}

--- a/web/src/shell/HeaderConversationMenu.test.tsx
+++ b/web/src/shell/HeaderConversationMenu.test.tsx
@@ -108,15 +108,17 @@ describe("HeaderConversationMenu", () => {
     expect(trigger.querySelector("svg")).toHaveClass("lucide-ellipsis");
 
     openMenu();
+    // Desktop drops "Move to project" from the kebab — the breadcrumb folder
+    // tag owns that shortcut (see ChatHeader / HeaderProjectTag).
     expect(screen.getAllByRole("menuitem").map((item) => item.textContent?.trim())).toEqual([
       "Pin",
       "Share",
       "Rename",
       "Mark as unread",
-      "Add to project",
       "Archive",
       "Delete",
     ]);
+    expect(screen.queryByTestId("header-move-to-project")).toBeNull();
   });
 
   it("opens from the keyboard and focuses the first action", () => {
@@ -170,6 +172,9 @@ describe("HeaderConversationMenu", () => {
   });
 
   it("labels project actions for filed and unfiled sessions", () => {
+    // Move to project is mobile-only in this menu now (desktop moved it to the
+    // breadcrumb folder tag).
+    mocks.isMobile = true;
     const view = renderMenu();
     openMenu();
     expect(screen.getByTestId("header-move-to-project")).toHaveTextContent("Add to project");
@@ -191,7 +196,7 @@ describe("HeaderConversationMenu", () => {
 
     expect(screen.getByTestId("header-project-picker-back")).toBeInTheDocument();
     expect(screen.queryByTestId("header-rename-conversation")).toBeNull();
-    expect(screen.getByRole("textbox", { name: "Search projects" })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Search or create project" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("menuitem", { name: "Sprint 42" }));
     expect(mocks.moveToProject).toHaveBeenCalledWith({ id: "conv-1", project: "Sprint 42" });
   });

--- a/web/src/shell/HeaderConversationMenu.tsx
+++ b/web/src/shell/HeaderConversationMenu.tsx
@@ -8,7 +8,6 @@ import {
 } from "react";
 import {
   ArchiveIcon,
-  CheckIcon,
   ChevronLeftIcon,
   EllipsisIcon,
   FolderInputIcon,
@@ -18,7 +17,6 @@ import {
   PencilIcon,
   PinIcon,
   PinOffIcon,
-  SearchIcon,
   ShareIcon,
   Trash2Icon,
 } from "lucide-react";
@@ -37,9 +35,6 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -47,11 +42,11 @@ import {
   type Conversation,
   useArchiveConversation,
   useMoveToProject,
-  useProjects,
   useRenameConversation,
   useStopAndDeleteConversation,
   useTogglePinnedConversation,
 } from "@/hooks/useConversations";
+import { ProjectPicker } from "./ProjectPicker";
 import { markConversationUnread } from "@/hooks/useUnseenConversations";
 import { useOmnigentAnalytics } from "@/lib/analytics";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
@@ -87,63 +82,6 @@ function ArchivedToast() {
 
 function showArchivedToast() {
   showToast(<ArchivedToast />);
-}
-
-function ProjectPicker({
-  currentProject,
-  onSelect,
-}: {
-  currentProject: string | null;
-  onSelect: (project: string) => void;
-}) {
-  const { data: projects = [] } = useProjects();
-  const [search, setSearch] = useState("");
-  const filtered = search
-    ? projects.filter((project) => project.name.toLowerCase().includes(search.toLowerCase()))
-    : projects;
-
-  return (
-    <>
-      <div className="flex items-center gap-2 border-b px-2 py-1.5">
-        <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
-        <input
-          aria-label="Search projects"
-          className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-          placeholder="Search projects"
-          value={search}
-          onChange={(event) => setSearch(event.target.value)}
-          onKeyDown={(event) => event.stopPropagation()}
-        />
-      </div>
-      <div className="max-h-48 overflow-y-auto">
-        {filtered.map((project) => (
-          <DropdownMenuItem
-            key={project.name}
-            className="px-2 py-1"
-            onSelect={() => onSelect(project.name)}
-          >
-            <span className="flex-1 truncate text-left">{project.name}</span>
-            {currentProject === project.name && (
-              <CheckIcon className="size-3.5 shrink-0 text-primary" />
-            )}
-          </DropdownMenuItem>
-        ))}
-        {filtered.length === 0 && (
-          <p className="px-2 py-1.5 text-sm text-muted-foreground">No projects yet.</p>
-        )}
-      </div>
-      {currentProject && (
-        <div className="border-t pt-1">
-          <DropdownMenuItem className="px-2 py-1" onSelect={() => onSelect("")}>
-            Remove from{" "}
-            <span className="rounded bg-muted px-1 py-0.5 font-mono text-[0.95em]">
-              {currentProject}
-            </span>
-          </DropdownMenuItem>
-        </div>
-      )}
-    </>
-  );
 }
 
 export function HeaderConversationMenu({
@@ -300,7 +238,10 @@ export function HeaderConversationMenu({
         <MailIcon className="size-3.5" />
         Mark as unread
       </DropdownMenuItem>
-      {isMobile ? (
+      {/* Move to project lives here only on mobile — the native mobile shells
+          hide the breadcrumb, so this menu is the sole entry point. On desktop
+          the shortcut is the breadcrumb's folder tag (HeaderProjectTag). */}
+      {isMobile && (
         <DropdownMenuItem
           data-testid="header-move-to-project"
           className={cn("whitespace-nowrap", itemClass)}
@@ -312,19 +253,6 @@ export function HeaderConversationMenu({
           <FolderInputIcon className="size-3.5" />
           {currentProject ? "Move session" : "Add to project"}
         </DropdownMenuItem>
-      ) : (
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger
-            data-testid="header-move-to-project"
-            className="whitespace-nowrap"
-          >
-            <FolderInputIcon className="size-3.5" />
-            {currentProject ? "Move session" : "Add to project"}
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent className="min-w-56">
-            <ProjectPicker currentProject={currentProject} onSelect={handleProjectSelect} />
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
       )}
       {workspaceItems && (
         <>

--- a/web/src/shell/HeaderProjectTag.test.tsx
+++ b/web/src/shell/HeaderProjectTag.test.tsx
@@ -1,0 +1,105 @@
+import type { ReactElement } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as ConversationsModule from "@/hooks/useConversations";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { HeaderProjectTag } from "./HeaderProjectTag";
+
+const mocks = vi.hoisted(() => ({
+  projects: [{ id: "project-1", name: "Sprint 42" }],
+  moveToProject: vi.fn(),
+}));
+
+vi.mock("@/hooks/useConversations", async (importOriginal) => {
+  const actual = await importOriginal<typeof ConversationsModule>();
+  return {
+    ...actual,
+    useProjects: () => ({ data: mocks.projects }),
+    useMoveToProject: () => ({ mutate: mocks.moveToProject }),
+  };
+});
+
+function renderTag(ui: ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+function openTag() {
+  fireEvent.pointerDown(screen.getByTestId("header-project-tag"), { button: 0 });
+}
+
+beforeEach(() => {
+  mocks.projects = [{ id: "project-1", name: "Sprint 42" }];
+  vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe("HeaderProjectTag", () => {
+  it("labels the trigger by project when filed and by intent when unfiled", () => {
+    const { rerender } = renderTag(
+      <HeaderProjectTag
+        conversationId="conv-1"
+
+        projectName="Payments"
+      />,
+    );
+    expect(screen.getByTestId("header-project-tag")).toHaveAttribute(
+      "aria-label",
+      "Project: Payments",
+    );
+
+    rerender(
+      <TooltipProvider>
+        <HeaderProjectTag conversationId="conv-1" projectName={null} />
+      </TooltipProvider>,
+    );
+    expect(screen.getByTestId("header-project-tag")).toHaveAttribute(
+      "aria-label",
+      "Add to project",
+    );
+  });
+
+  it("opens the picker and moves the session to the chosen project", () => {
+    renderTag(<HeaderProjectTag conversationId="conv-1" projectName={null} />);
+    openTag();
+
+    expect(screen.getByRole("textbox", { name: "Search or create project" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Sprint 42" }));
+    expect(mocks.moveToProject).toHaveBeenCalledWith({ id: "conv-1", project: "Sprint 42" });
+  });
+
+  it("creates and files into a new project from the typed name", () => {
+    renderTag(<HeaderProjectTag conversationId="conv-1" projectName={null} />);
+    openTag();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Search or create project" }), {
+      target: { value: "Roadmap" },
+    });
+    fireEvent.click(screen.getByRole("menuitem", { name: /Create Roadmap/ }));
+    expect(mocks.moveToProject).toHaveBeenCalledWith({ id: "conv-1", project: "Roadmap" });
+  });
+
+  it("offers no create row when the typed name already exists", () => {
+    renderTag(<HeaderProjectTag conversationId="conv-1" projectName={null} />);
+    openTag();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Search or create project" }), {
+      target: { value: "sprint 42" },
+    });
+    expect(screen.queryByRole("menuitem", { name: /Create/ })).toBeNull();
+  });
+
+  it("offers a remove option that unfiles the session", () => {
+    renderTag(
+      <HeaderProjectTag
+        conversationId="conv-1"
+
+        projectName="Sprint 42"
+      />,
+    );
+    openTag();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: /Remove from/ }));
+    expect(mocks.moveToProject).toHaveBeenCalledWith({ id: "conv-1", project: "" });
+  });
+});

--- a/web/src/shell/HeaderProjectTag.test.tsx
+++ b/web/src/shell/HeaderProjectTag.test.tsx
@@ -37,11 +37,7 @@ afterEach(cleanup);
 describe("HeaderProjectTag", () => {
   it("labels the trigger by project when filed and by intent when unfiled", () => {
     const { rerender } = renderTag(
-      <HeaderProjectTag
-        conversationId="conv-1"
-
-        projectName="Payments"
-      />,
+      <HeaderProjectTag conversationId="conv-1" projectName="Payments" />,
     );
     expect(screen.getByTestId("header-project-tag")).toHaveAttribute(
       "aria-label",
@@ -57,6 +53,25 @@ describe("HeaderProjectTag", () => {
       "aria-label",
       "Add to project",
     );
+  });
+
+  it("shows the current project in the tooltip when filed, else invites the move", () => {
+    const { rerender } = renderTag(
+      <HeaderProjectTag conversationId="conv-1" projectName="Payments" />,
+    );
+    // Radix opens the tooltip immediately on focus (no hover delay) and renders
+    // the content into a portal; getAllByText covers the visually-hidden a11y
+    // copy Radix mirrors alongside the visible one.
+    fireEvent.focus(screen.getByTestId("header-project-tag"));
+    expect(screen.getAllByText("Currently in: Payments").length).toBeGreaterThan(0);
+
+    rerender(
+      <TooltipProvider>
+        <HeaderProjectTag conversationId="conv-1" projectName={null} />
+      </TooltipProvider>,
+    );
+    fireEvent.focus(screen.getByTestId("header-project-tag"));
+    expect(screen.getAllByText("Move session").length).toBeGreaterThan(0);
   });
 
   it("opens the picker and moves the session to the chosen project", () => {

--- a/web/src/shell/HeaderProjectTag.tsx
+++ b/web/src/shell/HeaderProjectTag.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { FolderIcon, FolderPlusIcon } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useMoveToProject } from "@/hooks/useConversations";
+import { cn } from "@/lib/utils";
+import { ProjectPicker } from "./ProjectPicker";
+
+/**
+ * The breadcrumb's leading folder segment, as a Slack-style "Move
+ * conversation" shortcut. Clicking the folder icon opens a searchable project
+ * picker so the session can be filed, moved, or unfiled straight from the title
+ * — no trip to the kebab menu. Desktop only (the tag is `hidden md:flex`);
+ * mobile keeps the equivalent item in the header session menu, since the native
+ * mobile shells hide the breadcrumb.
+ *
+ * Filed sessions show `[folder] /`; unfiled ones show a faint add-to-project
+ * folder that only fully reveals on hover, so an empty state still has an entry
+ * point without cluttering the title.
+ */
+export function HeaderProjectTag({
+  conversationId,
+  projectName,
+}: {
+  conversationId: string;
+  projectName: string | null;
+}) {
+  const moveToProject = useMoveToProject();
+  const [open, setOpen] = useState(false);
+
+  const handleSelect = (project: string) => {
+    setOpen(false);
+    moveToProject.mutate({ id: conversationId, project });
+  };
+
+  return (
+    <div className="hidden md:flex min-w-0 items-center gap-1.5 text-ui shrink-0">
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <Tooltip>
+          {/* Wrap the dropdown trigger in a real span for the tooltip: two
+              `asChild` triggers merged onto the same button drop the tooltip's
+              hover handlers (the pattern ViewModeToggle uses). */}
+          <TooltipTrigger asChild>
+            <span className="inline-flex">
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  data-testid="header-project-tag"
+                  aria-label={projectName ? `Project: ${projectName}` : "Add to project"}
+                  className={cn(
+                    "breadcrumb-folder flex shrink-0 cursor-pointer items-center rounded text-muted-foreground transition-opacity hover:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100 focus-visible:outline-none",
+                    projectName ? "opacity-40" : "opacity-30",
+                  )}
+                >
+                  {projectName ? (
+                    <FolderIcon className="size-4" />
+                  ) : (
+                    <FolderPlusIcon className="size-4" />
+                  )}
+                </button>
+              </DropdownMenuTrigger>
+            </span>
+          </TooltipTrigger>
+          {/* Bottom placement: the header sits at top-0, so a top-side tooltip
+              would clip above the viewport edge. */}
+          <TooltipContent side="bottom">Move session</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="start" className="min-w-56">
+          <ProjectPicker currentProject={projectName} onSelect={handleSelect} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <span aria-hidden className="shrink-0 text-muted-foreground opacity-40">
+        /
+      </span>
+    </div>
+  );
+}

--- a/web/src/shell/HeaderProjectTag.tsx
+++ b/web/src/shell/HeaderProjectTag.tsx
@@ -18,9 +18,10 @@ import { ProjectPicker } from "./ProjectPicker";
  * mobile keeps the equivalent item in the header session menu, since the native
  * mobile shells hide the breadcrumb.
  *
- * Filed sessions show `[folder] /`; unfiled ones show a faint add-to-project
- * folder that only fully reveals on hover, so an empty state still has an entry
- * point without cluttering the title.
+ * Filed sessions show `[folder] /` with a "Currently in: ‹project›" tooltip;
+ * unfiled ones show a faint add-to-project folder that only fully reveals on
+ * hover, with a "Move session" tooltip — an entry point for an empty state
+ * without cluttering the title.
  */
 export function HeaderProjectTag({
   conversationId,
@@ -66,10 +67,21 @@ export function HeaderProjectTag({
             </span>
           </TooltipTrigger>
           {/* Bottom placement: the header sits at top-0, so a top-side tooltip
-              would clip above the viewport edge. */}
-          <TooltipContent side="bottom">Move session</TooltipContent>
+              would clip above the viewport edge. A filed session names its
+              folder ("Currently in: …"); an unfiled one invites the move. */}
+          <TooltipContent side="bottom">
+            {projectName ? `Currently in: ${projectName}` : "Move session"}
+          </TooltipContent>
         </Tooltip>
-        <DropdownMenuContent align="start" className="min-w-56">
+        <DropdownMenuContent
+          align="start"
+          className="min-w-56"
+          // Don't return focus to the folder button on close: Radix opens the
+          // tooltip on focus, so refocusing the trigger makes "Move session"
+          // pop up every time the dropdown is dismissed (even by an outside
+          // click, with the pointer nowhere near the tag).
+          onCloseAutoFocus={(event) => event.preventDefault()}
+        >
           <ProjectPicker currentProject={projectName} onSelect={handleSelect} />
         </DropdownMenuContent>
       </DropdownMenu>

--- a/web/src/shell/ProjectPicker.tsx
+++ b/web/src/shell/ProjectPicker.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { CheckIcon, PlusIcon, SearchIcon } from "lucide-react";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { useProjects } from "@/hooks/useConversations";
+
+/**
+ * Searchable list of projects to file a session into, rendered inside a
+ * dropdown/submenu. Selecting a project calls `onSelect(name)`; the "Remove
+ * from …" row (shown only when already filed) calls `onSelect("")` to unfile.
+ * A typed name with no exact match offers a "+ Create <name>" row — the move
+ * itself creates the project on demand (see `moveConversationToProject`).
+ *
+ * Shared by the desktop title folder-tag shortcut (HeaderProjectTag) and the
+ * mobile session menu's in-place project view (HeaderConversationMenu).
+ */
+export function ProjectPicker({
+  currentProject,
+  onSelect,
+}: {
+  currentProject: string | null;
+  onSelect: (project: string) => void;
+}) {
+  const { data: projects = [] } = useProjects();
+  const [search, setSearch] = useState("");
+  const trimmed = search.trim();
+  const filtered = trimmed
+    ? projects.filter((project) => project.name.toLowerCase().includes(trimmed.toLowerCase()))
+    : projects;
+  // Offer create only when the typed name isn't already an exact project.
+  const canCreate =
+    trimmed.length > 0 &&
+    !projects.some((project) => project.name.toLowerCase() === trimmed.toLowerCase());
+
+  return (
+    <>
+      <div className="flex items-center gap-2 border-b px-2 py-1.5">
+        <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
+        <input
+          aria-label="Search or create project"
+          className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          placeholder="Search or create project"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          onKeyDown={(event) => event.stopPropagation()}
+        />
+      </div>
+      <div className="max-h-48 overflow-y-auto">
+        {filtered.map((project) => (
+          <DropdownMenuItem
+            key={project.name}
+            className="px-2 py-1"
+            onSelect={() => onSelect(project.name)}
+          >
+            <span className="flex-1 truncate text-left">{project.name}</span>
+            {currentProject === project.name && (
+              <CheckIcon className="size-3.5 shrink-0 text-primary" />
+            )}
+          </DropdownMenuItem>
+        ))}
+        {filtered.length === 0 && !canCreate && (
+          <p className="px-2 py-1.5 text-sm text-muted-foreground">No projects yet.</p>
+        )}
+      </div>
+      {canCreate && (
+        <div className="border-t pt-1">
+          <DropdownMenuItem className="px-2 py-1" onSelect={() => onSelect(trimmed)}>
+            <PlusIcon className="size-3.5 shrink-0 text-muted-foreground" />
+            Create{" "}
+            <span className="truncate rounded bg-muted px-1 py-0.5 font-mono text-[0.95em]">
+              {trimmed}
+            </span>
+          </DropdownMenuItem>
+        </div>
+      )}
+      {currentProject && (
+        <div className="border-t pt-1">
+          <DropdownMenuItem className="px-2 py-1" onSelect={() => onSelect("")}>
+            Remove from{" "}
+            <span className="rounded bg-muted px-1 py-0.5 font-mono text-[0.95em]">
+              {currentProject}
+            </span>
+          </DropdownMenuItem>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -844,7 +844,7 @@ describe("mobile in-place project picker", () => {
     // actions are gone, and the picker (search + project list) plus a Back
     // control are shown.
     fireEvent.click(moveItem);
-    expect(screen.getByPlaceholderText("Search projects")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Search or create project")).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /Sprint 42/ })).toBeInTheDocument();
     expect(screen.getByTestId("project-picker-back")).toBeInTheDocument();
     // The main actions are no longer rendered — the body was replaced, not
@@ -857,7 +857,7 @@ describe("mobile in-place project picker", () => {
     fireEvent.click(screen.getByTestId("project-picker-back"));
     expect(screen.getByTestId("rename-conversation")).toBeInTheDocument();
     expect(screen.getByTestId("delete-conversation")).toBeInTheDocument();
-    expect(screen.queryByPlaceholderText("Search projects")).toBeNull();
+    expect(screen.queryByPlaceholderText("Search or create project")).toBeNull();
   });
 
   it("moves the session into a picked project just like desktop", () => {
@@ -874,6 +874,41 @@ describe("mobile in-place project picker", () => {
       id: "conv_1",
       project: "Sprint 42",
     });
+  });
+
+  it("creates a project from a typed name that matches nothing", () => {
+    mocks.isMobile = true;
+    mocks.projects = ["Sprint 42"];
+    renderSidebar();
+
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+    fireEvent.click(screen.getByTestId("move-to-project"));
+
+    fireEvent.change(screen.getByPlaceholderText("Search or create project"), {
+      target: { value: "Roadmap" },
+    });
+    fireEvent.click(screen.getByRole("menuitem", { name: /Create Roadmap/ }));
+
+    // The move resolves-or-creates the project id server-side, so filing into a
+    // brand-new name uses the same mutation contract as picking an existing one.
+    expect(mocks.moveToProject.mutate).toHaveBeenCalledWith({
+      id: "conv_1",
+      project: "Roadmap",
+    });
+  });
+
+  it("offers no create row when the typed name already exists", () => {
+    mocks.isMobile = true;
+    mocks.projects = ["Sprint 42"];
+    renderSidebar();
+
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+    fireEvent.click(screen.getByTestId("move-to-project"));
+
+    fireEvent.change(screen.getByPlaceholderText("Search or create project"), {
+      target: { value: "sprint 42" },
+    });
+    expect(screen.queryByRole("menuitem", { name: /Create/ })).toBeNull();
   });
 
   it("keeps the desktop side-flyout submenu (no in-place swap)", () => {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -41,6 +41,7 @@ import {
   PencilIcon,
   PinIcon,
   PinOffIcon,
+  PlusIcon,
   SearchIcon,
   Settings2Icon,
   ShareIcon,
@@ -4462,9 +4463,13 @@ function ProjectPickerMenu({
   const { data: projects = [] } = useProjects();
   const [search, setSearch] = useState("");
 
-  const filtered = search
-    ? projects.filter((p) => p.name.toLowerCase().includes(search.toLowerCase()))
+  const trimmed = search.trim();
+  const filtered = trimmed
+    ? projects.filter((p) => p.name.toLowerCase().includes(trimmed.toLowerCase()))
     : projects;
+  // Offer create only when the typed name isn't already an exact project.
+  const canCreate =
+    trimmed.length > 0 && !projects.some((p) => p.name.toLowerCase() === trimmed.toLowerCase());
 
   // Keep keystrokes inside the inputs from reaching the menu's typeahead /
   // navigation handlers (which would otherwise steal letters and arrows).
@@ -4478,7 +4483,7 @@ function ProjectPickerMenu({
         <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
         <input
           className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-          placeholder="Search projects"
+          placeholder="Search or create project"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           onKeyDown={swallowKeys}
@@ -4493,10 +4498,21 @@ function ProjectPickerMenu({
             )}
           </C.Item>
         ))}
-        {filtered.length === 0 && (
+        {filtered.length === 0 && !canCreate && (
           <p className="px-2 py-1.5 text-sm text-muted-foreground">No projects yet.</p>
         )}
       </div>
+      {canCreate && (
+        <div className="border-t pt-1">
+          <C.Item className="px-2 py-1" onSelect={() => onSelect(trimmed)}>
+            <PlusIcon className="size-3.5 shrink-0 text-muted-foreground" />
+            Create{" "}
+            <span className="truncate rounded bg-muted px-1 py-0.5 font-mono text-[0.95em]">
+              {trimmed}
+            </span>
+          </C.Item>
+        </div>
+      )}
       {currentProject && (
         <div className="border-t pt-1">
           <C.Item className="px-2 py-1" onSelect={() => onSelect("")}>


### PR DESCRIPTION
## Related issue

<!-- UI/UX change; no issue required per template. -->

## Summary

- Adds a Slack-style **"Move session"** shortcut on the session title's leading folder icon (`HeaderProjectTag`): click it to file, move, or unfile the session into a project without opening the kebab menu. Hover shows a "Move session" tooltip and a pointer cursor.
- The picker's search box doubles as a **create** field — typing a name with no exact match surfaces a **"+ Create ‹name›"** row, and the move creates the project on demand. Placeholder reads "Search or create project".
- Removes the now-redundant **"Move session / Add to project"** item from the *desktop* kebab. It stays on *mobile*, where the native shells hide the breadcrumb and the menu is the only entry point.
- Extracts the header/mobile picker into a shared `ProjectPicker` (used by `HeaderProjectTag` and the mobile `HeaderConversationMenu`). The sidebar row's `ProjectPickerMenu` is a **separate** component — it renders through a polymorphic `MenuComponents` bundle so the same body serves both the DropdownMenu kebab and the right-click ContextMenu — so it gets the same "Search or create" + "+ Create" behaviour applied in parallel rather than by consuming `ProjectPicker`. Sub-agent titles keep their back-to-parent link.

## Test Plan

- `cd web && npm test` (vitest) — touched-file suites green; the only failures are pre-existing in `NewChatDialog.test.tsx` (host picker), confirmed on a clean stash of this branch.
- `cd web && npm run build` — `tsc -b && vite build` clean.
- E2E UI (live server + Chromium), `-o addopts=""`:
  - `tests/e2e_ui/sessions/test_header_move_to_project.py` — 2 passed (move into existing project + create-from-typed-name, asserting committed `project_id`).
  - `tests/e2e_ui/sessions/test_header_session_menu.py` — 2 passed (updated for the 5-item desktop kebab after removing "Add to project").
- Manual: opened a session, clicked the folder tag, picked an existing project and created a new one via the "+ Create" row; verified the sidebar regroups and the tag flips to the filed state.

## Demo

<!-- TODO: drag in a short screen recording of the folder-tag move + create flow. Screenshots in the PR thread show the folder-tag picker, the "+ Create ‹name›" row, and the "Move session" tooltip. -->

UI preview: https://omnigent-ui-preview-pr-5698-3272836215725701.aws.databricksapps.com

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the shared `ProjectPicker` create/search behaviour (via `HeaderProjectTag`) and the sidebar row picker's parallel logic, plus the desktop-kebab removal / mobile retention. E2E covers the header folder-tag move into an existing project and create-from-typed-name, asserting the server-committed `project_id`. Manually verified the move + create flow and the "Move session" tooltip / pointer cursor in the running app.


## Design notes

- **Sub-agent (child) sessions have no desktop move-to-project affordance, by design.** The folder-tag shortcut is gated off child sessions so their title keeps its back-to-parent link, and the desktop kebab move item was removed for everyone. Sub-agents group under their parent session, so filing a child independently isn't a supported action — the move happens on the top-level session. (Mobile still surfaces the kebab move item for top-level sessions; child sessions there likewise omit it.)

## Changelog

Move a session into a project straight from the title's folder icon — with a search box that also creates new projects

This pull request and its description were written by Isaac.

