### PR TITLE
Re-enable color palettes in managed omni

### DIFF
--- a/web/src/embed.tsx
+++ b/web/src/embed.tsx
@@ -34,8 +34,21 @@ import { CapabilitiesContext } from "./lib/CapabilitiesContext";
 import { createBootServerInfo } from "./lib/bootCapabilities";
 import { resolveServerInfo, type ServerInfo } from "./lib/capabilities";
 import { EmbeddedProvider } from "./lib/embedded";
-import { type OmnigentHostConfig, setEmbedRoot, setOmnigentHostConfig } from "./lib/host";
+import {
+  type OmnigentHostConfig,
+  setEmbedRoot,
+  setEmbedScopeRoot,
+  setOmnigentHostConfig,
+} from "./lib/host";
 import { resolveIdentity } from "./lib/identity";
+import {
+  applyDesktopUiFontSize,
+  applyUiFontFamily,
+  readUiFontFamily,
+  readUiFontSizePx,
+} from "./lib/uiFontPreferences";
+import { applyThemePalette, readThemePalette } from "./lib/themePalette";
+import { applyCustomTheme, readCustomTheme } from "./lib/customTheme";
 import {
   type RoutingApi,
   RoutingProvider,
@@ -159,6 +172,22 @@ function OmnigentProviders({
     setEmbedRoot(el);
   }, []);
 
+  // The outer `.omnigent-app` scope root is where the scoped `:root` tokens
+  // live, so per-device preferences (UI font, color palette, custom theme) must
+  // be applied here — standalone main.tsx applies them to <html> at boot; the
+  // embed applies them once the scope root mounts. The inner `scopeRef` runs
+  // first (child refs fire before parent refs), so `getEmbedRoot()` is already
+  // set for the palette's dark-mode attribute stamping.
+  const scopeRootRef = useCallback((el: HTMLDivElement | null) => {
+    setEmbedScopeRoot(el);
+    if (el) {
+      applyDesktopUiFontSize(readUiFontSizePx());
+      applyUiFontFamily(readUiFontFamily());
+      applyThemePalette(readThemePalette());
+      applyCustomTheme(readCustomTheme());
+    }
+  }, []);
+
   return (
     // Two nested wrappers on purpose:
     //   - `.omnigent-app` (outer) is the scope anchor. The scoped stylesheet
@@ -169,7 +198,7 @@ function OmnigentProviders({
     //     the Radix portal root, so both the app and its overlays read the dark
     //     token overrides. Light mode = no class → inherits the scope root's
     //     light tokens.
-    <div className="omnigent-app" style={{ height: "100%", width: "100%" }}>
+    <div ref={scopeRootRef} className="omnigent-app" style={{ height: "100%", width: "100%" }}>
       <div
         ref={scopeRef}
         className={isDarkMode ? "dark" : undefined}

--- a/web/src/lib/customTheme.test.ts
+++ b/web/src/lib/customTheme.test.ts
@@ -9,11 +9,14 @@ import {
   writeCustomTheme,
 } from "./customTheme";
 import { PALETTES } from "./themePalette";
+import { setEmbedRoot, setEmbedScopeRoot } from "./host";
 
 const STORAGE_KEY = "omnigent:custom-theme";
 
 afterEach(() => {
   localStorage.clear();
+  setEmbedScopeRoot(null);
+  setEmbedRoot(null);
   document.documentElement.removeAttribute("data-custom-translucent-sidebar");
   for (const property of Array.from(document.documentElement.style)) {
     if (property.startsWith("--custom-")) {
@@ -219,5 +222,29 @@ describe("customTheme", () => {
     expect(style.getPropertyValue("--custom-light-sidebar")).toMatch(/^rgba\(/);
     expect(style.getPropertyValue("--custom-dark-sidebar")).toMatch(/^rgba\(/);
     expect(document.documentElement).toHaveAttribute("data-custom-translucent-sidebar");
+  });
+
+  it("targets the embed roots when embedded (vars on scope root, attr on both)", () => {
+    // Embedded, the `--custom-*` vars go on the scope root (inherited by the
+    // inner `.dark` root); the translucent attribute goes on BOTH roots so the
+    // light `:root[...]` and dark `.dark[...]` selectors each match.
+    const scope = document.createElement("div");
+    const inner = document.createElement("div");
+    setEmbedScopeRoot(scope);
+    setEmbedRoot(inner);
+    applyCustomTheme({
+      basePalette: "omni",
+      accent: "#2563eb",
+      darkAccent: "#2563eb",
+      tint: "#dbeafe",
+      darkTint: "#160e24",
+      contrast: 60,
+      translucentSidebar: true,
+    });
+    expect(scope.style.getPropertyValue("--custom-dark-background")).toBe("#160e24");
+    expect(scope).toHaveAttribute("data-custom-translucent-sidebar");
+    expect(inner).toHaveAttribute("data-custom-translucent-sidebar");
+    expect(document.documentElement.style.getPropertyValue("--custom-dark-background")).toBe("");
+    expect(document.documentElement).not.toHaveAttribute("data-custom-translucent-sidebar");
   });
 });

--- a/web/src/lib/customTheme.ts
+++ b/web/src/lib/customTheme.ts
@@ -7,6 +7,7 @@ import {
   type PaletteTokens,
   type ThemePalette,
 } from "./themePalette";
+import { getStyleRoot, getThemeRoots } from "./host";
 
 const STORAGE_KEY = "omnigent:custom-theme";
 const HEX_COLOR = /^#[0-9a-f]{6}$/i;
@@ -472,14 +473,19 @@ export function customThemeSwatches(theme: CustomTheme): {
 }
 
 export function applyCustomTheme(theme: CustomTheme): void {
-  if (typeof document === "undefined") return;
+  // The `--custom-*` variables go on the style root (embedded, the scope root;
+  // else the document root); the `data-custom-translucent-sidebar` attribute
+  // goes on every theme root so both the light `:root[...]` and dark `.dark[...]`
+  // selectors match. Standalone both are the document root, so behavior is the
+  // same as before.
+  const styleRoot = getStyleRoot();
+  if (!styleRoot) return;
   const normalized = normalizeTheme(theme) ?? DEFAULT_CUSTOM_THEME;
   const variants = deriveCustomTheme(normalized);
-  const style = document.documentElement.style;
-  document.documentElement.toggleAttribute(
-    "data-custom-translucent-sidebar",
-    normalized.translucentSidebar,
-  );
+  const style = styleRoot.style;
+  for (const root of getThemeRoots()) {
+    root.toggleAttribute("data-custom-translucent-sidebar", normalized.translucentSidebar);
+  }
   for (const mode of ["light", "dark"] as const) {
     for (const [key, token] of Object.entries(PALETTE_TOKEN_CSS_NAMES) as [
       keyof DerivedThemeVariant,

--- a/web/src/lib/host.ts
+++ b/web/src/lib/host.ts
@@ -132,6 +132,12 @@ export interface OmnigentHostConfig {
    */
   cliServerUrlSuffix?: string;
   /**
+   * Optional URL to the host's own appearance/theme settings. When the host
+   * owns light/dark (the embed's own switcher is hidden), the settings screen
+   * links here so users can find where to change it. Omitted standalone.
+   */
+  themeSettingsUrl?: string;
+  /**
    * Optional documentation links for embed-only UX hints.
    *
    * Standalone web ignores these values. Embedded hosts can pass one object
@@ -153,6 +159,7 @@ export interface OmnigentHostConfig {
 let hostConfig: OmnigentHostConfig = {};
 let hostConfigGeneration = 0;
 let embedRoot: HTMLElement | null = null;
+let embedScopeRoot: HTMLElement | null = null;
 
 export function setOmnigentHostConfig(config: OmnigentHostConfig): void {
   // Guard: never clobber an already-installed fetcher with an empty config.
@@ -210,6 +217,14 @@ export function getOmnigentTransformShareLink(): OmnigentHostConfig["transformSh
 }
 
 /**
+ * The host-provided URL to its own theme/appearance settings, or `undefined`
+ * standalone. The settings screen links here when the host owns light/dark.
+ */
+export function getOmnigentThemeSettingsUrl(): OmnigentHostConfig["themeSettingsUrl"] {
+  return hostConfig.themeSettingsUrl;
+}
+
+/**
  * The DOM node the embed is mounted into. Used as the portal container for
  * Radix overlays so portaled content (dialogs, popovers, tooltips, menus)
  * lands inside the scoped `.omnigent-app` subtree and inherits its styles.
@@ -221,6 +236,47 @@ export function setEmbedRoot(el: HTMLElement | null): void {
 
 export function getEmbedRoot(): HTMLElement | null {
   return embedRoot;
+}
+
+/**
+ * The embed's scope element (`.omnigent-app`) — the outer wrapper the scoped
+ * stylesheet collapses `:root` / `html` / `body` onto. Per-device preference DOM
+ * mutations (UI font size, `--custom-*` theme variables, the `data-theme`
+ * palette attribute) must land here (or a descendant) rather than on
+ * `document.documentElement`: the scoped `.omnigent-app` tokens shadow anything
+ * set on the real document root. Null standalone (falls back to the document
+ * root), where the scoped stylesheet isn't in play.
+ */
+export function setEmbedScopeRoot(el: HTMLElement | null): void {
+  embedScopeRoot = el;
+}
+
+export function getEmbedScopeRoot(): HTMLElement | null {
+  return embedScopeRoot;
+}
+
+/**
+ * The element preference CSS custom properties are set on (UI font size/family,
+ * `--custom-*` theme variables): the embed scope root when embedded, else the
+ * document root.
+ */
+export function getStyleRoot(): HTMLElement | null {
+  if (embedScopeRoot) return embedScopeRoot;
+  return typeof document !== "undefined" ? document.documentElement : null;
+}
+
+/**
+ * The elements theme *attributes* are stamped onto (`data-theme` palette,
+ * `data-custom-translucent-sidebar`). Embedded, both the scope root (matched by
+ * the light `:root[data-theme]` selectors) and the inner `.dark` root (matched
+ * by the dark `.dark[data-theme]` selectors) need them; standalone it's just the
+ * document root.
+ */
+export function getThemeRoots(): HTMLElement[] {
+  if (embedScopeRoot) {
+    return embedRoot ? [embedScopeRoot, embedRoot] : [embedScopeRoot];
+  }
+  return typeof document !== "undefined" ? [document.documentElement] : [];
 }
 
 /**

--- a/web/src/lib/themePalette.test.ts
+++ b/web/src/lib/themePalette.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { setEmbedRoot, setEmbedScopeRoot } from "./host";
 import {
   applyThemePalette,
   DEFAULT_PALETTE,
@@ -15,6 +16,8 @@ const STORAGE_KEY = "omnigent:ui-theme-palette";
 
 afterEach(() => {
   localStorage.clear();
+  setEmbedScopeRoot(null);
+  setEmbedRoot(null);
   document.documentElement.removeAttribute("data-theme");
 });
 
@@ -84,6 +87,22 @@ describe("themePalette", () => {
     expect(document.documentElement.getAttribute("data-theme")).toBe("github");
     applyThemePalette(DEFAULT_PALETTE);
     expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+  });
+
+  it("stamps data-theme on both embed roots when embedded (light + dark selectors)", () => {
+    // The light `:root[data-theme]` selectors match the scope root; the dark
+    // `.dark[data-theme]` selectors match the inner `.dark` root — both need it.
+    const scope = document.createElement("div");
+    const inner = document.createElement("div");
+    setEmbedScopeRoot(scope);
+    setEmbedRoot(inner);
+    applyThemePalette("dracula");
+    expect(scope.getAttribute("data-theme")).toBe("dracula");
+    expect(inner.getAttribute("data-theme")).toBe("dracula");
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+    applyThemePalette(DEFAULT_PALETTE);
+    expect(scope.hasAttribute("data-theme")).toBe(false);
+    expect(inner.hasAttribute("data-theme")).toBe(false);
   });
 
   it("exposes swatch metadata for every selectable palette, default first", () => {

--- a/web/src/lib/themePalette.ts
+++ b/web/src/lib/themePalette.ts
@@ -18,6 +18,8 @@
 // plus a single `apply*` function that owns the DOM side-effect, called at boot
 // (main.tsx) before first paint and on every change (Appearance settings).
 
+import { getThemeRoots } from "./host";
+
 const STORAGE_KEY = "omnigent:ui-theme-palette";
 
 /** Selectable color palettes. The first entry is the default (brand) look. */
@@ -606,17 +608,25 @@ export function writeThemePalette(palette: ThemeSelection): void {
 }
 
 /**
- * Apply the palette to the DOM by setting `data-theme` on the document root.
+ * Apply the palette to the DOM by setting `data-theme` on the theme roots.
  * The generated `[data-theme]` blocks re-point the color tokens; the default
- * "omni" palette removes the attribute. This composes with next-themes' `.dark`
+ * "omni" palette removes the attribute. This composes with the `.dark` mode
  * class untouched.
+ *
+ * Embedded, `getThemeRoots()` returns both the scope root (matched by the light
+ * `:root[data-theme]` selectors) and the inner `.dark` root (matched by the
+ * dark `.dark[data-theme]` selectors); standalone it's just the document root,
+ * so behavior is unchanged.
  */
 export function applyThemePalette(palette: ThemeSelection): void {
-  if (typeof document === "undefined") return;
+  const roots = getThemeRoots();
+  if (roots.length === 0) return;
   const next = isThemeSelection(palette) ? palette : DEFAULT_PALETTE;
-  if (next === DEFAULT_PALETTE) {
-    document.documentElement.removeAttribute("data-theme");
-    return;
+  for (const root of roots) {
+    if (next === DEFAULT_PALETTE) {
+      root.removeAttribute("data-theme");
+    } else {
+      root.setAttribute("data-theme", next);
+    }
   }
-  document.documentElement.setAttribute("data-theme", next);
 }

--- a/web/src/lib/themePalette.ts
+++ b/web/src/lib/themePalette.ts
@@ -18,7 +18,11 @@
 // plus a single `apply*` function that owns the DOM side-effect, called at boot
 // (main.tsx) before first paint and on every change (Appearance settings).
 
-import { getThemeRoots } from "./host";
+// `.ts` extension (not extensionless like the app's other imports): this module
+// is also loaded directly by the `generate-theme-palettes.mjs` node script,
+// whose ESM resolver can't do extensionless resolution. tsconfig has
+// `allowImportingTsExtensions`, and Vite resolves it the same either way.
+import { getThemeRoots } from "./host.ts";
 
 const STORAGE_KEY = "omnigent:ui-theme-palette";
 

--- a/web/src/lib/uiFontPreferences.test.ts
+++ b/web/src/lib/uiFontPreferences.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { setEmbedScopeRoot } from "./host";
 import {
   applyDesktopUiFontSize,
   applyUiFontFamily,
@@ -17,6 +18,7 @@ const FAMILY_STORAGE_KEY = "omnigent:ui-font-family";
 
 afterEach(() => {
   localStorage.clear();
+  setEmbedScopeRoot(null);
   document.documentElement.style.removeProperty("--desktop-ui-font-size");
   document.documentElement.style.removeProperty("--ui-font-family");
 });
@@ -68,6 +70,20 @@ describe("uiFontPreferences", () => {
   it("clamps before applying the desktop size", () => {
     applyDesktopUiFontSize(99);
     expect(document.documentElement.style.getPropertyValue("--desktop-ui-font-size")).toBe("18px");
+  });
+
+  it("applies onto the embed scope root when embedded, not the document root", () => {
+    // Embedded, the scoped `.omnigent-app` redefines the font tokens locally, so
+    // a value set on <html> is shadowed for the subtree — it must land on the
+    // scope root instead.
+    const scope = document.createElement("div");
+    setEmbedScopeRoot(scope);
+    applyDesktopUiFontSize(16);
+    applyUiFontFamily("Comic Sans");
+    expect(scope.style.getPropertyValue("--desktop-ui-font-size")).toBe("16px");
+    expect(scope.style.getPropertyValue("--ui-font-family")).toBe("Comic Sans, var(--font-sans)");
+    expect(document.documentElement.style.getPropertyValue("--desktop-ui-font-size")).toBe("");
+    expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("");
   });
 });
 

--- a/web/src/lib/uiFontPreferences.ts
+++ b/web/src/lib/uiFontPreferences.ts
@@ -11,7 +11,15 @@
 // stack into the `font-sans` utility instead of a `var()` reference, so setting
 // `--font-sans` at runtime is a no-op. The `html` rule reads
 // `var(--ui-font-family, var(--font-sans))`, so an unset family falls back to
-// the system stack and any value we set on documentElement wins.
+// the system stack and any value we set on the style root wins.
+//
+// The DOM mutations target `getStyleRoot()`, not `document.documentElement`
+// directly: embedded, the scoped `.omnigent-app` redefines the font tokens
+// locally, so a value set on the real document root is shadowed for the subtree
+// and must be set on the scope root instead. Standalone `getStyleRoot()` IS the
+// document root, so behavior is unchanged.
+
+import { getStyleRoot } from "./host";
 
 const STORAGE_KEY = "omnigent:ui-font-size";
 
@@ -70,11 +78,9 @@ export function writeUiFontSizePx(px: number): void {
  * independent. This is the single source of the DOM side-effect.
  */
 export function applyDesktopUiFontSize(px: number): void {
-  if (typeof document === "undefined") return;
-  document.documentElement.style.setProperty(
-    "--desktop-ui-font-size",
-    `${clampUiFontSizePx(px)}px`,
-  );
+  const root = getStyleRoot();
+  if (!root) return;
+  root.style.setProperty("--desktop-ui-font-size", `${clampUiFontSizePx(px)}px`);
 }
 
 // ---- Font family ---------------------------------------------------------
@@ -156,11 +162,12 @@ export function writeUiFontFamily(name: string): void {
  * DOM side-effect.
  */
 export function applyUiFontFamily(name: string): void {
-  if (typeof document === "undefined") return;
+  const root = getStyleRoot();
+  if (!root) return;
   const normalized = normalizeUiFontFamily(name);
   if (!normalized) {
-    document.documentElement.style.removeProperty("--ui-font-family");
+    root.style.removeProperty("--ui-font-family");
     return;
   }
-  document.documentElement.style.setProperty("--ui-font-family", `${normalized}, var(--font-sans)`);
+  root.style.setProperty("--ui-font-family", `${normalized}, var(--font-sans)`);
 }

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -188,6 +188,7 @@ import {
   writeCustomTheme,
 } from "@/lib/customTheme";
 import { useIsEmbedded } from "@/lib/embedded";
+import { getOmnigentThemeSettingsUrl } from "@/lib/host";
 import {
   type CliStatus,
   getCliStatus,
@@ -726,11 +727,12 @@ function HideUnconfiguredHarnessesControl() {
 }
 
 function AppearanceSection() {
-  // Embedded: the host owns light/dark, so the Mode and Color theme pickers
-  // would be no-ops — hide them and say so (matching ThemeModeMenu). Terminal
-  // theme and the font controls are per-device prefs that don't conflict with
-  // host theming, so they stay visible.
+  // Embedded: the host owns light/dark, so the Mode picker would be a no-op —
+  // replace it with a note (plus a link to the host's own theme settings when
+  // one is provided). The color palette, terminal theme, and font controls are
+  // per-device prefs that don't conflict with host light/dark, so they stay.
   const isEmbedded = useIsEmbedded();
+  const themeSettingsUrl = getOmnigentThemeSettingsUrl();
   const { setTheme } = useTheme();
   const [resetKey, setResetKey] = useState(0);
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
@@ -806,7 +808,19 @@ function AppearanceSection() {
           <div className="flex flex-col gap-3">
             <span className="text-ui font-medium">Theme</span>
             <p className="text-sm text-muted-foreground">
-              Theme is controlled by the host application.
+              Light and dark mode are controlled by the host application.
+              {themeSettingsUrl ? (
+                <>
+                  {" "}
+                  <a
+                    href={themeSettingsUrl}
+                    className="font-medium text-primary underline underline-offset-2 hover:text-primary/80"
+                  >
+                    Change it in your settings
+                  </a>
+                  .
+                </>
+              ) : null}
             </p>
           </div>
         ) : (
@@ -815,7 +829,7 @@ function AppearanceSection() {
 
         <TerminalThemeControl />
 
-        {!isEmbedded && <ColorThemeControl />}
+        <ColorThemeControl />
 
         <TranscriptViewDefaultControl />
 


### PR DESCRIPTION
## Related issue

N/A — no tracking issue.

## Summary

Preferences applied in **embedded** mode (a host renders `<OmnigentApp/>` via `embed.tsx`) were written to `document.documentElement`, but the embed's scoped stylesheet collapses `:root` / `html` / `body` onto the `.omnigent-app` scope element — which **shadows** anything set on the real document root. So inside an embed:

- **UI font size had no effect** — the scoped `.omnigent-app` redefines `--desktop-ui-font-size`, overriding the value set on `<html>`.
- **The color palette couldn't apply** — `data-theme` / `--custom-*` landed on `<html>`, where the scoped `[data-theme]` selectors never match, and the palette picker was hidden in embedded mode anyway.

This PR routes every preference DOM mutation through two scope-aware helpers and re-enables the palette:

- **`host.ts`** — add `getStyleRoot()` (CSS-var target) and `getThemeRoots()` (attribute targets), backed by a registered embed scope root (`setEmbedScopeRoot`). Standalone they resolve to `document.documentElement`, so non-embedded behavior is unchanged.
- **`uiFontPreferences.ts` / `themePalette.ts` / `customTheme.ts`** — target those helpers instead of `document.documentElement`. In an embed, `data-theme` + `--custom-*` land on the scope root (light `:root[data-theme]` selectors) and the inner `.dark` root (dark `.dark[data-theme]` selectors); the CSS scoper is untouched.
- **`embed.tsx`** — register the scope root and boot-apply font + palette + custom theme on mount (mirrors what `main.tsx` does standalone).
- **`SettingsPage.tsx`** — un-gate the color-palette control in embedded mode. Light/dark **Mode** stays host-controlled.
- **`host.ts` / `SettingsPage.tsx`** — add an optional `themeSettingsUrl` host-config field so a host that owns light/dark can surface a link to its own theme settings from the Appearance panel ("Change it in your settings"). Inert when the host leaves it unset.

### ELI5

The embed lives inside a `.omnigent-app` box, and the app's theme "knobs" are defined on that box. We were turning the knobs on the *outer wall of the house* (`<html>`) instead of *on the box*, so nothing changed inside. Now we turn them on the box.

### Diagram

```
standalone      apply*()  ─▶  <html>   ← scoped :root tokens live here            → works

embed (before)  apply*()  ─▶  <html>                       ✗ shadowed for subtree
                              └ .omnigent-app { …:root tokens… }                  → no effect

embed (after)   apply*()  ─▶  .omnigent-app   (getStyleRoot / getThemeRoots)
                              └ .dark inner root  ← dark [data-theme] selectors   → works
```

## Test Plan

- `pnpm test src/lib/uiFontPreferences.test.ts src/lib/themePalette.test.ts src/lib/customTheme.test.ts` → **62 pass**, including new embed-path cases asserting each preference targets the scope root(s) and **not** `document.documentElement`.
- `pnpm type-check` (`tsc -b`) → clean.
- Recommended before release: build the embed into a host and verify in the host's dark mode + exercise the palette picker — the palette's light/dark split only renders in a real host.

## Demo

UI change — screenshot/recording to attach: the Appearance panel in an embedded host showing the re-enabled color-palette picker and the "Change it in your settings" link, in both light and dark host modes.

## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added embed-mode unit tests to each of the three preference libs: with a scope root registered, font size + family land on the scope root; `data-theme` is stamped on both the scope root and the inner `.dark` root; `--custom-*` vars land on the scope root and the translucent-sidebar attribute on both — and none of it touches `document.documentElement`. The existing standalone assertions (targeting `document.documentElement`) are kept, since standalone falls back to it. Browser-level QA of the palette's dark/light rendering inside a host is recommended before release and is not automated here.

## Changelog

Embedded Omnigent now applies UI font size and the color palette, and can show a host-provided theme-settings link.

---

This pull request and its description were written by Isaac.
