### PR TITLE
test(e2e-ui): expect bare /settings to canonicalize to /settings/general

### DIFF
--- a/tests/e2e_ui/sessions/test_settings_back_navigation.py
+++ b/tests/e2e_ui/sessions/test_settings_back_navigation.py
@@ -42,7 +42,10 @@ def test_native_open_path_navigates_to_settings_without_reload(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """The desktop bridge's basename-less ``/settings`` path routes in place."""
+    """The desktop bridge's basename-less ``/settings`` path routes in place.
+
+    Bare ``/settings`` canonicalizes to ``/settings/general``.
+    """
     base_url, session_id = seeded_session
     page.add_init_script(_NATIVE_OPEN_PATH_INIT_SCRIPT)
     page.goto(f"{base_url}/c/{session_id}")
@@ -52,7 +55,7 @@ def test_native_open_path_navigates_to_settings_without_reload(
 
     page.evaluate("window.__nativeOpenPathListener('/settings')")
 
-    expect(page).to_have_url(f"{base_url}/settings", timeout=30_000)
+    expect(page).to_have_url(f"{base_url}/settings/general", timeout=30_000)
     expect(page.get_by_role("link", name="Back", exact=True)).to_be_visible(timeout=30_000)
     assert page.evaluate("window.__documentLoadMarker") == load_marker
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Update `test_native_open_path_navigates_to_settings_without_reload` to expect `${base_url}/settings/general` instead of `${base_url}/settings`.
- This is test expectation drift only: main now canonicalizes bare `/settings` to the default General section URL; no product code changes in this PR.

## Test Plan

- [x] `uv run ruff check tests/e2e_ui/sessions/test_settings_back_navigation.py`
- [x] `uv run pytest tests/e2e_ui/sessions/test_settings_back_navigation.py::test_native_open_path_navigates_to_settings_without_reload -v`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Updated the one failing ambient-main e2e assertion to match the canonical `/settings/general` URL.