### PR TITLE
Test resolve-agent fork push authorization

### DIFF
--- a/.resolve-fork-auth-probe
+++ b/.resolve-fork-auth-probe
@@ -1,0 +1,1 @@
+Temporary branch used to verify resolve-agent fork push authorization.


### PR DESCRIPTION
Temporary draft PR used solely to verify that the resolve-agent credential can push to a contributor fork when maintainer edits are enabled. It will be closed and the branch deleted immediately after verification.