### PR TITLE
fix(claude-native): recover unavailable model pins

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -431,6 +431,25 @@ def claude_config_serves_canonical_ids(
     return claude_config is None or _serves_canonical_anthropic_ids(claude_config)
 
 
+def is_canonical_claude_pin(model: str) -> bool:
+    """Whether *model* is recognized and already uses Claude's canonical spelling."""
+    if model != model.strip() or model != model.lower():
+        return False
+    bare = model.removesuffix("[1m]")
+    if bare in CLAUDE_MODEL_ALIASES:
+        return True
+    parts = bare.split("-")
+    if not parts or parts[0] != "claude":
+        return False
+    model_parts = parts[1:]
+    tiers = [part for part in model_parts if part in CLAUDE_MODEL_ALIASES]
+    return (
+        len(tiers) == 1
+        and any(part.isdigit() for part in model_parts)
+        and all(part.isdigit() or part in CLAUDE_MODEL_ALIASES for part in model_parts)
+    )
+
+
 def _claude_family(token: str) -> str | None:
     """
     The family alias a model id or alias folds onto, bracket markers dropped.
@@ -585,16 +604,16 @@ def resolve_claude_native_catalog_selection(
         exact_match = catalog_contains(rows, candidate)
         catalog_model = resolve_claude_catalog_model(rows, candidate)
         if catalog_model is not None:
-            launch_model = candidate if exact_match else catalog_model
+            if exact_match or (
+                is_canonical_claude_pin(candidate)
+                and claude_config_serves_canonical_ids(claude_config)
+            ):
+                launch_model = candidate
+            else:
+                launch_model = catalog_model
             if requested_model.lower().endswith("[1m]") != launch_model.lower().endswith("[1m]"):
                 reason = "the equivalent catalog model uses a different [1m] context marker"
-            elif (
-                candidate == requested_model
-                and not exact_match
-                and launch_model != requested_model
-                and requested_model.lower().endswith("[1m]")
-                == launch_model.lower().endswith("[1m]")
-            ):
+            elif candidate == requested_model and launch_model != requested_model:
                 reason = "the equivalent catalog model uses the host's verified spelling"
             else:
                 return launch_model, None

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -240,7 +240,8 @@ _UCODE_CLAUDE_TIER_TO_ENV: dict[str, str] = {
     "sonnet": _ANTHROPIC_DEFAULT_SONNET_MODEL_ENV,
     "haiku": _ANTHROPIC_DEFAULT_HAIKU_MODEL_ENV,
 }
-_CLAUDE_TIER_FALLBACK_ORDER = CLAUDE_MODEL_ALIASES
+# Capability-descending launch fallback policy. Vocabulary ordering is not policy.
+_CLAUDE_TIER_FALLBACK_ORDER: tuple[str, ...] = ("fable", "opus", "sonnet", "haiku")
 # The 4 family aliases above pin one model ID each. Claude Code has exactly
 # one more independently-selectable /model picker slot beyond those
 # families — ANTHROPIC_CUSTOM_MODEL_OPTION — used here to surface Sonnet 5
@@ -483,8 +484,56 @@ def claude_catalog_serves_model(
     )
 
 
+def resolve_claude_catalog_model(
+    rows: list[dict[str, object]],
+    model: str,
+) -> str | None:
+    """Resolve an exact or unambiguous equivalent catalog spelling."""
+    from omnigent.claude_model_vocabulary import normalized_model_id
+    from omnigent.model_catalog_store import catalog_contains
+
+    if catalog_contains(rows, model):
+        return model
+    normalized = normalized_model_id(model)
+    if not normalized:
+        return None
+    matches: set[str] = set()
+    for row in rows:
+        row_id = str(row.get("id") or "").strip()
+        row_model = str(row.get("model") or "").strip()
+        if any(
+            candidate and normalized_model_id(candidate) == normalized
+            for candidate in (row_id, row_model)
+        ):
+            matches.add(row_model or row_id)
+    return next(iter(matches)) if len(matches) == 1 else None
+
+
+def _claude_catalog_tier_rank(
+    row: dict[str, object],
+    tier: str,
+) -> tuple[bool, tuple[int, ...], bool, str, str]:
+    """Rank a tier's alias first, then newest standard-context model."""
+    from omnigent.claude_model_vocabulary import normalized_model_id
+
+    row_id = str(row.get("id") or "").strip()
+    row_model = str(row.get("model") or "").strip()
+    launch_model = row_model or row_id
+    normalized = normalized_model_id(launch_model)
+    family_tail = normalized.partition(f"{tier}-")[2]
+    generation = tuple(-int(part) for part in re.findall(r"\d+", family_tail)) or (0,)
+    return (
+        row_id.lower() != tier,
+        generation,
+        launch_model.lower().endswith("[1m]"),
+        launch_model.lower(),
+        row_id.lower(),
+    )
+
+
 def _claude_catalog_tier_model(rows: list[dict[str, object]], tier: str) -> str | None:
-    """Return the catalog's launch spelling for one Claude tier."""
+    """Return the catalog's deterministic launch spelling for one Claude tier."""
+    candidates: list[dict[str, object]] = []
     for row in rows:
         row_id = str(row.get("id") or "").strip()
         row_model = str(row.get("model") or "").strip()
@@ -494,8 +543,28 @@ def _claude_catalog_tier_model(rows: list[dict[str, object]], tier: str) -> str 
         lower_token = family_token.lower()
         if lower_token not in CLAUDE_MODEL_ALIASES and "claude" not in lower_token:
             continue
-        return row_model or row_id
+        candidates.append(row)
+    if not candidates:
+        return None
+    selected = min(candidates, key=lambda row: _claude_catalog_tier_rank(row, tier))
+    return str(selected.get("model") or selected.get("id") or "").strip() or None
+
+
+def _documented_claude_tier_alias(model: str) -> str | None:
+    """Return a documented bare or 1M tier alias, otherwise ``None``."""
+    candidate = model.strip().lower()
+    base = candidate.removesuffix("[1m]")
+    if base in CLAUDE_MODEL_ALIASES and candidate in {base, f"{base}[1m]"}:
+        return base
     return None
+
+
+def _claude_launchable_model_text(rows: list[dict[str, object]]) -> str:
+    """Render deterministic launchable picker and wire ids for an error."""
+    launchable = sorted(
+        {str(token) for row in rows for token in (row.get("id"), row.get("model")) if token}
+    )
+    return ", ".join(repr(token) for token in launchable) or "none"
 
 
 def resolve_claude_native_catalog_selection(
@@ -519,18 +588,16 @@ def resolve_claude_native_catalog_selection(
     resolved_request = (
         resolve_claude_native_model_selection(requested_model, claude_config) or requested_model
     )
-    if claude_catalog_serves_model(
-        rows, requested_model, claude_config
-    ) or claude_catalog_serves_model(rows, resolved_request, claude_config):
-        return resolved_request, None
+    for candidate in dict.fromkeys((requested_model, resolved_request)):
+        catalog_model = resolve_claude_catalog_model(rows, candidate)
+        if catalog_model is not None:
+            if candidate.lower().startswith("claude-") and (
+                claude_config is None or _serves_canonical_anthropic_ids(claude_config)
+            ):
+                return candidate, None
+            return catalog_model, None
 
-    lower_request = requested_model.strip().lower()
-    is_claude_request = (
-        lower_request in CLAUDE_MODEL_ALIASES
-        or lower_request == _UCODE_CLAUDE_CUSTOM_TIER
-        or "claude" in lower_request
-    )
-    requested_tier = _claude_family(resolved_request) if is_claude_request else None
+    requested_tier = _documented_claude_tier_alias(requested_model)
     if requested_tier in _CLAUDE_TIER_FALLBACK_ORDER:
         start = _CLAUDE_TIER_FALLBACK_ORDER.index(requested_tier)
         for tier in _CLAUDE_TIER_FALLBACK_ORDER[start:]:
@@ -552,7 +619,8 @@ def resolve_claude_native_catalog_selection(
 
     raise click.ClickException(
         f"the requested model {requested_model!r} is not in this host's current "
-        "model list — it may have changed since the pick. Pick again from the model menu."
+        "model list — it may have changed since the pick. Launchable model ids: "
+        f"{_claude_launchable_model_text(rows)}. Pick again from the model menu."
     )
 
 
@@ -1257,6 +1325,47 @@ async def claude_model_catalog(
                 }
             )
     return out
+
+
+class ClaudeLaunchCatalogStatus(Enum):
+    """Freshness provenance for launch-authoritative Claude catalogs."""
+
+    FRESH = "fresh"
+    EMPTY = "empty"
+    REFRESH_FAILED = "refresh_failed"
+
+
+@dataclass(frozen=True)
+class ClaudeLaunchCatalogResult:
+    """Catalog rows plus authoritative refresh provenance."""
+
+    rows: list[dict[str, object]]
+    status: ClaudeLaunchCatalogStatus
+
+
+async def claude_launch_catalog_result(
+    claude_config: ClaudeNativeUcodeConfig | None,
+) -> ClaudeLaunchCatalogResult:
+    """Return only fresh rows for launch selection, refreshing stale hits."""
+    from omnigent import model_catalog_store
+
+    fingerprint = claude_catalog_fingerprint(claude_config)
+    cached = model_catalog_store.read_catalog("claude-native", fingerprint)
+    if cached is not None and not model_catalog_store.catalog_is_stale(
+        "claude-native", fingerprint
+    ):
+        return ClaudeLaunchCatalogResult(cached, ClaudeLaunchCatalogStatus.FRESH)
+    try:
+        rows = await claude_model_catalog(claude_config)
+    except Exception:  # noqa: BLE001 — provenance is returned to the launch selector
+        _logger.warning("Claude launch catalog refresh failed", exc_info=True)
+        return ClaudeLaunchCatalogResult([], ClaudeLaunchCatalogStatus.REFRESH_FAILED)
+    if rows is None:
+        return ClaudeLaunchCatalogResult([], ClaudeLaunchCatalogStatus.REFRESH_FAILED)
+    if not rows:
+        return ClaudeLaunchCatalogResult([], ClaudeLaunchCatalogStatus.EMPTY)
+    model_catalog_store.write_catalog("claude-native", fingerprint, rows)
+    return ClaudeLaunchCatalogResult(rows, ClaudeLaunchCatalogStatus.FRESH)
 
 
 async def claude_launch_catalog(

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -424,6 +424,13 @@ def _serves_canonical_anthropic_ids(claude_config: ClaudeNativeUcodeConfig) -> b
     return host == "anthropic.com" or host.endswith(".anthropic.com")
 
 
+def claude_config_serves_canonical_ids(
+    claude_config: ClaudeNativeUcodeConfig | None,
+) -> bool:
+    """Whether a launch config accepts canonical Anthropic model ids."""
+    return claude_config is None or _serves_canonical_anthropic_ids(claude_config)
+
+
 def _claude_family(token: str) -> str | None:
     """
     The family alias a model id or alias folds onto, bracket markers dropped.
@@ -561,6 +568,8 @@ def resolve_claude_native_catalog_selection(
     :returns: ``(launch_model, notice)``; ``notice`` is set only on substitution.
     :raises click.ClickException: If the request cannot stay in the Claude family.
     """
+    from omnigent.model_catalog_store import catalog_contains
+
     resolved_request = (
         resolve_claude_native_model_selection(requested_model, claude_config) or requested_model
     )
@@ -573,30 +582,33 @@ def resolve_claude_native_catalog_selection(
         else None
     )
     for candidate in dict.fromkeys((requested_model, resolved_request)):
+        exact_match = catalog_contains(rows, candidate)
         catalog_model = resolve_claude_catalog_model(rows, candidate)
         if catalog_model is not None:
-            if candidate.lower().startswith("claude-") and (
-                claude_config is None or _serves_canonical_anthropic_ids(claude_config)
-            ):
-                launch_model = candidate
-            else:
-                launch_model = catalog_model
-            if requested_tier is None and requested_model.lower().endswith(
-                "[1m]"
-            ) != launch_model.lower().endswith("[1m]"):
+            launch_model = candidate if exact_match else catalog_model
+            if requested_model.lower().endswith("[1m]") != launch_model.lower().endswith("[1m]"):
                 reason = "the equivalent catalog model uses a different [1m] context marker"
-                _logger.warning(
-                    "native-claude: substituting requested model %r with %r: %s",
-                    requested_model,
-                    launch_model,
-                    reason,
-                )
-                notice = (
-                    f"Requested Claude model {requested_model!r} was substituted with "
-                    f"{launch_model!r} because {reason}."
-                )
-                return launch_model, notice
-            return launch_model, None
+            elif (
+                candidate == requested_model
+                and not exact_match
+                and launch_model != requested_model
+                and requested_model.lower().endswith("[1m]")
+                == launch_model.lower().endswith("[1m]")
+            ):
+                reason = "the equivalent catalog model uses the host's verified spelling"
+            else:
+                return launch_model, None
+            _logger.warning(
+                "native-claude: substituting requested model %r with %r: %s",
+                requested_model,
+                launch_model,
+                reason,
+            )
+            notice = (
+                f"Requested Claude model {requested_model!r} was substituted with "
+                f"{launch_model!r} because {reason}."
+            )
+            return launch_model, notice
 
     if requested_tier in _CLAUDE_TIER_FALLBACK_ORDER:
         start = _CLAUDE_TIER_FALLBACK_ORDER.index(requested_tier)

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -82,6 +82,7 @@ from omnigent._wrapper_labels import (
 from omnigent.claude_launcher import resolve_claude_launch
 from omnigent.claude_model_vocabulary import (
     ALIAS_MODEL_ENV_VARS,
+    CLAUDE_MODEL_ALIASES,
     CUSTOM_MODEL_OPTION_ENV_VAR,
     CUSTOM_MODEL_OPTION_NAME_ENV_VAR,
     LEGACY_CUSTOM_SLOT_ROW_ID,
@@ -239,6 +240,7 @@ _UCODE_CLAUDE_TIER_TO_ENV: dict[str, str] = {
     "sonnet": _ANTHROPIC_DEFAULT_SONNET_MODEL_ENV,
     "haiku": _ANTHROPIC_DEFAULT_HAIKU_MODEL_ENV,
 }
+_CLAUDE_TIER_FALLBACK_ORDER = CLAUDE_MODEL_ALIASES
 # The 4 family aliases above pin one model ID each. Claude Code has exactly
 # one more independently-selectable /model picker slot beyond those
 # families — ANTHROPIC_CUSTOM_MODEL_OPTION — used here to surface Sonnet 5
@@ -478,6 +480,79 @@ def claude_catalog_serves_model(
     family = _claude_family(model)
     return family is not None and any(
         _claude_family(str(row.get("id") or row.get("model") or "")) == family for row in rows
+    )
+
+
+def _claude_catalog_tier_model(rows: list[dict[str, object]], tier: str) -> str | None:
+    """Return the catalog's launch spelling for one Claude tier."""
+    for row in rows:
+        row_id = str(row.get("id") or "").strip()
+        row_model = str(row.get("model") or "").strip()
+        family_token = row_model or row_id
+        if _claude_family(family_token) != tier:
+            continue
+        lower_token = family_token.lower()
+        if lower_token not in CLAUDE_MODEL_ALIASES and "claude" not in lower_token:
+            continue
+        return row_model or row_id
+    return None
+
+
+def resolve_claude_native_catalog_selection(
+    requested_model: str,
+    rows: list[dict[str, object]],
+    claude_config: ClaudeNativeUcodeConfig | None,
+) -> tuple[str, str | None]:
+    """Resolve an explicit Claude launch request against the host catalog.
+
+    Available requests retain their exact resolved spelling. An unavailable
+    Claude tier steps down through Fable, Opus, Sonnet, and Haiku, never across
+    vendors. When no lower Claude tier is available, the existing actionable
+    launch error is preserved.
+
+    :param requested_model: Persisted picker id or concrete Claude model id.
+    :param rows: The host's current launch catalog.
+    :param claude_config: Resolved provider config for the terminal.
+    :returns: ``(launch_model, notice)``; ``notice`` is set only on substitution.
+    :raises click.ClickException: If the request cannot stay in the Claude family.
+    """
+    resolved_request = (
+        resolve_claude_native_model_selection(requested_model, claude_config) or requested_model
+    )
+    if claude_catalog_serves_model(
+        rows, requested_model, claude_config
+    ) or claude_catalog_serves_model(rows, resolved_request, claude_config):
+        return resolved_request, None
+
+    lower_request = requested_model.strip().lower()
+    is_claude_request = (
+        lower_request in CLAUDE_MODEL_ALIASES
+        or lower_request == _UCODE_CLAUDE_CUSTOM_TIER
+        or "claude" in lower_request
+    )
+    requested_tier = _claude_family(resolved_request) if is_claude_request else None
+    if requested_tier in _CLAUDE_TIER_FALLBACK_ORDER:
+        start = _CLAUDE_TIER_FALLBACK_ORDER.index(requested_tier)
+        for tier in _CLAUDE_TIER_FALLBACK_ORDER[start:]:
+            substitute = _claude_catalog_tier_model(rows, tier)
+            if substitute is None:
+                continue
+            reason = "the requested Claude model is absent from this host's current model list"
+            _logger.warning(
+                "native-claude: substituting unavailable requested model %r with %r: %s",
+                requested_model,
+                substitute,
+                reason,
+            )
+            notice = (
+                f"Requested Claude model {requested_model!r} is unavailable on this host. "
+                f"Launched with {substitute!r} instead because {reason}."
+            )
+            return substitute, notice
+
+    raise click.ClickException(
+        f"the requested model {requested_model!r} is not in this host's current "
+        "model list — it may have changed since the pick. Pick again from the model menu."
     )
 
 

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -512,7 +512,7 @@ def resolve_claude_catalog_model(
 def _claude_catalog_tier_rank(
     row: dict[str, object],
     tier: str,
-) -> tuple[bool, tuple[int, ...], bool, str, str]:
+) -> tuple[bool, tuple[int, ...], bool, str, str, str, str]:
     """Rank a tier's alias first, then newest standard-context model."""
     from omnigent.claude_model_vocabulary import normalized_model_id
 
@@ -528,6 +528,8 @@ def _claude_catalog_tier_rank(
         launch_model.lower().endswith("[1m]"),
         launch_model.lower(),
         row_id.lower(),
+        launch_model,
+        row_id,
     )
 
 
@@ -588,16 +590,33 @@ def resolve_claude_native_catalog_selection(
     resolved_request = (
         resolve_claude_native_model_selection(requested_model, claude_config) or requested_model
     )
+    requested_tier = _documented_claude_tier_alias(requested_model)
     for candidate in dict.fromkeys((requested_model, resolved_request)):
         catalog_model = resolve_claude_catalog_model(rows, candidate)
         if catalog_model is not None:
             if candidate.lower().startswith("claude-") and (
                 claude_config is None or _serves_canonical_anthropic_ids(claude_config)
             ):
-                return candidate, None
-            return catalog_model, None
+                launch_model = candidate
+            else:
+                launch_model = catalog_model
+            if requested_tier is None and requested_model.lower().endswith(
+                "[1m]"
+            ) != launch_model.lower().endswith("[1m]"):
+                reason = "the equivalent catalog model uses a different [1m] context marker"
+                _logger.warning(
+                    "native-claude: substituting requested model %r with %r: %s",
+                    requested_model,
+                    launch_model,
+                    reason,
+                )
+                notice = (
+                    f"Requested Claude model {requested_model!r} was substituted with "
+                    f"{launch_model!r} because {reason}."
+                )
+                return launch_model, notice
+            return launch_model, None
 
-    requested_tier = _documented_claude_tier_alias(requested_model)
     if requested_tier in _CLAUDE_TIER_FALLBACK_ORDER:
         start = _CLAUDE_TIER_FALLBACK_ORDER.index(requested_tier)
         for tier in _CLAUDE_TIER_FALLBACK_ORDER[start:]:
@@ -1335,6 +1354,10 @@ class ClaudeLaunchCatalogStatus(Enum):
     REFRESH_FAILED = "refresh_failed"
 
 
+class _UnavailableCatalogRefreshError(Exception):
+    """Sentinel used when structured catalog refresh errors are unavailable."""
+
+
 @dataclass(frozen=True)
 class ClaudeLaunchCatalogResult:
     """Catalog rows plus authoritative refresh provenance."""
@@ -1355,9 +1378,23 @@ async def claude_launch_catalog_result(
         "claude-native", fingerprint
     ):
         return ClaudeLaunchCatalogResult(cached, ClaudeLaunchCatalogStatus.FRESH)
+    catalog_refresh_error = cast(
+        type[Exception],
+        getattr(
+            model_catalog_store,
+            "CatalogRefreshError",
+            _UnavailableCatalogRefreshError,
+        ),
+    )
     try:
         rows = await claude_model_catalog(claude_config)
-    except Exception:  # noqa: BLE001 — provenance is returned to the launch selector
+    except catalog_refresh_error as exc:
+        failure_kind = getattr(getattr(exc, "kind", None), "value", None)
+        if failure_kind == "empty":
+            return ClaudeLaunchCatalogResult([], ClaudeLaunchCatalogStatus.EMPTY)
+        _logger.warning("Claude launch catalog refresh failed", exc_info=True)
+        return ClaudeLaunchCatalogResult([], ClaudeLaunchCatalogStatus.REFRESH_FAILED)
+    except Exception:  # noqa: BLE001 — return sanitized refresh provenance
         _logger.warning("Claude launch catalog refresh failed", exc_info=True)
         return ClaudeLaunchCatalogResult([], ClaudeLaunchCatalogStatus.REFRESH_FAILED)
     if rows is None:

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -230,16 +230,7 @@ _CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY_ENV = "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY"
 # model ID.  When set, the /model picker shows these IDs as options rather
 # than normalising to canonical Anthropic names (which the Databricks gateway
 # rejects).  See https://code.claude.com/docs/en/model-config#override-model-ids-per-version
-_ANTHROPIC_DEFAULT_FABLE_MODEL_ENV = "ANTHROPIC_DEFAULT_FABLE_MODEL"
-_ANTHROPIC_DEFAULT_OPUS_MODEL_ENV = "ANTHROPIC_DEFAULT_OPUS_MODEL"
-_ANTHROPIC_DEFAULT_SONNET_MODEL_ENV = "ANTHROPIC_DEFAULT_SONNET_MODEL"
-_ANTHROPIC_DEFAULT_HAIKU_MODEL_ENV = "ANTHROPIC_DEFAULT_HAIKU_MODEL"
-_UCODE_CLAUDE_TIER_TO_ENV: dict[str, str] = {
-    "fable": _ANTHROPIC_DEFAULT_FABLE_MODEL_ENV,
-    "opus": _ANTHROPIC_DEFAULT_OPUS_MODEL_ENV,
-    "sonnet": _ANTHROPIC_DEFAULT_SONNET_MODEL_ENV,
-    "haiku": _ANTHROPIC_DEFAULT_HAIKU_MODEL_ENV,
-}
+_UCODE_CLAUDE_TIER_TO_ENV = dict(ALIAS_MODEL_ENV_VARS)
 # Capability-descending launch fallback policy. Vocabulary ordering is not policy.
 _CLAUDE_TIER_FALLBACK_ORDER: tuple[str, ...] = ("fable", "opus", "sonnet", "haiku")
 # The 4 family aliases above pin one model ID each. Claude Code has exactly
@@ -552,23 +543,6 @@ def _claude_catalog_tier_model(rows: list[dict[str, object]], tier: str) -> str 
     return str(selected.get("model") or selected.get("id") or "").strip() or None
 
 
-def _documented_claude_tier_alias(model: str) -> str | None:
-    """Return a documented bare or 1M tier alias, otherwise ``None``."""
-    candidate = model.strip().lower()
-    base = candidate.removesuffix("[1m]")
-    if base in CLAUDE_MODEL_ALIASES and candidate in {base, f"{base}[1m]"}:
-        return base
-    return None
-
-
-def _claude_launchable_model_text(rows: list[dict[str, object]]) -> str:
-    """Render deterministic launchable picker and wire ids for an error."""
-    launchable = sorted(
-        {str(token) for row in rows for token in (row.get("id"), row.get("model")) if token}
-    )
-    return ", ".join(repr(token) for token in launchable) or "none"
-
-
 def resolve_claude_native_catalog_selection(
     requested_model: str,
     rows: list[dict[str, object]],
@@ -590,7 +564,14 @@ def resolve_claude_native_catalog_selection(
     resolved_request = (
         resolve_claude_native_model_selection(requested_model, claude_config) or requested_model
     )
-    requested_tier = _documented_claude_tier_alias(requested_model)
+    requested_alias = requested_model.strip().lower()
+    alias_base = requested_alias.removesuffix("[1m]")
+    requested_tier = (
+        alias_base
+        if alias_base in CLAUDE_MODEL_ALIASES
+        and requested_alias in {alias_base, f"{alias_base}[1m]"}
+        else None
+    )
     for candidate in dict.fromkeys((requested_model, resolved_request)):
         catalog_model = resolve_claude_catalog_model(rows, candidate)
         if catalog_model is not None:
@@ -636,10 +617,14 @@ def resolve_claude_native_catalog_selection(
             )
             return substitute, notice
 
+    launchable = sorted(
+        {str(token) for row in rows for token in (row.get("id"), row.get("model")) if token}
+    )
+    launchable_text = ", ".join(repr(token) for token in launchable) or "none"
     raise click.ClickException(
         f"the requested model {requested_model!r} is not in this host's current "
         "model list — it may have changed since the pick. Launchable model ids: "
-        f"{_claude_launchable_model_text(rows)}. Pick again from the model menu."
+        f"{launchable_text}. Pick again from the model menu."
     )
 
 
@@ -1354,10 +1339,6 @@ class ClaudeLaunchCatalogStatus(Enum):
     REFRESH_FAILED = "refresh_failed"
 
 
-class _UnavailableCatalogRefreshError(Exception):
-    """Sentinel used when structured catalog refresh errors are unavailable."""
-
-
 @dataclass(frozen=True)
 class ClaudeLaunchCatalogResult:
     """Catalog rows plus authoritative refresh provenance."""
@@ -1378,23 +1359,16 @@ async def claude_launch_catalog_result(
         "claude-native", fingerprint
     ):
         return ClaudeLaunchCatalogResult(cached, ClaudeLaunchCatalogStatus.FRESH)
-    catalog_refresh_error = cast(
-        type[Exception],
-        getattr(
-            model_catalog_store,
-            "CatalogRefreshError",
-            _UnavailableCatalogRefreshError,
-        ),
-    )
+    catalog_refresh_error = getattr(model_catalog_store, "CatalogRefreshError", None)
     try:
         rows = await claude_model_catalog(claude_config)
-    except catalog_refresh_error as exc:
-        failure_kind = getattr(getattr(exc, "kind", None), "value", None)
-        if failure_kind == "empty":
+    except Exception as exc:  # noqa: BLE001 — return sanitized refresh provenance
+        if (
+            catalog_refresh_error is not None
+            and isinstance(exc, catalog_refresh_error)
+            and (getattr(getattr(exc, "kind", None), "value", None) == "empty")
+        ):
             return ClaudeLaunchCatalogResult([], ClaudeLaunchCatalogStatus.EMPTY)
-        _logger.warning("Claude launch catalog refresh failed", exc_info=True)
-        return ClaudeLaunchCatalogResult([], ClaudeLaunchCatalogStatus.REFRESH_FAILED)
-    except Exception:  # noqa: BLE001 — return sanitized refresh provenance
         _logger.warning("Claude launch catalog refresh failed", exc_info=True)
         return ClaudeLaunchCatalogResult([], ClaudeLaunchCatalogStatus.REFRESH_FAILED)
     if rows is None:

--- a/omnigent/model_override.py
+++ b/omnigent/model_override.py
@@ -174,7 +174,10 @@ def model_family_mismatch(harness: str, model: str) -> str | None:
     canon = canonicalize_harness(harness)
     lower = model.lower()
     alias_base = lower.removesuffix("[1m]")
-    is_claude = alias_base in CLAUDE_MODEL_ALIASES or "claude" in lower
+    is_claude_native_alias = (
+        canon in {"claude-native", "native-claude"} and alias_base in CLAUDE_MODEL_ALIASES
+    )
+    is_claude = is_claude_native_alias or "claude" in lower
     # Antigravity's reject-list stays the narrow GPT/codex rule: GLM and Kimi
     # ids carry no Gemini-native verdict, so they are not newly excluded here.
     is_gpt = "gpt" in lower or "codex" in lower

--- a/omnigent/model_override.py
+++ b/omnigent/model_override.py
@@ -173,7 +173,8 @@ def model_family_mismatch(harness: str, model: str) -> str | None:
     """
     canon = canonicalize_harness(harness)
     lower = model.lower()
-    is_claude = lower in CLAUDE_MODEL_ALIASES or "claude" in lower
+    alias_base = lower.removesuffix("[1m]")
+    is_claude = alias_base in CLAUDE_MODEL_ALIASES or "claude" in lower
     # Antigravity's reject-list stays the narrow GPT/codex rule: GLM and Kimi
     # ids carry no Gemini-native verdict, so they are not newly excluded here.
     is_gpt = "gpt" in lower or "codex" in lower

--- a/omnigent/model_override.py
+++ b/omnigent/model_override.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import re
 
+from omnigent.claude_model_vocabulary import CLAUDE_MODEL_ALIASES
 from omnigent.harness_aliases import canonicalize_harness, is_native_harness
 from omnigent.harness_availability import CODEX_CANONICAL_HARNESSES
 from omnigent.harness_plugins import model_env_keys
@@ -152,9 +153,10 @@ def model_family_mismatch(harness: str, model: str) -> str | None:
     """
     Return a rejection reason when *model*'s family cannot run on *harness*.
 
-    Family is detected by vendor token: Claude ids contain ``"claude"``
-    (``databricks-claude-opus-4-8``); codex-compatible ids name gpt,
-    codex, glm, or kimi (``databricks-gpt-5-4``, ``system.ai.glm-5-2``).
+    Family is detected by vendor token or Claude's documented tier aliases:
+    Claude ids contain ``"claude"`` (``databricks-claude-opus-4-8``), while
+    codex-compatible ids name gpt, codex, glm, or kimi
+    (``databricks-gpt-5-4``, ``system.ai.glm-5-2``).
     Single-vendor harnesses reject the other family and ids whose family
     cannot be determined — failing loud at dispatch beats an opaque
     harness/gateway error after spawn.
@@ -171,7 +173,7 @@ def model_family_mismatch(harness: str, model: str) -> str | None:
     """
     canon = canonicalize_harness(harness)
     lower = model.lower()
-    is_claude = "claude" in lower
+    is_claude = lower in CLAUDE_MODEL_ALIASES or "claude" in lower
     # Antigravity's reject-list stays the narrow GPT/codex rule: GLM and Kimi
     # ids carry no Gemini-native verdict, so they are not newly excluded here.
     is_gpt = "gpt" in lower or "codex" in lower

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -5714,6 +5714,7 @@ def _select_authoritative_claude_launch_model(
     from omnigent.claude_native import (
         ClaudeLaunchCatalogStatus,
         claude_config_serves_canonical_ids,
+        is_canonical_claude_pin,
         resolve_claude_native_catalog_selection,
         resolve_claude_native_model_selection,
     )
@@ -5727,7 +5728,9 @@ def _select_authoritative_claude_launch_model(
     if explicit_model:
         if catalog is None or catalog.status is ClaudeLaunchCatalogStatus.REFRESH_FAILED:
             if claude_config_serves_canonical_ids(claude_config):
-                return launch_model, None
+                if is_canonical_claude_pin(explicit_model):
+                    return launch_model, None
+                return resolve_claude_native_catalog_selection(explicit_model, [], claude_config)
             raise click.ClickException(
                 f"could not verify requested Claude model {explicit_model!r} because "
                 "this host's current model list could not be refreshed. Try again "

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -5723,11 +5723,13 @@ def _select_authoritative_claude_launch_model(
         claude_config,
     )
     notice: str | None = None
-    if (
-        explicit_model
-        and catalog is not None
-        and catalog.status in {ClaudeLaunchCatalogStatus.FRESH, ClaudeLaunchCatalogStatus.EMPTY}
-    ):
+    if explicit_model:
+        if catalog is None or catalog.status is ClaudeLaunchCatalogStatus.REFRESH_FAILED:
+            raise click.ClickException(
+                f"could not verify requested Claude model {explicit_model!r} because "
+                "this host's current model list could not be refreshed. Try again "
+                "after model discovery recovers."
+            )
         launch_model, notice = resolve_claude_native_catalog_selection(
             explicit_model,
             catalog.rows,
@@ -6709,7 +6711,7 @@ async def _auto_create_claude_terminal(
     # or to resolve a Default launch that would otherwise pass no ``--model``
     # and leave the model to invisible CLI-private state.
     if explicit_model or configured_model is None:
-        from omnigent.claude_native import ClaudeLaunchCatalogStatus, claude_launch_catalog_result
+        from omnigent.claude_native import claude_launch_catalog_result
 
         try:
             launch_catalog_result = await claude_launch_catalog_result(claude_config)
@@ -6718,16 +6720,6 @@ async def _auto_create_claude_terminal(
                 "claude launch catalog unavailable for session=%s",
                 session_id,
                 exc_info=True,
-                extra={"session_id": session_id},
-            )
-        if (
-            launch_catalog_result is not None
-            and launch_catalog_result.status is ClaudeLaunchCatalogStatus.REFRESH_FAILED
-        ):
-            _logger.warning(
-                "claude launch catalog refresh failed for session=%s; "
-                "preserving the requested launch model without substitution",
-                session_id,
                 extra={"session_id": session_id},
             )
     launch_model, model_substitution_notice = _select_authoritative_claude_launch_model(

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -28,7 +28,7 @@ from omnigent.json_types import JsonObject as _JsonObject
 if TYPE_CHECKING:
     # Type-only import: the runner keeps codex deps out of its runtime import
     # graph (they are imported lazily inside the codex-native helpers).
-    from omnigent.claude_native import ClaudeNativeUcodeConfig
+    from omnigent.claude_native import ClaudeLaunchCatalogResult, ClaudeNativeUcodeConfig
     from omnigent.codex_native_app_server import CodexAppServerClient, CodexNativeAppServer
     from omnigent.inner.datamodel import OSEnvSpec
     from omnigent.opencode_native_app_server import OpenCodeNativeServer
@@ -2272,21 +2272,25 @@ async def _auto_create_pi_terminal(
     # message silently fails to reach the model — the user sees no reply and no
     # reason. Best-effort: a delivery failure must not fail the launch.
     if credential_warning is not None:
-        await _post_pi_native_credential_warning(
+        await _post_native_session_error_notice(
             session_id=session_id,
             server_client=server_client,
-            warning=credential_warning,
+            code="pi_credentials_unresolved",
+            message=credential_warning,
+            log_prefix="pi-native: failed to surface credential warning",
         )
     return terminal_view
 
 
-async def _post_pi_native_credential_warning(
+async def _post_native_session_error_notice(
     *,
     session_id: str,
     server_client: httpx.AsyncClient | None,
-    warning: str,
+    code: str,
+    message: str,
+    log_prefix: str,
 ) -> None:
-    """Surface a credential warning into the session as an error banner.
+    """Surface a native-launch warning into the session as an error banner.
 
     Posts an ``error`` item via ``external_conversation_item`` so the notice
     renders as the web UI's distinct destructive banner (not a misleading
@@ -2297,7 +2301,9 @@ async def _post_pi_native_credential_warning(
 
     :param session_id: Session/conversation identifier.
     :param server_client: Runner Omnigent server client (``None`` in tests).
-    :param warning: The user-facing warning text to surface.
+    :param code: Stable error item code.
+    :param message: User-facing warning text.
+    :param log_prefix: Harness-specific delivery failure description.
     """
     if server_client is None:
         return
@@ -2310,8 +2316,8 @@ async def _post_pi_native_credential_warning(
                     "item_type": "error",
                     "item_data": {
                         "source": "execution",
-                        "code": "pi_credentials_unresolved",
-                        "message": warning,
+                        "code": code,
+                        "message": message,
                     },
                 },
             },
@@ -2320,7 +2326,8 @@ async def _post_pi_native_credential_warning(
         resp.raise_for_status()
     except httpx.HTTPError:
         _logger.warning(
-            "pi-native: failed to surface credential warning for session %s",
+            "%s for session %s",
+            log_prefix,
             session_id,
             exc_info=True,
         )
@@ -5666,6 +5673,79 @@ def _is_runner_owned_antigravity_terminal(
     )
 
 
+def _claude_model_from_launch_args(terminal_launch_args: list[str] | None) -> str | None:
+    """Return the last valid explicit ``--model`` value in launch argv."""
+    model: str | None = None
+    args = terminal_launch_args or []
+    for index, arg in enumerate(args):
+        if arg == "--model" and index + 1 < len(args) and args[index + 1]:
+            model = args[index + 1]
+        elif arg.startswith("--model=") and arg.partition("=")[2]:
+            model = arg.partition("=")[2]
+    return model
+
+
+def _claude_launch_args_with_model(
+    terminal_launch_args: list[str] | None,
+    model: str,
+) -> list[str] | None:
+    """Replace the effective explicit ``--model`` value with *model*."""
+    if terminal_launch_args is None:
+        return None
+    args = list(terminal_launch_args)
+    for index in range(len(args) - 1, -1, -1):
+        if args[index].startswith("--model="):
+            args[index] = f"--model={model}"
+            return args
+        if args[index] == "--model" and index + 1 < len(args):
+            args[index + 1] = model
+            return args
+    return args
+
+
+def _select_authoritative_claude_launch_model(
+    *,
+    explicit_model: str | None,
+    configured_model: str | None,
+    claude_config: ClaudeNativeUcodeConfig | None,
+    catalog: ClaudeLaunchCatalogResult | None,
+) -> tuple[str | None, str | None]:
+    """Select one launch model from the effective pin and fresh catalog."""
+    from omnigent.claude_native import (
+        ClaudeLaunchCatalogStatus,
+        resolve_claude_native_catalog_selection,
+        resolve_claude_native_model_selection,
+    )
+    from omnigent.model_catalog_store import default_row
+
+    launch_model = resolve_claude_native_model_selection(
+        explicit_model or configured_model,
+        claude_config,
+    )
+    notice: str | None = None
+    if (
+        explicit_model
+        and catalog is not None
+        and catalog.status in {ClaudeLaunchCatalogStatus.FRESH, ClaudeLaunchCatalogStatus.EMPTY}
+    ):
+        launch_model, notice = resolve_claude_native_catalog_selection(
+            explicit_model,
+            catalog.rows,
+            claude_config,
+        )
+    if (
+        launch_model is None
+        and catalog is not None
+        and catalog.status is ClaudeLaunchCatalogStatus.FRESH
+    ):
+        catalog_default = default_row(catalog.rows)
+        if catalog_default is not None:
+            launch_model = (
+                str(catalog_default.get("model") or catalog_default.get("id") or "") or None
+            )
+    return launch_model, notice
+
+
 def _build_claude_native_base_args(
     *,
     reasoning_effort: str | None,
@@ -6186,38 +6266,6 @@ async def _load_claude_launch_metadata(
     return metadata
 
 
-async def _post_claude_native_model_substitution_notice(
-    *,
-    session_id: str,
-    server_client: httpx.AsyncClient,
-    notice: str,
-) -> None:
-    """Surface a Claude launch-model substitution in the session."""
-    try:
-        response = await server_client.post(
-            f"/v1/sessions/{urllib.parse.quote(session_id, safe='')}/events",
-            json={
-                "type": "external_conversation_item",
-                "data": {
-                    "item_type": "error",
-                    "item_data": {
-                        "source": "execution",
-                        "code": "claude_model_substituted",
-                        "message": notice,
-                    },
-                },
-            },
-            timeout=30.0,
-        )
-        response.raise_for_status()
-    except httpx.HTTPError:
-        _logger.warning(
-            "claude-native: failed to surface model substitution for session %s",
-            session_id,
-            exc_info=True,
-        )
-
-
 async def _auto_create_claude_terminal(
     session_id: str,
     resource_registry: SessionResourceRegistry,
@@ -6412,8 +6460,6 @@ async def _auto_create_claude_terminal(
         build_native_claude_terminal_env,
         claude_config_with_launch_model_pinned,
         claude_config_with_routed_arms_pinned,
-        resolve_claude_native_catalog_selection,
-        resolve_claude_native_model_selection,
         resolve_native_claude_config,
     )
 
@@ -6652,32 +6698,21 @@ async def _auto_create_claude_terminal(
         from omnigent.server.smart_routing import task_v1_claude_arms
 
         claude_config = claude_config_with_routed_arms_pinned(claude_config, task_v1_claude_arms())
-    launch_model = resolve_claude_native_model_selection(
-        session_model_override
-        or _claude_native_model_from_spec(agent_spec)
-        or (claude_config.model if claude_config is not None else None),
-        claude_config,
+    argv_model = _claude_model_from_launch_args(session_launch_args)
+    explicit_model = (
+        argv_model or session_model_override or _claude_native_model_from_spec(agent_spec)
     )
-    model_substitution_notice: str | None = None
+    configured_model = claude_config.model if claude_config is not None else None
+    launch_catalog_result: ClaudeLaunchCatalogResult | None = None
     # Explicit launches (model-flows design §4): consult the shared catalog
     # only when it can change the outcome — to validate an explicit request,
     # or to resolve a Default launch that would otherwise pass no ``--model``
     # and leave the model to invisible CLI-private state.
-    if session_model_override or launch_model is None:
-        from omnigent.claude_native import (
-            claude_launch_catalog,
-            claude_launch_catalog_is_stale,
-        )
-        from omnigent.model_catalog_store import default_row
+    if explicit_model or configured_model is None:
+        from omnigent.claude_native import ClaudeLaunchCatalogStatus, claude_launch_catalog_result
 
-        launch_catalog: list[dict[str, object]] | None = None
-        launch_catalog_was_stale = False
         try:
-            # Read staleness BEFORE the fetch: the fetch itself kicks the
-            # background re-probe, which could land between the two reads and
-            # make a same-launch check call yesterday's rows fresh.
-            launch_catalog_was_stale = claude_launch_catalog_is_stale(claude_config)
-            launch_catalog = await claude_launch_catalog(claude_config)
+            launch_catalog_result = await claude_launch_catalog_result(claude_config)
         except Exception:  # noqa: BLE001 — no catalog means no validation/default
             _logger.warning(
                 "claude launch catalog unavailable for session=%s",
@@ -6685,32 +6720,24 @@ async def _auto_create_claude_terminal(
                 exc_info=True,
                 extra={"session_id": session_id},
             )
-        if session_model_override and launch_catalog is not None:
-            launch_model, model_substitution_notice = resolve_claude_native_catalog_selection(
-                session_model_override,
-                launch_catalog,
-                claude_config,
+        if (
+            launch_catalog_result is not None
+            and launch_catalog_result.status is ClaudeLaunchCatalogStatus.REFRESH_FAILED
+        ):
+            _logger.warning(
+                "claude launch catalog refresh failed for session=%s; "
+                "preserving the requested launch model without substitution",
+                session_id,
+                extra={"session_id": session_id},
             )
-        if launch_model is None and launch_catalog:
-            # A stale entry's default is yesterday's answer: pinning it as
-            # ``--model`` turns a provider-side retirement or entitlement
-            # change into a hard launch failure. Launch bare instead — the
-            # CLI's own default is servable by construction, and the
-            # harness's ``reported_model`` records what it actually ran —
-            # while the store's background re-probe converges the catalog.
-            if launch_catalog_was_stale:
-                _logger.info(
-                    "claude catalog for session=%s is stale; deferring the Default "
-                    "launch to the CLI's own default model",
-                    session_id,
-                )
-            else:
-                catalog_default = default_row(launch_catalog)
-                if catalog_default is not None:
-                    launch_model = (
-                        str(catalog_default.get("model") or catalog_default.get("id") or "")
-                        or None
-                    )
+    launch_model, model_substitution_notice = _select_authoritative_claude_launch_model(
+        explicit_model=explicit_model,
+        configured_model=configured_model,
+        claude_config=claude_config,
+        catalog=launch_catalog_result,
+    )
+    if argv_model is not None and launch_model is not None and launch_model != argv_model:
+        session_launch_args = _claude_launch_args_with_model(session_launch_args, launch_model)
     # Give an exact launch model (a Smart Routing pick is resolved before the
     # terminal exists) a spelling of its own in the picker, so a later
     # ``/model`` can return to it instead of stepping onto whatever the family
@@ -6929,10 +6956,12 @@ async def _auto_create_claude_terminal(
         },
     )
     if model_substitution_notice is not None:
-        await _post_claude_native_model_substitution_notice(
+        await _post_native_session_error_notice(
             session_id=session_id,
             server_client=server_client,
-            notice=model_substitution_notice,
+            code="claude_model_substituted",
+            message=model_substitution_notice,
+            log_prefix="claude-native: failed to surface model substitution",
         )
     _publish_tmux_target_for_bridge(
         resource_registry=resource_registry,

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -5713,6 +5713,7 @@ def _select_authoritative_claude_launch_model(
     """Select one launch model from the effective pin and fresh catalog."""
     from omnigent.claude_native import (
         ClaudeLaunchCatalogStatus,
+        claude_config_serves_canonical_ids,
         resolve_claude_native_catalog_selection,
         resolve_claude_native_model_selection,
     )
@@ -5725,6 +5726,8 @@ def _select_authoritative_claude_launch_model(
     notice: str | None = None
     if explicit_model:
         if catalog is None or catalog.status is ClaudeLaunchCatalogStatus.REFRESH_FAILED:
+            if claude_config_serves_canonical_ids(claude_config):
+                return launch_model, None
             raise click.ClickException(
                 f"could not verify requested Claude model {explicit_model!r} because "
                 "this host's current model list could not be refreshed. Try again "

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -6186,6 +6186,38 @@ async def _load_claude_launch_metadata(
     return metadata
 
 
+async def _post_claude_native_model_substitution_notice(
+    *,
+    session_id: str,
+    server_client: httpx.AsyncClient,
+    notice: str,
+) -> None:
+    """Surface a Claude launch-model substitution in the session."""
+    try:
+        response = await server_client.post(
+            f"/v1/sessions/{urllib.parse.quote(session_id, safe='')}/events",
+            json={
+                "type": "external_conversation_item",
+                "data": {
+                    "item_type": "error",
+                    "item_data": {
+                        "source": "execution",
+                        "code": "claude_model_substituted",
+                        "message": notice,
+                    },
+                },
+            },
+            timeout=30.0,
+        )
+        response.raise_for_status()
+    except httpx.HTTPError:
+        _logger.warning(
+            "claude-native: failed to surface model substitution for session %s",
+            session_id,
+            exc_info=True,
+        )
+
+
 async def _auto_create_claude_terminal(
     session_id: str,
     resource_registry: SessionResourceRegistry,
@@ -6380,6 +6412,7 @@ async def _auto_create_claude_terminal(
         build_native_claude_terminal_env,
         claude_config_with_launch_model_pinned,
         claude_config_with_routed_arms_pinned,
+        resolve_claude_native_catalog_selection,
         resolve_claude_native_model_selection,
         resolve_native_claude_config,
     )
@@ -6625,13 +6658,13 @@ async def _auto_create_claude_terminal(
         or (claude_config.model if claude_config is not None else None),
         claude_config,
     )
+    model_substitution_notice: str | None = None
     # Explicit launches (model-flows design §4): consult the shared catalog
     # only when it can change the outcome — to validate an explicit request,
     # or to resolve a Default launch that would otherwise pass no ``--model``
     # and leave the model to invisible CLI-private state.
     if session_model_override or launch_model is None:
         from omnigent.claude_native import (
-            claude_catalog_serves_model,
             claude_launch_catalog,
             claude_launch_catalog_is_stale,
         )
@@ -6652,22 +6685,12 @@ async def _auto_create_claude_terminal(
                 exc_info=True,
                 extra={"session_id": session_id},
             )
-        if session_model_override and launch_catalog:
-            resolved_request = (
-                resolve_claude_native_model_selection(session_model_override, claude_config)
-                or session_model_override
+        if session_model_override and launch_catalog is not None:
+            launch_model, model_substitution_notice = resolve_claude_native_catalog_selection(
+                session_model_override,
+                launch_catalog,
+                claude_config,
             )
-            # A pane's ``/model`` persists the exact id it runs; the catalog
-            # may spell that model only by its family alias.
-            if not (
-                claude_catalog_serves_model(launch_catalog, session_model_override, claude_config)
-                or claude_catalog_serves_model(launch_catalog, resolved_request, claude_config)
-            ):
-                raise click.ClickException(
-                    f"the requested model {session_model_override!r} is not in this "
-                    "host's current model list — it may have changed since the pick. "
-                    "Pick again from the model menu."
-                )
         if launch_model is None and launch_catalog:
             # A stale entry's default is yesterday's answer: pinning it as
             # ``--model`` turns a provider-side retirement or entitlement
@@ -6905,6 +6928,12 @@ async def _auto_create_claude_terminal(
             "resource": terminal_payload,
         },
     )
+    if model_substitution_notice is not None:
+        await _post_claude_native_model_substitution_notice(
+            session_id=session_id,
+            server_client=server_client,
+            notice=model_substitution_notice,
+        )
     _publish_tmux_target_for_bridge(
         resource_registry=resource_registry,
         session_id=session_id,

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -26,6 +26,7 @@ from tests.runner.helpers import NullServerClient
 # attribute back to this. (An assignment, not an alias import, so lint
 # autofixes can't strip it as unused.)
 REAL_CLAUDE_LAUNCH_CATALOG = claude_native.claude_launch_catalog
+REAL_CLAUDE_LAUNCH_CATALOG_RESULT = claude_native.claude_launch_catalog_result
 REAL_CODEX_LAUNCH_CATALOG = codex_native_app_server.codex_launch_catalog
 
 # Project root: two parents up from this conftest (tests/runner/ → repo root).
@@ -52,7 +53,18 @@ def _isolated_model_catalog_store(
     async def _no_catalog(*_args: Any, **_kwargs: Any) -> None:
         return None
 
+    async def _no_claude_catalog_result(
+        *_args: Any, **_kwargs: Any
+    ) -> claude_native.ClaudeLaunchCatalogResult:
+        return claude_native.ClaudeLaunchCatalogResult(
+            [], claude_native.ClaudeLaunchCatalogStatus.REFRESH_FAILED
+        )
+
     monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", _no_catalog)
+    monkeypatch.setattr(
+        "omnigent.claude_native.claude_launch_catalog_result",
+        _no_claude_catalog_result,
+    )
     monkeypatch.setattr("omnigent.codex_native_app_server.codex_launch_catalog", _no_catalog)
 
 

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -3535,9 +3535,9 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
         pytest.param(
             "subscription",
             "claude-opus-4-8",
-            "claude-opus-4-8",
+            "claude-opus-4-8[1m]",
             "fresh",
-            id="subscription-canonical",
+            id="subscription-equivalent",
         ),
         pytest.param(
             "gateway",
@@ -3573,10 +3573,9 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
     """
     A persisted canonical id the catalog lists only by family still launches.
 
-    A live ``/model`` persists the pane's exact id (``claude-opus-4-8``) while
-    the catalog spells that family as alias rows and the 1M default. A canonical
-    endpoint honors that id; a gateway uses only an equivalent catalog spelling.
-    Unrecognized ids remain loud and never start a terminal.
+    A live ``/model`` can persist ``claude-opus-4-8`` while the current catalog
+    lists only the equivalent 1M spelling. Both endpoint types use the verified
+    catalog spelling visibly; unrecognized ids remain loud before launch.
     """
     from omnigent.claude_native import (
         ClaudeLaunchCatalogResult,
@@ -3651,7 +3650,7 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         )
         args = captured["spec"].args
         assert args[args.index("--model") + 1] == expected
-    if endpoint == "gateway" and requested == "claude-opus-4-8":
+    if requested == "claude-opus-4-8":
         assert len(event_posts) == 1
         item = event_posts[0]["data"]["item_data"]
         assert item["code"] == "claude_model_substituted"
@@ -3660,6 +3659,53 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         assert event_posts == []
 
     await fake_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auto_create_claude_terminal_spec_pin_survives_catalog_refresh_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Own-login launches pass a spec pin through when discovery is transiently down."""
+    from omnigent.claude_native import ClaudeLaunchCatalogResult, ClaudeLaunchCatalogStatus
+
+    async def _catalog(_config: object) -> ClaudeLaunchCatalogResult:
+        return ClaudeLaunchCatalogResult([], ClaudeLaunchCatalogStatus.REFRESH_FAILED)
+
+    monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog_result", _catalog)
+    resource_registry, fake_client, captured, event_posts = _prepare_claude_model_launch_test(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        snapshot={"labels": {}},
+    )
+
+    async def _resolve() -> None:
+        return None
+
+    requested = "claude-opus-4-8"
+    try:
+        await _auto_create_claude_terminal(
+            "1a2b3c4d5e6f70819283746556473829",
+            resource_registry,
+            lambda _sid, _evt: None,
+            server_client=fake_client,
+            resolve_launch_config=_resolve,
+            agent_spec=AgentSpec(
+                spec_version=1,
+                name="claude",
+                executor=ExecutorSpec(
+                    type="omnigent",
+                    model=requested,
+                    config={"harness": "claude-native"},
+                ),
+            ),
+        )
+    finally:
+        await fake_client.aclose()
+
+    args = captured["spec"].args
+    assert args[args.index("--model") + 1] == requested
+    assert event_posts == []
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -3530,20 +3530,30 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("endpoint", "requested", "expected", "catalog_status"),
+    ("endpoint", "requested", "expected", "catalog_status", "notice_reason"),
     [
         pytest.param(
             "subscription",
             "claude-opus-4-8",
-            "claude-opus-4-8[1m]",
+            "claude-opus-4-8",
             "fresh",
-            id="subscription-equivalent",
+            None,
+            id="subscription-canonical",
+        ),
+        pytest.param(
+            "subscription",
+            "Claude-Opus-4-8",
+            "claude-opus-4-8",
+            "fresh",
+            "host's verified spelling",
+            id="subscription-wrong-case",
         ),
         pytest.param(
             "gateway",
             "claude-opus-4-8",
             "system.ai.claude-opus-4-8[1m]",
             "fresh",
+            "different [1m] context marker",
             id="gateway-equivalent",
         ),
         pytest.param(
@@ -3551,6 +3561,7 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
             "claude-opus-bogus",
             None,
             "fresh",
+            None,
             id="gateway-unrecognized",
         ),
         pytest.param(
@@ -3558,6 +3569,7 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
             "claude-opus-bogus",
             None,
             "refresh-failed",
+            None,
             id="gateway-refresh-failed",
         ),
     ],
@@ -3567,15 +3579,16 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
     requested: str,
     expected: str | None,
     catalog_status: str,
+    notice_reason: str | None,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
     A persisted canonical id the catalog lists only by family still launches.
 
-    A live ``/model`` can persist ``claude-opus-4-8`` while the current catalog
-    lists only the equivalent 1M spelling. Both endpoint types use the verified
-    catalog spelling visibly; unrecognized ids remain loud before launch.
+    A canonical endpoint honors a recognized canonical pin by construction.
+    Gateways require a catalog spelling, while wrong-case and unrecognized ids
+    remain visible or loud before launch.
     """
     from omnigent.claude_native import (
         ClaudeLaunchCatalogResult,
@@ -3584,12 +3597,17 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
     )
 
     prefix = "" if endpoint == "subscription" else "system.ai."
+    equivalent = (
+        "claude-opus-4-8"
+        if endpoint == "subscription" and requested == "Claude-Opus-4-8"
+        else f"{prefix}claude-opus-4-8[1m]"
+    )
     catalog: list[dict[str, object]] = [
         {"id": "opus", "model": f"{prefix}claude-opus-5", "displayName": "Opus 5"},
         {
-            "id": f"{prefix}claude-opus-4-8[1m]",
-            "model": f"{prefix}claude-opus-4-8[1m]",
-            "displayName": "Opus 4.8 (1M context)",
+            "id": equivalent,
+            "model": equivalent,
+            "displayName": "Opus 4.8",
             "isDefault": True,
         },
     ]
@@ -3650,11 +3668,11 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         )
         args = captured["spec"].args
         assert args[args.index("--model") + 1] == expected
-    if requested == "claude-opus-4-8":
+    if notice_reason is not None:
         assert len(event_posts) == 1
         item = event_posts[0]["data"]["item_data"]
         assert item["code"] == "claude_model_substituted"
-        assert "different [1m] context marker" in item["message"]
+        assert notice_reason in item["message"]
     else:
         assert event_posts == []
 
@@ -3662,11 +3680,23 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
 
 
 @pytest.mark.asyncio
-async def test_auto_create_claude_terminal_spec_pin_survives_catalog_refresh_failure(
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        pytest.param("claude-opus-4-8", "claude-opus-4-8", id="canonical-id"),
+        pytest.param("opus[1m]", "opus[1m]", id="canonical-alias"),
+        pytest.param("claude-opus-bogus", None, id="bogus-id"),
+        pytest.param("Claude-Opus-4-8", None, id="wrong-case"),
+        pytest.param("databricks-claude-opus-4-8", None, id="provider-prefixed"),
+    ],
+)
+async def test_auto_create_claude_terminal_own_login_outage_only_passes_canonical_pins(
+    requested: str,
+    expected: str | None,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Own-login launches pass a spec pin through when discovery is transiently down."""
+    """Own-login outages pass only recognized, canonically-spelled pins through."""
     from omnigent.claude_native import ClaudeLaunchCatalogResult, ClaudeLaunchCatalogStatus
 
     async def _catalog(_config: object) -> ClaudeLaunchCatalogResult:
@@ -3682,29 +3712,50 @@ async def test_auto_create_claude_terminal_spec_pin_survives_catalog_refresh_fai
     async def _resolve() -> None:
         return None
 
-    requested = "claude-opus-4-8"
     try:
-        await _auto_create_claude_terminal(
-            "1a2b3c4d5e6f70819283746556473829",
-            resource_registry,
-            lambda _sid, _evt: None,
-            server_client=fake_client,
-            resolve_launch_config=_resolve,
-            agent_spec=AgentSpec(
-                spec_version=1,
-                name="claude",
-                executor=ExecutorSpec(
-                    type="omnigent",
-                    model=requested,
-                    config={"harness": "claude-native"},
+        if expected is None:
+            with pytest.raises(click.ClickException) as exc_info:
+                await _auto_create_claude_terminal(
+                    "1a2b3c4d5e6f70819283746556473829",
+                    resource_registry,
+                    lambda _sid, _evt: None,
+                    server_client=fake_client,
+                    resolve_launch_config=_resolve,
+                    agent_spec=AgentSpec(
+                        spec_version=1,
+                        name="claude",
+                        executor=ExecutorSpec(
+                            type="omnigent",
+                            model=requested,
+                            config={"harness": "claude-native"},
+                        ),
+                    ),
+                )
+            assert "Launchable model ids: none" in str(exc_info.value)
+            assert "spec" not in captured
+        else:
+            await _auto_create_claude_terminal(
+                "1a2b3c4d5e6f70819283746556473829",
+                resource_registry,
+                lambda _sid, _evt: None,
+                server_client=fake_client,
+                resolve_launch_config=_resolve,
+                agent_spec=AgentSpec(
+                    spec_version=1,
+                    name="claude",
+                    executor=ExecutorSpec(
+                        type="omnigent",
+                        model=requested,
+                        config={"harness": "claude-native"},
+                    ),
                 ),
-            ),
-        )
+            )
     finally:
         await fake_client.aclose()
 
-    args = captured["spec"].args
-    assert args[args.index("--model") + 1] == requested
+    if expected is not None:
+        args = captured["spec"].args
+        assert args[args.index("--model") + 1] == expected
     assert event_posts == []
 
 

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -15,7 +15,6 @@ import httpx
 import pytest
 
 from omnigent import (
-    claude_native,
     claude_native_bridge,
     cursor_native_bridge,
     kiro_native_bridge,
@@ -74,25 +73,12 @@ from omnigent.runner.session_init_protocol import RunnerSessionInitEnvelope
 from omnigent.spec.types import AgentSpec, ExecutorSpec
 from omnigent.terminals import TerminalRegistry
 from tests.runner.conftest import (
+    REAL_CLAUDE_LAUNCH_CATALOG_RESULT,
     _FakeProcessManager,
     _runner_client,
     _ScriptedHarnessClient,
 )
 from tests.runner.helpers import NullServerClient
-
-_REAL_CLAUDE_LAUNCH_CATALOG_RESULT = claude_native.claude_launch_catalog_result
-
-
-@pytest.fixture(autouse=True)
-def _disable_authoritative_claude_catalog_probe(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep auto-create unit tests from launching the real Claude CLI."""
-
-    async def _no_catalog(*_args: Any, **_kwargs: Any) -> claude_native.ClaudeLaunchCatalogResult:
-        return claude_native.ClaudeLaunchCatalogResult(
-            [], claude_native.ClaudeLaunchCatalogStatus.REFRESH_FAILED
-        )
-
-    monkeypatch.setattr(claude_native, "claude_launch_catalog_result", _no_catalog)
 
 
 def _load_claude_invocation_settings(args: list[str]) -> dict[str, Any]:
@@ -3383,7 +3369,7 @@ def test_routed_spawn_launch_args_need_a_router() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "pin_source",
-    ["session", "spec", "argv-unavailable", "argv-available"],
+    ["session", "spec", "session-over-spec", "argv-unavailable", "argv-available"],
 )
 async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_notice(
     pin_source: str,
@@ -3454,7 +3440,7 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
         if request.method == "GET":
             model_override = None
             terminal_launch_args = None
-            if pin_source == "session":
+            if pin_source in {"session", "session-over-spec"}:
                 model_override = "fable"
             elif pin_source == "argv-unavailable":
                 model_override = "haiku"
@@ -3485,11 +3471,11 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
             name="claude",
             executor=ExecutorSpec(
                 type="omnigent",
-                model="fable",
+                model="haiku" if pin_source == "session-over-spec" else "fable",
                 config={"harness": "claude-native"},
             ),
         )
-        if pin_source == "spec"
+        if pin_source in {"spec", "session-over-spec"}
         else None
     )
     try:
@@ -3532,27 +3518,43 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("endpoint", "requested", "expected"),
+    ("endpoint", "requested", "expected", "catalog_status"),
     [
         pytest.param(
             "subscription",
             "claude-opus-4-8",
             "claude-opus-4-8",
+            "fresh",
             id="subscription-canonical",
         ),
         pytest.param(
             "gateway",
             "claude-opus-4-8",
             "system.ai.claude-opus-4-8[1m]",
+            "fresh",
             id="gateway-equivalent",
         ),
-        pytest.param("gateway", "claude-opus-bogus", None, id="gateway-unrecognized"),
+        pytest.param(
+            "gateway",
+            "claude-opus-bogus",
+            None,
+            "fresh",
+            id="gateway-unrecognized",
+        ),
+        pytest.param(
+            "gateway",
+            "claude-opus-bogus",
+            None,
+            "refresh-failed",
+            id="gateway-refresh-failed",
+        ),
     ],
 )
 async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_override(
     endpoint: str,
     requested: str,
     expected: str | None,
+    catalog_status: str,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3594,6 +3596,8 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
 
     async def _catalog(config: object) -> ClaudeLaunchCatalogResult:
         del config
+        if catalog_status == "refresh-failed":
+            return ClaudeLaunchCatalogResult([], ClaudeLaunchCatalogStatus.REFRESH_FAILED)
         return ClaudeLaunchCatalogResult(catalog, ClaudeLaunchCatalogStatus.FRESH)
 
     monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog_result", _catalog)
@@ -3660,10 +3664,16 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
                 server_client=fake_client,
                 resolve_launch_config=_resolve,
             )
-        assert "Launchable model ids: 'opus', 'system.ai.claude-opus-4-8[1m]', " in str(
-            exc_info.value
-        )
-        assert "'system.ai.claude-opus-5'" in str(exc_info.value)
+        if catalog_status == "refresh-failed":
+            assert "could not verify requested Claude model 'claude-opus-bogus'" in str(
+                exc_info.value
+            )
+            assert "current model list could not be refreshed" in str(exc_info.value)
+        else:
+            assert "Launchable model ids: 'opus', 'system.ai.claude-opus-4-8[1m]', " in str(
+                exc_info.value
+            )
+            assert "'system.ai.claude-opus-5'" in str(exc_info.value)
         assert "spec" not in captured, "a refused launch must not start a terminal"
     else:
         await _auto_create_claude_terminal(
@@ -3675,7 +3685,13 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         )
         args = captured["spec"].args
         assert args[args.index("--model") + 1] == expected
-    assert event_posts == []
+    if endpoint == "gateway" and requested == "claude-opus-4-8":
+        assert len(event_posts) == 1
+        item = event_posts[0]["data"]["item_data"]
+        assert item["code"] == "claude_model_substituted"
+        assert "different [1m] context marker" in item["message"]
+    else:
+        assert event_posts == []
 
     await fake_client.aclose()
 
@@ -3709,7 +3725,7 @@ async def test_auto_create_claude_terminal_default_pin_requires_a_fresh_catalog(
     )
     monkeypatch.setattr(
         "omnigent.claude_native.claude_launch_catalog_result",
-        _REAL_CLAUDE_LAUNCH_CATALOG_RESULT,
+        REAL_CLAUDE_LAUNCH_CATALOG_RESULT,
     )
     refreshed: list[dict[str, object]] = [
         {"id": "sonnet", "model": "claude-sonnet-5", "isDefault": True}

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -3366,6 +3366,55 @@ def test_routed_spawn_launch_args_need_a_router() -> None:
     assert _routed_spawn_launch_args(False) == (None, ())
 
 
+def _prepare_claude_model_launch_test(
+    *,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    snapshot: dict[str, Any],
+) -> tuple[Any, httpx.AsyncClient, dict[str, Any], list[dict[str, Any]]]:
+    """Set up a captured Claude launch with an in-memory session snapshot."""
+    monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
+
+    async def _no_op_forwarder(**kwargs: Any) -> None:
+        del kwargs
+
+    monkeypatch.setattr(
+        "omnigent.claude_native_forwarder.supervise_forwarder",
+        _no_op_forwarder,
+    )
+    captured: dict[str, Any] = {}
+
+    class _FakeResourceRegistry:
+        terminal_registry = None
+
+        async def launch_required_terminal(self, **kwargs: Any) -> SessionResourceView:
+            captured["spec"] = kwargs["spec"]
+            return SessionResourceView(
+                id="terminal_claude_main",
+                type="terminal",
+                session_id=kwargs["session_id"],
+                name="claude:main",
+                metadata={"terminal_name": "claude", "session_key": "main", "running": True},
+            )
+
+    event_posts: list[dict[str, Any]] = []
+
+    def _handle_request(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, json=snapshot)
+        if request.method == "POST" and request.url.path.endswith("/events"):
+            event_posts.append(json.loads(request.content))
+        return httpx.Response(200, json={})
+
+    client = httpx.AsyncClient(
+        base_url="http://test-server",
+        transport=httpx.MockTransport(_handle_request),
+    )
+    return _FakeResourceRegistry(), client, captured, event_posts
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "pin_source",
@@ -3384,17 +3433,6 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
         ClaudeNativeUcodeConfig,
     )
 
-    monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
-    monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
-
-    async def _no_op_forwarder(**kwargs: Any) -> None:
-        del kwargs
-
-    monkeypatch.setattr(
-        "omnigent.claude_native_forwarder.supervise_forwarder",
-        _no_op_forwarder,
-    )
     catalog: list[dict[str, object]] = [
         {"id": "haiku", "model": "system.ai.claude-haiku-4-5"},
         {"id": "sonnet", "model": "system.ai.claude-sonnet-4-6[1m]"},
@@ -3419,50 +3457,24 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
     async def _resolve() -> ClaudeNativeUcodeConfig:
         return config
 
-    captured: dict[str, Any] = {}
-
-    class _FakeResourceRegistry:
-        terminal_registry = None
-
-        async def launch_required_terminal(self, **kwargs: Any) -> SessionResourceView:
-            captured["spec"] = kwargs["spec"]
-            return SessionResourceView(
-                id="terminal_claude_main",
-                type="terminal",
-                session_id=kwargs["session_id"],
-                name="claude:main",
-                metadata={"terminal_name": "claude", "session_key": "main", "running": True},
-            )
-
-    event_posts: list[dict[str, Any]] = []
-
-    def _handle_request(request: httpx.Request) -> httpx.Response:
-        if request.method == "GET":
-            model_override = None
-            terminal_launch_args = None
-            if pin_source in {"session", "session-over-spec"}:
-                model_override = "fable"
-            elif pin_source == "argv-unavailable":
-                model_override = "haiku"
-                terminal_launch_args = ["--model", "fable"]
-            elif pin_source == "argv-available":
-                model_override = "fable"
-                terminal_launch_args = ["--model", "system.ai.claude-sonnet-4-6[1m]"]
-            return httpx.Response(
-                200,
-                json={
-                    "model_override": model_override,
-                    "terminal_launch_args": terminal_launch_args,
-                    "labels": {},
-                },
-            )
-        if request.method == "POST" and request.url.path.endswith("/events"):
-            event_posts.append(json.loads(request.content))
-        return httpx.Response(200, json={})
-
-    fake_client = httpx.AsyncClient(
-        base_url="http://test-server",
-        transport=httpx.MockTransport(_handle_request),
+    model_override = None
+    terminal_launch_args = None
+    if pin_source in {"session", "session-over-spec"}:
+        model_override = "fable"
+    elif pin_source == "argv-unavailable":
+        model_override = "haiku"
+        terminal_launch_args = ["--model", "fable"]
+    elif pin_source == "argv-available":
+        model_override = "fable"
+        terminal_launch_args = ["--model", "system.ai.claude-sonnet-4-6[1m]"]
+    resource_registry, fake_client, captured, event_posts = _prepare_claude_model_launch_test(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        snapshot={
+            "model_override": model_override,
+            "terminal_launch_args": terminal_launch_args,
+            "labels": {},
+        },
     )
     session_id = "7d1e4a3c2b5f69807162534453627180"
     agent_spec = (
@@ -3482,7 +3494,7 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
         with caplog.at_level(logging.WARNING, logger="omnigent.claude_native"):
             await _auto_create_claude_terminal(
                 session_id,
-                _FakeResourceRegistry(),  # type: ignore[arg-type]
+                resource_registry,
                 lambda _sid, _evt: None,
                 server_client=fake_client,
                 resolve_launch_config=_resolve,
@@ -3572,17 +3584,6 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         ClaudeNativeUcodeConfig,
     )
 
-    monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
-    monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
-
-    async def _no_op_forwarder(**kwargs: Any) -> None:
-        del kwargs
-
-    monkeypatch.setattr(
-        "omnigent.claude_native_forwarder.supervise_forwarder",
-        _no_op_forwarder,
-    )
     prefix = "" if endpoint == "subscription" else "system.ai."
     catalog: list[dict[str, object]] = [
         {"id": "opus", "model": f"{prefix}claude-opus-5", "displayName": "Opus 5"},
@@ -3601,45 +3602,10 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         return ClaudeLaunchCatalogResult(catalog, ClaudeLaunchCatalogStatus.FRESH)
 
     monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog_result", _catalog)
-
-    captured: dict[str, Any] = {}
-
-    class _FakeResourceRegistry:
-        """Captures the launched terminal spec."""
-
-        terminal_registry = None
-
-        async def launch_required_terminal(
-            self,
-            *,
-            session_id: str,
-            terminal_name: str,
-            session_key: str,
-            spec: Any,
-            resource_role: str | None = None,
-            parent_os_env: Any = None,
-        ) -> SessionResourceView:
-            """Record the spec and return a terminal resource view."""
-            del terminal_name, session_key
-            captured["spec"] = spec
-            return SessionResourceView(
-                id="terminal_claude_main",
-                type="terminal",
-                session_id=session_id,
-                name="claude:main",
-                metadata={"terminal_name": "claude", "session_key": "main", "running": True},
-            )
-
-    event_posts: list[dict[str, Any]] = []
-
-    def _handle_request(request: httpx.Request) -> httpx.Response:
-        if request.method == "POST" and request.url.path.endswith("/events"):
-            event_posts.append(json.loads(request.content))
-        return httpx.Response(200, json={"model_override": requested, "labels": {}})
-
-    fake_client = httpx.AsyncClient(
-        base_url="http://test-server",
-        transport=httpx.MockTransport(_handle_request),
+    resource_registry, fake_client, captured, event_posts = _prepare_claude_model_launch_test(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        snapshot={"model_override": requested, "labels": {}},
     )
     config = (
         None
@@ -3659,7 +3625,7 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         with pytest.raises(click.ClickException) as exc_info:
             await _auto_create_claude_terminal(
                 session_id,
-                _FakeResourceRegistry(),
+                resource_registry,
                 lambda _sid, _evt: None,
                 server_client=fake_client,
                 resolve_launch_config=_resolve,
@@ -3678,7 +3644,7 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
     else:
         await _auto_create_claude_terminal(
             session_id,
-            _FakeResourceRegistry(),
+            resource_registry,
             lambda _sid, _evt: None,
             server_client=fake_client,
             resolve_launch_config=_resolve,
@@ -3712,17 +3678,6 @@ async def test_auto_create_claude_terminal_default_pin_requires_a_fresh_catalog(
     from omnigent import model_catalog_store
     from omnigent.claude_native import claude_catalog_fingerprint
 
-    monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
-    monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
-
-    async def _no_op_forwarder(**kwargs: Any) -> None:
-        del kwargs
-
-    monkeypatch.setattr(
-        "omnigent.claude_native_forwarder.supervise_forwarder",
-        _no_op_forwarder,
-    )
     monkeypatch.setattr(
         "omnigent.claude_native.claude_launch_catalog_result",
         REAL_CLAUDE_LAUNCH_CATALOG_RESULT,
@@ -3755,40 +3710,10 @@ async def test_auto_create_claude_terminal_default_pin_requires_a_fresh_catalog(
         old = time.time() - (model_catalog_store.CATALOG_STALE_AFTER_S + 60)
         os.utime(path, (old, old))
 
-    captured: dict[str, Any] = {}
-
-    class _FakeResourceRegistry:
-        """Captures the launched terminal spec."""
-
-        terminal_registry = None
-
-        async def launch_required_terminal(
-            self,
-            *,
-            session_id: str,
-            terminal_name: str,
-            session_key: str,
-            spec: Any,
-            resource_role: str | None = None,
-            parent_os_env: Any = None,
-        ) -> SessionResourceView:
-            """Record the spec and return a terminal resource view."""
-            del terminal_name, session_key
-            captured["spec"] = spec
-            return SessionResourceView(
-                id="terminal_claude_main",
-                type="terminal",
-                session_id=session_id,
-                name="claude:main",
-                metadata={"terminal_name": "claude", "session_key": "main", "running": True},
-            )
-
-    def _handle_request(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"labels": {}})
-
-    fake_client = httpx.AsyncClient(
-        base_url="http://test-server",
-        transport=httpx.MockTransport(_handle_request),
+    resource_registry, fake_client, captured, _event_posts = _prepare_claude_model_launch_test(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        snapshot={"labels": {}},
     )
 
     async def _resolve() -> None:
@@ -3796,7 +3721,7 @@ async def test_auto_create_claude_terminal_default_pin_requires_a_fresh_catalog(
 
     await _auto_create_claude_terminal(
         "9b1d2c3e4f5a6b7c8d9e0f1a2b3c4d5e",
-        _FakeResourceRegistry(),
+        resource_registry,
         lambda _sid, _evt: None,
         server_client=fake_client,
         resolve_launch_config=_resolve,

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -10,10 +10,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import click
 import httpx
 import pytest
 
 from omnigent import (
+    claude_native,
     claude_native_bridge,
     cursor_native_bridge,
     kiro_native_bridge,
@@ -77,6 +79,20 @@ from tests.runner.conftest import (
     _ScriptedHarnessClient,
 )
 from tests.runner.helpers import NullServerClient
+
+_REAL_CLAUDE_LAUNCH_CATALOG_RESULT = claude_native.claude_launch_catalog_result
+
+
+@pytest.fixture(autouse=True)
+def _disable_authoritative_claude_catalog_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep auto-create unit tests from launching the real Claude CLI."""
+
+    async def _no_catalog(*_args: Any, **_kwargs: Any) -> claude_native.ClaudeLaunchCatalogResult:
+        return claude_native.ClaudeLaunchCatalogResult(
+            [], claude_native.ClaudeLaunchCatalogStatus.REFRESH_FAILED
+        )
+
+    monkeypatch.setattr(claude_native, "claude_launch_catalog_result", _no_catalog)
 
 
 def _load_claude_invocation_settings(args: list[str]) -> dict[str, Any]:
@@ -3365,13 +3381,22 @@ def test_routed_spawn_launch_args_need_a_router() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "pin_source",
+    ["session", "spec", "argv-unavailable", "argv-available"],
+)
 async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_notice(
+    pin_source: str,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A stale Fable pin launches on Opus and makes the downgrade visible."""
-    from omnigent.claude_native import ClaudeNativeUcodeConfig
+    """The effective explicit pin is validated and any downgrade is visible."""
+    from omnigent.claude_native import (
+        ClaudeLaunchCatalogResult,
+        ClaudeLaunchCatalogStatus,
+        ClaudeNativeUcodeConfig,
+    )
 
     monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
@@ -3384,16 +3409,16 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
         "omnigent.claude_native_forwarder.supervise_forwarder",
         _no_op_forwarder,
     )
-    catalog = [
+    catalog: list[dict[str, object]] = [
         {"id": "haiku", "model": "system.ai.claude-haiku-4-5"},
         {"id": "sonnet", "model": "system.ai.claude-sonnet-4-6[1m]"},
         {"id": "opus", "model": "system.ai.claude-opus-4-8[1m]"},
     ]
 
-    async def _catalog(_config: object) -> list[dict[str, object]]:
-        return catalog
+    async def _catalog(_config: object) -> ClaudeLaunchCatalogResult:
+        return ClaudeLaunchCatalogResult(catalog, ClaudeLaunchCatalogStatus.FRESH)
 
-    monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", _catalog)
+    monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog_result", _catalog)
     config = ClaudeNativeUcodeConfig(
         env={
             "ANTHROPIC_BASE_URL": "https://gateway.example/anthropic",
@@ -3427,7 +3452,24 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
 
     def _handle_request(request: httpx.Request) -> httpx.Response:
         if request.method == "GET":
-            return httpx.Response(200, json={"model_override": "fable", "labels": {}})
+            model_override = None
+            terminal_launch_args = None
+            if pin_source == "session":
+                model_override = "fable"
+            elif pin_source == "argv-unavailable":
+                model_override = "haiku"
+                terminal_launch_args = ["--model", "fable"]
+            elif pin_source == "argv-available":
+                model_override = "fable"
+                terminal_launch_args = ["--model", "system.ai.claude-sonnet-4-6[1m]"]
+            return httpx.Response(
+                200,
+                json={
+                    "model_override": model_override,
+                    "terminal_launch_args": terminal_launch_args,
+                    "labels": {},
+                },
+            )
         if request.method == "POST" and request.url.path.endswith("/events"):
             event_posts.append(json.loads(request.content))
         return httpx.Response(200, json={})
@@ -3437,6 +3479,19 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
         transport=httpx.MockTransport(_handle_request),
     )
     session_id = "7d1e4a3c2b5f69807162534453627180"
+    agent_spec = (
+        AgentSpec(
+            spec_version=1,
+            name="claude",
+            executor=ExecutorSpec(
+                type="omnigent",
+                model="fable",
+                config={"harness": "claude-native"},
+            ),
+        )
+        if pin_source == "spec"
+        else None
+    )
     try:
         with caplog.at_level(logging.WARNING, logger="omnigent.claude_native"):
             await _auto_create_claude_terminal(
@@ -3445,6 +3500,7 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
                 lambda _sid, _evt: None,
                 server_client=fake_client,
                 resolve_launch_config=_resolve,
+                agent_spec=agent_spec,
             )
         await asyncio.sleep(0)
     finally:
@@ -3452,24 +3508,51 @@ async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_
 
     args = captured["spec"].args
     substitute = "system.ai.claude-opus-4-8[1m]"
-    assert args[args.index("--model") + 1] == substitute
-    warning = next(record for record in caplog.records if "substituting" in record.getMessage())
-    assert warning.levelno == logging.WARNING
-    assert "'fable'" in warning.getMessage()
-    assert repr(substitute) in warning.getMessage()
-    assert "absent from this host's current model list" in warning.getMessage()
-    assert len(event_posts) == 1
-    item = event_posts[0]["data"]
-    assert item["item_type"] == "error"
-    assert item["item_data"]["code"] == "claude_model_substituted"
-    assert "'fable' is unavailable" in item["item_data"]["message"]
-    assert f"with {substitute!r} instead" in item["item_data"]["message"]
+    selected = args[args.index("--model") + 1]
+    warnings = [record for record in caplog.records if "substituting" in record.getMessage()]
+    if pin_source == "argv-available":
+        assert selected == "system.ai.claude-sonnet-4-6[1m]"
+        assert warnings == []
+        assert event_posts == []
+    else:
+        assert selected == substitute
+        assert len(warnings) == 1
+        warning = warnings[0]
+        assert warning.levelno == logging.WARNING
+        assert "'fable'" in warning.getMessage()
+        assert repr(substitute) in warning.getMessage()
+        assert "absent from this host's current model list" in warning.getMessage()
+        assert len(event_posts) == 1
+        item = event_posts[0]["data"]
+        assert item["item_type"] == "error"
+        assert item["item_data"]["code"] == "claude_model_substituted"
+        assert "'fable' is unavailable" in item["item_data"]["message"]
+        assert f"with {substitute!r} instead" in item["item_data"]["message"]
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("endpoint", ["subscription", "gateway"])
+@pytest.mark.parametrize(
+    ("endpoint", "requested", "expected"),
+    [
+        pytest.param(
+            "subscription",
+            "claude-opus-4-8",
+            "claude-opus-4-8",
+            id="subscription-canonical",
+        ),
+        pytest.param(
+            "gateway",
+            "claude-opus-4-8",
+            "system.ai.claude-opus-4-8[1m]",
+            id="gateway-equivalent",
+        ),
+        pytest.param("gateway", "claude-opus-bogus", None, id="gateway-unrecognized"),
+    ],
+)
 async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_override(
     endpoint: str,
+    requested: str,
+    expected: str | None,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3478,9 +3561,14 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
 
     A live ``/model`` persists the pane's exact id (``claude-opus-4-8``) while
     the catalog spells that family as alias rows and the 1M default. A canonical
-    endpoint honors that id; a gateway substitutes its concrete current Opus.
+    endpoint honors that id; a gateway uses only an equivalent catalog spelling.
+    Unrecognized ids remain loud and never start a terminal.
     """
-    from omnigent.claude_native import ClaudeNativeUcodeConfig
+    from omnigent.claude_native import (
+        ClaudeLaunchCatalogResult,
+        ClaudeLaunchCatalogStatus,
+        ClaudeNativeUcodeConfig,
+    )
 
     monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
@@ -3494,7 +3582,7 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         _no_op_forwarder,
     )
     prefix = "" if endpoint == "subscription" else "system.ai."
-    catalog = [
+    catalog: list[dict[str, object]] = [
         {"id": "opus", "model": f"{prefix}claude-opus-5", "displayName": "Opus 5"},
         {
             "id": f"{prefix}claude-opus-4-8[1m]",
@@ -3504,11 +3592,11 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         },
     ]
 
-    async def _catalog(config: object) -> list[dict[str, object]]:
+    async def _catalog(config: object) -> ClaudeLaunchCatalogResult:
         del config
-        return catalog
+        return ClaudeLaunchCatalogResult(catalog, ClaudeLaunchCatalogStatus.FRESH)
 
-    monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", _catalog)
+    monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog_result", _catalog)
 
     captured: dict[str, Any] = {}
 
@@ -3538,8 +3626,12 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
                 metadata={"terminal_name": "claude", "session_key": "main", "running": True},
             )
 
-    def _handle_request(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"model_override": "claude-opus-4-8", "labels": {}})
+    event_posts: list[dict[str, Any]] = []
+
+    def _handle_request(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path.endswith("/events"):
+            event_posts.append(json.loads(request.content))
+        return httpx.Response(200, json={"model_override": requested, "labels": {}})
 
     fake_client = httpx.AsyncClient(
         base_url="http://test-server",
@@ -3559,16 +3651,31 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         return config
 
     session_id = "0f2d3d5c9a6b4e1f8c7d6e5f4a3b2c1d"
-    await _auto_create_claude_terminal(
-        session_id,
-        _FakeResourceRegistry(),
-        lambda _sid, _evt: None,
-        server_client=fake_client,
-        resolve_launch_config=_resolve,
-    )
-    args = captured["spec"].args
-    expected = "claude-opus-4-8" if endpoint == "subscription" else "system.ai.claude-opus-5"
-    assert args[args.index("--model") + 1] == expected
+    if expected is None:
+        with pytest.raises(click.ClickException) as exc_info:
+            await _auto_create_claude_terminal(
+                session_id,
+                _FakeResourceRegistry(),
+                lambda _sid, _evt: None,
+                server_client=fake_client,
+                resolve_launch_config=_resolve,
+            )
+        assert "Launchable model ids: 'opus', 'system.ai.claude-opus-4-8[1m]', " in str(
+            exc_info.value
+        )
+        assert "'system.ai.claude-opus-5'" in str(exc_info.value)
+        assert "spec" not in captured, "a refused launch must not start a terminal"
+    else:
+        await _auto_create_claude_terminal(
+            session_id,
+            _FakeResourceRegistry(),
+            lambda _sid, _evt: None,
+            server_client=fake_client,
+            resolve_launch_config=_resolve,
+        )
+        args = captured["spec"].args
+        assert args[args.index("--model") + 1] == expected
+    assert event_posts == []
 
     await fake_client.aclose()
 
@@ -3581,20 +3688,13 @@ async def test_auto_create_claude_terminal_default_pin_requires_a_fresh_catalog(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    A Default launch pins the stored default only while the entry is fresh.
-
-    The store never forgets an entry, so its ``isDefault`` row can outlive
-    the model it names (a retirement or an entitlement change); pinning it
-    as ``--model`` then hard-fails every Default launch on the host. A
-    stale entry defers to the CLI's own default — no ``--model`` at all —
-    while the store re-probes in the background.
+    A Default launch uses a fresh cached default or an authoritative refresh.
     """
     import os
     import time
 
     from omnigent import model_catalog_store
     from omnigent.claude_native import claude_catalog_fingerprint
-    from tests.runner.conftest import REAL_CLAUDE_LAUNCH_CATALOG
 
     monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
@@ -3607,10 +3707,13 @@ async def test_auto_create_claude_terminal_default_pin_requires_a_fresh_catalog(
         "omnigent.claude_native_forwarder.supervise_forwarder",
         _no_op_forwarder,
     )
-    # The real store-backed resolver, against the conftest-isolated store
-    # dir; the background re-probe is stubbed so no real CLI ever runs.
-    monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", REAL_CLAUDE_LAUNCH_CATALOG)
-    refreshed = [{"id": "sonnet", "model": "claude-sonnet-5", "isDefault": True}]
+    monkeypatch.setattr(
+        "omnigent.claude_native.claude_launch_catalog_result",
+        _REAL_CLAUDE_LAUNCH_CATALOG_RESULT,
+    )
+    refreshed: list[dict[str, object]] = [
+        {"id": "sonnet", "model": "claude-sonnet-5", "isDefault": True}
+    ]
 
     async def _fake_probe_catalog(config: object) -> list[dict[str, object]]:
         del config
@@ -3686,11 +3789,7 @@ async def test_auto_create_claude_terminal_default_pin_requires_a_fresh_catalog(
     if freshness == "fresh":
         assert args[args.index("--model") + 1] == "claude-3-5-sonnet-20241022"
     else:
-        assert "--model" not in args, f"a stale default was still pinned: {args}"
-        task = model_catalog_store._inflight.get(("claude-native", fingerprint))
-        if task is not None:
-            await task
-        # The background re-probe healed the store for the next launch.
+        assert args[args.index("--model") + 1] == "claude-sonnet-5"
         assert model_catalog_store.read_catalog("claude-native", fingerprint) == refreshed
 
     await fake_client.aclose()

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import click
 import httpx
 import pytest
 
@@ -3366,6 +3365,108 @@ def test_routed_spawn_launch_args_need_a_router() -> None:
 
 
 @pytest.mark.asyncio
+async def test_auto_create_claude_terminal_substitutes_an_unavailable_tier_with_notice(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A stale Fable pin launches on Opus and makes the downgrade visible."""
+    from omnigent.claude_native import ClaudeNativeUcodeConfig
+
+    monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
+
+    async def _no_op_forwarder(**kwargs: Any) -> None:
+        del kwargs
+
+    monkeypatch.setattr(
+        "omnigent.claude_native_forwarder.supervise_forwarder",
+        _no_op_forwarder,
+    )
+    catalog = [
+        {"id": "haiku", "model": "system.ai.claude-haiku-4-5"},
+        {"id": "sonnet", "model": "system.ai.claude-sonnet-4-6[1m]"},
+        {"id": "opus", "model": "system.ai.claude-opus-4-8[1m]"},
+    ]
+
+    async def _catalog(_config: object) -> list[dict[str, object]]:
+        return catalog
+
+    monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", _catalog)
+    config = ClaudeNativeUcodeConfig(
+        env={
+            "ANTHROPIC_BASE_URL": "https://gateway.example/anthropic",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": "system.ai.claude-opus-4-8[1m]",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": "system.ai.claude-sonnet-4-6[1m]",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": "system.ai.claude-haiku-4-5",
+        },
+        model="system.ai.claude-opus-4-8[1m]",
+        routable_models=tuple(str(row["model"]) for row in catalog),
+    )
+
+    async def _resolve() -> ClaudeNativeUcodeConfig:
+        return config
+
+    captured: dict[str, Any] = {}
+
+    class _FakeResourceRegistry:
+        terminal_registry = None
+
+        async def launch_required_terminal(self, **kwargs: Any) -> SessionResourceView:
+            captured["spec"] = kwargs["spec"]
+            return SessionResourceView(
+                id="terminal_claude_main",
+                type="terminal",
+                session_id=kwargs["session_id"],
+                name="claude:main",
+                metadata={"terminal_name": "claude", "session_key": "main", "running": True},
+            )
+
+    event_posts: list[dict[str, Any]] = []
+
+    def _handle_request(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, json={"model_override": "fable", "labels": {}})
+        if request.method == "POST" and request.url.path.endswith("/events"):
+            event_posts.append(json.loads(request.content))
+        return httpx.Response(200, json={})
+
+    fake_client = httpx.AsyncClient(
+        base_url="http://test-server",
+        transport=httpx.MockTransport(_handle_request),
+    )
+    session_id = "7d1e4a3c2b5f69807162534453627180"
+    try:
+        with caplog.at_level(logging.WARNING, logger="omnigent.claude_native"):
+            await _auto_create_claude_terminal(
+                session_id,
+                _FakeResourceRegistry(),  # type: ignore[arg-type]
+                lambda _sid, _evt: None,
+                server_client=fake_client,
+                resolve_launch_config=_resolve,
+            )
+        await asyncio.sleep(0)
+    finally:
+        await fake_client.aclose()
+
+    args = captured["spec"].args
+    substitute = "system.ai.claude-opus-4-8[1m]"
+    assert args[args.index("--model") + 1] == substitute
+    warning = next(record for record in caplog.records if "substituting" in record.getMessage())
+    assert warning.levelno == logging.WARNING
+    assert "'fable'" in warning.getMessage()
+    assert repr(substitute) in warning.getMessage()
+    assert "absent from this host's current model list" in warning.getMessage()
+    assert len(event_posts) == 1
+    item = event_posts[0]["data"]
+    assert item["item_type"] == "error"
+    assert item["item_data"]["code"] == "claude_model_substituted"
+    assert "'fable' is unavailable" in item["item_data"]["message"]
+    assert f"with {substitute!r} instead" in item["item_data"]["message"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("endpoint", ["subscription", "gateway"])
 async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_override(
     endpoint: str,
@@ -3376,10 +3477,8 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
     A persisted canonical id the catalog lists only by family still launches.
 
     A live ``/model`` persists the pane's exact id (``claude-opus-4-8``) while
-    the catalog spells that family as alias rows and the 1M default. On a
-    canonical endpoint the relaunch must pass the id through as ``--model``
-    rather than refuse the resume; a gateway, which routes only its own
-    spellings, keeps refusing it.
+    the catalog spells that family as alias rows and the 1M default. A canonical
+    endpoint honors that id; a gateway substitutes its concrete current Opus.
     """
     from omnigent.claude_native import ClaudeNativeUcodeConfig
 
@@ -3460,26 +3559,16 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         return config
 
     session_id = "0f2d3d5c9a6b4e1f8c7d6e5f4a3b2c1d"
-    if endpoint == "subscription":
-        await _auto_create_claude_terminal(
-            session_id,
-            _FakeResourceRegistry(),
-            lambda _sid, _evt: None,
-            server_client=fake_client,
-            resolve_launch_config=_resolve,
-        )
-        args = captured["spec"].args
-        assert args[args.index("--model") + 1] == "claude-opus-4-8"
-    else:
-        with pytest.raises(click.ClickException, match="not in this host's current model list"):
-            await _auto_create_claude_terminal(
-                session_id,
-                _FakeResourceRegistry(),
-                lambda _sid, _evt: None,
-                server_client=fake_client,
-                resolve_launch_config=_resolve,
-            )
-        assert "spec" not in captured, "a refused launch must not start a terminal"
+    await _auto_create_claude_terminal(
+        session_id,
+        _FakeResourceRegistry(),
+        lambda _sid, _evt: None,
+        server_client=fake_client,
+        resolve_launch_config=_resolve,
+    )
+    args = captured["spec"].args
+    expected = "claude-opus-4-8" if endpoint == "subscription" else "system.ai.claude-opus-5"
+    assert args[args.index("--model") + 1] == expected
 
     await fake_client.aclose()
 

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -4075,6 +4075,26 @@ async def test_sys_session_send_passes_model_through_when_provider_undeterminabl
 
 
 @pytest.mark.asyncio
+async def test_sys_session_send_accepts_a_documented_claude_model_alias(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The claude-native family guard accepts the launchable ``opus`` alias."""
+    _isolate_model_providers(monkeypatch, tmp_path, "")
+    result = await _dispatch_model_send(
+        monkeypatch,
+        agent_spec=_spec_with_subagent_harness("claude-native"),
+        model="opus",
+        conv_id="conv_parent_claude_alias",
+    )
+
+    payload = json.loads(result.output)
+    assert payload["status"] == "launching"
+    assert len(result.create_bodies) == 1
+    assert result.create_bodies[0]["model_override"] == "opus"
+
+
+@pytest.mark.asyncio
 async def test_sys_session_send_family_guard_runs_before_normalization(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -4075,23 +4075,25 @@ async def test_sys_session_send_passes_model_through_when_provider_undeterminabl
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["opus", "opus[1m]", "sonnet[1m]"])
 async def test_sys_session_send_accepts_a_documented_claude_model_alias(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    model: str,
 ) -> None:
-    """The claude-native family guard accepts the launchable ``opus`` alias."""
+    """The claude-native family guard accepts documented tier aliases."""
     _isolate_model_providers(monkeypatch, tmp_path, "")
     result = await _dispatch_model_send(
         monkeypatch,
         agent_spec=_spec_with_subagent_harness("claude-native"),
-        model="opus",
+        model=model,
         conv_id="conv_parent_claude_alias",
     )
 
     payload = json.loads(result.output)
     assert payload["status"] == "launching"
     assert len(result.create_bodies) == 1
-    assert result.create_bodies[0]["model_override"] == "opus"
+    assert result.create_bodies[0]["model_override"] == model
 
 
 @pytest.mark.asyncio

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -9,6 +9,7 @@ import contextlib
 import importlib.metadata
 import io
 import json
+import logging
 import os
 import re
 import shlex
@@ -9847,4 +9848,43 @@ def test_claude_catalog_serves_model(
     Exact rows serve; a canonical id serves on a canonical endpoint when its family is listed."""
     assert (
         claude_native.claude_catalog_serves_model(_subscription_catalog(), model, config) is served
+    )
+
+
+def test_claude_catalog_selection_honors_an_available_concrete_pin(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An exact live pin is launched unchanged and emits no downgrade warning."""
+    requested = "system.ai.claude-opus-4-8[1m]"
+    catalog = [
+        {"id": "opus", "model": "system.ai.claude-opus-5"},
+        {"id": requested, "model": requested},
+    ]
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"}
+    )
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.claude_native"):
+        selection = claude_native.resolve_claude_native_catalog_selection(
+            requested,
+            catalog,
+            config,
+        )
+
+    assert selection == (requested, None)
+    assert not [record for record in caplog.records if "substitut" in record.getMessage()]
+
+
+def test_claude_catalog_selection_keeps_loud_failure_without_a_claude_tier() -> None:
+    """A catalog with no Claude tier preserves the actionable launch failure."""
+    with pytest.raises(click.ClickException) as exc_info:
+        claude_native.resolve_claude_native_catalog_selection(
+            "fable",
+            [{"id": "gpt-5.4", "model": "gpt-5.4"}],
+            None,
+        )
+
+    assert exc_info.value.message == (
+        "the requested model 'fable' is not in this host's current model list — "
+        "it may have changed since the pick. Pick again from the model menu."
     )

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -8,6 +8,7 @@ import binascii
 import contextlib
 import importlib.metadata
 import io
+import itertools
 import json
 import logging
 import os
@@ -9856,7 +9857,7 @@ def test_claude_catalog_selection_honors_an_available_concrete_pin(
 ) -> None:
     """An exact live pin is launched unchanged and emits no downgrade warning."""
     requested = "system.ai.claude-opus-4-8[1m]"
-    catalog = [
+    catalog: list[dict[str, object]] = [
         {"id": "opus", "model": "system.ai.claude-opus-5"},
         {"id": requested, "model": requested},
     ]
@@ -9875,16 +9876,154 @@ def test_claude_catalog_selection_honors_an_available_concrete_pin(
     assert not [record for record in caplog.records if "substitut" in record.getMessage()]
 
 
-def test_claude_catalog_selection_keeps_loud_failure_without_a_claude_tier() -> None:
+def test_claude_catalog_selection_matches_an_equivalent_generation_before_fallback() -> None:
+    """A provider spelling and context marker do not change the pinned generation."""
+    requested = "databricks-claude-opus-4-8"
+    equivalent = "system.ai.claude-opus-4-8[1m]"
+
+    assert claude_native.resolve_claude_native_catalog_selection(
+        requested,
+        [
+            {"id": "opus", "model": "system.ai.claude-opus-5"},
+            {"id": equivalent, "model": equivalent},
+        ],
+        claude_native.ClaudeNativeUcodeConfig(
+            env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"}
+        ),
+    ) == (equivalent, None)
+
+
+def test_claude_tier_fallback_order_is_capability_descending() -> None:
+    """Launch policy has explicit order and exactly the documented tier membership."""
+    from omnigent.claude_model_vocabulary import CLAUDE_MODEL_ALIASES
+
+    assert claude_native._CLAUDE_TIER_FALLBACK_ORDER == (
+        "fable",
+        "opus",
+        "sonnet",
+        "haiku",
+    )
+    assert set(claude_native._CLAUDE_TIER_FALLBACK_ORDER) == set(CLAUDE_MODEL_ALIASES)
+    assert claude_native._CLAUDE_TIER_FALLBACK_ORDER is not CLAUDE_MODEL_ALIASES
+
+
+def test_claude_tier_fallback_is_stable_across_catalog_order() -> None:
+    """Newest standard-context model wins within a tier regardless of row order."""
+    catalog: list[dict[str, object]] = [
+        {"id": "opus-4-8", "model": "system.ai.claude-opus-4-8"},
+        {"id": "opus-4-8-1m", "model": "system.ai.claude-opus-4-8[1m]"},
+        {"id": "opus-5-1m", "model": "system.ai.claude-opus-5[1m]"},
+        {"id": "opus-5", "model": "system.ai.claude-opus-5"},
+    ]
+
+    for permuted in itertools.permutations(catalog):
+        selection, notice = claude_native.resolve_claude_native_catalog_selection(
+            "fable",
+            list(permuted),
+            None,
+        )
+        assert selection == "system.ai.claude-opus-5"
+        assert notice is not None
+
+
+@pytest.mark.parametrize(
+    ("catalog", "launchable"),
+    [
+        pytest.param([], "none", id="empty"),
+        pytest.param(
+            [{"id": "gpt-row", "model": "gpt-5.4"}],
+            "'gpt-5.4', 'gpt-row'",
+            id="non-claude",
+        ),
+    ],
+)
+def test_claude_catalog_selection_keeps_loud_failure_without_a_claude_tier(
+    catalog: list[dict[str, object]],
+    launchable: str,
+) -> None:
     """A catalog with no Claude tier preserves the actionable launch failure."""
     with pytest.raises(click.ClickException) as exc_info:
         claude_native.resolve_claude_native_catalog_selection(
             "fable",
-            [{"id": "gpt-5.4", "model": "gpt-5.4"}],
+            catalog,
             None,
         )
 
     assert exc_info.value.message == (
         "the requested model 'fable' is not in this host's current model list — "
-        "it may have changed since the pick. Pick again from the model menu."
+        "it may have changed since the pick. Launchable model ids: "
+        f"{launchable}. Pick again from the model menu."
     )
+
+
+def test_claude_catalog_selection_rejects_an_unrecognized_claude_looking_id() -> None:
+    """Only documented tier aliases can degrade after catalog matching fails."""
+    catalog: list[dict[str, object]] = [
+        {"id": "opus", "model": "system.ai.claude-opus-5"},
+        {"id": "sonnet", "model": "system.ai.claude-sonnet-4-6[1m]"},
+    ]
+
+    with pytest.raises(click.ClickException) as exc_info:
+        claude_native.resolve_claude_native_catalog_selection(
+            "claude-opus-bogus",
+            catalog,
+            None,
+        )
+
+    assert exc_info.value.message == (
+        "the requested model 'claude-opus-bogus' is not in this host's current "
+        "model list — it may have changed since the pick. Launchable model ids: "
+        "'opus', 'sonnet', 'system.ai.claude-opus-5', "
+        "'system.ai.claude-sonnet-4-6[1m]'. Pick again from the model menu."
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("probe_rows", "expected_status", "expected_rows"),
+    [
+        pytest.param(
+            [{"id": "opus", "model": "claude-opus-5"}],
+            claude_native.ClaudeLaunchCatalogStatus.FRESH,
+            [{"id": "opus", "model": "claude-opus-5"}],
+            id="fresh",
+        ),
+        pytest.param([], claude_native.ClaudeLaunchCatalogStatus.EMPTY, [], id="empty"),
+        pytest.param(
+            None,
+            claude_native.ClaudeLaunchCatalogStatus.REFRESH_FAILED,
+            [],
+            id="refresh-failed",
+        ),
+    ],
+)
+async def test_claude_launch_catalog_result_ignores_stale_rows_and_reports_refresh_outcome(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    probe_rows: list[dict[str, object]] | None,
+    expected_status: claude_native.ClaudeLaunchCatalogStatus,
+    expected_rows: list[dict[str, object]],
+) -> None:
+    """Launch selection sees fresh rows and distinguishes empty from failed refreshes."""
+    import time
+
+    from omnigent import model_catalog_store
+
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
+    fingerprint = claude_native.claude_catalog_fingerprint(None)
+    stale_rows = [{"id": "fable", "model": "claude-fable-retired"}]
+    model_catalog_store.write_catalog("claude-native", fingerprint, stale_rows)
+    path = model_catalog_store.catalog_path("claude-native", fingerprint)
+    stale_time = time.time() - model_catalog_store.CATALOG_STALE_AFTER_S - 1
+    os.utime(path, (stale_time, stale_time))
+
+    async def _probe(_config: object) -> list[dict[str, object]] | None:
+        return probe_rows
+
+    monkeypatch.setattr(claude_native, "claude_model_catalog", _probe)
+
+    result = await claude_native.claude_launch_catalog_result(None)
+
+    assert result.status is expected_status
+    assert result.rows == expected_rows
+    assert result.rows != stale_rows

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -9876,21 +9876,32 @@ def test_claude_catalog_selection_honors_an_available_concrete_pin(
     assert not [record for record in caplog.records if "substitut" in record.getMessage()]
 
 
-def test_claude_catalog_selection_matches_an_equivalent_generation_before_fallback() -> None:
-    """A provider spelling and context marker do not change the pinned generation."""
+def test_claude_catalog_selection_surfaces_an_equivalent_context_marker_change(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An equivalent generation with a different context marker is visible."""
     requested = "databricks-claude-opus-4-8"
     equivalent = "system.ai.claude-opus-4-8[1m]"
 
-    assert claude_native.resolve_claude_native_catalog_selection(
-        requested,
-        [
-            {"id": "opus", "model": "system.ai.claude-opus-5"},
-            {"id": equivalent, "model": equivalent},
-        ],
-        claude_native.ClaudeNativeUcodeConfig(
-            env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"}
-        ),
-    ) == (equivalent, None)
+    with caplog.at_level(logging.WARNING, logger="omnigent.claude_native"):
+        selected, notice = claude_native.resolve_claude_native_catalog_selection(
+            requested,
+            [
+                {"id": "opus", "model": "system.ai.claude-opus-5"},
+                {"id": equivalent, "model": equivalent},
+            ],
+            claude_native.ClaudeNativeUcodeConfig(
+                env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"}
+            ),
+        )
+
+    assert selected == equivalent
+    assert notice is not None
+    assert "different [1m] context marker" in notice
+    warnings = [record for record in caplog.records if "substituting" in record.getMessage()]
+    assert len(warnings) == 1
+    assert repr(requested) in warnings[0].getMessage()
+    assert repr(equivalent) in warnings[0].getMessage()
 
 
 def test_claude_tier_fallback_order_is_capability_descending() -> None:
@@ -9923,6 +9934,23 @@ def test_claude_tier_fallback_is_stable_across_catalog_order() -> None:
             None,
         )
         assert selection == "system.ai.claude-opus-5"
+        assert notice is not None
+
+
+def test_claude_tier_fallback_is_stable_for_case_distinct_rows() -> None:
+    """Original-case tie-breakers make case-distinct rows deterministic."""
+    catalog: list[dict[str, object]] = [
+        {"id": "OPUS-5", "model": "SYSTEM.AI.CLAUDE-OPUS-5"},
+        {"id": "opus-5", "model": "system.ai.claude-opus-5"},
+    ]
+
+    for permuted in itertools.permutations(catalog):
+        selection, notice = claude_native.resolve_claude_native_catalog_selection(
+            "fable",
+            list(permuted),
+            None,
+        )
+        assert selection == "SYSTEM.AI.CLAUDE-OPUS-5"
         assert notice is not None
 
 
@@ -9980,7 +10008,7 @@ def test_claude_catalog_selection_rejects_an_unrecognized_claude_looking_id() ->
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("probe_rows", "expected_status", "expected_rows"),
+    ("probe_outcome", "expected_status", "expected_rows"),
     [
         pytest.param(
             [{"id": "opus", "model": "claude-opus-5"}],
@@ -9988,9 +10016,14 @@ def test_claude_catalog_selection_rejects_an_unrecognized_claude_looking_id() ->
             [{"id": "opus", "model": "claude-opus-5"}],
             id="fresh",
         ),
-        pytest.param([], claude_native.ClaudeLaunchCatalogStatus.EMPTY, [], id="empty"),
         pytest.param(
-            None,
+            "empty-error",
+            claude_native.ClaudeLaunchCatalogStatus.EMPTY,
+            [],
+            id="empty",
+        ),
+        pytest.param(
+            "refresh-error",
             claude_native.ClaudeLaunchCatalogStatus.REFRESH_FAILED,
             [],
             id="refresh-failed",
@@ -10000,7 +10033,7 @@ def test_claude_catalog_selection_rejects_an_unrecognized_claude_looking_id() ->
 async def test_claude_launch_catalog_result_ignores_stale_rows_and_reports_refresh_outcome(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    probe_rows: list[dict[str, object]] | None,
+    probe_outcome: list[dict[str, object]] | str,
     expected_status: claude_native.ClaudeLaunchCatalogStatus,
     expected_rows: list[dict[str, object]],
 ) -> None:
@@ -10017,8 +10050,26 @@ async def test_claude_launch_catalog_result_ignores_stale_rows_and_reports_refre
     stale_time = time.time() - model_catalog_store.CATALOG_STALE_AFTER_S - 1
     os.utime(path, (stale_time, stale_time))
 
-    async def _probe(_config: object) -> list[dict[str, object]] | None:
-        return probe_rows
+    class _EmptyKind:
+        value = "empty"
+
+    class CatalogRefreshError(Exception):
+        kind = _EmptyKind()
+
+    monkeypatch.setattr(
+        model_catalog_store,
+        "CatalogRefreshError",
+        CatalogRefreshError,
+        raising=False,
+    )
+
+    async def _probe(_config: object) -> list[dict[str, object]]:
+        if probe_outcome == "empty-error":
+            raise CatalogRefreshError("model catalog refresh returned no models")
+        if probe_outcome == "refresh-error":
+            raise RuntimeError("catalog refresh unavailable")
+        assert isinstance(probe_outcome, list)
+        return probe_outcome
 
     monkeypatch.setattr(claude_native, "claude_model_catalog", _probe)
 

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -9944,7 +9944,9 @@ def test_claude_catalog_selection_surfaces_alias_context_marker_change(
         selected, notice = claude_native.resolve_claude_native_catalog_selection(
             requested,
             [{"id": catalog_model, "model": catalog_model}],
-            None,
+            claude_native.ClaudeNativeUcodeConfig(
+                env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"}
+            ),
         )
 
     assert selected == catalog_model

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -9904,6 +9904,58 @@ def test_claude_catalog_selection_surfaces_an_equivalent_context_marker_change(
     assert repr(equivalent) in warnings[0].getMessage()
 
 
+def test_claude_catalog_selection_uses_verified_case_with_notice(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A wrong-case legacy pin launches the catalog's verified spelling visibly."""
+    requested = "Claude-Opus-4-8"
+    verified = "claude-opus-4-8"
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.claude_native"):
+        selected, notice = claude_native.resolve_claude_native_catalog_selection(
+            requested,
+            [{"id": verified, "model": verified}],
+            None,
+        )
+
+    assert selected == verified
+    assert notice is not None
+    assert "host's verified spelling" in notice
+    warnings = [record for record in caplog.records if "substituting" in record.getMessage()]
+    assert len(warnings) == 1
+    assert repr(requested) in warnings[0].getMessage()
+    assert repr(verified) in warnings[0].getMessage()
+
+
+@pytest.mark.parametrize(
+    ("requested", "catalog_model"),
+    [
+        pytest.param("opus[1m]", "opus", id="long-to-standard"),
+        pytest.param("opus", "opus[1m]", id="standard-to-long"),
+    ],
+)
+def test_claude_catalog_selection_surfaces_alias_context_marker_change(
+    requested: str,
+    catalog_model: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An alias's explicit context marker cannot change silently."""
+    with caplog.at_level(logging.WARNING, logger="omnigent.claude_native"):
+        selected, notice = claude_native.resolve_claude_native_catalog_selection(
+            requested,
+            [{"id": catalog_model, "model": catalog_model}],
+            None,
+        )
+
+    assert selected == catalog_model
+    assert notice is not None
+    assert "different [1m] context marker" in notice
+    warnings = [record for record in caplog.records if "substituting" in record.getMessage()]
+    assert len(warnings) == 1
+    assert repr(requested) in warnings[0].getMessage()
+    assert repr(catalog_model) in warnings[0].getMessage()
+
+
 def test_claude_tier_fallback_order_is_capability_descending() -> None:
     """Launch policy has explicit order and exactly the documented tier membership."""
     from omnigent.claude_model_vocabulary import CLAUDE_MODEL_ALIASES

--- a/tests/test_model_override.py
+++ b/tests/test_model_override.py
@@ -138,6 +138,8 @@ class TestModelFamilyMismatch:
             ("claude-native", "opus"),
             ("claude-native", "sonnet"),
             ("claude-native", "haiku"),
+            ("claude-native", "opus[1m]"),
+            ("claude-native", "sonnet[1m]"),
             ("codex-native", "databricks-gpt-5-4"),
             ("codex", "gpt-5.1-codex"),
             # The OpenAI family is matched as a substring, which is the only

--- a/tests/test_model_override.py
+++ b/tests/test_model_override.py
@@ -201,6 +201,8 @@ class TestModelFamilyMismatch:
             ("claude-native", "databricks-glm-5-2", "only runs Claude models"),
             ("claude-sdk", "system.ai.glm-5-2", "only runs Claude models"),
             ("claude-sdk", "databricks-kimi-k2-6", "only runs Claude models"),
+            ("claude-sdk", "opus", "only runs Claude models"),
+            ("claude_sdk", "sonnet[1m]", "only runs Claude models"),
             (
                 "codex-native",
                 "databricks-claude-sonnet-4-6",

--- a/tests/test_model_override.py
+++ b/tests/test_model_override.py
@@ -134,6 +134,10 @@ class TestModelFamilyMismatch:
         [
             ("claude-native", "databricks-claude-sonnet-4-6"),
             ("claude-sdk", "claude-opus-4-8"),
+            ("claude-native", "fable"),
+            ("claude-native", "opus"),
+            ("claude-native", "sonnet"),
+            ("claude-native", "haiku"),
             ("codex-native", "databricks-gpt-5-4"),
             ("codex", "gpt-5.1-codex"),
             # The OpenAI family is matched as a substring, which is the only


### PR DESCRIPTION
## Related issue

Part of #5737 — https://github.com/omnigent-ai/omnigent/issues/5737

## Summary

- Resolve one effective claude-native pin in precedence order: explicit `terminal_launch_args --model`, live session override, then `agent_spec.executor.model`. Exact catalog matches remain exact; recognized, canonically-spelled pins stay exact on canonical endpoints, while gateways require their catalog spelling.
- For a genuinely unavailable documented Claude tier alias, walk the deterministic Fable → Opus → Sonnet → Haiku ladder over fresh authoritative rows, WARN with requested/substituted IDs and reason, and post a visible session notice. Context-marker changes such as plain → `[1m]` are also visible.
- On catalog refresh failure, canonical/own-login endpoints pass through only recognized, canonically-spelled Claude ids and aliases. Wrong-case, provider-prefixed, and bogus pins fail with the launchable-id list; gateways retain their existing fail-closed behavior.
- Keep bare/bracket Claude Code tier aliases scoped to claude-native; claude-sdk continues rejecting them because it does not resolve Claude Code aliases.

ELI5: a saved Fable pin no longer prevents Claude from starting when Fable disappears. Omnigent chooses the best Claude tier the host currently offers and tells the operator, while never quietly changing an available or unrecognized model. Transient discovery outages no longer block own-login launches with recognized canonical pins.

```text
argv pin → session pin → spec pin → exact/equivalent catalog match → launch
                                      └→ documented tier ladder → WARN + notice
                                      └→ unknown/no tier → actionable refusal
catalog refresh failure + canonical endpoint + canonical pin → launch unchanged
catalog refresh failure + canonical endpoint + unverified pin → actionable refusal
catalog refresh failure + gateway endpoint → actionable refusal
```

Staging reconciliation: PR #5366/staging already defines `resolve_claude_catalog_model`, a single-flight authoritative catalog result API, and a centralized launch selector. This main-based branch must not be layered onto staging verbatim. The minimal safe staging landing is to delete this branch's duplicate resolver/wrapper, use staging's authoritative result API, and fold the fallback/context-notice policy into staging's existing selector.

## Test Plan

- `uv run --frozen python -m pytest tests/test_claude_native.py tests/runner/test_app_sessions_native_terminals_autocreate.py --collect-only -q -p no:randomly` — 412 cases collected.
- `uv run --frozen python -m pytest tests/test_claude_native.py tests/runner/test_app_sessions_native_terminals_autocreate.py -q -p no:randomly` — 412 passed, 3 warnings.
- `uv run --frozen python -m pytest tests/runner --collect-only -q -p no:randomly` — 1781 cases collected. The +5 from the prior 1776-case head are one fresh wrong-case case and four additional outage-pin parameters.
- `uv run --frozen python -m pytest tests/runner -q -p no:randomly` — 1771 passed, 1 skipped, 4 xfailed, 5 failed, 6 warnings. The failing ID set exactly matches the supplied baseline.
- Focused restored mutation selection — 9 passed. Reverting each guard produced RED: EMPTY mapping (1 failed), generic refresh classification (1 failed), refresh-failure fail-closed behavior (1 failed), context-marker notice (2 failed), WARN severity (1 failed), session-over-spec precedence (1 failed), case-sensitive total ordering (1 failed), and claude-sdk alias isolation (2 failed).
- Tribunal R3 mutation selection — 6 passed. Reverting canonical pass-through produced 1 failed; reverting verified catalog-spelling preservation produced 2 failed; restoring the alias-only context-marker guard produced 2 failed bidirectional cases.
- Tribunal R4 mutation checks: catalog-only authority failed the subscription canonical case; case-insensitive predicate acceptance failed the subscription wrong-case case; endpoint-only outage pass-through failed bogus, wrong-case, and provider-prefixed cases; disabling outage pass-through failed canonical id and alias cases; reversing context-marker parity failed both gateway marker directions. Restored focused selection: 17 passed.
- Controlled hermeticity spy on `test_auto_create_claude_terminal_recreate_cancels_prior_forwarder`: removing the shared runner fixture reached the Claude probe twice and errored at teardown; restored fixture reported `CLAUDE_PROBE_SPY_CALLS=0` and passed.
- `.venv/bin/pyrefly check omnigent/claude_native.py omnigent/model_override.py omnigent/runner/native/orchestration.py` — `INFO 0 errors (3 suppressed, 3 warnings not shown)`.
- `.venv/bin/pre-commit run --all-files` — every runnable hook passed, including VS Code TypeScript. The Pyrefly hook alone exited 1 because the parent repo's `.git/info/exclude` excludes `.worktrees/`, so its configured globs matched zero Python files; the explicit-path Pyrefly command above performs the real typecheck.

Required fork CI pytest/pre-commit jobs remain skipped behind the failed Maintainer Approval check, so local results are the available gate evidence.

## Demo

N/A — non-visual launch-resolution change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover every explicit-pin source and precedence, exact/equivalent preservation, context-marker notices, fallback order and deterministic ranking, WARN and visible notice delivery, fresh/empty/refresh-failed catalogs, no-Claude and bogus-ID refusals, pre-launch terminal refusal, alias-family isolation, and runner-wide CLI-probe hermeticity.

## Changelog

Claude-native sessions now distinguish canonically servable own-login pins from gateway catalog spellings, preserving valid context choices while rejecting unverified outage pins.

Part of #5737



