### PR TITLE
fix(web): show newly-created sessions in the sidebar immediately

### DIFF
--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -19,13 +19,16 @@ import { type ReactNode, useCallback, useEffect, useRef } from "react";
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { useActiveConversationId } from "@/hooks/useActiveConversationId";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
+import { isSessionDeleting } from "@/hooks/useConversations";
 import {
   type ConversationsInfiniteData,
   type SessionListWireItem,
   collectConversationIds,
   filtersFromConversationQueryKey,
+  insertNewRowsIntoPages,
   mergeItemsIntoPages,
   nullsToUndefined,
+  PROJECT_LABEL_KEY,
   removeIdsFromPages,
 } from "@/lib/sessionListCache";
 import { isModalHostResolved, resolveModalHost } from "@/lib/sessionHost";
@@ -66,13 +69,30 @@ function applyItemsToCache(
     queryKey: ["conversations"],
   });
   for (const [key, data] of entries) {
+    const filters = filtersFromConversationQueryKey(key);
     const {
-      data: next,
+      data: merged,
       found,
       needsRefetch: queryNeedsRefetch,
-    } = mergeItemsIntoPages(data, itemsById, filtersFromConversationQueryKey(key), activeId);
+    } = mergeItemsIntoPages(data, itemsById, filters, activeId);
     for (const id of found) foundAnywhere.add(id);
     if (queryNeedsRefetch) needsRefetch = true;
+    // Surface a brand-new watched session (a create here or elsewhere, a share)
+    // at the top now, instead of after the debounced refetch (which lags the
+    // search index). An unfiled row is fully placed → mark it found so it skips
+    // that refetch; a filed row can't be placed in its folder locally → leave it
+    // missing so the folder still reconciles via the scheduled refetch.
+    const missingHere = new Map([...itemsById].filter(([id]) => !found.has(id)));
+    const { data: next, inserted } = insertNewRowsIntoPages(
+      merged,
+      missingHere,
+      filters,
+      isSessionDeleting,
+    );
+    for (const id of inserted) {
+      const wire = itemsById.get(id);
+      if (wire?.project_id == null && !wire?.labels?.[PROJECT_LABEL_KEY]) foundAnywhere.add(id);
+    }
     if (next !== data) queryClient.setQueryData(key, next);
   }
   // Each project folder fetches its own ["project-sessions", <name>] list, so

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -259,6 +259,11 @@ export function markSessionsDeleting(ids: Iterable<string>): void {
   for (const id of ids) deletingSessionIds.add(id);
 }
 
+/** Whether a session has an optimistic delete in flight (tombstoned). */
+export function isSessionDeleting(id: string): boolean {
+  return deletingSessionIds.has(id);
+}
+
 /**
  * Stop hiding sessions — their delete failed, so the rows return.
  * Omit `ids` to release every tombstone at once.

--- a/web/src/lib/sessionListCache.test.ts
+++ b/web/src/lib/sessionListCache.test.ts
@@ -6,6 +6,7 @@ import {
   type SessionListWireItem,
   collectConversationIds,
   filtersFromConversationQueryKey,
+  insertNewRowsIntoPages,
   mergeItemsIntoPages,
   nullsToUndefined,
   overlayArchivedIntoCaches,
@@ -439,5 +440,72 @@ describe("overlayArchivedIntoCaches", () => {
 
     const folder = qc.getQueryData<ConversationsInfiniteData>(["project-sessions", "proj"])!;
     expect(folder.pages[0].data.map((c) => c.id)).toEqual([]);
+  });
+});
+
+describe("insertNewRowsIntoPages", () => {
+  const candidate = (id: string, extra: Partial<Conversation> = {}) =>
+    new Map<string, SessionListWireItem>([[id, { id, updated_at: 100, ...extra }]]);
+
+  it("prepends a brand-new row to the top of page 0 and reports it inserted", () => {
+    const before = data([conv("a"), conv("b")]);
+    const { data: after, inserted } = insertNewRowsIntoPages(
+      before,
+      candidate("new"),
+      DEFAULT_FILTERS,
+    );
+    expect(after!.pages[0].data.map((c) => c.id)).toEqual(["new", "a", "b"]);
+    expect(after!.pages[0].first_id).toBe("new");
+    expect(inserted).toEqual(new Set(["new"]));
+  });
+
+  it("skips a row already present (idempotent)", () => {
+    const before = data([conv("new"), conv("a")]);
+    const { data: after, inserted } = insertNewRowsIntoPages(
+      before,
+      candidate("new"),
+      DEFAULT_FILTERS,
+    );
+    expect(after).toBe(before);
+    expect(inserted.size).toBe(0);
+  });
+
+  it("skips search-filtered lists (membership unknown)", () => {
+    const before = data([conv("a")]);
+    const { inserted } = insertNewRowsIntoPages(before, candidate("new"), {
+      searchQuery: "hi",
+      includeArchived: false,
+    });
+    expect(inserted.size).toBe(0);
+  });
+
+  it("skips an archived row in a non-archived list", () => {
+    const before = data([conv("a")]);
+    const { inserted } = insertNewRowsIntoPages(before, candidate("new", { archived: true }), {
+      searchQuery: "",
+      includeArchived: false,
+    });
+    expect(inserted.size).toBe(0);
+  });
+
+  it("never inserts a sub-agent/child session (parent_session_id set)", () => {
+    const before = data([conv("a")]);
+    const { inserted } = insertNewRowsIntoPages(
+      before,
+      candidate("child", { parent_session_id: "parent" }),
+      DEFAULT_FILTERS,
+    );
+    expect(inserted.size).toBe(0);
+  });
+
+  it("skips ids the caller excludes (e.g. a session being deleted)", () => {
+    const before = data([conv("a")]);
+    const { inserted } = insertNewRowsIntoPages(
+      before,
+      candidate("gone"),
+      DEFAULT_FILTERS,
+      (id) => id === "gone",
+    );
+    expect(inserted.size).toBe(0);
   });
 });

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -273,6 +273,48 @@ export function mergeItemsIntoPages(
 }
 
 /**
+ * Prepend brand-new rows (a create here or elsewhere, a share) to page 0 so the
+ * sidebar shows them the instant the push lands, instead of after the debounced
+ * refetch (which lags the search index). A new row sorts newest-first, so page 0
+ * is its home. Skips: search lists (membership unknown), archived/wrong-project
+ * rows, sub-agent children (`parent_session_id` — they live off the sidebar),
+ * and ids the caller excludes via `skip` (e.g. an optimistic delete in flight).
+ * `candidates` should already exclude rows the list holds.
+ */
+export function insertNewRowsIntoPages(
+  data: ConversationsInfiniteData | undefined,
+  candidates: Map<string, SessionListWireItem>,
+  filters: ConversationListFilters,
+  skip?: (id: string) => boolean,
+): { data: ConversationsInfiniteData | undefined; inserted: Set<string> } {
+  const inserted = new Set<string>();
+  if (!data || candidates.size === 0 || filters.searchQuery) return { data, inserted };
+  const present = new Set<string>();
+  for (const page of data.pages) for (const c of page.data) present.add(c.id);
+  const rows: Conversation[] = [];
+  for (const [id, wire] of candidates) {
+    if (present.has(id) || skip?.(id)) continue;
+    const conv: Conversation = {
+      object: "conversation",
+      title: null,
+      created_at: 0,
+      updated_at: 0,
+      labels: {},
+      permission_level: null,
+      ...nullsToUndefined(wire),
+      id,
+    };
+    if (conv.parent_session_id != null || violatesKnownMembership(conv, filters)) continue;
+    rows.push(conv);
+    inserted.add(id);
+  }
+  if (rows.length === 0) return { data, inserted };
+  const [first, ...rest] = data.pages;
+  const nextFirst = { ...first, data: [...rows, ...first.data], first_id: rows[0].id };
+  return { data: { ...data, pages: [nextFirst, ...rest] }, inserted };
+}
+
+/**
  * Drop rows with the given ids from one infinite query's cached pages.
  *
  * Page cursors are recomputed from the surviving rows: `last_id` of the


### PR DESCRIPTION
## Related issue

Tracked in Linear [OMNI-5744](https://linear.app/omnigent/issue/OMNI-5744) (eagerly update the sidebar client-side). No GitHub issue.

## Summary

A newly-created session took a few seconds to appear in the sidebar. Creating a session relies on a `["conversations"]` list refetch that is served from a search index which lags the write, so the row shows up late. The `WS /v1/sessions/updates` stream knows about the session instantly, but the handler only used that signal to *trigger* the lagging refetch.

- The WS handler now **inserts** a brand-new watched session (a create here or in another tab, a share, a scheduled task) at the top of the **global** sidebar list on push, instead of only scheduling the refetch. It's **self-healing**: if a later refetch clobbers the row on a lagging deployment, the next push re-inserts it.
- Guards mirror the membership signals the rest of the system relies on, so only real top-level sessions are inserted:
  - skip **sub-agent/child** sessions (`parent_session_id` — they live off the sidebar),
  - skip sessions with an **optimistic delete in flight** (`isSessionDeleting`),
  - skip **search** lists and **archived / wrong-project** rows.
- **No insertion into project folders.** A filed row is left "missing" so its folder still reconciles via the existing scheduled refetch (server-owned membership), rather than guessing folder membership client-side.

New pure helper in `sessionListCache`: `insertNewRowsIntoPages`; new exported predicate `isSessionDeleting`.

## ELI5

Before: you create a chat, it opens, but its row shows up in the left list a few seconds later (we were waiting for the server to re-list everything). After: the row drops into the list the instant the session is announced on the updates stream.

```
create session ──► WS push "new session"
                        │
        before:         └─► schedule refetch ──(debounce + reindex lag)──► row appears
        after:          └─► insert at top of the global list now ──► row appears;
                            the refetch only reconciles (and re-inserts if it clobbers)
```

## Test Plan

- `cd web && npx vitest run src/lib/sessionListCache.test.ts src/hooks/SessionUpdatesProvider.test.tsx src/hooks/useConversations.test.ts src/store/chatStore.test.ts` → 495 pass.
- `npx tsc -p tsconfig.app.json --noEmit` → clean (only the pre-existing unrelated `rehype-slug` error).
- Manual: open the New Chat modal and create a session → its row appears at the top of the sidebar the moment it's announced, not after a beat. Create a session in a second tab → it appears in this tab's sidebar right away. Delete a session, then trigger a stray frame for it → it does not pop back at the top.

## Demo

https://github.com/user-attachments/assets/fe8fb416-d6b4-4cc8-8b66-41cd434190e6

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`sessionListCache.test.ts` covers `insertNewRowsIntoPages` directly: prepend + idempotency, search-list skip, archived-in-non-archived skip, **child-session skip** (`parent_session_id`), and **caller-excluded (deleting) skip**. The existing `SessionUpdatesProvider` / `chatStore` suites cover that the wiring doesn't regress the merge/refetch paths. The live WS push and the on-a-lagging-deployment self-heal are verified manually (the unit tests mock the socket).

Prior review (Polly) flagged four issues on earlier iterations; this implementation resolves them by construction: **B1** (child sessions) and **B2** (deleting sessions) via the guards above; **2a/2b** (project-folder mis-insertion / reconcile) by not inserting into folders at all and deferring filed rows to the server refetch.

## Changelog

Newly-created sessions now appear in the sidebar immediately instead of a few seconds later.