### PR TITLE
feat(electron): open settings with Cmd+,

### DIFF
--- a/tests/e2e_ui/sessions/test_settings_back_navigation.py
+++ b/tests/e2e_ui/sessions/test_settings_back_navigation.py
@@ -19,6 +19,43 @@ from __future__ import annotations
 
 from playwright.sync_api import Page, expect
 
+_NATIVE_OPEN_PATH_INIT_SCRIPT = """
+window.__nativeOpenPathListener = null;
+window.__documentLoadMarker = crypto.randomUUID();
+window.omnigentDesktop = {
+  kind: "electron",
+  setBadgeCount() {},
+  notify() { return Promise.resolve(true); },
+  onOpenPath(callback) {
+    window.__nativeOpenPathListener = callback;
+    return () => {
+      if (window.__nativeOpenPathListener === callback) {
+        window.__nativeOpenPathListener = null;
+      }
+    };
+  },
+};
+"""
+
+
+def test_native_open_path_navigates_to_settings_without_reload(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The desktop bridge's basename-less ``/settings`` path routes in place."""
+    base_url, session_id = seeded_session
+    page.add_init_script(_NATIVE_OPEN_PATH_INIT_SCRIPT)
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page).to_have_url(f"{base_url}/c/{session_id}")
+    page.wait_for_function("typeof window.__nativeOpenPathListener === 'function'")
+    load_marker = page.evaluate("window.__documentLoadMarker")
+
+    page.evaluate("window.__nativeOpenPathListener('/settings')")
+
+    expect(page).to_have_url(f"{base_url}/settings", timeout=30_000)
+    expect(page.get_by_role("link", name="Back", exact=True)).to_be_visible(timeout=30_000)
+    assert page.evaluate("window.__documentLoadMarker") == load_marker
+
 
 def test_settings_back_returns_to_conversation(
     page: Page,

--- a/web/electron/README.md
+++ b/web/electron/README.md
@@ -47,8 +47,10 @@ adds native niceties:
   the badge.
 - **The standard native menu** (App / Edit / View / Window / Help) built from
   Electron's menu roles, so the usual text-editing shortcuts — Cmd/Ctrl-A,
-  C, V, X, Z — work inside the webview's text fields. Our custom actions —
-  **New Window**, **New Window on Different Server…**, and
+  C, V, X, Z — work inside the webview's text fields. **Settings…** uses the
+  native `Cmd+,` accelerator on macOS (`Ctrl+,` elsewhere) and routes the
+  focused connected window through the SPA without reloading it. Our other
+  custom actions — **New Window**, **New Window on Different Server…**, and
   **Change Server…** — live in a dedicated **Server** submenu. On macOS a
   **Notifications** submenu turns the notification sound on/off (**Play
   Notification Sound**, **off by default** — the user opts in) and picks which

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -56,6 +56,12 @@ const { isDeveloperModeEnabled } = require("./developer_mode");
 const { excludingManagedServers, getManagedServerUrls } = require("./managed_preferences");
 const { registerSessionExpiryReload } = require("./session-expiry");
 const { decideWindowOpen, stripCrossOriginOpenerHeaders, WEB_SCHEMES } = require("./popupPolicy");
+const {
+  SETTINGS_PATH,
+  focusedConnectedWindow,
+  macApplicationMenu,
+  settingsMenuItem,
+} = require("./settingsNavigation");
 const omnigentCli = require("./omnigent_cli");
 const serverManager = require("./server_manager");
 
@@ -1919,18 +1925,23 @@ function changeServer() {
 
 function buildMenu() {
   const isMac = process.platform === "darwin";
+  const settingsItem = settingsMenuItem(() => {
+    const target = focusedConnectedWindow(BrowserWindow.getFocusedWindow(), windows);
+    sendOpenPath(target, SETTINGS_PATH);
+  });
 
   /** @type {Electron.MenuItemConstructorOptions[]} */
   const template = [];
 
-  // macOS app menu (About/Services/Hide/Quit), named "Omnigent" via the
-  // app name set below. Non-mac platforms have no app menu.
+  // Settings belongs in the macOS app menu. Keep the standard app roles that
+  // Electron's composite appMenu role would otherwise provide.
   if (isMac) {
-    template.push({ role: "appMenu" });
+    template.push(macApplicationMenu(app.name, settingsItem));
   }
 
   /** @type {Electron.MenuItemConstructorOptions[]} */
   const serverSubmenu = [
+    ...(!isMac ? [settingsItem, { type: "separator" }] : []),
     {
       id: "new_session",
       label: "New Session",
@@ -2798,20 +2809,17 @@ function focusAndRestore(win) {
 }
 
 /**
- * Tell a pinned window's SPA to navigate in-place to an in-app path
- * (`/c/<id>`), without a reload — reuses the SPA's router, the same path a
- * notification click routes (basename-less; the embedded build's
- * `basenamedRouting` rebases it under the mount). Main→renderer only; the page
- * cannot invoke it. The caller (reuse-inplace) only sends when the window's
- * top-level page IS the pinned server (SPA listener mounted); this is
- * defense-in-depth on top of that.
+ * Tell a pinned window's SPA to navigate in-place to a basename-less app path
+ * (`/c/<id>`, `/settings`), without a reload. The embedded build's
+ * `basenamedRouting` rebases it under the mount. Main→renderer only; the page
+ * cannot invoke it. Callers send only while the pinned app is visible.
  *
  * @param {BrowserWindow | null | undefined} win
  * @param {string} routePath
  */
 function sendOpenPath(win, routePath) {
   if (!win || win.isDestroyed()) return;
-  console.log(`[omnigent] deep-link: send open-path ${routePath}`);
+  console.log(`[omnigent] send open-path ${routePath}`);
   try {
     win.webContents.send("omnigent:open-path", routePath);
   } catch {

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -70,11 +70,9 @@ contextBridge.exposeInMainWorld("omnigentDesktop", {
     return () => ipcRenderer.removeListener("omnigent:notification-activated", listener);
   },
   /**
-   * Subscribe to deep-link navigations. When the user clicks an
-   * `omnigent://.../c/<id>` link for a server this window is already on, the
-   * main process sends the in-app path here so the SPA routes to it in-place
-   * (no reload) — same path shape as onNotificationActivated. Returns an
-   * unsubscribe function.
+   * Subscribe to in-app navigation from the main process. Native menu actions
+   * and same-server deep links send a basename-less path so the SPA can route
+   * in place without reloading. Returns an unsubscribe function.
    * @param {(path: string) => void} callback
    * @returns {() => void}
    */

--- a/web/electron/src/settingsNavigation.js
+++ b/web/electron/src/settingsNavigation.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const SETTINGS_PATH = "/settings";
+const SETTINGS_ACCELERATOR = "CmdOrCtrl+,";
+
+/**
+ * Return the focused window only while its connected app is visible.
+ *
+ * @param {Electron.BrowserWindow | null | undefined} focused
+ * @param {Map<Electron.BrowserWindow, {origin: string | null, serverUrl?: string | null}>} windows
+ * @returns {Electron.BrowserWindow | null}
+ */
+function focusedConnectedWindow(focused, windows) {
+  if (!focused || !windows.has(focused) || focused.isDestroyed()) return null;
+  const state = windows.get(focused);
+  if (!state?.origin || !state.serverUrl) return null;
+  try {
+    if (new URL(focused.webContents.getURL()).origin !== state.origin) return null;
+  } catch {
+    return null;
+  }
+  return focused;
+}
+
+/**
+ * Build the shared native Settings menu item.
+ *
+ * @param {() => void} openSettings
+ * @returns {Electron.MenuItemConstructorOptions}
+ */
+function settingsMenuItem(openSettings) {
+  return {
+    id: "open_settings",
+    label: "Settings…",
+    accelerator: SETTINGS_ACCELERATOR,
+    click: openSettings,
+  };
+}
+
+/**
+ * Add Settings to the conventional macOS application menu.
+ *
+ * @param {string} appName
+ * @param {Electron.MenuItemConstructorOptions} item
+ * @returns {Electron.MenuItemConstructorOptions}
+ */
+function macApplicationMenu(appName, item) {
+  return {
+    label: appName,
+    submenu: [
+      { role: "about" },
+      { type: "separator" },
+      item,
+      { type: "separator" },
+      { role: "services" },
+      { type: "separator" },
+      { role: "hide" },
+      { role: "hideOthers" },
+      { role: "unhide" },
+      { type: "separator" },
+      { role: "quit" },
+    ],
+  };
+}
+
+module.exports = {
+  SETTINGS_ACCELERATOR,
+  SETTINGS_PATH,
+  focusedConnectedWindow,
+  macApplicationMenu,
+  settingsMenuItem,
+};

--- a/web/electron/test/settingsNavigation.test.js
+++ b/web/electron/test/settingsNavigation.test.js
@@ -1,0 +1,81 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  SETTINGS_ACCELERATOR,
+  SETTINGS_PATH,
+  focusedConnectedWindow,
+  macApplicationMenu,
+  settingsMenuItem,
+} = require("../src/settingsNavigation");
+
+function fakeWindow(url, destroyed = false) {
+  return {
+    isDestroyed: () => destroyed,
+    webContents: { getURL: () => url },
+  };
+}
+
+describe("Settings native menu item", () => {
+  it("uses the platform-native Command/Ctrl-comma accelerator", () => {
+    let opened = 0;
+    const item = settingsMenuItem(() => {
+      opened += 1;
+    });
+
+    assert.equal(SETTINGS_PATH, "/settings");
+    assert.equal(SETTINGS_ACCELERATOR, "CmdOrCtrl+,");
+    assert.equal(item.id, "open_settings");
+    assert.equal(item.label, "Settings…");
+    assert.equal(item.accelerator, SETTINGS_ACCELERATOR);
+    item.click();
+    assert.equal(opened, 1);
+  });
+
+  it("keeps Settings in the conventional macOS application menu", () => {
+    const item = settingsMenuItem(() => {});
+    const menu = macApplicationMenu("Omnigent", item);
+
+    assert.equal(menu.label, "Omnigent");
+    assert.equal(menu.submenu[0].role, "about");
+    assert.equal(menu.submenu[2], item);
+    assert.deepEqual(
+      menu.submenu.filter((entry) => entry.role).map((entry) => entry.role),
+      ["about", "services", "hide", "hideOthers", "unhide", "quit"],
+    );
+  });
+});
+
+describe("focusedConnectedWindow", () => {
+  it("targets the focused connected window, not another server window", () => {
+    const first = fakeWindow("https://one.example/app/c/first");
+    const focused = fakeWindow("https://two.example/base/c/second");
+    const windows = new Map([
+      [first, { origin: "https://one.example", serverUrl: "https://one.example/app" }],
+      [focused, { origin: "https://two.example", serverUrl: "https://two.example/base" }],
+    ]);
+
+    assert.equal(focusedConnectedWindow(focused, windows), focused);
+  });
+
+  it("rejects setup, foreign-login, popup, destroyed, and invalid windows", () => {
+    const setup = fakeWindow("file:///setup/index.html");
+    const away = fakeWindow("https://login.example/sso");
+    const destroyed = fakeWindow("https://server.example/app", true);
+    const invalid = fakeWindow("not a URL");
+    const popup = fakeWindow("https://server.example/oauth");
+    const windows = new Map([
+      [setup, { origin: null, serverUrl: null }],
+      [away, { origin: "https://server.example", serverUrl: "https://server.example/app" }],
+      [destroyed, { origin: "https://server.example", serverUrl: "https://server.example/app" }],
+      [invalid, { origin: "https://server.example", serverUrl: "https://server.example/app" }],
+    ]);
+
+    assert.equal(focusedConnectedWindow(null, windows), null);
+    assert.equal(focusedConnectedWindow(setup, windows), null);
+    assert.equal(focusedConnectedWindow(away, windows), null);
+    assert.equal(focusedConnectedWindow(popup, windows), null);
+    assert.equal(focusedConnectedWindow(destroyed, windows), null);
+    assert.equal(focusedConnectedWindow(invalid, windows), null);
+  });
+});

--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -252,15 +252,19 @@ function hasDebugMenu(menu) {
   return menu.template.some((item) => item.label === "Debug");
 }
 
-describe("new session menu action", () => {
-  it("routes Cmd/Ctrl+N to the current window without replacing the New Window action", (t) => {
+describe("in-app navigation menu actions", () => {
+  it("routes Settings and New Session through the focused connected window", (t) => {
     const harness = loadMainHarness();
     t.after(harness.cleanup);
 
     harness.api.buildMenu();
     const menu = harness.calls.setApplicationMenu.at(-1);
+    const settingsItem = findMenuItem(menu, "open_settings");
     const newSessionItem = findMenuItem(menu, "new_session");
     const newWindowItem = findMenuItem(menu, "new_window");
+
+    settingsItem.click();
+    assert.deepEqual(harness.calls.sent, [{ channel: "omnigent:open-path", payload: "/settings" }]);
 
     assert.equal(newSessionItem.label, "New Session");
     assert.equal(newSessionItem.accelerator, "CmdOrCtrl+N");
@@ -268,7 +272,10 @@ describe("new session menu action", () => {
 
     newSessionItem.click();
 
-    assert.deepEqual(harness.calls.sent, [{ channel: "omnigent:open-path", payload: "/" }]);
+    assert.deepEqual(harness.calls.sent.at(-1), {
+      channel: "omnigent:open-path",
+      payload: "/",
+    });
   });
 });
 

--- a/web/src/hooks/useIdleNotifications.test.tsx
+++ b/web/src/hooks/useIdleNotifications.test.tsx
@@ -24,7 +24,7 @@ vi.mock("@/lib/nativeBridge", () => ({
   // Returns an unsubscribe fn; tests that exercise native click routing
   // capture the registered callback via this mock's calls.
   onNativeNotificationActivated: vi.fn().mockReturnValue(() => {}),
-  // Deep-link routing reuses the same navigate; tests don't assert on it,
+  // In-app routing reuses the same navigate; tests don't assert on it,
   // but the hook calls it on mount, so it must be a no-op fn (not undefined).
   onOpenPath: vi.fn().mockReturnValue(() => {}),
 }));

--- a/web/src/hooks/useIdleNotifications.ts
+++ b/web/src/hooks/useIdleNotifications.ts
@@ -183,11 +183,9 @@ export function useIdleNotifications(activeConversationId?: string): void {
     // navigateRef is stable; the listener is mounted once for the app's life.
   }, []);
 
-  // Desktop shell only: clicking an `omnigent://.../c/<id>` deep link for a
-  // server this window is already on sends the in-app path here (no reload —
-  // the main process only forwards it for a window currently on its pinned
-  // server), so we route to it with the same navigate the notification path
-  // uses. basename-less `/c/<id>` is rebased under the mount by the router.
+  // Desktop shell only: native menu actions and same-server deep links send a
+  // basename-less in-app path here, so route it with the same navigate used for
+  // notification clicks. The router rebases it under the current mount.
   useEffect(() => {
     return onOpenPath((path) => navigateRef.current(path));
   }, []);

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -72,11 +72,10 @@ interface NativeShellApi {
    */
   onNotificationActivated?: (callback: (path: string) => void) => () => void;
   /**
-   * Subscribe to deep-link navigations from the desktop shell. When the user
-   * clicks an `omnigent://.../c/<id>` link for a server this window is already
-   * on, the main process sends the in-app path here so the SPA routes to it
-   * in-place (no reload). Same path shape as onNotificationActivated. Absent
-   * on older shells / outside Electron; returns an unsubscribe.
+   * Subscribe to in-app navigation from the desktop shell. Native menu actions
+   * and same-server deep links send a basename-less path so the SPA can route
+   * in place without reloading. Absent on older shells / outside Electron;
+   * returns an unsubscribe.
    */
   onOpenPath?: (callback: (path: string) => void) => () => void;
   /**
@@ -512,16 +511,14 @@ export function onNativeNotificationActivated(callback: (path: string) => void):
 }
 
 /**
- * Subscribe to deep-link navigations from the desktop shell. When the user
- * clicks an `omnigent://.../c/<id>` link for a server this window is already
- * on, the main process sends the in-app path here so the SPA can route to it
- * in-place (no reload) — reusing the same router `navigate` a notification
- * click uses. The path is basename-less (`/c/<id>`); the embedded build's
- * `basenamedRouting` rebases it under the mount.
+ * Subscribe to in-app navigation from the desktop shell. Native menu actions
+ * and same-server deep links send basename-less paths such as `/settings` and
+ * `/c/<id>` so the SPA can route in place without reloading. The embedded
+ * build's `basenamedRouting` rebases them under the mount.
  *
  * Returns an unsubscribe function. A no-op (returning a no-op unsubscribe)
- * outside the Electron shell or under a shell too old to support deep-link
- * routing, so callers can register it unconditionally.
+ * outside the Electron shell or under a shell too old to support in-app
+ * navigation, so callers can register it unconditionally.
  */
 export function onOpenPath(callback: (path: string) => void): () => void {
   const native = nativeApi();


### PR DESCRIPTION
## Summary
- add a native Settings menu item with `Cmd+,` on macOS and `Ctrl+,` elsewhere
- route the focused connected desktop window to the SPA Settings page without reloading or affecting setup/SSO windows

## Test plan

I manually tested this

- [x] `pnpm --dir web/electron run test` (335 passed)
- [x] Prettier check for changed Electron files
- [x] Manual macOS verification: focus the composer and press `Cmd+,`; Settings opens in place

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Breaking change