### PR TITLE
fix(claude-sdk): persist compaction before errors

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -2543,6 +2543,8 @@ class ClaudeSDKExecutor(Executor):
         terminal_error: str | None = None
         compaction_occurred: bool = False
         claude_session_id: str | None = None
+        compaction_transcript_path: pathlib.Path | None = None
+        compaction_transcript_offset: int | None = None
 
         # Track in-flight tool calls so we can emit ToolCallComplete
         # with the tool name and duration when results arrive.
@@ -2567,6 +2569,98 @@ class ClaudeSDKExecutor(Executor):
         # mirroring how the openai-agents executor uses ``raw_responses[-1]``
         # for ``context_tokens``. ``None`` until the first call starts.
         last_call_usage: dict[str, Any] | None = None  # type: ignore[explicit-any]
+
+        def _new_compact_summary_visible() -> bool:
+            if compaction_transcript_path is None or compaction_transcript_offset is None:
+                logger.warning(
+                    "Skipping Claude compaction checkpoint after stream failure: "
+                    "PreCompact did not provide a readable transcript boundary "
+                    "(session=%s).",
+                    claude_session_id,
+                )
+                return False
+
+            try:
+                with compaction_transcript_path.open("rb") as transcript:
+                    transcript.seek(compaction_transcript_offset)
+                    appended = transcript.read()
+            except OSError:
+                logger.warning(
+                    "Skipping Claude compaction checkpoint after stream failure: "
+                    "could not read appended transcript records (session=%s, path=%s).",
+                    claude_session_id,
+                    compaction_transcript_path,
+                    exc_info=True,
+                )
+                return False
+
+            for raw_line in appended.splitlines():
+                try:
+                    entry = json.loads(raw_line)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                if isinstance(entry, dict) and entry.get("isCompactSummary") is True:
+                    return True
+
+            logger.warning(
+                "Skipping Claude compaction checkpoint after stream failure: "
+                "no post-PreCompact summary record is visible yet (session=%s, path=%s).",
+                claude_session_id,
+                compaction_transcript_path,
+            )
+            return False
+
+        def _build_compaction_complete_event(
+            *, require_new_compact_summary: bool = False
+        ) -> ExecutorEvent | None:
+            from omnigent.inner.executor import CompactionComplete
+
+            assert claude_session_id is not None
+            if require_new_compact_summary and not _new_compact_summary_visible():
+                return None
+
+            compaction_tokens = 0
+            if turn_usage is not None:
+                compaction_tokens = turn_usage.get("context_tokens", 0) or 0
+
+            try:
+                from claude_agent_sdk import get_session_messages
+
+                messages = get_session_messages(claude_session_id, directory=self._cwd)
+                compacted_messages = [
+                    {
+                        "type": "message",
+                        "role": message.type,
+                        "content": message.message.get("content", []),
+                    }
+                    for message in messages
+                    if isinstance(message.message, dict)
+                ]
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to read Claude post-compaction session messages "
+                    "(session=%s); preserving full server history instead of "
+                    "persisting an empty checkpoint.",
+                    claude_session_id,
+                    exc_info=True,
+                )
+                return None
+
+            if not compacted_messages:
+                logger.warning(
+                    "Claude post-compaction read returned no messages "
+                    "(session=%s); preserving full server history instead of "
+                    "persisting an empty checkpoint.",
+                    claude_session_id,
+                )
+                return None
+
+            return CompactionComplete(
+                summary="[Claude Code compaction — context was automatically compacted]",
+                token_count=compaction_tokens,
+                model=observed_model or model,
+                compacted_messages=compacted_messages,
+            )
 
         client = await self._get_or_create_client(
             sdk,
@@ -2946,6 +3040,22 @@ class ClaudeSDKExecutor(Executor):
                                 break
                         elif getattr(system_msg, "hook_event_name", None) == "PreCompact":
                             compaction_occurred = True
+                            hook_session_id = getattr(system_msg, "session_id", None)
+                            if hook_session_id is None and isinstance(data, dict):
+                                hook_session_id = data.get("session_id")
+                            if hook_session_id:
+                                claude_session_id = str(hook_session_id)
+                            hook_transcript_path = getattr(system_msg, "transcript_path", None)
+                            if hook_transcript_path is None and isinstance(data, dict):
+                                hook_transcript_path = data.get("transcript_path")
+                            if isinstance(hook_transcript_path, str) and hook_transcript_path:
+                                compaction_transcript_path = pathlib.Path(hook_transcript_path)
+                                try:
+                                    compaction_transcript_offset = (
+                                        compaction_transcript_path.stat().st_size
+                                    )
+                                except OSError:
+                                    compaction_transcript_offset = None
                             logger.info("Claude SDK compaction detected (PreCompact hook)")
                             from omnigent.inner.executor import CompactionStarted
 
@@ -2982,6 +3092,12 @@ class ClaudeSDKExecutor(Executor):
                 stderr_text,
                 diagnostics_text,
             )
+            if compaction_occurred and claude_session_id:
+                compaction_event = _build_compaction_complete_event(
+                    require_new_compact_summary=True
+                )
+                if compaction_event is not None:
+                    yield compaction_event
             yield ExecutorError(
                 message=(
                     f"Claude SDK error: {exc}\n"
@@ -2993,7 +3109,6 @@ class ClaudeSDKExecutor(Executor):
                 else _usage_from_observed_call(last_call_usage, observed_model or model),
             )
             return
-
         # A turn can end without ``ResultMessage`` usage — the CLI can close
         # the stream early, fail terminally (auth failure, rejected retries),
         # or be cut short before its final usage is reported. In all of those
@@ -3010,6 +3125,10 @@ class ClaudeSDKExecutor(Executor):
             turn_usage = _usage_from_observed_call(last_call_usage, observed_model or model)
 
         if terminal_error:
+            if compaction_occurred and claude_session_id:
+                compaction_event = _build_compaction_complete_event()
+                if compaction_event is not None:
+                    yield compaction_event
             yield ExecutorError(message=terminal_error, usage=turn_usage)
             return
 
@@ -3027,56 +3146,19 @@ class ClaudeSDKExecutor(Executor):
             _resp_verdict = await _policy_eval("PHASE_LLM_RESPONSE", _resp_data)
             if _resp_verdict.action == "POLICY_ACTION_DENY":
                 _deny_reason = _resp_verdict.reason or "no reason given"
+                if compaction_occurred and claude_session_id:
+                    compaction_event = _build_compaction_complete_event()
+                    if compaction_event is not None:
+                        yield compaction_event
                 yield ExecutorError(message=(f"LLM response denied by policy: {_deny_reason}"))
                 return
 
         _notify_usage_from_dict(model=model, usage=turn_usage)
 
         if compaction_occurred and claude_session_id:
-            from omnigent.inner.executor import CompactionComplete
-
-            _compaction_tokens = 0
-            if turn_usage is not None:
-                _compaction_tokens = turn_usage.get("context_tokens", 0) or 0
-            # Read the post-compaction session messages so the runner
-            # can persist them for session resume in ephemeral
-            # environments where the CLI's own transcript is lost.
-            _compacted: list[_JsonObject] | None = None
-            try:
-                from claude_agent_sdk import get_session_messages
-
-                _msgs = get_session_messages(claude_session_id, directory=self._cwd)
-                _compacted = [
-                    {"type": "message", "role": m.type, "content": m.message.get("content", [])}
-                    for m in _msgs
-                    if isinstance(m.message, dict)
-                ]
-                if not _compacted:
-                    logger.warning(
-                        "Claude post-compaction read returned no messages "
-                        "(session=%s); resume will fall back to the synthetic "
-                        "summary instead of the harness's real compacted state.",
-                        claude_session_id,
-                    )
-            except Exception:  # noqa: BLE001
-                # WARNING, not DEBUG: a swallowed read here silently degrades
-                # EVERY later resume of this conversation. The runner persists a
-                # compaction item with no ``compacted_messages``, so resume
-                # replays the lossy synthetic-summary pair instead of the
-                # harness's real post-compaction context. Surface it.
-                logger.warning(
-                    "Failed to read Claude post-compaction session messages "
-                    "(session=%s); resume fidelity for this conversation will "
-                    "degrade to the synthetic summary.",
-                    claude_session_id,
-                    exc_info=True,
-                )
-            yield CompactionComplete(
-                summary="[Claude Code compaction — context was automatically compacted]",
-                token_count=_compaction_tokens,
-                model=observed_model or model,
-                compacted_messages=_compacted,
-            )
+            compaction_event = _build_compaction_complete_event()
+            if compaction_event is not None:
+                yield compaction_event
 
         yield TurnComplete(response=response_text, usage=turn_usage)
 

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -4633,6 +4633,452 @@ def test_precompact_hook_emits_compaction_complete_with_session_messages() -> No
     _run(_t())
 
 
+def test_precompact_exception_persists_compaction_before_executor_error(tmp_path: Path) -> None:
+    """A stream failure after PreCompact still emits the durable boundary."""
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+    from omnigent.inner.executor import CompactionComplete, CompactionStarted
+
+    class _SystemMessage:
+        def __init__(self, subtype, data, hook_event_name=None, session_id=None):
+            self.subtype = subtype
+            self.data = data
+            self.hook_event_name = hook_event_name
+            self.session_id = session_id
+
+    class _FakeSessionMessage:
+        def __init__(self, type, message):
+            self.type = type
+            self.message = message
+
+    class _FakeSDK:
+        AssistantMessage = type("AssistantMessage", (), {})
+        UserMessage = type("UserMessage", (), {})
+        SystemMessage = _SystemMessage
+        ResultMessage = type("ResultMessage", (), {})
+        StreamEvent = type("StreamEvent", (), {})
+        ClaudeAgentOptions = type(
+            "ClaudeAgentOptions",
+            (),
+            {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+        )
+
+        class ClaudeSDKClient:
+            def __init__(self, options):
+                self.options = options
+
+            async def connect(self):
+                return
+
+            async def query(self, prompt, session_id="default"):
+                return
+
+            async def receive_response(self):
+                yield _SystemMessage(
+                    subtype="hook_started",
+                    data={
+                        "hook_event": "PreCompact",
+                        "session_id": "claude-uuid-error",
+                        "transcript_path": str(transcript_path),
+                    },
+                    hook_event_name="PreCompact",
+                    session_id="claude-uuid-error",
+                )
+                with transcript_path.open("a", encoding="utf-8") as transcript:
+                    transcript.write(
+                        json.dumps(
+                            {
+                                "type": "user",
+                                "uuid": "compact-summary-1",
+                                "isCompactSummary": True,
+                                "message": {
+                                    "role": "user",
+                                    "content": "compacted summary",
+                                },
+                            }
+                        )
+                        + "\n"
+                    )
+                raise RuntimeError("Autocompact is thrashing: the context refilled to the limit")
+
+            async def disconnect(self):
+                return None
+
+    fake_session_msgs = [
+        _FakeSessionMessage(
+            "assistant",
+            {"content": [{"type": "text", "text": "compacted summary"}]},
+        )
+    ]
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "uuid": "precompact-1",
+                "message": {"role": "user", "content": "continue"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    async def _t():
+        executor = ClaudeSDKExecutor()
+        with (
+            patch(
+                "omnigent.inner.claude_sdk_executor._ensure_sdk",
+                return_value=_FakeSDK,
+            ),
+            patch(
+                "claude_agent_sdk.get_session_messages",
+                return_value=fake_session_msgs,
+            ) as mock_get_msgs,
+        ):
+            events = [
+                event
+                async for event in executor.run_turn(
+                    [{"role": "user", "content": "continue", "session_id": "s1"}],
+                    [],
+                    "",
+                )
+            ]
+
+        started = [event for event in events if isinstance(event, CompactionStarted)]
+        completed = [event for event in events if isinstance(event, CompactionComplete)]
+        errors = [event for event in events if isinstance(event, ExecutorError)]
+
+        assert len(started) == 1
+        assert len(completed) == 1
+        assert len(errors) == 1
+        assert not [event for event in events if isinstance(event, TurnComplete)]
+        assert events.index(started[0]) < events.index(completed[0])
+        assert events.index(completed[0]) < events.index(errors[0])
+        assert completed[0].compacted_messages == [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "compacted summary"}],
+            }
+        ]
+        mock_get_msgs.assert_called_once_with("claude-uuid-error", directory=None)
+
+    _run(_t())
+
+
+@pytest.mark.parametrize(
+    ("transcript_location", "expect_checkpoint"),
+    [("top_level", True), ("nested", False)],
+)
+def test_precompact_exception_sdk_wire_payload_contract(
+    tmp_path: Path,
+    transcript_location: str,
+    expect_checkpoint: bool,
+) -> None:
+    """The SDK-decoded hook payload exposes a safe transcript boundary."""
+    import claude_agent_sdk as real_sdk
+    from claude_agent_sdk._internal.message_parser import parse_message
+
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+    from omnigent.inner.executor import CompactionComplete
+
+    class _FakeSessionMessage:
+        def __init__(self, type, message):
+            self.type = type
+            self.message = message
+
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "uuid": "precompact-wire-1",
+                "message": {"role": "user", "content": "continue"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    raw_hook_payload = {
+        "type": "system",
+        "subtype": "hook_started",
+        "hook_id": "hook-precompact-wire-1",
+        "hook_name": "PreCompact:auto",
+        "hook_event": "PreCompact",
+        "uuid": "hook-event-precompact-wire-1",
+        "session_id": "claude-uuid-wire",
+        "cwd": str(tmp_path),
+        "trigger": "auto",
+        "custom_instructions": None,
+    }
+    if transcript_location == "top_level":
+        raw_hook_payload["transcript_path"] = str(transcript_path)
+    else:
+        raw_hook_payload["input"] = {"transcript_path": str(transcript_path)}
+
+    hook_message = parse_message(raw_hook_payload)
+    assert isinstance(hook_message, real_sdk.HookEventMessage)
+
+    class _FakeSDK:
+        AssistantMessage = real_sdk.AssistantMessage
+        UserMessage = real_sdk.UserMessage
+        SystemMessage = real_sdk.SystemMessage
+        ResultMessage = real_sdk.ResultMessage
+        StreamEvent = real_sdk.StreamEvent
+        ClaudeAgentOptions = type(
+            "ClaudeAgentOptions",
+            (),
+            {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+        )
+
+        class ClaudeSDKClient:
+            def __init__(self, options):
+                self.options = options
+
+            async def connect(self):
+                return
+
+            async def query(self, prompt, session_id="default"):
+                return
+
+            async def receive_response(self):
+                yield hook_message
+                with transcript_path.open("a", encoding="utf-8") as transcript:
+                    transcript.write(
+                        json.dumps(
+                            {
+                                "type": "user",
+                                "uuid": "compact-summary-wire-1",
+                                "isCompactSummary": True,
+                                "message": {
+                                    "role": "user",
+                                    "content": "compacted summary",
+                                },
+                            }
+                        )
+                        + "\n"
+                    )
+                raise RuntimeError("Autocompact refilled the context")
+
+            async def disconnect(self):
+                return None
+
+    fake_session_msgs = [
+        _FakeSessionMessage(
+            "assistant",
+            {"content": [{"type": "text", "text": "compacted summary"}]},
+        )
+    ]
+
+    async def _t():
+        executor = ClaudeSDKExecutor()
+        with (
+            patch(
+                "omnigent.inner.claude_sdk_executor._ensure_sdk",
+                return_value=_FakeSDK,
+            ),
+            patch(
+                "claude_agent_sdk.get_session_messages",
+                return_value=fake_session_msgs,
+            ) as mock_get_messages,
+        ):
+            events = [
+                event
+                async for event in executor.run_turn(
+                    [{"role": "user", "content": "continue", "session_id": "s1"}],
+                    [],
+                    "",
+                )
+            ]
+
+        checkpoints = [event for event in events if isinstance(event, CompactionComplete)]
+        assert len(checkpoints) == int(expect_checkpoint)
+        if expect_checkpoint:
+            mock_get_messages.assert_called_once_with("claude-uuid-wire", directory=None)
+        else:
+            mock_get_messages.assert_not_called()
+
+    _run(_t())
+
+
+@pytest.mark.parametrize("session_read", [[], RuntimeError("transcript not flushed")])
+def test_precompact_exception_preserves_history_without_exportable_checkpoint(
+    tmp_path: Path,
+    session_read: list[object] | Exception,
+) -> None:
+    """An empty or failed export never replaces full history with a placeholder."""
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+    from omnigent.inner.executor import CompactionComplete
+
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+
+    class _SystemMessage:
+        def __init__(self, subtype, data, hook_event_name=None, session_id=None):
+            self.subtype = subtype
+            self.data = data
+            self.hook_event_name = hook_event_name
+            self.session_id = session_id
+
+    class _FakeSDK:
+        AssistantMessage = type("AssistantMessage", (), {})
+        UserMessage = type("UserMessage", (), {})
+        SystemMessage = _SystemMessage
+        ResultMessage = type("ResultMessage", (), {})
+        StreamEvent = type("StreamEvent", (), {})
+        ClaudeAgentOptions = type(
+            "ClaudeAgentOptions",
+            (),
+            {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+        )
+
+        class ClaudeSDKClient:
+            def __init__(self, options):
+                self.options = options
+
+            async def connect(self):
+                return
+
+            async def query(self, prompt, session_id="default"):
+                return
+
+            async def receive_response(self):
+                yield _SystemMessage(
+                    subtype="hook_started",
+                    data={
+                        "hook_event": "PreCompact",
+                        "session_id": "claude-uuid-error",
+                        "transcript_path": str(transcript_path),
+                    },
+                    hook_event_name="PreCompact",
+                    session_id="claude-uuid-error",
+                )
+                with transcript_path.open("a", encoding="utf-8") as transcript:
+                    transcript.write(
+                        json.dumps(
+                            {
+                                "type": "user",
+                                "uuid": "compact-summary-1",
+                                "isCompactSummary": True,
+                                "message": {
+                                    "role": "user",
+                                    "content": "compacted summary",
+                                },
+                            }
+                        )
+                        + "\n"
+                    )
+                raise RuntimeError("Autocompact is thrashing: the context refilled to the limit")
+
+            async def disconnect(self):
+                return None
+
+    async def _t():
+        executor = ClaudeSDKExecutor()
+        get_messages = (
+            patch("claude_agent_sdk.get_session_messages", side_effect=session_read)
+            if isinstance(session_read, Exception)
+            else patch("claude_agent_sdk.get_session_messages", return_value=session_read)
+        )
+        with (
+            patch(
+                "omnigent.inner.claude_sdk_executor._ensure_sdk",
+                return_value=_FakeSDK,
+            ),
+            get_messages,
+        ):
+            events = [
+                event
+                async for event in executor.run_turn(
+                    [{"role": "user", "content": "continue", "session_id": "s1"}],
+                    [],
+                    "",
+                )
+            ]
+
+        assert not [event for event in events if isinstance(event, CompactionComplete)]
+        assert len([event for event in events if isinstance(event, ExecutorError)]) == 1
+
+    _run(_t())
+
+
+def test_precompact_exception_without_new_summary_preserves_history(tmp_path: Path) -> None:
+    """PreCompact alone is not evidence that Claude finished compaction."""
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+    from omnigent.inner.executor import CompactionComplete
+
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+
+    class _SystemMessage:
+        def __init__(self, subtype, data, hook_event_name=None, session_id=None):
+            self.subtype = subtype
+            self.data = data
+            self.hook_event_name = hook_event_name
+            self.session_id = session_id
+
+    class _FakeSDK:
+        AssistantMessage = type("AssistantMessage", (), {})
+        UserMessage = type("UserMessage", (), {})
+        SystemMessage = _SystemMessage
+        ResultMessage = type("ResultMessage", (), {})
+        StreamEvent = type("StreamEvent", (), {})
+        ClaudeAgentOptions = type(
+            "ClaudeAgentOptions",
+            (),
+            {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+        )
+
+        class ClaudeSDKClient:
+            def __init__(self, options):
+                self.options = options
+
+            async def connect(self):
+                return
+
+            async def query(self, prompt, session_id="default"):
+                return
+
+            async def receive_response(self):
+                yield _SystemMessage(
+                    subtype="hook_started",
+                    data={
+                        "hook_event": "PreCompact",
+                        "session_id": "claude-uuid-error",
+                        "transcript_path": str(transcript_path),
+                    },
+                    hook_event_name="PreCompact",
+                    session_id="claude-uuid-error",
+                )
+                raise RuntimeError("stream failed before compaction completed")
+
+            async def disconnect(self):
+                return None
+
+    async def _t():
+        executor = ClaudeSDKExecutor()
+        with (
+            patch(
+                "omnigent.inner.claude_sdk_executor._ensure_sdk",
+                return_value=_FakeSDK,
+            ),
+            patch("claude_agent_sdk.get_session_messages") as mock_get_messages,
+        ):
+            events = [
+                event
+                async for event in executor.run_turn(
+                    [{"role": "user", "content": "continue", "session_id": "s1"}],
+                    [],
+                    "",
+                )
+            ]
+
+        assert not [event for event in events if isinstance(event, CompactionComplete)]
+        assert len([event for event in events if isinstance(event, ExecutorError)]) == 1
+        mock_get_messages.assert_not_called()
+
+    _run(_t())
+
+
 def test_precompact_hook_emits_compaction_started_before_complete() -> None:
     """CompactionStarted is yielded when PreCompact fires, before CompactionComplete.
 
@@ -4660,6 +5106,11 @@ def test_precompact_hook_emits_compaction_started_before_complete() -> None:
             self.subtype = subtype
             self.data = data
             self.hook_event_name = hook_event_name
+
+    class _FakeSessionMessage:
+        def __init__(self, type, message):
+            self.type = type
+            self.message = message
 
     class _FakeSDK:
         AssistantMessage = type("AssistantMessage", (), {})
@@ -4707,7 +5158,12 @@ def test_precompact_hook_emits_compaction_started_before_complete() -> None:
             ),
             patch(
                 "claude_agent_sdk.get_session_messages",
-                return_value=[],
+                return_value=[
+                    _FakeSessionMessage(
+                        "user",
+                        {"content": [{"type": "text", "text": "compacted summary"}]},
+                    )
+                ],
             ),
         ):
             events = [


### PR DESCRIPTION
## Related issue

N/A — reported from a shared session that failed immediately after Claude auto-compaction.

## Summary

- Capture Claude's `PreCompact` session ID, transcript path, and byte offset so exception paths can inspect only records appended after the hook.
- Emit `CompactionComplete` on an errored turn only when the transcript contains a newly appended `isCompactSummary: true` record, proving compaction actually completed.
- Export and persist only a non-empty post-compaction checkpoint; if transcript export is empty or fails, preserve the server's existing full history rather than replacing it with a lossy placeholder.
- Add regressions for positive compact-summary evidence, missing completion evidence, empty/raised exports, and the installed SDK's raw hook-message decoding contract.

**ELI5:** Claude shortens its context internally, but Omnigent needs a durable copy for resume on another process or host. Omnigent now saves that copy after seeing Claude's actual compact-summary record—even if the turn then errors—and keeps the original full history when it cannot safely export the shortened checkpoint.

```text
PreCompact → record transcript offset → observe new compact summary → export non-empty checkpoint → persist CompactionComplete → surface error
```

## Test Plan

- `pytest tests/inner/test_claude_sdk_executor.py -q` — `132 passed, 1 xfailed`; covers the complete Claude SDK executor suite, the rapid-refill failure path, completion-evidence gating, empty/raised checkpoint exports, and the SDK-decoded `hook_started` payload boundary.
- `pytest tests/inner/test_claude_sdk_executor.py -q -k 'precompact or compaction'` — `9 passed`; covers the focused compaction lifecycle cases.
- `pre-commit run --all-files` — all hooks passed, including Ruff, Pyrefly, TypeScript checks, formatting, and generated-file checks.
- Copied the reported session into an isolated local Omnigent session and confirmed it accepted a new turn (`COPY_OK`) without modifying the original session.

## Demo

N/A — backend-only persistence fix with no visual changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regressions deterministically inject the observed `PreCompact` → rapid-refill exception. They verify that exception-path persistence requires a newly appended compact-summary record, emits `CompactionComplete` before `ExecutorError`, and skips persistence when completion evidence is absent or checkpoint export is empty/raises. The compatibility regression passes a raw CLI-style `hook_started` dictionary through the installed Claude Agent SDK parser before the executor sees it: a top-level `transcript_path` produces the checkpoint, while an unsupported nested shape fails safely without exporting or replacing history. The copied-session check verifies normal continuation in isolation; its context occupancy was too low to naturally trigger auto-compaction.

## Changelog

Claude SDK sessions now retain a verified compacted checkpoint when a turn errors after compaction, without discarding full history when a safe checkpoint cannot be exported.