### PR TITLE
fix(logging): thread session_id through debug logs; dedupe noisy native logs

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -135,6 +135,7 @@ from omnigent.native_terminal import (
 from omnigent.native_terminal import (
     terminal_attach_url as _attach_url,
 )
+from omnigent.process_logging import log_info_once
 from omnigent.terminals.ws_common import (
     WS_CLOSE_TERMINAL_DETACHED,
     WS_CLOSE_TERMINAL_NOT_FOUND,
@@ -2731,7 +2732,8 @@ def _provider_config_for_native_claude(entry: ProviderEntry) -> ClaudeNativeUcod
             entry.name,
         )
         return None
-    _logger.info(
+    log_info_once(
+        _logger,
         "native-claude routing: provider %r (base_url=%s, model=%s)",
         entry.name,
         family.base_url,
@@ -2860,7 +2862,8 @@ def _bedrock_config_for_native_claude(entry: ProviderEntry) -> ClaudeNativeUcode
             "Bedrock account. Set models.default to a Bedrock inference-profile id.",
             entry.name,
         )
-    _logger.info(
+    log_info_once(
+        _logger,
         "native-claude routing: bedrock provider %r (base_url=%s, model=%s)",
         entry.name,
         family.base_url,
@@ -2917,9 +2920,11 @@ def _native_claude_config_from_entry(
     if entry.kind == BEDROCK_KIND:
         return _bedrock_config_for_native_claude(entry)
     if entry.kind == DATABRICKS_KIND:
-        _logger.info("native-claude routing: Databricks ucode profile %r", entry.profile)
+        log_info_once(_logger, "native-claude routing: Databricks ucode profile %r", entry.profile)
         return _ucode_config_for_profile(entry.profile, refresh_models=refresh_models)
-    _logger.info("native-claude routing: Claude CLI login (subscription provider %r)", entry.name)
+    log_info_once(
+        _logger, "native-claude routing: Claude CLI login (subscription provider %r)", entry.name
+    )
     return None
 
 
@@ -2991,10 +2996,11 @@ def resolve_native_claude_config(
     entry = default_provider_for_harness(effective_config_with_detected(explicit), "claude-sdk")
     if entry is not None:
         return _native_claude_config_from_entry(entry, refresh_models=refresh_models)
-    _logger.info(
+    log_info_once(
+        _logger,
         "native-claude routing: Claude CLI login (no provider configured for the Claude "
         "harness, no Databricks profile). Run `omnigent setup --no-internal-beta` to route "
-        "through a provider."
+        "through a provider.",
     )
     return None
 

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -64,6 +64,7 @@ from omnigent.inner.codex_executor import (
     write_codex_hooks_file,
 )
 from omnigent.inner.databricks_executor import _databricks_gateway_host
+from omnigent.process_logging import log_info_once, log_once
 
 _logger = logging.getLogger(__name__)
 
@@ -1031,7 +1032,9 @@ async def codex_launch_catalog(*, codex_path: str | None = None) -> list[_JsonOb
         try:
             return await probe_codex_model_options(codex_path=codex_path)
         except Exception:  # noqa: BLE001 — probe failure means "no catalog", never a crash
-            _logger.warning("codex catalog probe failed", exc_info=True)
+            # Best-effort probe re-run on every catalog fetch; log once so a
+            # persistently failing probe doesn't flood the logs.
+            log_once(_logger, logging.WARNING, "codex catalog probe failed", exc_info=True)
             return None
 
     return await model_catalog_store.ensure_catalog("codex-native", fingerprint, _probe)
@@ -2620,7 +2623,8 @@ def _resolve_subscription_launch(
     # the exact auth.json the launched Codex process will use.
     real_codex_home = _codex_home_config_source_from_env()
     if codex_auth_has_credential(real_codex_home / "auth.json"):
-        _logger.info(
+        log_info_once(
+            _logger,
             "native-codex routing: Codex CLI login (subscription provider %r; Codex is logged in)",
             entry.name,
         )
@@ -2633,7 +2637,8 @@ def _resolve_subscription_launch(
     fallback = _first_routable_codex_provider(explicit, exclude=entry.name, model=model)
     if fallback is not None:
         return fallback
-    _logger.info(
+    log_info_once(
+        _logger,
         "native-codex routing: Codex CLI login (subscription provider %r has no usable "
         "Codex login and no alternative provider is configured)",
         entry.name,
@@ -2764,12 +2769,14 @@ def resolve_native_codex_launch(
             launch = _codex_provider_launch(spec_entry, model)
             if launch is not None:
                 if launch.profile is not None:
-                    _logger.info(
+                    log_info_once(
+                        _logger,
                         "native-codex routing: Databricks ucode profile %r (spec auth)",
                         launch.profile,
                     )
                 else:
-                    _logger.info(
+                    log_info_once(
+                        _logger,
                         "native-codex routing: provider %r (spec auth, model=%s)",
                         spec_entry.name,
                         launch.model,
@@ -2814,7 +2821,8 @@ def resolve_native_codex_launch(
         # This keeps rollout metadata, app-server, and remote TUI routing on
         # one immutable provider selection during cold resume.
         provider_id = config_detection.model_provider
-        _logger.info(
+        log_info_once(
+            _logger,
             "native-codex routing: config.toml provider %r (ambient fallback, model=%s)",
             provider_id,
             model,
@@ -2827,10 +2835,11 @@ def resolve_native_codex_launch(
         )
 
     if entry is None:
-        _logger.info(
+        log_info_once(
+            _logger,
             "native-codex routing: Codex CLI login (no provider configured for the Codex "
             "harness, no Databricks profile). Run `omnigent setup --no-internal-beta` to route "
-            "through a provider."
+            "through a provider.",
         )
         return NativeCodexLaunch(
             config_overrides=no_provider_overrides,
@@ -2849,9 +2858,13 @@ def resolve_native_codex_launch(
     launch = _codex_provider_launch(entry, model)
     if launch is not None:
         if launch.profile is not None:
-            _logger.info("native-codex routing: Databricks ucode profile %r", launch.profile)
+            log_info_once(
+                _logger, "native-codex routing: Databricks ucode profile %r", launch.profile
+            )
         else:
-            _logger.info("native-codex routing: provider %r (model=%s)", entry.name, launch.model)
+            log_info_once(
+                _logger, "native-codex routing: provider %r (model=%s)", entry.name, launch.model
+            )
         return launch
     # Default provider can't route on its own (no openai surface / no usable
     # credential / unresolvable secret) → Codex's own login.

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -301,12 +301,15 @@ def debug_event(
             "tool_call_dispatched", session_id=session_id,
             tool_call_id=tc.id, model=model))
 
-    ``session_id``/``turn_id`` are populated only from what the callsite passes;
-    ``user_id`` additionally has an ambient fallback the sink applies when the
-    record carries none (a request-scoped ContextVar on the server, the
-    ``OMNIGENT_USER_ID`` env on the runner/host). Freeform ``_logger.debug("…")``
-    calls need no ``extra``; they ship with null correlation columns and an empty
-    attributes map.
+    ``turn_id`` is populated only from what the callsite passes. ``session_id``
+    is likewise callsite-driven, but the sink additionally falls back to the
+    runner's primary (parent) conversation id when a record carries none (see
+    :func:`record_to_row`); that fallback is runner-only, so on the server an
+    unthreaded ``session_id`` stays null. ``user_id`` has its own ambient
+    fallback (a request-scoped ContextVar on the server, the ``OMNIGENT_USER_ID``
+    env on the runner/host). Freeform ``_logger.debug("…")`` calls need no
+    ``extra``; they ship with null correlation columns and an empty attributes
+    map.
     """
     extra: dict[str, object] = {"event_name": event_name, "attributes": dict(attributes)}
     if session_id is not None:
@@ -339,6 +342,15 @@ def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
     the two shapes the ZeroBus JSON path requires for the ``TIMESTAMP`` and
     ``MAP<STRING,STRING>`` columns respectively.
 
+    ``session_id`` is taken from what the callsite threaded via ``extra`` and,
+    failing that, falls back to the runner's primary (parent) conversation id
+    (:func:`runner_primary_session_id`). That fallback reads a runner-only env
+    that is absent on the multi-tenant server, so a server record with no
+    explicit id stays null rather than risk cross-request mis-attribution --
+    this is deliberate; do NOT add an ambient request-scoped fallback here. On a
+    runner, a co-located subagent turn whose log is not threaded can be
+    attributed to the parent conversation, an accepted trade-off.
+
     ``workspace_id``/``app_name`` describe the record's origin deployment: the
     managed service stamps ``record.workspace_id`` per request (so it wins),
     while single-tenant deployments fall back to the process-constant
@@ -347,7 +359,7 @@ def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
     """
     workspace_id, app_name = _process_identity()
     return {
-        "session_id": getattr(record, "session_id", None),
+        "session_id": getattr(record, "session_id", None) or runner_primary_session_id(),
         "turn_id": getattr(record, "turn_id", None),
         "source": source,
         "event_name": getattr(record, "event_name", None),

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -7,6 +7,7 @@ import contextlib
 import logging
 import os
 import sys
+import threading
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -27,6 +28,49 @@ class ChildLoggingPopenKwargs(TypedDict, total=False):
     """Keyword arguments forwarded to :class:`subprocess.Popen`."""
 
     pass_fds: tuple[int, ...]
+
+
+_log_once_seen: set[str] = set()
+_log_once_lock = threading.Lock()
+
+
+def _mark_once(formatted: str) -> bool:
+    """Return ``True`` the first time *formatted* is seen this process, then remember it."""
+    with _log_once_lock:
+        if formatted in _log_once_seen:
+            return False
+        _log_once_seen.add(formatted)
+        return True
+
+
+def log_once(
+    logger: logging.Logger,
+    level: int,
+    msg: str,
+    *args: object,
+    exc_info: bool = False,
+) -> None:
+    """Log *msg* at *level* the first time this exact line is seen in the process.
+
+    For near-static diagnostics a hot path recomputes and would otherwise re-log
+    on every call -- a harness routing decision resolved on every turn, or a
+    best-effort probe that fails identically on every catalog fetch. The
+    formatted message is the dedup key, so a *changed* line logs again while
+    identical repeats are dropped. Per-process and thread-safe (these callers run
+    under ``asyncio.to_thread``). ``stacklevel=2`` attributes the record to the
+    caller (correct ``func_name`` in the debug-logs table); ``exc_info`` is
+    forwarded so the first occurrence of a failure keeps its traceback.
+    """
+    formatted = msg % args if args else msg
+    if _mark_once(formatted):
+        logger.log(level, formatted, exc_info=exc_info, stacklevel=2)
+
+
+def log_info_once(logger: logging.Logger, msg: str, *args: object) -> None:
+    """INFO convenience wrapper around :func:`log_once`; see it for semantics."""
+    formatted = msg % args if args else msg
+    if _mark_once(formatted):
+        logger.info(formatted, stacklevel=2)
 
 
 class _ProcessLogStreamHandler(logging.StreamHandler[TextIO]):

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -210,6 +210,21 @@ _DEBBY_AGENT_NAME = "debby"
 _POLLY_AGENT_NAME = "polly"
 _UNMATCHED_ROUTE_TEMPLATE = "<unmatched>"
 _SESSION_PATH_RE = re.compile(r"/v1/sessions/([^/]+)")
+
+
+def _session_id_from_request(request: Request) -> str | None:
+    """Best-effort session id parsed from a ``/v1/sessions/<id>/…`` request path.
+
+    Threaded into exception-handler logs (``extra={"session_id": …}``) so a 500
+    on a session route carries its conversation id in the debug-logs table. Read
+    from the request explicitly per-invocation — no ambient/request-scoped
+    session ContextVar exists on the server, deliberately, to avoid
+    cross-request mis-attribution.
+    """
+    match = _SESSION_PATH_RE.search(request.url.path)
+    return match.group(1) if match else None
+
+
 # polly's and debby's multi-file bundles are packaged under
 # omnigent.resources.examples (see pyproject package-data), so they resolve
 # in both a repo checkout and an installed wheel. The presence check in each
@@ -1561,15 +1576,24 @@ def create_app(
         """
         Convert application errors to structured JSON responses.
 
-        :param request: The incoming request (unused — FastAPI signature requirement).
+        :param request: The incoming request; its path supplies the session id
+            threaded into the error log.
         :param exc: The application error.
         :returns: A JSON response with the error code and message.
         """
         if exc.http_status >= 500:
-            _logger.error("Internal error: %s", exc.message, exc_info=exc)
+            _logger.error(
+                "Internal error: %s",
+                exc.message,
+                exc_info=exc,
+                extra={"session_id": _session_id_from_request(request)},
+            )
         elif exc.http_status == 400 and request.url.path.endswith("/policies/evaluate"):
             _logger.warning(
-                "Policy evaluate rejected 400 on %s: %s", request.url.path, exc.message
+                "Policy evaluate rejected 400 on %s: %s",
+                request.url.path,
+                exc.message,
+                extra={"session_id": _session_id_from_request(request)},
             )
         return JSONResponse(
             status_code=exc.http_status,
@@ -1578,7 +1602,7 @@ def create_app(
 
     @app.exception_handler(StatementError)
     async def _handle_statement_error(
-        request: Request,  # noqa: ARG001 — FastAPI exception-handler signature requires (request, exc); we only use exc
+        request: Request,
         exc: StatementError,
     ) -> JSONResponse:
         """
@@ -1591,7 +1615,8 @@ def create_app(
         not-found instead of an internal error. Any other statement error (real
         DB failure) falls through to the standard 500 shape.
 
-        :param request: The incoming request (unused — FastAPI signature requirement).
+        :param request: The incoming request; its path supplies the session id
+            threaded into the error log.
         :param exc: The SQLAlchemy statement error.
         :returns: 404 for a malformed id, otherwise a 500 JSON response.
         """
@@ -1604,7 +1629,12 @@ def create_app(
                 status_code=404,
                 content={"error": {"code": ErrorCode.NOT_FOUND, "message": "Not found."}},
             )
-        _logger.error("Database error: %s", exc, exc_info=exc)
+        _logger.error(
+            "Database error: %s",
+            exc,
+            exc_info=exc,
+            extra={"session_id": _session_id_from_request(request)},
+        )
         return JSONResponse(
             status_code=500,
             content={
@@ -1617,7 +1647,7 @@ def create_app(
 
     @app.exception_handler(Exception)
     async def _handle_unhandled_exception(
-        request: Request,  # noqa: ARG001 — FastAPI exception-handler signature requires (request, exc); we only use exc
+        request: Request,
         exc: Exception,
     ) -> JSONResponse:
         """
@@ -1625,11 +1655,17 @@ def create_app(
         OperationalError). Returns the standard JSON error schema
         so clients always get a consistent response format.
 
-        :param request: The incoming request (unused — FastAPI signature requirement).
+        :param request: The incoming request; its path supplies the session id
+            threaded into the error log.
         :param exc: The unhandled exception.
         :returns: A 500 JSON response with ``internal_error`` code.
         """
-        _logger.error("Unhandled exception: %s", exc, exc_info=exc)
+        _logger.error(
+            "Unhandled exception: %s",
+            exc,
+            exc_info=exc,
+            extra={"session_id": _session_id_from_request(request)},
+        )
         return JSONResponse(
             status_code=500,
             content={

--- a/omnigent/server/background_session_titles.py
+++ b/omnigent/server/background_session_titles.py
@@ -225,6 +225,7 @@ class BackgroundSessionTitleCoordinator:
                         "reason=seed_unavailable elapsed_ms=%.1f",
                         request.session_id,
                         (time.perf_counter() - started) * 1000,
+                        extra={"session_id": request.session_id},
                     )
                     return
                 generated = await asyncio.wait_for(
@@ -238,6 +239,7 @@ class BackgroundSessionTitleCoordinator:
                     "reason=invalid_title elapsed_ms=%.1f",
                     request.session_id,
                     (time.perf_counter() - started) * 1000,
+                    extra={"session_id": request.session_id},
                 )
                 return
             updated = await asyncio.to_thread(
@@ -251,12 +253,14 @@ class BackgroundSessionTitleCoordinator:
                 request.session_id,
                 updated is not None,
                 (time.perf_counter() - started) * 1000,
+                extra={"session_id": request.session_id},
             )
         except TimeoutError:
             _logger.info(
                 "background session title timed out session=%s elapsed_ms=%.1f",
                 request.session_id,
                 (time.perf_counter() - started) * 1000,
+                extra={"session_id": request.session_id},
             )
         except asyncio.CancelledError:
             raise
@@ -266,6 +270,7 @@ class BackgroundSessionTitleCoordinator:
                 request.session_id,
                 (time.perf_counter() - started) * 1000,
                 exc_info=True,
+                extra={"session_id": request.session_id},
             )
 
     async def _run_task_summary(

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -781,6 +781,7 @@ def _publish_and_persist_resource_event(
             "Failed to persist resource event for session=%s",
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
 
 
@@ -2914,6 +2915,7 @@ async def _forward_approval_to_runner(
         _logger.exception(
             "Approval forward failed for %r",
             session_id,
+            extra={"session_id": session_id},
         )
 
 
@@ -4296,6 +4298,7 @@ async def _persist_session_status_error_labels(
         _logger.exception(
             "Failed to persist session status error labels for %s",
             session_id,
+            extra={"session_id": session_id},
         )
 
 
@@ -4632,6 +4635,7 @@ def _publish_session_superseded(session_id: str, target_conversation_id: str) ->
             "Discarded %d unconsumed pending input(s) on superseded session %s",
             discarded,
             session_id,
+            extra={"session_id": session_id},
         )
 
 
@@ -4683,6 +4687,7 @@ async def _get_runner_client_impl(
             _logger.debug(
                 "No runner bound for session=%s",
                 session_id,
+                extra={"session_id": session_id},
             )
             return None
     return cast("httpx.AsyncClient | None", get_runner_client())
@@ -4964,6 +4969,7 @@ def _spawn_superseded_runner_stop(
                 session_id,
                 runner_id,
                 exc_info=True,
+                extra={"session_id": session_id},
             )
 
     task = asyncio.create_task(_stop_and_log())
@@ -5074,6 +5080,7 @@ async def _launch_runner_on_host_locked(
             "constraint should have prevented this",
             conv.id,
             conv.host_id,
+            extra={"session_id": conv.id},
         )
         return _HostLaunchAttempt(runner_id=new_runner_id)
     request_id = secrets.token_hex(8)
@@ -5101,6 +5108,7 @@ async def _launch_runner_on_host_locked(
             "Host %s connection lost while launching runner for %s",
             conv.host_id,
             conv.id,
+            extra={"session_id": conv.id},
         )
         return _HostLaunchAttempt(runner_id=new_runner_id)
     try:
@@ -5220,6 +5228,7 @@ async def _provision_managed_sandbox(
             "Managed sandbox launch failed for session %s: %s",
             session_id,
             exc.detail,
+            extra={"session_id": session_id},
         )
         tracker.fail(session_id, str(exc.detail))
         _publish_sandbox_status(session_id, "failed", str(exc.detail))
@@ -5232,6 +5241,7 @@ async def _provision_managed_sandbox(
         _logger.exception(
             "Managed sandbox launch crashed for session %s",
             session_id,
+            extra={"session_id": session_id},
         )
         tracker.fail(session_id, "internal error during managed sandbox launch")
         _publish_sandbox_status(
@@ -5367,6 +5377,7 @@ async def _proxy_get_session_resources_to_runner(
                 "session resources: runner returned %d for session=%s",
                 resp.status_code,
                 session_id,
+                extra={"session_id": session_id},
             )
             raise HTTPException(
                 status_code=502,
@@ -5383,6 +5394,7 @@ async def _proxy_get_session_resources_to_runner(
                 "session resources: malformed runner response for session=%s: %s",
                 session_id,
                 exc,
+                extra={"session_id": session_id},
             )
             raise HTTPException(
                 status_code=502,
@@ -5402,6 +5414,7 @@ async def _proxy_get_session_resources_to_runner(
             "session resources: runner call failed for session=%s (%s)",
             session_id,
             exc,
+            extra={"session_id": session_id},
         )
         raise HTTPException(
             status_code=502,
@@ -5474,7 +5487,10 @@ async def _reset_runner_resources_after_switch_impl(session_id: str) -> None:
         # still the OLD agent's, so a triggered refetch would re-serve it —
         # and a lost runner rebuilds from the new spec on relaunch anyway.
         _logger.warning(
-            "post-switch runner-resource reset failed for session=%s", session_id, exc_info=True
+            "post-switch runner-resource reset failed for session=%s",
+            session_id,
+            exc_info=True,
+            extra={"session_id": session_id},
         )
         return
     # The old agent's cached OSEnv is now closed, so a refetch triggered by
@@ -5718,6 +5734,7 @@ def _surface_model_change_forward_failure(
             "off the row",
             session_id,
             model,
+            extra={"session_id": session_id},
         )
         return
     if 200 <= runner_result.status_code < 300:
@@ -5736,6 +5753,7 @@ def _surface_model_change_forward_failure(
         model,
         reason,
         runner_result.body,
+        extra={"session_id": session_id},
     )
     target = model or "its default model"
     _publish_error_event(
@@ -5930,6 +5948,7 @@ async def _forward_session_change_to_runner_impl(
             "Session-change forward failed for session=%r type=%r",
             session_id,
             event.get("type"),
+            extra={"session_id": session_id},
         )
         return None
     if resp.status_code >= 400:
@@ -5939,6 +5958,7 @@ async def _forward_session_change_to_runner_impl(
             event.get("type"),
             resp.status_code,
             resp.text,
+            extra={"session_id": session_id},
         )
     return _RunnerForwardResult(status_code=resp.status_code, body=resp.text)
 
@@ -6082,6 +6102,7 @@ async def _stop_session_host_runner(
             runner_id,
             session_id,
             host_id,
+            extra={"session_id": session_id},
         )
         return False
     from omnigent.host.frames import HostStopRunnerFrame, encode_host_frame
@@ -6101,6 +6122,7 @@ async def _stop_session_host_runner(
             runner_id,
             session_id,
             host_id,
+            extra={"session_id": session_id},
         )
         return False
     try:
@@ -6115,6 +6137,7 @@ async def _stop_session_host_runner(
             host_id,
             runner_id,
             session_id,
+            extra={"session_id": session_id},
         )
         return False
     if result.get("status") == "failed":
@@ -6127,6 +6150,7 @@ async def _stop_session_host_runner(
             runner_id,
             session_id,
             result.get("error"),
+            extra={"session_id": session_id},
         )
         return False
     return True
@@ -6438,6 +6462,7 @@ async def _dispatch_skill_slash_command_to_runner(
         _logger.exception(
             "Forward of skill slash command failed for session=%s",
             session_id,
+            extra={"session_id": session_id},
         )
         _publish_status(session_id, "idle")
         raise OmnigentError(
@@ -6622,7 +6647,10 @@ async def _emit_server_routing_decision(
     try:
         parsed_data = parse_item_data("routing_decision", item_data)
     except (ValueError, TypeError):
-        _logger.warning("Server routing: failed to parse routing_decision data")
+        _logger.warning(
+            "Server routing: failed to parse routing_decision data",
+            extra={"session_id": session_id},
+        )
         return None
 
     routing_item = NewConversationItem(
@@ -6637,6 +6665,7 @@ async def _emit_server_routing_decision(
         _logger.exception(
             "Server routing: routing_decision persist failed for session=%s",
             session_id,
+            extra={"session_id": session_id},
         )
         persisted_id = None
 
@@ -6982,6 +7011,7 @@ async def _relay_persist_error_once(
         _logger.exception(
             "Relay error persist failed for session=%s",
             session_id,
+            extra={"session_id": session_id},
         )
         return "failed"
 
@@ -7010,6 +7040,7 @@ async def _relay_persist(
         _logger.exception(
             "Relay persist failed for session=%s",
             session_id,
+            extra={"session_id": session_id},
         )
 
 
@@ -7095,6 +7126,7 @@ async def _flush_relay_text(
         _logger.exception(
             "Relay: failed to persist assistant text segment for session=%s",
             session_id,
+            extra={"session_id": session_id},
         )
         return
     # Confirmed persisted — now safe to clear. Synchronous (no await before
@@ -7219,7 +7251,11 @@ async def _run_compact_locked(
                 preserve_recent_window=1,
             )
         except Exception as exc:
-            _logger.exception("Explicit session compaction failed for %s", session_id)
+            _logger.exception(
+                "Explicit session compaction failed for %s",
+                session_id,
+                extra={"session_id": session_id},
+            )
             detail = str(exc) or repr(exc)
             _publish_compaction_failed(session_id)
             raise OmnigentError(
@@ -8098,6 +8134,7 @@ async def _stream_live_events(
         _logger.warning(
             "session stream subscriber overflowed for %s; closing for snapshot reconnect",
             session_id,
+            extra={"session_id": session_id},
         )
     else:
         # Normal completion only — never yield from ``finally`` (aclose /
@@ -9104,6 +9141,7 @@ async def _notify_runner_of_bundled_child(
             "Failed to notify runner about bundled session %s",
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
 
 
@@ -9651,7 +9689,11 @@ async def _handle_mcp_tools_list(
         runner_client = cast("httpx.AsyncClient | None", get_runner_client())
     if runner_client is None:
         return _mcp_error_response(rpc_id, -32000, f"No runner bound for session {session_id!r}")
-    _logger.debug("MCP tools/list: delegating to runner execute for session=%r", session_id)
+    _logger.debug(
+        "MCP tools/list: delegating to runner execute for session=%r",
+        session_id,
+        extra={"session_id": session_id},
+    )
     try:
         resp = await runner_client.post(
             f"/v1/sessions/{session_id}/mcp/execute",
@@ -9696,6 +9738,7 @@ async def _handle_mcp_tools_list(
         session_id,
         len(tools),
         len(failures),
+        extra={"session_id": session_id},
     )
     return _mcp_ok_response(rpc_id, {"tools": tools})
 
@@ -9753,7 +9796,9 @@ async def _load_runner_skills(
             timeout=5.0,
         )
     except (httpx.HTTPError, ConnectionError):
-        _logger.debug("Runner skills query failed for %s", session_id)
+        _logger.debug(
+            "Runner skills query failed for %s", session_id, extra={"session_id": session_id}
+        )
         return
     if resp.status_code != 200:
         return
@@ -9761,7 +9806,9 @@ async def _load_runner_skills(
         raw = resp.json().get("skills", [])
         skills = [SkillSummary(name=s["name"], description=s["description"]) for s in raw]
     except (ValueError, AttributeError, KeyError, TypeError):
-        _logger.debug("Runner skills payload malformed for %s", session_id)
+        _logger.debug(
+            "Runner skills payload malformed for %s", session_id, extra={"session_id": session_id}
+        )
         return
     _runner_skills_cache[session_id] = skills
     # Nudge any subscribed client to re-read the (now-warm) snapshot so
@@ -9823,7 +9870,11 @@ async def _load_model_options(
         try:
             resp = await runner_client.get(path, timeout=5.0)
         except (httpx.HTTPError, ConnectionError):
-            _logger.debug("Runner model-options query failed for %s", session_id)
+            _logger.debug(
+                "Runner model-options query failed for %s",
+                session_id,
+                extra={"session_id": session_id},
+            )
             return
         if resp.status_code != 200:
             # An older runner has no unified route; drop to the harness-named
@@ -9841,7 +9892,11 @@ async def _load_model_options(
         try:
             options = _model_options_from_wire(resp.json().get("models", []))
         except (ValueError, KeyError, TypeError, ValidationError):
-            _logger.debug("Runner model-options payload malformed for %s", session_id)
+            _logger.debug(
+                "Runner model-options payload malformed for %s",
+                session_id,
+                extra={"session_id": session_id},
+            )
             return
         if not options:
             # Older runners returned 200 + [] for the same not-ready window.
@@ -9906,7 +9961,12 @@ async def _run_catalog_prefetch(
         coro.close()
         raise
     except Exception:  # noqa: BLE001 - best-effort warm-up; a cold cache is fine.
-        _logger.debug("Catalog prefetch failed for %s", session_id, exc_info=True)
+        _logger.debug(
+            "Catalog prefetch failed for %s",
+            session_id,
+            exc_info=True,
+            extra={"session_id": session_id},
+        )
 
 
 def prefetch_session_routing_catalogs(

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -616,6 +616,7 @@ async def _best_effort_stop(
             "Best-effort stop failed for %s; proceeding anyway",
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
         return
 
@@ -636,6 +637,7 @@ async def _best_effort_stop(
                 "Best-effort stop failed for %s; proceeding anyway",
                 target_id,
                 exc_info=True,
+                extra={"session_id": target_id},
             )
 
     if own_status == "running" or has_background_tasks:
@@ -687,6 +689,7 @@ async def _archive_stop(
             "Archive host-runner teardown lookup failed for %s",
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
         return
     if conv is None or not conv.host_id or not conv.runner_id:
@@ -706,6 +709,7 @@ async def _archive_stop(
             "Archive host-runner teardown failed for %s",
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
         delivered = False
     if not delivered:
@@ -2914,6 +2918,7 @@ async def _bind_and_launch_managed_runner(
             "terminating fresh sandbox on host %s",
             session_id,
             managed.host_id,
+            extra={"session_id": session_id},
         )
         host = await asyncio.to_thread(host_store.get_host, managed.host_id)
         if host is not None:
@@ -3155,6 +3160,7 @@ async def _maybe_wake_stale_resumable_managed_sandbox(
         sandbox_running,
         host_tunnel_stale,
         runner_tunnel_stale,
+        extra={"session_id": session_id},
     )
     return await _maybe_relaunch_managed_sandbox(
         session_id=session_id,
@@ -3408,11 +3414,13 @@ def _kick_managed_relaunch(
                 session_id,
                 MANAGED_REPO_LABEL_KEY,
                 raw_repo,
+                extra={"session_id": session_id},
             )
     _logger.info(
         "Managed sandbox for session %s (host %s) is gone; relaunching a new generation",
         session_id,
         conv.host_id,
+        extra={"session_id": session_id},
     )
     tracker.begin(session_id)
     # Seed the relaunch's progress indicator immediately — the user is
@@ -3423,6 +3431,7 @@ def _kick_managed_relaunch(
         _logger.warning(
             "session %s: relaunch has no agent store; runner stays unclassified",
             session_id,
+            extra={"session_id": session_id},
         )
     relaunch_task = asyncio.create_task(
         _run_managed_launch(
@@ -3505,6 +3514,7 @@ def _kick_managed_wake_impl(
         "Managed host %s (session %s) is dormant but resumable; waking in background",
         conv.host_id,
         session_id,
+        extra={"session_id": session_id},
     )
     tracker.begin(session_id)
     # Seed the progress indicator immediately — the user is watching the
@@ -3785,6 +3795,7 @@ async def _ensure_runner_session_initialized(
             "forwarding the message anyway",
             session_id,
             exc_info=True,
+            extra={"session_id": session_id},
         )
         if require_success:
             raise OmnigentError(
@@ -5922,6 +5933,7 @@ async def _relay_runner_stream(
                     "Relay: transport lost during server shutdown for session=%s; "
                     "not failing the turn",
                     session_id,
+                    extra={"session_id": session_id},
                 )
             elif not await _runner_drop_interrupted_turn(session_id, conversation_store):
                 # The runner went away while this session sat idle (host
@@ -9424,6 +9436,7 @@ async def _get_session_snapshot(
                 _logger.debug(
                     "Runner status query failed for %s",
                     session_id,
+                    extra={"session_id": session_id},
                 )
     # last_total_tokens and last_task_error come from the context-tokens
     # label written by the forwarder (tasks table has been removed).
@@ -9477,6 +9490,7 @@ async def _get_session_snapshot(
                                 "renamed/removed sub-agent or stale session metadata.",
                                 conv.sub_agent_name,
                                 session_id,
+                                extra={"session_id": session_id},
                             )
                         else:
                             resolved_spec = _sub_spec

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -1637,6 +1637,7 @@ def register_events_routes(
                     _sf._HOST_BOUND_RUNNER_CONNECT_GRACE_S,
                     conv.runner_id,
                     session_id,
+                    extra={"session_id": session_id},
                 )
                 if _grace_host_reg is not None and _grace_host_conn is not None:
                     runner_client = await _wait_for_host_bound_runner_client(

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -1891,3 +1891,21 @@ def test_load_debug_routers_collects_entries() -> None:
     _router, prefix, tags = entries[0]
     assert prefix == "/debug"
     assert tags == ["debug"]
+
+
+def test_session_id_from_request_parses_session_path() -> None:
+    """The exception handlers read the session id off the request path.
+
+    A ``/v1/sessions/<id>/…`` path yields the id (threaded into the 500 log so
+    the debug-logs row is correlated); anything else yields ``None``.
+    """
+    from types import SimpleNamespace
+
+    def _req(path: str) -> object:
+        return SimpleNamespace(url=SimpleNamespace(path=path))
+
+    parse = server_app._session_id_from_request
+    assert parse(_req("/v1/sessions/conv_abc/events")) == "conv_abc"  # type: ignore[arg-type]
+    assert parse(_req("/v1/sessions/conv_abc")) == "conv_abc"  # type: ignore[arg-type]
+    assert parse(_req("/health")) is None  # type: ignore[arg-type]
+    assert parse(_req("/v1/sessions")) is None  # type: ignore[arg-type]

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -114,9 +114,11 @@ def test_record_to_row_shape_and_coercions() -> None:
     }
 
 
-def test_record_to_row_reads_session_id_from_extra() -> None:
+def test_record_to_row_reads_session_id_from_extra(monkeypatch: pytest.MonkeyPatch) -> None:
     # session_id is passed explicitly at the callsite via extra= and read off
-    # the record; there is no ambient contextvar fallback.
+    # the record. There is deliberately no ambient request-scoped fallback; an
+    # explicit id also wins over the runner-primary env fallback.
+    monkeypatch.setenv(dl.PRIMARY_SESSION_ID_ENV_VAR, "conv_primary")
     record = logging.LogRecord(
         "omnigent.runner", logging.INFO, __file__, 1, "hi", (), None, func="f"
     )
@@ -125,7 +127,22 @@ def test_record_to_row_reads_session_id_from_extra() -> None:
     assert row["session_id"] == "conv_row"
 
 
+def test_record_to_row_session_id_falls_back_to_primary_on_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # On a runner the primary-session env is set, so an unthreaded log is
+    # attributed to the primary (parent) conversation. A co-located subagent's
+    # unthreaded log can be mis-attributed to the parent — an accepted trade-off.
+    monkeypatch.setenv(dl.PRIMARY_SESSION_ID_ENV_VAR, "conv_primary")
+    record = logging.LogRecord("omnigent.runner", logging.INFO, __file__, 1, "hi", (), None)
+    assert dl.record_to_row(record, source="runner")["session_id"] == "conv_primary"
+
+
 def test_record_to_row_null_correlation_without_extra() -> None:
+    # The server never sets the primary-session env (the _clear_env fixture
+    # mirrors that), so an unthreaded server log stays null rather than
+    # borrowing another concurrent request's id — the deliberate no-ambient-
+    # fallback property.
     record = logging.LogRecord("omnigent", logging.INFO, __file__, 1, "hi", (), None)
     row = dl.record_to_row(record, source="server")
     assert row["session_id"] is None

--- a/tests/test_process_logging.py
+++ b/tests/test_process_logging.py
@@ -19,10 +19,13 @@ from omnigent.process_logging import (
     PROCESS_LOG_FILE_ENV_VAR,
     TerminalLogFormatter,
     _debug_sink_target_loggers,
+    _log_once_seen,
     _unlink_if_empty,
     child_logging_popen_kwargs,
     configure_process_logging,
     current_process_log_path,
+    log_info_once,
+    log_once,
     process_log_dir_reference,
     process_log_reference,
     terminal_stream_handler,
@@ -348,3 +351,39 @@ def test_debug_sink_targets_follow_non_propagating_package_logger() -> None:
         assert targets == [logging.getLogger()]
     finally:
         logger.propagate = original
+
+
+def test_log_info_once_dedupes_identical_and_relogs_changed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Same formatted line logs once per process; a changed line logs again."""
+    logger = logging.getLogger("omnigent.test.log_info_once")
+    # The dedup set is process-global; clear it so a prior test cannot mask this.
+    _log_once_seen.clear()
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        log_info_once(logger, "routing decision provider=%s", "alpha")
+        log_info_once(logger, "routing decision provider=%s", "alpha")  # identical -> dropped
+        log_info_once(logger, "routing decision provider=%s", "beta")  # changed -> logged
+    messages = [r.getMessage() for r in caplog.records if r.name == logger.name]
+    assert messages == [
+        "routing decision provider=alpha",
+        "routing decision provider=beta",
+    ]
+
+
+def test_log_once_respects_level_and_captures_exc_info(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """log_once emits at the given level with the traceback, then dedupes repeats."""
+    logger = logging.getLogger("omnigent.test.log_once")
+    _log_once_seen.clear()
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            log_once(logger, logging.WARNING, "codex catalog probe failed", exc_info=True)
+            log_once(logger, logging.WARNING, "codex catalog probe failed", exc_info=True)
+    records = [r for r in caplog.records if r.name == logger.name]
+    assert len(records) == 1  # identical repeat dropped
+    assert records[0].levelno == logging.WARNING
+    assert records[0].exc_info is not None  # first occurrence keeps its traceback


### PR DESCRIPTION
## Related issue

_No linked GitHub issue — reported directly by a maintainer (null `session_id`
in debug logs + repeated native-harness log lines)._

## Summary

Two debug-log papercuts:

- **`session_id` was null for logs that clearly happen inside a session — especially exceptions.** `record_to_row` filled `session_id` *only* from an explicit `extra={"session_id": …}`, with no fallback, so freeform logs and exceptions landed null (e.g. the global handler's `Internal error: runner … is offline for conversation …`).
- **Repeated native-harness log lines.** The `native-{claude,codex} routing:` decision and the best-effort `codex catalog probe failed` warning are near-static, but were logged on every resolver/catalog call (gateway inference, background titles, every app-server request, every relaunch).

What changed:

- **`debug_logging.record_to_row`** now falls back to `runner_primary_session_id()` (the parent conversation) when a record carries no explicit id. That env is **runner-only**, so the multi-tenant server stays *null-unless-threaded* — its deliberate no-ambient-fallback / no-misattribution property is preserved. (A co-located subagent's un-threaded runner log may be attributed to the parent — an accepted trade-off.)
- **Server:** thread the session id (parsed from the request path) into the three global exception handlers, so every 500 on a `/v1/sessions/<id>/…` route carries it; plus explicit `extra={"session_id": …}` on the three reported examples and ~52 session-scoped catch-and-log sites in `routes/_sessions/{helpers,orchestration}.py`.
- **`process_logging`:** add `log_once(logger, level, msg, …, exc_info=)` + a `log_info_once()` wrapper — a per-process, thread-safe dedup keyed on the formatted message (`stacklevel=2` keeps `func_name` at the callsite). Convert all 13 `native-{claude,codex} routing:` info lines and the `codex catalog probe failed` warning: each distinct line logs once, identical repeats drop, a *changed* line re-logs.

No ambient session ContextVar is introduced — intentionally, to avoid cross-request misattribution on the server.

## Test Plan

```bash
# Strip the debug-log env or a PRE-EXISTING env-leak test fails (see notes)
env -u OMNIGENT_DEBUG_LOG_CLIENT_ID -u OMNIGENT_DEBUG_LOG_CLIENT_SECRET \
    -u OMNIGENT_DEBUG_LOG_WORKSPACE_URL -u OMNIGENT_DEBUG_LOG_ENDPOINT \
    .venv/bin/python -m pytest tests/test_debug_logging.py \
      tests/test_process_logging.py tests/server/test_app.py -q
```

Manual:
- Trigger a server error on a `/v1/sessions/<id>/…` route (e.g. post to a session whose runner is offline), then query the debug-logs table filtered by that `session_id` — the `Internal error…` row (and the swept exception rows) now appear instead of being invisible.
- Start a native claude/codex session and watch the process log — each `native-* routing:` line and `codex catalog probe failed` appear **once**, not on every turn/title/relaunch/catalog fetch.

## Demo

N/A — non-visual (logging / backend).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover: `record_to_row` fallback precedence (explicit id > runner-primary; server stays null with no env), `log_once`/`log_info_once` dedup (incl. level + `exc_info`), and request-path session parsing. The session-threading sweep is purely additive (an `extra=` kwarg on log calls, no logic change) and verified via `ruff`, AST, module import, and the server-route test suite (107 tests green). Manual verification as above — end-to-end ZeroBus table delivery needs the internal `OMNIGENT_DEBUG_LOG_*` env, so attribution is proven via the unit assertions rather than a live round-trip.

Note: without the `env -u …` prefix, `test_process_logging::test_configure_registers_the_empty_log_sweep_for_self_allocated_paths` fails — a **pre-existing** env-leak (a shell with `OMNIGENT_DEBUG_LOG_*` set makes the sink register an `atexit` the test doesn't clear), unrelated to this change.

## Changelog

Debug-log rows now carry their `session_id` for session-scoped logs and exceptions; repeated native-harness routing / catalog-probe log lines are deduped to once per process.
