### PR TITLE
fix(harness): bump absolute turn watchdog default from 1 h to 3 h

### DIFF
--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -127,7 +127,7 @@ _TURN_IDLE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_TIMEOUT_S", "600"))
 # keeps emitting, so a runaway-but-active loop (e.g. an infinite tool
 # loop emitting steadily) needs this. Generous so it never clips a real
 # long turn. ``<= 0`` disables. Whichever of (idle, absolute) trips first.
-_TURN_ABSOLUTE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "3600"))
+_TURN_ABSOLUTE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "10800"))
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Raises `_TURN_ABSOLUTE_TIMEOUT_S` default from 3600 s (1 hour) to 10800 s (3 hours).
- Long-running turns (deep research, large context compaction, tool-heavy agents) were hitting the hard cap and being killed mid-turn. The idle watchdog (10 min, resets on each emit) already handles truly-wedged turns; the absolute cap is a backstop for runaway-but-active loops, so 3 h is still conservative.
- The `HARNESS_TURN_ABSOLUTE_TIMEOUT_S` env var remains the ops override.

## Test Plan

- Start a long-running turn that previously hit the 1-hour wall and confirm it completes.
- Set `HARNESS_TURN_ABSOLUTE_TIMEOUT_S=60` to verify the env var override still works.

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Not applicable

## Coverage notes

Config-default change only; no logic altered. The env-var override path is exercised by existing tests.

## Changelog

Raises the per-turn absolute watchdog timeout from 1 hour to 3 hours so long-running turns are no longer killed prematurely.