### PR TITLE
feat(host): expose filesystem roots behind a capability

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -2348,17 +2348,60 @@ class HostProcess:
         symlinks for type detection (matching ``host.stat``), and
         returns a paginated result. ``~`` in the input path expands
         against the host process owner's home, same rules as
-        ``host.stat``. Per-entry I/O errors (broken symlinks,
+        ``host.stat``. An empty path enumerates platform roots and is
+        sent only after this Host advertised filesystem-root support.
+        Per-entry I/O errors (broken symlinks,
         ephemeral files) are silently skipped so a single bad
         entry doesn't fail the whole listing — same posture as
         the runner's ``list_dir``.
 
-        :param frame: The list_dir request frame. ``frame.path``
-            may be absolute or tilde-prefixed; ``limit`` /
-            ``after`` / ``before`` drive pagination.
+        :param frame: The list_dir request frame. ``frame.path`` may be
+            absolute, tilde-prefixed, or the capability-gated empty platform
+            roots sentinel; ``limit`` / ``after`` / ``before`` drive
+            pagination.
         :returns: List_dir result frame with entries sorted by
             name plus a ``has_more`` flag for the page.
         """
+        if frame.path == "":
+            if os.name == "nt":
+                list_drives = getattr(os, "listdrives", None)
+                drives: list[str] = (
+                    cast(list[str], list_drives())
+                    if callable(list_drives)
+                    else [
+                        f"{letter}:\\"
+                        for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                        if os.path.isdir(f"{letter}:\\")
+                    ]
+                )
+                roots = [
+                    HostListDirEntry(
+                        name=drive,
+                        path=drive,
+                        type="directory",
+                        bytes=None,
+                        modified_at=0,
+                    )
+                    for drive in drives
+                ]
+            else:
+                roots = [
+                    HostListDirEntry(
+                        name="/",
+                        path="/",
+                        type="directory",
+                        bytes=None,
+                        modified_at=0,
+                    )
+                ]
+            return _paginate_list_dir(
+                entries=roots,
+                request_id=frame.request_id,
+                limit=frame.limit,
+                after=frame.after,
+                before=frame.before,
+            )
+
         try:
             expanded = os.path.expanduser(frame.path)
         except (TypeError, ValueError) as exc:
@@ -3777,6 +3820,7 @@ class HostProcess:
             gateway_inference=self._gateway_inference,
             telemetry_opt_out=_tel_opt_out,
             installation_id=_tel_install_id,
+            filesystem_roots=True,
         )
         try:
             encoded_hello = encode_host_frame(hello)

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -109,6 +109,9 @@ class HostHelloFrame:
         ``omnigent.gateway_inference``). A family that could not be evaluated
         is omitted. ``None`` means unknown (an older host, or a startup probe
         that failed) — never treat it as "nothing is gateway-backed".
+    :param filesystem_roots: Whether this Host understands an empty filesystem
+        path as a request to enumerate platform roots. Older Hosts omit the
+        field and therefore decode as ``False``.
     """
 
     version: str
@@ -119,6 +122,7 @@ class HostHelloFrame:
     gateway_inference: dict[str, bool] | None = None
     telemetry_opt_out: bool = False
     installation_id: str | None = None
+    filesystem_roots: bool = False
 
 
 @dataclass
@@ -405,15 +409,16 @@ class HostListDirFrame:
 
     Used by ``GET /v1/hosts/{id}/filesystem/{path}`` to render the
     directory picker before any runner exists. The host owns ``~``
-    resolution; the server passes whatever the user supplied (or
-    ``~`` when the REST path is empty).
+    resolution. After this Host advertises filesystem-root support,
+    the server may use an empty path to request platform roots.
 
     :param request_id: Unique ID for correlating the result, e.g.
         ``"req_list_1"``.
     :param path: Absolute or tilde-prefixed directory path, e.g.
         ``"/Users/corey/projects"`` or ``"~/projects"``. Same rules
         as ``host.stat`` — the host expands ``~`` against its own
-        process owner's home.
+        process owner's home. An empty path is reserved for platform-root
+        enumeration after this Host advertised the capability.
     :param limit: Maximum entries to return per page,
         e.g. ``20``. Pagination is in-memory at the host since
         most directories fit easily in one page.
@@ -1049,6 +1054,7 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "gateway_inference": frame.gateway_inference,
                 "telemetry_opt_out": frame.telemetry_opt_out,
                 "installation_id": frame.installation_id,
+                "filesystem_roots": frame.filesystem_roots,
             }
         )
     if isinstance(frame, HostConnectionErrorFrame):
@@ -1558,6 +1564,9 @@ def _decode_host_hello(msg: _JsonObject) -> HostHelloFrame:
         gateway_inference=optional_str_bool_map(msg, "gateway_inference"),
         telemetry_opt_out=bool(msg.get("telemetry_opt_out", False)),
         installation_id=_optional_nullable_str(msg, "installation_id"),
+        filesystem_roots=(
+            _required_bool(msg, "filesystem_roots") if "filesystem_roots" in msg else False
+        ),
     )
 
 

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -590,6 +590,7 @@ def create_hosts_router(
         now = now_epoch()
         result: list[dict[str, Any]] = []
         for host in hosts:
+            live_connection = host_registry.get(host.host_id)
             # Status comes from the DB, not host_registry. The registry
             # is per-replica; if a host is connected to replica B and
             # this request lands on replica A, A's registry won't know
@@ -612,6 +613,12 @@ def create_hosts_router(
                     # user-connectable machines.
                     "sandbox_provider": host.sandbox_provider,
                     "configured_harnesses": host.configured_harnesses,
+                    # Root enumeration was added after the original filesystem
+                    # RPC. Older Hosts and connections on another replica fail
+                    # closed so clients retain the existing home/path flow.
+                    "filesystem_roots": bool(
+                        live_connection and live_connection.hello.filesystem_roots
+                    ),
                     # Held in memory from the host's connect handshake, not the
                     # hosts row. ``None`` means this replica has no report yet —
                     # emitted as-is so a client can tell "unknown" from "not
@@ -656,6 +663,10 @@ def create_hosts_router(
             # server-managed sandbox host (e.g. "modal").
             "sandbox_provider": host.sandbox_provider,
             "configured_harnesses": host.configured_harnesses,
+            "filesystem_roots": bool(
+                (live_connection := host_registry.get(host.host_id))
+                and live_connection.hello.filesystem_roots
+            ),
             # Same semantics as list_hosts: reported on connect and held in
             # memory, so ``None`` is "no report on this replica yet".
             "gateway_inference": host_registry.gateway_inference(host.host_id),
@@ -999,24 +1010,35 @@ def create_hosts_router(
             "status": "launching",
         }
 
-    @router.get("/hosts/{host_id}/filesystem")
+    @router.get(
+        "/hosts/{host_id}/filesystem",
+        responses={
+            409: {
+                "description": (
+                    "Host is offline or does not advertise filesystem-root enumeration"
+                )
+            }
+        },
+    )
     async def list_host_filesystem_root(
         request: Request,
         host_id: str,
+        roots: bool = Query(default=False),
         limit: int = Query(default=_LIST_DIR_DEFAULT_LIMIT, ge=1, le=_LIST_DIR_MAX_LIMIT),
         after: str | None = Query(default=None),
         before: str | None = Query(default=None),
     ) -> dict[str, Any]:
         """
-        List the contents of the host daemon's home directory.
+        List the host daemon's home directory or platform roots.
 
-        Empty trailing path → forward ``~`` to the host (the host
-        expands against its own process owner). Used by the
-        Web UI's directory picker to show the "root" view.
+        By default, forwards ``~`` so the Host expands its process owner's
+        home. ``roots=true`` asks a capable Host to enumerate Windows drives
+        or the POSIX ``/`` root.
 
         :param request: FastAPI request (for auth).
         :param host_id: Host identifier, e.g.
             ``"host_a1b2c3d4..."``.
+        :param roots: Whether to enumerate platform filesystem roots.
         :param limit: Max entries per page.
         :param after: Optional forward pagination cursor (entry
             path), e.g. ``"/Users/corey/projects/m"``.
@@ -1025,16 +1047,18 @@ def create_hosts_router(
             mirroring the existing session-scoped filesystem
             endpoint shape.
         :raises HTTPException: 404 if host not found, 403 if not
-            owned by caller, 409 if host is offline, 504 on host
-            timeout, 502 on host I/O failure.
+            owned by caller, 409 if host is offline or ``roots=true`` is not
+            supported by its current connection, 504 on host timeout, 502 on
+            host I/O failure.
         """
         return await _list_host_filesystem(
             request=request,
             host_id=host_id,
-            path="~",
+            path="" if roots else "~",
             limit=limit,
             after=after,
             before=before,
+            require_filesystem_roots=roots,
         )
 
     @router.get("/hosts/{host_id}/filesystem/{path:path}")
@@ -1094,6 +1118,7 @@ def create_hosts_router(
         limit: int,
         after: str | None,
         before: str | None,
+        require_filesystem_roots: bool = False,
     ) -> dict[str, Any]:
         """
         Shared implementation for the filesystem endpoints.
@@ -1108,6 +1133,8 @@ def create_hosts_router(
         :param limit: Max entries.
         :param after: Forward cursor.
         :param before: Backward cursor.
+        :param require_filesystem_roots: Whether the live Host must advertise
+            filesystem-root enumeration before the request is forwarded.
         :returns: Listing dict with ``object``, ``data``, ``has_more``.
         :raises HTTPException: See per-route docstrings for codes.
         """
@@ -1133,6 +1160,11 @@ def create_hosts_router(
         conn = host_registry.get(host.host_id)
         if conn is None:
             raise _host_absent_error(host)
+        if require_filesystem_roots and not conn.hello.filesystem_roots:
+            raise HTTPException(
+                status_code=409,
+                detail="host does not support filesystem root enumeration",
+            )
 
         result = await _proxy_list_dir(
             host_registry=host_registry,

--- a/openapi.json
+++ b/openapi.json
@@ -9264,7 +9264,7 @@
     },
     "/v1/hosts/{host_id}/filesystem": {
       "get": {
-        "description": "List the contents of the host daemon's home directory.\n\nEmpty trailing path \u2192 forward `~` to the host (the host\nexpands against its own process owner). Used by the\nWeb UI's directory picker to show the \"root\" view.\n\n**Returns:** `{\"object\": \"list\", \"data\": [...], \"has_more\": bool}` mirroring the existing session-scoped filesystem endpoint shape.\n\n**Raises**\n\n- `HTTPException` \u2014 404 if host not found, 403 if not owned by caller, 409 if host is offline, 504 on host timeout, 502 on host I/O failure.",
+        "description": "List the host daemon's home directory or platform roots.\n\nBy default, forwards `~` so the Host expands its process owner's\nhome. `roots=true` asks a capable Host to enumerate Windows drives\nor the POSIX `/` root.\n\n**Returns:** `{\"object\": \"list\", \"data\": [...], \"has_more\": bool}` mirroring the existing session-scoped filesystem endpoint shape.\n\n**Raises**\n\n- `HTTPException` \u2014 404 if host not found, 403 if not owned by caller, 409 if host is offline or `roots=true` is not supported by its current connection, 504 on host timeout, 502 on host I/O failure.",
         "operationId": "list_host_filesystem_root_v1_hosts__host_id__filesystem_get",
         "parameters": [
           {
@@ -9275,6 +9275,17 @@
             "schema": {
               "title": "Host Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Whether to enumerate platform filesystem roots.",
+            "in": "query",
+            "name": "roots",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Roots",
+              "type": "boolean"
             }
           },
           {
@@ -9337,6 +9348,9 @@
               }
             },
             "description": "Successful Response"
+          },
+          "409": {
+            "description": "Host is offline or does not advertise filesystem-root enumeration"
           },
           "422": {
             "content": {

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import errno
 import logging
+import os
 import subprocess
 import sys
 import threading
@@ -2339,6 +2340,32 @@ def test_build_runner_env_propagates_disable_keyring() -> None:
 
 
 # ── host.list_dir handler ───────────────────────────────
+
+
+def test_handle_list_dir_empty_path_returns_windows_drives(monkeypatch) -> None:
+    """An empty list_dir path is the cross-platform filesystem-roots request."""
+    host = _make_host_process()
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(os, "listdrives", lambda: ["C:\\", "D:\\"], raising=False)
+
+    result = host._handle_list_dir(HostListDirFrame(request_id="roots", path=""))
+
+    assert result.status == "ok"
+    assert [(entry.name, entry.path) for entry in result.entries] == [
+        ("C:\\", "C:\\"),
+        ("D:\\", "D:\\"),
+    ]
+
+
+def test_handle_list_dir_empty_path_returns_posix_root(monkeypatch) -> None:
+    """A capable POSIX Host maps the empty roots sentinel to ``/``."""
+    host = _make_host_process()
+    monkeypatch.setattr(os, "name", "posix")
+
+    result = host._handle_list_dir(HostListDirFrame(request_id="roots", path=""))
+
+    assert result.status == "ok"
+    assert [(entry.name, entry.path) for entry in result.entries] == [("/", "/")]
 
 
 def test_handle_list_dir_returns_sorted_entries(tmp_path: Path) -> None:

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -229,6 +229,7 @@ def test_hello_frame_round_trip() -> None:
         frame_protocol_version=1,
         name="corey-laptop",
         runners=["runner_token_aaa", "runner_token_bbb"],
+        filesystem_roots=True,
     )
     decoded = decode_host_frame(encode_host_frame(original))
     assert isinstance(decoded, HostHelloFrame)
@@ -236,6 +237,7 @@ def test_hello_frame_round_trip() -> None:
     assert decoded.frame_protocol_version == 1
     assert decoded.name == "corey-laptop"
     assert decoded.runners == ["runner_token_aaa", "runner_token_bbb"]
+    assert decoded.filesystem_roots is True
 
 
 def test_hello_frame_empty_runners() -> None:
@@ -252,6 +254,42 @@ def test_hello_frame_empty_runners() -> None:
     decoded = decode_host_frame(encode_host_frame(original))
     assert isinstance(decoded, HostHelloFrame)
     assert decoded.runners == []
+    assert decoded.filesystem_roots is False
+
+
+def test_hello_frame_omitted_filesystem_roots_is_legacy_false() -> None:
+    """An older Host that omits the capability keeps root browsing disabled."""
+    decoded = decode_host_frame(
+        json.dumps(
+            {
+                "kind": "host.hello",
+                "version": "0.1.0",
+                "frame_protocol_version": 1,
+                "name": "older-host",
+                "runners": [],
+            }
+        )
+    )
+
+    assert isinstance(decoded, HostHelloFrame)
+    assert decoded.filesystem_roots is False
+
+
+def test_hello_frame_filesystem_roots_requires_boolean() -> None:
+    """Capability metadata must fail closed instead of coercing strings."""
+    with pytest.raises(ValueError, match="filesystem_roots"):
+        decode_host_frame(
+            json.dumps(
+                {
+                    "kind": "host.hello",
+                    "version": "0.1.0",
+                    "frame_protocol_version": 1,
+                    "name": "invalid-host",
+                    "runners": [],
+                    "filesystem_roots": "true",
+                }
+            )
+        )
 
 
 def test_launch_runner_frame_round_trip() -> None:

--- a/tests/server/integration/test_hosts_api.py
+++ b/tests/server/integration/test_hosts_api.py
@@ -59,6 +59,7 @@ def _make_hello(
     name: str = "test-laptop",
     configured_harnesses: dict[str, bool | str] | None = None,
     gateway_inference: dict[str, bool] | None = None,
+    filesystem_roots: bool = False,
 ) -> str:
     """Encode a HostHelloFrame for tests.
 
@@ -69,6 +70,7 @@ def _make_hello(
     :param gateway_inference: Per-harness AI-Gateway-backed inference map to
         report, e.g. ``{"claude-native": True}``; ``None`` mimics a host that
         doesn't report it.
+    :param filesystem_roots: Whether the Host supports root enumeration.
     :returns: JSON-encoded hello frame.
     """
     return encode_host_frame(
@@ -78,6 +80,7 @@ def _make_hello(
             name=name,
             configured_harnesses=configured_harnesses,
             gateway_inference=gateway_inference,
+            filesystem_roots=filesystem_roots,
         )
     )
 
@@ -140,6 +143,7 @@ async def _connect_host(
     name: str = "test-laptop",
     configured_harnesses: dict[str, bool | str] | None = None,
     gateway_inference: dict[str, bool] | None = None,
+    filesystem_roots: bool = False,
 ) -> ApplicationCommunicator:
     """Connect a mock host via WebSocket tunnel.
 
@@ -151,6 +155,7 @@ async def _connect_host(
         e.g. ``{"codex": False}``; ``None`` mimics an older host.
     :param gateway_inference: Gateway-inference map for the hello frame,
         e.g. ``{"codex": True}``; ``None`` mimics a host that doesn't report it.
+    :param filesystem_roots: Whether the Host supports root enumeration.
     :returns: Connected ASGI communicator.
     """
     path = f"/v1/hosts/{host_id}/tunnel"
@@ -162,7 +167,12 @@ async def _connect_host(
     await comm.send_input(
         {
             "type": "websocket.receive",
-            "text": _make_hello(name, configured_harnesses, gateway_inference),
+            "text": _make_hello(
+                name,
+                configured_harnesses,
+                gateway_inference,
+                filesystem_roots,
+            ),
         },
     )
     while registry.get(host_id) is None:
@@ -335,6 +345,36 @@ async def test_hosts_api_configured_harnesses_null_for_older_host(
 
     assert resp.status_code == 200
     assert resp.json()["hosts"][0]["configured_harnesses"] is None
+
+
+async def test_hosts_api_gates_filesystem_roots_on_host_capability(
+    host_api_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """Only a Host advertising root enumeration exposes the capability."""
+    app, registry, _hs, _cs = host_api_app
+    _comm = await _connect_host(app, registry, filesystem_roots=True)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        listing = await client.get("/v1/hosts")
+        single = await client.get(f"/v1/hosts/{_HOST_ID}")
+
+    assert listing.json()["hosts"][0]["filesystem_roots"] is True
+    assert single.json()["filesystem_roots"] is True
+
+
+async def test_hosts_api_hides_filesystem_roots_for_older_host(
+    host_api_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """An older Host keeps the legacy picker flow."""
+    app, registry, _hs, _cs = host_api_app
+    _comm = await _connect_host(app, registry)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        listing = await client.get("/v1/hosts")
+        single = await client.get(f"/v1/hosts/{_HOST_ID}")
+
+    assert listing.json()["hosts"][0]["filesystem_roots"] is False
+    assert single.json()["filesystem_roots"] is False
 
 
 async def test_hosts_api_surfaces_gateway_inference(

--- a/tests/server/integration/test_hosts_filesystem.py
+++ b/tests/server/integration/test_hosts_filesystem.py
@@ -460,8 +460,12 @@ async def test_list_filesystem_offline_host_returns_409(
     )
     host_store.set_offline("3d9665477127e41f42de3f4109418173")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/v1/hosts/3d9665477127e41f42de3f4109418173/filesystem")
+        resp = await client.get(
+            "/v1/hosts/3d9665477127e41f42de3f4109418173/filesystem",
+            params={"roots": "true"},
+        )
     assert resp.status_code == 409
+    assert "offline" in resp.text
 
 
 async def test_list_filesystem_missing_path_returns_404(
@@ -606,6 +610,7 @@ async def test_list_filesystem_owner_check_blocks_other_users(
         resp = await client.get(
             "/v1/hosts/f54bb9272002938a3a934bfcb6bb228a/filesystem",
             headers={"X-Test-User": "bob@example.com"},
+            params={"roots": "true"},
         )
     assert resp.status_code == 403
 
@@ -674,6 +679,53 @@ async def test_list_filesystem_forwards_pagination_params(
         )
     assert resp.status_code == 200
     assert captured == {"limit": 5, "after": "/foo/m", "before": None}
+
+
+async def test_list_filesystem_roots_forwards_empty_path(
+    fs_setup: tuple[
+        FastAPI,
+        HostRegistry,
+        ApplicationCommunicator,
+        dict[str, dict[str, Any]],
+        asyncio.Task[None],
+    ],
+) -> None:
+    """The roots query sends the Host's explicit root-enumeration sentinel."""
+    app, registry, _comm, replies, _drain = fs_setup
+    connection = registry.get(_HOST_ID)
+    assert connection is not None
+    connection.hello.filesystem_roots = True
+    replies[""] = {"entries": [], "has_more": False}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            f"/v1/hosts/{_HOST_ID}/filesystem",
+            params={"roots": "true"},
+        )
+
+    assert response.status_code == 200
+
+
+async def test_list_filesystem_roots_rejects_legacy_host(
+    fs_setup: tuple[
+        FastAPI,
+        HostRegistry,
+        ApplicationCommunicator,
+        dict[str, dict[str, Any]],
+        asyncio.Task[None],
+    ],
+) -> None:
+    """An old Host must not interpret the empty roots sentinel as its CWD."""
+    app, _registry, _comm, _replies, _drain = fs_setup
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            f"/v1/hosts/{_HOST_ID}/filesystem",
+            params={"roots": "true"},
+        )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "host does not support filesystem root enumeration"}
 
 
 async def test_list_filesystem_limit_above_max_rejected(


### PR DESCRIPTION
## Related issue

Part of #5905

## Summary

- Let a Host advertise filesystem-root enumeration and return Windows drives or the POSIX root through the existing list-directory frame.
- Project the capability through the Host API and add `roots=true` without changing ordinary path URLs, so a new Web client remains compatible with an old Server.
- Fail closed with `409` before forwarding the empty-path roots sentinel unless the current Host connection advertised the capability; owner and offline errors retain precedence.

ELI5: a capable computer can tell the picker which top-level drives exist, while older computers keep the current home-folder flow.

```mermaid
flowchart LR
  Hello[Host hello capability] --> API[Host API]
  API -->|roots=true| Frame[empty-path list frame]
  Frame --> Roots[Windows drives or POSIX root]
```

## Test Plan

Base: `upstream/main` at `440b9f3a7dc8548d4dfddcae9a3076478351bf2f`.

- Host hello/frame, Windows/POSIX root enumeration, list-directory handler and Server roots contract: 34 passed; 266 unrelated tests deselected.
- Generated OpenAPI drift suite: 3 passed.
- Ruff check, Ruff format check and `git diff --check` passed for the slice.
- Exact patch applies cleanly on a detached `440b9f3` worktree.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Physical Windows and macOS Host acceptance is deferred to the Web consumer stack; this PR proves the Host frame and Server API contract with synthetic Hosts. A broad native-Windows run passed 273 tests and failed 30 unchanged upstream fixture assumptions that invoke POSIX `sleep`/`sh` or set only `HOME` while `Path.expanduser()` resolves `USERPROFILE`. The focused root-capability matrix is green; no product change was made to hide those baseline-only failures.

## Changelog

Expose filesystem roots from compatible Hosts for workspace browsing.
