### PR TITLE
fix(ci): align demo checks with evidence policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,11 +34,13 @@ Closes #
 ## Demo
 
 <!--
-Video or images demonstrating the change. Drag-and-drop a screenshot or screen
-recording, or paste a link. Expected for UI / frontend changes (check the
-"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
-use `N/A` for non-visual changes.
+Choose the evidence format that applies. UI / frontend changes require video or
+images. For non-visual changes, put reproducible evidence here or in Test Plan.
 -->
+
+- [ ] Visual demo attached below
+- [ ] Non-visual evidence provided below or in Test Plan
+- [ ] Not applicable — no behavioral change
 
 ## Type of change
 

--- a/.github/workflows/demo-check-test.yml
+++ b/.github/workflows/demo-check-test.yml
@@ -1,0 +1,27 @@
+name: Demo Check Policy Test
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/demo-check.js
+      - .github/workflows/demo-check.test.js
+      - .github/workflows/demo-check-test.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: demo-check-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run demo policy unit test
+        run: node .github/workflows/demo-check.test.js

--- a/.github/workflows/demo-check.js
+++ b/.github/workflows/demo-check.js
@@ -5,7 +5,7 @@ const MS_PER_HOUR = 60 * 60 * 1000;
 const HOURS_TO_SCAN = 24;
 const NEEDS_DEMO_LABEL = "needs-demo";
 const DEMO_COMMENT_MARKER = "<!-- needs-demo-comment -->";
-const DEMO_COMMENT_TEXT =
+const LEGACY_DEMO_COMMENT_TEXT =
   "This PR is a **Bug fix**, **Feature**, or **UI / frontend change** but the **Demo** section is missing";
 
 const MAINTAINER_ASSOCIATIONS = ["MEMBER", "OWNER", "COLLABORATOR"];
@@ -42,15 +42,10 @@ const QUERY = `
   }
 `;
 
-// Returns true when any change type that requires a demo is checked:
-// Bug fix, Feature, or UI / frontend change.
+// Visual media is required only when UI / frontend change is checked.
 function requiresDemo(body) {
   const text = body ?? "";
-  return (
-    /- \[[xX]\] Bug fix/.test(text) ||
-    /- \[[xX]\] Feature/.test(text) ||
-    /- \[[xX]\] UI \/ frontend change/.test(text)
-  );
+  return /- \[[xX]\] UI \/ frontend change/.test(text);
 }
 
 // Extracts the text content of the Demo section (between ## Demo and the next
@@ -79,16 +74,20 @@ function hasDemoContent(body) {
   return DEMO_MEDIA_PATTERNS.some((re) => re.test(content));
 }
 
+function bodyNeedsDemo(body) {
+  return requiresDemo(body) && !hasDemoContent(body);
+}
+
 const demoRequiredMessage = (author) =>
   `${DEMO_COMMENT_MARKER}
-@${author} This PR is a **Bug fix**, **Feature**, or **UI / frontend change** but the **Demo** section is missing or only contains a placeholder.
+@${author} This PR checks **UI / frontend change**, but the **Demo** section has no screenshot or recording.
 
-These change types require a screenshot or screen recording so reviewers can see the new behaviour without checking out the branch. Please update the **Demo** section with:
+UI / frontend changes require visual evidence so reviewers can see the new behaviour without checking out the branch. Please update the **Demo** section with:
 
 - A screenshot or screen recording of the change, or
 - A link to a hosted video or GIF showing the new behaviour.
 
-_Use \`N/A\` only when the change has no user-visible effect whatsoever (e.g. a pure refactor or test-only change). If that's the case, uncheck the relevant type box and check **Refactor / chore** or **Test / CI** instead._`;
+_If this PR has no visual surface, uncheck **UI / frontend change** and provide non-visual evidence in the **Test Plan**._`;
 
 const demoResolvedMessage = `${DEMO_COMMENT_MARKER}
 ✅ This PR no longer requires demo follow-up.`;
@@ -124,7 +123,7 @@ module.exports = async ({ context, github, core }) => {
         repo,
         name: NEEDS_DEMO_LABEL,
         color: "e4e669",
-        description: "PR needs a demo screenshot or recording",
+        description: "UI PR needs a demo screenshot or recording",
       });
     } catch (err) {
       // 422 = already exists; anything else is unexpected.
@@ -143,7 +142,8 @@ module.exports = async ({ context, github, core }) => {
       return comments.find(
         (comment) =>
           comment.user?.type === "Bot" &&
-          (comment.body?.includes(DEMO_COMMENT_MARKER) || comment.body?.includes(DEMO_COMMENT_TEXT))
+          (comment.body?.includes(DEMO_COMMENT_MARKER) ||
+            comment.body?.includes(LEGACY_DEMO_COMMENT_TEXT))
       );
     };
 
@@ -210,8 +210,7 @@ module.exports = async ({ context, github, core }) => {
         pr.state === "OPEN" &&
         !pr.isDraft &&
         !isMaintainer &&
-        requiresDemo(pr.body) &&
-        !hasDemoContent(pr.body);
+        bodyNeedsDemo(pr.body);
 
       if (!needsDemo && isLabeled) {
         try {
@@ -291,3 +290,5 @@ module.exports = async ({ context, github, core }) => {
     throw error;
   }
 };
+
+module.exports.bodyNeedsDemo = bodyNeedsDemo;

--- a/.github/workflows/demo-check.test.js
+++ b/.github/workflows/demo-check.test.js
@@ -1,0 +1,47 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { bodyNeedsDemo } = require("./demo-check.js");
+
+function body(type, demo) {
+  return `## Demo
+
+${demo}
+
+## Type of change
+
+- [${type === "Bug fix" ? "x" : " "}] Bug fix
+- [${type === "Feature" ? "x" : " "}] Feature
+- [${type === "UI / frontend change" ? "x" : " "}] UI / frontend change`;
+}
+
+test("a backend bug may use non-visual evidence", () => {
+  assert.equal(bodyNeedsDemo(body("Bug fix", "N/A — verified by the Test Plan.")), false);
+});
+
+test("a backend feature may use a written reproduction", () => {
+  assert.equal(bodyNeedsDemo(body("Feature", "Run `pytest tests/server/test_api.py`.")), false);
+});
+
+test("a UI change without media needs a demo", () => {
+  assert.equal(bodyNeedsDemo(body("UI / frontend change", "The layout looks better.")), true);
+});
+
+test("a checked evidence-format box is not itself a visual demo", () => {
+  assert.equal(
+    bodyNeedsDemo(body("UI / frontend change", "- [x] Visual demo attached below")),
+    true
+  );
+});
+
+test("a UI change with media satisfies the policy", () => {
+  assert.equal(
+    bodyNeedsDemo(
+      body(
+        "UI / frontend change",
+        "![updated layout](https://github.com/omnigent-ai/omnigent/assets/1/layout.png)"
+      )
+    ),
+    false
+  );
+});

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -344,7 +344,8 @@ request enforces this, so unsigned commits will block merging.
 - Sign off your commits with `git commit -s` (see
   [Developer Certificate of Origin](#developer-certificate-of-origin) above).
 - **Reference an issue** (see below).
-- Fill in the PR template. For **UI / frontend changes**, check the
+- Fill in the PR template. Bug fixes and features should include reproducible
+  evidence in the Demo or Test Plan. For **UI / frontend changes**, check the
   "UI / frontend change" box and attach a **video or images** in the `Demo`
   section showing the new behaviour, so reviewers can see it without checking
   out the branch.


### PR DESCRIPTION
## Related issue

Closes #4857

## Summary

- Require recognized screenshot/video media only when **UI / frontend change** is checked, matching the published contribution policy.
- Add optional evidence-format checkboxes and clarify that non-visual bug fixes and features can provide reproducible evidence in Demo or Test Plan.
- Add focused policy tests and a read-only workflow to keep the behavior stable. Label reconciliation already landed in #5926.

ELI5: visual changes still need something reviewers can see; backend changes can instead show commands, output, or another reproducible verification.

```text
UI / frontend checked? -- yes --> media present? -- no --> needs-demo
          |                            |
          no                           yes
          |                            |
          +----------------------------+------> no needs-demo
```

## Test Plan

- `node --check .github/workflows/demo-check.js`
- `node .github/workflows/demo-check.test.js` (5 tests pass)
- `pre-commit run`
- Dry-ran the policy against the issue examples: #3057, #4304, and #4848 all clear without requiring visual media.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — this changes PR automation and documentation; verification output is in Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The updated predicate was evaluated against the three existing PR descriptions cited by #4857, in addition to the automated policy cases.
