### PR TITLE
fix(onboarding): databricks extra hint installs from the package index, not git

### DIFF
--- a/omnigent/onboarding/databricks_config.py
+++ b/omnigent/onboarding/databricks_config.py
@@ -42,16 +42,10 @@ def normalize_workspace_url(raw: str) -> str:
 
 # The install command surfaced wherever a Databricks flow is gated on the
 # `databricks` extra (the add-provider menu, `setup --internal-beta`).
-# Matches the README's canonical `uv tool install` path. Dev clones use
-# `uv sync --extra databricks` instead, but the tool install is the path
-# end users actually took. The repo URL sits on its own line: the slug
-# differs per distribution, and inlining it into the hint string would
-# make the line's width — and therefore its ruff formatting — depend on
-# which slug a checkout carries.
-_SOURCE_REPO_URL = "https://github.com/omnigent-ai/omnigent.git"
-DATABRICKS_EXTRA_INSTALL_HINT = (
-    f'uv tool install --force "omnigent[databricks] @ git+{_SOURCE_REPO_URL}"'
-)
+# Matches the README's canonical `uv tool install` path: install from the
+# package index, not git. Dev clones use `uv sync --extra databricks`
+# instead, but the tool install is the path end users actually took.
+DATABRICKS_EXTRA_INSTALL_HINT = 'uv tool install --force "omnigent[databricks]"'
 
 
 def databricks_sdk_installed() -> bool:


### PR DESCRIPTION
fix(onboarding): databricks extra hint installs from the package index, not git

## Related issue

OMNI-2872

## Summary

- The `databricks` extra install hint (`DATABRICKS_EXTRA_INSTALL_HINT`, shown in the add-provider menu, `setup --internal-beta`, and Databricks server login when the extra is missing) previously suggested reinstalling from git directly (`uv tool install --force "omnigent[databricks] @ git+https://…"`), which tracks whatever is on the default branch rather than a released version.
- It now suggests the normal package-index install, `uv tool install --force "omnigent[databricks]"`, matching the README's canonical install path.

## Test Plan

- `uv run ruff check omnigent/onboarding/databricks_config.py` — clean.
- `uv run pytest tests/onboarding/test_databricks_config.py tests/cli/test_login_databricks.py -q` — no new failures (the 5 failures present are pre-existing on a clean tree: environment-dependent databricks-sdk presence and org-selector discovery tests).
- Existing assertions on the hint text (e.g. `tests/cli/test_login_databricks.py`, `tests/runtime/credentials/test_databricks.py`) check for `omnigent[databricks]`, which the new message still contains.

## Demo

N/A — CLI hint string change, no visual surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tests assert the hint names the `omnigent[databricks]` extra; the updated message keeps that substring, so no test changes were needed.

## Changelog

The install hint shown when the `databricks` extra is missing now suggests `uv tool install "omnigent[databricks]"` from the package index instead of installing from git

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>

