### PR TITLE
fix(web): drop maximized-rail traffic-light clearance when the sidebar reopens

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -617,8 +617,15 @@ aside[aria-label="Workspace"][data-maximized] {
  * the traffic lights float (0–5rem) and the title-bar cluster sits (5rem–10rem,
  * z above the rail). Pad the strip past both so its leftmost tab icon clears
  * them. Only the maximized rail reaches this corner; the docked rail sits right
- * of the sidebar and is untouched. */
-[data-electron-mac] aside[aria-label="Workspace"][data-maximized] .workspace-tab-strip {
+ * of the sidebar and is untouched.
+ *
+ * Skip the clearance when the sidebar is reopened over a maximized rail: the
+ * sidebar (z above the rail) then covers the window corner, so the lights and
+ * cluster sit over IT, not the strip — the strip starts right of the sidebar
+ * with nothing to clear, and the padding would shove the tabs into the middle. */
+[data-electron-mac]:not([data-sidebar-open])
+  aside[aria-label="Workspace"][data-maximized]
+  .workspace-tab-strip {
   padding-left: 10.5rem;
 }
 /* Drag regions are geometric, not z-ordered: anything that overlaps the

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -636,6 +636,70 @@ describe("index.css electron-mac sidebar header", () => {
   });
 });
 
+/* Regression test for the "maximized rail tabs float in the middle when the
+ * sidebar is reopened" bug on the macOS desktop shell.
+ *
+ * A maximized workspace rail breaks out to the window's top-left corner, so its
+ * tab strip is padded 10.5rem to clear the traffic lights and the title-bar
+ * cluster. Maximizing normally collapses the sidebar, but the user can reopen
+ * it (⌘⌥[ / the title-bar toggle) over the still-maximized rail. The sidebar
+ * (z above the rail) then covers that corner — the lights sit over IT, and the
+ * strip starts to the sidebar's right with nothing to clear — so the clearance
+ * must drop, or the padding shoves the tabs into the middle. The rule keys off
+ * `data-sidebar-open` on the app shell (set by AppShell) to do this; asserted at
+ * the CSS level because the lights are painted by macOS OUTSIDE the page, so no
+ * DOM test or screenshot can see them. This selector IS the alignment.
+ */
+describe("index.css maximized workspace rail traffic-light clearance", () => {
+  const rule = (cssSource.match(/[^{}]+\{[^{}]*\}/g) ?? []).find(
+    (block) => block.includes(".workspace-tab-strip") && /padding-left/.test(block),
+  );
+  const selector = (rule ?? "")
+    .slice(0, rule ? rule.indexOf("{") : 0)
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .trim();
+
+  function makeStrip(shellAttrs: Record<string, string>): HTMLElement {
+    const shell = document.createElement("div");
+    shell.className = "app-shell";
+    for (const [k, v] of Object.entries(shellAttrs)) shell.setAttribute(k, v);
+    const rail = document.createElement("aside");
+    rail.setAttribute("aria-label", "Workspace");
+    rail.setAttribute("data-maximized", "true");
+    const strip = document.createElement("div");
+    strip.className = "workspace-tab-strip";
+    rail.appendChild(strip);
+    shell.appendChild(rail);
+    document.body.appendChild(shell);
+    return strip;
+  }
+
+  it("has the clearance rule this test exists to protect", () => {
+    expect(rule, "the maximized rail tab-strip padding rule is gone from index.css").toBeDefined();
+    expect(rule).toMatch(/padding-left:\s*10\.5rem/);
+  });
+
+  it("clears the lights on the mac shell while the sidebar is collapsed", () => {
+    const strip = makeStrip({ "data-electron-mac": "true" });
+    expect(strip.matches(selector)).toBe(true);
+    strip.closest(".app-shell")?.remove();
+  });
+
+  it("drops the clearance once the sidebar is reopened over the maximized rail", () => {
+    // The exact bug: sidebar open covers the window corner, so the 10.5rem
+    // padding has nothing to clear and would push the tabs into the middle.
+    const strip = makeStrip({ "data-electron-mac": "true", "data-sidebar-open": "true" });
+    expect(strip.matches(selector)).toBe(false);
+    strip.closest(".app-shell")?.remove();
+  });
+
+  it("never clears in a plain browser (no lights to avoid)", () => {
+    const strip = makeStrip({});
+    expect(strip.matches(selector)).toBe(false);
+    strip.closest(".app-shell")?.remove();
+  });
+});
+
 describe("index.css native conversation breadcrumb", () => {
   it("does not hide the parent-session link on iOS/Android native shells", () => {
     // Native chrome is a server switcher, not session back. A blanket

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -1779,6 +1779,28 @@ describe("Workspace rail maximize", () => {
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
   });
 
+  it("reflects the docked sidebar's open state on the app shell for CSS to key off", () => {
+    // The maximized rail's traffic-light clearance (index.css) must drop when
+    // the sidebar is reopened over it — the sidebar then covers the window
+    // corner, so there are no lights to clear. That CSS keys off
+    // `data-sidebar-open` on the app shell, so the attribute has to track the
+    // docked open state (absent when closed, "true" when open).
+    mockConversations([{ id: "conv_abc", permission_level: null }]);
+    renderShell("/c/conv_abc");
+
+    const shell = document.querySelector(".app-shell");
+    expect(shell).not.toBeNull();
+    // Collapsed going in (jsdom default): the attribute is absent, so
+    // `:not([data-sidebar-open])` matches and the clearance still applies.
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "false");
+    expect(shell?.hasAttribute("data-sidebar-open")).toBe(false);
+
+    // Reopen the sidebar: the attribute appears, dropping the clearance.
+    fireEvent.click(screen.getByRole("button", { name: /open sidebar/i }));
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
+    expect(shell).toHaveAttribute("data-sidebar-open", "true");
+  });
+
   it("pins the sidebar open on /settings so the Back row is reachable", () => {
     // The settings nav replaces the session list INSIDE the sidebar, and its
     // Back row is the only way off the page. Collapsed, that row is clipped and

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1748,6 +1748,11 @@ export function AppShell() {
         traffic lights and supplies a drag strip in the freed space. */}
           <div
             className="app-shell relative flex h-dvh bg-sidebar text-foreground"
+            // Reflect the docked sidebar's open state so CSS can drop the
+            // traffic-light clearance on surfaces the sidebar covers (see the
+            // maximized workspace rail's tab strip in index.css): with the
+            // sidebar open over the window corner there are no lights to clear.
+            data-sidebar-open={sidebarOpen ? "true" : undefined}
             data-electron-mac={isMacElectronShell() ? "true" : undefined}
             data-ios-native={isIOSShell() ? "true" : undefined}
             data-android-native={isAndroidShell() ? "true" : undefined}


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- On the macOS desktop shell, a maximized workspace rail's tab strip is padded
  `10.5rem` to clear the traffic lights + title-bar cluster at the window's
  top-left corner. Maximizing collapses the sidebar, so this normally lines up.
- But reopening the sidebar (⌘⌥[ or the title-bar toggle) over a still-maximized
  rail paints the sidebar *over* that corner — the lights now sit on the sidebar,
  and the tab strip starts to its right with nothing to clear. The padding stayed,
  shoving the tabs into the middle of the panel (see the reported screenshot).
- Fix: reflect the docked sidebar's open state on the app shell as
  `data-sidebar-open`, and scope the clearance to
  `[data-electron-mac]:not([data-sidebar-open])` so the padding drops whenever the
  sidebar covers the corner. Mirrors the existing `traffic-light-clearance` gating
  in `ChatHeader`.

## Test Plan

- `cd web && npm test` — new tests pass; the 3 pre-existing `NewChatDialog.test.tsx`
  failures also fail on unmodified `main` (unrelated host-picker flake).
- `cd web && npm run build` — clean.
- Added regression coverage:
  - `index.css.test.ts` — runs the actual selector against a real DOM: clears
    while the sidebar is collapsed on the mac shell, **drops** the clearance once
    `data-sidebar-open` is set, and never clears in a plain browser.
  - `AppShell.test.tsx` — asserts the app shell reflects `data-sidebar-open`
    (absent when collapsed, `"true"` when reopened).
- Manual: `just electron-dev` → open a session with a workspace → maximize the
  rail → reopen the sidebar (⌘⌥[). Tabs sit flush against the panel's left edge,
  immediately right of the sidebar, instead of floating in the middle. With the
  sidebar closed, the maximized rail still clears the traffic lights.

## Demo

N/A — verify locally via the manual steps above (the traffic lights are painted
by macOS outside the page, so a page screenshot can't capture the alignment; the
CSS-selector test encodes the contract instead).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: the traffic lights are drawn by macOS outside the DOM, so
alignment can't be asserted from a page screenshot. The CSS-selector DOM test
pins the contract (clearance applies when the sidebar is collapsed, drops when
open), and the behavioral test pins the `data-sidebar-open` reflection; the
remaining pixel alignment was confirmed by hand in the Electron shell.

## Changelog

Fix desktop header/tab-strip drifting to the center when the sidebar is reopened over a full-screen workspace panel

---
This pull request and its description were written by Isaac.
