### PR TITLE
Prefer repro artifacts during resolve recovery

### DIFF
--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -99,26 +99,32 @@ The repro worktree is gone, so recover from the run's artifacts and logs with th
 `gh` CLI. Be **tolerant** — the exact artifact layout may vary, so try in order
 and fall back rather than assuming a fixed structure:
 
-1. `gh run view <ci_link> --log` (and `--json` for metadata) to read the job
-   output. repro-agent's final message is echoed in its step log **untruncated**,
-   so the log carries two things you need: the final ```json handoff block (parse
-   `verdict`/`facets`/`test_path`/`journey`/`bug_url`/`session_id` from it) and,
-   immediately before it, the **complete verbatim source of the e2e test** pasted
-   as a path-labelled code block (repro-agent's contract). Prefer reading the test
-   body from that inline block in the log — unlike a live session transcript, the
-   CI log is not truncated, so the pasted test is complete here.
+1. Download this run's `repro-bundle-<run-id>` artifact first. If it contains
+   top-level `repro-handoff.json`, parse and validate that checkpoint before
+   reading the full job log: it is the smallest, most direct structured source
+   for `verdict`/`facets`/`test_path`/`journey`/`bug_url`/`session_id`. Copy each
+   test named by `test_path` from the artifact's `files/` tree into your checkout.
+   Also retain `patch.diff`, recordings, and `run.log` as supporting evidence.
+
+   The checkpoint is intentionally raw: a producing workflow may have classified
+   a forward-compatible schema as unknown while your newer consumer understands
+   it. Validate it yourself against the authoritative input `bug_url`; do not
+   reject it merely because the old run reported an unknown handoff.
+
+2. Only when the artifact checkpoint is absent or invalid, inspect `run.log` from
+   the downloaded bundle, then fall back to `gh run view <ci_link> --log`. The
+   final repro message is echoed in the job log **untruncated**, so its last
+   ```json block can recover the handoff. The log may also carry the complete
+   verbatim source of the e2e test as a path-labelled code block; use that only
+   when the artifact's `files/` tree did not preserve the test.
 
    **This run's handoff is authoritative.** The `ci_link` you were given names
    exactly one repro run, and its `bug_url` is the bug you resolve — no other.
    You are running on a **shared server that hosts many other repro sessions**;
    do **not** call `sys_session_list` and pick "a" repro session, and do not
    resolve a different bug because its session looks handy on this server. If you
-   cannot find the handoff block in this run's log, stop with `needs_more_info` —
-   never fall back to a bug you found by browsing the server.
-2. `gh run download <run-id>` to pull artifacts as a fallback for the test's
-   content — an authored test file or a diff/patch artifact — if the log's inline
-   block is unavailable or was clipped. Either way, materialize the full test into
-   your checkout at `test_path`.
+   cannot find a handoff in this run's artifact or logs, stop with
+   `needs_more_info` — never fall back to a bug you found by browsing the server.
 3. If the run also recorded a shareable `session_id` you can reach, read it with
    `sys_session_get_history` for richer context — but **only** the exact
    `session_id` this run's handoff named. Before trusting it, confirm that

--- a/dev/resolve-agent/README.md
+++ b/dev/resolve-agent/README.md
@@ -87,7 +87,9 @@ the review gate after the fact.
 ## What it does
 
 1. Recovers the repro handoff (verdict, facets, journey, `bug_url`) and the e2e
-   test's content from the `session` or `ci_link`.
+   test's content from the `session` or `ci_link`. CI recovery reads the compact
+   artifact checkpoint and preserved test files first, using multi-megabyte job
+   logs only as a compatibility fallback for older bundles.
 2. **Looks for an open PR already fixing the bug.** This decides the path:
    - **Existing fix PR** → checks it out, runs the repro test against it (pass =
      it fixes the bug; fail = it doesn't — the key review finding), reviews the


### PR DESCRIPTION
## Related issue

N/A — resolve-agent CI recovery optimization.

## Summary

- Make resolve-agent download the compact repro artifact before fetching the full Actions log.
- Prefer the artifact's raw `repro-handoff.json` and preserved `files/` tests, while retaining bundle logs and live sessions as compatibility fallbacks.
- Explicitly allow a newer consumer to revalidate checkpoints that an older producing workflow classified as unknown.

ELI5: read the small structured receipt first instead of rereading the entire investigation transcript.

```text
repro artifact -> checkpoint + test -> resolve
       | missing/invalid
       v
 bundle run.log -> full Actions log -> exact session
```

Producer-side artifact support: https://github.com/omnigent-ai/omnigent-internal/pull/196

## Test Plan

- Ran `uv tool run pre-commit run --files dev/resolve-agent/AGENTS.md dev/resolve-agent/README.md`.
- Confirmed the instructions retain fallbacks for legacy artifacts without a checkpoint.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The recovery order is documented in `dev/resolve-agent/AGENTS.md`: artifact checkpoint, bundle log, full Actions log, then the exact recorded session for optional context.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This changes the resolve-agent operating procedure rather than executable application code. I verified the ordered fallback contract manually and ran the repository pre-commit hooks for both modified files.
