### PR TITLE
fix(triage): avoid Arrow nullability mismatch

### DIFF
--- a/.github/triage_v2/src/issue_prioritization/databricks_io.py
+++ b/.github/triage_v2/src/issue_prioritization/databricks_io.py
@@ -37,10 +37,10 @@ class SparkIssueSource:
 
     def load_open_issues(self) -> list[BronzeIssue]:
         frame = self.spark.table(self.table)
-        rows = frame.where("state = 'open'").collect()
+        rows = frame.where("state = 'open'").drop("state").collect()
         issues = []
         for row in rows:
-            value = row.asDict(recursive=True)
+            value = {**row.asDict(recursive=True), "state": "open"}
             if value.get("repo") != self.repo:
                 continue
             issue = BronzeIssue.from_mapping(value)

--- a/.github/triage_v2/tests/test_bronze.py
+++ b/.github/triage_v2/tests/test_bronze.py
@@ -75,6 +75,11 @@ def test_spark_source_filters_repository_and_pull_requests() -> None:
         "raw_json": json.dumps({"html_url": "https://github.com/issues/42"}),
     }
 
+    def without_state(**overrides):
+        value = {**base, **overrides}
+        value.pop("state")
+        return value
+
     class Row:
         def __init__(self, value):
             self.value = value
@@ -83,25 +88,32 @@ def test_spark_source_filters_repository_and_pull_requests() -> None:
             return self.value
 
     class Frame:
+        state_dropped = False
+
         def where(self, expression):
             assert expression == "state = 'open'"
             return self
 
+        def drop(self, column):
+            assert column == "state"
+            self.state_dropped = True
+            return self
+
         def collect(self):
+            assert self.state_dropped
             return [
-                Row(base),
-                Row({**base, "issue_number": 43, "repo": "other/repo"}),
+                Row(without_state()),
+                Row(without_state(issue_number=43, repo="other/repo")),
                 Row(
-                    {
-                        **base,
-                        "issue_number": 44,
-                        "raw_json": json.dumps(
+                    without_state(
+                        issue_number=44,
+                        raw_json=json.dumps(
                             {
                                 "html_url": "https://github.com/pull/44",
                                 "pull_request": {"url": "https://api.github.com/pulls/44"},
                             }
                         ),
-                    }
+                    )
                 ),
             ]
 


### PR DESCRIPTION
## Related issue

N/A — operational regression in the scheduled issue-prioritization job.

## Summary

- Avoid collecting the filtered `state` column after Spark inferred inconsistent Arrow nullability across result batches.
- Restore the known `open` state in each row mapping before normalizing the issue.
- Update the Spark source test to enforce this projection behavior.

ELI5: the job already knows every selected row is open. It now leaves that redundant field out of the Arrow transfer and adds it back locally, avoiding a disagreement between result batches.

```text
bronze table -> filter open -> drop state -> Arrow collect -> restore state=open -> score
```

## Test Plan

- `uv run --frozen pytest` — 78 passed.
- `uv run --frozen pytest tests/test_bronze.py` — 4 passed after final formatting.
- `pre-commit run --files .github/triage_v2/src/issue_prioritization/databricks_io.py .github/triage_v2/tests/test_bronze.py` — passed.

## Demo

N/A — non-visual scheduled-job fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The updated unit test verifies that `state` is removed before collection and restored before issue normalization. After merge and bundle deployment, the scheduled Databricks job should be rerun against the affected table as the production verification.
