### PR TITLE
Fold codex launch model vocabulary before rejecting an explicit pin

### DIFF
--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3731,13 +3731,6 @@ def _resolve_codex_launch_model_override(requested: str, catalog: list[_JsonObje
     """
     from omnigent.codex_model_vocabulary import codex_reachable_model_slug
 
-    def _valid_row_id(row: _JsonObject) -> str | None:
-        row_id = row.get("id")
-        if not isinstance(row_id, str):
-            return None
-        row_id = row_id.strip()
-        return row_id or None
-
     def _launchable_text() -> str:
         launchable = sorted(
             {str(token) for row in catalog for token in (row.get("id"), row.get("model")) if token}
@@ -3745,17 +3738,14 @@ def _resolve_codex_launch_model_override(requested: str, catalog: list[_JsonObje
         return ", ".join(repr(token) for token in launchable) or "none"
 
     # A selectable id is stronger than another row's model alias.
-    for row in catalog:
-        row_id = _valid_row_id(row)
-        if row_id is not None and requested == row_id:
-            return row_id
-
     exact_model_ids: set[str] = set()
     for row in catalog:
-        if requested != row.get("model"):
+        row_id = row.get("id")
+        if not isinstance(row_id, str) or not (row_id := row_id.strip()):
             continue
-        row_id = _valid_row_id(row)
-        if row_id is not None:
+        if requested == row_id:
+            return row_id
+        if requested == row.get("model"):
             exact_model_ids.add(row_id)
     if len(exact_model_ids) == 1:
         return next(iter(exact_model_ids))

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3731,23 +3731,50 @@ def _resolve_codex_launch_model_override(requested: str, catalog: list[_JsonObje
     """
     from omnigent.codex_model_vocabulary import codex_reachable_model_slug
 
-    # An exact id/model match wins over any folding alias, so a persisted pin's
-    # own spelling survives regardless of catalog row order.
-    for row in catalog:
+    def _valid_row_id(row: _JsonObject) -> str | None:
         row_id = row.get("id")
-        if isinstance(row_id, str) and requested in (row_id, row.get("model")):
+        if not isinstance(row_id, str):
+            return None
+        row_id = row_id.strip()
+        return row_id or None
+
+    def _launchable_text() -> str:
+        launchable = sorted(
+            {str(token) for row in catalog for token in (row.get("id"), row.get("model")) if token}
+        )
+        return ", ".join(repr(token) for token in launchable) or "none"
+
+    # A selectable id is stronger than another row's model alias.
+    for row in catalog:
+        row_id = _valid_row_id(row)
+        if row_id is not None and requested == row_id:
             return row_id
+
+    exact_model_match = False
+    exact_model_ids: set[str] = set()
+    for row in catalog:
+        if requested != row.get("model"):
+            continue
+        exact_model_match = True
+        row_id = _valid_row_id(row)
+        if row_id is not None:
+            exact_model_ids.add(row_id)
+    if exact_model_match:
+        if len(exact_model_ids) == 1:
+            return next(iter(exact_model_ids))
+        raise click.ClickException(
+            f"the requested model {requested!r} exactly matches catalog rows that "
+            "do not resolve to exactly one valid catalog id. Launchable model ids: "
+            f"{_launchable_text()}. Pick again from the model menu."
+        )
+
     resolved = codex_reachable_model_slug(requested, catalog)
     if resolved is not None:
         return resolved
-    launchable = sorted(
-        {str(token) for row in catalog for token in (row.get("id"), row.get("model")) if token}
-    )
-    launchable_text = ", ".join(repr(token) for token in launchable) or "none"
     raise click.ClickException(
         f"the requested model {requested!r} is not in this host's current model "
         f"list — it may have changed since the pick. Launchable model ids: "
-        f"{launchable_text}. Pick again from the model menu."
+        f"{_launchable_text()}. Pick again from the model menu."
     )
 
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3762,11 +3762,12 @@ def _resolve_codex_launch_model_override(requested: str, catalog: list[_JsonObje
     if exact_model_match:
         if len(exact_model_ids) == 1:
             return next(iter(exact_model_ids))
-        raise click.ClickException(
-            f"the requested model {requested!r} exactly matches catalog rows that "
-            "do not resolve to exactly one valid catalog id. Launchable model ids: "
-            f"{_launchable_text()}. Pick again from the model menu."
-        )
+        if len(exact_model_ids) > 1:
+            raise click.ClickException(
+                f"the requested model {requested!r} exactly matches catalog rows that "
+                "do not resolve to exactly one valid catalog id. Launchable model ids: "
+                f"{_launchable_text()}. Pick again from the model menu."
+            )
 
     resolved = codex_reachable_model_slug(requested, catalog)
     if resolved is not None:

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3719,6 +3719,32 @@ async def _auto_create_kimi_terminal(
     return terminal_view
 
 
+def _resolve_codex_launch_model_override(requested: str, catalog: list[_JsonObject]) -> str:
+    """Resolve an explicit codex model pin to the id its catalog advertises.
+
+    An orchestrator-selected id can arrive in gateway vocabulary
+    (``system.ai.gpt-5.6-sol``) or with dashed version digits
+    (``system.ai.gpt-5-6-sol``) while codex's own ``model/list`` spells the
+    same model ``gpt-5.6-sol``. Fold both sides to codex's comparison form and
+    return the catalog's own spelling so the launch pins what codex serves. A
+    model no row names is rejected with the launchable ids enumerated.
+    """
+    from omnigent.codex_model_vocabulary import codex_reachable_model_slug
+
+    resolved = codex_reachable_model_slug(requested, catalog)
+    if resolved is not None:
+        return resolved
+    launchable = sorted(
+        {str(token) for row in catalog for token in (row.get("id"), row.get("model")) if token}
+    )
+    launchable_text = ", ".join(repr(token) for token in launchable) or "none"
+    raise click.ClickException(
+        f"the requested model {requested!r} is not in this host's current model "
+        f"list — it may have changed since the pick. Launchable model ids: "
+        f"{launchable_text}. Pick again from the model menu."
+    )
+
+
 async def _auto_create_codex_terminal(
     session_id: str,
     resource_registry: SessionResourceRegistry,
@@ -3830,19 +3856,26 @@ async def _auto_create_codex_terminal(
             codex_launch_catalog,
             codex_launch_catalog_is_stale,
         )
-        from omnigent.model_catalog_store import catalog_contains, default_row
+        from omnigent.model_catalog_store import default_row
 
         # Read staleness BEFORE the fetch — the fetch kicks the background
         # re-probe, which could land between the two reads.
         _codex_catalog_was_stale = await codex_launch_catalog_is_stale()
         _codex_catalog = await codex_launch_catalog(codex_path=_codex_cli_path)
         if launch_config.model_override and _codex_catalog:
-            if not catalog_contains(_codex_catalog, launch_config.model_override):
-                raise click.ClickException(
-                    f"the requested model {launch_config.model_override!r} is not in "
-                    "this host's current model list — it may have changed since the "
-                    "pick. Pick again from the model menu."
+            # Fold gateway/dashed vocabulary onto codex's own spelling before
+            # accepting or rejecting, and pin the id codex actually advertises.
+            _resolved_model = _resolve_codex_launch_model_override(
+                launch_config.model_override, _codex_catalog
+            )
+            if _resolved_model != _codex_launch.model:
+                _logger.info(
+                    "codex launch for session=%s: resolved requested model %r to catalog id %r",
+                    session_id,
+                    launch_config.model_override,
+                    _resolved_model,
                 )
+                _codex_launch = _dataclass_replace(_codex_launch, model=_resolved_model)
         if _codex_launch.model is None and _codex_launch.profile is None and _codex_catalog:
             # Same staleness rule as the claude branch: never convert a stale
             # entry's default into an explicit model pin.

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3750,24 +3750,21 @@ def _resolve_codex_launch_model_override(requested: str, catalog: list[_JsonObje
         if row_id is not None and requested == row_id:
             return row_id
 
-    exact_model_match = False
     exact_model_ids: set[str] = set()
     for row in catalog:
         if requested != row.get("model"):
             continue
-        exact_model_match = True
         row_id = _valid_row_id(row)
         if row_id is not None:
             exact_model_ids.add(row_id)
-    if exact_model_match:
-        if len(exact_model_ids) == 1:
-            return next(iter(exact_model_ids))
-        if len(exact_model_ids) > 1:
-            raise click.ClickException(
-                f"the requested model {requested!r} exactly matches catalog rows that "
-                "do not resolve to exactly one valid catalog id. Launchable model ids: "
-                f"{_launchable_text()}. Pick again from the model menu."
-            )
+    if len(exact_model_ids) == 1:
+        return next(iter(exact_model_ids))
+    if len(exact_model_ids) > 1:
+        raise click.ClickException(
+            f"the requested model {requested!r} exactly matches catalog rows that "
+            "do not resolve to exactly one valid catalog id. Launchable model ids: "
+            f"{_launchable_text()}. Pick again from the model menu."
+        )
 
     resolved = codex_reachable_model_slug(requested, catalog)
     if resolved is not None:

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3731,6 +3731,12 @@ def _resolve_codex_launch_model_override(requested: str, catalog: list[_JsonObje
     """
     from omnigent.codex_model_vocabulary import codex_reachable_model_slug
 
+    # An exact id/model match wins over any folding alias, so a persisted pin's
+    # own spelling survives regardless of catalog row order.
+    for row in catalog:
+        row_id = row.get("id")
+        if isinstance(row_id, str) and requested in (row_id, row.get("model")):
+            return row_id
     resolved = codex_reachable_model_slug(requested, catalog)
     if resolved is not None:
         return resolved

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -3693,18 +3693,37 @@ def test_resolve_codex_launch_model_override_rejects_ambiguous_exact_models() ->
     assert "'second-selector'" in message
 
 
-@pytest.mark.parametrize("invalid_id", ["", "   "], ids=["empty", "whitespace"])
-def test_resolve_codex_launch_model_override_never_returns_a_blank_id(invalid_id: str) -> None:
-    """An exact model match without a valid selectable id fails loudly."""
+@pytest.mark.parametrize("reverse_rows", [False, True], ids=["blank-row-first", "fold-row-first"])
+def test_resolve_codex_launch_model_override_folds_past_a_blank_exact_model_id(
+    reverse_rows: bool,
+) -> None:
+    """A malformed exact-model row cannot hide a valid fold-only row."""
     from omnigent.runner.native.orchestration import (
         _resolve_codex_launch_model_override,
     )
 
-    with pytest.raises(click.ClickException, match="exactly one valid catalog id"):
+    catalog = [
+        {"id": "   ", "model": "system.ai.gpt-5.6-sol"},
+        {"id": "gpt-5.6-sol", "model": "gpt-5.6-sol"},
+    ]
+    if reverse_rows:
+        catalog.reverse()
+    assert _resolve_codex_launch_model_override("system.ai.gpt-5.6-sol", catalog) == "gpt-5.6-sol"
+
+
+@pytest.mark.parametrize("invalid_id", ["", "   "], ids=["empty", "whitespace"])
+def test_resolve_codex_launch_model_override_never_returns_a_blank_id(invalid_id: str) -> None:
+    """A blank-only exact model falls through, then fails without returning it."""
+    from omnigent.runner.native.orchestration import (
+        _resolve_codex_launch_model_override,
+    )
+
+    with pytest.raises(click.ClickException) as excinfo:
         _resolve_codex_launch_model_override(
             "shared-provider-model",
             [{"id": invalid_id, "model": "shared-provider-model"}],
         )
+    assert "is not in this host's current model list" in str(excinfo.value)
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -3640,20 +3640,8 @@ def test_resolve_codex_launch_model_override_folds_to_catalog_spelling(
 
 
 def test_resolve_codex_launch_model_override_rejects_unlisted_model() -> None:
-    """A model with no launchable counterpart is rejected, not substituted."""
-    from omnigent.runner.native.orchestration import (
-        _resolve_codex_launch_model_override,
-    )
-
-    with pytest.raises(click.ClickException) as excinfo:
-        _resolve_codex_launch_model_override(
-            "databricks-gpt-5-3-codex", _codex_launch_catalog_rows()
-        )
-    assert "databricks-gpt-5-3-codex" in str(excinfo.value)
-
-
-def test_resolve_codex_launch_model_override_enumerates_launchable_ids() -> None:
-    """The rejection names every launchable id so the failure is diagnosable."""
+    """An unlisted model is rejected, not substituted, and the error names it
+    alongside every launchable id so the failure is diagnosable."""
     from omnigent.runner.native.orchestration import (
         _resolve_codex_launch_model_override,
     )
@@ -3663,6 +3651,7 @@ def test_resolve_codex_launch_model_override_enumerates_launchable_ids() -> None
             "databricks-gpt-5-3-codex", _codex_launch_catalog_rows()
         )
     message = str(excinfo.value)
+    assert "databricks-gpt-5-3-codex" in message
     assert "Launchable model ids:" in message
     for launchable in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.2"):
         assert repr(launchable) in message

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -3655,3 +3655,109 @@ def test_resolve_codex_launch_model_override_rejects_unlisted_model() -> None:
     assert "Launchable model ids:" in message
     for launchable in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.2"):
         assert repr(launchable) in message
+
+
+def test_resolve_codex_launch_model_override_exact_match_beats_earlier_fold() -> None:
+    """An exact pin wins over an earlier row that merely folds to it, so its own
+    spelling survives regardless of catalog row order.
+
+    Distinct tiers (``-sol``/``-terra``/``-luna``) never fold together, so a
+    fold collision only ever pairs two spellings of one model; the hazard is
+    purely that row order could shadow an exact pin — which this pins shut.
+    """
+    from omnigent.runner.native.orchestration import (
+        _resolve_codex_launch_model_override,
+    )
+
+    catalog = [
+        {"id": "system.ai.gpt-5-6-sol", "model": "system.ai.gpt-5-6-sol"},
+        {"id": "gpt-5.6-sol", "model": "gpt-5.6-sol", "isDefault": True},
+    ]
+    assert _resolve_codex_launch_model_override("gpt-5.6-sol", catalog) == "gpt-5.6-sol"
+    assert (
+        _resolve_codex_launch_model_override("gpt-5.6-sol", list(reversed(catalog)))
+        == "gpt-5.6-sol"
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_create_codex_terminal_launch_gate_folds_a_gateway_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The launch path pins codex's advertised spelling for a gateway override.
+
+    Drives ``_auto_create_codex_terminal`` with a persisted
+    ``system.ai.gpt-5.6-sol`` pin and asserts the app-server builder receives
+    codex's own ``gpt-5.6-sol`` — exercising the resolve → replace on
+    ``_codex_launch.model`` that is the actual fix and the site of the bug.
+    """
+    import omnigent.codex_native_app_server as codex_app_server
+    from omnigent.codex_native_app_server import NativeCodexLaunch
+    from omnigent.runner.native.orchestration import _auto_create_codex_terminal
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
+    monkeypatch.setattr("omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-bridge")
+
+    catalog = _codex_launch_catalog_rows()
+
+    async def _catalog(*, codex_path: object = None) -> list[dict[str, Any]]:
+        del codex_path
+        return catalog
+
+    async def _not_stale() -> bool:
+        return False
+
+    def _resolve_launch(*, model: str | None, spec: object = None) -> NativeCodexLaunch:
+        del spec
+        return NativeCodexLaunch(config_overrides=[], model=model, profile=None)
+
+    monkeypatch.setattr(codex_app_server, "codex_launch_catalog", _catalog)
+    monkeypatch.setattr(codex_app_server, "codex_launch_catalog_is_stale", _not_stale)
+    monkeypatch.setattr(codex_app_server, "resolve_native_codex_launch", _resolve_launch)
+
+    captured: dict[str, Any] = {}
+
+    class _StopBeforeLaunch(Exception):
+        """Halts the launch once the resolved model reaches the server builder."""
+
+    def _capture_build(**kwargs: Any) -> None:
+        captured["model"] = kwargs.get("model")
+        raise _StopBeforeLaunch
+
+    monkeypatch.setattr(codex_app_server, "build_codex_native_server", _capture_build)
+
+    def _handle_request(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "model_override": "system.ai.gpt-5.6-sol",
+                "workspace": str(tmp_path),
+                "labels": {},
+            },
+        )
+
+    fake_client = httpx.AsyncClient(
+        base_url="http://test-server",
+        transport=httpx.MockTransport(_handle_request),
+    )
+
+    class _FakeResourceRegistry:
+        """Never reached — the launch is halted at the server builder."""
+
+        terminal_registry = None
+
+    session_id = "c0dec0dec0dec0dec0dec0dec0dec0de"
+    with caplog.at_level(logging.INFO, logger="omnigent.runner.app"):
+        with pytest.raises(_StopBeforeLaunch):
+            await _auto_create_codex_terminal(
+                session_id,
+                _FakeResourceRegistry(),
+                lambda _sid, _evt: None,
+                server_client=fake_client,
+            )
+    assert captured["model"] == "gpt-5.6-sol"
+    assert "resolved requested model" in caplog.text
+
+    await fake_client.aclose()

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -3605,3 +3605,64 @@ async def test_auto_create_claude_terminal_default_pin_requires_a_fresh_catalog(
         assert model_catalog_store.read_catalog("claude-native", fingerprint) == refreshed
 
     await fake_client.aclose()
+
+
+def _codex_launch_catalog_rows() -> list[dict[str, Any]]:
+    """This host's codex launchable ids in codex's own dotted spelling."""
+    return [
+        {"id": "gpt-5.6-sol", "model": "gpt-5.6-sol", "isDefault": True},
+        {"id": "gpt-5.6-terra", "model": "gpt-5.6-terra"},
+        {"id": "gpt-5.6-luna", "model": "gpt-5.6-luna"},
+        {"id": "gpt-5.5", "model": "gpt-5.5"},
+        {"id": "gpt-5.2", "model": "gpt-5.2"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "requested",
+    ["system.ai.gpt-5.6-sol", "system.ai.gpt-5-6-sol", "gpt-5.6-sol"],
+)
+def test_resolve_codex_launch_model_override_folds_to_catalog_spelling(
+    requested: str,
+) -> None:
+    """Gateway/dashed vocabulary resolves to codex's own advertised id.
+
+    An orchestrator can hand this branch ``system.ai.gpt-5.6-sol`` or the
+    dashed ``system.ai.gpt-5-6-sol``; both name codex's ``gpt-5.6-sol``, and
+    the exact spelling passes through unchanged.
+    """
+    from omnigent.runner.native.orchestration import (
+        _resolve_codex_launch_model_override,
+    )
+
+    resolved = _resolve_codex_launch_model_override(requested, _codex_launch_catalog_rows())
+    assert resolved == "gpt-5.6-sol"
+
+
+def test_resolve_codex_launch_model_override_rejects_unlisted_model() -> None:
+    """A model with no launchable counterpart is rejected, not substituted."""
+    from omnigent.runner.native.orchestration import (
+        _resolve_codex_launch_model_override,
+    )
+
+    with pytest.raises(click.ClickException) as excinfo:
+        _resolve_codex_launch_model_override(
+            "databricks-gpt-5-3-codex", _codex_launch_catalog_rows()
+        )
+    assert "databricks-gpt-5-3-codex" in str(excinfo.value)
+
+
+def test_resolve_codex_launch_model_override_enumerates_launchable_ids() -> None:
+    """The rejection names every launchable id so the failure is diagnosable."""
+    from omnigent.runner.native.orchestration import (
+        _resolve_codex_launch_model_override,
+    )
+
+    with pytest.raises(click.ClickException) as excinfo:
+        _resolve_codex_launch_model_override(
+            "databricks-gpt-5-3-codex", _codex_launch_catalog_rows()
+        )
+    message = str(excinfo.value)
+    assert "Launchable model ids:" in message
+    for launchable in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.2"):
+        assert repr(launchable) in message

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -3657,27 +3657,54 @@ def test_resolve_codex_launch_model_override_rejects_unlisted_model() -> None:
         assert repr(launchable) in message
 
 
-def test_resolve_codex_launch_model_override_exact_match_beats_earlier_fold() -> None:
-    """An exact pin wins over an earlier row that merely folds to it, so its own
-    spelling survives regardless of catalog row order.
-
-    Distinct tiers (``-sol``/``-terra``/``-luna``) never fold together, so a
-    fold collision only ever pairs two spellings of one model; the hazard is
-    purely that row order could shadow an exact pin — which this pins shut.
-    """
+@pytest.mark.parametrize("reverse_rows", [False, True], ids=["model-row-first", "id-row-first"])
+def test_resolve_codex_launch_model_override_exact_match_beats_earlier_fold(
+    reverse_rows: bool,
+) -> None:
+    """An exact selectable id wins over another row's exact model alias."""
     from omnigent.runner.native.orchestration import (
         _resolve_codex_launch_model_override,
     )
 
     catalog = [
-        {"id": "system.ai.gpt-5-6-sol", "model": "system.ai.gpt-5-6-sol"},
-        {"id": "gpt-5.6-sol", "model": "gpt-5.6-sol", "isDefault": True},
+        {"id": "other-selector", "model": "gpt-5.6-sol"},
+        {"id": "gpt-5.6-sol", "model": "system.ai.gpt-5-6-sol", "isDefault": True},
     ]
+    if reverse_rows:
+        catalog.reverse()
     assert _resolve_codex_launch_model_override("gpt-5.6-sol", catalog) == "gpt-5.6-sol"
-    assert (
-        _resolve_codex_launch_model_override("gpt-5.6-sol", list(reversed(catalog)))
-        == "gpt-5.6-sol"
+
+
+def test_resolve_codex_launch_model_override_rejects_ambiguous_exact_models() -> None:
+    """Two selectable ids for one exact model spelling fail loudly."""
+    from omnigent.runner.native.orchestration import (
+        _resolve_codex_launch_model_override,
     )
+
+    catalog = [
+        {"id": "first-selector", "model": "shared-provider-model"},
+        {"id": "second-selector", "model": "shared-provider-model"},
+    ]
+    with pytest.raises(click.ClickException) as excinfo:
+        _resolve_codex_launch_model_override("shared-provider-model", catalog)
+    message = str(excinfo.value)
+    assert "do not resolve to exactly one valid catalog id" in message
+    assert "'first-selector'" in message
+    assert "'second-selector'" in message
+
+
+@pytest.mark.parametrize("invalid_id", ["", "   "], ids=["empty", "whitespace"])
+def test_resolve_codex_launch_model_override_never_returns_a_blank_id(invalid_id: str) -> None:
+    """An exact model match without a valid selectable id fails loudly."""
+    from omnigent.runner.native.orchestration import (
+        _resolve_codex_launch_model_override,
+    )
+
+    with pytest.raises(click.ClickException, match="exactly one valid catalog id"):
+        _resolve_codex_launch_model_override(
+            "shared-provider-model",
+            [{"id": invalid_id, "model": "shared-provider-model"}],
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

<!-- Bug fix with no tracked issue; the failure was root-caused from runner logs. -->

Closes #

## Summary

Native Codex terminal launches hard-failed for model ids the orchestrator itself
selected — e.g. `ClickException: the requested model 'databricks-gpt-5-3-codex'
is not in this host's current model list` and the same for
`system.ai.gpt-5.6-sol` / `system.ai.gpt-5-6-sol`. The explicit-pin branch of
`_auto_create_codex_terminal` validated the requested id against codex's own
`model/list` vocabulary with a raw exact-string compare (`catalog_contains`), so
a gateway-vocabulary id or a dashed-version id was rejected even though codex
serves the same model under a dotted, unprefixed spelling (`gpt-5.6-sol`).

- **Normalize at the validation boundary.** Resolve the pin through codex's own
  comparison form via the existing `codex_reachable_model_slug` /
  `comparable_model_id` (already used in this file's `mark_launch_default`),
  which folds the `system.ai.` / `databricks-` prefixes **and** dot↔dash version
  spelling. `system.ai.gpt-5.6-sol` and `system.ai.gpt-5-6-sol` now both resolve
  to launchable `gpt-5.6-sol`; an exact `gpt-5.6-sol` passes through; the launch
  pins the id the catalog actually advertises and logs the requested→resolved
  mapping so the substitution is visible rather than silent.
- **Enumerate launchable ids in the rejection.** `databricks-gpt-5-3-codex` is
  still rejected (no launchable counterpart — never silently substituted), but
  the error now lists the launchable ids, mirroring the claude launch gate, so
  this failure class is diagnosable.

I reused `codex_reachable_model_slug` rather than the `canonical_model_spelling`
helper named in the root-cause notes: `canonical_model_spelling` strips the
vendor prefixes but does **not** reconcile dot↔dash, whereas
`codex_reachable_model_slug` is the purpose-built, already-imported codex-domain
helper that does both and returns the catalog's advertised spelling — so this
adds zero new normalizer.

### ELI5

The orchestrator says "launch `system.ai.gpt-5.6-sol`". Codex's own menu calls
that exact model `gpt-5.6-sol`. We used to compare the two names letter-for-letter,
see they differ, and refuse to start. Now we translate the name into codex's
spelling first, start on the name codex knows, and — when a name really has no
match — we print the list of names that *would* work.

## Test Plan

Focused unit tests for the extracted `_resolve_codex_launch_model_override`
helper (fast, deterministic, no app-server boot):

```
uv run --frozen --group test python -m pytest \
  tests/runner/test_app_sessions_native_terminals_autocreate.py \
  -k resolve_codex_launch_model_override -o addopts=""
# 5 passed
```

Full touched module + codex vocabulary module (no regressions):

```
uv run --frozen --group test python -m pytest \
  tests/runner/test_app_sessions_native_terminals_autocreate.py \
  tests/test_codex_model_vocabulary.py -o addopts=""
# 99 passed
```

**Mutation check** (fix reverted to the old exact-compare + old message): the 3
tests locking in the new behavior fail —
`folds_to_catalog_spelling[system.ai.gpt-5.6-sol]`,
`folds_to_catalog_spelling[system.ai.gpt-5-6-sol]`, and
`enumerates_launchable_ids` (2 remaining tests guard invariants both versions
preserve: exact-spelling accept, unlisted-model reject).

`ruff format` / `ruff check` clean; `pyrefly check omnigent/runner/native/orchestration.py`
reports 0 errors.

## Demo

N/A — non-visual runner-side change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the four required outcomes (gateway-prefix resolve,
dot↔dash resolve, exact-spelling passthrough, unlisted-model rejection) plus the
enumerated-error message, each shown red under a reverted fix. Manual
verification: confirmed pyrefly reports 0 errors on the changed module and the
full autocreate + codex-vocabulary modules pass (99 tests).

### Known follow-up (out of scope)

The deeper inventory gap remains: the orchestrator's advertised gateway catalog
can offer codex ids that codex's `model/list` never serves
(`smart_routing.py` selecting an id that becomes the child's `model_override`).
This PR makes an unserved pin fail *loudly and diagnosably* at the launch
boundary; reconciling the advertised catalog with codex's served vocabulary is a
separate change.

## Changelog

Native Codex sessions now launch on orchestrator-selected model ids by folding gateway/dashed model spellings onto codex's own vocabulary, and unavailable pins fail with the launchable ids listed.



Part of #5737
