### PR TITLE
fix(web): restore native chat link behavior

### DIFF
--- a/web/src/components/ai-elements/streamdown-security.ts
+++ b/web/src/components/ai-elements/streamdown-security.ts
@@ -57,11 +57,11 @@ interface HastElement {
 
 // Streamdown enables a link-safety confirmation modal by default: clicking any
 // markdown link pops an "Open external link?" dialog instead of following the
-// link. Disable it so chat links behave like ordinary links — a plain click
-// opens them and cmd/ctrl-click opens a new tab. With safety off Streamdown
-// still renders the anchor as `<a target="_blank" rel="noreferrer">`, so we
-// keep new-tab opening plus referrer/reverse-tabnabbing protection without the
-// extra confirmation click.
+// link. Disable it so the renderer can use native anchors without an extra
+// confirmation click. ChatMarkdown owns the final target: non-Electron links
+// use `_self` (native shells may still intercept off-origin activation), while
+// Electron keeps `_blank` so its main-process popup and external-protocol
+// policy remains on the navigation path.
 export const CHAT_LINK_SAFETY: LinkSafetyConfig = { enabled: false };
 
 /**

--- a/web/src/components/blocks/ChatMarkdown.fileLinks.test.tsx
+++ b/web/src/components/blocks/ChatMarkdown.fileLinks.test.tsx
@@ -12,11 +12,23 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type * as NativeBridge from "@/lib/nativeBridge";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FileViewerContext } from "@/shell/FileViewerContext";
 import { FilePathAwareMessageResponse } from "./ChatMarkdown";
 
-afterEach(cleanup);
+const nativeShell = vi.hoisted(() => ({ electron: false }));
+
+vi.mock("@/lib/nativeBridge", async (importOriginal) => ({
+  ...(await importOriginal<typeof NativeBridge>()),
+  isElectronShell: () => nativeShell.electron,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  nativeShell.electron = false;
+});
 
 const WORKSPACE = "/home/u/ws";
 
@@ -54,6 +66,8 @@ describe("markdown links to workspace files", () => {
     const link = screen.getByRole("button", { name: "proposal.md" });
     // No href at all: the parked fragment must not survive as clickable.
     expect(link).not.toHaveAttribute("href");
+    expect(link).not.toHaveAttribute("target");
+    expect(link).not.toHaveAttribute("rel");
 
     fireEvent.click(link);
     expect(openFile).toHaveBeenCalledWith("docs/proposal.md");
@@ -75,11 +89,57 @@ describe("markdown links to workspace files", () => {
     expect(openFile).toHaveBeenCalledWith("docs/notes.md");
   });
 
-  it("leaves an external link as a real anchor", () => {
+  it("leaves an external web link as a real current-tab anchor", () => {
     renderMarkdown("[docs](https://example.com/page)");
 
     const link = screen.getByRole("link", { name: "docs" });
     expect(link).toHaveAttribute("href", "https://example.com/page");
+    expect(link).toHaveAttribute("target", "_self");
+    expect(link).toHaveAttribute("rel", "noreferrer");
+  });
+
+  it("keeps Electron external links on the desktop popup-policy path", () => {
+    nativeShell.electron = true;
+    renderMarkdown("[docs](https://example.com/page)");
+
+    const link = screen.getByRole("link", { name: "docs" });
+    expect(link).toHaveAttribute("href", "https://example.com/page");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("leaves primary-click current-tab navigation to the browser", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    renderMarkdown("[docs](https://example.com/page)");
+
+    const link = screen.getByRole("link", { name: "docs" });
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 });
+    link.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["ctrl-click", "click", { button: 0, ctrlKey: true }],
+    ["meta-click", "click", { button: 0, metaKey: true }],
+    ["shift-click", "click", { button: 0, shiftKey: true }],
+    ["middle-click", "auxclick", { button: 1 }],
+  ])("leaves %s to the browser", (_label, type, init) => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    renderMarkdown("[docs](https://example.com/page)");
+
+    const event = new MouseEvent(type, { bubbles: true, cancelable: true, ...init });
+    screen.getByRole("link", { name: "docs" }).dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps dangerous link targets blocked", () => {
+    renderMarkdown("[unsafe](javascript:alert(1))");
+
+    expect(screen.queryByRole("link", { name: "unsafe" })).toBeNull();
   });
 
   // Overriding the `a` slot replaces Streamdown's link component, so its

--- a/web/src/components/blocks/ChatMarkdown.tsx
+++ b/web/src/components/blocks/ChatMarkdown.tsx
@@ -19,6 +19,7 @@ import { MessageResponse } from "@/components/ai-elements/message";
 import { WORKSPACE_FILE_LINK_ATTR } from "@/components/ai-elements/streamdown-security";
 import { ZoomableImage } from "@/components/ImageLightbox";
 import { useThrottledValue } from "@/hooks/useThrottledValue";
+import { isElectronShell } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
 import {
   useFileViewer,
@@ -173,6 +174,8 @@ function WorkspaceFileLink({
   children,
   className,
   title,
+  target: _target,
+  rel: _rel,
   node: _node,
   ...props
 }: WithHastNode<React.ComponentPropsWithoutRef<"a">>) {
@@ -181,13 +184,16 @@ function WorkspaceFileLink({
   const openWorkspaceFile = useWorkspaceFileOpener(path);
 
   if (!path) {
+    const opensOutsideShell = isElectronShell();
     return (
       <a
+        {...props}
         href={href}
+        target={opensOutsideShell ? "_blank" : "_self"}
+        rel={opensOutsideShell ? "noopener noreferrer" : "noreferrer"}
         className={cn(STREAMDOWN_LINK_CLASS, className)}
         title={title}
         data-streamdown="link"
-        {...props}
       >
         {children}
       </a>


### PR DESCRIPTION
## Related issue

The Linear identifier is still pending, so this PR does not claim or close an issue yet. This work is independent of OMNI-5684 and OMNI-5685.

## Summary

- Restore ordinary browser behavior for chat web links: primary click navigates the current tab, while native modifier-click, middle-click, context-menu, and copy-link affordances remain available.
- Preserve Electron's external-browser policy by retaining `_blank` links there, so the main-process popup and external-protocol handlers stay on the navigation path.
- Keep workspace paths routed through FileViewer and unsafe URL schemes blocked.

**ELI5:** Chat links are real links again. The web app lets the browser handle them normally, the desktop app still sends them through its external-browser safety path, and workspace files keep opening inside Omnigent.

```text
chat markdown link
├─ workspace path ──> Omnigent FileViewer
├─ unsafe scheme ───> blocked
├─ Electron web URL -> main-process external-browser policy
└─ browser web URL ─> native current-tab / modifier-click behavior
```

## Test Plan

- `cd web && npm test -- src/components/blocks/ChatMarkdown.fileLinks.test.tsx src/components/ai-elements/streamdownFileLinks.test.ts` — 2 files passed, 36/36 tests passed.
- `/home/jackson.zheng/omnigent/.venv/bin/pre-commit run --all-files` — formatting, Ruff, web Prettier/Oxlint/TypeScript, VS Code TypeScript, Android, iOS, generated-file, and repository hygiene hooks passed. The unrelated `pyrefly` hook could not resolve the shared venv's base-checkout editable paths and optional Python modules from this worktree; it did not modify files, and the web-only branch remained clean at the reviewed SHA.
- Live three-process stack: backend health OK, local host online, and Vite UI exercised in the SP2K Browser on the exact reviewed commit.

## Demo

Live verification on commit `4ad3f17c33b413b5edb4f5674eaf1c4bb81a5b3a`:

- Primary-clicked an external chat link, confirmed current-tab navigation, then used Back and verified exact chat restoration.
- Opened a workspace link and confirmed it rendered in Omnigent FileViewer.
- Confirmed a `javascript:` target stayed blocked and was not rendered as an actionable link.
- Repeated visual checks in light and dark themes; link alignment passed and measured contrast was 15.80:1 and 8.85:1 respectively.
- Confirmed the rendered anchors retain browser-native modifier-click and context-menu semantics; the SP2K embedded Browser does not expose those input gestures directly.

A fresh attachment could not be captured from this background squad session because the SP2K recorder requires the session's Browser pane to be focused and refused to take over the user's active pane. The existing live fixture and stack remain available for maintainers to reproduce with the steps above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused renderer and sanitization tests cover browser/Electron targets, workspace FileViewer routing, unsafe URL blocking, and non-interception of primary/modifier/middle clicks. Manual verification covered real current-tab navigation, Back restoration, FileViewer behavior, blocked unsafe links, and light/dark presentation in the live three-process stack.

## Changelog

Chat links now support normal navigation, new-tab, and copy-link behavior while workspace files still open inside Omnigent.