### PR TITLE
chore(packaging): declare Apache-2.0 license metdata in sdk sub-package…

### DIFF
--- a/integrations/slack/LICENSE
+++ b/integrations/slack/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/integrations/slack/pyproject.toml
+++ b/integrations/slack/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]

--- a/integrations/slack/pyproject.toml
+++ b/integrations/slack/pyproject.toml
@@ -7,6 +7,8 @@ name = "omnigent-slack"
 version = "0.12.0.dev0"
 description = "Slack Socket Mode bot that drives Omnigent sessions."
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.12"
 dependencies = [
     "aiosqlite>=0.21.0",

--- a/sdks/python-client/LICENSE
+++ b/sdks/python-client/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/sdks/python-client/pyproject.toml
+++ b/sdks/python-client/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]

--- a/sdks/python-client/pyproject.toml
+++ b/sdks/python-client/pyproject.toml
@@ -7,6 +7,8 @@ name = "omnigent-client"
 version = "0.12.0.dev0"
 description = "Python client SDK for the omnigent server API"
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.12"
 dependencies = [
     # Sibling package — provides the SessionStreamEventType /

--- a/sdks/ui/LICENSE
+++ b/sdks/ui/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/sdks/ui/pyproject.toml
+++ b/sdks/ui/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]

--- a/sdks/ui/pyproject.toml
+++ b/sdks/ui/pyproject.toml
@@ -7,6 +7,8 @@ name = "omnigent-ui-sdk"
 version = "0.12.0.dev0"
 description = "Terminal UI components (Rich + prompt_toolkit) for building omnigent frontends"
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.12"
 dependencies = [
     # Version-locked (==) with the sibling client SDK; released together

--- a/tests/e2e/test_sdk_wheel_license_metadata_e2e.py
+++ b/tests/e2e/test_sdk_wheel_license_metadata_e2e.py
@@ -1,0 +1,176 @@
+"""Sub-package wheels must carry license metadata.
+
+Corporate license/SCA scanners (FOSSA, Black Duck, ...) block installing
+``omnigent-client`` / ``omnigent-ui-sdk`` / ``omnigent-slack`` because the
+wheels' core METADATA has no ``License-Expression``, ``License-File``, or
+``License ::`` classifier — even though the repo root is Apache-2.0.
+
+The wheels are built by hatchling straight from each sub-package's
+``pyproject.toml`` ``[project]`` table, so the reproduction/guard is
+two-layered:
+
+* a static check that each sub-package's ``pyproject.toml`` declares a
+  license (PEP 621/639 ``license`` or an OSI ``License ::`` classifier)
+  plus ``license-files`` globs that resolve to real files — the absence of
+  these declarations is exactly what produces a license-less wheel;
+* an artifact check that actually builds each wheel with ``uv build`` and
+  asserts the METADATA inside it carries the license fields scanners look
+  for. This layer skips (with the concrete reason) when the build backend
+  cannot be fetched in a network-restricted environment.
+
+Run with::
+
+    pytest tests/e2e/test_sdk_wheel_license_metadata_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tomllib
+import zipfile
+from email import message_from_string
+from email.message import Message
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[2]
+
+# (distribution name, package dir relative to repo root)
+SUB_PACKAGES = [
+    ("omnigent-client", Path("sdks/python-client")),
+    ("omnigent-ui-sdk", Path("sdks/ui")),
+    ("omnigent-slack", Path("integrations/slack")),
+]
+
+# Error fragments that mean "the build backend could not be fetched", not
+# "the package metadata is wrong" — e.g. the registry proxy being down.
+_NETWORK_ERROR_MARKERS = (
+    "Failed to fetch",
+    "operation timed out",
+    "tunnel error",
+    "Request failed after",
+    "No solution found when resolving",
+    "error sending request",
+)
+
+
+def _core_metadata_license_fields(metadata: Message) -> list[tuple[str, str]]:
+    """License-bearing core-metadata fields, as SCA scanners read them."""
+    fields: list[tuple[str, str]] = []
+    for key in ("License", "License-Expression", "License-File"):
+        for value in metadata.get_all(key) or []:
+            fields.append((key, value))
+    for classifier in metadata.get_all("Classifier") or []:
+        if classifier.startswith("License ::"):
+            fields.append(("Classifier", classifier))
+    return fields
+
+
+@pytest.mark.parametrize(
+    ("dist_name", "pkg_dir"),
+    SUB_PACKAGES,
+    ids=[name for name, _ in SUB_PACKAGES],
+)
+def test_pyproject_declares_license_metadata(dist_name: str, pkg_dir: Path) -> None:
+    """Each sub-package pyproject must declare the license hatchling emits.
+
+    A hatchling wheel's METADATA is generated mechanically from the
+    ``[project]`` table, so a pyproject with no ``license``, no
+    ``license-files``, and no ``License ::`` classifier provably yields a
+    wheel with zero license fields — the exact state SCA scanners reject.
+    """
+    pyproject_path = REPO_ROOT / pkg_dir / "pyproject.toml"
+    project = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))["project"]
+
+    problems: list[str] = []
+
+    has_license_key = "license" in project
+    has_license_classifier = any(
+        c.startswith("License ::") for c in project.get("classifiers", [])
+    )
+    if not has_license_key and not has_license_classifier:
+        problems.append(
+            "no `license` (PEP 621/639 expression) and no `License ::` classifier"
+        )
+
+    license_files = project.get("license-files")
+    if not license_files:
+        problems.append("no `license-files` — the wheel ships no license text")
+    else:
+        for pattern in license_files:
+            if not list((REPO_ROOT / pkg_dir).glob(pattern)):
+                problems.append(
+                    f"`license-files` glob {pattern!r} matches no file "
+                    f"under {pkg_dir}"
+                )
+
+    assert not problems, (
+        f"{dist_name} ({pkg_dir}/pyproject.toml) declares no license metadata, "
+        f"so its wheel METADATA carries no license fields and SCA scanners "
+        f"block the install: " + "; ".join(problems)
+    )
+
+
+@pytest.mark.parametrize(
+    ("dist_name", "pkg_dir"),
+    SUB_PACKAGES,
+    ids=[name for name, _ in SUB_PACKAGES],
+)
+def test_built_wheel_carries_license_metadata(
+    tmp_path: Path, dist_name: str, pkg_dir: Path
+) -> None:
+    """Building the wheel (the reporter's journey) must yield license fields."""
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.skip("uv is not on PATH; cannot build the wheel here")
+
+    result = subprocess.run(
+        [uv, "build", "--wheel", "--out-dir", str(tmp_path), str(REPO_ROOT / pkg_dir)],
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=False,
+    )
+    if result.returncode != 0:
+        combined = result.stdout + result.stderr
+        if any(marker in combined for marker in _NETWORK_ERROR_MARKERS):
+            pytest.skip(
+                "cannot fetch the hatchling build backend in this "
+                f"network-restricted environment: {combined.strip()[-500:]}"
+            )
+        pytest.fail(f"uv build failed for {pkg_dir}: {combined.strip()[-2000:]}")
+
+    wheel_name_prefix = dist_name.replace("-", "_")
+    wheels = sorted(tmp_path.glob(f"{wheel_name_prefix}-*.whl"))
+    assert wheels, f"uv build produced no {wheel_name_prefix}-*.whl in {tmp_path}"
+    wheel_path = wheels[-1]
+
+    with zipfile.ZipFile(wheel_path) as wheel:
+        metadata_names = [
+            n
+            for n in wheel.namelist()
+            if n.count("/") == 1 and n.endswith(".dist-info/METADATA")
+        ]
+        assert metadata_names, f"{wheel_path.name} contains no dist-info METADATA"
+        metadata = message_from_string(
+            wheel.read(metadata_names[0]).decode("utf-8")
+        )
+        license_fields = _core_metadata_license_fields(metadata)
+        assert license_fields, (
+            f"{wheel_path.name} METADATA carries no license fields "
+            "(no License, License-Expression, License-File, or "
+            "`License ::` classifier) — corporate SCA scanners block this wheel"
+        )
+
+        # The license text itself must ship inside the wheel, next to the
+        # metadata that references it.
+        license_file_entries = metadata.get_all("License-File") or []
+        dist_info_dir = metadata_names[0].rsplit("/", 1)[0]
+        for entry in license_file_entries:
+            shipped = f"{dist_info_dir}/licenses/{entry}"
+            assert shipped in wheel.namelist(), (
+                f"{wheel_path.name} declares License-File {entry!r} but does "
+                f"not ship {shipped}"
+            )

--- a/tests/e2e/test_sdk_wheel_license_metadata_e2e.py
+++ b/tests/e2e/test_sdk_wheel_license_metadata_e2e.py
@@ -5,18 +5,12 @@ Corporate license/SCA scanners (FOSSA, Black Duck, ...) block installing
 wheels' core METADATA has no ``License-Expression``, ``License-File``, or
 ``License ::`` classifier — even though the repo root is Apache-2.0.
 
-The wheels are built by hatchling straight from each sub-package's
-``pyproject.toml`` ``[project]`` table, so the reproduction/guard is
-two-layered:
-
-* a static check that each sub-package's ``pyproject.toml`` declares a
-  license (PEP 621/639 ``license`` or an OSI ``License ::`` classifier)
-  plus ``license-files`` globs that resolve to real files — the absence of
-  these declarations is exactly what produces a license-less wheel;
-* an artifact check that actually builds each wheel with ``uv build`` and
-  asserts the METADATA inside it carries the license fields scanners look
-  for. This layer skips (with the concrete reason) when the build backend
-  cannot be fetched in a network-restricted environment.
+This artifact check actually builds each wheel with ``uv build`` and
+asserts the METADATA inside it carries the license fields scanners look
+for. It skips (with the concrete reason) when the build backend cannot be
+fetched in a network-restricted environment. The fast, network-free static
+companion check on each sub-package's ``pyproject.toml`` runs in the
+default unit lane: ``tests/test_sub_package_license_metadata.py``.
 
 Run with::
 
@@ -33,7 +27,6 @@ from email.message import Message
 from pathlib import Path
 
 import pytest
-import tomllib
 
 REPO_ROOT = Path(__file__).parents[2]
 
@@ -66,48 +59,6 @@ def _core_metadata_license_fields(metadata: Message) -> list[tuple[str, str]]:
         if classifier.startswith("License ::"):
             fields.append(("Classifier", classifier))
     return fields
-
-
-@pytest.mark.parametrize(
-    ("dist_name", "pkg_dir"),
-    SUB_PACKAGES,
-    ids=[name for name, _ in SUB_PACKAGES],
-)
-def test_pyproject_declares_license_metadata(dist_name: str, pkg_dir: Path) -> None:
-    """Each sub-package pyproject must declare the license hatchling emits.
-
-    A hatchling wheel's METADATA is generated mechanically from the
-    ``[project]`` table, so a pyproject with no ``license``, no
-    ``license-files``, and no ``License ::`` classifier provably yields a
-    wheel with zero license fields — the exact state SCA scanners reject.
-    """
-    pyproject_path = REPO_ROOT / pkg_dir / "pyproject.toml"
-    project = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))["project"]
-
-    problems: list[str] = []
-
-    has_license_key = "license" in project
-    has_license_classifier = any(
-        c.startswith("License ::") for c in project.get("classifiers", [])
-    )
-    if not has_license_key and not has_license_classifier:
-        problems.append("no `license` (PEP 621/639 expression) and no `License ::` classifier")
-
-    license_files = project.get("license-files")
-    if not license_files:
-        problems.append("no `license-files` — the wheel ships no license text")
-    else:
-        for pattern in license_files:
-            if not list((REPO_ROOT / pkg_dir).glob(pattern)):
-                problems.append(
-                    f"`license-files` glob {pattern!r} matches no file under {pkg_dir}"
-                )
-
-    assert not problems, (
-        f"{dist_name} ({pkg_dir}/pyproject.toml) declares no license metadata, "
-        f"so its wheel METADATA carries no license fields and SCA scanners "
-        f"block the install: " + "; ".join(problems)
-    )
 
 
 @pytest.mark.parametrize(

--- a/tests/e2e/test_sdk_wheel_license_metadata_e2e.py
+++ b/tests/e2e/test_sdk_wheel_license_metadata_e2e.py
@@ -27,13 +27,13 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-import tomllib
 import zipfile
 from email import message_from_string
 from email.message import Message
 from pathlib import Path
 
 import pytest
+import tomllib
 
 REPO_ROOT = Path(__file__).parents[2]
 
@@ -91,9 +91,7 @@ def test_pyproject_declares_license_metadata(dist_name: str, pkg_dir: Path) -> N
         c.startswith("License ::") for c in project.get("classifiers", [])
     )
     if not has_license_key and not has_license_classifier:
-        problems.append(
-            "no `license` (PEP 621/639 expression) and no `License ::` classifier"
-        )
+        problems.append("no `license` (PEP 621/639 expression) and no `License ::` classifier")
 
     license_files = project.get("license-files")
     if not license_files:
@@ -102,8 +100,7 @@ def test_pyproject_declares_license_metadata(dist_name: str, pkg_dir: Path) -> N
         for pattern in license_files:
             if not list((REPO_ROOT / pkg_dir).glob(pattern)):
                 problems.append(
-                    f"`license-files` glob {pattern!r} matches no file "
-                    f"under {pkg_dir}"
+                    f"`license-files` glob {pattern!r} matches no file under {pkg_dir}"
                 )
 
     assert not problems, (
@@ -149,14 +146,10 @@ def test_built_wheel_carries_license_metadata(
 
     with zipfile.ZipFile(wheel_path) as wheel:
         metadata_names = [
-            n
-            for n in wheel.namelist()
-            if n.count("/") == 1 and n.endswith(".dist-info/METADATA")
+            n for n in wheel.namelist() if n.count("/") == 1 and n.endswith(".dist-info/METADATA")
         ]
         assert metadata_names, f"{wheel_path.name} contains no dist-info METADATA"
-        metadata = message_from_string(
-            wheel.read(metadata_names[0]).decode("utf-8")
-        )
+        metadata = message_from_string(wheel.read(metadata_names[0]).decode("utf-8"))
         license_fields = _core_metadata_license_fields(metadata)
         assert license_fields, (
             f"{wheel_path.name} METADATA carries no license fields "
@@ -171,6 +164,5 @@ def test_built_wheel_carries_license_metadata(
         for entry in license_file_entries:
             shipped = f"{dist_info_dir}/licenses/{entry}"
             assert shipped in wheel.namelist(), (
-                f"{wheel_path.name} declares License-File {entry!r} but does "
-                f"not ship {shipped}"
+                f"{wheel_path.name} declares License-File {entry!r} but does not ship {shipped}"
             )

--- a/tests/test_sub_package_license_metadata.py
+++ b/tests/test_sub_package_license_metadata.py
@@ -1,0 +1,71 @@
+"""Sub-package pyprojects must declare license metadata.
+
+Corporate license/SCA scanners (FOSSA, Black Duck, ...) block installing
+``omnigent-client`` / ``omnigent-ui-sdk`` / ``omnigent-slack`` when the
+wheels' core METADATA has no ``License-Expression``, ``License-File``, or
+``License ::`` classifier — even though the repo root is Apache-2.0.
+
+Hatchling generates a wheel's METADATA mechanically from the ``[project]``
+table, so a pyproject with no license declarations provably yields a
+license-less wheel. This static check runs in the default unit lane on every
+PR; the companion artifact check that actually builds each wheel lives in
+``tests/e2e/test_sdk_wheel_license_metadata_e2e.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import tomllib
+
+REPO_ROOT = Path(__file__).parents[1]
+
+# (distribution name, package dir relative to repo root)
+SUB_PACKAGES = [
+    ("omnigent-client", Path("sdks/python-client")),
+    ("omnigent-ui-sdk", Path("sdks/ui")),
+    ("omnigent-slack", Path("integrations/slack")),
+]
+
+
+@pytest.mark.parametrize(
+    ("dist_name", "pkg_dir"),
+    SUB_PACKAGES,
+    ids=[name for name, _ in SUB_PACKAGES],
+)
+def test_pyproject_declares_license_metadata(dist_name: str, pkg_dir: Path) -> None:
+    """Each sub-package pyproject must declare the license hatchling emits.
+
+    A hatchling wheel's METADATA is generated mechanically from the
+    ``[project]`` table, so a pyproject with no ``license``, no
+    ``license-files``, and no ``License ::`` classifier provably yields a
+    wheel with zero license fields — the exact state SCA scanners reject.
+    """
+    pyproject_path = REPO_ROOT / pkg_dir / "pyproject.toml"
+    project = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))["project"]
+
+    problems: list[str] = []
+
+    has_license_key = "license" in project
+    has_license_classifier = any(
+        c.startswith("License ::") for c in project.get("classifiers", [])
+    )
+    if not has_license_key and not has_license_classifier:
+        problems.append("no `license` (PEP 621/639 expression) and no `License ::` classifier")
+
+    license_files = project.get("license-files")
+    if not license_files:
+        problems.append("no `license-files` — the wheel ships no license text")
+    else:
+        for pattern in license_files:
+            if not list((REPO_ROOT / pkg_dir).glob(pattern)):
+                problems.append(
+                    f"`license-files` glob {pattern!r} matches no file under {pkg_dir}"
+                )
+
+    assert not problems, (
+        f"{dist_name} ({pkg_dir}/pyproject.toml) declares no license metadata, "
+        f"so its wheel METADATA carries no license fields and SCA scanners "
+        f"block the install: " + "; ".join(problems)
+    )


### PR DESCRIPTION
## Related issue

Closes #5890 

## Summary

- `omnigent-client`, `omnigent-ui-sdk`, and `omnigent-slack` publish to PyPI/build as wheels with no license classifier, SPDX expression, or bundled LICENSE file
- The repo root is Apache-2.0; this blocks installs under corporate license-compliance scanning.
- Adds `license = "Apache-2.0"` + `license-files = ["LICENSE"]` (PEP 639) to each sub-package's `pyproject.toml`, and copies the root `LICENSE` into each package directory so the wheel actually bundles it.
- Root `omnigent` package is untouched

## Test Plan

Rebuilt all three wheels locally (`uv build` in each package dir) and inspected the built METADATA directly: each now shows `License-Expression: Apache-2.0` and `License-File: LICENSE`, where before neither was present. 

Ran `twine check` on all 6 built artifacts (3 wheels + 3 sdists) — all PASSED. 

Ran `pre-commit` scoped to the changed files and `pyrefly check` against the full project — no failures; this diff only touches `pyproject.toml`/`LICENSE` files, which
none of the lint/type-check hooks apply to.

########## twine check ##########
Checking omnigent_client-0.12.0.dev0-py3-none-any.whl: PASSED
Checking omnigent_slack-0.12.0.dev0-py3-none-any.whl: PASSED
Checking omnigent_ui_sdk-0.12.0.dev0-py3-none-any.whl: PASSED
Checking omnigent_client-0.12.0.dev0.tar.gz: PASSED
Checking omnigent_slack-0.12.0.dev0.tar.gz: PASSED
Checking omnigent_ui_sdk-0.12.0.dev0.tar.gz: PASSED

########## pre-commit (scoped to the 6 changed files) ##########
ruff format..........................................(no files to check)Skipped
ruff check...........................................(no files to check)Skipped
pyrefly...............................................(no files to check)Skipped
[... all other hooks: (no files to check)Skipped ...]

########## pyrefly check (full project) ##########
INFO Checking project configured at `pyrefly.toml`
INFO 0 errors (418 suppressed, 205 warnings not shown)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Packaging-metadata-only change with no runtime behavior change; no existing test suite covers `pyproject.toml` metadata. Verified manually by rebuilding each wheel and inspecting its `METADATA` file for `License-Expression`/`License-File`, plus `twine check`.

## Changelog

`omnigent-client`, `omnigent-ui-sdk`, and `omnigent-slack` now declare Apache-2.0 license metadata in their published packages
