### PR TITLE
fix(claude-native): key the model catalog on the CLI binary

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -1096,21 +1096,29 @@ async def probe_claude_model_options(
 
 
 def claude_catalog_fingerprint(claude_config: ClaudeNativeUcodeConfig | None) -> str:
-    """The launch-config fingerprint keying claude's shared model catalog.
+    """The launch fingerprint keying claude's shared model catalog.
 
     One formula for every consumer (host boot probe, runner launch, session
     listing), so they read and write the same catalog file.
 
+    The Claude Code executable is part of the key. The catalog holds that
+    binary's own answer, so an upgraded CLI must re-probe instead of
+    serving model names the previous release printed. The binary is
+    resolved the same way the probe launches it.
+
     :param claude_config: The resolved launch config, or ``None``.
     :returns: A stable fingerprint string.
     """
-    from omnigent.model_catalog_store import fingerprint_of
+    from omnigent.claude_launcher import resolve_claude_launch
+    from omnigent.model_catalog_store import binary_identity, fingerprint_of
 
+    command, _ = resolve_claude_launch("claude", [])
     return fingerprint_of(
         "claude-native",
         sorted(claude_config.env.items()) if claude_config is not None else None,
         claude_config.api_key_helper if claude_config is not None else None,
         claude_config.model if claude_config is not None else None,
+        binary_identity(command),
     )
 
 

--- a/omnigent/model_catalog_store.py
+++ b/omnigent/model_catalog_store.py
@@ -21,6 +21,7 @@ import hashlib
 import json
 import logging
 import os
+import shutil
 import tempfile
 import time
 from collections.abc import Awaitable, Callable
@@ -43,6 +44,35 @@ def fingerprint_of(*parts: object) -> str:
         digest.update(repr(part).encode("utf-8"))
         digest.update(b"\x00")
     return digest.hexdigest()[:16]
+
+
+def binary_identity(command: str | None) -> tuple[str, int, int] | None:
+    """
+    Identity of the executable a harness probe runs, for its fingerprint.
+
+    A catalog records what one specific binary offers, so an upgraded
+    binary must miss rather than serve the old answer. The real path
+    catches installs that keep each release in its own directory, and
+    size plus mtime catches a binary replaced in place.
+
+    :param command: Executable name or path, e.g. ``"claude"``, or
+        ``None`` when the caller resolved none.
+    :returns: ``(real path, size, mtime_ns)``, or ``None`` when the
+        executable is missing or unreadable. ``None`` fingerprints the
+        same as before this facet existed, so an unresolvable binary
+        never invalidates a stored catalog.
+    """
+    if not command:
+        return None
+    resolved = command if os.path.isabs(command) else shutil.which(command)
+    if not resolved:
+        return None
+    try:
+        real_path = os.path.realpath(resolved)
+        stat_result = os.stat(real_path)
+    except OSError:
+        return None
+    return real_path, stat_result.st_size, stat_result.st_mtime_ns
 
 
 #: Catalog entries older than this get a background refresh on read, and
@@ -246,6 +276,7 @@ def catalog_contains(rows: list[dict[str, Any]], token: str) -> bool:
 
 __all__ = [
     "CATALOG_STALE_AFTER_S",
+    "binary_identity",
     "catalog_age_s",
     "catalog_contains",
     "catalog_is_stale",

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -9848,3 +9848,62 @@ def test_claude_catalog_serves_model(
     assert (
         claude_native.claude_catalog_serves_model(_subscription_catalog(), model, config) is served
     )
+
+
+# ── catalog fingerprint keys on the CLI binary ───────────
+
+
+def _point_claude_at(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    """Make the fingerprint resolve the Claude binary to *path*."""
+    monkeypatch.setattr(
+        "omnigent.claude_launcher.resolve_claude_launch",
+        lambda command, args: (str(path), list(args)),
+    )
+
+
+def test_catalog_fingerprint_changes_when_the_cli_is_upgraded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An upgraded Claude Code misses the catalog its predecessor wrote.
+
+    The catalog stores the model names one binary printed. Without the
+    binary in the key, an upgrade keeps serving the old names until the
+    entry ages out, which hides models a release adds or renames.
+    """
+    old_release = tmp_path / "2.1.247"
+    new_release = tmp_path / "2.1.250"
+    old_release.write_text("old")
+    new_release.write_text("newer build")
+    link = tmp_path / "claude"
+    link.symlink_to(old_release)
+    _point_claude_at(monkeypatch, link)
+
+    before = claude_native.claude_catalog_fingerprint(None)
+
+    link.unlink()
+    link.symlink_to(new_release)
+    after = claude_native.claude_catalog_fingerprint(None)
+
+    assert before != after
+
+
+def test_catalog_fingerprint_is_stable_for_one_binary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unchanged binary keeps its catalog, so no probe is repaid."""
+    binary = tmp_path / "claude"
+    binary.write_text("build")
+    _point_claude_at(monkeypatch, binary)
+
+    assert claude_native.claude_catalog_fingerprint(None) == (
+        claude_native.claude_catalog_fingerprint(None)
+    )
+
+
+def test_catalog_fingerprint_survives_a_missing_binary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A binary the resolver cannot find still yields a usable key."""
+    _point_claude_at(monkeypatch, tmp_path / "absent")
+
+    assert isinstance(claude_native.claude_catalog_fingerprint(None), str)

--- a/tests/test_model_catalog_store.py
+++ b/tests/test_model_catalog_store.py
@@ -132,3 +132,72 @@ async def test_ensure_catalog_stale_refresh_failure_keeps_serving() -> None:
     # The stale rows keep serving; nothing crashed and nothing was clobbered.
     assert store.read_catalog("claude-native", "abc123") == _ROWS
     assert await store.ensure_catalog("claude-native", "abc123", _probe) == _ROWS
+
+
+# ── binary_identity ──────────────────────────────────────
+
+
+def test_binary_identity_is_none_without_a_resolvable_command() -> None:
+    """An unresolvable binary keys exactly as it did before this facet.
+
+    Returning ``None`` keeps the fingerprint stable, so a probe that
+    cannot name its executable never invalidates a stored catalog.
+    """
+    assert store.binary_identity(None) is None
+    assert store.binary_identity("") is None
+    assert store.binary_identity("/nonexistent/claude") is None
+
+
+def test_binary_identity_follows_a_version_symlink_to_its_target(tmp_path: Path) -> None:
+    """Two links to one release share an identity; a new release does not.
+
+    Claude Code keeps each release in its own directory and moves a
+    symlink, so the resolved target is what changes on upgrade.
+    """
+    old_release = tmp_path / "2.1.247"
+    new_release = tmp_path / "2.1.250"
+    old_release.write_text("old")
+    new_release.write_text("newer build")
+    link = tmp_path / "claude"
+    link.symlink_to(old_release)
+
+    before = store.binary_identity(str(link))
+    assert before is not None
+    assert before[0] == str(old_release.resolve())
+
+    link.unlink()
+    link.symlink_to(new_release)
+    after = store.binary_identity(str(link))
+
+    assert after is not None
+    assert after != before
+
+
+def test_binary_identity_notices_a_binary_replaced_in_place(tmp_path: Path) -> None:
+    """Installs that overwrite one path still register as a new binary."""
+    binary = tmp_path / "claude"
+    binary.write_text("old")
+    before = store.binary_identity(str(binary))
+
+    binary.write_text("a longer, newer build")
+    os.utime(binary, (0, 0))
+    after = store.binary_identity(str(binary))
+
+    assert before is not None
+    assert after is not None
+    assert after != before
+
+
+def test_binary_identity_resolves_a_bare_name_through_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bare name is looked up on PATH, the way a launch spawns it."""
+    binary = tmp_path / "claude"
+    binary.write_text("build")
+    binary.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    identity = store.binary_identity("claude")
+
+    assert identity is not None
+    assert identity[0] == str(binary.resolve())


### PR DESCRIPTION
## Related issue

Closes #5750

## Summary

The `claude-native` model catalog is cached on disk under a fingerprint. That fingerprint covered the launch config only, so a Claude Code upgrade kept the same key. Omnigent then read the previous build's entry and served the model names that build printed, until the one-hour TTL expired.

The fingerprint now also covers the Claude Code executable. An upgraded CLI misses the catalog and probes again. An unchanged CLI keeps its catalog and pays no probe.

`binary_identity` resolves the executable, then reads its real path, size, and mtime. The real path catches installs that keep each release in its own directory, which is what Claude Code does. Size and mtime catch a binary that an installer overwrites in place. The helper returns `None` when it cannot find or read the executable, which fingerprints exactly as before, so a missing binary never invalidates a stored catalog.

The fingerprint resolves the executable through `resolve_claude_launch`, the same call the probe uses, so the key always describes the binary that produced the answer.

**Note for reviewers:** this changes every existing `claude-native` fingerprint. Each install pays one extra probe on first use after upgrade, then caches as normal.

**Not in this PR:** `codex_catalog_fingerprint` (`omnigent/codex_native_app_server.py:1005`) has the same gap. Its executable reaches the call site differently, so it belongs in a separate change. Issue #5750 records it.

## Test Plan

Automated, against `origin/main` at `8ad8c7bd7`:

| Check | Result |
|---|---|
| `pytest tests/test_claude_native.py tests/test_model_catalog_store.py` | 338 passed |
| `pytest tests/runner/test_app_sessions_native_terminals_autocreate.py -k catalog` | 2 passed (a consumer of this fingerprint) |
| `pre-commit run --from-ref HEAD~1 --to-ref HEAD` | 12 hooks pass |

The new tests cover these behaviors:

- A moved version symlink changes the fingerprint. This is the upgrade case.
- A binary replaced in place changes the fingerprint.
- An unchanged binary keeps its fingerprint, so no probe is repaid.
- A missing binary still yields a usable fingerprint.
- A bare name resolves through `PATH`.

I reverted the source change and confirmed `test_catalog_fingerprint_changes_when_the_cli_is_upgraded` fails without it. It reported the collision as `419fc65207ad0616`, which is the same fingerprint two real installs shared on the machine where this was found.

Steps for a reviewer:

1. Start a `claude-native` session and open the model picker. This writes a catalog.
2. Read the file under `<data-dir>/cache/model-catalogs/claude-native-<fingerprint>.json`.
3. Upgrade or downgrade the Claude Code CLI.
4. Open the picker again.
5. Confirm a second catalog file appears under a different fingerprint, and that the picker shows the new build's names.

## Demo

N/A — no user-visible surface changes. The fix corrects which cached answer the picker reads.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit tests cover the fingerprint contract and the `binary_identity` helper. An existing runner test that consumes this fingerprint still passes. I did not run the manual CLI-upgrade sequence above, so that box stays unchecked.

## Changelog

The Claude Code model picker now refreshes after a CLI upgrade instead of showing the previous build's model list for up to an hour.
