### PR TITLE
fix(ci): let trusted-author forks skip the ui-preview deploy approval gate

### DIFF
--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -18,12 +18,13 @@ name: UI Preview
 #   1. The build checks out the PR's *head SHA* (immutable), never the live
 #      `refs/pull/<n>/merge` ref that silently re-points to whatever was last
 #      pushed -- so a run only ever builds one specific, inspectable commit.
-#   2. For FORK PRs the secret-bearing `deploy` job runs in the protected
-#      `ui-preview-fork` Environment, which requires a human reviewer to approve
-#      *each* run -- so every new commit on a labelled fork PR waits for a fresh
-#      approval before it can deploy. Same-repo PRs (maintainer + resolve-agent
-#      bot branches, which outside contributors cannot push to) are trusted and
-#      deploy without the gate.
+#   2. For UNTRUSTED fork PRs the secret-bearing `deploy` job runs in the
+#      protected `ui-preview-fork` Environment, which requires a human reviewer
+#      to approve *each* run -- so every new commit on a labelled fork PR waits
+#      for a fresh approval before it can deploy. Trusted authors (repo
+#      owners/members/collaborators, incl. a maintainer pushing from their own
+#      personal fork) and same-repo branches (resolve-agent bot, which outside
+#      contributors cannot push to) are trusted and deploy without the gate.
 # Repo-settings prerequisite: create an Environment named `ui-preview-fork`
 # (Settings -> Environments) with "Required reviewers" set to the maintainer
 # team. Without it the gate is a no-op (the job just runs), so it must be
@@ -225,16 +226,23 @@ jobs:
 
   deploy:
     needs: build
-    # Gate the secret-bearing deploy behind a protected Environment for FORK PRs
-    # only: a labelled fork PR that gets a new commit must wait for a human
-    # reviewer to approve this run before it can deploy with Databricks
-    # OAuth-M2M creds. Same-repo PRs (maintainer + resolve-agent bot branches,
-    # which outside contributors can't push to) and `push` to main are trusted
-    # and skip the gate. `environment` must be a static string, so select it with
-    # a conditional: `ui-preview-fork` (protected -> requires approval) for forks,
-    # empty (no gate) otherwise. The Environment's "Required reviewers" rule is
-    # configured in repo Settings; see the header note.
-    environment: ${{ (github.event.pull_request.head.repo.fork && 'ui-preview-fork') || '' }}
+    # Gate the secret-bearing deploy behind a protected Environment for
+    # UNTRUSTED fork PRs only: a labelled outside-contributor fork PR that gets a
+    # new commit must wait for a human reviewer to approve this run before it can
+    # deploy with Databricks OAuth-M2M creds. Trusted authors (repo
+    # owners/members/collaborators -- e.g. a maintainer working from their own
+    # personal fork) skip the gate, as do same-repo branches (resolve-agent bot,
+    # which outside contributors can't push to) and `push` to main. `fork` alone
+    # is true even for a maintainer's own fork, so we also check
+    # `author_association` to keep maintainer forks from hitting the approval
+    # prompt. `environment` must be a static string, so select it with a
+    # conditional: `ui-preview-fork` (protected -> requires approval) for
+    # untrusted forks, empty (no gate) otherwise. The Environment's "Required
+    # reviewers" rule is configured in repo Settings; see the header note.
+    environment: >-
+      ${{ (github.event.pull_request.head.repo.fork
+           && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+           && 'ui-preview-fork') || '' }}
     # Use ubuntu-latest. If the Databricks workspace IP-allowlists, register a
     # static-IP runner and switch `runs-on` to it.
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Related issue

N/A — surfaced while working on a maintainer fork PR (#5730).

## Summary

The `ui-preview` deploy job routes fork PRs through the protected
`ui-preview-fork` Environment, which requires a human to approve each run.
The gate keyed solely on `github.event.pull_request.head.repo.fork`, which is
`true` even for a **maintainer pushing from their own personal fork** — so
maintainers hit the approval prompt on every commit (e.g. #5730, authored from
`serena-ruan/omnigent`).

This change also consults `author_association`: repo `OWNER`/`MEMBER`/
`COLLABORATOR` authors deploy without the gate (like same-repo branches), while
outside contributors (`CONTRIBUTOR`/`NONE`) still require per-run approval. The
`ui-preview` label remains the primary trust boundary, so this doesn't weaken
the model for untrusted PRs.

```yaml
environment: >-
  ${{ (github.event.pull_request.head.repo.fork
       && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
       && 'ui-preview-fork') || '' }}
```

Note: this is a convenience/UX fix, not a merge-gating one — `UI Preview` is not
a required status check, so a pending/unapproved deploy never blocked auto-merge
either way.

## Test Plan

- `python dev/lint/lint_no_hardcoded_models.py .github/workflows/ui-preview.yml` → clean.
- YAML validated with `yaml.safe_load`.
- `pre-commit` hooks pass on the staged change.
- Behavioral verification (requires a live run): push a commit to a
  maintainer-fork PR labelled `ui-preview` and confirm the **UI Preview /
  deploy** job runs without an environment-approval wait; confirm an
  outside-contributor fork PR still shows "waiting for review".

## Demo

N/A — CI workflow change, no UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The gate only evaluates during a live `pull_request_target` run, which can't be
exercised by unit tests; verified statically (linter + YAML parse + pre-commit)
and to be confirmed on the next preview run for a labelled fork PR.

## Changelog

Fixed the UI Preview deploy gate prompting maintainers for environment approval
on PRs pushed from their own forks.

This pull request and its description were written by Isaac.
