### PR TITLE
fix(server): redirect front-door auth paths (/.auth/*, /oidc/*) to the app

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any, Literal, Protocol
 
 from fastapi import FastAPI, Query, Request
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from sqlalchemy.exc import StatementError
@@ -195,6 +195,13 @@ _WEB_UI_HTML_CACHE_CONTROL = "no-cache"
 _WEB_UI_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable"
 _WEB_UI_STATIC_CACHE_CONTROL = "public, max-age=3600"
 _WEB_UI_API_FALLBACK_PREFIXES = frozenset({"api", "auth", "health", "v1", ".well-known"})
+# Auth namespaces owned by the hosting platform's front door (e.g. the
+# Databricks Apps proxy, which runs the Okta login flow under ``/oidc/`` and
+# receives its callback at ``/.auth/callback``). When such a path leaks
+# through to the app — an expired session replaying the callback, a bookmark
+# to the login URL — it must redirect to the Omnigent page, not render the
+# bare SPA shell.
+_WEB_UI_AUTH_REDIRECT_PREFIXES = frozenset({".auth", "oidc"})
 
 # Envelope version of GET /.well-known/omnigent.json (see the route for the
 # full contract). Bump ONLY for a change a client cannot absorb by ignoring
@@ -3023,6 +3030,8 @@ class _SPAStaticFiles(StaticFiles):
                         }
                     },
                 )
+            if exc.status_code == 404 and _is_web_ui_auth_redirect_path(path):
+                return RedirectResponse(url="/", status_code=302)
             if exc.status_code == 404 and "." not in path.rsplit("/", 1)[-1]:
                 served_path = "index.html"
                 response = await super().get_response("index.html", scope)
@@ -3046,6 +3055,23 @@ def _is_web_ui_api_fallback_path(path: str) -> bool:
     """
     first_segment = path.lstrip("/").split("/", 1)[0]
     return first_segment in _WEB_UI_API_FALLBACK_PREFIXES
+
+
+def _is_web_ui_auth_redirect_path(path: str) -> bool:
+    """
+    Return whether an unmatched static path belongs to the platform auth namespace.
+
+    A request for ``/.auth/*`` or ``/oidc/*`` that reaches the app has escaped
+    the front-door proxy that owns those paths. Serving the SPA shell there
+    leaves the browser on an auth URL showing a bare page; redirecting to
+    ``/`` sends the user back to the Omnigent page, where the proxy can
+    restart its login flow if the session is still unauthenticated.
+
+    :param path: Static mount-relative path, e.g. ``".auth/callback"``.
+    :returns: True for paths that should redirect to ``/``.
+    """
+    first_segment = path.lstrip("/").split("/", 1)[0]
+    return first_segment in _WEB_UI_AUTH_REDIRECT_PREFIXES
 
 
 class _RangeAwareGZipMiddleware(GZipMiddleware):

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -132,6 +132,30 @@ def test_well_known_prefix_is_not_spa_fallback() -> None:
     assert not server_app._is_web_ui_api_fallback_path("c/conv_abc123")
 
 
+def test_hosted_auth_prefix_is_auth_redirect() -> None:
+    """Front-door auth paths classify as redirect-to-app, not SPA fallback."""
+    assert server_app._is_web_ui_auth_redirect_path(".auth/callback")
+    assert server_app._is_web_ui_auth_redirect_path("oidc/oauth2/v2.0/authorize")
+    # A real client route must NOT redirect — it still falls back to the SPA.
+    assert not server_app._is_web_ui_auth_redirect_path("c/conv_abc123")
+
+
+@pytest.mark.asyncio
+async def test_hosted_auth_paths_redirect_to_app(client: httpx.AsyncClient) -> None:
+    """``/.auth/*`` and ``/oidc/*`` redirect to ``/`` instead of serving the SPA.
+
+    The Databricks Apps front door owns these paths (the Okta login flow and
+    its callback). One that leaks through to the app — e.g. an expired
+    session replaying ``/.auth/callback`` — must send the user back to the
+    Omnigent page rather than leaving them on an auth URL showing the bare
+    SPA shell.
+    """
+    for path in ("/.auth/callback", "/oidc/oauth2/v2.0/authorize"):
+        resp = await client.get(path)
+        assert resp.status_code == 302, path
+        assert resp.headers["location"] == "/", path
+
+
 class _StubWebSocket:
     """
     Minimal real ``WebSocketLike`` for registering a runner tunnel.


### PR DESCRIPTION
fix(server): redirect front-door auth paths (/.auth/*, /oidc/*) to the app

## Related issue

Linear: OMNI-5763

## Summary

- On Databricks-hosted deployments the platform front door owns the Okta login flow under `/oidc/*` and its callback at `/.auth/callback`. When one of those paths leaks through to the app (expired session replaying the callback, a bookmarked login URL), the SPA history fallback served `index.html` as 200 — leaving the browser on an auth URL showing a bare page.
- Unmatched `/.auth/*` and `/oidc/*` requests now 302 to `/` (the Omnigent page) instead of falling back to the SPA shell, so the front door can restart its login flow if the session is still unauthenticated.

## Test Plan

- `uv run pytest tests/server/test_app.py -k 'hosted_auth or well_known_prefix or api_only'` — 6 passed. New tests assert `/.auth/callback` and `/oidc/oauth2/v2.0/authorize` return 302 with `Location: /`, and that client routes (e.g. `/c/<id>`) still fall back to `index.html`.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

## Changelog

Hosted login callback and OIDC paths now redirect to the Omnigent page instead of showing a bare screen

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>

