### PR TITLE
feat(web): hint users to switch to edit mode for commenting in markdown preview

### DIFF
--- a/web/src/shell/CodeViewer.test.tsx
+++ b/web/src/shell/CodeViewer.test.tsx
@@ -92,7 +92,11 @@ function renderViewer(
   content: string,
   panelOpen = true,
   path = "notes.md",
-  opts: { viewMode?: "editor" | "preview" | "source" | "diff"; truncated?: boolean } = {},
+  opts: {
+    viewMode?: "editor" | "preview" | "source" | "diff";
+    truncated?: boolean;
+    onRequestEditMode?: () => void;
+  } = {},
 ) {
   // Markdown source view still renders via the Shiki DOM, where the
   // select-all/copy override under test lives. Non-markdown files now render in
@@ -111,6 +115,7 @@ function renderViewer(
       setSearchOpen={() => {}}
       searchInputRef={noopRef}
       viewMode={opts.viewMode ?? "source"}
+      onRequestEditMode={opts.onRequestEditMode}
     />,
   );
 }
@@ -267,6 +272,47 @@ describe("CodeViewer truncated preview", () => {
   it("shows no banner in markdown preview when not truncated", () => {
     renderViewer("# full file", true, "notes.md", { viewMode: "preview", truncated: false });
     expect(screen.queryByText(/too large to load fully/)).toBeNull();
+  });
+});
+
+describe("CodeViewer markdown preview comment hint", () => {
+  // The rendered preview can't anchor text-selection comments, so it points the
+  // user at the editor instead of offering a second, fuzzier comment surface.
+  it("shows the switch-to-edit hint in markdown preview", () => {
+    renderViewer("# doc", true, "notes.md", { viewMode: "preview", onRequestEditMode: () => {} });
+    expect(screen.getByRole("button", { name: /switch to edit mode/i })).toBeDefined();
+  });
+
+  it("switches to the editor when the hint is clicked", () => {
+    const onRequestEditMode = vi.fn();
+    renderViewer("# doc", true, "notes.md", { viewMode: "preview", onRequestEditMode });
+    fireEvent.click(screen.getByRole("button", { name: /switch to edit mode/i }));
+    expect(onRequestEditMode).toHaveBeenCalledOnce();
+  });
+
+  it("hides the hint for read-only viewers", () => {
+    vi.mocked(permissions.useCanEdit).mockReturnValue(false);
+    renderViewer("# doc", true, "notes.md", { viewMode: "preview", onRequestEditMode: () => {} });
+    expect(screen.queryByRole("button", { name: /switch to edit mode/i })).toBeNull();
+  });
+
+  it("shows no hint when the editor isn't reachable (no callback)", () => {
+    renderViewer("# doc", true, "notes.md", { viewMode: "preview" });
+    expect(screen.queryByRole("button", { name: /switch to edit mode/i })).toBeNull();
+  });
+
+  it("shows no hint in the editor surface", () => {
+    renderViewer("# doc", true, "notes.md", { viewMode: "editor", onRequestEditMode: () => {} });
+    expect(screen.queryByRole("button", { name: /switch to edit mode/i })).toBeNull();
+  });
+
+  it("shows no hint for a truncated file (the editor can't comment on it either)", () => {
+    renderViewer("# big", true, "notes.md", {
+      viewMode: "preview",
+      truncated: true,
+      onRequestEditMode: () => {},
+    });
+    expect(screen.queryByRole("button", { name: /switch to edit mode/i })).toBeNull();
   });
 });
 

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -73,6 +73,7 @@ import { useScrollRestore } from "./useScrollRestore";
 import { PreviewSearchBar } from "./PreviewSearchBar";
 import { renderLineTokens } from "./codeViewerRendering";
 import { HtmlCommentViewer } from "./HtmlCommentViewer";
+import { PreviewCommentBanner } from "./PreviewCommentBanner";
 import { TruncatedBanner } from "./TruncatedBanner";
 import { useLightbox } from "@/components/ImageLightbox";
 import { getEmbedRoot } from "@/lib/host";
@@ -250,6 +251,7 @@ function PreviewWithSearch({
   scrollReady,
   tocOpen,
   onTocOpenChange,
+  commentHint,
 }: {
   content: string;
   isNotebook: boolean;
@@ -263,6 +265,12 @@ function PreviewWithSearch({
   scrollReady: boolean;
   tocOpen: boolean;
   onTocOpenChange: (open: boolean) => void;
+  /**
+   * When present, shows a banner pointing users at the editor for commenting
+   * (the rendered preview can't anchor text-selection comments). Omitted for
+   * notebooks, which have no comment surface.
+   */
+  commentHint?: { conversationId: string; onSwitchToEdit: () => void };
 }) {
   const previewRef = useRef<HTMLDivElement>(null);
   // The preview div (not the FileViewer content area) is the real scroller
@@ -294,6 +302,14 @@ function PreviewWithSearch({
     <div className="flex h-full flex-col">
       {bar}
       {truncated && <TruncatedBanner />}
+      {/* A truncated file can't be edited (or commented on) in the editor
+          either, so the hint would send the user to a dead end — suppress it. */}
+      {commentHint && !truncated && (
+        <PreviewCommentBanner
+          conversationId={commentHint.conversationId}
+          onSwitchToEdit={commentHint.onSwitchToEdit}
+        />
+      )}
       <div className="min-h-0 flex-1">{preview}</div>
     </div>
   );
@@ -409,6 +425,12 @@ export interface CodeViewerProps {
   tocOpen?: boolean;
   /** Callback to toggle TOC panel. */
   onTocToggle?: () => void;
+  /**
+   * Switches a markdown file to the rich-text editor. When set, the rendered
+   * preview shows a banner pointing users there for commenting (the preview
+   * itself can't anchor text-selection comments).
+   */
+  onRequestEditMode?: () => void;
 }
 
 export function CodeViewer({
@@ -429,6 +451,7 @@ export function CodeViewer({
   pendingBodyRef,
   tocOpen = false,
   onTocToggle,
+  onRequestEditMode,
 }: CodeViewerProps) {
   const canEdit = useCanEdit(conversationId);
   const activeCommentId = activeSelection?.comment_id;
@@ -804,10 +827,11 @@ export function CodeViewer({
   }
 
   if (viewMode === "preview" && (lang === "markdown" || isNotebookPath(path))) {
+    const isNotebook = isNotebookPath(path);
     return (
       <PreviewWithSearch
         content={content}
-        isNotebook={isNotebookPath(path)}
+        isNotebook={isNotebook}
         truncated={truncated}
         searchOpen={searchOpen}
         onSearchHandled={handleSearchHandled}
@@ -816,6 +840,11 @@ export function CodeViewer({
         scrollReady={fileQuery.data !== undefined}
         tocOpen={tocOpen}
         onTocOpenChange={(open) => !open && onTocToggle?.()}
+        commentHint={
+          !isNotebook && onRequestEditMode
+            ? { conversationId, onSwitchToEdit: onRequestEditMode }
+            : undefined
+        }
       />
     );
   }

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -699,6 +699,15 @@ function FileViewerBody({
     initialCommentIdRef.current ? path : null,
   );
 
+  // Switch a markdown file to the rich-text editor — the surface where text-
+  // selection commenting works. Used by the preview's "switch to edit mode"
+  // hint. Coming from preview/source there are no edits to guard, so it applies
+  // directly (mirrors the toolbar's switchTo for the non-editor case).
+  const handleRequestEditMode = useCallback(() => {
+    setDeepLinkBiasPath(null);
+    setPreviewableViewMode("editor");
+  }, []);
+
   // Persist the global view preferences so they survive a refresh. commentsOpen
   // is intentionally excluded — it's contextual (per-open), not a sticky
   // preference. Idempotent on mount (writes back the seeded values).
@@ -1468,6 +1477,7 @@ function FileViewerBody({
               viewMode={viewMode}
               tocOpen={tocOpen}
               onTocToggle={() => setTocOpen((prev) => !prev)}
+              onRequestEditMode={lang === "markdown" ? handleRequestEditMode : undefined}
             />
           )}
         </div>

--- a/web/src/shell/PreviewCommentBanner.test.tsx
+++ b/web/src/shell/PreviewCommentBanner.test.tsx
@@ -1,0 +1,36 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as permissions from "@/hooks/usePermissions";
+import { PreviewCommentBanner } from "./PreviewCommentBanner";
+
+vi.mock("@/hooks/usePermissions", () => ({ useCanEdit: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(permissions.useCanEdit).mockReturnValue(true);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PreviewCommentBanner", () => {
+  it("renders a switch-to-edit action for editors", () => {
+    render(<PreviewCommentBanner conversationId="conv_1" onSwitchToEdit={() => {}} />);
+    expect(screen.getByRole("button", { name: /switch to edit mode/i })).toBeDefined();
+  });
+
+  it("invokes onSwitchToEdit when the action is clicked", () => {
+    const onSwitchToEdit = vi.fn();
+    render(<PreviewCommentBanner conversationId="conv_1" onSwitchToEdit={onSwitchToEdit} />);
+    fireEvent.click(screen.getByRole("button", { name: /switch to edit mode/i }));
+    expect(onSwitchToEdit).toHaveBeenCalledOnce();
+  });
+
+  it("renders nothing for read-only viewers", () => {
+    vi.mocked(permissions.useCanEdit).mockReturnValue(false);
+    const { container } = render(
+      <PreviewCommentBanner conversationId="conv_1" onSwitchToEdit={() => {}} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/shell/PreviewCommentBanner.tsx
+++ b/web/src/shell/PreviewCommentBanner.tsx
@@ -27,7 +27,7 @@ export function PreviewCommentBanner({
         <button
           type="button"
           onClick={onSwitchToEdit}
-          className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
+          className="cursor-pointer font-medium text-foreground underline underline-offset-2 hover:text-primary"
         >
           switch to edit mode
         </button>

--- a/web/src/shell/PreviewCommentBanner.tsx
+++ b/web/src/shell/PreviewCommentBanner.tsx
@@ -1,0 +1,38 @@
+import { MessageSquarePlusIcon } from "lucide-react";
+import { useCanEdit } from "@/hooks/usePermissions";
+
+/**
+ * Shown atop the rendered Markdown preview to point users at the editor for
+ * commenting. The rendered preview has no source-offset mapping, so text-
+ * selection comments only work on the rich-text Editor surface (and Source);
+ * rather than a second, fuzzier comment path here, we nudge the user to switch.
+ *
+ * Only rendered for users who can edit — a read-only viewer has no comment
+ * action to reach, so the hint would be noise.
+ */
+export function PreviewCommentBanner({
+  conversationId,
+  onSwitchToEdit,
+}: {
+  conversationId: string;
+  onSwitchToEdit: () => void;
+}) {
+  const canEdit = useCanEdit(conversationId);
+  if (!canEdit) return null;
+  return (
+    <div className="flex items-center gap-2 border-b border-border bg-muted/40 px-4 py-1.5 text-sm text-muted-foreground shrink-0">
+      <MessageSquarePlusIcon className="size-3.5 shrink-0" />
+      <span>
+        To comment on this file,{" "}
+        <button
+          type="button"
+          onClick={onSwitchToEdit}
+          className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
+        >
+          switch to edit mode
+        </button>
+        .
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Related issue

<!-- No issue: UX gap discovered while exploring the preview surface. -->

Closes #

## Summary

The rendered Markdown **preview** has no source-offset mapping, so text-selection comments only work on the rich-text **Edit** (and **Source**) surfaces. In preview, selecting text did nothing and there was no affordance to comment — users were silently stuck, with no cue that another surface supports it. (This is the same limitation that already forces `?comment=` deep links onto the editor.)

- Adds a small banner atop the Markdown preview: *"To comment on this file, **switch to edit mode**."* — the action switches directly to the rich-text editor.
- The banner only shows for users who **can edit**, only for **markdown** (not notebooks), and **not for truncated files** (the editor disables commenting there too, so the hint would be a dead end).

We considered building commenting directly into the preview by fuzzy-matching the selected text back to source offsets, but it was inconsistent with the editor's anchoring and unreliable across wrapped lines / inline formatting — so we nudge users to the surface that works instead.

## Test Plan

- `cd web && npm test` — added unit tests for the banner (`PreviewCommentBanner.test.tsx`, 3 cases) and its wiring in `CodeViewer.test.tsx` (shown in preview, click switches mode, hidden for read-only, hidden without callback, hidden in editor, hidden when truncated).
- `cd web && npm run build` — passes (`tsc -b` + `vite build`).
- Manual: open a `.md` file → **Preview** shows the banner; clicking "switch to edit mode" lands on the editor. Toggling to **Edit**/**Source** hides it. Read-only sessions and truncated files show no banner.

## Demo

![Markdown preview with a "To comment on this file, switch to edit mode" banner above the rendered content](https://github.com/user-attachments/assets/placeholder)

<!-- Screenshot: the banner sits above the rendered preview; the "switch to edit mode" link jumps to the editor. -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the surfaces unit tests can't easily assert: the actual view-mode switch landing on the rich-text editor, and the banner's appearance/placement in the running app across edit/read-only sessions.

## Changelog

Markdown file preview now points you to edit mode when you want to add a comment

This pull request and its description were written by Isaac.