### PR TITLE
ci: notify Slack about VIP GitHub activity

### DIFF
--- a/.github/scripts/vip_activity_alert.py
+++ b/.github/scripts/vip_activity_alert.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Send a Slack alert when a configured VIP acts in the Omnigent repository."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import pathlib
+import re
+import urllib.error
+import urllib.request
+
+
+class SlackPostError(RuntimeError):
+    """A Slack post failed without exposing the secret webhook URL."""
+
+
+def vip_logins(mapping: str) -> set[str]:
+    """Extract GitHub logins from the top-level ``vip`` YAML mapping."""
+    in_vip = False
+    logins: set[str] = set()
+    for line in mapping.splitlines():
+        if not in_vip:
+            if re.fullmatch(r"vip:\s*(?:#.*)?", line):
+                in_vip = True
+            continue
+        if line and not line[0].isspace():
+            break
+        match = re.match(r"^  ([A-Za-z0-9](?:[A-Za-z0-9-]{0,38})):\s*", line)
+        if match:
+            logins.add(match.group(1).lower())
+    return logins
+
+
+def _target(payload: dict) -> tuple[str, str, str]:
+    issue = payload.get("issue") or {}
+    pull = payload.get("pull_request") or {}
+    discussion = payload.get("discussion") or {}
+    if "pull_request" in payload:
+        return "PR", str(pull.get("number", "")), str(pull.get("title", ""))
+    if issue:
+        kind = "PR" if "pull_request" in issue else "issue"
+        return kind, str(issue.get("number", "")), str(issue.get("title", ""))
+    if discussion:
+        return "discussion", str(discussion.get("number", "")), str(discussion.get("title", ""))
+    return "repository", "", ""
+
+
+def _url(payload: dict) -> str:
+    for key in ("comment", "review", "pull_request", "issue", "discussion"):
+        value = payload.get(key) or {}
+        if value.get("html_url"):
+            return str(value["html_url"])
+    return str((payload.get("repository") or {}).get("html_url", ""))
+
+
+def _activity(event_name: str, payload: dict) -> str:
+    action = str(payload.get("action", "updated")).replace("_", " ")
+    if event_name == "issue_comment":
+        return {
+            "created": "commented on",
+            "edited": "edited a comment on",
+            "deleted": "deleted a comment on",
+        }.get(action, f"{action} a comment on")
+    if event_name == "pull_request_review_comment":
+        return {
+            "created": "left a review comment on",
+            "edited": "edited a review comment on",
+            "deleted": "deleted a review comment on",
+        }.get(action, f"{action} a review comment on")
+    if event_name == "pull_request_review":
+        state = str((payload.get("review") or {}).get("state", "review")).lower()
+        if action == "submitted":
+            article = "an" if state[:1] in "aeiou" else "a"
+            return f"submitted {article} {state} review on"
+        return f"{action} a review on"
+    if event_name == "discussion_comment":
+        return {
+            "created": "commented on",
+            "edited": "edited a comment on",
+            "deleted": "deleted a comment on",
+        }.get(action, f"{action} a comment on")
+    if event_name == "workflow_dispatch":
+        return "triggered a test alert for"
+    return f"{action}"
+
+
+def build_alert(
+    mapping: str,
+    event_name: str,
+    payload: dict,
+    *,
+    actor_override: str | None = None,
+) -> str | None:
+    """Build Slack text for a VIP-authored event, or return ``None``."""
+    actor = actor_override or str((payload.get("sender") or {}).get("login", ""))
+    if not actor or actor.lower() not in vip_logins(mapping):
+        return None
+
+    kind, number, title = _target(payload)
+    if event_name == "workflow_dispatch":
+        kind, number, title = "notification pipeline", "", ""
+    repo = str((payload.get("repository") or {}).get("full_name", "omnigent-ai/omnigent"))
+    label = f"{kind} #{number}" if number else kind
+    if title:
+        label += f": {title[:180]}"
+    label = html.escape(label.replace("|", "¦"))
+    target_url = html.escape(_url(payload), quote=True)
+    linked_label = f"<{target_url}|{label}>" if target_url else label
+    return (
+        f":rotating_light: *VIP GitHub activity* — *{html.escape(actor)}* "
+        f"{_activity(event_name, payload)} {linked_label} in `{html.escape(repo)}`"
+    )
+
+
+def post_to_slack(webhook_url: str, text: str) -> None:
+    request = urllib.request.Request(
+        webhook_url,
+        data=json.dumps({"text": text}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            response.read()
+    except urllib.error.HTTPError as exc:
+        raise SlackPostError(f"Slack returned HTTP {exc.code} {exc.reason}") from None
+    except urllib.error.URLError as exc:
+        raise SlackPostError(f"could not reach Slack: {exc.reason}") from None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mapping", type=pathlib.Path, required=True)
+    parser.add_argument("--event", type=pathlib.Path, required=True)
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--actor")
+    parser.add_argument("--slack-webhook")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    mapping = args.mapping.read_text(encoding="utf-8")
+    payload = json.loads(args.event.read_text(encoding="utf-8"))
+    text = build_alert(mapping, args.event_name, payload, actor_override=args.actor)
+    if text is None:
+        actor = args.actor or str((payload.get("sender") or {}).get("login", "unknown"))
+        print(f"{actor} is not in the VIP mapping; no alert sent.")
+        return 0
+    if args.dry_run:
+        print(text)
+        return 0
+    if not args.slack_webhook:
+        raise SystemExit("VIP_ACTIVITY_SLACK_WEBHOOK_URL is not configured")
+    post_to_slack(args.slack_webhook, text)
+    print("VIP activity alert sent to Slack.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/vip_activity_alert_test.py
+++ b/.github/scripts/vip_activity_alert_test.py
@@ -1,0 +1,75 @@
+import importlib.util
+import pathlib
+import unittest
+
+SCRIPT = pathlib.Path(__file__).with_name("vip_activity_alert.py")
+SPEC = importlib.util.spec_from_file_location("vip_activity_alert", SCRIPT)
+assert SPEC and SPEC.loader
+alert = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(alert)
+
+
+MAPPING = """
+users:
+  somebody: person@example.com
+vip:
+  terrytangyuan: "Red Hat"
+  LittleChimera: "Caffeine"
+priorities:
+  P1-high: 2
+"""
+
+
+class VipActivityAlertTest(unittest.TestCase):
+    def test_extracts_only_vip_mapping(self):
+        self.assertEqual(alert.vip_logins(MAPPING), {"terrytangyuan", "littlechimera"})
+
+    def test_ignores_non_vip_actor(self):
+        payload = {"sender": {"login": "somebody"}}
+        self.assertIsNone(alert.build_alert(MAPPING, "issues", payload))
+
+    def test_formats_opened_issue(self):
+        payload = {
+            "action": "opened",
+            "sender": {"login": "terrytangyuan"},
+            "repository": {"full_name": "omnigent-ai/omnigent"},
+            "issue": {
+                "number": 42,
+                "title": "Kubernetes & sandbox",
+                "html_url": "https://github.com/omnigent-ai/omnigent/issues/42",
+            },
+        }
+        text = alert.build_alert(MAPPING, "issues", payload)
+        self.assertIn("*terrytangyuan* opened", text)
+        self.assertIn("issue #42: Kubernetes &amp; sandbox", text)
+
+    def test_formats_pr_comment_case_insensitively(self):
+        payload = {
+            "action": "created",
+            "sender": {"login": "littlechimera"},
+            "issue": {
+                "number": 99,
+                "title": "Add auth",
+                "html_url": "https://github.com/omnigent-ai/omnigent/pull/99",
+                "pull_request": {},
+            },
+            "comment": {"html_url": "https://github.com/x/y/pull/99#issuecomment-1"},
+        }
+        text = alert.build_alert(MAPPING, "issue_comment", payload)
+        self.assertIn("*littlechimera* commented on", text)
+        self.assertIn("PR #99", text)
+        self.assertIn("#issuecomment-1", text)
+
+    def test_formats_review_state(self):
+        payload = {
+            "action": "submitted",
+            "sender": {"login": "terrytangyuan"},
+            "pull_request": {"number": 7, "title": "K8s", "html_url": "https://example/pull/7"},
+            "review": {"state": "approved", "html_url": "https://example/pull/7#review"},
+        }
+        text = alert.build_alert(MAPPING, "pull_request_review", payload)
+        self.assertIn("submitted an approved review on", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/vip-activity-alert.yml
+++ b/.github/workflows/vip-activity-alert.yml
@@ -1,0 +1,74 @@
+name: VIP activity alert
+
+# This workflow handles untrusted contributor events, so it checks out only the
+# default branch and never executes code from a pull request.
+on:
+  issues:
+    types: [opened, edited, deleted, closed, reopened, assigned, unassigned, labeled, unlabeled, locked, unlocked, milestoned, demilestoned]
+  issue_comment:
+    types: [created, edited, deleted]
+  pull_request_target:
+    types: [opened, edited, closed, reopened, synchronize, converted_to_draft, ready_for_review, locked, unlocked]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  discussion:
+    types: [created, edited, deleted, answered, unanswered, labeled, unlabeled, locked, unlocked]
+  discussion_comment:
+    types: [created, edited, deleted]
+  workflow_dispatch:
+    inputs:
+      vip_login:
+        description: "VIP GitHub login to use for an end-to-end test"
+        required: true
+        type: string
+        default: terrytangyuan
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vip-activity-${{ github.event_name }}-${{ github.event.sender.login || inputs.vip_login }}-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # pull_request_target exposes secrets for fork PRs. Pinning the checkout to
+      # the default branch ensures contributor-controlled code never sees them.
+      - name: Check out trusted notifier
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Mint token for the private VIP mapping
+        id: vip-map-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.OMNIGENT_BOT_APP_ID }}
+          private-key: ${{ secrets.OMNIGENT_BOT_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: omnigent-internal
+
+      - name: Read private VIP mapping
+        env:
+          GH_TOKEN: ${{ steps.vip-map-token.outputs.token }}
+        run: |
+          gh api repos/omnigent-ai/omnigent-internal/contents/agents/issue-sync/mapping.yaml \
+            --jq .content | base64 --decode > "$RUNNER_TEMP/vip-mapping.yaml"
+
+      - name: Notify private Slack channel
+        env:
+          ALERT_ACTOR: ${{ github.event_name == 'workflow_dispatch' && inputs.vip_login || github.event.sender.login }}
+          SLACK_WEBHOOK_URL: ${{ secrets.VIP_ACTIVITY_SLACK_WEBHOOK_URL }}
+        run: |
+          python .github/scripts/vip_activity_alert.py \
+            --mapping "$RUNNER_TEMP/vip-mapping.yaml" \
+            --event "$GITHUB_EVENT_PATH" \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --actor "$ALERT_ACTOR" \
+            --slack-webhook "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Related issue

N/A — test/CI automation.

## Summary

VIP contributor activity currently reaches Linear only during the hourly issue-sync pass, so comments, reviews, and discussions can be missed. This adds a near-real-time GitHub event workflow that:

- reads the canonical VIP list from private `omnigent-internal` using the existing `omnigent-ci` GitHub App;
- filters issues, PRs, comments, reviews, and discussions by the event actor; and
- sends matching activity to a dedicated private Slack webhook without executing contributor-controlled code.

ELI5: `GitHub event → trusted default-branch workflow → private VIP check → private Slack alert`.

## Test Plan

- `python .github/scripts/vip_activity_alert_test.py -v`
- `pre-commit run --all-files`
- After configuring `VIP_ACTIVITY_SLACK_WEBHOOK_URL`, manually dispatch **VIP activity alert** with `terrytangyuan` and confirm the message arrives in `dhruv-omnigent`.

## Demo

N/A — non-visual automation.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover VIP-map parsing, case-insensitive actor matching, non-VIP suppression, and Slack formatting for issues, PR comments, and reviews. The manual dispatch above verifies repository secrets, private-repo access, and Slack delivery after merge.

## Changelog

VIP GitHub activity can now trigger near-real-time alerts in a private Slack channel.
