### PR TITLE
feat(electron): add Cmd+Shift+N new-window shortcut

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -1953,6 +1953,7 @@ function buildMenu() {
     {
       id: "new_window",
       label: "New Window",
+      accelerator: "CmdOrCtrl+Shift+N",
       click: () => newWindow(),
     },
     {

--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -268,7 +268,7 @@ describe("in-app navigation menu actions", () => {
 
     assert.equal(newSessionItem.label, "New Session");
     assert.equal(newSessionItem.accelerator, "CmdOrCtrl+N");
-    assert.equal(newWindowItem.accelerator, undefined);
+    assert.equal(newWindowItem.accelerator, "CmdOrCtrl+Shift+N");
 
     newSessionItem.click();
 


### PR DESCRIPTION
## Summary
- keep Cmd+N mapped to New Session
- map Cmd+Shift+N to New Window, preserving the focused window's server and URL
- add regression coverage for both menu accelerators

## Test plan
<img width="846" height="456" alt="image" src="https://github.com/user-attachments/assets/79a7d7dd-46c2-454d-a6d8-a65bdb78a8a4" />
- [x] `pnpm test` in `web/electron` (342 tests)
- [x] Manually verify Cmd+N opens a new session in place
- [x] Manually verify Cmd+Shift+N opens another window on the same server