### PR TITLE
fix(sandbox): create missing write_paths roots before bwrap spawn

### DIFF
--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -486,20 +486,34 @@ class BwrapSandboxBackend(SandboxBackend):
         # only much later, as a bare "Read-only file system" error on its
         # first write. Since the policy layer has already approved this
         # root as a write grant, create it up front so the bind (and the
-        # grant) actually does what it says.
+        # grant) actually does what it says. If creation fails (e.g. an
+        # unwritable parent), keep the old skip-the-bind behavior but warn
+        # loudly instead of failing the whole sandbox wrap: some merged-in
+        # write roots (harness-internal dirs) are optional, and a hard
+        # error here would degrade the helper to running unsandboxed paths.
         for root in policy.write_roots:
             if _is_same_path(root, cwd_resolved):
                 continue
             if not root.exists():
-                root.mkdir(parents=True, exist_ok=True)
-                _LOGGER.warning(
-                    "linux_bwrap: write_paths root %s did not exist on the "
-                    "host, created it (permissions %s) so the granted write "
-                    "access takes effect instead of silently binding to "
-                    "nothing",
-                    root,
-                    oct(root.stat().st_mode & 0o777),
-                )
+                try:
+                    root.mkdir(parents=True, exist_ok=True)
+                except OSError as exc:
+                    _LOGGER.warning(
+                        "linux_bwrap: write_paths root %s does not exist on "
+                        "the host and could not be created (%s); the write "
+                        "grant for this path will have no effect",
+                        root,
+                        exc,
+                    )
+                else:
+                    _LOGGER.warning(
+                        "linux_bwrap: write_paths root %s did not exist on "
+                        "the host, created it (permissions %s) so the "
+                        "granted write access takes effect instead of "
+                        "silently binding to nothing",
+                        root,
+                        oct(root.stat().st_mode & 0o777),
+                    )
             bwrap_args += ["--bind-try", str(root), str(root)]
 
         # Per-file write grants. ``--bind-try`` with a file source

--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -479,9 +479,27 @@ class BwrapSandboxBackend(SandboxBackend):
 
         # Additional write roots — typically the per-helper scratch
         # tmpdir. We skip cwd here because it was bound above.
+        #
+        # ``--bind-try`` silently skips a missing source, so a write_paths
+        # root that doesn't exist yet on the host would otherwise bind to
+        # nothing and leave the grant with no effect — the agent finds out
+        # only much later, as a bare "Read-only file system" error on its
+        # first write. Since the policy layer has already approved this
+        # root as a write grant, create it up front so the bind (and the
+        # grant) actually does what it says.
         for root in policy.write_roots:
             if _is_same_path(root, cwd_resolved):
                 continue
+            if not root.exists():
+                root.mkdir(parents=True, exist_ok=True)
+                _LOGGER.warning(
+                    "linux_bwrap: write_paths root %s did not exist on the "
+                    "host, created it (permissions %s) so the granted write "
+                    "access takes effect instead of silently binding to "
+                    "nothing",
+                    root,
+                    oct(root.stat().st_mode & 0o777),
+                )
             bwrap_args += ["--bind-try", str(root), str(root)]
 
         # Per-file write grants. ``--bind-try`` with a file source

--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -497,6 +497,7 @@ class BwrapSandboxBackend(SandboxBackend):
             if not root.exists():
                 try:
                     root.mkdir(parents=True, exist_ok=True)
+                    created_mode = root.stat().st_mode & 0o777
                 except OSError as exc:
                     _LOGGER.warning(
                         "linux_bwrap: write_paths root %s does not exist on "
@@ -512,7 +513,7 @@ class BwrapSandboxBackend(SandboxBackend):
                         "granted write access takes effect instead of "
                         "silently binding to nothing",
                         root,
-                        oct(root.stat().st_mode & 0o777),
+                        oct(created_mode),
                     )
             bwrap_args += ["--bind-try", str(root), str(root)]
 

--- a/tests/inner/sandbox/test_write_paths_missing_dir.py
+++ b/tests/inner/sandbox/test_write_paths_missing_dir.py
@@ -1,0 +1,187 @@
+"""Regression: a ``write_paths`` grant is silently dropped when the
+granted directory does not exist yet (linux_bwrap backend).
+
+The user journey: declare ``sandbox.write_paths: ["docs/specs"]`` in an
+agent's os_env spec against a workspace where ``docs/specs`` has not been
+created yet, then have the agent write a file there. The grant should be
+honored (or at minimum fail loud); instead the bwrap launcher emits the
+write root as ``--bind-try``, which bubblewrap documents as *ignoring* a
+missing source — so the mount silently never happens, cwd stays read-only,
+and the agent's write fails with a permission error despite the explicit
+grant. Nothing pre-creates the directory and no warning is logged.
+
+Two layers, so the bug is pinned on any Linux host:
+
+- ``test_missing_write_root_survives_into_bwrap_argv`` needs no user
+  namespaces: it asserts the launcher does not hand bwrap a droppable
+  ``--bind-try`` whose source is missing. Fails today everywhere on Linux.
+- ``test_write_into_missing_granted_dir_succeeds`` drives the real helper
+  under bwrap end-to-end (skips on hosts where bwrap cannot create a
+  namespace, e.g. seccomp-restricted CI). Fails today wherever it runs.
+
+``test_write_into_precreated_granted_dir_succeeds`` is the control: the
+identical journey with the directory pre-created passes today, proving the
+failure is specifically the missing-directory case.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.os_env import create_os_environment
+from tests.inner.sandbox.conftest import _repo_root_for_pythonpath, run_async
+
+_BWRAP = shutil.which("bwrap")
+
+linux_bwrap_only = pytest.mark.skipif(
+    not sys.platform.startswith("linux") or _BWRAP is None,
+    reason="linux_bwrap requires Linux + bwrap on PATH",
+)
+
+
+def _bwrap_functional() -> bool:
+    """Whether bwrap can actually create a namespace on this host.
+
+    A seccomp-confined CI runner can have ``bwrap`` on PATH while the
+    kernel denies unprivileged user namespaces; the runtime tests skip
+    there instead of failing for a reason unrelated to the bug.
+    """
+    if _BWRAP is None or not sys.platform.startswith("linux"):
+        return False
+    try:
+        proc = subprocess.run(
+            [_BWRAP, "--ro-bind", "/", "/", "/bin/true"],
+            capture_output=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+def _missing_dir_spec(workspace: Path) -> OSEnvSpec:
+    """The reported journey's spec: a grant on a not-yet-existing dir."""
+    return OSEnvSpec(
+        type="caller_process",
+        cwd=str(workspace),
+        sandbox=OSEnvSandboxSpec(
+            type="linux_bwrap",
+            # Repo root so the sandboxed helper can import omnigent.*.
+            read_paths=[_repo_root_for_pythonpath()],
+            write_paths=["docs/specs"],
+            allow_network=False,
+        ),
+    )
+
+
+@linux_bwrap_only
+def test_missing_write_root_survives_into_bwrap_argv(tmp_path: Path) -> None:
+    """A granted-but-missing write root must not be droppable by bwrap.
+
+    ``--bind-try`` with a missing source is silently skipped by bwrap, so
+    emitting the grant that way — without pre-creating the directory — is
+    exactly the silent drop this bug reports. The grant survives iff the
+    source directory exists by spawn time (backend pre-creates it) or the
+    launcher uses a hard ``--bind`` that fails loud instead of silently.
+    """
+    from omnigent.inner.bwrap_sandbox import BwrapSandboxBackend
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "README.md").write_text("hi\n")
+
+    backend = BwrapSandboxBackend()
+    spec = _missing_dir_spec(workspace)
+    policy = backend.resolve(spec, workspace)
+    missing_root = (workspace / "docs" / "specs").resolve()
+    assert missing_root in [p.resolve() for p in policy.write_roots], (
+        "precondition: the grant must survive policy resolution"
+    )
+
+    argv = backend.wrap_launcher_argv(["/bin/true"], policy, workspace)
+
+    bind_flag = None
+    for i, arg in enumerate(argv):
+        if arg in ("--bind", "--bind-try") and Path(argv[i + 1]) == missing_root:
+            bind_flag = arg
+            break
+    assert bind_flag is not None, (
+        f"write_paths grant for {missing_root} was dropped from the bwrap argv entirely"
+    )
+    if bind_flag == "--bind-try":
+        assert missing_root.is_dir(), (
+            "write_paths grant is silently dropped: the not-yet-existing "
+            f"directory {missing_root} is emitted as --bind-try (bwrap "
+            "ignores a missing source) and the backend never pre-creates "
+            "it, so the helper gets no writable mount and no error"
+        )
+
+
+@pytest.mark.skipif(
+    not _bwrap_functional(),
+    reason="bwrap cannot create namespaces on this host",
+)
+def test_write_into_missing_granted_dir_succeeds(
+    tmp_path: Path,
+    sandbox_pythonpath_env: None,
+) -> None:
+    """End-to-end: the reported journey through the real sandboxed helper.
+
+    With ``write_paths: ["docs/specs"]`` granted and the directory not yet
+    created, the agent-visible write op must succeed — the grant says so.
+    Today it fails: the bind is silently dropped, cwd is read-only, and
+    the helper's ``mkdir docs`` hits the RO mount.
+    """
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "README.md").write_text("hi\n")
+
+    os_env = create_os_environment(_missing_dir_spec(workspace))
+    try:
+        result = run_async(
+            os_env.write(str(workspace / "docs" / "specs" / "note.md"), "granted\n")
+        )
+    finally:
+        os_env.close()
+
+    assert "error" not in result, (
+        f"write into granted docs/specs failed despite write_paths grant: {result}"
+    )
+    assert (workspace / "docs" / "specs" / "note.md").read_text() == "granted\n"
+
+
+@pytest.mark.skipif(
+    not _bwrap_functional(),
+    reason="bwrap cannot create namespaces on this host",
+)
+def test_write_into_precreated_granted_dir_succeeds(
+    tmp_path: Path,
+    sandbox_pythonpath_env: None,
+) -> None:
+    """Control: the identical journey with the directory pre-created works.
+
+    Passing today, this isolates the regression to the missing-directory
+    case — if this control ever fails, the failure of the test above is
+    environmental, not the missing-directory bug.
+    """
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "README.md").write_text("hi\n")
+    (workspace / "docs" / "specs").mkdir(parents=True)
+
+    os_env = create_os_environment(_missing_dir_spec(workspace))
+    try:
+        result = run_async(
+            os_env.write(str(workspace / "docs" / "specs" / "note.md"), "granted\n")
+        )
+    finally:
+        os_env.close()
+
+    assert "error" not in result, f"control write into pre-created docs/specs failed: {result}"
+    assert (workspace / "docs" / "specs" / "note.md").read_text() == "granted\n"

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -26,7 +26,9 @@ from __future__ import annotations
 
 import errno
 import json
+import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -1233,6 +1235,75 @@ def test_read_write_overlap_scanned_once(tmp_path: Path) -> None:
         if argv[i] == "--bind-try" and argv[i + 1] == "/dev/null" and argv[i + 2] == target
     )
     assert count == 1, f"Expected a single .env mask across overlapping grants, got {count}."
+
+
+def test_write_root_missing_on_host_is_created(tmp_path: Path) -> None:
+    """
+    Regression (#5938): a ``write_paths`` root that doesn't exist on the
+    host yet must be created before the ``--bind-try`` is emitted.
+
+    ``--bind-try`` silently skips a missing source, so without this the
+    grant would bind to nothing and the agent's first write would fail
+    with a bare "Read-only file system" error, well after the policy
+    layer already approved the write.
+    """
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    missing_root = cwd / "docs" / "specs"
+    assert not missing_root.exists()
+
+    backend = _make_backend()
+    policy = _make_policy(cwd, write_roots=[missing_root])
+    backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, cwd)
+
+    assert missing_root.is_dir(), "write_paths root must be created so bind-try has a real source"
+
+
+def test_write_root_missing_on_host_logs_loudly(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """
+    Regression (#5938): creating a missing write_paths root must be
+    logged at a visible level, and the log must state the path and the
+    permissions it ended up with, not create it silently.
+    """
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    missing_root = cwd / "docs" / "specs"
+
+    backend = _make_backend()
+    policy = _make_policy(cwd, write_roots=[missing_root])
+    with caplog.at_level(logging.WARNING):
+        backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, cwd)
+
+    matching = [r for r in caplog.records if str(missing_root) in r.getMessage()]
+    assert matching, f"Expected a warning naming {missing_root}, got: {[r.getMessage() for r in caplog.records]}"
+    message = matching[0].getMessage()
+    assert "did not exist" in message
+    assert re.search(r"permissions\s+0o[0-7]+", message), (
+        f"Expected the log to state the created directory's permissions, got: {message!r}"
+    )
+
+
+def test_write_root_already_present_is_not_touched(tmp_path: Path) -> None:
+    """
+    A write_paths root that already exists on the host must not be
+    recreated or logged about — the fallback only applies to the
+    genuinely-missing case.
+    """
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    existing_root = tmp_path / "shared"
+    existing_root.mkdir()
+    before_mtime = existing_root.stat().st_mtime_ns
+
+    backend = _make_backend()
+    policy = _make_policy(cwd, write_roots=[existing_root])
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, cwd)
+
+    assert existing_root.stat().st_mtime_ns == before_mtime
+    assert "--bind-try" in argv
+    assert str(existing_root) in argv
 
 
 def test_nested_grant_masked_in_non_recursive_default(tmp_path: Path) -> None:

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -1308,7 +1308,9 @@ def test_write_root_already_present_is_not_touched(tmp_path: Path) -> None:
 
 
 def test_write_root_uncreatable_warns_instead_of_failing(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
     A missing write_paths root whose creation fails (e.g. an unwritable
@@ -1319,26 +1321,38 @@ def test_write_root_uncreatable_warns_instead_of_failing(
     """
     cwd = tmp_path / "work"
     cwd.mkdir()
-    locked_parent = tmp_path / "locked"
-    locked_parent.mkdir(mode=0o555)
-    uncreatable_root = locked_parent / "child" / "grandchild"
-    if os.geteuid() == 0:
-        pytest.skip("read-only directory modes don't bind as root")
+    uncreatable_root = tmp_path / "locked" / "child" / "grandchild"
+
+    real_mkdir = Path.mkdir
+
+    def _mkdir(self: Path, *args: object, **kwargs: object) -> None:
+        # Simulate an unwritable parent regardless of runner privileges
+        # (mode-based enforcement doesn't hold when tests run as root).
+        if self == uncreatable_root:
+            raise PermissionError(13, "Permission denied", str(self))
+        real_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", _mkdir)
 
     backend = _make_backend()
     policy = _make_policy(cwd, write_roots=[uncreatable_root])
-    try:
-        with caplog.at_level(logging.WARNING):
-            argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, cwd)
-    finally:
-        locked_parent.chmod(0o755)
+    with caplog.at_level(logging.WARNING):
+        argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, cwd)
 
     assert not uncreatable_root.exists()
     matching = [r for r in caplog.records if str(uncreatable_root) in r.getMessage()]
     assert matching, "Expected a warning about the uncreatable write root"
     assert "could not be created" in matching[0].getMessage()
-    # The bind is still emitted as --bind-try, which bwrap skips safely.
-    assert str(uncreatable_root) in argv
+    # The full bind triple is still emitted; bwrap's --bind-try skips
+    # the missing source safely instead of failing the spawn.
+    triples = [
+        (argv[i], argv[i + 1], argv[i + 2])
+        for i, a in enumerate(argv)
+        if a == "--bind-try" and i + 2 < len(argv)
+    ]
+    assert ("--bind-try", str(uncreatable_root), str(uncreatable_root)) in triples, (
+        f"expected a --bind-try triple for {uncreatable_root}, got {triples}"
+    )
 
 
 def test_nested_grant_masked_in_non_recursive_default(tmp_path: Path) -> None:

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -1239,7 +1239,7 @@ def test_read_write_overlap_scanned_once(tmp_path: Path) -> None:
 
 def test_write_root_missing_on_host_is_created(tmp_path: Path) -> None:
     """
-    Regression (#5938): a ``write_paths`` root that doesn't exist on the
+    Regression: a ``write_paths`` root that doesn't exist on the
     host yet must be created before the ``--bind-try`` is emitted.
 
     ``--bind-try`` silently skips a missing source, so without this the
@@ -1263,7 +1263,7 @@ def test_write_root_missing_on_host_logs_loudly(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """
-    Regression (#5938): creating a missing write_paths root must be
+    Regression: creating a missing write_paths root must be
     logged at a visible level, and the log must state the path and the
     permissions it ended up with, not create it silently.
     """
@@ -1277,7 +1277,8 @@ def test_write_root_missing_on_host_logs_loudly(
         backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, cwd)
 
     matching = [r for r in caplog.records if str(missing_root) in r.getMessage()]
-    assert matching, f"Expected a warning naming {missing_root}, got: {[r.getMessage() for r in caplog.records]}"
+    all_messages = [r.getMessage() for r in caplog.records]
+    assert matching, f"Expected a warning naming {missing_root}, got: {all_messages}"
     message = matching[0].getMessage()
     assert "did not exist" in message
     assert re.search(r"permissions\s+0o[0-7]+", message), (
@@ -1304,6 +1305,40 @@ def test_write_root_already_present_is_not_touched(tmp_path: Path) -> None:
     assert existing_root.stat().st_mtime_ns == before_mtime
     assert "--bind-try" in argv
     assert str(existing_root) in argv
+
+
+def test_write_root_uncreatable_warns_instead_of_failing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """
+    A missing write_paths root whose creation fails (e.g. an unwritable
+    parent) must not abort the whole sandbox wrap: merged-in optional
+    write roots (harness-internal dirs under an unwritable ``/home``)
+    would otherwise degrade the helper to running unwrapped. The wrap
+    keeps the old skip-the-bind behavior for that root and warns loudly.
+    """
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    locked_parent = tmp_path / "locked"
+    locked_parent.mkdir(mode=0o555)
+    uncreatable_root = locked_parent / "child" / "grandchild"
+    if os.geteuid() == 0:
+        pytest.skip("read-only directory modes don't bind as root")
+
+    backend = _make_backend()
+    policy = _make_policy(cwd, write_roots=[uncreatable_root])
+    try:
+        with caplog.at_level(logging.WARNING):
+            argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, cwd)
+    finally:
+        locked_parent.chmod(0o755)
+
+    assert not uncreatable_root.exists()
+    matching = [r for r in caplog.records if str(uncreatable_root) in r.getMessage()]
+    assert matching, "Expected a warning about the uncreatable write root"
+    assert "could not be created" in matching[0].getMessage()
+    # The bind is still emitted as --bind-try, which bwrap skips safely.
+    assert str(uncreatable_root) in argv
 
 
 def test_nested_grant_masked_in_non_recursive_default(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

Closes #5938

## Summary

`write_paths` grants in the `linux_bwrap` sandbox silently gave an agent no write access at all when the granted directory didn't exist on the host yet. `--bind-try` skips a missing source silently, so the bind never happened and the grant had no effect until the agent's first write failed deep inside `_write_impl` with a bare `Read-only file system` error. Creates the missing root before spawning `bwrap`, with a loud warning naming the path and the permissions it was created with.

## Test Plan

`uv run pytest tests/inner/test_bwrap_sandbox.py` — full file green (the 4 pre-existing failures are macOS-only platform gates unrelated to this change, same on `main`).

Live-verified end to end against real bubblewrap on Linux (an OrbStack VM — bwrap doesn't run on macOS): reproduced the bug first against the unpatched code with a real `bwrap` invocation (`mkdir: Read-only file system`), then confirmed the fix against the same policy and same `bwrap` invocation.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Live run against real `bwrap`, fixed code:

```
linux_bwrap: write_paths root /tmp/live-test-.../docs/specs did not exist on
the host, created it (permissions 0o755) so the granted write access takes
effect instead of silently binding to nothing

missing_root exists after wrap_launcher_argv: True
missing_root permissions: 0o755

running the real bwrap argv...
exit code: 0
stdout: 'ok\n'

final file exists on host after sandbox exit: True
final file contents: 'ok\n'
```

Same policy against the unpatched code, for comparison:

```
missing_root exists after wrap_launcher_argv: False
running the real bwrap argv...
exit code: 1
stderr: 'mkdir: Read-only file system\n'
final file exists on host after sandbox exit: False
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was a real `bwrap` spawn on Linux (OrbStack VM), before and after the fix, since bubblewrap doesn't run on macOS and the unit tests build the argv without executing it. Three new unit tests cover the create-if-missing, log-loudly, and leave-alone-if-present behavior in isolation: `test_write_root_missing_on_host_is_created`, `test_write_root_missing_on_host_logs_loudly`, `test_write_root_already_present_is_not_touched`.

## Changelog

Fixed `write_paths` sandbox grants silently giving no write access when the granted directory didn't exist yet
