### PR TITLE
Update color theme info in embedded app

### DIFF
--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -851,7 +851,7 @@ function AppearanceSection() {
           <div className="flex flex-col gap-3">
             <span className="text-ui font-medium">Theme</span>
             <p className="text-sm text-muted-foreground">
-              Light and dark mode are controlled by the host application.
+              Light and dark mode are configured in Databricks preferences.
               {themeSettingsUrl ? (
                 <>
                   {" "}
@@ -859,7 +859,7 @@ function AppearanceSection() {
                     href={themeSettingsUrl}
                     className="font-medium text-primary underline underline-offset-2 hover:text-primary/80"
                   >
-                    Change it in your settings
+                    Click to open Databricks user preferences page.
                   </a>
                   .
                 </>


### PR DESCRIPTION
## Related issue

N/A — copy-only UI tweak, no tracked issue.

## Summary

Updates the Theme copy in the embedded app's **Settings → Appearance** section to reference Databricks specifically instead of the generic "host application" wording:

- Body text: "Light and dark mode are controlled by the host application." → "Light and dark mode are configured in Databricks preferences."
- Link text: "Change it in your settings" → "Click to open Databricks user preferences page."

Only the embedded (`isEmbedded`) variant is affected; the standalone `ModeControl` path is unchanged.

## Test Plan

- Open the app embedded in Databricks and go to **Settings → Appearance**.
- Confirm the Theme section shows the new copy.
- With a theme-settings URL configured, confirm the link reads "Click to open Databricks user preferences page." and opens the Databricks user preferences page.

## Demo

Text-only change; screenshot of **Settings → Appearance** (embedded):

- Before: "Light and dark mode are controlled by the host application. Change it in your settings."
- After: "Light and dark mode are configured in Databricks preferences. Click to open Databricks user preferences page."

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Static copy-only change to already-existing conditional rendering — no logic or behavior changed, so no automated coverage was added.

## Changelog

Embedded app Appearance settings now point to Databricks preferences for the light/dark theme.
