### PR TITLE
fix(credential_proxy): re-resolve env/file/command sources on a refresh interval

### DIFF
--- a/omnigent/inner/credential_proxy.py
+++ b/omnigent/inner/credential_proxy.py
@@ -27,6 +27,7 @@ This module owns two pieces:
 
 from __future__ import annotations
 
+import math
 import os
 import secrets
 import subprocess
@@ -195,7 +196,22 @@ def prepare_credential_proxy_runtime(
         _prepare_databricks_runtime(spec.databricks, runtime)
 
     for entry in spec.entries:
-        real_secret = _resolve_secret(entry.source, parent_env=parent_env)
+        # A source with a refresh interval is re-resolved on each swap
+        # (throttled) so a rotating secret — e.g. a ``command`` minting a
+        # short-lived token — stays fresh for long sessions, instead of
+        # being baked in once here. A source without one resolves once and
+        # is attached as a static ``real_secret`` (the original behavior).
+        real_secret: str | None = None
+        secret_provider: Callable[[], str] | None = None
+        if entry.source.refresh_interval is not None:
+            provider = RefreshingSecretProvider(
+                entry.source,
+                parent_env=parent_env,
+                refresh_interval=entry.source.refresh_interval,
+            )
+            secret_provider = provider.resolve
+        else:
+            real_secret = _resolve_secret(entry.source, parent_env=parent_env)
         # Mint a placeholder only when the entry injects an env var. The
         # placeholder is what the cross-host leak guard keys on; pure
         # swap-on-access entries put nothing in the sandbox, so there is
@@ -212,6 +228,7 @@ def prepare_credential_proxy_runtime(
                 host=entry.host,
                 scheme=entry.scheme,
                 real_secret=real_secret,
+                secret_provider=secret_provider,
                 synthetic=synthetic,
                 username=entry.username,
             )
@@ -273,6 +290,95 @@ def _resolve_secret(source: CredentialSourceSpec, *, parent_env: dict[str, str])
             raise ValueError("credential_proxy command source produced empty stdout")
         return value
     raise ValueError(f"unsupported credential_proxy source kind: {source.kind!r}")
+
+
+class RefreshingSecretProvider:
+    """Re-resolving secret source for ``env`` / ``file`` / ``command`` kinds.
+
+    Wraps :func:`_resolve_secret` so a source whose backing value rotates
+    mid-session is re-read for the egress proxy instead of baked in once at
+    helper start. The motivating case is a ``command`` source that mints a
+    short-lived token (e.g. a GitHub App installation token that expires in
+    ~1h): a session running past expiry would otherwise hit proxy-injected
+    401s.
+
+    The value is resolved eagerly at construction — so a misconfigured
+    source still fails loud at prepare time, exactly as the static path
+    does — and re-resolved at most once per :attr:`_refresh_interval` on
+    each swap; ``0`` re-resolves on every swap. Thread-safe: the egress
+    proxy resolves from its own event-loop thread. This mirrors
+    :class:`DatabricksProfileTokenProvider`, which already uses the same
+    throttle to survive Databricks OAuth expiry.
+    """
+
+    def __init__(
+        self,
+        source: CredentialSourceSpec,
+        *,
+        parent_env: dict[str, str],
+        refresh_interval: float,
+        clock: Callable[[], float] = time.monotonic,
+        resolver: Callable[[CredentialSourceSpec], str] | None = None,
+    ) -> None:
+        """
+        Build a provider for *source* and resolve it once, eagerly.
+
+        :param source: The ``env`` / ``file`` / ``command`` source to
+            re-resolve.
+        :param parent_env: Parent process environment for ``env`` lookups
+            and as the environment for ``command`` execution.
+        :param refresh_interval: Minimum seconds between re-resolutions.
+            ``0`` re-resolves on every swap.
+        :param clock: Monotonic clock, injectable for tests.
+        :param resolver: Test seam resolving *source* to a secret
+            (defaults to :func:`_resolve_secret` bound to *parent_env*).
+        :raises ValueError: If *refresh_interval* is not a finite,
+            non-negative number, or if the source cannot be resolved to a
+            non-empty secret (both raised eagerly here).
+        """
+        if not math.isfinite(refresh_interval) or refresh_interval < 0:
+            # Prepare-time fail-loud boundary for callers that build a
+            # CredentialSourceSpec directly, bypassing the spec parser's
+            # equivalent check (NaN would re-resolve on every swap; infinity
+            # would disable refresh forever).
+            raise ValueError(
+                f"refresh_interval must be a finite, non-negative number, got {refresh_interval!r}"
+            )
+        self._source = source
+        self._refresh_interval = refresh_interval
+        self._clock = clock
+        if resolver is None:
+            # Snapshot the parent environment at construction so a later
+            # mutation of the caller's dict can't change what env / command
+            # sources resolve against — the trusted startup env is fixed here.
+            frozen_env = dict(parent_env)
+            self._resolver: Callable[[CredentialSourceSpec], str] = lambda src: _resolve_secret(
+                src, parent_env=frozen_env
+            )
+        else:
+            self._resolver = resolver
+        self._lock = threading.Lock()
+        self._value: str | None = None
+        self._next_refresh = 0.0
+        # Resolve now so a misconfigured source fails at prepare time,
+        # matching the fail-loud behavior of the static resolution path.
+        self.resolve()
+
+    def resolve(self) -> str:
+        """
+        Return the current secret, re-resolving past the throttle window.
+
+        :returns: The freshest resolved secret.
+        :raises ValueError: If re-resolution fails.
+        """
+        with self._lock:
+            now = self._clock()
+            if self._value is not None and now < self._next_refresh:
+                return self._value
+            value = self._resolver(self._source)
+            self._value = value
+            self._next_refresh = now + self._refresh_interval
+            return value
 
 
 # Default seconds between re-authentications for a Databricks profile. The
@@ -490,5 +596,6 @@ __all__ = [
     "CredentialRewriteRule",
     "DatabricksProfileTokenProvider",
     "MaterializedFile",
+    "RefreshingSecretProvider",
     "prepare_credential_proxy_runtime",
 ]

--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -389,12 +389,23 @@ class CredentialSourceSpec:
         expanded), e.g. ``"~/.config/tokens/github_pat.txt"``.
     :param command: Shell command whose stdout is the secret when
         ``kind="command"``, e.g. ``"gh auth token"``.
+    :param refresh_interval: Optional throttle, in seconds, after which the
+        parent re-resolves the source instead of baking its value in once
+        at helper start. ``None`` (the default) resolves once and reuses
+        the value for the whole session — correct for a static secret. Set
+        it for a source whose backing value rotates mid-session (most
+        notably a ``command`` that mints a short-lived token, e.g. a
+        GitHub App installation token that expires in ~1h): the value is
+        then re-read at most once per interval on each proxy swap, so a
+        long session survives expiry. ``0`` re-resolves on every swap
+        (cheap for ``file`` / ``command`` sources).
     """
 
     kind: Literal["env", "file", "command"]
     env: str | None = None
     path: str | None = None
     command: str | None = None
+    refresh_interval: float | None = None
 
 
 @dataclass

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 import re
 import sys
@@ -1340,6 +1341,12 @@ class _CredentialSourceModel(BaseModel):  # type: ignore[explicit-any]
         secret, e.g. ``"~/.config/tokens/github_pat.txt"``.
     :param command: Shell command whose stdout is the secret, e.g.
         ``"gh auth token"``.
+    :param refresh_interval: Optional non-negative throttle, in seconds,
+        after which the parent re-resolves the source instead of baking its
+        value in once at helper start (``NaN`` / infinity are rejected).
+        Omit for a static secret; set it for
+        a source whose value rotates mid-session (e.g. a ``command`` that
+        mints a short-lived token). ``0`` re-resolves on every proxy swap.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -1347,6 +1354,7 @@ class _CredentialSourceModel(BaseModel):  # type: ignore[explicit-any]
     env: str | None = None
     file: str | None = None
     command: str | None = None
+    refresh_interval: float | None = None
 
     @model_validator(mode="after")
     def _exactly_one_source(self) -> _CredentialSourceModel:
@@ -1371,6 +1379,10 @@ class _CredentialSourceModel(BaseModel):  # type: ignore[explicit-any]
             raise ValueError("source 'file' must be a non-empty path")
         if self.command is not None and not self.command.strip():
             raise ValueError("source 'command' must be a non-empty command")
+        if self.refresh_interval is not None and (
+            not math.isfinite(self.refresh_interval) or self.refresh_interval < 0
+        ):
+            raise ValueError("source 'refresh_interval' must be a finite, non-negative number")
         return self
 
     def to_spec(self) -> CredentialSourceSpec:
@@ -1382,11 +1394,17 @@ class _CredentialSourceModel(BaseModel):  # type: ignore[explicit-any]
             (guaranteed by :meth:`_exactly_one_source`).
         """
         if self.env is not None:
-            return CredentialSourceSpec(kind="env", env=self.env)
+            return CredentialSourceSpec(
+                kind="env", env=self.env, refresh_interval=self.refresh_interval
+            )
         if self.file is not None:
-            return CredentialSourceSpec(kind="file", path=self.file.strip())
+            return CredentialSourceSpec(
+                kind="file", path=self.file.strip(), refresh_interval=self.refresh_interval
+            )
         assert self.command is not None
-        return CredentialSourceSpec(kind="command", command=self.command.strip())
+        return CredentialSourceSpec(
+            kind="command", command=self.command.strip(), refresh_interval=self.refresh_interval
+        )
 
 
 class _CredentialProxyItemModel(BaseModel):  # type: ignore[explicit-any]

--- a/tests/inner/test_credential_proxy.py
+++ b/tests/inner/test_credential_proxy.py
@@ -21,6 +21,7 @@ from omnigent.inner.credential_proxy import (
     SYNTHETIC_CREDENTIAL_PREFIX,
     CredentialProxyRuntime,
     DatabricksProfileTokenProvider,
+    RefreshingSecretProvider,
     _prepare_databricks_runtime,
     prepare_credential_proxy_runtime,
 )
@@ -375,3 +376,158 @@ def test_databricks_runtime_rejects_same_host_profiles() -> None:
 
     with pytest.raises(OmnigentError, match="resolve to workspace host"):
         _prepare_databricks_runtime(spec, CredentialProxyRuntime(), provider_factory=factory)
+
+
+def test_refresh_interval_reresolves_rotated_source(tmp_path: Path) -> None:
+    """A source with ``refresh_interval`` re-reads a value that rotates mid-run.
+
+    This is the whole point of the feature: our GitHub App token source is a
+    ``command`` that force-mints a fresh ~1h token, so a session running past
+    expiry must see the *new* value on a later swap, not the one baked in at
+    helper start. Modeled with a ``file`` source rotated between swaps.
+    ``refresh_interval=0`` re-resolves on every swap. This assertion fails on
+    unpatched main, where the value is resolved once and frozen (and where the
+    ``refresh_interval`` field does not exist).
+    """
+    secret_file = tmp_path / "token.txt"
+    secret_file.write_text("token-v1\n", encoding="utf-8")
+    spec = CredentialProxySpec(
+        entries=[
+            _bearer_entry(
+                "api.example.com",
+                env_var="API_TOKEN",
+                source=CredentialSourceSpec(
+                    kind="file", path=str(secret_file), refresh_interval=0.0
+                ),
+            )
+        ]
+    )
+    runtime = prepare_credential_proxy_runtime(spec, parent_env={})
+    rule = runtime.rewrites[0]
+    # No static secret is baked in for a refreshing source; the proxy pulls
+    # the current value through the provider on each swap.
+    assert rule.real_secret is None
+    assert rule.resolve_secret() == "token-v1"
+
+    # Rotate the backing source mid-session (as a fresh App-token mint would).
+    secret_file.write_text("token-v2\n", encoding="utf-8")
+    assert rule.resolve_secret() == "token-v2"
+
+
+def test_no_refresh_interval_bakes_in_source(tmp_path: Path) -> None:
+    """Without ``refresh_interval`` the secret is resolved once and frozen.
+
+    The control for :func:`test_refresh_interval_reresolves_rotated_source`:
+    the default (static) path must keep its baked-in value even after the
+    backing source changes, so refreshing is strictly opt-in.
+    """
+    secret_file = tmp_path / "token.txt"
+    secret_file.write_text("token-v1\n", encoding="utf-8")
+    spec = CredentialProxySpec(
+        entries=[
+            _bearer_entry(
+                "api.example.com",
+                env_var="API_TOKEN",
+                source=CredentialSourceSpec(kind="file", path=str(secret_file)),
+            )
+        ]
+    )
+    runtime = prepare_credential_proxy_runtime(spec, parent_env={})
+    rule = runtime.rewrites[0]
+    assert rule.real_secret == "token-v1"
+    assert rule.secret_provider is None
+
+    secret_file.write_text("token-v2\n", encoding="utf-8")
+    # Static source: the rotated value is intentionally NOT picked up.
+    assert rule.resolve_secret() == "token-v1"
+
+
+def test_refreshing_provider_throttles_re_resolution() -> None:
+    """The provider caches within the window and re-resolves once past it.
+
+    Mirrors ``test_databricks_provider_resolves_host_and_refreshes``: uses a
+    clock seam and a resolver seam so no real subprocess/file is needed. The
+    eager resolve at construction consumes the first value; subsequent calls
+    inside the window reuse it, and one call past the window re-resolves.
+    """
+    values = iter(["v1", "v2"])
+    resolver_calls = {"n": 0}
+
+    def resolver(_source: CredentialSourceSpec) -> str:
+        resolver_calls["n"] += 1
+        return next(values)
+
+    clock = {"now": 0.0}
+    provider = RefreshingSecretProvider(
+        CredentialSourceSpec(kind="command", command="unused"),
+        parent_env={},
+        refresh_interval=100.0,
+        clock=lambda: clock["now"],
+        resolver=resolver,
+    )
+    # Eager resolve at construction already fetched v1.
+    assert resolver_calls["n"] == 1
+    assert provider.resolve() == "v1"
+    clock["now"] = 50.0  # still inside the window -> cached
+    assert provider.resolve() == "v1"
+    assert resolver_calls["n"] == 1
+    clock["now"] = 150.0  # past the window -> re-resolve
+    assert provider.resolve() == "v2"
+    assert resolver_calls["n"] == 2
+
+
+def test_refreshing_source_fails_loud_eagerly() -> None:
+    """A misconfigured refreshing source raises at prepare time, not first swap.
+
+    Fail-loud parity with the static path: a refreshing ``env`` source whose
+    variable is missing must raise during
+    :func:`prepare_credential_proxy_runtime`, so a bad config never yields a
+    live rule that only blows up on the first outbound request.
+    """
+    spec = CredentialProxySpec(
+        entries=[
+            _bearer_entry(
+                "h.example.com",
+                env_var="T",
+                source=CredentialSourceSpec(kind="env", env="MISSING", refresh_interval=0.0),
+            )
+        ]
+    )
+    with pytest.raises(ValueError, match="missing or empty"):
+        prepare_credential_proxy_runtime(spec, parent_env={})
+
+
+@pytest.mark.parametrize("bad", [-1.0, float("nan"), float("inf")])
+def test_refreshing_provider_rejects_non_finite_or_negative_interval(bad: float) -> None:
+    """The provider fails loud on a negative / NaN / infinite interval.
+
+    This is the prepare-time boundary for callers that build a
+    :class:`CredentialSourceSpec` directly (bypassing the parser check):
+    ``NaN`` would re-resolve on every swap and infinity would disable
+    refresh forever, both silently violating the throttle contract.
+    """
+    with pytest.raises(ValueError, match="finite, non-negative"):
+        RefreshingSecretProvider(
+            CredentialSourceSpec(kind="command", command="unused"),
+            parent_env={},
+            refresh_interval=bad,
+            resolver=lambda _s: "unused",
+        )
+
+
+def test_refreshing_provider_snapshots_parent_env() -> None:
+    """The provider resolves against the env captured at construction.
+
+    A later mutation of the caller's ``parent_env`` dict must not change
+    what an ``env`` source resolves to — the trusted startup environment is
+    frozen when the provider is built.
+    """
+    env = {"OA_SECRET": "v1"}
+    provider = RefreshingSecretProvider(
+        CredentialSourceSpec(kind="env", env="OA_SECRET", refresh_interval=0.0),
+        parent_env=env,
+        refresh_interval=0.0,
+    )
+    assert provider.resolve() == "v1"
+    env["OA_SECRET"] = "v2"  # mutate the original dict after construction
+    assert provider.resolve() == "v1"

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -3690,6 +3690,70 @@ def test_parse_credential_proxy_https_env_optional(tmp_path: Path) -> None:
     assert entry.inject_env == []
 
 
+def test_parse_credential_proxy_source_refresh_interval(tmp_path: Path) -> None:
+    """A source ``refresh_interval`` parses through to the runtime spec.
+
+    Without the passthrough a rotating-source config would parse but the
+    runtime would still bake the value in once, so a long session would hit
+    proxy-injected 401s after the backing token expired.
+    """
+    config = _credential_proxy_config(
+        [
+            {
+                "type": "gh_basic",
+                "source": {"command": "gh auth token", "refresh_interval": 300},
+            }
+        ]
+    )
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    entry = spec.os_env.sandbox.credential_proxy.entries[0]
+    assert entry.source.kind == "command"
+    assert entry.source.refresh_interval == 300
+
+
+def test_parse_credential_proxy_source_rejects_negative_refresh(tmp_path: Path) -> None:
+    """A negative ``refresh_interval`` fails loudly at parse time.
+
+    A negative throttle is meaningless; rejecting it up front stops a
+    nonsensical config from reaching the runtime.
+    """
+    config = _credential_proxy_config(
+        [
+            {
+                "type": "gh_basic",
+                "source": {"command": "gh auth token", "refresh_interval": -1},
+            }
+        ]
+    )
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match="refresh_interval"):
+        parse(tmp_path)
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+def test_parse_credential_proxy_source_rejects_non_finite_refresh(
+    tmp_path: Path, bad: float
+) -> None:
+    """A non-finite ``refresh_interval`` fails loudly at parse time.
+
+    ``NaN`` slips past a bare ``< 0`` guard (``NaN < 0`` is false) yet would
+    re-resolve on every swap; infinity would disable refresh forever. Both
+    must be rejected up front.
+    """
+    config = _credential_proxy_config(
+        [
+            {
+                "type": "gh_basic",
+                "source": {"command": "gh auth token", "refresh_interval": bad},
+            }
+        ]
+    )
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match="refresh_interval"):
+        parse(tmp_path)
+
+
 def test_parse_credential_proxy_databricks_cli(tmp_path: Path) -> None:
     """A ``databricks_cli`` entry parses into a profile-keyed policy.
 


### PR DESCRIPTION
## Problem

The generic `credential_proxy` source kinds (`env` / `file` / `command`) resolve their real secret exactly once in `prepare_credential_proxy_runtime` and bake it into the in-memory `CredentialRewriteRule` as a static `real_secret`. It is never re-read. A source whose backing value rotates mid-session — most notably a `command` that mints a short-lived token, e.g. a GitHub App installation token that expires in ~1h — leaves a long session hitting proxy-injected 401s after expiry.

Fixes #3247.

## Fix

`CredentialRewriteRule` already carries the seam for this: `secret_provider`, a zero-arg callable re-resolved on each swap that takes precedence over the static `real_secret`. The `databricks_cli` type already uses it (via `DatabricksProfileTokenProvider`) to survive ~1h OAuth expiry; the generic source kinds simply did not.

This adds an optional `refresh_interval` (seconds) to `CredentialSourceSpec`. When set, the source is wired through `secret_provider` via a new `RefreshingSecretProvider` that re-resolves `_resolve_secret` at most once per interval on each swap (`0` = every swap), mirroring the databricks throttle and its clock/resolver test seams. When unset (the default) behaviour is unchanged: resolve once, static.

Details:

- The value is resolved eagerly at construction, so a misconfigured source still fails loud at prepare time rather than on first swap.
- The field is wired through the spec parser (`_CredentialSourceModel`); the interval is validated as a finite, non-negative number in both the parser and `RefreshingSecretProvider.__init__`, so a direct-datamodel caller is guarded too (NaN would re-resolve every swap; infinity would disable refresh forever).
- The provider snapshots the parent environment at construction, so a later mutation of the caller's dict cannot change what a refreshed `env`/`command` source resolves against.
- `command` sources remain bounded by the existing 30s subprocess timeout.

## Tests

New tests mirror the existing databricks refresh tests: the rotation fix, the throttle window, eager fail-loud, non-finite/negative rejection, and the parent-env snapshot, across both the runtime (`tests/inner/test_credential_proxy.py`) and the parser (`tests/spec/test_parser.py`).
