### PR TITLE
feat(pi-native): add 'Pi — use own login' option in omni setup

### DIFF
--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -766,56 +766,82 @@ def _configure_harness_add(family: str | None = None) -> str | None:
         )
 
     elif kind == "subscription":
-        cli_name = chosen.cli  # preset by the flat option (claude / codex)
+        cli_name = chosen.cli  # preset by the flat option (claude / codex / pi)
         if cli_name is None:
             raise click.ClickException("internal: subscription option missing a cli login")
-        from omnigent.onboarding.harness_install import harness_install_spec, harness_login
 
-        login_family = {agent: fam for fam, agent in _FAMILY_UCODE_AGENT.items()}.get(cli_name)
-        if login_family is None:
-            raise click.ClickException(f"internal: no login family for cli {cli_name!r}")
-        spec = harness_install_spec(login_family)
-        disp = spec.display if spec is not None else cli_name
-        # A harness has at most ONE subscription — the CLI's own login. If one
-        # is already configured for this CLI (under any name, including an
-        # ambient login adopted as e.g. ``claude``), adding another just
-        # duplicates it — the ``claude`` + ``claude-subscription`` bug. Offer to
-        # replace the existing one; declining aborts before we touch the login.
-        existing_subs = [
-            n
-            for n, e in load_providers(_load_global_config()).items()
-            if e.kind == SUBSCRIPTION_KIND and e.cli == cli_name
-        ]
-        if existing_subs:
-            brand = _CLI_LOGIN_BRAND.get(cli_name, cli_name)
-            replace = select(
-                f"A {brand} subscription is already configured. Replace it?",
-                ["Replace it", "Keep the current one"],
-                default=0,
-                clear_on_exit=True,
-            )
-            if replace != 0:  # "Keep the current one" or Esc — abort the add
-                return None
-        # Configure is the single place to sign in: drive the harness's own
-        # login (a no-op if already logged in). Only record the subscription
-        # once the CLI is actually authenticated — otherwise we'd persist a
-        # phantom subscription that strands the user at the harness's own login
-        # screen at run time (the exact bug this whole flow fixes).
-        console.print(f"  [dim]Signing in to {disp} (its login will open)…[/dim]")
-        if not harness_login(login_family):
-            return f"✗ {disp} login not completed — subscription not added"
-        # Login succeeded — drop the existing subscription(s) for this CLI so the
-        # canonical entry is the only one left (clearing the old default lets the
-        # new entry re-claim the family default below). Done AFTER login so a
-        # failed login leaves the existing subscription intact.
-        if existing_subs:
-            block = _load_global_config().get("providers")
-            if isinstance(block, dict):
-                remaining = {k: v for k, v in block.items() if k not in existing_subs}
-                _save_global_config({"providers": remaining})  # wholesale replace
-        # Subscription name is derived from the CLI login — no prompt.
-        name = f"{cli_name}-subscription"
-        entry = build_subscription_provider_entry(cli_name)
+        if cli_name == "pi":
+            # A pi subscription signals "use Pi's own native auth" — no login
+            # step required (Pi manages its own credentials in ~/.pi/agent).
+            existing_subs = [
+                n
+                for n, e in load_providers(_load_global_config()).items()
+                if e.kind == SUBSCRIPTION_KIND and e.cli == cli_name
+            ]
+            if existing_subs:
+                replace = select(
+                    "A Pi native-login preference is already configured. Replace it?",
+                    ["Replace it", "Keep the current one"],
+                    default=0,
+                    clear_on_exit=True,
+                )
+                if replace != 0:
+                    return None
+            if existing_subs:
+                block = _load_global_config().get("providers")
+                if isinstance(block, dict):
+                    remaining = {k: v for k, v in block.items() if k not in existing_subs}
+                    _save_global_config({"providers": remaining})
+            name = "pi-subscription"
+            entry = build_subscription_provider_entry(cli_name)
+        else:
+            from omnigent.onboarding.harness_install import harness_install_spec, harness_login
+
+            login_family = {agent: fam for fam, agent in _FAMILY_UCODE_AGENT.items()}.get(cli_name)
+            if login_family is None:
+                raise click.ClickException(f"internal: no login family for cli {cli_name!r}")
+            spec = harness_install_spec(login_family)
+            disp = spec.display if spec is not None else cli_name
+            # A harness has at most ONE subscription — the CLI's own login. If one
+            # is already configured for this CLI (under any name, including an
+            # ambient login adopted as e.g. ``claude``), adding another just
+            # duplicates it — the ``claude`` + ``claude-subscription`` bug. Offer to
+            # replace the existing one; declining aborts before we touch the login.
+            existing_subs = [
+                n
+                for n, e in load_providers(_load_global_config()).items()
+                if e.kind == SUBSCRIPTION_KIND and e.cli == cli_name
+            ]
+            if existing_subs:
+                brand = _CLI_LOGIN_BRAND.get(cli_name, cli_name)
+                replace = select(
+                    f"A {brand} subscription is already configured. Replace it?",
+                    ["Replace it", "Keep the current one"],
+                    default=0,
+                    clear_on_exit=True,
+                )
+                if replace != 0:  # "Keep the current one" or Esc — abort the add
+                    return None
+            # Configure is the single place to sign in: drive the harness's own
+            # login (a no-op if already logged in). Only record the subscription
+            # once the CLI is actually authenticated — otherwise we'd persist a
+            # phantom subscription that strands the user at the harness's own login
+            # screen at run time (the exact bug this whole flow fixes).
+            console.print(f"  [dim]Signing in to {disp} (its login will open)…[/dim]")
+            if not harness_login(login_family):
+                return f"✗ {disp} login not completed — subscription not added"
+            # Login succeeded — drop the existing subscription(s) for this CLI so the
+            # canonical entry is the only one left (clearing the old default lets the
+            # new entry re-claim the family default below). Done AFTER login so a
+            # failed login leaves the existing subscription intact.
+            if existing_subs:
+                block = _load_global_config().get("providers")
+                if isinstance(block, dict):
+                    remaining = {k: v for k, v in block.items() if k not in existing_subs}
+                    _save_global_config({"providers": remaining})  # wholesale replace
+            # Subscription name is derived from the CLI login — no prompt.
+            name = f"{cli_name}-subscription"
+            entry = build_subscription_provider_entry(cli_name)
 
     elif kind == "gateway":
         name = prompt_text("Name for this gateway", default="gateway")

--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -769,32 +769,28 @@ def _configure_harness_add(family: str | None = None) -> str | None:
         cli_name = chosen.cli  # preset by the flat option (claude / codex / pi)
         if cli_name is None:
             raise click.ClickException("internal: subscription option missing a cli login")
+        from omnigent.onboarding.configure_models import cli_display_name
 
-        if cli_name == "pi":
-            # A pi subscription signals "use Pi's own native auth" — no login
-            # step required (Pi manages its own credentials in ~/.pi/agent).
-            existing_subs = [
-                n
-                for n, e in load_providers(_load_global_config()).items()
-                if e.kind == SUBSCRIPTION_KIND and e.cli == cli_name
-            ]
-            if existing_subs:
-                replace = select(
-                    "A Pi native-login preference is already configured. Replace it?",
-                    ["Replace it", "Keep the current one"],
-                    default=0,
-                    clear_on_exit=True,
-                )
-                if replace != 0:
-                    return None
-            if existing_subs:
-                block = _load_global_config().get("providers")
-                if isinstance(block, dict):
-                    remaining = {k: v for k, v in block.items() if k not in existing_subs}
-                    _save_global_config({"providers": remaining})
-            name = "pi-subscription"
-            entry = build_subscription_provider_entry(cli_name)
-        else:
+        # A harness has at most ONE subscription. If one is already configured
+        # for this CLI (under any name), offer to replace it — declining aborts
+        # before we touch any login.
+        existing_subs = [
+            n
+            for n, e in load_providers(_load_global_config()).items()
+            if e.kind == SUBSCRIPTION_KIND and e.cli == cli_name
+        ]
+        if existing_subs:
+            replace = select(
+                f"A {cli_display_name(cli_name)} subscription is already configured. Replace it?",
+                ["Replace it", "Keep the current one"],
+                default=0,
+                clear_on_exit=True,
+            )
+            if replace != 0:  # "Keep the current one" or Esc — abort the add
+                return None
+        # CLIs listed in _CLI_LOGIN_BRAND (claude / codex) require a login step.
+        # CLIs not listed (pi) manage their own auth — no login step needed.
+        if cli_name in _CLI_LOGIN_BRAND:
             from omnigent.onboarding.harness_install import harness_install_spec, harness_login
 
             login_family = {agent: fam for fam, agent in _FAMILY_UCODE_AGENT.items()}.get(cli_name)
@@ -802,26 +798,6 @@ def _configure_harness_add(family: str | None = None) -> str | None:
                 raise click.ClickException(f"internal: no login family for cli {cli_name!r}")
             spec = harness_install_spec(login_family)
             disp = spec.display if spec is not None else cli_name
-            # A harness has at most ONE subscription — the CLI's own login. If one
-            # is already configured for this CLI (under any name, including an
-            # ambient login adopted as e.g. ``claude``), adding another just
-            # duplicates it — the ``claude`` + ``claude-subscription`` bug. Offer to
-            # replace the existing one; declining aborts before we touch the login.
-            existing_subs = [
-                n
-                for n, e in load_providers(_load_global_config()).items()
-                if e.kind == SUBSCRIPTION_KIND and e.cli == cli_name
-            ]
-            if existing_subs:
-                brand = _CLI_LOGIN_BRAND.get(cli_name, cli_name)
-                replace = select(
-                    f"A {brand} subscription is already configured. Replace it?",
-                    ["Replace it", "Keep the current one"],
-                    default=0,
-                    clear_on_exit=True,
-                )
-                if replace != 0:  # "Keep the current one" or Esc — abort the add
-                    return None
             # Configure is the single place to sign in: drive the harness's own
             # login (a no-op if already logged in). Only record the subscription
             # once the CLI is actually authenticated — otherwise we'd persist a
@@ -830,18 +806,16 @@ def _configure_harness_add(family: str | None = None) -> str | None:
             console.print(f"  [dim]Signing in to {disp} (its login will open)…[/dim]")
             if not harness_login(login_family):
                 return f"✗ {disp} login not completed — subscription not added"
-            # Login succeeded — drop the existing subscription(s) for this CLI so the
-            # canonical entry is the only one left (clearing the old default lets the
-            # new entry re-claim the family default below). Done AFTER login so a
-            # failed login leaves the existing subscription intact.
-            if existing_subs:
-                block = _load_global_config().get("providers")
-                if isinstance(block, dict):
-                    remaining = {k: v for k, v in block.items() if k not in existing_subs}
-                    _save_global_config({"providers": remaining})  # wholesale replace
-            # Subscription name is derived from the CLI login — no prompt.
-            name = f"{cli_name}-subscription"
-            entry = build_subscription_provider_entry(cli_name)
+        # Drop the existing subscription(s) now that we know we're proceeding.
+        # Done after any login so a failed login leaves the existing entry intact.
+        if existing_subs:
+            block = _load_global_config().get("providers")
+            if isinstance(block, dict):
+                remaining = {k: v for k, v in block.items() if k not in existing_subs}
+                _save_global_config({"providers": remaining})
+        # Subscription name is derived from the CLI — no prompt.
+        name = f"{cli_name}-subscription"
+        entry = build_subscription_provider_entry(cli_name)
 
     elif kind == "gateway":
         name = prompt_text("Name for this gateway", default="gateway")

--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -1344,6 +1344,8 @@ def _credential_label(name: str, entry: ProviderEntry) -> str:
         gateway = _claude_managed_gateway_label()
         if gateway is not None:
             return gateway
+    if entry.kind == SUBSCRIPTION_KIND and entry.cli == "pi":
+        return "Pi original auth"
     return credential_label(
         entry.kind, name, profile=entry.profile, display_name=entry.display_name
     )

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -457,8 +457,8 @@ def add_menu_options() -> list[AddOption]:
             cli="claude",
         ),
         _opt(
-            "Pi — use own login",
-            "Let Pi use its own login (~/.pi/agent) instead of an Omnigent-managed provider.",
+            "Pi — original auth",
+            "Use Pi's own auth (~/.pi/agent) as-is, without Omnigent managing the provider.",
             SUBSCRIPTION_KIND,
             cli="pi",
         ),

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -276,7 +276,7 @@ def cli_display_name(cli: str) -> str:
         or ``"ChatGPT"`` for ``codex`` (the ChatGPT plan drives codex).
         Falls back to a title-cased form for any other value.
     """
-    return {"claude": "Claude (Pro/Max)", "codex": "ChatGPT"}.get(cli, cli.title())
+    return {"claude": "Claude (Pro/Max)", "codex": "ChatGPT", "pi": "Pi"}.get(cli, cli.title())
 
 
 def kind_glyph(kind: str) -> str:
@@ -456,6 +456,12 @@ def add_menu_options() -> list[AddOption]:
             SUBSCRIPTION_KIND,
             cli="claude",
         ),
+        _opt(
+            "Pi — use own login",
+            "Let Pi use its own login (~/.pi/agent) instead of an Omnigent-managed provider.",
+            SUBSCRIPTION_KIND,
+            cli="pi",
+        ),
         # Cross-vendor extras, alphabetical (Gateway before OpenRouter).
         _opt(
             "Gateway — custom base URL + key",
@@ -528,6 +534,8 @@ def _add_option_families(opt: AddOption) -> frozenset[str]:
             return frozenset({ANTHROPIC_FAMILY})
         if opt.cli == "codex":
             return frozenset({OPENAI_FAMILY})
+        if opt.cli == "pi":
+            return frozenset({PI_SURFACE})
         return frozenset()
     if opt.kind == KEY_KIND:
         if opt.other:

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -471,14 +471,30 @@ def _harness_availability(canonical: str) -> HarnessAvailability:
         # warning copy uniform across every CLI-backed native harness.
         return _cli_family_availability(canonical, install_key)
     if canonical in _PI_HARNESSES:
-        # pi has no CLI login — its only credential is an omnigent-managed
-        # provider (an API key / gateway, incl. one set from the UI). So the
-        # two-step signal is binary + provider: installed-but-no-provider is
-        # the yellow "needs-auth" state the setup dialog acts on.
+        # pi has no CLI login — its only credential is either an omnigent-managed
+        # provider (an API key / gateway) or a pi-subscription ("Pi original auth",
+        # which signals "use Pi's own ~/.pi/agent as-is"). So the two-step signal
+        # is binary + provider: installed-but-no-provider is the yellow "needs-auth"
+        # state the setup dialog acts on.
         binary_state = _binary_availability_reason(PI_KEY)
         if binary_state is not True:
             return binary_state
-        return True if _family_provider_configured(PI_SURFACE) else "needs-auth"
+        if _family_provider_configured(PI_SURFACE):
+            return True
+        # A pi subscription (original auth) is also a valid configured state —
+        # it means Pi will use its own ~/.pi/agent credentials, no omnigent
+        # provider needed.
+        try:
+            provider = default_provider_for_harness(load_config(), PI_SURFACE)
+            if (
+                provider is not None
+                and provider.kind == SUBSCRIPTION_KIND
+                and provider.cli == "pi"
+            ):
+                return True
+        except Exception:
+            pass
+        return "needs-auth"
     return _harness_availability_core(canonical)
 
 

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -96,10 +96,11 @@ _PI_FALLBACK_FAMILIES = (ANTHROPIC_FAMILY, OPENAI_FAMILY)
 # too (a Databricks AI Gateway is pi-consumable — Pi speaks its Anthropic
 # surface), with the actual gateway capability validated at resolution time.
 # A ``subscription`` (CLI login, unusable outside its own CLI) and ``bedrock``
-# (native-``omnigent claude`` only) can never drive pi. Resolution: an
-# explicit pi default wins; otherwise pi falls back to the anthropic then
-# openai family default, skipping the non-pi kinds (see
-# :func:`default_provider_for_harness`).
+# (native-``omnigent claude`` only) can never drive pi — EXCEPT for a pi
+# subscription (``kind="subscription", cli="pi"``), which explicitly opts into
+# Pi's own native auth and may default the pi surface. Resolution: an explicit
+# pi default wins; otherwise pi falls back to the anthropic then openai family
+# default, skipping the non-pi kinds (see :func:`default_provider_for_harness`).
 PI_SURFACE = "pi"
 
 # Accepted ``wire_api`` values. ``responses`` is the OpenAI Responses API;
@@ -856,7 +857,7 @@ def _parse_default_families(
     # ``provider_families`` and rejects a hand-edited ``default: ["gemini",
     # "pi"]`` at parse time (parity with how a subscription's pi scope is
     # rejected), rather than failing loudly only at pi launch.
-    pi_ok = pi_capable and bool(served & frozenset(_PI_FALLBACK_FAMILIES))
+    pi_ok = pi_capable and (bool(served & frozenset(_PI_FALLBACK_FAMILIES)) or not served)
     allowed = served | {PI_SURFACE} if pi_ok else served
     invalid = requested - allowed
     if invalid:
@@ -937,19 +938,24 @@ def _parse_provider(name: str, raw: dict[str, object]) -> ProviderEntry:
                 code=ErrorCode.INVALID_INPUT,
             )
         # A subscription serves the family its CLI implies (claude→anthropic,
-        # codex→openai); an unknown CLI serves nothing.
+        # codex→openai); a pi subscription serves no model family directly —
+        # it is pi-capable so it can claim the pi scope explicitly, signalling
+        # "use Pi's own native auth"; an unknown CLI serves nothing.
         served = (
             {ANTHROPIC_FAMILY}
             if cli_raw == "claude"
             else ({OPENAI_FAMILY} if cli_raw == "codex" else set())
         )
+        # claude/codex subscriptions are locked to their own CLIs and cannot
+        # drive pi. A pi subscription explicitly opts into Pi's own native auth
+        # and may default the pi surface (pi_capable=True, served={}).
         return ProviderEntry(
             name=name,
             kind=kind,
             cli=cli_raw,
-            # A subscription is locked to its own CLI, so it can never drive
-            # pi — naming "pi" in its default scope is a config error.
-            default_families=_parse_default_families(name, default_raw, served, pi_capable=False),
+            default_families=_parse_default_families(
+                name, default_raw, served, pi_capable=(cli_raw == "pi")
+            ),
         )
 
     if kind == CLI_CONFIG_KIND:
@@ -1213,8 +1219,8 @@ def provider_families(entry: ProviderEntry) -> frozenset[str]:
       plus the :data:`PI_SURFACE` scope (pi consumes either family).
     - ``subscription`` / ``cli-config``: derived from the CLI — ``claude``
       serves the ``anthropic`` surface, ``codex`` serves the ``openai``
-      surface. Never pi: a CLI login (or a provider pinned in the CLI's
-      own config file) is unusable outside its own CLI.
+      surface, ``pi`` serves only the :data:`PI_SURFACE` scope (signals
+      "use Pi's own native auth"). Other CLIs serve nothing.
     - ``databricks``: both families plus pi — ucode routes the Claude,
       Codex, and pi surfaces.
 
@@ -1254,6 +1260,10 @@ def provider_families(entry: ProviderEntry) -> frozenset[str]:
     if entry.kind in (SUBSCRIPTION_KIND, CLI_CONFIG_KIND):
         if entry.cli == "claude":
             return frozenset({ANTHROPIC_FAMILY})
+        if entry.cli == "pi":
+            # A pi subscription signals "use Pi's own native auth" — it serves
+            # only the pi scope (no model family directly).
+            return frozenset({PI_SURFACE})
         if entry.cli == "codex":
             # A codex *cli-config* provider may ALSO serve pi: a Databricks AI
             # Gateway exposes an Anthropic Messages surface Pi speaks natively

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -47,6 +47,7 @@ from omnigent.onboarding.provider_config import (
     KEY_KIND,
     LOCAL_KIND,
     PI_SURFACE,
+    SUBSCRIPTION_KIND,
     ProviderEntry,
     default_provider_for_harness,
     load_config,
@@ -1155,14 +1156,23 @@ def resolve_pi_native_provider(
         elif entry.kind in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):
             resolved = _inline_family_pi_provider(entry, model=model)
         else:
-            # subscription (a CLI's own login can't be reused outside that CLI):
-            # let Pi use its own login.
-            _LOGGER.info(
-                "pi-native: configured provider %r (kind %r) cannot drive Pi; "
-                "Pi will use its own login.",
-                entry.name,
-                entry.kind,
-            )
+            if entry.kind == SUBSCRIPTION_KIND and entry.cli == "pi":
+                # Explicitly configured to use Pi's own native auth — skip the
+                # managed models.json so Pi reads its own ~/.pi/agent config.
+                _LOGGER.info(
+                    "pi-native: provider %r is a pi-native subscription; "
+                    "Pi will use its own login.",
+                    entry.name,
+                )
+            else:
+                # subscription (a CLI's own login can't be reused outside that CLI):
+                # let Pi use its own login.
+                _LOGGER.info(
+                    "pi-native: configured provider %r (kind %r) cannot drive Pi; "
+                    "Pi will use its own login.",
+                    entry.name,
+                    entry.kind,
+                )
             return None
         if resolved is None:
             # The provider matched a translatable kind but its details could not

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -47,7 +47,6 @@ from omnigent.onboarding.provider_config import (
     KEY_KIND,
     LOCAL_KIND,
     PI_SURFACE,
-    SUBSCRIPTION_KIND,
     ProviderEntry,
     default_provider_for_harness,
     load_config,
@@ -1156,23 +1155,14 @@ def resolve_pi_native_provider(
         elif entry.kind in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):
             resolved = _inline_family_pi_provider(entry, model=model)
         else:
-            if entry.kind == SUBSCRIPTION_KIND and entry.cli == "pi":
-                # Explicitly configured to use Pi's own native auth — skip the
-                # managed models.json so Pi reads its own ~/.pi/agent config.
-                _LOGGER.info(
-                    "pi-native: provider %r is a pi-native subscription; "
-                    "Pi will use its own login.",
-                    entry.name,
-                )
-            else:
-                # subscription (a CLI's own login can't be reused outside that CLI):
-                # let Pi use its own login.
-                _LOGGER.info(
-                    "pi-native: configured provider %r (kind %r) cannot drive Pi; "
-                    "Pi will use its own login.",
-                    entry.name,
-                    entry.kind,
-                )
+            # subscription (a CLI's own login can't be reused outside that CLI):
+            # let Pi use its own login.
+            _LOGGER.info(
+                "pi-native: configured provider %r (kind %r) cannot drive Pi; "
+                "Pi will use its own login.",
+                entry.name,
+                entry.kind,
+            )
             return None
         if resolved is None:
             # The provider matched a translatable kind but its details could not

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -585,7 +585,7 @@ def test_add_menu_options_ordering() -> None:
         "Gemini — API key",
         "ChatGPT — subscription",
         "Claude — subscription (Pro/Max)",
-        "Pi — use own login",
+        "Pi — original auth",
         "Gateway — custom base URL + key",
         "OpenRouter — API key",
         "Databricks — workspace",
@@ -2341,7 +2341,7 @@ def test_pi_add_menu_offers_keys_gateway_databricks_but_no_subscription() -> Non
 
     options = add_menu_options_for_family(PI_SURFACE)
     kinds = {o.kind for o in options}
-    # The pi subscription ("Pi — use own login") IS offered for pi — it lets
+    # The pi subscription ("Pi — original auth") IS offered for pi — it lets
     # users bypass Omnigent-managed auth and use Pi's own credentials.
     assert any(o.kind == "subscription" and o.cli == "pi" for o in options)
     # claude/codex subscriptions must NOT appear — a CLI login is unusable

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -585,6 +585,7 @@ def test_add_menu_options_ordering() -> None:
         "Gemini — API key",
         "ChatGPT — subscription",
         "Claude — subscription (Pro/Max)",
+        "Pi — use own login",
         "Gateway — custom base URL + key",
         "OpenRouter — API key",
         "Databricks — workspace",
@@ -2340,8 +2341,12 @@ def test_pi_add_menu_offers_keys_gateway_databricks_but_no_subscription() -> Non
 
     options = add_menu_options_for_family(PI_SURFACE)
     kinds = {o.kind for o in options}
-    # No subscription row — the one credential kind pi can't consume.
-    assert "subscription" not in kinds
+    # The pi subscription ("Pi — use own login") IS offered for pi — it lets
+    # users bypass Omnigent-managed auth and use Pi's own credentials.
+    assert any(o.kind == "subscription" and o.cli == "pi" for o in options)
+    # claude/codex subscriptions must NOT appear — a CLI login is unusable
+    # outside its own CLI, so offering one would configure a broken credential.
+    assert not any(o.kind == "subscription" and o.cli in ("claude", "codex") for o in options)
     # Both vendors' keys are offered (pi spans both families), plus the
     # cross-vendor extras and Databricks.
     assert any(o.label.endswith("Anthropic — API key") for o in options)

--- a/tests/onboarding/test_provider_config.py
+++ b/tests/onboarding/test_provider_config.py
@@ -512,11 +512,11 @@ def test_key_with_gemini_block_still_serves_gemini() -> None:
 
 
 def test_subscription_cannot_claim_pi_scope() -> None:
-    """Naming ``"pi"`` in a subscription's default scope fails loud.
+    """A claude/codex subscription cannot claim the pi scope.
 
     Both at parse time (a hand-edited config) and via set_default_provider
-    (the menu path) — a subscription can never drive pi, so persisting the
-    scope would wedge pi on an unusable credential.
+    (the menu path) — a claude/codex subscription can never drive pi, so
+    persisting the scope would wedge pi on an unusable credential.
     """
     raw = {"kind": "subscription", "cli": "claude", "default": ["pi"]}
     with pytest.raises(OmnigentError):
@@ -524,6 +524,33 @@ def test_subscription_cannot_claim_pi_scope() -> None:
     block = {"claude-subscription": {"kind": "subscription", "cli": "claude"}}
     with pytest.raises(OmnigentError):
         set_default_provider(block, "claude-subscription", PI_SURFACE)
+
+
+def test_pi_subscription_claims_pi_scope() -> None:
+    """A pi subscription (cli: pi) can default the pi surface.
+
+    ``kind="subscription", cli="pi"`` signals "use Pi's own native auth". It
+    may claim the pi scope, be set as the pi-surface default via
+    ``set_default_provider``, and be returned by ``default_provider_for_harness``.
+    """
+    raw = {"kind": "subscription", "cli": "pi", "default": "pi"}
+    providers = load_providers({"providers": {"pi-subscription": raw}})
+    entry = providers["pi-subscription"]
+    assert entry.kind == "subscription"
+    assert entry.cli == "pi"
+    assert PI_SURFACE in entry.default_families
+    # A pi subscription serves no model family directly.
+    assert ANTHROPIC_FAMILY not in entry.default_families
+    assert OPENAI_FAMILY not in entry.default_families
+    # default_provider_for_harness picks it up as the explicit pi default.
+    config = {"providers": {"pi-subscription": raw}}
+    assert default_provider_for_harness(config, "pi").name == "pi-subscription"
+    # set_default_provider accepts the pi scope (this was the bug:
+    # provider_families returned {} so the scope check rejected it).
+    block: dict[str, object] = {"pi-subscription": {"kind": "subscription", "cli": "pi"}}
+    result = set_default_provider(block, "pi-subscription", PI_SURFACE)
+    reparsed = load_providers({"providers": result})
+    assert PI_SURFACE in reparsed["pi-subscription"].default_families
 
 
 def test_set_default_provider_pi_scope_round_trips_and_moves() -> None:
@@ -585,19 +612,21 @@ def test_set_default_provider_pi_scope_round_trips_and_moves() -> None:
             },
             True,
         ),
-        # A CLI login is unusable outside its own CLI — never pi-capable.
+        # A claude/codex CLI login is unusable outside its own CLI — never pi-capable.
         ({"kind": "subscription", "cli": "claude"}, False),
+        # A pi subscription explicitly opts into Pi's own native auth — pi-capable.
+        ({"kind": "subscription", "cli": "pi"}, True),
     ],
 )
 def test_provider_families_pi_capability(raw: dict[str, object], expect_pi: bool) -> None:
     """``provider_families`` reports the pi scope only for pi-capable providers.
 
     pi-capable = an inline key/gateway/local declaring an anthropic or openai
-    family, or a databricks profile. A gemini-only key (Gemini surface only)
-    and a subscription (CLI-bound) are NOT pi-capable. This drives both the Pi
-    page's credential list (which rows appear) and set-default validation — a
-    regression in either direction lets the menu offer a credential pi can't
-    use, or hides one it can.
+    family, a databricks profile, or a pi subscription. A gemini-only key
+    (Gemini surface only) and a claude/codex subscription (CLI-bound) are NOT
+    pi-capable. This drives both the Pi page's credential list (which rows
+    appear) and set-default validation — a regression in either direction lets
+    the menu offer a credential pi can't use, or hides one it can.
     """
     entry = load_providers({"providers": {"p": raw}})["p"]
     assert (PI_SURFACE in provider_families(entry)) is expect_pi

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -183,6 +183,20 @@ def test_subscription_default_returns_none() -> None:
     assert creds.resolve_pi_native_provider(config_loader=lambda: config) is None
 
 
+def test_pi_native_subscription_returns_none() -> None:
+    """A pi subscription as the pi-surface default returns None.
+
+    ``kind="subscription", cli="pi"`` signals "use Pi's own native auth".
+    When it is configured as the pi-surface default,
+    ``resolve_pi_native_provider`` returns ``None`` so Pi reads from its
+    own ``~/.pi/agent`` without an Omnigent-managed ``models.json``.
+    """
+    config = {
+        "providers": {"pi-subscription": {"kind": "subscription", "cli": "pi", "default": "pi"}}
+    }
+    assert creds.resolve_pi_native_provider(config_loader=lambda: config) is None
+
+
 def test_no_providers_returns_none() -> None:
     """No configured providers → None (Pi uses its own login)."""
     assert creds.resolve_pi_native_provider(config_loader=dict) is None


### PR DESCRIPTION
## Related issue

Closes #5325

## Summary

- Adds a **"🎟️ Pi — use own login"** option to `omni setup → Pi → Add a credential`, storing `kind: subscription, cli: pi` in `~/.omnigent/config.yaml`
- When this entry is the Pi-surface default, `resolve_pi_native_provider` returns `None` → Pi launches without a managed `models.json` and reads its own `~/.pi/agent` credentials (Llama, Google, or anything the user configured in Pi directly)
- Fixes the root bug: `provider_families` returned `{}` for a pi subscription, so `set_default_provider` rejected the pi scope — the "Make default for Pi" action silently failed

**ELI5:** Pi normally lets Omnigent inject credentials (models.json). With this change users can say "no thanks, use my own Pi login" — useful for local Llama, Google Gemini, or any provider they already set up inside Pi.

## Test Plan

1. `omnigent setup` → Pi → **Add a credential** → select **"🎟️ Pi — use own login"** → confirm it appears and saves
2. Select it → **Make default for Pi** → confirm it shows `✓ default · Pi`
3. Start a `omnigent pi` session → confirm `PI_CODING_AGENT_DIR` is NOT set (Pi uses `~/.pi/agent`)

Unit tests added: `test_pi_subscription_claims_pi_scope` (parse + set_default + default_provider round-trip) and `test_pi_native_subscription_returns_none` (resolver returns None).

## Demo

<img width="318" height="146" alt="image" src="https://github.com/user-attachments/assets/8ba16e8e-d77d-4c86-b3d9-18c4c6e0ca6a" />


## Type of change

- [x] Bug fix
- [x] Feature

## Test coverage

- [x] Unit tests added / updated
- [x] Manual verification completed

## Coverage notes

Manual: verified the full omni setup flow — add, make default, launch pi session without managed models.json. Unit tests cover the parse/set-default/resolver paths.

## Changelog

`omni setup` now offers a "Pi — use own login" credential option, letting Pi users with local Llama, Google, or other natively-configured providers bypass Omnigent-managed authentication.