### PR TITLE
feat(web): rename a session by clicking its title

### DIFF
--- a/tests/e2e_ui/sessions/test_header_session_menu.py
+++ b/tests/e2e_ui/sessions/test_header_session_menu.py
@@ -49,27 +49,33 @@ def test_header_session_menu_renames_owner_and_hides_for_subagent(
         expect(trigger).to_be_visible(timeout=30_000)
         trigger.click()
 
-        # Desktop drops "Add to project" from the kebab — the breadcrumb's
-        # folder tag owns that shortcut now (see HeaderProjectTag). It stays in
-        # this menu only on mobile, where the native shells hide the breadcrumb.
+        # Desktop drops "Rename" and "Add to project" from the kebab — the
+        # breadcrumb title (HeaderTitle) and folder tag (HeaderProjectTag) own
+        # those shortcuts now. Both stay in this menu only on mobile, where the
+        # native shells hide the breadcrumb.
         menu_items = page.get_by_role("menuitem")
-        expect(menu_items).to_have_count(5)
+        expect(menu_items).to_have_count(4)
         assert menu_items.all_inner_texts() == [
             "Pin",
-            "Rename",
             "Mark as unread",
             "Archive",
             "Delete",
         ]
+        # Dismiss the menu and wait for it to fully detach — Radix briefly puts
+        # `pointer-events: none` on the body while closing, which would swallow
+        # the title click that follows.
+        page.keyboard.press("Escape")
+        expect(page.get_by_role("menu")).to_have_count(0)
 
-        page.get_by_role("menuitem", name="Rename").click()
+        # Rename by clicking the breadcrumb title → inline input, Enter commits.
+        breadcrumb = page.get_by_role("navigation", name="Conversation")
+        page.get_by_test_id("header-title").click()
         rename_input = page.get_by_role("textbox", name="Session name")
         expect(rename_input).to_be_visible()
-        renamed_title = "Header menu renamed session"
+        renamed_title = "Header title renamed session"
         rename_input.fill(renamed_title)
-        page.get_by_role("button", name="Rename").click()
+        rename_input.press("Enter")
 
-        breadcrumb = page.get_by_role("navigation", name="Conversation")
         expect(breadcrumb.get_by_text(renamed_title, exact=True)).to_be_visible(timeout=15_000)
 
         agent_resp = httpx.get(

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -25,6 +25,7 @@ import { AgentInfoButton } from "@/components/AgentInfo";
 import { ConversationBreadcrumb } from "./ConversationBreadcrumb";
 import { HeaderConversationMenu } from "./HeaderConversationMenu";
 import { HeaderProjectTag } from "./HeaderProjectTag";
+import { HeaderTitle } from "./HeaderTitle";
 import { UNTITLED_CONVERSATION_LABEL } from "./sidebarNav";
 import { PresenceAvatars } from "@/components/PresenceAvatars";
 import type { Agent } from "@/hooks/useAgents";
@@ -354,6 +355,17 @@ export function ChatHeader({
     !isMobile && actionConversation && !isChildSession ? (
       <HeaderProjectTag conversationId={actionConversation.id} projectName={projectName} />
     ) : null;
+  // Click-to-rename on the breadcrumb title, same gating as the folder tag:
+  // desktop, owner-managed top-level row. A sub-agent's title stays a
+  // back-to-parent link (titleLinkTo wins over titleSlot in the breadcrumb),
+  // and mobile keeps the Rename item in the kebab.
+  const titleSlot =
+    !isMobile && actionConversation && !isChildSession ? (
+      <HeaderTitle
+        conversationId={actionConversation.id}
+        title={conversationTitle ?? UNTITLED_CONVERSATION_LABEL}
+      />
+    ) : null;
   return (
     <header
       className={cn(
@@ -431,6 +443,7 @@ export function ChatHeader({
             conversationTitle={conversationTitle ?? UNTITLED_CONVERSATION_LABEL}
             projectName={projectName}
             projectTag={projectTag ?? undefined}
+            titleSlot={titleSlot ?? undefined}
             titleLinkTo={titleLinkTo}
             isChildSession={isChildSession}
             boundAgent={boundAgent}

--- a/web/src/shell/ConversationBreadcrumb.tsx
+++ b/web/src/shell/ConversationBreadcrumb.tsx
@@ -25,6 +25,7 @@ export function ConversationBreadcrumb({
   conversationTitle,
   projectName,
   projectTag,
+  titleSlot,
   titleLinkTo,
   isChildSession,
   boundAgent,
@@ -43,6 +44,12 @@ export function ConversationBreadcrumb({
    * is set — the fallback for surfaces without the shortcut (e.g. sub-agents).
    */
   projectTag?: ReactNode;
+  /**
+   * Interactive title node (the desktop click-to-rename control). Replaces the
+   * plain-text title. Ignored when `titleLinkTo` is set — a sub-agent keeps its
+   * back-to-parent link rather than becoming editable.
+   */
+  titleSlot?: ReactNode;
   /** Parent-session route the title links to, or `undefined` for plain text. */
   titleLinkTo?: string;
   /** Whether the active session is a sub-agent (appends its identity). */
@@ -121,7 +128,7 @@ export function ConversationBreadcrumb({
           )}
         </Link>
       ) : (
-        <span className="min-w-0 truncate text-foreground">{conversationTitle}</span>
+        (titleSlot ?? <span className="min-w-0 truncate text-foreground">{conversationTitle}</span>)
       )}
       {actions}
       {isChildSession && (

--- a/web/src/shell/HeaderConversationMenu.test.tsx
+++ b/web/src/shell/HeaderConversationMenu.test.tsx
@@ -108,17 +108,18 @@ describe("HeaderConversationMenu", () => {
     expect(trigger.querySelector("svg")).toHaveClass("lucide-ellipsis");
 
     openMenu();
-    // Desktop drops "Move to project" from the kebab — the breadcrumb folder
-    // tag owns that shortcut (see ChatHeader / HeaderProjectTag).
+    // Desktop drops "Rename" and "Move to project" from the kebab — the
+    // breadcrumb title (HeaderTitle) and folder tag (HeaderProjectTag) own
+    // those shortcuts now.
     expect(screen.getAllByRole("menuitem").map((item) => item.textContent?.trim())).toEqual([
       "Pin",
       "Share",
-      "Rename",
       "Mark as unread",
       "Archive",
       "Delete",
     ]);
     expect(screen.queryByTestId("header-move-to-project")).toBeNull();
+    expect(screen.queryByTestId("header-rename-conversation")).toBeNull();
   });
 
   it("opens from the keyboard and focuses the first action", () => {
@@ -130,7 +131,7 @@ describe("HeaderConversationMenu", () => {
     expect(screen.getByRole("menuitem", { name: "Pin" })).toHaveFocus();
   });
 
-  it("runs pin, mark-unread, and rename actions for the active session", () => {
+  it("runs pin and mark-unread actions for the active session", () => {
     renderMenu();
 
     openMenu();
@@ -140,6 +141,13 @@ describe("HeaderConversationMenu", () => {
     openMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: "Mark as unread" }));
     expect(mocks.markUnread).toHaveBeenCalledWith("conv-1", 1_700_000_100);
+  });
+
+  it("renames from the mobile Rename dialog", () => {
+    // Rename is mobile-only in this menu now — desktop renames by clicking the
+    // breadcrumb title (HeaderTitle).
+    mocks.isMobile = true;
+    renderMenu();
 
     openMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
@@ -202,6 +210,8 @@ describe("HeaderConversationMenu", () => {
   });
 
   it("closes and resets Rename when the conversation id changes", async () => {
+    // Rename item is mobile-only now.
+    mocks.isMobile = true;
     const view = renderMenu();
     openMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));

--- a/web/src/shell/HeaderConversationMenu.tsx
+++ b/web/src/shell/HeaderConversationMenu.tsx
@@ -222,14 +222,19 @@ export function HeaderConversationMenu({
           Agent info
         </DropdownMenuItem>
       )}
-      <DropdownMenuItem
-        data-testid="header-rename-conversation"
-        className={itemClass}
-        onSelect={() => setRenameOpen(true)}
-      >
-        <PencilIcon className="size-3.5" />
-        Rename
-      </DropdownMenuItem>
+      {/* Rename lives here only on mobile — the native shells hide the
+          breadcrumb, so this menu is the sole entry point. On desktop the
+          shortcut is clicking the breadcrumb title (HeaderTitle). */}
+      {isMobile && (
+        <DropdownMenuItem
+          data-testid="header-rename-conversation"
+          className={itemClass}
+          onSelect={() => setRenameOpen(true)}
+        >
+          <PencilIcon className="size-3.5" />
+          Rename
+        </DropdownMenuItem>
+      )}
       <DropdownMenuItem
         data-testid="header-mark-unread-conversation"
         className={itemClass}

--- a/web/src/shell/HeaderTitle.test.tsx
+++ b/web/src/shell/HeaderTitle.test.tsx
@@ -1,0 +1,92 @@
+import type { ReactElement } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as ConversationsModule from "@/hooks/useConversations";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { HeaderTitle } from "./HeaderTitle";
+
+const mocks = vi.hoisted(() => ({
+  rename: vi.fn(),
+  pending: false,
+}));
+
+vi.mock("@/hooks/useConversations", async (importOriginal) => {
+  const actual = await importOriginal<typeof ConversationsModule>();
+  return {
+    ...actual,
+    useRenameConversation: () => ({ mutate: mocks.rename, isPending: mocks.pending }),
+  };
+});
+
+function renderTitle(ui: ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+function enterEdit() {
+  fireEvent.click(screen.getByTestId("header-title"));
+}
+
+beforeEach(() => {
+  mocks.pending = false;
+  vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe("HeaderTitle", () => {
+  it("shows the title as a button that opens an inline input on click", () => {
+    renderTitle(<HeaderTitle conversationId="conv-1" title="Planning" />);
+    const trigger = screen.getByTestId("header-title");
+    expect(trigger).toHaveTextContent("Planning");
+
+    enterEdit();
+    const input = screen.getByRole("textbox", { name: "Session name" });
+    expect(input).toHaveValue("Planning");
+  });
+
+  it("commits a changed title on Enter", () => {
+    renderTitle(<HeaderTitle conversationId="conv-1" title="Planning" />);
+    enterEdit();
+
+    const input = screen.getByRole("textbox", { name: "Session name" });
+    fireEvent.change(input, { target: { value: "Roadmap" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mocks.rename).toHaveBeenCalledWith({ id: "conv-1", title: "Roadmap" });
+  });
+
+  it("commits on blur and leaves edit mode", () => {
+    renderTitle(<HeaderTitle conversationId="conv-1" title="Planning" />);
+    enterEdit();
+
+    const input = screen.getByRole("textbox", { name: "Session name" });
+    fireEvent.change(input, { target: { value: "Roadmap" } });
+    fireEvent.blur(input);
+    expect(mocks.rename).toHaveBeenCalledWith({ id: "conv-1", title: "Roadmap" });
+    expect(screen.getByTestId("header-title")).toBeInTheDocument();
+  });
+
+  it("cancels on Escape without renaming", () => {
+    renderTitle(<HeaderTitle conversationId="conv-1" title="Planning" />);
+    enterEdit();
+
+    const input = screen.getByRole("textbox", { name: "Session name" });
+    fireEvent.change(input, { target: { value: "Roadmap" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(mocks.rename).not.toHaveBeenCalled();
+    // Back to the button, showing the original title.
+    expect(screen.getByTestId("header-title")).toHaveTextContent("Planning");
+  });
+
+  it("does not rename when the title is unchanged or blank", () => {
+    renderTitle(<HeaderTitle conversationId="conv-1" title="Planning" />);
+    enterEdit();
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "Session name" }), { key: "Enter" });
+    expect(mocks.rename).not.toHaveBeenCalled();
+
+    enterEdit();
+    const input = screen.getByRole("textbox", { name: "Session name" });
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mocks.rename).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/shell/HeaderTitle.tsx
+++ b/web/src/shell/HeaderTitle.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useRenameConversation } from "@/hooks/useConversations";
+import { isImeCompositionKeyEvent } from "@/lib/ime";
+import { cn } from "@/lib/utils";
+
+/**
+ * The breadcrumb title as a click-to-rename control (desktop).
+ *
+ * Clicking the title swaps it for an inline input so the session can be renamed
+ * straight from the header — no trip to the kebab menu. Enter commits, Escape
+ * cancels, blur commits (matching the sidebar's inline rename). Desktop only
+ * and only for owner-managed top-level sessions; mobile keeps the Rename item
+ * in the header session menu, since the native shells hide the breadcrumb.
+ */
+export function HeaderTitle({ conversationId, title }: { conversationId: string; title: string }) {
+  const rename = useRenameConversation();
+  const [editing, setEditing] = useState(false);
+
+  if (!editing) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            data-testid="header-title"
+            onClick={() => setEditing(true)}
+            className="min-w-0 cursor-pointer truncate rounded text-left text-foreground hover:underline focus-visible:underline focus-visible:outline-none"
+          >
+            {title}
+          </button>
+        </TooltipTrigger>
+        {/* Bottom placement: the header sits at top-0, so a top-side tooltip
+            would clip above the viewport edge. */}
+        <TooltipContent side="bottom">Rename</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <HeaderTitleInput
+      initialTitle={title}
+      pending={rename.isPending}
+      onCommit={(next) => {
+        const trimmed = next.trim();
+        if (trimmed && trimmed !== title) {
+          rename.mutate({ id: conversationId, title: trimmed });
+        }
+        setEditing(false);
+      }}
+      onCancel={() => setEditing(false)}
+    />
+  );
+}
+
+/**
+ * Inline rename input. Auto-focuses and selects the whole title on mount so a
+ * user can type to replace. Enter commits, Escape cancels, blur commits — with
+ * an IME-composition guard so the Enter that confirms a candidate (e.g.
+ * Japanese conversion) doesn't commit the rename, and a cancel flag so the
+ * unmount blur doesn't re-commit after Escape.
+ */
+function HeaderTitleInput({
+  initialTitle,
+  pending,
+  onCommit,
+  onCancel,
+}: {
+  initialTitle: string;
+  pending: boolean;
+  onCommit: (title: string) => void;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(initialTitle);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const cancelledRef = useRef(false);
+  const isComposingRef = useRef(false);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (isImeCompositionKeyEvent(event, isComposingRef.current)) return;
+    if (event.key === "Enter") {
+      event.preventDefault();
+      onCommit(value);
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancelledRef.current = true;
+      onCancel();
+    }
+  }
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      aria-label="Session name"
+      data-testid="header-title-input"
+      value={value}
+      disabled={pending}
+      onChange={(event) => setValue(event.target.value)}
+      onCompositionStart={() => {
+        isComposingRef.current = true;
+      }}
+      onCompositionEnd={() => {
+        isComposingRef.current = false;
+      }}
+      onKeyDown={handleKeyDown}
+      onBlur={() => {
+        if (cancelledRef.current) return;
+        onCommit(value);
+      }}
+      className={cn(
+        // Sit flush with the static title: no vertical padding or box border,
+        // just a subtle focus ring so edit mode doesn't change the title's
+        // height or shift the breadcrumb.
+        "min-w-0 w-56 max-w-full truncate rounded-sm bg-transparent px-1 -mx-1 py-0",
+        "text-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring/60",
+      )}
+    />
+  );
+}


### PR DESCRIPTION
## Related issue

<!-- UI/UX change; no issue required per template. -->

## Summary

- Adds **click-to-rename** on the session title: clicking the breadcrumb title swaps it for an inline input (auto-focus + select-all, **Enter** commits, **Escape** cancels, **blur** commits, IME-composition guard), mirroring the sidebar's inline rename. The input sits flush with the static title so entering edit mode doesn't change its height or shift the breadcrumb.
- Removes the now-redundant **"Rename"** item from the *desktop* kebab. It stays on *mobile*, where the native shells hide the breadcrumb and the menu is the only entry point.
- Desktop-only and top-level-only, matching the folder-tag move shortcut: a sub-agent title keeps its back-to-parent link (the breadcrumb's `titleLinkTo` wins over the editable slot).

Follow-up to #5698 (move-to-project from the title's folder tag); the desktop kebab now reads **Pin · Share · Mark as unread · Archive · Delete**.

## Test Plan

- `cd web && npm test` — touched-file suites green; the only failures are the pre-existing `NewChatDialog.test.tsx` host-picker cases, confirmed on a clean stash of this branch.
- `cd web && npm run build` — `tsc -b && vite build` clean.
- E2E UI (live server + Chromium), `-o addopts=""`:
  - `tests/e2e_ui/sessions/test_header_session_menu.py` — 2 passed (desktop kebab now 4 items; rename driven by clicking the title).
- Manual: clicked the title, renamed via Enter and via blur, cancelled via Escape; confirmed the dots menu no longer lists Rename on desktop and still does on mobile.

## Demo

<!-- TODO: drag in a short screen recording of click-title → inline rename. -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New `HeaderTitle.test.tsx` covers open-on-click, commit-on-Enter, commit-on-blur, cancel-on-Escape, and no-op on unchanged/blank. `HeaderConversationMenu.test.tsx` updated so the desktop kebab drops Rename (5 items) while the mobile rename dialog is exercised on a mobile viewport. E2E asserts the 4-item desktop kebab and the click-title rename flow end-to-end.

## Changelog

Rename a session by clicking its title in the header

This pull request and its description were written by Isaac.
