### PR TITLE
fix: workspace Download file silently truncates files larger than 10 MiB

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -406,6 +406,12 @@ _SILENT_CONNECT_ESCALATE_ATTEMPTS = 10
 # Capability discovery is advisory and must not delay the host channel forever.
 _HOST_CAPABILITY_INIT_TIMEOUT_S = 15.0
 
+# Raw-byte cap for a host-served file download. The result travels base64
+# (4/3 expansion) inside a single tunnel frame, and the WebSocket message
+# limit on both ends is 100 MiB — 64 MiB raw leaves comfortable headroom
+# for the frame's JSON envelope.
+_MAX_TUNNEL_DOWNLOAD_BYTES = 64 * 1024 * 1024
+
 # Host-environment variables a spawned runner is allowed to inherit.
 # Deliberately an allowlist (not ``{**os.environ}``): the host runs as the
 # user, so its environment holds the user's personal secrets (API keys,
@@ -2822,6 +2828,19 @@ class HostProcess:
                 exclude=cast("str | None", params.get("exclude")),
                 limit=_coerce_int(params.get("limit", 500)),
             )
+        if op == "download":
+            import base64
+
+            filename, raw = r.download_bytes(
+                str(params.get("path", "")),
+                max_bytes=_MAX_TUNNEL_DOWNLOAD_BYTES,
+            )
+            return {
+                "object": "session.environment.filesystem.download",
+                "filename": filename,
+                "bytes": len(raw),
+                "content": base64.b64encode(raw).decode(),
+            }
         raise ValueError(f"unknown fs op: {op!r}")
 
     async def _handle_create_worktree(

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -800,7 +800,7 @@ class HostFsRequestFrame:
 
     :param request_id: Correlates the result, e.g. ``"req_fs_1"``.
     :param op: Operation name — one of ``"list_or_read"``, ``"changes"``,
-        ``"diff"``, ``"search"``.
+        ``"diff"``, ``"search"``, ``"download"``.
     :param workspace: Absolute path to the session's workspace on the
         host, e.g. ``"/Users/alice/project"``.
     :param session_id: Session id, forwarded to the change registry.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -9154,7 +9154,7 @@ def create_runner_app(
         before: str | None = Query(default=None),
         order: str = Query(default="desc", pattern="^(asc|desc)$"),
         download: bool = Query(default=False),
-    ) -> JSONResponse | Response:
+    ) -> Response:
         await _require_os_env(session_id)
         if download:
             return await _fs_download(session_id, environment_id, relative_path)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -9153,8 +9153,11 @@ def create_runner_app(
         after: str | None = Query(default=None),
         before: str | None = Query(default=None),
         order: str = Query(default="desc", pattern="^(asc|desc)$"),
-    ) -> JSONResponse:
+        download: bool = Query(default=False),
+    ) -> JSONResponse | Response:
         await _require_os_env(session_id)
+        if download:
+            return await _fs_download(session_id, environment_id, relative_path)
         return await _fs_list_or_read(
             session_id,
             environment_id,
@@ -9163,6 +9166,42 @@ def create_runner_app(
             after=after,
             before=before,
             order=order,
+        )
+
+    async def _fs_download(
+        session_id: str,
+        environment_id: str,
+        path: str,
+    ) -> Response:
+        """Stream a workspace file to the client without a size cap.
+
+        Uses FileResponse so the file is sent directly from disk without
+        loading it into memory, which keeps large-file downloads safe.
+        The 10 MiB preview cap in ``_fs_list_or_read`` / ``CallerProcessFilesystem.read``
+        intentionally does not apply here: the caller requested a full download.
+        """
+        from fastapi.responses import FileResponse
+
+        from omnigent.runner.environment_filesystem import CallerProcessFilesystem
+
+        agent_spec = await _resolve_session_agent_spec(session_id)
+        env = resource_registry.resolve_environment(session_id, environment_id, agent_spec)
+        fs = CallerProcessFilesystem(env)
+        resolved = fs._resolve(path)
+        if not resolved.exists():
+            raise HTTPException(status_code=404, detail=f"Path {path!r} not found")
+        if not resolved.is_file():
+            raise HTTPException(status_code=400, detail=f"Path {path!r} is not a file")
+        media_type = mimetypes.guess_type(str(resolved))[0] or "application/octet-stream"
+        filename = resolved.name
+        return FileResponse(
+            str(resolved),
+            media_type=media_type,
+            filename=filename,
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "X-Content-Type-Options": "nosniff",
+            },
         )
 
     @app.put(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -9177,31 +9177,35 @@ def create_runner_app(
 
         Uses FileResponse so the file is sent directly from disk without
         loading it into memory, which keeps large-file downloads safe.
-        The 10 MiB preview cap in ``_fs_list_or_read`` / ``CallerProcessFilesystem.read``
-        intentionally does not apply here: the caller requested a full download.
+        The preview caps in ``_fs_list_or_read`` /
+        ``CallerProcessFilesystem.read`` intentionally do not apply here:
+        the caller requested the complete file.
         """
         from fastapi.responses import FileResponse
 
         from omnigent.runner.environment_filesystem import CallerProcessFilesystem
 
+        await _ensure_session_registered(session_id)
         agent_spec = await _resolve_session_agent_spec(session_id)
         env = resource_registry.resolve_environment(session_id, environment_id, agent_spec)
         fs = CallerProcessFilesystem(env)
+        # Same resolution as the read path: relative paths are confined to
+        # the environment root, absolute paths go through browse
+        # authorization. InvalidPath/PathUnreachable map via the app's
+        # ResourceError handler (400/403), matching the read endpoints.
         resolved = fs._resolve(path)
         if not resolved.exists():
             raise HTTPException(status_code=404, detail=f"Path {path!r} not found")
         if not resolved.is_file():
             raise HTTPException(status_code=400, detail=f"Path {path!r} is not a file")
         media_type = mimetypes.guess_type(str(resolved))[0] or "application/octet-stream"
-        filename = resolved.name
+        # FileResponse's ``filename=`` builds a correctly escaped
+        # Content-Disposition: attachment header (RFC 5987 for non-ASCII).
         return FileResponse(
             str(resolved),
             media_type=media_type,
-            filename=filename,
-            headers={
-                "Content-Disposition": f'attachment; filename="{filename}"',
-                "X-Content-Type-Options": "nosniff",
-            },
+            filename=resolved.name,
+            headers={"X-Content-Type-Options": "nosniff"},
         )
 
     @app.put(

--- a/omnigent/server/routes/_host_filesystem.py
+++ b/omnigent/server/routes/_host_filesystem.py
@@ -71,7 +71,7 @@ async def read_workspace_from_host(
     :param host_registry: Registry used to enqueue the outbound frame.
     :param host_conn: Live host connection for the session's host.
     :param op: Operation name — ``"list_or_read"`` / ``"changes"`` /
-        ``"diff"`` / ``"search"``.
+        ``"diff"`` / ``"search"`` / ``"download"``.
     :param workspace: Absolute workspace path on the host.
     :param session_id: Session id, forwarded to the change registry.
     :param params: Operation-specific arguments.

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import json
 import mimetypes
 import ntpath
 import urllib.parse
@@ -22,6 +23,7 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.responses import Response, StreamingResponse
+from starlette.background import BackgroundTask
 
 from omnigent.entities import (
     Conversation,
@@ -308,41 +310,84 @@ def register_resources_routes(
         return cast(dict[str, Any], response_payload)
 
     async def _proxy_download_from_runner(
-        runner_client: Any,
+        session_id: str,
         runner_path: str,
+        conversation: Conversation,
     ) -> Response:
-        """Proxy a file download from the runner as a binary response.
+        """Proxy a file download from the runner as a streamed binary response.
 
-        Unlike :func:`_proxy_get_to_runner`, this does not parse JSON —
-        it forwards the raw bytes and the runner's Content-Disposition
-        header directly.  Used by the ``?download=1`` path so large
-        workspace files are not truncated by the 10 MiB preview cap.
+        Unlike :func:`_proxy_get_to_runner`, this does not parse JSON — it
+        relays the body bytes as they arrive and forwards the runner's
+        Content-Disposition header directly. Used by the ``?download=1``
+        path so large workspace files are neither truncated by the 10 MiB
+        preview cap nor buffered whole in server memory.
 
-        :param runner_client: Authenticated HTTP client for the runner.
+        :param session_id: Session/conversation identifier.
         :param runner_path: Runner-relative URL including query string.
-        :returns: Binary response with Content-Disposition: attachment.
-        :raises HTTPException: 502 on transport failure or runner error.
+        :param conversation: Conversation loaded during authorization.
+        :returns: Streamed binary response with Content-Disposition: attachment.
+        :raises OmnigentError: Runner-offline / not-found, for the caller's
+            host fallback and the standard error mapping respectively.
+        :raises HTTPException: 502 on transport failure, 400/502 on runner
+            errors.
         """
+        runner_client = await _get_runner_client_for_resource_access(
+            session_id,
+            conversation=conversation,
+        )
+        if runner_client is None:
+            raise HTTPException(
+                status_code=502,
+                detail="no runner available for resource access",
+            )
+        request = runner_client.build_request(
+            "GET",
+            runner_path,
+            # No read deadline: a large file may take arbitrarily long to
+            # stream, and the per-chunk arrival is what read timeouts gate.
+            timeout=httpx.Timeout(30.0, read=None),
+        )
         try:
-            resp = await runner_client.get(runner_path, timeout=120.0)
+            resp = await runner_client.send(request, stream=True)
         except (httpx.HTTPError, ConnectionError) as exc:
             raise HTTPException(
                 status_code=502,
                 detail="runner download endpoint unavailable",
             ) from exc
-        if resp.status_code == 404:
-            raise OmnigentError("File not found", code=ErrorCode.NOT_FOUND)
         if resp.status_code != 200:
-            raise HTTPException(status_code=502, detail="runner download failed")
-        content_type = resp.headers.get("content-type", "application/octet-stream")
-        content_disposition = resp.headers.get("content-disposition", "attachment")
-        return Response(
-            content=resp.content,
-            media_type=content_type,
-            headers={
-                "Content-Disposition": content_disposition,
-                "X-Content-Type-Options": "nosniff",
-            },
+            detail = "runner download failed"
+            try:
+                body = await resp.aread()
+                error_payload = json.loads(body.decode("utf-8"))
+                if isinstance(error_payload, dict):
+                    # FastAPI HTTPException shape and the runner's
+                    # ResourceError handler shape, respectively.
+                    if isinstance(error_payload.get("detail"), str):
+                        detail = error_payload["detail"]
+                    elif isinstance(error_payload.get("error"), dict) and isinstance(
+                        error_payload["error"].get("message"), str
+                    ):
+                        detail = error_payload["error"]["message"]
+            except (ValueError, UnicodeDecodeError):
+                pass
+            finally:
+                await resp.aclose()
+            if resp.status_code == 404:
+                raise OmnigentError(detail, code=ErrorCode.NOT_FOUND)
+            if resp.status_code == 400:
+                raise HTTPException(status_code=400, detail=detail)
+            raise HTTPException(status_code=502, detail=detail)
+        headers = {
+            "Content-Disposition": resp.headers.get("content-disposition", "attachment"),
+            "X-Content-Type-Options": "nosniff",
+        }
+        if resp.headers.get("content-length"):
+            headers["Content-Length"] = resp.headers["content-length"]
+        return StreamingResponse(
+            resp.aiter_bytes(),
+            media_type=resp.headers.get("content-type", "application/octet-stream"),
+            headers=headers,
+            background=BackgroundTask(resp.aclose),
         )
 
     async def _fs_get_with_host_fallback(
@@ -2105,28 +2150,33 @@ def register_resources_routes(
         )
 
         if download:
-            # Download path: bypass the 10 MiB cap; return raw bytes with
-            # Content-Disposition: attachment so the browser saves the file.
-            # The runner streams directly from disk via FileResponse. The host
-            # fallback reads the full file from the workspace on disk.
+            # Download path: bypass the 10 MiB preview cap; return raw bytes
+            # with Content-Disposition: attachment so the browser saves the
+            # complete file. The runner streams it straight from disk; when
+            # the runner is offline the host serves the bytes over its tunnel,
+            # like every other offline filesystem read.
+            #
+            # Opt out of this route's gzip: compressing an arbitrary (often
+            # already-compressed) attachment wastes event-loop time and
+            # drops the Content-Length the browser uses for save progress.
+            skip_gzip(request)
             runner_download_path = (
                 f"/v1/sessions/{session_id}/resources/environments"
                 f"/{environment_id}/filesystem/{runner_rel}?download=1"
             )
-            runner_client = await _get_runner_client_for_resource_access(
-                session_id, conversation=conv
-            )
-            if runner_client is not None:
-                try:
-                    return await _proxy_download_from_runner(runner_client, runner_download_path)
-                except OmnigentError as exc:
-                    if exc.code != ErrorCode.RUNNER_UNAVAILABLE:
-                        raise
-            # Runner offline — fall back to the host workspace reader.
+            try:
+                return await _proxy_download_from_runner(session_id, runner_download_path, conv)
+            except OmnigentError as exc:
+                # Only the runner-offline case falls back to the host; a real
+                # 404 from a live runner must surface unchanged.
+                if exc.code != ErrorCode.RUNNER_UNAVAILABLE:
+                    raise
+                runner_offline = exc
             return await _download_from_host(
                 session_id,
                 conv,
                 path="" if absolute else relative_path,
+                runner_offline=runner_offline,
                 host_workspace_resolver=(
                     functools.partial(_authorize_absolute_browse, conv, relative_path)
                     if absolute
@@ -2179,47 +2229,51 @@ def register_resources_routes(
         conversation: Conversation,
         path: str,
         *,
+        runner_offline: OmnigentError,
         host_workspace_resolver: Callable[[], Awaitable[str]] | None = None,
     ) -> Response:
-        """Download a file from the host workspace when the runner is offline.
+        """Download a file over the host tunnel when the runner is offline.
 
-        Uses :meth:`omnigent.workspace_fs.WorkspaceReader.download_bytes`
-        to read the complete file without the 10 MiB preview cap.
+        Sends a ``download`` fs op over the session's host tunnel — the
+        host reads the complete file from the workspace on ITS disk (the
+        server never has the workspace locally) and returns it
+        base64-encoded in the result frame, bypassing the 10 MiB preview
+        cap up to the tunnel's own message limit.
 
         :param session_id: Session/conversation identifier.
         :param conversation: Conversation loaded during authorization.
         :param path: Workspace-relative (or host-absolute) file path.
+        :param runner_offline: The runner-offline error to re-raise when
+            the host cannot serve the download either.
         :param host_workspace_resolver: Optional resolver for absolute paths.
         :returns: Binary response with Content-Disposition: attachment.
-        :raises OmnigentError: RUNNER_UNAVAILABLE when neither runner nor
-            host can serve the download.
+        :raises OmnigentError: The original runner-offline error when no
+            host can answer, or NOT_FOUND for a missing file.
+        :raises HTTPException: On host-reported filesystem failures.
         """
-        from omnigent.workspace_fs import WorkspaceReader, WorkspaceReaderError
+        import base64 as _base64
 
-        if host_registry is None or not conversation.host_id or not conversation.workspace:
-            raise OmnigentError(
-                "Session runner is unavailable and no host fallback is configured",
-                code=ErrorCode.RUNNER_UNAVAILABLE,
-            )
-        host_conn = host_registry.get(conversation.host_id)
-        if host_conn is None:
-            raise OmnigentError(
-                "Session runner is unavailable and host is not connected",
-                code=ErrorCode.RUNNER_UNAVAILABLE,
-            )
-
-        workspace = conversation.workspace
-        if host_workspace_resolver is not None:
-            workspace = await host_workspace_resolver()
-
+        workspace = (
+            await host_workspace_resolver() if host_workspace_resolver is not None else None
+        )
+        payload = await _read_workspace_via_host(
+            session_id,
+            conversation,
+            "download",
+            {"path": path},
+            workspace_override=workspace,
+        )
+        if payload is None:
+            # No reachable host either — surface the original offline error
+            # (503) so the client shows its reconnect affordance.
+            raise runner_offline
+        filename = str(payload.get("filename") or ntpath.basename(path) or path)
         try:
-            reader = WorkspaceReader(Path(workspace))
-            filename, raw = await asyncio.to_thread(reader.download_bytes, path)
-        except WorkspaceReaderError as exc:
-            if exc.status == 404:
-                raise OmnigentError(exc.message, code=ErrorCode.NOT_FOUND) from exc
-            raise HTTPException(status_code=exc.status, detail=exc.message) from exc
-
+            raw = _base64.b64decode(str(payload.get("content") or ""), validate=True)
+        except (ValueError, TypeError) as exc:
+            raise HTTPException(
+                status_code=502, detail="host returned an invalid download payload"
+            ) from exc
         media_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
         return Response(
             content=raw,

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -21,7 +21,7 @@ from fastapi import (
     Request,
     UploadFile,
 )
-from fastapi.responses import Response
+from fastapi.responses import Response, StreamingResponse
 
 from omnigent.entities import (
     Conversation,
@@ -306,6 +306,55 @@ def register_resources_routes(
                 status_code=502, detail="runner resource endpoint returned non-object JSON"
             )
         return cast(dict[str, Any], response_payload)
+
+    async def _proxy_download_from_runner(
+        session_id: str,
+        runner_path: str,
+        conversation: Conversation,
+    ) -> Response:
+        """Proxy a file download from the runner as a binary response.
+
+        Unlike :func:`_proxy_get_to_runner`, this does not parse JSON —
+        it forwards the raw bytes and the runner's Content-Disposition
+        header directly.  Used by the ``?download=1`` path so large
+        workspace files are not truncated by the 10 MiB preview cap.
+
+        :param session_id: Session/conversation identifier.
+        :param runner_path: Runner-relative URL including query string.
+        :param conversation: Conversation loaded during authorization.
+        :returns: Binary response with Content-Disposition: attachment.
+        :raises HTTPException: 502 on transport failure or runner error.
+        """
+        runner_client = await _get_runner_client_for_resource_access(
+            session_id,
+            conversation=conversation,
+        )
+        if runner_client is None:
+            raise HTTPException(
+                status_code=502,
+                detail="no runner available for resource access",
+            )
+        try:
+            resp = await runner_client.get(runner_path, timeout=120.0)
+        except (httpx.HTTPError, ConnectionError) as exc:
+            raise HTTPException(
+                status_code=502,
+                detail="runner download endpoint unavailable",
+            ) from exc
+        if resp.status_code == 404:
+            raise OmnigentError("File not found", code=ErrorCode.NOT_FOUND)
+        if resp.status_code != 200:
+            raise HTTPException(status_code=502, detail="runner download failed")
+        content_type = resp.headers.get("content-type", "application/octet-stream")
+        content_disposition = resp.headers.get("content-disposition", "attachment")
+        return Response(
+            content=resp.content,
+            media_type=content_type,
+            headers={
+                "Content-Disposition": content_disposition,
+                "X-Content-Type-Options": "nosniff",
+            },
+        )
 
     async def _fs_get_with_host_fallback(
         session_id: str,
@@ -2031,6 +2080,7 @@ def register_resources_routes(
         after: str | None = Query(default=None),
         before: str | None = Query(default=None),
         order: str = Query(default="desc", pattern="^(asc|desc)$"),
+        download: bool = Query(default=False),
     ) -> Any:
         """
         Read a file or list a directory in an environment.
@@ -2044,14 +2094,11 @@ def register_resources_routes(
         :param after: Cursor entry id for forward pagination.
         :param before: Cursor entry id for backward pagination.
         :param order: Sort order, ``"asc"`` or ``"desc"``.
+        :param download: When ``True``, stream the complete file without
+            the 10 MiB preview cap and set Content-Disposition: attachment.
+            Ignored for directory listings.
         :returns: File content or directory listing.
         """
-        params: dict[str, str] = {"limit": str(limit), "order": order}
-        if after is not None:
-            params["after"] = after
-        if before is not None:
-            params["before"] = before
-
         # A leading slash means an absolute location rather than a path under
         # the workspace, so it is owner-only: the workspace is the session's
         # shared context, everything past it is the owner's own machine. See
@@ -2062,12 +2109,45 @@ def register_resources_routes(
             session_id, request, _browse_level(relative_path, within_workspace=LEVEL_READ)
         )
 
-        qs = urllib.parse.urlencode(params)
         # Encode only the leading slash: a literal "//" is what proxies
         # collapse, while interior slashes travel fine and keep logs readable.
         runner_rel = (
             "%2F" + urllib.parse.quote(relative_path.lstrip("/")) if absolute else relative_path
         )
+
+        if download:
+            # Download path: bypass the 10 MiB cap; return raw bytes with
+            # Content-Disposition: attachment so the browser saves the file.
+            # The runner streams directly from disk via FileResponse. The host
+            # fallback reads the full file from the workspace on disk.
+            runner_download_path = (
+                f"/v1/sessions/{session_id}/resources/environments"
+                f"/{environment_id}/filesystem/{runner_rel}?download=1"
+            )
+            try:
+                return await _proxy_download_from_runner(session_id, runner_download_path, conv)
+            except OmnigentError as exc:
+                if exc.code != ErrorCode.RUNNER_UNAVAILABLE:
+                    raise
+            # Runner offline — fall back to the host workspace reader.
+            return await _download_from_host(
+                session_id,
+                conv,
+                path="" if absolute else relative_path,
+                host_workspace_resolver=(
+                    functools.partial(_authorize_absolute_browse, conv, relative_path)
+                    if absolute
+                    else None
+                ),
+            )
+
+        params: dict[str, str] = {"limit": str(limit), "order": order}
+        if after is not None:
+            params["after"] = after
+        if before is not None:
+            params["before"] = before
+
+        qs = urllib.parse.urlencode(params)
         path = (
             f"/v1/sessions/{session_id}/resources/environments"
             f"/{environment_id}/filesystem/{runner_rel}?{qs}"
@@ -2099,6 +2179,62 @@ def register_resources_routes(
                 runner_path=path,
                 host_workspace_resolver=resolver,
             ),
+        )
+
+    async def _download_from_host(
+        session_id: str,
+        conversation: Conversation,
+        path: str,
+        *,
+        host_workspace_resolver: Callable[[], Awaitable[str]] | None = None,
+    ) -> Response:
+        """Download a file from the host workspace when the runner is offline.
+
+        Uses :meth:`omnigent.workspace_fs.WorkspaceReader.download_bytes`
+        to read the complete file without the 10 MiB preview cap.
+
+        :param session_id: Session/conversation identifier.
+        :param conversation: Conversation loaded during authorization.
+        :param path: Workspace-relative (or host-absolute) file path.
+        :param host_workspace_resolver: Optional resolver for absolute paths.
+        :returns: Binary response with Content-Disposition: attachment.
+        :raises OmnigentError: RUNNER_UNAVAILABLE when neither runner nor
+            host can serve the download.
+        """
+        from omnigent.workspace_fs import WorkspaceReader, WorkspaceReaderError
+
+        if host_registry is None or not conversation.host_id or not conversation.workspace:
+            raise OmnigentError(
+                "Session runner is unavailable and no host fallback is configured",
+                code=ErrorCode.RUNNER_UNAVAILABLE,
+            )
+        host_conn = host_registry.get(conversation.host_id)
+        if host_conn is None:
+            raise OmnigentError(
+                "Session runner is unavailable and host is not connected",
+                code=ErrorCode.RUNNER_UNAVAILABLE,
+            )
+
+        workspace = conversation.workspace
+        if host_workspace_resolver is not None:
+            workspace = await host_workspace_resolver()
+
+        try:
+            reader = WorkspaceReader(Path(workspace))
+            filename, raw = await asyncio.to_thread(reader.download_bytes, path)
+        except WorkspaceReaderError as exc:
+            if exc.status == 404:
+                raise OmnigentError(exc.message, code=ErrorCode.NOT_FOUND) from exc
+            raise HTTPException(status_code=exc.status, detail=exc.message) from exc
+
+        media_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+        return Response(
+            content=raw,
+            media_type=media_type,
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "X-Content-Type-Options": "nosniff",
+            },
         )
 
     @router.put(

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -308,9 +308,8 @@ def register_resources_routes(
         return cast(dict[str, Any], response_payload)
 
     async def _proxy_download_from_runner(
-        session_id: str,
+        runner_client: Any,
         runner_path: str,
-        conversation: Conversation,
     ) -> Response:
         """Proxy a file download from the runner as a binary response.
 
@@ -319,21 +318,11 @@ def register_resources_routes(
         header directly.  Used by the ``?download=1`` path so large
         workspace files are not truncated by the 10 MiB preview cap.
 
-        :param session_id: Session/conversation identifier.
+        :param runner_client: Authenticated HTTP client for the runner.
         :param runner_path: Runner-relative URL including query string.
-        :param conversation: Conversation loaded during authorization.
         :returns: Binary response with Content-Disposition: attachment.
         :raises HTTPException: 502 on transport failure or runner error.
         """
-        runner_client = await _get_runner_client_for_resource_access(
-            session_id,
-            conversation=conversation,
-        )
-        if runner_client is None:
-            raise HTTPException(
-                status_code=502,
-                detail="no runner available for resource access",
-            )
         try:
             resp = await runner_client.get(runner_path, timeout=120.0)
         except (httpx.HTTPError, ConnectionError) as exc:
@@ -2124,11 +2113,15 @@ def register_resources_routes(
                 f"/v1/sessions/{session_id}/resources/environments"
                 f"/{environment_id}/filesystem/{runner_rel}?download=1"
             )
-            try:
-                return await _proxy_download_from_runner(session_id, runner_download_path, conv)
-            except OmnigentError as exc:
-                if exc.code != ErrorCode.RUNNER_UNAVAILABLE:
-                    raise
+            runner_client = await _get_runner_client_for_resource_access(
+                session_id, conversation=conv
+            )
+            if runner_client is not None:
+                try:
+                    return await _proxy_download_from_runner(runner_client, runner_download_path)
+                except OmnigentError as exc:
+                    if exc.code != ErrorCode.RUNNER_UNAVAILABLE:
+                        raise
             # Runner offline — fall back to the host workspace reader.
             return await _download_from_host(
                 session_id,

--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -297,19 +297,24 @@ class WorkspaceReader:
             payload["content"] = base64.b64encode(capped).decode()
         return payload
 
-    def download_bytes(self, path: str) -> tuple[str, bytes]:
+    def download_bytes(self, path: str, *, max_bytes: int | None = None) -> tuple[str, bytes]:
         """Return ``(filename, raw_bytes)`` for a full file download.
 
-        Unlike :meth:`_read_file`, this imposes no size cap so the caller
-        receives the complete file regardless of size.  Only use this on
-        the download path — the preview/read path deliberately caps at
-        ``_MAX_READ_BYTES`` to avoid OOM on multi-GB files opened in the
+        Unlike :meth:`_read_file`, this imposes no size cap by default so
+        the caller receives the complete file regardless of size.  Only use
+        this on the download path — the preview/read path deliberately caps
+        at ``_MAX_READ_BYTES`` to avoid OOM on multi-GB files opened in the
         viewer.
 
         :param path: Relative path within the workspace.
+        :param max_bytes: Optional hard cap for transports that cannot carry
+            arbitrarily large payloads (e.g. the host tunnel's framed
+            messages). Checked against the on-disk size *before* reading, so
+            an oversize file never gets slurped into memory first.
         :returns: ``(filename, raw_bytes)`` of the complete file.
         :raises WorkspaceReaderError: 400 when path is not a file, 404
-            when the path does not exist.
+            when the path does not exist, 413 when the file exceeds
+            ``max_bytes``.
         """
         resolved = self._resolve(path)
         if not resolved.exists():
@@ -317,6 +322,12 @@ class WorkspaceReader:
         if not resolved.is_file():
             raise WorkspaceReaderError(400, "not_a_file", f"Path {path!r} is not a file")
         try:
+            if max_bytes is not None and resolved.stat().st_size > max_bytes:
+                raise WorkspaceReaderError(
+                    413,
+                    "too_large",
+                    f"File {path!r} exceeds the {max_bytes}-byte cap for this transport",
+                )
             return resolved.name, resolved.read_bytes()
         except OSError as exc:
             raise WorkspaceReaderError(404, "not_found", f"Path {path!r} not found") from exc

--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -297,6 +297,30 @@ class WorkspaceReader:
             payload["content"] = base64.b64encode(capped).decode()
         return payload
 
+    def download_bytes(self, path: str) -> tuple[str, bytes]:
+        """Return ``(filename, raw_bytes)`` for a full file download.
+
+        Unlike :meth:`_read_file`, this imposes no size cap so the caller
+        receives the complete file regardless of size.  Only use this on
+        the download path — the preview/read path deliberately caps at
+        ``_MAX_READ_BYTES`` to avoid OOM on multi-GB files opened in the
+        viewer.
+
+        :param path: Relative path within the workspace.
+        :returns: ``(filename, raw_bytes)`` of the complete file.
+        :raises WorkspaceReaderError: 400 when path is not a file, 404
+            when the path does not exist.
+        """
+        resolved = self._resolve(path)
+        if not resolved.exists():
+            raise WorkspaceReaderError(404, "not_found", f"Path {path!r} not found")
+        if not resolved.is_file():
+            raise WorkspaceReaderError(400, "not_a_file", f"Path {path!r} is not a file")
+        try:
+            return resolved.name, resolved.read_bytes()
+        except OSError as exc:
+            raise WorkspaceReaderError(404, "not_found", f"Path {path!r} not found") from exc
+
     # ── Search ─────────────────────────────────────────────────────
 
     def search(

--- a/openapi.json
+++ b/openapi.json
@@ -12225,6 +12225,16 @@
               "title": "Order",
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "download",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Download",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/openapi.json
+++ b/openapi.json
@@ -12227,6 +12227,7 @@
             }
           },
           {
+            "description": "When `True`, stream the complete file without the 10 MiB preview cap and set Content-Disposition: attachment. Ignored for directory listings.",
             "in": "query",
             "name": "download",
             "required": false,

--- a/tests/e2e_ui/files/test_large_file_download_full_content.py
+++ b/tests/e2e_ui/files/test_large_file_download_full_content.py
@@ -1,0 +1,117 @@
+"""E2E: downloading a large workspace file must deliver its full content.
+
+The filesystem file-content API returns the whole file as one inline JSON
+payload and truncates large files (2,000-line / 10 MiB read caps) instead of
+streaming them. The FileViewer's truncation banner tells users to download
+the file "to view or edit the full content", but the Download action reuses
+the same truncated payload, so the saved file silently loses everything past
+the cap — there is no way to retrieve the full file through the app.
+
+Journey pinned here: seed a 3,000-line file into the session workspace →
+open it in the file viewer → trigger "Download file" from the viewer
+toolbar → the downloaded file must contain all 3,000 lines.
+
+Seeded via the filesystem PUT endpoint (no agent run).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Locator, Page, expect
+
+# The repo root is three levels up (``<repo>/tests/e2e_ui/files/...``).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_FILE_PATH = "large_download_journey.txt"
+_TOTAL_LINES = 3_000
+_LINE_TEMPLATE = "LINE {index:05d}: filesystem content that must survive a download"
+_FILE_CONTENT = (
+    "\n".join(_LINE_TEMPLATE.format(index=i) for i in range(1, _TOTAL_LINES + 1)) + "\n"
+)
+_FIRST_LINE = _LINE_TEMPLATE.format(index=1)
+_LAST_LINE = _LINE_TEMPLATE.format(index=_TOTAL_LINES)
+
+
+@pytest.fixture
+def seeded_large_file_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str]]:
+    """Seed the large text file and yield ``(base_url, session_id)``.
+
+    :param seeded_session: Runner-bound ``(base_url, session_id)`` pair.
+    :returns: The same pair, with the large file present in the workspace.
+    """
+    base_url, session_id = seeded_session
+    resp = httpx.put(
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_FILE_PATH}",
+        json={"content": _FILE_CONTENT, "encoding": "utf-8"},
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    try:
+        yield (base_url, session_id)
+    finally:
+        # The spawned runner's workspace is the repo root, so the seeded
+        # file lands there; remove it so reruns start clean.
+        (_REPO_ROOT / _FILE_PATH).unlink(missing_ok=True)
+
+
+def _open_viewer_settings_menu(file_viewer: Locator) -> None:
+    """Open the viewer toolbar menu that carries the Download action.
+
+    The toolbar renders inline icon buttons ("View settings") while they
+    fit and folds everything into a single "More actions" menu when the
+    pane is narrow, so try the inline trigger first and fall back.
+
+    :param file_viewer: The visible FileViewer locator.
+    """
+    inline = file_viewer.get_by_role("button", name="View settings")
+    if inline.count() > 0 and inline.first.is_visible():
+        inline.first.click()
+        return
+    file_viewer.get_by_role("button", name="More actions").first.click()
+
+
+def test_download_of_large_file_delivers_full_content(
+    page: Page,
+    seeded_large_file_session: tuple[str, str],
+) -> None:
+    """Downloading a file larger than the read caps must not lose content."""
+    base_url, session_id = seeded_large_file_session
+    page.goto(f"{base_url}/c/{session_id}?file={_FILE_PATH}")
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible(timeout=30_000)
+    # The open file is identified by its tab; the tab's close button proves
+    # the viewer opened the seeded file (not some other panel state).
+    expect(page.get_by_role("button", name=f"Close {_FILE_PATH}", exact=True).first).to_be_visible(
+        timeout=30_000
+    )
+    # Content rendered — the Download action only appears in the toolbar
+    # menu once the file-content query has resolved.
+    expect(file_viewer.get_by_text("LINE 00001").first).to_be_visible(timeout=30_000)
+
+    _open_viewer_settings_menu(file_viewer)
+    download_item = page.get_by_role("menuitem", name="Download file")
+    expect(download_item).to_be_visible()
+
+    with page.expect_download() as download_info:
+        download_item.click()
+    download = download_info.value
+    assert download.suggested_filename == _FILE_PATH
+
+    saved = Path(str(download.path())).read_text(encoding="utf-8")
+    lines = saved.splitlines()
+    assert lines and lines[0] == _FIRST_LINE
+    # The whole point of the download affordance (and the truncation banner
+    # that points users at it) is retrieving the file in full; a capped,
+    # non-streamed read silently drops everything past the cap.
+    assert len(lines) == _TOTAL_LINES, (
+        f"downloaded file is truncated: got {len(lines)} of {_TOTAL_LINES} lines"
+    )
+    assert lines[-1] == _LAST_LINE

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -5192,3 +5192,85 @@ async def test_handle_import_local_reports_unreadable_sessions_as_failed(
     assert [f.session.external_session_id for f in session_frames] == ["good"]
     assert len(done_frames) == 1
     assert done_frames[0].status == "ok" and done_frames[0].failed == 1
+
+
+# ── Host-served filesystem download op ───────────────────────────────────────
+
+
+def test_fs_request_download_returns_full_file_base64(tmp_path: Path) -> None:
+    """The host's ``download`` fs op returns the complete file, base64-encoded.
+
+    The runner-offline download fallback rides the host tunnel; the host
+    reads the file from ITS disk in full (past the viewer's preview cap)
+    and returns it in the result frame.
+    """
+    import base64
+
+    from omnigent.host.frames import HostFsRequestFrame
+
+    content = b"\x00\x01binary and text mixed\n" * 4096  # ~92 KiB
+    (tmp_path / "artifact.bin").write_bytes(content)
+    host = _make_host_process()
+
+    result = host._handle_fs_request(
+        HostFsRequestFrame(
+            request_id="req_dl",
+            op="download",
+            workspace=str(tmp_path),
+            session_id="conv_dl",
+            params={"path": "artifact.bin"},
+        )
+    )
+
+    assert result.status == "ok", result.error
+    assert result.payload is not None
+    assert result.payload["filename"] == "artifact.bin"
+    assert result.payload["bytes"] == len(content)
+    assert base64.b64decode(str(result.payload["content"])) == content
+
+
+def test_fs_request_download_missing_file_maps_404(tmp_path: Path) -> None:
+    """A missing path comes back as the runner-shaped 404 error frame."""
+    from omnigent.host.frames import HostFsRequestFrame
+
+    host = _make_host_process()
+
+    result = host._handle_fs_request(
+        HostFsRequestFrame(
+            request_id="req_missing",
+            op="download",
+            workspace=str(tmp_path),
+            session_id="conv_dl",
+            params={"path": "nope.bin"},
+        )
+    )
+
+    assert result.status == "error"
+    assert result.error_status == 404
+    assert result.error_code == "not_found"
+
+
+def test_fs_request_download_oversize_maps_413(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file past the tunnel cap is refused with 413, never half-sent."""
+    import omnigent.host.connect as connect_mod
+    from omnigent.host.frames import HostFsRequestFrame
+
+    monkeypatch.setattr(connect_mod, "_MAX_TUNNEL_DOWNLOAD_BYTES", 16)
+    (tmp_path / "huge.bin").write_bytes(b"Z" * 64)
+    host = _make_host_process()
+
+    result = host._handle_fs_request(
+        HostFsRequestFrame(
+            request_id="req_huge",
+            op="download",
+            workspace=str(tmp_path),
+            session_id="conv_dl",
+            params={"path": "huge.bin"},
+        )
+    )
+
+    assert result.status == "error"
+    assert result.error_status == 413
+    assert result.error_code == "too_large"

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -496,6 +496,90 @@ async def test_read_nonexistent_file_returns_404(
 
 
 @pytest.mark.asyncio
+async def test_download_returns_full_file_past_read_caps(
+    workspace: Path,
+    client: httpx.AsyncClient,
+) -> None:
+    """``?download=1`` returns the COMPLETE file as a raw attachment.
+
+    The plain read caps text files at the default line limit, so a file
+    past that cap comes back ``truncated: true`` and the JSON payload
+    loses the tail. The download mode must bypass the caps and deliver
+    every byte, or "Download file" silently saves an incomplete file.
+    """
+    lines = 3000  # beyond the 2000-line default read cap
+    content = "".join(f"line {i}\n" for i in range(1, lines + 1))
+    (workspace / "big.txt").write_text(content)
+
+    read_resp = await client.get(
+        f"/v1/sessions/conv_test/resources/environments"
+        f"/{DEFAULT_ENVIRONMENT_ID}/filesystem/big.txt"
+    )
+    assert read_resp.status_code == 200
+    assert read_resp.json()["truncated"] is True  # the preview IS capped
+
+    dl_resp = await client.get(
+        f"/v1/sessions/conv_test/resources/environments"
+        f"/{DEFAULT_ENVIRONMENT_ID}/filesystem/big.txt?download=1"
+    )
+    assert dl_resp.status_code == 200
+    assert dl_resp.content.decode("utf-8") == content
+    assert "attachment" in dl_resp.headers["content-disposition"]
+    assert 'filename="big.txt"' in dl_resp.headers["content-disposition"]
+
+
+@pytest.mark.asyncio
+async def test_download_binary_round_trips_verbatim(
+    client: httpx.AsyncClient,
+) -> None:
+    """``?download=1`` on a binary file returns its exact bytes."""
+    resp = await client.get(
+        f"/v1/sessions/conv_test/resources/environments"
+        f"/{DEFAULT_ENVIRONMENT_ID}/filesystem/logo.png?download=1"
+    )
+    assert resp.status_code == 200
+    assert resp.content == b"\x89PNG\r\n\x1a\n\x00\x01\x02\xff"
+    assert resp.headers["content-type"] == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_download_missing_file_returns_404(
+    client: httpx.AsyncClient,
+) -> None:
+    """``?download=1`` on a missing path is a 404, not an empty file."""
+    resp = await client.get(
+        f"/v1/sessions/conv_test/resources/environments"
+        f"/{DEFAULT_ENVIRONMENT_ID}/filesystem/nope.bin?download=1"
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_download_directory_returns_400(
+    client: httpx.AsyncClient,
+) -> None:
+    """``?download=1`` on a directory is rejected."""
+    resp = await client.get(
+        f"/v1/sessions/conv_test/resources/environments"
+        f"/{DEFAULT_ENVIRONMENT_ID}/filesystem/src?download=1"
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_download_path_traversal_rejected(
+    client: httpx.AsyncClient,
+) -> None:
+    """``?download=1`` goes through the same path confinement as reads."""
+    resp = await client.get(
+        f"/v1/sessions/conv_test/resources/environments"
+        f"/{DEFAULT_ENVIRONMENT_ID}/filesystem/" + "..%2F..%2Fetc%2Fpasswd?download=1"
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_path"
+
+
+@pytest.mark.asyncio
 async def test_filesystem_session_without_agent_id_returns_typed_404(
     registry: SessionResourceRegistry,
 ) -> None:

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -361,6 +361,27 @@ class _FakeRunnerClient:
         self.get_params.append(params)
         return self._make_response("GET", url)
 
+    def build_request(self, method: str, url: str, *, timeout: object = None) -> httpx.Request:
+        """Build a request for the streamed-send path (download proxy).
+
+        :param method: HTTP method, e.g. ``"GET"``.
+        :param url: Request URL path including query string.
+        :param timeout: Request timeout (ignored).
+        :returns: The httpx request.
+        """
+        del timeout
+        return httpx.Request(method, url)
+
+    async def send(self, request: httpx.Request, *, stream: bool = False) -> httpx.Response:
+        """Answer a streamed send with the same canned-response lookup.
+
+        :param request: Request built by :meth:`build_request`.
+        :param stream: Streaming flag (ignored — canned bodies are in memory).
+        :returns: The canned response.
+        """
+        del stream
+        return self._make_response(request.method, str(request.url))
+
     async def post(
         self,
         url: str,
@@ -5292,6 +5313,18 @@ class _OfflineRunnerClient:
         del params, timeout
         raise OmnigentError(f"runner is not connected ({url})", code=ErrorCode.RUNNER_UNAVAILABLE)
 
+    def build_request(self, method: str, url: str, *, timeout: object = None) -> httpx.Request:
+        """Build a request; the failure surfaces on :meth:`send`."""
+        del timeout
+        return httpx.Request(method, url)
+
+    async def send(self, request: httpx.Request, *, stream: bool = False) -> Any:
+        """Raise the offline error the tunnel client raises."""
+        del stream
+        raise OmnigentError(
+            f"runner is not connected ({request.url})", code=ErrorCode.RUNNER_UNAVAILABLE
+        )
+
 
 @pytest.fixture
 def offline_env_app(
@@ -5383,6 +5416,168 @@ async def test_offline_environment_advertises_the_same_reach_as_the_runner(
         "unconfined": True,
         "roots": [{"path": _OFFLINE_WORKSPACE, "access": "write", "origin": "cwd"}],
     }
+
+
+# ── Full-file download proxy (?download=1) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_filesystem_download_relays_runner_bytes_verbatim(
+    client: httpx.AsyncClient,
+) -> None:
+    """``?download=1`` relays the runner's raw attachment bytes unchanged.
+
+    The plain read path parses JSON and inherits the preview caps; the
+    download path must forward the body and Content-Disposition as-is so
+    large files survive intact.
+    """
+    body = "line data\n" * 5000
+    url = (
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources"
+        "/environments/default/filesystem/big.txt?download=1"
+    )
+    fake_runner = _FakeRunnerClient(
+        text_responses={
+            url: (
+                200,
+                body,
+                {
+                    "content-type": "text/plain",
+                    "content-disposition": 'attachment; filename="big.txt"',
+                },
+            )
+        }
+    )
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+
+    resp = await client.get(url)
+
+    assert resp.status_code == 200
+    assert resp.text == body
+    assert resp.headers["content-disposition"] == 'attachment; filename="big.txt"'
+    assert resp.headers["content-type"].startswith("text/plain")
+    # The proxy hit the runner's download mode, not the capped JSON read.
+    assert fake_runner.calls == [("GET", url)]
+
+
+@pytest.mark.asyncio
+async def test_filesystem_download_maps_runner_404(
+    client: httpx.AsyncClient,
+) -> None:
+    """A live runner's 404 surfaces as NOT_FOUND, not a hollow download."""
+    url = (
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources"
+        "/environments/default/filesystem/nope.txt?download=1"
+    )
+    fake_runner = _FakeRunnerClient(
+        responses={url: (404, {"detail": "Path 'nope.txt' not found"})}
+    )
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+
+    resp = await client.get(url)
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_filesystem_download_offline_falls_back_to_host_tunnel(
+    offline_env_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runner offline → the download is served over the HOST tunnel.
+
+    The workspace lives on the host machine, not the server, so the
+    fallback must send a ``download`` fs op over the host tunnel (like
+    every other offline filesystem read) and decode the base64 payload
+    the host returns — never read the server's local disk.
+    """
+    import base64
+
+    from omnigent.server.routes.sessions import routes_resources as _routes
+
+    raw = b"complete file bytes \x00\x01 past any preview cap"
+    seen: list[tuple[str, dict[str, Any]]] = []
+
+    async def _fake_host_read(
+        host_registry: Any,
+        host_conn: Any,
+        *,
+        op: str = "",
+        workspace: str = "",
+        session_id: str = "",
+        params: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        del host_registry, host_conn, session_id, kwargs
+        seen.append((op, {"workspace": workspace, **(params or {})}))
+        return {
+            "object": "session.environment.filesystem.download",
+            "filename": "report.bin",
+            "bytes": len(raw),
+            "content": base64.b64encode(raw).decode(),
+        }
+
+    monkeypatch.setattr(
+        "omnigent.server.routes._host_filesystem.read_workspace_from_host",
+        _fake_host_read,
+    )
+    del _routes  # imported for the lazy-import target above
+
+    resp = await offline_env_client.get(
+        f"/v1/sessions/{_OFFLINE_SESSION}/resources"
+        "/environments/default/filesystem/report.bin?download=1"
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.content == raw
+    assert 'filename="report.bin"' in resp.headers["content-disposition"]
+    assert seen == [("download", {"workspace": _OFFLINE_WORKSPACE, "path": "report.bin"})]
+
+
+@pytest.mark.asyncio
+async def test_filesystem_download_offline_without_host_returns_503(
+    runner_globals_reset: None,
+) -> None:
+    """Runner offline and no host bound → the original offline error (503)."""
+    del runner_globals_reset
+    conv = Conversation(
+        id=_OFFLINE_SESSION,
+        created_at=1,
+        updated_at=1,
+        root_conversation_id=_OFFLINE_SESSION,
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
+        # No host_id / workspace: nothing to fall back to.
+    )
+    set_runner_router(_FakeRunnerRouter(_OfflineRunnerClient()))  # type: ignore[arg-type]
+
+    application = FastAPI()
+
+    @application.exception_handler(OmnigentError)
+    async def _handle(request: Request, exc: OmnigentError) -> JSONResponse:
+        del request
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    from types import SimpleNamespace
+
+    application.include_router(
+        create_sessions_router(
+            SimpleNamespace(get_conversation=lambda _sid: conv),  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
+        ),
+        prefix="/v1",
+    )
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(transport=transport, base_url="http://server") as c:
+        resp = await c.get(
+            f"/v1/sessions/{_OFFLINE_SESSION}/resources"
+            "/environments/default/filesystem/report.bin?download=1"
+        )
+
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == ErrorCode.RUNNER_UNAVAILABLE
 
 
 # ── Workspace-file gzip (GZipFileContentRoute) ───────────────────

--- a/tests/test_workspace_fs_download.py
+++ b/tests/test_workspace_fs_download.py
@@ -1,8 +1,9 @@
-"""Tests for WorkspaceReader.download_bytes (fix for issue #5793).
+"""Tests for WorkspaceReader.download_bytes.
 
-The 10 MiB cap in _read_file / _MAX_READ_BYTES is intentional for the
+The byte cap in _read_file / _MAX_READ_BYTES is intentional for the
 preview/viewer path.  download_bytes must bypass it so "Download file"
-returns the complete file.
+returns the complete file, while still honoring an explicit transport
+cap (``max_bytes``) for framed carriers like the host tunnel.
 """
 
 from __future__ import annotations
@@ -86,4 +87,32 @@ def test_download_bytes_binary_file_intact(tmp_path):
     name, data = reader.download_bytes("data.bin")
 
     assert name == "data.bin"
+    assert data == content
+
+
+def test_download_bytes_transport_cap_rejects_oversize(tmp_path):
+    """An explicit ``max_bytes`` rejects an oversize file with 413.
+
+    Framed transports (the host tunnel) cannot carry arbitrarily large
+    payloads; the cap must be checked against the on-disk size so the
+    file is never read into memory first.
+    """
+    f = tmp_path / "big.bin"
+    f.write_bytes(b"A" * 100)
+
+    reader = _make_workspace(tmp_path)
+    with pytest.raises(WorkspaceReaderError) as exc_info:
+        reader.download_bytes("big.bin", max_bytes=99)
+    assert exc_info.value.status == 413
+    assert exc_info.value.code == "too_large"
+
+
+def test_download_bytes_transport_cap_allows_exact_size(tmp_path):
+    content = b"B" * 100
+    f = tmp_path / "fits.bin"
+    f.write_bytes(content)
+
+    reader = _make_workspace(tmp_path)
+    name, data = reader.download_bytes("fits.bin", max_bytes=100)
+    assert name == "fits.bin"
     assert data == content

--- a/tests/test_workspace_fs_download.py
+++ b/tests/test_workspace_fs_download.py
@@ -1,0 +1,89 @@
+"""Tests for WorkspaceReader.download_bytes (fix for issue #5793).
+
+The 10 MiB cap in _read_file / _MAX_READ_BYTES is intentional for the
+preview/viewer path.  download_bytes must bypass it so "Download file"
+returns the complete file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.workspace_fs import WorkspaceReader, WorkspaceReaderError
+
+
+def _make_workspace(tmp_path):
+    return WorkspaceReader(tmp_path)
+
+
+def test_download_bytes_small_file(tmp_path):
+    content = b"hello world"
+    f = tmp_path / "hello.txt"
+    f.write_bytes(content)
+
+    reader = _make_workspace(tmp_path)
+    name, data = reader.download_bytes("hello.txt")
+
+    assert name == "hello.txt"
+    assert data == content
+
+
+def test_download_bytes_exceeds_preview_cap(tmp_path, monkeypatch):
+    """download_bytes must return the full file even when it exceeds _MAX_READ_BYTES."""
+    import omnigent.workspace_fs as ws_mod
+
+    # Temporarily shrink the cap so we can test with a small file.
+    monkeypatch.setattr(ws_mod, "_MAX_READ_BYTES", 5)
+
+    content = b"A" * 20  # 20 bytes > cap of 5
+    f = tmp_path / "big.bin"
+    f.write_bytes(content)
+
+    reader = _make_workspace(tmp_path)
+
+    # _read_file with the shrunken cap would truncate to 5 bytes.
+    payload = reader._read_file("big.bin", tmp_path / "big.bin")
+    assert payload["truncated"] is True
+
+    # download_bytes must return all 20 bytes regardless of the cap.
+    name, data = reader.download_bytes("big.bin")
+    assert name == "big.bin"
+    assert data == content
+    assert len(data) == 20
+
+
+def test_download_bytes_missing_file(tmp_path):
+    reader = _make_workspace(tmp_path)
+    with pytest.raises(WorkspaceReaderError) as exc_info:
+        reader.download_bytes("nonexistent.txt")
+    assert exc_info.value.status == 404
+    assert exc_info.value.code == "not_found"
+
+
+def test_download_bytes_directory_raises(tmp_path):
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+
+    reader = _make_workspace(tmp_path)
+    with pytest.raises(WorkspaceReaderError) as exc_info:
+        reader.download_bytes("subdir")
+    assert exc_info.value.status == 400
+    assert exc_info.value.code == "not_a_file"
+
+
+def test_download_bytes_path_traversal_rejected(tmp_path):
+    reader = _make_workspace(tmp_path)
+    with pytest.raises(WorkspaceReaderError):
+        reader.download_bytes("../../../etc/passwd")
+
+
+def test_download_bytes_binary_file_intact(tmp_path):
+    content = bytes(range(256)) * 100  # 25 600 bytes of binary
+    f = tmp_path / "data.bin"
+    f.write_bytes(content)
+
+    reader = _make_workspace(tmp_path)
+    name, data = reader.download_bytes("data.bin")
+
+    assert name == "data.bin"
+    assert data == content

--- a/web/src/hooks/useFileContent.test.tsx
+++ b/web/src/hooks/useFileContent.test.tsx
@@ -201,17 +201,18 @@ describe("triggerBrowserDownload", () => {
 // ---------------------------------------------------------------------------
 
 describe("downloadWorkspaceFile", () => {
-  it("fetches the correct URL and triggers a download with the filename from the path", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        object: "session.environment.filesystem.file_content",
-        path: "src/main.py",
-        content_type: "text/x-python",
-        encoding: "utf-8",
-        content: "print('hi')",
-        bytes: 11,
-      }),
-    );
+  function blobResponse(blob: Blob): Response {
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      blob: async () => blob,
+    } as unknown as Response;
+  }
+
+  it("fetches the uncapped download URL and saves the raw body verbatim", async () => {
+    const body = new Blob(["print('hi')"], { type: "text/x-python" });
+    fetchMock.mockResolvedValueOnce(blobResponse(body));
     const clickedLinks: string[] = [];
     const origCreateElement = document.createElement.bind(document);
     vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
@@ -222,17 +223,20 @@ describe("downloadWorkspaceFile", () => {
         });
       return el;
     });
-    vi.stubGlobal("URL", { createObjectURL: vi.fn(() => "blob:x"), revokeObjectURL: vi.fn() });
+    const createObjectURL = vi.fn(() => "blob:x");
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL: vi.fn() });
 
     await downloadWorkspaceFile("sess_123", "src/main.py");
 
-    // fetchFileContent goes through authenticatedFetch, which adds auth headers
-    // and `cache: "no-store"` (see lib/identity.ts) — assert the URL plus that
-    // cache-bypass init rather than a bare single-arg call.
+    // The download must hit the ?download=1 mode of the filesystem endpoint —
+    // the plain JSON read is capped and would silently truncate large files.
+    // authenticatedFetch adds auth headers and `cache: "no-store"`.
     expect(fetchMock).toHaveBeenCalledWith(
-      "/v1/sessions/sess_123/resources/environments/default/filesystem/src/main.py",
+      "/v1/sessions/sess_123/resources/environments/default/filesystem/src/main.py?download=1",
       expect.objectContaining({ cache: "no-store" }),
     );
+    // The response body is saved as-is (no JSON decode / re-encode round trip).
+    expect(createObjectURL).toHaveBeenCalledWith(body);
     // The download filename is derived from the last path segment.
     expect(clickedLinks).toEqual(["main.py"]);
 
@@ -240,19 +244,8 @@ describe("downloadWorkspaceFile", () => {
     vi.unstubAllGlobals();
   });
 
-  it("logs a console warning when the server returns truncated: true", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        object: "session.environment.filesystem.file_content",
-        path: "big.txt",
-        content_type: "text/plain",
-        encoding: "utf-8",
-        content: "partial content",
-        bytes: 15,
-        truncated: true,
-      }),
-    );
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("marks a host-absolute path with base=host alongside download=1", async () => {
+    fetchMock.mockResolvedValueOnce(blobResponse(new Blob(["x"])));
     const origCreateElement = document.createElement.bind(document);
     vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
       const el = origCreateElement(tag);
@@ -261,10 +254,12 @@ describe("downloadWorkspaceFile", () => {
     });
     vi.stubGlobal("URL", { createObjectURL: vi.fn(() => "blob:x"), revokeObjectURL: vi.fn() });
 
-    await downloadWorkspaceFile("sess_abc", "big.txt");
+    await downloadWorkspaceFile("sess_abs", "/tmp/dbexec.log");
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("big.txt"));
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("truncated"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/sessions/sess_abs/resources/environments/default/filesystem/tmp/dbexec.log?download=1&base=host",
+      expect.objectContaining({ cache: "no-store" }),
+    );
 
     vi.restoreAllMocks();
     vi.unstubAllGlobals();

--- a/web/src/hooks/useFileContent.ts
+++ b/web/src/hooks/useFileContent.ts
@@ -92,23 +92,27 @@ export function triggerBrowserDownload(blob: Blob, filename: string): void {
 }
 
 /**
- * Fetch a workspace file and trigger a browser download of its contents.
+ * Fetch a workspace file in full and trigger a browser download.
  *
- * Logs a console warning when the server indicates the file was truncated
- * (``truncated: true``) so callers know the downloaded content may be
- * incomplete.
+ * Uses the filesystem endpoint's ``download=1`` mode, which streams the
+ * complete file as raw bytes with no preview cap — unlike the viewer's
+ * JSON read, which truncates large files. The response body is saved
+ * verbatim, so the download never loses content past the preview cap.
  *
  * :param conversationId: The session/conversation ID, e.g. ``"sess_abc123"``.
  * :param path: Workspace-relative file path, e.g. ``"src/main.py"``.
  */
 export async function downloadWorkspaceFile(conversationId: string, path: string): Promise<void> {
-  const data = await fetchFileContent(conversationId, path);
-  if (data.truncated) {
-    console.warn(
-      `[web] File "${path}" was truncated by the server — downloaded content may be incomplete.`,
-    );
-  }
-  triggerBrowserDownload(fileContentToBlob(data), path.split("/").pop() ?? path);
+  const encodedPath = browseLocationSegment(path);
+  const base = browseLocationBase(path);
+  const url =
+    `/v1/sessions/${encodeURIComponent(conversationId)}` +
+    `/resources/environments/${DEFAULT_ENVIRONMENT_ID}/filesystem/${encodedPath}` +
+    `?download=1` +
+    (base ? `&base=${base}` : "");
+  const res = await authenticatedFetch(url);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  triggerBrowserDownload(await res.blob(), path.split("/").pop() ?? path);
 }
 
 /**

--- a/web/src/shell/FileViewer.test.tsx
+++ b/web/src/shell/FileViewer.test.tsx
@@ -103,6 +103,7 @@ vi.mock("@/hooks/useComments", () => ({
 
 vi.mock("@/hooks/useFileContent", () => ({
   useFileContent: vi.fn(() => ({ data: { content: "", path: "file1.py" } })),
+  downloadWorkspaceFile: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("@/hooks/useFileDiff", () => ({

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -67,7 +67,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { fileContentToBlob, triggerBrowserDownload, useFileContent } from "@/hooks/useFileContent";
+import { downloadWorkspaceFile, useFileContent } from "@/hooks/useFileContent";
 import { useFileDiff } from "@/hooks/useFileDiff";
 import {
   type Comment,
@@ -490,10 +490,14 @@ function FileViewerBody({
   );
 
   const downloadFile = useCallback(() => {
-    const data = fileQuery.data;
-    if (!data) return;
-    triggerBrowserDownload(fileContentToBlob(data), path.split("/").pop() ?? path);
-  }, [fileQuery.data, path]);
+    // Always re-fetch through the uncapped download endpoint rather than
+    // saving the viewer's payload: the viewer read is truncated for large
+    // files, and its own banner points users at Download for the full
+    // content. There is no toast surface here, so log failures.
+    downloadWorkspaceFile(conversationId, path).catch((err) =>
+      console.warn(`Download of "${path}" failed`, err),
+    );
+  }, [conversationId, path]);
 
   // Pop the HTML artifact into its own browser tab. The artifact is rendered in
   // a sandboxed, opaque-origin iframe (see `openHtmlArtifactInNewTab`), so it
@@ -996,9 +1000,9 @@ function FileViewerBody({
     settingsMenu.push({
       key: "download",
       label: "Download file",
-      tooltip: fileQuery.data.truncated
-        ? "Download (file was truncated — content may be incomplete)"
-        : "Download",
+      // The download endpoint streams the complete file even when the
+      // viewer shows a truncated preview.
+      tooltip: fileQuery.data.truncated ? "Download the complete file" : "Download",
       icon: <DownloadIcon className="size-4" />,
       active: false,
       onSelect: downloadFile,


### PR DESCRIPTION
## Related issue

Closes #5793

## Summary

- The "Download file" button used the same capped read endpoint as the file
  viewer (`_MAX_READ_BYTES = 10 MiB`), silently truncating any file >10 MiB
  with no user-visible error.
- Added `?download=1` query param to the existing filesystem endpoint. When
  set, the runner streams the full file from disk via `FileResponse` with no
  size cap and `Content-Disposition: attachment`.
- Added `WorkspaceReader.download_bytes()` for the host-fallback path (runner
  offline). Server proxy layer forwards the binary response verbatim.

## Type of change

- [x] Bug fix

## Test plan

- [x] 6 unit tests in `tests/test_workspace_fs_download.py`: small file,
  file exceeding the 10 MiB cap, missing path (404), directory path (400),
  path traversal rejection, binary round-trip
- [ ] Manual end-to-end: download a file >10 MiB and verify size matches

## Coverage notes

Frontend change still needed — the web UI download button must append
`?download=1` to the filesystem URL. Server and runner are ready; without
that the bug persists for users.

## Issues

Resolves [OMNI-1275](https://linear.app/omnigent/issue/OMNI-1275/filesystem-streaming)
