### PR TITLE
fix(opencode-native): guard non-string plugins, de-contradict merge docstring

### DIFF
--- a/omnigent/opencode_native_provider.py
+++ b/omnigent/opencode_native_provider.py
@@ -451,11 +451,14 @@ def maybe_merge_user_provider_config(config: dict[str, object]) -> dict[str, obj
     server sees both the user's providers (with their custom base URLs) and
     any Omnigent-synthesized providers (e.g. Databricks gateway).
 
-    ``provider`` entries are merged and top-level ``plugin`` entries are
-    preserved (with synthesized plugins taking precedence). The user config's ``model``
-    default is adopted **only when the synthesized config pins none** — the
-    synthesized config still takes precedence for all keys it sets (model, mcp,
-    plugin, permission, etc.). The ``model`` carry-over matters because when
+    ``provider`` entries are merged, and the user's top-level ``plugin``
+    entries are appended after any synthesized ones (synthesized policy
+    plugins stay first; duplicate paths are dropped) so plugin-based
+    provider auth keeps working in native sessions. The user config's
+    ``model`` default is adopted **only when the synthesized config pins
+    none** — for the other keys it sets (model, mcp, permission, etc.) the
+    synthesized config still takes precedence. The ``model`` carry-over
+    matters because when
     neither a gateway nor a spec-supplied ``model_override`` is present, the
     synthesized config has no ``model`` key, and opencode-native would otherwise
     pick its own default over the merged models map (e.g. landing on a served
@@ -512,6 +515,10 @@ def maybe_merge_user_provider_config(config: dict[str, object]) -> dict[str, obj
         existing = target.get("plugin")
         merged: list[object] = list(existing) if isinstance(existing, list) else []
         for plugin in user_plugins:
+            # Plugin entries are paths/identifiers; skip anything that isn't a
+            # non-empty string so we never emit a config OpenCode would reject.
+            if not isinstance(plugin, str) or not plugin:
+                continue
             if plugin not in merged:
                 merged.append(plugin)
         if merged:

--- a/tests/test_opencode_native_provider.py
+++ b/tests/test_opencode_native_provider.py
@@ -446,6 +446,27 @@ def test_merge_user_provider_config_preserves_plugins_and_deduplicates(
     ]
 
 
+def test_merge_user_provider_config_skips_non_string_plugins(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Malformed plugin entries are dropped rather than propagated."""
+    cfg_dir = tmp_path / "cfg" / "opencode"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "opencode.jsonc").write_text(
+        '{"plugin": ["/opt/pulse-agents-harnesses/marshal-opencode", {"bad": "entry"}, "", 42]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+    config: dict[str, object] = {"plugin": ["/tmp/omnigent-policy.js"]}
+    result = maybe_merge_user_provider_config(config)
+
+    assert result["plugin"] == [
+        "/tmp/omnigent-policy.js",
+        "/opt/pulse-agents-harnesses/marshal-opencode",
+    ]
+
+
 def test_merge_user_provider_config_merges_alongside_synthesized_providers(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Follow-up to #4151 (merged), addressing the non-blocking review notes from Copilot and the resolve agent on the plugin-merge path in `maybe_merge_user_provider_config`. Related to #5345.

Two small hardening/clarity fixes, no behavior change for real-world configs:

- **Guard non-string plugin entries.** The merge appended whatever was in the user's global `plugin` list into the synthesized session config. A malformed global config (a dict/int/empty-string entry) could therefore emit a `plugin` list OpenCode would reject. Now user entries are filtered to non-empty strings before being merged.
- **De-contradict the docstring.** It previously said the synthesized config "takes precedence for all keys it sets (… plugin …)" while the code *merges* plugins. Reworded so plugin "precedence" reads as ordering (synthesized policy plugins first, user plugins appended, dupes dropped).
- **Regression coverage** for the non-string filter.

Tests: 41 passed (`tests/test_opencode_native_provider.py`).
