### PR TITLE
feat(web): add configurable composer send shortcut

### DIFF
--- a/tests/e2e_ui/chat/test_composer_submit_shortcut.py
+++ b/tests/e2e_ui/chat/test_composer_submit_shortcut.py
@@ -1,0 +1,102 @@
+"""E2E: the local Composer submit shortcut persists and controls submission."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Request, expect
+
+_STORAGE_KEY = "omnigent:composer-submit-with-mod-enter"
+_COMPOSER_LABEL = "Message the agent"
+
+
+def _record_message_posts(page: Page, session_id: str) -> list[str]:
+    posts: list[str] = []
+
+    def record(request: Request) -> None:
+        if request.method != "POST":
+            return
+        if urlparse(request.url).path != f"/v1/sessions/{session_id}/events":
+            return
+        body = request.post_data_json
+        if not isinstance(body, dict) or body.get("type") != "message":
+            return
+        for block in body.get("data", {}).get("content", []):
+            if isinstance(block, dict) and block.get("type") == "input_text":
+                posts.append(str(block.get("text", "")))
+
+    page.on("request", record)
+    return posts
+
+
+def _wait_for_posts(page: Page, posts: list[str], count: int) -> None:
+    deadline = time.monotonic() + 30
+    while len(posts) < count and time.monotonic() < deadline:
+        page.wait_for_timeout(100)
+    assert len(posts) == count
+
+
+def _screenshot(page: Page) -> None:
+    shot_dir = os.environ.get("E2E_SCREENSHOT_DIR")
+    if shot_dir:
+        Path(shot_dir).mkdir(parents=True, exist_ok=True)
+        page.screenshot(path=str(Path(shot_dir) / "composer-submit-shortcut.png"))
+
+
+def test_submit_with_mod_enter_persists_and_is_the_only_send_gesture(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    base_url, session_id = seeded_session
+    posts = _record_message_posts(page, session_id)
+
+    page.goto(f"{base_url}/settings/general")
+    expect(page.get_by_role("heading", name="Composer", exact=True)).to_be_visible(timeout=30_000)
+    toggle = page.get_by_test_id("composer-submit-with-mod-enter-toggle")
+    expect(toggle).to_have_attribute("aria-checked", "false")
+    is_mac = page.evaluate(
+        "() => /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent || '')"
+    )
+    mod_key = "⌘" if is_mac else "Ctrl"
+    expect(page.get_by_text(f"Submit with {mod_key} + Enter", exact=True)).to_be_visible()
+    expect(page.get_by_role("radio")).to_have_count(0)
+    assert page.evaluate(f"localStorage.getItem('{_STORAGE_KEY}')") is None
+
+    started = time.perf_counter()
+    toggle.click()
+    expect(toggle).to_have_attribute("aria-checked", "true")
+    assert page.evaluate(f"localStorage.getItem('{_STORAGE_KEY}')") == "true"
+    print(f"composer_shortcut_toggle_ms={(time.perf_counter() - started) * 1000:.2f}")
+
+    page.reload()
+    toggle = page.get_by_test_id("composer-submit-with-mod-enter-toggle")
+    expect(toggle).to_have_attribute("aria-checked", "true", timeout=30_000)
+
+    page.goto(f"{base_url}/c/{session_id}")
+    composer = page.get_by_label(_COMPOSER_LABEL)
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill("first line")
+    composer.press("Enter")
+    composer.type("second line")
+    expect(composer).to_have_value("first line\nsecond line")
+    page.wait_for_timeout(300)
+    assert posts == []
+
+    composer.press("Meta+Enter")
+    _wait_for_posts(page, posts, 1)
+    assert posts == ["first line\nsecond line"]
+
+    composer.fill("plain Enter stays multiline")
+    composer.press("Enter")
+    expect(composer).to_have_value("plain Enter stays multiline\n")
+    page.wait_for_timeout(300)
+    assert posts == ["first line\nsecond line"]
+
+    page.goto(f"{base_url}/settings/general")
+    expect(page.get_by_test_id("composer-submit-with-mod-enter-toggle")).to_have_attribute(
+        "aria-checked", "true"
+    )
+    _screenshot(page)

--- a/tests/e2e_ui/chat/test_composer_submit_shortcut.py
+++ b/tests/e2e_ui/chat/test_composer_submit_shortcut.py
@@ -61,7 +61,9 @@ def test_submit_with_mod_enter_persists_and_is_the_only_send_gesture(
         "() => /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent || '')"
     )
     mod_key = "⌘" if is_mac else "Ctrl"
-    expect(page.get_by_text(f"Submit with {mod_key} + Enter", exact=True)).to_be_visible()
+    expect(
+        page.get_by_text(f"Submit with {mod_key} + Enter on desktop", exact=True)
+    ).to_be_visible()
     expect(page.get_by_role("radio")).to_have_count(0)
     assert page.evaluate(f"localStorage.getItem('{_STORAGE_KEY}')") is None
 
@@ -85,7 +87,7 @@ def test_submit_with_mod_enter_persists_and_is_the_only_send_gesture(
     page.wait_for_timeout(300)
     assert posts == []
 
-    composer.press("Meta+Enter")
+    composer.press("Meta+Enter" if is_mac else "Control+Enter")
     _wait_for_posts(page, posts, 1)
     assert posts == ["first line\nsecond line"]
 

--- a/tests/e2e_ui/chat/test_mobile_composer_enter.py
+++ b/tests/e2e_ui/chat/test_mobile_composer_enter.py
@@ -1,0 +1,64 @@
+"""Mobile composer Enter inserts a newline; only the Send button submits."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from playwright.sync_api import Browser, Route, expect
+
+_MOBILE_VIEWPORT = {"width": 390, "height": 844}
+_PROMPT = "first line\nsecond line"
+
+
+def test_mobile_enter_inserts_newline_and_send_submits_once(
+    browser: Browser,
+    seeded_session: tuple[str, str],
+) -> None:
+    base_url, session_id = seeded_session
+    context = browser.new_context(
+        viewport=_MOBILE_VIEWPORT,
+        has_touch=True,
+        is_mobile=True,
+        record_video_dir=os.environ.get("OMNIGENT_E2E_RECORD_DIR"),
+    )
+    page = context.new_page()
+    event_posts: list[dict[str, Any]] = []
+
+    def capture_event(route: Route) -> None:
+        request = route.request
+        if request.method == "POST":
+            event_posts.append(request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"queued": True, "item_id": "ci_mobile_enter"}),
+        )
+
+    page.route(f"**/v1/sessions/{session_id}/events", capture_event)
+    try:
+        page.goto(f"{base_url}/c/{session_id}")
+        composer = page.get_by_label("Message the agent")
+        expect(composer).to_be_visible(timeout=30_000)
+        assert page.evaluate("matchMedia('(max-width: 767.98px)').matches")
+
+        composer.fill("first line")
+        composer.press("Enter")
+        composer.type("second line")
+
+        expect(composer).to_have_value(_PROMPT)
+        assert event_posts == []
+
+        send = page.get_by_role("button", name="Send", exact=True)
+        expect(send).to_be_visible()
+        send.click()
+
+        expect(
+            page.locator('[data-testid="message-bubble"][data-role="user"]', has_text="first line")
+        ).to_have_count(1)
+        assert len(event_posts) == 1
+        content = event_posts[0]["data"]["content"]
+        assert content[0]["text"] == _PROMPT
+    finally:
+        context.close()

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -16,6 +16,12 @@ vi.mock("@/shell/AppShell", () => ({
 vi.mock("@/pages/ChatPage", () => ({ ChatPage: () => <div>chat page</div> }));
 vi.mock("@/pages/NotFoundPage", () => ({ NotFoundPage: () => <div>not found</div> }));
 vi.mock("@/pages/UsagePage", () => ({ UsagePage: () => <div>usage page</div> }));
+vi.mock("@/pages/SettingsPage", async () => {
+  const { useLocation } = await import("react-router-dom");
+  return {
+    SettingsPage: () => <div data-testid="settings-location">{useLocation().pathname}</div>,
+  };
+});
 
 import App from "./App";
 
@@ -33,6 +39,16 @@ function renderUsageRoute(enabled: boolean) {
   );
 }
 
+function renderRoute(path: string) {
+  return render(
+    <CapabilitiesProvider info={FALLBACK_SERVER_INFO}>
+      <MemoryRouter initialEntries={[path]}>
+        <App />
+      </MemoryRouter>
+    </CapabilitiesProvider>,
+  );
+}
+
 describe("Usage release feature route", () => {
   it("does not register /usage while the feature is off", async () => {
     renderUsageRoute(false);
@@ -44,5 +60,21 @@ describe("Usage release feature route", () => {
     renderUsageRoute(true);
     expect(await screen.findByText("usage page")).toBeInTheDocument();
     expect(screen.queryByText("not found")).toBeNull();
+  });
+});
+
+describe("Settings routes", () => {
+  it("redirects bare settings to the canonical General section", async () => {
+    renderRoute("/settings");
+
+    expect(await screen.findByTestId("settings-location")).toHaveTextContent("/settings/general");
+  });
+
+  it("preserves an explicit settings section", async () => {
+    renderRoute("/settings/appearance");
+
+    expect(await screen.findByTestId("settings-location")).toHaveTextContent(
+      "/settings/appearance",
+    );
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -161,8 +161,11 @@ function App({ basename }: AppProps = {}) {
               sidebar stays put — entering settings only swaps the card's
               content (the section nav) and the main area. The active section
               is carried in the URL (/settings/<section>); bare /settings
-              defaults to Appearance. */}
-          <Route path={`${prefix}/settings`} element={<SettingsPage />} />
+              redirects to the canonical General section. */}
+          <Route
+            path={`${prefix}/settings`}
+            element={<Navigate to={`${prefix}/settings/general`} replace />}
+          />
           <Route path={`${prefix}/settings/:section`} element={<SettingsPage />} />
           {/* Members / Policies are now settings sub-categories
               (/settings/members, /settings/policies) so entering them

--- a/web/src/components/KeyboardShortcut.tsx
+++ b/web/src/components/KeyboardShortcut.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react";
+import { TooltipContent } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+const IS_MAC =
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent || "");
+
+export const MOD_KEY = IS_MAC ? "⌘" : "Ctrl";
+export const ALT_KEY = IS_MAC ? "⌥" : "Alt";
+export const ENTER_KEY = "↵";
+export const SHIFT_KEY = "⇧";
+
+export function composerSendShortcutKeys(submitWithModEnter: boolean): string[] {
+  return submitWithModEnter ? [MOD_KEY, ENTER_KEY] : [ENTER_KEY];
+}
+
+export function composerNewLineShortcutKeys(submitWithModEnter: boolean): string[] {
+  return submitWithModEnter ? [ENTER_KEY] : [SHIFT_KEY, ENTER_KEY];
+}
+
+export function Kbd({
+  children,
+  variant = "default",
+}: {
+  children: ReactNode;
+  variant?: "default" | "dark";
+}) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        "inline-flex h-6 min-w-6 items-center justify-center rounded-md border border-border bg-muted px-1.5 font-sans text-sm font-medium text-muted-foreground",
+        variant === "dark" && "border-slate-600 bg-slate-700 text-slate-300",
+      )}
+    >
+      {children}
+    </kbd>
+  );
+}
+
+export function KeyboardShortcutHint({ label, keys }: { label: string; keys: string[] }) {
+  return (
+    <>
+      <span>{label}</span>
+      {keys.map((key) => (
+        <Kbd key={`${label}-${key}`} variant="dark">
+          {key}
+        </Kbd>
+      ))}
+    </>
+  );
+}
+
+export function KeyboardShortcutTooltipContent({ label, keys }: { label: string; keys: string[] }) {
+  return (
+    <TooltipContent
+      side="top"
+      className="border border-slate-700 bg-slate-900 text-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+    >
+      <KeyboardShortcutHint label={label} keys={keys} />
+    </TooltipContent>
+  );
+}

--- a/web/src/components/KeyboardShortcutsDialog.test.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.test.tsx
@@ -6,6 +6,7 @@ import {
   KeyboardShortcutsList,
   openKeyboardShortcuts,
 } from "./KeyboardShortcutsDialog";
+import { COMPOSER_SEND_SHORTCUT_STORAGE_KEY } from "@/lib/composerSendShortcutPreferences";
 
 // The pinned-session row shows in both shells; only its chord differs (Alt in
 // the browser). Default the mock to browser (false); flip per-test for native.
@@ -24,6 +25,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   localStorage.clear();
+  vi.restoreAllMocks();
 });
 
 // jsdom's navigator is non-mac, so the modifier glyph renders as "Ctrl".
@@ -46,11 +48,23 @@ describe("KeyboardShortcutsList composer rows", () => {
   });
 
   it("shows Ctrl+Enter to send and Enter for a new line in alternate mode", () => {
-    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
+    localStorage.setItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY, "true");
     render(<KeyboardShortcutsList />);
 
     expect(keysFor("Send message")).toEqual(["Ctrl", "↵"]);
     expect(keysFor("New line in message")).toEqual(["↵"]);
+  });
+
+  it("does not advertise inactive composer chords on touch-primary devices", () => {
+    const matchMedia = window.matchMedia;
+    vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+      ...matchMedia(query),
+      matches: query.includes("pointer: coarse"),
+    }));
+    render(<KeyboardShortcutsList />);
+
+    expect(screen.queryByText("Send message")).toBeNull();
+    expect(screen.queryByText("New line in message")).toBeNull();
   });
 });
 

--- a/web/src/components/KeyboardShortcutsDialog.test.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.test.tsx
@@ -1,7 +1,11 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { KeyboardShortcutsDialog, openKeyboardShortcuts } from "./KeyboardShortcutsDialog";
+import {
+  KeyboardShortcutsDialog,
+  KeyboardShortcutsList,
+  openKeyboardShortcuts,
+} from "./KeyboardShortcutsDialog";
 
 // The pinned-session row shows in both shells; only its chord differs (Alt in
 // the browser). Default the mock to browser (false); flip per-test for native.
@@ -15,13 +19,40 @@ vi.mock("@/lib/nativeBridge", () => ({
 
 beforeEach(() => {
   isNativeShell.mockReturnValue(false);
+  localStorage.clear();
 });
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
 
 // jsdom's navigator is non-mac, so the modifier glyph renders as "Ctrl".
 function toggleViaHotkey() {
   fireEvent.keyDown(window, { key: "/", ctrlKey: true });
 }
+
+function keysFor(label: string): string[] {
+  const row = screen.getByText(label).closest("li");
+  expect(row).toBeTruthy();
+  return Array.from(row!.querySelectorAll('[data-slot="kbd"]')).map((key) => key.textContent ?? "");
+}
+
+describe("KeyboardShortcutsList composer rows", () => {
+  it("shows Enter to send and Shift+Enter for a new line by default", () => {
+    render(<KeyboardShortcutsList />);
+
+    expect(keysFor("Send message")).toEqual(["↵"]);
+    expect(keysFor("New line in message")).toEqual(["⇧", "↵"]);
+  });
+
+  it("shows Ctrl+Enter to send and Enter for a new line in alternate mode", () => {
+    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
+    render(<KeyboardShortcutsList />);
+
+    expect(keysFor("Send message")).toEqual(["Ctrl", "↵"]);
+    expect(keysFor("New line in message")).toEqual(["↵"]);
+  });
+});
 
 describe("KeyboardShortcutsDialog", () => {
   it("renders nothing until opened", () => {

--- a/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.tsx
@@ -9,8 +9,16 @@
 // (a window keydown for ⌘/Ctrl+/, plus a custom event so a menu entry can open
 // it without prop-drilling). Mount it once near the app shell.
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 
+import {
+  ALT_KEY,
+  composerNewLineShortcutKeys,
+  composerSendShortcutKeys,
+  ENTER_KEY,
+  Kbd,
+  MOD_KEY,
+} from "@/components/KeyboardShortcut";
 import {
   Dialog,
   DialogContent,
@@ -18,6 +26,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { readSubmitWithModEnter } from "@/lib/composerSendShortcutPreferences";
 import { isNativeShell } from "@/lib/nativeBridge";
 
 // Custom event the dialog listens for, so non-adjacent surfaces (e.g. the
@@ -30,19 +39,7 @@ export function openKeyboardShortcuts(): void {
   window.dispatchEvent(new Event(KEYBOARD_SHORTCUTS_EVENT));
 }
 
-// Platform-aware modifier glyphs. macOS shows ⌘/⌥; elsewhere Ctrl/Alt — the
-// same split the underlying handlers use (`metaKey || ctrlKey`).
-const IS_MAC =
-  typeof navigator !== "undefined" &&
-  /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent || "");
-
-/** Modifier label shown in menu hints (⌘ on macOS, Ctrl elsewhere). */
-export const MOD_KEY = IS_MAC ? "⌘" : "Ctrl";
-
 // Glyphs match the in-app tooltips (e.g. UserMessageNav's "⌘⌥↑").
-const ENTER = "↵";
-const SHIFT = "⇧";
-const ALT = IS_MAC ? "⌥" : "Alt";
 const UP = "↑";
 const DOWN = "↓";
 
@@ -74,12 +71,10 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
   {
     title: "In chats",
     items: [
-      { label: "Send message", keys: [ENTER] },
-      { label: "New line in message", keys: [SHIFT, ENTER] },
       { label: "Recall previous prompt", keys: [UP] },
       { label: "Recall next prompt", keys: [DOWN] },
-      { label: "Accept approval prompt", keys: [MOD_KEY, ENTER] },
-      { label: "Toggle voice dictation", keys: [MOD_KEY, ALT, "V"] },
+      { label: "Accept approval prompt", keys: [MOD_KEY, ENTER_KEY] },
+      { label: "Toggle voice dictation", keys: [MOD_KEY, ALT_KEY, "V"] },
       { label: "Stop response", keys: ["Esc"] },
     ],
   },
@@ -93,8 +88,8 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
   {
     title: "View",
     items: [
-      { label: "Toggle conversations sidebar", keys: [MOD_KEY, ALT, "["] },
-      { label: "Toggle workspace sidebar", keys: [MOD_KEY, ALT, "]"] },
+      { label: "Toggle conversations sidebar", keys: [MOD_KEY, ALT_KEY, "["] },
+      { label: "Toggle workspace sidebar", keys: [MOD_KEY, ALT_KEY, "]"] },
     ],
   },
   {
@@ -115,25 +110,31 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
 function pinnedSessionShortcut(native: boolean): Shortcut {
   return {
     label: "Jump to pinned session (1–10)",
-    keys: native ? [MOD_KEY, "1…0"] : [MOD_KEY, ALT, "1…0"],
+    keys: native ? [MOD_KEY, "1…0"] : [MOD_KEY, ALT_KEY, "1…0"],
   };
 }
 
-/** Shortcut groups for the current runtime — the pinned-jump chord differs by shell. */
-function shortcutGroupsFor(native: boolean): ShortcutGroup[] {
-  return SHORTCUT_GROUPS.map((group) =>
-    group.title === "Navigation"
-      ? { ...group, items: [...group.items, pinnedSessionShortcut(native)] }
-      : group,
-  );
-}
-
-function Kbd({ children }: { children: ReactNode }) {
-  return (
-    <kbd className="inline-flex h-6 min-w-6 items-center justify-center rounded-md border border-border bg-muted px-1.5 font-sans text-sm font-medium text-muted-foreground">
-      {children}
-    </kbd>
-  );
+/** Shortcut groups for the current runtime and composer preference. */
+function shortcutGroupsFor(native: boolean, submitWithModEnter: boolean): ShortcutGroup[] {
+  return SHORTCUT_GROUPS.map((group) => {
+    if (group.title === "In chats") {
+      return {
+        ...group,
+        items: [
+          { label: "Send message", keys: composerSendShortcutKeys(submitWithModEnter) },
+          {
+            label: "New line in message",
+            keys: composerNewLineShortcutKeys(submitWithModEnter),
+          },
+          ...group.items,
+        ],
+      };
+    }
+    if (group.title === "Navigation") {
+      return { ...group, items: [...group.items, pinnedSessionShortcut(native)] };
+    }
+    return group;
+  });
 }
 
 /**
@@ -143,7 +144,7 @@ function Kbd({ children }: { children: ReactNode }) {
  */
 export function KeyboardShortcutsList() {
   // Feature-based, stable per session; computed at render so tests can vary it.
-  const groups = shortcutGroupsFor(isNativeShell());
+  const groups = shortcutGroupsFor(isNativeShell(), readSubmitWithModEnter());
   return (
     <>
       {groups.map((group) => (

--- a/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.tsx
@@ -26,6 +26,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { readSubmitWithModEnter } from "@/lib/composerSendShortcutPreferences";
 import { isNativeShell } from "@/lib/nativeBridge";
 
@@ -115,9 +117,13 @@ function pinnedSessionShortcut(native: boolean): Shortcut {
 }
 
 /** Shortcut groups for the current runtime and composer preference. */
-function shortcutGroupsFor(native: boolean, submitWithModEnter: boolean): ShortcutGroup[] {
+function shortcutGroupsFor(
+  native: boolean,
+  submitWithModEnter: boolean,
+  preventsKeyboardSubmit: boolean,
+): ShortcutGroup[] {
   return SHORTCUT_GROUPS.map((group) => {
-    if (group.title === "In chats") {
+    if (group.title === "In chats" && !preventsKeyboardSubmit) {
       return {
         ...group,
         items: [
@@ -144,7 +150,14 @@ function shortcutGroupsFor(native: boolean, submitWithModEnter: boolean): Shortc
  */
 export function KeyboardShortcutsList() {
   // Feature-based, stable per session; computed at render so tests can vary it.
-  const groups = shortcutGroupsFor(isNativeShell(), readSubmitWithModEnter());
+  const isMobileViewport = useIsMobileViewport();
+  const isCoarsePointer = useIsCoarsePointer();
+  const preventsKeyboardSubmit = isMobileViewport || isCoarsePointer;
+  const groups = shortcutGroupsFor(
+    isNativeShell(),
+    readSubmitWithModEnter(),
+    preventsKeyboardSubmit,
+  );
   return (
     <>
       {groups.map((group) => (

--- a/web/src/lib/composerSendShortcutPreferences.test.ts
+++ b/web/src/lib/composerSendShortcutPreferences.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_SUBMIT_WITH_MOD_ENTER,
+  isComposerSendKey,
+  parseSubmitWithModEnter,
+  readSubmitWithModEnter,
+  writeSubmitWithModEnter,
+} from "./composerSendShortcutPreferences";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("composerSendShortcutPreferences", () => {
+  it("enables the alternate behavior only for the exact persisted value", () => {
+    expect(parseSubmitWithModEnter("true")).toBe(true);
+    expect(parseSubmitWithModEnter("false")).toBe(false);
+    expect(parseSubmitWithModEnter("1")).toBe(false);
+    expect(parseSubmitWithModEnter(null)).toBe(DEFAULT_SUBMIT_WITH_MOD_ENTER);
+  });
+
+  it("round-trips the opt-in and removes the default override", () => {
+    writeSubmitWithModEnter(true);
+    expect(readSubmitWithModEnter()).toBe(true);
+
+    writeSubmitWithModEnter(false);
+    expect(readSubmitWithModEnter()).toBe(false);
+    expect(localStorage.getItem("omnigent:composer-submit-with-mod-enter")).toBeNull();
+  });
+
+  it("falls back safely when storage cannot be read or written", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("access denied");
+    });
+
+    expect(() => writeSubmitWithModEnter(true)).not.toThrow();
+    expect(readSubmitWithModEnter()).toBe(DEFAULT_SUBMIT_WITH_MOD_ENTER);
+  });
+});
+
+describe("isComposerSendKey", () => {
+  it("uses unmodified Enter only for the default shortcut", () => {
+    expect(isComposerSendKey({ key: "Enter" }, false, false)).toBe(true);
+    expect(isComposerSendKey({ key: "Enter", shiftKey: true }, false, false)).toBe(false);
+    expect(isComposerSendKey({ key: "Enter", metaKey: true }, false, false)).toBe(false);
+  });
+
+  it("uses Command/Ctrl+Enter only for the alternate shortcut", () => {
+    expect(isComposerSendKey({ key: "Enter" }, true, false)).toBe(false);
+    expect(isComposerSendKey({ key: "Enter", metaKey: true }, true, false)).toBe(true);
+    expect(isComposerSendKey({ key: "Enter", ctrlKey: true }, true, false)).toBe(true);
+  });
+
+  it("never submits from composition, modified chords, or mobile Enter", () => {
+    expect(isComposerSendKey({ key: "Enter", metaKey: true, isComposing: true }, true, false)).toBe(
+      false,
+    );
+    expect(isComposerSendKey({ key: "Enter", metaKey: true, shiftKey: true }, true, false)).toBe(
+      false,
+    );
+    expect(isComposerSendKey({ key: "Enter", metaKey: true }, true, true)).toBe(false);
+  });
+});

--- a/web/src/lib/composerSendShortcutPreferences.test.ts
+++ b/web/src/lib/composerSendShortcutPreferences.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  COMPOSER_SEND_SHORTCUT_STORAGE_KEY,
   DEFAULT_SUBMIT_WITH_MOD_ENTER,
   isComposerSendKey,
   parseSubmitWithModEnter,
@@ -26,7 +27,7 @@ describe("composerSendShortcutPreferences", () => {
 
     writeSubmitWithModEnter(false);
     expect(readSubmitWithModEnter()).toBe(false);
-    expect(localStorage.getItem("omnigent:composer-submit-with-mod-enter")).toBeNull();
+    expect(localStorage.getItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY)).toBeNull();
   });
 
   it("falls back safely when storage cannot be read or written", () => {
@@ -43,10 +44,11 @@ describe("composerSendShortcutPreferences", () => {
 });
 
 describe("isComposerSendKey", () => {
-  it("uses unmodified Enter only for the default shortcut", () => {
+  it("keeps Enter and the legacy modifier chord in default mode", () => {
     expect(isComposerSendKey({ key: "Enter" }, false, false)).toBe(true);
     expect(isComposerSendKey({ key: "Enter", shiftKey: true }, false, false)).toBe(false);
-    expect(isComposerSendKey({ key: "Enter", metaKey: true }, false, false)).toBe(false);
+    expect(isComposerSendKey({ key: "Enter", metaKey: true }, false, false)).toBe(true);
+    expect(isComposerSendKey({ key: "Enter", ctrlKey: true }, false, false)).toBe(true);
   });
 
   it("uses Command/Ctrl+Enter only for the alternate shortcut", () => {

--- a/web/src/lib/composerSendShortcutPreferences.ts
+++ b/web/src/lib/composerSendShortcutPreferences.ts
@@ -1,0 +1,51 @@
+const STORAGE_KEY = "omnigent:composer-submit-with-mod-enter";
+
+export const DEFAULT_SUBMIT_WITH_MOD_ENTER = false;
+
+interface ComposerSendKeyEvent {
+  key: string;
+  shiftKey?: boolean;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  isComposing?: boolean;
+}
+
+export function parseSubmitWithModEnter(value: unknown): boolean {
+  return value === "true";
+}
+
+export function readSubmitWithModEnter(): boolean {
+  if (typeof window === "undefined") return DEFAULT_SUBMIT_WITH_MOD_ENTER;
+  try {
+    return parseSubmitWithModEnter(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return DEFAULT_SUBMIT_WITH_MOD_ENTER;
+  }
+}
+
+export function writeSubmitWithModEnter(value: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (value === DEFAULT_SUBMIT_WITH_MOD_ENTER) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, "true");
+    }
+  } catch {
+    // A storage failure must not make the composer unusable.
+  }
+}
+
+export function isComposerSendKey(
+  event: ComposerSendKeyEvent,
+  submitWithModEnter: boolean,
+  isMobile: boolean,
+): boolean {
+  if (isMobile || event.key !== "Enter" || event.isComposing || event.shiftKey || event.altKey) {
+    return false;
+  }
+
+  const hasMod = event.metaKey === true || event.ctrlKey === true;
+  return submitWithModEnter ? hasMod : !hasMod;
+}

--- a/web/src/lib/composerSendShortcutPreferences.ts
+++ b/web/src/lib/composerSendShortcutPreferences.ts
@@ -1,4 +1,4 @@
-const STORAGE_KEY = "omnigent:composer-submit-with-mod-enter";
+export const COMPOSER_SEND_SHORTCUT_STORAGE_KEY = "omnigent:composer-submit-with-mod-enter";
 
 export const DEFAULT_SUBMIT_WITH_MOD_ENTER = false;
 
@@ -18,7 +18,7 @@ export function parseSubmitWithModEnter(value: unknown): boolean {
 export function readSubmitWithModEnter(): boolean {
   if (typeof window === "undefined") return DEFAULT_SUBMIT_WITH_MOD_ENTER;
   try {
-    return parseSubmitWithModEnter(window.localStorage.getItem(STORAGE_KEY));
+    return parseSubmitWithModEnter(window.localStorage.getItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY));
   } catch {
     return DEFAULT_SUBMIT_WITH_MOD_ENTER;
   }
@@ -28,9 +28,9 @@ export function writeSubmitWithModEnter(value: boolean): void {
   if (typeof window === "undefined") return;
   try {
     if (value === DEFAULT_SUBMIT_WITH_MOD_ENTER) {
-      window.localStorage.removeItem(STORAGE_KEY);
+      window.localStorage.removeItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY);
     } else {
-      window.localStorage.setItem(STORAGE_KEY, "true");
+      window.localStorage.setItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY, "true");
     }
   } catch {
     // A storage failure must not make the composer unusable.
@@ -47,5 +47,5 @@ export function isComposerSendKey(
   }
 
   const hasMod = event.metaKey === true || event.ctrlKey === true;
-  return submitWithModEnter ? hasMod : !hasMod;
+  return submitWithModEnter ? hasMod : true;
 }

--- a/web/src/lib/settingsPortability.test.ts
+++ b/web/src/lib/settingsPortability.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { COMPOSER_SEND_SHORTCUT_STORAGE_KEY } from "./composerSendShortcutPreferences";
+import { applyImportedSettings, collectSettings } from "./settingsPortability";
+
+beforeEach(() => localStorage.clear());
+
+describe("composer shortcut portability", () => {
+  it("exports, imports, and clears the device-local preference", () => {
+    localStorage.setItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY, "true");
+    expect(collectSettings()?.settings[COMPOSER_SEND_SHORTCUT_STORAGE_KEY]).toBe("true");
+
+    applyImportedSettings({ version: 1, settings: {} });
+    expect(localStorage.getItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY)).toBeNull();
+
+    applyImportedSettings({
+      version: 1,
+      settings: { [COMPOSER_SEND_SHORTCUT_STORAGE_KEY]: "true" },
+    });
+    expect(localStorage.getItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY)).toBe("true");
+  });
+});

--- a/web/src/lib/settingsPortability.ts
+++ b/web/src/lib/settingsPortability.ts
@@ -6,6 +6,8 @@
 // field for future compatibility, plus one entry per localStorage key that
 // holds a non-default value.
 
+import { COMPOSER_SEND_SHORTCUT_STORAGE_KEY } from "./composerSendShortcutPreferences";
+
 /** localStorage keys that constitute exportable user preferences. */
 const EXPORTABLE_KEYS = [
   "omnigent:ui-font-size",
@@ -21,6 +23,7 @@ const EXPORTABLE_KEYS = [
   "omnigent:hide-unconfigured-harnesses",
   "omnigent:default-base-branch",
   "omnigent:always-use-worktree",
+  COMPOSER_SEND_SHORTCUT_STORAGE_KEY,
   "web-theme",
 ] as const;
 

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -105,6 +105,23 @@ function textarea() {
   return screen.getByLabelText("Message the agent") as HTMLTextAreaElement;
 }
 
+function forceMobileViewport(): () => void {
+  const original = window.matchMedia;
+  window.matchMedia = ((query: string) => ({
+    matches: query.includes("max-width"),
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as typeof window.matchMedia;
+  return () => {
+    window.matchMedia = original;
+  };
+}
+
 /** The currently highlighted menu row, or null when none is highlighted. */
 function activeRow(): HTMLElement | null {
   return document.querySelector('[data-active="true"]');
@@ -112,6 +129,25 @@ function activeRow(): HTMLElement | null {
 
 function renderWithTooltips(ui: ReactElement) {
   return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+function tooltipKeys(tooltip: HTMLElement): string[] {
+  return Array.from(tooltip.querySelectorAll('[data-slot="kbd"]')).map(
+    (key) => key.textContent ?? "",
+  );
+}
+
+function expectDarkShortcutTooltip(tooltip: HTMLElement): void {
+  expect(tooltip).toHaveClass(
+    "border-slate-700",
+    "bg-slate-900",
+    "text-slate-100",
+    "dark:bg-slate-900",
+    "dark:text-slate-100",
+  );
+  for (const key of tooltip.querySelectorAll('[data-slot="kbd"]')) {
+    expect(key).toHaveClass("border-slate-600", "bg-slate-700", "text-slate-300");
+  }
 }
 
 describe("Composer session drafts", () => {
@@ -181,6 +217,101 @@ describe("Composer growth layout", () => {
       "[&::-webkit-scrollbar]:hidden",
     );
     expect(ta.parentElement).toHaveClass("overflow-hidden");
+  });
+});
+
+describe("Composer send shortcut", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clearSessionDrafts();
+    useChatStore.setState({
+      conversationId: "conv_shortcut",
+      skills: [{ name: "deslop", description: "Remove AI slop" }],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    clearSessionDrafts();
+  });
+
+  it("keeps unmodified Enter as the default send shortcut", () => {
+    const onSend = vi.fn();
+    render(<Composer {...composerProps({ onSend })} />);
+    fireEvent.change(textarea(), { target: { value: "default shortcut" } });
+
+    fireEvent.keyDown(textarea(), { key: "Enter", shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(textarea(), { key: "Enter" });
+    expect(onSend.mock.calls[0]?.[0]).toBe("default shortcut");
+  });
+
+  it("uses Mod+Enter after the alternate preference is restored", () => {
+    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
+    const onSend = vi.fn();
+    render(<Composer {...composerProps({ onSend })} />);
+    fireEvent.change(textarea(), { target: { value: "alternate shortcut" } });
+
+    fireEvent.keyDown(textarea(), { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(textarea(), { key: "Enter", metaKey: true });
+    expect(onSend.mock.calls[0]?.[0]).toBe("alternate shortcut");
+  });
+
+  it("shows the default Send shortcut in the button tooltip", async () => {
+    render(<Composer {...composerProps()} />);
+    fireEvent.change(textarea(), { target: { value: "ready to send" } });
+
+    fireEvent.focus(screen.getByRole("button", { name: "Send" }));
+    const tooltip = await screen.findByRole("tooltip");
+
+    expect(within(tooltip).getByText("Send")).toBeInTheDocument();
+    expect(tooltipKeys(tooltip)).toEqual(["↵"]);
+    expectDarkShortcutTooltip(tooltip);
+  });
+
+  it("shows the alternate Send shortcut in the button tooltip", async () => {
+    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
+    render(<Composer {...composerProps()} />);
+    fireEvent.change(textarea(), { target: { value: "ready to send" } });
+
+    fireEvent.pointerMove(screen.getByRole("button", { name: "Send" }), {
+      pointerType: "mouse",
+    });
+    const tooltip = await screen.findByRole("tooltip");
+
+    expect(within(tooltip).getByText("Send")).toBeInTheDocument();
+    expect(tooltipKeys(tooltip)).toEqual(["Ctrl", "↵"]);
+    expectDarkShortcutTooltip(tooltip);
+  });
+
+  it("does not submit a Mod+Enter event during IME composition", () => {
+    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
+    const onSend = vi.fn();
+    render(<Composer {...composerProps({ onSend })} />);
+    fireEvent.change(textarea(), { target: { value: "変換中" } });
+
+    fireEvent.compositionStart(textarea());
+    fireEvent.keyDown(textarea(), { key: "Enter", metaKey: true, isComposing: true });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("keeps plain Enter completion while Mod+Enter bypasses an open slash menu", () => {
+    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
+    const onSend = vi.fn();
+    render(<Composer {...composerProps({ onSend })} />);
+    fireEvent.change(textarea(), { target: { value: "/des" } });
+
+    fireEvent.keyDown(textarea(), { key: "Enter" });
+    expect(textarea().value).toBe("/deslop ");
+    expect(onSend).not.toHaveBeenCalled();
+
+    fireEvent.change(textarea(), { target: { value: "/des" } });
+    fireEvent.keyDown(textarea(), { key: "Enter", ctrlKey: true });
+    expect(onSend.mock.calls[0]?.[0]).toBe("/des");
   });
 });
 
@@ -329,6 +460,45 @@ describe("Composer slash-command menu", () => {
       componentId: "chat.composer.send",
       componentKind: "button",
     });
+  });
+
+  it("leaves mobile Enter to the textarea instead of sending", () => {
+    const restoreViewport = forceMobileViewport();
+    const onSend = vi.fn();
+    try {
+      render(<Composer {...composerProps({ onSend })} />);
+      const ta = textarea();
+      fireEvent.change(ta, { target: { value: "first line" } });
+      const enter = new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      });
+
+      fireEvent(ta, enter);
+
+      expect(enter.defaultPrevented).toBe(false);
+      expect(onSend).not.toHaveBeenCalled();
+    } finally {
+      restoreViewport();
+    }
+  });
+
+  it("does not accept slash suggestions when Enter is pressed on mobile", () => {
+    const restoreViewport = forceMobileViewport();
+    const onSend = vi.fn();
+    try {
+      render(<Composer {...composerProps({ onSend })} />);
+      const ta = textarea();
+      fireEvent.change(ta, { target: { value: "/des" } });
+
+      fireEvent.keyDown(ta, { key: "Enter" });
+
+      expect(ta.value).toBe("/des");
+      expect(onSend).not.toHaveBeenCalled();
+    } finally {
+      restoreViewport();
+    }
   });
 
   it("Enter on an empty composer neither sends nor reports a send", () => {

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatStore } from "@/store/chatStore";
 import { clearSessionDrafts, hasSessionDraft } from "@/lib/sessionDrafts";
 import { setOmnigentHostConfig } from "@/lib/host";
+import { COMPOSER_SEND_SHORTCUT_STORAGE_KEY } from "@/lib/composerSendShortcutPreferences";
 
 // Composer reads workspace files via a TanStack query hook (for "@"-file
 // mentions). These slash-command tests don't exercise that, so stub the hook
@@ -105,10 +106,10 @@ function textarea() {
   return screen.getByLabelText("Message the agent") as HTMLTextAreaElement;
 }
 
-function forceMobileViewport(): () => void {
+function forceDesktopCoarsePointer(): () => void {
   const original = window.matchMedia;
   window.matchMedia = ((query: string) => ({
-    matches: query.includes("max-width"),
+    matches: query.includes("pointer: coarse"),
     media: query,
     onchange: null,
     addListener: () => {},
@@ -135,19 +136,6 @@ function tooltipKeys(tooltip: HTMLElement): string[] {
   return Array.from(tooltip.querySelectorAll('[data-slot="kbd"]')).map(
     (key) => key.textContent ?? "",
   );
-}
-
-function expectDarkShortcutTooltip(tooltip: HTMLElement): void {
-  expect(tooltip).toHaveClass(
-    "border-slate-700",
-    "bg-slate-900",
-    "text-slate-100",
-    "dark:bg-slate-900",
-    "dark:text-slate-100",
-  );
-  for (const key of tooltip.querySelectorAll('[data-slot="kbd"]')) {
-    expect(key).toHaveClass("border-slate-600", "bg-slate-700", "text-slate-300");
-  }
 }
 
 describe("Composer session drafts", () => {
@@ -236,20 +224,20 @@ describe("Composer send shortcut", () => {
     clearSessionDrafts();
   });
 
-  it("keeps unmodified Enter as the default send shortcut", () => {
+  it("keeps Enter and the legacy Mod+Enter alias in default mode", () => {
     const onSend = vi.fn();
     render(<Composer {...composerProps({ onSend })} />);
+    fireEvent.change(textarea(), { target: { value: "legacy alias" } });
+    fireEvent.keyDown(textarea(), { key: "Enter", metaKey: true });
+    expect(onSend).toHaveBeenCalledWith("legacy alias", undefined);
+
     fireEvent.change(textarea(), { target: { value: "default shortcut" } });
-
-    fireEvent.keyDown(textarea(), { key: "Enter", shiftKey: true });
-    expect(onSend).not.toHaveBeenCalled();
-
     fireEvent.keyDown(textarea(), { key: "Enter" });
-    expect(onSend.mock.calls[0]?.[0]).toBe("default shortcut");
+    expect(onSend).toHaveBeenLastCalledWith("default shortcut", undefined);
   });
 
   it("uses Mod+Enter after the alternate preference is restored", () => {
-    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
+    localStorage.setItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY, "true");
     const onSend = vi.fn();
     render(<Composer {...composerProps({ onSend })} />);
     fireEvent.change(textarea(), { target: { value: "alternate shortcut" } });
@@ -261,20 +249,8 @@ describe("Composer send shortcut", () => {
     expect(onSend.mock.calls[0]?.[0]).toBe("alternate shortcut");
   });
 
-  it("shows the default Send shortcut in the button tooltip", async () => {
-    render(<Composer {...composerProps()} />);
-    fireEvent.change(textarea(), { target: { value: "ready to send" } });
-
-    fireEvent.focus(screen.getByRole("button", { name: "Send" }));
-    const tooltip = await screen.findByRole("tooltip");
-
-    expect(within(tooltip).getByText("Send")).toBeInTheDocument();
-    expect(tooltipKeys(tooltip)).toEqual(["↵"]);
-    expectDarkShortcutTooltip(tooltip);
-  });
-
   it("shows the alternate Send shortcut in the button tooltip", async () => {
-    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
+    localStorage.setItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY, "true");
     render(<Composer {...composerProps()} />);
     fireEvent.change(textarea(), { target: { value: "ready to send" } });
 
@@ -285,22 +261,27 @@ describe("Composer send shortcut", () => {
 
     expect(within(tooltip).getByText("Send")).toBeInTheDocument();
     expect(tooltipKeys(tooltip)).toEqual(["Ctrl", "↵"]);
-    expectDarkShortcutTooltip(tooltip);
   });
 
-  it("does not submit a Mod+Enter event during IME composition", () => {
-    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
+  it("keeps Enter native and hides its hint on a desktop-width coarse pointer", () => {
+    const restorePointer = forceDesktopCoarsePointer();
     const onSend = vi.fn();
-    render(<Composer {...composerProps({ onSend })} />);
-    fireEvent.change(textarea(), { target: { value: "変換中" } });
+    try {
+      render(<Composer {...composerProps({ onSend })} />);
+      fireEvent.change(textarea(), { target: { value: "/des" } });
+      fireEvent.keyDown(textarea(), { key: "Enter" });
+      expect(textarea().value).toBe("/des");
+      expect(onSend).not.toHaveBeenCalled();
 
-    fireEvent.compositionStart(textarea());
-    fireEvent.keyDown(textarea(), { key: "Enter", metaKey: true, isComposing: true });
-    expect(onSend).not.toHaveBeenCalled();
+      fireEvent.focus(screen.getByRole("button", { name: "Send" }));
+      expect(screen.queryByRole("tooltip")).toBeNull();
+    } finally {
+      restorePointer();
+    }
   });
 
   it("keeps plain Enter completion while Mod+Enter bypasses an open slash menu", () => {
-    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
+    localStorage.setItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY, "true");
     const onSend = vi.fn();
     render(<Composer {...composerProps({ onSend })} />);
     fireEvent.change(textarea(), { target: { value: "/des" } });
@@ -460,45 +441,6 @@ describe("Composer slash-command menu", () => {
       componentId: "chat.composer.send",
       componentKind: "button",
     });
-  });
-
-  it("leaves mobile Enter to the textarea instead of sending", () => {
-    const restoreViewport = forceMobileViewport();
-    const onSend = vi.fn();
-    try {
-      render(<Composer {...composerProps({ onSend })} />);
-      const ta = textarea();
-      fireEvent.change(ta, { target: { value: "first line" } });
-      const enter = new KeyboardEvent("keydown", {
-        key: "Enter",
-        bubbles: true,
-        cancelable: true,
-      });
-
-      fireEvent(ta, enter);
-
-      expect(enter.defaultPrevented).toBe(false);
-      expect(onSend).not.toHaveBeenCalled();
-    } finally {
-      restoreViewport();
-    }
-  });
-
-  it("does not accept slash suggestions when Enter is pressed on mobile", () => {
-    const restoreViewport = forceMobileViewport();
-    const onSend = vi.fn();
-    try {
-      render(<Composer {...composerProps({ onSend })} />);
-      const ta = textarea();
-      fireEvent.change(ta, { target: { value: "/des" } });
-
-      fireEvent.keyDown(ta, { key: "Enter" });
-
-      expect(ta.value).toBe("/des");
-      expect(onSend).not.toHaveBeenCalled();
-    } finally {
-      restoreViewport();
-    }
   });
 
   it("Enter on an empty composer neither sends nor reports a send", () => {

--- a/web/src/pages/ChatPage.mention.test.tsx
+++ b/web/src/pages/ChatPage.mention.test.tsx
@@ -112,23 +112,6 @@ function textarea() {
   return screen.getByLabelText("Message the agent") as HTMLTextAreaElement;
 }
 
-function forceMobileViewport(): () => void {
-  const original = window.matchMedia;
-  window.matchMedia = ((query: string) => ({
-    matches: query.includes("max-width"),
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  })) as typeof window.matchMedia;
-  return () => {
-    window.matchMedia = original;
-  };
-}
-
 /** Type `text` into the composer with the caret at the end. */
 function type(text: string) {
   fireEvent.change(textarea(), { target: { value: text, selectionStart: text.length } });
@@ -356,21 +339,6 @@ describe("Composer @-file-mention browser (native sessions)", () => {
     fireEvent.keyDown(ta, { key: "ArrowDown" });
     fireEvent.keyDown(ta, { key: "Enter" });
     expect(screen.getByText("@readme.md")).toBeInTheDocument();
-  });
-
-  it("does not accept the highlighted mention when Enter is pressed on mobile", () => {
-    const restoreViewport = forceMobileViewport();
-    try {
-      renderWithTooltips(<Composer {...composerProps()} />);
-      type("@readme");
-
-      fireEvent.keyDown(textarea(), { key: "Enter" });
-
-      expect(textarea().value).toBe("@readme");
-      expect(screen.queryByText("@readme.md")).not.toBeInTheDocument();
-    } finally {
-      restoreViewport();
-    }
   });
 
   it("ArrowUp from the top row wraps to the last row", () => {

--- a/web/src/pages/ChatPage.mention.test.tsx
+++ b/web/src/pages/ChatPage.mention.test.tsx
@@ -112,6 +112,23 @@ function textarea() {
   return screen.getByLabelText("Message the agent") as HTMLTextAreaElement;
 }
 
+function forceMobileViewport(): () => void {
+  const original = window.matchMedia;
+  window.matchMedia = ((query: string) => ({
+    matches: query.includes("max-width"),
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as typeof window.matchMedia;
+  return () => {
+    window.matchMedia = original;
+  };
+}
+
 /** Type `text` into the composer with the caret at the end. */
 function type(text: string) {
   fireEvent.change(textarea(), { target: { value: text, selectionStart: text.length } });
@@ -339,6 +356,21 @@ describe("Composer @-file-mention browser (native sessions)", () => {
     fireEvent.keyDown(ta, { key: "ArrowDown" });
     fireEvent.keyDown(ta, { key: "Enter" });
     expect(screen.getByText("@readme.md")).toBeInTheDocument();
+  });
+
+  it("does not accept the highlighted mention when Enter is pressed on mobile", () => {
+    const restoreViewport = forceMobileViewport();
+    try {
+      renderWithTooltips(<Composer {...composerProps()} />);
+      type("@readme");
+
+      fireEvent.keyDown(textarea(), { key: "Enter" });
+
+      expect(textarea().value).toBe("@readme");
+      expect(screen.queryByText("@readme.md")).not.toBeInTheDocument();
+    } finally {
+      restoreViewport();
+    }
   });
 
   it("ArrowUp from the top row wraps to the last row", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -226,6 +226,7 @@ import { SessionImage } from "@/components/SessionImage";
 import { GoalControl, GoalStatusPill, useGoalState, type Goal } from "@/components/goal";
 import { copyText } from "@/lib/clipboard";
 import { showToast } from "@/components/ui/toast";
+import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import {
   ConnectionIndicator,
@@ -4460,6 +4461,8 @@ export function Composer({
   // Keep desktop's fast-type affordance, but let mobile users explicitly tap
   // the composer when switching back from Terminal or changing sessions.
   const isMobile = useIsMobileViewport();
+  const isCoarsePointer = useIsCoarsePointer();
+  const preventsKeyboardSubmit = isMobile || isCoarsePointer;
   const isMobileRef = useRef(isMobile);
   isMobileRef.current = isMobile;
 
@@ -5032,9 +5035,9 @@ export function Composer({
       return;
     }
 
-    // Mobile newline behavior outranks autocomplete and desktop submit
+    // Touch-primary newline behavior outranks autocomplete and desktop submit
     // preferences. Leave the event untouched so the textarea inserts it.
-    if (isMobile && e.key === "Enter") {
+    if (preventsKeyboardSubmit && e.key === "Enter") {
       return;
     }
 
@@ -5048,7 +5051,7 @@ export function Composer({
         isComposing: e.nativeEvent.isComposing,
       },
       submitWithModEnter,
-      isMobile,
+      preventsKeyboardSubmit,
     );
     // Plain Enter still completes an open suggestion. In Mod+Enter mode, the
     // explicit send chord bypasses suggestions so the modifier has one meaning.
@@ -5619,7 +5622,7 @@ export function Composer({
                     <span className="sr-only">{showInterruptButton ? "Interrupt" : "Send"}</span>
                   </Button>
                 </TooltipTrigger>
-                {!showInterruptButton && (
+                {!showInterruptButton && !preventsKeyboardSubmit && (
                   <KeyboardShortcutTooltipContent
                     label="Send"
                     keys={composerSendShortcutKeys(submitWithModEnter)}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -32,6 +32,10 @@ import {
 } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  composerSendShortcutKeys,
+  KeyboardShortcutTooltipContent,
+} from "@/components/KeyboardShortcut";
 import { userColor, userColorTint, userInitials } from "@/lib/userBadge";
 import { useNavigate, useParams } from "@/lib/routing";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
@@ -121,6 +125,7 @@ import {
   WRAPPER_LABEL_KEY,
 } from "@/lib/nativeCodingAgents";
 import { readAlwaysSteer } from "@/lib/alwaysSteerPreferences";
+import { isComposerSendKey, readSubmitWithModEnter } from "@/lib/composerSendShortcutPreferences";
 import {
   buildMentionPreamble,
   detectMentionAt,
@@ -4301,6 +4306,7 @@ export function Composer({
   wrapperLabel = null,
 }: ComposerProps) {
   const [value, setValue] = useState("");
+  const [submitWithModEnter] = useState(() => readSubmitWithModEnter());
   const [files, setFiles] = useState<File[]>([]);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [commandError, setCommandError] = useState<string | null>(null);
@@ -4453,17 +4459,9 @@ export function Composer({
   // On mobile, programmatic focus immediately summons the software keyboard.
   // Keep desktop's fast-type affordance, but let mobile users explicitly tap
   // the composer when switching back from Terminal or changing sessions.
-  const [isMobile, setIsMobile] = useState(
-    () => typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches,
-  );
+  const isMobile = useIsMobileViewport();
   const isMobileRef = useRef(isMobile);
   isMobileRef.current = isMobile;
-  useEffect(() => {
-    const mq = window.matchMedia("(max-width: 767px)");
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
 
   useEffect(() => {
     const restored = conversationId ? getSessionDraft(conversationId) : undefined;
@@ -5034,10 +5032,32 @@ export function Composer({
       return;
     }
 
+    // Mobile newline behavior outranks autocomplete and desktop submit
+    // preferences. Leave the event untouched so the textarea inserts it.
+    if (isMobile && e.key === "Enter") {
+      return;
+    }
+
+    const shouldSubmitFromKeyboard = isComposerSendKey(
+      {
+        key: e.key,
+        shiftKey: e.shiftKey,
+        metaKey: e.metaKey,
+        ctrlKey: e.ctrlKey,
+        altKey: e.altKey,
+        isComposing: e.nativeEvent.isComposing,
+      },
+      submitWithModEnter,
+      isMobile,
+    );
+    // Plain Enter still completes an open suggestion. In Mod+Enter mode, the
+    // explicit send chord bypasses suggestions so the modifier has one meaning.
+    const shouldPreferSendOverCompletion = submitWithModEnter && shouldSubmitFromKeyboard;
+
     // "@"-mention menu navigation (shared useMentionBrowser) — mutually
     // exclusive with the slash menu below (a mention token can't also read as a
     // "/"-command). Takes priority over history recall and submission.
-    if (handleMentionKeyDown(e)) return;
+    if (!shouldPreferSendOverCompletion && handleMentionKeyDown(e)) return;
 
     // When the suggestions menu is open, ArrowUp/Down navigate it and
     // Enter/Tab complete the highlighted item. These take priority over
@@ -5053,7 +5073,11 @@ export function Composer({
         setMenuIndex((i) => (i <= 0 ? menuMatches.length - 1 : i - 1));
         return;
       }
-      if ((e.key === "Tab" || (e.key === "Enter" && !e.shiftKey && !isMobile)) && menuIndex >= 0) {
+      if (
+        !shouldPreferSendOverCompletion &&
+        (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey && !isMobile)) &&
+        menuIndex >= 0
+      ) {
         e.preventDefault();
         applyMenuSelection(menuMatches[menuIndex]!);
         return;
@@ -5067,9 +5091,9 @@ export function Composer({
       }
     }
 
-    // Enter sends; Shift+Enter inserts a newline. On mobile, Enter inserts a
-    // newline (no Shift available on-screen) and Send must be tapped instead.
-    if (e.key === "Enter" && !e.shiftKey && !isMobile && !e.nativeEvent.isComposing) {
+    // Mobile Enter behavior takes precedence over this desktop preference:
+    // software-keyboard Enter inserts a newline and Send remains an explicit tap.
+    if (shouldSubmitFromKeyboard) {
       e.preventDefault();
       // The mention menu is briefly closed while its listing loads (see
       // ``mentionListingPending``); swallow Enter so the in-progress "@dir/"
@@ -5562,35 +5586,47 @@ export function Composer({
                 openNonce={pickerOpenNonce}
               />
             </div>
-            <Button
-              type="submit"
-              size="icon"
-              variant={showInterruptButton ? "destructive" : "default"}
-              // Send button fades more decisively when there's no draft —
-              // overrides the base 50% disabled-opacity so the affordance
-              // reads as "waiting for input", not "almost active".
-              className={cn(
-                "size-9 shrink-0 rounded-lg md:size-8",
-                !showInterruptButton &&
-                  "hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100",
-              )}
-              // Interrupt stays live during a pending elicitation —
-              // cancelling the turn is the other legitimate way out.
-              disabled={
-                showInterruptButton
-                  ? isReadOnly
-                  : !hasDraft || disabled || isReadOnly || hasPendingElicitation
-              }
-              title={showInterruptButton ? "Interrupt" : "Send"}
-              aria-label={showInterruptButton ? "Interrupt" : "Send"}
-            >
-              {showInterruptButton ? (
-                <SquareIcon className="size-4 fill-current" />
-              ) : (
-                <ArrowUpIcon className="size-4" viewBox="4 4 16 16" />
-              )}
-              <span className="sr-only">{showInterruptButton ? "Interrupt" : "Send"}</span>
-            </Button>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="submit"
+                    size="icon"
+                    variant={showInterruptButton ? "destructive" : "default"}
+                    // Send button fades more decisively when there's no draft —
+                    // overrides the base 50% disabled-opacity so the affordance
+                    // reads as "waiting for input", not "almost active".
+                    className={cn(
+                      "size-9 shrink-0 rounded-lg md:size-8",
+                      !showInterruptButton &&
+                        "hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100",
+                    )}
+                    // Interrupt stays live during a pending elicitation —
+                    // cancelling the turn is the other legitimate way out.
+                    disabled={
+                      showInterruptButton
+                        ? isReadOnly
+                        : !hasDraft || disabled || isReadOnly || hasPendingElicitation
+                    }
+                    title={showInterruptButton ? "Interrupt" : undefined}
+                    aria-label={showInterruptButton ? "Interrupt" : "Send"}
+                  >
+                    {showInterruptButton ? (
+                      <SquareIcon className="size-4 fill-current" />
+                    ) : (
+                      <ArrowUpIcon className="size-4" viewBox="4 4 16 16" />
+                    )}
+                    <span className="sr-only">{showInterruptButton ? "Interrupt" : "Send"}</span>
+                  </Button>
+                </TooltipTrigger>
+                {!showInterruptButton && (
+                  <KeyboardShortcutTooltipContent
+                    label="Send"
+                    keys={composerSendShortcutKeys(submitWithModEnter)}
+                  />
+                )}
+              </Tooltip>
+            </TooltipProvider>
           </div>
         </div>
       </div>

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -275,6 +275,24 @@ function installUpdateBridge(config: UpdateConfig = DEFAULT_UPDATE_CONFIG) {
 }
 
 describe("SettingsPage", () => {
+  it("renders composer shortcut guidance as two accessible lines", () => {
+    renderPage("/settings/general");
+    const toggle = screen.getByTestId("composer-submit-with-mod-enter-toggle");
+    const descriptionId = toggle.getAttribute("aria-describedby");
+    const description = descriptionId ? document.getElementById(descriptionId) : null;
+
+    expect(description).toBeTruthy();
+    if (description === null) throw new Error("Missing composer shortcut description");
+    expect(Array.from(description.children).map((line) => line.tagName)).toEqual(["P", "P"]);
+    expect(
+      within(description).getByText("Off: Enter submits and Shift+Enter inserts a newline."),
+    ).toBeInTheDocument();
+    expect(
+      within(description).getByText(/On: Enter inserts a newline and (?:⌘|Ctrl)\+Enter submits\./),
+    ).toBeInTheDocument();
+    expect(toggle).toHaveAttribute("aria-labelledby");
+  });
+
   it("renders the Appearance section and applies a theme on card click", () => {
     renderPage("/settings/appearance");
     expect(screen.getByRole("heading", { name: "Appearance" })).toBeInTheDocument();

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -765,18 +765,15 @@ describe("SettingsPage", () => {
     expect(screen.getByTestId("heavier-code-text-toggle")).toHaveAttribute("aria-checked", "false");
   });
 
-  it("defaults bare /settings to Account when a login session exists, else Appearance", async () => {
-    // Login session (accounts OR OIDC) → Account leads, so /settings lands on it.
+  it("defaults bare /settings to General regardless of login mode", () => {
     renderPage("/settings");
-    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+    expect(screen.getByRole("heading", { name: "General" })).toBeInTheDocument();
 
-    // Header single-user (no login_url) → no Account section; falls back to
-    // Appearance.
     cleanup();
     mocks.accountsEnabled = false;
     mocks.loginUrl = null;
     renderPage("/settings");
-    expect(screen.getByRole("heading", { name: "Appearance" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "General" })).toBeInTheDocument();
   });
 
   it("renders the Account section at /settings/account for any login session", async () => {

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -291,6 +291,7 @@ describe("SettingsPage", () => {
       within(description).getByText(/On: Enter inserts a newline and (?:⌘|Ctrl)\+Enter submits\./),
     ).toBeInTheDocument();
     expect(toggle).toHaveAttribute("aria-labelledby");
+    expect(toggle).toHaveAccessibleName(/Submit with (?:⌘|Ctrl) \+ Enter on desktop/);
   });
 
   it("renders the Appearance section and applies a theme on card click", () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1104,7 +1104,7 @@ function ComposerSendShortcutControl() {
     <div className="flex items-start justify-between gap-6">
       <div className="flex min-w-0 flex-1 flex-col">
         <span id={labelId} className="text-ui font-medium">
-          Submit with {MOD_KEY} + Enter
+          Submit with {MOD_KEY} + Enter on desktop
         </span>
         <div id={descriptionId} className="text-ui text-muted-foreground">
           <p>Off: Enter submits and Shift+Enter inserts a newline.</p>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -93,6 +93,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { MOD_KEY } from "@/components/KeyboardShortcut";
 import { KeyboardShortcutsList } from "@/components/KeyboardShortcutsDialog";
 import { changePassword, logout } from "@/lib/accountsApi";
 import { getCurrentIsAdmin, getCurrentUserId, resolveIdentity } from "@/lib/identity";
@@ -169,6 +170,10 @@ import {
 } from "@/lib/transcriptViewPreferences";
 import { readDefaultBaseBranch, writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 import { readAlwaysSteer, writeAlwaysSteer } from "@/lib/alwaysSteerPreferences";
+import {
+  readSubmitWithModEnter,
+  writeSubmitWithModEnter,
+} from "@/lib/composerSendShortcutPreferences";
 import { readAlwaysUseWorktree, writeAlwaysUseWorktree } from "@/lib/worktreeDefaultPreferences";
 import {
   DEFAULT_HIDE_UNCONFIGURED_HARNESSES,
@@ -1086,14 +1091,50 @@ function AlwaysSteerControl() {
   );
 }
 
+function ComposerSendShortcutControl() {
+  const [enabled, setEnabled] = useState(() => readSubmitWithModEnter());
+  const labelId = useId();
+  const descriptionId = useId();
+  const toggle = useCallback((next: boolean) => {
+    setEnabled(next);
+    writeSubmitWithModEnter(next);
+  }, []);
+
+  return (
+    <div className="flex items-start justify-between gap-6">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span id={labelId} className="text-ui font-medium">
+          Submit with {MOD_KEY} + Enter
+        </span>
+        <div id={descriptionId} className="text-ui text-muted-foreground">
+          <p>Off: Enter submits and Shift+Enter inserts a newline.</p>
+          <p>On: Enter inserts a newline and {MOD_KEY}+Enter submits.</p>
+        </div>
+      </div>
+      <Switch
+        aria-labelledby={labelId}
+        aria-describedby={descriptionId}
+        checked={enabled}
+        onCheckedChange={toggle}
+        data-testid="composer-submit-with-mod-enter-toggle"
+        className="mt-0.5 shrink-0"
+        componentId="settings.general.submit_with_mod_enter"
+      />
+    </div>
+  );
+}
+
 /** App-wide behavior settings. */
 function GeneralSection() {
   return (
     <Section title="General" description="Configure general Omnigent behavior.">
       <div className="flex flex-col gap-3">
         <h2 className="text-ui font-medium">Composer</h2>
-        <div className="rounded-xl border border-border bg-card px-4 py-3">
-          <AlwaysSteerControl />
+        <div className="rounded-xl border border-border bg-card p-4">
+          <ComposerSendShortcutControl />
+          <div className="mt-4 border-t border-border pt-4">
+            <AlwaysSteerControl />
+          </div>
         </div>
       </div>
     </Section>

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -1827,12 +1827,14 @@ describe("sanitizeInitialPrompt", () => {
   });
 });
 
-describe("create-session input on mobile viewports", () => {
-  it("Enter inserts a newline instead of submitting", async () => {
-    // Mobile layout owns this behavior regardless of which keyboard produced
-    // the event. Enter stays native to the textarea; Send remains explicit.
+describe("create-session input on touch-primary devices", () => {
+  it("Enter inserts a newline instead of submitting when the pointer is coarse", async () => {
+    // Phones have no practical Shift+Enter, so an Enter-submit in the
+    // create-session composer was an unrecoverable accidental send. On
+    // coarse-pointer devices the composer must let Enter fall through to the
+    // textarea's native newline; sending stays an explicit tap.
     const matchMediaSpy = vi.spyOn(window, "matchMedia").mockImplementation((query: string) =>
-      query.includes("max-width")
+      query.includes("pointer: coarse")
         ? ({
             matches: true,
             media: query,
@@ -1867,6 +1869,9 @@ describe("create-session input on mobile viewports", () => {
       // intercepted, so the composer still holds the user's draft.
       expect(authenticatedFetch).not.toHaveBeenCalled();
       expect(navigateMock).not.toHaveBeenCalled();
+
+      fireEvent.focus(screen.getByTestId("new-chat-landing-submit"));
+      expect(screen.queryByRole("tooltip")).toBeNull();
     } finally {
       matchMediaSpy.mockRestore();
     }

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -1827,14 +1827,12 @@ describe("sanitizeInitialPrompt", () => {
   });
 });
 
-describe("create-session input on touch-primary devices", () => {
-  it("Enter inserts a newline instead of submitting when the pointer is coarse", async () => {
-    // Phones have no practical Shift+Enter, so an Enter-submit in the
-    // create-session composer was an unrecoverable accidental send. On
-    // coarse-pointer devices the composer must let Enter fall through to the
-    // textarea's native newline; sending stays an explicit tap.
+describe("create-session input on mobile viewports", () => {
+  it("Enter inserts a newline instead of submitting", async () => {
+    // Mobile layout owns this behavior regardless of which keyboard produced
+    // the event. Enter stays native to the textarea; Send remains explicit.
     const matchMediaSpy = vi.spyOn(window, "matchMedia").mockImplementation((query: string) =>
-      query.includes("pointer: coarse")
+      query.includes("max-width")
         ? ({
             matches: true,
             media: query,

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -44,6 +44,7 @@ import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import type { Conversation } from "@/hooks/useConversations";
 import { setOmnigentHostConfig } from "@/lib/host";
+import { COMPOSER_SEND_SHORTCUT_STORAGE_KEY } from "@/lib/composerSendShortcutPreferences";
 import {
   controlHost,
   getHostIdentity,
@@ -976,27 +977,6 @@ describe("NewChatLandingScreen", () => {
     expect(screen.getByTestId("new-chat-landing-input")).toBeTruthy();
   });
 
-  it("leaves mobile Enter to the textarea instead of creating a session", () => {
-    const restoreViewport = forceMobileViewport();
-    try {
-      renderLanding();
-      const input = screen.getByTestId("new-chat-landing-input");
-      fireEvent.change(input, { target: { value: "first line" } });
-      const enter = new KeyboardEvent("keydown", {
-        key: "Enter",
-        bubbles: true,
-        cancelable: true,
-      });
-
-      fireEvent(input, enter);
-
-      expect(enter.defaultPrevented).toBe(false);
-      expect(authenticatedFetchMock).not.toHaveBeenCalled();
-    } finally {
-      restoreViewport();
-    }
-  });
-
   it("does not replace a missing remembered host with the first cached host", async () => {
     localStorage.setItem("omnigent:last-host-choice", "host_2");
     // The shared query cache can render an older host list first while a
@@ -1187,35 +1167,6 @@ describe("NewChatLandingScreen", () => {
 
     expect(within(tooltip).getByText("Start session")).toBeInTheDocument();
     expect(tooltipKeys(tooltip)).toEqual(["↵"]);
-    expect(tooltip).toHaveClass(
-      "border-slate-700",
-      "bg-slate-900",
-      "text-slate-100",
-      "dark:bg-slate-900",
-    );
-    expect(tooltip.querySelector('[data-slot="kbd"]')).toHaveClass(
-      "border-slate-600",
-      "bg-slate-700",
-      "text-slate-300",
-    );
-  });
-
-  it("shows the alternate shortcut in the new-chat submit tooltip", async () => {
-    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
-    renderLanding();
-    await waitFor(() =>
-      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
-    );
-    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
-      target: { value: "inspect the repo" },
-    });
-    const submit = screen.getByTestId("new-chat-landing-submit");
-
-    fireEvent.focus(submit);
-    const tooltip = await screen.findByRole("tooltip");
-
-    expect(within(tooltip).getByText("Start session")).toBeInTheDocument();
-    expect(tooltipKeys(tooltip)).toEqual(["Ctrl", "↵"]);
   });
 
   it("keeps submit disabled when no agents exist", () => {
@@ -1683,7 +1634,7 @@ describe("NewChatLandingScreen", () => {
     expect(useHostModelOptionsMock).toHaveBeenCalledWith("host_1", "codex-native", true);
   });
 
-  it("reports start-session telemetry when a create is triggered with the Enter key", async () => {
+  it("keeps legacy Mod+Enter as a default-mode send alias", async () => {
     authenticatedFetchMock.mockResolvedValue({
       ok: true,
       json: async () => ({ id: "conv_new" }),
@@ -1694,9 +1645,10 @@ describe("NewChatLandingScreen", () => {
     fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
       target: { value: "run the build" },
     });
-    // Enter creates the session without going through the Start button, so the
-    // telemetry has to fire from handleCreate — not the Button's componentId.
-    fireEvent.keyDown(screen.getByTestId("new-chat-landing-input"), { key: "Enter" });
+    fireEvent.keyDown(screen.getByTestId("new-chat-landing-input"), {
+      key: "Enter",
+      ctrlKey: true,
+    });
     await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
     expect(analytics).toHaveBeenCalledWith({
       type: "click",
@@ -1706,7 +1658,7 @@ describe("NewChatLandingScreen", () => {
   });
 
   it("uses Mod+Enter to start a session when the alternate composer behavior is enabled", async () => {
-    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
+    localStorage.setItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY, "true");
     authenticatedFetchMock.mockResolvedValue({
       ok: true,
       json: async () => ({ id: "conv_new" }),

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -800,6 +800,12 @@ function renderLanding(infoOverrides: Partial<ServerInfo> = {}, route = "/") {
   );
 }
 
+function tooltipKeys(tooltip: HTMLElement): string[] {
+  return Array.from(tooltip.querySelectorAll('[data-slot="kbd"]')).map(
+    (key) => key.textContent ?? "",
+  );
+}
+
 /** Open the picker and commit (select + close) an agent by clicking its row. */
 /** Drop the mounted landing screen + its in-memory draft, keeping localStorage. */
 function remountLanding(infoOverrides: Partial<ServerInfo> = {}): void {
@@ -970,6 +976,27 @@ describe("NewChatLandingScreen", () => {
     expect(screen.getByTestId("new-chat-landing-input")).toBeTruthy();
   });
 
+  it("leaves mobile Enter to the textarea instead of creating a session", () => {
+    const restoreViewport = forceMobileViewport();
+    try {
+      renderLanding();
+      const input = screen.getByTestId("new-chat-landing-input");
+      fireEvent.change(input, { target: { value: "first line" } });
+      const enter = new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      });
+
+      fireEvent(input, enter);
+
+      expect(enter.defaultPrevented).toBe(false);
+      expect(authenticatedFetchMock).not.toHaveBeenCalled();
+    } finally {
+      restoreViewport();
+    }
+  });
+
   it("does not replace a missing remembered host with the first cached host", async () => {
     localStorage.setItem("omnigent:last-host-choice", "host_2");
     // The shared query cache can render an older host list first while a
@@ -1131,6 +1158,64 @@ describe("NewChatLandingScreen", () => {
     // (e.g. dropped the workspace gate), the blank cases above would have
     // enabled too.
     expect(submit.disabled).toBe(false);
+  });
+
+  it("keeps the disabled reason tooltip on the new-chat submit button", async () => {
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+    const submit = screen.getByTestId("new-chat-landing-submit");
+
+    fireEvent.pointerMove(submit.parentElement!, { pointerType: "mouse" });
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Enter a message to get started");
+  });
+
+  it("shows the default shortcut in the new-chat submit tooltip", async () => {
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "inspect the repo" },
+    });
+    const submit = screen.getByTestId("new-chat-landing-submit");
+
+    fireEvent.pointerMove(submit.parentElement!, { pointerType: "mouse" });
+    const tooltip = await screen.findByRole("tooltip");
+
+    expect(within(tooltip).getByText("Start session")).toBeInTheDocument();
+    expect(tooltipKeys(tooltip)).toEqual(["↵"]);
+    expect(tooltip).toHaveClass(
+      "border-slate-700",
+      "bg-slate-900",
+      "text-slate-100",
+      "dark:bg-slate-900",
+    );
+    expect(tooltip.querySelector('[data-slot="kbd"]')).toHaveClass(
+      "border-slate-600",
+      "bg-slate-700",
+      "text-slate-300",
+    );
+  });
+
+  it("shows the alternate shortcut in the new-chat submit tooltip", async () => {
+    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "inspect the repo" },
+    });
+    const submit = screen.getByTestId("new-chat-landing-submit");
+
+    fireEvent.focus(submit);
+    const tooltip = await screen.findByRole("tooltip");
+
+    expect(within(tooltip).getByText("Start session")).toBeInTheDocument();
+    expect(tooltipKeys(tooltip)).toEqual(["Ctrl", "↵"]);
   });
 
   it("keeps submit disabled when no agents exist", () => {
@@ -1618,6 +1703,23 @@ describe("NewChatLandingScreen", () => {
       componentId: "new_chat.start_session",
       componentKind: "button",
     });
+  });
+
+  it("uses Mod+Enter to start a session when the alternate composer behavior is enabled", async () => {
+    localStorage.setItem("omnigent:composer-submit-with-mod-enter", "true");
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    renderLanding();
+    const input = screen.getByTestId("new-chat-landing-input");
+    fireEvent.change(input, { target: { value: "run the build" } });
+
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(authenticatedFetchMock).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(input, { key: "Enter", metaKey: true });
+    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
   });
 
   it("arms codex full bypass as a plain Approval option, with no warning banner", () => {
@@ -2779,6 +2881,24 @@ describe("NewChatLandingScreen skills menu", () => {
     );
   });
 
+  it("does not accept a highlighted skill when Enter is pressed on mobile", () => {
+    const restoreViewport = forceMobileViewport();
+    try {
+      mockAgents([skilledAgent()]);
+      renderLanding();
+      typeMessage("/rev");
+
+      fireEvent.keyDown(screen.getByTestId("new-chat-landing-input"), { key: "Enter" });
+
+      expect((screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement).value).toBe(
+        "/rev",
+      );
+      expect(authenticatedFetchMock).not.toHaveBeenCalled();
+    } finally {
+      restoreViewport();
+    }
+  });
+
   it("Tab completes a match found only mid-name (exercises slashMenuMatches, not just the render filter)", () => {
     mockAgents([skilledAgent()]);
     renderLanding();
@@ -3106,6 +3226,27 @@ describe("NewChatLandingScreen @-file-mention", () => {
     // Host absolute paths are shown as workspace-relative rows (folders first).
     expect(screen.getByTitle("Open omnigent")).toBeInTheDocument();
     expect(screen.getByTitle("Attach README.md")).toBeInTheDocument();
+  });
+
+  it("does not accept the highlighted mention when Enter is pressed on mobile", async () => {
+    const restoreViewport = forceMobileViewport();
+    try {
+      renderLanding();
+      await waitFor(() =>
+        expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+      );
+      fireEvent.change(input(), {
+        target: { value: "@README", selectionStart: 7 },
+      });
+
+      fireEvent.keyDown(input(), { key: "Enter" });
+
+      expect((input() as HTMLTextAreaElement).value).toBe("@README");
+      expect(screen.queryByText("@README.md")).not.toBeInTheDocument();
+      expect(authenticatedFetchMock).not.toHaveBeenCalled();
+    } finally {
+      restoreViewport();
+    }
   });
 
   it("does NOT open the menu for a non-native (SDK) agent", () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -80,6 +80,7 @@ import {
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { authenticatedFetch } from "@/lib/identity";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
+import { isComposerSendKey, readSubmitWithModEnter } from "@/lib/composerSendShortcutPreferences";
 import { attachmentKey, validateAttachments } from "@/lib/attachments";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
@@ -104,7 +105,6 @@ import {
 import { setPendingInitialPrompt } from "@/store/chatStore";
 import { markSessionCreated } from "@/store/interactionTelemetry";
 import { appendPromptHistoryEntry } from "@/hooks/usePromptHistory";
-import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { CliCommandBlock, renderTextWithInlineCode } from "./CliCommandBlock";
 import { WorkspacePicker, isNavigablePath } from "./WorkspacePicker";
@@ -236,6 +236,10 @@ import { PoweredByOmnigent } from "@/components/PoweredByOmnigent";
 import { SkillPills } from "@/components/SkillPills";
 import { ComposerMicButton } from "@/components/ComposerMicButton";
 import type { CostControlMode } from "@/components/CostRoutingControl";
+import {
+  composerSendShortcutKeys,
+  KeyboardShortcutTooltipContent,
+} from "@/components/KeyboardShortcut";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { AgentRowTooltip } from "@/components/AgentHoverCard";
 import { CreateAgentDialog } from "./CreateAgentDialog";
@@ -1994,7 +1998,7 @@ export function NewChatLandingScreen() {
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const isMobileViewport = useIsMobileViewport();
-  const isCoarsePointer = useIsCoarsePointer();
+  const [submitWithModEnter] = useState(() => readSubmitWithModEnter());
   // Single send-telemetry point (see handleCreate). Emitting there rather than
   // via the Start button's componentId covers Enter-key sends too, which never
   // submit the form and would otherwise bypass the Button entirely.
@@ -4393,10 +4397,31 @@ export function NewChatLandingScreen() {
                     return;
                   }
 
+                  // Mobile newline behavior outranks autocomplete and desktop
+                  // submit preferences. The textarea owns native line insertion.
+                  if (isMobileViewport && e.key === "Enter") {
+                    return;
+                  }
+
+                  const shouldSubmitFromKeyboard = isComposerSendKey(
+                    {
+                      key: e.key,
+                      shiftKey: e.shiftKey,
+                      metaKey: e.metaKey,
+                      ctrlKey: e.ctrlKey,
+                      altKey: e.altKey,
+                      isComposing: e.nativeEvent.isComposing,
+                    },
+                    submitWithModEnter,
+                    isMobileViewport,
+                  );
+                  const shouldPreferSendOverCompletion =
+                    submitWithModEnter && shouldSubmitFromKeyboard;
+
                   // "@"-mention menu navigation (shared useMentionBrowser) —
                   // mutually exclusive with the slash menu (a token can't be both)
                   // and takes priority over submission.
-                  if (handleMentionKeyDown(e)) return;
+                  if (!shouldPreferSendOverCompletion && handleMentionKeyDown(e)) return;
 
                   // While the skills menu is open, ArrowUp/Down navigate it and
                   // Enter/Tab complete the highlighted item — these take
@@ -4414,6 +4439,7 @@ export function NewChatLandingScreen() {
                       return;
                     }
                     if (
+                      !shouldPreferSendOverCompletion &&
                       (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) &&
                       slashMenuIndex >= 0
                     ) {
@@ -4430,11 +4456,7 @@ export function NewChatLandingScreen() {
                       return;
                     }
                   }
-                  // Enter sends; Shift+Enter inserts a newline. On touch-primary
-                  // devices there is no practical Shift+Enter and an accidental
-                  // submit is unrecoverable, so Enter only inserts a newline and
-                  // sending stays an explicit tap on the send button.
-                  if (e.key === "Enter" && !e.shiftKey && !isCoarsePointer) {
+                  if (shouldSubmitFromKeyboard) {
                     e.preventDefault();
                     // The mention menu is briefly closed while its listing loads;
                     // swallow Enter so the in-progress "@dir/" token isn't sent.
@@ -4754,9 +4776,14 @@ export function NewChatLandingScreen() {
                         </Button>
                       </span>
                     </TooltipTrigger>
-                    {submitDisabledReason != null && (
+                    {submitDisabledReason != null ? (
                       <TooltipContent>{submitDisabledReason}</TooltipContent>
-                    )}
+                    ) : !creating ? (
+                      <KeyboardShortcutTooltipContent
+                        label="Start session"
+                        keys={composerSendShortcutKeys(submitWithModEnter)}
+                      />
+                    ) : null}
                   </Tooltip>
                 </TooltipProvider>
               </div>

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -105,6 +105,7 @@ import {
 import { setPendingInitialPrompt } from "@/store/chatStore";
 import { markSessionCreated } from "@/store/interactionTelemetry";
 import { appendPromptHistoryEntry } from "@/hooks/usePromptHistory";
+import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { CliCommandBlock, renderTextWithInlineCode } from "./CliCommandBlock";
 import { WorkspacePicker, isNavigablePath } from "./WorkspacePicker";
@@ -1998,6 +1999,8 @@ export function NewChatLandingScreen() {
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const isMobileViewport = useIsMobileViewport();
+  const isCoarsePointer = useIsCoarsePointer();
+  const preventsKeyboardSubmit = isMobileViewport || isCoarsePointer;
   const [submitWithModEnter] = useState(() => readSubmitWithModEnter());
   // Single send-telemetry point (see handleCreate). Emitting there rather than
   // via the Start button's componentId covers Enter-key sends too, which never
@@ -4397,9 +4400,9 @@ export function NewChatLandingScreen() {
                     return;
                   }
 
-                  // Mobile newline behavior outranks autocomplete and desktop
-                  // submit preferences. The textarea owns native line insertion.
-                  if (isMobileViewport && e.key === "Enter") {
+                  // Touch-primary newline behavior outranks autocomplete and
+                  // desktop submit preferences. The textarea owns line insertion.
+                  if (preventsKeyboardSubmit && e.key === "Enter") {
                     return;
                   }
 
@@ -4413,7 +4416,7 @@ export function NewChatLandingScreen() {
                       isComposing: e.nativeEvent.isComposing,
                     },
                     submitWithModEnter,
-                    isMobileViewport,
+                    preventsKeyboardSubmit,
                   );
                   const shouldPreferSendOverCompletion =
                     submitWithModEnter && shouldSubmitFromKeyboard;
@@ -4778,7 +4781,7 @@ export function NewChatLandingScreen() {
                     </TooltipTrigger>
                     {submitDisabledReason != null ? (
                       <TooltipContent>{submitDisabledReason}</TooltipContent>
-                    ) : !creating ? (
+                    ) : !creating && !preventsKeyboardSubmit ? (
                       <KeyboardShortcutTooltipContent
                         label="Start session"
                         keys={composerSendShortcutKeys(submitWithModEnter)}

--- a/web/src/shell/settingsNav.test.tsx
+++ b/web/src/shell/settingsNav.test.tsx
@@ -15,7 +15,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 const mocks = vi.hoisted(() => ({
   accountsEnabled: false,
   // login_url: non-null for any sign-in mode (accounts OR OIDC), null in
-  // header mode. Gates the Account section + the bare-/settings default.
+  // header mode. Gates the Account section.
   loginUrl: null as string | null,
   // single_user: the server's explicit single-user marker. A multi-user
   // header-auth deploy reports false even though it has no accounts / login,
@@ -246,6 +246,7 @@ describe("SettingsSidebarBody", () => {
       "href",
       "/c/conv_123?file=foo.ts",
     );
+    expect(screen.getByTestId("settings-nav-general")).toHaveAttribute("aria-current", "page");
   });
 
   it("DOES close the sidebar when a section is tapped (drills into content)", () => {
@@ -349,12 +350,12 @@ describe("useSettingsRoute", () => {
   it("redirects a direct /settings/members or /settings/sharing to the default section in single-user mode", () => {
     // Explicit single-user local runtime (single_user marker): Members and
     // Sharing are hidden, so a direct hit to either falls back to the default
-    // section (Appearance). Policies stays valid — it's functional single-user.
+    // section (General). Policies stays valid — it's functional single-user.
     mocks.accountsEnabled = false;
     mocks.loginUrl = null;
     mocks.singleUser = true;
-    expect(routeHook("/settings/members")).toEqual({ inSettings: true, section: "appearance" });
-    expect(routeHook("/settings/sharing")).toEqual({ inSettings: true, section: "appearance" });
+    expect(routeHook("/settings/members")).toEqual({ inSettings: true, section: "general" });
+    expect(routeHook("/settings/sharing")).toEqual({ inSettings: true, section: "general" });
     expect(routeHook("/settings/policies")).toEqual({ inSettings: true, section: "policies" });
   });
 
@@ -365,7 +366,7 @@ describe("useSettingsRoute", () => {
     expect(routeHook("/policies").inSettings).toBe(false);
   });
 
-  it("keeps recognizing the other settings sections and their bare-path default", () => {
+  it("keeps explicit settings sections and defaults bare or unknown sections to General", () => {
     expect(routeHook("/settings/appearance")).toEqual({
       inSettings: true,
       section: "appearance",
@@ -374,17 +375,18 @@ describe("useSettingsRoute", () => {
       inSettings: true,
       section: "updates",
     });
-    // Bare /settings: in-settings, defaulting to Appearance in header mode
-    // (no login session — loginUrl null per beforeEach).
-    expect(routeHook("/settings")).toEqual({ inSettings: true, section: "appearance" });
+    expect(routeHook("/settings")).toEqual({ inSettings: true, section: "general" });
+    expect(routeHook("/settings/not-a-section")).toEqual({
+      inSettings: true,
+      section: "general",
+    });
     // A non-settings route is out of settings.
     expect(routeHook("/inbox").inSettings).toBe(false);
   });
 
-  it("defaults bare /settings to Account when a login session exists", () => {
-    // login_url set (accounts OR OIDC) → Account is the landing section.
+  it("keeps General as the bare settings default when a login session exists", () => {
     mocks.loginUrl = "/login";
-    expect(routeHook("/settings")).toEqual({ inSettings: true, section: "account" });
+    expect(routeHook("/settings")).toEqual({ inSettings: true, section: "general" });
   });
 
   it("matches the settings segment under an embed basename", () => {

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -140,19 +140,13 @@ export function settingsNavGroups(
 /**
  * Parse the active route into a settings descriptor. `inSettings` gates the
  * sidebar body swap; `section` drives the content. Bare `/settings` (no
- * section segment) defaults to Account when accounts auth is on — the most
- * relevant landing there — and Appearance otherwise. Basename-agnostic —
- * matches the `settings` segment wherever it lands, same approach as the
+ * section segment) and unknown sections default to General. Basename-agnostic
+ * — matches the `settings` segment wherever it lands, same approach as the
  * sidebar's top-level nav detection.
  */
 export function useSettingsRoute(): { inSettings: boolean; section: SettingsSectionId } {
   const info = useServerInfo();
-  // A login session exists (accounts OR OIDC) when the server advertises a
-  // login_url; header single-user mode reports null. The Account section —
-  // and the bare-/settings default landing on it — follows that, not
-  // accounts specifically.
-  const hasAuthSession = info !== "loading" && info.login_url !== null;
-  const defaultSection: SettingsSectionId = hasAuthSession ? "account" : "appearance";
+  const defaultSection: SettingsSectionId = "general";
 
   const segments = useLocation().pathname.split("/").filter(Boolean);
   const idx = segments.lastIndexOf("settings");


### PR DESCRIPTION
## Related issue

Closes #5830

## Summary

- Add a device-local Composer preference for choosing Enter or Command/Ctrl+Enter to send. Existing installs keep the current Enter-to-send behavior because the opt-in is stored only in browser `localStorage`.
- Apply the preference to existing-session and New Session composers, while mobile Enter always takes precedence and inserts a newline.
- Show the active chords in compact dark tooltips and Settings > Keyboard shortcuts, split the Off/On guidance into readable lines, and make General the canonical Settings landing section.

ELI5: desktop users can choose whether Enter means “send” or “new line”; phones always treat Enter as “new line.”

```text
Desktop Enter ──> device preference ──> send or newline
Mobile Enter  ────────────────────────> newline
```

This is frontend-only and backward-compatible. It adds no server API, database schema, migration, or persisted server contract.

## Test Plan

- `pnpm exec vitest run ... -t <composer preference/mobile/tooltips/settings/routing>` — 48 passed across 9 files.
- `pnpm run test:coverage` — 6,253 passed, 3 expected baseline-only failures in `NewChatDialog.test.tsx` that still look for the stale `This machine` host label:
  - `switching between a host and the sandbox swaps the workspace chrome`
  - `shows 'Create custom agent' on a host and opens the dialog`
  - `drops a selected pending custom agent when the target switches to a sandbox`
  These same failures were independently reproduced from clean `main`; no production behavior was changed for them.
- Changed-file pre-commit suite — passed (ruff, project test lints, Prettier, oxlint, TypeScript, file hygiene).
- `pnpm run lint`, `pnpm run type-check`, and `pnpm run build` — passed.
- Ruff check and format check for both added Playwright files — passed.
- Playwright collection for both added E2E UI tests — 2 collected successfully; execution left to CI because the canonical suite provisions its own built app and browser environment.
- `git diff --check` — passed.
- The aggregate `pnpm run format:check` also examined ignored generated Electron overlay assets in the running development worktree and reported those three generated files; all tracked changed files and the complete changed-file pre-commit formatting hook passed.

## Demo

Manually verified in the running Electron app with HMR: preference persistence, both send modes, mobile newline precedence, compact always-dark shortcut tooltips in dark mode, dynamic shortcut rows, two-line guidance, and General as the Settings default. The user reviewed and approved the dark-mode tooltip appearance during implementation.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used the existing worktree's running Electron app and HMR. The preference was checked in both states, the shortcut tooltip was reviewed in dark mode, and Settings opened on General. Automated coverage includes preference parsing/storage, keyboard dispatch in both composers, mobile precedence, tooltip and shortcut-reference rendering, and Settings routing.

## Changelog

Choose whether Enter or Command/Ctrl+Enter sends composer messages while mobile Enter always inserts a new line.