### PR TITLE
refactor: write Protocol method stubs as `...` instead of `pass`

### DIFF
--- a/omnigent/inner/_proc.py
+++ b/omnigent/inner/_proc.py
@@ -95,18 +95,14 @@ class _ProcessLike(Protocol):
     """The subset of ``subprocess.Popen`` / ``asyncio.subprocess.Process`` used here."""
 
     @property
-    def pid(self) -> int | None:
-        pass
+    def pid(self) -> int | None: ...
 
     @property
-    def returncode(self) -> int | None:
-        pass
+    def returncode(self) -> int | None: ...
 
-    def terminate(self) -> None:
-        pass
+    def terminate(self) -> None: ...
 
-    def kill(self) -> None:
-        pass
+    def kill(self) -> None: ...
 
 
 def spawn_kwargs() -> SpawnKwargs:

--- a/omnigent/inner/copilot_executor.py
+++ b/omnigent/inner/copilot_executor.py
@@ -273,14 +273,11 @@ def _encode_tool_result(result: object) -> object:
 class _CopilotSession(Protocol):
     """SDK session methods used by the executor."""
 
-    def on(self, callback: Callable[[object], None]) -> Callable[[], None]:
-        pass
+    def on(self, callback: Callable[[object], None]) -> Callable[[], None]: ...
 
-    async def send_and_wait(self, prompt: str, *, timeout: float) -> object:
-        pass
+    async def send_and_wait(self, prompt: str, *, timeout: float) -> object: ...
 
-    async def abort(self) -> object:
-        pass
+    async def abort(self) -> object: ...
 
 
 @dataclass

--- a/omnigent/inner/sandbox.py
+++ b/omnigent/inner/sandbox.py
@@ -317,8 +317,7 @@ class ContainmentHandle(Protocol):
     process tree.
     """
 
-    def close(self) -> None:
-        pass
+    def close(self) -> None: ...
 
 
 class SandboxBackend(ABC):

--- a/omnigent/onboarding/sandboxes/blaxel.py
+++ b/omnigent/onboarding/sandboxes/blaxel.py
@@ -1010,7 +1010,8 @@ class BlaxelSandboxLauncher(ExecModelHostLauncher):
         name = f"omni-command-{uuid.uuid4().hex[:12]}"
 
         def _discard_progress(_text: str) -> None:
-            pass
+            # Progress chunks are dropped: the final process state is authoritative.
+            return None
 
         handle, _process, identifier, log_stream = self._start_process(
             sandbox_id,

--- a/omnigent/onboarding/sandboxes/registry.py
+++ b/omnigent/onboarding/sandboxes/registry.py
@@ -33,13 +33,11 @@ class SandboxRegistryError(Exception):
 
 
 class _WorkspaceHostLauncherFactory(Protocol):
-    def __call__(self, *, workspace_host: str) -> SandboxHostLauncher:
-        pass
+    def __call__(self, *, workspace_host: str) -> SandboxHostLauncher: ...
 
 
 class _ConfiguredLauncherFactory(Protocol):
-    def __call__(self, *, config: object) -> SandboxHostLauncher:
-        pass
+    def __call__(self, *, config: object) -> SandboxHostLauncher: ...
 
 
 @dataclass(frozen=True)

--- a/omnigent/runner/background_titles/service.py
+++ b/omnigent/runner/background_titles/service.py
@@ -76,16 +76,14 @@ class BackgroundTitleProcessManager(Protocol):
         conversation_id: str,
         harness: str,
         env: dict[str, str] | None = None,
-    ) -> httpx.AsyncClient:
-        pass
+    ) -> httpx.AsyncClient: ...
 
     async def release(
         self,
         conversation_id: str,
         *,
         only_if_idle_cutoff: float | None = None,
-    ) -> None:
-        pass
+    ) -> None: ...
 
 
 @dataclass(frozen=True)

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -100,8 +100,7 @@ class _EnsureCommentRelay(Protocol):
         explicit_bridge_dir: Path | None = None,
         await_notify: bool = False,
         session_labels: Mapping[str, str] | None = None,
-    ) -> None:
-        pass
+    ) -> None: ...
 
 
 def _publish_tmux_target_for_bridge(

--- a/tests/test_protocol_stub_body_guards.py
+++ b/tests/test_protocol_stub_body_guards.py
@@ -1,0 +1,113 @@
+"""Guard: ``typing.Protocol`` method stubs use ``...``, never ``pass``.
+
+A Protocol method has no implementation by construction — the class *is* the
+contract. ``...`` and ``pass`` behave identically, but only ``...`` reads as a
+stub, and static analysis reports a bare ``pass`` body as an unexplained empty
+method. The package already writes ~150 stubs as ``...``.
+
+This is a source-level invariant, so the check is a static walk rather than a
+per-module test: the next Protocol added by copy-paste must not regress it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_OMNIGENT = _REPO_ROOT / "omnigent"
+
+# Caches and third-party trees, not our sources.
+_SKIPPED_DIRS = frozenset({"__pycache__", "node_modules", "_vendor", "vendor", ".venv"})
+
+
+def _is_protocol_class(node: ast.ClassDef) -> bool:
+    """
+    Whether a class declares ``Protocol`` among its bases.
+
+    Accepts the bare name, the ``typing.Protocol`` attribute form, and the
+    generic ``Protocol[T]`` subscript.
+
+    :param node: The class definition to inspect.
+    :returns: ``True`` when the class is a Protocol.
+    """
+    for base in node.bases:
+        if isinstance(base, ast.Subscript):
+            base = base.value
+        if isinstance(base, ast.Name) and base.id == "Protocol":
+            return True
+        if isinstance(base, ast.Attribute) and base.attr == "Protocol":
+            return True
+    return False
+
+
+def _body_is_only_pass(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """
+    Whether a method's body is nothing but ``pass``.
+
+    A leading docstring is stripped first, so ``...``, a docstring, a docstring
+    followed by ``...`` and ``raise NotImplementedError`` all pass the guard.
+
+    :param node: The method to inspect.
+    :returns: ``True`` when only ``pass`` remains.
+    """
+    body = node.body
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]
+    return len(body) == 1 and isinstance(body[0], ast.Pass)
+
+
+def _pass_bodied_protocol_stubs(path: Path) -> list[str]:
+    """
+    Find Protocol methods in one module whose body is only ``pass``.
+
+    :param path: Module to scan.
+    :returns: ``file:line method`` descriptions, one per offending stub.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    relative = path.relative_to(_REPO_ROOT)
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or not _is_protocol_class(node):
+            continue
+        for member in node.body:
+            if not isinstance(member, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            if _body_is_only_pass(member):
+                offenders.append(f"{relative}:{member.lineno} {node.name}.{member.name}")
+    return offenders
+
+
+def _source_modules() -> list[Path]:
+    """
+    Every first-party module under ``omnigent/``.
+
+    :returns: Sorted module paths, caches and vendored trees excluded.
+    """
+    return sorted(
+        path for path in _OMNIGENT.rglob("*.py") if not _SKIPPED_DIRS.intersection(path.parts)
+    )
+
+
+def test_protocol_method_stubs_use_ellipsis_not_pass() -> None:
+    """No Protocol method body may be a bare ``pass``.
+
+    ``pass`` is flagged as an unexplained empty method; ``...`` is the
+    convention the rest of the package already follows.
+    """
+    modules = _source_modules()
+    assert modules, "the guard found no modules at all — has the package moved?"
+
+    offenders = [stub for module in modules for stub in _pass_bodied_protocol_stubs(module)]
+
+    assert not offenders, (
+        "Protocol method stubs with a bare `pass` body:\n  "
+        + "\n  ".join(offenders)
+        + "\nA `pass` body is reported as an unexplained empty method. Use `...`, "
+        "the repo convention for Protocol stubs."
+    )


### PR DESCRIPTION
## Related issue

No issue required — this is a `Refactor / chore` change with no user-visible behaviour, which the contributing guide exempts from the issue requirement.

## Summary

Thirteen `typing.Protocol` method stubs across six modules had a bare `pass` body. Static analysis reports each one as an unexplained empty method (13 Critical findings), but they are not incomplete work: every one of these classes is an annotation-only contract, never inherited or called at runtime, so `pass` and `...` behave identically. `...` is already the repo's convention — roughly 150 other stubs use it, and none of those are flagged.

- Rewrites the 13 stubs as `...` in `_proc.py`, `copilot_executor.py`, `sandbox.py`, `sandboxes/registry.py`, `background_titles/service.py`, and `runner/native/orchestration.py`.
- Gives the one genuine no-op — `_discard_progress` in the Blaxel launcher's `run()` — a one-line reason instead. It drops streamed progress chunks because `run()` re-reads the final process state afterwards as the authoritative stdout/stderr, so `...` would be wrong there.
- Adds `tests/test_protocol_stub_body_guards.py`, a static guard so the next Protocol added by copy-paste doesn't reintroduce the pattern.

No behaviour changes. Placed at the top level of `tests/` alongside the existing cross-cutting guards (`test_loopback_proxy_guards.py`, `test_routing_model_switch_guards.py`) because the change spans `inner/`, `onboarding/`, and `runner/` rather than one area suite.

## Test Plan

The guard test fails on the pre-fix tree and passes after — verified by stashing only the source edits:

```bash
git stash push -- omnigent/
uv run --no-sync pytest tests/test_protocol_stub_body_guards.py -q
```

```
AssertionError: Protocol method stubs with a bare `pass` body:
    omnigent/inner/_proc.py:98 _ProcessLike.pid
    omnigent/inner/_proc.py:102 _ProcessLike.returncode
    omnigent/inner/_proc.py:105 _ProcessLike.terminate
    omnigent/inner/_proc.py:108 _ProcessLike.kill
    omnigent/inner/copilot_executor.py:276 _CopilotSession.on
    omnigent/inner/copilot_executor.py:279 _CopilotSession.send_and_wait
    omnigent/inner/copilot_executor.py:282 _CopilotSession.abort
    omnigent/inner/sandbox.py:320 ContainmentHandle.close
    omnigent/onboarding/sandboxes/registry.py:36 _WorkspaceHostLauncherFactory.__call__
    omnigent/onboarding/sandboxes/registry.py:41 _ConfiguredLauncherFactory.__call__
    omnigent/runner/background_titles/service.py:74 BackgroundTitleProcessManager.get_client
    omnigent/runner/background_titles/service.py:82 BackgroundTitleProcessManager.release
    omnigent/runner/native/orchestration.py:95 _EnsureCommentRelay.__call__
```

Exactly the 13 stubs, no false positives. After `git stash pop`: `1 passed in 2.5s`.

Regression check on the touched modules — `tests/inner/test_proc_and_platform.py`, `test_copilot_executor.py`, `test_sandbox.py`, `tests/onboarding/sandboxes/test_blaxel.py`, `test_registry.py`, `tests/runner/test_background_session_title.py` — **211 passed, 8 skipped**.

Orchestration consumers (`tests/runner/test_app_sessions_native_events_lifecycle.py`, `test_session_resources.py`, `test_app_sessions_native_terminals_autocreate.py`, `test_app_sessions_native_workflow_init.py`) — **223 passed, 1 failed**. The failure, `test_session_resources.py::test_reset_state_rematerializes_env_from_new_agent_spec`, is pre-existing and unrelated: it fails identically with `omnigent/` stashed (`OSError` at `omnigent/inner/bwrap_sandbox.py:313` — `bwrap` is Linux-only and absent on the macOS dev machine).

`uv run --no-sync pre-commit run` over the commit range: all applicable hooks pass, including `ruff format`, `ruff check`, and `pyrefly`.

## Demo

N/A — no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new guard is a static invariant rather than a behaviour test, since there is no behaviour to cover — the change is semantically a no-op by construction. It is included anyway because the pattern regresses by copy-paste, and it does fail on the pre-fix tree as shown above. The existing area suites listed in the Test Plan cover the touched modules and were run to confirm nothing moved.
