### PR TITLE
fix(cli): report malformed setup provider config without crashing

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10459,9 +10459,23 @@ def setup(internal_beta: bool) -> None:
         )
         return
 
-    # --no-internal-beta: the standard model/credential picker. It warns
-    # about missing Node/tmux itself, configures providers/defaults, and
-    # returns; the user then starts a session with ``omnigent run``.
+    # --no-internal-beta: validate existing providers before entering the
+    # picker so malformed user config is reported as an actionable CLI error,
+    # not an application crash from the picker's ambient-adoption step.
+    from omnigent.errors import ErrorCode, OmnigentError
+    from omnigent.onboarding.provider_config import load_providers
+
+    try:
+        load_providers(_load_global_config())
+    except OmnigentError as exc:
+        if exc.code != ErrorCode.INVALID_INPUT:
+            raise
+        path = _display_config_path(_effective_global_config_path())
+        raise click.ClickException(f"Invalid provider configuration in {path}: {exc}") from None
+
+    # The picker warns about missing Node/tmux itself, configures
+    # providers/defaults, and returns; the user then starts a session with
+    # ``omnigent run``.
     _run_configure_harnesses_interactive()
 
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -5594,6 +5594,39 @@ def test_unknown_command_reports_no_such_command(
     assert "ad-hoc chat was removed" not in combined
 
 
+def test_setup_invalid_provider_is_a_user_error_not_a_crash(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Malformed provider config exits actionably without crash reporting."""
+    from omnigent import cli as cli_module
+    from omnigent import crash_handler
+
+    message = (
+        "provider 'example-proxy' (kind 'gateway') configures no "
+        "'anthropic', 'openai', or 'gemini' family."
+    )
+    config = {"providers": {"example-proxy": {"kind": "gateway"}}}
+    crashes: list[Exception] = []
+    configure_flow = Mock()
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "argv", ["omnigent", "setup"])
+    monkeypatch.setattr(cli_module, "_load_global_config", lambda: config)
+    monkeypatch.setattr(cli_module, "_run_configure_harnesses_interactive", configure_flow)
+    monkeypatch.setattr(crash_handler, "handle_crash", lambda exc: crashes.append(exc))
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_module.main()
+
+    assert exc_info.value.code == 1
+    terminal = capsys.readouterr()
+    assert f"Invalid provider configuration in {tmp_path / 'config.yaml'}" in terminal.err
+    assert message in terminal.err
+    configure_flow.assert_not_called()
+    assert crashes == []
+
+
 def test_setup_command_replaces_wizard(monkeypatch: pytest.MonkeyPatch) -> None:
     """``omnigent setup`` is the visible standard setup flow command."""
     configure_flow = Mock()


### PR DESCRIPTION
## Related issue

Closes #5723
Closes #5722 (the crash report this was filed from)

## Summary

- Validate existing provider entries before opening the setup picker.
- Render malformed provider configuration as an actionable CLI error with the config path instead of invoking crash reporting.

## Test Plan

- `uv run --no-sync pytest -q tests/cli/test_cli.py` → 303 passed.
- `uv run --no-sync pre-commit run --all-files` → all hooks passed.
- Ran `omnigent setup` with an isolated incomplete gateway entry → exit 1 with the config path and required family fields; no crash UI.

## Demo

Given this malformed provider entry:

```yaml
providers:
  example-proxy:
    kind: gateway
```

**Before:** `omnigent setup` opened the crash-report flow shown in #5722.

**After:** the same command exits normally as a user error and identifies both the file and the missing provider configuration:

```console
$ OMNIGENT_CONFIG_HOME=/tmp/omnigent-demo-5726 omnigent setup
Error: Invalid provider configuration in /tmp/omnigent-demo-5726/config.yaml: provider 'example-proxy' (kind 'gateway') configures no 'anthropic', 'openai', or 'gemini' family.
$ echo $?
1
```

The command does not display or invoke the crash reporter.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression test drives the top-level CLI through `omnigent setup` with malformed provider configuration and asserts that crash reporting is not invoked. Manual verification exercised the installed console entry point against an isolated config directory.

## Changelog

`omnigent setup` now reports malformed provider configuration with the config path instead of treating it as an application crash.

