### PR TITLE
docs(repro-agent): checkpoint verdict handoff

### DIFF
--- a/dev/repro-agent/AGENTS.md
+++ b/dev/repro-agent/AGENTS.md
@@ -309,6 +309,16 @@ You author the test as the reproduction artifact. You do **not** run a
 before/after fix proof — that is the fix step's job (it builds a candidate fix
 and verifies the same test goes fail→pass).
 
+**Checkpoint the handoff before long finishing work.** As soon as Step 2 settles
+the overall verdict, atomically write the complete Output JSON object to
+`.omnigent/repro-handoff.json` in the workspace (create `.omnigent/` if needed;
+write a temporary sibling and rename it into place). Update that checkpoint if
+later test or recording work changes any handoff field. The checkpoint is a
+crash-safe copy of the final machine-readable handoff: it must use the exact
+fixed shape documented under Output, including `bug_url`, `verdict`, and
+`session_id`. Do this **before** authoring or recording work that could exhaust
+the turn, so CI can still dispatch the fix step if the final response is cut off.
+
 **Show the test inline in your final message.** After you write the file to
 disk, also paste its **complete, verbatim source** into your final message as a
 fenced code block (labelled with the path), so anyone browsing this session sees
@@ -351,6 +361,10 @@ block — the machine-readable handoff to the fix step and to the caller that
 labels the issue. This block is parsed programmatically by taking the last
 ```json fence in the message, so the format and its position are **not** your
 choice:
+
+- Load `.omnigent/repro-handoff.json`, update it with the final test and
+  recording results, atomically rewrite it, and emit that same object in the
+  final fence. The checkpoint and final block must not disagree.
 
 - You may write comprehensive prose above the block (a human-readable summary,
   the journey, the per-facet notes) — that's fine and encouraged. Then, as the

--- a/dev/repro-agent/README.md
+++ b/dev/repro-agent/README.md
@@ -71,7 +71,11 @@ with `git worktree remove <path>` when done.
    the fix step pairs with its after-fix re-recording); an already-fixed facet is
    filmed passing (proof-it-works footage). Best-effort: skipped (and noted) when
    the recorders aren't installed.
-5. Emits a single fenced ```json block (the machine-readable handoff) whose
+5. Checkpoints the machine-readable handoff to
+   `.omnigent/repro-handoff.json` as soon as the verdict is known, updating it
+   as test and recording evidence lands so an interrupted final response does
+   not lose a completed reproduction.
+6. Emits a single fenced ```json block (the machine-readable handoff) whose
    `verdict` is exactly one of `reproduced` / `not_reproduced` / `already_fixed`
    / `needs_more_info`, alongside the per-facet breakdown (each facet stamped
    with its `surface`), test path, recordings list, session id, journey, and


### PR DESCRIPTION
## Related issue

Related to #5498

## Summary

- Require repro-agent to checkpoint its fixed-shape verdict handoff to `.omnigent/repro-handoff.json` as soon as the verdict is known.
- Require the final fenced JSON response to match the checkpoint after test and recording results are added.
- This preserves a completed reproduction when the agent turn ends before it emits its final response.

## Test Plan

- `uv run --with pre-commit pre-commit run --files dev/repro-agent/AGENTS.md dev/repro-agent/README.md`

## Demo

N/A — agent operating-procedure documentation only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the checkpoint instructions require atomic writes, the complete fixed handoff shape, early persistence before long finishing work, and equality with the final JSON fence.
