### PR TITLE
Fix Databricks host auth for workspace routing

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3371,9 +3371,13 @@ def _ensure_databricks_server_auth(server: str, *, non_interactive: bool = False
     if workspace_host is None:
         return
     org_id = load_databricks_org_id(server)
-    token = _databricks_workspace_token(workspace_host)
-    if token is not None:
-        refreshed_probe = _verify_databricks_server_token(server, token, org_id)
+    auth_info = _databricks_workspace_auth_info(workspace_host)
+    if auth_info is not None:
+        if org_id is None:
+            org_id = _workspace_hosted_profile_org_id(
+                server, workspace_host, auth_info.profile_name
+            )
+        refreshed_probe = _verify_databricks_server_token(server, auth_info.token, org_id)
         if refreshed_probe.status_code == 200:
             store_databricks_auth(server, workspace_host, org_id=org_id)
             return
@@ -11299,6 +11303,23 @@ def _databricks_default_workspace_id(workspace_host: str) -> str | None:
     return databrickscfg_workspace_id_for_host(workspace_host)
 
 
+def _workspace_hosted_profile_org_id(
+    server: str,
+    workspace_host: str,
+    profile_name: str | None = None,
+) -> str | None:
+    """Return the CLI-recorded workspace id for workspace-hosted Omnigent."""
+    from omnigent.server_url import is_workspace_hosted_url
+
+    if not is_workspace_hosted_url(server):
+        return None
+    if profile_name:
+        from omnigent.inner.databricks_executor import databrickscfg_workspace_id_for_profile
+
+        return databrickscfg_workspace_id_for_profile(profile_name)
+    return _databricks_default_workspace_id(workspace_host)
+
+
 def _databricks_host_needs_org_selector(workspace_host: str) -> bool:
     """Whether *workspace_host* fronts many workspaces and needs a ``?o=`` selector.
 
@@ -11357,11 +11378,6 @@ def _databricks_login(server: str, workspace_host: str, org_id: str | None = Non
         databricks_sdk_installed,
     )
 
-    # User-facing: the display form (workspace /omnigent URL with ?o= when
-    # known) — the API mount is an implementation detail.
-    display = ServerUrl(api_base=server, org_id=org_id).display
-    click.echo(f"{display} authenticates via the Databricks workspace {workspace_host}.")
-
     if not databricks_sdk_installed():
         raise click.ClickException(
             "Logging in to a Databricks-fronted server (a Databricks App or "
@@ -11371,6 +11387,15 @@ def _databricks_login(server: str, workspace_host: str, org_id: str | None = Non
         )
 
     from omnigent.cli_auth import is_workspace_hosted_url
+
+    auth_info = _databricks_workspace_auth_info(workspace_host)
+    if org_id is None and auth_info is not None:
+        org_id = _workspace_hosted_profile_org_id(server, workspace_host, auth_info.profile_name)
+
+    # User-facing: the display form (workspace /omnigent URL with ?o= when
+    # known) — the API mount is an implementation detail.
+    display = ServerUrl(api_base=server, org_id=org_id).display
+    click.echo(f"{display} authenticates via the Databricks workspace {workspace_host}.")
 
     # An account-fronting workspace mount serves many workspaces under one host,
     # so the login URL carries no ?o= selector — but the Databricks CLI still
@@ -11383,20 +11408,26 @@ def _databricks_login(server: str, workspace_host: str, org_id: str | None = Non
         and _databricks_host_needs_org_selector(workspace_host)
     )
 
-    token = _databricks_workspace_token(workspace_host)
+    token = auth_info.token if auth_info is not None else None
     fresh_login_done = False
     if token is None:
-        token = _login_and_mint_workspace_token(workspace_host, org_id)
+        auth_info = _login_and_mint_workspace_auth_info(workspace_host, org_id)
+        token = auth_info.token
         fresh_login_done = True
+        if org_id is None:
+            org_id = _workspace_hosted_profile_org_id(
+                server, workspace_host, auth_info.profile_name
+            )
 
     # Inherit the workspace the CLI selected: the browser login (or a prior one)
     # auto-selected a workspace and recorded its id in the profile; replaying it
     # as ?o= routes the account token to that workspace. Without it the login
     # would fail on an account host it could have completed unattended.
-    if account_host_without_selector:
+    if org_id is None and (account_host_without_selector or is_workspace_hosted_url(server)):
         org_id = _databricks_default_workspace_id(workspace_host)
         if org_id:
             click.echo(f"Routing to workspace {org_id}, selected during the Databricks login.")
+            display = ServerUrl(api_base=server, org_id=org_id).display
 
     # Verify the workspace token actually gets through the edge to THIS
     # server (the user may lack access to it), and learn our identity
@@ -11411,7 +11442,14 @@ def _databricks_login(server: str, workspace_host: str, org_id: str | None = Non
             f"The cached Databricks credentials were rejected by {display} "
             f"(HTTP {verify.status_code}) — refreshing the workspace login."
         )
-        token = _login_and_mint_workspace_token(workspace_host, org_id)
+        auth_info = _login_and_mint_workspace_auth_info(workspace_host, org_id)
+        token = auth_info.token
+        if org_id is None:
+            org_id = _workspace_hosted_profile_org_id(
+                server, workspace_host, auth_info.profile_name
+            )
+            if org_id:
+                display = ServerUrl(api_base=server, org_id=org_id).display
         verify = _verify_databricks_server_token(server, token, org_id)
     if verify.status_code != 200:
         raise click.ClickException(
@@ -11453,14 +11491,21 @@ def _login_and_mint_workspace_token(workspace_host: str, org_id: str | None = No
         missing, the login exits non-zero, or no token resolves after
         a successful login.
     """
+    return _login_and_mint_workspace_auth_info(workspace_host, org_id).token
+
+
+def _login_and_mint_workspace_auth_info(
+    workspace_host: str, org_id: str | None = None
+) -> _DatabricksWorkspaceAuthInfo:
+    """Run the browser login and return the selected workspace auth info."""
     _run_databricks_browser_login(workspace_host, org_id)
-    token = _databricks_workspace_token(workspace_host)
-    if token is None:
+    auth_info = _databricks_workspace_auth_info(workspace_host)
+    if auth_info is None:
         raise click.ClickException(
             f"Workspace login completed but no token resolves for {workspace_host}. "
             f"Run `databricks auth token --host {workspace_host}` to debug."
         )
-    return token
+    return auth_info
 
 
 def _run_databricks_browser_login(workspace_host: str, org_id: str | None = None) -> None:
@@ -11540,6 +11585,29 @@ def _verify_databricks_server_token(
         ) from exc
 
 
+@dataclass(frozen=True)
+class _DatabricksWorkspaceAuthInfo:
+    token: str
+    profile_name: str | None
+
+
+def _databricks_workspace_auth_info(workspace_host: str) -> _DatabricksWorkspaceAuthInfo | None:
+    """Mint a bearer and remember the Databricks profile that supplied it."""
+    from omnigent.inner.databricks_executor import (
+        DatabricksAuthError,
+        _resolve_databricks_auth,
+    )
+
+    try:
+        auth, _host = _resolve_databricks_auth(host=workspace_host)
+        token = auth.current_token()
+    except (DatabricksAuthError, ImportError, ValueError):
+        return None
+    if not token:
+        return None
+    return _DatabricksWorkspaceAuthInfo(token=token, profile_name=auth.profile_name)
+
+
 def _databricks_workspace_token(workspace_host: str) -> str | None:
     """Mint a bearer for a workspace from the host-keyed OAuth cache.
 
@@ -11548,16 +11616,8 @@ def _databricks_workspace_token(workspace_host: str) -> str | None:
     :returns: A bearer token, or ``None`` when no cached grant
         resolves (the caller should run ``databricks auth login``).
     """
-    from omnigent.inner.databricks_executor import (
-        DatabricksAuthError,
-        _resolve_databricks_auth,
-    )
-
-    try:
-        auth, _host = _resolve_databricks_auth(host=workspace_host)
-        return auth.current_token()
-    except (DatabricksAuthError, ImportError, ValueError):
-        return None
+    info = _databricks_workspace_auth_info(workspace_host)
+    return info.token if info is not None else None
 
 
 def _remember_default_server(server: str) -> None:

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -15,12 +15,16 @@ Environment:
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import json
 import logging
 import os
 import shlex
+import shutil
+import subprocess
+import time
 from collections.abc import AsyncIterator, Generator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
 
 import httpx
@@ -55,6 +59,8 @@ OpenAIKwargs: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
 
 _API_CALL_TIMEOUT_SECONDS = 30.0
 _STREAM_IDLE_TIMEOUT_SECONDS = 60.0
+_CLI_TOKEN_REFRESH_MARGIN_SECONDS = 90.0
+_CLI_TOKEN_DEFAULT_TTL_SECONDS = 50 * 60.0
 
 _SESSION_ONLY_EXECUTOR_EXTRA_KEYS = {
     "new_user_messages_flushed",
@@ -397,6 +403,90 @@ class _DatabricksAuthConfig(Protocol):
         raise NotImplementedError
 
 
+@dataclass(frozen=True)
+class _DatabricksCliToken:
+    access_token: str
+    expires_at: float
+
+
+@dataclass
+class _DatabricksCliProfileAuthConfig:
+    """Profile-pinned Databricks CLI OAuth token source."""
+
+    profile: str
+    host: str
+    _cached_token: _DatabricksCliToken | None = field(default=None, init=False, repr=False)
+
+    def authenticate(self) -> dict[str, str]:
+        now = time.time()
+        cached = self._cached_token
+        if cached is None or cached.expires_at - now <= _CLI_TOKEN_REFRESH_MARGIN_SECONDS:
+            cached = _databricks_cli_profile_token(self.profile, now=now)
+            self._cached_token = cached
+        return {"Authorization": f"Bearer {cached.access_token}"}
+
+
+def _databricks_cli_profile_token(
+    profile: str, *, now: float | None = None
+) -> _DatabricksCliToken:
+    """Mint a bearer token by profile, avoiding ambiguous host lookup."""
+    databricks_bin = shutil.which("databricks")
+    if databricks_bin is None:
+        raise ValueError("databricks CLI is not installed")
+    try:
+        result = subprocess.run(
+            [databricks_bin, "auth", "token", "--profile", profile, "--output", "json"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30.0,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError(f"databricks auth token --profile {profile} timed out") from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip()
+        raise ValueError(detail or f"databricks auth token --profile {profile} failed")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"databricks auth token --profile {profile} returned invalid JSON"
+        ) from exc
+    token = payload.get("access_token") if isinstance(payload, dict) else None
+    if not isinstance(token, str) or not token.strip():
+        raise ValueError(f"databricks auth token --profile {profile} returned no access_token")
+    return _DatabricksCliToken(
+        access_token=token.strip(),
+        expires_at=_databricks_cli_token_expires_at(payload, now=now),
+    )
+
+
+def _databricks_cli_token_expires_at(
+    payload: dict[str, Any], *, now: float | None = None
+) -> float:
+    """Return the CLI token expiry timestamp, falling back conservatively."""
+    base = time.time() if now is None else now
+    expires_in = payload.get("expires_in")
+    if isinstance(expires_in, (int, float)):
+        return base + max(float(expires_in), 0.0)
+    if isinstance(expires_in, str):
+        try:
+            return base + max(float(expires_in), 0.0)
+        except ValueError:
+            pass
+    expiry = payload.get("expiry")
+    if isinstance(expiry, str) and expiry:
+        try:
+            normalized = expiry.replace("Z", "+00:00")
+            parsed = dt.datetime.fromisoformat(normalized)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=dt.UTC)
+            return parsed.timestamp()
+        except ValueError:
+            pass
+    return base + _CLI_TOKEN_DEFAULT_TTL_SECONDS
+
+
 class _DatabricksBearerAuth(httpx.Auth):
     """httpx Auth that calls ``Config.authenticate()`` on every HTTP request.
 
@@ -432,6 +522,10 @@ class _DatabricksBearerAuth(httpx.Auth):
         self._config = config
         self._profile_name = profile_name
         self._failure_message = failure_message
+
+    @property
+    def profile_name(self) -> str | None:
+        return self._profile_name
 
     def _authenticate_headers(self) -> dict[str, str]:
         """
@@ -645,8 +739,21 @@ def _resolve_databricks_auth_for_host(host: str) -> tuple[_DatabricksBearerAuth,
             cfg = _sdk_config(profile=profile_name)
             cfg.authenticate()
         except Exception:  # noqa: BLE001 — try the next matching profile
-            logger.debug("profile %r matched host %s but did not authenticate", profile_name, host)
-            continue
+            logger.debug(
+                "profile %r matched host %s but did not authenticate via SDK",
+                profile_name,
+                host,
+            )
+            try:
+                cfg = _DatabricksCliProfileAuthConfig(profile=profile_name, host=host)
+                cfg.authenticate()
+            except Exception:  # noqa: BLE001 — try the next matching profile
+                logger.debug(
+                    "profile %r matched host %s but did not authenticate via CLI",
+                    profile_name,
+                    host,
+                )
+                continue
         return _DatabricksBearerAuth(cfg, profile_name=profile_name), cfg.host or host
     try:
         host_cfg = _sdk_config(host=host, auth_type="databricks-cli")
@@ -728,6 +835,31 @@ def databrickscfg_workspace_id_for_host(host: str) -> str | None:
         if workspace_id:
             return workspace_id
     return None
+
+
+def databrickscfg_workspace_id_for_profile(profile: str) -> str | None:
+    """Return the ``workspace_id`` recorded for an exact Databricks profile."""
+    import configparser
+    from pathlib import Path
+
+    cfg_path = Path(os.environ.get("DATABRICKS_CONFIG_FILE") or (Path.home() / ".databrickscfg"))
+    if not cfg_path.exists():
+        return None
+    config = configparser.ConfigParser()
+    try:
+        config.read(cfg_path)
+    except configparser.Error:
+        return None
+    if profile == "DEFAULT":
+        values = config.defaults()
+    elif profile in config:
+        values = config[profile]
+    else:
+        values = None
+    if values is None:
+        return None
+    workspace_id = values.get("workspace_id")
+    return workspace_id if workspace_id else None
 
 
 def _get_openai_client(profile: str | None = None) -> OpenAI:

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -1853,7 +1853,11 @@ def test_databricks_preflight_silent_sdk_refresh_skips_login(
         return next(responses)
 
     monkeypatch.setattr(httpx, "get", _get)
-    monkeypatch.setattr(cli, "_databricks_workspace_token", lambda workspace: "fresh-token")
+    monkeypatch.setattr(
+        cli,
+        "_databricks_workspace_auth_info",
+        lambda workspace: cli._DatabricksWorkspaceAuthInfo(token="fresh-token", profile_name=None),
+    )
     monkeypatch.setattr(cli, "_databricks_login", lambda *args, **kwargs: pytest.fail("login"))
     monkeypatch.setattr("omnigent.cli_auth.load_databricks_org_id", lambda server: "123")
 
@@ -1872,6 +1876,191 @@ def test_databricks_preflight_silent_sdk_refresh_skips_login(
     assert requests[1]["headers"] == {"Authorization": "Bearer fresh-token"}
     assert requests[1]["params"] == {"o": "123"}
     assert stored == [(_HOST_DATABRICKS_SERVER, "https://example.databricks.com", "123")]
+
+
+def test_databricks_preflight_uses_cli_workspace_id_for_workspace_mount(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``omni host`` routes workspace-hosted auth with the CLI profile workspace id."""
+    import httpx
+
+    server = "https://example.databricks.com/api/2.0/omnigent"
+    requests: list[dict[str, object]] = []
+    stored: list[tuple[str, str, str | None]] = []
+    cfg_path = tmp_path / "databrickscfg"
+    cfg_path.write_text(
+        "[expired]\n"
+        "host = https://example.databricks.com\n"
+        "workspace_id = 111\n"
+        "auth_type = databricks-cli\n"
+        "[fresh]\n"
+        "host = https://example.databricks.com\n"
+        "workspace_id = 1965859176160743\n"
+        "auth_type = databricks-cli\n"
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+
+    monkeypatch.setattr(
+        "omnigent.chat._remote_headers",
+        lambda server_url=None, *, host_id=None: {},
+    )
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_org_id", lambda server: None)
+    monkeypatch.setattr(
+        cli,
+        "_databricks_workspace_auth_info",
+        lambda workspace: cli._DatabricksWorkspaceAuthInfo(
+            token="fresh-token", profile_name="fresh"
+        ),
+    )
+    monkeypatch.setattr(cli, "_databricks_login", lambda *args, **kwargs: pytest.fail("login"))
+
+    def _get(url: str, **kwargs: object) -> httpx.Response:
+        requests.append(kwargs)
+        if len(requests) == 1:
+            return httpx.Response(
+                401,
+                headers={"www-authenticate": 'Bearer realm="DatabricksRealm"'},
+                request=httpx.Request("GET", url),
+            )
+        return httpx.Response(
+            200,
+            content=json.dumps({"user_id": "alice@example.com"}).encode(),
+            request=httpx.Request("GET", url),
+        )
+
+    def _store(
+        server: str,
+        workspace: str,
+        user_id: str | None = None,
+        org_id: str | None = None,
+    ) -> None:
+        stored.append((server, workspace, org_id))
+
+    monkeypatch.setattr(httpx, "get", _get)
+    monkeypatch.setattr("omnigent.cli_auth.store_databricks_auth", _store)
+
+    cli._ensure_databricks_server_auth(server, non_interactive=True)
+
+    assert requests[1]["headers"] == {"Authorization": "Bearer fresh-token"}
+    assert requests[1]["params"] == {"o": "1965859176160743"}
+    assert stored == [(server, "https://example.databricks.com", "1965859176160743")]
+
+
+def test_databricks_preflight_refresh_handles_duplicate_workspace_profiles(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``omnigent host`` preflight avoids ambiguous host-keyed token lookup.
+
+    When two ``~/.databrickscfg`` profiles point at the same workspace, the
+    Databricks SDK's ``Config(profile=...)`` path can still shell out to
+    ``databricks auth token --host ...``. The preflight refresh must recover by
+    pinning the CLI token call to ``--profile``.
+    """
+    import httpx
+
+    from omnigent.inner import databricks_executor
+
+    cfg_path = tmp_path / "databrickscfg"
+    cfg_path.write_text(
+        "[expired]\n"
+        "host = https://example.databricks.com\n"
+        "auth_type = databricks-cli\n"
+        "[fresh]\n"
+        "host = https://example.databricks.com\n"
+        "auth_type = databricks-cli\n"
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+    monkeypatch.setattr(
+        "omnigent.chat._remote_headers",
+        lambda server_url=None, *, host_id=None: {"Authorization": "Bearer expired-token"},
+    )
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_org_id", lambda server: None)
+
+    attempts: list[tuple[str, object]] = []
+
+    def _ambiguous_sdk_config(**kwargs: str) -> object:
+        attempts.append(("sdk", kwargs))
+        raise ValueError(
+            "databricks-cli: expired and fresh match "
+            "https://example.databricks.com. Use --profile to specify which profile to use"
+        )
+
+    def _run_databricks(args: list[str], **kwargs: object) -> object:
+        attempts.append(("cli", args))
+        assert "--host" not in args
+        profile = args[args.index("--profile") + 1]
+        if profile == "expired":
+            return type("_Result", (), {"returncode": 1, "stdout": "", "stderr": "expired"})()
+        if profile == "fresh":
+            return type(
+                "_Result",
+                (),
+                {
+                    "returncode": 0,
+                    "stdout": json.dumps({"access_token": "fresh-token"}),
+                    "stderr": "",
+                },
+            )()
+        raise AssertionError(f"unexpected Databricks profile lookup: {args!r}")
+
+    def _get(url: str, **kwargs: object) -> httpx.Response:
+        headers = kwargs.get("headers")
+        auth_header = headers.get("Authorization") if isinstance(headers, dict) else None
+        if auth_header == "Bearer fresh-token":
+            return _databricks_probe_response(200)
+        return _databricks_probe_response(302)
+
+    stored: list[tuple[str, str, str | None]] = []
+
+    def _store(
+        server: str,
+        workspace: str,
+        user_id: str | None = None,
+        org_id: str | None = None,
+    ) -> None:
+        stored.append((server, workspace, org_id))
+
+    monkeypatch.setattr(databricks_executor, "_sdk_config", _ambiguous_sdk_config)
+    monkeypatch.setattr(databricks_executor.shutil, "which", lambda name: "/usr/bin/databricks")
+    monkeypatch.setattr(databricks_executor.subprocess, "run", _run_databricks)
+    monkeypatch.setattr(httpx, "get", _get)
+    monkeypatch.setattr(cli, "_databricks_login", lambda *args, **kwargs: pytest.fail("login"))
+    monkeypatch.setattr("omnigent.cli_auth.store_databricks_auth", _store)
+
+    cli._ensure_databricks_server_auth(_HOST_DATABRICKS_SERVER, non_interactive=True)
+
+    assert attempts == [
+        ("sdk", {"profile": "expired"}),
+        (
+            "cli",
+            [
+                "/usr/bin/databricks",
+                "auth",
+                "token",
+                "--profile",
+                "expired",
+                "--output",
+                "json",
+            ],
+        ),
+        ("sdk", {"profile": "fresh"}),
+        (
+            "cli",
+            [
+                "/usr/bin/databricks",
+                "auth",
+                "token",
+                "--profile",
+                "fresh",
+                "--output",
+                "json",
+            ],
+        ),
+    ]
+    assert stored == [
+        (_HOST_DATABRICKS_SERVER, "https://example.databricks.com", None),
+    ]
 
 
 # ── Foreground ``host`` auth pre-flight ─────────────────────────────

--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -116,7 +116,7 @@ def _patch_login_env(
     :param monkeypatch: Pytest monkeypatch fixture.
     :param fake_httpx: Scripted httpx.get replacement.
     :param sdk_installed: What ``databricks_sdk_installed()`` reports.
-    :param cached_tokens: Successive ``_databricks_workspace_token``
+    :param cached_tokens: Successive workspace auth token
         results, e.g. ``[None, "tok"]`` for "no cached grant, then a
         token after ``databricks auth login`` runs". Defaults to a
         cached token on first try.
@@ -147,11 +147,14 @@ def _patch_login_env(
         lambda: sdk_installed,
     )
     tokens = list(cached_tokens if cached_tokens is not None else ["tok-cached"])
-    monkeypatch.setattr(
-        cli_mod,
-        "_databricks_workspace_token",
-        lambda workspace_host: tokens.pop(0),
-    )
+
+    def _auth_info(workspace_host: str) -> cli_mod._DatabricksWorkspaceAuthInfo | None:
+        token = tokens.pop(0)
+        if token is None:
+            return None
+        return cli_mod._DatabricksWorkspaceAuthInfo(token=token, profile_name=None)
+
+    monkeypatch.setattr(cli_mod, "_databricks_workspace_auth_info", _auth_info)
 
     login_calls: list[str] = []
 
@@ -276,6 +279,37 @@ def test_login_account_host_inherits_cli_selected_workspace(
     assert load_databricks_workspace_host(_WORKSPACE_API_URL) == _WORKSPACE
 
 
+def test_login_workspace_hosted_uses_cli_workspace_id_without_metadata(
+    monkeypatch: pytest.MonkeyPatch, token_dir: Path
+) -> None:
+    """Workspace-hosted login can route with only the CLI profile workspace id."""
+    from omnigent.cli_auth import load_databricks_org_id, load_databricks_workspace_host
+
+    fake = _FakeHttpx(
+        responses=[
+            _response(
+                401,
+                headers={"www-authenticate": 'Bearer realm="DatabricksRealm"'},
+                body={"error_code": 401, "message": "Credential was not sent"},
+            ),
+            _response(200, body={"user_id": "alice@example.com"}),
+        ]
+    )
+    _patch_login_env(
+        monkeypatch,
+        fake_httpx=fake,
+        host_needs_selector=False,
+        default_workspace_id="1965859176160743",
+    )
+
+    result = CliRunner().invoke(cli_group, ["login", _WORKSPACE_API_URL])
+
+    assert result.exit_code == 0, result.output
+    assert fake.requests[-1]["params"] == {"o": "1965859176160743"}
+    assert load_databricks_org_id(_WORKSPACE_API_URL) == "1965859176160743"
+    assert load_databricks_workspace_host(_WORKSPACE_API_URL) == _WORKSPACE
+
+
 @pytest.mark.parametrize(
     ("account_id", "workspace_id", "expected"),
     [
@@ -304,6 +338,7 @@ def test_databricks_host_needs_org_selector_reads_discovery_metadata(
         sdk_oauth,
         "get_host_metadata",
         lambda host: SimpleNamespace(account_id=account_id, workspace_id=workspace_id),
+        raising=False,
     )
     assert cli_mod._databricks_host_needs_org_selector("https://host.example") is expected
 
@@ -317,7 +352,7 @@ def test_databricks_host_needs_org_selector_swallows_discovery_failure(
     def _boom(host: str) -> object:
         raise ValueError("no route to host")
 
-    monkeypatch.setattr(sdk_oauth, "get_host_metadata", _boom)
+    monkeypatch.setattr(sdk_oauth, "get_host_metadata", _boom, raising=False)
     assert cli_mod._databricks_host_needs_org_selector("https://host.example") is False
 
 

--- a/tests/inner/test_databricks_executor.py
+++ b/tests/inner/test_databricks_executor.py
@@ -715,6 +715,7 @@ from omnigent.inner.databricks_executor import (  # noqa: E402
     _read_databrickscfg_file_fallback,
     _read_databrickscfg_host,
     databrickscfg_workspace_id_for_host,
+    databrickscfg_workspace_id_for_profile,
 )
 
 _AUTH_ENV_VARS: tuple[str, ...] = (
@@ -770,6 +771,7 @@ def pat_only_cfg(
     monkeypatch.setattr(
         "databricks.sdk.config.get_host_metadata",
         _raise_offline_host_metadata,
+        raising=False,
     )
     contents = textwrap.dedent(
         """
@@ -934,6 +936,7 @@ def test_databricks_gateway_host_missing_profile_falls_back_to_ambient(
     monkeypatch.setattr(
         "databricks.sdk.config.get_host_metadata",
         _raise_offline_host_metadata,
+        raising=False,
     )
     cfg_path = tmp_path / "databrickscfg"
     cfg_path.write_text("# no matching profile\n")
@@ -1782,6 +1785,141 @@ def test_resolve_auth_for_host_prefers_matching_profile(
     assert constructed == [{"profile": "my-ws"}]
 
 
+def test_resolve_auth_for_host_uses_profile_cli_when_sdk_is_ambiguous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SDK profile auth can still hit ambiguous host lookup for CLI profiles."""
+    from omnigent.inner import databricks_executor
+
+    cfg_path = tmp_path / "databrickscfg"
+    cfg_path.write_text(
+        "[expired]\n"
+        "host = https://example.databricks.com\n"
+        "auth_type = databricks-cli\n"
+        "[fresh]\n"
+        "host = https://example.databricks.com\n"
+        "auth_type = databricks-cli\n"
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+
+    attempts: list[tuple[str, object]] = []
+
+    def _ambiguous_sdk_config(**kwargs: str) -> object:
+        attempts.append(("sdk", kwargs))
+        raise ValueError(
+            "databricks-cli: expired and fresh match "
+            "https://example.databricks.com. Use --profile to specify which profile to use"
+        )
+
+    def _run_databricks(args: list[str], **kwargs: object) -> SimpleNamespace:
+        attempts.append(("cli", args))
+        assert "--host" not in args
+        profile = args[args.index("--profile") + 1]
+        if profile == "expired":
+            return SimpleNamespace(returncode=1, stdout="", stderr="expired")
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"access_token": "fresh-token"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(databricks_executor, "_sdk_config", _ambiguous_sdk_config)
+    monkeypatch.setattr(databricks_executor.shutil, "which", lambda name: "/usr/bin/databricks")
+    monkeypatch.setattr(databricks_executor.subprocess, "run", _run_databricks)
+
+    auth, host = databricks_executor._resolve_databricks_auth(
+        host="https://example.databricks.com"
+    )
+
+    assert auth.current_token() == "fresh-token"
+    assert auth.current_token() == "fresh-token"
+    assert host == "https://example.databricks.com"
+    assert attempts == [
+        ("sdk", {"profile": "expired"}),
+        (
+            "cli",
+            [
+                "/usr/bin/databricks",
+                "auth",
+                "token",
+                "--profile",
+                "expired",
+                "--output",
+                "json",
+            ],
+        ),
+        ("sdk", {"profile": "fresh"}),
+        (
+            "cli",
+            [
+                "/usr/bin/databricks",
+                "auth",
+                "token",
+                "--profile",
+                "fresh",
+                "--output",
+                "json",
+            ],
+        ),
+    ]
+
+
+def test_profile_cli_auth_config_caches_until_token_nears_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The profile CLI fallback does not re-shell for every auth header."""
+    from omnigent.inner import databricks_executor
+
+    calls = 0
+    timestamps = iter([1000.0, 1001.0, 1020.0])
+
+    def _run_databricks(args: list[str], **kwargs: object) -> SimpleNamespace:
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"access_token": f"token-{calls}", "expires_in": 100}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(databricks_executor.time, "time", lambda: next(timestamps))
+    monkeypatch.setattr(databricks_executor.shutil, "which", lambda name: "/usr/bin/databricks")
+    monkeypatch.setattr(databricks_executor.subprocess, "run", _run_databricks)
+
+    cfg = databricks_executor._DatabricksCliProfileAuthConfig(
+        profile="fresh",
+        host="https://example.databricks.com",
+    )
+
+    assert cfg.authenticate() == {"Authorization": "Bearer token-1"}
+    assert cfg.authenticate() == {"Authorization": "Bearer token-1"}
+    assert cfg.authenticate() == {"Authorization": "Bearer token-2"}
+    assert calls == 2
+
+
+def test_profile_cli_token_error_does_not_include_stdout_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-zero CLI exit never reports stdout, which may contain a token."""
+    from omnigent.inner import databricks_executor
+
+    def _run_databricks(args: list[str], **kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            returncode=1,
+            stdout=json.dumps({"access_token": "secret-token"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(databricks_executor.shutil, "which", lambda name: "/usr/bin/databricks")
+    monkeypatch.setattr(databricks_executor.subprocess, "run", _run_databricks)
+
+    with pytest.raises(ValueError) as exc:
+        databricks_executor._databricks_cli_profile_token("fresh")
+
+    assert "secret-token" not in str(exc.value)
+    assert str(exc.value) == "databricks auth token --profile fresh failed"
+
+
 def test_resolve_auth_for_host_falls_back_to_cli_when_no_profile_matches(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1907,6 +2045,37 @@ def test_databrickscfg_workspace_id_for_host_reads_matching_profile(
     # A profile without the field, and an unknown host, both resolve to None.
     assert databrickscfg_workspace_id_for_host("https://plain.databricks.com") is None
     assert databrickscfg_workspace_id_for_host("https://other.databricks.com") is None
+
+
+def test_databrickscfg_workspace_id_for_profile_reads_exact_profile(
+    tmp_path: _Path, monkeypatch: pytest.MonkeyPatch, clean_databricks_env: None
+) -> None:
+    """Profile-based workspace lookup does not pick another matching host."""
+    cfg = tmp_path / "databrickscfg"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            [DEFAULT]
+            workspace_id = default-ws
+
+            [expired]
+            host = https://acme.databricks.com
+            workspace_id = workspace-a
+            auth_type = databricks-cli
+
+            [fresh]
+            host = https://acme.databricks.com
+            workspace_id = workspace-b
+            auth_type = databricks-cli
+            """
+        ).lstrip()
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+
+    assert databrickscfg_workspace_id_for_profile("fresh") == "workspace-b"
+    assert databrickscfg_workspace_id_for_profile("expired") == "workspace-a"
+    assert databrickscfg_workspace_id_for_profile("DEFAULT") == "default-ws"
+    assert databrickscfg_workspace_id_for_profile("missing") is None
 
 
 def test_databrickscfg_workspace_id_for_host_missing_file_returns_none(


### PR DESCRIPTION
## Related issue

Linear: OMNI-5552

## Summary

Fix `omnigent host` authentication for Databricks workspace-hosted servers in two related routing cases:

- Multiple Databricks CLI profiles can point at the same workspace URL. The Databricks SDK may still shell out through an ambiguous host-keyed token lookup even when Omnigent selected a specific profile, so Omnigent now falls back to `databricks auth token --profile <profile> --output json` for matching profiles.
- Account-style workspace hosts such as `https://isaac.databricks.com/omnigent` need the workspace selector even when the URL does not include `?o=...`. Omnigent now infers that selector from the Databricks CLI profile that actually supplied the bearer token, so `/v1/me` verifies against the same workspace/profile pair instead of the account root.

Review follow-ups addressed:

- The profile-pinned CLI token fallback now caches the minted token until it nears expiry, so validation and immediate follow-up requests do not re-shell the Databricks CLI.
- Failed `databricks auth token` subprocesses no longer include stdout in exception detail, avoiding accidental token leakage if stdout contains token JSON on a non-zero exit.
- Workspace-id routing is keyed from the selected/authenticating profile where available, avoiding first-matching-profile drift when profiles on the same host carry different `workspace_id`s.

ELI5: when one Databricks URL can mean more than one saved login or workspace, Omnigent now uses the specific profile/workspace id that Databricks already recorded instead of asking by URL alone.

```mermaid
flowchart LR
  A[omnigent host preflight] --> B[workspace-hosted server]
  B --> C[matching databrickscfg profile]
  C --> D[workspace_id routes ?o=]
  C --> E[databricks auth token --profile]
  E --> G[in-memory token cache]
  D --> F[verify /v1/me]
  G --> F
```

## Test Plan

- `uv run pytest tests/inner/test_databricks_executor.py tests/cli/test_backend.py tests/cli/test_login_databricks.py -q`
- `uv run pre-commit run --files omnigent/inner/databricks_executor.py omnigent/cli.py tests/inner/test_databricks_executor.py tests/cli/test_backend.py tests/cli/test_login_databricks.py`
- Manually reproduced the duplicate-profile failure with `omni host --server https://e2-dogfood.staging.cloud.databricks.com/`, where `databricks auth token --host https://e2-dogfood.staging.cloud.databricks.com` failed because both `e2` and `e2-dogfood` matched the workspace.
- Retried `omni host --server https://e2-dogfood.staging.cloud.databricks.com/` after the fix and confirmed the host connected successfully, then interrupted the foreground host process with Ctrl-C.
- Manually reproduced the `isaac` failure with `omni host --server https://isaac.databricks.com/omnigent`; verifying without `o=1965859176160743` returned HTTP 403, while verifying with the CLI profile's `workspace_id` returned HTTP 200.
- Retried `omni host --server https://isaac.databricks.com/omnigent` after the fix and confirmed the host connected successfully as `FY49XFP3QG`, then interrupted the foreground host process with Ctrl-C.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added resolver-level, login, and host preflight regression tests for duplicate workspace profiles, profile-pinned CLI token caching, stdout-safe subprocess errors, exact-profile workspace-id lookup, and workspace-hosted account routing without a stored org selector. Manual verification covered both the staging workspace from OMNI-5552 and `https://isaac.databricks.com/omnigent`.

## Changelog

`omnigent host` can connect to Databricks workspace-hosted servers when CLI profile selection or workspace-id routing would otherwise make the Databricks edge reject the token.
