### PR TITLE
fix(cursor-native): harden the MCP bridge dir before writing the relay token

### DIFF
--- a/omnigent/cursor_native_bridge.py
+++ b/omnigent/cursor_native_bridge.py
@@ -125,6 +125,28 @@ def _ensure_dir(path: Path) -> None:
         os.chmod(path, 0o700)
 
 
+def _ensure_secure_bridge_dir(bridge_dir: Path) -> None:
+    """Create/validate *bridge_dir* as an owner-only chain before writing secrets.
+
+    ``_ensure_dir`` only ``mkdir(parents=True, exist_ok=True)`` + a suppressed
+    ``chmod`` on the leaf: it trusts pre-existing ancestors, so on a shared host
+    an attacker could pre-create ``$TMPDIR/omnigent-<uid>`` (or a deeper ancestor)
+    as a symlink / world-writable dir and redirect the bridge tree. That tree now
+    holds ``bridge.json`` — a bearer token for the relay's localhost control
+    endpoint — so its directory must be hardened. Delegate to the same
+    ``_ensure_secure_dir`` the shared relay (``start_tool_relay``) already applies
+    to token-bearing trees; it rejects symlinked / non-owned / group-or-other
+    accessible ancestors (the cursor-native root is in its allowlist). Lazy import
+    avoids a cycle (``claude_native_bridge`` resolves cursor's ``bridge_root``
+    lazily in turn).
+
+    :raises RuntimeError: If any ancestor fails owner-only validation.
+    """
+    from omnigent.claude_native_bridge import _ensure_secure_dir
+
+    _ensure_secure_dir(bridge_dir)
+
+
 #: File the runner drops into a fork's bridge dir holding the prior-conversation
 #: text preamble, consumed once by the executor on the first injected message.
 #: cursor's conversation is server-backed (a synthesized local store.db is NOT
@@ -287,8 +309,12 @@ def build_mcp_config(
 
 
 def write_mcp_bridge_config(bridge_dir: Path) -> None:
-    """Write the token config required by the shared Omnigent MCP bridge."""
-    _ensure_dir(bridge_dir)
+    """Write the token config required by the shared Omnigent MCP bridge.
+
+    :raises RuntimeError: If the bridge dir fails owner-only validation
+        (:func:`_ensure_secure_bridge_dir`) — the token is not written.
+    """
+    _ensure_secure_bridge_dir(bridge_dir)
     config_path = bridge_dir / _BRIDGE_CONFIG_FILE
     if config_path.exists():
         return

--- a/tests/e2e/test_cursor_native_bridge_token_dir_e2e.py
+++ b/tests/e2e/test_cursor_native_bridge_token_dir_e2e.py
@@ -1,0 +1,146 @@
+"""E2E: cursor-native must validate the bridge-dir ancestor chain before writing the relay token.
+
+``cursor-native`` keeps its per-session bridge tree under
+``$TMPDIR/omnigent-<uid>/cursor-native/<digest>/``. At terminal launch the
+runner calls :func:`omnigent.cursor_native_bridge.write_mcp_config`, which
+routes through :func:`write_mcp_bridge_config` to write ``bridge.json`` — the
+bearer token for the Omnigent MCP relay's localhost control endpoint.
+
+On a multi-user POSIX host an attacker can pre-create an ancestor of that tree
+(``$TMPDIR/omnigent-<uid>``) as a symlink or a group/other-writable directory.
+The token write must then fail loudly (or repair an owned-but-permissive dir to
+owner-only) instead of landing the token in a directory chain the user does not
+exclusively control — exactly what ``qwen-native`` already does by routing the
+write through ``claude_native_bridge._ensure_secure_dir``.
+
+Each scenario runs in a **fresh Python subprocess** with a hostile ``TMPDIR``
+staged before interpreter start, so ``cursor_native_bridge._BRIDGE_ROOT`` is
+computed from the environment exactly as in a real runner process — no
+monkeypatching of the module under test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX uid/mode semantics required (symlink + permission-bit ancestor attacks)",
+)
+
+# Runs inside a fresh interpreter whose TMPDIR the test staged. Reports what the
+# production token-write path did as JSON on stdout; never asserts itself.
+_CHILD_SCRIPT = """
+import json
+import os
+import stat
+import sys
+
+from omnigent import cursor_native_bridge as cnb
+
+result = {"raised": None, "token_written": False, "token_realpath": None, "ancestor_mode": None}
+bridge_dir = cnb.bridge_dir_for_session_id(sys.argv[1])
+try:
+    # The exact call the runner makes at cursor terminal launch before the
+    # relay token is persisted (write_mcp_config -> write_mcp_bridge_config).
+    cnb.write_mcp_bridge_config(bridge_dir)
+except RuntimeError as exc:
+    result["raised"] = str(exc)
+token_path = bridge_dir / "bridge.json"
+if token_path.is_file():
+    result["token_written"] = True
+    result["token_realpath"] = os.path.realpath(token_path)
+ancestor = cnb.bridge_root().parent  # $TMPDIR/omnigent-<uid>
+if ancestor.exists() or ancestor.is_symlink():
+    result["ancestor_mode"] = stat.S_IMODE(os.lstat(ancestor).st_mode)
+print(json.dumps(result))
+"""
+
+
+def _run_token_write(tmpdir: Path, session_id: str) -> dict:
+    """Run the cursor-native token write in a fresh process with ``TMPDIR=tmpdir``."""
+    env = dict(os.environ)
+    env["TMPDIR"] = str(tmpdir)
+    proc = subprocess.run(
+        [sys.executable, "-c", _CHILD_SCRIPT, session_id],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"token-write child crashed (rc={proc.returncode}):\n"
+        f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+    )
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def _uid_scoped_dirname() -> str:
+    """Name of the uid-scoped temp dir cursor-native anchors under."""
+    from omnigent._platform import stable_user_id
+
+    return f"omnigent-{stable_user_id()}"
+
+
+def test_symlinked_ancestor_refuses_token_write(tmp_path: Path) -> None:
+    """A symlinked ``$TMPDIR/omnigent-<uid>`` ancestor must refuse the token write.
+
+    An attacker pre-creates the uid-scoped ancestor as a symlink into a
+    directory they control. Writing ``bridge.json`` through it silently hands
+    the relay bearer token to the attacker, so the write must fail loudly
+    (RuntimeError) and leave no token behind the redirect — matching the
+    hardened qwen-native behaviour on the identical layout.
+    """
+    hostile_tmp = tmp_path / "tmp"
+    hostile_tmp.mkdir()
+    attacker = tmp_path / "attacker"
+    attacker.mkdir()
+    (hostile_tmp / _uid_scoped_dirname()).symlink_to(attacker, target_is_directory=True)
+
+    result = _run_token_write(hostile_tmp, "sess-symlink-ancestor")
+
+    leaked = list(attacker.rglob("bridge.json"))
+    assert result["raised"] is not None and not result["token_written"] and not leaked, (
+        "cursor-native wrote the relay token through a symlinked bridge ancestor "
+        "instead of failing loudly: "
+        f"raised={result['raised']!r} token_written={result['token_written']} "
+        f"token_realpath={result['token_realpath']!r} leaked_into_attacker_dir={leaked}"
+    )
+
+
+def test_world_writable_ancestor_is_not_trusted_for_token_write(tmp_path: Path) -> None:
+    """A pre-existing 0o777 uid-scoped ancestor must not be accepted as-is.
+
+    The ancestor is owned by this uid but group/other-writable, so any local
+    user can replace entries beneath it. Before the token lands, the chain must
+    be validated: an owned-but-permissive dir is repaired to owner-only (0o700)
+    or the write is refused — never "token written, mode left 0o777".
+    """
+    hostile_tmp = tmp_path / "tmp"
+    hostile_tmp.mkdir()
+    uid_dir = hostile_tmp / _uid_scoped_dirname()
+    uid_dir.mkdir()
+    os.chmod(uid_dir, 0o777)
+
+    result = _run_token_write(hostile_tmp, "sess-world-writable-ancestor")
+
+    if result["token_written"]:
+        # Token written is acceptable only once the ancestor was repaired to
+        # owner-only, i.e. the chain was actually validated before the write.
+        assert result["ancestor_mode"] is not None and (result["ancestor_mode"] & 0o077) == 0, (
+            "cursor-native wrote the relay token below a group/other-accessible "
+            f"ancestor without repairing it: mode={oct(result['ancestor_mode'])} "
+            f"token_realpath={result['token_realpath']!r}"
+        )
+    else:
+        assert result["raised"] is not None, (
+            "token not written but no loud failure either: "
+            f"raised={result['raised']!r}"
+        )

--- a/tests/e2e/test_cursor_native_bridge_token_dir_e2e.py
+++ b/tests/e2e/test_cursor_native_bridge_token_dir_e2e.py
@@ -141,6 +141,5 @@ def test_world_writable_ancestor_is_not_trusted_for_token_write(tmp_path: Path) 
         )
     else:
         assert result["raised"] is not None, (
-            "token not written but no loud failure either: "
-            f"raised={result['raised']!r}"
+            f"token not written but no loud failure either: raised={result['raised']!r}"
         )

--- a/tests/e2e/test_cursor_native_bridge_token_dir_e2e.py
+++ b/tests/e2e/test_cursor_native_bridge_token_dir_e2e.py
@@ -65,7 +65,7 @@ print(json.dumps(result))
 
 def _run_token_write(tmpdir: Path, session_id: str) -> dict:
     """Run the cursor-native token write in a fresh process with ``TMPDIR=tmpdir``."""
-    env = dict(os.environ)
+    env = os.environ.copy()
     env["TMPDIR"] = str(tmpdir)
     proc = subprocess.run(
         [sys.executable, "-c", _CHILD_SCRIPT, session_id],

--- a/tests/inner/test_cursor_native_executor.py
+++ b/tests/inner/test_cursor_native_executor.py
@@ -221,6 +221,18 @@ class TestPastePayload:
 
 
 class TestBridge:
+    @pytest.fixture
+    def bridge_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """A bridge dir under a production-shaped cursor root.
+
+        ``write_mcp_bridge_config`` hardens the token tree via
+        ``_ensure_secure_dir``, which only accepts dirs below a known bridge root,
+        so mirror the real ``<uid-scoped temp>/cursor-native/<digest>`` layout.
+        """
+        root = tmp_path / "omnigent-test" / "cursor-native"
+        monkeypatch.setattr("omnigent.cursor_native_bridge._BRIDGE_ROOT", root)
+        return root / "sess"
+
     def test_bridge_dir_is_deterministic_and_session_scoped(self) -> None:
         a1 = bridge_dir_for_session_id("conv_a")
         a2 = bridge_dir_for_session_id("conv_a")
@@ -262,9 +274,10 @@ class TestBridge:
         assert server["autoApprove"] == sorted(server["autoApprove"])
         assert server["env"]["TMPDIR"]
 
-    def test_write_mcp_config_is_workspace_scoped(self, tmp_path: Path, monkeypatch) -> None:
+    def test_write_mcp_config_is_workspace_scoped(
+        self, tmp_path: Path, bridge_dir: Path, monkeypatch
+    ) -> None:
         workspace = tmp_path / "workspace"
-        bridge_dir = tmp_path / "bridge"
         monkeypatch.setattr(
             "omnigent.cursor_native_bridge.approve_mcp_server_for_workspace",
             lambda _workspace: pytest.fail("approval must happen after tool relay starts"),
@@ -276,7 +289,9 @@ class TestBridge:
         assert payload["mcpServers"]["omnigent"]["command"] == "python-test"
         assert json.loads((bridge_dir / "bridge.json").read_text(encoding="utf-8"))["token"]
 
-    def test_write_mcp_config_preserves_user_servers(self, tmp_path: Path) -> None:
+    def test_write_mcp_config_preserves_user_servers(
+        self, tmp_path: Path, bridge_dir: Path
+    ) -> None:
         workspace = tmp_path / "workspace"
         cursor_dir = workspace / ".cursor"
         cursor_dir.mkdir(parents=True)
@@ -290,7 +305,7 @@ class TestBridge:
             encoding="utf-8",
         )
 
-        path = write_mcp_config(workspace, tmp_path / "bridge", python_executable="python-test")
+        path = write_mcp_config(workspace, bridge_dir, python_executable="python-test")
 
         payload = json.loads(path.read_text(encoding="utf-8"))
         assert payload["mcpServers"]["atlassian"] == {"command": "atlassian-mcp"}
@@ -298,22 +313,24 @@ class TestBridge:
         assert payload["someOtherKey"] == {"keep": True}
 
     @pytest.mark.parametrize("body", ["[]", "null", '"text"', '{"mcpServers": null}', "not json"])
-    def test_write_mcp_config_survives_malformed_config(self, tmp_path: Path, body: str) -> None:
+    def test_write_mcp_config_survives_malformed_config(
+        self, tmp_path: Path, bridge_dir: Path, body: str
+    ) -> None:
         workspace = tmp_path / "workspace"
         cursor_dir = workspace / ".cursor"
         cursor_dir.mkdir(parents=True)
         (cursor_dir / "mcp.json").write_text(body, encoding="utf-8")
 
-        path = write_mcp_config(workspace, tmp_path / "bridge", python_executable="python-test")
+        path = write_mcp_config(workspace, bridge_dir, python_executable="python-test")
 
         payload = json.loads(path.read_text(encoding="utf-8"))
         assert payload["mcpServers"]["omnigent"]["command"] == "python-test"
 
-    def test_write_mcp_bridge_config_is_idempotent(self, tmp_path: Path) -> None:
-        write_mcp_bridge_config(tmp_path)
-        first = (tmp_path / "bridge.json").read_text(encoding="utf-8")
-        write_mcp_bridge_config(tmp_path)
-        assert (tmp_path / "bridge.json").read_text(encoding="utf-8") == first
+    def test_write_mcp_bridge_config_is_idempotent(self, bridge_dir: Path) -> None:
+        write_mcp_bridge_config(bridge_dir)
+        first = (bridge_dir / "bridge.json").read_text(encoding="utf-8")
+        write_mcp_bridge_config(bridge_dir)
+        assert (bridge_dir / "bridge.json").read_text(encoding="utf-8") == first
 
     def test_cursor_project_key_matches_cursor_workspace_state(self) -> None:
         assert cursor_project_key(Path("/Users/corey.zumar")) == "Users-corey.zumar"

--- a/tests/test_cursor_native_bridge.py
+++ b/tests/test_cursor_native_bridge.py
@@ -361,3 +361,74 @@ class TestHooksConfig:
         assert payload["hooks"]["stop"][0]["command"].endswith(str(bridge_dir))
         # No leftover temp file from the atomic write.
         assert not (workspace / ".cursor" / "hooks.json.tmp").exists()
+
+
+class TestMcpBridgeConfigSecureDir:
+    """``bridge.json`` holds a relay bearer token, so its tree must be owner-only."""
+
+    @staticmethod
+    def _bridge_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+        """Point the bridge root at a production-shaped tree under ``tmp_path``.
+
+        ``_ensure_secure_bridge_dir`` anchors the ancestor walk at the uid-scoped
+        dir's parent, so mirror ``<trusted>/omnigent-<uid>/cursor-native/<digest>``.
+        """
+        uid_dir = tmp_path / "omnigent-test"
+        monkeypatch.setattr(cursor_native_bridge, "_BRIDGE_ROOT", uid_dir / "cursor-native")
+        return uid_dir, cursor_native_bridge.bridge_dir_for_session_id("sess")
+
+    def test_writes_token_under_owner_only_tree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The happy path still mints and persists the relay token."""
+        import json
+
+        _, bridge_dir = self._bridge_dir(tmp_path, monkeypatch)
+        cursor_native_bridge.write_mcp_bridge_config(bridge_dir)
+
+        token = json.loads((bridge_dir / "bridge.json").read_text(encoding="utf-8"))["token"]
+        assert isinstance(token, str) and token
+
+    def test_rejects_symlinked_ancestor(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A symlinked bridge-tree ancestor is refused — the token is never written.
+
+        On a shared host the sticky bit on ``/tmp`` blocks deletion, not creation,
+        so another local user can pre-create the uid-scoped dir as a symlink and
+        capture the relay token. Writing must fail loudly instead.
+        """
+        uid_dir, bridge_dir = self._bridge_dir(tmp_path, monkeypatch)
+        elsewhere = tmp_path / "attacker"
+        elsewhere.mkdir()
+        uid_dir.symlink_to(elsewhere, target_is_directory=True)
+
+        with pytest.raises(RuntimeError, match="is a symlink"):
+            cursor_native_bridge.write_mcp_bridge_config(bridge_dir)
+        # No token leaked into the attacker-controlled destination.
+        assert not (elsewhere / "cursor-native").exists()
+        assert not (bridge_dir / "bridge.json").exists()
+
+    def test_rejects_foreign_owned_ancestor(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A pre-existing world-writable ancestor owned by another uid is refused.
+
+        Models the attacker pre-creating ``$TMPDIR/omnigent-<uid>`` as a 0o777
+        directory they own: the ancestor walk must reject it rather than write the
+        token into a tree somebody else controls.
+        """
+        import os
+
+        if not hasattr(os, "getuid"):
+            pytest.skip("POSIX uid ownership checks are unavailable on this platform")
+
+        uid_dir, bridge_dir = self._bridge_dir(tmp_path, monkeypatch)
+        uid_dir.mkdir(parents=True)
+        uid_dir.chmod(0o777)
+        # The dir belongs to the real uid, so pretend we are somebody else.
+        monkeypatch.setattr(os, "getuid", lambda: os.stat(uid_dir).st_uid + 1)
+
+        with pytest.raises(RuntimeError, match="owned by uid"):
+            cursor_native_bridge.write_mcp_bridge_config(bridge_dir)
+        assert not (bridge_dir / "bridge.json").exists()


### PR DESCRIPTION
## Related issue

Closes #5769

## Summary

- `write_mcp_bridge_config` mints the Omnigent MCP relay bearer token and writes
  it to `bridge.json` under `$TMPDIR/omnigent-<uid>/cursor-native/<digest>/`, but
  built that tree with `_ensure_dir` — `mkdir(parents=True, exist_ok=True)` plus a
  suppressed `chmod` on the leaf. No mode reaches the parents and any
  pre-existing ancestor is trusted as-is.
- Routes the token write through `_ensure_secure_bridge_dir`, a thin wrapper over
  the shared `claude_native_bridge._ensure_secure_dir` that `qwen-native` already
  uses. It walks every ancestor from the trusted anchor down, creating missing
  ones at `0o700` and rejecting symlinked, non-owned, or group/other-accessible
  ones. The cursor-native root was already in that helper's allowlist — no
  allowlist change needed.
- `_ensure_dir` and its three other call sites are untouched; they create
  non-secret directories.

**ELI5:** the token was being put in a folder whose parent folders nobody had
checked. On a machine you share with other people, one of those parents might not
be yours. Now the whole chain is checked first, and the session stops instead of
writing the token somewhere it shouldn't.

```
 $TMPDIR/omnigent-<uid>/ cursor-native/ <digest>/ bridge.json
 └──────── before: unchecked ────────┘ └─ 0o700 ─┘ └─ token ─┘
 └──────── after:  every ancestor validated ─────┘
```

No behaviour change on a single-user machine.

## Test Plan

```bash
uv run --no-sync pytest tests/test_cursor_native_bridge.py tests/inner/test_cursor_native_executor.py -q
# 57 passed
```

New `TestMcpBridgeConfigSecureDir` covers the happy path plus two rejection
vectors (symlinked ancestor, ancestor owned by another uid), each asserting no
`bridge.json` is written and nothing lands in the redirected location.

Verified the tests fail before the fix — reverting only
`omnigent/cursor_native_bridge.py` to `main` and re-running gives
`2 failed, 1 passed`, both with `DID NOT RAISE <class 'RuntimeError'>`.

Also run: `ruff check` / `ruff format --check` clean, `pyrefly check` reports no
diagnostics on any changed file, and a wider cursor-native sweep (forwarder,
permissions, executor, session-cleanup) is green at `209 passed`.

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing `TestBridge` cases in `tests/inner/test_cursor_native_executor.py`
passed a bare `tmp_path` as the bridge dir, which the validation now correctly
rejects as outside any known bridge root. They gain a `bridge_dir` fixture that
mirrors the production layout; no production code outside
`omnigent/cursor_native_bridge.py` changed.

## Changelog

cursor-native now refuses to start a session when its bridge directory sits under a directory tree it does not exclusively own, instead of writing the relay token there

## Issues

Resolves [OMNI-5775](https://linear.app/omnigent/issue/OMNI-5775/cursor-native-bridge-dir-ancestor-chain-is-not-validated-before-the)
