### PR TITLE
Add host and runner WebSocket lifecycle metrics

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -139,6 +139,10 @@ from omnigent.runner.transports.ws_tunnel.limits import (
     TUNNEL_KEEPALIVE_PING_INTERVAL_S,
     TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
 )
+from omnigent.runtime.websocket_metrics import (
+    record_websocket_connected,
+    record_websocket_disconnected,
+)
 from omnigent.suspend_watch import watch_for_resume
 from omnigent.tls import client_ssl_context
 from omnigent.version import VERSION
@@ -3351,15 +3355,30 @@ class HostProcess:
             raise
         # An accepted upgrade proves the credentials work: login redirects
         # from here on are server restarts, not an unauthenticated host.
+        reconnect = self._ever_connected
         self._ever_connected = True
         self._login_redirect_streak = 0
         self._auth_retry_streak = 0
         self._refused_streak = 0
         self._conn_upgrade_accepted = True
-        await self._ensure_owner_user_id()
+        record_websocket_connected("host", reconnect=reconnect)
+        disconnect_error: BaseException | None = None
         try:
+            await self._ensure_owner_user_id()
             await self._serve_frames(ws)
+        except BaseException as exc:
+            disconnect_error = exc
+            raise
         finally:
+            record_websocket_disconnected(
+                "host",
+                disconnect_error,
+                local_shutdown=(
+                    isinstance(disconnect_error, asyncio.CancelledError | KeyboardInterrupt)
+                    or self._lifecycle_lost.is_set()
+                ),
+                resumed_from_suspend=self._woke_from_suspend,
+            )
             # Drop the watcher tasks' send target — exit reports raised
             # between connections park in _unreported_exits instead of
             # racing a half-closed socket.

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -55,6 +55,10 @@ from omnigent.runner.transports.ws_tunnel.limits import (
     TUNNEL_KEEPALIVE_PING_INTERVAL_S,
     TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
 )
+from omnigent.runtime.websocket_metrics import (
+    record_websocket_connected,
+    record_websocket_disconnected,
+)
 from omnigent.suspend_watch import watch_for_resume
 from omnigent.tls import client_ssl_context
 
@@ -350,9 +354,15 @@ async def serve_tunnel(
     login_redirect_streak = 0
     # Consecutive HTTP 401/403 rejections; reset by a successful upgrade.
     http_auth_rejection_streak = 0
+    connected_this_attempt = False
 
     def _mark_connected() -> None:
-        nonlocal ever_connected, login_redirect_streak, http_auth_rejection_streak
+        nonlocal connected_this_attempt
+        nonlocal ever_connected
+        nonlocal login_redirect_streak
+        nonlocal http_auth_rejection_streak
+        record_websocket_connected("runner", reconnect=ever_connected)
+        connected_this_attempt = True
         ever_connected = True
         login_redirect_streak = 0
         http_auth_rejection_streak = 0
@@ -371,6 +381,8 @@ async def serve_tunnel(
             # A shutdown requested between reconnect attempts (no live
             # connection to drain): nothing to flush, just stop looping.
             return
+        connected_this_attempt = False
+        disconnect_error: BaseException | None = None
         auth_token = await _refresh_auth_token(auth_token, auth_token_factory)
         if ever_connected and on_reconnect is not None:
             try:
@@ -405,9 +417,11 @@ async def serve_tunnel(
             if shutdown_event is not None and shutdown_event.is_set():
                 return
             delay_s = _INITIAL_RECONNECT_DELAY_S
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as exc:
+            disconnect_error = exc
             raise
         except WebSocketException as exc:
+            disconnect_error = exc
             redirect_url = _websocket_auth_redirect_url(exc)
             if redirect_url is not None:
                 login_redirect_streak += 1
@@ -525,7 +539,19 @@ async def serve_tunnel(
                     else:
                         retry_reason = str(exc)
         except (ConnectionError, OSError, ValueError) as exc:
+            disconnect_error = exc
             retry_reason = str(exc)
+        finally:
+            if connected_this_attempt:
+                record_websocket_disconnected(
+                    "runner",
+                    disconnect_error,
+                    local_shutdown=(
+                        (shutdown_event is not None and shutdown_event.is_set())
+                        or isinstance(disconnect_error, asyncio.CancelledError)
+                    ),
+                    resumed_from_suspend=woke_from_suspend,
+                )
         if woke_from_suspend:
             # A wake from system suspend already aborted the live tunnel (see
             # _serve_tunnel_once's watcher). The abrupt close would otherwise

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -541,6 +541,11 @@ async def serve_tunnel(
         except (ConnectionError, OSError, ValueError) as exc:
             disconnect_error = exc
             retry_reason = str(exc)
+        except BaseException as exc:
+            # Unexpected post-connect failures (e.g. a raising callback) must
+            # not be recorded as clean peer closes.
+            disconnect_error = exc
+            raise
         finally:
             if connected_this_attempt:
                 record_websocket_disconnected(

--- a/omnigent/runtime/websocket_metrics.py
+++ b/omnigent/runtime/websocket_metrics.py
@@ -1,0 +1,253 @@
+"""OpenTelemetry metrics for client-side WebSocket tunnel lifecycle."""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from typing import Literal, Protocol
+
+from opentelemetry import metrics as otel_metrics
+from opentelemetry.util.types import Attributes
+
+from omnigent.runtime.telemetry import telemetry_enabled
+
+_logger = logging.getLogger(__name__)
+
+_OTEL_METER_NAME = "omnigent.client.websocket"
+
+CONNECTIONS_METRIC_NAME = "omnigent.client.websocket.connections"
+DISCONNECTIONS_METRIC_NAME = "omnigent.client.websocket.disconnections"
+
+TunnelKind = Literal["host", "runner"]
+DisconnectReason = Literal[
+    "authentication_error",
+    "local_shutdown",
+    "peer_closed",
+    "ping_timeout",
+    "protocol_error",
+    "server_rehome",
+    "server_restart",
+    "suspend_resume",
+    "transport_error",
+    "unknown",
+]
+
+
+class _CounterLike(Protocol):
+    """Subset of the OpenTelemetry counter API used by this module."""
+
+    def add(self, amount: int | float, attributes: Attributes = None) -> None:
+        """Add a value with optional metric attributes."""
+
+
+class _MeterLike(Protocol):
+    """Subset of the OpenTelemetry meter API used by this module."""
+
+    def create_counter(
+        self,
+        name: str,
+        unit: str = "",
+        description: str = "",
+    ) -> _CounterLike:
+        """Create a monotonic counter."""
+
+
+def websocket_close_code(error: BaseException | None) -> int | None:
+    """Return a WebSocket close code carried by an exception.
+
+    ``websockets`` has exposed close metadata both directly and through
+    ``rcvd`` / ``sent`` objects across supported versions.
+
+    :param error: Tunnel exception, or ``None`` for a clean return.
+    :returns: Close code such as ``1012`` or ``4003`` when available.
+    """
+    if error is None:
+        return None
+    for attr in ("rcvd", "sent"):
+        close = getattr(error, attr, None)
+        code = getattr(close, "code", None)
+        if isinstance(code, int):
+            return code
+    direct = getattr(error, "code", None)
+    if isinstance(direct, int):
+        return direct
+    return None
+
+
+def websocket_close_reason(error: BaseException | None) -> str | None:
+    """Return a WebSocket close reason carried by an exception.
+
+    :param error: Tunnel exception, or ``None`` for a clean return.
+    :returns: Peer-provided close reason when available.
+    """
+    if error is None:
+        return None
+    for attr in ("rcvd", "sent"):
+        close = getattr(error, attr, None)
+        reason = getattr(close, "reason", None)
+        if isinstance(reason, str) and reason:
+            return reason
+    direct = getattr(error, "reason", None)
+    if isinstance(direct, str) and direct:
+        return direct
+    return None
+
+
+def classify_disconnect_reason(
+    error: BaseException | None,
+    *,
+    local_shutdown: bool = False,
+    resumed_from_suspend: bool = False,
+) -> DisconnectReason:
+    """Map tunnel termination details to a bounded reason.
+
+    Raw exception and peer reason text are used only for classification; they
+    are never attached to the metric.
+
+    :param error: Exception that ended the connection, or ``None`` for a clean
+        peer close.
+    :param local_shutdown: Whether the local process requested shutdown.
+    :param resumed_from_suspend: Whether a suspend watcher dropped the stale
+        socket to reconnect.
+    :returns: A stable low-cardinality disconnect reason.
+    """
+    if local_shutdown:
+        return "local_shutdown"
+    if resumed_from_suspend:
+        return "suspend_resume"
+
+    code = websocket_close_code(error)
+    close_reason = websocket_close_reason(error) or ""
+    error_text = str(error) if error is not None else ""
+    detail = f"{close_reason} {error_text}".lower()
+
+    if any(token in detail for token in ("reassigned", "re-home", "rehome")):
+        return "server_rehome"
+    if code == 1012 or "service restart" in detail:
+        return "server_restart"
+    if "ping timeout" in detail or "keepalive ping" in detail:
+        return "ping_timeout"
+    if code == 4004 or "unauthenticated" in detail or "authentication" in detail:
+        return "authentication_error"
+    if code in {1002, 1003, 1007, 1008, 4001, 4002, 4500} or "protocol" in detail:
+        return "protocol_error"
+    if (
+        code == 1006
+        or isinstance(error, ConnectionError | OSError)
+        or any(
+            token in detail
+            for token in (
+                "connection reset",
+                "connection refused",
+                "no close frame",
+                "timed out",
+                "transport",
+            )
+        )
+    ):
+        return "transport_error"
+    if error is None or code is not None:
+        return "peer_closed"
+    return "unknown"
+
+
+class ClientWebSocketMetrics:
+    """Record bounded host and runner tunnel lifecycle metrics.
+
+    :param meter: Optional meter for tests. The global OpenTelemetry meter is
+        used in production.
+    """
+
+    def __init__(self, meter: _MeterLike | None = None) -> None:
+        """Create the connection and disconnection counters."""
+        effective_meter = meter or otel_metrics.get_meter(_OTEL_METER_NAME)
+        self._connections = effective_meter.create_counter(
+            CONNECTIONS_METRIC_NAME,
+            unit="{connection}",
+            description="Accepted client WebSocket tunnel connections.",
+        )
+        self._disconnections = effective_meter.create_counter(
+            DISCONNECTIONS_METRIC_NAME,
+            unit="{connection}",
+            description="Ended client WebSocket tunnel connections.",
+        )
+
+    def record_connected(self, kind: TunnelKind, *, reconnect: bool) -> None:
+        """Record one accepted WebSocket upgrade.
+
+        :param kind: Tunnel client component.
+        :param reconnect: Whether this follows an earlier accepted connection.
+        """
+        self._connections.add(
+            1,
+            attributes={
+                "tunnel.kind": kind,
+                "connection.type": "reconnect" if reconnect else "initial",
+            },
+        )
+
+    def record_disconnected(
+        self,
+        kind: TunnelKind,
+        error: BaseException | None,
+        *,
+        local_shutdown: bool = False,
+        resumed_from_suspend: bool = False,
+    ) -> None:
+        """Record one ended established WebSocket connection.
+
+        :param kind: Tunnel client component.
+        :param error: Exception that ended the connection, if any.
+        :param local_shutdown: Whether the local process requested shutdown.
+        :param resumed_from_suspend: Whether the stale socket was dropped after
+            system resume.
+        """
+        attributes: dict[str, str | int] = {
+            "tunnel.kind": kind,
+            "disconnect.reason": classify_disconnect_reason(
+                error,
+                local_shutdown=local_shutdown,
+                resumed_from_suspend=resumed_from_suspend,
+            ),
+        }
+        close_code = websocket_close_code(error)
+        if close_code is not None:
+            attributes["websocket.close.code"] = close_code
+        self._disconnections.add(1, attributes=attributes)
+
+
+@lru_cache(maxsize=1)
+def _default_metrics() -> ClientWebSocketMetrics:
+    """Return the process-wide WebSocket metric instruments."""
+    return ClientWebSocketMetrics()
+
+
+def record_websocket_connected(kind: TunnelKind, *, reconnect: bool) -> None:
+    """Best-effort record of an accepted client WebSocket upgrade."""
+    if not telemetry_enabled():
+        return
+    try:
+        _default_metrics().record_connected(kind, reconnect=reconnect)
+    except Exception:  # Telemetry must never disrupt the tunnel.
+        _logger.debug("failed to record WebSocket connection metric", exc_info=True)
+
+
+def record_websocket_disconnected(
+    kind: TunnelKind,
+    error: BaseException | None,
+    *,
+    local_shutdown: bool = False,
+    resumed_from_suspend: bool = False,
+) -> None:
+    """Best-effort record of an ended client WebSocket connection."""
+    if not telemetry_enabled():
+        return
+    try:
+        _default_metrics().record_disconnected(
+            kind,
+            error,
+            local_shutdown=local_shutdown,
+            resumed_from_suspend=resumed_from_suspend,
+        )
+    except Exception:  # Telemetry must never disrupt the tunnel.
+        _logger.debug("failed to record WebSocket disconnection metric", exc_info=True)

--- a/omnigent/runtime/websocket_metrics.py
+++ b/omnigent/runtime/websocket_metrics.py
@@ -8,6 +8,7 @@ from typing import Literal, Protocol
 
 from opentelemetry import metrics as otel_metrics
 from opentelemetry.util.types import Attributes
+from websockets.exceptions import ConnectionClosed
 
 from omnigent.runtime.telemetry import telemetry_enabled
 
@@ -68,6 +69,11 @@ def websocket_close_code(error: BaseException | None) -> int | None:
         code = getattr(close, "code", None)
         if isinstance(code, int):
             return code
+    if isinstance(error, ConnectionClosed):
+        # ``ConnectionClosed.code`` is deprecated (websockets >=13.1) and
+        # warns on every abnormal reconnect; ``rcvd``/``sent`` already cover
+        # any real close frame, so a code-less close stays uncoded here.
+        return None
     direct = getattr(error, "code", None)
     if isinstance(direct, int):
         return direct
@@ -87,6 +93,10 @@ def websocket_close_reason(error: BaseException | None) -> str | None:
         reason = getattr(close, "reason", None)
         if isinstance(reason, str) and reason:
             return reason
+    if isinstance(error, ConnectionClosed):
+        # ``ConnectionClosed.reason`` is deprecated (websockets >=13.1); see
+        # websocket_close_code for why the direct fallback is skipped.
+        return None
     direct = getattr(error, "reason", None)
     if isinstance(direct, str) and direct:
         return direct
@@ -147,6 +157,8 @@ def classify_disconnect_reason(
     ):
         return "transport_error"
     if error is None or code is not None:
+        # Any unclassified close frame is an application-level close by the
+        # peer; "unknown" is reserved for code-less unexpected exceptions.
         return "peer_closed"
     return "unknown"
 

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -3649,6 +3649,34 @@ async def test_reconnect_uses_shorter_handshake_timeout(
     assert [call["open_timeout"] for call in spy.calls] == [10.0, 3.0]
 
 
+async def test_host_records_accepted_connection_and_disconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The host reports lifecycle metrics only after an accepted upgrade."""
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", dict)
+    monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", dict)
+    spy = _ConnectSpy([None, asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    connected: list[tuple[str, bool]] = []
+    disconnected: list[tuple[str, BaseException | None]] = []
+    monkeypatch.setattr(
+        "omnigent.host.connect.record_websocket_connected",
+        lambda kind, *, reconnect: connected.append((kind, reconnect)),
+    )
+    monkeypatch.setattr(
+        "omnigent.host.connect.record_websocket_disconnected",
+        lambda kind, error, **_kwargs: disconnected.append((kind, error)),
+    )
+
+    await _host().run()
+
+    assert connected == [("host", False)]
+    assert len(disconnected) == 1
+    assert disconnected[0][0] == "host"
+    assert isinstance(disconnected[0][1], ConnectionClosedError)
+
+
 def _refused_exc() -> ConnectionRefusedError:
     """A single-stack connection-refused, as asyncio raises it.
 

--- a/tests/runner/transports/ws_tunnel/test_serve_extended.py
+++ b/tests/runner/transports/ws_tunnel/test_serve_extended.py
@@ -422,6 +422,51 @@ async def test_serve_tunnel_on_reconnect_callback(
     assert reconnects == ["reconnected"]
 
 
+@pytest.mark.asyncio
+async def test_serve_tunnel_records_connection_lifecycle_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runner metrics distinguish an initial connection from a reconnect."""
+    call_count = 0
+    connected: list[tuple[str, bool]] = []
+    disconnected: list[tuple[str, BaseException | None]] = []
+
+    async def _serve_once(app: Any, **kwargs: Any) -> None:
+        nonlocal call_count
+        del app
+        call_count += 1
+        kwargs["on_connected"]()
+
+    async def _sleep(delay: float) -> None:
+        del delay
+        if call_count >= 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
+    monkeypatch.setattr(serve_module.asyncio, "sleep", _sleep)
+    monkeypatch.setattr(
+        serve_module,
+        "record_websocket_connected",
+        lambda kind, *, reconnect: connected.append((kind, reconnect)),
+    )
+    monkeypatch.setattr(
+        serve_module,
+        "record_websocket_disconnected",
+        lambda kind, error, **_kwargs: disconnected.append((kind, error)),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await serve_tunnel(
+            _noop_app,
+            server_url="http://localhost:8000",
+            runner_id="r1",
+            runner_version="0.1.0",
+        )
+
+    assert connected == [("runner", False), ("runner", True)]
+    assert disconnected == [("runner", None), ("runner", None)]
+
+
 # ── websocket_http_status edge cases ────────────────────
 
 

--- a/tests/runner/transports/ws_tunnel/test_serve_extended.py
+++ b/tests/runner/transports/ws_tunnel/test_serve_extended.py
@@ -467,6 +467,38 @@ async def test_serve_tunnel_records_connection_lifecycle_metrics(
     assert disconnected == [("runner", None), ("runner", None)]
 
 
+@pytest.mark.asyncio
+async def test_serve_tunnel_records_unexpected_error_disconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unexpected post-connect exception is recorded, not a clean close."""
+    disconnected: list[tuple[str, BaseException | None]] = []
+
+    async def _serve_once(app: Any, **kwargs: Any) -> None:
+        del app
+        kwargs["on_connected"]()
+        raise RuntimeError("callback blew up")
+
+    monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
+    monkeypatch.setattr(
+        serve_module,
+        "record_websocket_disconnected",
+        lambda kind, error, **_kwargs: disconnected.append((kind, error)),
+    )
+
+    with pytest.raises(RuntimeError, match="callback blew up"):
+        await serve_tunnel(
+            _noop_app,
+            server_url="http://localhost:8000",
+            runner_id="r1",
+            runner_version="0.1.0",
+        )
+
+    assert len(disconnected) == 1
+    assert disconnected[0][0] == "runner"
+    assert isinstance(disconnected[0][1], RuntimeError)
+
+
 # ── websocket_http_status edge cases ────────────────────
 
 

--- a/tests/runtime/test_websocket_metrics.py
+++ b/tests/runtime/test_websocket_metrics.py
@@ -1,0 +1,149 @@
+"""Tests for client-side WebSocket lifecycle metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+from opentelemetry.util.types import Attributes
+
+from omnigent.runtime.websocket_metrics import (
+    CONNECTIONS_METRIC_NAME,
+    DISCONNECTIONS_METRIC_NAME,
+    ClientWebSocketMetrics,
+    classify_disconnect_reason,
+    record_websocket_connected,
+    record_websocket_disconnected,
+)
+
+
+@dataclass(frozen=True)
+class _Record:
+    """One recorded counter delta."""
+
+    amount: int | float
+    attributes: Attributes
+
+
+@dataclass
+class _Counter:
+    """Fake OpenTelemetry counter."""
+
+    records: list[_Record] = field(default_factory=list)
+
+    def add(self, amount: int | float, attributes: Attributes = None) -> None:
+        """Record one counter addition."""
+        self.records.append(_Record(amount, attributes))
+
+
+@dataclass
+class _Meter:
+    """Fake OpenTelemetry meter."""
+
+    counters: dict[str, _Counter] = field(default_factory=dict)
+
+    def create_counter(
+        self,
+        name: str,
+        unit: str = "",
+        description: str = "",
+    ) -> _Counter:
+        """Create a named fake counter."""
+        del unit, description
+        counter = _Counter()
+        self.counters[name] = counter
+        return counter
+
+
+@dataclass(frozen=True)
+class _Close:
+    """Minimal close metadata carried by ``websockets`` exceptions."""
+
+    code: int
+    reason: str = ""
+
+
+class _Closed(Exception):
+    """Exception carrying received WebSocket close metadata."""
+
+    def __init__(self, code: int, reason: str = "") -> None:
+        """Create an exception with a received close frame."""
+        super().__init__(f"closed {code}: {reason}")
+        self.rcvd = _Close(code, reason)
+
+
+@pytest.mark.parametrize(
+    ("error", "kwargs", "expected"),
+    [
+        (None, {"local_shutdown": True}, "local_shutdown"),
+        (_Closed(1006), {"resumed_from_suspend": True}, "suspend_resume"),
+        (_Closed(4003, "server reassigned; reconnecting"), {}, "server_rehome"),
+        (_Closed(1012, "service restart"), {}, "server_restart"),
+        (_Closed(4003, "ping timeout"), {}, "ping_timeout"),
+        (_Closed(4004, "unauthenticated"), {}, "authentication_error"),
+        (_Closed(1002, "bad frame"), {}, "protocol_error"),
+        (ConnectionResetError("connection reset"), {}, "transport_error"),
+        (_Closed(1000, "normal closure"), {}, "peer_closed"),
+        (RuntimeError("unexpected"), {}, "unknown"),
+    ],
+)
+def test_classify_disconnect_reason_is_bounded(
+    error: BaseException | None,
+    kwargs: dict[str, bool],
+    expected: str,
+) -> None:
+    """Raw failures map to a fixed reason vocabulary."""
+    assert classify_disconnect_reason(error, **kwargs) == expected
+
+
+def test_records_host_and_runner_connection_types() -> None:
+    """Connection counters distinguish initial connects from reconnects."""
+    meter = _Meter()
+    metrics = ClientWebSocketMetrics(meter)
+
+    metrics.record_connected("host", reconnect=False)
+    metrics.record_connected("runner", reconnect=True)
+
+    assert meter.counters[CONNECTIONS_METRIC_NAME].records == [
+        _Record(1, {"tunnel.kind": "host", "connection.type": "initial"}),
+        _Record(1, {"tunnel.kind": "runner", "connection.type": "reconnect"}),
+    ]
+
+
+def test_records_normalized_disconnect_and_close_code() -> None:
+    """Disconnect metrics contain bounded reason and close-code attributes."""
+    meter = _Meter()
+    metrics = ClientWebSocketMetrics(meter)
+
+    metrics.record_disconnected(
+        "host",
+        _Closed(4003, "server reassigned; reconnecting"),
+    )
+
+    assert meter.counters[DISCONNECTIONS_METRIC_NAME].records == [
+        _Record(
+            1,
+            {
+                "tunnel.kind": "host",
+                "disconnect.reason": "server_rehome",
+                "websocket.close.code": 4003,
+            },
+        )
+    ]
+
+
+def test_public_recorders_respect_telemetry_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Public helpers remain no-ops unless telemetry is explicitly enabled."""
+    calls: list[ClientWebSocketMetrics] = []
+    monkeypatch.delenv("OMNIGENT_TELEMETRY_ENABLED", raising=False)
+    monkeypatch.setattr(
+        "omnigent.runtime.websocket_metrics._default_metrics",
+        lambda: calls.append(ClientWebSocketMetrics(_Meter())) or calls[-1],
+    )
+
+    record_websocket_connected("runner", reconnect=False)
+    record_websocket_disconnected("runner", None)
+
+    assert calls == []

--- a/tests/runtime/test_websocket_metrics.py
+++ b/tests/runtime/test_websocket_metrics.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 
 import pytest
 from opentelemetry.util.types import Attributes
+from websockets.exceptions import ConnectionClosedError
 
 from omnigent.runtime.websocket_metrics import (
     CONNECTIONS_METRIC_NAME,
@@ -14,6 +16,8 @@ from omnigent.runtime.websocket_metrics import (
     classify_disconnect_reason,
     record_websocket_connected,
     record_websocket_disconnected,
+    websocket_close_code,
+    websocket_close_reason,
 )
 
 
@@ -94,6 +98,17 @@ def test_classify_disconnect_reason_is_bounded(
 ) -> None:
     """Raw failures map to a fixed reason vocabulary."""
     assert classify_disconnect_reason(error, **kwargs) == expected
+
+
+def test_code_less_connection_closed_avoids_deprecated_properties() -> None:
+    """A no-close-frame drop classifies without deprecated attribute access."""
+    error = ConnectionClosedError(None, None)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        assert websocket_close_code(error) is None
+        assert websocket_close_reason(error) is None
+        assert classify_disconnect_reason(error) == "transport_error"
 
 
 def test_records_host_and_runner_connection_types() -> None:


### PR DESCRIPTION
## Related issue

Closes #5763

## Summary

- Emit OpenTelemetry counters when the host and runner WebSocket tunnels connect or disconnect.
- Distinguish initial connections from reconnects and classify disconnects into bounded, low-cardinality reasons, with a close code when available.
- Keep telemetry best-effort and behind the existing `OMNIGENT_TELEMETRY_ENABLED` opt-in.

### ELI5

The host and runner now increment a small set of counters whenever their server connection starts or ends. Operators can see which side disconnected and the broad reason without placing raw error text, IDs, or other high-cardinality data in metrics.

```mermaid
flowchart LR
    H[Host tunnel] -->|accepted upgrade| C[connections counter]
    R[Runner tunnel] -->|accepted upgrade| C
    H -->|connection ends| D[disconnections counter]
    R -->|connection ends| D
    D --> B[bounded reason and optional close code]
```

### Disconnect reason detection

Host and runner use the same bounded classifier; the first matching condition wins.

| `disconnect.reason` | Detection |
|---|---|
| `local_shutdown` | Cancellation, shutdown event, keyboard interrupt, or host lifecycle loss |
| `suspend_resume` | The suspend watcher detects a system resume |
| `server_rehome` | Close/error text contains `reassigned`, `re-home`, or `rehome` |
| `server_restart` | Close code `1012` or text contains `service restart` |
| `ping_timeout` | Close/error text contains `ping timeout` or `keepalive ping` |
| `authentication_error` | Close code `4004`, or text contains `unauthenticated` or `authentication` |
| `protocol_error` | Close code `1002`, `1003`, `1007`, `1008`, `4001`, `4002`, or `4500`, or text contains `protocol` |
| `transport_error` | Close code `1006`, a connection/OS error, or text indicates reset, refusal, timeout, missing close frame, or transport failure |
| `peer_closed` | Clean return or another WebSocket close code not classified above |
| `unknown` | No bounded classification matched |

When available, `websocket.close.code` is also emitted. Raw exception and close-reason text are not metric attributes. Upgrade failures before a connection is established do not emit a disconnect metric.

## Test Plan

- `uv run --group test pytest -q tests/runtime/test_websocket_metrics.py tests/runner/transports/ws_tunnel/test_serve_extended.py tests/host/test_connect.py` (178 passed)
- `uv run --extra tracing --group lint pre-commit run --files omnigent/runtime/websocket_metrics.py omnigent/host/connect.py omnigent/runner/transports/ws_tunnel/serve.py tests/runtime/test_websocket_metrics.py tests/host/test_connect.py tests/runner/transports/ws_tunnel/test_serve_extended.py`

## Demo

N/A — non-visual observability change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover reason classification, metric attributes, telemetry opt-in behavior, and host/runner lifecycle instrumentation across reconnects.

## Changelog

Host and runner WebSocket connection lifecycle is now observable through OpenTelemetry metrics.