### PR TITLE
fix(web): render PDFs in managed omnigent (worker asset + Blob-fed Document)

### DIFF
--- a/web/src/shell/PdfViewer.tsx
+++ b/web/src/shell/PdfViewer.tsx
@@ -36,13 +36,24 @@ import {
 import { TruncatedBanner } from "./TruncatedBanner";
 import "./pdfViewer.css";
 
-// Point pdf.js at its worker. Vite imports the worker entry as a static asset so
-// the bundled SPA emits it as a hashed file without relying on the package
-// path resolving from `node_modules`.
-// oxlint-disable-next-line import/default -- Vite's `?url` import returns the asset URL.
-import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
-
-pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
+// Point pdf.js at its worker via a real Worker instance, mirroring
+// monacoSetup.ts. Only the `new Worker(new URL(..., import.meta.url))` pattern
+// gets emitted as a content-hashed asset by BOTH Vite (standalone) and the
+// embed library build (which the universe monolith's rspack then re-emits). A
+// `workerSrc` string — whether from `?url` or `new URL(...).toString()` — is
+// treated as a generic asset and INLINED as a `data:` URL in the embed lib
+// build; the browser can't load a module worker from a data: URL, which is why
+// managed omnigent failed to render PDFs.
+//
+// Eager at module scope, but this module is lazy-loaded (only when a PDF opens,
+// via CodeViewer) so the worker is created once and reused for the app
+// lifetime. It bypasses pdf.js's fake-worker fallback, so a restrictive worker
+// CSP or a non-Worker environment (jsdom) throws on import — importing tests
+// must mock this module (CodeViewer.test.tsx already mocks ./PdfViewer).
+pdfjs.GlobalWorkerOptions.workerPort = new Worker(
+  new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url),
+  { type: "module" },
+);
 
 const MIN_SCALE = 0.5;
 const MAX_SCALE = 3;
@@ -123,7 +134,6 @@ export function PdfViewer({
   onSetActiveSelection,
 }: PdfViewerProps) {
   const canEdit = useCanEdit(conversationId);
-  const [url, setUrl] = useState<string | null>(null);
   const [numPages, setNumPages] = useState(0);
   const [errored, setErrored] = useState(false);
   const [scale, setScale] = useState(1);
@@ -138,20 +148,22 @@ export function PdfViewer({
   const activeSelectionRef = useRef(activeSelection);
   activeSelectionRef.current = activeSelection;
 
-  // Build/revoke the object URL when the file changes. A truncated PDF is a
-  // partial byte stream that pdf.js can't parse, so skip the blob and show the
-  // error/banner UI instead of flashing a failed render.
+  // Hand pdf.js a Blob rather than an object URL. A URL string makes pdf.js run
+  // its own fetch on the main thread and build request Headers — under the
+  // managed (embedded) host that fetch path threw "Failed to construct
+  // 'Headers'" and the PDF never rendered. react-pdf reads a Blob via FileReader
+  // (no fetch), and — crucially — decodes fresh bytes on each load: pdf.js
+  // transfers/detaches the buffer it's handed, so a shared `{ data }` array
+  // would fail its second load (StrictMode's double-mount, a retry, a remount)
+  // with a detached-ArrayBuffer DataCloneError. The Blob is re-read each time,
+  // so every load gets its own buffer. Memoized so the Document only reloads
+  // when the file changes. A truncated PDF is a partial byte stream pdf.js can't
+  // parse, so show the error/banner UI instead.
+  const pdfFile = useMemo(() => (data.truncated ? null : fileContentToBlob(data)), [data]);
+
   useEffect(() => {
-    if (data.truncated) {
-      setUrl(null);
-      setErrored(true);
-      return;
-    }
-    setErrored(false);
+    setErrored(!!data.truncated);
     setNumPages(0);
-    const objectUrl = URL.createObjectURL(fileContentToBlob(data));
-    setUrl(objectUrl);
-    return () => URL.revokeObjectURL(objectUrl);
   }, [data]);
 
   // Measure the container so pages fit its width (minus padding) at scale 1.
@@ -339,9 +351,9 @@ export function PdfViewer({
       </div>
 
       <div ref={containerRef} className="pdf-viewer min-h-0 flex-1 overflow-auto bg-muted/30 p-4">
-        {url && (
+        {pdfFile && (
           <Document
-            file={url}
+            file={pdfFile}
             onLoadSuccess={(doc) => setNumPages(doc.numPages)}
             onLoadError={() => setErrored(true)}
             loading={centered("Loading PDF…")}


### PR DESCRIPTION
## Related issue

N/A — no tracking issue (bug fix surfaced while testing managed omnigent).

## Summary

PDFs never rendered in the **managed (embedded) build**, failing with two distinct errors that only occur in the embed → universe-rspack pipeline (standalone was fine). Both are fixed in `PdfViewer.tsx`:

- **Worker inlined as a `data:` URL.** The pdf.js worker was set via a `?url` string import. Vite's embed *library* build inlines that as a `data:text/javascript;base64,…` URL, and a browser can't load a module worker from a data: URL (`Failed to fetch dynamically imported module`). Fixed by `new Worker(new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url), { type: "module" })` on `workerPort` — the only worker idiom Vite's lib build (and the monolith's rspack) re-emit as a content-hashed asset, matching `monacoSetup.ts`.
- **`Failed to construct 'Headers': Invalid name`.** With the worker fixed, PDFs then hit this — PDF-specific because `PdfViewer` handed pdf.js a `blob:` object **URL**, so pdf.js ran its own main-thread `fetch` and built request `Headers`, which the embedded host's fetch path rejected. Fixed by handing pdf.js a **`Blob` object** (not a URL): react-pdf reads it via `FileReader` — no fetch, no `Headers`.

The Blob path also avoids a detached-buffer bug (flagged in review): pdf.js *transfers* the buffer it's given to the worker, so a shared `{ data: Uint8Array }` fails its **second** load — StrictMode's dev double-mount, a retry, or a remount — with a detached-`ArrayBuffer` `DataCloneError`. react-pdf re-reads the Blob into fresh bytes on every load, so each load gets its own buffer. `useFileContent.ts` (`fileContentToBlob`) is unchanged.

## Test Plan

- Built the embed and ran the universe managed devloop; opened a PDF in a managed omnigent session (under `<StrictMode>`) — it **renders**, with no `data:`-module error and no `Failed to construct 'Headers'` modal. Markdown/text viewers unaffected.
- `pnpm exec vitest run src/hooks/useFileContent.test.tsx` → 20/20 pass; `tsc` + `oxlint` clean.

## Demo

Before: file viewer showed "Unable to render PDF" + a console `TypeError`. After: the PDF renders inline. (Verified in the managed StrictMode devloop; screen recording available on request.)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The worker/`data:`-URL, blob-fetch `Headers`, and StrictMode detached-buffer failures only reproduce inside the embedded (library-build → rspack) host under `<StrictMode>`, which unit tests don't exercise, so they were verified manually in the managed devloop. `fileContentToBlob` is unchanged, so its existing `useFileContent` unit tests still apply.

## Changelog

Fixed PDF files not rendering in managed (embedded) omnigent.

This pull request and its description were written by Isaac.
