### PR TITLE
refactor(logging): make debug log delivery pluggable

### DIFF
--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -6,12 +6,13 @@ extra logging handler that also forwards each record, as JSON, to a Databricks
 Delta table through the ZeroBus REST ingest endpoint, so a whole session's logs
 can be queried in one place (see the Omnigent Debuggability Plan, OMNI-4198).
 
-The sink is enabled only when the ``OMNIGENT_DEBUG_LOG_*`` environment variables
-are present -- the internal ``omni`` config CLI sets them for internal users, so
-the feature is off by default for OSS users and customers. Uploading is
-best-effort and fully non-blocking: records are queued and flushed by a daemon
-thread, and any failure (auth, network, overflow) drops rows rather than
-disrupting the process.
+By default, the sink is enabled only when the ``OMNIGENT_DEBUG_LOG_*``
+environment variables are present -- the internal ``omni`` config CLI sets them
+for internal users, so the feature is off by default for OSS users and
+customers. Integrations can instead provide their own batch-send function.
+Delivery is best-effort and fully non-blocking: records are queued and flushed
+by a daemon thread, and any failure drops rows rather than disrupting the
+process.
 """
 
 from __future__ import annotations
@@ -28,7 +29,7 @@ import time
 import traceback
 import urllib.parse
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextvars import ContextVar
 from dataclasses import dataclass
 
@@ -481,30 +482,36 @@ class _TokenSource:
         return token, time.time() + expires_in
 
 
-class ZerobusLogHandler(logging.Handler):
-    """Non-blocking logging handler that batches records to a ZeroBus table."""
+DebugLogRow = dict[str, object]
+DebugLogSend = Callable[[list[DebugLogRow]], None]
 
-    def __init__(self, config: DebugLogConfig, source: str) -> None:
+
+class DebugLogHandler(logging.Handler):
+    """Non-blocking handler that queues rows and sends them in batches.
+
+    ``send`` runs on the handler's daemon thread and receives a prepared batch
+    of debug-log row objects. It owns only delivery; this handler retains record
+    serialization, queue overflow, batching, flush timing, and shutdown drains.
+    """
+
+    def __init__(self, source: str, send: DebugLogSend) -> None:
         super().__init__()
-        self._config = config
         self._source = source
+        self._send = send
         self._closed = False
-        self._delivered_any = False
         self._start_worker()
         atexit.register(self.close)
 
     def _start_worker(self) -> None:
-        """Create the queue/client and launch the uploader thread.
+        """Create the queue and launch the sender thread.
 
         Re-invoked by :meth:`emit` when the thread has stopped — after a
         ``logging.config.dictConfig()`` (uvicorn) or an ``os.fork()`` (the
         runner ``_zygote``), which leave the handler attached but kill the
-        thread. Fresh queue/client/thread let delivery resume; the inherited
-        ones (whose locks are in an indeterminate post-fork state) are dropped.
+        thread. A fresh queue/thread lets delivery resume; the inherited ones
+        (whose locks are in an indeterminate post-fork state) are dropped.
         """
-        self._queue: queue.Queue[dict[str, object]] = queue.Queue(maxsize=_QUEUE_MAX_RECORDS)
-        self._client = httpx.Client(timeout=_HTTP_TIMEOUT_S)
-        self._tokens = _TokenSource(self._config, self._client)
+        self._queue: queue.Queue[DebugLogRow] = queue.Queue(maxsize=_QUEUE_MAX_RECORDS)
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, name="omnigent-debug-log", daemon=True)
         self._thread.start()
@@ -525,10 +532,9 @@ class ZerobusLogHandler(logging.Handler):
         # logging.shutdown() on every handler — which close()s this one and stops
         # its uploader thread while leaving it attached to root; os.fork() (the
         # runner _zygote) likewise kills the thread. Receiving a record means the
-        # handler is still live, so revive the worker (fresh queue/client/thread)
-        # and delivery resumes on the next line. A real shutdown emits nothing
-        # afterward, so this never fights atexit. emit() is serialized by the
-        # Handler lock, so the restart happens once.
+        # handler is still live, so revive it with fresh worker state. A real
+        # shutdown emits nothing afterward, so this never fights atexit. emit()
+        # is serialized by the Handler lock, so the restart happens once.
         if self._closed or not self._thread.is_alive():
             try:
                 self._closed = False
@@ -553,37 +559,28 @@ class ZerobusLogHandler(logging.Handler):
                 pass
 
     def _run(self) -> None:
-        # This worker owns the client captured at start and closes it on exit,
-        # so close() never shuts the client down from another thread while a
-        # post/token-mint is in flight (which raises inside httpx and would
-        # otherwise kill this thread with an uncaught exception).
-        client = self._client
         try:
             while not self._stop.is_set():
                 try:
                     batch = self._collect_batch(self._FLUSH_WAIT)
                     if batch:
-                        self._post(batch)
+                        self._send(batch)
                 except Exception:  # noqa: BLE001 — the uploader thread must never die
-                    # A transient error (or a closed client during a shutdown
-                    # race) must not kill the worker: emit()'s self-heal only
-                    # revives a *stopped* thread, so a crash would silently end
-                    # delivery for the process. Drop and keep going.
+                    # A sender failure must not kill the worker: emit()'s
+                    # self-heal only revives a *stopped* thread, so a crash would
+                    # silently end delivery for the process. Drop and continue.
                     time.sleep(0.1)
             # Best-effort drain of whatever is left on shutdown.
             remaining = self._collect_batch(0.0)
             if remaining:
-                self._post(remaining)
+                self._send(remaining)
         except Exception:  # noqa: BLE001 — shutdown drain is best-effort
             pass
-        finally:
-            with contextlib.suppress(Exception):
-                client.close()
 
     _FLUSH_WAIT = _FLUSH_INTERVAL_S
 
-    def _collect_batch(self, wait: float) -> list[dict[str, object]]:
-        batch: list[dict[str, object]] = []
+    def _collect_batch(self, wait: float) -> list[DebugLogRow]:
+        batch: list[DebugLogRow] = []
         try:
             batch.append(self._queue.get(timeout=wait) if wait else self._queue.get_nowait())
         except queue.Empty:
@@ -595,7 +592,44 @@ class ZerobusLogHandler(logging.Handler):
                 break
         return batch
 
-    def _post(self, batch: list[dict[str, object]]) -> None:
+    def close(self) -> None:
+        if self._closed:
+            return
+        # Capture the worker being stopped: a concurrent emit() can revive the
+        # handler during the join and replace self._stop/self._thread.
+        stop, thread = self._stop, self._thread
+        self._closed = True
+        stop.set()
+        thread.join(timeout=5.0)
+        super().close()
+
+
+class ZerobusLogHandler(DebugLogHandler):
+    """Default batched debug-log handler that delivers through ZeroBus."""
+
+    def __init__(self, config: DebugLogConfig, source: str) -> None:
+        self._config = config
+        self._delivered_any = False
+        super().__init__(source, self._post)
+
+    def _start_worker(self) -> None:
+        # Recreate the transport on every worker start. After a fork, inherited
+        # httpx/token locks may be indeterminate and must not be reused.
+        self._client = httpx.Client(timeout=_HTTP_TIMEOUT_S)
+        self._tokens = _TokenSource(self._config, self._client)
+        super()._start_worker()
+
+    def _run(self) -> None:
+        # The worker owns the client captured at start, so close() never shuts
+        # it down while a post or token mint is in flight.
+        client = self._client
+        try:
+            super()._run()
+        finally:
+            with contextlib.suppress(Exception):
+                client.close()
+
+    def _post(self, batch: list[DebugLogRow]) -> None:
         payload = json.dumps(batch)
         for attempt in range(3):
             token = self._tokens.token()
@@ -647,25 +681,10 @@ class ZerobusLogHandler(logging.Handler):
             time.sleep(min(0.5 * 2**attempt, 3.0))
         _diag("post_dropped", "dropped %d row(s) after 3 failed insert attempts", len(batch))
 
-    def close(self) -> None:
-        if self._closed:
-            return
-        # Signal the worker and let it finish and close its own client. Capture
-        # the worker we are tearing down first: a concurrent emit() (under the
-        # handler lock) can revive the sink during the join below, reassigning
-        # self._stop/_thread to fresh ones. Do NOT close the client here — the
-        # worker's shutdown drain may still be minting a token / posting, and
-        # closing it underneath raises inside httpx and kills the thread.
-        stop, thread = self._stop, self._thread
-        self._closed = True
-        stop.set()
-        thread.join(timeout=5.0)
-        super().close()
-
 
 # Process-wide sink; recreated only if a prior instance was closed (e.g. a
 # logging reconfigure closed the root handlers out from under us).
-_active_sink: ZerobusLogHandler | None = None
+_active_sink: DebugLogHandler | None = None
 _sink_lock = threading.Lock()
 
 # Dedicated logger for the server's outgoing SSE-event stream. It gets the sink
@@ -698,33 +717,49 @@ def sse_event_logger() -> logging.Logger:
     return logging.getLogger(SSE_LOGGER_NAME)
 
 
-def attach_debug_log_sink(loggers: list[logging.Logger], *, source: str, level: int) -> None:
+def attach_debug_log_sink(
+    loggers: list[logging.Logger],
+    *,
+    source: str,
+    level: int,
+    send: DebugLogSend | None = None,
+) -> None:
     """Attach the shared debug-log sink to *loggers* when configured.
 
-    A no-op unless the ``OMNIGENT_DEBUG_LOG_*`` variables are set. Reuses one
-    handler per process; ``Logger.addHandler`` is idempotent for a given
-    instance, so repeated calls do not double-ship.
+    ``send`` is an optional integration hook receiving each prepared batch on a
+    daemon thread. When omitted, the sink uses ZeroBus and is a no-op unless the
+    ``OMNIGENT_DEBUG_LOG_*`` variables are set. Reuses one handler per process;
+    ``Logger.addHandler`` is idempotent for a given instance, so repeated calls
+    do not double-ship.
     """
     global _active_sink
-    config = config_from_env()
-    if config is None:
-        return
+    config: DebugLogConfig | None = None
+    if send is None:
+        config = config_from_env()
+        if config is None:
+            return
     with _sink_lock:
         if _active_sink is None or _active_sink.closed:
             try:
-                _active_sink = ZerobusLogHandler(config, source)
+                if send is not None:
+                    _active_sink = DebugLogHandler(source, send)
+                elif config is not None:
+                    _active_sink = ZerobusLogHandler(config, source)
+                else:
+                    return
             except Exception:  # noqa: BLE001 — the sink must never break logging setup
-                # Honor the module's best-effort contract: handler construction
-                # (httpx client, uploader thread, probe timer) failing must not
-                # take down configure_process_logging() and thus process startup.
+                # Handler construction must not take down process logging setup.
                 _logger.warning("debug-log sink disabled: handler init failed", exc_info=True)
                 return
-            _logger.info(
-                "debug-log sink enabled: source=%s table=%s endpoint=%s",
-                source,
-                config.table,
-                config.insert_url,
-            )
+            if config is None:
+                _logger.info("debug-log sink enabled: source=%s custom sender", source)
+            else:
+                _logger.info(
+                    "debug-log sink enabled: source=%s table=%s endpoint=%s",
+                    source,
+                    config.table,
+                    config.insert_url,
+                )
         _active_sink.setLevel(level)
         for target in loggers:
             target.addHandler(_active_sink)

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -8,7 +8,7 @@ import logging
 import os
 import sys
 import threading
-from collections.abc import Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -413,11 +413,14 @@ def configure_process_logging(
     logger_names: Sequence[str] = ("omnigent",),
     root: bool = True,
     force: bool = False,
+    debug_log_send: Callable[[list[dict[str, object]]], None] | None = None,
 ) -> Path:
     """Configure Python logging for one process destination.
 
     The returned file always receives logs. Stderr receives logs only when
-    requested and an interactive terminal stream is available.
+    requested and an interactive terminal stream is available. When provided,
+    ``debug_log_send`` receives prepared debug-log batches on a daemon thread;
+    otherwise the environment-gated ZeroBus sender remains the default.
     """
     global _current_process_log_path
 
@@ -478,7 +481,12 @@ def configure_process_logging(
     from omnigent.debug_logging import attach_debug_log_sink
 
     sink_targets = _debug_sink_target_loggers(logger_names, root=root)
-    attach_debug_log_sink(sink_targets, source=destination, level=resolved_level)
+    attach_debug_log_sink(
+        sink_targets,
+        source=destination,
+        level=resolved_level,
+        send=debug_log_send,
+    )
 
     logging.captureWarnings(True)
     return path

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 
 import pytest
 
@@ -269,6 +270,39 @@ def test_emit_revives_closed_uploader(_configured_env: None) -> None:
         sink.close()
 
 
+def test_custom_send_receives_prepared_rows_without_zerobus_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dl.DebugLogHandler, "_FLUSH_WAIT", 0.01)
+    batches: list[list[dl.DebugLogRow]] = []
+    delivered = threading.Event()
+
+    def send(batch: list[dl.DebugLogRow]) -> None:
+        batches.append(batch)
+        delivered.set()
+
+    sink = dl.DebugLogHandler("integration", send)
+    try:
+        record = logging.LogRecord(
+            "integration.logger",
+            logging.INFO,
+            __file__,
+            1,
+            "hello %s",
+            ("world",),
+            None,
+        )
+        sink.emit(record)
+
+        assert delivered.wait(timeout=1.0)
+        assert len(batches) == 1
+        assert len(batches[0]) == 1
+        assert batches[0][0]["source"] == "integration"
+        assert batches[0][0]["message"] == "hello world"
+    finally:
+        sink.close()
+
+
 def test_ignored_loggers_are_dropped() -> None:
     # httpx/httpcore records are chatty HTTP-client noise and must be dropped;
     # everything else is kept.
@@ -284,6 +318,40 @@ def test_attach_is_noop_when_disabled() -> None:
     target.handlers.clear()
     dl.attach_debug_log_sink([target], source="runner", level=logging.INFO)
     assert not any(isinstance(h, dl.ZerobusLogHandler) for h in target.handlers)
+
+
+def test_attach_uses_custom_send_without_zerobus_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dl.DebugLogHandler, "_FLUSH_WAIT", 0.01)
+    monkeypatch.setattr(dl, "_active_sink", None)
+    target = logging.getLogger("test.debug_logging.custom")
+    target.handlers.clear()
+    target.setLevel(logging.INFO)
+    batches: list[list[dl.DebugLogRow]] = []
+    delivered = threading.Event()
+
+    def send(batch: list[dl.DebugLogRow]) -> None:
+        batches.append(batch)
+        delivered.set()
+
+    dl.attach_debug_log_sink(
+        [target],
+        source="custom",
+        level=logging.INFO,
+        send=send,
+    )
+    sink = dl._active_sink
+    assert sink is not None
+    assert type(sink) is dl.DebugLogHandler
+    try:
+        target.info("custom delivery")
+        assert delivered.wait(timeout=1.0)
+        assert batches[0][0]["message"] == "custom delivery"
+    finally:
+        target.removeHandler(sink)
+        dl.sse_event_logger().removeHandler(sink)
+        sink.close()
 
 
 def test_runner_primary_session_id(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_process_logging.py
+++ b/tests/test_process_logging.py
@@ -275,6 +275,45 @@ def test_configure_process_logging_publishes_its_log_path(
             handler.close()
 
 
+def test_configure_process_logging_forwards_custom_debug_log_send(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from omnigent import debug_logging
+
+    captured: list[object] = []
+
+    def send(batch: list[dict[str, object]]) -> None:
+        captured.append(batch)
+
+    def attach(
+        loggers: list[logging.Logger],
+        *,
+        source: str,
+        level: int,
+        send: debug_logging.DebugLogSend | None = None,
+    ) -> None:
+        captured.extend((loggers, source, level, send))
+
+    monkeypatch.setattr(debug_logging, "attach_debug_log_sink", attach)
+    logger_name = "omnigent.test_custom_debug_send"
+    configure_process_logging(
+        "integration",
+        log_path=tmp_path / "integration.log",
+        level=logging.WARNING,
+        logger_names=(logger_name,),
+        root=False,
+        debug_log_send=send,
+    )
+    try:
+        assert captured[1:] == ["integration", logging.WARNING, send]
+    finally:
+        logger = logging.getLogger(logger_name)
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            handler.close()
+
+
 def test_unlink_if_empty_sweeps_only_empty_files(tmp_path: Path) -> None:
     """The exit sweep removes an empty log, keeps a written one, tolerates absence."""
     empty = tmp_path / "empty.log"


### PR DESCRIPTION
## Related issue

N/A — refactor / chore; no linked issue required.

## Summary

- Decouple debug-log queueing, serialization, batching, overflow handling, and shutdown draining from the final delivery transport.
- Add a `DebugLogHandler` that accepts a plain batch-send callable, and expose it through `attach_debug_log_sink(send=...)` and `configure_process_logging(debug_log_send=...)`.
- Keep environment-gated `ZerobusLogHandler` delivery as the unchanged default, including its authentication, retry, and post-fork transport recreation behavior.

### ELI5

Omnigent still packs logs into boxes the same way, but integrations can now choose their own delivery truck. If they do not provide one, the existing ZeroBus truck is used.

```mermaid
flowchart LR
    A[Log records] --> B[DebugLogHandler]
    B --> C[Queue and batch]
    C --> D{Send callable}
    D -->|Default| E[ZeroBus]
    D -->|Integration supplied| F[Custom destination]
```

## Test Plan

- `.venv/bin/python -m pytest tests/test_debug_logging.py tests/test_process_logging.py -q` — 56 passed.
- `.venv/bin/pre-commit run --all-files` — all hooks passed.
- Added coverage for direct custom delivery without ZeroBus configuration, custom sender attachment, and forwarding through normal process logging setup.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

A custom sender now receives prepared row batches on the background worker thread; omitting it continues to select ZeroBus from the existing environment configuration.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The tests exercise both the new custom-sender path and the existing ZeroBus worker lifecycle, including close/revive behavior.

## Changelog

Debug logs can now be delivered through a custom batch sender while ZeroBus remains the default.
