### PR TITLE
fix(claude-native): approve web-UI plans via hook updatedInput, not a keystroke

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -3239,52 +3239,6 @@ def inject_interrupt(
     _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Escape")
 
 
-# Option-1 label in Claude Code's plan-review dialog: proof that dialog is
-# what's on screen before a verdict is keyed into it.
-_PLAN_DIALOG_MARKER = "Yes, and use auto mode"
-
-_PLAN_VERDICT_KEYS = {"auto": "1", "manual": "2", "reject": "Escape"}
-
-
-def inject_plan_verdict(
-    bridge_dir: Path,
-    *,
-    verdict: str,
-    timeout_s: float = _TMUX_READY_TIMEOUT_S,
-) -> bool:
-    """
-    Answer Claude Code's plan-review dialog by keystroke.
-
-    Claude Code ignores a ``PermissionRequest`` hook's ``allow`` for
-    ``ExitPlanMode`` — that dialog is answerable only from the TUI — so a
-    web-UI plan verdict has to be keyed in the way a local user would.
-    Every other gated tool honors the hook decision instead.
-
-    The pane check is the only guard available (the verdict carries no tool
-    identity), and it doubles as the "already answered in the terminal" case.
-
-    :param bridge_dir: Bridge directory path, e.g.
-        ``/tmp/omnigent/claude-native/<digest>``.
-    :param verdict: ``"auto"`` (approve + auto mode), ``"manual"``
-        (approve, keep approving edits), or ``"reject"``.
-    :param timeout_s: Seconds to wait for ``tmux.json``, e.g. ``1.0``.
-    :returns: ``True`` when the keystroke was sent, ``False`` when the
-        plan dialog was not showing.
-    :raises ValueError: If *verdict* is not a known option.
-    :raises RuntimeError: If the tmux target is not advertised in time,
-        or if the ``tmux send-keys`` invocation fails.
-    """
-    key = _PLAN_VERDICT_KEYS.get(verdict)
-    if key is None:
-        raise ValueError(f"unknown plan verdict {verdict!r}")
-    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
-    if _PLAN_DIALOG_MARKER not in _capture_pane(info["socket_path"], info["tmux_target"]):
-        return False
-    # No ``-l``: tmux must read ``Escape`` as a key name, not literal text.
-    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], key)
-    return True
-
-
 def kill_session(
     bridge_dir: Path,
     *,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5136,58 +5136,6 @@ def create_runner_app(
             },
         )
 
-    async def _apply_claude_native_plan_verdict(
-        conv_id: str,
-        data: Mapping[str, object],
-    ) -> None:
-        """
-        Key a web-UI plan verdict into Claude Code's plan-review dialog.
-
-        Claude Code ignores a ``PermissionRequest`` hook's ``allow`` for
-        ``ExitPlanMode``, so a plan approved in the web UI never reaches the
-        pane and the session stays parked on the TUI dialog. Best-effort:
-        :func:`inject_plan_verdict` no-ops unless that dialog is on screen,
-        so a non-plan verdict (or one already answered in the terminal)
-        presses nothing.
-
-        :param conv_id: Session/conversation identifier, e.g.
-            ``"conv_abc123"``.
-        :param data: The approval payload, e.g.
-            ``{"elicitation_id": "elicit_claude_ab12", "action": "accept",
-            "content": {"allow_all_edits": True}}``.
-        :returns: None.
-        """
-        from omnigent.claude_native_bridge import (
-            bridge_dir_for_bridge_id,
-            inject_plan_verdict,
-        )
-
-        content = data.get("content")
-        if data.get("action") != "accept":
-            verdict = "reject"
-        elif isinstance(content, dict) and content.get("allow_all_edits") is True:
-            verdict = "auto"
-        else:
-            verdict = "manual"
-        try:
-            bridge_id = await _claude_native_bridge_id_for_session(
-                server_client=server_client,
-                session_id=conv_id,
-            )
-            # Short timeout: a missing tmux.json means no pane to answer.
-            await asyncio.to_thread(
-                inject_plan_verdict,
-                bridge_dir_for_bridge_id(bridge_id),
-                verdict=verdict,
-                timeout_s=1.0,
-            )
-        except Exception:  # noqa: BLE001 — best-effort; TUI can still answer
-            _logger.debug(
-                "claude-native plan verdict not applied",
-                exc_info=True,
-                extra={"session_id": conv_id},
-            )
-
     async def _handle_cursor_native_model_change(
         conv_id: str,
         model: str | None,
@@ -8099,8 +8047,6 @@ def create_runner_app(
             _data = body.get("data") or body
             _elicit_action = _data.get("action", "")
             pending_approvals.resolve(_data.get("elicitation_id", ""), _elicit_action == "accept")
-            if _session_harness_name(conversation_id) == "claude-native":
-                await _apply_claude_native_plan_verdict(conversation_id, _data)
             if _elicit_action == "decline":
                 try:
                     _int_client = await process_manager.get_client(conversation_id, "any")

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -366,6 +366,18 @@ def register_hooks_routes(
             and result.content
         ):
             decision["updatedInput"] = {**tool_input, "answers": result.content}
+        # ExitPlanMode is a requiresUserInteraction tool: Claude Code coerces a
+        # bare PermissionRequest allow back to an interactive prompt unless the
+        # decision also carries ``updatedInput``. The plan needs no change, so
+        # echo the model's own input verbatim — its presence, not its content,
+        # is what lets a web-UI approval proceed without a TUI keystroke.
+        if (
+            behavior == "allow"
+            and tool_name == "ExitPlanMode"
+            and isinstance(tool_input, dict)
+            and tool_input
+        ):
+            decision["updatedInput"] = tool_input
         # "Accept & allow all edits" — the user approved this edit AND
         # asked to auto-accept future edits. Echo a ``setMode`` permission
         # update so Claude Code switches this session into ``acceptEdits``

--- a/tests/server/integration/test_sessions_permission_request_hook.py
+++ b/tests/server/integration/test_sessions_permission_request_hook.py
@@ -1307,6 +1307,12 @@ async def test_permission_request_hook_surfaces_exit_plan_mode_input(
     # without the allow_all_edits flag.
     assert resp.json()["hookSpecificOutput"]["decision"] == {
         "behavior": "allow",
+        # ExitPlanMode is a requiresUserInteraction tool: Claude Code coerces a
+        # bare allow back to an interactive prompt unless the decision echoes
+        # ``updatedInput``. It mirrors the model's own tool_input (a no-op to
+        # the plan), and its presence is what lets a web-UI approval exit plan
+        # mode with no TUI keystroke.
+        "updatedInput": payload["tool_input"],
         "updatedPermissions": [{"type": "setMode", "mode": "default", "destination": "session"}],
     }
 
@@ -1369,6 +1375,9 @@ async def test_permission_request_hook_exit_plan_mode_auto_accept_round_trip(
     assert decision["updatedPermissions"] == [
         {"type": "setMode", "mode": "auto", "destination": "session"}
     ]
+    # updatedInput rides along on the auto path too — the requiresUserInteraction
+    # escape hatch is mode-independent.
+    assert decision["updatedInput"] == payload["tool_input"]
 
 
 async def test_permission_request_hook_decline_forwards_feedback_message(


### PR DESCRIPTION
## Related issue

No filed issue — reported directly by a user ("every time I reject the plan
with feedback, it causes an interrupt"). Happy to link a `Closes #` if one is
filed.

## Summary

On `claude-native` sessions, answering a plan review (`ExitPlanMode`) from the
web UI went through `inject_plan_verdict` (added in #4067), which keyed the
verdict (`1`/`2`/`Escape`) into the tmux pane. On a **reject** that `Escape`
raced the `PermissionRequest` hook's own dialog dismissal and intermittently
landed on the fresh revision turn, cancelling it.

The obvious fix — just delete the keystroke — is **not** safe on its own, and
this is where #4067's premise was wrong. A bare `PermissionRequest` `allow` does
**not** approve `ExitPlanMode`. The reason is specific: `ExitPlanMode` is a
`requiresUserInteraction` tool, so Claude Code's permission engine coerces a hook
`allow` back to an interactive `"ask"` (the plan dialog stays parked) **unless
the decision also carries `updatedInput`** — the same escape hatch that lets
`AskUserQuestion` answers through. Verified live against `claude 2.1.251`: with
the keystroke removed and no `updatedInput`, a web-UI approve does nothing and
the plan stays parked.

So this PR does two things:

1. **Removes the racy keystroke** (`inject_plan_verdict` /
   `_apply_claude_native_plan_verdict`) — the actual cause of the reject
   interrupt.
2. **Echoes the model's own `tool_input` back as `decision.updatedInput`** on an
   `ExitPlanMode` `allow` (`routes_hooks.py`). Its *presence* (not its content)
   satisfies the escape hatch, so a web-UI approval exits plan mode with **no
   keystroke and no race**.

`deny + message` (reject with feedback) is unchanged and needs no `updatedInput`:
the deny path is applied directly and is **not** subject to the
`requiresUserInteraction` coercion, so the feedback still reaches the model and
the session stays in plan mode. Only `claude-native` paths are touched.

### ELI5

Approving a plan from the web UI, the site mails Claude a "yes". But Claude
treats "exit plan mode" as something a human must click in the terminal, so a
plain mailed "yes" is bounced back to "please answer in the terminal" — the plan
just sits there. #4067 worked around that by having the runner reach over and
press the key itself; on a *reject* that keypress sometimes landed a beat too
late and cancelled Claude's next step. The fix: instead of pressing a key, the
mailed "yes" now includes the plan itself, which is the one thing that makes
Claude accept a mailed answer for this tool. No keypress, no race.

### Mechanism

```
web approve ─▶ resolve endpoint ─▶ PermissionRequest allow ─▶ Claude
                                    bare allow                 ✘ coerced back to "ask"
                                                                 (ExitPlanMode is
                                                                  requiresUserInteraction)
                                    allow + updatedInput        ✔ escape hatch → plan exits
                                    (this PR)

web reject ──▶ resolve endpoint ─▶ PermissionRequest deny+message ─▶ Claude  ✔ applied directly
                                                                             (feedback delivered,
                                                                              stays in plan mode)

removed: runner inject_plan_verdict — keyed 1 / 2 / Esc into the pane; the stray Esc was the bug
```

### What changed

- `omnigent/server/routes/sessions/routes_hooks.py` (**+**): echo `tool_input`
  as `decision.updatedInput` on an `ExitPlanMode` `allow`.
- `omnigent/runner/app.py` (**−**): `_apply_claude_native_plan_verdict` + its
  call site.
- `omnigent/claude_native_bridge.py` (**−**): `inject_plan_verdict`,
  `_PLAN_DIALOG_MARKER`, `_PLAN_VERDICT_KEYS`, and the now-incorrect comments
  claiming the hook is ignored for `ExitPlanMode`.
- `tests/server/integration/test_sessions_permission_request_hook.py`: assert the
  `ExitPlanMode` `allow` decision now carries `updatedInput` (default and
  auto-mode paths).

`inject_interrupt` (the web-UI Stop button / Escape keybind) is untouched, as is
the generic `decline → interrupt` branch (shared by all harnesses).

## Test Plan

Root-caused and verified **live against a real `claude 2.1.251` native session**:

1. **Reproduced the failure** on the keystroke-removed code with a bare `allow`:
   the model called `ExitPlanMode`, the web UI approved, and the server returned
   `allow` (`200`, unblocked by the accept `resolve`) — yet the plan dialog
   stayed parked with no `toolUseResult`. Confirmed via the server access log (a
   single `permission-request` long-poll returning right after the `resolve`),
   the session transcript (no result after the `ExitPlanMode` call), and the live
   tmux pane.
2. **With the `updatedInput` fix**: approving a plan from the web UI now exits
   plan mode and the session proceeds, with no keystroke. Confirmed end-to-end by
   the reporter on their live stack.
3. **Binary basis**: `ExitPlanMode`'s tool descriptor is
   `requiresUserInteraction(){return!0}`; the permission engine skips the
   `requiresUserInteraction → ask` coercion only when `updatedInput` is present
   (its gate excludes MCP tools, and `ExitPlanMode` is a built-in), so echoing
   `tool_input` is sufficient.

Automated:
- `tests/server/integration/test_sessions_permission_request_hook.py` — **60
  passed** (the two `ExitPlanMode` allow round-trips updated to expect
  `updatedInput`).

## Demo

N/A (no frontend files changed; behavior verified live per Test Plan). The
user-visible effect: web-UI plan approval now takes effect on `claude-native`,
and rejecting with feedback no longer fires a spurious interrupt.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

The `updatedInput` behavior is covered by the two `ExitPlanMode` round-trip
assertions in `test_sessions_permission_request_hook.py` (default + auto mode).
The existing e2e_ui plan-review test
(`tests/e2e_ui/approvals/test_exit_plan_mode.py`) is a **mock** ("no real Claude
Code"), which is why the real `requiresUserInteraction` coercion was never
exercised there — the failure only reproduces against a real `claude` binary.
Manual verification was performed end-to-end on a live `2.1.251` session
(reproduced the parked-plan failure with a bare allow, then confirmed the fix
approves the plan). The removed keystroke path had no automated test (#4067
shipped without one).

## Changelog

Approving or rejecting a plan from the web UI now works reliably in Claude Code
sessions — approvals take effect, and rejecting with feedback no longer
occasionally interrupts Claude's next response.

This pull request and its description were written by Isaac.
