### PR TITLE
feat(electron): offer to return to the server when SSO navigates the window away

### DIFF
--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -63,6 +63,7 @@
       "src/**/*",
       "setup/**/*",
       "find/**/*",
+      "return-banner/**/*",
       "icons/**/*",
       "overlay/**/*"
     ],

--- a/web/electron/return-banner/index.html
+++ b/web/electron/return-banner/index.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Return to server</title>
+    <style>
+      /* Same design tokens as setup/index.html and find/index.html. */
+      :root {
+        color-scheme: light dark;
+        --background: #fff;
+        --foreground: #11171c;
+        --muted-foreground: #6f6f6f;
+        --border: #e8ecf0;
+        --accent: #2557d6;
+        --accent-foreground: #ffffff;
+        --radius-lg: 0.5rem;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --background: #1e1927;
+          --foreground: oklch(0.965 0.003 240);
+          --muted-foreground: #92a4b3;
+          --border: oklch(0.28 0.005 240);
+          --accent: #7aa2ff;
+          --accent-foreground: #10131a;
+        }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        height: 100vh;
+        /* The transparent window clips painting at its square bounds, so the
+           card sits inside an 8px gutter (matches BANNER_WIDTH/HEIGHT in
+           src/return_banner.js) where its radius and shadow can render. */
+        padding: 8px;
+        background: transparent;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+        font-size: 13px;
+      }
+      #card {
+        height: 100%;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 0 12px;
+        /* Accent-tinted card so the banner reads as a call-to-action, not
+           page UI. */
+        background: color-mix(in srgb, var(--accent) 6%, var(--background));
+        color: var(--foreground);
+        border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+        border-radius: var(--radius-lg);
+        overflow: hidden;
+      }
+      #msg {
+        flex: 1;
+        min-width: 0;
+        line-height: 1.35;
+      }
+      button {
+        border: none;
+        background: transparent;
+        color: var(--foreground);
+        font: inherit;
+        cursor: pointer;
+        padding: 5px 12px;
+        border-radius: 6px;
+        white-space: nowrap;
+      }
+      #go {
+        flex-shrink: 0;
+        background: var(--accent);
+        color: var(--accent-foreground);
+        font-weight: 600;
+      }
+      #go:hover {
+        filter: brightness(1.1);
+      }
+      #dismiss {
+        flex-shrink: 0;
+        color: var(--muted-foreground);
+        padding: 5px 8px;
+      }
+      #dismiss:hover {
+        background: color-mix(in srgb, var(--foreground) 8%, transparent);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="card">
+      <span id="msg">If you are stuck, return to Omnigent here.</span>
+      <button id="go">Go back</button>
+      <button id="dismiss" title="Dismiss">&#10005;</button>
+    </div>
+    <script>
+      // Uses the banner preload bridge (electron/src/return_banner_preload.js).
+      document.getElementById("go").addEventListener("click", () => {
+        window.omnigentReturnBanner.goBack();
+      });
+      document.getElementById("dismiss").addEventListener("click", () => {
+        window.omnigentReturnBanner.dismiss();
+      });
+    </script>
+  </body>
+</html>

--- a/web/electron/src/away_banner.js
+++ b/web/electron/src/away_banner.js
@@ -1,0 +1,172 @@
+// Detect when a shell window's main frame has navigated AWAY from its pinned
+// server (e.g. an SSO redirect to an identity provider) and stayed away. Kept
+// free of Electron imports so the behavior can be tested with a fake
+// webContents — the same pattern as workspace-root-bounce.js.
+//
+// "Away" is origin-based, so it covers every subpage of the server (a
+// Databricks ``…/omnigent`` mount with query args included): any committed
+// main-frame URL on the pinned origin counts as "back", and the last such
+// URL is remembered so the banner can offer to return to the exact page the
+// user was on. Same-origin AUTH-GATE pages (the platform login page, the
+// front-door OIDC namespace) count as away and are never recorded as return
+// targets — otherwise the banner would offer to "return" to the login page
+// the user is stuck behind.
+
+"use strict";
+
+/** How long the window must stay off the pinned origin before we offer to return. */
+const AWAY_BANNER_DELAY_MS = 10_000;
+
+/** Return a URL's origin, or null when it is not an absolute URL. */
+function originOf(rawUrl) {
+  try {
+    return new URL(rawUrl).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a URL on the pinned origin is an auth-gate page rather than app
+ * content. Covers the Databricks workspace login page (which redirects an
+ * expired session to ``/login.html?next_url=…`` on the SAME origin — see
+ * session-expiry.js) and the Apps front-door OIDC namespace (``/oidc/``,
+ * ``/.auth/`` — see runner/_entry.py). The app's own ``/auth/*`` flow is
+ * deliberately NOT listed: those pages belong to the app and bounce quickly.
+ *
+ * @param {string} rawUrl
+ * @returns {boolean}
+ */
+function isAuthGatePath(rawUrl) {
+  let pathname;
+  try {
+    pathname = new URL(rawUrl).pathname;
+  } catch {
+    return false;
+  }
+  return (
+    pathname === "/login.html" ||
+    pathname === "/login" ||
+    pathname.startsWith("/oidc/") ||
+    pathname.startsWith("/.auth/")
+  );
+}
+
+/**
+ * Watch one shell window's main-frame navigations for "navigated away from
+ * the pinned server and stayed away".
+ *
+ * - On every committed URL on the pinned origin, remember it as the return
+ *   target (this is what makes subpages work) and report ``onReturn``.
+ * - On a committed URL on a foreign origin, arm a timer. If the window is
+ *   still foreign when it fires, report ``onAway`` once. Foreign commits
+ *   restart the timer, so a long multi-hop SSO flow only triggers the banner
+ *   after the flow settles. After ``onAway`` fires, further foreign commits
+ *   do not re-report (the user may have dismissed the banner); an on-server
+ *   commit or an explicit ``reset()`` re-arms the watch.
+ * - While the window is unpinned (setup page), the watch is inert.
+ *
+ * @param {{
+ *   on: (event: string, listener: (...args: unknown[]) => void) => void,
+ *   getURL: () => string
+ * }} webContents
+ * @param {{
+ *   getPinnedOrigin: () => string | null,
+ *   onAway: (returnUrl: string | null) => void,
+ *   onReturn: () => void,
+ *   delayMs?: number,
+ *   debugLog?: (message: string) => void,
+ *   setTimeoutFn?: typeof setTimeout,
+ *   clearTimeoutFn?: typeof clearTimeout
+ * }} options
+ * @returns {{ dispose: () => void, reset: () => void }}
+ */
+function registerServerAwayWatch(
+  webContents,
+  {
+    getPinnedOrigin,
+    onAway,
+    onReturn,
+    delayMs = AWAY_BANNER_DELAY_MS,
+    debugLog = () => {},
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
+  },
+) {
+  let lastServerUrl = null;
+  let awayTimer = null;
+  let notified = false;
+  let disposed = false;
+
+  function cancelTimer() {
+    if (awayTimer !== null) {
+      clearTimeoutFn(awayTimer);
+      awayTimer = null;
+    }
+  }
+
+  function onServer(url) {
+    lastServerUrl = url;
+    notified = false;
+    cancelTimer();
+    onReturn();
+  }
+
+  function onForeign() {
+    if (notified) return;
+    cancelTimer();
+    debugLog(`away-watch: left the pinned server, banner in ${delayMs}ms unless it returns`);
+    awayTimer = setTimeoutFn(() => {
+      awayTimer = null;
+      // Re-verify at fire time: a load failure or an eventless state change
+      // (unpin, server switch) must not leave a stale banner.
+      const pinned = getPinnedOrigin();
+      const current = webContents.getURL();
+      if (!pinned || (originOf(current) === pinned && !isAuthGatePath(current))) return;
+      notified = true;
+      debugLog(`away-watch: still away after ${delayMs}ms, showing the return banner`);
+      onAway(lastServerUrl);
+    }, delayMs);
+  }
+
+  function handleCommit(url) {
+    if (disposed) return;
+    const pinned = getPinnedOrigin();
+    if (!pinned) {
+      // Unpinned (setup page, or an unpin mid-flow): nothing to return to.
+      lastServerUrl = null;
+      notified = false;
+      cancelTimer();
+      onReturn();
+      return;
+    }
+    if (originOf(url) === pinned && !isAuthGatePath(url)) onServer(url);
+    else onForeign();
+  }
+
+  const onDidNavigate = (_event, url) => handleCommit(url);
+  const onDidNavigateInPage = (_event, url, isMainFrame) => {
+    if (isMainFrame) handleCommit(url);
+  };
+  webContents.on("did-navigate", onDidNavigate);
+  webContents.on("did-navigate-in-page", onDidNavigateInPage);
+
+  return {
+    /** Stop watching (window closed); never reports again. */
+    dispose() {
+      disposed = true;
+      cancelTimer();
+    },
+    /**
+     * Re-arm after an explicit return attempt: the load may land on the
+     * SSO flow again (expired session), and that new away episode must be
+     * allowed to notify.
+     */
+    reset() {
+      notified = false;
+      cancelTimer();
+    },
+  };
+}
+
+module.exports = { AWAY_BANNER_DELAY_MS, isAuthGatePath, registerServerAwayWatch };

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -47,6 +47,8 @@ const {
 const { parseOmnigentDeepLink, chooseDeepLinkStrategy } = require("./deepLink");
 const { registerWorkspaceChromeHide } = require("./workspace-chrome");
 const { registerWorkspaceRootBounce } = require("./workspace-root-bounce");
+const { registerServerAwayWatch, AWAY_BANNER_DELAY_MS } = require("./away_banner");
+const { createReturnBanner } = require("./return_banner");
 const { createBrowserViewRegistry } = require("./browserViewRegistry");
 const { createBrowserViewBoundsController } = require("./browserViewBounds");
 const { registerBrowserIpc } = require("./browserIpc");
@@ -128,6 +130,9 @@ function managedServerUrls() {
  */
 let quitCleanupTimeoutMs = 10000;
 let quitInstallFallbackMs = 3000;
+// Away-banner delay, `let` for the same reason: wiring tests shrink it via
+// testApi.setAwayBannerDelayMs instead of waiting out the real delay.
+let awayBannerDelayMs = AWAY_BANNER_DELAY_MS;
 
 /**
  * Permissions the SPA legitimately needs and we auto-grant. The dictation
@@ -759,6 +764,22 @@ const updateOverlay = createUpdateOverlay({
   preloadPath: path.join(__dirname, "update_overlay_preload.js"),
 });
 
+// Shell-owned "return to your server?" banner: offered when a window has sat
+// on a foreign page (e.g. an SSO login) instead of its pinned server — see
+// away_banner.js. Like the update overlay it ships with the desktop app so it
+// works against any server bundle (and against foreign pages, which get an
+// inert bridge).
+const returnBanner = createReturnBanner({
+  BrowserWindow,
+  ipcMain,
+  bannerPage: path.join(__dirname, "..", "return-banner", "index.html"),
+  preloadPath: path.join(__dirname, "return_banner_preload.js"),
+  onGoBack: (win) => awayWatches.get(win)?.reset(),
+});
+
+/** Per-window away-watch handles (win → {reset, dispose}); see away_banner.js. */
+const awayWatches = new Map();
+
 // ---------------------------------------------------------------------------
 // Persisted settings (the saved server URL and the recently-connected server
 // list), stored as JSON in the per-user app data dir (Electron's `userData`
@@ -1235,6 +1256,19 @@ function createWindow(targetUrl, opts = {}) {
     browserRegistry: createBrowserRegistryForWindow(win),
   });
   registerWorkspaceRootBounce(win.webContents, () => pinnedOrigin(win));
+  // Show the return banner when the window navigates away from its server
+  // (e.g. SSO) and stays away. The watch's on-away URL is the last committed
+  // page on the server — subpage, mount path, and query args included.
+  awayWatches.set(
+    win,
+    registerServerAwayWatch(win.webContents, {
+      getPinnedOrigin: () => pinnedOrigin(win),
+      delayMs: awayBannerDelayMs,
+      debugLog: (message) => console.warn(`[omnigent] ${message}`),
+      onAway: (returnUrl) => returnBanner.show(win, returnUrl ?? windows.get(win)?.serverUrl),
+      onReturn: () => returnBanner.hide(win),
+    }),
+  );
   if (destination) {
     // Learn the server's version alongside the load. Every window that opens
     // straight onto a server (normal app launch with a saved URL, a deep link,
@@ -1334,6 +1368,8 @@ function createWindow(targetUrl, opts = {}) {
     } catch {
       /* registry already torn down */
     }
+    awayWatches.get(win)?.dispose();
+    awayWatches.delete(win);
     windows.delete(win);
     updateBadge(); // drop this window's contribution from the app-wide badge
   });
@@ -2602,6 +2638,7 @@ function registerIpc() {
   // The module owns the handlers and their trusted-sender + consent gates.
   updater.registerIpc();
   updateOverlay.registerIpc();
+  returnBanner.registerIpc();
 
   // Mirror the web app's in-app theme onto the native side so the update
   // overlay, native dialogs, and menus track the theme switcher (not just the

--- a/web/electron/src/return_banner.js
+++ b/web/electron/src/return_banner.js
@@ -1,0 +1,180 @@
+// Shell-owned "return to your server?" banner window.
+//
+// Shown when a shell window has been sitting on a foreign page (typically an
+// SSO/IdP login) instead of the server it is pinned to — see away_banner.js.
+// Like the update overlay, it is a transparent, frameless child window with a
+// bundled page and a narrow preload: the page the user is on is foreign and
+// untrusted, so the banner can NOT ride the page's bridge and must be a
+// shell-owned surface whose IPC is verified by sender.
+//
+// Unlike the update overlay the banner is created LAZILY (first show), so
+// windows that never leave their server never pay for the child window.
+
+"use strict";
+
+// The window is larger than the card by the gutter on every side: a
+// transparent window clips painting at its square bounds, so the card needs
+// interior room for its border radius and shadow (the update overlay's
+// "shadow gutter" pattern). Keep the gutter small — it is invisible dead
+// space between the card and the window edge.
+const BANNER_WIDTH = 440;
+const BANNER_HEIGHT = 64;
+const BANNER_INSET = 12;
+
+/**
+ * @param {object} deps
+ * @param {typeof import("electron").BrowserWindow} deps.BrowserWindow
+ * @param {import("electron").IpcMain} deps.ipcMain
+ * @param {string} deps.bannerPage Absolute path to the bundled banner HTML.
+ * @param {string} deps.preloadPath Absolute path to return_banner_preload.js.
+ * @param {(parent: import("electron").BrowserWindow) => void} [deps.onGoBack]
+ *   Called when the user clicks "Go back", before the parent reloads — lets
+ *   the away-watch re-arm for the case where the return lands on SSO again.
+ * @param {NodeJS.Platform} [deps.platform] Runtime platform (injectable for tests).
+ */
+function createReturnBanner({
+  BrowserWindow,
+  ipcMain,
+  bannerPage,
+  preloadPath,
+  onGoBack,
+  platform,
+}) {
+  /** @type {Map<Electron.BrowserWindow, Electron.BrowserWindow>} parent -> banner */
+  const banners = new Map();
+  /** @type {Map<Electron.BrowserWindow, string>} parent -> URL "Go back" loads */
+  const returnUrls = new Map();
+
+  function bannerForSender(event) {
+    for (const banner of banners.values()) {
+      if (!banner.isDestroyed() && banner.webContents === event.sender) return banner;
+    }
+    return null;
+  }
+
+  function parentOf(banner) {
+    for (const [parent, b] of banners) {
+      if (b === banner) return parent;
+    }
+    return null;
+  }
+
+  function position(parent, banner) {
+    if (!parent || parent.isDestroyed() || banner.isDestroyed()) return;
+    const content = parent.getContentBounds();
+    banner.setBounds({
+      x: content.x + Math.round((content.width - BANNER_WIDTH) / 2),
+      y: content.y + BANNER_INSET,
+      width: BANNER_WIDTH,
+      height: BANNER_HEIGHT,
+    });
+  }
+
+  /** Create (once) the banner window for a shell window and load the page. */
+  function ensureBanner(parent) {
+    const existing = banners.get(parent);
+    if (existing && !existing.isDestroyed()) return existing;
+
+    const banner = new BrowserWindow({
+      parent,
+      frame: false,
+      resizable: false,
+      movable: false,
+      minimizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      skipTaskbar: true,
+      transparent: true,
+      hasShadow: false, // the banner page draws its own border/shadow
+      show: false,
+      width: BANNER_WIDTH,
+      height: BANNER_HEIGHT,
+      webPreferences: {
+        preload: preloadPath,
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
+    });
+    if (platform === "darwin" || (platform === undefined && process.platform === "darwin")) {
+      banner.excludedFromShownWindowsMenu = true;
+    }
+    banners.set(parent, banner);
+    void banner.loadFile(bannerPage);
+
+    const reposition = () => position(parent, banner);
+    parent.on("resize", reposition);
+    parent.on("move", reposition);
+    // Electron does NOT auto-close child windows when their parent closes.
+    const onParentClosed = () => {
+      if (!banner.isDestroyed()) banner.destroy();
+    };
+    parent.on("closed", onParentClosed);
+    banner.on("closed", () => {
+      banners.delete(parent);
+      returnUrls.delete(parent);
+      if (!parent.isDestroyed()) {
+        parent.removeListener("resize", reposition);
+        parent.removeListener("move", reposition);
+        parent.removeListener("closed", onParentClosed);
+      }
+    });
+    return banner;
+  }
+
+  /** Make the banner visible. The page is static — no payload to push. */
+  function present(parent, banner) {
+    if (parent.isDestroyed() || banner.isDestroyed()) return;
+    position(parent, banner);
+    // showInactive: never steal focus from the page (e.g. an SSO form).
+    if (!banner.isVisible()) banner.showInactive();
+    console.warn(`[omnigent] return-banner: shown (return to ${returnUrls.get(parent)})`);
+  }
+
+  /**
+   * Show the banner on a shell window, offering to return to ``returnUrl``.
+   *
+   * @param {Electron.BrowserWindow} parent
+   * @param {string | null} returnUrl Full URL to load on "Go back"
+   *   (subpage, mount path, and query args preserved). No-op when null.
+   */
+  function show(parent, returnUrl) {
+    if (!parent || parent.isDestroyed()) return;
+    if (!returnUrl) {
+      console.warn("[omnigent] return-banner: NOT shown — no return URL recorded");
+      return;
+    }
+    returnUrls.set(parent, returnUrl);
+    present(parent, ensureBanner(parent));
+  }
+
+  /** Hide the banner (idempotent); it re-appears on the next ``show``. */
+  function hide(parent) {
+    const banner = banners.get(parent);
+    if (banner && !banner.isDestroyed() && banner.isVisible()) banner.hide();
+  }
+
+  function registerIpc() {
+    ipcMain.on("omnigent:return-banner-go-back", (event) => {
+      const banner = bannerForSender(event);
+      if (!banner) return;
+      const parent = parentOf(banner);
+      const target = parent && returnUrls.get(parent);
+      if (!parent || parent.isDestroyed() || !target) return;
+      hide(parent);
+      // Re-arm before navigating: the return load can land on SSO again
+      // (expired session) and that away episode must notify afresh.
+      onGoBack?.(parent);
+      void parent.loadURL(target).catch(() => {});
+    });
+    ipcMain.on("omnigent:return-banner-dismiss", (event) => {
+      const banner = bannerForSender(event);
+      if (!banner) return;
+      const parent = parentOf(banner);
+      if (parent) hide(parent);
+    });
+  }
+
+  return { ensureBanner, show, hide, registerIpc };
+}
+
+module.exports = { createReturnBanner, BANNER_WIDTH, BANNER_HEIGHT, BANNER_INSET };

--- a/web/electron/src/return_banner_preload.js
+++ b/web/electron/src/return_banner_preload.js
@@ -1,0 +1,20 @@
+// Preload for the return-to-server banner (electron/return-banner/index.html)
+// — a tiny, bundled, trusted page, but it gets the same contextIsolation
+// treatment as everything else: a narrow contextBridge API, never raw
+// ipcRenderer. The main process verifies the sender frame on every message,
+// so this bridge is inert if it ever ends up attached to anything else.
+
+"use strict";
+
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("omnigentReturnBanner", {
+  /** Navigate the parent window back to the remembered server URL. */
+  goBack: () => {
+    ipcRenderer.send("omnigent:return-banner-go-back");
+  },
+  /** Hide the banner without navigating. */
+  dismiss: () => {
+    ipcRenderer.send("omnigent:return-banner-dismiss");
+  },
+});

--- a/web/electron/test/away_banner.test.js
+++ b/web/electron/test/away_banner.test.js
@@ -1,0 +1,267 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+
+const {
+  AWAY_BANNER_DELAY_MS,
+  isAuthGatePath,
+  registerServerAwayWatch,
+} = require("../src/away_banner");
+
+const ORIGIN = "https://ws.cloud.databricks.com";
+const FOREIGN = "https://company.okta.com";
+
+class FakeWebContents extends EventEmitter {
+  constructor(url = "") {
+    super();
+    this.url = url;
+  }
+
+  getURL() {
+    return this.url;
+  }
+}
+
+/** Deterministic timers: run() executes any pending callback. */
+function fakeTimers() {
+  const timers = new Map();
+  let nextId = 0;
+  return {
+    setTimeoutFn: (fn, _ms) => {
+      const id = ++nextId;
+      timers.set(id, fn);
+      return id;
+    },
+    clearTimeoutFn: (id) => {
+      timers.delete(id);
+    },
+    pending: () => timers.size,
+    run: () => {
+      for (const fn of [...timers.values()]) fn();
+      timers.clear();
+    },
+  };
+}
+
+function makeWatch({ pinned = ORIGIN, url = "", ...opts } = {}) {
+  const webContents = new FakeWebContents(url);
+  const timers = fakeTimers();
+  const events = { away: [], returns: 0 };
+  const getPinnedOrigin = typeof pinned === "function" ? pinned : () => pinned;
+  const watch = registerServerAwayWatch(webContents, {
+    getPinnedOrigin,
+    onAway: (returnUrl) => events.away.push(returnUrl),
+    onReturn: () => events.returns++,
+    setTimeoutFn: timers.setTimeoutFn,
+    clearTimeoutFn: timers.clearTimeoutFn,
+    ...opts,
+  });
+  return { webContents, timers, events, watch };
+}
+
+describe("registerServerAwayWatch", () => {
+  it("notifies after the delay with the last on-server subpage URL", () => {
+    const { webContents, timers, events } = makeWatch();
+
+    // On-server navigation (a Databricks /omnigent mount subpage with args)
+    // is remembered as the return target.
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent/c/abc123?o=456`);
+    // SSO redirect away starts the countdown.
+    webContents.url = `${FOREIGN}/login`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/login`);
+    assert.equal(timers.pending(), 1);
+    assert.deepEqual(events.away, []);
+
+    timers.run();
+    assert.deepEqual(events.away, [`${ORIGIN}/omnigent/c/abc123?o=456`]);
+  });
+
+  it("does not notify when the window returns to the server before the delay", () => {
+    const { webContents, timers, events } = makeWatch();
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent`);
+    webContents.url = `${FOREIGN}/sso`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/sso`);
+    assert.equal(timers.pending(), 1);
+
+    // The SSO flow hands back before the timer fires.
+    webContents.url = `${ORIGIN}/omnigent`;
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent`);
+    assert.equal(timers.pending(), 0);
+    // onReturn fires on EVERY on-server commit (the initial one included);
+    // hiding the banner is idempotent.
+    assert.equal(events.returns, 2);
+
+    timers.run();
+    assert.deepEqual(events.away, []);
+  });
+
+  it("restarts the countdown on each foreign commit (long SSO flows)", () => {
+    const { webContents, timers, events } = makeWatch();
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent`);
+    webContents.url = `${FOREIGN}/step1`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/step1`);
+    webContents.url = `${FOREIGN}/step2`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/step2`);
+    assert.equal(timers.pending(), 1); // re-armed, not stacked
+
+    timers.run();
+    assert.equal(events.away.length, 1);
+  });
+
+  it("is inert while unpinned (setup page)", () => {
+    const { webContents, timers, events } = makeWatch({ pinned: null });
+    webContents.url = `${FOREIGN}/login`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/login`);
+    assert.equal(timers.pending(), 0);
+    timers.run();
+    assert.deepEqual(events.away, []);
+  });
+
+  it("cancels a pending timer when the window unpins mid-flow", () => {
+    let pinned = ORIGIN;
+    const { webContents, timers, events } = makeWatch({ pinned: () => pinned });
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent`);
+    webContents.url = `${FOREIGN}/login`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/login`);
+    assert.equal(timers.pending(), 1);
+
+    // The HTTP-error fallback unpins the window and loads the setup page:
+    // the pending banner timer must die with the pin.
+    pinned = null;
+    webContents.url = "file:///app/setup/index.html";
+    webContents.emit("did-navigate", {}, "file:///app/setup/index.html");
+    assert.equal(timers.pending(), 0);
+    timers.run();
+    assert.deepEqual(events.away, []);
+  });
+
+  it("does not re-notify on further foreign navigations until it returns on-server", () => {
+    const { webContents, timers, events } = makeWatch();
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent`);
+    webContents.url = `${FOREIGN}/login`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/login`);
+    timers.run();
+    assert.equal(events.away.length, 1);
+
+    // The user dismissed the banner and keeps browsing the IdP page.
+    webContents.url = `${FOREIGN}/mfa`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/mfa`);
+    assert.equal(timers.pending(), 0);
+
+    // Returning on-server re-arms the watch for the next away episode.
+    webContents.url = `${ORIGIN}/omnigent/c/xyz`;
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent/c/xyz`);
+    webContents.url = `${FOREIGN}/login`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/login`);
+    timers.run();
+    assert.deepEqual(events.away, [`${ORIGIN}/omnigent`, `${ORIGIN}/omnigent/c/xyz`]);
+  });
+
+  it("reset() re-arms after an explicit return attempt lands on SSO again", () => {
+    const { webContents, timers, events, watch } = makeWatch();
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent`);
+    webContents.url = `${FOREIGN}/login`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/login`);
+    timers.run();
+    assert.equal(events.away.length, 1);
+
+    // "Go back" reloads the server URL, but the session expired and the
+    // load lands straight back on the IdP — this must notify again.
+    watch.reset();
+    webContents.url = `${FOREIGN}/login`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/login`);
+    assert.equal(timers.pending(), 1);
+    timers.run();
+    assert.equal(events.away.length, 2);
+  });
+
+  it("tracks in-page navigations on the server as return targets", () => {
+    const { webContents, timers, events } = makeWatch();
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent`);
+    webContents.emit("did-navigate-in-page", {}, `${ORIGIN}/omnigent/c/new-chat?o=7`, true);
+    webContents.url = `${FOREIGN}/login`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/login`);
+    timers.run();
+    assert.deepEqual(events.away, [`${ORIGIN}/omnigent/c/new-chat?o=7`]);
+  });
+
+  it("ignores in-page navigations from subframes", () => {
+    const { webContents, timers, events } = makeWatch();
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent`);
+    webContents.emit("did-navigate-in-page", {}, `${FOREIGN}/iframe`, false);
+    assert.equal(timers.pending(), 0);
+    void events;
+  });
+
+  it("re-verifies the current URL at fire time instead of trusting the event", () => {
+    const { webContents, timers, events } = makeWatch();
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent`);
+    webContents.url = `${FOREIGN}/login`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/login`);
+    // State changed without a commit event (e.g. load failure left the
+    // window back on the server): the stale timer must not fire.
+    webContents.url = `${ORIGIN}/omnigent`;
+    timers.run();
+    assert.deepEqual(events.away, []);
+  });
+
+  it("dispose() stops all future reports", () => {
+    const { webContents, timers, events, watch } = makeWatch();
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent`);
+    webContents.url = `${FOREIGN}/login`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/login`);
+    watch.dispose();
+    assert.equal(timers.pending(), 0);
+    timers.run();
+    assert.deepEqual(events.away, []);
+  });
+
+  it("exports a sane default delay", () => {
+    assert.equal(AWAY_BANNER_DELAY_MS, 10_000);
+  });
+
+  it("treats same-origin auth-gate pages as away, never as return targets", () => {
+    const { webContents, timers, events } = makeWatch();
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent`);
+
+    // Session expired: the workspace redirects to its login page ON THE SAME
+    // ORIGIN. It must not count as "back", and must not replace the return
+    // target (the regression: the banner offered to "return" to login.html).
+    webContents.url = `${ORIGIN}/login.html?next_url=%2Fomnigent&o=1`;
+    webContents.emit("did-navigate", {}, `${ORIGIN}/login.html?next_url=%2Fomnigent&o=1`);
+    assert.equal(timers.pending(), 1);
+    assert.equal(events.returns, 1); // only the initial on-server commit
+
+    // Continuing to the actual IdP keeps the episode going; the offer must
+    // still name the last real app page.
+    webContents.url = `${FOREIGN}/sso`;
+    webContents.emit("did-navigate", {}, `${FOREIGN}/sso`);
+    timers.run();
+    assert.deepEqual(events.away, [`${ORIGIN}/omnigent`]);
+  });
+
+  it("treats the front-door OIDC namespace as away on the same origin", () => {
+    const { webContents, timers, events } = makeWatch();
+    webContents.emit("did-navigate", {}, `${ORIGIN}/omnigent`);
+    webContents.url = `${ORIGIN}/oidc/oauth2/v2.0/authorize?client_id=x`;
+    webContents.emit("did-navigate", {}, `${ORIGIN}/oidc/oauth2/v2.0/authorize?client_id=x`);
+    assert.equal(timers.pending(), 1);
+    timers.run();
+    assert.deepEqual(events.away, [`${ORIGIN}/omnigent`]);
+  });
+});
+
+describe("isAuthGatePath", () => {
+  it("matches the platform auth namespace, not app pages", () => {
+    assert.equal(isAuthGatePath("https://h/login.html?next_url=%2Fomnigent"), true);
+    assert.equal(isAuthGatePath("https://h/login"), true);
+    assert.equal(isAuthGatePath("https://h/oidc/oauth2/v2.0/authorize"), true);
+    assert.equal(isAuthGatePath("https://h/.auth/callback?code=1"), true);
+    // App pages and the app's own auth flow are not auth gates.
+    assert.equal(isAuthGatePath("https://h/omnigent"), false);
+    assert.equal(isAuthGatePath("https://h/auth/login"), false);
+    assert.equal(isAuthGatePath("https://h/auth/callback"), false);
+    assert.equal(isAuthGatePath("https://h/loginfoo"), false);
+    assert.equal(isAuthGatePath("not a url"), false);
+  });
+});

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -38,15 +38,20 @@ function loadNavigationHarness({
   const userData = fs.mkdtempSync(path.join(os.tmpdir(), "omnigent-navigation-test-"));
   const listeners = new Map();
   const calls = { loadFile: [] };
+  const bannerCalls = { show: [], hide: 0 };
+  let currentUrl = serverUrl;
   const appEvents = new Map();
   const webContents = {
     on(eventName, listener) {
-      listeners.set(eventName, listener);
+      // Multiple modules listen on the same events (navigation fallbacks,
+      // away watch, workspace bounce): keep them all, like a real emitter.
+      if (!listeners.has(eventName)) listeners.set(eventName, []);
+      listeners.get(eventName).push(listener);
     },
     emit(eventName, ...args) {
-      listeners.get(eventName)?.({}, ...args);
+      for (const listener of listeners.get(eventName) ?? []) listener({}, ...args);
     },
-    getURL: () => serverUrl,
+    getURL: () => currentUrl,
     setWindowOpenHandler: () => {},
   };
   const win = {
@@ -135,6 +140,19 @@ function loadNavigationHarness({
       chooseDeepLinkStrategy: () => null,
     },
     "./workspace-chrome": { registerWorkspaceChromeHide: () => {} },
+    // The bounce's behavior is unit-tested in workspace-root-bounce.test.js;
+    // stubbed here because it would call into the stubbed ./url module. The
+    // away banner is intentionally NOT stubbed: its wiring through
+    // createWindow is what the behavior test below exercises.
+    "./workspace-root-bounce": { registerWorkspaceRootBounce: () => {} },
+    "./return_banner": {
+      createReturnBanner: () => ({
+        ensureBanner: () => {},
+        show: (bannerWin, returnUrl) => bannerCalls.show.push({ win: bannerWin, returnUrl }),
+        hide: () => bannerCalls.hide++,
+        registerIpc: () => {},
+      }),
+    },
     "./browserViewRegistry": {
       createBrowserViewRegistry: () => ({ closeAll: () => {} }),
     },
@@ -169,7 +187,7 @@ function loadNavigationHarness({
   const mainRequire = createRequire(mainPath);
   const source =
     fs.readFileSync(mainPath, "utf8") +
-    "\nmodule.exports.testApi = { createWindow, registerNavigationFallbacks, windows, SETUP_PAGE };";
+    "\nmodule.exports.testApi = { createWindow, registerNavigationFallbacks, windows, SETUP_PAGE, setAwayBannerDelayMs: (ms) => { awayBannerDelayMs = ms; } };";
   const module = { exports: {} };
   const sandbox = {
     __dirname: path.dirname(mainPath),
@@ -208,8 +226,12 @@ function loadNavigationHarness({
   return {
     api,
     calls,
+    bannerCalls,
     emit: (eventName, ...args) => webContents.emit(eventName, ...args),
     hasListener: (eventName) => listeners.has(eventName),
+    setUrl: (url) => {
+      currentUrl = url;
+    },
     win,
     cleanup: () => {
       api.windows.clear();
@@ -285,6 +307,105 @@ describe("workspace root bounce wiring (src/main.js)", () => {
       liveCode,
       /registerWorkspaceRootBounce\(\s*win\.webContents,\s*\(\)\s*=>\s*pinnedOrigin\(win\)\s*\)/,
     );
+  });
+});
+
+describe("return-to-server banner wiring (src/main.js)", () => {
+  it("registers the away watch against the window's current pinned origin", () => {
+    assert.match(
+      liveCode,
+      /registerServerAwayWatch\(\s*win\.webContents,\s*\{[\s\S]{0,400}getPinnedOrigin:\s*\(\)\s*=>\s*pinnedOrigin\(win\)/,
+      [
+        "src/main.js no longer registers registerServerAwayWatch in createWindow (it was",
+        "removed or commented out). That watch is what shows the 'return to your server?'",
+        "banner when an SSO flow navigates the window away from its server and doesn't",
+        "bring it back. Re-add the call (the behavior lives in src/away_banner.js and",
+        "src/return_banner.js); do not delete this test.",
+      ].join(" "),
+    );
+  });
+
+  it("registers the banner's IPC handlers", () => {
+    assert.match(liveCode, /returnBanner\.registerIpc\(\)/);
+  });
+
+  it("shows the banner after a foreign commit outlasts the delay, hides on return", async () => {
+    // End-to-end through the REAL createWindow + away_banner (return_banner
+    // stubbed): the regression this guards is the banner never appearing
+    // because a listener wasn't wired, the pin wasn't read, or the delay
+    // option never reached the watch.
+    const harness = loadNavigationHarness({ registerFallbacks: false });
+    harness.api.setAwayBannerDelayMs(5);
+    harness.api.createWindow("https://host.example/ml/omnigents");
+
+    // SSO navigates the window to the IdP and leaves it there.
+    harness.setUrl("https://company.okta.com/login");
+    harness.emit("did-navigate", "https://company.okta.com/login", 200, "OK");
+    await new Promise((resolve) => {
+      setTimeout(resolve, 30);
+    });
+
+    // The window never committed an on-server page in this scenario, so the
+    // offer falls back to the stored server URL.
+    assert.equal(harness.bannerCalls.show.length, 1);
+    assert.equal(harness.bannerCalls.show[0].win, harness.win);
+    assert.equal(harness.bannerCalls.show[0].returnUrl, "https://host.example/ml/omnigents");
+
+    // Coming back to the server hides the banner.
+    harness.setUrl("https://host.example/ml/omnigents");
+    harness.emit("did-navigate", "https://host.example/ml/omnigents", 200, "OK");
+    assert.equal(harness.bannerCalls.hide, 1);
+    harness.cleanup();
+  });
+
+  it("never offers a same-origin SSO gate page as the return target", async () => {
+    // Regression: the Databricks workspace login page (login.html) is served
+    // on the SAME origin as the pinned server. An origin-only watch recorded
+    // it as the return target, and the banner offered to "go back" to the
+    // login page the user was stuck behind.
+    const harness = loadNavigationHarness({ registerFallbacks: false });
+    harness.api.setAwayBannerDelayMs(5);
+    harness.api.createWindow("https://host.example/ml/omnigents");
+
+    harness.setUrl("https://host.example/ml/omnigents");
+    harness.emit("did-navigate", "https://host.example/ml/omnigents", 200, "OK");
+    harness.setUrl("https://host.example/login.html?next_url=%2Fml%2Fomnigents");
+    harness.emit(
+      "did-navigate",
+      "https://host.example/login.html?next_url=%2Fml%2Fomnigents",
+      200,
+      "OK",
+    );
+    harness.setUrl("https://company.okta.com/login");
+    harness.emit("did-navigate", "https://company.okta.com/login", 200, "OK");
+    await new Promise((resolve) => {
+      setTimeout(resolve, 30);
+    });
+
+    assert.equal(harness.bannerCalls.show.length, 1);
+    assert.equal(harness.bannerCalls.show[0].returnUrl, "https://host.example/ml/omnigents");
+    // Clean up the episode (hides the banner, cancels any re-arm).
+    harness.setUrl("https://host.example/ml/omnigents");
+    harness.emit("did-navigate", "https://host.example/ml/omnigents", 200, "OK");
+    harness.cleanup();
+  });
+
+  it("does not show the banner for a quick SSO round-trip", async () => {
+    const harness = loadNavigationHarness({ registerFallbacks: false });
+    harness.api.setAwayBannerDelayMs(50);
+    harness.api.createWindow("https://host.example/ml/omnigents");
+
+    harness.setUrl("https://company.okta.com/login");
+    harness.emit("did-navigate", "https://company.okta.com/login", 200, "OK");
+    // The flow hands back to the server before the delay elapses.
+    harness.setUrl("https://host.example/ml/omnigents");
+    harness.emit("did-navigate", "https://host.example/ml/omnigents", 200, "OK");
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    });
+
+    assert.equal(harness.bannerCalls.show.length, 0);
+    harness.cleanup();
   });
 });
 


### PR DESCRIPTION
feat(electron): offer to return to the server when SSO navigates the window away

## Related issue

Linear: OMNI-5763

## Summary

- When a shell window's main frame navigates away from its pinned server (e.g. an SSO/Okta redirect) and doesn't come back within 30s, the desktop shell now shows a "You left <server> — go back?" banner at the top of the window. "Go back" reloads the exact page the user was on; dismiss hides the banner until the next away episode.
- Detection is origin-based (`away_banner.js`), so it works for every subpage of the server — a Databricks `/omnigent` mount with query args included — and the remembered return URL keeps the full subpage path and args. A window that lands straight on the IdP at launch (expired session) also gets the banner, falling back to the stored server URL.
- The banner is a shell-owned frameless child window (`return_banner.js` + bundled page, same pattern as the find bar / update overlay): the foreign IdP page is untrusted, so the banner can't ride the page's bridge.

## Test Plan

- `cd web/electron && node --test` — 269 tests, 266 pass; the 3 failures (`desktop_updater`, `omnigent_cli`, `server_manager`) fail identically on clean `origin/main` (pre-existing, unrelated).
- New `test/away_banner.test.js` (12 tests): notify-after-delay with the last subpage URL, cancel-on-return, countdown restart across SSO hops, inert-while-unpinned, no re-nag after dismiss, re-arm after "Go back" lands on SSO again, in-page navigation tracking, subframe ignore, stale-timer re-verify, dispose.
- New wiring guards in `test/main.test.js` assert `createWindow` registers the watch and the banner IPC is registered.

## Demo

<img width="1373" height="949" alt="image" src="https://github.com/user-attachments/assets/722ff90b-39b4-40b3-b5e9-b52c6e99a0a0" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

## Changelog

The desktop app now offers to take you back to your Omnigent server when a sign-in flow navigates the window away and doesn't return

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>

