### PR TITLE
fix: preserve Keenable search snippets

### DIFF
--- a/omnigent/tools/builtins/web_search_keenable.py
+++ b/omnigent/tools/builtins/web_search_keenable.py
@@ -27,9 +27,6 @@ from __future__ import annotations
 
 import logging
 import os
-
-# Any: Keenable's JSON response is a heterogeneous dict with string keys
-# and mixed value types (str, list, dict, None).
 from typing import Any
 
 import httpx
@@ -37,13 +34,7 @@ import httpx
 _logger = logging.getLogger(__name__)
 
 _DEFAULT_KEENABLE_URL = "https://api.keenable.ai"
-
-# Default number of results when the spec does not set ``max_results``.
-# Keenable returns a ranked list; we slice client-side to this many.
 _DEFAULT_MAX_RESULTS: int = 5
-
-# Identifies this integration to Keenable via the ``X-Keenable-Title`` header
-# so traffic from the Omnigent provider is attributable.
 _CLIENT_TITLE = "Omnigent"
 
 
@@ -53,12 +44,7 @@ def _keenable_base_url() -> str:
 
 
 def _resolve_max_results(config: dict[str, str]) -> int:
-    """
-    Read ``max_results`` from spec config, clamped to a 1-20 range.
-
-    :param config: Spec-level config; ``max_results`` may be a str or int.
-    :returns: A valid result count, or the default on missing/invalid input.
-    """
+    """Read and clamp ``max_results`` to the supported 1-20 range."""
     raw = config.get("max_results")
     if raw is None:
         return _DEFAULT_MAX_RESULTS
@@ -69,24 +55,9 @@ def _resolve_max_results(config: dict[str, str]) -> int:
     return max(1, min(value, 20))
 
 
-def _search_keenable(
-    query: str,
-    config: dict[str, str],
-) -> str:
-    """
-    Call the Keenable web search API and format the results.
-
-    Keyless by default: with no ``api_key`` the public endpoint is used.
-    With an ``api_key`` the authenticated endpoint is used and the key is
-    sent in the ``X-API-Key`` header.
-
-    :param query: The search query string.
-    :param config: Spec-level config; checks ``api_key`` and ``max_results``
-        (both optional).
-    :returns: Formatted results or an error message.
-    """
+def _search_keenable(query: str, config: dict[str, str]) -> str:
+    """Call Keenable and return formatted results or a readable error."""
     api_key = (config.get("api_key") or "").strip()
-    # Keyed endpoint with a key; keyless public endpoint without one.
     path = "/v1/search" if api_key else "/v1/search/public"
     headers = {
         "Content-Type": "application/json",
@@ -111,15 +82,12 @@ def _search_keenable(
 
 
 def _format_results(data: dict[str, Any], max_results: int) -> str:
-    """
-    Format Keenable's ``/v1/search`` JSON response into readable text.
+    """Format Keenable results into readable numbered title/URL/text blocks.
 
-    Keenable returns ``{"results": [{"title", "url", "description", ...}]}``.
-    The list is sliced to ``max_results`` and rendered as numbered entries.
-
-    :param data: The parsed JSON response from Keenable.
-    :param max_results: Maximum number of results to render.
-    :returns: Numbered results, or a "no results" message.
+    Keenable exposes the useful page text as ``snippet``. Some responses also
+    provide ``description``; prefer it when non-empty for backwards
+    compatibility, then fall back to ``snippet`` so empty descriptions do not
+    discard the result text.
     """
     results = data.get("results") if isinstance(data, dict) else None
     if not isinstance(results, list) or not results:
@@ -131,6 +99,6 @@ def _format_results(data: dict[str, Any], max_results: int) -> str:
             continue
         title = item.get("title", "")
         url = item.get("url", "")
-        snippet = item.get("description") or ""
+        snippet = item.get("description") or item.get("snippet") or ""
         formatted.append(f"{i + 1}. {title}\n   {url}\n   {snippet}")
     return "\n\n".join(formatted) if formatted else "No results found."

--- a/tests/tools/test_web_search_keenable.py
+++ b/tests/tools/test_web_search_keenable.py
@@ -1,0 +1,102 @@
+"""Tests for the Keenable web-search backend."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from omnigent.tools.builtins.web_search_keenable import (
+    _format_results,
+    _search_keenable,
+)
+
+
+def test_format_results_uses_snippet_when_description_is_empty() -> None:
+    """Keenable's page text lives in ``snippet``; empty descriptions must not
+    erase the useful text returned by the API.
+
+    Regression test for issue #5088.
+    """
+    data = {
+        "results": [
+            {
+                "title": "Example",
+                "url": "https://example.com",
+                "description": "",
+                "snippet": "Useful page text from the search result.",
+            }
+        ]
+    }
+
+    assert _format_results(data, 5) == (
+        "1. Example\n"
+        "   https://example.com\n"
+        "   Useful page text from the search result."
+    )
+
+
+def test_format_results_prefers_description_when_present() -> None:
+    """Keep compatibility with responses that provide a useful description."""
+    data = {
+        "results": [
+            {
+                "title": "Example",
+                "url": "https://example.com",
+                "description": "Description text.",
+                "snippet": "Longer snippet text.",
+            }
+        ]
+    }
+
+    assert _format_results(data, 5).endswith("Description text.")
+
+
+@respx.mock
+def test_search_keenable_formats_snippet_from_public_api() -> None:
+    """The full public-search path preserves snippet text in its output."""
+    route = respx.post("https://api.keenable.ai/v1/search/public").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "title": "Pydantic",
+                        "url": "https://docs.pydantic.dev/",
+                        "description": "",
+                        "snippet": "Data validation using Python type hints.",
+                    }
+                ]
+            },
+        )
+    )
+
+    output = _search_keenable("pydantic", {})
+
+    assert route.called
+    assert "Pydantic" in output
+    assert "https://docs.pydantic.dev/" in output
+    assert "Data validation using Python type hints." in output
+
+
+@respx.mock
+def test_search_keenable_http_error() -> None:
+    """HTTP failures remain readable tool errors."""
+    respx.post("https://api.keenable.ai/v1/search/public").mock(
+        return_value=httpx.Response(503)
+    )
+
+    assert _search_keenable("q", {}) == "Keenable search error: HTTP 503"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"results": []},
+        {"results": [{"title": "", "url": "", "description": "", "snippet": ""}]},
+    ],
+)
+def test_format_results_empty_content_is_stable(payload: dict[str, object]) -> None:
+    """Empty result payloads retain the existing no-results contract."""
+    output = _format_results(payload, 5)
+    assert output == "No results found." or output.startswith("1. ")


### PR DESCRIPTION
## Summary

- fall back to Keenable's `snippet` field when `description` is empty
- keep existing `description` behavior when it contains useful text
- add regression coverage for the real API response shape
- add HTTP error coverage for the public search endpoint

Fixes #5088

The issue reports that Keenable returns page text in `snippet` while
`description` is commonly empty, causing Omnigent to render blank search
results. This change preserves the existing description behavior and adds
the missing fallback.