### PR TITLE
fix(ci): reconcile needs-demo as derived state

### DIFF
--- a/.github/workflows/demo-check.js
+++ b/.github/workflows/demo-check.js
@@ -1,13 +1,12 @@
-// Scan contributor PRs opened in the last 24 hours and comment when a Bug fix,
-// Feature, or UI / frontend change is checked but no real demo (screenshot /
-// video) is provided. Runs hourly; the 24-hour window ensures every new PR is
-// checked even if it was opened just before a cron tick. Drafts and maintainer
-// PRs are skipped. Already-flagged PRs (labeled `needs-demo`) are skipped to
-// avoid duplicate comments on subsequent runs.
+// Keep `needs-demo` aligned with the current PR. PR_NUMBER checks one PR after
+// a lifecycle event; without it, a manual run also repairs existing labels.
 
 const MS_PER_HOUR = 60 * 60 * 1000;
 const HOURS_TO_SCAN = 24;
 const NEEDS_DEMO_LABEL = "needs-demo";
+const DEMO_COMMENT_MARKER = "<!-- needs-demo-comment -->";
+const DEMO_COMMENT_TEXT =
+  "This PR is a **Bug fix**, **Feature**, or **UI / frontend change** but the **Demo** section is missing";
 
 const MAINTAINER_ASSOCIATIONS = ["MEMBER", "OWNER", "COLLABORATOR"];
 
@@ -31,6 +30,7 @@ const QUERY = `
       nodes {
         ... on PullRequest {
           number
+          state
           author { login }
           authorAssociation
           isDraft
@@ -80,7 +80,8 @@ function hasDemoContent(body) {
 }
 
 const demoRequiredMessage = (author) =>
-  `@${author} This PR is a **Bug fix**, **Feature**, or **UI / frontend change** but the **Demo** section is missing or only contains a placeholder.
+  `${DEMO_COMMENT_MARKER}
+@${author} This PR is a **Bug fix**, **Feature**, or **UI / frontend change** but the **Demo** section is missing or only contains a placeholder.
 
 These change types require a screenshot or screen recording so reviewers can see the new behaviour without checking out the branch. Please update the **Demo** section with:
 
@@ -88,6 +89,9 @@ These change types require a screenshot or screen recording so reviewers can see
 - A link to a hosted video or GIF showing the new behaviour.
 
 _Use \`N/A\` only when the change has no user-visible effect whatsoever (e.g. a pure refactor or test-only change). If that's the case, uncheck the relevant type box and check **Refactor / chore** or **Test / CI** instead._`;
+
+const demoResolvedMessage = `${DEMO_COMMENT_MARKER}
+✅ This PR no longer requires demo follow-up.`;
 
 module.exports = async ({ context, github, core }) => {
   const { owner, repo } = context.repo;
@@ -129,78 +133,142 @@ module.exports = async ({ context, github, core }) => {
       }
     }
 
-    const cutoff = new Date(Date.now() - HOURS_TO_SCAN * MS_PER_HOUR);
-    // GitHub search supports ISO 8601 timestamps for sub-day precision.
-    const cutoffString = cutoff.toISOString().replace(/\.\d{3}Z$/, "Z");
-    const searchQuery = `repo:${owner}/${repo} is:pr is:open created:>${cutoffString}`;
+    const findDemoComment = async (issueNumber) => {
+      const comments = await github.paginate(github.rest.issues.listComments, {
+        owner,
+        repo,
+        issue_number: issueNumber,
+        per_page: 100,
+      });
+      return comments.find(
+        (comment) =>
+          comment.user?.type === "Bot" &&
+          (comment.body?.includes(DEMO_COMMENT_MARKER) || comment.body?.includes(DEMO_COMMENT_TEXT))
+      );
+    };
 
-    console.log(`Scanning PRs: ${searchQuery}`);
+    const allPRs = new Map();
+    const labeledPRs = new Set();
+    const single = Number(process.env.PR_NUMBER) || null;
 
-    let cursor = null;
-    let hasNextPage = true;
-    const allPRs = [];
+    if (single) {
+      const response = await github.rest.pulls.get({ owner, repo, pull_number: single });
+      const pr = response.data;
+      allPRs.set(pr.number, {
+        number: pr.number,
+        state: pr.merged ? "MERGED" : pr.state.toUpperCase(),
+        author: { login: pr.user?.login },
+        authorAssociation: pr.author_association,
+        isDraft: pr.draft,
+        labels: { nodes: pr.labels },
+        body: pr.body,
+      });
+      console.log(`Checking PR #${single}`);
+    } else {
+      const fetchPRs = async (searchQuery) => {
+        console.log(`Scanning PRs: ${searchQuery}`);
+        const found = [];
+        let cursor = null;
+        let hasNextPage = true;
+        while (hasNextPage) {
+          const response = await github.graphql(QUERY, { cursor, searchQuery });
+          const { remaining, resetAt } = response.rateLimit;
+          console.log(`Rate limit: ${remaining} remaining, resets at ${resetAt}`);
+          const { nodes, pageInfo } = response.search;
+          found.push(...nodes);
+          hasNextPage = pageInfo.hasNextPage;
+          cursor = pageInfo.endCursor;
+        }
+        return found;
+      };
 
-    while (hasNextPage) {
-      const response = await github.graphql(QUERY, { cursor, searchQuery });
-      const { remaining, resetAt } = response.rateLimit;
-      console.log(`Rate limit: ${remaining} remaining, resets at ${resetAt}`);
+      const cutoff = new Date(Date.now() - HOURS_TO_SCAN * MS_PER_HOUR);
+      const cutoffString = cutoff.toISOString().replace(/\.\d{3}Z$/, "Z");
+      const recentQuery = `repo:${owner}/${repo} is:pr is:open created:>${cutoffString}`;
+      const labeledQuery = `repo:${owner}/${repo} is:pr label:${NEEDS_DEMO_LABEL}`;
 
-      const { nodes, pageInfo } = response.search;
-      hasNextPage = pageInfo.hasNextPage;
-      cursor = pageInfo.endCursor;
-      allPRs.push(...nodes);
+      for (const pr of await fetchPRs(recentQuery)) allPRs.set(pr.number, pr);
+      for (const pr of await fetchPRs(labeledQuery)) {
+        allPRs.set(pr.number, pr);
+        labeledPRs.add(pr.number);
+      }
+      console.log(`Found ${allPRs.size} PR(s) to check`);
     }
 
-    console.log(`Found ${allPRs.length} open PRs from the last ${HOURS_TO_SCAN} hours`);
-
     let flaggedCount = 0;
+    let clearedCount = 0;
     let skippedCount = 0;
 
-    for (const pr of allPRs) {
-      // Skip drafts and maintainer PRs (by association and MAINTAINER file).
-      if (pr.isDraft) {
-        skippedCount++;
-        continue;
-      }
-      if (MAINTAINER_ASSOCIATIONS.includes(pr.authorAssociation)) {
-        skippedCount++;
-        continue;
-      }
-
+    for (const pr of allPRs.values()) {
       const author = pr.author?.login ?? "contributor";
-      if (maintainers.has(author.toLowerCase())) {
-        skippedCount++;
-        continue;
-      }
-
-      // Skip PRs we've already flagged.
       const labels = pr.labels?.nodes?.map((l) => l.name) ?? [];
-      if (labels.includes(NEEDS_DEMO_LABEL)) {
+      const isLabeled = labeledPRs.has(pr.number) || labels.includes(NEEDS_DEMO_LABEL);
+      const isMaintainer =
+        MAINTAINER_ASSOCIATIONS.includes(pr.authorAssociation) ||
+        maintainers.has(author.toLowerCase());
+      const needsDemo =
+        pr.state === "OPEN" &&
+        !pr.isDraft &&
+        !isMaintainer &&
+        requiresDemo(pr.body) &&
+        !hasDemoContent(pr.body);
+
+      if (!needsDemo && isLabeled) {
+        try {
+          const existing = await findDemoComment(pr.number);
+          if (existing && existing.body !== demoResolvedMessage) {
+            await github.rest.issues.updateComment({
+              owner,
+              repo,
+              comment_id: existing.id,
+              body: demoResolvedMessage,
+            });
+          }
+        } catch (err) {
+          if (err.status === 429 || err.message?.includes("rate limit")) throw err;
+          core.warning(`Could not resolve the demo reminder on #${pr.number}: ${err.message}`);
+        }
+        try {
+          await github.rest.issues.removeLabel({
+            owner,
+            repo,
+            issue_number: pr.number,
+            name: NEEDS_DEMO_LABEL,
+          });
+          console.log(`PR #${pr.number}: removed '${NEEDS_DEMO_LABEL}'`);
+          clearedCount++;
+        } catch (err) {
+          // A concurrent run may already have removed it.
+          if (err.status !== 404) throw err;
+        }
+        continue;
+      }
+
+      if (!needsDemo || isLabeled) {
         skippedCount++;
-        continue;
-      }
-
-      // Only care about PRs that checked Bug fix, Feature, or UI / frontend change.
-      if (!requiresDemo(pr.body)) {
-        continue;
-      }
-
-      // Demo content is present — nothing to do.
-      if (hasDemoContent(pr.body)) {
         continue;
       }
 
       console.log(`PR #${pr.number} (@${author}): demo required but not provided`);
 
-      // Comment before labeling: if the comment fails the PR stays unlabeled
-      // and will be retried on the next run. Labeling first would permanently
-      // suppress the reminder on a transient comment failure.
-      await github.rest.issues.createComment({
-        owner,
-        repo,
-        issue_number: pr.number,
-        body: demoRequiredMessage(author),
-      });
+      const body = demoRequiredMessage(author);
+      const existing = await findDemoComment(pr.number);
+
+      if (!existing) {
+        await github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: pr.number,
+          body,
+        });
+      } else if (existing.body !== body) {
+        await github.rest.issues.updateComment({
+          owner,
+          repo,
+          comment_id: existing.id,
+          body,
+        });
+      }
 
       await github.rest.issues.addLabels({
         owner,
@@ -213,7 +281,7 @@ module.exports = async ({ context, github, core }) => {
     }
 
     console.log(
-      `Done. Flagged ${flaggedCount} PR(s); skipped ${skippedCount} (drafts / maintainers / already labeled).`
+      `Done. Flagged ${flaggedCount} PR(s); cleared ${clearedCount}; skipped ${skippedCount}.`
     );
   } catch (error) {
     if (error.status === 429 || error.message?.includes("rate limit")) {

--- a/.github/workflows/demo-check.yml
+++ b/.github/workflows/demo-check.yml
@@ -1,21 +1,18 @@
 name: PR Hygiene
 
-# Hourly sweep over recently-opened PRs. Two independent checks share the run:
+# Hourly issue-link and review-readiness sweep. Manual dispatch also runs the
+# demo check as recovery for missed live events and existing stale labels:
 #
-#   1. Demo check -- comment on PRs that check "Bug fix" / "Feature" /
-#      "UI / frontend change" but provide no demo (screenshot / video).
-#      See demo-check.js.
+#   1. Demo check (manual only) -- reconcile the `needs-demo` label.
 #   2. Issue-link check -- comment on PRs that reference no issue and label them
 #      `needs-issue`, then close one still unlinked 7 days later. Forward-only:
 #      nothing opened before its effective date is considered, so the backlog is
 #      untouched. Enforcing, capped at LIMIT comments and LIMIT closures per run.
 #      See pr-issue-link.js.
 #
-# Both skip drafts and PRs they've already flagged, each deduping on its own label
-# (`needs-demo`, `needs-issue`). The demo check never closes anything; the
-# issue-link check closes only over its own label, only past the deadline the nudge
-# announced, and reversibly via `/reopen`. Never checks out or runs PR code -- they
-# read PR metadata via the API using only the default-branch script.
+# The demo check never closes anything; the issue-link check closes only over its
+# own label, only past the deadline the nudge announced, and reversibly via
+# `/reopen`. Neither checks out nor runs PR code.
 #
 # Two dispatch inputs exist for one-off runs: `scan_hours` widens the issue-link
 # window so PRs older than a day can be brought into the rule (hand-labeling them
@@ -68,10 +65,10 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           sparse-checkout: .github
-      # demo-check.js has no dry-run mode, so a dry run skips it rather than pass a
-      # flag it ignores. Nothing in the sweep writes when enforce is "false".
+      # Normal demo reconciliation is event-driven in pr-hygiene-live.yml. This
+      # manual-only sweep is the recovery path for missed events and old labels.
       - name: Demo check
-        if: inputs.enforce != 'false'
+        if: github.event_name == 'workflow_dispatch' && inputs.enforce != 'false'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           retries: 3

--- a/.github/workflows/pr-hygiene-live.yml
+++ b/.github/workflows/pr-hygiene-live.yml
@@ -1,14 +1,9 @@
 name: PR Hygiene (live)
 
-# Runs the issue-reference nudge and the ready-for-review gate against a single PR
-# the moment something changes on it, so a contributor is not waiting on the hourly
-# sweep. GitHub's cron is best-effort and in practice fires every 1.5 to 2.5 hours.
+# Runs demo, issue-reference, and ready-for-review checks against a single PR the
+# moment something changes on it.
 #
-# The sweep in demo-check.yml stays as the safety net: it catches PRs this misses
-# (a run that failed, a link added from the sidebar, which fires no webhook) and it
-# is the only path that reaches PRs opened before this workflow existed. Both routes
-# call the same scripts with the same decision logic; only the fetch differs, so
-# they cannot disagree.
+# The demo sweep in demo-check.yml is manual-only recovery for missed events.
 #
 # `pull_request_target` because the scripts need write access to comment and label on
 # fork PRs. Safe here: it checks out only the trusted default branch's .github and
@@ -16,21 +11,22 @@ name: PR Hygiene (live)
 
 on:
   pull_request_target:
-    # `edited` matters: adding "Closes #123" to the description is how a nudged
-    # contributor satisfies the rule, and it should clear immediately.
-    types: [opened, reopened, ready_for_review, edited, synchronize]
+    # Description edits can satisfy either content rule. Draft conversion and
+    # closure clear a stale demo label.
+    types: [opened, reopened, ready_for_review, converted_to_draft, edited, synchronize, closed]
 
 permissions:
   contents: read
 
 concurrency:
-  # Per PR, cancelling superseded runs: rapid edits should not queue up duplicates.
+  # Serialize each PR so a run cannot be cancelled between commenting and labeling.
+  # Label and comment writes are not subscribed event types, so there is no loop.
   group: pr-hygiene-live-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   hygiene:
-    if: github.repository == 'omnigent-ai/omnigent' && !github.event.pull_request.draft
+    if: github.repository == 'omnigent-ai/omnigent'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -46,7 +42,20 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           sparse-checkout: .github
+      - name: Demo check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          retries: 3
+          script: |
+            const script = require(".github/workflows/demo-check.js");
+            await script({ context, github, core });
       - name: Issue-link check
+        if: >-
+          always() &&
+          github.event.action != 'closed' &&
+          !github.event.pull_request.draft
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ENFORCE: "true"
@@ -61,7 +70,10 @@ jobs:
             const script = require(".github/workflows/pr-issue-link.js");
             await script({ context, github, core });
       - name: Ready-for-review gate
-        if: always()
+        if: >-
+          always() &&
+          github.event.action != 'closed' &&
+          !github.event.pull_request.draft
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ENFORCE: "true"


### PR DESCRIPTION
## Related issue

Closes #3020. Supersedes #3079 with the label-clearing fix rebased onto the current PR hygiene workflow.

## Summary

`needs-demo` should describe the PR's current state, not remember that the check failed once.

- `.github/workflows/demo-check.js` reuses the existing demo predicate for a single PR: add the label when it is true and remove it when false. The bot keeps one marked comment per PR and edits it between warning and resolved states instead of posting again. Manual mode also reconciles currently labeled PRs as a one-off recovery path.
- `.github/workflows/pr-hygiene-live.yml` reruns that logic on PR lifecycle events and serializes runs per PR. It does not subscribe to label or comment events, so its own writes cannot cause a loop.
- `.github/workflows/demo-check.yml` no longer runs the demo check on the hourly schedule. Manual dispatch remains available for missed events and the existing backlog; the unrelated issue-link and review-readiness checks remain hourly.

No new workflow, production sweep, or test harness is introduced.

ELI5: the label is now a warning light that turns off when the problem is fixed.

```text
PR lifecycle event -> existing demo predicate -> true  -> show warning + add label
                                             -> false -> show resolved + remove label

label/comment write -X-> no subscribed event
```

## Test Plan

- `node --check .github/workflows/demo-check.js`
- Exercised the script with a mocked GitHub client for add, keep, remove, closed-PR cleanup, manual reconciliation, warning/resolved transitions, legacy-comment reuse, human-comment isolation, and comment-edit failure.
- `pre-commit run`
- `git diff --check`

## Demo

N/A — repository automation only; no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The workflow script was executed locally against mocked REST and GraphQL responses. Assertions covered live single-PR transitions, manually dispatched reconciliation, warning/resolved comment reuse, and label cleanup when a comment edit fails; no network writes were made.
