### PR TITLE
Make executor.reasoning_effort a first-class spec default

### DIFF
--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -57,6 +57,7 @@ of the agent YAML.
 executor:
   harness: claude-sdk        # claude-sdk, openai-agents, codex, cursor, kiro-native, pi, antigravity, qwen, kimi, copilot, hermes, ...
   model: databricks-claude-opus-4-7
+  reasoning_effort: high     # optional spec default: low | medium | high | xhigh (harness-dependent)
   auth:
     type: databricks
     profile: oss             # Databricks profile for model routing
@@ -64,6 +65,13 @@ executor:
 
 Set the Databricks profile under `executor.auth`. The older top-level
 `executor.profile` shorthand is legacy and should not be used in new specs.
+
+`executor.reasoning_effort` sets the agent's default reasoning effort. It applies
+to the main session and to every sub-agent dispatch that doesn't pass its own
+per-dispatch effort, and is validated against the harness's effort vocabulary at
+launch. The older `llm.reasoning_effort` is still accepted as a back-compat alias
+(lifted to `executor.reasoning_effort` at parse time); when both are set,
+`executor.reasoning_effort` takes precedence.
 
 The `cursor` harness (Cursor's `cursor-agent`) is the exception: it talks
 only to Cursor's own backend and has no custom API base-URL, so the Databricks

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -8232,6 +8232,31 @@ async def _create_session_from_existing_agent(
                 code=ErrorCode.INVALID_INPUT,
             ) from exc
 
+    if reasoning_effort is None:
+        effort_spec: AgentSpec | None = sub_spec
+        if effort_spec is None and agent_cache is not None and agent.bundle_location is not None:
+            try:
+                effort_loaded = await asyncio.to_thread(
+                    agent_cache.load,
+                    agent.id,
+                    agent.bundle_location,
+                    expand_env=agent.session_id is None,
+                )
+                effort_spec = effort_loaded.spec if effort_loaded is not None else None
+            except (OSError, ValueError, RuntimeError, KeyError, AttributeError, ImportError):
+                _logger.warning(
+                    "create: spec load for reasoning_effort default failed "
+                    "(agent=%s); session starts with no spec-level effort",
+                    agent.id,
+                    exc_info=True,
+                )
+        spec_effort = effort_spec.executor.reasoning_effort if effort_spec is not None else None
+        if spec_effort is not None:
+            _, reasoning_effort = validate_session_model_metadata(
+                model_override=None,
+                reasoning_effort=spec_effort,
+            )
+
     try:
         conv = conversation_store.create_conversation(
             agent_id=agent.id,
@@ -8605,6 +8630,13 @@ def _create_session_from_bundle(
         enforce_handler_allowlist=not local_single_user_enabled(),
     )
     assert spec.name is not None
+
+    if metadata.reasoning_effort is None and spec.executor.reasoning_effort is not None:
+        _, seeded_effort = validate_session_model_metadata(
+            model_override=None,
+            reasoning_effort=spec.executor.reasoning_effort,
+        )
+        metadata = metadata.model_copy(update={"reasoning_effort": seeded_effort})
 
     agent_id = generate_agent_id()
     agent_bundle_location = bundle_location(agent_id, bundle_bytes)

--- a/omnigent/server/scheduled/fire.py
+++ b/omnigent/server/scheduled/fire.py
@@ -630,6 +630,32 @@ async def _permission_mode_launch_args(deps: FireDeps, task: ScheduledTask) -> l
     return ["--permission-mode", task.permission_mode]
 
 
+async def _spec_reasoning_effort(deps: FireDeps, task: ScheduledTask) -> str | None:
+    """Read ``executor.reasoning_effort`` from the task's agent spec.
+
+    Fail-safe like :func:`_permission_mode_launch_args`: a task with no explicit
+    effort inherits the spec default, and any load failure yields ``None`` (the
+    harness default) rather than breaking the fire. The spec value is validated
+    at spec load, so it needs no re-validation here.
+    """
+    if deps.agent_cache is None:
+        return None
+    try:
+        agent = await asyncio.to_thread(deps.agent_store.get, task.agent_id)
+        if agent is None or getattr(agent, "bundle_location", None) is None:
+            return None
+        loaded = await asyncio.to_thread(deps.agent_cache.load, agent.id, agent.bundle_location)
+        executor = getattr(loaded.spec, "executor", None)
+        return getattr(executor, "reasoning_effort", None) if executor else None
+    except Exception:
+        _logger.exception(
+            "scheduled fire: could not resolve reasoning_effort for task %s; "
+            "using harness default",
+            task.id,
+        )
+        return None
+
+
 async def _create_session(deps: FireDeps, task: ScheduledTask) -> Conversation:
     """Create a conversation bound to the task's agent, carrying the stored spec."""
     # Connected-host, existing-workspace runs create the conversation directly.
@@ -643,12 +669,15 @@ async def _create_session(deps: FireDeps, task: ScheduledTask) -> Conversation:
         workspace=task.workspace,
         terminal_launch_args=await _permission_mode_launch_args(deps, task),
     )
-    if task.model_override is not None or task.reasoning_effort is not None:
+    reasoning_effort = task.reasoning_effort
+    if reasoning_effort is None:
+        reasoning_effort = await _spec_reasoning_effort(deps, task)
+    if task.model_override is not None or reasoning_effort is not None:
         updated: Conversation | None = await asyncio.to_thread(
             deps.conversation_store.update_conversation,
             conv.id,
             model_override=task.model_override,
-            reasoning_effort=task.reasoning_effort,
+            reasoning_effort=reasoning_effort,
         )
         if updated is not None:
             conv = updated

--- a/omnigent/spec/AGENTSPEC.md
+++ b/omnigent/spec/AGENTSPEC.md
@@ -53,7 +53,8 @@ llm:
                               #   anthropic/claude-opus-4-6,
                               #   google/gemini-2.5-pro
   max_completion_tokens: 4096 # optional; caps total output including reasoning tokens
-  reasoning_effort: medium    # optional; low | medium | high
+  reasoning_effort: medium    # optional; low | medium | high | xhigh
+                              # back-compat alias — prefer executor.reasoning_effort
 
 interaction:
   conversational: true        # maintain history across turns (default: true)

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -218,6 +218,12 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
             executor.model = llm.model
         if executor.connection is None and llm.connection is not None:
             executor.connection = llm.connection
+        if executor.reasoning_effort is None:
+            llm_effort = llm.extra.get("reasoning_effort")
+            if llm_effort is not None:
+                executor.reasoning_effort = str(llm_effort)
+        elif "reasoning_effort" in llm.extra:
+            llm.extra["reasoning_effort"] = executor.reasoning_effort
     # Ensure spec.llm is populated from executor fields when only the
     # executor: block declares model/connection (the common case for
     # user-authored YAML). Internal consumers (policy builder,

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -555,8 +555,9 @@ class ExecutorSpec:  # type: ignore[explicit-any]  # config: dict[str, Any] fiel
         auto-detection, telemetry, and tool-provider inference.
         ``None`` only when no model is declared anywhere in the spec.
     :param reasoning_effort: Default reasoning level for this agent,
-        e.g. ``"high"``. Read from the ``executor.reasoning_effort``
-        YAML key, alongside ``model``. Applies when nothing more
+        e.g. ``"high"``. Populated by the parser from either the
+        ``executor.reasoning_effort`` YAML key or (for backward
+        compatibility) ``llm.reasoning_effort``. Applies when nothing more
         specific asks for one: a per-dispatch
         ``sys_session_send``/``sys_session_create`` argument wins over
         it, and it in turn wins over whatever default the harness CLI
@@ -607,7 +608,8 @@ class ExecutorSpec:  # type: ignore[explicit-any]  # config: dict[str, Any] fiel
     # the parser from executor.model or (backward compat) llm.model.
     model: str | None = None
     # Spec-level default reasoning effort, applied when no per-dispatch
-    # value asks for one. Populated from executor.reasoning_effort.
+    # value asks for one. Populated from executor.reasoning_effort or
+    # (backward compat) llm.reasoning_effort.
     reasoning_effort: str | None = None
     # Per-provider connection overrides (api_key, base_url, etc.).
     # Populated from executor.connection or (backward compat) llm.connection.

--- a/omnigent/spec/validator.py
+++ b/omnigent/spec/validator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 
+from omnigent.reasoning_effort import EFFORT_VALUES, validate_effort
 from omnigent.spec.types import AgentSpec, ToolRuntime
 
 _SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9-]+$")
@@ -86,6 +87,7 @@ def validate(spec: AgentSpec) -> ValidationResult:
     _validate_spec_version(spec, result)
     _validate_executor_type(spec, result)
     _validate_llm(spec, result)
+    _validate_reasoning_effort(spec, result)
     _validate_interaction(spec, result)
     _validate_skills(spec, result)
     _validate_mcp_servers(spec, result)
@@ -219,6 +221,25 @@ def _validate_llm(spec: AgentSpec, result: ValidationResult) -> None:
             f"executor.model ({spec.executor.model!r}) and llm.model "
             f"({spec.llm.model!r}) disagree — use executor.model only",
         )
+
+
+def _validate_reasoning_effort(spec: AgentSpec, result: ValidationResult) -> None:
+    """
+    Validate ``executor.reasoning_effort`` against the shared effort vocabulary.
+
+    Runs the same check as session create, so a spec that validates cannot be
+    rejected when a session is created; harness-specific support is enforced
+    downstream at launch.
+
+    :param spec: The agent spec to check.
+    :param result: Accumulator for any validation errors found.
+    """
+    if spec.executor.reasoning_effort is None:
+        return
+    try:
+        validate_effort(spec.executor.reasoning_effort, "reasoning_effort", EFFORT_VALUES)
+    except ValueError as exc:
+        result.add("executor.reasoning_effort", str(exc))
 
 
 def _validate_interaction(spec: AgentSpec, result: ValidationResult) -> None:

--- a/tests/server/integration/test_sessions_model_override.py
+++ b/tests/server/integration/test_sessions_model_override.py
@@ -291,6 +291,79 @@ async def test_create_session_rejects_invalid_reasoning_effort(
     )
 
 
+async def test_create_session_inherits_spec_reasoning_effort(
+    client: httpx.AsyncClient,
+) -> None:
+    """A client-less create inherits ``executor.reasoning_effort`` from the spec.
+
+    The spec-level default must reach the session (and thus the runner /
+    native ``--effort``) with no per-request effort, mirroring how the model
+    default comes from the spec rather than the create body.
+    """
+    agent = await create_test_agent(
+        client,
+        executor={
+            "type": "omnigent",
+            "config": {"harness": "claude-sdk"},
+            "model": "databricks-claude-sonnet-4-6",
+            "reasoning_effort": "high",
+        },
+        include_llm=False,
+    )
+    session = await _create_session(client, agent["id"])
+    assert session["reasoning_effort"] == "high"
+    get = await client.get(f"/v1/sessions/{session['id']}")
+    assert get.status_code == 200
+    assert get.json()["reasoning_effort"] == "high"
+
+
+async def test_create_session_explicit_reasoning_effort_overrides_spec(
+    client: httpx.AsyncClient,
+) -> None:
+    """A client-supplied ``reasoning_effort`` wins over the spec default."""
+    agent = await create_test_agent(
+        client,
+        executor={
+            "type": "omnigent",
+            "config": {"harness": "claude-sdk"},
+            "model": "databricks-claude-sonnet-4-6",
+            "reasoning_effort": "high",
+        },
+        include_llm=False,
+    )
+    resp = await client.post(
+        "/v1/sessions",
+        json={"agent_id": agent["id"], "initial_items": [], "reasoning_effort": "low"},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["reasoning_effort"] == "low"
+
+
+async def test_bundle_create_inherits_spec_reasoning_effort(
+    client: httpx.AsyncClient,
+) -> None:
+    """A bundle upload (the ``omnigent run <dir>`` path) inherits spec effort.
+
+    ``create_test_agent`` creates its owning session via the multipart bundle
+    path, which must seed ``executor.reasoning_effort`` from the spec just like
+    the agent-id path — otherwise ``omnigent run`` with a spec-level default
+    would silently start at the harness default.
+    """
+    agent = await create_test_agent(
+        client,
+        executor={
+            "type": "omnigent",
+            "config": {"harness": "claude-sdk"},
+            "model": "databricks-claude-sonnet-4-6",
+            "reasoning_effort": "high",
+        },
+        include_llm=False,
+    )
+    owning = await client.get(f"/v1/sessions/{agent['_session_id']}")
+    assert owning.status_code == 200
+    assert owning.json()["reasoning_effort"] == "high"
+
+
 class _CaptureClient:
     """Stub runner client that records the POSTed body for inspection."""
 

--- a/tests/server/scheduled/test_fire.py
+++ b/tests/server/scheduled/test_fire.py
@@ -58,32 +58,36 @@ class FakeAgentStore:
 
 
 class _FakeExecutor:
-    def __init__(self, harness: str) -> None:
+    def __init__(self, harness: str, reasoning_effort: str | None = None) -> None:
         # Mirrors AgentSpec.executor: a canonical harness in ``config['harness']``
         # (falls back to ``type``). The permission-mode injection reads this to
         # confirm a claude-native agent before adding ``--permission-mode``.
         self.type = harness
         self.config = {"harness": harness}
+        self.reasoning_effort = reasoning_effort
 
 
 class _FakeSpec:
-    def __init__(self, harness: str) -> None:
-        self.executor = _FakeExecutor(harness)
+    def __init__(self, harness: str, reasoning_effort: str | None = None) -> None:
+        self.executor = _FakeExecutor(harness, reasoning_effort)
 
 
 class _FakeLoadedAgent:
-    def __init__(self, harness: str) -> None:
-        self.spec = _FakeSpec(harness)
+    def __init__(self, harness: str, reasoning_effort: str | None = None) -> None:
+        self.spec = _FakeSpec(harness, reasoning_effort)
 
 
 class FakeAgentCache:
     """Resolves an agent id to a spec with a fixed harness (for launch gating)."""
 
-    def __init__(self, harness: str = "claude-native") -> None:
+    def __init__(
+        self, harness: str = "claude-native", reasoning_effort: str | None = None
+    ) -> None:
         self._harness = harness
+        self._reasoning_effort = reasoning_effort
 
     def load(self, agent_id: str, bundle_location: str, **_: Any) -> _FakeLoadedAgent:
-        return _FakeLoadedAgent(self._harness)
+        return _FakeLoadedAgent(self._harness, self._reasoning_effort)
 
 
 class FakeScheduledTaskStore:
@@ -139,6 +143,7 @@ class SequencedScheduledTaskStore(FakeScheduledTaskStore):
 class FakeConversationStore:
     def __init__(self, *, fail_create: bool = False) -> None:
         self.created: list[dict[str, Any]] = []
+        self.updated: list[dict[str, Any]] = []
         self.create_workspace_ids: list[int] = []
         self._seq = 0
         self.fail_create = fail_create
@@ -159,6 +164,7 @@ class FakeConversationStore:
         return conv
 
     def update_conversation(self, conversation_id: str, **kwargs: Any) -> _FakeConversation:
+        self.updated.append({"id": conversation_id, **kwargs})
         return _FakeConversation(id=conversation_id, agent_id="")
 
     def get_conversation(self, conversation_id: str) -> _FakeConversation | None:
@@ -475,6 +481,80 @@ async def test_permission_mode_omitted_for_non_claude_agent() -> None:
 
     assert len(conv_store.created) == 1
     assert conv_store.created[0]["terminal_launch_args"] is None
+
+
+def _effort_agent_deps(
+    store: FakeScheduledTaskStore,
+    conv_store: FakeConversationStore,
+    *,
+    reasoning_effort: str | None,
+) -> FireDeps:
+    """Deps whose agent ``ag_1`` resolves to a spec carrying *reasoning_effort*."""
+    return _deps(
+        store,
+        permission_store=FakePermissionStore(),
+        conversation_store=conv_store,
+        agent_store=FakeAgentStore({"ag_1": _FakeAgent("ag_1", bundle_location="ag_1/hash")}),
+        agent_cache=FakeAgentCache(harness="claude-native", reasoning_effort=reasoning_effort),
+    )
+
+
+@pytest.mark.asyncio
+async def test_spec_reasoning_effort_seeded_at_fire() -> None:
+    """A task with no explicit effort inherits ``executor.reasoning_effort``."""
+    conv_store = FakeConversationStore()
+    store = FakeScheduledTaskStore(rows={"task_1": _task()})
+
+    async def _launch(conv: Any, task: Any) -> None:
+        return None
+
+    on_fire = build_on_fire(
+        _effort_agent_deps(store, conv_store, reasoning_effort="high"),
+        launch_dispatch=_launch,
+    )
+    await on_fire(0, "task_1")
+    await _drain()
+
+    assert any(u.get("reasoning_effort") == "high" for u in conv_store.updated)
+
+
+@pytest.mark.asyncio
+async def test_task_reasoning_effort_overrides_spec_at_fire() -> None:
+    """An explicit task effort wins over the spec default."""
+    conv_store = FakeConversationStore()
+    store = FakeScheduledTaskStore(rows={"task_1": _task(reasoning_effort="low")})
+
+    async def _launch(conv: Any, task: Any) -> None:
+        return None
+
+    on_fire = build_on_fire(
+        _effort_agent_deps(store, conv_store, reasoning_effort="high"),
+        launch_dispatch=_launch,
+    )
+    await on_fire(0, "task_1")
+    await _drain()
+
+    assert any(u.get("reasoning_effort") == "low" for u in conv_store.updated)
+    assert not any(u.get("reasoning_effort") == "high" for u in conv_store.updated)
+
+
+@pytest.mark.asyncio
+async def test_no_reasoning_effort_when_spec_has_none() -> None:
+    """A task and spec both without effort seed nothing (harness default)."""
+    conv_store = FakeConversationStore()
+    store = FakeScheduledTaskStore(rows={"task_1": _task()})
+
+    async def _launch(conv: Any, task: Any) -> None:
+        return None
+
+    on_fire = build_on_fire(
+        _effort_agent_deps(store, conv_store, reasoning_effort=None),
+        launch_dispatch=_launch,
+    )
+    await on_fire(0, "task_1")
+    await _drain()
+
+    assert not any("reasoning_effort" in u for u in conv_store.updated)
 
 
 @pytest.mark.asyncio

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -90,6 +90,7 @@ def test_parse_full_config(tmp_path: Path) -> None:
     assert spec.llm.model == "openai/gpt-5.4"
     # executor.model is the canonical source — verify consolidation
     assert spec.executor.model == "openai/gpt-5.4"
+    assert spec.executor.reasoning_effort == "medium"
     assert spec.llm.extra == {
         "max_completion_tokens": 4096,
         "reasoning_effort": "medium",
@@ -99,6 +100,44 @@ def test_parse_full_config(tmp_path: Path) -> None:
     assert spec.interaction.modalities.output == ["text"]
     assert spec.tools.agents == ["researcher", "critic"]
     assert spec.params == {"max_results": 10, "prefer_recent": True}
+
+
+def test_parse_llm_reasoning_effort_lifted_to_executor(tmp_path: Path) -> None:
+    """The deprecated ``llm.reasoning_effort`` lifts to the canonical field.
+
+    Mirrors the model/connection consolidation: ``executor.reasoning_effort``
+    is the source of truth, populated from the ``llm:`` block for back-compat.
+    """
+    config = {
+        "spec_version": 1,
+        "name": "eff-llm",
+        "llm": {"model": "openai/gpt-5.4", "reasoning_effort": "xhigh"},
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    assert spec.executor.reasoning_effort == "xhigh"
+    assert spec.llm is not None
+    assert spec.llm.extra.get("reasoning_effort") == "xhigh"
+
+
+def test_parse_executor_reasoning_effort_supersedes_llm(tmp_path: Path) -> None:
+    """When both are set, executor.reasoning_effort wins and llm is synced to it."""
+    config = {
+        "spec_version": 1,
+        "name": "eff-both",
+        "executor": {
+            "type": "omnigent",
+            "config": {"harness": "claude-sdk"},
+            "model": "openai/gpt-5.4",
+            "reasoning_effort": "high",
+        },
+        "llm": {"model": "openai/gpt-5.4", "reasoning_effort": "low"},
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    assert spec.executor.reasoning_effort == "high"
+    assert spec.llm is not None
+    assert spec.llm.extra.get("reasoning_effort") == "high"
 
 
 def test_parse_llm_missing_model(tmp_path: Path) -> None:

--- a/tests/spec/test_validator.py
+++ b/tests/spec/test_validator.py
@@ -90,6 +90,37 @@ def test_llm_arbitrary_extra_passes_validation() -> None:
     assert result.valid
 
 
+def test_reasoning_effort_invalid_value_rejected() -> None:
+    """An unknown ``executor.reasoning_effort`` fails validation up front.
+
+    A spec that validates must never be rejected later at session create, so an
+    out-of-vocabulary value is caught here rather than when a session is made.
+    """
+    spec = _minimal_spec(
+        executor=ExecutorSpec(
+            config={"harness": "claude-sdk"},
+            model="openai/gpt-5.4",
+            reasoning_effort="hihg",
+        ),
+    )
+    result = validate(spec)
+    assert not result.valid
+    assert any("executor.reasoning_effort" in e.path for e in result.errors)
+
+
+def test_reasoning_effort_valid_value_ok() -> None:
+    """A known ``executor.reasoning_effort`` validates cleanly."""
+    spec = _minimal_spec(
+        executor=ExecutorSpec(
+            config={"harness": "claude-sdk"},
+            model="openai/gpt-5.4",
+            reasoning_effort="high",
+        ),
+    )
+    result = validate(spec)
+    assert result.valid
+
+
 def test_valid_input_modalities() -> None:
     spec = _minimal_spec(
         interaction=InteractionConfig(


### PR DESCRIPTION
## Related issue

Closes #5756

## Summary

`executor.reasoning_effort` parsed into a dedicated field but was never honored by the **main session** — session create read effort only from the client (`omnigent run` sends none), and `llm.reasoning_effort` only survived inside `llm.extra` and (unlike `llm.model`) was never lifted onto the executor. So a spec-level effort default was effectively dead outside sub-agent dispatch.

This makes `executor.reasoning_effort` the first-class spec default (the mirror of `executor.model`), honored on every harness, with `llm.reasoning_effort` kept as a deprecated back-compat alias:

- **Parser** (`spec/parser.py`) — `executor.reasoning_effort` is authoritative: lift `llm.reasoning_effort` onto it when the `executor` block sets none, and when both are set `executor` wins and the `llm` value is synced to it — mirroring how `executor.model` supersedes `llm.model`. No conflict error.
- **Validator** (`spec/validator.py`) — reject an out-of-vocabulary `executor.reasoning_effort` at spec validation, using the same effort vocabulary as session create. A spec that validates can never be rejected later when a session is created; harness-specific support is still enforced downstream at launch.
- **Session create** (`server/routes/_sessions/orchestration.py`) — when the client sends no effort, fall back to the spec's `executor.reasoning_effort` on **both** create paths: the agent-id path (`_create_session_from_existing_agent`, best-effort spec load) and the bundle-upload path that `omnigent run <dir>` uses (`_create_session_from_bundle`, spec already parsed from the bundle). The persisted `conv.reasoning_effort` is already read by both the relay runner (forwarded per turn) and native launch (`--effort`), so the seed reaches every harness.
- **Scheduled tasks** (`server/scheduled/fire.py`) — the fire path seeds `executor.reasoning_effort` when a task sets none, mirroring the create paths, so a spec-level default reaches scheduled runs instead of silently starting at the harness default. The spec load is fail-safe: any error yields the harness default rather than breaking the fire.
- **Docs** (`docs/AGENT_YAML_SPEC.md`, `spec/AGENTSPEC.md`, `ExecutorSpec` docstring) — document `executor.reasoning_effort` as primary; `llm.reasoning_effort` as a deprecated alias.

## Test Plan

Added spec + integration regression tests; re-ran the create-path suites (no regressions); ruff + pyrefly clean:

- `tests/spec/test_parser.py` — `llm.reasoning_effort` lifts to `executor.reasoning_effort`; when both are set, `executor` wins and `llm.extra` is synced to it.
- `tests/spec/test_validator.py` — an out-of-vocabulary `executor.reasoning_effort` fails validation; a known value validates cleanly.
- `tests/server/integration/test_sessions_model_override.py` — a client-less session inherits `executor.reasoning_effort` (agent-id path); a client value overrides it; a bundle upload (`omnigent run <dir>` path) inherits it.
- `tests/server/scheduled/test_fire.py` — a scheduled task with no effort inherits `executor.reasoning_effort` at fire; an explicit task effort overrides the spec default; neither set launches at the harness default.

```
uv run --group test pytest tests/spec/test_parser.py tests/spec/test_validator.py -q
uv run --group test pytest tests/server/integration/test_sessions_model_override.py \
    tests/server/integration/test_sessions_endpoints.py -q
uv run --group test pytest tests/server/scheduled/test_fire.py -q
```

Verified end-to-end on a live server: `omnigent run <dir>` with a `claude-sdk` agent declaring `executor.reasoning_effort: high` (no `llm` block, no client effort) launches the `claude` subprocess with `--effort high` (visible in its argv); a control agent with no spec effort launches without `--effort`.

## Type of change

- [x] Bug fix

## Test coverage

- [x] This PR adds or updates tests

---
This pull request and its description were written by Isaac.
