### PR TITLE
fix(web): keep the mobile header pill's Chat/Terminal track inside its rounded edge

### DIFF
--- a/tests/e2e_ui/mobile/test_header_pill_overflow.py
+++ b/tests/e2e_ui/mobile/test_header_pill_overflow.py
@@ -1,0 +1,203 @@
+"""E2E: the mobile header glass pill contains its own controls.
+
+``ChatHeader.test.tsx`` asserts the pill's Tailwind classes, but jsdom
+performs no layout, so it cannot prove the *geometric* contract: the
+Chat/Terminal ``ViewModeToggle`` paints its own background, and the pill
+is a ``rounded-full`` stadium, so that painted track must stay inside the
+pill's rounded caps — not just its rectangular bounds. A real browser at
+a phone viewport is the only place that geometry runs.
+
+The fixture stamps ``omnigent.ui: terminal`` on a plain runner-bound
+session (no wrapper label), which is all the SPA needs to render the
+``ViewModeToggle`` without booting a native CLI. Two cluster shapes are
+covered:
+
+  - toggle **+ kebab** — the shape every reachable state produces (see
+    below), and
+  - toggle **alone** — a SYNTHETIC shape produced by removing the kebab in
+    the browser. It is NOT reachable in current app code: ``hasHeaderMenu``
+    is ``!!conversationId``-equivalent (``AppShell.tsx:591-593`` +
+    ``AgentInfo.tsx:1245-1246``), and ``railTabsAvailable.subagents`` is
+    literally ``true`` (``AppShell.tsx:744``), so every conversation renders
+    either the owner kebab or the fallback ``session-actions-menu``
+    (``ChatHeader.tsx:481``). This case is a defense-in-depth guard: it
+    would go live only if that always-true gate were ever narrowed. It is
+    the mutation-check RED→GREEN, and must not be read as a reproduction of
+    user-visible behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, ViewportSize, expect
+
+from tests.e2e_ui.conftest import (
+    _build_hello_world_bundle,
+    _ensure_runner_online,
+    _server_state,
+)
+
+# Two phone widths below the Tailwind ``md`` breakpoint (768px): 360px is a
+# common Android portrait width and 390px an iPhone-12-class one. A ~1080px
+# device screenshot reports as 360 CSS px at devicePixelRatio 3.
+_WIDTHS = (360, 390)
+
+
+@pytest.fixture
+def terminal_first_session(
+    live_server: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str]]:
+    """A runner-bound, owner-managed session flagged terminal-first.
+
+    The ``omnigent.ui: terminal`` label makes the SPA render the header's
+    Chat/Terminal ``ViewModeToggle``; being owner-managed (a top-level
+    session in the sidebar list) makes it render the "Conversation
+    actions" kebab.
+    """
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+    bundle = _build_hello_world_bundle()
+    create = httpx.post(
+        f"{live_server}/v1/sessions",
+        data={"metadata": json.dumps({"labels": {"omnigent.ui": "terminal"}})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = create.json()["session_id"]
+    httpx.patch(
+        f"{live_server}/v1/sessions/{session_id}",
+        json={"runner_id": runner_id},
+        timeout=10.0,
+    ).raise_for_status()
+    try:
+        yield (live_server, session_id)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
+            respawned.wait(timeout=5)
+
+
+# For every direct child of the pill that paints a background (the
+# ViewModeToggle track — ghost icon buttons stay transparent), report how
+# far each corner of its border box sits outside the pill's ``rounded-full``
+# stadium. A positive ``worst`` means visible overflow past the rounded edge.
+_CONTAINMENT_JS = """
+() => {
+  const toggle = document.querySelector('[data-testid="view-mode-toggle"]');
+  if (!toggle) return null;
+  const pill = toggle.parentElement;
+  const p = pill.getBoundingClientRect();
+  const r = Math.min(p.width, p.height) / 2;   // rounded-full cap radius
+  const cy = (p.top + p.bottom) / 2;
+  // Signed distance of a point outside the stadium (>0 means outside).
+  const outside = (x, y) => {
+    const leftCx = p.left + r;
+    const rightCx = p.right - r;
+    let cx = x;
+    if (x < leftCx) cx = leftCx;
+    else if (x > rightCx) cx = rightCx;
+    if (cx === x) {
+      // Flat middle band: only the top/bottom edges bound it.
+      return Math.max(p.top - y, y - p.bottom);
+    }
+    return Math.hypot(x - cx, y - cy) - r;
+  };
+  let worst = -Infinity;
+  let culprit = null;
+  for (const c of pill.children) {
+    const bg = getComputedStyle(c).backgroundColor;
+    const painted = bg && bg !== 'transparent' && !/rgba?\\([^)]*,\\s*0\\s*\\)$/.test(bg);
+    const cr = c.getBoundingClientRect();
+    if (!painted || cr.width === 0) continue;
+    for (const [x, y] of [
+      [cr.left, cr.top], [cr.right, cr.top],
+      [cr.left, cr.bottom], [cr.right, cr.bottom],
+    ]) {
+      const d = outside(x, y);
+      if (d > worst) {
+        worst = d;
+        culprit = c.getAttribute('data-testid') || c.tagName;
+      }
+    }
+  }
+  return { worst, culprit, height: p.height };
+}
+"""
+
+
+def _assert_pill_contains_painted_controls(page: Page, width: int, *, drop_kebab: bool) -> None:
+    expect(page.get_by_test_id("view-mode-toggle")).to_be_visible(timeout=30_000)
+    if drop_kebab:
+        # SYNTHETIC: remove the kebab so the track is the pill's rightmost
+        # painted child. No reachable app state does this (hasHeaderMenu is
+        # !!conversationId-equivalent — AppShell.tsx:591-593 — so a kebab always
+        # renders); this exercises the pill geometry as a guard against that
+        # gate ever narrowing. Not a reproduction of user-visible behavior.
+        expect(page.get_by_role("button", name="Conversation actions")).to_be_visible()
+        page.get_by_role("button", name="Conversation actions").evaluate("el => el.remove()")
+    else:
+        expect(page.get_by_role("button", name="Conversation actions")).to_be_visible()
+
+    result = page.evaluate(_CONTAINMENT_JS)
+    assert result is not None, "the terminal-first Chat/Terminal toggle did not render"
+    # Fail loudly if nothing was measured: if no direct child paints a
+    # background (e.g. a restyle moves the track's paint to a descendant or to
+    # background-image), `worst` stays -Infinity and the bound below would pass
+    # vacuously. Require that we actually measured a painted control.
+    assert result["culprit"] is not None, (
+        "no painted pill control was measured — the containment check would "
+        "pass vacuously; the track's background detection needs updating"
+    )
+    # `worst` is signed distance of the track's furthest border-box corner from
+    # the rounded cap (negative = inside). With the fix it clears by ~0.9px
+    # (worst ≈ -0.9); with the fix reverted the lone track measures ~+4.8px
+    # outside. 0.25px is a sub-pixel/rendering-variance margin — well below that
+    # ~0.9px clearance and far below any real overflow — not a slack that could
+    # mask a regression.
+    assert result["worst"] <= 0.25, (
+        f"a painted control ({result['culprit']}) overflows the pill's rounded "
+        f"edge at {width}px by {result['worst']:.1f}px (pill height {result['height']:.1f})"
+    )
+
+
+@pytest.mark.parametrize("width", _WIDTHS, ids=[f"{w}px" for w in _WIDTHS])
+def test_pill_contains_toggle_and_kebab(
+    page: Page,
+    terminal_first_session: tuple[str, str],
+    width: int,
+) -> None:
+    """The Chat/Terminal track stays inside the pill next to the owner kebab."""
+    base_url, session_id = terminal_first_session
+    viewport: ViewportSize = {"width": width, "height": 844}
+    page.set_viewport_size(viewport)
+    page.goto(f"{base_url}/c/{session_id}")
+    _assert_pill_contains_painted_controls(page, width, drop_kebab=False)
+
+
+@pytest.mark.parametrize("width", _WIDTHS, ids=[f"{w}px" for w in _WIDTHS])
+def test_pill_contains_lone_toggle(
+    page: Page,
+    terminal_first_session: tuple[str, str],
+    width: int,
+) -> None:
+    """A lone Chat/Terminal track stays inside the pill (synthetic guard).
+
+    Removes the kebab in-browser to make the track the pill's rightmost
+    painted child — a configuration NOT reachable in current app code (a
+    kebab always renders; see module docstring). Guards the trailing-edge
+    inset + pinned height: without them the pill collapses to the 28px track
+    height and the track's ink crosses the rounded trailing cap. This is the
+    mutation-check RED→GREEN, not a reproduction of user-visible behavior.
+    """
+    base_url, session_id = terminal_first_session
+    viewport: ViewportSize = {"width": width, "height": 844}
+    page.set_viewport_size(viewport)
+    page.goto(f"{base_url}/c/{session_id}")
+    _assert_pill_contains_painted_controls(page, width, drop_kebab=True)

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -351,56 +351,41 @@ function makeTerminalFirstCtx(
  * mounts. QueryClientProvider covers AgentInfoButton's react-query hooks; it
  * self-hides here (no agent info), leaving the toggle as the asserted control.
  */
-function renderHeaderWithSession(ctx: TerminalFirstContextValue | null) {
+function renderHeaderWithSession(
+  ctx: TerminalFirstContextValue | null,
+  overrides: { hasHeaderMenu?: boolean; hasRailContent?: boolean; showFilesPanel?: boolean } = {},
+) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const header = (
+    <ChatHeader
+      sidebarOpen
+      onOpenSidebar={() => {}}
+      isChildSession={false}
+      conversationId="sess-1"
+      conversationTitle={null}
+      projectName={null}
+      boundAgent={undefined}
+      wrapperLabel={null}
+      canShare={false}
+      onShare={() => {}}
+      hasAgentInfo={false}
+      onAgentInfo={() => {}}
+      hasHeaderMenu={overrides.hasHeaderMenu ?? false}
+      showFilesPanel={overrides.showFilesPanel ?? false}
+      hasRailContent={overrides.hasRailContent ?? false}
+      rightPanelOpen={false}
+      onToggleRightPanel={() => {}}
+      mobileMenu={mobileMenu}
+    />
+  );
   return render(
     <MemoryRouter initialEntries={["/c/sess-1"]}>
       <QueryClientProvider client={qc}>
         <TooltipProvider>
           {ctx ? (
-            <TerminalFirstContextProvider value={ctx}>
-              <ChatHeader
-                sidebarOpen
-                onOpenSidebar={() => {}}
-                isChildSession={false}
-                conversationId="sess-1"
-                conversationTitle={null}
-                projectName={null}
-                boundAgent={undefined}
-                wrapperLabel={null}
-                canShare={false}
-                onShare={() => {}}
-                hasAgentInfo={false}
-                onAgentInfo={() => {}}
-                hasHeaderMenu={false}
-                showFilesPanel={false}
-                hasRailContent={false}
-                rightPanelOpen={false}
-                onToggleRightPanel={() => {}}
-                mobileMenu={mobileMenu}
-              />
-            </TerminalFirstContextProvider>
+            <TerminalFirstContextProvider value={ctx}>{header}</TerminalFirstContextProvider>
           ) : (
-            <ChatHeader
-              sidebarOpen
-              onOpenSidebar={() => {}}
-              isChildSession={false}
-              conversationId="sess-1"
-              conversationTitle={null}
-              projectName={null}
-              boundAgent={undefined}
-              wrapperLabel={null}
-              canShare={false}
-              onShare={() => {}}
-              hasAgentInfo={false}
-              onAgentInfo={() => {}}
-              hasHeaderMenu={false}
-              showFilesPanel={false}
-              hasRailContent={false}
-              rightPanelOpen={false}
-              onToggleRightPanel={() => {}}
-              mobileMenu={mobileMenu}
-            />
+            header
           )}
         </TooltipProvider>
       </QueryClientProvider>
@@ -474,18 +459,50 @@ describe("ChatHeader — floating mobile controls", () => {
     expect(toggle).toHaveClass("size-10");
   });
 
-  it("insets the pill's leading edge for the Chat/Terminal track", () => {
+  it("insets both ends and pins the pill height for the Chat/Terminal track", () => {
     // The track paints its own background to its edge, so with the pill's
-    // zero padding it sat flush against the border while an icon-only
-    // neighbour cleared it by the slack in its 40px box. The inset is
-    // conditional: a lone kebab must stay the 40px circle asserted above.
+    // zero padding its ink runs into the rounded cap. When the track is
+    // present the pill insets BOTH ends and pins itself to 40px, so the 28px
+    // track sits centered and clears the caps whether a kebab flanks it (the
+    // reachable shape) or it is the only control (an unreachable
+    // defense-in-depth guard). The inset is conditional: a lone kebab must
+    // stay the 40px circle asserted above.
     isMobileMock.mockReturnValue(true);
     renderHeaderWithSession(makeTerminalFirstCtx());
 
     const cluster = screen.getByTestId("view-mode-toggle").parentElement;
-    expect(cluster).toHaveClass("max-md:has-data-[slot=view-mode-toggle]:pl-1.5");
+    expect(cluster).toHaveClass(
+      "max-md:has-data-[slot=view-mode-toggle]:px-1.5",
+      "max-md:has-data-[slot=view-mode-toggle]:h-10",
+    );
     // The guard keys off the track's own data-slot, so it has to be present.
     expect(screen.getByTestId("view-mode-toggle")).toHaveAttribute("data-slot", "view-mode-toggle");
+  });
+
+  it("renders the Chat/Terminal track and the session kebab in one pill", () => {
+    // PRODUCTION-STRUCTURE coverage: the reachable mobile shape is track +
+    // kebab (the class-string tests above mounted only a lone control, since
+    // hasHeaderMenu / hasRailContent were false). Mount the real 3-icon
+    // cluster so a regression that drops or detaches a control from the pill
+    // is caught. This guards STRUCTURE only — it is green with or without the
+    // CSS change (the 40px kebab already forces a 40px pill); the CSS
+    // regression is the synthetic lone-track case in
+    // tests/e2e_ui/mobile/test_header_pill_overflow, where the geometry lives.
+    isMobileMock.mockReturnValue(true);
+    renderHeaderWithSession(makeTerminalFirstCtx(), {
+      hasHeaderMenu: true,
+      hasRailContent: true,
+      showFilesPanel: true,
+    });
+
+    const toggle = screen.getByTestId("view-mode-toggle");
+    const kebab = screen.getByTestId("session-actions-menu");
+    // Both controls share the one glass pill.
+    expect(toggle.parentElement).toBe(kebab.parentElement);
+    expect(toggle.parentElement).toHaveClass(
+      "max-md:has-data-[slot=view-mode-toggle]:px-1.5",
+      "max-md:has-data-[slot=view-mode-toggle]:h-10",
+    );
   });
 
   it("rounds the kebab's own background so no square shows inside the pill", () => {

--- a/web/src/shell/mobileGlass.ts
+++ b/web/src/shell/mobileGlass.ts
@@ -16,11 +16,19 @@ export const MOBILE_GLASS_SURFACE =
  * session kebab must read as the same size.
  *
  * The exception is the Chat/Terminal track (ViewModeToggle): it paints its
- * own background out to its edge, so with no padding it collides with the
- * pill's border while an icon-only neighbour still clears it by the slack
- * inside its 40px box. Inset the leading edge by that slack — only when the
- * track is present — so ink sits 12px from either end. Assumes the track is
- * the cluster's leading child on mobile; a control added ahead of it would
- * take the inset instead.
+ * own background out to its edge, so with no padding its ink runs into the
+ * pill's rounded cap while an icon-only neighbour clears it by the slack
+ * inside its 40px box. When the track is present, inset BOTH ends by that
+ * slack and pin the pill to 40px, so the 28px track sits centered with
+ * vertical clearance and its ink stays inside the rounded caps in every
+ * cluster shape — flanked by a kebab (the shape every reachable state
+ * produces) or, as a defense-in-depth guard, alone. The symmetric inset also
+ * makes it RTL-safe: the old physical `pl-1.5` inset the wrong edge under RTL.
+ *
+ * `has-data-[…]` compiles to `:has()`, which shipped in Safari/iOS 15.4; on
+ * 15.0–15.3 (still inside this build's `safari15`/`ios15` target) the selector
+ * never matches, so the pill keeps its unpinned/lone-edge geometry there. This
+ * is the same floor the prior `pl-1.5` depended on, and the guarded case is
+ * latent anyway, so it does not warrant a JS-applied class.
  */
-export const MOBILE_GLASS_PILL = `${MOBILE_GLASS_SURFACE} max-md:rounded-full max-md:has-data-[slot=view-mode-toggle]:pl-1.5`;
+export const MOBILE_GLASS_PILL = `${MOBILE_GLASS_SURFACE} max-md:rounded-full max-md:has-data-[slot=view-mode-toggle]:h-10 max-md:has-data-[slot=view-mode-toggle]:px-1.5`;


### PR DESCRIPTION
## Related issue

Closes #5738

## Summary

**Latent rendering defect + regression guard — not a user-visible bug fix.**

- The mobile header glass pill insets **only its leading edge** for the
  Chat/Terminal `ViewModeToggle` track (`mobileGlass.ts:26`:
  `has-data-[slot=view-mode-toggle]:pl-1.5`, no trailing inset) and pins no
  height. **If** the track is ever the pill's rightmost painted child, the pill
  collapses to the 28px track height (`rounded-full` → 15px cap) and the track's
  corner ink crosses the rounded trailing cap by ~4.8px.
- **Not reachable today:** `hasHeaderMenu` is `!!conversationId`-equivalent
  (`AppShell.tsx:591-593` + `AgentInfo.tsx:1245-1246`) and
  `railTabsAvailable.subagents` is always `true` (`AppShell.tsx:744`), so a kebab
  always follows the track (`ChatHeader.tsx:481`). The fix is defense-in-depth
  against that always-true gate ever narrowing.
- **Fix (`mobileGlass.ts`, `max-md:`-scoped, gated on the track's `data-slot`):**
  inset **both** ends (`px-1.5`) and pin the pill to `h-10` (40px) so a centered
  28px track clears the caps in every shape. Desktop unchanged; the lone-control
  pill stays a 40px circle. This PR does **not** touch `ChatHeader.tsx`.
- **`getBoundingClientRect()` reports 0px overflow** for this bug (the box is
  inside the box; only the *rounded cap* is crossed), so rect-based tests/review
  can't see it — the guard test checks corner containment against the stadium.

The originally-suspected "cluster shrinks / children spill right" mechanism was
**refuted** by measurement (left slot `min-w-0` at `ChatHeader.tsx:381` absorbs
the pressure; 0px overflow in the kebab-present state). See #5738 for the full
RCA, the reachability proof, and a **"what this does NOT explain"** note (the
reporter's kebab-present screenshot is not explained by this change and is under
separate investigation).

## Test Plan

Toolchain: `web/` is pnpm on the root lockfile (Node ≥ 22); vitest needs
`NODE_OPTIONS=--no-experimental-webstorage` on Node 26; e2e_ui runs under
`uv --frozen --group test` with ambient `OMNIGENT_RUNNER_*` stripped.

- **web typecheck** — `tsc -b` → pass. **web lint** — `oxlint` → pass.
- **web vitest** — `ChatHeader.test.tsx` 33/33; full suite green except 3
  pre-existing `NewChatDialog` failures reproduced on the clean base.
- **e2e_ui** — `pytest tests/e2e_ui/mobile/test_header_pill_overflow.py --ui-skip-build` → 4/4.
- **Synthetic guard test:** `test_pill_contains_lone_toggle` removes the kebab
  **in-browser** to make the track the pill's rightmost child — a configuration
  the app cannot produce today (a kebab always renders). It is a guard, not a
  reproduction, and is labeled as such in the test file.
- **Mutation check** (revert **only** `mobileGlass.ts`): that test fails —
  *"a painted control (view-mode-toggle) overflows the pill's rounded edge at
  360px by 4.8px (pill height 30.0)"* (same at 390px); restored → 4/4 pass.
- **pre-commit** — `pre-commit run --all-files` green for every hook touching
  this change (ruff, oxlint, prettier, web TS check, ktlint, uv-lock normalize, …).

## Demo

**An on-device recording could not be produced, and I am not passing off a
desktop-browser recording as one.** The iOS Simulator (iPhone 17) boots, and
Mobile Safari reaches the local server and renders pages — a trivial page
renders fine ([sim_hello_connectivity.png](https://raw.githubusercontent.com/btli/omnigent/demo/pill-overflow-asset/sim_hello_connectivity.png)) —
but the **omnigent SPA renders blank** in Simulator Safari
([sim_omnigent_blank.png](https://raw.githubusercontent.com/btli/omnigent/demo/pill-overflow-asset/sim_omnigent_blank.png)) while it renders under
Chromium (the e2e suite drives the same server + session). That blank is a
pre-existing app-boot issue in Simulator Safari, unrelated to this 16-line
Tailwind change. Android emulator is unavailable on this machine (no
AVD/emulator binary, no JDK 21), and the native iOS shell hides the
`ViewModeToggle` entirely (`isIOSShell`), so `just run-ios` cannot show this bug.

Supplementary before/after — **rendered via Chromium at iPhone metrics (390px,
DPR 3), synthetic lone-track configuration; NOT a device recording:**

![before/after](https://raw.githubusercontent.com/btli/omnigent/demo/pill-overflow-asset/pill-overflow-demo.gif)

- **Before:** the terminal segment paints past the pill's rounded trailing edge.
- **After:** both controls sit inside the 40px pill.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

- **E2E:** `tests/e2e_ui/mobile/test_header_pill_overflow.py` asserts painted pill
  controls stay within the `rounded-full` stadium at 360px/390px. The
  toggle+kebab case is the reachable shape; the lone-toggle case is synthetic
  (kebab suppressed in-browser) and is the mutation-check RED→GREEN.
- **Unit:** `ChatHeader.test.tsx` now mounts the 3-icon cluster (previously only
  lone controls) and asserts the symmetric-inset / height-pin class contract.
  jsdom does no layout, so geometry is proven by the e2e test.
- **Manual:** verified under Chromium at iPhone metrics (see Demo) and attempted
  an on-device capture (blocked — see Demo); confirmed the lone sidebar-toggle
  pill stays a 40px circle and desktop is unchanged.

## Changelog

DELETE THIS WHOLE SECTION — latent geometry hardening with no user-visible change today.
