### PR TITLE
fix(scheduled): show Chat/Terminal switcher on automation-created terminal sessions

### DIFF
--- a/omnigent/server/scheduled/fire.py
+++ b/omnigent/server/scheduled/fire.py
@@ -656,6 +656,58 @@ async def _spec_reasoning_effort(deps: FireDeps, task: ScheduledTask) -> str | N
         return None
 
 
+async def _presentation_labels(deps: FireDeps, task: ScheduledTask) -> dict[str, str]:
+    """Resolve the terminal-first presentation labels for a fired session.
+
+    The interactive New Chat path stamps ``omnigent.ui = "terminal"`` (plus the
+    matching ``omnigent.wrapper`` for native CLIs) at create time so the web
+    UI's Chat/Terminal switcher is available; the fire path bypasses that path
+    and must stamp the same labels itself, or an automation-created session on a
+    terminal harness renders Chat-only with no way to reach its live terminal.
+
+    Two harness shapes get a terminal:
+
+    * A native-CLI wrapper agent (``pi-native-ui`` etc.) — the terminal IS the
+      main view. Resolved from the bound agent's name, mirroring
+      ``native_coding_agent_for_agent_name`` in the interactive create path.
+    * A non-native SDK agent whose runner auto-creates the ``omnigent`` REPL
+      terminal — host-bound only (an in-process session has no runner to host
+      a terminal), mirroring ``_repl_terminal_ui_labels``.
+
+    Fail-safe: any resolution error omits the labels rather than guessing, so
+    the session falls back to Chat-only rather than breaking the fire.
+    """
+    if deps.agent_cache is None:
+        return {}
+    from omnigent.native_coding_agents import native_coding_agent_for_agent_name
+    from omnigent.server.routes.sessions import _repl_terminal_ui_labels
+
+    try:
+        agent = await asyncio.to_thread(deps.agent_store.get, task.agent_id)
+        if agent is None:
+            return {}
+        native_agent = native_coding_agent_for_agent_name(agent.name)
+        if native_agent is not None:
+            return dict(native_agent.presentation_labels)
+        # Non-native SDK session: it only gets a REPL terminal when a runner
+        # hosts it, so a task with no resolved host stays Chat-only.
+        if task.host_id is None:
+            return {}
+        return await asyncio.to_thread(
+            _repl_terminal_ui_labels,
+            agent=agent,
+            agent_cache=deps.agent_cache,
+            harness_override=None,
+        )
+    except Exception:
+        _logger.exception(
+            "scheduled fire: could not resolve presentation labels for task %s; "
+            "session will render Chat-only",
+            task.id,
+        )
+        return {}
+
+
 async def _create_session(deps: FireDeps, task: ScheduledTask) -> Conversation:
     """Create a conversation bound to the task's agent, carrying the stored spec."""
     # Connected-host, existing-workspace runs create the conversation directly.
@@ -681,6 +733,15 @@ async def _create_session(deps: FireDeps, task: ScheduledTask) -> Conversation:
         )
         if updated is not None:
             conv = updated
+    # Stamp terminal-first presentation labels the interactive create path would
+    # have set, so a fired session on a terminal harness exposes the
+    # Chat/Terminal switcher instead of rendering Chat-only. Stamped last (after
+    # the override reload above) so the labels land on the conversation returned
+    # to the launch/dispatch caller, not a stale pre-label reload of it.
+    labels = await _presentation_labels(deps, task)
+    if labels:
+        await asyncio.to_thread(deps.conversation_store.set_labels, conv.id, labels)
+        conv.labels.update(labels)
     return conv
 
 

--- a/omnigent/server/scheduled/fire.py
+++ b/omnigent/server/scheduled/fire.py
@@ -677,8 +677,6 @@ async def _presentation_labels(deps: FireDeps, task: ScheduledTask) -> dict[str,
     Fail-safe: any resolution error omits the labels rather than guessing, so
     the session falls back to Chat-only rather than breaking the fire.
     """
-    if deps.agent_cache is None:
-        return {}
     from omnigent.native_coding_agents import native_coding_agent_for_agent_name
     from omnigent.server.routes.sessions import _repl_terminal_ui_labels
 
@@ -686,12 +684,16 @@ async def _presentation_labels(deps: FireDeps, task: ScheduledTask) -> dict[str,
         agent = await asyncio.to_thread(deps.agent_store.get, task.agent_id)
         if agent is None:
             return {}
+        # Native-wrapper labels come solely from the agent name, so they resolve
+        # without the cache — matching the interactive path, which has no cache
+        # dependency for this branch.
         native_agent = native_coding_agent_for_agent_name(agent.name)
         if native_agent is not None:
             return dict(native_agent.presentation_labels)
         # Non-native SDK session: it only gets a REPL terminal when a runner
-        # hosts it, so a task with no resolved host stays Chat-only.
-        if task.host_id is None:
+        # hosts it, so a task with no resolved host stays Chat-only. Resolving
+        # the harness for that branch needs the cache.
+        if task.host_id is None or deps.agent_cache is None:
             return {}
         return await asyncio.to_thread(
             _repl_terminal_ui_labels,

--- a/tests/server/scheduled/test_fire.py
+++ b/tests/server/scheduled/test_fire.py
@@ -150,7 +150,6 @@ class FakeConversationStore:
         self._seq = 0
         self.fail_create = fail_create
         self.label_writes: dict[str, dict[str, str]] = {}
-        self._by_id: dict[str, _FakeConversation] = {}
 
     def create_conversation(self, **kwargs: Any) -> _FakeConversation:
         self.create_workspace_ids.append(current_workspace_id())
@@ -165,7 +164,6 @@ class FakeConversationStore:
             git_branch=kwargs.get("git_branch"),
         )
         self.created.append(kwargs)
-        self._by_id[conv.id] = conv
         return conv
 
     def update_conversation(self, conversation_id: str, **kwargs: Any) -> _FakeConversation:
@@ -626,15 +624,19 @@ async def test_non_native_host_bound_task_stamps_repl_terminal_label() -> None:
 
 
 @pytest.mark.asyncio
-async def test_task_without_agent_cache_stamps_no_labels() -> None:
-    """No agent cache → no label resolution → Chat-only, fire still succeeds."""
+async def test_non_native_task_without_agent_cache_stamps_no_labels() -> None:
+    """A non-native SDK task without an agent cache stays Chat-only.
+
+    The REPL-terminal branch needs the cache to resolve the harness, so with no
+    cache it can't confirm a terminal — Chat-only, and the fire still succeeds.
+    """
     conv_store = FakeConversationStore()
     store = FakeScheduledTaskStore(rows={"task_1": _task()})
 
     async def _launch(conv: Any, task: Any) -> None:
         return None
 
-    # Default _deps leaves agent_cache=None.
+    # Default _deps leaves agent_cache=None and the default agent is non-native.
     on_fire = build_on_fire(
         _deps(store, conversation_store=conv_store),
         launch_dispatch=_launch,
@@ -644,6 +646,38 @@ async def test_task_without_agent_cache_stamps_no_labels() -> None:
 
     assert len(conv_store.created) == 1
     assert conv_store.label_writes == {}
+
+
+@pytest.mark.asyncio
+async def test_native_wrapper_labels_resolve_without_agent_cache() -> None:
+    """Native-wrapper labels come from the agent name, so they need no cache.
+
+    Parity with the interactive create path, which resolves these labels with no
+    cache dependency — a deployment with no fire-deps cache must not silently
+    drop the switcher for a Pi/OpenCode/etc. automation.
+    """
+    from omnigent.native_coding_agents import PI_NATIVE_AGENT_NAME
+
+    conv_store = FakeConversationStore()
+    store = FakeScheduledTaskStore(rows={"task_1": _task()})
+    deps = _deps(
+        store,
+        conversation_store=conv_store,
+        agent_store=FakeAgentStore({"ag_1": _FakeAgent("ag_1", name=PI_NATIVE_AGENT_NAME)}),
+        # agent_cache left None.
+    )
+
+    async def _launch(conv: Any, task: Any) -> None:
+        return None
+
+    on_fire = build_on_fire(deps, launch_dispatch=_launch)
+    await on_fire(0, "task_1")
+    await _drain()
+
+    assert conv_store.label_writes["conv_1"] == {
+        "omnigent.ui": "terminal",
+        "omnigent.wrapper": PI_NATIVE_AGENT_NAME,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/server/scheduled/test_fire.py
+++ b/tests/server/scheduled/test_fire.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import pytest
@@ -40,6 +40,7 @@ class _FakeConversation:
     workspace: str | None = None
     host_id: str | None = None
     git_branch: str | None = None
+    labels: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -47,6 +48,7 @@ class _FakeAgent:
     id: str
     bundle_location: str | None = None
     session_id: str | None = None
+    name: str = "assistant"
 
 
 class FakeAgentStore:
@@ -147,6 +149,8 @@ class FakeConversationStore:
         self.create_workspace_ids: list[int] = []
         self._seq = 0
         self.fail_create = fail_create
+        self.label_writes: dict[str, dict[str, str]] = {}
+        self._by_id: dict[str, _FakeConversation] = {}
 
     def create_conversation(self, **kwargs: Any) -> _FakeConversation:
         self.create_workspace_ids.append(current_workspace_id())
@@ -161,11 +165,15 @@ class FakeConversationStore:
             git_branch=kwargs.get("git_branch"),
         )
         self.created.append(kwargs)
+        self._by_id[conv.id] = conv
         return conv
 
     def update_conversation(self, conversation_id: str, **kwargs: Any) -> _FakeConversation:
         self.updated.append({"id": conversation_id, **kwargs})
         return _FakeConversation(id=conversation_id, agent_id="")
+
+    def set_labels(self, conversation_id: str, labels: dict[str, str]) -> None:
+        self.label_writes[conversation_id] = dict(labels)
 
     def get_conversation(self, conversation_id: str) -> _FakeConversation | None:
         return _FakeConversation(id=conversation_id, agent_id="ag_1")
@@ -555,6 +563,87 @@ async def test_no_reasoning_effort_when_spec_has_none() -> None:
     await _drain()
 
     assert not any("reasoning_effort" in u for u in conv_store.updated)
+
+
+@pytest.mark.asyncio
+async def test_native_wrapper_task_stamps_terminal_first_labels() -> None:
+    """A native-CLI (Pi) automation session gets the terminal-first labels.
+
+    Interactive New Chat stamps ``omnigent.ui = terminal`` + the wrapper label
+    so the web UI shows the Chat/Terminal switcher; the fire path must stamp the
+    same labels or the session renders Chat-only with no way to its terminal.
+    """
+    from omnigent.native_coding_agents import PI_NATIVE_AGENT_NAME
+
+    conv_store = FakeConversationStore()
+    store = FakeScheduledTaskStore(rows={"task_1": _task()})
+    deps = _deps(
+        store,
+        conversation_store=conv_store,
+        agent_store=FakeAgentStore(
+            {"ag_1": _FakeAgent("ag_1", bundle_location="ag_1/hash", name=PI_NATIVE_AGENT_NAME)}
+        ),
+        agent_cache=FakeAgentCache(harness="pi-native"),
+    )
+
+    async def _launch(conv: Any, task: Any) -> None:
+        return None
+
+    on_fire = build_on_fire(deps, launch_dispatch=_launch)
+    await on_fire(0, "task_1")
+    await _drain()
+
+    assert conv_store.label_writes["conv_1"] == {
+        "omnigent.ui": "terminal",
+        "omnigent.wrapper": PI_NATIVE_AGENT_NAME,
+    }
+
+
+@pytest.mark.asyncio
+async def test_non_native_host_bound_task_stamps_repl_terminal_label() -> None:
+    """A non-native SDK automation on a host gets ``omnigent.ui = terminal``.
+
+    Its runner auto-creates the omnigent REPL terminal, so the switcher must be
+    available from creation — mirroring ``_repl_terminal_ui_labels``.
+    """
+    conv_store = FakeConversationStore()
+    store = FakeScheduledTaskStore(rows={"task_1": _task()})
+    deps = _deps(
+        store,
+        conversation_store=conv_store,
+        agent_store=FakeAgentStore({"ag_1": _FakeAgent("ag_1", bundle_location="ag_1/hash")}),
+        agent_cache=FakeAgentCache(harness="claude-sdk"),
+    )
+
+    async def _launch(conv: Any, task: Any) -> None:
+        return None
+
+    on_fire = build_on_fire(deps, launch_dispatch=_launch)
+    await on_fire(0, "task_1")
+    await _drain()
+
+    assert conv_store.label_writes["conv_1"] == {"omnigent.ui": "terminal"}
+
+
+@pytest.mark.asyncio
+async def test_task_without_agent_cache_stamps_no_labels() -> None:
+    """No agent cache → no label resolution → Chat-only, fire still succeeds."""
+    conv_store = FakeConversationStore()
+    store = FakeScheduledTaskStore(rows={"task_1": _task()})
+
+    async def _launch(conv: Any, task: Any) -> None:
+        return None
+
+    # Default _deps leaves agent_cache=None.
+    on_fire = build_on_fire(
+        _deps(store, conversation_store=conv_store),
+        launch_dispatch=_launch,
+    )
+    await on_fire(0, "task_1")
+    await _drain()
+
+    assert len(conv_store.created) == 1
+    assert conv_store.label_writes == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Closes #4494

## Summary

- Automation-created (scheduled-task) sessions on a terminal harness rendered **Chat-only** with no way to reach their live terminal — losing the terminal fallback the issue asks for.
- **Root cause:** the interactive New Chat path stamps `omnigent.ui=terminal` (plus the `omnigent.wrapper` label for native CLIs) at create time so the web UI shows the Chat/Terminal switcher, but the scheduled fire path (`_create_session`) calls `conversation_store.create_conversation` directly with **no labels** and bypasses that. Claude/Codex didn't reproduce because their label is *synthesized* from the agent name in the session snapshot; pi/opencode/cursor/hermes/antigravity had no such fallback.
- **Fix:** resolve the same presentation labels at fire time and stamp them (after the model/effort override reload) so a fired session on a terminal harness exposes the switcher with full parity to interactive sessions (toggle persists while the runner is offline/starting, startup spinner, sidebar card).

This fixes the bug at its origin rather than in the frontend, so pre-existing per-harness special-casing isn't extended.

### How labels are resolved

Two harness shapes get a terminal:

- **Native-CLI wrapper agent** (`pi-native-ui`, etc.) — the terminal *is* the main view. Resolved from the bound agent name (mirrors `native_coding_agent_for_agent_name` in the interactive path).
- **Non-native SDK agent on a host** — its runner auto-creates the `omnigent` REPL terminal (mirrors `_repl_terminal_ui_labels`); host-bound only, since an in-process session has no runner to host a terminal.

Fail-safe: any resolution error omits the labels (session stays Chat-only) rather than breaking the fire.

## Test Plan

- `uv run --no-sync python -m pytest tests/server/scheduled/test_fire.py` — 44 passed. Added 3 cases: native-wrapper labels stamped, non-native host-bound REPL label stamped, and no-agent-cache → no labels (Chat-only, fire still succeeds).
- `ruff format --check` + `ruff check` — clean.
- `pyrefly check` — 0 errors on changed files.

**Manual verification (recommended before merge):**

1. Scheduled Tasks → New automation. Under **Runs with**, pick **Pi** (or OpenCode / Cursor / Hermes / Antigravity). Choose an online host + workspace and a simple prompt.
2. Save → task's **⋯ → Run now**.
3. Open the created run once its terminal is live.
4. **Expected:** the header shows the **Chat / Terminal** switcher; selecting **Terminal** opens the live `pi · main` terminal; switching back to **Chat** works.
5. **Regression:** a scheduled task on a chat-only SDK agent with no host/terminal stays Chat-only (no switcher).

## Demo

N/A — server-side change; the visible effect is the restored Chat/Terminal switcher, reproduced via the manual steps above. (Behavior matches the switcher already shown on interactively-created terminal sessions.)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover both label-stamping paths (native wrapper + non-native host-bound REPL) and the fail-safe no-cache case, asserting the exact `omnigent.ui` / `omnigent.wrapper` labels written. Manual verification confirms the end-to-end switcher behavior against a live Pi automation, since the visible outcome is a web-UI control driven by the stamped labels.

## Changelog

Automation-created sessions on a terminal harness now show the Chat/Terminal switcher.

This pull request and its description were written by Isaac.
