### PR TITLE
docs: document needs-info issue lifecycle

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,10 +16,12 @@ body:
     attributes:
       label: Steps to reproduce
       description: >
-        Minimal steps to reproduce the issue. If you can't reproduce it
-        reliably (e.g. an intermittent crash or race), describe what you
-        observed and when — write "N/A — cannot reproduce reliably" and give
-        as much detail as you can.
+        Give minimal steps to reproduce the issue. If direct steps aren't
+        available, provide other actionable evidence, such as a clear
+        intermittent observation, a controlled test, diagnostics, or concrete
+        analysis of the failing code path. For an intermittent crash or race,
+        write "N/A — cannot reproduce reliably" and describe what you observed
+        and when in as much detail as you can.
       placeholder: |
         1. ...
         2. ...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,11 @@ An LLM reads the issue title, body, and labels and classifies its type, severity
 and affected areas. It does not assign the final priority directly. Priority
 comes from deterministic arithmetic:
 
+The issue template provides an initial type, but automation may correct the
+`Bug`, `Feature`, or `Docs` label when the issue content indicates a different
+type. For example, a feature request that describes broken existing behavior is
+reclassified as a bug and follows the bug-report evidence requirements below.
+
 ```text
 score = severity points × component weight + community-demand points
 ```
@@ -44,10 +49,13 @@ missing from the model. Automation preserves those overrides and does not
 replace a maintainer-set priority with its own proposal. The queue is rerun as
 issues change, while unchanged LLM classifications are reused.
 
-For bugs, include the observed impact, reproduction steps, Omnigent version,
-platform, and affected harness or authentication mode. For feature requests,
-describe the user problem and expected reach. Use a `+1` reaction when an
-existing issue matters to you; ordinary comments are not counted as votes.
+For bugs, include the observed impact, reproduction evidence, Omnigent version,
+platform, and affected harness or authentication mode. Direct steps are best,
+but a clear intermittent observation, controlled test, diagnostics, or concrete
+analysis of the failing code path can also give maintainers enough to
+investigate. For feature requests, describe the user problem and expected
+reach. Use a `+1` reaction when an existing issue matters to you; ordinary
+comments are not counted as votes.
 
 The scoring configuration and component map are public in
 [`default_scoring.json`](.github/triage_v2/src/issue_prioritization/default_scoring.json)
@@ -64,9 +72,17 @@ Issues with no activity for 30 days are marked `stale` and close after another
 14 days without activity. New activity restarts that inactivity window. Issues
 labeled `pinned`, `security`, or `bug` are exempt.
 
-If an issue is labeled `needs-info`, a comment from its author clears the label
-and triggers another triage pass. Without an author response, the normal stale
-policy applies unless the issue also has one of the exempt labels above.
+If a bug is labeled `needs-info`, the automation asks its author for the
+specific missing information and gives them 7 days to respond. An author reply
+triggers another triage pass; the label clears only when the new information is
+actionable. A reply that still does not provide enough evidence does not reset
+the original deadline.
+
+If the requested information is still missing when the deadline passes, the
+issue is automatically closed as not planned. A later author reply reopens the
+issue and sends it through triage again. This lifecycle is separate from the
+normal stale policy and applies to bug reports that would otherwise be exempt
+from stale closure.
 
 Pull requests waiting for an author response follow the separate 7-day policy
 described under [Review state labels](#review-state-labels).


### PR DESCRIPTION
## Related issue

Part of [OMNI-4269](https://linear.app/omnigent/issue/OMNI-4269/make-sure-issues-contain-valid-steps-to-reproduce).

## Summary

- Document the public `needs-info` lifecycle, including the seven-day response window, response re-evaluation, automatic closure, and reopening.
- Explain that triage corrects mismatched `Bug`, `Feature`, or `Docs` labels before applying the corresponding rules.
- Clarify that actionable reproduction evidence can include intermittent observations, controlled tests, diagnostics, or concrete code-path analysis when direct steps are unavailable.
- Keep internal implementation details and rollout controls out of the public contributor guidance.

## Test Plan

- `git diff --check -- CONTRIBUTING.md .github/ISSUE_TEMPLATE/bug_report.yml`
- `pre-commit run --files CONTRIBUTING.md .github/ISSUE_TEMPLATE/bug_report.yml`
- Read the rendered Markdown and bug-report YAML copy for consistency with the implemented lifecycle.

## Demo

N/A — documentation and issue-template copy only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

The change only updates contributor-facing prose and issue-template help text. YAML syntax and repository pre-commit checks pass.
