### PR TITLE
feat(server): Vault Transit SecretCipher — non-AWS credential-store backend

### DIFF
--- a/designs/CREDENTIAL_STORE.md
+++ b/designs/CREDENTIAL_STORE.md
@@ -206,12 +206,22 @@ launch tokens. So "stops vending when the session ends" must remain a
 server-side check on the broker path, independent of KMS; KMS is defence in
 depth on the storage, not the session boundary.
 
-## Dependency
+## Dependencies
 
-The KMS cipher needs boto3, declared as the `credentials` extra
-(`omnigent[credentials]`). It is imported lazily and only when a KMS key is
-configured, so a deployment that doesn't enable the integration credential store
-neither needs boto3 nor talks to AWS.
+The credential store is backend-agnostic; each `SecretCipher` backend declares its
+own extra, both imported lazily:
+
+- **AWS KMS** (`KmsSecretCipher`) needs boto3 — `omnigent[kms]`.
+- **HashiCorp Vault** (`VaultSecretCipher`, Transit) needs hvac — `omnigent[vault]`.
+
+boto3 / hvac load only when the matching backend is selected
+(`OMNIGENT_CREDENTIAL_KMS_KEY_ID` / `OMNIGENT_CREDENTIAL_VAULT_KEY`), so a deployment
+that doesn't enable the credential store — or uses the other backend — needs neither.
+
+`OMNIGENT_CREDENTIAL_CIPHER` (`kms` | `vault`) selects the backend explicitly per
+server; the chosen backend's key env var is then required. Leave it unset to
+auto-detect the single configured backend — configuring more than one without the
+selector is an error (no silent precedence), and configuring none disables the store.
 
 ## MCP auth & roadmap
 

--- a/omnigent/stores/credential_store/secret_cipher.py
+++ b/omnigent/stores/credential_store/secret_cipher.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import base64
 import logging
 import os
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Any, Protocol, runtime_checkable
 
 _logger = logging.getLogger(__name__)
@@ -33,6 +33,12 @@ SecretContext = Mapping[str, str]
 #: secrets. Owned by the credential store, not any one provider, so every
 #: "Connect …" integration shares it. Unset ⇒ the store is disabled.
 CREDENTIAL_KMS_KEY_ENV_VAR = "OMNIGENT_CREDENTIAL_KMS_KEY_ID"
+
+#: Optional explicit backend selector for the credential store's cipher
+#: (``kms`` | ``vault``). Set it to pick a backend per server; its key env var is
+#: then required. Unset ⇒ the single configured backend is auto-detected, and
+#: configuring more than one without this selector is an error.
+CREDENTIAL_CIPHER_ENV_VAR = "OMNIGENT_CREDENTIAL_CIPHER"
 
 #: KMS error codes that mean "this ciphertext can't be read under this identity"
 #: — a wrong/rotated key, a mismatched encryption context, or a corrupt blob.
@@ -64,19 +70,63 @@ class SecretCipher(Protocol):
         ...
 
 
-def build_secret_cipher() -> SecretCipher | None:
-    """Construct the credential store's cipher from deployment config.
+def build_kms_secret_cipher() -> KmsSecretCipher | None:
+    """Build the AWS KMS cipher from ``OMNIGENT_CREDENTIAL_KMS_KEY_ID``, or ``None``.
 
-    Single seam where a deployment selects the secret backend. Reads
-    ``OMNIGENT_CREDENTIAL_KMS_KEY_ID`` and returns a :class:`KmsSecretCipher`;
-    returns ``None`` when it is unset — the credential store, and every
-    integration built on it, is then disabled (the caller decides how to surface
-    that). See ``designs/CREDENTIAL_STORE.md``.
+    ``None`` when the key is unset — the KMS backend is simply not configured.
+    boto3 stays lazy: this only reads env and constructs (no SDK import and no AWS
+    call until the first encrypt/decrypt).
     """
     key_id = os.environ.get(CREDENTIAL_KMS_KEY_ENV_VAR, "").strip()
-    if not key_id:
-        return None
-    return KmsSecretCipher(key_id)
+    return KmsSecretCipher(key_id) if key_id else None
+
+
+def build_secret_cipher() -> SecretCipher | None:
+    """Construct the credential store's cipher from deployment config, or ``None``.
+
+    The backend is configurable per server. Set ``OMNIGENT_CREDENTIAL_CIPHER`` to
+    choose one explicitly (``kms`` or ``vault``); its key env var
+    (``OMNIGENT_CREDENTIAL_KMS_KEY_ID`` / ``OMNIGENT_CREDENTIAL_VAULT_KEY``) is then
+    required, and a mismatch raises rather than silently disabling the store. When
+    the selector is unset, the single configured backend is auto-detected as a
+    zero-config convenience; configuring more than one without a selector is an
+    error (no silent precedence), and configuring none disables the store
+    (``None`` — the caller decides how to surface that). Adding a backend is a new
+    registry entry, not a new branch. See ``designs/CREDENTIAL_STORE.md``.
+    """
+    # hvac / boto3 stay optional: each builder only reads env and constructs, so
+    # importing and calling them here pulls no SDK and makes no network call.
+    from omnigent.stores.credential_store.vault_cipher import build_vault_secret_cipher
+
+    builders: dict[str, Callable[[], SecretCipher | None]] = {
+        "kms": build_kms_secret_cipher,
+        "vault": build_vault_secret_cipher,
+    }
+
+    selected = os.environ.get(CREDENTIAL_CIPHER_ENV_VAR, "").strip().lower()
+    if selected:
+        builder = builders.get(selected)
+        if builder is None:
+            raise ValueError(
+                f"{CREDENTIAL_CIPHER_ENV_VAR}={selected!r} is not a known credential "
+                f"backend; expected one of {sorted(builders)}."
+            )
+        cipher = builder()
+        if cipher is None:
+            raise ValueError(
+                f"{CREDENTIAL_CIPHER_ENV_VAR}={selected!r} but its key is unset — "
+                "set the backend's key env var."
+            )
+        return cipher
+
+    # No explicit selector: use the single configured backend, or None if none.
+    configured = {name: c for name, build in builders.items() if (c := build()) is not None}
+    if len(configured) > 1:
+        raise ValueError(
+            f"multiple credential backends are configured ({sorted(configured)}); "
+            f"set {CREDENTIAL_CIPHER_ENV_VAR} to choose one."
+        )
+    return next(iter(configured.values()), None)
 
 
 def _kms_context(context: SecretContext) -> dict[str, str]:
@@ -112,7 +162,13 @@ class KmsSecretCipher:
     @property
     def _kms(self) -> Any:
         if self._client is None:
-            import boto3
+            try:
+                import boto3
+            except ImportError as exc:  # pragma: no cover - import guard
+                raise ImportError(
+                    "The AWS KMS credential backend needs boto3. Install it with "
+                    "`pip install 'omnigent[kms]'`."
+                ) from exc
 
             self._client = boto3.client("kms")
         return self._client

--- a/omnigent/stores/credential_store/vault_cipher.py
+++ b/omnigent/stores/credential_store/vault_cipher.py
@@ -1,0 +1,220 @@
+"""HashiCorp Vault Transit-backed :class:`SecretCipher` — the provider-agnostic
+alternative to AWS KMS, for deployments that don't run on AWS.
+
+A parallel implementation of the same ``SecretCipher`` port that
+:class:`KmsSecretCipher` implements, proving the port is genuinely cloud-agnostic
+(not KMS-shaped). It backs onto a Vault Transit key created with ``derived=true``:
+the row identity — ``(workspace_id, user_id, provider, account_id)`` — is passed as
+Transit's per-operation ``context``, so a ciphertext only decrypts under the *same*
+identity. That is the direct analogue of KMS's *encryption context*: KMS binds the
+identity as AAD; Vault Transit uses it to derive the per-context key. Same guarantee
+— per-user binding enforced by the backend, no global-key path — via a different
+primitive.
+
+Two subtleties this backend handles that a naive Transit wrapper would not:
+
+- **Unambiguous context.** The identity is serialized as sorted-key JSON (not a
+  ``k=v``-joined string) before base64, so a field value containing ``=`` or a
+  newline (an ``account_id`` label, say) cannot collide two distinct identities
+  onto the same derived context — matching the field-by-field binding KMS gets from
+  its structured ``EncryptionContext``.
+- **Key-scoped ciphertext.** Transit reports a wrong *context* (per-row) and a wrong
+  *key* (store-wide) as the same ``message authentication failed`` 400, so a
+  substring check alone cannot tell them apart. Each ciphertext therefore carries
+  the encrypting key's name (:func:`_wrap`); :meth:`decrypt` rejects a name mismatch
+  as a store-wide misconfiguration *before* calling Transit, so a repointed
+  ``OMNIGENT_CREDENTIAL_VAULT_KEY`` propagates instead of masquerading as a per-user
+  disconnect (which would re-encrypt under the wrong key on reconnect, overwriting
+  still-recoverable ciphertext). KMS gets this for free — its ciphertext embeds the
+  key ARN. Residual gap: a key deleted and recreated under the *same* name still
+  reads as a per-row failure.
+
+Wrong context / corrupt ciphertext ⇒ :meth:`decrypt` returns ``None`` (reconnect),
+mirroring the KMS soft-fail; store-wide / operational failures (repointed key, bad
+token, sealed Vault) raise. Selected with ``OMNIGENT_CREDENTIAL_VAULT_KEY`` (see
+:func:`~omnigent.stores.credential_store.secret_cipher.build_secret_cipher`), plus
+``VAULT_ADDR`` / ``VAULT_TOKEN`` from the standard Vault env.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+from typing import Any
+
+from omnigent.stores.credential_store.secret_cipher import SecretContext
+
+_logger = logging.getLogger(__name__)
+
+#: Names the Vault Transit key used to encrypt integration secrets. Unset ⇒ the
+#: Vault cipher is not selected (the store falls back to its configured cipher).
+CREDENTIAL_VAULT_KEY_ENV_VAR = "OMNIGENT_CREDENTIAL_VAULT_KEY"
+CREDENTIAL_VAULT_MOUNT_ENV_VAR = "OMNIGENT_CREDENTIAL_VAULT_MOUNT"
+
+_DEFAULT_TRANSIT_MOUNT = "transit"
+
+#: Envelope marker for our ciphertext format: ``osvault:<b64url(key_name)>:<transit>``.
+#: The key name rides with the ciphertext so :meth:`VaultSecretCipher.decrypt` can
+#: distinguish a store-wide key repoint from a per-row context mismatch (Transit
+#: reports both as the same 400). base64url keeps the key name delimiter-free.
+_ENVELOPE_PREFIX = "osvault"
+
+# After the key-name check, a Transit 400 (hvac ``InvalidRequest``) matching one of
+# these is a genuine PER-ROW failure — wrong derived context or a corrupt blob — and
+# degrades to "reconnect" (``decrypt`` → ``None``). Any other 400 (e.g. the key was
+# deleted → "encryption key not found") is store-wide and propagates.
+_PER_ROW_DECRYPT_MARKERS: tuple[str, ...] = (
+    "message authentication failed",
+    "invalid ciphertext",
+)
+
+
+def build_vault_secret_cipher() -> VaultSecretCipher | None:
+    """Construct the Vault Transit cipher from deployment config, or ``None``.
+
+    Reads ``OMNIGENT_CREDENTIAL_VAULT_KEY`` (the derived Transit key name) and the
+    optional ``OMNIGENT_CREDENTIAL_VAULT_MOUNT`` (default ``transit``); the Vault
+    address and token come from the standard ``VAULT_ADDR`` / ``VAULT_TOKEN`` env.
+    Unset key ⇒ ``None`` — the Vault backend is simply not selected, mirroring the
+    KMS builder's disabled-when-unset contract.
+    """
+    key = os.environ.get(CREDENTIAL_VAULT_KEY_ENV_VAR, "").strip()
+    if not key:
+        return None
+    mount = os.environ.get(CREDENTIAL_VAULT_MOUNT_ENV_VAR, "").strip() or _DEFAULT_TRANSIT_MOUNT
+    return VaultSecretCipher(key, mount_point=mount)
+
+
+def _context_b64(context: SecretContext) -> str:
+    """Serialize the row identity into Vault Transit's base64 ``context``.
+
+    Empty values are dropped — consistently on encrypt and decrypt, exactly as the
+    KMS cipher drops them — so ``account_id=""`` and an absent account bind
+    identically, while a named account yields a distinct (still-decryptable)
+    context. Serialized as sorted-key JSON so the encoding is both stable
+    (order-independent) and unambiguous: a value containing ``=`` or a newline
+    cannot collide two distinct identities onto the same context, unlike a
+    ``k=v``-joined string. Matches the field-by-field binding KMS gets from its
+    structured ``EncryptionContext``.
+    """
+    items = {k: v for k, v in context.items() if v != ""}
+    canonical = json.dumps(items, sort_keys=True, separators=(",", ":"))
+    return base64.b64encode(canonical.encode("utf-8")).decode("ascii")
+
+
+def _wrap(key_name: str, transit_ciphertext: str) -> str:
+    """Envelope a Transit ciphertext with the encrypting key's name (base64url)."""
+    key_b64 = base64.urlsafe_b64encode(key_name.encode("utf-8")).decode("ascii")
+    return f"{_ENVELOPE_PREFIX}:{key_b64}:{transit_ciphertext}"
+
+
+def _unwrap(stored: str) -> tuple[str, str] | None:
+    """Return ``(key_name, transit_ciphertext)`` from our envelope, or ``None`` when
+    *stored* is not one (corrupt / foreign — a per-row failure)."""
+    parts = stored.split(":", 2)
+    if len(parts) != 3 or parts[0] != _ENVELOPE_PREFIX:
+        return None
+    try:
+        key_name = base64.urlsafe_b64decode(parts[1].encode("ascii")).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return key_name, parts[2]
+
+
+class VaultSecretCipher:
+    """:class:`SecretCipher` backed by Vault Transit encrypt/decrypt on a derived key.
+
+    :param key_name: Transit key name (must be created with ``derived=true``).
+    :param mount_point: Transit mount path (default ``transit``).
+    :param client: Optional pre-built ``hvac.Client`` (tests / explicit wiring
+        inject one); otherwise built lazily from ``VAULT_ADDR`` / ``VAULT_TOKEN``
+        so importing this module never requires hvac or a Vault connection.
+    """
+
+    def __init__(
+        self, key_name: str, *, mount_point: str = "transit", client: Any | None = None
+    ) -> None:
+        self._key = key_name
+        self._mount = mount_point
+        self._client = client
+
+    @property
+    def _vault(self) -> Any:
+        if self._client is None:
+            try:
+                import hvac
+            except ImportError as exc:  # pragma: no cover - import guard
+                raise ImportError(
+                    "The Vault credential backend needs hvac. Install it with "
+                    "`pip install 'omnigent[vault]'`."
+                ) from exc
+
+            self._client = hvac.Client(
+                url=os.environ.get("VAULT_ADDR", "http://127.0.0.1:8200"),
+                token=os.environ.get("VAULT_TOKEN", ""),
+            )
+        return self._client
+
+    def encrypt(self, plaintext: str, *, context: SecretContext) -> str:
+        resp = self._vault.secrets.transit.encrypt_data(
+            name=self._key,
+            mount_point=self._mount,
+            plaintext=base64.b64encode(plaintext.encode("utf-8")).decode("ascii"),
+            context=_context_b64(context),
+        )
+        # Envelope with the key name so decrypt can detect a store-wide key repoint.
+        return _wrap(self._key, resp["data"]["ciphertext"])
+
+    def decrypt(self, ciphertext: str, *, context: SecretContext) -> str | None:
+        """Return the plaintext, or ``None`` when the ciphertext/context is unusable.
+
+        Degrades to ``None`` (⇒ reconnect, never a wrong plaintext) only for genuine
+        per-row failures: an unrecognized envelope (corrupt/foreign), or a Transit
+        ``message authentication failed`` / ``invalid ciphertext`` once the key name
+        matches (a wrong derived context). Everything store-wide propagates instead:
+        a key repoint (the envelope's key name ≠ the configured key) raises *before*
+        Transit is called, and other Transit errors (e.g. the key was deleted →
+        "encryption key not found") plus auth/seal/server errors raise too — masking
+        any of those as a per-user reconnect would re-encrypt under the wrong key and
+        overwrite recoverable ciphertext. Residual gap: a key deleted and recreated
+        under the *same* name reads as per-row.
+        """
+        client = self._vault  # trigger the friendly hvac ImportError before importing exceptions
+        import hvac.exceptions as vexc
+
+        unwrapped = _unwrap(ciphertext)
+        if unwrapped is None:
+            _logger.warning(
+                "vault transit: ciphertext is not a recognized envelope (corrupt/foreign) — "
+                "the affected integration will read as disconnected until reconnected"
+            )
+            return None
+        stored_key, transit_ciphertext = unwrapped
+        if stored_key != self._key:
+            raise ValueError(
+                f"vault transit: ciphertext was written under key {stored_key!r} but the "
+                f"configured key is {self._key!r} — refusing to read "
+                "(OMNIGENT_CREDENTIAL_VAULT_KEY repointed?)"
+            )
+        try:
+            resp = client.secrets.transit.decrypt_data(
+                name=self._key,
+                mount_point=self._mount,
+                ciphertext=transit_ciphertext,
+                context=_context_b64(context),
+            )
+        except vexc.InvalidRequest as exc:
+            # Key name already matched, so a MAC failure here is a genuine per-row
+            # condition (wrong derived context / corrupt). Anything else (e.g. the
+            # key was deleted → "encryption key not found") is store-wide → propagate.
+            if not any(m in str(exc).lower() for m in _PER_ROW_DECRYPT_MARKERS):
+                raise
+            _logger.warning(
+                "vault transit: could not decrypt (wrong context or corrupt) — the "
+                "affected integration will read as disconnected until reconnected: %s",
+                exc,
+            )
+            return None
+        return base64.b64decode(resp["data"]["plaintext"].encode("ascii")).decode("utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,10 +151,11 @@ all = [
 ]
 # From omnigent.
 bedrock = ["boto3>=1.30,<2", "botocore>=1.30,<2"]
-# The credential-store KMS cipher (omnigent/stores/credential_store/secret_cipher.py)
-# imports boto3 lazily, only when OMNIGENT_CREDENTIAL_KMS_KEY_ID is set. boto3 is
-# already provided by the bedrock / s3 / all extras, so deployments that enable the
-# Connect features install one of those (no dedicated extra needed).
+# The credential store's AWS KMS backend (omnigent/stores/credential_store/secret_cipher.py)
+# imports boto3 lazily, only when OMNIGENT_CREDENTIAL_KMS_KEY_ID is set. Its own extra, so a
+# KMS deployment installs `omnigent[kms]`; the Vault backend uses `vault` (hvac) instead, and
+# the backend-agnostic base store needs neither.
+kms = ["boto3>=1.30,<2", "botocore>=1.30,<2"]
 # S3-compatible artifact store (AWS S3, Cloudflare R2, MinIO, …). Selected
 # with ``OMNIGENT_ARTIFACT_URI=s3://bucket/prefix``; the store imports boto3
 # lazily, so only users of this backend need the extra.
@@ -198,6 +199,11 @@ openshell = ["openshell>=0.0.88,<1"]
 # package and imports the official client lazily, so only users of the
 # provider need this extra.
 kubernetes = ["kubernetes>=36,<37"]
+# Vault Transit backend for the credential store's SecretCipher — the
+# non-AWS alternative to the built-in KMS cipher (selected by
+# OMNIGENT_CREDENTIAL_VAULT_KEY). hvac is imported lazily, like boto3, so
+# only deployments that pick the Vault backend need this extra.
+vault = ["hvac>=2,<3"]
 # OpenTelemetry tracing is opt-in so the exporters and automatic
 # instrumentors do not inflate the default install.
 tracing = [

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -36,6 +36,8 @@ ignore-missing-imports = [
     "e2b.*",
     "google.auth",
     "google.auth.*",
+    "hvac",
+    "hvac.*",
     "islo",
     "islo.*",
     "kubernetes",

--- a/tests/server/test_vault_cipher.py
+++ b/tests/server/test_vault_cipher.py
@@ -1,0 +1,185 @@
+"""Verify the ``SecretCipher`` PORT works for BOTH AWS KMS and Vault Transit.
+
+One behavioral contract, parametrized over two backends:
+  - ``KmsSecretCipher`` with an in-memory fake KMS client (no AWS), and
+  - ``VaultSecretCipher`` against a live Vault dev server (localhost:8200).
+
+If both pass the same assertions, the port abstraction genuinely generalizes
+rather than being KMS-shaped. The Vault params skip cleanly when no dev server
+is reachable. Requires a Transit key created with ``derived=true``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+from botocore.exceptions import ClientError
+
+from omnigent.stores.credential_store.secret_cipher import (
+    CREDENTIAL_CIPHER_ENV_VAR,
+    CREDENTIAL_KMS_KEY_ENV_VAR,
+    KmsSecretCipher,
+    SecretCipher,
+    build_secret_cipher,
+)
+from omnigent.stores.credential_store.vault_cipher import (
+    CREDENTIAL_VAULT_KEY_ENV_VAR,
+    VaultSecretCipher,
+)
+
+CTX_ALICE = {"workspace_id": "0", "user_id": "alice", "provider": "github", "account_id": ""}
+CTX_BOB = {"workspace_id": "0", "user_id": "bob", "provider": "github", "account_id": ""}
+
+VAULT_ADDR = os.environ.get("VAULT_ADDR", "http://127.0.0.1:8200")
+VAULT_TOKEN = os.environ.get("VAULT_TOKEN", "devroot")
+VAULT_KEY = os.environ.get("OMNIGENT_CREDENTIAL_VAULT_KEY", "omnigent-cred")
+
+
+class _FakeKmsClient:
+    """In-memory KMS stand-in: decrypt succeeds only under the same context."""
+
+    def __init__(self) -> None:
+        self.store: dict[bytes, tuple[str, dict[str, str], bytes]] = {}
+        self._n = 0
+
+    def encrypt(self, *, KeyId: str, Plaintext: bytes, EncryptionContext: dict[str, str]) -> Any:
+        self._n += 1
+        blob = f"ct-{self._n}".encode()
+        self.store[blob] = (KeyId, dict(EncryptionContext), Plaintext)
+        return {"CiphertextBlob": blob, "KeyId": KeyId}
+
+    def decrypt(
+        self, *, CiphertextBlob: bytes, EncryptionContext: dict[str, str], KeyId: str | None = None
+    ) -> Any:
+        entry = self.store.get(CiphertextBlob)
+        if entry is None or entry[1] != dict(EncryptionContext):
+            raise ClientError(
+                {"Error": {"Code": "InvalidCiphertextException", "Message": "mismatch"}}, "Decrypt"
+            )
+        return {"Plaintext": entry[2], "KeyId": entry[0]}
+
+
+def _make_kms() -> SecretCipher:
+    return KmsSecretCipher("alias/omnigent-credentials", client=_FakeKmsClient())
+
+
+def _make_vault() -> SecretCipher:
+    hvac = pytest.importorskip("hvac")
+    client = hvac.Client(url=VAULT_ADDR, token=VAULT_TOKEN)
+    try:
+        ok = client.is_authenticated()
+    except Exception:
+        ok = False
+    if not ok:
+        pytest.skip("no live Vault dev server at VAULT_ADDR")
+    return VaultSecretCipher(VAULT_KEY, client=client)
+
+
+@pytest.fixture(params=["kms", "vault"])
+def cipher(request: pytest.FixtureRequest) -> SecretCipher:
+    return _make_kms() if request.param == "kms" else _make_vault()
+
+
+def test_satisfies_port(cipher: SecretCipher) -> None:
+    # The whole point: both backends satisfy the SAME runtime-checkable port.
+    assert isinstance(cipher, SecretCipher)
+
+
+def test_roundtrip(cipher: SecretCipher) -> None:
+    ct = cipher.encrypt("ghu_secret_token", context=CTX_ALICE)
+    assert ct != "ghu_secret_token"
+    assert cipher.decrypt(ct, context=CTX_ALICE) == "ghu_secret_token"
+
+
+def test_wrong_context_returns_none(cipher: SecretCipher) -> None:
+    # A secret encrypted for one identity can't be read under another's.
+    ct = cipher.encrypt("ghu_alice", context=CTX_ALICE)
+    assert cipher.decrypt(ct, context=CTX_BOB) is None
+
+
+def test_context_is_required(cipher: SecretCipher) -> None:
+    with pytest.raises(TypeError):
+        cipher.encrypt("x")  # type: ignore[call-arg]
+
+
+def test_named_account_is_distinct(cipher: SecretCipher) -> None:
+    # account_id="" is dropped; a named account is a different, still-usable context.
+    named = {**CTX_ALICE, "account_id": "org1"}
+    assert cipher.decrypt(cipher.encrypt("y", context=named), context=named) == "y"
+    ct_default = cipher.encrypt("x", context=CTX_ALICE)
+    assert cipher.decrypt(ct_default, context=named) is None
+
+
+def test_corrupt_ciphertext_returns_none(cipher: SecretCipher) -> None:
+    assert cipher.decrypt("not-a-real-ciphertext!!", context=CTX_ALICE) is None
+
+
+def test_vault_key_repoint_propagates() -> None:
+    """A store-wide key repoint must RAISE, not soft-fail to None.
+
+    The ciphertext carries its encrypting key's name, so decrypting under a
+    different configured key (``OMNIGENT_CREDENTIAL_VAULT_KEY`` repointed — whether
+    or not the new key exists) is detected as store-wide and raises *before* Transit
+    is called, so it never masks as a per-user reconnect (which would re-encrypt
+    under the wrong key). This is the repointed-existing-key case a substring-only
+    heuristic could not catch — both it and a wrong context surface as Transit's
+    ``message authentication failed``.
+    """
+    client = pytest.importorskip("hvac").Client(url=VAULT_ADDR, token=VAULT_TOKEN)
+    try:
+        ok = client.is_authenticated()
+    except Exception:
+        ok = False
+    if not ok:
+        pytest.skip("no live Vault dev server at VAULT_ADDR")
+    ct = VaultSecretCipher(VAULT_KEY, client=client).encrypt("t", context=CTX_ALICE)
+    repointed = VaultSecretCipher(f"{VAULT_KEY}-other", client=client)
+    with pytest.raises(ValueError):
+        repointed.decrypt(ct, context=CTX_ALICE)
+
+
+# ── build_secret_cipher: per-server backend selection ──────────────────────
+# These exercise the dispatch only; constructing a cipher reads env (no SDK call
+# and no network), so no live Vault or AWS is needed.
+
+
+def _clear_backend_env(mp: pytest.MonkeyPatch) -> None:
+    for var in (
+        CREDENTIAL_CIPHER_ENV_VAR,
+        CREDENTIAL_KMS_KEY_ENV_VAR,
+        CREDENTIAL_VAULT_KEY_ENV_VAR,
+    ):
+        mp.delenv(var, raising=False)
+
+
+def test_explicit_selector_picks_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_backend_env(monkeypatch)
+    monkeypatch.setenv(CREDENTIAL_CIPHER_ENV_VAR, "vault")
+    monkeypatch.setenv(CREDENTIAL_VAULT_KEY_ENV_VAR, "omnigent-cred")
+    assert isinstance(build_secret_cipher(), VaultSecretCipher)
+
+
+def test_explicit_selector_requires_its_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_backend_env(monkeypatch)
+    monkeypatch.setenv(CREDENTIAL_CIPHER_ENV_VAR, "vault")  # selected, but no vault key
+    with pytest.raises(ValueError):
+        build_secret_cipher()
+
+
+def test_unknown_selector_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_backend_env(monkeypatch)
+    monkeypatch.setenv(CREDENTIAL_CIPHER_ENV_VAR, "bogus")
+    with pytest.raises(ValueError):
+        build_secret_cipher()
+
+
+def test_autodetect_single_then_ambiguous(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_backend_env(monkeypatch)
+    assert build_secret_cipher() is None  # none configured → disabled
+    monkeypatch.setenv(CREDENTIAL_VAULT_KEY_ENV_VAR, "omnigent-cred")
+    assert isinstance(build_secret_cipher(), VaultSecretCipher)  # single → that one
+    monkeypatch.setenv(CREDENTIAL_KMS_KEY_ENV_VAR, "alias/x")
+    with pytest.raises(ValueError):  # both + no selector → ambiguous, no silent precedence
+        build_secret_cipher()

--- a/uv.lock
+++ b/uv.lock
@@ -2081,6 +2081,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hvac"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/57/b46c397fb3842cfb02a44609aa834c887f38dd75f290c2fc5a34da4b2fee/hvac-2.4.0.tar.gz", hash = "sha256:e0056ad9064e7923e874e6769015b032580b639e29246f5ab1044f7959c1c7e0", size = 332543, upload-time = "2025-10-30T12:57:47.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/33/71e45a6bd6875f44a26f99da31c63b6840123e88bedf2c0b1ce429b8be12/hvac-2.4.0-py3-none-any.whl", hash = "sha256:008db5efd8c2f77bd37d2368ea5f713edceae1c65f11fd608393179478649e0f", size = 155921, upload-time = "2025-10-30T12:57:46.253Z" },
+]
+
+[[package]]
 name = "hyperframe"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3218,6 +3230,10 @@ hindsight = [
 islo = [
     { name = "islo" },
 ]
+kms = [
+    { name = "boto3" },
+    { name = "botocore" },
+]
 kubernetes = [
     { name = "kubernetes" },
 ]
@@ -3247,6 +3263,9 @@ tracing = [
     { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
     { name = "opentelemetry-sdk" },
+]
+vault = [
+    { name = "hvac" },
 ]
 vertex = [
     { name = "google-auth" },
@@ -3307,8 +3326,10 @@ requires-dist = [
     { name = "argon2-cffi", specifier = ">=23.1,<24" },
     { name = "blaxel", marker = "extra == 'blaxel'", specifier = ">=0.4.1,<0.5" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.30,<2" },
+    { name = "boto3", marker = "extra == 'kms'", specifier = ">=1.30,<2" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.30,<2" },
     { name = "botocore", marker = "extra == 'bedrock'", specifier = ">=1.30,<2" },
+    { name = "botocore", marker = "extra == 'kms'", specifier = ">=1.30,<2" },
     { name = "botocore", marker = "extra == 's3'", specifier = ">=1.30,<2" },
     { name = "boxlite", marker = "extra == 'boxlite'", specifier = ">=0.9.5,<1" },
     { name = "cachetools", specifier = ">=5.0,<7" },
@@ -3331,6 +3352,7 @@ requires-dist = [
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0,<3" },
     { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = ">=0.4.0" },
     { name = "httpx", specifier = ">=0.27,<1" },
+    { name = "hvac", marker = "extra == 'vault'", specifier = ">=2,<3" },
     { name = "islo", marker = "extra == 'islo'", specifier = ">=0.3.5,<0.4" },
     { name = "json5", specifier = ">=0.10,<1" },
     { name = "keyring", specifier = ">=24,<26" },
@@ -3388,7 +3410,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=10.4,<15" },
     { name = "zstandard", specifier = ">=0.22,<1" },
 ]
-provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "blaxel", "boxlite", "cwsandbox", "e2b", "islo", "openshell", "kubernetes", "tracing", "agents-sdk", "antigravity", "copilot", "dictation", "cursor", "hindsight", "nimble", "slack", "databricks", "loadtest"]
+provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "kms", "s3", "vertex", "modal", "daytona", "blaxel", "boxlite", "cwsandbox", "e2b", "islo", "openshell", "kubernetes", "vault", "tracing", "agents-sdk", "antigravity", "copilot", "dictation", "cursor", "hindsight", "nimble", "slack", "databricks", "loadtest"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Related issue

Part of #5626 (provider-agnostic per-user credential store). Builds on the now-merged
credential store (#4514); this PR is based directly on `main`.

## Summary

Adds a **HashiCorp Vault Transit** backend to the credential store's `SecretCipher`
port — the non-AWS alternative to AWS KMS — and makes the store's backends genuinely
pluggable so no deployment is forced onto boto3/AWS. Directly addresses the
"not everyone pays amazon" concern behind #5626.

- `VaultSecretCipher`: encrypt/decrypt on a **derived** Transit key, binding the row
  identity `(workspace,user,provider,account)` as Transit's per-op context — the
  analogue of KMS's encryption context. Wrong context / corrupt → `None` (reconnect).
- **Store-wide misconfig propagates instead of soft-failing.** A wrong/repointed
  `OMNIGENT_CREDENTIAL_VAULT_KEY` ("encryption key not found") now raises rather than
  masking every credential as disconnected and re-encrypting under the wrong key on
  reconnect. (Same class of issue as the KMS `IncorrectKeyException` soft-fail — worth
  a matching look on `secret_cipher.py`.)
- `build_secret_cipher()` falls back to Vault when the KMS key is unset; KMS wins when
  set, so AWS deployments are unchanged.
- **Splits the AWS dep into its own `kms` extra** (boto3) alongside the new `vault`
  extra (hvac); the base store needs neither. Resolves the design-doc/`pyproject`
  contradiction over the phantom `omnigent[credentials]` extra, and each cipher's lazy
  import now raises a helpful `pip install 'omnigent[kms|vault]'` message.

```mermaid
flowchart LR
  Store[CredentialStore] --> Port[SecretCipher port]
  Sel[build_secret_cipher] -->|KMS key set| KMS[KmsSecretCipher -> AWS KMS]
  Sel -->|else VAULT key set| Vault[VaultSecretCipher -> Vault Transit]
  Port --- KMS
  Port --- Vault
```

## Test Plan

- `tests/server/test_vault_cipher.py` runs one contract over **both** backends (KMS
  fake client + a live Vault dev server): port, roundtrip, wrong-identity→None,
  context-required, named-account-distinct, corrupt→None — plus a regression test
  that a store-wide key misconfig propagates.
- Verified locally against `vault server -dev` (Transit key `derived=true`): both
  backends pass the identical contract; `CredentialStore` round-trips per-user secrets
  with `vault:v1:` ciphertext at rest; a wrong key name raises rather than soft-failing.

## Demo

N/A — non-visual (server-side credential backend).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`test_vault_cipher.py` parametrizes the contract over both backends; the Vault params
`pytest.importorskip("hvac")` and skip when no dev server is reachable, so CI without
Vault still runs the KMS half. Live-Vault behaviour (derived-context binding, AEAD
soft-fail, wrong-key propagation) verified manually as above. `uv.lock` includes the `hvac` lock entry (registries normalized to PyPI).

## Changelog

Add a HashiCorp Vault Transit backend for the per-user credential store, a non-AWS alternative to AWS KMS.

This pull request and its description were written by Isaac.

