### PR TITLE
feat(web): restore Rename and Move session in the header kebab menu

### DIFF
--- a/tests/e2e_ui/sessions/test_header_session_menu.py
+++ b/tests/e2e_ui/sessions/test_header_session_menu.py
@@ -49,15 +49,18 @@ def test_header_session_menu_renames_owner_and_hides_for_subagent(
         expect(trigger).to_be_visible(timeout=30_000)
         trigger.click()
 
-        # Desktop drops "Rename" and "Add to project" from the kebab — the
-        # breadcrumb title (HeaderTitle) and folder tag (HeaderProjectTag) own
-        # those shortcuts now. Both stay in this menu only on mobile, where the
-        # native shells hide the breadcrumb.
+        # Desktop keeps "Rename" and "Add to project" in the kebab, alongside the
+        # breadcrumb title (HeaderTitle) and folder tag (HeaderProjectTag)
+        # shortcuts. "Add to project" is a submenu trigger, so its label carries
+        # the flyout's own items; match only the leading action label.
         menu_items = page.get_by_role("menuitem")
-        expect(menu_items).to_have_count(4)
-        assert menu_items.all_inner_texts() == [
+        expect(menu_items).to_have_count(6)
+        labels = [text.split("\n")[0] for text in menu_items.all_inner_texts()]
+        assert labels == [
             "Pin",
+            "Rename",
             "Mark as unread",
+            "Add to project",
             "Archive",
             "Delete",
         ]

--- a/web/src/shell/HeaderConversationMenu.test.tsx
+++ b/web/src/shell/HeaderConversationMenu.test.tsx
@@ -109,18 +109,19 @@ describe("HeaderConversationMenu", () => {
     expect(trigger.querySelector("svg")).toHaveClass("lucide-ellipsis");
 
     openMenu();
-    // Desktop drops "Rename" and "Move to project" from the kebab — the
-    // breadcrumb title (HeaderTitle) and folder tag (HeaderProjectTag) own
-    // those shortcuts now.
+    // Rename and Move session live in the kebab on desktop too, alongside the
+    // breadcrumb title (HeaderTitle) and folder tag (HeaderProjectTag) shortcuts.
     expect(screen.getAllByRole("menuitem").map((item) => item.textContent?.trim())).toEqual([
       "Pin",
       "Share",
+      "Rename",
       "Mark as unread",
+      "Add to project",
       "Archive",
       "Delete",
     ]);
-    expect(screen.queryByTestId("header-move-to-project")).toBeNull();
-    expect(screen.queryByTestId("header-rename-conversation")).toBeNull();
+    expect(screen.getByTestId("header-move-to-project")).toBeInTheDocument();
+    expect(screen.getByTestId("header-rename-conversation")).toBeInTheDocument();
   });
 
   it("opens from the keyboard and focuses the first action", () => {
@@ -208,6 +209,25 @@ describe("HeaderConversationMenu", () => {
     expect(screen.queryByTestId("header-rename-conversation")).toBeNull();
     expect(screen.getByRole("textbox", { name: "Search or create project" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("menuitem", { name: "Sprint 42" }));
+    expect(mocks.moveToProject).toHaveBeenCalledWith({ id: "conv-1", project: "Sprint 42" });
+  });
+
+  it("opens the project picker as a submenu flyout on desktop and moves the session", async () => {
+    // Desktop has room for a side flyout, so Move session is a submenu trigger
+    // (not the in-place body swap the mobile menu uses).
+    renderMenu();
+    openMenu();
+
+    const projectAction = screen.getByTestId("header-move-to-project");
+    expect(projectAction).toHaveAttribute("aria-haspopup", "menu");
+    // No in-place "Back" affordance — the flyout keeps the parent items visible.
+    expect(screen.queryByTestId("header-project-picker-back")).toBeNull();
+
+    fireEvent.click(projectAction);
+    expect(
+      await screen.findByRole("textbox", { name: "Search or create project" }),
+    ).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Sprint 42" }));
     expect(mocks.moveToProject).toHaveBeenCalledWith({ id: "conv-1", project: "Sprint 42" });
   });
 

--- a/web/src/shell/HeaderConversationMenu.tsx
+++ b/web/src/shell/HeaderConversationMenu.tsx
@@ -35,6 +35,9 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -223,19 +226,17 @@ export function HeaderConversationMenu({
           Agent info
         </DropdownMenuItem>
       )}
-      {/* Rename lives here only on mobile — the native shells hide the
-          breadcrumb, so this menu is the sole entry point. On desktop the
-          shortcut is clicking the breadcrumb title (HeaderTitle). */}
-      {isMobile && (
-        <DropdownMenuItem
-          data-testid="header-rename-conversation"
-          className={itemClass}
-          onSelect={() => setRenameOpen(true)}
-        >
-          <PencilIcon className="size-3.5" />
-          Rename
-        </DropdownMenuItem>
-      )}
+      {/* Rename is also reachable on desktop by clicking the breadcrumb title
+          (HeaderTitle); on mobile the native shells hide the breadcrumb, so this
+          menu is the sole entry point. */}
+      <DropdownMenuItem
+        data-testid="header-rename-conversation"
+        className={itemClass}
+        onSelect={() => setRenameOpen(true)}
+      >
+        <PencilIcon className="size-3.5" />
+        Rename
+      </DropdownMenuItem>
       <DropdownMenuItem
         data-testid="header-mark-unread-conversation"
         className={itemClass}
@@ -244,10 +245,12 @@ export function HeaderConversationMenu({
         <MailIcon className="size-3.5" />
         Mark as unread
       </DropdownMenuItem>
-      {/* Move to project lives here only on mobile — the native mobile shells
-          hide the breadcrumb, so this menu is the sole entry point. On desktop
-          the shortcut is the breadcrumb's folder tag (HeaderProjectTag). */}
-      {isMobile && (
+      {/* Move to project is also reachable on desktop via the breadcrumb's
+          folder tag (HeaderProjectTag); on mobile the native shells hide the
+          breadcrumb, so this menu is the sole entry point. */}
+      {isMobile ? (
+        // Mobile has no room for a side flyout, so this item swaps the menu body
+        // to the project picker in place (see the `projectPickerOpen` branch).
         <DropdownMenuItem
           data-testid="header-move-to-project"
           className={cn("whitespace-nowrap", itemClass)}
@@ -259,6 +262,21 @@ export function HeaderConversationMenu({
           <FolderInputIcon className="size-3.5" />
           {currentProject ? "Move session" : "Add to project"}
         </DropdownMenuItem>
+      ) : (
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger
+            data-testid="header-move-to-project"
+            className="whitespace-nowrap"
+          >
+            <FolderInputIcon className="size-3.5" />
+            {currentProject ? "Move session" : "Add to project"}
+          </DropdownMenuSubTrigger>
+          {/* A native submenu flyout — no separate popover layer, so no
+              open/dismiss race with the parent menu. */}
+          <DropdownMenuSubContent className="min-w-56">
+            <ProjectPicker currentProject={currentProject} onSelect={handleProjectSelect} />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
       )}
       {workspaceItems && (
         <>
@@ -324,7 +342,7 @@ export function HeaderConversationMenu({
               <DropdownMenuSeparator />
             </>
           )}
-          {isMobile && projectPickerOpen ? (
+          {projectPickerOpen ? (
             <>
               <DropdownMenuItem
                 data-testid="header-project-picker-back"


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- The desktop header session (kebab) menu had dropped **Rename** and **Move session**, leaving the breadcrumb title and folder tag as the only ways to reach them. This restores both to the menu so it's a complete surface again.
- **Rename** opens the existing rename dialog.
- **Move session** (or **Add to project** when unfiled) opens the project picker as a **native submenu flyout on desktop** — hover/focus to reveal the search + project list, matching the sidebar row menu. Mobile is unchanged: it keeps the in-place body-swap picker since there's no room for a side flyout.

## Test Plan

- `cd web && pnpm test` — `HeaderConversationMenu.test.tsx` passes (21 tests), including a new case asserting the desktop submenu flyout (`aria-haspopup="menu"`, no in-place Back affordance) moves the session to the picked project, and the existing mobile in-place picker case is retained.
- `pnpm run build` (`tsc -b && vite build`) passes.
- Manual: opened a session, clicked the kebab, confirmed Rename opens its dialog and hovering Move session reveals the project flyout (search / select / create / remove). Verified mobile viewport still swaps the menu body in place.
- Note: 3 pre-existing failures in `NewChatDialog.test.tsx` are unrelated (fail on a clean tree without this change).

## Demo

| Move session flyout (desktop) |
| --- |
| Hovering **Move session** opens the project picker to the side (search + project list + Remove from …), matching the sidebar row menu. |

_See linked screenshots in the PR conversation._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added/updated unit tests in `HeaderConversationMenu.test.tsx`: the menu-order test now expects Rename and Move session on desktop, and a new test covers the desktop submenu flyout move. Manually verified in the running app that Rename opens its dialog, the desktop Move session flyout files/creates/removes projects, and mobile still uses the in-place picker.

## Changelog

Restored Rename and Move session to the chat header kebab menu, with a hover flyout project picker on desktop
