### PR TITLE
fix(proxy): share injected credentials across targets

### DIFF
--- a/omnigent/inner/credential_proxy.py
+++ b/omnigent/inner/credential_proxy.py
@@ -194,17 +194,32 @@ def prepare_credential_proxy_runtime(
     if spec.databricks is not None:
         _prepare_databricks_runtime(spec.databricks, runtime)
 
-    for entry in spec.entries:
-        real_secret = _resolve_secret(entry.source, parent_env=parent_env)
+    # ``targets`` normalizes to one entry per host. Entries with the same
+    # source and injected env must share one placeholder so the client can use
+    # that env value on every explicitly bound host.
+    shared: dict[str, tuple[str, str]] = {}
+    for position, entry in enumerate(spec.entries):
+        key: str | None = None
+        prepared: tuple[str, str] | None = None
+        if entry.inject_env:
+            # Hand-built entries have no parser identity and remain isolated.
+            key = entry.placeholder_group or f"runtime-entry[{position}]"
+            prepared = shared.get(key)
+        if prepared is not None:
+            real_secret, synthetic = prepared
+        else:
+            real_secret = _resolve_secret(entry.source, parent_env=parent_env)
+            synthetic = None
+            if entry.inject_env:
+                assert key is not None
+                synthetic = f"{SYNTHETIC_CREDENTIAL_PREFIX}{secrets.token_urlsafe(24)}"
+                shared[key] = (real_secret, synthetic)
         # Mint a placeholder only when the entry injects an env var. The
         # placeholder is what the cross-host leak guard keys on; pure
         # swap-on-access entries put nothing in the sandbox, so there is
         # no placeholder to mint or guard.
-        synthetic: str | None = None
         if entry.inject_env:
-            # 24 bytes -> 192 bits of entropy, well past any brute-force or
-            # collision concern for a short-lived per-session placeholder.
-            synthetic = f"{SYNTHETIC_CREDENTIAL_PREFIX}{secrets.token_urlsafe(24)}"
+            assert synthetic is not None
             for env_name in entry.inject_env:
                 runtime.helper_env_updates[env_name] = synthetic
         runtime.rewrites.append(

--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -441,6 +441,8 @@ class CredentialProxyEntry:
         emit a request the proxy can rewrite. Empty (the default) means
         pure swap-on-access — nothing is injected and the proxy attaches
         the credential unconditionally for :attr:`host`.
+    :param placeholder_group: Identity of the source YAML entry. Host bindings
+        normalized from one ``targets`` list share one injected placeholder.
     """
 
     host: str
@@ -448,6 +450,7 @@ class CredentialProxyEntry:
     source: CredentialSourceSpec
     username: str | None = None
     inject_env: list[str] = field(default_factory=list)
+    placeholder_group: str | None = None
 
 
 @dataclass

--- a/omnigent/inner/egress/proxy.py
+++ b/omnigent/inner/egress/proxy.py
@@ -246,16 +246,14 @@ class EgressProxy:
         #   injects the real credential. Exactly one rule per host — the
         #   parser rejects duplicate-host bindings, so this map never
         #   silently drops a rule.
-        # - ``_cred_by_synthetic``: the opt-in placeholder path. Only
-        #   entries that injected an ``oa_cred_*`` env var register here;
-        #   the synthetic is globally unique so it alone identifies the
-        #   rule (and thus the bound host) for the swap + leak guard.
+        # - ``_cred_by_synthetic_host``: the opt-in placeholder path. A
+        #   placeholder may bind to several explicitly configured targets.
         self._cred_by_host: dict[str, CredentialRewriteRule] = {}
-        self._cred_by_synthetic: dict[str, CredentialRewriteRule] = {}
+        self._cred_by_synthetic_host: dict[tuple[str, str], CredentialRewriteRule] = {}
         for rule in credential_rewrites or []:
             self._cred_by_host[rule.host.lower()] = rule
             if rule.synthetic is not None:
-                self._cred_by_synthetic[rule.synthetic] = rule
+                self._cred_by_synthetic_host[(rule.synthetic, rule.host.lower())] = rule
         # Precompute the expected header bytes ONCE so the per-request
         # comparison is a constant-time memcmp instead of repeating
         # the base64 round-trip on every connection. Stored as bytes
@@ -1225,8 +1223,8 @@ class EgressProxy:
                     # leave it alone (and don't also inject over it).
                     rewritten.append(value)
                     continue
-                rule = self._cred_by_synthetic.get(synthetic)
-                if rule is None or rule.host != host_key:
+                rule = self._cred_by_synthetic_host.get((synthetic, host_key))
+                if rule is None:
                     # A value carrying our placeholder prefix that we don't
                     # recognise for this host. Refuse rather than forward —
                     # this is the leak guard for a compromised sandbox that

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -1809,6 +1809,7 @@ def _normalize_https_bearer(
             scheme="bearer",
             source=source,
             inject_env=inject_env,
+            placeholder_group=f"credential_proxy[{index}]",
         )
         for host in _resolve_credential_hosts(model, index=index)
     ]
@@ -1844,6 +1845,7 @@ def _normalize_https_basic(
             source=source,
             username=username,
             inject_env=inject_env,
+            placeholder_group=f"credential_proxy[{index}]",
         )
         for host in _resolve_credential_hosts(model, index=index)
     ]
@@ -1881,6 +1883,7 @@ def _normalize_git_https(
             scheme="basic",
             source=source,
             username=username,
+            placeholder_group=f"credential_proxy[{index}]",
         )
         for host in _resolve_credential_hosts(model, index=index)
     ]
@@ -1922,6 +1925,7 @@ def _normalize_gh_basic(
                     scheme="token",
                     source=source,
                     inject_env=list(_GH_TOKEN_ENV_VARS),
+                    placeholder_group=f"credential_proxy[{index}]",
                 )
             )
         else:
@@ -1931,6 +1935,7 @@ def _normalize_gh_basic(
                     scheme="basic",
                     source=source,
                     username=DEFAULT_BASIC_USERNAME,
+                    placeholder_group=f"credential_proxy[{index}]",
                 )
             )
     return entries

--- a/tests/inner/egress/test_proxy.py
+++ b/tests/inner/egress/test_proxy.py
@@ -2363,6 +2363,41 @@ def test_rewrite_authorization_skips_forbidden_methods(
     assert b"real-secret-value" not in result.headers
 
 
+def test_rewrite_authorization_accepts_shared_synthetic_on_each_bound_host(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    """One injected placeholder may authenticate to several declared targets."""
+    cert_path, key_path, _ = ca_paths
+    synthetic = f"{SYNTHETIC_CREDENTIAL_PREFIX}shared"
+    rules = [
+        CredentialRewriteRule(
+            host=host,
+            scheme="bearer",
+            real_secret="real-secret-value",
+            synthetic=synthetic,
+        )
+        for host in ("api.example.com", "agent.example.com")
+    ]
+    proxy = EgressProxy(
+        parse_rules(["* api.example.com/**", "* agent.example.com/**"]),
+        cert_path,
+        key_path,
+        credential_rewrites=rules,
+    )
+    headers = f"Authorization: Bearer {synthetic}\r\n\r\n".encode()
+
+    for host in ("api.example.com", "agent.example.com"):
+        result = proxy._rewrite_authorization(method="POST", host=host, headers_raw=headers)
+        assert result.error is None
+        assert b"Authorization: Bearer real-secret-value" in result.headers
+
+    rejected = proxy._rewrite_authorization(
+        method="POST", host="other.example.com", headers_raw=headers
+    )
+    assert rejected.error == "synthetic credential is not allowed for this host"
+    assert b"real-secret-value" not in rejected.headers
+
+
 # ---------------------------------------------------------------------------
 # Single-shot upstream framing (Connection: close) and shutdown draining.
 #

--- a/tests/inner/test_credential_proxy.py
+++ b/tests/inner/test_credential_proxy.py
@@ -123,6 +123,71 @@ def test_env_source_resolves_and_mints_synthetic() -> None:
     assert rule.scheme == "bearer"
 
 
+def test_targets_share_one_injected_synthetic() -> None:
+    """Hosts normalized from one multi-target credential share its env value."""
+    source = CredentialSourceSpec(kind="env", env="OA_SECRET")
+    entries = [
+        _bearer_entry("api.example.com", env_var="API_TOKEN", source=source),
+        _bearer_entry("agent.example.com", env_var="API_TOKEN", source=source),
+    ]
+    for entry in entries:
+        entry.placeholder_group = "credential_proxy[0]"
+    spec = CredentialProxySpec(entries=entries)
+
+    runtime = prepare_credential_proxy_runtime(spec, parent_env={"OA_SECRET": "real-secret"})
+
+    synthetic = runtime.helper_env_updates["API_TOKEN"]
+    assert [rule.synthetic for rule in runtime.rewrites] == [synthetic, synthetic]
+    assert [rule.host for rule in runtime.rewrites] == [
+        "api.example.com",
+        "agent.example.com",
+    ]
+
+
+def test_group_ignores_swap_on_access_entry() -> None:
+    """A non-injected binding cannot suppress its group's placeholder."""
+    source = CredentialSourceSpec(kind="env", env="OA_SECRET")
+    entries = [
+        CredentialProxyEntry(
+            host="git.example.com",
+            scheme="basic",
+            source=source,
+            placeholder_group="credential_proxy[0]",
+        ),
+        CredentialProxyEntry(
+            host="api.example.com",
+            scheme="token",
+            source=source,
+            inject_env=["API_TOKEN"],
+            placeholder_group="credential_proxy[0]",
+        ),
+    ]
+
+    runtime = prepare_credential_proxy_runtime(
+        CredentialProxySpec(entries=entries), parent_env={"OA_SECRET": "real-secret"}
+    )
+
+    assert runtime.rewrites[0].synthetic is None
+    assert runtime.rewrites[1].synthetic == runtime.helper_env_updates["API_TOKEN"]
+
+
+def test_separate_groups_mint_distinct_synthetics() -> None:
+    """Matching sources and env names do not merge separate YAML entries."""
+    source = CredentialSourceSpec(kind="env", env="OA_SECRET")
+    entries = [
+        _bearer_entry("first.example.com", env_var="API_TOKEN", source=source),
+        _bearer_entry("second.example.com", env_var="API_TOKEN", source=source),
+    ]
+    entries[0].placeholder_group = "credential_proxy[0]"
+    entries[1].placeholder_group = "credential_proxy[1]"
+
+    runtime = prepare_credential_proxy_runtime(
+        CredentialProxySpec(entries=entries), parent_env={"OA_SECRET": "real-secret"}
+    )
+
+    assert runtime.rewrites[0].synthetic != runtime.rewrites[1].synthetic
+
+
 def test_file_source_resolves_secret(tmp_path: Path) -> None:
     """A ``file`` source reads the secret from disk, stripped of whitespace.
 
@@ -209,22 +274,23 @@ def test_gh_basic_shape_injects_env_for_api_host_only() -> None:
     API host's env injection, would break one of the two GitHub paths.
     """
     source = CredentialSourceSpec(kind="env", env="GH_PAT")
-    spec = CredentialProxySpec(
-        entries=[
-            CredentialProxyEntry(
-                host="github.com",
-                scheme="basic",
-                source=source,
-                username="x-access-token",
-            ),
-            CredentialProxyEntry(
-                host="api.github.com",
-                scheme="token",
-                source=source,
-                inject_env=["GH_TOKEN", "GITHUB_TOKEN"],
-            ),
-        ]
-    )
+    entries = [
+        CredentialProxyEntry(
+            host="github.com",
+            scheme="basic",
+            source=source,
+            username="x-access-token",
+        ),
+        CredentialProxyEntry(
+            host="api.github.com",
+            scheme="token",
+            source=source,
+            inject_env=["GH_TOKEN", "GITHUB_TOKEN"],
+        ),
+    ]
+    for entry in entries:
+        entry.placeholder_group = "credential_proxy[0]"
+    spec = CredentialProxySpec(entries=entries)
     runtime = prepare_credential_proxy_runtime(spec, parent_env={"GH_PAT": "ghp_real"})
 
     # Both gh env vars carry the *same* synthetic as the api.github.com

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -3635,6 +3635,34 @@ def test_parse_credential_proxy_all_four_types(tmp_path: Path) -> None:
     assert basic.source.kind == "file" and basic.source.path == "/tmp/secret"
 
 
+def test_credential_targets_preserve_placeholder_group(tmp_path: Path) -> None:
+    """Only hosts declared together share an injected placeholder identity."""
+    config = _credential_proxy_config(
+        [
+            {
+                "type": "https_bearer",
+                "targets": ["api.example.com", "agent.example.com"],
+                "source": {"env": "TOKEN"},
+                "env": "API_TOKEN",
+            },
+            {
+                "type": "https_bearer",
+                "target": "separate.example.com",
+                "source": {"env": "TOKEN"},
+                "env": "API_TOKEN",
+            },
+        ]
+    )
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+
+    proxy = parse(tmp_path).os_env.sandbox.credential_proxy
+
+    assert proxy is not None
+    groups = {entry.host: entry.placeholder_group for entry in proxy.entries}
+    assert groups["api.example.com"] == groups["agent.example.com"]
+    assert groups["api.example.com"] != groups["separate.example.com"]
+
+
 def test_parse_credential_proxy_rejects_duplicate_host(tmp_path: Path) -> None:
     """Two entries binding the same host fail loudly at parse time.
 


### PR DESCRIPTION
## Related issue

N/A — credential-proxy correctness fix.

## Summary

- Preserve the identity of each YAML credential entry when `targets` is normalized into host bindings.
- Reuse one synthetic environment credential only across hosts explicitly listed in that entry.
- Keep separate entries isolated, even when they reference the same source and environment variable.

ELI5: a client with one API-key environment variable can contact several approved service hosts. The sandbox still receives only a temporary placeholder, and any host not listed in the same credential entry remains blocked.

```text
one YAML `targets` entry
        |
        +-- api.example.com   -- shared placeholder --> real key
        +-- agent.example.com -- shared placeholder --> real key

separate/unlisted host        -- same placeholder --> 403
```

## Test Plan

- `.venv/bin/python -m pytest tests/inner/test_credential_proxy.py tests/spec/test_parser.py::test_credential_targets_preserve_placeholder_group tests/inner/egress/test_proxy.py::test_rewrite_authorization_accepts_shared_synthetic_on_each_bound_host -q`
- Result: 17 passed, 1 skipped.
- `pre-commit run --files ...`: repository-independent checks passed; `ruff` and `pyrefly` could not start because those optional tools are absent from this checkout.

## Demo

N/A — backend credential-proxy behavior only.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Parser, runtime placeholder generation, multi-host rewriting, and wrong-host rejection are covered by focused unit tests.

