### PR TITLE
fix(compact): reject /compact for SDK and unready native harnesses

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -6062,12 +6062,12 @@ async def _cmd_compact(
     from omnigent.harness_aliases import is_native_harness
 
     _harness = getattr(session, "harness", None)
-    if not is_native_harness(_harness):
+    if _harness is not None and not is_native_harness(_harness):
         host.output(
             Text.from_markup(
                 f"  [{fmt.muted}]/compact is only available for native-TUI sessions "
                 f"(claude, codex, cursor, …). This session uses the "
-                f"{_harness or 'unknown'} harness, which manages its own "
+                f"{_harness} harness, which manages its own "
                 f"context window.[/{fmt.muted}]"
             )
         )

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -6059,6 +6059,19 @@ async def _cmd_compact(
     """Request proactive context compaction for the current conversation."""
     from rich.text import Text
 
+    from omnigent.harness_aliases import is_native_harness
+
+    _harness = getattr(session, "harness", None)
+    if not is_native_harness(_harness):
+        host.output(
+            Text.from_markup(
+                f"  [{fmt.muted}]/compact is only available for native-TUI sessions "
+                f"(claude, codex, cursor, …). This session uses the "
+                f"{_harness or 'unknown'} harness, which manages its own "
+                f"context window.[/{fmt.muted}]"
+            )
+        )
+        return
     if session.is_streaming:
         host.output(
             Text.from_markup(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5281,7 +5281,13 @@ def create_runner_app(
         registry = resource_registry.terminal_registry
         instance = registry.get(conv_id, "codex", "main") if registry is not None else None
         if instance is None or not instance.running:
-            return Response(status_code=204)
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "codex_native_compact_failed",
+                    "detail": "Codex terminal is not running; reconnect first.",
+                },
+            )
 
         socket_path = str(instance.socket_path)
         target = instance.tmux_target
@@ -5305,7 +5311,13 @@ def create_runner_app(
         server = _AUTO_OPENCODE_SERVERS.get(conv_id)
         state = read_bridge_state(bridge_dir_for_bridge_id(conv_id))
         if server is None or state is None or not state.opencode_session_id:
-            return Response(status_code=204)
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "opencode_native_compact_failed",
+                    "detail": "OpenCode session is not active; reconnect first.",
+                },
+            )
         client = server.client()
         try:
             session = await client.get_session(state.opencode_session_id)
@@ -5314,7 +5326,13 @@ def create_runner_app(
                 session, messages, state.model_override
             )
             if not provider_id or not model_id:
-                return Response(status_code=204)
+                return JSONResponse(
+                    status_code=503,
+                    content={
+                        "error": "opencode_native_compact_failed",
+                        "detail": "Could not resolve a compaction model; try switching the model.",
+                    },
+                )
             await client.summarize(
                 state.opencode_session_id, provider_id=provider_id, model_id=model_id
             )
@@ -6436,8 +6454,8 @@ def create_runner_app(
         try:
             await _run_turn_bg_setup_and_stream(msg_body, conv)
         except _ContextWindowOverflow:
-            # The streaming phase handles reactive compaction itself; re-raise so
-            # its handler is never shadowed by the generic except below.
+            # Re-raise so the streaming-phase handler (which publishes the
+            # error event) is never shadowed by the generic except below.
             raise
         except asyncio.CancelledError as exc:
             _logger.error(

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -693,9 +693,6 @@ _RUNNER_SESSION_INIT_TIMEOUT_S = 10.0
 _STOP_RUNNER_RESULT_TIMEOUT_S = 10.0
 
 
-_COMPACT_LOCKS: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
-
-
 # Derived from the fork_history capability axis (see harness_capabilities). A
 # harness declaring fork_history=REBUILD rebuilds its resumable session file
 # from the copied items (e.g. qwen rebuilds its on-disk chat recording via
@@ -869,7 +866,6 @@ __all__ = [
     "_CODEX_NATIVE_SUBAGENT_TOOL_CALL_ID_LABEL_KEY",
     "_CODEX_NATIVE_SUBAGENT_WRAPPER_LABEL_VALUE",
     "_CODEX_NATIVE_WRAPPER_LABEL_VALUE",
-    "_COMPACT_LOCKS",
     "_COMPACT_TYPE",
     "_CURSOR_FORK_HISTORY_HARNESSES",
     "_CURSOR_NATIVE_HARNESS",

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -7196,92 +7196,6 @@ def _compact_lock_impl(session_id: str) -> asyncio.Lock:
     return lock
 
 
-async def _run_compact_locked(
-    session_id: str,
-    conv: Conversation,
-    agent_store: AgentStore,
-    agent_cache: AgentCache | None,
-) -> None:
-    """
-    Run explicit compaction while holding the per-session compact lock.
-
-    :param session_id: Session/conversation identifier.
-    :param conv: Conversation row.
-    :param agent_store: Agent store for spec lookup.
-    :param agent_cache: Agent cache for bundle loading.
-    """
-    lock = _compact_lock(session_id)
-    async with lock:
-        if conv.agent_id is None:
-            raise OmnigentError("Session has no agent binding", code=ErrorCode.INTERNAL_ERROR)
-        if agent_cache is None:
-            raise OmnigentError(
-                "Compaction is unavailable: agent cache is not configured",
-                code=ErrorCode.INTERNAL_ERROR,
-            )
-        # Recheck after acquiring — a turn may have started while waiting.
-        if _session_status_cache.get(session_id) in ("running", "waiting"):
-            raise OmnigentError(
-                "Cannot compact while a turn is running; cancel or wait for it to finish first",
-                code=ErrorCode.CONFLICT,
-            )
-        agent = await asyncio.to_thread(agent_store.get, conv.agent_id)
-        if agent is None or agent.bundle_location is None:
-            raise OmnigentError(
-                f"Agent not found: {conv.agent_id!r}",
-                code=ErrorCode.NOT_FOUND,
-            )
-        loaded = agent_cache.load(
-            agent.id, agent.bundle_location, expand_env=agent.session_id is None
-        )
-        spec = loaded.spec
-        if spec.llm is not None:
-            llm_config = spec.llm
-        elif spec.executor.model is not None:
-            from omnigent.spec.types import LLMConfig
-
-            llm_config = LLMConfig(model=spec.executor.model, connection=spec.executor.connection)
-        else:
-            harness = spec.executor.harness_kind
-            raise OmnigentError(
-                f"/compact is unavailable for this {harness} session because the agent "
-                "does not declare an LLM model for server-side compaction. Configure "
-                "`llm.model` or `executor.model`, or use a harness-native compaction "
-                "control when one is available.",
-                code=ErrorCode.INVALID_INPUT,
-            )
-        task_id = f"compact_{int(time.time() * 1000)}"
-        # compact() publishes its own in_progress / completed SSE events when
-        # conversation_id is set, and the web UI's compaction bubble owns the
-        # busy state from those. Deliberately no ``session.status`` bracket:
-        # compaction is not an agent turn, so reporting running→idle would
-        # invent one — and its idle would land mid-turn on a session that is
-        # genuinely working, which clients then had to second-guess.
-        from omnigent.runtime.workflow import compact_conversation_now
-
-        try:
-            await compact_conversation_now(
-                task_id=task_id,
-                conversation_id=session_id,
-                spec=spec,
-                llm_config=llm_config,
-                tool_schemas=[],
-                preserve_recent_window=1,
-            )
-        except Exception as exc:
-            _logger.exception(
-                "Explicit session compaction failed for %s",
-                session_id,
-                extra={"session_id": session_id},
-            )
-            detail = str(exc) or repr(exc)
-            _publish_compaction_failed(session_id)
-            raise OmnigentError(
-                f"Compaction failed while generating a summary: {detail}",
-                code=ErrorCode.INTERNAL_ERROR,
-            ) from exc
-
-
 def _agent_provider_family(agent: Agent) -> str | None:
     """Return the provider family of an agent's harness, or ``None``.
 
@@ -10313,7 +10227,6 @@ __all__ = [
     "_resolve_subagent_spec",
     "_resource_event_item_from_sse",
     "_routing_decision_item_from_sse",
-    "_run_compact_locked",
     "_same_provider_family",
     "_same_provider_family_impl",
     "_seed_missing_title",

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -160,7 +160,6 @@ from omnigent.server.routes._sessions.common import (  # noqa: F401
     _CODEX_NATIVE_SUBAGENT_THREAD_ID_LABEL_KEY,
     _CODEX_NATIVE_SUBAGENT_TOOL_CALL_ID_LABEL_KEY,
     _CODEX_NATIVE_SUBAGENT_WRAPPER_LABEL_VALUE,
-    _COMPACT_LOCKS,
     _CURSOR_FORK_HISTORY_HARNESSES,
     _CURSOR_NATIVE_HARNESS,
     _DENY_SENTINEL_PREFIX,
@@ -7164,38 +7163,6 @@ async def _flush_relay_text(
     session_stream.publish(session_id, done_event.model_dump())
 
 
-def _compact_lock(session_id: str) -> asyncio.Lock:
-    """
-    Return the lock serializing explicit compaction for one session.
-
-    Call-time proxy to the facade so a test's ``monkeypatch.setattr`` of
-    this name on ``sessions`` is honored by sibling impl callers.
-    """
-    from omnigent.server.routes import sessions as _facade
-
-    return _facade._compact_lock(session_id)
-
-
-def _compact_lock_impl(session_id: str) -> asyncio.Lock:
-    """
-    Return the lock serializing explicit compaction for one session.
-
-    Concurrent ``/compact`` events for the same session must not overlap;
-    different sessions get distinct locks so they may compact concurrently.
-    Get-or-create is race-free because there is no ``await`` between the
-    lookup and the insert (single event loop).
-
-    :param session_id: Session/conversation id being compacted.
-    :returns: A process-wide :class:`asyncio.Lock` shared by every concurrent
-        caller for the same ``session_id``.
-    """
-    lock = _COMPACT_LOCKS.get(session_id)
-    if lock is None:
-        lock = asyncio.Lock()
-        _COMPACT_LOCKS[session_id] = lock
-    return lock
-
-
 def _agent_provider_family(agent: Agent) -> str | None:
     """Return the provider family of an agent's harness, or ``None``.
 
@@ -10081,7 +10048,6 @@ __all__ = [
     "_codex_subagent_labels_from_body",
     "_coerce_cumulative_field",
     "_collect_descendant_conversation_ids",
-    "_compact_lock",
     "_consume_pre_resolved_harness_elicitation",
     "_create_and_publish_antigravity_child",
     "_create_and_publish_codex_child",

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -505,7 +505,6 @@ from omnigent.server.routes._sessions.helpers import (
     _resolve_subagent_spec as _resolve_subagent_spec,
     _resource_event_item_from_sse as _resource_event_item_from_sse,
     _routing_decision_item_from_sse as _routing_decision_item_from_sse,
-    _run_compact_locked as _run_compact_locked,
     _same_provider_family_impl as _same_provider_family_impl,
     _seed_missing_title as _seed_missing_title,
     _seed_missing_title_from_user_message as _seed_missing_title_from_user_message,

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -211,7 +211,6 @@ from omnigent.server.routes._sessions.common import (
     _CODEX_NATIVE_SUBAGENT_TOOL_CALL_ID_LABEL_KEY as _CODEX_NATIVE_SUBAGENT_TOOL_CALL_ID_LABEL_KEY,
     _CODEX_NATIVE_SUBAGENT_WRAPPER_LABEL_VALUE as _CODEX_NATIVE_SUBAGENT_WRAPPER_LABEL_VALUE,
     _CODEX_NATIVE_WRAPPER_LABEL_VALUE as _CODEX_NATIVE_WRAPPER_LABEL_VALUE,
-    _COMPACT_LOCKS as _COMPACT_LOCKS,
     _COMPACT_TYPE as _COMPACT_TYPE,
     _CURSOR_FORK_HISTORY_HARNESSES as _CURSOR_FORK_HISTORY_HARNESSES,
     _CURSOR_NATIVE_HARNESS as _CURSOR_NATIVE_HARNESS,
@@ -551,9 +550,6 @@ from omnigent.server.routes._sessions.helpers import (
     _build_policy_engine_from_spec_impl as _build_policy_engine_from_spec,
 )
 from omnigent.server.routes._sessions.helpers import (
-    _compact_lock_impl as _compact_lock,
-)
-from omnigent.server.routes._sessions.helpers import (
     _forward_session_change_to_runner_impl as _forward_session_change_to_runner,
 )
 from omnigent.server.routes._sessions.helpers import (
@@ -745,7 +741,6 @@ if TYPE_CHECKING:
         "_agent_carries_native_fork_history",
         "_agent_is_native",
         "_build_policy_engine_from_spec",
-        "_compact_lock",
         "_dispatch_session_event_to_runner",
         "_ensure_runner_relay_ready",
         "_forward_session_change_to_runner",

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -166,7 +166,6 @@ from omnigent.server.routes._sessions.helpers import (
     _publish_status,
     _remove_session_worktree_best_effort,
     _require_external_status_forward,
-    _run_compact_locked,
     _signal_harness_elicitation_resolved_by_id,
     _stop_session_host_runner,
     _stop_session_via_runner,
@@ -1020,20 +1019,14 @@ def register_events_routes(
             # Unified control dispatch (designs/CLAUDE_NATIVE.md
             # "Control events dispatch on the runner"): forward /compact
             # to the bound runner first, regardless of harness. The
-            # runner dispatches by harness — claude-native injects
-            # /compact into the tmux pane so Claude Code compacts its
-            # own context and returns 200; other harnesses 204 no-op.
-            # The Omnigent server stays harness-agnostic: it runs its own
-            # in-process compaction only when the runner did NOT handle
-            # the control (204 / no runner bound). A 4xx/5xx from the
-            # runner (e.g. 503 when the claude-native pane isn't
-            # attached) is surfaced as an error rather than silently
-            # falling through to AP-side compaction, which would be
-            # wrong for a terminal-owned session.
+            # runner dispatches by harness — native harnesses inject
+            # /compact into the vendor TUI and return 200 on success or
+            # 5xx on failure. SDK harnesses return 204 (no-op) because
+            # their context is controlled entirely by the vendor harness.
+            # A 4xx/5xx from the runner is surfaced as an error.
             # TUI budget, not the 5s default: the claude-native handler
             # drives a delivery-verified slash-command inject, and a timeout
-            # here falls through to AP-side compaction on top of the
-            # terminal's own still-running /compact.
+            # here would surface as an error mid-TUI-compact.
             runner_result = await _forward_session_change_to_runner(
                 session_id,
                 runner_router,
@@ -1088,13 +1081,10 @@ def register_events_routes(
                     "run /compact again.",
                     code=ErrorCode.RUNNER_UNAVAILABLE,
                 )
-            await _run_compact_locked(
-                session_id,
-                conv,
-                agent_store,
-                agent_cache,
+            raise OmnigentError(
+                "/compact is not available for this session type.",
+                code=ErrorCode.INVALID_INPUT,
             )
-            return {"queued": False}
         if body.type == "compaction":
             import uuid as _uuid
 

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -653,9 +653,8 @@ class CompactionConfig:
     truncation as emergency fallback.
 
     :param trigger_threshold: Fraction of the model's context window
-        at which proactive compaction fires (after the first overflow
-        has been observed and the window size is known), e.g. ``0.8``
-        means fire at 80% of the window.
+        at which proactive compaction fires, e.g. ``0.8`` means fire
+        at 80% of the window.
     :param recent_window: Number of recent LLM iterations to protect
         from compaction. Items within this window are never cleared or
         summarized — the agent always has verbatim access to its most

--- a/tests/repl/test_compact_command.py
+++ b/tests/repl/test_compact_command.py
@@ -12,10 +12,17 @@ from tests.repl.helpers import CapturingHost
 class _CompactSession:
     """Minimal session stub for ``/compact`` tests."""
 
-    def __init__(self, *, is_streaming: bool = False, fail: Exception | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        is_streaming: bool = False,
+        fail: Exception | None = None,
+        harness: str | None = None,
+    ) -> None:
         self.is_streaming = is_streaming
         self.calls = 0
         self._fail = fail
+        self.harness = harness
 
     async def compact(self) -> None:
         """Record the compaction request or raise the configured failure."""
@@ -72,6 +79,25 @@ async def test_compact_refuses_while_streaming() -> None:
 
     assert session.calls == 0
     assert "Cannot compact while a response is running" in host.text
+
+
+@pytest.mark.asyncio
+async def test_compact_blocked_for_sdk_harness() -> None:
+    """The command is blocked for non-native harnesses with a clear message."""
+    host = CapturingHost()
+    session = _CompactSession(harness="claude-sdk")
+
+    await handle_slash_command(
+        "/compact",
+        session,  # type: ignore[arg-type]
+        None,  # type: ignore[arg-type]
+        host,
+        RichBlockFormatter(),  # type: ignore[arg-type]
+    )
+
+    assert session.calls == 0
+    assert "only available for native-TUI sessions" in host.text
+    assert "claude-sdk" in host.text
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native_events_options.py
+++ b/tests/runner/test_app_sessions_native_events_options.py
@@ -743,13 +743,12 @@ async def test_events_compact_on_codex_native_injects_slash_command(
 
 
 @pytest.mark.asyncio
-async def test_events_compact_on_codex_native_returns_204_when_no_terminal() -> None:
+async def test_events_compact_on_codex_native_returns_503_when_no_terminal() -> None:
     """
-    Codex-native compact returns 204 when no live terminal is registered.
+    Codex-native compact returns 503 when no live terminal is registered.
 
-    Without a running codex terminal the ``/compact`` slash command
-    has nowhere to go.  204 tells the Omnigent server to fall back to
-    its own AP-side compaction (or skip it).
+    Without a running codex terminal the ``/compact`` slash command has
+    nowhere to go. 503 tells the caller to reconnect first.
     """
     codex_native_spec = AgentSpec(
         spec_version=1,
@@ -786,8 +785,8 @@ async def test_events_compact_on_codex_native_returns_204_when_no_terminal() -> 
             json={"type": "compact"},
         )
 
-    assert resp.status_code == 204, (
-        f"Codex-native compact with no terminal must return 204; "
+    assert resp.status_code == 503, (
+        f"Codex-native compact with no terminal must return 503; "
         f"got {resp.status_code}: {resp.text}"
     )
 
@@ -1742,14 +1741,15 @@ async def test_events_compact_on_opencode_native_summarizes_from_model_override(
 
 
 @pytest.mark.asyncio
-async def test_events_compact_on_opencode_native_204_when_model_unresolvable(
+async def test_events_compact_on_opencode_native_503_when_model_unresolvable(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """
-    No resolvable model → 204 and ``/summarize`` is never called.
+    No resolvable model → 503 and ``/summarize`` is never called.
 
-    The 204 tells the Omnigent server to run its own AP-side compaction.
+    Without a model the compaction has nowhere to go; 503 tells the caller
+    to switch the model first.
     """
     resp, client = await _drive_opencode_native_compact(
         monkeypatch,
@@ -1760,8 +1760,8 @@ async def test_events_compact_on_opencode_native_204_when_model_unresolvable(
         model_override=None,
     )
 
-    assert resp.status_code == 204, (
-        f"opencode-native compact must 204 when no model resolves; "
+    assert resp.status_code == 503, (
+        f"opencode-native compact must 503 when no model resolves; "
         f"got {resp.status_code}: {resp.text}"
     )
     assert client.summarize_calls == [], (

--- a/tests/runner/test_app_sessions_native_events_options.py
+++ b/tests/runner/test_app_sessions_native_events_options.py
@@ -470,10 +470,9 @@ async def test_events_compact_on_native_session_types_slash_command(
     types the slash command into the pane.
 
     The 200 (not 204) is load-bearing: the Omnigent server reads it to know
-    the control was handled in the terminal and skips its own
-    in-process compaction. A regression returning 204 here would make
-    the Omnigent server fall through to ``_run_compact_locked``, which 400s
-    on the LLM-less claude-native pseudo-agent — the original bug.
+    the control was handled in the terminal. A regression returning 204 here
+    would make the server return a 400 "not available for this session type"
+    error instead of the native compact succeeding.
     """
     from omnigent.runner.app import _session_event_queues_ref
     from omnigent.spec.types import ExecutorSpec
@@ -542,11 +541,9 @@ async def test_events_compact_on_native_session_types_slash_command(
                 if isinstance(item, dict):
                     queued_events.append(item)
 
-    # 200 = native dispatch routed to the compact handler and it
-    # injected successfully. 204 would mean the handler returned the
-    # in-process no-op (wrong harness branch) → Omnigent falls through to
-    # _run_compact_locked and 400s. 404 = the dispatch fell through to
-    # the generic harness-forward.
+    # 200 = native dispatch routed to the compact handler and injected
+    # successfully. 204 would mean the wrong harness branch fired (→ server
+    # returns 400). 404 = dispatch fell through to the generic forward.
     assert resp.status_code == 200, (
         f"Native compact must return 200 from /events; got {resp.status_code}: {resp.text}"
     )
@@ -875,9 +872,8 @@ async def test_events_compact_on_cursor_native_pastes_summarize_and_raises_spinn
     cursor-agent manages its own context window in the TUI, so explicit
     compaction must run there (its built-in ``/summarize`` command) rather
     than as AP-side compaction — the same rationale as the claude-native
-    path.  The 200 (not 204) is load-bearing: the Omnigent server reads it to
-    skip its own ``_run_compact_locked`` (which 400s on the LLM-less native
-    pseudo-agent).
+    path. The 200 (not 204) is load-bearing: the Omnigent server reads it to
+    know the control was handled in the terminal.
 
     Two properties are pinned here:
 
@@ -1262,7 +1258,7 @@ async def test_events_compact_on_qwen_native_submits_compress_and_raises_spinner
     Unlike cursor, injection is file-based: a ``submit`` line routes through
     qwen's ``RemoteInputWatcher`` then ``submitQuery``, which processes the slash
     command (no autocomplete-dropdown trap). The 200 is load-bearing (server
-    skips its own ``_run_compact_locked``). The handler publishes only
+    reads it to know the control was handled). The handler publishes only
     ``in_progress``; the ``completed`` edge is the compaction mirror's job once
     the ``chat_compression`` record lands (covered in test_qwen_native_forwarder).
     """
@@ -1820,12 +1816,10 @@ async def test_events_compact_on_non_native_session_is_204_noop(
     """
     Non-native sessions accept compact and 204 without side effects.
 
-    For in-process harnesses, explicit compaction is an AP-side
-    operation (``_run_compact_locked`` → ``compact_conversation_now``).
-    The Omnigent server forwards ``compact`` to ``/events`` for every harness
-    (it stays harness-agnostic), so the runner must accept the event
-    and 204 — never reach the slash-command injector. The 204 tells the
-    Omnigent server to run its own compaction.
+    The Omnigent server forwards ``compact`` to ``/events`` for every harness,
+    so the runner must accept the event and 204 — never reach the
+    slash-command injector. The server then returns a 400 to the client
+    (SDK harnesses control their own context; AP-side compaction is not available).
     """
     from omnigent.spec.types import ExecutorSpec
 

--- a/tests/server/integration/test_sessions_compact.py
+++ b/tests/server/integration/test_sessions_compact.py
@@ -186,7 +186,7 @@ async def test_compact_sdk_harness_no_runner_returns_not_available(
 ) -> None:
     """
     A compact request for an SDK-harness session with no runner returns a
-    clear 400, not the internal ``_run_compact_locked`` model-requirement error.
+    clear 400 "not available for this session type" error.
     """
     agent = await create_test_agent(
         client,

--- a/tests/server/integration/test_sessions_compact.py
+++ b/tests/server/integration/test_sessions_compact.py
@@ -3,28 +3,25 @@
 The web-UI ``/compact`` command and compact button POST
 ``{"type": "compact"}`` to ``POST /v1/sessions/{id}/events``. Per
 ``designs/CLAUDE_NATIVE.md`` ("Control events dispatch on the runner"),
-the Omnigent server stays harness-agnostic: it forwards the control to the
-bound runner and only runs its own in-process compaction
-(``_run_compact_locked`` → ``compact_conversation_now``) when the
-runner did NOT handle it.
+the Omnigent server forwards the control to the bound runner and lets the
+runner's harness-specific handler own the operation.
 
 The runner's dispatch contract (verified in
 ``tests/runner/test_app_sessions_native.py``):
 
-* claude-native injects ``/compact`` into the tmux pane and returns
-  **200** — Claude Code compacts its own context.
-* other harnesses **204** no-op — the Omnigent server owns the operation.
-* a failed injection (pane not attached) returns **503**.
+* Native harnesses inject ``/compact`` into the vendor TUI and return
+  **200** on success or **5xx** on failure.
+* SDK harnesses return **204** (no-op) because their context is controlled
+  entirely by the vendor harness; the server surfaces a 400 error.
+* A failed injection (pane not attached) returns **503**.
 
 These tests pin the Omnigent side of that contract by stubbing the runner's
-HTTP response and asserting whether the AP-side compaction ran.
+HTTP response and asserting the correct server behaviour.
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
-from collections import defaultdict
 from typing import Any
 
 import httpx
@@ -62,9 +59,8 @@ def _fake_runner_returning(compact_status: int) -> tuple[httpx.AsyncClient, list
     runner POST so unrelated session traffic passes through).
 
     :param compact_status: HTTP status the fake runner returns for a
-        ``compact`` ``/events`` POST, e.g. ``200`` (claude-native
-        handled), ``204`` (in-process no-op), or ``503`` (pane not
-        attached).
+        ``compact`` ``/events`` POST, e.g. ``200`` (native handled),
+        ``204`` (SDK no-op), or ``503`` (pane not attached).
     :returns: The mock ``httpx.AsyncClient`` and the list that captures
         forwarded compact bodies.
     """
@@ -100,10 +96,8 @@ async def test_compact_skips_omnigent_compaction_when_runner_handles_it(
     A 200 from the runner (claude-native injected ``/compact``) makes
     the Omnigent server skip its own compaction.
 
-    This is the fix for the original bug: claude-native sessions bind
-    to an LLM-less pseudo-agent, so ``_run_compact_locked`` would 400.
-    When the runner reports it handled the control (200), the Omnigent server
-    must NOT run ``compact_conversation_now`` at all.
+    When the runner reports it handled the control (200), the Omnigent
+    server must NOT run ``compact_conversation_now`` at all.
     """
     from omnigent.runtime import set_runner_client
 
@@ -138,39 +132,31 @@ async def test_compact_skips_omnigent_compaction_when_runner_handles_it(
     # compaction.
     assert resp.status_code == 202, resp.text
     assert resp.json() == {"queued": False}, resp.text
-    # Exactly one compact control was forwarded to the runner. 0 = the
-    # Omnigent server never forwarded (it would have run _run_compact_locked
-    # directly — the pre-fix behavior); 2+ = duplicate forward.
+    # Exactly one compact control was forwarded to the runner.
     assert captured == [{"type": "compact"}], (
         f"AP server must forward exactly one compact control to the runner; got {captured!r}."
     )
 
 
-async def test_compact_runs_omnigent_compaction_when_runner_noops(
+async def test_compact_returns_error_when_runner_noops(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    A 204 from the runner (in-process harness) makes the Omnigent server run
-    its own ``compact_conversation_now``.
+    A 204 from the runner (SDK harness) surfaces a clear 400 error.
 
-    In-process harnesses have no terminal to inject into — explicit
-    compaction is an AP-side LLM summarisation. The 204 no-op tells the
-    Omnigent server it owns the operation, so it must still forward the
-    control (harness-agnostic) AND then run the compaction.
+    SDK harnesses own their own context; the server cannot compact on their
+    behalf. The 204 no-op signals "not handled here" and the server must
+    reject the request rather than attempting AP-side compaction.
     """
     from omnigent.runtime import set_runner_client
 
-    calls: list[dict[str, Any]] = []
-
-    async def _record(**kwargs: Any) -> CompactionResult:
-        """Record that AP-side compaction ran; return a real result."""
-        calls.append(kwargs)
-        return CompactionResult(messages=[], summary_metadata=None, total_tokens=1234)
+    async def _must_not_run(**_: Any) -> CompactionResult:
+        raise AssertionError("compact_conversation_now must not run when the runner returned 204")
 
     monkeypatch.setattr(
         "omnigent.runtime.workflow.compact_conversation_now",
-        _record,
+        _must_not_run,
     )
 
     runner, captured = _fake_runner_returning(204)
@@ -186,39 +172,25 @@ async def test_compact_runs_omnigent_compaction_when_runner_noops(
         await runner.aclose()
         set_runner_client(None)
 
-    assert resp.status_code == 202, resp.text
-    assert resp.json() == {"queued": False}, resp.text
-    # Control was still forwarded even though the runner no-ops — the
-    # Omnigent server is harness-agnostic and forwards for every harness.
+    assert resp.status_code == 400, resp.text
+    assert "/compact is not available" in resp.text
+    # Control was still forwarded before the error.
     assert captured == [{"type": "compact"}], (
-        f"AP server must forward compact to the runner even on the "
-        f"in-process path; got {captured!r}."
-    )
-    # AP-side compaction ran exactly once for the session it was asked
-    # to compact. 0 = the 204 path skipped compaction (the in-process
-    # /compact silently does nothing); 2+ = double compaction.
-    assert len(calls) == 1, (
-        f"Expected exactly one compact_conversation_now call on the 204 path; got {len(calls)}."
-    )
-    assert calls[0]["conversation_id"] == sid, (
-        f"AP-side compaction ran for the wrong session; got "
-        f"{calls[0].get('conversation_id')!r}, expected {sid!r}."
+        f"AP server must forward compact to the runner before returning the error; "
+        f"got {captured!r}."
     )
 
 
-async def test_compact_model_less_sdk_harness_returns_clear_unavailable_message(
+async def test_compact_sdk_harness_no_runner_returns_not_available(
     client: httpx.AsyncClient,
 ) -> None:
     """
-    A model-less SDK-style harness should not expose the raw server-side
-    compaction model requirement.
+    A compact request for an SDK-harness session with no runner returns a
+    clear 400, not the internal ``_run_compact_locked`` model-requirement error.
     """
     agent = await create_test_agent(
         client,
-        name="model-less-sdk",
-        # Explicit harness: build_agent_bundle defaults config.harness to
-        # "claude-sdk", which harness_kind would echo instead of the real
-        # model-less SDK harness under test.
+        name="sdk-no-runner-compact",
         executor={"type": "omnigent", "config": {"harness": "openai-agents"}},
         include_llm=False,
     )
@@ -230,161 +202,7 @@ async def test_compact_model_less_sdk_harness_returns_clear_unavailable_message(
     )
 
     assert resp.status_code == 400, resp.text
-    assert "/compact is unavailable" in resp.text
-    assert "openai-agents" in resp.text
-    assert "llm.model" in resp.text
-    assert "executor.model" in resp.text
-
-
-async def test_compact_single_flight_per_session(
-    client: httpx.AsyncClient,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """
-    Explicit compaction is single-flight per session, not globally.
-
-    Two ``/compact`` POSTs for one session must never overlap inside
-    ``compact_conversation_now``. Different sessions may overlap. A
-    failed compaction must release the lock so a later request can run.
-    """
-    from omnigent.runtime import set_runner_client
-    from omnigent.server.routes import sessions as sessions_routes
-
-    active: dict[str, int] = defaultdict(int)
-    max_active: dict[str, int] = defaultdict(int)
-    simultaneous_sessions = 0
-    entered: dict[str, asyncio.Event] = {}
-    release: dict[str, asyncio.Event] = {}
-    fail_once: set[str] = set()
-    calls: list[str] = []
-    lock_requests: dict[str, int] = defaultdict(int)
-    second_lock_requested: dict[str, asyncio.Event] = {}
-
-    real_compact_lock = sessions_routes._compact_lock
-
-    def _instrumented_compact_lock(session_id: str) -> asyncio.Lock:
-        lock_requests[session_id] += 1
-        if lock_requests[session_id] == 2:
-            second_lock_requested.setdefault(session_id, asyncio.Event()).set()
-        return real_compact_lock(session_id)
-
-    monkeypatch.setattr(sessions_routes, "_compact_lock", _instrumented_compact_lock)
-
-    async def _gated(**kwargs: Any) -> CompactionResult:
-        """Hold inside compaction until the test releases this session."""
-        nonlocal simultaneous_sessions
-        cid = kwargs["conversation_id"]
-        assert isinstance(cid, str)
-        calls.append(cid)
-        active[cid] += 1
-        max_active[cid] = max(max_active[cid], active[cid])
-        simultaneous_sessions = max(
-            simultaneous_sessions,
-            sum(1 for count in active.values() if count > 0),
-        )
-        entered.setdefault(cid, asyncio.Event()).set()
-        try:
-            if cid in fail_once:
-                fail_once.discard(cid)
-                raise RuntimeError("injected compact failure")
-            await release.setdefault(cid, asyncio.Event()).wait()
-            return CompactionResult(messages=[], summary_metadata=None, total_tokens=1)
-        finally:
-            active[cid] -= 1
-
-    monkeypatch.setattr(
-        "omnigent.runtime.workflow.compact_conversation_now",
-        _gated,
-    )
-
-    runner, _captured = _fake_runner_returning(204)
-    set_runner_client(runner)
-    try:
-        agent = await create_test_agent(client)
-        sid_a = await _create_session(client, agent["id"])
-        sid_b = await _create_session(client, agent["id"])
-        release[sid_a] = asyncio.Event()
-        release[sid_b] = asyncio.Event()
-        entered[sid_a] = asyncio.Event()
-        entered[sid_b] = asyncio.Event()
-        second_lock_requested[sid_a] = asyncio.Event()
-
-        # Same session: second request must wait outside compact_conversation_now
-        # until the first releases — never overlap.
-        first_a = asyncio.create_task(
-            client.post(f"/v1/sessions/{sid_a}/events", json={"type": "compact", "data": {}})
-        )
-        await asyncio.wait_for(entered[sid_a].wait(), timeout=5.0)
-        entered[sid_a].clear()
-        second_a = asyncio.create_task(
-            client.post(f"/v1/sessions/{sid_a}/events", json={"type": "compact", "data": {}})
-        )
-        await asyncio.wait_for(second_lock_requested[sid_a].wait(), timeout=5.0)
-        assert active[sid_a] == 1, (
-            f"Same-session compact overlapped inside compact_conversation_now; "
-            f"active={active[sid_a]}."
-        )
-        assert not entered[sid_a].is_set(), (
-            "Second same-session compact entered before the first released."
-        )
-        release[sid_a].set()
-        resp_a1, resp_a2 = await asyncio.wait_for(
-            asyncio.gather(first_a, second_a),
-            timeout=5.0,
-        )
-        assert resp_a1.status_code == 202, resp_a1.text
-        assert resp_a2.status_code == 202, resp_a2.text
-        assert max_active[sid_a] == 1, (
-            f"Same-session compact overlapped; max_active={max_active[sid_a]}."
-        )
-
-        # Different sessions may hold compact_conversation_now concurrently.
-        release[sid_a].clear()
-        release[sid_b].clear()
-        entered[sid_a].clear()
-        entered[sid_b].clear()
-        task_a = asyncio.create_task(
-            client.post(f"/v1/sessions/{sid_a}/events", json={"type": "compact", "data": {}})
-        )
-        task_b = asyncio.create_task(
-            client.post(f"/v1/sessions/{sid_b}/events", json={"type": "compact", "data": {}})
-        )
-        await asyncio.wait_for(
-            asyncio.gather(entered[sid_a].wait(), entered[sid_b].wait()),
-            timeout=5.0,
-        )
-        assert simultaneous_sessions >= 2, (
-            "Different sessions failed to overlap inside compact_conversation_now; "
-            f"simultaneous_sessions={simultaneous_sessions}."
-        )
-        release[sid_a].set()
-        release[sid_b].set()
-        resp_cross_a, resp_cross_b = await asyncio.wait_for(
-            asyncio.gather(task_a, task_b),
-            timeout=5.0,
-        )
-        assert resp_cross_a.status_code == 202, resp_cross_a.text
-        assert resp_cross_b.status_code == 202, resp_cross_b.text
-
-        # Failure must release the lock so a later compact can run.
-        fail_once.add(sid_a)
-        release[sid_a].set()
-        fail_resp = await client.post(
-            f"/v1/sessions/{sid_a}/events",
-            json={"type": "compact", "data": {}},
-        )
-        assert fail_resp.status_code == 500, fail_resp.text
-        retry_resp = await client.post(
-            f"/v1/sessions/{sid_a}/events",
-            json={"type": "compact", "data": {}},
-        )
-        assert retry_resp.status_code == 202, retry_resp.text
-        assert calls.count(sid_a) >= 4, (
-            f"Expected failed compact plus successful retry for {sid_a}; calls={calls!r}."
-        )
-    finally:
-        await runner.aclose()
-        set_runner_client(None)
+    assert "/compact is not available" in resp.text
 
 
 async def test_compact_errors_when_runner_injection_fails(
@@ -403,11 +221,8 @@ async def test_compact_errors_when_runner_injection_fails(
     from omnigent.runtime import set_runner_client
 
     async def _must_not_run(**_: Any) -> CompactionResult:
-        """Fail loudly if AP-side compaction is reached on the error path."""
         raise AssertionError(
-            "compact_conversation_now must not run when the runner "
-            "returned a non-200/204 status — Omnigent fell through to its "
-            "own compaction instead of surfacing the runner failure."
+            "compact_conversation_now must not run when the runner returned a 5xx"
         )
 
     monkeypatch.setattr(
@@ -428,9 +243,6 @@ async def test_compact_errors_when_runner_injection_fails(
         await runner.aclose()
         set_runner_client(None)
 
-    # 500 = INTERNAL_ERROR raised from the compact branch on a runner
-    # 5xx. A 200 here would mean the error was swallowed; a 400 would
-    # mean it fell through to _run_compact_locked's LLM-config check.
     assert resp.status_code == 500, resp.text
     # The control was forwarded before the failure was detected.
     assert captured == [{"type": "compact"}], (
@@ -445,22 +257,16 @@ async def test_compact_native_session_no_runner_returns_reconnect_error(
 ) -> None:
     """
     A native-terminal /compact with no reachable runner surfaces a clear
-    "reconnect first" error, not the confusing no-LLM-model message.
+    "reconnect first" 503, not a generic error.
 
-    A native session compacts only in its vendor TUI, so when no runner is
-    bound (disconnected session) the compact branch must NOT fall through to
-    server-side ``_run_compact_locked`` — which would 400 with the opaque
-    "does not declare an LLM model" text. Instead it should try to wake the
-    runner; an un-host-bound native session can't be woken, so it returns a
-    503 RUNNER_UNAVAILABLE the user can act on.
+    Native sessions compact only in their vendor TUI, so when no runner is
+    bound the compact branch must try to wake the runner and, when it can't
+    (un-host-bound session), return a RUNNER_UNAVAILABLE the user can act on.
     """
 
     async def _must_not_run(**_: Any) -> CompactionResult:
-        """Fail loudly if AP-side compaction is reached on the native path."""
         raise AssertionError(
-            "compact_conversation_now must not run for a native-terminal "
-            "session with no runner — the compact branch fell through to "
-            "in-process compaction instead of the reconnect error."
+            "compact_conversation_now must not run for a native session with no runner"
         )
 
     monkeypatch.setattr(
@@ -481,8 +287,6 @@ async def test_compact_native_session_no_runner_returns_reconnect_error(
         json={"type": "compact", "data": {}},
     )
 
-    # 503 = RUNNER_UNAVAILABLE (reconnect-first). A 400 would mean it fell
-    # through to the no-LLM-model check (the original confusing bug).
     assert resp.status_code == 503, resp.text
     assert "Reconnect the session" in resp.text
     assert "llm.model" not in resp.text


### PR DESCRIPTION
## Related issue

Closes #2967

## Summary

Server-side compaction (`_run_compact_locked`) was dead code for SDK harnesses: the UI already gates `/compact` to native TUI sessions only (`showCompact = isNativeWrapper` in `ChatPage.tsx`), and the harness controls its own context so AP-side compaction can't help it. The path was also silently reached for two native harnesses when their vendor TUI wasn't ready — codex-native when the tmux instance isn't running, and opencode-native when no session is active or no model can be resolved — where it was equally useless.

- `_handle_codex_native_compact`: 204 when instance not running → 503 "Codex terminal is not running; reconnect first."
- `_handle_opencode_native_compact`: two 204 paths → 503 (session not active / can't resolve model)
- `routes_events.py`: replace the `_run_compact_locked` fallthrough (reached when runner returns 204 or no runner is bound for a non-native session) with an explicit `400 INVALID_INPUT` — SDK sessions get a clear error instead of silently hitting AP-side compaction
- Remove the `_run_compact_locked` import from `routes_events.py`; update the surrounding comment to describe the actual contract
- Fix two stale comments left from a previously closed PR (OMNI-1852 phases 3+4) that described behaviour that was never merged

## Test Plan

- Updated `test_compact_runs_omnigent_compaction_when_runner_noops` → `test_compact_returns_error_when_runner_noops`: asserts 400 on runner 204, confirms `compact_conversation_now` is not called
- Updated `test_compact_model_less_sdk_harness_returns_clear_unavailable_message` → `test_compact_sdk_harness_no_runner_returns_not_available`: asserts 400 with the new message
- Removed `test_compact_single_flight_per_session`: tested `_run_compact_locked` concurrency via the 204 path — the behaviour no longer exists
- Cleaned up stale `_run_compact_locked` references and `asyncio`/`defaultdict` imports left over by the deleted test

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Integration tests added / updated
- [ ] Unit tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The codex-native and opencode-native 204→503 changes are covered by the runner's existing native compact integration tests; the new server-side behaviour (400 on SDK/204 path) is covered by the updated integration tests above.

## Changelog

`/compact` now returns a clear error for SDK-harness sessions instead of silently attempting server-side compaction.