### PR TITLE
fix(resolve-agent): never commit repro recordings or handoff artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,9 @@ node_modules/
 .pnpm-debug.log*
 reviews/
 
-# repro/resolve-agent workspace artifacts — bug-repro recordings and the
-# machine-readable handoff. Ride in the PR Demo section / CI artifact bundle,
-# never in the diff. Gitignored so a stray `git add` can't sweep them into a PR.
-recordings/
+# repro/resolve-agent workspace artifact — the machine-readable handoff.
+# Rides in the PR Demo section / CI artifact bundle, never in the diff.
+# Gitignored so a stray `git add` can't sweep it into a PR.
 .omnigent/
 
 # Generated artifact; never committed.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ node_modules/
 .pnpm-debug.log*
 reviews/
 
+# repro/resolve-agent workspace artifacts — bug-repro recordings and the
+# machine-readable handoff. Ride in the PR Demo section / CI artifact bundle,
+# never in the diff. Gitignored so a stray `git add` can't sweep them into a PR.
+recordings/
+.omnigent/
+
 # Generated artifact; never committed.
 .pytest_cache/
 __pycache__/

--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -611,6 +611,17 @@ Once the set is genuinely green:
    diff). Follow the repo's commit conventions. You likely committed already in
    2B.6 to produce the review diff; if the cross-vendor review led to further
    changes, amend or add a follow-up commit so the branch reflects the final fix.
+   **Never commit workspace artifacts.** The commit must contain only the fix and
+   its reproduction test — nothing else. In particular, **never** stage or commit
+   the `recordings/` clips or any `.omnigent/` handoff files (e.g.
+   `.omnigent/repro-handoff.json`): recordings are workspace artifacts that ride
+   in the PR's Demo section / CI artifact bundle, not in the diff (see
+   [`dev/recording-lanes.md`](../recording-lanes.md)). Do **not** use a blanket
+   `git add -A` / `git add .` that sweeps them in — stage the fix and test paths
+   explicitly, and run `git status` / `git diff --cached --stat` before committing
+   to confirm the staged set is only the fix + test. If a recording or handoff
+   file already landed in an earlier commit on this branch, remove it (e.g.
+   `git rm --cached`) so it never reaches the PR.
 2. **If the input has `skip_push: true`, stop here** — the fix is committed
    locally; do **not** push and do **not** open a PR. Report the branch name in
    your output (`pushed_branch`) so a human can inspect, push, and PR it. (The


### PR DESCRIPTION
## Related issue

N/A — follow-up to a resolve-agent behavior seen in #5786, where a bug-repro recording was committed into the PR diff.

## Summary

The resolve agent (`dev/resolve-agent`) sometimes commits workspace artifacts — bug-repro `recordings/` clips and the `.omnigent/` handoff JSON — into the PR it opens. Per `dev/recording-lanes.md` these are meant to ride in the PR's **Demo** section / CI artifact bundle, never in the diff. The commit step (3.1) only said "commit the fix and the tests" with no guard against a blanket `git add` sweeping them in.

Fixed in two layers:

- **Instruction** — resolve step 3.1 now explicitly forbids staging/committing `recordings/` and `.omnigent/` files, requires staging the fix + test paths explicitly (no `git add -A` / `git add .`), verifying the staged set with `git status` / `git diff --cached --stat` before committing, and `git rm --cached`-ing any artifact that slipped into an earlier commit.
- **Enforcement** — gitignore `recordings/` and `.omnigent/` so a stray blanket `git add` can't stage them.

## Test Plan

- `git check-ignore -v recordings/1234/after-x.webm .omnigent/repro-handoff.json` → both match the new ignore rules.
- Confirmed no `recordings/` or `.omnigent/` files are currently tracked, so nothing gets orphaned.
- Docs/instruction + gitignore only; no code paths execute.

## Demo

N/A — instruction and gitignore change, no UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually with `git check-ignore` that both artifact paths are now ignored, and confirmed no such files are tracked today. The change is agent instructions plus gitignore rules — there is no executable code path to unit-test.

## Changelog

DELETE THIS WHOLE SECTION if the change isn't noteworthy

This pull request and its description were written by Isaac.