### PR TITLE
Honor harness.<id> command/args config in the runner native-terminal auto-create

### DIFF
--- a/omnigent/cli_native.py
+++ b/omnigent/cli_native.py
@@ -278,7 +278,12 @@ def register_native_commands(cli: click.Group) -> None:
             explicit=claude_command,
             cfg=cfg,
         )
-        extra_args = _resolve_harness_startup_args(cfg, "claude-native", claude_args)
+        # The daemon runner is the single merge point for harness.<id>.args on
+        # the native claude/codex terminal (_auto_create_*_terminal resolves
+        # them), and every CLI launch here reaches that daemon path. Persist the
+        # RAW pass-through so the runner merge is not stacked on top of a
+        # CLI-merged prefix — that doubled the wrapper (e.g. `isaac -- -- …`).
+        extra_args = claude_args
         if smart_routing:
             # Arming creates the session (that is where Smart Routing is turned
             # on and the decision card lands), so attach to it instead of
@@ -434,7 +439,7 @@ def register_native_commands(cli: click.Group) -> None:
             server=server,
             session_id=resolved_session_id,
             resume_picker=choice.picker,
-            extra_args=_resolve_harness_startup_args(cfg, "codex-native", codex_args),
+            extra_args=codex_args,  # raw; runner is the sole arg-merge point (see claude)
             model=model,
             prompt=prompt,
             auto_open_conversation=auto_open_conversation,

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4226,46 +4226,63 @@ async def _auto_create_codex_terminal(
     # background task adopts it. Resume sessions pass the persisted
     # external_session_id so the runner-owned TUI reopens the existing
     # app-server thread.
-    codex_remote_args = build_codex_remote_args(
-        codex_args=tuple(launch_config.terminal_launch_args or ()),
-        thread_id=launch_config.external_session_id,
-        remote_url=codex_ws_url,
-        bypass_sandbox=launch_config.bypass_sandbox,
-        # The --remote TUI loads its own config and does not inherit the
-        # app-server's -c flags; pass the same provider/model overrides so it
-        # resolves the Omnigent provider instead of falling back to the OpenAI
-        # built-in (which would force the first-run login screen and block
-        # thread creation).
-        config_overrides=tuple(app_server.config_overrides),
-        # Omnigent provisions the private CODEX_HOME and vets hook sources
-        # itself; skip the interactive trust prompt that headless sub-agents
-        # can never answer.
-        #
-        # A failed version probe must not restore the interactive gate:
-        # Omnigent's supported Codex floor is newer than the release that added
-        # this flag. Otherwise a transient ``codex --version`` failure strands
-        # the queued web message behind the terminal-only review screen.
-        bypass_hook_trust=(
-            app_server.codex_cli_version is None
-            or app_server.codex_cli_version >= _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION
-        ),
-    )
-    # Apply the per-harness startup command/args override from config
-    # (``harness.codex-native.{command,args}``) so a downstream integration can
-    # wrap this launch — e.g. Databricks' ``isaac`` sets ``command: isaac`` +
-    # ``args: ["codex", "--"]`` to run ``isaac codex -- <remote args>``. Identity
-    # by default; the same resolver the local-CLI codex launch uses.
-    from omnigent.config import load_effective_config
-    from omnigent.harness_startup_config import resolve_harness_args, resolve_harness_command
-
-    _codex_harness_cfg = load_effective_config()
-    codex_command = resolve_harness_command(
-        "codex-native", default=app_server.codex_path, cfg=_codex_harness_cfg
-    )
-    codex_launch_args = resolve_harness_args(
-        "codex-native", tuple(codex_remote_args), cfg=_codex_harness_cfg
-    )
+    # The app-server and event client are live by this point, so the pre-launch
+    # setup (arg build + config resolve) shares the terminal launch's teardown
+    # below: a raise here must still close them and drop the
+    # ``_AUTO_CODEX_APP_SERVERS`` entry, or the failure leaks the app-server.
     try:
+        codex_remote_args = build_codex_remote_args(
+            codex_args=tuple(launch_config.terminal_launch_args or ()),
+            thread_id=launch_config.external_session_id,
+            remote_url=codex_ws_url,
+            bypass_sandbox=launch_config.bypass_sandbox,
+            # The --remote TUI loads its own config and does not inherit the
+            # app-server's -c flags; pass the same provider/model overrides so it
+            # resolves the Omnigent provider instead of falling back to the OpenAI
+            # built-in (which would force the first-run login screen and block
+            # thread creation).
+            config_overrides=tuple(app_server.config_overrides),
+            # Omnigent provisions the private CODEX_HOME and vets hook sources
+            # itself; skip the interactive trust prompt that headless sub-agents
+            # can never answer.
+            #
+            # A failed version probe must not restore the interactive gate:
+            # Omnigent's supported Codex floor is newer than the release that added
+            # this flag. Otherwise a transient ``codex --version`` failure strands
+            # the queued web message behind the terminal-only review screen.
+            bypass_hook_trust=(
+                app_server.codex_cli_version is None
+                or app_server.codex_cli_version >= _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION
+            ),
+        )
+        # Apply the per-harness startup command/args override from config
+        # (``harness.codex-native.{command,args}``) so a downstream integration
+        # can wrap this launch — e.g. Databricks' ``isaac`` sets ``command:
+        # isaac`` + ``args: ["codex", "--"]`` to run ``isaac codex -- <remote
+        # args>``. Identity by default; the runner is the single args merge
+        # point (the CLI persists raw pass-through, see cli_native).
+        from omnigent.config import load_effective_config  # noqa: FlagLocalImports
+        from omnigent.harness_startup_config import (  # noqa: FlagLocalImports
+            resolve_harness_args,
+            resolve_harness_config,
+        )
+
+        _codex_harness_cfg = load_effective_config()
+        # Config-only command resolve: the managed host provisions
+        # ``app_server.codex_path`` (the vetted binary), so a stray
+        # ``OMNIGENT_CODEX_PATH`` in the runner env must not silently replace it.
+        # A config ``command`` (isaac's wrapper) still applies; env path
+        # overrides are deliberately not consulted on this managed-host path.
+        _, _codex_overrides = resolve_harness_config(_codex_harness_cfg)
+        _codex_cmd_override = (_codex_overrides.get("codex-native") or {}).get("command")
+        codex_command = (
+            _codex_cmd_override.strip()
+            if isinstance(_codex_cmd_override, str) and _codex_cmd_override.strip()
+            else app_server.codex_path
+        )
+        codex_launch_args = resolve_harness_args(
+            "codex-native", tuple(codex_remote_args), cfg=_codex_harness_cfg
+        )
         terminal_view = await resource_registry.launch_auxiliary_terminal(
             session_id=session_id,
             terminal_name="codex",
@@ -6874,8 +6891,11 @@ async def _auto_create_claude_terminal(
     # appended above, so the ``--`` stays first). Identity by default. This is
     # the same resolver the local-CLI native launch uses (see cli_native.py), so
     # both terminal-creation paths honour one config surface.
-    from omnigent.config import load_effective_config
-    from omnigent.harness_startup_config import resolve_harness_args, resolve_harness_command
+    from omnigent.config import load_effective_config  # noqa: FlagLocalImports
+    from omnigent.harness_startup_config import (  # noqa: FlagLocalImports
+        resolve_harness_args,
+        resolve_harness_command,
+    )
 
     _harness_cfg = load_effective_config()
     launch_command = resolve_harness_command("claude-native", default="claude", cfg=_harness_cfg)

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4222,6 +4222,49 @@ async def _auto_create_codex_terminal(
     # and ``parent_os_env`` below, launch_terminal falls back to
     # _default_sandbox_for_platform (linux_bwrap), overriding the YAML config.
     agent_os_env = _agent_os_env_from_spec(agent_spec)
+    # Fresh sessions pass no thread id so the TUI creates the thread and the
+    # background task adopts it. Resume sessions pass the persisted
+    # external_session_id so the runner-owned TUI reopens the existing
+    # app-server thread.
+    codex_remote_args = build_codex_remote_args(
+        codex_args=tuple(launch_config.terminal_launch_args or ()),
+        thread_id=launch_config.external_session_id,
+        remote_url=codex_ws_url,
+        bypass_sandbox=launch_config.bypass_sandbox,
+        # The --remote TUI loads its own config and does not inherit the
+        # app-server's -c flags; pass the same provider/model overrides so it
+        # resolves the Omnigent provider instead of falling back to the OpenAI
+        # built-in (which would force the first-run login screen and block
+        # thread creation).
+        config_overrides=tuple(app_server.config_overrides),
+        # Omnigent provisions the private CODEX_HOME and vets hook sources
+        # itself; skip the interactive trust prompt that headless sub-agents
+        # can never answer.
+        #
+        # A failed version probe must not restore the interactive gate:
+        # Omnigent's supported Codex floor is newer than the release that added
+        # this flag. Otherwise a transient ``codex --version`` failure strands
+        # the queued web message behind the terminal-only review screen.
+        bypass_hook_trust=(
+            app_server.codex_cli_version is None
+            or app_server.codex_cli_version >= _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION
+        ),
+    )
+    # Apply the per-harness startup command/args override from config
+    # (``harness.codex-native.{command,args}``) so a downstream integration can
+    # wrap this launch — e.g. Databricks' ``isaac`` sets ``command: isaac`` +
+    # ``args: ["codex", "--"]`` to run ``isaac codex -- <remote args>``. Identity
+    # by default; the same resolver the local-CLI codex launch uses.
+    from omnigent.config import load_effective_config
+    from omnigent.harness_startup_config import resolve_harness_args, resolve_harness_command
+
+    _codex_harness_cfg = load_effective_config()
+    codex_command = resolve_harness_command(
+        "codex-native", default=app_server.codex_path, cfg=_codex_harness_cfg
+    )
+    codex_launch_args = resolve_harness_args(
+        "codex-native", tuple(codex_remote_args), cfg=_codex_harness_cfg
+    )
     try:
         terminal_view = await resource_registry.launch_auxiliary_terminal(
             session_id=session_id,
@@ -4235,37 +4278,8 @@ async def _auto_create_codex_terminal(
                     cwd=workspace,
                     sandbox=(agent_os_env.sandbox if agent_os_env is not None else None),
                 ),
-                command=app_server.codex_path,
-                # Fresh sessions pass no thread id so the TUI creates the
-                # thread and the background task adopts it. Resume sessions
-                # pass the persisted external_session_id so the runner-owned
-                # TUI reopens the existing app-server thread.
-                args=build_codex_remote_args(
-                    codex_args=tuple(launch_config.terminal_launch_args or ()),
-                    thread_id=launch_config.external_session_id,
-                    remote_url=codex_ws_url,
-                    bypass_sandbox=launch_config.bypass_sandbox,
-                    # The --remote TUI loads its own config and does not
-                    # inherit the app-server's -c flags; pass the same
-                    # provider/model overrides so it resolves the
-                    # Omnigent provider instead of falling back to the
-                    # OpenAI built-in (which would force the first-run
-                    # login screen and block thread creation).
-                    config_overrides=tuple(app_server.config_overrides),
-                    # Omnigent provisions the private CODEX_HOME and vets
-                    # hook sources itself; skip the interactive trust prompt
-                    # that headless sub-agents can never answer.
-                    #
-                    # A failed version probe must not restore the interactive
-                    # gate: Omnigent's supported Codex floor is newer than the
-                    # release that added this flag. Otherwise a transient
-                    # ``codex --version`` failure strands the queued web
-                    # message behind the terminal-only review screen.
-                    bypass_hook_trust=(
-                        app_server.codex_cli_version is None
-                        or app_server.codex_cli_version >= _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION
-                    ),
-                ),
+                command=codex_command,
+                args=codex_launch_args,
                 env=codex_terminal_env(app_server),
                 # Match the local ``omnigent codex`` terminal scrollback.
                 scrollback=100_000,
@@ -6429,7 +6443,6 @@ async def _auto_create_claude_terminal(
     _runner_headers = databricks_request_headers(server_url, bearer_token=_auth_token)
     _runner_auth = _RunnerDatabricksAuth(_auth_factory)
 
-    from omnigent.claude_launcher import resolve_claude_launch
     from omnigent.claude_native import (
         build_native_claude_terminal_env,
         claude_config_with_launch_model_pinned,
@@ -6853,10 +6866,20 @@ async def _auto_create_claude_terminal(
         turn_routing=_claude_turn_router is not None,
     )
 
-    # Let a registered launcher plugin (e.g. Databricks' isaac) rewrite the
-    # command/args to wrap the same fully-augmented Claude launch on this
-    # managed-host path. Identity by default. See omnigent.claude_launcher.
-    launch_command, launch_args = resolve_claude_launch("claude", list(claude_args))
+    # Apply the per-harness startup command/args override from config
+    # (``harness.claude-native.{command,args}`` in ~/.omnigent/config.yaml) so a
+    # downstream integration can wrap this managed-host launch — e.g. Databricks'
+    # ``isaac`` sets ``command: isaac`` + ``args: ["--"]`` to run
+    # ``isaac -- <augmented args>`` (the config args prepend, and augmentation
+    # appended above, so the ``--`` stays first). Identity by default. This is
+    # the same resolver the local-CLI native launch uses (see cli_native.py), so
+    # both terminal-creation paths honour one config surface.
+    from omnigent.config import load_effective_config
+    from omnigent.harness_startup_config import resolve_harness_args, resolve_harness_command
+
+    _harness_cfg = load_effective_config()
+    launch_command = resolve_harness_command("claude-native", default="claude", cfg=_harness_cfg)
+    launch_args = resolve_harness_args("claude-native", tuple(claude_args), cfg=_harness_cfg)
 
     claude_terminal_env_unset = _claude_terminal_env_unset(claude_config)
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -981,10 +981,13 @@ def test_antigravity_command_empty_resolved_falls_back_to_none(
 # ---------------------------------------------------------------------------
 
 
-def test_codex_config_args_form_base_cli_args_append(
+def test_codex_cli_persists_raw_args_not_config_merged(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Config ``harness.codex-native.args`` is the base; CLI pass-through appends."""
+    """The codex CLI persists RAW pass-through. ``harness.codex-native.args`` is
+    merged by the daemon runner's native-terminal auto-create (the single merge
+    point every launch reaches), not here — merging in both layers wrapped a
+    managed session twice (``isaac codex -- codex -- ...``)."""
     captured: dict[str, object] = {}
     monkeypatch.setattr(
         "omnigent.cli._load_effective_config",
@@ -999,17 +1002,15 @@ def test_codex_config_args_form_base_cli_args_append(
     result = CliRunner().invoke(cli, ["codex", "--dangerously-skip-permissions"])
 
     assert result.exit_code == 0, result.output
-    assert captured["extra_args"] == (
-        "--config",
-        "k=v",
-        "--dangerously-skip-permissions",
-    )
+    # Raw pass-through only — the config base is NOT merged at the CLI layer.
+    assert captured["extra_args"] == ("--dangerously-skip-permissions",)
 
 
-def test_codex_config_args_only_when_no_cli_args(
+def test_codex_cli_no_pass_through_persists_empty_args(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With no CLI pass-through, config args are the whole arg list."""
+    """With no CLI pass-through, the codex CLI persists no args even when config
+    sets ``harness.codex-native.args`` — the runner applies the config base."""
     captured: dict[str, object] = {}
     monkeypatch.setattr(
         "omnigent.cli._load_effective_config",
@@ -1024,7 +1025,7 @@ def test_codex_config_args_only_when_no_cli_args(
     result = CliRunner().invoke(cli, ["codex"])
 
     assert result.exit_code == 0, result.output
-    assert captured["extra_args"] == ("--verbose",)
+    assert captured["extra_args"] == ()
 
 
 def test_codex_args_no_config_is_cli_args_only(

--- a/tests/test_harness_startup_config.py
+++ b/tests/test_harness_startup_config.py
@@ -317,3 +317,22 @@ def test_args_alias_canonicalized() -> None:
 
 def test_args_no_config_layer() -> None:
     assert resolve_harness_args("codex", ("--verbose",), cfg=None) == ["--verbose"]
+
+
+# ── isaac wrapper shape (the runner auto-create's contract) ──────────
+# The runner's native terminal auto-create resolves command+args through the
+# resolvers above; these pin the exact `isaac -- <args>` / `isaac codex --
+# <args>` shape a downstream integration configures. The config `args` base
+# prepends before Omnigent's already-augmented args, so the `--` stays first.
+def test_isaac_wrap_shape_claude_native() -> None:
+    cfg = {"harness": {"claude-native": {"command": "isaac", "args": ["--"]}}}
+    assert resolve_harness_command("claude-native", default="claude", cfg=cfg) == "isaac"
+    built = ("--model", "x", "--mcp-config", "{}")
+    assert resolve_harness_args("claude-native", built, cfg=cfg) == ["--", *built]
+
+
+def test_isaac_wrap_shape_codex_native() -> None:
+    cfg = {"harness": {"codex-native": {"command": "isaac", "args": ["codex", "--"]}}}
+    assert resolve_harness_command("codex-native", default="codex", cfg=cfg) == "isaac"
+    built = ("--remote", "ws://127.0.0.1:9876")
+    assert resolve_harness_args("codex-native", built, cfg=cfg) == ["codex", "--", *built]

--- a/tests/test_harness_startup_config.py
+++ b/tests/test_harness_startup_config.py
@@ -336,3 +336,52 @@ def test_isaac_wrap_shape_codex_native() -> None:
     assert resolve_harness_command("codex-native", default="codex", cfg=cfg) == "isaac"
     built = ("--remote", "ws://127.0.0.1:9876")
     assert resolve_harness_args("codex-native", built, cfg=cfg) == ["codex", "--", *built]
+
+
+# ── CLI persists RAW args; the runner is the single merge point ──────
+
+
+@pytest.mark.parametrize("harness", ["codex", "claude"])
+def test_native_cli_persists_raw_args_not_config_merged(
+    harness: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The native ``codex``/``claude`` CLI must hand *raw* pass-through args to
+    ``run_*_native``. The daemon runner is the single ``harness.<id>.args`` merge
+    point (``_auto_create_*_terminal``), and every CLI launch reaches it; if the
+    CLI also pre-merged, a managed session wrapped twice (``isaac codex -- codex
+    -- …``), which broke the launch. Regression for that double-apply.
+    """
+    import click
+    from click.testing import CliRunner
+
+    import omnigent.claude_native as claude_native
+    import omnigent.cli as _cli
+    import omnigent.cli_native as cli_native
+    import omnigent.codex_native as codex_native
+
+    cfg = {
+        "harness": {
+            "claude-native": {"command": "isaac", "args": ["--"]},
+            "codex-native": {"command": "isaac", "args": ["codex", "--"]},
+        }
+    }
+    # Both are late-bound in cli_native to the omnigent.cli module (see _late_bound).
+    monkeypatch.setattr(_cli, "_load_effective_config", lambda: dict(cfg))
+    monkeypatch.setattr(_cli, "_ensure_backend", lambda server: "https://example/api/2.0/omnigent")
+
+    captured: dict[str, tuple[str, ...]] = {}
+    monkeypatch.setattr(
+        codex_native, "run_codex_native", lambda **kw: captured.update(args=kw["extra_args"])
+    )
+    monkeypatch.setattr(
+        claude_native, "run_claude_native", lambda **kw: captured.update(args=kw["extra_args"])
+    )
+
+    group = click.Group()
+    cli_native.register_native_commands(group)
+    result = CliRunner().invoke(group, [harness, "userarg"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    # Raw pass-through only — NOT the config-merged ("codex", "--", "userarg")
+    # or ("--", "userarg") that a second merge on the runner would double.
+    assert captured["args"] == ("userarg",)


### PR DESCRIPTION
## Related issue

N/A — internal refactor of the native-terminal launch path (Type: Refactor / chore).

## Summary

- The managed-host runner's native-terminal **auto-create** (`_auto_create_claude_terminal` / `_auto_create_codex_terminal`) now resolves the terminal **command + base args** through `resolve_harness_command` / `resolve_harness_args` — the same per-harness config resolver the local-CLI native launch (`cli_native.py`) already uses — instead of a hardcoded command.
- So both terminal-creation paths (CLI `run_*_native` and the runner auto-create) honour **one** config surface: `harness.<id>.command` / `harness.<id>.args` in `~/.omnigent/config.yaml`.
- A downstream integration can route the native launch through a wrapper via **config alone**, no plugin: `harness.claude-native: {command: isaac, args: ["--"]}` → `isaac -- <augmented args>` (the config `args` prepend, Omnigent's own augmentation appends after, so the `--` stays first); `harness.codex-native: {command: isaac, args: ["codex", "--"]}` → `isaac codex -- <remote args>`. Identity by default — no config, no change.

## Test Plan

- `uv run pytest tests/test_harness_startup_config.py` — 30 pass, including new `test_isaac_wrap_shape_claude_native` / `test_isaac_wrap_shape_codex_native` pinning the exact `isaac -- <args>` / `isaac codex -- <args>` shape the auto-create relies on.
- **Full-stack local e2e:** a real `omnigent server` + host daemon + runner (all subprocesses). With `harness.claude-native: {command: isaac, args: ["--"]}` in config and a fake `isaac` on PATH, drove a claude-native terminal ensure and confirmed the runner logged `command=isaac` and spawned argv `-- --model system.ai.claude-opus-4-8[1m] --mcp-config {…omnigent bridge…} --settings … --append-system-prompt … --plugin-dir …` — the `--` first, the full Omnigent bridge forwarded. Config only, no launcher plugin.

## Demo

N/A (non-visual).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the full-stack local e2e in the Test Plan (real server + host daemon + runner spawning the native terminal as `isaac -- <args>` from config). The resolver functions themselves have existing unit coverage; this change wires the runner auto-create path into them.

## Changelog

The runner's native-terminal auto-create now honours `harness.<id>.command`/`args` from `~/.omnigent/config.yaml`, so a downstream wrapper can be selected by config on both the CLI and runner launch paths.
