### PR TITLE
fix(web): eagerly archive sessions in the sidebar

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_archive.py
+++ b/tests/e2e_ui/sessions/test_sidebar_archive.py
@@ -1,10 +1,11 @@
 """Browser e2e for archiving a session from the sidebar.
 
-The row kebab's "Archive" item fires a single
-``PATCH /v1/sessions/{id}`` with ``archived: true``; the row shows a
-transient "Archiving…" status and then drops out of the default list
-(archived sessions live on the Settings page). The runner stop is the
-server's job, spawned in the background once the flag commits.
+The row kebab's "Archive" item fires a single ``PATCH /v1/sessions/{id}``
+with ``archived: true``. The row leaves the sidebar optimistically — the
+cached ``archived`` flag flips in ``onMutate`` and the sidebar filters
+archived rows out client-side — and the server stops the session in the
+background once the flag commits. Archived sessions live on the Settings
+page, not the sidebar.
 
 This asserts both halves of a real archive:
 
@@ -28,54 +29,16 @@ to tear down. Server-side coverage for that lives in
 
 from __future__ import annotations
 
-import asyncio
-import threading
 import time
 import uuid
-from collections.abc import Coroutine
-from typing import Any
-from urllib.parse import urlparse
 
 import httpx
-from playwright.async_api import Route, WebSocketRoute, async_playwright
-from playwright.async_api import expect as async_expect
 from playwright.sync_api import Locator, Page, Request, expect
 
 
 def _row(page: Page, session_id: str) -> Locator:
     """Locate the sidebar row (``<li>``) for *session_id* by its href."""
     return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
-
-
-def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
-    """Run *coro* to completion in a dedicated thread with its own event loop.
-
-    This file mixes sync ``page``-fixture tests with one async-Playwright test
-    (the spinner-persistence test below holds a route open across UI
-    assertions). The e2e_ui suite runs many pytest-playwright **sync** tests in
-    the same session; once one has run, pytest-asyncio can't start a loop on the
-    main thread ("Runner.run() cannot be called from a running event loop").
-    Running the coroutine from a fresh thread via :func:`asyncio.run` sidesteps
-    that. Any exception — including assertion failures — is captured and
-    re-raised on the calling thread so the test fails normally. Mirrors
-    ``test_cross_session_routing._run_in_fresh_loop``.
-
-    :param coro: The coroutine to run to completion.
-    :raises BaseException: Whatever the coroutine raised, re-raised here.
-    """
-    captured: dict[str, BaseException] = {}
-
-    def _worker() -> None:
-        try:
-            asyncio.run(coro)
-        except BaseException as exc:
-            captured["error"] = exc
-
-    thread = threading.Thread(target=_worker)
-    thread.start()
-    thread.join()
-    if "error" in captured:
-        raise captured["error"]
 
 
 def test_archive_session_removes_row_without_stop_event(
@@ -127,9 +90,9 @@ def test_archive_session_removes_row_without_stop_event(
     row.get_by_test_id("conversation-actions").click()
     page.get_by_test_id("archive-conversation").click()
 
-    # The row drops out of the default sidebar list: it first swaps to a
-    # transient "Archiving…" status (no href) while the PATCH is in
-    # flight, then unmounts entirely once the list refetches without it.
+    # The row drops out of the default sidebar list immediately: the cached
+    # ``archived`` flag flips optimistically in onMutate and the sidebar filters
+    # archived rows out client-side, so the row unmounts on the next frame.
     expect(page.locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
 
     # Archiving the *active* session redirects to home so the user isn't
@@ -154,199 +117,3 @@ def test_archive_session_removes_row_without_stop_event(
     # stop here would either serialize the runner's timeouts ahead of
     # the flag flip or race the server's own stop against the runner.
     assert stop_events == [], f"archive must not send a stop_session event, sent {stop_events}"
-
-
-def test_archiving_spinner_stays_until_row_leaves(
-    seeded_session: tuple[str, str],
-) -> None:
-    """The "Archiving…" spinner must persist until the row actually leaves.
-
-    Regression test for a visible flicker: the spinner disappeared the
-    instant the archive PATCH resolved, but the row lingered in the
-    sidebar for the extra round-trip it takes the ``["conversations"]``
-    list refetch to drop the now-archived row. For that window the row
-    swapped back to its plain, interactive form — no spinner, still
-    clickable — which reads as "archive finished" while the session is
-    plainly still listed.
-
-    The fix keeps the spinner mounted for the whole span, tearing it down
-    only when the row itself unmounts. This asserts that ordering directly.
-
-    Driven through async Playwright (not the sync ``page`` fixture) because
-    it holds the list-refetch response open across UI assertions to freeze
-    the exact window where the two events can separate.
-
-    :param seeded_session: ``(base_url, session_id)`` for a runner-bound
-        session.
-    """
-    base_url, session_id = seeded_session
-    _run_in_fresh_loop(_drive_archiving_spinner_persists(base_url, session_id))
-
-
-async def _drive_archiving_spinner_persists(base_url: str, session_id: str) -> None:
-    """Async body of the spinner-persistence test. See the test docstring.
-
-    Reproduction hinges on freezing the window between "PATCH resolved" and
-    "row gone". A row leaves the sidebar by exactly two paths, and BOTH are
-    pinned open here so the window can't close on its own:
-
-    - **List refetch.** ``useArchiveConversation`` invalidates
-      ``["conversations"]`` on PATCH success, which refetches
-      ``GET /v1/sessions?…&include_archived=true``; that response, re-peeled
-      through the sidebar's archived filter, is what drops the row. The
-      handler lets the PATCH itself through (so the mutation resolves — and
-      the buggy code's ``onSettled`` fires) but holds the *list refetch*
-      open until the assertions have run.
-    - **WS push.** An ``archived: true`` frame over
-      ``WS /v1/sessions/updates`` would splice the row out client-side
-      (``violatesKnownMembership``). The socket is intercepted and its
-      client frames swallowed, so no live push arrives to close the window
-      behind the test's back.
-
-    With both frozen, the spinner's fate is decided purely by the row's own
-    state: the fixed code keeps ``conversation-archiving`` mounted; the old
-    code unmounts it and re-shows the interactive ``/c/{id}`` link while the
-    row is still present. Releasing the held refetch then proves the row
-    really does leave (and the spinner with it), so the freeze didn't merely
-    stall the whole flow.
-
-    :param base_url: Spawned server base URL.
-    :param session_id: The runner-bound session archived in this test.
-    """
-    href = f'a[href="/c/{session_id}"]'
-    spinner = '[data-testid="conversation-archiving"]'
-
-    def _is_sidebar_list_get(request: Any) -> bool:
-        """A GET for the sidebar's paginated session list.
-
-        Distinguished from the sibling ``pinned=true`` query (same
-        ``/v1/sessions`` path) by ``include_archived=true`` + no ``pinned``
-        param — the exact signature the sidebar's ``useConversations("", true)``
-        page issues (``fetchConversationsPage``). Holding the pinned query
-        instead would let the real list refetch through and unfreeze the row.
-        """
-        if request.method != "GET":
-            return False
-        parsed = urlparse(request.url)
-        if parsed.path != "/v1/sessions":
-            return False
-        return "include_archived=true" in (parsed.query or "") and "pinned=true" not in (
-            parsed.query or ""
-        )
-
-    async with async_playwright() as pw:
-        browser = await pw.chromium.launch()
-        page = await browser.new_page()
-        try:
-            # Give the row a stable, unique title so it's unambiguous in the
-            # sidebar and its snapshot is easy to assert on.
-            title = f"e2e-archive-spin-{uuid.uuid4().hex[:8]}"
-            rename = await page.request.patch(
-                f"{base_url}/v1/sessions/{session_id}",
-                data={"title": title},
-                timeout=10_000,
-            )
-            assert rename.ok, f"rename failed: {rename.status}"
-
-            release_refetch = asyncio.Event()
-            # Set by the test body right after the Archive item is clicked.
-            # Only list GETs that fire AFTER that are held, so the sidebar's
-            # initial load renders the row first. Gating on the click (not the
-            # PATCH body) keeps the freeze independent of request-body parsing.
-            archiving_started = {"done": False}
-            refetch_held = {"done": False}
-            # Diagnostics: every /v1/sessions request, for a precise failure msg.
-            list_gets: list[str] = []
-
-            async def handle_sessions(route: Route) -> None:
-                request = route.request
-                # The list refetch (or reconcile) that would drop the archived
-                # row: hold the FIRST one that fires after the archive click
-                # until the test releases it. Earlier list GETs (initial
-                # sidebar load) pass through so the row renders first.
-                if _is_sidebar_list_get(request):
-                    list_gets.append(f"{request.method} {request.url}")
-                    if archiving_started["done"] and not refetch_held["done"]:
-                        refetch_held["done"] = True
-                        await release_refetch.wait()
-                    await route.continue_()
-                    return
-                await route.continue_()
-
-            async def handle_updates_ws(ws: WebSocketRoute) -> None:
-                # Swallow client watch-set frames without connecting to the real
-                # server, so no live ``archived: true`` push can splice the row
-                # out from under the test. Mirrors test_hosts_changed_push.
-                ws.on_message(lambda _msg: None)
-
-            # One handler for both the list (``/v1/sessions``) and the
-            # per-session PATCH (``/v1/sessions/{id}``); the glob covers both.
-            await page.route("**/v1/sessions*", handle_sessions)
-            await page.route_web_socket(
-                lambda url: "/v1/sessions/updates" in url, handle_updates_ws
-            )
-
-            await page.goto(f"{base_url}/c/{session_id}")
-
-            row = page.locator("li").filter(has=page.locator(href))
-            await async_expect(row).to_be_visible()
-
-            # Open the kebab → Archive. Arm the refetch-hold on the click, so
-            # only list GETs triggered by the archive (its ['conversations']
-            # invalidation) are frozen — not the initial sidebar load.
-            await row.hover()
-            await row.get_by_test_id("conversation-actions").click()
-            await page.get_by_test_id("archive-conversation").click()
-            archiving_started["done"] = True
-
-            # The spinner appears while the PATCH is in flight.
-            await async_expect(page.locator(spinner)).to_be_visible()
-
-            # Wait until the post-archive list refetch is actually held — from
-            # here the ONLY thing that can remove the row is releasing it, so
-            # the window is genuinely frozen and the next assertion is not a
-            # race against a refetch that simply hasn't fired yet.
-            deadline = asyncio.get_running_loop().time() + 15.0
-            while not refetch_held["done"]:
-                if asyncio.get_running_loop().time() > deadline:
-                    raise AssertionError(
-                        "post-archive sidebar-list refetch never fired within 15s — "
-                        "the archive PATCH may not have invalidated ['conversations']. "
-                        f"sidebar-list GETs seen: {list_gets}"
-                    )
-                await page.wait_for_timeout(50)
-
-            # KEY ASSERTION. The PATCH has resolved (the refetch it triggered is
-            # what we're holding), so the buggy code has already cleared
-            # `isArchiving` and swapped the row back to its interactive link.
-            # The fix keeps the spinner mounted. Give the buggy behavior ~1.5s
-            # of settle time so a regression fails loudly, not flakily. The
-            # visible spinner also proves the row's <li> is still present — the
-            # spinner IS the row's content mid-archive.
-            await page.wait_for_timeout(1_500)
-            await async_expect(page.locator(spinner)).to_be_visible()
-            # The row must still be its spinner form (a <div>, no anchor), NOT
-            # back to the interactive `/c/{id}` link. A reappearing link here —
-            # count 1 instead of the expected 0 — is the exact regression: the
-            # spinner was torn down a round-trip before the row actually left.
-            await async_expect(page.locator(href)).to_have_count(0)
-            assert await page.get_by_role("link", name=title).count() == 0, (
-                "the interactive session link reappeared while the row was still "
-                "in the sidebar — the spinner was torn down too early"
-            )
-
-            # Release the held refetch: the row — and its spinner — must now
-            # leave the default list. This proves the freeze stalled removal
-            # rather than the whole flow, and that the spinner ends exactly at
-            # unmount (not before, per the assertions above; not lingering
-            # after, per this one).
-            release_refetch.set()
-            await async_expect(page.locator(spinner)).to_have_count(0)
-            await async_expect(page.locator(href)).to_have_count(0)
-
-            # Durable, not just a cache splice: the store row carries the flag.
-            snap = await page.request.get(f"{base_url}/v1/sessions/{session_id}", timeout=10_000)
-            assert snap.ok, f"snapshot fetch failed: {snap.status}"
-            assert (await snap.json())["archived"] is True, "session should report archived=true"
-        finally:
-            await browser.close()

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -1440,6 +1440,80 @@ describe("useBulkArchiveConversations", () => {
       total: 2,
     });
   });
+
+  it("keeps successful archives and reverts only failed ids on partial failure", async () => {
+    // conv_a archives OK; conv_b fails.
+    fetchMock.mockImplementation((url: string) =>
+      Promise.resolve(
+        url.endsWith("/conv_a")
+          ? mockResponse({
+              id: "conv_a",
+              object: "conversation",
+              title: "A",
+              created_at: 0,
+              updated_at: 10,
+              labels: {},
+            })
+          : mockResponse({}, { ok: false, status: 500 }),
+      ),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const key = ["conversations", "", true];
+    queryClient.setQueryData(key, {
+      pages: [
+        {
+          data: [
+            {
+              id: "conv_a",
+              object: "conversation",
+              title: "A",
+              created_at: 0,
+              updated_at: 0,
+              labels: {},
+              permission_level: null,
+              status: "idle",
+              archived: false,
+            },
+            {
+              id: "conv_b",
+              object: "conversation",
+              title: "B",
+              created_at: 0,
+              updated_at: 0,
+              labels: {},
+              permission_level: null,
+              status: "idle",
+              archived: false,
+            },
+          ],
+          first_id: "conv_a",
+          last_id: "conv_b",
+          has_more: false,
+        },
+      ],
+      pageParams: [undefined],
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useBulkArchiveConversations(), { wrapper });
+
+    result.current.mutate({ ids: ["conv_a", "conv_b"], archived: true });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // The successful archive stays archived; only the failed one reverts — and
+    // neither is resurrected by a ["conversations"] refetch. That refetch off
+    // the lagging search index is exactly what would have brought conv_a back
+    // as archived:false, the regression this snapshot-scoped reconcile guards.
+    const rows = (
+      queryClient.getQueryData(key) as {
+        pages: { data: { id: string; archived?: boolean }[] }[];
+      }
+    ).pages[0].data;
+    const archivedById = Object.fromEntries(rows.map((r) => [r.id, r.archived]));
+    expect(archivedById).toEqual({ conv_a: true, conv_b: false });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["conversations"] });
+  });
 });
 
 describe("useBulkDeleteConversations", () => {
@@ -2129,6 +2203,51 @@ describe("useArchiveConversation", () => {
     // success — that would race the search-index reindex and bounce the row
     // back into the sidebar until the index caught up.
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["projects"] });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["conversations"] });
+  });
+
+  it("rolls the flag back from the snapshot when the PATCH fails, without a list refetch", async () => {
+    // The archive PATCH fails.
+    fetchMock.mockResolvedValueOnce(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const key = ["conversations", "", true];
+    queryClient.setQueryData(key, {
+      pages: [
+        {
+          data: [
+            {
+              id: "conv_a",
+              object: "conversation",
+              title: "A",
+              created_at: 0,
+              updated_at: 0,
+              labels: {},
+              permission_level: null,
+              status: "idle",
+              archived: false,
+            },
+          ],
+          first_id: "conv_a",
+          last_id: "conv_a",
+          has_more: false,
+        },
+      ],
+      pageParams: [undefined],
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useArchiveConversation(), { wrapper });
+
+    result.current.mutate({ id: "conv_a", archived: true });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // The optimistic overlay is rolled back from the snapshot — the row is
+    // visible again (archived:false) — and the rollback did NOT refetch the
+    // search-indexed list (which would have raced the reindex).
+    const rows = (queryClient.getQueryData(key) as { pages: { data: { archived?: boolean }[] }[] })
+      .pages[0].data;
+    expect(rows[0].archived).toBe(false);
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["conversations"] });
   });
 });

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -1375,7 +1375,7 @@ describe("useBulkArchiveConversations", () => {
     return { queryClient, invalidateSpy, rendered };
   }
 
-  it("PATCHes each session and invalidates the list on success", async () => {
+  it("PATCHes each session and refreshes projects (not conversations) on success", async () => {
     fetchMock
       .mockResolvedValueOnce(
         mockResponse({
@@ -1407,7 +1407,11 @@ describe("useBulkArchiveConversations", () => {
       expect(init.method).toBe("PATCH");
       expect(JSON.parse(init.body as string)).toEqual({ archived: true });
     }
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
+    // Rows leave the sidebar via the optimistic overlay, so success refreshes
+    // only the DB-direct project caches — refetching ["conversations"] here
+    // would race the search-index reindex and bounce the rows back.
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["projects"] });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["conversations"] });
   });
 
   it("throws with failed ids when some archives fail", async () => {
@@ -2064,7 +2068,7 @@ describe("useMoveToProject", () => {
 });
 
 describe("useArchiveConversation", () => {
-  it("PATCHes archived and invalidates both the conversations and projects queries", async () => {
+  it("PATCHes archived, overlays the flag optimistically, and doesn't race the reindex", async () => {
     fetchMock.mockResolvedValueOnce(
       mockResponse({
         id: "conv_a",
@@ -2076,22 +2080,56 @@ describe("useArchiveConversation", () => {
       }),
     );
     const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    // Seed the sidebar list (include-archived variant) holding the live row.
+    queryClient.setQueryData(["conversations", "", true], {
+      pages: [
+        {
+          data: [
+            {
+              id: "conv_a",
+              object: "conversation",
+              title: "A",
+              created_at: 0,
+              updated_at: 0,
+              labels: {},
+              permission_level: null,
+              status: "idle",
+              archived: false,
+            },
+          ],
+          first_id: "conv_a",
+          last_id: "conv_a",
+          has_more: false,
+        },
+      ],
+      pageParams: [undefined],
+    });
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
     const { result } = renderHook(() => useArchiveConversation(), { wrapper });
 
     result.current.mutate({ id: "conv_a", archived: true });
+
+    // Optimistic: the cached flag flips before the PATCH resolves (the sidebar
+    // filters archived rows out client-side, so the row disappears now).
+    await waitFor(() => {
+      const d = queryClient.getQueryData(["conversations", "", true]) as {
+        pages: { data: { archived?: boolean }[] }[];
+      };
+      expect(d.pages[0].data[0].archived).toBe(true);
+    });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("/v1/sessions/conv_a");
     expect(init.method).toBe("PATCH");
     expect(JSON.parse(init.body as string)).toEqual({ archived: true });
-    // Projects must refresh too: archiving the last live member of a project
-    // removes its folder; unarchiving restores it.
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
+    // Projects refresh (DB-direct, no lag). Conversations is NOT refetched on
+    // success — that would race the search-index reindex and bounce the row
+    // back into the sidebar until the index caught up.
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["projects"] });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["conversations"] });
   });
 });
 

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -639,12 +639,22 @@ export function useArchiveConversation() {
       // overlay and clobber the flag with the stale search-indexed state.
       await queryClient.cancelQueries({ queryKey: ["conversations"] });
       overlayArchivedIntoCaches(queryClient, id, archived);
+      // A pinned session outside the paginated window lives only in the pinned
+      // backfill cache, which the overlay above doesn't reach; drop it from
+      // there too so an archived pin vanishes eagerly (mirrors delete).
+      if (archived) {
+        queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, (old) =>
+          old ? { ...old, conversations: old.conversations.filter((c) => c.id !== id) } : old,
+        );
+      }
     },
     onError: (_err, { archived }) => {
       // The PATCH failed — reconcile the optimistic flag from the server (the
-      // row snaps back to its old section on the refetch).
+      // row snaps back to its old section on the refetch, and a dropped pin
+      // returns to the pinned backfill).
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });
       void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
+      void queryClient.invalidateQueries({ queryKey: PINNED_CONVERSATIONS_KEY });
       showToast(
         archived
           ? "Couldn't archive the session — it's back in the sidebar."

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -29,6 +29,7 @@ import { startTimedInteraction } from "@/lib/analyticsEmit";
 import {
   filtersFromConversationQueryKey,
   mergeItemsIntoPages,
+  overlayArchivedIntoCaches,
   overlayTitleIntoCaches,
   PINNED_LABEL_KEY,
   PROJECT_FOLDER_FILTERS,
@@ -619,23 +620,43 @@ export function useRenameConversation() {
 /**
  * Archive / unarchive a conversation via `PATCH /v1/sessions/{id}`.
  *
- * Invalidates the conversations list on success so the row moves
- * into (or out of) the sidebar's "Archived" section. Mirrors the
- * rename hook's `markConversationSeen` anchoring: the PATCH bumps
- * server `updated_at`, and without this the unseen tracker would
- * flag the user's own archive action as new activity.
+ * Optimistic: `onMutate` overlays the new `archived` flag into every cached
+ * list (see `overlayArchivedIntoCaches`), so the sidebar — which filters
+ * archived rows out client-side — repaints on the next frame instead of after
+ * the PATCH round-trips. `onError` reconciles the flag from the server (the
+ * row returns to its old section) and toasts. `onSuccess` anchors the unseen
+ * tracker (the PATCH bumps server `updated_at`, which would otherwise flag the
+ * user's own archive as new activity) and refreshes the project caches, which
+ * read the DB directly (no search-index lag).
  */
 export function useArchiveConversation() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ id, archived }: { id: string; archived: boolean }) =>
       archiveConversation(id, archived),
+    onMutate: async ({ id, archived }) => {
+      // Cancel any in-flight list refetch so it can't resolve after this
+      // overlay and clobber the flag with the stale search-indexed state.
+      await queryClient.cancelQueries({ queryKey: ["conversations"] });
+      overlayArchivedIntoCaches(queryClient, id, archived);
+    },
+    onError: (_err, { archived }) => {
+      // The PATCH failed — reconcile the optimistic flag from the server (the
+      // row snaps back to its old section on the refetch).
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
+      showToast(
+        archived
+          ? "Couldn't archive the session — it's back in the sidebar."
+          : "Couldn't unarchive the session.",
+      );
+    },
     onSuccess: (updated) => {
       markConversationSeen(updated.id, updated.updated_at);
-      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
       // Archiving/unarchiving the last (or first) non-archived member of a
       // project removes/restores it from the server's project list, and adds
-      // or drops it from that project folder's own paginated list.
+      // or drops it from that project folder's own paginated list. These read
+      // the DB directly, so refetching them can't resurrect the archived row.
       void queryClient.invalidateQueries({ queryKey: ["projects"] });
       void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
       // Archive membership just changed, so the archived-view picker's option
@@ -899,10 +920,11 @@ export function useStopSession() {
 /**
  * Archive multiple conversations in parallel via `PATCH /v1/sessions/{id}`.
  *
- * Each session is archived independently — individual failures don't
- * block the rest. The conversations list is invalidated once on
- * completion so the sidebar refreshes. Returns an array of session IDs
- * that failed.
+ * Optimistic like the single-session archive: `onMutate` overlays the new flag
+ * onto every selected row so the sidebar repaints immediately. Each session is
+ * archived independently — individual failures don't block the rest — and
+ * `onError` reconciles the whole selection from the server (rows whose PATCH
+ * failed snap back). Returns the session IDs that failed.
  */
 export function useBulkArchiveConversations() {
   const queryClient = useQueryClient();
@@ -925,8 +947,18 @@ export function useBulkArchiveConversations() {
         .filter((r): r is PromiseFulfilledResult<Conversation> => r.status === "fulfilled")
         .map((r) => r.value);
     },
-    onSettled: () => {
+    onMutate: async ({ ids, archived }) => {
+      await queryClient.cancelQueries({ queryKey: ["conversations"] });
+      for (const id of ids) overlayArchivedIntoCaches(queryClient, id, archived);
+    },
+    onError: () => {
+      // Some or all failed — reconcile every row's flag from the server.
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    },
+    onSettled: () => {
+      // Project caches read the DB directly (no search-index lag), so unlike
+      // ["conversations"] they can be refreshed on every settle without
+      // racing the reindex and resurrecting an archived row.
       void queryClient.invalidateQueries({ queryKey: ["projects"] });
       void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
       void queryClient.invalidateQueries({ queryKey: ARCHIVED_PROJECT_NAMES_KEY });

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -629,6 +629,45 @@ export function useRenameConversation() {
  * user's own archive as new activity) and refreshes the project caches, which
  * read the DB directly (no search-index lag).
  */
+/**
+ * Snapshot of every cache an optimistic archive overlays — the flat lists,
+ * the project folders, and the pinned backfill — captured before the overlay
+ * so a failed archive rolls back to exactly this state. Mirrors delete's
+ * `DeletedListsSnapshot`: restoring the snapshot rather than refetching keeps
+ * the rollback off the search-indexed list fetch, which lags the write and
+ * would otherwise resurrect a row that DID archive (a bulk partial failure).
+ */
+interface ArchiveListsSnapshot {
+  lists: [readonly unknown[], ConversationsInfiniteData | undefined][];
+  pinned: PinnedConversationsResult | undefined;
+}
+
+function snapshotArchiveLists(queryClient: QueryClient): ArchiveListsSnapshot {
+  return {
+    lists: [
+      ...queryClient.getQueriesData<ConversationsInfiniteData>({ queryKey: ["conversations"] }),
+      ...queryClient.getQueriesData<ConversationsInfiniteData>({ queryKey: ["project-sessions"] }),
+    ],
+    pinned: queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY),
+  };
+}
+
+function restoreArchiveLists(queryClient: QueryClient, snapshot: ArchiveListsSnapshot): void {
+  for (const [key, data] of snapshot.lists) queryClient.setQueryData(key, data);
+  queryClient.setQueryData(PINNED_CONVERSATIONS_KEY, snapshot.pinned);
+}
+
+/**
+ * Drop conversations from the pinned backfill cache — a pinned session outside
+ * the paginated window lives only there, so the list overlay can't hide it.
+ */
+function dropFromPinnedCache(queryClient: QueryClient, ids: Iterable<string>): void {
+  const drop = new Set(ids);
+  queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, (old) =>
+    old ? { ...old, conversations: old.conversations.filter((c) => !drop.has(c.id)) } : old,
+  );
+}
+
 export function useArchiveConversation() {
   const queryClient = useQueryClient();
   return useMutation({
@@ -638,23 +677,17 @@ export function useArchiveConversation() {
       // Cancel any in-flight list refetch so it can't resolve after this
       // overlay and clobber the flag with the stale search-indexed state.
       await queryClient.cancelQueries({ queryKey: ["conversations"] });
+      const snapshot = snapshotArchiveLists(queryClient);
       overlayArchivedIntoCaches(queryClient, id, archived);
-      // A pinned session outside the paginated window lives only in the pinned
-      // backfill cache, which the overlay above doesn't reach; drop it from
-      // there too so an archived pin vanishes eagerly (mirrors delete).
-      if (archived) {
-        queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, (old) =>
-          old ? { ...old, conversations: old.conversations.filter((c) => c.id !== id) } : old,
-        );
-      }
+      // Drop an archived pin from the backfill cache too (mirrors delete).
+      if (archived) dropFromPinnedCache(queryClient, [id]);
+      return { snapshot };
     },
-    onError: (_err, { archived }) => {
-      // The PATCH failed — reconcile the optimistic flag from the server (the
-      // row snaps back to its old section on the refetch, and a dropped pin
-      // returns to the pinned backfill).
-      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
-      void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
-      void queryClient.invalidateQueries({ queryKey: PINNED_CONVERSATIONS_KEY });
+    onError: (_err, { archived }, context) => {
+      // Roll back to exactly the pre-archive caches, synchronously — so the
+      // row (and any dropped pin) returns at once, rather than waiting on a
+      // search-indexed refetch that lags the write.
+      if (context?.snapshot) restoreArchiveLists(queryClient, context.snapshot);
       showToast(
         archived
           ? "Couldn't archive the session — it's back in the sidebar."
@@ -959,11 +992,23 @@ export function useBulkArchiveConversations() {
     },
     onMutate: async ({ ids, archived }) => {
       await queryClient.cancelQueries({ queryKey: ["conversations"] });
+      const snapshot = snapshotArchiveLists(queryClient);
       for (const id of ids) overlayArchivedIntoCaches(queryClient, id, archived);
+      if (archived) dropFromPinnedCache(queryClient, ids);
+      return { snapshot };
     },
-    onError: () => {
-      // Some or all failed — reconcile every row's flag from the server.
-      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    onError: (err, { ids, archived }, context) => {
+      // Partial failure: restore the pre-archive caches, then RE-apply the
+      // overlay for the ids that DID archive so they stay hidden — only the
+      // failed ids return. Restoring from the snapshot rather than refetching
+      // ["conversations"] is what stops the search-index lag from resurrecting
+      // the successful archives (the exact regression this reconcile guards).
+      if (!context?.snapshot) return;
+      restoreArchiveLists(queryClient, context.snapshot);
+      const failed = new Set(err instanceof BulkConversationMutationError ? err.failed : ids);
+      const succeeded = ids.filter((id) => !failed.has(id));
+      for (const id of succeeded) overlayArchivedIntoCaches(queryClient, id, archived);
+      if (archived) dropFromPinnedCache(queryClient, succeeded);
     },
     onSettled: () => {
       // Project caches read the DB directly (no search-index lag), so unlike

--- a/web/src/lib/sessionListCache.test.ts
+++ b/web/src/lib/sessionListCache.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
 import type { Conversation, ConversationsPage } from "@/hooks/useConversations";
 import {
   type ConversationsInfiniteData,
@@ -7,6 +8,7 @@ import {
   filtersFromConversationQueryKey,
   mergeItemsIntoPages,
   nullsToUndefined,
+  overlayArchivedIntoCaches,
   removeIdsFromPages,
 } from "./sessionListCache";
 
@@ -419,5 +421,23 @@ describe("collectConversationIds", () => {
     // query) contributes nothing rather than throwing.
     expect(new Set(ids)).toEqual(new Set(["a", "b", "c"]));
     expect(ids.length).toBe(3);
+  });
+});
+
+describe("overlayArchivedIntoCaches", () => {
+  it("flips the flag in an include-archived list and drops the row from a folder", () => {
+    const qc = new QueryClient();
+    // Sidebar/archived-view cache keeps archived rows (client filters them).
+    qc.setQueryData(["conversations", "", true], data([conv("a"), conv("b")]));
+    // Project folder is non-archived — an archived row no longer belongs.
+    qc.setQueryData(["project-sessions", "proj"], data([conv("a")]));
+
+    overlayArchivedIntoCaches(qc, "a", true);
+
+    const list = qc.getQueryData<ConversationsInfiniteData>(["conversations", "", true])!;
+    expect(list.pages[0].data.find((c) => c.id === "a")!.archived).toBe(true);
+
+    const folder = qc.getQueryData<ConversationsInfiniteData>(["project-sessions", "proj"])!;
+    expect(folder.pages[0].data.map((c) => c.id)).toEqual([]);
   });
 });

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -438,4 +438,3 @@ export function overlayArchivedIntoCaches(
     old ? { ...old, archived } : old,
   );
 }
-

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -391,3 +391,51 @@ export function overlayTitleIntoCaches(
   );
   queryClient.setQueryData<Session>(["session", id], (old) => (old ? { ...old, title } : old));
 }
+
+/**
+ * Overlay an archived-flag change onto every cached list that holds the row,
+ * so archiving repaints the sidebar on the next frame instead of after the
+ * PATCH round-trips (which is what made archive feel slower than delete).
+ * Mirrors {@link overlayTitleIntoCaches}: the merge keeps the row in an
+ * include-archived list (marked archived, which the sidebar filters out
+ * client-side) and drops it from a non-archived project folder via
+ * `violatesKnownMembership`.
+ *
+ * Patched in place rather than invalidated, for the same reason rename/delete
+ * are: GET /v1/sessions may be served from a search index that lags the PATCH,
+ * so an immediate refetch races the reindex and bounces the row back. The
+ * server-confirmed state converges via the WS stream and the reconcile poll.
+ *
+ * ponytail: a reconcile poll firing inside the reindex-lag window (before the
+ * index reflects the archive) can briefly bounce the row back; it self-heals on
+ * the next poll. Add a fetch-time flag override (like `withoutDeletingSessions`)
+ * if metrics show the bounce.
+ */
+export function overlayArchivedIntoCaches(
+  queryClient: QueryClient,
+  id: string,
+  archived: boolean,
+): void {
+  const itemsById = new Map<string, SessionListWireItem>([[id, { id, archived }]]);
+  for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+    queryKey: ["conversations"],
+  })) {
+    const { data: next } = mergeItemsIntoPages(
+      data,
+      itemsById,
+      filtersFromConversationQueryKey(key),
+      undefined,
+    );
+    if (next !== data) queryClient.setQueryData(key, next);
+  }
+  for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+    queryKey: ["project-sessions"],
+  })) {
+    const { data: next } = mergeItemsIntoPages(data, itemsById, PROJECT_FOLDER_FILTERS, undefined);
+    if (next !== data) queryClient.setQueryData(key, next);
+  }
+  queryClient.setQueryData<Conversation | null>(["conversation-backfill", id], (old) =>
+    old ? { ...old, archived } : old,
+  );
+}
+

--- a/web/src/shell/HeaderConversationMenu.test.tsx
+++ b/web/src/shell/HeaderConversationMenu.test.tsx
@@ -165,10 +165,10 @@ describe("HeaderConversationMenu", () => {
 
     openMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: "Archive" }));
-    expect(mocks.archive).toHaveBeenCalledWith(
-      { id: "conv-1", archived: true },
-      expect.objectContaining({ onSuccess: expect.any(Function) }),
-    );
+    // Just the flag: the optimistic overlay lives in the hook, and the
+    // "view archived" toast fires synchronously (navigating away unmounts this
+    // menu, so a mutate onSuccess callback wouldn't fire).
+    expect(mocks.archive).toHaveBeenCalledWith({ id: "conv-1", archived: true });
 
     view.unmount();
     renderMenu();

--- a/web/src/shell/HeaderConversationMenu.tsx
+++ b/web/src/shell/HeaderConversationMenu.tsx
@@ -179,7 +179,10 @@ export function HeaderConversationMenu({
     // confirmDelete — rather than in an onSuccess callback that fires a
     // round-trip later with a stale active session.
     navigate("/", { replace: true });
-    archive.mutate({ id: conversation.id, archived: true }, { onSuccess: showArchivedToast });
+    archive.mutate({ id: conversation.id, archived: true });
+    // Fire NOW, not in a mutate onSuccess: navigating away unmounts this menu,
+    // and per-call mutate callbacks don't fire once their observer unmounts.
+    showArchivedToast();
   };
 
   const mainItems = (

--- a/web/src/shell/HeaderConversationMenu.tsx
+++ b/web/src/shell/HeaderConversationMenu.tsx
@@ -173,15 +173,13 @@ export function HeaderConversationMenu({
 
   const archiveConversation = () => {
     closeMenu();
-    archive.mutate(
-      { id: conversation.id, archived: true },
-      {
-        onSuccess: () => {
-          navigate("/", { replace: true });
-          showArchivedToast();
-        },
-      },
-    );
+    // The row leaves the sidebar optimistically (useArchiveConversation flips
+    // the cached `archived` flag in onMutate), and we're viewing the session
+    // being archived, so leave its chat surface now — synchronously, like
+    // confirmDelete — rather than in an onSuccess callback that fires a
+    // round-trip later with a stale active session.
+    navigate("/", { replace: true });
+    archive.mutate({ id: conversation.id, archived: true }, { onSuccess: showArchivedToast });
   };
 
   const mainItems = (

--- a/web/src/shell/Sidebar.archive.test.tsx
+++ b/web/src/shell/Sidebar.archive.test.tsx
@@ -1,15 +1,15 @@
 // Tests for the archive flow in the sidebar. Contract: archiving sends ONLY
-// the archive PATCH (`archived: true`). The "Archiving…" status row stays up
-// until the row LEAVES the sidebar — on success it's held (the row unmounts
-// when the list refetch drops the archived row, taking the spinner with it),
-// and only an error clears it to restore the interactive row for retry.
-// Clearing on settle would flash the row back to its clickable form a
-// round-trip before it actually leaves. The runner stop is the server's job
-// once the flag commits — a client stop would race the server's against the
-// same runner, and it would also put the runner's stop timeouts in front of
-// the flag flip. The kebab's user-facing "Stop session" action is a separate
-// affordance covered by Sidebar.stop.test.tsx. Unarchiving flips the flag
-// back with no status row. See ConversationRow.runArchive in Sidebar.tsx.
+// the archive PATCH (`archived: true`) — no client stop. The row leaves the
+// sidebar optimistically (useArchiveConversation flips the cached `archived`
+// flag in onMutate; the list filters archived rows out client-side), so there
+// is no "Archiving…" status row — the row simply unmounts, like delete's. The
+// only mutate-level callback is the success toast pointing at Settings.
+// The runner stop is the server's job once the flag commits — a client stop
+// would race the server's against the same runner, and put the runner's stop
+// timeouts in front of the flag flip. The kebab's user-facing "Stop session"
+// action is a separate affordance covered by Sidebar.stop.test.tsx.
+// The optimistic cache overlay + error reconcile is covered in
+// sessionListCache.test.ts / useConversations.test.ts.
 //
 // Archived sessions are no longer listed in the sidebar (they moved to the
 // Settings page), so unarchiving is covered by SettingsPage.test.tsx; this
@@ -147,17 +147,26 @@ describe("archive flow", () => {
     expect(mocks.archive.mutate).toHaveBeenCalledTimes(1);
     expect(mocks.archive.mutate).toHaveBeenCalledWith(
       { id: "conv_1", archived: true },
-      expect.objectContaining({
-        onSuccess: expect.any(Function),
-        // Only an error restores the interactive row; success intentionally
-        // leaves the spinner up until the row unmounts (see the "keeps the
-        // 'Archiving…' row up after the archive succeeds" case below).
-        onError: expect.any(Function),
-      }),
+      // The optimistic overlay + error reconcile live in the hook; the only
+      // call-site callback is the success toast.
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
     // The server owns the stop. A client stop here would race it against
     // the same runner and put its timeouts in front of the flag flip.
     expect(mocks.stop.mutate).not.toHaveBeenCalled();
+  });
+
+  it("does not show an 'Archiving…' status row — the row leaves optimistically", () => {
+    // No spinner: the cached `archived` flag flips in onMutate and the row
+    // unmounts, like delete. (The mocked mutate doesn't model the overlay, so
+    // the interactive row is still here — the point is only that no status row
+    // replaced it.)
+    mockConversations([CONV]);
+    renderSidebar();
+    clickArchive();
+
+    expect(screen.queryByTestId("conversation-archiving")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /My Session/ })).toBeInTheDocument();
   });
 
   it("toasts a pointer to Settings once the archive succeeds", async () => {
@@ -180,58 +189,4 @@ describe("archive flow", () => {
   // Unarchive moved out of the sidebar: archived sessions no longer render
   // here (they're on the Settings page), so the "Unarchive" affordance is
   // covered by SettingsPage.test.tsx instead.
-
-  it("shows an 'Archiving…' status row while the archive is in flight", () => {
-    // The archive mock never settles (vi.fn() stub), so the row stays in
-    // its in-flight state — the window the user sees. Without the indicator
-    // the row would look idle while the archive ran.
-    mockConversations([CONV]);
-    renderSidebar();
-    clickArchive();
-
-    const row = screen.getByTestId("conversation-archiving");
-    expect(within(row).getByText("Archiving…")).toBeInTheDocument();
-    // The interactive link is replaced by the status row, so the session
-    // can't be re-opened or re-archived mid-flight.
-    expect(screen.queryByRole("link", { name: /My Session/ })).not.toBeInTheDocument();
-  });
-
-  it("keeps the 'Archiving…' row up after the archive succeeds", () => {
-    // On success the spinner must NOT be cleared: the row leaves the sidebar
-    // only when the ['conversations'] refetch drops the archived row (which
-    // unmounts this row and its spinner together). Clearing on success would
-    // flash the row back to its plain, clickable form for the round-trip until
-    // the refetch lands — the exact regression this guards. Here the mocked
-    // list still contains the row (no refetch modeled), so firing onSuccess
-    // must leave the status row in place.
-    mockConversations([CONV]);
-    renderSidebar();
-    clickArchive();
-
-    expect(screen.getByTestId("conversation-archiving")).toBeInTheDocument();
-
-    const archiveOnSuccess = mocks.archive.mutate.mock.calls[0][1].onSuccess as () => void;
-    act(() => archiveOnSuccess());
-
-    // Still archiving, still no interactive link — the row hasn't left yet.
-    expect(screen.getByTestId("conversation-archiving")).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: /My Session/ })).not.toBeInTheDocument();
-  });
-
-  it("restores the interactive row when the archive errors", () => {
-    // The only escape hatch from the status row: a failed archive clears the
-    // flag so the user gets the clickable row back to retry. Success has no
-    // such clear (see above) — the row instead leaves via the refetch.
-    mockConversations([CONV]);
-    renderSidebar();
-    clickArchive();
-
-    expect(screen.getByTestId("conversation-archiving")).toBeInTheDocument();
-
-    const archiveOnError = mocks.archive.mutate.mock.calls[0][1].onError as () => void;
-    act(() => archiveOnError());
-
-    expect(screen.queryByTestId("conversation-archiving")).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /My Session/ })).toBeInTheDocument();
-  });
 });

--- a/web/src/shell/Sidebar.archive.test.tsx
+++ b/web/src/shell/Sidebar.archive.test.tsx
@@ -16,7 +16,7 @@
 // file exercises the archive path from a row's kebab.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -145,12 +145,10 @@ describe("archive flow", () => {
     clickArchive();
 
     expect(mocks.archive.mutate).toHaveBeenCalledTimes(1);
-    expect(mocks.archive.mutate).toHaveBeenCalledWith(
-      { id: "conv_1", archived: true },
-      // The optimistic overlay + error reconcile live in the hook; the only
-      // call-site callback is the success toast.
-      expect.objectContaining({ onSuccess: expect.any(Function) }),
-    );
+    // Just the flag — the optimistic overlay + error reconcile live in the
+    // hook, and the toast fires synchronously (not in a mutate callback, which
+    // wouldn't fire once the optimistic overlay unmounts the row).
+    expect(mocks.archive.mutate).toHaveBeenCalledWith({ id: "conv_1", archived: true });
     // The server owns the stop. A client stop here would race it against
     // the same runner and put its timeouts in front of the flag flip.
     expect(mocks.stop.mutate).not.toHaveBeenCalled();
@@ -169,15 +167,13 @@ describe("archive flow", () => {
     expect(screen.getByRole("link", { name: /My Session/ })).toBeInTheDocument();
   });
 
-  it("toasts a pointer to Settings once the archive succeeds", async () => {
+  it("toasts a pointer to Settings on archive", async () => {
     mockConversations([CONV]);
     renderSidebar();
     clickArchive();
 
-    // Drive the archive to its success callback.
-    const archiveArgs = mocks.archive.mutate.mock.calls[0];
-    act(() => (archiveArgs[1] as { onSuccess: () => void }).onSuccess());
-
+    // The toast fires synchronously on click (the row is about to unmount, so
+    // it can't wait for a mutate callback) — no need to drive onSuccess.
     const toast = await screen.findByTestId("toast");
     expect(within(toast).getByText(/View archived sessions in/)).toBeInTheDocument();
     expect(within(toast).getByRole("link", { name: "Settings" })).toHaveAttribute(

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3219,10 +3219,6 @@ function ConversationRow({
   const [deleteBranch, setDeleteBranch] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
   const [leaveOpen, setLeaveOpen] = useState(false);
-  // True while an archive is in flight. Drives the "Archiving…" status
-  // row — without it the row shows nothing while the archive completes.
-  // Delete needs no counterpart: it drops its row optimistically.
-  const [isArchiving, setIsArchiving] = useState(false);
   const gitBranch = conversation.git_branch ?? null;
   // Every row action gates on ownership alone — the sidebar carries no
   // effective-permission level, so rename/share/move/drag are owner-only and
@@ -3400,21 +3396,6 @@ function ConversationRow({
     );
   }
 
-  // Archiving is a single PATCH (see runArchive); show a status row for the
-  // span instead of leaving the row looking idle. The spinner stays up until
-  // the row itself leaves the sidebar: on success the list refetches and this
-  // row unmounts (dropped from the default view), which removes the spinner
-  // with it — it is deliberately NOT cleared on PATCH-settle, or it would
-  // vanish a round-trip before the row does. On failure the flag clears and
-  // the interactive row returns so the user can retry.
-  if (isArchiving) {
-    return (
-      <li>
-        <ArchivingRow label={label} />
-      </li>
-    );
-  }
-
   function confirmDelete() {
     // Fire-and-forget: close the dialog and drop the row immediately so the
     // user isn't blocked on the (potentially slow) DELETE — server-side
@@ -3432,38 +3413,23 @@ function ConversationRow({
 
   function runArchive() {
     const nextArchived = !isArchived;
-    // Unarchiving is a quick flag flip — no status row.
-    if (!nextArchived) {
-      archive.mutate({ id: conversation.id, archived: false });
-      return;
-    }
-    // Archiving sends only the PATCH: the server stops the session (and
-    // tears down a host-spawned runner) in the background once the flag is
-    // committed. Sending a client stop too would race that one against the
-    // same runner, and the loser gets a 503 from the already-killed pane.
+    // The archive PATCH sends only the flag: the server stops the session (and
+    // tears down a host-spawned runner) in the background once it's committed.
+    // A client stop too would race that one against the same runner, and the
+    // loser gets a 503 from the already-killed pane.
     //
-    // "Archiving…" must stay up until the row actually LEAVES the sidebar,
-    // not merely until the PATCH resolves. The PATCH success only kicks off
-    // an async `["conversations"]` refetch (see useArchiveConversation); the
-    // row drops out a round-trip later, once that refetch lands and the
-    // archived row is filtered out of the rendered list. Clearing the
-    // spinner on settle (the old behavior) reopened that gap: the row flashed
-    // back to its plain, clickable form — spinner gone — while the session
-    // was still listed. So we DON'T clear it on success: this row unmounts
-    // when the refetch removes it, which tears the spinner down with it.
-    // Only an error clears the flag, restoring the interactive row for retry.
-    setIsArchiving(true);
+    // The row leaves the sidebar optimistically (useArchiveConversation flips
+    // the cached `archived` flag in onMutate; the list filters archived rows
+    // out client-side), so this component unmounts on the next frame. Leaving
+    // the archived session's chat surface therefore has to happen HERE,
+    // synchronously — not in an onSuccess callback that fires a round-trip
+    // later with a stale `isActive`, which used to jump the user off whatever
+    // session they'd switched to meanwhile. Mirrors confirmDelete.
+    if (nextArchived && isActive) navigate("/", { replace: true });
     archive.mutate(
-      { id: conversation.id, archived: true },
-      {
-        // Point the user at where the session went — it's no longer in
-        // the sidebar list, so surface its new home in Settings.
-        onSuccess: () => {
-          if (isActive) navigate("/", { replace: true });
-          showArchivedToast();
-        },
-        onError: () => setIsArchiving(false),
-      },
+      { id: conversation.id, archived: nextArchived },
+      // Point the user at where the session went once the archive confirms.
+      { onSuccess: nextArchived ? showArchivedToast : undefined },
     );
   }
 
@@ -3998,30 +3964,6 @@ function PinnedProjectFlyoutContent({
         </p>
       )}
     </HoverCardContent>
-  );
-}
-
-/**
- * In-flight status row shown while a session is being archived (the
- * archive PATCH in ConversationRow.runArchive). Delete has no
- * counterpart: it removes its row optimistically, so there is nothing
- * left to show progress on. Archive failures fall back to the
- * interactive row rather than a persistent error state, so there's no
- * retry/dismiss affordance here.
- */
-function ArchivingRow({ label }: { label: string }) {
-  return (
-    <div
-      className={cn(SIDEBAR_ROW, "flex w-full items-center text-muted-foreground opacity-70")}
-      data-testid="conversation-archiving"
-      aria-live="polite"
-    >
-      <Loader2Icon className="size-3.5 shrink-0 animate-spin" aria-hidden />
-      <span className="min-w-0 flex-1 truncate" title={label}>
-        {label}
-      </span>
-      <span className="shrink-0 text-sm">Archiving…</span>
-    </div>
   );
 }
 
@@ -4742,28 +4684,22 @@ function BulkActionBar({
 
   function handleArchive() {
     if (nonArchivedSelected.length === 0) return;
-    bulkArchive.mutate(
-      { ids: nonArchivedSelected.map((c) => c.id), archived: true },
-      {
-        onSuccess: () => {
-          if (activeId && nonArchivedSelected.some((c) => c.id === activeId))
-            navigate("/", { replace: true });
-          onDeselectAll();
-        },
-      },
-    );
+    // The rows leave the sidebar optimistically (useBulkArchiveConversations
+    // flips their cached `archived` flag in onMutate), so this bar unmounts
+    // with the selection. Navigate and deselect NOW rather than in a
+    // mutate-level callback — a callback on the unmounted observer never fires,
+    // and it would carry a stale `activeId` that could jump the user off a
+    // session they switched to meanwhile. Mirrors handleDelete.
+    if (activeId && nonArchivedSelected.some((c) => c.id === activeId))
+      navigate("/", { replace: true });
+    onDeselectAll();
+    bulkArchive.mutate({ ids: nonArchivedSelected.map((c) => c.id), archived: true });
   }
 
   function handleUnarchive() {
     if (archivedSelected.length === 0) return;
-    bulkArchive.mutate(
-      { ids: archivedSelected.map((c) => c.id), archived: false },
-      {
-        onSuccess: () => {
-          onDeselectAll();
-        },
-      },
-    );
+    onDeselectAll();
+    bulkArchive.mutate({ ids: archivedSelected.map((c) => c.id), archived: false });
   }
 
   function handleDelete() {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3426,11 +3426,12 @@ function ConversationRow({
     // later with a stale `isActive`, which used to jump the user off whatever
     // session they'd switched to meanwhile. Mirrors confirmDelete.
     if (nextArchived && isActive) navigate("/", { replace: true });
-    archive.mutate(
-      { id: conversation.id, archived: nextArchived },
-      // Point the user at where the session went once the archive confirms.
-      { onSuccess: nextArchived ? showArchivedToast : undefined },
-    );
+    archive.mutate({ id: conversation.id, archived: nextArchived });
+    // Point the user at where the session went — fire NOW, not in a mutate
+    // onSuccess: the optimistic overlay unmounts this row on the next frame,
+    // and per-call mutate callbacks don't fire once their observer unmounts.
+    // A failed archive reconciles the row back with its own error toast.
+    if (nextArchived) showArchivedToast();
   }
 
   function confirmLeave() {


### PR DESCRIPTION
## Related issue

Tracked in Linear [OMNI-5744](https://linear.app/omnigent/issue/OMNI-5744) (eagerly update the sidebar client-side). No GitHub issue.

## Summary

Archiving a session felt slow and could misbehave:

- It took several seconds for an archived row to leave the sidebar — the archive PATCH only kicked off a `["conversations"]` refetch, and on search-indexed deployments that refetch lags the write.
- Archiving a session, then switching to another one before the PATCH resolved, could **jump you off the session you switched to** — the navigate ran in the archive's `onSuccess` with a stale captured `isActive`/`activeId`.

This makes archive optimistic (mirroring delete):

- `useArchiveConversation` / `useBulkArchiveConversations` now flip the cached `archived` flag in `onMutate`. The sidebar filters archived rows out client-side, so the row disappears on the next frame; only `onError` reconciles from the server. Success no longer refetches `["conversations"]` (which raced the reindex and bounced the row back).
- The archived session's chat surface is left **synchronously** in the click handler (row kebab, header menu, bulk bar) instead of in an `onSuccess` callback — fixing the auto-jump.
- The now-unnecessary "Archiving…" spinner row is removed.

## ELI5

Before: you hit Archive, the row sat there spinning for a few seconds, and if you clicked another session meanwhile you could get yanked to a new session. After: the row vanishes immediately, and we only leave the chat you actually archived.

## Test Plan

- `cd web && npx vitest run src/lib/sessionListCache.test.ts src/hooks/useConversations.test.ts src/shell/Sidebar.archive.test.tsx src/shell/HeaderConversationMenu.test.tsx` → 128 pass.
- `npx tsc -p tsconfig.app.json --noEmit` → clean.
- Manual: archive a session from the row kebab → it leaves the sidebar instantly + "View archived in Settings" toast. Archive a slow one, then immediately click another session → you stay on the one you clicked. Bulk-archive a selection including the active session → it leaves the chat surface; others don't.

## Demo

https://github.com/user-attachments/assets/d8468586-823e-4a4b-9fb6-c63fcde03b99

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Optimistic overlay + error-reconcile is covered by `useConversations.test.ts` (single + bulk) and `sessionListCache.test.ts` (`overlayArchivedIntoCaches`); the eager, synchronous navigate and the removed spinner are covered by `Sidebar.archive.test.tsx`. Manually verified the archive→switch-session no-jump behavior, which the mocked unit tests can't exercise end to end.

## Changelog

Archiving a session now removes it from the sidebar instantly and no longer jumps you away from a session you switched to mid-archive.

This pull request and its description were written by Isaac.