### PR TITLE
feat(desktop): connect Arca as a host behind an MDM internal-features flag

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,12 @@ importers:
 
   web/electron:
     dependencies:
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       electron-updater:
         specifier: ^6.3.9
         version: 6.8.9(supports-color@10.2.2)

--- a/web/electron/arca-connect/console.js
+++ b/web/electron/arca-connect/console.js
@@ -1,0 +1,76 @@
+// Renderer logic for the Arca connect console (see index.html for the page
+// and src/arca_connect_window.js for the flow + trust model). Talks only to
+// the narrow `window.arcaConnect` bridge exposed by arca_connect_preload.js.
+"use strict";
+
+const serverEl = document.getElementById("server");
+const commandEl = document.getElementById("command");
+const terminalEl = document.getElementById("terminal");
+const statusEl = document.getElementById("status");
+const confirmBtn = document.getElementById("confirm");
+const cancelBtn = document.getElementById("cancel");
+
+window.arcaConnect.onInit(({ serverUrl, command }) => {
+  // textContent only: the server URL is remote-influenced data.
+  serverEl.textContent = serverUrl;
+  commandEl.textContent = command;
+});
+
+confirmBtn.addEventListener("click", () => {
+  window.arcaConnect.confirm();
+});
+// Cancel doubles as Close after the run; the main process treats both as
+// "close the window" and settles accordingly.
+cancelBtn.addEventListener("click", () => {
+  window.arcaConnect.cancel();
+});
+
+window.arcaConnect.onStarted(() => {
+  // Reveal the terminal pane (the main process grows the window to match).
+  document.body.dataset.phase = "running";
+  // Mount the terminal now that its container has real dimensions.
+  requestAnimationFrame(() => ensureTerminal());
+  // The button itself carries the progress: spinner + "Connecting…".
+  confirmBtn.disabled = true;
+  confirmBtn.classList.add("loading");
+  confirmBtn.textContent = "Connecting…";
+  statusEl.dataset.kind = "";
+  statusEl.textContent = "A cold instance can take a few minutes to start.";
+});
+
+// The output pane is a real terminal (xterm.js, read-only), so arca/ssh ANSI
+// output — colors, \r progress rewrites, cursor movement — renders exactly as
+// it would in a shell. Loaded from the packaged node_modules (UMD globals:
+// `Terminal`, `FitAddon`); created lazily on first output since the pane is
+// hidden (zero-sized) until the run starts.
+let term = null;
+let fitAddon = null;
+
+function ensureTerminal() {
+  if (term !== null) return term;
+  term = new window.Terminal({
+    convertEol: true, // ssh output is \n-terminated
+    disableStdin: true,
+    fontSize: 12,
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+    theme: { background: "#0d1117", foreground: "#e6edf3" },
+  });
+  fitAddon = new window.FitAddon.FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(terminalEl);
+  fitAddon.fit();
+  window.addEventListener("resize", () => fitAddon.fit());
+  return term;
+}
+
+window.arcaConnect.onOutput((text) => {
+  ensureTerminal().write(text);
+});
+
+window.arcaConnect.onDone(({ ok, error }) => {
+  statusEl.dataset.kind = ok ? "ok" : "error";
+  statusEl.textContent = ok ? "Connected. The Arca host should appear online shortly." : error;
+  confirmBtn.classList.remove("loading");
+  confirmBtn.hidden = true;
+  cancelBtn.textContent = "Close";
+});

--- a/web/electron/arca-connect/index.html
+++ b/web/electron/arca-connect/index.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<!--
+  Arca connect console — a SHELL-OWNED modal page (see src/arca_connect_window.js
+  for the trust model). Shows the exact command that will run on the user's Arca
+  instance, then streams its live output into the terminal pane below, so
+  enrollment is fully transparent. All dynamic values are set via textContent —
+  never innerHTML — since the server URL is remote-influenced data.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; style-src 'unsafe-inline' 'self'; script-src 'self'; font-src 'self'"
+    />
+    <title>Connect Arca</title>
+    <link rel="stylesheet" href="../node_modules/@xterm/xterm/css/xterm.css" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --fg: #1f2328;
+        --muted: #656d76;
+        --border: #d0d7de;
+        --accent: #0969da;
+        --danger: #cf222e;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --fg: #e6edf3;
+          --muted: #8d96a0;
+          --border: #30363d;
+          --accent: #4493f8;
+          --danger: #f85149;
+        }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        padding: 16px;
+        font:
+          13px/1.45 -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        color: var(--fg);
+        background: Canvas;
+        user-select: none;
+      }
+      h1 {
+        margin: 0;
+        font-size: 15px;
+        font-weight: 600;
+      }
+      p {
+        margin: 0;
+        color: var(--muted);
+      }
+      #server {
+        font-weight: 500;
+        color: var(--fg);
+      }
+      /* One terminal box: the `$ command` line pinned up top, and — once the
+         run starts — an xterm.js pane streaming the live output below it. In
+         the asking phase it hugs the command; on confirm it expands. */
+      #console {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        font:
+          12px/1.5 ui-monospace,
+          SFMono-Regular,
+          Menlo,
+          monospace;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 10px;
+        background: #0d1117;
+        color: #e6edf3;
+        user-select: text;
+      }
+      body:not([data-phase="asking"]) #console {
+        flex: 1;
+        min-height: 0;
+      }
+      #command {
+        margin: 0;
+        flex: none;
+        font: inherit;
+        /* Wrap rather than scroll: the user is asked to READ this command,
+           and scrollbars in a small consent card hide the tail of the very
+           thing being consented to. break-all because a URL is one long
+           unbreakable token. */
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
+      /* Shell prompt, as CSS generated content: visually a `$ ` prefix, but
+         never part of a copy/paste selection. */
+      #command::before {
+        content: "$ ";
+        color: #8d96a0;
+        user-select: none;
+      }
+      /* The xterm.js mount point; the addon-fit sizes the grid to it. */
+      #terminal {
+        flex: 1;
+        min-height: 0;
+      }
+      /* Output exists only once a run started. */
+      body[data-phase="asking"] #terminal,
+      body[data-phase="asking"] #status {
+        display: none;
+      }
+      #status {
+        min-height: 1.4em;
+        font-weight: 500;
+      }
+      #status[data-kind="error"] {
+        color: var(--danger);
+      }
+      #status[data-kind="ok"] {
+        color: var(--accent);
+      }
+      footer {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+      }
+      button {
+        padding: 5px 14px;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        background: Canvas;
+        color: var(--fg);
+        font: inherit;
+        cursor: pointer;
+      }
+      button.primary {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: #fff;
+      }
+      button:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+      /* Inline spinner for the (still disabled) Connect button while the
+         command runs. Flex centering keeps the ring optically middle-aligned
+         with the label at any font metrics. */
+      button.loading {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        opacity: 0.85;
+      }
+      button.loading::before {
+        content: "";
+        flex: none;
+        width: 10px;
+        height: 10px;
+        border: 2px solid rgb(255 255 255 / 40%);
+        border-top-color: #fff;
+        border-radius: 50%;
+        animation: spin 0.8s linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
+  </head>
+  <body data-phase="asking">
+    <h1>Connect your Arca instance?</h1>
+    <p>
+      This runs the command below over <span id="server">…</span>. While connected as a runner, that
+      server can execute agent code and commands on the Arca instance on its behalf. Only confirm
+      for servers you trust.
+    </p>
+    <div id="console">
+      <div id="command">…</div>
+      <div id="terminal"></div>
+    </div>
+    <div id="status"></div>
+    <footer>
+      <button id="cancel" type="button">Cancel</button>
+      <button id="confirm" type="button" class="primary">Connect</button>
+    </footer>
+    <script src="../node_modules/@xterm/xterm/lib/xterm.js"></script>
+    <script src="../node_modules/@xterm/addon-fit/lib/addon-fit.js"></script>
+    <script src="./console.js"></script>
+  </body>
+</html>

--- a/web/electron/docs/managed-preferences.md
+++ b/web/electron/docs/managed-preferences.md
@@ -10,11 +10,12 @@ The preference domain is the desktop bundle identifier:
 ai.omnigent.desktop
 ```
 
-## Key
+## Keys
 
-| Key          | Type             | Required | Default | Description                                                                       |
-| ------------ | ---------------- | -------- | ------- | --------------------------------------------------------------------------------- |
-| `serverUrls` | Array of strings | No       | `[]`    | Server URLs to offer, most-preferred first. Each must use `https://`. At most 10. |
+| Key                                 | Type             | Required | Default | Description                                                                                                                                                                                     |
+| ----------------------------------- | ---------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `serverUrls`                        | Array of strings | No       | `[]`    | Server URLs to offer, most-preferred first. Each must use `https://`. At most 10.                                                                                                               |
+| `databricksInternalFeaturesEnabled` | Boolean          | No       | `false` | Enables Databricks-internal features (e.g. the Arca host option) on windows connected to a Databricks-managed server. Fails closed — anything but an explicit boolean `true` reads as disabled. |
 
 A schemeless host is accepted and interpreted as `https://`. Paths are
 preserved, so an administrator can provide a workspace mount directly:
@@ -40,6 +41,26 @@ screen and in the in-app server switcher. They are offered, not enforced:
 
 Applying or removing a profile is reflected the next time the server switcher
 is opened or the connect screen is loaded.
+
+## Databricks-internal features
+
+When `databricksInternalFeaturesEnabled` is `true` **and** the window is
+connected to a Databricks-managed server (a workspace mount on
+`*.databricks.com` / `*.azuredatabricks.net`, or a Databricks App on
+`*.databricksapps.com`, https only), the new-session host picker offers
+**Run on Arca**: connecting the user's Arca dev instance to the current
+server as a host. On any other server the flag reads as disabled. Selecting it
+opens a shell-owned connect console that shows the exact command — `arca ssh`
+with a remote `isaac omni host --background --non-interactive` — and, after
+confirmation, streams the command's live output into an embedded terminal
+pane; the instance authenticates with its own Databricks credentials. A
+connect already in flight is re-surfaced (console focused, outcome shared)
+rather than refused, and the run has a hard timeout so a wedged connection
+always settles. No local process outlives the connect — the enrolled host
+keeps its own outbound tunnel from the Arca box. Once connected, the option
+disappears and the box's host row is tagged **Arca instance** (recognized by
+the host id remembered at connect time). Like the server list, the flag is read from
+macOS on demand, so profile changes apply without a restart.
 
 ## MDM profile example
 
@@ -70,6 +91,8 @@ this as a custom settings or managed preferences payload.
                   <string>https://omnigent.corp.example.com</string>
                   <string>https://my-workspace.cloud.databricks.com/ml/omnigents</string>
                 </array>
+                <key>databricksInternalFeaturesEnabled</key>
+                <false/>
               </dict>
             </dict>
           </array>
@@ -116,12 +139,14 @@ identifier, not `ai.omnigent.desktop`, so it will not see this value:
 defaults write ai.omnigent.desktop serverUrls -array \
   "https://omnigent.corp.example.com" \
   "https://my-workspace.cloud.databricks.com/ml/omnigents"
+defaults write ai.omnigent.desktop databricksInternalFeaturesEnabled -bool true
 ```
 
-Remove the test value with:
+Remove the test values with:
 
 ```bash
 defaults delete ai.omnigent.desktop serverUrls
+defaults delete ai.omnigent.desktop databricksInternalFeaturesEnabled
 ```
 
 Production deployment should use an MDM-forced preference rather than a local

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -2,7 +2,7 @@
   "name": "omnigent-desktop-electron",
   "productName": "Omnigent",
   "version": "0.13.0-dev.0",
-  "description": "Omnigent desktop shell (Electron edition) — a thin native wrapper around the server-served web UI.",
+  "description": "Omnigent desktop shell (Electron edition) \u2014 a thin native wrapper around the server-served web UI.",
   "private": true,
   "main": "src/main.js",
   "homepage": "https://omnigent.ai",
@@ -62,6 +62,7 @@
     "files": [
       "src/**/*",
       "setup/**/*",
+      "arca-connect/**/*",
       "server-selector-v2/**/*",
       "find/**/*",
       "return-banner/**/*",
@@ -164,6 +165,8 @@
     }
   },
   "dependencies": {
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "electron-updater": "^6.3.9",
     "js-yaml": "^4.3.0"
   }

--- a/web/electron/src/arca.js
+++ b/web/electron/src/arca.js
@@ -1,0 +1,352 @@
+"use strict";
+
+/**
+ * Arca host connection (Databricks-internal).
+ *
+ * Arca is Databricks' internal sandbox CLI: each user has one EC2 dev
+ * instance, `arca ssh <args...>` passes the args through to ssh against it
+ * (starting the instance first when needed). Connecting that instance as an
+ * Omnigent host means running, over `arca ssh`:
+ *
+ *   isaac omni host --server <url> --background --non-interactive
+ *
+ * (`isaac` is the Databricks-internal launcher that provides the `omni` CLI
+ * on Arca instances.)
+ *
+ * The remote daemon then opens the ordinary outbound host tunnel using the
+ * Arca box's own Databricks credentials (synced by arca), so no secret ever
+ * leaves this machine. `--background` exits 0 only once the daemon survived
+ * startup, and `--non-interactive` fails loud instead of dangling on a browser
+ * login — both are what make the exit code a trustworthy signal here.
+ *
+ * This module is main-process-free: the binary probe and process spawn are
+ * injected so everything is unit-testable without Electron or a real arca.
+ */
+
+const { execFileSync, spawn } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+/**
+ * Connecting may cold-start the EC2 instance, which takes minutes — give the
+ * whole ssh + remote daemon startup a generous ceiling.
+ */
+const CONNECT_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * The only characters allowed in the server URL that rides inside the ssh
+ * remote command. ssh joins argv with spaces and the REMOTE shell re-parses
+ * the line, so the URL (the one non-literal argument) must not smuggle shell
+ * metacharacters (`;`, `$`, backticks, quotes, spaces…) through its path or
+ * query — URL-legal but shell-hostile. Allowlist, not escape: a URL outside
+ * this set is refused outright.
+ */
+const SAFE_URL_RE = /^[A-Za-z0-9\-._~:/?=&%]+$/;
+
+/**
+ * Well-known install locations for the arca binary. Probed because a
+ * GUI-launched Electron app inherits a minimal PATH (mirrors the omnigent CLI
+ * resolution in omnigent_cli.js).
+ *
+ * @returns {string[]}
+ */
+function candidatePaths() {
+  const home = os.homedir();
+  return [
+    "/usr/local/bin/arca",
+    "/opt/homebrew/bin/arca",
+    path.join(home, ".local", "bin", "arca"),
+  ];
+}
+
+/**
+ * True when `p` exists, is a regular file, and is executable by this process.
+ *
+ * @param {string} p
+ * @returns {boolean}
+ */
+function isExecutableFile(p) {
+  try {
+    if (!fs.statSync(p).isFile()) return false;
+    fs.accessSync(p, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve `arca` on PATH via the shell (so login-shell PATHs resolve), else
+ * null. Arca is macOS-only, so no Windows branch.
+ *
+ * @returns {string | null}
+ */
+function whichArca() {
+  try {
+    const out = execFileSync("/bin/sh", ["-c", "command -v arca"], { encoding: "utf8" });
+    return out.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Locate the arca binary: PATH first, then well-known locations. Null when
+ * arca isn't installed on this machine.
+ *
+ * @param {{
+ *   isExecutableFile?: (p: string) => boolean,
+ *   whichArca?: () => string | null,
+ *   candidatePaths?: () => string[],
+ * }} [deps]
+ * @returns {string | null}
+ */
+function resolveArcaPath(deps = {}) {
+  const isExec = deps.isExecutableFile || isExecutableFile;
+  const onPath = (deps.whichArca || whichArca)();
+  if (onPath && isExec(onPath)) return onPath;
+  for (const candidate of (deps.candidatePaths || candidatePaths)()) {
+    if (isExec(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Build the arca argv that connects the instance to `serverUrl`. Everything
+ * after "ssh" is passed through to ssh and runs as the remote command.
+ *
+ * @param {string} serverUrl
+ * @returns {string[]}
+ */
+function buildConnectArgs(serverUrl) {
+  const url = new URL(serverUrl);
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error(`unsupported server URL scheme: ${url.protocol}`);
+  }
+  if (!SAFE_URL_RE.test(url.toString())) {
+    throw new Error("server URL contains characters that are not allowed in an ssh command");
+  }
+  return [
+    "ssh",
+    // Ordinary arca ssh inherits -R 19222 from ~/.ssh/config. Arca Companion
+    // concurrently reclaims that reserved listener with `fuser -k`, which can
+    // kill this session during cold start even after the remote command
+    // succeeded. This headless launch needs no forwards, so opt out entirely.
+    "-o",
+    "ClearAllForwardings=yes",
+    "isaac",
+    "omni",
+    "host",
+    "--server",
+    url.toString(),
+    "--background",
+    "--non-interactive",
+  ];
+}
+
+/**
+ * Map a failed connect run to an actionable user-facing result. Matched
+ * against known arca / omnigent CLI failure shapes; anything unrecognized
+ * falls through to the captured output.
+ *
+ * @param {{ code: number | null, stdout: string, stderr: string, timedOut?: boolean }} run
+ * @returns {{ ok: false, error: string, authError?: boolean }}
+ */
+function describeConnectFailure(run) {
+  const output = `${run.stderr}\n${run.stdout}`;
+  if (run.timedOut) {
+    return {
+      ok: false,
+      error:
+        "Connecting to Arca timed out. The instance may still be starting — " +
+        "check `arca status` and try again.",
+    };
+  }
+  // `omni host --non-interactive` fails loud with a sign-in hint when the
+  // Arca box's Databricks credentials can't mint a server token.
+  if (/not signed in/i.test(output)) {
+    return {
+      ok: false,
+      authError: true,
+      error:
+        "The Arca instance isn't signed in to this server. Run " +
+        "`arca ssh` and sign in with `isaac omni login <server-url>`, then try again.",
+    };
+  }
+  // The remote shell couldn't find isaac (or isaac couldn't find omni) on the
+  // Arca instance.
+  if (run.code === 127 || /(isaac|omni(gent)?):? .*(command )?not found/i.test(output)) {
+    return {
+      ok: false,
+      error:
+        "`isaac omni` isn't available on the Arca instance. " +
+        "Check the isaac setup there (`arca ssh`, then `isaac omni --help`) and try again.",
+    };
+  }
+  if (/error connecting to arca/i.test(output)) {
+    return {
+      ok: false,
+      error:
+        "Couldn't reach the Arca instance. Try `arca stop && arca start` in a terminal, " +
+        "then connect again.",
+    };
+  }
+  const detail = run.stderr.trim() || run.stdout.trim();
+  return {
+    ok: false,
+    error: detail
+      ? `Connecting to Arca failed: ${lastLine(detail)}`
+      : `Connecting to Arca failed (exit code ${run.code ?? "unknown"}).`,
+  };
+}
+
+/**
+ * The last non-empty line of captured output — arca and ssh are chatty, and
+ * the final line is where both put the actual error.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function lastLine(text) {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines[lines.length - 1] ?? text;
+}
+
+/**
+ * Start connecting the user's Arca instance to `serverUrl` as an Omnigent
+ * host, streaming the command's live output. Built for the connect console:
+ * the caller shows `command` to the user, pipes `onOutput` chunks into a
+ * terminal pane, and may `cancel()` (window closed). The promise never
+ * rejects — every failure resolves as `{ ok: false, error }`.
+ *
+ * @param {string} serverUrl The window's connected server URL.
+ * @param {{
+ *   timeoutMs?: number,
+ *   resolveArcaPath?: () => string | null,
+ *   spawn?: typeof spawn,
+ *   onOutput?: (text: string) => void,
+ * }} [deps]
+ * @returns {{
+ *   command: string | null,
+ *   promise: Promise<{
+ *     ok: boolean,
+ *     alreadyRunning?: boolean,
+ *     error?: string,
+ *     authError?: boolean,
+ *     canceled?: boolean,
+ *   }>,
+ *   cancel: () => void,
+ * }}
+ */
+function startArcaConnect(serverUrl, deps = {}) {
+  const timeoutMs = deps.timeoutMs ?? CONNECT_TIMEOUT_MS;
+  const onOutput = deps.onOutput || (() => {});
+  const arcaPath = (deps.resolveArcaPath || resolveArcaPath)();
+  if (!arcaPath) {
+    return {
+      command: null,
+      promise: Promise.resolve({
+        ok: false,
+        error: "The arca CLI was not found on this machine.",
+      }),
+      cancel: () => {},
+    };
+  }
+  let args;
+  try {
+    args = buildConnectArgs(serverUrl);
+  } catch (error) {
+    return {
+      command: null,
+      promise: Promise.resolve({ ok: false, error: `Invalid server URL: ${error.message}` }),
+      cancel: () => {},
+    };
+  }
+  const spawnFn = deps.spawn || spawn;
+  const child = spawnFn(arcaPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+  let stdout = "";
+  let stderr = "";
+  let timedOut = false;
+  let canceled = false;
+  const promise = new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        child.kill();
+      } catch {
+        // Already gone.
+      }
+    }, timeoutMs);
+    if (typeof timer.unref === "function") timer.unref();
+    child.stdout?.on("data", (chunk) => {
+      const text = String(chunk);
+      stdout += text;
+      onOutput(text);
+    });
+    child.stderr?.on("data", (chunk) => {
+      const text = String(chunk);
+      stderr += text;
+      onOutput(text);
+    });
+    let settled = false;
+    const settle = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    child.on("error", (error) => {
+      settle({ ok: false, error: `Couldn't run arca: ${error.message}` });
+    });
+    child.on("exit", (code) => {
+      if (canceled) {
+        settle({ ok: false, canceled: true, error: "Connecting to Arca was canceled." });
+        return;
+      }
+      if (code === 0) {
+        // `omni host --background` reuses a healthy daemon and says so — the
+        // caller can then skip waiting for a host that was online all along.
+        settle({ ok: true, alreadyRunning: /already running/i.test(stdout + stderr) });
+        return;
+      }
+      settle(describeConnectFailure({ code, stdout, stderr, timedOut }));
+    });
+  });
+  return {
+    command: `arca ${args.join(" ")}`,
+    promise,
+    cancel: () => {
+      canceled = true;
+      try {
+        child.kill();
+      } catch {
+        // Already gone.
+      }
+    },
+  };
+}
+
+/**
+ * Connect the user's Arca instance to `serverUrl` as an Omnigent host. Thin
+ * non-streaming wrapper over {@link startArcaConnect}; never rejects.
+ *
+ * @param {string} serverUrl The window's connected server URL.
+ * @param {Parameters<typeof startArcaConnect>[1]} [deps]
+ * @returns {Promise<{ ok: boolean, error?: string, authError?: boolean }>}
+ */
+function connectArcaHost(serverUrl, deps = {}) {
+  return startArcaConnect(serverUrl, deps).promise;
+}
+
+module.exports = {
+  CONNECT_TIMEOUT_MS,
+  buildConnectArgs,
+  connectArcaHost,
+  describeConnectFailure,
+  resolveArcaPath,
+  startArcaConnect,
+};

--- a/web/electron/src/arca_connect_preload.js
+++ b/web/electron/src/arca_connect_preload.js
@@ -1,0 +1,31 @@
+"use strict";
+
+/**
+ * Preload for the SHELL-OWNED Arca connect console (arca-connect/index.html).
+ * Deliberately narrow: the page can confirm/cancel its own flow and receive
+ * init/output/done events — nothing else. It must NOT reuse the main shell
+ * preload: this page needs none of those bridges, and consent surfaces should
+ * carry the minimum possible capability.
+ */
+
+const { contextBridge, ipcRenderer } = require("electron");
+
+/** Subscribe to a main→console channel, passing the payload through. */
+function on(channel, callback) {
+  ipcRenderer.on(channel, (_event, payload) => callback(payload));
+}
+
+contextBridge.exposeInMainWorld("arcaConnect", {
+  /** The user confirmed — run the command. Accepted only from this window. */
+  confirm: () => ipcRenderer.send("arca-connect:confirm"),
+  /** Cancel / close the console (kills a mid-run command). */
+  cancel: () => ipcRenderer.send("arca-connect:cancel"),
+  /** `{ serverUrl, command }` once the flow is ready. */
+  onInit: (callback) => on("arca-connect:init", callback),
+  /** The command was spawned. */
+  onStarted: (callback) => on("arca-connect:started", callback),
+  /** A chunk of live stdout/stderr. */
+  onOutput: (callback) => on("arca-connect:output", callback),
+  /** `{ ok, error }` when the command settles. */
+  onDone: (callback) => on("arca-connect:done", callback),
+});

--- a/web/electron/src/arca_connect_window.js
+++ b/web/electron/src/arca_connect_window.js
@@ -1,0 +1,210 @@
+"use strict";
+
+/**
+ * The Arca connect console — a SHELL-OWNED modal window that replaces the
+ * bare native consent dialog. It shows the exact `arca ssh` command that will
+ * run and, after the user confirms, streams the command's live stdout/stderr
+ * into an embedded terminal pane, so enrollment is fully transparent.
+ *
+ * Trust model: this window is created by the main process and loads a bundled
+ * file:// page with its own narrow preload. The server-served SPA can neither
+ * draw over it, forge a click in it, nor reach its IPC channels — so a
+ * Confirm click here carries the same authority as the old native dialog
+ * (see confirmHostEnrollment for why consent must live outside the server's
+ * page). Confirm/cancel messages are accepted only from this window's own
+ * webContents.
+ *
+ * All Electron surfaces are injected so the flow is unit-testable.
+ */
+
+/** Channels between this window's preload and main. */
+const CONFIRM_CHANNEL = "arca-connect:confirm";
+const CANCEL_CHANNEL = "arca-connect:cancel";
+
+/**
+ * @param {{
+ *   BrowserWindow: typeof import("electron").BrowserWindow,
+ *   ipcMain: import("electron").IpcMain,
+ *   pagePath: string,
+ *   preloadPath: string,
+ *   startConnect: (serverUrl: string, onOutput: (text: string) => void) =>
+ *     ReturnType<typeof import("./arca").startArcaConnect>,
+ *   commandLine: (serverUrl: string) => string,
+ *   log?: (message: string) => void,
+ * }} deps
+ * @returns {{ run: (parentWin: unknown, serverUrl: string) => Promise<object> }}
+ */
+function createArcaConnectFlow({
+  BrowserWindow,
+  ipcMain,
+  pagePath,
+  preloadPath,
+  startConnect,
+  commandLine,
+  log = () => {},
+}) {
+  /**
+   * Button routing, keyed by the console window's webContents id and kept
+   * for the window's WHOLE life (not the run's): the post-run "Close" click
+   * must still route after the result promise settled. Only messages from a
+   * registered console's own webContents are honored — a server page
+   * (different webContents) can't spoof consent.
+   * @type {Map<number, { onConfirm: () => void, onCancel: () => void }>}
+   */
+  const consoles = new Map();
+  /**
+   * The in-flight run's window + shared outcome promise, or null. One run at
+   * a time — a second run() while it exists re-attaches (focuses the window,
+   * shares the outcome) instead of failing, so a refreshed SPA can always get
+   * back to an in-flight connect.
+   */
+  let activeRun = null;
+
+  ipcMain.on(CONFIRM_CHANNEL, (event) => {
+    consoles.get(event.sender.id)?.onConfirm();
+  });
+  ipcMain.on(CANCEL_CHANNEL, (event) => {
+    consoles.get(event.sender.id)?.onCancel();
+  });
+
+  /**
+   * Open the console over `parentWin` and drive one connect to `serverUrl`.
+   * Resolves with the connect result: `{ ok: false }` (not approved) when the
+   * user cancels or closes before confirming; the command's own result after
+   * a confirmed run. The window stays open after a run so the user can read
+   * the output; the promise resolves as soon as the command settles.
+   *
+   * @param {unknown} parentWin
+   * @param {string} serverUrl
+   */
+  function run(parentWin, serverUrl) {
+    // Re-attach: an in-flight console survives an SPA refresh (it's a shell
+    // window), so a repeat click surfaces it and awaits the same outcome
+    // rather than erroring with "already in progress".
+    if (activeRun) {
+      try {
+        if (!activeRun.win.isDestroyed()) {
+          activeRun.win.show();
+          activeRun.win.focus();
+        }
+      } catch {
+        // Window mid-teardown; the shared promise still settles.
+      }
+      return activeRun.promise;
+    }
+    const promise = new Promise((resolve) => {
+      // Opens as a compact consent card; grows on Confirm when the page
+      // reveals its terminal pane (see index.html's data-phase styling).
+      const win = new BrowserWindow({
+        parent: parentWin ?? undefined,
+        modal: true,
+        width: 720,
+        height: 264, // fits the consent copy + a wrapped two-line command
+        minimizable: false,
+        maximizable: false,
+        fullscreenable: false,
+        show: false,
+        title: "Connect Arca",
+        webPreferences: {
+          preload: preloadPath,
+          contextIsolation: true,
+          nodeIntegration: false,
+          sandbox: true,
+        },
+      });
+
+      // Captured now: webContents is unreadable after the window is destroyed,
+      // and the closed handler needs the id to unregister the console.
+      const consoleId = win.webContents.id;
+      let phase = "asking"; // "asking" → "running" → "done"
+      let connect = null;
+      let settled = false;
+      const settle = (result) => {
+        if (settled) return;
+        settled = true;
+        activeRun = null;
+        resolve(result);
+      };
+
+      const send = (channel, payload) => {
+        try {
+          if (!win.isDestroyed()) win.webContents.send(channel, payload);
+        } catch {
+          // Window torn down mid-send; the close handler settles the flow.
+        }
+      };
+
+      consoles.set(consoleId, {
+        onConfirm: () => {
+          if (phase !== "asking") return;
+          phase = "running";
+          log(`arca connect: user confirmed; running against ${serverUrl}`);
+          // Grow to fit the terminal pane the page is about to reveal.
+          try {
+            win.setSize(720, 500, true);
+          } catch {
+            // Window mid-teardown; the run itself proceeds regardless.
+          }
+          connect = startConnect(serverUrl, (text) => send("arca-connect:output", text));
+          send("arca-connect:started", null);
+          void connect.promise.then((result) => {
+            phase = "done";
+            send("arca-connect:done", {
+              ok: result.ok === true,
+              error: result.ok === true ? null : (result.error ?? "Connecting to Arca failed."),
+            });
+            // Resolve now — the SPA proceeds (host auto-select) while the
+            // user reads the output; the window closes on their Close click.
+            // `shownInConsole` tells the picker this outcome was already
+            // displayed here, so it must not be echoed as a second error.
+            settle({ ...result, shownInConsole: true });
+          });
+        },
+        onCancel: () => {
+          // Cancel button (or Close after a run) — just close; the close
+          // handler owns settling so both paths behave identically.
+          try {
+            win.close();
+          } catch {
+            // Already closing.
+          }
+        },
+      });
+
+      win.on("closed", () => {
+        consoles.delete(consoleId);
+        if (phase === "running" && connect) {
+          // Closing mid-run kills the command: an unwatched enrollment must
+          // not keep executing after its console is gone.
+          log("arca connect: console closed mid-run; canceling");
+          connect.cancel();
+          // The canceled command's exit settles via the promise above; as a
+          // belt-and-brace, settle here too (settle() is idempotent).
+          settle({ ok: false, canceled: true, error: "Connecting to Arca was canceled." });
+          return;
+        }
+        // Declining the console is a deliberate user choice, not a failure —
+        // `canceled` tells the picker to stay silent instead of rendering a
+        // red error with a retry.
+        settle({ ok: false, canceled: true, error: "Connecting Arca wasn't approved." });
+      });
+
+      // did-finish-load fires after the page's top-level script ran, so its
+      // IPC listeners exist before init arrives (ready-to-show can race them).
+      win.webContents.once("did-finish-load", () => {
+        send("arca-connect:init", { serverUrl, command: commandLine(serverUrl) });
+      });
+      win.once("ready-to-show", () => {
+        win.show();
+      });
+      void win.loadFile(pagePath);
+      activeRun = { win, promise: null };
+    });
+    if (activeRun) activeRun.promise = promise;
+    return promise;
+  }
+
+  return { run };
+}
+
+module.exports = { CANCEL_CHANNEL, CONFIRM_CHANNEL, createArcaConnectFlow };

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -43,6 +43,7 @@ const {
   expandDatabricksWorkspaceUrl,
   normalizeSavedServerUrl,
   fetchServerManifest,
+  isDatabricksManagedServerUrl,
   PRE_MANIFEST_BASELINE,
   LOCAL_HOSTS,
 } = require("./url");
@@ -55,7 +56,13 @@ const { createBrowserViewRegistry } = require("./browserViewRegistry");
 const { createBrowserViewBoundsController } = require("./browserViewBounds");
 const { registerBrowserIpc } = require("./browserIpc");
 const { isDeveloperModeEnabled } = require("./developer_mode");
-const { excludingManagedServers, getManagedServerUrls } = require("./managed_preferences");
+const {
+  excludingManagedServers,
+  getDatabricksInternalFeaturesEnabled,
+  getManagedServerUrls,
+} = require("./managed_preferences");
+const arca = require("./arca");
+const { createArcaConnectFlow } = require("./arca_connect_window");
 const { registerSessionExpiryReload } = require("./session-expiry");
 const { decideWindowOpen, stripCrossOriginOpenerHeaders, WEB_SCHEMES } = require("./popupPolicy");
 const {
@@ -190,6 +197,43 @@ function managedServerUrls() {
         : undefined,
   });
 }
+
+/**
+ * Whether the MDM-managed Databricks-internal-features flag is set. Read from
+ * macOS on every call (never persisted), so profile changes apply live.
+ */
+function databricksInternalFeaturesEnabled() {
+  return getDatabricksInternalFeaturesEnabled({
+    platform: process.platform,
+    getUserDefault:
+      typeof systemPreferences.getUserDefault === "function"
+        ? systemPreferences.getUserDefault.bind(systemPreferences)
+        : undefined,
+  });
+}
+
+/**
+ * The Arca connect console: a shell-owned modal that asks consent by showing
+ * the exact command, then streams its live output (replaces the bare native
+ * dialog — same trust model, full transparency). The flow also de-duplicates:
+ * a repeat connect while one is in flight re-focuses the existing console and
+ * shares its outcome, so a refreshed SPA can always get back to it.
+ */
+const arcaConnectFlow = createArcaConnectFlow({
+  BrowserWindow,
+  ipcMain,
+  pagePath: path.join(__dirname, "..", "arca-connect", "index.html"),
+  preloadPath: path.join(__dirname, "arca_connect_preload.js"),
+  startConnect: (serverUrl, onOutput) => arca.startArcaConnect(serverUrl, { onOutput }),
+  commandLine: (serverUrl) => {
+    try {
+      return `arca ${arca.buildConnectArgs(serverUrl).join(" ")}`;
+    } catch {
+      return "arca ssh isaac omni host …"; // the run itself re-validates and fails loud
+    }
+  },
+  log: (message) => console.log(`[omnigent] ${message}`),
+});
 
 /**
  * Quit-safety timeouts (see the before-quit handler near the end of this
@@ -2877,6 +2921,51 @@ function registerIpc() {
     }
     broadcastHostStatus();
     return result;
+  });
+
+  // SPA → desktop feature gates the server can't know about, currently just
+  // the MDM-managed Databricks-internal flag (Arca). Scoped per window: the
+  // flag reads true only when the window's own server is Databricks-managed
+  // (a workspace mount or a Databricks App) — internal features must not
+  // light up against arbitrary self-hosted servers. Read fresh per call so
+  // applying/removing the profile takes effect without a restart.
+  ipcMain.handle("omnigent:get-desktop-features", (event) => {
+    if (!isPinnedOriginSender(event)) {
+      console.warn("[omnigent] get-desktop-features from untrusted sender dropped");
+      return null;
+    }
+    return {
+      databricksInternalFeatures:
+        databricksInternalFeaturesEnabled() && isDatabricksManagedServerUrl(senderServerUrl(event)),
+    };
+  });
+
+  // SPA → connect the user's Arca instance (Databricks-internal sandbox) to
+  // the window's server as a host, by running `isaac omni host --background`
+  // on the instance over `arca ssh`. Gated three ways: pinned-origin sender,
+  // the MDM flag re-checked HERE (the renderer is not trusted to have checked
+  // it), and user consent in the shell-owned connect console — which shows
+  // the exact command and streams its live output (arca_connect_window.js).
+  // A connect already in flight is re-surfaced (console focused, outcome
+  // shared), never refused; the runner itself enforces CONNECT_TIMEOUT_MS so
+  // a wedged command always settles. No local process outlives the connect:
+  // the enrolled host keeps its own outbound tunnel from the Arca box.
+  ipcMain.handle("omnigent:arca-connect", async (event) => {
+    if (!isPinnedOriginSender(event)) {
+      throw new Error("arca-connect is only available to a connected server page");
+    }
+    if (!databricksInternalFeaturesEnabled()) {
+      return { ok: false, error: "Arca support is not enabled on this machine." };
+    }
+    const serverUrl = senderServerUrl(event);
+    if (!serverUrl) return { ok: false, error: "this window is not connected to a server" };
+    // Same scope as get-desktop-features, re-checked here: an Arca box may
+    // only be enrolled against a Databricks-managed server.
+    if (!isDatabricksManagedServerUrl(serverUrl)) {
+      return { ok: false, error: "Arca hosts can only connect to Databricks-managed servers." };
+    }
+    const win = BrowserWindow.fromWebContents(event.sender);
+    return arcaConnectFlow.run(win, serverUrl);
   });
 
   // Push a status ping when a host child connects or exits on its own (no

--- a/web/electron/src/managed_preferences.js
+++ b/web/electron/src/managed_preferences.js
@@ -3,6 +3,12 @@
 /** Public macOS Managed Preferences key in the ai.omnigent.desktop domain. */
 const SERVER_URLS_KEY = "serverUrls";
 
+/**
+ * Managed Preferences key gating Databricks-internal features (e.g. the Arca
+ * host option). Boolean; anything but an explicit true reads as disabled.
+ */
+const DATABRICKS_INTERNAL_FEATURES_KEY = "databricksInternalFeaturesEnabled";
+
 /** Keep organization-provided choices bounded on the connect screen. */
 const MAX_SERVER_URLS = 10;
 
@@ -79,6 +85,30 @@ function getManagedServerUrls({ platform = process.platform, getUserDefault } = 
 }
 
 /**
+ * Read the Databricks-internal-features flag from effective macOS preferences.
+ * Fails closed: any missing value, wrong type, non-darwin platform, or read
+ * error reads as disabled. Like the managed server list, the value is read on
+ * demand and never persisted, so removing the profile disables it immediately.
+ *
+ * @param {{
+ *   platform?: NodeJS.Platform,
+ *   getUserDefault?: (key: string, type: string) => unknown,
+ * }} [options]
+ * @returns {boolean}
+ */
+function getDatabricksInternalFeaturesEnabled({
+  platform = process.platform,
+  getUserDefault,
+} = {}) {
+  if (platform !== "darwin" || typeof getUserDefault !== "function") return false;
+  try {
+    return getUserDefault(DATABRICKS_INTERNAL_FEATURES_KEY, "boolean") === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Remove user recents whose origin is already supplied by the organization.
  *
  * @param {unknown} candidates
@@ -99,9 +129,11 @@ function excludingManagedServers(candidates, managedServers) {
 }
 
 module.exports = {
+  DATABRICKS_INTERNAL_FEATURES_KEY,
   MAX_SERVER_URLS,
   SERVER_URLS_KEY,
   excludingManagedServers,
+  getDatabricksInternalFeaturesEnabled,
   getManagedServerUrls,
   normalizeManagedServerUrl,
   parseManagedServerUrls,

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -113,6 +113,20 @@ contextBridge.exposeInMainWorld("omnigentDesktop", {
    */
   controlHost: (action) => ipcRenderer.invoke("omnigent:host-control", action),
   /**
+   * Desktop feature gates the server can't know about — currently
+   * `{ databricksInternalFeatures }` from macOS Managed Preferences, scoped
+   * to the window's server (true only on Databricks-managed servers).
+   * Resolves null off a connected server.
+   */
+  getDesktopFeatures: () => ipcRenderer.invoke("omnigent:get-desktop-features"),
+  /**
+   * Connect the user's Arca instance (Databricks-internal) to the window's
+   * server as a host, via `arca ssh`. Native consent is asked in the main
+   * process. Resolves a `{ ok, error?, authError? }` result.
+   */
+  connectArcaHost: () => ipcRenderer.invoke("omnigent:arca-connect"),
+
+  /**
    * Subscribe to host status-change pings. Fired only on real events (a host
    * child connecting/exiting, or a control action) — never on a timer — so the
    * renderer re-reads what it needs on demand. The callback takes no argument.

--- a/web/electron/src/url.js
+++ b/web/electron/src/url.js
@@ -233,6 +233,31 @@
   }
 
   /**
+   * True when a server URL is hosted by Databricks — a workspace domain
+   * (workspace-mounted Omnigent) or a Databricks App. Https-only: a local or
+   * self-hosted server is never "Databricks-managed", whatever its hostname
+   * claims. Used to scope Databricks-internal desktop features (e.g. the Arca
+   * host option) to Databricks-managed servers.
+   *
+   * @param {string | null | undefined} rawUrl
+   * @returns {boolean}
+   */
+  function isDatabricksManagedServerUrl(rawUrl) {
+    let url;
+    try {
+      url = new URL(rawUrl);
+    } catch {
+      return false;
+    }
+    if (url.protocol !== "https:") return false;
+    const host = url.hostname.toLowerCase();
+    if (host === DATABRICKS_APPS_HOST_SUFFIX || host.endsWith(`.${DATABRICKS_APPS_HOST_SUFFIX}`)) {
+      return true;
+    }
+    return isDatabricksWorkspaceHost(host);
+  }
+
+  /**
    * Probe timeout for Databricks workspace detection. Deliberately short: a
    * slow or unreachable host must not stall the connect flow — on timeout we
    * fall back to loading the URL exactly as entered.
@@ -400,6 +425,7 @@
     WORKSPACE_PROBE_TIMEOUT_MS,
     databricksWorkspaceUiUrl,
     expandDatabricksWorkspaceUrl,
+    isDatabricksManagedServerUrl,
     WELL_KNOWN_MANIFEST_PATH,
     MANIFEST_FETCH_TIMEOUT_MS,
     PRE_MANIFEST_BASELINE,

--- a/web/electron/test/arca.test.js
+++ b/web/electron/test/arca.test.js
@@ -1,0 +1,218 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const {
+  buildConnectArgs,
+  connectArcaHost,
+  describeConnectFailure,
+  resolveArcaPath,
+  startArcaConnect,
+} = require("../src/arca");
+
+/** A fake connect child: an EventEmitter with stdout/stderr stream stubs. */
+function fakeConnectChild() {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.killed = false;
+  child.kill = () => {
+    child.killed = true;
+  };
+  return child;
+}
+
+describe("arca binary resolution", () => {
+  it("prefers PATH, then falls back to well-known locations", () => {
+    assert.equal(
+      resolveArcaPath({
+        whichArca: () => "/from/path/arca",
+        isExecutableFile: (p) => p === "/from/path/arca",
+        candidatePaths: () => ["/usr/local/bin/arca"],
+      }),
+      "/from/path/arca",
+    );
+    assert.equal(
+      resolveArcaPath({
+        whichArca: () => null,
+        isExecutableFile: (p) => p === "/usr/local/bin/arca",
+        candidatePaths: () => ["/opt/homebrew/bin/arca", "/usr/local/bin/arca"],
+      }),
+      "/usr/local/bin/arca",
+    );
+    assert.equal(
+      resolveArcaPath({
+        whichArca: () => null,
+        isExecutableFile: () => false,
+        candidatePaths: () => ["/usr/local/bin/arca"],
+      }),
+      null,
+    );
+  });
+});
+
+describe("arca connect command", () => {
+  it("passes the remote isaac omni host command through ssh", () => {
+    assert.deepEqual(buildConnectArgs("https://workspace.example.com/ml/omnigents"), [
+      "ssh",
+      "-o",
+      "ClearAllForwardings=yes",
+      "isaac",
+      "omni",
+      "host",
+      "--server",
+      "https://workspace.example.com/ml/omnigents",
+      "--background",
+      "--non-interactive",
+    ]);
+  });
+
+  it("rejects non-http(s) server URLs", () => {
+    assert.throws(() => buildConnectArgs("file:///etc/passwd"));
+    assert.throws(() => buildConnectArgs("not a url"));
+  });
+
+  it("rejects URLs smuggling shell metacharacters through path or query", () => {
+    // ssh re-parses the remote command in a shell, so URL-legal but
+    // shell-hostile characters must be refused, not passed through.
+    assert.throws(() => buildConnectArgs("https://ws.cloud.databricks.com/omnigent;id"));
+    assert.throws(() => buildConnectArgs("https://ws.cloud.databricks.com/a$(id)"));
+    assert.throws(() => buildConnectArgs("https://ws.cloud.databricks.com/a'b"));
+    // The ordinary workspace-mount shape stays accepted.
+    assert.doesNotThrow(() => buildConnectArgs("https://ws.cloud.databricks.com/omnigent?o=123"));
+  });
+});
+
+describe("arca connect failures", () => {
+  it("maps a timeout, sign-in, missing-CLI, and unreachable instance", () => {
+    assert.match(
+      describeConnectFailure({ code: null, stdout: "", stderr: "", timedOut: true }).error,
+      /timed out/i,
+    );
+
+    const auth = describeConnectFailure({
+      code: 1,
+      stdout: "",
+      stderr: "Not signed in to https://srv (\u2026). Run `omnigent login https://srv` and retry.",
+    });
+    assert.equal(auth.authError, true);
+    assert.match(auth.error, /isaac omni login/);
+
+    assert.match(
+      describeConnectFailure({ code: 127, stdout: "", stderr: "bash: isaac: command not found" })
+        .error,
+      /isn't available on the Arca instance/,
+    );
+    assert.match(
+      describeConnectFailure({ code: 1, stdout: "", stderr: "isaac: omni: command not found" })
+        .error,
+      /isn't available on the Arca instance/,
+    );
+
+    assert.match(
+      describeConnectFailure({
+        code: 1,
+        stdout: "",
+        stderr: "Error connecting to arca. The instance may be stopped or unreachable.",
+      }).error,
+      /arca stop && arca start/,
+    );
+  });
+
+  it("falls back to the last output line for unrecognized failures", () => {
+    const result = describeConnectFailure({
+      code: 1,
+      stdout: "",
+      stderr: "noise line\nssh: connect to host 1.2.3.4 port 22: Connection refused",
+    });
+    assert.match(result.error, /Connection refused/);
+    assert.doesNotMatch(result.error, /noise line/);
+  });
+});
+
+describe("startArcaConnect / connectArcaHost", () => {
+  it("streams live output, exposes the command, and resolves ok on exit 0", async () => {
+    const chunks = [];
+    let child;
+    const run = startArcaConnect("https://srv.example.com", {
+      resolveArcaPath: () => "/usr/local/bin/arca",
+      spawn: (file, args) => {
+        assert.equal(file, "/usr/local/bin/arca");
+        assert.equal(args[0], "ssh");
+        child = fakeConnectChild();
+        return child;
+      },
+      onOutput: (text) => chunks.push(text),
+    });
+    assert.equal(
+      run.command,
+      "arca ssh -o ClearAllForwardings=yes isaac omni host --server https://srv.example.com/ --background --non-interactive",
+    );
+    child.stdout.emit("data", "Attempting to start your Arca instance\n");
+    child.stderr.emit("data", "synced dbcert\n");
+    child.emit("exit", 0);
+    assert.deepEqual(await run.promise, { ok: true, alreadyRunning: false });
+    assert.deepEqual(chunks, ["Attempting to start your Arca instance\n", "synced dbcert\n"]);
+  });
+
+  it("reports a reused daemon so callers don't wait for a new host", async () => {
+    let child;
+    const run = startArcaConnect("https://srv.example.com", {
+      resolveArcaPath: () => "/usr/local/bin/arca",
+      spawn: () => {
+        child = fakeConnectChild();
+        return child;
+      },
+    });
+    child.stdout.emit("data", "Host daemon already running (pid 4242).\n");
+    child.emit("exit", 0);
+    assert.deepEqual(await run.promise, { ok: true, alreadyRunning: true });
+  });
+
+  it("maps a failing exit through the captured output and never rejects", async () => {
+    let child;
+    const failRun = startArcaConnect("https://srv.example.com", {
+      resolveArcaPath: () => "/usr/local/bin/arca",
+      spawn: () => {
+        child = fakeConnectChild();
+        return child;
+      },
+    });
+    child.stderr.emit("data", "bash: isaac: command not found");
+    child.emit("exit", 1);
+    const result = await failRun.promise;
+    assert.equal(result.ok, false);
+    assert.match(result.error, /Arca instance/);
+  });
+
+  it("cancel kills the child and resolves as canceled", async () => {
+    let child;
+    const run = startArcaConnect("https://srv.example.com", {
+      resolveArcaPath: () => "/usr/local/bin/arca",
+      spawn: () => {
+        child = fakeConnectChild();
+        return child;
+      },
+    });
+    run.cancel();
+    assert.equal(child.killed, true);
+    child.emit("exit", null); // the kill lands
+    const result = await run.promise;
+    assert.equal(result.ok, false);
+    assert.equal(result.canceled, true);
+  });
+
+  it("fails cleanly when arca is not installed", async () => {
+    const result = await connectArcaHost("https://srv.example.com", {
+      resolveArcaPath: () => null,
+      spawn: () => {
+        throw new Error("must not spawn");
+      },
+    });
+    assert.deepEqual(result, {
+      ok: false,
+      error: "The arca CLI was not found on this machine.",
+    });
+  });
+});

--- a/web/electron/test/arca_connect_window.test.js
+++ b/web/electron/test/arca_connect_window.test.js
@@ -1,0 +1,180 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const { createArcaConnectFlow } = require("../src/arca_connect_window");
+
+/** A fake Electron world: BrowserWindow + ipcMain + a controllable connect. */
+function flowHarness() {
+  const world = {
+    windows: [],
+    ipc: new EventEmitter(),
+    connects: [],
+  };
+
+  class FakeWindow extends EventEmitter {
+    constructor() {
+      super();
+      this.webContents = new EventEmitter();
+      this.webContents.id = 100 + world.windows.length;
+      this.webContents.sent = [];
+      this.webContents.send = (channel, payload) => {
+        this.webContents.sent.push([channel, payload]);
+      };
+      this.destroyed = false;
+      this.shown = 0;
+      this.focused = 0;
+      this.size = null;
+      world.windows.push(this);
+    }
+    setSize(width, height) {
+      this.size = [width, height];
+    }
+    loadFile() {
+      // The page "loads" immediately: fire the init + show hooks.
+      this.webContents.emit("did-finish-load");
+      this.emit("ready-to-show");
+    }
+    isDestroyed() {
+      return this.destroyed;
+    }
+    show() {
+      this.shown += 1;
+    }
+    focus() {
+      this.focused += 1;
+    }
+    close() {
+      this.destroyed = true;
+      this.emit("closed");
+    }
+  }
+  const flow = createArcaConnectFlow({
+    BrowserWindow: FakeWindow,
+    ipcMain: {
+      on: (channel, fn) => world.ipc.on(channel, fn),
+    },
+    pagePath: "/bundle/arca-connect/index.html",
+    preloadPath: "/bundle/src/arca_connect_preload.js",
+    commandLine: (url) => `arca ssh isaac omni host --server ${url} …`,
+    startConnect: (serverUrl, onOutput) => {
+      const connect = {
+        serverUrl,
+        onOutput,
+        canceled: false,
+        cancel() {
+          this.canceled = true;
+        },
+      };
+      connect.promise = new Promise((resolve) => {
+        connect.finish = resolve;
+      });
+      world.connects.push(connect);
+      return connect;
+    },
+  });
+
+  /** Emit a preload→main message as if it came from `win`'s webContents. */
+  world.sendFrom = (win, channel) =>
+    world.ipc.emit(channel, { sender: { id: win.webContents.id } });
+  return { world, flow };
+}
+
+describe("arca connect console flow", () => {
+  it("shows the command, runs only after confirm, streams output, resolves the result", async () => {
+    const { world, flow } = flowHarness();
+    const resultPromise = flow.run(null, "https://srv.example.com");
+    const win = world.windows[0];
+
+    const init = win.webContents.sent.find(([c]) => c === "arca-connect:init");
+    assert.equal(init[1].command, "arca ssh isaac omni host --server https://srv.example.com …");
+    assert.equal(world.connects.length, 0); // nothing ran yet — consent first
+
+    world.sendFrom(win, "arca-connect:confirm");
+    assert.equal(world.connects.length, 1);
+    assert.deepEqual(win.size, [720, 500]); // grows to reveal the terminal pane
+    world.connects[0].onOutput("booting…\n");
+    assert.ok(
+      win.webContents.sent.some(([c, p]) => c === "arca-connect:output" && p === "booting…\n"),
+    );
+
+    world.connects[0].finish({ ok: true });
+    assert.deepEqual(await resultPromise, { ok: true, shownInConsole: true });
+    const done = win.webContents.sent.find(([c]) => c === "arca-connect:done");
+    assert.deepEqual(done[1], { ok: true, error: null });
+    assert.equal(win.destroyed, false); // stays open so the output is readable
+  });
+
+  it("Close still works after the run finished (routing outlives the result)", async () => {
+    const { world, flow } = flowHarness();
+    const resultPromise = flow.run(null, "https://srv.example.com");
+    const win = world.windows[0];
+    world.sendFrom(win, "arca-connect:confirm");
+    world.connects[0].finish({ ok: true });
+    await resultPromise; // the run settled — the console is now just a report
+
+    world.sendFrom(win, "arca-connect:cancel"); // the "Close" button
+    assert.equal(win.destroyed, true);
+  });
+
+  it("ignores confirm from a foreign webContents (a server page can't consent)", () => {
+    const { world, flow } = flowHarness();
+    void flow.run(null, "https://srv.example.com");
+    world.ipc.emit("arca-connect:confirm", { sender: { id: 9999 } });
+    assert.equal(world.connects.length, 0);
+  });
+
+  it("resolves a silent cancel when closed before confirming", async () => {
+    const { world, flow } = flowHarness();
+    const resultPromise = flow.run(null, "https://srv.example.com");
+    world.sendFrom(world.windows[0], "arca-connect:cancel");
+    const result = await resultPromise;
+    assert.equal(result.ok, false);
+    // Declining is a deliberate choice, not a failure — flagged so the
+    // picker doesn't render an error for it.
+    assert.equal(result.canceled, true);
+    assert.match(result.error, /wasn't approved/);
+  });
+
+  it("flags a failed run as already shown in the console", async () => {
+    const { world, flow } = flowHarness();
+    const resultPromise = flow.run(null, "https://srv.example.com");
+    world.sendFrom(world.windows[0], "arca-connect:confirm");
+    world.connects[0].finish({ ok: false, error: "Couldn't reach the Arca instance." });
+    const result = await resultPromise;
+    assert.equal(result.ok, false);
+    assert.equal(result.shownInConsole, true);
+  });
+
+  it("kills the command when the console is closed mid-run", async () => {
+    const { world, flow } = flowHarness();
+    const resultPromise = flow.run(null, "https://srv.example.com");
+    const win = world.windows[0];
+    world.sendFrom(win, "arca-connect:confirm");
+    win.close();
+    assert.equal(world.connects[0].canceled, true);
+    const result = await resultPromise;
+    assert.equal(result.canceled, true);
+  });
+
+  it("re-attaches to an in-flight console instead of refusing", async () => {
+    const { world, flow } = flowHarness();
+    const first = flow.run(null, "https://srv.example.com");
+    const win = world.windows[0];
+    world.sendFrom(win, "arca-connect:confirm");
+
+    // A refreshed SPA clicks again: same console focused, same outcome shared.
+    const second = flow.run(null, "https://srv.example.com");
+    assert.equal(world.windows.length, 1);
+    assert.equal(win.focused, 1);
+
+    world.connects[0].finish({ ok: true });
+    assert.deepEqual(await first, { ok: true, shownInConsole: true });
+    assert.deepEqual(await second, { ok: true, shownInConsole: true });
+
+    // After settling, a new run opens a fresh console.
+    void flow.run(null, "https://srv.example.com");
+    assert.equal(world.windows.length, 2);
+  });
+});

--- a/web/electron/test/managed_preferences.test.js
+++ b/web/electron/test/managed_preferences.test.js
@@ -3,9 +3,11 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const {
+  DATABRICKS_INTERNAL_FEATURES_KEY,
   MAX_SERVER_URLS,
   SERVER_URLS_KEY,
   excludingManagedServers,
+  getDatabricksInternalFeaturesEnabled,
   getManagedServerUrls,
   parseManagedServerUrls,
 } = require("../src/managed_preferences");
@@ -74,6 +76,56 @@ describe("managed server preferences", () => {
         },
       }),
       [],
+    );
+  });
+
+  it("reads the Databricks-internal-features boolean on macOS", () => {
+    const calls = [];
+    const enabled = getDatabricksInternalFeaturesEnabled({
+      platform: "darwin",
+      getUserDefault: (...args) => {
+        calls.push(args);
+        return true;
+      },
+    });
+
+    assert.deepEqual(calls, [[DATABRICKS_INTERNAL_FEATURES_KEY, "boolean"]]);
+    assert.equal(enabled, true);
+  });
+
+  it("fails the internal-features flag closed", () => {
+    // Non-darwin platforms never read preferences.
+    let reads = 0;
+    assert.equal(
+      getDatabricksInternalFeaturesEnabled({
+        platform: "linux",
+        getUserDefault: () => {
+          reads += 1;
+          return true;
+        },
+      }),
+      false,
+    );
+    assert.equal(reads, 0);
+    // Only an explicit boolean true enables; truthy junk does not.
+    for (const value of [undefined, null, "true", 1, [true]]) {
+      assert.equal(
+        getDatabricksInternalFeaturesEnabled({
+          platform: "darwin",
+          getUserDefault: () => value,
+        }),
+        false,
+      );
+    }
+    // A read error also reads as disabled.
+    assert.equal(
+      getDatabricksInternalFeaturesEnabled({
+        platform: "darwin",
+        getUserDefault: () => {
+          throw new Error("NSUserDefaults unavailable");
+        },
+      }),
+      false,
     );
   });
 

--- a/web/electron/test/url.test.js
+++ b/web/electron/test/url.test.js
@@ -13,6 +13,7 @@ const {
   serverDisplayLabel,
   isPlainHttpRemote,
   normalizeSavedServerUrl,
+  isDatabricksManagedServerUrl,
   databricksWorkspaceUiUrl,
   expandDatabricksWorkspaceUrl,
   WORKSPACE_UI_PATH,
@@ -143,6 +144,29 @@ describe("serverDisplayLabel", () => {
 
   it("falls back to the raw value when the URL is invalid", () => {
     assert.equal(serverDisplayLabel("not a URL"), "not a URL");
+  });
+});
+
+describe("isDatabricksManagedServerUrl", () => {
+  it("accepts Databricks Apps and workspace domains, https only", () => {
+    assert.equal(
+      isDatabricksManagedServerUrl("https://omnigent-x-123.aws.databricksapps.com"),
+      true,
+    );
+    assert.equal(
+      isDatabricksManagedServerUrl("https://my-workspace.cloud.databricks.com/omnigent"),
+      true,
+    );
+    assert.equal(isDatabricksManagedServerUrl("https://adb-1.2.azuredatabricks.net"), true);
+    // Not Databricks-hosted, https or not:
+    assert.equal(isDatabricksManagedServerUrl("https://omnigent.example.com"), false);
+    assert.equal(isDatabricksManagedServerUrl("http://localhost:8000"), false);
+    // A lookalike suffix must not pass, and neither may plain http:
+    assert.equal(isDatabricksManagedServerUrl("https://evildatabricks.com"), false);
+    assert.equal(isDatabricksManagedServerUrl("http://x.databricksapps.com"), false);
+    // Junk input fails closed:
+    assert.equal(isDatabricksManagedServerUrl(null), false);
+    assert.equal(isDatabricksManagedServerUrl("not a url"), false);
   });
 });
 

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -34,7 +34,7 @@ interface HostsResponse {
   hosts: Host[];
 }
 
-async function fetchHosts(includeSandbox: boolean): Promise<Host[]> {
+export async function fetchHosts(includeSandbox: boolean): Promise<Host[]> {
   const res = await authenticatedFetch("/v1/hosts");
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   const body = (await res.json()) as HostsResponse;

--- a/web/src/lib/arcaHost.ts
+++ b/web/src/lib/arcaHost.ts
@@ -1,0 +1,30 @@
+/**
+ * Remembering which host is the user's Arca instance (Databricks-internal).
+ *
+ * The only reliable signal is the host id captured when "Run on Arca"
+ * connected it: a host row's `name` is the machine's hostname, which has no
+ * dependable relationship to the arca instance name, so no heuristic
+ * matching is attempted.
+ */
+
+const STORAGE_KEY = "omnigent:arca-host-id";
+
+/** The host id last connected via Run on Arca, or null. */
+export function readArcaHostId(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Remember (or with null, forget) the Arca host id. */
+export function writeArcaHostId(hostId: string | null): void {
+  try {
+    if (hostId === null) localStorage.removeItem(STORAGE_KEY);
+    else localStorage.setItem(STORAGE_KEY, hostId);
+  } catch {
+    // Storage unavailable (private mode) — the Arca option simply stays
+    // offered; reconnecting an already-connected host is harmless.
+  }
+}

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -167,6 +167,11 @@ interface ElectronDesktopApi extends NativeShellApi {
   controlHost?: (action: HostControlAction) => Promise<HostActionResult>;
   /** Subscribe to host status-change pings (re-read on fire); returns an unsubscribe. */
   onHostStatusChanged?: (callback: () => void) => () => void;
+  /** Desktop feature gates (MDM-managed); absent on older shells. */
+  getDesktopFeatures?: () => Promise<DesktopFeatures | null>;
+  /** Connect the user's Arca instance to the window's server as a host. */
+  connectArcaHost?: () => Promise<ArcaConnectResult>;
+
   /** The local `omni` CLI status (installed, resolved path, version, source). */
   getCliStatus?: () => Promise<CliStatus | null>;
   /** Clear the CLI-path override (revert to auto-detection); resolves status. */
@@ -193,6 +198,38 @@ interface ElectronDesktopApi extends NativeShellApi {
 
 /** A lifecycle action for the host daemon. */
 export type HostControlAction = "start" | "stop" | "restart";
+
+/** Result of connecting the Arca instance as a host, from the desktop shell. */
+export interface ArcaConnectResult extends HostActionResult {
+  /**
+   * The box's host daemon was already connected to this server (the command
+   * reused it) — so no new host will appear in the host list.
+   */
+  alreadyRunning?: boolean;
+  /**
+   * The user deliberately declined or dismissed the connect console (before
+   * or during the run) — not a failure; UIs should stay silent.
+   */
+  canceled?: boolean;
+  /**
+   * The outcome (success or failure) was already displayed in the connect
+   * console's terminal — UIs must not echo it a second time.
+   */
+  shownInConsole?: boolean;
+}
+
+/**
+ * Desktop-shell feature gates the server can't know about, sourced from MDM
+ * managed preferences. All fields optional: an older shell reports fewer.
+ */
+export interface DesktopFeatures {
+  /**
+   * Databricks-internal features (e.g. the Arca host option) are enabled.
+   * Already scoped by the shell: true only when the MDM flag is set AND the
+   * window's server is Databricks-managed.
+   */
+  databricksInternalFeatures?: boolean;
+}
 
 /** Status of the local `omni` CLI, from the desktop shell. */
 export interface CliStatus {
@@ -753,6 +790,41 @@ export async function controlHost(action: HostControlAction): Promise<HostAction
     return await electron.controlHost(action);
   } catch (err) {
     console.warn("[nativeBridge] electron controlHost failed:", err);
+    return { ok: false, error: String(err) };
+  }
+}
+
+/**
+ * Fetch the desktop shell's feature gates (MDM-managed). Resolves `null`
+ * outside the Electron shell or under a shell too old to expose them — callers
+ * must treat null / a missing field as disabled.
+ */
+export async function getDesktopFeatures(): Promise<DesktopFeatures | null> {
+  const electron = electronApi();
+  if (!electron?.getDesktopFeatures) return null;
+  try {
+    return await electron.getDesktopFeatures();
+  } catch (err) {
+    console.warn("[nativeBridge] electron getDesktopFeatures failed:", err);
+    return null;
+  }
+}
+
+/**
+ * Connect the user's Arca instance (Databricks-internal sandbox) to the
+ * window's server as a host, via the desktop shell. The shell asks native
+ * consent and runs `arca ssh` — resolving only once the remote host daemon
+ * started (or failed). A no-op `{ ok: false }` outside the shell.
+ */
+export async function connectArcaHost(): Promise<ArcaConnectResult> {
+  const electron = electronApi();
+  if (!electron?.connectArcaHost) {
+    return { ok: false, error: "not running under the desktop shell" };
+  }
+  try {
+    return await electron.connectArcaHost();
+  } catch (err) {
+    console.warn("[nativeBridge] electron connectArcaHost failed:", err);
     return { ok: false, error: String(err) };
   }
 }

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -32,6 +32,7 @@ import type { ServerInfo } from "@/lib/capabilities";
 import { authenticatedFetch } from "@/lib/identity";
 import {
   useHostModelOptions,
+  fetchHosts,
   useHosts,
   useInstallHarness,
   useInstallingHarnesses,
@@ -46,7 +47,9 @@ import type { Conversation } from "@/hooks/useConversations";
 import { setOmnigentHostConfig } from "@/lib/host";
 import { COMPOSER_SEND_SHORTCUT_STORAGE_KEY } from "@/lib/composerSendShortcutPreferences";
 import {
+  connectArcaHost,
   controlHost,
+  getDesktopFeatures,
   getHostIdentity,
   isElectronShell,
   onHostStatusChanged,
@@ -70,10 +73,13 @@ vi.mock("@/lib/nativeBridge", async (importOriginal) => ({
   getHostIdentity: vi.fn(async () => null),
   onHostStatusChanged: vi.fn(() => () => {}),
   controlHost: vi.fn(async () => ({ ok: false })),
+  getDesktopFeatures: vi.fn(async () => null),
+  connectArcaHost: vi.fn(async () => ({ ok: false })),
 }));
 vi.mock("@/hooks/useHosts", () => ({
   useHosts: vi.fn(),
   useHostModelOptions: vi.fn(),
+  fetchHosts: vi.fn(async () => []),
   // The setup dialog mounts these; default to inert so tests that don't
   // exercise install / credential-write don't need to wire them up.
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
@@ -959,6 +965,148 @@ describe("Run on this machine (desktop host enrollment)", () => {
     vi.mocked(controlHost).mockClear();
     fireEvent.click(screen.getByTestId("new-chat-landing-connect-error-retry"));
     await waitFor(() => expect(vi.mocked(controlHost)).toHaveBeenCalledWith("start"));
+  });
+});
+
+describe("Run on Arca (Databricks-internal, MDM-gated)", () => {
+  beforeEach(() => {
+    setupLandingMocks();
+    mockHosts([]);
+    vi.mocked(isElectronShell).mockReturnValue(true);
+    vi.mocked(getHostIdentity).mockResolvedValue({ cliInstalled: false, hostId: null });
+    vi.mocked(onHostStatusChanged).mockReturnValue(() => {});
+    vi.mocked(getDesktopFeatures).mockResolvedValue({ databricksInternalFeatures: true });
+    vi.mocked(connectArcaHost).mockClear();
+    vi.mocked(fetchHosts).mockClear();
+  });
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    // Restore the browser defaults so these overrides don't leak into the
+    // other describe blocks (which assume no desktop shell / no MDM flag).
+    vi.mocked(isElectronShell).mockReturnValue(false);
+    vi.mocked(getDesktopFeatures).mockResolvedValue(null);
+  });
+
+  async function openHostMenu() {
+    const chip = await screen.findByTestId("new-chat-landing-host-chip");
+    fireEvent.pointerDown(chip, { button: 0 });
+    fireEvent.click(chip);
+  }
+
+  it("offers the Arca option only when the desktop shell reports the MDM flag", async () => {
+    renderLanding();
+    await openHostMenu();
+    expect(await screen.findByTestId("new-chat-landing-run-on-arca")).toBeTruthy();
+  });
+
+  it("hides the Arca option when the flag is off or unknown (old shell)", async () => {
+    vi.mocked(getDesktopFeatures).mockResolvedValue(null);
+    renderLanding();
+    await openHostMenu();
+    // The menu is open (the escape hatch renders), but no Arca entry.
+    await screen.findByTestId("new-chat-landing-connect-host");
+    expect(screen.queryByTestId("new-chat-landing-run-on-arca")).toBeNull();
+  });
+
+  it("state 3: hides the Arca option entirely and tags the connected row", async () => {
+    // The row is recognized by the host id remembered at connect time — a
+    // host's name (machine hostname) is deliberately not matched against
+    // anything from `arca status`.
+    localStorage.setItem("omnigent:arca-host-id", "arca-1");
+    mockHosts([{ host_id: "arca-1", name: "ip-10-0-0-7", owner: "me", status: "online" }]);
+    renderLanding();
+    await openHostMenu();
+
+    const row = await screen.findByTestId("new-chat-landing-host-arca-1");
+    expect(row.textContent).toContain("Arca instance");
+    expect(screen.queryByTestId("new-chat-landing-run-on-arca")).toBeNull();
+  });
+
+  it("shows a plain Run on Arca item (no status line) while not connected", async () => {
+    renderLanding();
+    await openHostMenu();
+
+    const item = await screen.findByTestId("new-chat-landing-run-on-arca");
+    expect(item.textContent).toContain("Run on Arca");
+    expect(screen.queryByTestId("new-chat-landing-arca-subtitle")).toBeNull();
+  });
+
+  // Silent-outcome cases: a deliberate dismissal, and a failure the connect
+  // console already displayed — neither may echo into the composer strip.
+  async function expectNoArcaError(result: Awaited<ReturnType<typeof connectArcaHost>>) {
+    vi.mocked(connectArcaHost).mockResolvedValue(result);
+    renderLanding();
+    await openHostMenu();
+    fireEvent.click(await screen.findByTestId("new-chat-landing-run-on-arca"));
+    await waitFor(() => expect(vi.mocked(connectArcaHost)).toHaveBeenCalled());
+    expect(screen.queryByTestId("new-chat-landing-arca-error")).toBeNull();
+  }
+
+  it("stays silent when the user dismissed the console", async () => {
+    await expectNoArcaError({
+      ok: false,
+      canceled: true,
+      error: "Connecting Arca wasn't approved.",
+    });
+  });
+
+  it("stays silent for a failure the console already displayed", async () => {
+    await expectNoArcaError({
+      ok: false,
+      shownInConsole: true,
+      error: "Couldn't reach the Arca instance.",
+    });
+  });
+
+  it("surfaces a gate failure (no console shown) with a retry", async () => {
+    vi.mocked(connectArcaHost).mockResolvedValue({
+      ok: false,
+      error: "Couldn't reach the Arca instance.",
+    });
+    renderLanding();
+    await openHostMenu();
+    fireEvent.click(await screen.findByTestId("new-chat-landing-run-on-arca"));
+
+    const err = await screen.findByTestId("new-chat-landing-arca-error");
+    expect(err.textContent).toContain("Couldn't reach the Arca instance.");
+    expect(vi.mocked(connectArcaHost)).toHaveBeenCalledTimes(1);
+
+    // Retry re-invokes the connect.
+    vi.mocked(connectArcaHost).mockClear();
+    fireEvent.click(screen.getByTestId("new-chat-landing-arca-error-retry"));
+    await waitFor(() => expect(vi.mocked(connectArcaHost)).toHaveBeenCalledTimes(1));
+  });
+
+  it("skips the new-host wait when the daemon was already connected", async () => {
+    vi.mocked(connectArcaHost).mockResolvedValue({ ok: true, alreadyRunning: true });
+    renderLanding();
+    await openHostMenu();
+    fireEvent.click(await screen.findByTestId("new-chat-landing-run-on-arca"));
+
+    // No 30s poll, no error — an explanatory toast instead.
+    await waitFor(() =>
+      expect(showToastMock).toHaveBeenCalledWith(
+        "Arca is already connected to this server — pick its host from the list.",
+      ),
+    );
+    expect(vi.mocked(fetchHosts)).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("new-chat-landing-arca-error")).toBeNull();
+  });
+
+  it("selects the host that newly came online after a successful connect", async () => {
+    vi.mocked(connectArcaHost).mockResolvedValue({ ok: true });
+    // First post-connect poll already sees the freshly-registered Arca host.
+    vi.mocked(fetchHosts).mockResolvedValue([
+      { host_id: "arca-1", name: "arca-box", owner: "me", status: "online" },
+    ]);
+    renderLanding();
+    await openHostMenu();
+    fireEvent.click(await screen.findByTestId("new-chat-landing-run-on-arca"));
+
+    // selectHost persists the pick — the observable effect of auto-selection.
+    await waitFor(() => expect(localStorage.getItem("omnigent:last-host-choice")).toBe("arca-1"));
+    expect(vi.mocked(connectArcaHost)).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -183,9 +183,12 @@ import {
   CURSOR_NATIVE_DEFAULT_EXEC_MODE,
   CURSOR_NATIVE_EXEC_MODES,
 } from "@/lib/nativeHarnessModes";
-import { useHostModelOptions, useHosts, type Host } from "@/hooks/useHosts";
+import { fetchHosts, useHostModelOptions, useHosts, type Host } from "@/hooks/useHosts";
+import { readArcaHostId, writeArcaHostId } from "@/lib/arcaHost";
 import {
+  connectArcaHost,
   controlHost,
+  getDesktopFeatures,
   getHostIdentity,
   isElectronShell,
   isIOSShell,
@@ -2388,6 +2391,13 @@ export function NewChatLandingScreen() {
   // consumed in the menu's onOpenChange) — connecting while the menu is open
   // looks janky. A ref so the close handler sees it synchronously.
   const pendingConnectRef = useRef(false);
+  // Arca (Databricks-internal): the desktop shell reports the MDM flag; when
+  // set, the picker offers connecting the user's Arca dev instance as a host.
+  const [arcaEnabled, setArcaEnabled] = useState(false);
+  const [connectingArca, setConnectingArca] = useState(false);
+  const [arcaError, setArcaError] = useState<string | null>(null);
+  // Mirrors pendingConnectRef for the Arca row: connect after the menu closes.
+  const pendingArcaConnectRef = useRef(false);
   // Sandbox repository inputs — composed into the managed create's
   // `workspace` string (`<url>[#<branch>]`); both blank = empty
   // server-created workspace.
@@ -2605,6 +2615,20 @@ export function NewChatLandingScreen() {
     return () => {
       cancelled = true;
       unsubscribe();
+    };
+  }, []);
+
+  // Desktop feature gates (MDM-managed). Read once per mount — the shell
+  // re-reads macOS preferences on every call, so reopening the composer is
+  // enough to pick up a profile change.
+  useEffect(() => {
+    if (!isElectronShell()) return;
+    let cancelled = false;
+    void getDesktopFeatures().then((features) => {
+      if (!cancelled) setArcaEnabled(features?.databricksInternalFeatures === true);
+    });
+    return () => {
+      cancelled = true;
     };
   }, []);
 
@@ -3754,11 +3778,22 @@ export function NewChatLandingScreen() {
   const selectedHostDisplayName = selectedHost
     ? displayNameForHost(selectedHost, thisMachineHostId, navigator.userAgent)
     : null;
+  // The Arca box's row in the host list, known only from the host id stored
+  // when Run on Arca connected it (a host's name is its machine hostname —
+  // no reliable relationship to the arca instance name, so no matching).
+  // While that host is online the Arca option disappears entirely; otherwise
+  // one click connects (starting a stopped instance along the way — the
+  // connect console shows what's happening, so no status needs pre-fetching).
+  const arcaHostId = arcaEnabled ? readArcaHostId() : null;
+  const arcaHostOnline = arcaHostId !== null && onlineHosts.some((h) => h.host_id === arcaHostId);
+  const showArcaOption = arcaEnabled && !arcaHostOnline;
   const hostLabel = connectingThisMachine
     ? "Connecting…"
-    : sandboxSelected
-      ? selectedSandboxLabel
-      : (selectedHostDisplayName ?? (onlineHosts.length === 0 ? "No hosts" : "Choose host"));
+    : connectingArca
+      ? "Connecting to Arca…"
+      : sandboxSelected
+        ? selectedSandboxLabel
+        : (selectedHostDisplayName ?? (onlineHosts.length === 0 ? "No hosts" : "Choose host"));
   // The chip shows just the branch (the "(existing)" distinction lives in the
   // popover's warning; appending it here only gets clipped by the chip's cap).
   const worktreeLabel = branchName.trim() || "Worktree";
@@ -3924,6 +3959,70 @@ export function NewChatLandingScreen() {
       if (identity?.hostId) selectHost(identity.hostId);
     } finally {
       setConnectingThisMachine(false);
+    }
+  }
+
+  // Connect the user's Arca dev instance (Databricks-internal sandbox) as a
+  // host, then select it. The bridge runs `arca ssh … isaac omni host
+  // --background` and resolves once the remote daemon started; the daemon then
+  // registers over its own tunnel moments later, so we poll the host list
+  // briefly to pick the host that newly came online.
+  async function connectArca() {
+    if (connectingArca) return;
+    setConnectingArca(true);
+    setArcaError(null);
+    const onlineBefore = new Set(
+      allHosts.filter((h) => h.status === "online").map((h) => h.host_id),
+    );
+    try {
+      const res = await connectArcaHost();
+      if (!res.ok) {
+        // Deliberate dismissals are not failures, and failures the connect
+        // console already displayed must not be echoed as a second error —
+        // this strip is only for gate failures with no other surface (e.g.
+        // the feature being unavailable to this window).
+        if (!res.canceled && !res.shownInConsole) {
+          setArcaError(res.error ?? "Couldn't connect to Arca.");
+        }
+        return;
+      }
+      // The box's daemon was already connected — its host has been in the
+      // list all along (just not recognized as Arca, e.g. enrolled before
+      // this app remembered ids), so waiting for a NEW online host would
+      // hang out the full grace window and then mislead.
+      if (res.alreadyRunning) {
+        await queryClient.invalidateQueries({ queryKey: ["hosts"] });
+        showToast("Arca is already connected to this server — pick its host from the list.");
+        return;
+      }
+      // Sequential by design: each poll must see the previous one's result.
+      /* oxlint-disable no-await-in-loop */
+      const deadline = Date.now() + 30_000;
+      while (Date.now() < deadline) {
+        const hostList = await queryClient.fetchQuery({
+          queryKey: ["hosts", { includeSandbox: false }],
+          queryFn: () => fetchHosts(false),
+          staleTime: 0,
+        });
+        const fresh = hostList.find((h) => h.status === "online" && !onlineBefore.has(h.host_id));
+        if (fresh) {
+          // Remember which host is the Arca box so the picker can tag it.
+          writeArcaHostId(fresh.host_id);
+          selectHost(fresh.host_id);
+          return;
+        }
+        await new Promise((resolve) => {
+          setTimeout(resolve, 1500);
+        });
+      }
+      /* oxlint-enable no-await-in-loop */
+      // The daemon started but its registration hasn't landed — soft-fail so
+      // the user knows to look at the host list rather than re-running.
+      setArcaError(
+        "Arca started, but the host hasn't appeared yet — it should show up in the host list shortly.",
+      );
+    } finally {
+      setConnectingArca(false);
     }
   }
 
@@ -4929,6 +5028,10 @@ export function NewChatLandingScreen() {
                     pendingConnectRef.current = false;
                     void connectThisMachine();
                   }
+                  if (!open && pendingArcaConnectRef.current) {
+                    pendingArcaConnectRef.current = false;
+                    void connectArca();
+                  }
                 }}
               >
                 <DropdownMenuTrigger asChild>
@@ -5034,6 +5137,7 @@ export function NewChatLandingScreen() {
                           thisMachineHostId,
                           navigator.userAgent,
                         )}
+                        subtitle={host.host_id === arcaHostId ? "Arca instance" : undefined}
                       />
                     </DropdownMenuItem>
                   ))}
@@ -5094,7 +5198,28 @@ export function NewChatLandingScreen() {
                       </span>
                     </DropdownMenuItem>
                   )}
-                  {(allHosts.length > 0 || showConnectThisMachine) && <DropdownMenuSeparator />}
+                  {/* Databricks-internal (MDM-gated): one flat action — run
+                    on the Arca instance, starting it first when it's down.
+                    Hidden entirely once the box is connected: its own
+                    (tagged) host row above covers it. */}
+                  {showArcaOption && (
+                    <DropdownMenuItem
+                      onSelect={() => {
+                        pendingArcaConnectRef.current = true;
+                      }}
+                      disabled={connectingArca}
+                      data-testid="new-chat-landing-run-on-arca"
+                      className="gap-2 text-sm"
+                    >
+                      <MonitorCloudIcon className="size-4 shrink-0 text-muted-foreground" />
+                      <span className="text-sm">
+                        {connectingArca ? "Connecting to Arca…" : "Run on Arca"}
+                      </span>
+                    </DropdownMenuItem>
+                  )}
+                  {(allHosts.length > 0 || showConnectThisMachine || showArcaOption) && (
+                    <DropdownMenuSeparator />
+                  )}
                   {/* Persistent escape hatch: open the connect-a-host
                     instructions. Present even with zero hosts so a fresh user
                     is never stuck. */}
@@ -5465,6 +5590,24 @@ export function NewChatLandingScreen() {
                 onClick={() => void connectThisMachine()}
                 disabled={connectingThisMachine}
                 data-testid="new-chat-landing-connect-error-retry"
+              >
+                Try again
+              </button>
+            </p>
+          )}
+
+          {arcaError && (
+            <p
+              className="flex flex-wrap items-center gap-x-1.5 text-sm text-destructive"
+              data-testid="new-chat-landing-arca-error"
+            >
+              <span>{arcaError}</span>
+              <button
+                type="button"
+                className="underline underline-offset-2 hover:no-underline disabled:opacity-60"
+                onClick={() => void connectArca()}
+                disabled={connectingArca}
+                data-testid="new-chat-landing-arca-error-retry"
               >
                 Try again
               </button>


### PR DESCRIPTION
## Related issue

N/A — Databricks-internal feature, no public issue.

## Summary

- Adds the macOS Managed Preferences boolean `databricksInternalFeaturesEnabled`. It is read on demand, fails closed, and enables Arca only in desktop windows connected to a Databricks-managed HTTPS server.
- Adds a flat **Run on Arca** action to the new-chat host picker. It disappears once the remembered Arca host is online; that host's normal row is tagged **Arca instance**. Identification uses only the host ID captured after connection—never hostname guessing.
- Opens a shell-owned modal before connecting. It shows the exact command, then expands into a read-only xterm.js terminal that renders live stdout/stderr and ANSI output. The modal survives SPA refreshes, re-focuses for an in-flight connection, supports cancellation, and applies a five-minute hard timeout.
- Runs `arca ssh -o ClearAllForwardings=yes isaac omni host --server <url> --background --non-interactive`. `ClearAllForwardings` fixes the cold-start failure at its root: ordinary Arca SSH inherits `-R 19222`, while Arca Companion reclaims that reserved port with `fuser -k`, killing the otherwise-successful session.
- Treats deliberate dismissal and errors already shown in the terminal as handled, so the composer does not repeat them. Detects the CLI's “Host daemon already running” result and skips waiting for a host that was already online.

ELI5: an MDM-enabled Databricks desktop user can click **Run on Arca**, review the exact command and its live terminal output, and connect the Arca machine as an ordinary Omnigent host.

```text
Server SPA (pinned origin)
        │ Run on Arca
        ▼
Electron main ── MDM + Databricks-host checks
        │
        ▼
Shell-owned consent/terminal modal
        │ confirmed command, no inherited SSH forwards
        ▼
Arca instance ── isaac omni host ──▶ Omnigent host WebSocket tunnel
```

## Test Plan

- `cd web/electron && node --test` — Electron unit tests, including managed-preference parsing, Databricks URL gating, Arca command construction and error mapping, streaming/cancel behavior, timeout-facing flow, console sender isolation, in-flight reattachment, and post-run Close behavior.
- `cd web && npm run type-check && npm run lint`.
- `cd web && npx vitest run src/shell/NewChatDialog.test.tsx -t "Arca"` — feature gating, flat picker item, connected-host hiding/tagging, cancellation/error suppression, already-running handling, and new-host selection.
- Manually cold-started a terminated Arca instance with the final command against `omnigent-zeyi`. The previous command reproduced the port-19222 collision and exited 255 despite starting the host; `-o ClearAllForwardings=yes` completed the same cold-start path on the first post-start session and exited 0.

## Demo

Not attached yet. The UI is gated by macOS Managed Preferences and a Databricks-managed server; it has been exercised against the internal `omnigent-zeyi` app and a real Arca instance.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The Electron command runner and modal flow use injected child processes/windows in unit tests. Manual verification covered a real stopped-instance cold start and the exact SSH-forward collision/fix; a live Arca instance is unavailable in CI.

## Changelog

Desktop: MDM-enabled Databricks users can connect an Arca instance as a host from a transparent, live terminal flow.
