### PR TITLE
fix(claude-native): strip markdown backticks from harness model labels

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -774,9 +774,9 @@ def _parse_claude_current_model(stdout: str) -> dict[str, str]:
     Extract the resolved model from a stream-json ``/model`` probe run.
 
     Two harness-owned facts, taken verbatim: the ``init`` event's exact
-    model id, and the printed ``Current model:`` label with only the
-    trailing ``(effort: …)`` suffix stripped — so labels like
-    ``Opus 4.8 (1M context)`` survive untouched.
+    model id, and the printed ``Current model:`` label with only markdown
+    backticks and the trailing ``(effort: …)`` suffix stripped — so labels
+    like ``Opus 4.8 (1M context)`` survive untouched.
 
     :param stdout: The run's ``--output-format stream-json`` stdout.
     :returns: Whichever of ``{"model": …, "label": …}`` parsed.
@@ -798,7 +798,10 @@ def _parse_claude_current_model(stdout: str) -> dict[str, str]:
                 _, marker, tail = text_line.partition("Current model:")
                 if not marker:
                     continue
-                label = re.sub(r"\s*\(effort:[^)]*\)\s*$", "", tail).strip()
+                # Some harness releases print the name as markdown code
+                # (``Current model: `Opus 5```); no model name holds a backtick.
+                plain = tail.replace("`", "")
+                label = re.sub(r"\s*\(effort:[^)]*\)\s*$", "", plain).strip()
                 if label:
                     resolved["label"] = label
                 break

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -9431,17 +9431,70 @@ def test_parse_claude_model_aliases_reads_the_usage_line() -> None:
             {"label": "Opus in plan mode, else Sonnet"},
             id="prose-label-kept-verbatim",
         ),
+        pytest.param(
+            json.dumps({"type": "result", "result": "Current model: `Sonnet 5` (effort: high)"}),
+            {"label": "Sonnet 5"},
+            id="markdown-backticks-around-the-name-are-stripped",
+        ),
+        pytest.param(
+            json.dumps({"type": "result", "result": "Current model: `Opus 5 (1M context)`"}),
+            {"label": "Opus 5 (1M context)"},
+            id="markdown-backticks-around-the-whole-label-are-stripped",
+        ),
+        pytest.param(
+            json.dumps({"type": "result", "result": "Current model: `Opus 5 (effort: high)`"}),
+            {"label": "Opus 5"},
+            id="effort-suffix-inside-the-backticks-still-strips",
+        ),
         pytest.param("Current model: Opus 5\nnot json", {}, id="non-stream-json-yields-nothing"),
     ],
 )
 def test_parse_claude_current_model(stdout: str, expected: dict[str, str]) -> None:
     """The stream-json run's exact id and printed label parse verbatim.
 
-    Only the trailing ``(effort: …)`` suffix is stripped from the label —
-    context markers and prose like opusplan's description survive, because
-    the parser knows no model names.
+    Only markdown backticks and the trailing ``(effort: …)`` suffix are
+    stripped from the label — context markers and prose like opusplan's
+    description survive, because the parser knows no model names.
     """
     assert claude_native._parse_claude_current_model(stdout) == expected
+
+
+@pytest.mark.parametrize(
+    ("alias", "label", "model", "expected"),
+    [
+        pytest.param(
+            "sonnet[1m]",
+            "`Sonnet 5`",
+            "claude-sonnet-5[1m]",
+            "Sonnet 5 (1M context)",
+            id="marker-appended-outside-stripped-backticks",
+        ),
+        pytest.param(
+            "opus[1m]",
+            "`Opus 5 (1M context)`",
+            "claude-opus-5[1m]",
+            "Opus 5 (1M context)",
+            id="marker-already-present-inside-backticks",
+        ),
+    ],
+)
+def test_claude_alias_row_marks_1m_context_consistently(
+    alias: str, label: str, model: str, expected: str
+) -> None:
+    """A markdown-quoted harness label cannot split the 1M-context marker.
+
+    Backticks leave at parse time, so the marker lands on plain text and
+    the guard against a duplicate marker sees the name it is guarding.
+    """
+    resolution = claude_native._parse_claude_current_model(
+        json.dumps({"type": "system", "subtype": "init", "model": model})
+        + "\n"
+        + json.dumps({"type": "result", "result": f"Current model: {label} (effort: high)"})
+    )
+
+    row = claude_native._claude_alias_row(alias, resolution)
+
+    assert row == {"id": alias, "model": model, "displayName": expected}
 
 
 async def test_probe_claude_model_options_runs_bare(


### PR DESCRIPTION
## Related issue

Closes #5747

## Summary

The Claude Code CLI prints its `Current model:` line as markdown code, so the model picker showed `` `Sonnet 5` `` with literal backticks. The backticks also split the 1M-context marker across two rows: one read `` `Sonnet 5` (1M context) `` and the other read `` `Opus 5 (1M context)` ``.

`_parse_claude_current_model` now removes backticks before it removes the `(effort: …)` suffix. One change covers both label paths, because both read that parser:

- `_resolve_claude_model_alias` (`claude_native.py:906` on main) builds every row's `displayName` through `_claude_alias_row`.
- `probe_claude_model_options` (`claude_native.py:1074` on main) builds the `Default (…)` label.

The strip runs before `_claude_alias_row` appends the 1M-context marker, so the two rows now agree. `` `Sonnet 5` `` becomes `Sonnet 5 (1M context)`. `` `Opus 5 (1M context)` `` becomes `Opus 5 (1M context)`, because the guard against a duplicate marker now sees the name it guards.

The web side needs no change. `nativeModelLabel` and `defaultModelLabel` in `web/src/components/HarnessConfigControls.tsx` print `displayName` verbatim, and the server route passes it through unchanged.

## Test Plan

- Added parametrized cases to `test_parse_claude_current_model` for a backticked name, a fully backticked label, and an `(effort: …)` suffix inside the backticks.
- Added `test_claude_alias_row_marks_1m_context_consistently`, which drives both 1M-context spellings end to end through the parser and `_claude_alias_row`.
- `uv run pytest tests/test_claude_native.py` — 326 passed.
- `pre-commit run --from-ref HEAD~1 --to-ref HEAD` — all hooks passed.

## Demo

Before, in a `claude-native` session:

![Model picker showing backticks around model names](https://raw.githubusercontent.com/tyler-lynch/omnigent/issue-assets/model-picker-backticks.png)

After, the same rows read `Sonnet 5`, `Opus 5`, `Haiku 4.5`, `Fable 5`, `Sonnet 5 (1M context)`, and `Opus 5 (1M context)`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit tests drive the real parser and the real row builder, so they reproduce both picker rows. I did not run the picker against a live CLI for the "after" state.

## Changelog

The Claude Code model picker shows plain model names, not names wrapped in backticks.
