### PR TITLE
fix(terminals): rejoin soft-wrapped lines in the terminal attach seed

### DIFF
--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -241,6 +241,13 @@ async def _run_tmux_capture(socket_path: str, tmux_target: str) -> bytes | None:
     stream (which already carries CRLF). Home + clear (``\\x1b[H\\x1b[2J``) is
     prepended so the seed lands on a clean screen at the top-left.
 
+    ``-J`` joins soft-wrapped rows back into their original logical lines, so
+    a long line the pane wrapped across rows is written to xterm as one line
+    and xterm re-wraps it with its own wrapped-line flags. Without it the
+    seed turns every soft wrap into a hard line break, and copying the line
+    back out of the browser terminal inserts a newline at each wrap point
+    (xterm's selection joiner only rejoins rows flagged as wrapped).
+
     ``capture-pane`` records only the cell contents, not the cursor. Writing
     the seed leaves the browser cursor wherever the last row ended, not where
     the application actually parked it (e.g. inside a prompt input box). We
@@ -277,7 +284,8 @@ async def _run_tmux_capture(socket_path: str, tmux_target: str) -> bytes | None:
     meta = await _capture_pane_metadata(tmux, socket_path, tmux_target)
     # Only extend the capture into history when on the primary screen; on the
     # alternate screen ``-S -`` leaks stale primary history (see docstring).
-    capture_args = ["capture-pane", "-e", "-p", "-t", tmux_target]
+    # ``-J`` joins soft-wrapped rows into logical lines (see docstring).
+    capture_args = ["capture-pane", "-e", "-p", "-J", "-t", tmux_target]
     if meta is not None and not meta.alternate_on:
         capture_args += ["-S", "-"]
     try:
@@ -330,6 +338,8 @@ class _PaneMetadata:
         ``#{mouse_utf8_flag}``.
     :param app_cursor_keys: DECCKM (application cursor keys) from
         ``#{keypad_cursor_flag}``.
+    :param bracket_paste: DECSET 2004 (bracketed paste) from
+        ``#{bracket_paste_flag}``.
     """
 
     cursor_x: int
@@ -342,6 +352,7 @@ class _PaneMetadata:
     mouse_sgr: bool = False
     mouse_utf8: bool = False
     app_cursor_keys: bool = False
+    bracket_paste: bool = False
 
 
 def _mode_restore_escapes(meta: _PaneMetadata | None) -> tuple[bytes, bytes]:
@@ -362,8 +373,15 @@ def _mode_restore_escapes(meta: _PaneMetadata | None) -> tuple[bytes, bytes]:
       pollutes primary-screen scrollback.
     - Postlude (after the cursor restore): the mouse tracking mode
       (``?1000h``/``?1002h``/``?1003h``), its report encoding
-      (``?1005h``/``?1006h``), and DECCKM (``?1h``) so wheel-to-arrow
-      fallback picks the encoding the program expects.
+      (``?1005h``/``?1006h``), DECCKM (``?1h``) so wheel-to-arrow
+      fallback picks the encoding the program expects, and bracketed
+      paste (``?2004h``). Without the 2004 replay, a pane program that
+      enabled bracketed paste before this client attached (readline,
+      claude) leaves the browser xterm unaware, so a multi-line paste is
+      sent as raw newlines and readline executes each line on arrival
+      instead of inserting the block. ``#{bracket_paste_flag}`` needs
+      tmux >= 3.7; older tmux expands it empty, degrading to no replay
+      (the pre-replay behavior).
 
     Only enables are emitted: every attach starts a fresh xterm whose modes
     default off, so disables would be no-ops.
@@ -387,6 +405,8 @@ def _mode_restore_escapes(meta: _PaneMetadata | None) -> tuple[bytes, bytes]:
         postlude += b"\x1b[?1006h"
     if meta.app_cursor_keys:
         postlude += b"\x1b[?1h"
+    if meta.bracket_paste:
+        postlude += b"\x1b[?2004h"
     return prelude, postlude
 
 
@@ -415,7 +435,8 @@ async def _capture_pane_metadata(
             tmux_target,
             "#{cursor_x},#{cursor_y},#{cursor_flag},#{alternate_on},"
             "#{mouse_standard_flag},#{mouse_button_flag},#{mouse_all_flag},"
-            "#{mouse_sgr_flag},#{mouse_utf8_flag},#{keypad_cursor_flag}",
+            "#{mouse_sgr_flag},#{mouse_utf8_flag},#{keypad_cursor_flag},"
+            "#{bracket_paste_flag}",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
         )
@@ -432,8 +453,8 @@ async def _capture_pane_metadata(
         # field count holds), but pad regardless: a flags anomaly must cost
         # only the optional mode replay, never the mandatory cursor and
         # alt-screen state the rest of the seed depends on.
-        fields += ["0"] * (10 - len(fields))
-        x_str, y_str, flag_str, alt_str, std, btn, allm, sgr, utf8, ckm = fields[:10]
+        fields += ["0"] * (11 - len(fields))
+        x_str, y_str, flag_str, alt_str, std, btn, allm, sgr, utf8, ckm, bpaste = fields[:11]
         return _PaneMetadata(
             cursor_x=int(x_str),
             cursor_y=int(y_str),
@@ -445,6 +466,7 @@ async def _capture_pane_metadata(
             mouse_sgr=sgr == "1",
             mouse_utf8=utf8 == "1",
             app_cursor_keys=ckm == "1",
+            bracket_paste=bpaste == "1",
         )
     except (ValueError, UnicodeDecodeError):
         return None

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -16,6 +16,7 @@ import contextlib
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -31,6 +32,27 @@ from omnigent.terminals.control_bridge import (
 )
 
 _HAS_TMUX = shutil.which("tmux") is not None
+
+
+def _tmux_supports_bracket_paste_flag() -> bool:
+    """tmux exposes ``#{bracket_paste_flag}`` only since 3.7."""
+    tmux = shutil.which("tmux")
+    if tmux is None:
+        return False
+    try:
+        out = subprocess.run(
+            [tmux, "-V"], capture_output=True, text=True, check=True, timeout=5
+        ).stdout.strip()
+        # "tmux 3.7b" / "tmux next-3.7" — take the trailing version token and
+        # strip any suffix letters.
+        version = out.split()[-1].removeprefix("next-")
+        major, minor = version.rstrip("abcdefghijklmnopqrstuvwxyz").split(".")[:2]
+        return (int(major), int(minor)) >= (3, 7)
+    except (OSError, subprocess.SubprocessError, ValueError, IndexError):
+        return False
+
+
+_HAS_TMUX_BRACKET_PASTE_FLAG = _tmux_supports_bracket_paste_flag()
 
 
 def test_unescape_control_output_round_trips_control_bytes() -> None:
@@ -602,6 +624,59 @@ async def test_seed_replays_alt_screen_and_mouse_modes() -> None:
         # Modes the program never set stay unset.
         assert b"\x1b[?1002h" not in seed
         assert b"\x1b[?1000h" not in seed
+    finally:
+        await _kill_tmux(sock)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_seed_rejoins_soft_wrapped_lines() -> None:
+    """A pane line wrapped across rows seeds as one logical line.
+
+    ``capture-pane`` without ``-J`` emits one entry per screen row, so a long
+    line would seed into xterm as hard lines and copying it back out would
+    insert a newline at each wrap point (xterm only rejoins rows it flagged
+    as wrapped itself).
+    """
+    from omnigent.terminals.control_bridge import _run_tmux_capture
+
+    # 150 chars in an 80-col pane wraps across two rows.
+    sock, target = await _new_private_tmux(
+        'python3 -c \'import sys,time; sys.stdout.write("x" * 150); '
+        "sys.stdout.flush(); time.sleep(30)'"
+    )
+    await asyncio.sleep(0.5)
+    try:
+        seed = await _run_tmux_capture(str(sock), target)
+        assert seed is not None
+        assert b"x" * 150 in seed, "soft-wrapped line was not rejoined in the seed"
+    finally:
+        await _kill_tmux(sock)
+
+
+@pytest.mark.skipif(
+    not _HAS_TMUX_BRACKET_PASTE_FLAG,
+    reason="tmux #{bracket_paste_flag} requires tmux >= 3.7",
+)
+@pytest.mark.asyncio
+async def test_seed_replays_bracketed_paste_mode() -> None:
+    """The seed replays bracketed paste when the pane program enabled it.
+
+    A shell/TUI that enabled bracketed paste (``?2004h``) BEFORE this client
+    attached would otherwise leave the browser xterm unaware, so a multi-line
+    paste arrives as raw newlines and readline executes each line on arrival.
+    """
+    from omnigent.terminals.control_bridge import _run_tmux_capture
+
+    sock, target = await _new_private_tmux(
+        "python3 -c 'import sys,time; "
+        'sys.stdout.write("\\x1b[?2004h"); sys.stdout.flush(); time.sleep(30)\''
+    )
+    await asyncio.sleep(0.5)
+    try:
+        seed = await _run_tmux_capture(str(sock), target)
+        assert seed is not None
+        assert b"\x1b[?2004h" in seed, "bracketed paste mode not replayed in seed"
     finally:
         await _kill_tmux(sock)
 


### PR DESCRIPTION
## Related issue

OMNI-5707 (Linear) — multiline terminal copy pasting. N/A on GitHub; no issue opened per maintainer workflow.

## Summary

Copying a soft-wrapped line out of the web/Electron/mobile terminal inserted
a newline at every wrap point. The capture-pane attach seed ran without
`-J`, so tmux emitted one entry per screen *row* and the bridge painted each
row as a hard buffer line in xterm — destroying the wrapped-line flags that
xterm's selection copy relies on to rejoin a logical line. Because nearly
everything on screen arrives via the seed (every mount/reconnect re-attaches
and re-seeds), wrapped lines copied as `abcdef\nghijkl` instead of
`abcdefghijkl`.

- Pass `-J` to `capture-pane` so soft-wrapped rows join back into logical
  lines before seeding; xterm then re-wraps them with its own wrapped flags
  and copy rejoins them. This also makes xterm reflow-on-resize work for
  seeded content. `-J` predates the tmux versions in use and composes with
  `-e` and `-S -`.
- Also in this PR, same seed-mode-loss class: replay `\x1b[?2004h` in the
  seed postlude when the pane enabled bracketed paste before the attach
  (`#{bracket_paste_flag}`, tmux >= 3.7; older tmux expands the format empty
  and degrades to no replay). Without it, multi-line paste *into* the
  terminal after a re-attach sent raw newlines and readline executed each
  pasted line on arrival.

## Test Plan

- `uv run pytest tests/terminals/test_control_bridge.py -q` — 21 passed,
  including a new test that writes 150 chars into an 80-col pane and asserts
  the seed contains the line contiguously (without `-J` it arrives as
  80 + LF + 70), and the bracketed-paste replay test (gated on tmux >= 3.7).
- `uv run ruff check` on both files — clean.
- Manual: attached `tmux -C` control clients to private tmux servers and
  confirmed a client attaching after `?2004h` receives nothing about it, and
  that capture-pane without `-J` splits a wrapped line per row.

## Demo


https://github.com/user-attachments/assets/6f4f7abc-c0f6-40c6-aa2b-4126e7e37ce8



## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new tests drive real private tmux servers: one writes a pane-wrapping
line and asserts the seed carries it as one logical line; the other enables
`?2004h` pre-attach and asserts the seed replays it. Manual verification with
live control-mode clients established the before/after tmux behavior.

## Changelog

Copying a soft-wrapped line from the terminal no longer inserts newlines at wrap points

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>

