### PR TITLE
fix(claude-native): dedupe transcript commit-gap retries

### DIFF
--- a/omnigent/_native_post_delivery.py
+++ b/omnigent/_native_post_delivery.py
@@ -3,12 +3,12 @@ event POSTs.
 
 The claude-native, codex-native, and antigravity-native forwarders mirror
 transcript items into AP as ``external_conversation_item`` POSTs. The server
-persists those with a random primary key and does NOT dedupe them — producers
-are responsible for not re-posting items they have already sent. That makes a
-blind retry after a failed POST unsafe: if the server committed the item and
-published ``session.input.consumed`` but the response was lost, a retry appends
-a second copy and the web UI renders a duplicate bubble. The native tmux pane
-is unaffected, which is why the duplicate is web-only.
+can dedupe events that carry a durable ``source_id`` (currently Claude
+transcript items); source-less events still receive a random primary key. The
+shared retry policy therefore remains conservative: if the server committed a
+source-less item but the response was lost, a retry appends a second copy and
+the web UI renders a duplicate bubble. The native tmux pane is unaffected,
+which is why the duplicate is web-only.
 
 :func:`post_may_have_been_delivered` is the shared classifier all forwarders
 use to decide whether a failed POST is safe to retry.

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -354,13 +354,13 @@ class PreparedClaudeTerminal:
         transcript end in this case — when ``--resume <claude_sid>``
         is injected into the launch args, Claude reopens the prior
         JSONL transcript, and re-reading it from offset 0 would
-        re-post every prior turn to AP. There is no server-side dedup:
-        seeking to the end (plus the forwarder's persisted byte offset
-        on subsequent ticks) is the only thing keeping old turns from
-        being re-posted as new messages. ``cold_resumed`` is
-        *independent* of ``reattached``: cold resume creates a new
-        terminal (we own teardown) but the forwarder still needs the
-        skip-existing behavior.
+        re-post every prior turn to AP. Seeking to the end (plus the
+        forwarder's persisted byte offset on subsequent ticks) avoids
+        unnecessary retries; the transcript source ids provide the durable
+        server-side backstop against duplicate items. ``cold_resumed`` is
+        *independent* of ``reattached``: cold resume creates a new terminal
+        (we own teardown) but the forwarder still needs the skip-existing
+        behavior.
     :param tmux_socket: Runner tmux server socket path when the
         terminal exposed one and it is reachable from this process,
         e.g. ``Path("/tmp/omnigent-501/.../tmux.sock")``. ``None``

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -4027,7 +4027,18 @@ async def _post_clear_supersession(
 
 def _source_id_post_route_unavailable(exc: httpx.HTTPError) -> bool:
     """Return whether an older server rejected the versioned POST before commit."""
-    return isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code in {404, 405}
+    if not isinstance(exc, httpx.HTTPStatusError) or exc.response.status_code != 404:
+        return False
+    if not exc.response.headers.get("content-type", "").startswith("application/json"):
+        return False
+    try:
+        payload = exc.response.json()
+    except ValueError:
+        return False
+    # Starlette's unmatched-route response is stable and intentionally generic.
+    # Domain 404s from a server that owns source-id-v1 carry Omnigent's error
+    # envelope and must flow through bounded permanent-failure handling.
+    return payload == {"detail": "Not Found"}
 
 
 async def _post_external_conversation_item(

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -1517,6 +1517,7 @@ async def _forward_available_subagents(
                             "item_type": item.item_type,
                             "item_data": item.data,
                             "response_id": item.response_id,
+                            "source_id": item.source_id,
                         },
                         reason="permanent HTTP failure after retries",
                         # Claude only dead-letters permanent 4xx (it retries
@@ -3458,6 +3459,7 @@ async def _forward_available_items(
                         "item_type": item.item_type,
                         "item_data": item.data,
                         "response_id": item.response_id,
+                        "source_id": item.source_id,
                     },
                     reason="permanent HTTP failure after retries",
                     # Claude only dead-letters permanent 4xx (it retries
@@ -4043,6 +4045,7 @@ async def _post_external_conversation_item(
                     "item_type": item.item_type,
                     "item_data": item.data,
                     "response_id": item.response_id,
+                    "source_id": item.source_id,
                 },
             },
         )

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -744,6 +744,27 @@ class _PostRetryTracker:
             permanent=permanent,
         )
 
+    def record_retryable_failure(self, key: str) -> _PostRetryDecision:
+        """Record a protocol-rollout rejection that must never be exhausted."""
+        _note_forward_failure(key)
+        entry = self._entries.get(key)
+        if entry is None:
+            entry = _PostRetryEntry()
+            self._entries[key] = entry
+        entry.attempts += 1
+        exponent = min(max(0, entry.attempts - 1), _HTTP_POST_RETRY_MAX_BACKOFF_EXPONENT)
+        delay_s = min(
+            self._base_delay_s * (2**exponent),
+            self._max_delay_s,
+        )
+        entry.next_attempt_at = time.monotonic() + delay_s
+        return _PostRetryDecision(
+            attempts=entry.attempts,
+            delay_s=delay_s,
+            exhausted=False,
+            permanent=False,
+        )
+
 
 async def forward_claude_transcript_to_session(
     *,
@@ -1497,6 +1518,18 @@ async def _forward_available_subagents(
                     item=item,
                 )
             except httpx.HTTPError as exc:
+                if _source_id_post_route_unavailable(exc):
+                    decision = item_retry_tracker.record_retryable_failure(retry_key)
+                    _logger.warning(
+                        "Claude sub-agent item reached a server without the source-id "
+                        "POST protocol; retaining it for retry after rollout; "
+                        "child=%s source_id=%s next_retry_s=%.3f",
+                        entry.child_conversation_id,
+                        item.source_id,
+                        decision.delay_s,
+                    )
+                    items_failed = True
+                    break
                 decision = item_retry_tracker.record_failure(retry_key, exc)
                 if decision.exhausted:
                     _logger.error(
@@ -1546,34 +1579,19 @@ async def _forward_available_subagents(
                     await _write_subagent_forward_state_async(bridge_dir, updated)
                     continue
                 if post_may_have_been_delivered(exc):
-                    # Ambiguous failure: the item may already be committed
-                    # (no external-item dedup), so a retry would duplicate
-                    # it. Skip rather than re-post.
+                    # The versioned route is accepted only by source-id-aware
+                    # servers, so retain the item and safely retry.
                     _logger.warning(
-                        "Skipping claude-native sub-agent item after an ambiguous POST "
-                        "failure (may already be committed); not retrying to avoid a "
-                        "duplicate; child=%s source_id=%s http_status=%s",
+                        "Retrying claude-native sub-agent item after an ambiguous "
+                        "source-id POST; child=%s source_id=%s http_status=%s",
                         entry.child_conversation_id,
                         item.source_id,
                         _http_status_for_log(exc),
                         exc_info=True,
                     )
                     item_retry_tracker.clear(retry_key)
-                    seen.add(item.source_id)
-                    seen_source_ids.append(item.source_id)
-                    new_entry = SubagentEntry(
-                        subagent_id=entry.subagent_id,
-                        child_conversation_id=entry.child_conversation_id,
-                        byte_offset=entry.byte_offset,
-                        seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
-                        last_activity_ts=new_entry.last_activity_ts,
-                        last_status=new_entry.last_status,
-                    )
-                    updated = SubagentForwardState(
-                        subagents={**updated.subagents, subagent_id: new_entry}
-                    )
-                    await _write_subagent_forward_state_async(bridge_dir, updated)
-                    continue
+                    items_failed = True
+                    break
                 _logger.warning(
                     "Failed to forward claude-native sub-agent item; child=%s "
                     "source_id=%s attempt=%s permanent=%s next_retry_s=%.3f "
@@ -3436,6 +3454,19 @@ async def _forward_available_items(
                 item=item,
             )
         except httpx.HTTPError as exc:
+            if _source_id_post_route_unavailable(exc):
+                decision = retry_tracker.record_retryable_failure(retry_key)
+                _logger.warning(
+                    "Claude transcript item reached a server without the source-id "
+                    "POST protocol; retaining it for retry after rollout; "
+                    "session=%s bridge_dir=%s source_id=%s next_retry_s=%.3f",
+                    session_id,
+                    bridge_dir,
+                    item.source_id,
+                    decision.delay_s,
+                    extra={"session_id": session_id},
+                )
+                return updated
             decision = retry_tracker.record_failure(retry_key, exc)
             if decision.exhausted:
                 _logger.error(
@@ -3490,31 +3521,12 @@ async def _forward_available_items(
                 await _write_forward_state_async(bridge_dir, updated)
                 continue
             if post_may_have_been_delivered(exc):
-                if await _server_supports_source_id_retry(client):
-                    # The upgraded server keys this event by source_id, so both
-                    # ambiguous outcomes are safe: a committed request resolves
-                    # to its existing row, while an uncommitted request inserts
-                    # on retry. Keep the cursor before the item.
-                    _logger.warning(
-                        "Retrying Claude transcript item after an ambiguous POST "
-                        "failure because the server advertises source-id idempotency; "
-                        "session=%s bridge_dir=%s source_id=%s item_type=%s",
-                        session_id,
-                        bridge_dir,
-                        item.source_id,
-                        item.item_type,
-                        exc_info=True,
-                        extra={"session_id": session_id},
-                    )
-                    retry_tracker.clear(retry_key)
-                    return updated
-                # Ambiguous failure: the server may have committed this
-                # item before the response was lost. An older server does not
-                # advertise source-keyed dedupe, so preserve the conservative
-                # mixed-version behavior and skip it rather than duplicate it.
+                # Only upgraded servers route this versioned POST. Retrying is
+                # therefore safe regardless of which replica receives the next
+                # attempt: upgraded targets dedupe by source_id, while older
+                # targets reject the unknown route before committing.
                 _logger.warning(
-                    "Skipping Claude transcript item after an ambiguous POST failure "
-                    "(may already be committed); not retrying to avoid a duplicate; "
+                    "Retrying Claude transcript item after an ambiguous source-id POST; "
                     "session=%s bridge_dir=%s source_id=%s item_type=%s http_status=%s",
                     session_id,
                     bridge_dir,
@@ -3525,20 +3537,7 @@ async def _forward_available_items(
                     extra={"session_id": session_id},
                 )
                 retry_tracker.clear(retry_key)
-                seen.add(item.source_id)
-                seen_source_ids.append(item.source_id)
-                updated = TranscriptForwardState(
-                    transcript_path=state.transcript_path,
-                    line_cursor=state.line_cursor,
-                    byte_offset=state.byte_offset,
-                    current_response_id=current_response_id,
-                    seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
-                    cursor_fingerprint=state.cursor_fingerprint,
-                    settled_response_id=dedupe.settled_response_id,
-                    pending_settled_response_id=dedupe.pending_settled_response_id,
-                )
-                await _write_forward_state_async(bridge_dir, updated)
-                continue
+                return updated
             _logger.warning(
                 "Failed to forward Claude transcript item; session=%s bridge_dir=%s "
                 "source_id=%s item_type=%s attempt=%s permanent=%s "
@@ -4026,18 +4025,9 @@ async def _post_clear_supersession(
         )
 
 
-async def _server_supports_source_id_retry(client: httpx.AsyncClient) -> bool:
-    """Return whether this server safely deduplicates source-keyed retries."""
-    try:
-        response = await client.get("/v1/native-forwarder-capabilities")
-        response.raise_for_status()
-        payload = response.json()
-    except (httpx.HTTPError, ValueError):
-        return False
-    return (
-        isinstance(payload, dict)
-        and payload.get("external_conversation_item_source_id_idempotency") is True
-    )
+def _source_id_post_route_unavailable(exc: httpx.HTTPError) -> bool:
+    """Return whether an older server rejected the versioned POST before commit."""
+    return isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code in {404, 405}
 
 
 async def _post_external_conversation_item(
@@ -4070,7 +4060,7 @@ async def _post_external_conversation_item(
         ),
     ):
         resp = await client.post(
-            f"/v1/sessions/{session_id}/events",
+            f"/v1/sessions/{session_id}/events/source-id-v1",
             json={
                 "type": "external_conversation_item",
                 "data": {

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -3490,10 +3490,28 @@ async def _forward_available_items(
                 await _write_forward_state_async(bridge_dir, updated)
                 continue
             if post_may_have_been_delivered(exc):
+                if await _server_supports_source_id_retry(client):
+                    # The upgraded server keys this event by source_id, so both
+                    # ambiguous outcomes are safe: a committed request resolves
+                    # to its existing row, while an uncommitted request inserts
+                    # on retry. Keep the cursor before the item.
+                    _logger.warning(
+                        "Retrying Claude transcript item after an ambiguous POST "
+                        "failure because the server advertises source-id idempotency; "
+                        "session=%s bridge_dir=%s source_id=%s item_type=%s",
+                        session_id,
+                        bridge_dir,
+                        item.source_id,
+                        item.item_type,
+                        exc_info=True,
+                        extra={"session_id": session_id},
+                    )
+                    retry_tracker.clear(retry_key)
+                    return updated
                 # Ambiguous failure: the server may have committed this
-                # item before the response was lost. External items aren't
-                # deduped, so a retry would duplicate the bubble —
-                # skip it. At worst one item is lost on a flaky POST.
+                # item before the response was lost. An older server does not
+                # advertise source-keyed dedupe, so preserve the conservative
+                # mixed-version behavior and skip it rather than duplicate it.
                 _logger.warning(
                     "Skipping Claude transcript item after an ambiguous POST failure "
                     "(may already be committed); not retrying to avoid a duplicate; "
@@ -4006,6 +4024,20 @@ async def _post_clear_supersession(
             exc_info=True,
             extra={"session_id": old_session_id},
         )
+
+
+async def _server_supports_source_id_retry(client: httpx.AsyncClient) -> bool:
+    """Return whether this server safely deduplicates source-keyed retries."""
+    try:
+        response = await client.get("/v1/native-forwarder-capabilities")
+        response.raise_for_status()
+        payload = response.json()
+    except (httpx.HTTPError, ValueError):
+        return False
+    return (
+        isinstance(payload, dict)
+        and payload.get("external_conversation_item_source_id_idempotency") is True
+    )
 
 
 async def _post_external_conversation_item(

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -4035,10 +4035,13 @@ def _source_id_post_route_unavailable(exc: httpx.HTTPError) -> bool:
         payload = exc.response.json()
     except ValueError:
         return False
-    # Starlette's unmatched-route response is stable and intentionally generic.
-    # Domain 404s from a server that owns source-id-v1 carry Omnigent's error
-    # envelope and must flow through bounded permanent-failure handling.
-    return payload == {"detail": "Not Found"}
+    # Old API-only and bundled-SPA packages expose two stable generic fallback
+    # envelopes. Domain 404s from a server that owns source-id-v1 include a
+    # specific session/access message and must use bounded permanent handling.
+    return payload in (
+        {"detail": "Not Found"},
+        {"error": {"code": "not_found", "message": "Not found"}},
+    )
 
 
 async def _post_external_conversation_item(

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -3459,9 +3459,8 @@ async def _forward_available_items(
                 _logger.warning(
                     "Claude transcript item reached a server without the source-id "
                     "POST protocol; retaining it for retry after rollout; "
-                    "session=%s bridge_dir=%s source_id=%s next_retry_s=%.3f",
+                    "session=%s source_id=%s next_retry_s=%.3f",
                     session_id,
-                    bridge_dir,
                     item.source_id,
                     decision.delay_s,
                     extra={"session_id": session_id},

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -947,6 +947,8 @@ class SqlConversationItem(ConversationBase):
             "workspace_id",
             "conversation_id",
             "source_id",
+            sqlite_where=text("source_id IS NOT NULL"),
+            postgresql_where=text("source_id IS NOT NULL"),
         ),
         # Latest-message previews scan one type per conversation ordered by
         # position DESC (list_latest_message_items_for_conversations). Ordering

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -877,6 +877,8 @@ class SqlConversationItem(ConversationBase):
     :param created_by: Identity of the human actor who authored the
         item, or ``None`` for agent/tool/system items and single-user
         mode. Mirrors :class:`SqlComment.created_by`.
+    :param source_id: Stable producer identity for idempotent external
+        transcript appends. ``None`` for ordinary AP-created items.
     """
 
     __tablename__ = "conversation_items"
@@ -913,6 +915,7 @@ class SqlConversationItem(ConversationBase):
     data: Mapped[str] = mapped_column(Text)
     search_text: Mapped[str] = mapped_column(Text)
     created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    source_id: Mapped[str | None] = mapped_column(String(512), nullable=True)
 
     __table_args__ = (
         # Backs the per-conversation position-ordered scan (the dominant read).
@@ -935,6 +938,15 @@ class SqlConversationItem(ConversationBase):
             "conversation_id",
             "response_id",
             "id",
+        ),
+        # External transcript retries resolve by stable producer source id.
+        # The conversation row lock in ConversationStore.append serializes the
+        # lookup + insert; this index makes the lookup a narrow prefix seek.
+        Index(
+            "ix_conversation_items_source_id",
+            "workspace_id",
+            "conversation_id",
+            "source_id",
         ),
         # Latest-message previews scan one type per conversation ordered by
         # position DESC (list_latest_message_items_for_conversations). Ordering

--- a/omnigent/db/migrations/versions/f3c7a1d9e2b4_add_conversation_item_source_id.py
+++ b/omnigent/db/migrations/versions/f3c7a1d9e2b4_add_conversation_item_source_id.py
@@ -24,22 +24,66 @@ depends_on: str | Sequence[str] | None = None
 _INDEX_NAME = "ix_conversation_items_source_id"
 
 
+def _drop_postgresql_index_if_invalid() -> None:
+    """Remove an unusable remnant from a failed concurrent index build."""
+    if op.get_context().as_sql:
+        return
+    invalid = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid "
+                "WHERE c.relname = :name AND NOT i.indisvalid"
+            ),
+            {"name": _INDEX_NAME},
+        )
+        .scalar()
+    )
+    if invalid:
+        op.execute(f"DROP INDEX {_INDEX_NAME}")
+
+
 def upgrade() -> None:
     """Add the nullable source identity and its lookup index."""
     op.add_column(
         "conversation_items",
         sa.Column("source_id", sa.String(length=512), nullable=True),
     )
-    op.create_index(
-        _INDEX_NAME,
-        "conversation_items",
-        ["workspace_id", "conversation_id", "source_id"],
-        unique=False,
-    )
+    dialect_name = op.get_context().dialect.name
+    if dialect_name == "postgresql":
+        # A production conversation_items table can be large. PostgreSQL's
+        # regular CREATE INDEX blocks writes, while CONCURRENTLY is illegal
+        # inside Alembic's migration transaction.
+        with op.get_context().autocommit_block():
+            _drop_postgresql_index_if_invalid()
+            op.execute(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {_INDEX_NAME} "
+                "ON conversation_items (workspace_id, conversation_id, source_id) "
+                "WHERE source_id IS NOT NULL"
+            )
+    elif dialect_name == "sqlite":
+        op.create_index(
+            _INDEX_NAME,
+            "conversation_items",
+            ["workspace_id", "conversation_id", "source_id"],
+            unique=False,
+            sqlite_where=sa.text("source_id IS NOT NULL"),
+        )
+    else:
+        op.create_index(
+            _INDEX_NAME,
+            "conversation_items",
+            ["workspace_id", "conversation_id", "source_id"],
+            unique=False,
+        )
 
 
 def downgrade() -> None:
     """Remove the source identity lookup and column."""
-    op.drop_index(_INDEX_NAME, table_name="conversation_items")
+    if op.get_context().dialect.name == "postgresql":
+        with op.get_context().autocommit_block():
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")
+    else:
+        op.drop_index(_INDEX_NAME, table_name="conversation_items")
     with op.batch_alter_table("conversation_items") as batch_op:
         batch_op.drop_column("source_id")

--- a/omnigent/db/migrations/versions/f3c7a1d9e2b4_add_conversation_item_source_id.py
+++ b/omnigent/db/migrations/versions/f3c7a1d9e2b4_add_conversation_item_source_id.py
@@ -24,38 +24,56 @@ depends_on: str | Sequence[str] | None = None
 _INDEX_NAME = "ix_conversation_items_source_id"
 
 
-def _drop_postgresql_index_if_invalid() -> None:
-    """Remove an unusable remnant from a failed concurrent index build."""
+def _source_id_column_exists() -> bool:
+    """Return whether a prior interrupted attempt already committed the column."""
+    if op.get_context().as_sql:
+        return False
+    return "source_id" in {
+        column["name"] for column in sa.inspect(op.get_bind()).get_columns("conversation_items")
+    }
+
+
+def _repair_postgresql_index_artifact() -> None:
+    """Remove an invalid or wrongly-shaped remnant before concurrent creation."""
     if op.get_context().as_sql:
         return
-    invalid = (
+    row = (
         op.get_bind()
         .execute(
             sa.text(
-                "SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid "
-                "WHERE c.relname = :name AND NOT i.indisvalid"
+                "SELECT i.indisvalid, pg_get_indexdef(i.indexrelid) AS definition "
+                "FROM pg_index i WHERE i.indexrelid = to_regclass(:name)"
             ),
             {"name": _INDEX_NAME},
         )
-        .scalar()
+        .mappings()
+        .first()
     )
-    if invalid:
-        op.execute(f"DROP INDEX {_INDEX_NAME}")
+    if row is None:
+        return
+    definition = str(row["definition"])
+    expected_shape = (
+        "(workspace_id, conversation_id, source_id)" in definition
+        and "WHERE (source_id IS NOT NULL)" in definition
+    )
+    if not row["indisvalid"] or not expected_shape:
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")
 
 
 def upgrade() -> None:
     """Add the nullable source identity and its lookup index."""
-    op.add_column(
-        "conversation_items",
-        sa.Column("source_id", sa.String(length=512), nullable=True),
-    )
+    if not _source_id_column_exists():
+        op.add_column(
+            "conversation_items",
+            sa.Column("source_id", sa.String(length=512), nullable=True),
+        )
     dialect_name = op.get_context().dialect.name
     if dialect_name == "postgresql":
         # A production conversation_items table can be large. PostgreSQL's
         # regular CREATE INDEX blocks writes, while CONCURRENTLY is illegal
         # inside Alembic's migration transaction.
         with op.get_context().autocommit_block():
-            _drop_postgresql_index_if_invalid()
+            _repair_postgresql_index_artifact()
             op.execute(
                 f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {_INDEX_NAME} "
                 "ON conversation_items (workspace_id, conversation_id, source_id) "

--- a/omnigent/db/migrations/versions/f3c7a1d9e2b4_add_conversation_item_source_id.py
+++ b/omnigent/db/migrations/versions/f3c7a1d9e2b4_add_conversation_item_source_id.py
@@ -1,0 +1,45 @@
+"""add source_id to conversation_items
+
+Revision ID: f3c7a1d9e2b4
+Revises: e5d9bc8ac650
+Create Date: 2026-08-30 00:00:00.000000
+
+Persists a native transcript record's stable source identity so an
+``external_conversation_item`` retry after a forwarder crash can resolve the
+already-committed item instead of appending a duplicate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f3c7a1d9e2b4"
+down_revision: str | None = "e5d9bc8ac650"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX_NAME = "ix_conversation_items_source_id"
+
+
+def upgrade() -> None:
+    """Add the nullable source identity and its lookup index."""
+    op.add_column(
+        "conversation_items",
+        sa.Column("source_id", sa.String(length=512), nullable=True),
+    )
+    op.create_index(
+        _INDEX_NAME,
+        "conversation_items",
+        ["workspace_id", "conversation_id", "source_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Remove the source identity lookup and column."""
+    op.drop_index(_INDEX_NAME, table_name="conversation_items")
+    with op.batch_alter_table("conversation_items") as batch_op:
+        batch_op.drop_column("source_id")

--- a/omnigent/db/migrations/versions/f3c7a1d9e2b4_add_conversation_item_source_id.py
+++ b/omnigent/db/migrations/versions/f3c7a1d9e2b4_add_conversation_item_source_id.py
@@ -22,6 +22,7 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 _INDEX_NAME = "ix_conversation_items_source_id"
+_INDEX_COLUMNS = ("workspace_id", "conversation_id", "source_id")
 
 
 def _source_id_column_exists() -> bool:
@@ -55,9 +56,32 @@ def _repair_postgresql_index_artifact() -> None:
     expected_shape = (
         "(workspace_id, conversation_id, source_id)" in definition
         and "WHERE (source_id IS NOT NULL)" in definition
+        and not definition.startswith("CREATE UNIQUE INDEX")
     )
     if not row["indisvalid"] or not expected_shape:
         op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")
+
+
+def _portable_index_status() -> tuple[bool, bool]:
+    """Return whether the named index exists and has this revision's shape."""
+    if op.get_context().as_sql:
+        return False, False
+    dialect_name = op.get_context().dialect.name
+    for index in sa.inspect(op.get_bind()).get_indexes("conversation_items"):
+        if index["name"] != _INDEX_NAME:
+            continue
+        correct = tuple(index.get("column_names") or ()) == _INDEX_COLUMNS and not bool(
+            index.get("unique")
+        )
+        if dialect_name == "sqlite":
+            where = (index.get("dialect_options") or {}).get("sqlite_where")
+            predicate = "".join(str(where).lower().split())
+            correct = correct and predicate in {
+                "source_idisnotnull",
+                "(source_idisnotnull)",
+            }
+        return True, correct
+    return False, False
 
 
 def upgrade() -> None:
@@ -79,21 +103,26 @@ def upgrade() -> None:
                 "ON conversation_items (workspace_id, conversation_id, source_id) "
                 "WHERE source_id IS NOT NULL"
             )
-    elif dialect_name == "sqlite":
-        op.create_index(
-            _INDEX_NAME,
-            "conversation_items",
-            ["workspace_id", "conversation_id", "source_id"],
-            unique=False,
-            sqlite_where=sa.text("source_id IS NOT NULL"),
-        )
     else:
-        op.create_index(
-            _INDEX_NAME,
-            "conversation_items",
-            ["workspace_id", "conversation_id", "source_id"],
-            unique=False,
-        )
+        exists, current = _portable_index_status()
+        if not current:
+            if exists:
+                op.drop_index(_INDEX_NAME, table_name="conversation_items")
+            if dialect_name == "sqlite":
+                op.create_index(
+                    _INDEX_NAME,
+                    "conversation_items",
+                    list(_INDEX_COLUMNS),
+                    unique=False,
+                    sqlite_where=sa.text("source_id IS NOT NULL"),
+                )
+            else:
+                op.create_index(
+                    _INDEX_NAME,
+                    "conversation_items",
+                    list(_INDEX_COLUMNS),
+                    unique=False,
+                )
 
 
 def downgrade() -> None:
@@ -102,6 +131,9 @@ def downgrade() -> None:
         with op.get_context().autocommit_block():
             op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")
     else:
-        op.drop_index(_INDEX_NAME, table_name="conversation_items")
-    with op.batch_alter_table("conversation_items") as batch_op:
-        batch_op.drop_column("source_id")
+        index_exists, _current = _portable_index_status()
+        if op.get_context().as_sql or index_exists:
+            op.drop_index(_INDEX_NAME, table_name="conversation_items")
+    if op.get_context().as_sql or _source_id_column_exists():
+        with op.batch_alter_table("conversation_items") as batch_op:
+            batch_op.drop_column("source_id")

--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy import Engine, create_engine, event, inspect, text
+from sqlalchemy import Connection, Engine, create_engine, event, inspect, text
 
 if TYPE_CHECKING:
     from alembic.config import Config
@@ -258,8 +258,16 @@ def _create_engine(db_uri: str) -> Engine:
         def _set_sqlite_pragma(dbapi_conn: sqlite3.Connection, _conn_record: object) -> None:
             cur = dbapi_conn.cursor()
             try:
-                cur.execute("PRAGMA journal_mode=WAL")
                 cur.execute("PRAGMA busy_timeout=20000")  # 20s
+                try:
+                    cur.execute("PRAGMA journal_mode=WAL")
+                except sqlite3.OperationalError as exc:
+                    # A different process may already hold BEGIN EXCLUSIVE
+                    # while upgrading this database. Its connection set WAL
+                    # before taking that lock, so this idempotent write can be
+                    # skipped until a later fresh connection.
+                    if "database is locked" not in str(exc):
+                        raise
                 cur.execute("PRAGMA synchronous=NORMAL")  # WAL-safe + fast
                 cur.execute("PRAGMA foreign_keys=ON")
             finally:
@@ -360,9 +368,79 @@ def _ensure_conversation_tables(engine: Engine) -> None:
     from omnigent.db.db_models import ConversationBase
 
     with query_name_scope("omnigent.database.ensure_conversation_schema"):
-        ConversationBase.metadata.create_all(bind=engine, checkfirst=True)
-        _run_conversation_schema_upgrades(engine)
-        ensure_fts_table(engine)
+        if engine.dialect.name == "sqlite":
+            # BEGIN EXCLUSIVE is SQLite's database-level schema lock. Every
+            # schema read/write below uses this same connection so another
+            # process cannot observe or apply a half-finished upgrade.
+            with engine.connect() as connection:
+                connection.exec_driver_sql("BEGIN EXCLUSIVE")
+                try:
+                    ConversationBase.metadata.create_all(bind=connection, checkfirst=True)
+                    _run_sqlite_conversation_schema_upgrades(connection)
+                    connection.execute(_CREATE_FTS)
+                    connection.commit()
+                except BaseException:
+                    connection.rollback()
+                    raise
+            return
+
+        with _server_conversation_schema_lock(engine):
+            ConversationBase.metadata.create_all(bind=engine, checkfirst=True)
+            _run_conversation_schema_upgrades(engine)
+            ensure_fts_table(engine)
+
+
+@contextmanager
+def _server_conversation_schema_lock(engine: Engine) -> Iterator[None]:
+    """Hold a backend-native cross-process lock for split schema upgrades."""
+    with engine.connect() as connection:
+        if engine.dialect.name == "postgresql":
+            connection.execute(sa.text("SELECT pg_advisory_lock(5714303826658643542)"))
+            try:
+                yield
+            finally:
+                connection.execute(sa.text("SELECT pg_advisory_unlock(5714303826658643542)"))
+            return
+        if engine.dialect.name == "mysql":
+            acquired = connection.execute(
+                sa.text("SELECT GET_LOCK('omnigent_conversation_schema', 60)")
+            ).scalar()
+            if acquired != 1:
+                raise RuntimeError("Timed out acquiring split conversation schema lock")
+            try:
+                yield
+            finally:
+                connection.execute(sa.text("SELECT RELEASE_LOCK('omnigent_conversation_schema')"))
+            return
+        yield
+
+
+def _run_sqlite_conversation_schema_upgrades(connection: Connection) -> None:
+    """Apply split schema versions while holding SQLite's exclusive lock."""
+    _CONVERSATION_SCHEMA_METADATA.create_all(bind=connection, checkfirst=True)
+    applied = set(
+        connection.execute(sa.select(_CONVERSATION_SCHEMA_MIGRATIONS.c.version)).scalars()
+    )
+    if _CONVERSATION_SCHEMA_SOURCE_ID_VERSION in applied:
+        return
+
+    columns = {column["name"] for column in inspect(connection).get_columns("conversation_items")}
+    if "source_id" not in columns:
+        connection.exec_driver_sql(
+            "ALTER TABLE conversation_items ADD COLUMN source_id VARCHAR(512)"
+        )
+    indexes = {index["name"] for index in inspect(connection).get_indexes("conversation_items")}
+    if "ix_conversation_items_source_id" not in indexes:
+        connection.exec_driver_sql(
+            "CREATE INDEX ix_conversation_items_source_id "
+            "ON conversation_items (workspace_id, conversation_id, source_id) "
+            "WHERE source_id IS NOT NULL"
+        )
+    connection.execute(
+        sa.insert(_CONVERSATION_SCHEMA_MIGRATIONS).values(
+            version=_CONVERSATION_SCHEMA_SOURCE_ID_VERSION
+        )
+    )
 
 
 def _run_conversation_schema_upgrades(engine: Engine) -> None:
@@ -393,20 +471,33 @@ def _upgrade_split_conversation_source_id(engine: Engine) -> None:
             )
 
     indexes = {index["name"] for index in inspect(engine).get_indexes("conversation_items")}
-    if "ix_conversation_items_source_id" in indexes:
+    if engine.dialect.name != "postgresql" and "ix_conversation_items_source_id" in indexes:
         return
     columns_sql = "(workspace_id, conversation_id, source_id)"
     if engine.dialect.name == "postgresql":
         with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as connection:
-            invalid = connection.execute(
-                sa.text(
-                    "SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid "
-                    "WHERE c.relname = :name AND NOT i.indisvalid"
-                ),
-                {"name": "ix_conversation_items_source_id"},
-            ).scalar()
-            if invalid:
-                connection.exec_driver_sql("DROP INDEX ix_conversation_items_source_id")
+            row = (
+                connection.execute(
+                    sa.text(
+                        "SELECT i.indisvalid, pg_get_indexdef(i.indexrelid) AS definition "
+                        "FROM pg_index i WHERE i.indexrelid = to_regclass(:name)"
+                    ),
+                    {"name": "ix_conversation_items_source_id"},
+                )
+                .mappings()
+                .first()
+            )
+            if row is not None:
+                definition = str(row["definition"])
+                expected_shape = (
+                    "(workspace_id, conversation_id, source_id)" in definition
+                    and "WHERE (source_id IS NOT NULL)" in definition
+                )
+                if row["indisvalid"] and expected_shape:
+                    return
+                connection.exec_driver_sql(
+                    "DROP INDEX CONCURRENTLY IF EXISTS ix_conversation_items_source_id"
+                )
             connection.exec_driver_sql(
                 "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
                 f"ix_conversation_items_source_id ON conversation_items {columns_sql} "

--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -429,8 +429,10 @@ def _run_sqlite_conversation_schema_upgrades(connection: Connection) -> None:
         connection.exec_driver_sql(
             "ALTER TABLE conversation_items ADD COLUMN source_id VARCHAR(512)"
         )
-    indexes = {index["name"] for index in inspect(connection).get_indexes("conversation_items")}
-    if "ix_conversation_items_source_id" not in indexes:
+    index_exists, index_current = _split_source_index_status(connection, "sqlite")
+    if not index_current:
+        if index_exists:
+            connection.exec_driver_sql("DROP INDEX ix_conversation_items_source_id")
         connection.exec_driver_sql(
             "CREATE INDEX ix_conversation_items_source_id "
             "ON conversation_items (workspace_id, conversation_id, source_id) "
@@ -441,6 +443,29 @@ def _run_sqlite_conversation_schema_upgrades(connection: Connection) -> None:
             version=_CONVERSATION_SCHEMA_SOURCE_ID_VERSION
         )
     )
+
+
+def _split_source_index_status(
+    bind: Engine | Connection,
+    dialect_name: str,
+) -> tuple[bool, bool]:
+    """Return whether the split source index exists with its expected shape."""
+    expected_columns = ("workspace_id", "conversation_id", "source_id")
+    for index in inspect(bind).get_indexes("conversation_items"):
+        if index["name"] != "ix_conversation_items_source_id":
+            continue
+        current = tuple(index.get("column_names") or ()) == expected_columns and not bool(
+            index.get("unique")
+        )
+        if dialect_name == "sqlite":
+            where = (index.get("dialect_options") or {}).get("sqlite_where")
+            predicate = "".join(str(where).lower().split())
+            current = current and predicate in {
+                "source_idisnotnull",
+                "(source_idisnotnull)",
+            }
+        return True, current
+    return False, False
 
 
 def _run_conversation_schema_upgrades(engine: Engine) -> None:
@@ -470,9 +495,7 @@ def _upgrade_split_conversation_source_id(engine: Engine) -> None:
                 "ALTER TABLE conversation_items ADD COLUMN source_id VARCHAR(512)"
             )
 
-    indexes = {index["name"] for index in inspect(engine).get_indexes("conversation_items")}
-    if engine.dialect.name != "postgresql" and "ix_conversation_items_source_id" in indexes:
-        return
+    index_exists, index_current = _split_source_index_status(engine, engine.dialect.name)
     columns_sql = "(workspace_id, conversation_id, source_id)"
     if engine.dialect.name == "postgresql":
         with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as connection:
@@ -492,6 +515,7 @@ def _upgrade_split_conversation_source_id(engine: Engine) -> None:
                 expected_shape = (
                     "(workspace_id, conversation_id, source_id)" in definition
                     and "WHERE (source_id IS NOT NULL)" in definition
+                    and not definition.startswith("CREATE UNIQUE INDEX")
                 )
                 if row["indisvalid"] and expected_shape:
                     return
@@ -506,6 +530,10 @@ def _upgrade_split_conversation_source_id(engine: Engine) -> None:
         return
     where = " WHERE source_id IS NOT NULL" if engine.dialect.name == "sqlite" else ""
     with engine.begin() as connection:
+        if index_current:
+            return
+        if index_exists:
+            connection.exec_driver_sql("DROP INDEX ix_conversation_items_source_id")
         connection.exec_driver_sql(
             f"CREATE INDEX ix_conversation_items_source_id "
             f"ON conversation_items {columns_sql}{where}"

--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import sqlalchemy as sa
 from sqlalchemy import Engine, create_engine, event, inspect, text
 
 if TYPE_CHECKING:
@@ -35,6 +36,14 @@ NamedManagedSessionMaker = Callable[[str], AbstractContextManager[Session]]
 # A zero-argument callable returning a fresh database password (e.g. a
 # short-lived Lakebase OAuth token). Invoked once per *new* DBAPI connection.
 LakebaseTokenProvider = Callable[[], str]
+
+_CONVERSATION_SCHEMA_METADATA = sa.MetaData()
+_CONVERSATION_SCHEMA_MIGRATIONS = sa.Table(
+    "omnigent_conversation_schema_migrations",
+    _CONVERSATION_SCHEMA_METADATA,
+    sa.Column("version", sa.Integer, primary_key=True),
+)
+_CONVERSATION_SCHEMA_SOURCE_ID_VERSION = 1
 
 
 # ── Lakebase token-aware connections ───────────────────
@@ -324,9 +333,10 @@ def get_or_create_conversation_engine(conv_uri: str) -> Engine:
     """
     Return a cached engine for the Agent Platform DB URI.
 
-    Unlike :func:`get_or_create_engine`, this does NOT run Alembic
-    migrations — the AP DB is expected to be a fresh database that
-    gets its tables created via ``ConversationBase.metadata.create_all()``.
+    Unlike :func:`get_or_create_engine`, this does not run the combined
+    Omnigent Alembic lineage, because a split AP database intentionally
+    contains only conversation tables. It does run the split schema's
+    own versioned upgrades after ``ConversationBase.metadata.create_all()``.
     For the common case where AP DB == Omnigent DB, callers should
     use :func:`get_or_create_engine` directly and share the engine.
 
@@ -346,12 +356,69 @@ def get_or_create_conversation_engine(conv_uri: str) -> Engine:
 
 
 def _ensure_conversation_tables(engine: Engine) -> None:
-    """Create AP tables (conversations, conversation_items, conversation_labels) if absent."""
+    """Create and upgrade the split Agent Platform conversation schema."""
     from omnigent.db.db_models import ConversationBase
 
     with query_name_scope("omnigent.database.ensure_conversation_schema"):
         ConversationBase.metadata.create_all(bind=engine, checkfirst=True)
+        _run_conversation_schema_upgrades(engine)
         ensure_fts_table(engine)
+
+
+def _run_conversation_schema_upgrades(engine: Engine) -> None:
+    """Apply idempotent, split-database-only schema upgrades in version order."""
+    _CONVERSATION_SCHEMA_METADATA.create_all(bind=engine, checkfirst=True)
+    with engine.connect() as connection:
+        applied = set(
+            connection.execute(sa.select(_CONVERSATION_SCHEMA_MIGRATIONS.c.version)).scalars()
+        )
+
+    if _CONVERSATION_SCHEMA_SOURCE_ID_VERSION not in applied:
+        _upgrade_split_conversation_source_id(engine)
+        with engine.begin() as connection:
+            connection.execute(
+                sa.insert(_CONVERSATION_SCHEMA_MIGRATIONS).values(
+                    version=_CONVERSATION_SCHEMA_SOURCE_ID_VERSION
+                )
+            )
+
+
+def _upgrade_split_conversation_source_id(engine: Engine) -> None:
+    """Add the external-source identity column and lookup index when absent."""
+    columns = {column["name"] for column in inspect(engine).get_columns("conversation_items")}
+    if "source_id" not in columns:
+        with engine.begin() as connection:
+            connection.exec_driver_sql(
+                "ALTER TABLE conversation_items ADD COLUMN source_id VARCHAR(512)"
+            )
+
+    indexes = {index["name"] for index in inspect(engine).get_indexes("conversation_items")}
+    if "ix_conversation_items_source_id" in indexes:
+        return
+    columns_sql = "(workspace_id, conversation_id, source_id)"
+    if engine.dialect.name == "postgresql":
+        with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as connection:
+            invalid = connection.execute(
+                sa.text(
+                    "SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid "
+                    "WHERE c.relname = :name AND NOT i.indisvalid"
+                ),
+                {"name": "ix_conversation_items_source_id"},
+            ).scalar()
+            if invalid:
+                connection.exec_driver_sql("DROP INDEX ix_conversation_items_source_id")
+            connection.exec_driver_sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+                f"ix_conversation_items_source_id ON conversation_items {columns_sql} "
+                "WHERE source_id IS NOT NULL"
+            )
+        return
+    where = " WHERE source_id IS NOT NULL" if engine.dialect.name == "sqlite" else ""
+    with engine.begin() as connection:
+        connection.exec_driver_sql(
+            f"CREATE INDEX ix_conversation_items_source_id "
+            f"ON conversation_items {columns_sql}{where}"
+        )
 
 
 def _set_alembic_database_url(config: Config, db_uri: str) -> None:

--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -781,12 +781,15 @@ class NewConversationItem(BaseModel):
         item (e.g. ``"alice@example.com"``), or ``None`` for
         agent/tool/system-generated items and single-user mode.
         Mirrors the comment ``created_by`` contract.
+    :param source_id: Optional stable producer identity used to make
+        external transcript retries idempotent within a conversation.
     """
 
     type: str
     response_id: str
     data: ItemData
     created_by: str | None = None
+    source_id: str | None = Field(default=None, min_length=1, max_length=512)
 
     @model_validator(mode="after")
     def check_type_matches_data(self) -> NewConversationItem:

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -3034,11 +3034,15 @@ def _parse_external_conversation_item(
             "external_conversation_item data.response_id must be a non-empty string",
             code=ErrorCode.INVALID_INPUT,
         )
-    # NOTE: external conversation items are persisted with a random
-    # primary key like any other item — there is no server-side dedup.
-    # Producers (the claude-native / codex-native forwarders) are
-    # responsible for not re-posting records they have already sent;
-    # they no longer emit a ``source_id`` dedup key to the server.
+    source_id = body.data.get("source_id")
+    if source_id is not None:
+        if not isinstance(source_id, str) or not source_id.strip() or len(source_id.strip()) > 512:
+            raise OmnigentError(
+                "external_conversation_item data.source_id must be a non-empty string "
+                "of at most 512 characters",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        source_id = source_id.strip()
     # Cap a native tool result so a multi-MB output isn't persisted + broadcast as one frame.
     if item_type == "function_call_output" and isinstance(item_data.get("output"), str):
         item_data = {**item_data, "output": cap_tool_output(item_data["output"])}
@@ -3053,6 +3057,7 @@ def _parse_external_conversation_item(
         type=item_type,
         response_id=response_id.strip(),
         data=data,
+        source_id=source_id,
     )
 
 

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -13,6 +13,7 @@ import json
 import math
 import secrets
 import time
+import weakref
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Literal, cast
 
@@ -2171,6 +2172,11 @@ async def _persist_external_codex_subagent_start(
     )
 
 
+_external_item_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
+    weakref.WeakValueDictionary()
+)
+
+
 async def _persist_external_conversation_item(
     session_id: str,
     conv: Conversation,
@@ -2200,6 +2206,38 @@ async def _persist_external_conversation_item(
     :returns: Store-assigned conversation item id.
     """
     item = _parse_external_conversation_item(body)
+    lock = _external_item_locks.setdefault(session_id, asyncio.Lock())
+    async with lock:
+        # Resolve a committed retry before touching pending_inputs. The lock
+        # keeps this lookup, pending reconciliation, and append in one
+        # process-wide serialization boundary for the session.
+        if item.source_id is not None:
+            existing = await asyncio.to_thread(
+                conversation_store.get_item_by_source_id,
+                session_id,
+                item.source_id,
+            )
+            if existing is not None:
+                return existing.id
+        return await _persist_new_external_conversation_item(
+            session_id,
+            conv,
+            item,
+            conversation_store,
+            created_by=created_by,
+            background_title_coordinator=background_title_coordinator,
+        )
+
+
+async def _persist_new_external_conversation_item(
+    session_id: str,
+    conv: Conversation,
+    item: NewConversationItem,
+    conversation_store: ConversationStore,
+    created_by: str | None = None,
+    background_title_coordinator: BackgroundSessionTitleCoordinator | None = None,
+) -> str:
+    """Reconcile and persist an external item known to be new."""
     # A native user message round-tripping back from the transcript:
     # drain its optimistic pending-input entry (FIFO) and fold the
     # entry's file blocks (image / file) into the item BEFORE persisting.

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -371,6 +371,15 @@ def register_events_routes(
 ) -> None:
     """Register the events, stream, and delete routes on router."""
 
+    @router.get(
+        "/native-forwarder-capabilities",
+        include_in_schema=False,
+        response_model=None,
+    )
+    async def native_forwarder_capabilities() -> dict[str, bool]:
+        """Advertise retry semantics understood by this server build."""
+        return {"external_conversation_item_source_id_idempotency": True}
+
     def _has_runner_created_by_authority(request: Request, conv: Any) -> bool:
         token = (request.headers.get(RUNNER_TUNNEL_TOKEN_HEADER) or "").strip()
         if not token:

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -371,15 +371,6 @@ def register_events_routes(
 ) -> None:
     """Register the events, stream, and delete routes on router."""
 
-    @router.get(
-        "/native-forwarder-capabilities",
-        include_in_schema=False,
-        response_model=None,
-    )
-    async def native_forwarder_capabilities() -> dict[str, bool]:
-        """Advertise retry semantics understood by this server build."""
-        return {"external_conversation_item_source_id_idempotency": True}
-
     def _has_runner_created_by_authority(request: Request, conv: Any) -> bool:
         token = (request.headers.get(RUNNER_TUNNEL_TOKEN_HEADER) or "").strip()
         if not token:
@@ -389,6 +380,12 @@ def register_events_routes(
         runner_id = getattr(conv, "runner_id", None)
         return isinstance(runner_id, str) and token_bound_runner_id(token) == runner_id
 
+    @router.post(
+        "/sessions/{session_id}/events/source-id-v1",
+        include_in_schema=False,
+        status_code=202,
+        response_model=None,
+    )
     @router.post(
         "/sessions/{session_id}/events",
         # Internal event ingestion — hidden from the public API reference.
@@ -486,6 +483,15 @@ def register_events_routes(
             control and internal transient events.
         :raises OmnigentError: 404 if no session exists.
         """
+        if request.url.path.endswith("/events/source-id-v1") and (
+            body.type != _EXTERNAL_CONVERSATION_ITEM_TYPE
+            or not isinstance(body.data.get("source_id"), str)
+            or not body.data["source_id"].strip()
+        ):
+            raise OmnigentError(
+                "source-id-v1 requires external_conversation_item with source_id",
+                code=ErrorCode.INVALID_INPUT,
+            )
         user_id = _get_user_id(request, auth_provider)
         access = await _require_access_and_level(
             user_id, session_id, LEVEL_EDIT, permission_store, conversation_store

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -608,6 +608,21 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def get_item_by_source_id(
+        self,
+        conversation_id: str,
+        source_id: str,
+    ) -> ConversationItem | None:
+        """
+        Return an item by its producer-assigned identity.
+
+        :param conversation_id: Conversation containing the item.
+        :param source_id: Stable external producer identity.
+        :returns: The matching item, or ``None``.
+        """
+        ...
+
+    @abstractmethod
     def append(
         self,
         conversation_id: str,

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -1989,6 +1989,25 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         return strip_nul_bytes(extract_search_text(item))
 
+    def get_item_by_source_id(
+        self,
+        conversation_id: str,
+        source_id: str,
+    ) -> ConversationItem | None:
+        """Return the durable item carrying one external producer identity."""
+        with self._conv_session("get_conversation_item_by_source_id") as session:
+            row = session.execute(
+                select(SqlConversationItem).where(
+                    SqlConversationItem.workspace_id == current_workspace_id(),
+                    SqlConversationItem.conversation_id == conversation_id,
+                    SqlConversationItem.source_id == source_id,
+                )
+            ).scalar_one_or_none()
+            if row is None:
+                return None
+            data_json = self._decode_item_data_batch([row.data])[0]
+            return _to_item(row, data_json)
+
     def append(
         self,
         conversation_id: str,

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -1999,7 +1999,9 @@ class SqlAlchemyConversationStore(ConversationStore):
 
         Assigns a globally unique ID, timestamp, and incrementing
         position to each item. Also inserts FTS records for
-        searchability.
+        searchability. Items carrying a ``source_id`` are idempotent
+        within their workspace and conversation: a retry returns the
+        already-persisted item.
 
         :param conversation_id: Unique conversation identifier,
             e.g. ``"conv_abc123"``.
@@ -2017,10 +2019,31 @@ class SqlAlchemyConversationStore(ConversationStore):
             # SQLite the database-level lock already serializes.
             self._lock_conversation(session, conversation_id)
 
-            # Bump updated_at on the conversation.
-            conv_row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
-            if conv_row is not None:
-                conv_row.updated_at = now
+            workspace_id = current_workspace_id()
+            conv_row = session.get(SqlConversation, (workspace_id, conversation_id))
+
+            # Resolve durable producer identities while holding the same
+            # conversation lock that serializes inserts. This closes the window
+            # where a native transcript POST commits but its forwarder dies
+            # before advancing local state, then retries the identical source.
+            source_ids = [item.source_id for item in items if item.source_id is not None]
+            persisted_by_source: dict[str, ConversationItem] = {}
+            if source_ids:
+                existing_rows = list(
+                    session.execute(
+                        select(SqlConversationItem).where(
+                            SqlConversationItem.workspace_id == workspace_id,
+                            SqlConversationItem.conversation_id == conversation_id,
+                            SqlConversationItem.source_id.in_(source_ids),
+                        )
+                    ).scalars()
+                )
+                decoded = self._decode_item_data_batch([row.data for row in existing_rows])
+                persisted_by_source = {
+                    row.source_id: _to_item(row, data_json)
+                    for row, data_json in zip(existing_rows, decoded, strict=True)
+                    if row.source_id is not None
+                }
 
             # Allocate item positions from the conversation's maintained
             # next_position counter instead of running a MAX(position) aggregate
@@ -2041,18 +2064,21 @@ class SqlAlchemyConversationStore(ConversationStore):
                 next_pos = (
                     session.execute(
                         select(func.coalesce(func.max(SqlConversationItem.position), -1)).where(
-                            SqlConversationItem.workspace_id == current_workspace_id(),
+                            SqlConversationItem.workspace_id == workspace_id,
                             SqlConversationItem.conversation_id == conversation_id,
                         )
                     ).scalar_one()
                     + 1
                 )
 
-            workspace_id = current_workspace_id()
             completed_status = encode_item_status("completed")  # items are final on append
             fts_rows: list[tuple[str, str, str]] = []
             row_values: list[dict[str, object]] = []
             for item in items:
+                if item.source_id is not None and item.source_id in persisted_by_source:
+                    persisted.append(persisted_by_source[item.source_id])
+                    continue
+
                 position = next_pos
                 next_pos += 1
                 data_dict = item.data.model_dump(exclude_none=True)
@@ -2074,6 +2100,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     "type": encode_item_type(item.type),
                     "data": data,
                     "created_by": item.created_by,
+                    "source_id": item.source_id,
                 }
                 # A backend may omit search_text (see _item_search_text): when it
                 # returns None we drop the column so a schema without it still
@@ -2083,20 +2110,21 @@ class SqlAlchemyConversationStore(ConversationStore):
                     values["search_text"] = search
                     fts_rows.append((item_id, conversation_id, search))
                 row_values.append(values)
-                persisted.append(
-                    ConversationItem(
-                        id=item_id,
-                        # The row stores int codes; the entity carries the
-                        # string names. item.type is the source string and
-                        # the status was just written as "completed".
-                        type=item.type,
-                        status="completed",
-                        response_id=item.response_id,
-                        created_at=now,
-                        data=item.data,
-                        created_by=item.created_by,
-                    )
+                persisted_item = ConversationItem(
+                    id=item_id,
+                    # The row stores int codes; the entity carries the
+                    # string names. item.type is the source string and
+                    # the status was just written as "completed".
+                    type=item.type,
+                    status="completed",
+                    response_id=item.response_id,
+                    created_at=now,
+                    data=item.data,
+                    created_by=item.created_by,
                 )
+                persisted.append(persisted_item)
+                if item.source_id is not None:
+                    persisted_by_source[item.source_id] = persisted_item
             # One executemany for the batch: positions are pre-allocated above so
             # the rows carry no inter-row dependency, and a single round-trip
             # persists all N. A per-row ORM add round-trips per item, which
@@ -2105,9 +2133,10 @@ class SqlAlchemyConversationStore(ConversationStore):
                 session.execute(insert(SqlConversationItem), row_values)
             insert_fts_bulk(session, fts_rows)
 
-            # Persist the advanced counter so the next append reads it instead
-            # of scanning; this also lazily backfills a pre-counter conversation.
-            if conv_row is not None:
+            # Only a genuinely new item advances the conversation. Retried
+            # source ids are a storage no-op.
+            if conv_row is not None and row_values:
+                conv_row.updated_at = now
                 conv_row.next_position = next_pos
 
         return persisted

--- a/tests/db/test_migration_source_id_index.py
+++ b/tests/db/test_migration_source_id_index.py
@@ -1,0 +1,53 @@
+"""DDL coverage for the conversation-item source identity migration."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+from omnigent.db.migrations.versions import (
+    f3c7a1d9e2b4_add_conversation_item_source_id as migration,
+)
+
+
+def _compile_upgrade(monkeypatch: pytest.MonkeyPatch, dialect_name: str) -> str:
+    output = io.StringIO()
+    context = MigrationContext.configure(
+        dialect_name=dialect_name,
+        opts={"as_sql": True, "output_buffer": output},
+    )
+    monkeypatch.setattr(migration, "op", Operations(context))
+    with context.begin_transaction():
+        migration.upgrade()
+    return output.getvalue()
+
+
+def test_postgresql_source_index_is_concurrent_partial_and_autocommitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PostgreSQL must not build the large lookup index in a transaction."""
+    ddl = _compile_upgrade(monkeypatch, "postgresql")
+
+    index = ddl.index("CREATE INDEX CONCURRENTLY")
+    assert ddl.rfind("COMMIT", 0, index) >= 0
+    assert "WHERE source_id IS NOT NULL" in ddl[index:]
+
+
+@pytest.mark.parametrize(
+    ("dialect_name", "partial"),
+    [("sqlite", True), ("mysql", False)],
+)
+def test_source_index_ddl_remains_portable(
+    monkeypatch: pytest.MonkeyPatch,
+    dialect_name: str,
+    partial: bool,
+) -> None:
+    """SQLite gets its supported partial form; MySQL gets a plain index."""
+    ddl = _compile_upgrade(monkeypatch, dialect_name)
+
+    assert "CREATE INDEX ix_conversation_items_source_id" in ddl
+    assert ("WHERE source_id IS NOT NULL" in ddl) is partial
+    assert "CONCURRENTLY" not in ddl

--- a/tests/db/test_migration_source_id_index.py
+++ b/tests/db/test_migration_source_id_index.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import io
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from alembic.migration import MigrationContext
@@ -51,3 +54,98 @@ def test_source_index_ddl_remains_portable(
     assert "CREATE INDEX ix_conversation_items_source_id" in ddl
     assert ("WHERE source_id IS NOT NULL" in ddl) is partial
     assert "CONCURRENTLY" not in ddl
+
+
+class _FakeMappings:
+    """Minimal mapping result used by the restart simulation."""
+
+    def __init__(self, row: dict[str, Any] | None) -> None:
+        self._row = row
+
+    def mappings(self) -> _FakeMappings:
+        return self
+
+    def first(self) -> dict[str, Any] | None:
+        return self._row
+
+
+class _RestartablePostgresOperations:
+    """Stateful Alembic-operation fake that leaves an invalid first index."""
+
+    def __init__(self) -> None:
+        self.column_exists = False
+        self.index: dict[str, Any] | None = None
+        self.create_attempts = 0
+        self.drop_attempts = 0
+        self.context = SimpleNamespace(
+            as_sql=False,
+            dialect=SimpleNamespace(name="postgresql"),
+            autocommit_block=nullcontext,
+        )
+        self.bind = SimpleNamespace(execute=self._catalog_query)
+
+    def get_context(self) -> Any:
+        return self.context
+
+    def get_bind(self) -> Any:
+        return self.bind
+
+    def add_column(self, table: str, column: Any) -> None:
+        assert table == "conversation_items"
+        assert column.name == "source_id"
+        assert not self.column_exists
+        self.column_exists = True
+
+    def execute(self, statement: str) -> None:
+        if statement.startswith("DROP INDEX CONCURRENTLY"):
+            self.drop_attempts += 1
+            self.index = None
+            return
+        assert statement.startswith("CREATE INDEX CONCURRENTLY")
+        self.create_attempts += 1
+        definition = (
+            "CREATE INDEX ix_conversation_items_source_id ON conversation_items "
+            "USING btree (workspace_id, conversation_id, source_id) "
+            "WHERE (source_id IS NOT NULL)"
+        )
+        if self.create_attempts == 1:
+            self.index = {"indisvalid": False, "definition": definition}
+            raise RuntimeError("concurrent build cancelled")
+        self.index = {"indisvalid": True, "definition": definition}
+
+    def _catalog_query(self, statement: Any, params: dict[str, str]) -> _FakeMappings:
+        assert "pg_get_indexdef" in str(statement)
+        assert params["name"] == "ix_conversation_items_source_id"
+        return _FakeMappings(self.index)
+
+
+def test_postgresql_migration_recovers_after_cancelled_index_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A committed column and invalid index are repaired on migration retry."""
+    operations = _RestartablePostgresOperations()
+    monkeypatch.setattr(migration, "op", operations)
+    monkeypatch.setattr(
+        migration,
+        "_source_id_column_exists",
+        lambda: operations.column_exists,
+    )
+    stamped = False
+
+    with pytest.raises(RuntimeError, match="cancelled"):
+        migration.upgrade()
+        stamped = True
+
+    assert operations.column_exists is True
+    assert operations.index is not None
+    assert operations.index["indisvalid"] is False
+    assert stamped is False
+
+    migration.upgrade()
+    stamped = True
+
+    assert operations.create_attempts == 2
+    assert operations.drop_attempts == 1
+    assert operations.index is not None
+    assert operations.index["indisvalid"] is True
+    assert stamped is True

--- a/tests/db/test_migration_source_id_index.py
+++ b/tests/db/test_migration_source_id_index.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import io
 from contextlib import nullcontext
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 
@@ -149,3 +151,186 @@ def test_postgresql_migration_recovers_after_cancelled_index_build(
     assert operations.index is not None
     assert operations.index["indisvalid"] is True
     assert stamped is True
+
+
+def _create_minimal_conversation_items(engine: sa.Engine) -> None:
+    """Create the columns required to compile and inspect the source index."""
+    with engine.begin() as connection:
+        connection.exec_driver_sql(
+            "CREATE TABLE conversation_items ("
+            "id VARCHAR(64) PRIMARY KEY, "
+            "workspace_id VARCHAR(64) NOT NULL, "
+            "conversation_id VARCHAR(64) NOT NULL"
+            ")"
+        )
+
+
+def test_sqlite_upgrade_and_downgrade_are_restartable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Committed SQLite DDL can be retried without an Alembic stamp."""
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'restartable.db'}")
+    _create_minimal_conversation_items(engine)
+    with engine.connect() as connection:
+        context = MigrationContext.configure(connection)
+        monkeypatch.setattr(migration, "op", Operations(context))
+
+        migration.upgrade()
+        connection.commit()
+        migration.upgrade()
+        connection.commit()
+
+        inspector = sa.inspect(connection)
+        assert "source_id" in {
+            column["name"] for column in inspector.get_columns("conversation_items")
+        }
+        indexes = {index["name"]: index for index in inspector.get_indexes("conversation_items")}
+        source_index = indexes["ix_conversation_items_source_id"]
+        assert tuple(source_index["column_names"]) == (
+            "workspace_id",
+            "conversation_id",
+            "source_id",
+        )
+        assert "source_id IS NOT NULL" in str(source_index["dialect_options"]["sqlite_where"])
+
+        migration.downgrade()
+        connection.commit()
+        migration.downgrade()
+        connection.commit()
+        assert "source_id" not in {
+            column["name"] for column in sa.inspect(connection).get_columns("conversation_items")
+        }
+    engine.dispose()
+
+
+def test_sqlite_upgrade_replaces_wrong_shape_index(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A matching index name cannot hide incompatible columns or predicate."""
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'wrong-index.db'}")
+    _create_minimal_conversation_items(engine)
+    with engine.begin() as connection:
+        connection.exec_driver_sql(
+            "ALTER TABLE conversation_items ADD COLUMN source_id VARCHAR(512)"
+        )
+        connection.exec_driver_sql(
+            "CREATE INDEX ix_conversation_items_source_id ON conversation_items (conversation_id)"
+        )
+    with engine.connect() as connection:
+        context = MigrationContext.configure(connection)
+        monkeypatch.setattr(migration, "op", Operations(context))
+        migration.upgrade()
+        connection.commit()
+        indexes = {
+            index["name"]: index
+            for index in sa.inspect(connection).get_indexes("conversation_items")
+        }
+        source_index = indexes["ix_conversation_items_source_id"]
+        assert tuple(source_index["column_names"]) == (
+            "workspace_id",
+            "conversation_id",
+            "source_id",
+        )
+        assert "source_id IS NOT NULL" in str(source_index["dialect_options"]["sqlite_where"])
+    engine.dispose()
+
+
+class _PortableOperations:
+    """Minimal online operation state for MySQL restart behavior."""
+
+    def __init__(self) -> None:
+        self.column_exists = False
+        self.index_exists = False
+        self.index_current = False
+        self.add_attempts = 0
+        self.create_attempts = 0
+        self.drop_attempts = 0
+        self.drop_column_attempts = 0
+        self.context = SimpleNamespace(
+            as_sql=False,
+            dialect=SimpleNamespace(name="mysql"),
+        )
+
+    def get_context(self) -> Any:
+        return self.context
+
+    def add_column(self, table: str, column: Any) -> None:
+        assert table == "conversation_items"
+        assert column.name == "source_id"
+        self.add_attempts += 1
+        self.column_exists = True
+
+    def create_index(
+        self,
+        name: str,
+        table: str,
+        columns: list[str],
+        *,
+        unique: bool,
+    ) -> None:
+        assert name == "ix_conversation_items_source_id"
+        assert table == "conversation_items"
+        assert tuple(columns) == ("workspace_id", "conversation_id", "source_id")
+        assert unique is False
+        self.create_attempts += 1
+        self.index_exists = True
+        self.index_current = True
+
+    def drop_index(self, name: str, *, table_name: str) -> None:
+        assert name == "ix_conversation_items_source_id"
+        assert table_name == "conversation_items"
+        self.drop_attempts += 1
+        self.index_exists = False
+        self.index_current = False
+
+    def batch_alter_table(self, table: str) -> _PortableOperations:
+        assert table == "conversation_items"
+        return self
+
+    def __enter__(self) -> _PortableOperations:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def drop_column(self, name: str) -> None:
+        assert name == "source_id"
+        self.drop_column_attempts += 1
+        self.column_exists = False
+
+
+def test_mysql_upgrade_retry_and_wrong_index_repair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MySQL retries committed DDL and replaces a same-name wrong index."""
+    operations = _PortableOperations()
+    monkeypatch.setattr(migration, "op", operations)
+    monkeypatch.setattr(
+        migration,
+        "_source_id_column_exists",
+        lambda: operations.column_exists,
+    )
+    monkeypatch.setattr(
+        migration,
+        "_portable_index_status",
+        lambda: (operations.index_exists, operations.index_current),
+    )
+
+    migration.upgrade()
+    migration.upgrade()
+    assert operations.add_attempts == 1
+    assert operations.create_attempts == 1
+    assert operations.drop_attempts == 0
+
+    operations.index_current = False
+    migration.upgrade()
+    assert operations.add_attempts == 1
+    assert operations.create_attempts == 2
+    assert operations.drop_attempts == 1
+
+    migration.downgrade()
+    migration.downgrade()
+    assert operations.drop_attempts == 2
+    assert operations.drop_column_attempts == 1

--- a/tests/db/test_migration_task_summary_preexisting.py
+++ b/tests/db/test_migration_task_summary_preexisting.py
@@ -41,7 +41,7 @@ from omnigent.db.utils import (
 # Revision one step before ``za2b3c4d5e6f`` (which adds ``task_summary``).
 _REVISION_BEFORE_TASK_SUMMARY = "d5e9f1a2b3c4"
 # Current head at the time this bug was filed; asserted as the reachable target.
-_EXPECTED_HEAD = "e5d9bc8ac650"
+_EXPECTED_HEAD = "f3c7a1d9e2b4"
 
 _METADATA_TABLE = "omnigent_conversation_metadata"
 

--- a/tests/db/test_split_conversation_schema_upgrade.py
+++ b/tests/db/test_split_conversation_schema_upgrade.py
@@ -1,0 +1,62 @@
+"""Regression tests for versioned split conversation-database upgrades."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa
+
+from omnigent.db import ConversationBase
+from omnigent.db.utils import _run_conversation_schema_upgrades, clear_engine_cache
+from omnigent.entities import MessageData, NewConversationItem
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+
+def test_preexisting_split_database_upgrades_before_append(tmp_path: Path) -> None:
+    """A legacy split DB gains source identity before normal store writes."""
+    main_uri = f"sqlite:///{tmp_path / 'main.db'}"
+    split_uri = f"sqlite:///{tmp_path / 'conversations.db'}"
+    legacy_engine = sa.create_engine(split_uri)
+    ConversationBase.metadata.create_all(legacy_engine)
+    with legacy_engine.begin() as connection:
+        connection.exec_driver_sql("DROP INDEX ix_conversation_items_source_id")
+        connection.exec_driver_sql("ALTER TABLE conversation_items DROP COLUMN source_id")
+    assert "source_id" not in {
+        column["name"] for column in sa.inspect(legacy_engine).get_columns("conversation_items")
+    }
+    legacy_engine.dispose()
+
+    clear_engine_cache()
+    store = SqlAlchemyConversationStore(main_uri, split_uri)
+    conversation = store.create_conversation()
+    persisted = store.append(
+        conversation.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_split_upgrade",
+                source_id="legacy-split-source:0:message",
+                data=MessageData(
+                    role="assistant",
+                    agent="claude-code",
+                    content=[{"type": "output_text", "text": "after split upgrade"}],
+                ),
+            )
+        ],
+    )
+
+    assert len(persisted) == 1
+    _run_conversation_schema_upgrades(store._conv_engine)
+    inspector = sa.inspect(store._conv_engine)
+    assert "source_id" in {
+        column["name"] for column in inspector.get_columns("conversation_items")
+    }
+    assert "ix_conversation_items_source_id" in {
+        index["name"] for index in inspector.get_indexes("conversation_items")
+    }
+    assert "omnigent_conversation_schema_migrations" in inspector.get_table_names()
+    with store._conv_engine.connect() as connection:
+        versions = connection.execute(
+            sa.text("SELECT version FROM omnigent_conversation_schema_migrations")
+        ).scalars()
+        assert list(versions) == [1]

--- a/tests/db/test_split_conversation_schema_upgrade.py
+++ b/tests/db/test_split_conversation_schema_upgrade.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import multiprocessing
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
 import sqlalchemy as sa
@@ -12,15 +14,35 @@ from omnigent.entities import MessageData, NewConversationItem
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
 
 
-def test_preexisting_split_database_upgrades_before_append(tmp_path: Path) -> None:
-    """A legacy split DB gains source identity before normal store writes."""
-    main_uri = f"sqlite:///{tmp_path / 'main.db'}"
-    split_uri = f"sqlite:///{tmp_path / 'conversations.db'}"
+def _initialize_store_process(main_uri: str, split_uri: str) -> tuple[bool, bool]:
+    """Initialize one store in a fresh process and report split schema state."""
+    clear_engine_cache()
+    store = SqlAlchemyConversationStore(main_uri, split_uri)
+    inspector = sa.inspect(store._conv_engine)
+    columns = {column["name"] for column in inspector.get_columns("conversation_items")}
+    indexes = {index["name"] for index in inspector.get_indexes("conversation_items")}
+    return (
+        "source_id" in columns,
+        "ix_conversation_items_source_id" in indexes,
+    )
+
+
+def _create_legacy_split_database(split_uri: str) -> None:
+    """Create the pre-source-id split schema used by upgrade regressions."""
     legacy_engine = sa.create_engine(split_uri)
     ConversationBase.metadata.create_all(legacy_engine)
     with legacy_engine.begin() as connection:
         connection.exec_driver_sql("DROP INDEX ix_conversation_items_source_id")
         connection.exec_driver_sql("ALTER TABLE conversation_items DROP COLUMN source_id")
+    legacy_engine.dispose()
+
+
+def test_preexisting_split_database_upgrades_before_append(tmp_path: Path) -> None:
+    """A legacy split DB gains source identity before normal store writes."""
+    main_uri = f"sqlite:///{tmp_path / 'main.db'}"
+    split_uri = f"sqlite:///{tmp_path / 'conversations.db'}"
+    _create_legacy_split_database(split_uri)
+    legacy_engine = sa.create_engine(split_uri)
     assert "source_id" not in {
         column["name"] for column in sa.inspect(legacy_engine).get_columns("conversation_items")
     }
@@ -60,3 +82,40 @@ def test_preexisting_split_database_upgrades_before_append(tmp_path: Path) -> No
             sa.text("SELECT version FROM omnigent_conversation_schema_migrations")
         ).scalars()
         assert list(versions) == [1]
+
+
+def test_concurrent_processes_serialize_split_database_upgrade(tmp_path: Path) -> None:
+    """Multiple server processes can initialize one legacy split database."""
+    split_uri = f"sqlite:///{tmp_path / 'shared-conversations.db'}"
+    _create_legacy_split_database(split_uri)
+    context = multiprocessing.get_context("spawn")
+    with ProcessPoolExecutor(max_workers=4, mp_context=context) as executor:
+        futures = [
+            executor.submit(
+                _initialize_store_process,
+                f"sqlite:///{tmp_path / f'main-{index}.db'}",
+                split_uri,
+            )
+            for index in range(4)
+        ]
+        assert [future.result(timeout=60) for future in futures] == [
+            (True, True),
+            (True, True),
+            (True, True),
+            (True, True),
+        ]
+
+    engine = sa.create_engine(split_uri)
+    inspector = sa.inspect(engine)
+    assert "source_id" in {
+        column["name"] for column in inspector.get_columns("conversation_items")
+    }
+    assert "ix_conversation_items_source_id" in {
+        index["name"] for index in inspector.get_indexes("conversation_items")
+    }
+    with engine.connect() as connection:
+        versions = connection.execute(
+            sa.text("SELECT version FROM omnigent_conversation_schema_migrations")
+        ).scalars()
+        assert list(versions) == [1]
+    engine.dispose()

--- a/tests/db/test_split_conversation_schema_upgrade.py
+++ b/tests/db/test_split_conversation_schema_upgrade.py
@@ -84,6 +84,34 @@ def test_preexisting_split_database_upgrades_before_append(tmp_path: Path) -> No
         assert list(versions) == [1]
 
 
+def test_split_upgrade_replaces_wrong_shape_source_index(tmp_path: Path) -> None:
+    """A legacy same-name index is validated rather than silently stamped."""
+    main_uri = f"sqlite:///{tmp_path / 'main-wrong-index.db'}"
+    split_uri = f"sqlite:///{tmp_path / 'conversations-wrong-index.db'}"
+    legacy_engine = sa.create_engine(split_uri)
+    ConversationBase.metadata.create_all(legacy_engine)
+    with legacy_engine.begin() as connection:
+        connection.exec_driver_sql("DROP INDEX ix_conversation_items_source_id")
+        connection.exec_driver_sql(
+            "CREATE INDEX ix_conversation_items_source_id ON conversation_items (conversation_id)"
+        )
+    legacy_engine.dispose()
+
+    clear_engine_cache()
+    store = SqlAlchemyConversationStore(main_uri, split_uri)
+    indexes = {
+        index["name"]: index
+        for index in sa.inspect(store._conv_engine).get_indexes("conversation_items")
+    }
+    source_index = indexes["ix_conversation_items_source_id"]
+    assert tuple(source_index["column_names"]) == (
+        "workspace_id",
+        "conversation_id",
+        "source_id",
+    )
+    assert "source_id IS NOT NULL" in str(source_index["dialect_options"]["sqlite_where"])
+
+
 def test_concurrent_processes_serialize_split_database_upgrade(tmp_path: Path) -> None:
     """Multiple server processes can initialize one legacy split database."""
     split_uri = f"sqlite:///{tmp_path / 'shared-conversations.db'}"

--- a/tests/server/integration/test_claude_forwarder_commit_gap.py
+++ b/tests/server/integration/test_claude_forwarder_commit_gap.py
@@ -1,0 +1,80 @@
+"""Regression coverage for Claude transcript commit-gap retries."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import httpx
+import pytest
+
+from omnigent.claude_native_bridge import ClaudeTranscriptItem
+from omnigent.claude_native_forwarder import _post_external_conversation_item
+from tests.server.helpers import create_test_agent
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_claude_source_retry_is_idempotent_but_distinct_sources_are_preserved(
+    client: httpx.AsyncClient,
+) -> None:
+    """A stale cursor retry dedupes by source identity, not message text."""
+    agent = await create_test_agent(client)
+    created = await client.post("/v1/sessions", json={"agent_id": agent["id"]})
+    assert created.status_code == 201, created.text
+    session_id = created.json()["id"]
+
+    transcript_item = ClaudeTranscriptItem(
+        source_id="claude-record-uuid:0:message",
+        item_type="message",
+        data={
+            "role": "assistant",
+            "agent": "claude-code",
+            "content": [{"type": "output_text", "text": "commit-gap-marker"}],
+        },
+        response_id="resp_claude_record_uuid",
+    )
+
+    # First forwarder process: the server commits, then the process dies before
+    # transcript_forwarder.json records source_id/cursor advancement.
+    await _post_external_conversation_item(
+        client,
+        session_id=session_id,
+        item=transcript_item,
+    )
+    # Restarted process: stale durable state re-reads and reposts the same source.
+    await _post_external_conversation_item(
+        client,
+        session_id=session_id,
+        item=transcript_item,
+    )
+
+    response = await client.get(f"/v1/sessions/{session_id}/items")
+    assert response.status_code == 200, response.text
+    matching = [
+        item
+        for item in response.json()["data"]
+        if item["type"] == "message"
+        and any(block.get("text") == "commit-gap-marker" for block in item.get("content", []))
+    ]
+    assert len(matching) == 1, (
+        "one Claude transcript source produced multiple durable items: "
+        f"{[item['id'] for item in matching]}"
+    )
+
+    # Identical visible content from a distinct transcript record remains a
+    # distinct conversation item; text is not the idempotency key.
+    await _post_external_conversation_item(
+        client,
+        session_id=session_id,
+        item=replace(transcript_item, source_id="claude-record-uuid-2:0:message"),
+    )
+    response = await client.get(f"/v1/sessions/{session_id}/items")
+    assert response.status_code == 200, response.text
+    matching = [
+        item
+        for item in response.json()["data"]
+        if item["type"] == "message"
+        and any(block.get("text") == "commit-gap-marker" for block in item.get("content", []))
+    ]
+    assert len(matching) == 2
+    assert len({item["id"] for item in matching}) == 2

--- a/tests/server/integration/test_claude_forwarder_commit_gap.py
+++ b/tests/server/integration/test_claude_forwarder_commit_gap.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import replace
+from pathlib import Path
 
 import httpx
 import pytest
+from fastapi import FastAPI
 
+from omnigent import claude_native_forwarder as forwarder
 from omnigent.claude_native_bridge import ClaudeTranscriptItem
-from omnigent.claude_native_forwarder import _post_external_conversation_item
 from omnigent.runtime import pending_inputs
+from omnigent.server import app as app_module
 from tests.server.helpers import create_test_agent
 
 pytestmark = pytest.mark.asyncio
@@ -37,13 +41,13 @@ async def test_claude_source_retry_is_idempotent_but_distinct_sources_are_preser
 
     # First forwarder process: the server commits, then the process dies before
     # transcript_forwarder.json records source_id/cursor advancement.
-    await _post_external_conversation_item(
+    await forwarder._post_external_conversation_item(
         client,
         session_id=session_id,
         item=transcript_item,
     )
     # Restarted process: stale durable state re-reads and reposts the same source.
-    await _post_external_conversation_item(
+    await forwarder._post_external_conversation_item(
         client,
         session_id=session_id,
         item=transcript_item,
@@ -64,7 +68,7 @@ async def test_claude_source_retry_is_idempotent_but_distinct_sources_are_preser
 
     # Identical visible content from a distinct transcript record remains a
     # distinct conversation item; text is not the idempotency key.
-    await _post_external_conversation_item(
+    await forwarder._post_external_conversation_item(
         client,
         session_id=session_id,
         item=replace(transcript_item, source_id="claude-record-uuid-2:0:message"),
@@ -99,7 +103,11 @@ async def test_committed_source_retry_does_not_drain_newer_pending_input(
         response_id="resp_a",
     )
 
-    await _post_external_conversation_item(client, session_id=session_id, item=source_a)
+    await forwarder._post_external_conversation_item(
+        client,
+        session_id=session_id,
+        item=source_a,
+    )
     pending_b = pending_inputs.record(
         session_id,
         [
@@ -109,7 +117,11 @@ async def test_committed_source_retry_does_not_drain_newer_pending_input(
         created_by="bob@example.com",
     )
     try:
-        await _post_external_conversation_item(client, session_id=session_id, item=source_a)
+        await forwarder._post_external_conversation_item(
+            client,
+            session_id=session_id,
+            item=source_a,
+        )
 
         pending = pending_inputs.snapshot_for(session_id)
         assert [entry["pending_id"] for entry in pending] == [pending_b]
@@ -126,3 +138,121 @@ async def test_committed_source_retry_does_not_drain_newer_pending_input(
         assert all(block.get("file_id") != "file_b" for block in matching_a[0]["content"])
     finally:
         pending_inputs.reset_for_tests()
+
+
+async def test_spa_packaged_old_server_keeps_parent_and_subagent_retryable(
+    tmp_path: Path,
+) -> None:
+    """Exercise the bundled-SPA fallback used by old packaged servers."""
+    web_ui_dist = tmp_path / "web-ui"
+    web_ui_dist.mkdir()
+    (web_ui_dist / "index.html").write_text(
+        "<!doctype html><div id='root'></div>",
+        encoding="utf-8",
+    )
+    old_app = FastAPI()
+
+    @old_app.post("/v1/sessions/{session_id}/events")
+    async def legacy_events(session_id: str) -> dict[str, bool]:
+        """Represent the only event route present in the old package."""
+        assert session_id
+        return {"queued": False}
+
+    old_app.mount(
+        "/",
+        app_module._SPAStaticFiles(directory=web_ui_dist, html=True),
+    )
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript_path = tmp_path / "parent.jsonl"
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "uuid": "spa-parent-source",
+                "message": {"role": "assistant", "content": "parent output"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    parent_state = forwarder.TranscriptForwardState(
+        transcript_path=transcript_path,
+        line_cursor=0,
+        byte_offset=0,
+        cursor_fingerprint=forwarder._jsonl_cursor_fingerprint(transcript_path, 0),
+    )
+
+    subagents_dir = transcript_path.parent / transcript_path.stem / "subagents"
+    subagents_dir.mkdir(parents=True)
+    child_path = subagents_dir / "agent-spa-child.jsonl"
+    child_path.write_text(
+        json.dumps(
+            {
+                "isSidechain": True,
+                "type": "assistant",
+                "uuid": "spa-child-source",
+                "message": {"role": "assistant", "content": "child output"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    subagent_state = forwarder.SubagentForwardState(
+        subagents={
+            "spa-child": forwarder.SubagentEntry(
+                subagent_id="spa-child",
+                child_conversation_id="conv_spa_child",
+            )
+        }
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=old_app),
+        base_url="http://old-package",
+    ) as old_client:
+        probe = await old_client.post(
+            "/v1/sessions/conv_spa_parent/events/source-id-v1",
+            json={"type": "external_conversation_item", "data": {"source_id": "probe"}},
+        )
+        assert probe.status_code == 404
+        assert probe.json() == {
+            "error": {
+                "code": "not_found",
+                "message": "Not found",
+            }
+        }
+
+        parent_result = await forwarder._forward_available_items(
+            client=old_client,
+            session_id="conv_spa_parent",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=parent_state,
+            retry_tracker=forwarder._PostRetryTracker(
+                base_delay_s=0.0,
+                max_delay_s=0.0,
+            ),
+            dedupe=forwarder._ForwardDedupeState(),
+        )
+        subagent_result = await forwarder._forward_available_subagents(
+            client=old_client,
+            parent_session_id="conv_spa_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=subagent_state,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(
+                base_delay_s=0.0,
+                max_delay_s=0.0,
+            ),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+    assert parent_result.byte_offset == 0
+    assert parent_result.seen_source_ids == ()
+    child_result = subagent_result.subagents["spa-child"]
+    assert child_result.byte_offset == 0
+    assert child_result.seen_source_ids == ()

--- a/tests/server/integration/test_claude_forwarder_commit_gap.py
+++ b/tests/server/integration/test_claude_forwarder_commit_gap.py
@@ -9,6 +9,7 @@ import pytest
 
 from omnigent.claude_native_bridge import ClaudeTranscriptItem
 from omnigent.claude_native_forwarder import _post_external_conversation_item
+from omnigent.runtime import pending_inputs
 from tests.server.helpers import create_test_agent
 
 pytestmark = pytest.mark.asyncio
@@ -22,6 +23,9 @@ async def test_claude_source_retry_is_idempotent_but_distinct_sources_are_preser
     created = await client.post("/v1/sessions", json={"agent_id": agent["id"]})
     assert created.status_code == 201, created.text
     session_id = created.json()["id"]
+    capabilities = await client.get("/v1/native-forwarder-capabilities")
+    assert capabilities.status_code == 200
+    assert capabilities.json()["external_conversation_item_source_id_idempotency"] is True
 
     transcript_item = ClaudeTranscriptItem(
         source_id="claude-record-uuid:0:message",
@@ -78,3 +82,50 @@ async def test_claude_source_retry_is_idempotent_but_distinct_sources_are_preser
     ]
     assert len(matching) == 2
     assert len({item["id"] for item in matching}) == 2
+
+
+async def test_committed_source_retry_does_not_drain_newer_pending_input(
+    client: httpx.AsyncClient,
+) -> None:
+    """Retrying committed A must leave the newer optimistic input B intact."""
+    agent = await create_test_agent(client)
+    created = await client.post("/v1/sessions", json={"agent_id": agent["id"]})
+    assert created.status_code == 201, created.text
+    session_id = created.json()["id"]
+    source_a = ClaudeTranscriptItem(
+        source_id="claude-user-a:0:message",
+        item_type="message",
+        data={
+            "role": "user",
+            "content": [{"type": "input_text", "text": "message A"}],
+        },
+        response_id="resp_a",
+    )
+
+    await _post_external_conversation_item(client, session_id=session_id, item=source_a)
+    pending_b = pending_inputs.record(
+        session_id,
+        [
+            {"type": "input_image", "file_id": "file_b", "filename": "b.png"},
+            {"type": "input_text", "text": "message B"},
+        ],
+        created_by="bob@example.com",
+    )
+    try:
+        await _post_external_conversation_item(client, session_id=session_id, item=source_a)
+
+        pending = pending_inputs.snapshot_for(session_id)
+        assert [entry["pending_id"] for entry in pending] == [pending_b]
+        assert pending[0]["created_by"] == "bob@example.com"
+        assert pending[0]["content"][0]["file_id"] == "file_b"
+        response = await client.get(f"/v1/sessions/{session_id}/items")
+        matching_a = [
+            item
+            for item in response.json()["data"]
+            if item["type"] == "message"
+            and any(block.get("text") == "message A" for block in item.get("content", []))
+        ]
+        assert len(matching_a) == 1
+        assert all(block.get("file_id") != "file_b" for block in matching_a[0]["content"])
+    finally:
+        pending_inputs.reset_for_tests()

--- a/tests/server/integration/test_claude_forwarder_commit_gap.py
+++ b/tests/server/integration/test_claude_forwarder_commit_gap.py
@@ -23,9 +23,6 @@ async def test_claude_source_retry_is_idempotent_but_distinct_sources_are_preser
     created = await client.post("/v1/sessions", json={"agent_id": agent["id"]})
     assert created.status_code == 201, created.text
     session_id = created.json()["id"]
-    capabilities = await client.get("/v1/native-forwarder-capabilities")
-    assert capabilities.status_code == 200
-    assert capabilities.json()["external_conversation_item_source_id_idempotency"] is True
 
     transcript_item = ClaudeTranscriptItem(
         source_id="claude-record-uuid:0:message",

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -214,6 +214,10 @@ class _ConversationStore:
             result.append(persisted)
         return result
 
+    def get_item_by_source_id(self, conversation_id: str, source_id: str) -> None:
+        """The route-test fake has no durable external-source index."""
+        del conversation_id, source_id
+
     def list_items(
         self,
         conversation_id: str,

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -1193,7 +1193,9 @@ async def test_forwarder_posts_visible_transcript_items(tmp_path: Path) -> None:
         server.server_close()
         thread.join(timeout=5.0)
 
-    assert [request["path"] for request in requests] == ["/v1/sessions/conv_abc/events"] * 7
+    assert [request["path"] for request in requests] == [
+        "/v1/sessions/conv_abc/events/source-id-v1"
+    ] * 7
     assert [request["body"]["type"] for request in requests] == ["external_conversation_item"] * 7
     posted = [request["body"]["data"] for request in requests]
     assert [item["item_type"] for item in posted] == [
@@ -1394,7 +1396,7 @@ async def test_forwarder_posts_web_injected_terminal_transcript_items(tmp_path: 
         server.server_close()
         thread.join(timeout=5.0)
 
-    assert request["path"] == "/v1/sessions/conv_abc/events"
+    assert request["path"] == "/v1/sessions/conv_abc/events/source-id-v1"
     assert request["body"]["type"] == "external_conversation_item"
     assert request["body"]["data"]["item_type"] == "message"
     assert request["body"]["data"]["item_data"] == {
@@ -3052,17 +3054,12 @@ async def test_forwarder_drops_poison_item_after_bounded_permanent_retries(
 
 
 @pytest.mark.asyncio
-async def test_forwarder_skips_ambiguous_item_for_older_server(tmp_path: Path) -> None:
+async def test_forwarder_waits_when_versioned_post_hits_older_server(tmp_path: Path) -> None:
     """
-    An ambiguous POST failure stays conservative with an older server.
+    A rolling-deployment old target rejects before commit and leaves state.
 
-    A mixed-version deployment can run a new forwarder against a server
-    that does not advertise source-keyed idempotency. Retrying there could
-    duplicate a committed item, so the compatibility behavior remains the
-    historical conservative skip.
-
-    A failure here (the item POSTed twice across two polls) is exactly
-    the duplicate-user-message regression this guards against.
+    The next attempt may hit a new target and commit once. There is no
+    capability request that can race against a different POST replica.
     """
     bridge_dir = tmp_path / "bridge"
     transcript_path = tmp_path / "session.jsonl"
@@ -3088,25 +3085,19 @@ async def test_forwarder_skips_ambiguous_item_for_older_server(tmp_path: Path) -
 
     def _handle_request(request: httpx.Request) -> httpx.Response:
         """
-        Record the POST, then fail the item POST with a read timeout.
-
-        The timeout stands in for "server committed, response lost" —
-        the ambiguous case where a blind retry duplicates.
+        Route the first POST to an old server and the second to a new one.
 
         :param request: Outbound HTTP request from the forwarder.
         :returns: HTTP response (never reached for the item POST).
-        :raises httpx.ReadTimeout: For every ``external_conversation_item``
-            POST, simulating a lost response.
         """
-        if request.method == "GET":
-            assert request.url.path == "/v1/native-forwarder-capabilities"
-            return httpx.Response(404, json={"detail": "Not Found"})
+        assert request.method == "POST"
+        assert request.url.path.endswith("/events/source-id-v1")
         payload = json.loads(request.content.decode("utf-8"))
         assert isinstance(payload, dict)
         requests.append(payload)
-        if payload["type"] == "external_conversation_item":
-            raise httpx.ReadTimeout("response lost", request=request)
-        return httpx.Response(202, json={})
+        if len(requests) == 1:
+            return httpx.Response(404, json={"detail": "Not Found"})
+        return httpx.Response(202, json={"item_id": "msg_once"})
 
     transport = httpx.MockTransport(_handle_request)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
@@ -3130,24 +3121,16 @@ async def test_forwarder_skips_ambiguous_item_for_older_server(tmp_path: Path) -
             dedupe=dedupe,
         )
 
-    item_posts = [r for r in requests if r["type"] == "external_conversation_item"]
-    # The item was POSTed exactly once. If the ambiguous-failure skip
-    # were missing, the second poll would re-read offset 0 and POST it
-    # again (len 2) — the duplicate user bubble.
-    assert len(item_posts) == 1
-    # No "failed" status: unlike a permanent 4xx rejection, an ambiguous
-    # failure most likely succeeded, so we must not flag the turn failed.
-    assert all(r["type"] != "external_session_status" for r in requests)
-    # Cursor advanced past the item and it is recorded as handled, so it
-    # is not re-read on subsequent polls.
-    assert first.byte_offset == transcript_path.stat().st_size
-    assert first.seen_source_ids == ("user-msg-1:0:message",)
+    assert len(requests) == 2
+    assert first.byte_offset == 0
+    assert first.seen_source_ids == ()
     assert second.byte_offset == transcript_path.stat().st_size
+    assert second.seen_source_ids == ("user-msg-1:0:message",)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("commit_before_response_loss", [True, False])
-async def test_forwarder_retries_ambiguous_item_when_server_advertises_idempotency(
+async def test_forwarder_retries_ambiguous_item_on_versioned_route(
     tmp_path: Path,
     commit_before_response_loss: bool,
 ) -> None:
@@ -3176,12 +3159,8 @@ async def test_forwarder_retries_ambiguous_item_when_server_advertises_idempoten
     item_posts: list[dict[str, Any]] = []
 
     def _handle_request(request: httpx.Request) -> httpx.Response:
-        if request.method == "GET":
-            assert request.url.path == "/v1/native-forwarder-capabilities"
-            return httpx.Response(
-                200,
-                json={"external_conversation_item_source_id_idempotency": True},
-            )
+        assert request.method == "POST"
+        assert request.url.path.endswith("/events/source-id-v1")
         payload = json.loads(request.content.decode("utf-8"))
         assert payload["type"] == "external_conversation_item"
         item_posts.append(payload)
@@ -5226,8 +5205,8 @@ async def test_subagent_watcher_forwards_transcript_items_to_child_session(
     try:
         # We need: the start event + at least one item event addressed
         # to the child. Drain up to N requests and collect every
-        # request bound for the child's ``/events`` path.
-        child_path = "/v1/sessions/conv_child_beta/events"
+        # request bound for the child's versioned item path.
+        child_path = "/v1/sessions/conv_child_beta/events/source-id-v1"
         child_requests: list[dict[str, Any]] = []
         for _ in range(40):
             req = await _get_recorded_request(server)
@@ -5356,6 +5335,154 @@ async def test_subagent_watcher_retry_skips_previously_posted_items(
         "sa-user-retry:0:message",
         "sa-assistant-retry:0:message",
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("commit_before_response_loss", [True, False])
+async def test_subagent_retries_ambiguous_source_item_idempotently(
+    tmp_path: Path,
+    commit_before_response_loss: bool,
+) -> None:
+    """The subagent state loop retains and safely retries ambiguous items."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    subagent_jsonl = _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="ambiguous1",
+        agent_type="Explore",
+        description="ambiguous child delivery",
+        tool_use_id="toolu_ambiguous",
+        transcript_records=[
+            {
+                "isSidechain": True,
+                "type": "assistant",
+                "uuid": "sa-ambiguous",
+                "message": {"role": "assistant", "content": "child output"},
+            }
+        ],
+    )
+    state = forwarder.SubagentForwardState(
+        subagents={
+            "ambiguous1": forwarder.SubagentEntry(
+                subagent_id="ambiguous1",
+                child_conversation_id="conv_child_ambiguous",
+            )
+        }
+    )
+    committed: set[str] = set()
+    item_posts: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        if body["type"] != "external_conversation_item":
+            return httpx.Response(202, json={})
+        assert request.url.path.endswith("/events/source-id-v1")
+        source_id = body["data"]["source_id"]
+        item_posts.append(source_id)
+        if len(item_posts) == 1:
+            if commit_before_response_loss:
+                committed.add(source_id)
+            raise httpx.ReadTimeout("response lost", request=request)
+        committed.add(source_id)
+        return httpx.Response(202, json={"item_id": "msg_child"})
+
+    tracker = forwarder._PostRetryTracker(base_delay_s=0.0, max_delay_s=0.0)
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        first = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=state,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=tracker,
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+        second = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=first,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=tracker,
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+    first_child = first.subagents["ambiguous1"]
+    assert first_child.byte_offset == 0
+    assert first_child.seen_source_ids == ()
+    second_child = second.subagents["ambiguous1"]
+    assert second_child.byte_offset == subagent_jsonl.stat().st_size
+    assert second_child.seen_source_ids == ("sa-ambiguous:0:message",)
+    assert item_posts == ["sa-ambiguous:0:message", "sa-ambiguous:0:message"]
+    assert committed == {"sa-ambiguous:0:message"}
+
+
+@pytest.mark.asyncio
+async def test_subagent_old_server_reject_keeps_source_unseen(tmp_path: Path) -> None:
+    """An old server's unknown-route response cannot consume child state."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="oldserver1",
+        agent_type="Explore",
+        description="rolling deploy",
+        tool_use_id="toolu_oldserver",
+        transcript_records=[
+            {
+                "isSidechain": True,
+                "type": "assistant",
+                "uuid": "sa-old-server",
+                "message": {"role": "assistant", "content": "wait for rollout"},
+            }
+        ],
+    )
+    state = forwarder.SubagentForwardState(
+        subagents={
+            "oldserver1": forwarder.SubagentEntry(
+                subagent_id="oldserver1",
+                child_conversation_id="conv_child_oldserver",
+            )
+        }
+    )
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        assert request.url.path.endswith("/events/source-id-v1")
+        return httpx.Response(404, json={"detail": "Not Found"})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        result = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=state,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+    child = result.subagents["oldserver1"]
+    assert len(requests) == 1
+    assert child.byte_offset == 0
+    assert child.seen_source_ids == ()
 
 
 async def test_subagent_watcher_skips_subagents_already_in_state(

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -1233,6 +1233,7 @@ async def test_forwarder_posts_visible_transcript_items(tmp_path: Path) -> None:
     assert posted[5]["response_id"] == posted[6]["response_id"]
     assert posted[5]["response_id"] != posted[4]["response_id"]
     assert posted[1]["response_id"].startswith("resp_claude_")
+    assert len({item["source_id"] for item in posted}) == len(posted)
 
 
 @pytest.mark.asyncio

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -3054,14 +3054,17 @@ async def test_forwarder_drops_poison_item_after_bounded_permanent_retries(
 
 
 @pytest.mark.asyncio
-async def test_forwarder_waits_when_versioned_post_hits_older_server(tmp_path: Path) -> None:
+async def test_forwarder_waits_when_versioned_post_hits_older_server(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """
     A rolling-deployment old target rejects before commit and leaves state.
 
     The next attempt may hit a new target and commit once. There is no
     capability request that can race against a different POST replica.
     """
-    bridge_dir = tmp_path / "bridge"
+    bridge_dir = tmp_path / "secret-bridge-path"
     transcript_path = tmp_path / "session.jsonl"
     transcript_path.write_text(
         json.dumps(
@@ -3082,6 +3085,7 @@ async def test_forwarder_waits_when_versioned_post_hits_older_server(tmp_path: P
     )
     retry_tracker = forwarder._PostRetryTracker(base_delay_s=0.0, max_delay_s=0.0)
     requests: list[dict[str, Any]] = []
+    caplog.set_level(logging.WARNING, logger="omnigent.claude_native_forwarder")
 
     def _handle_request(request: httpx.Request) -> httpx.Response:
         """
@@ -3126,6 +3130,10 @@ async def test_forwarder_waits_when_versioned_post_hits_older_server(tmp_path: P
     assert first.seen_source_ids == ()
     assert second.byte_offset == transcript_path.stat().st_size
     assert second.seen_source_ids == ("user-msg-1:0:message",)
+    assert "retaining it for retry after rollout" in caplog.text
+    assert str(bridge_dir) not in caplog.text
+    assert "hello while busy" not in caplog.text
+    assert "Not Found" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -3052,19 +3052,14 @@ async def test_forwarder_drops_poison_item_after_bounded_permanent_retries(
 
 
 @pytest.mark.asyncio
-async def test_forwarder_skips_user_item_on_ambiguous_post_failure(tmp_path: Path) -> None:
+async def test_forwarder_skips_ambiguous_item_for_older_server(tmp_path: Path) -> None:
     """
-    An ambiguous POST failure skips the item instead of re-posting it.
+    An ambiguous POST failure stays conservative with an older server.
 
-    A user message typed while Claude is busy round-trips through the
-    transcript and is POSTed as an ``external_conversation_item``. If
-    that POST's response is lost (e.g. a read timeout AFTER the server
-    appended the item and published ``session.input.consumed``), the
-    server has already committed it — and external items are not deduped
-    server-side. Retrying would append a second copy and re-publish the
-    consume event, producing a duplicate user bubble in the web UI.
-    The forwarder must instead treat the item as delivered:
-    mark it handled, advance the byte cursor, and never re-POST it.
+    A mixed-version deployment can run a new forwarder against a server
+    that does not advertise source-keyed idempotency. Retrying there could
+    duplicate a committed item, so the compatibility behavior remains the
+    historical conservative skip.
 
     A failure here (the item POSTed twice across two polls) is exactly
     the duplicate-user-message regression this guards against.
@@ -3103,6 +3098,9 @@ async def test_forwarder_skips_user_item_on_ambiguous_post_failure(tmp_path: Pat
         :raises httpx.ReadTimeout: For every ``external_conversation_item``
             POST, simulating a lost response.
         """
+        if request.method == "GET":
+            assert request.url.path == "/v1/native-forwarder-capabilities"
+            return httpx.Response(404, json={"detail": "Not Found"})
         payload = json.loads(request.content.decode("utf-8"))
         assert isinstance(payload, dict)
         requests.append(payload)
@@ -3145,6 +3143,84 @@ async def test_forwarder_skips_user_item_on_ambiguous_post_failure(tmp_path: Pat
     assert first.byte_offset == transcript_path.stat().st_size
     assert first.seen_source_ids == ("user-msg-1:0:message",)
     assert second.byte_offset == transcript_path.stat().st_size
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("commit_before_response_loss", [True, False])
+async def test_forwarder_retries_ambiguous_item_when_server_advertises_idempotency(
+    tmp_path: Path,
+    commit_before_response_loss: bool,
+) -> None:
+    """An upgraded server safely resolves both ambiguous delivery outcomes."""
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "uuid": "ambiguous-item",
+                "message": {"role": "assistant", "content": "ambiguous delivery"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    state = forwarder.TranscriptForwardState(
+        transcript_path=transcript_path,
+        line_cursor=0,
+        byte_offset=0,
+        cursor_fingerprint=forwarder._jsonl_cursor_fingerprint(transcript_path, 0),
+    )
+    retry_tracker = forwarder._PostRetryTracker(base_delay_s=0.0, max_delay_s=0.0)
+    committed_sources: set[str] = set()
+    item_posts: list[dict[str, Any]] = []
+
+    def _handle_request(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            assert request.url.path == "/v1/native-forwarder-capabilities"
+            return httpx.Response(
+                200,
+                json={"external_conversation_item_source_id_idempotency": True},
+            )
+        payload = json.loads(request.content.decode("utf-8"))
+        assert payload["type"] == "external_conversation_item"
+        item_posts.append(payload)
+        source_id = payload["data"]["source_id"]
+        if len(item_posts) == 1:
+            if commit_before_response_loss:
+                committed_sources.add(source_id)
+            raise httpx.ReadTimeout("response lost", request=request)
+        committed_sources.add(source_id)
+        return httpx.Response(202, json={})
+
+    transport = httpx.MockTransport(_handle_request)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        dedupe = forwarder._ForwardDedupeState()
+        first = await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_abc",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=state,
+            retry_tracker=retry_tracker,
+            dedupe=dedupe,
+        )
+        second = await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_abc",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=first,
+            retry_tracker=retry_tracker,
+            dedupe=dedupe,
+        )
+
+    assert first.byte_offset == 0
+    assert first.seen_source_ids == ()
+    assert second.byte_offset == transcript_path.stat().st_size
+    assert second.seen_source_ids == ("ambiguous-item:0:message",)
+    assert len(item_posts) == 2
+    assert committed_sources == {"ambiguous-item:0:message"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -3129,6 +3129,87 @@ async def test_forwarder_waits_when_versioned_post_hits_older_server(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_forwarder_domain_404_drops_item_and_continues(tmp_path: Path) -> None:
+    """A new-server session 404 is definitive, not a rollout retry."""
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "uuid": "missing-session-item",
+                        "message": {"role": "assistant", "content": "first"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "uuid": "later-item",
+                        "message": {"role": "assistant", "content": "second"},
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    state = forwarder.TranscriptForwardState(
+        transcript_path=transcript_path,
+        line_cursor=0,
+        byte_offset=0,
+        cursor_fingerprint=forwarder._jsonl_cursor_fingerprint(transcript_path, 0),
+    )
+    requests: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode("utf-8"))
+        requests.append(payload)
+        if payload["type"] == "external_session_status":
+            return httpx.Response(202, json={})
+        if payload["data"]["source_id"] == "missing-session-item:0:message":
+            return httpx.Response(
+                404,
+                json={
+                    "error": {
+                        "code": "not_found",
+                        "message": "Session does not exist",
+                    }
+                },
+            )
+        return httpx.Response(202, json={"item_id": "msg_later"})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://test",
+    ) as client:
+        result = await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_missing",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=state,
+            retry_tracker=forwarder._PostRetryTracker(
+                max_permanent_attempts=1,
+                base_delay_s=0.0,
+            ),
+            dedupe=forwarder._ForwardDedupeState(),
+        )
+
+    assert [request["type"] for request in requests] == [
+        "external_conversation_item",
+        "external_session_status",
+        "external_conversation_item",
+    ]
+    assert result.byte_offset == transcript_path.stat().st_size
+    assert result.seen_source_ids == (
+        "missing-session-item:0:message",
+        "later-item:0:message",
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("commit_before_response_loss", [True, False])
 async def test_forwarder_retries_ambiguous_item_on_versioned_route(
     tmp_path: Path,
@@ -5483,6 +5564,93 @@ async def test_subagent_old_server_reject_keeps_source_unseen(tmp_path: Path) ->
     assert len(requests) == 1
     assert child.byte_offset == 0
     assert child.seen_source_ids == ()
+
+
+@pytest.mark.asyncio
+async def test_subagent_domain_404_drops_item_and_continues(tmp_path: Path) -> None:
+    """A new-server session 404 does not park the child transcript."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    subagent_jsonl = _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="missingchild1",
+        agent_type="Explore",
+        description="missing child session",
+        tool_use_id="toolu_missingchild",
+        transcript_records=[
+            {
+                "isSidechain": True,
+                "type": "assistant",
+                "uuid": "sa-missing-session",
+                "message": {"role": "assistant", "content": "first"},
+            },
+            {
+                "isSidechain": True,
+                "type": "assistant",
+                "uuid": "sa-later",
+                "message": {"role": "assistant", "content": "second"},
+            },
+        ],
+    )
+    state = forwarder.SubagentForwardState(
+        subagents={
+            "missingchild1": forwarder.SubagentEntry(
+                subagent_id="missingchild1",
+                child_conversation_id="conv_child_missing",
+            )
+        }
+    )
+    item_sources: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode("utf-8"))
+        if payload["type"] != "external_conversation_item":
+            return httpx.Response(202, json={})
+        source_id = payload["data"]["source_id"]
+        item_sources.append(source_id)
+        if source_id == "sa-missing-session:0:message":
+            return httpx.Response(
+                404,
+                json={
+                    "error": {
+                        "code": "not_found",
+                        "message": "Session does not exist",
+                    }
+                },
+            )
+        return httpx.Response(202, json={"item_id": "msg_later"})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        result = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=state,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(
+                max_permanent_attempts=1,
+                base_delay_s=0.0,
+            ),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+    child = result.subagents["missingchild1"]
+    assert item_sources == [
+        "sa-missing-session:0:message",
+        "sa-later:0:message",
+    ]
+    assert child.byte_offset == subagent_jsonl.stat().st_size
+    assert child.seen_source_ids == (
+        "sa-missing-session:0:message",
+        "sa-later:0:message",
+    )
 
 
 async def test_subagent_watcher_skips_subagents_already_in_state(


### PR DESCRIPTION
## Summary

- persist Claude transcript `source_id` and deduplicate commit-gap retries
- use a versioned POST so old replicas reject before commit and upgraded replicas retry idempotently
- recognize both exact old-server unmatched-route envelopes, including the bundled-SPA package path
- retain definitive bounded handling for upgraded-server missing/inaccessible-session 404s
- make combined and split database upgrades versioned, serialized, shape-validating, and restartable
- resolve committed retries before pending-input reconciliation

## Reproduction and fix

The original `origin/main` reproducer posted one `ClaudeTranscriptItem` twice after a simulated commit/cursor gap and produced two durable conversation items. The server now persists stable source identity and resolves retries under the conversation serialization boundary while preserving distinct sources with identical text.

New forwarders send source-keyed parent and subagent items only to:

```text
POST /v1/sessions/{session_id}/events/source-id-v1
```

There is no capability GET and no fallback to the legacy item POST. An upgraded target accepts this route and deduplicates ambiguous committed/uncommitted retries. An old target rejects before dispatch; the forwarder retains cursor and seen-source state.

## Mixed-version 404 classification

Old packages have two exact unmatched-route responses:

```json
{"detail":"Not Found"}
```

```json
{"error":{"code":"not_found","message":"Not found"}}
```

The second response is produced by the bundled SPA's API fallback. The classifier requires HTTP 404, JSON content type, and exact equality with one of these generic payloads. Upgraded-server missing/inaccessible-session errors carry a specific Omnigent domain message, remain definitive permanent failures, advance/dead-letter after their bounded retry budget, and do not block later records.

A new integration regression mounts the real `_SPAStaticFiles` fallback behind an old-style event route and exercises `_forward_available_items` plus `_forward_available_subagents` through `httpx.ASGITransport`—not `MockTransport`. It verifies the real packaged envelope and proves valid parent/child records remain unseen with byte offsets retained. Existing parent/subagent tests continue to prove new-server domain 404s terminate and later records proceed.

Recommended rollout remains server route/migration first, then forwarder. Mixed-version overlap is safe because old targets reject before mutation and new targets commit once.

## Migration behavior

PostgreSQL source-index creation is concurrent, partial, outside the migration transaction, and repairs interrupted/invalid/wrong-shape artifacts. SQLite, MySQL, and other supported dialects introspect columns/indexes before upgrade and downgrade, reuse only the expected index shape, rebuild incompatible same-name indexes, and tolerate already-committed DDL without an Alembic stamp.

Split databases use their own version table and backend-native schema locks (`BEGIN EXCLUSIVE`, PostgreSQL advisory lock, or MySQL named lock), with concurrent-process and wrong-shape regressions.

## Verification

- [x] Packaged-SPA and domain-404 focused tests: `5 passed`
- [x] Broad forwarder/integration/migration/database suite: `216 passed`
- [x] Portable migration suite and full SQLite Alembic chain
- [x] PostgreSQL, SQLite, and MySQL DDL checks
- [x] Ruff check and format check
- [x] Pyrefly: `0 errors`

## Remaining risks

- PostgreSQL concurrent DDL/advisory locking and MySQL named locking were not exercised against live database servers in this PR; they are compiler/state-machine tested.
- The old-server classifier deliberately accepts only the two observed exact generic JSON envelopes. A proxy that rewrites them is treated as a definitive failure rather than risking an indefinite retry of a domain 404.