### PR TITLE
fix(harness): extend the absolute turn watchdog on real progress

### DIFF
--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -126,7 +126,9 @@ _TURN_IDLE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_TIMEOUT_S", "600"))
 # the idle watchdog is enabled: every real progress event extends the
 # ceiling to at least one idle window past now, so a turn that keeps
 # emitting is never killed mid-work merely for running long — a stalled
-# turn past the ceiling dies via the idle watchdog instead. Only when
+# turn past the ceiling dies via the idle watchdog instead. Deliberate
+# tradeoff: under the default config a steadily-emitting turn has NO
+# wall-clock cap (this constant does not bound active turns); only when
 # the idle watchdog is disabled (``HARNESS_TURN_TIMEOUT_S <= 0``) does
 # this act as a strict wall-clock cap. ``<= 0`` disables.
 _TURN_ABSOLUTE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "10800"))

--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -122,11 +122,13 @@ _TURN_CONTEXT_DESYNC_CODE = "runner_turn_context_desync"
 # Env var name kept for the ops knob; ``<= 0`` disables.
 _TURN_IDLE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_TIMEOUT_S", "600"))
 
-# Absolute per-turn ceiling: a hard cap on TOTAL turn duration, backstop
-# to the idle watchdog above. The idle watchdog never trips a turn that
-# keeps emitting, so a runaway-but-active loop (e.g. an infinite tool
-# loop emitting steadily) needs this. Generous so it never clips a real
-# long turn. ``<= 0`` disables. Whichever of (idle, absolute) trips first.
+# Absolute per-turn ceiling on TOTAL turn duration. Progress-aware when
+# the idle watchdog is enabled: every real progress event extends the
+# ceiling to at least one idle window past now, so a turn that keeps
+# emitting is never killed mid-work merely for running long — a stalled
+# turn past the ceiling dies via the idle watchdog instead. Only when
+# the idle watchdog is disabled (``HARNESS_TURN_TIMEOUT_S <= 0``) does
+# this act as a strict wall-clock cap. ``<= 0`` disables.
 _TURN_ABSOLUTE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "10800"))
 
 
@@ -1480,10 +1482,13 @@ class HarnessApp:
           calls) is never killed — only one that emits nothing for the
           whole window. This replaces the prior fixed *cumulative* cap,
           which guillotined long-but-healthy turns mid-stream.
-        - ABSOLUTE (:data:`_TURN_ABSOLUTE_TIMEOUT_S`): a hard ceiling on
-          total duration, never rescheduled. Backstops the idle watchdog
-          against a runaway-but-active loop the idle one never sees as
-          stuck.
+        - ABSOLUTE (:data:`_TURN_ABSOLUTE_TIMEOUT_S`): a ceiling on total
+          duration that real progress extends: each non-heartbeat emit
+          pushes the deadline to at least one idle window past now, so an
+          actively-progressing turn is never killed merely for running
+          long. A turn that outlives the ceiling and then stalls dies via
+          the idle watchdog; only with the idle watchdog disabled does
+          this act as a strict wall-clock cap.
 
         Either expiry surfaces a wedged/runaway ``run_turn`` as
         ``response.failed``.
@@ -1500,11 +1505,26 @@ class HarnessApp:
             loop = asyncio.get_running_loop()
 
             def _reset() -> None:
-                # Push ONLY the idle deadline ``idle_timeout`` s past now
-                # (the absolute ceiling is never rescheduled). Called from
-                # ``ctx.emit`` during ``run_turn`` (inside the active
-                # context), so the reschedule is always valid.
-                idle_wd.reschedule(loop.time() + idle_timeout)
+                # Push the idle deadline ``idle_timeout`` s past now. Called
+                # from ``ctx.emit`` during ``run_turn`` (inside the active
+                # context). ``expired()`` guards a late emit racing a
+                # just-fired timeout: rescheduling an expiring/expired
+                # ``asyncio.Timeout`` raises RuntimeError out of ``emit``.
+                now = loop.time()
+                if not idle_wd.expired():
+                    idle_wd.reschedule(now + idle_timeout)
+                # Real progress also extends the absolute ceiling to at
+                # least one idle window past now, so an actively-emitting
+                # turn is never guillotined mid-work for total duration
+                # alone. A turn that outlives the original ceiling and then
+                # stalls is failed by the idle watchdog one window later.
+                absolute_deadline = absolute_wd.when()
+                if (
+                    not absolute_wd.expired()
+                    and absolute_deadline is not None
+                    and absolute_deadline < now + idle_timeout
+                ):
+                    absolute_wd.reschedule(now + idle_timeout)
 
             ctx._reset_idle_watchdog = _reset
         try:
@@ -1550,7 +1570,7 @@ class HarnessApp:
                 )
                 raise RuntimeError(
                     f"turn exceeded the {absolute_timeout:.0f}s harness absolute watchdog "
-                    f"(total turn duration cap; the turn kept emitting but never finished)"
+                    f"(total turn duration cap)"
                 ) from exc
             # Neither ceiling tripped — an inner ``run_turn`` TimeoutError;
             # pass it through unchanged.

--- a/tests/e2e_ui/chat/test_absolute_watchdog_spares_active_turn.py
+++ b/tests/e2e_ui/chat/test_absolute_watchdog_spares_active_turn.py
@@ -1,0 +1,381 @@
+"""An actively-progressing turn must not be killed by the absolute watchdog.
+
+Reproduces the reported failure: a healthy harness
+turn that keeps emitting real progress events (tool calls, deltas — each of
+which resets the idle watchdog) is forcibly failed the moment its cumulative
+duration crosses ``HARNESS_TURN_ABSOLUTE_TIMEOUT_S`` (default 10,800 s). The
+user sees the turn die mid-work with::
+
+    turn exceeded the 10800s harness absolute watchdog (total turn duration
+    cap; the turn kept emitting but never finished)
+
+Journey (the reported 3 h ceiling is scaled to 10 s via the product's own
+``HARNESS_TURN_ABSOLUTE_TIMEOUT_S`` env knob on a dedicated runner — the
+same time-scaling the scaffold's unit tests use — so the reproduction runs
+in seconds while exercising the identical code path):
+
+1. start a session on a scaffolded-harness agent (openai-agents, driven by
+   the mock LLM),
+2. send a message that starts a long multi-step turn: the agent runs several
+   tool-call rounds, each emitting progress events well inside the idle
+   window (idle is set to 120 s and is reset by every emit — it never trips),
+3. keep the turn active past the absolute ceiling,
+4. observe: on a build with the bug the stream ends in ``response.failed``
+   with the "absolute watchdog" error and the chat shows an error pill; the
+   expected behavior is that the still-progressing turn completes normally.
+
+On a buggy build this test FAILS at the ``watchdog_error is None`` assertion
+(the reproduction); after a fix the same journey completes and the test
+passes.
+
+Run::
+
+    pytest tests/e2e_ui/chat/test_absolute_watchdog_spares_active_turn.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import secrets
+import shutil
+import signal
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import configure_mock_llm, set_fallback_mock_llm
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Scaled-down absolute turn ceiling (prod default: 10,800 s). The scripted
+# turn below is guaranteed to outlast it by LLM-side delays alone.
+_ABSOLUTE_TIMEOUT_S = 10
+# Idle watchdog kept far above the inter-event cadence so it never trips —
+# the point of the bug is that the turn IS making progress.
+_IDLE_TIMEOUT_S = 120
+
+# Seconds for the dedicated runner to tunnel into the shared server.
+_RUNNER_ONLINE_TIMEOUT_S = 30.0
+
+# Number of scripted tool-call rounds and the mock LLM's per-response delay.
+# 5 rounds + final text at 2.0 s each = >= 12 s of LLM time, always past the
+# 10 s absolute ceiling regardless of how fast tool execution is.
+_TOOL_ROUNDS = 5
+_LLM_DELAY_S = 2.0
+
+# The sentinel the final (post-tool-rounds) assistant reply carries; its
+# presence in the transcript is the "turn completed" signal.
+_DONE_SENTINEL = "LONG_TASK_COMPLETED_SENTINEL"
+
+# Ceiling for the whole turn to settle (complete or fail) — natural
+# completion is ~15-25 s including first-turn harness boot.
+_TURN_SETTLE_TIMEOUT_S = 120.0
+
+_AGENT_YAML = """\
+name: {name}
+prompt: |
+  You are a deterministic test assistant working through a long multi-step
+  task. You run each step with a shell command and report when done.
+
+executor:
+  model: {model}
+  harness: openai-agents
+
+os_env:
+  type: caller_process
+  cwd: {cwd}
+  sandbox:
+    type: none
+"""
+
+
+def _agent_bundle(name: str, model: str, cwd: str) -> bytes:
+    """Gzip-tar the inline agent YAML for multipart upload."""
+    yaml_text = _AGENT_YAML.format(name=name, model=model, cwd=cwd)
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = yaml_text.encode()
+        info = tarfile.TarInfo(name=f"{name}.yaml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+@pytest.fixture(scope="module")
+def short_watchdog_runner(
+    live_server: str,
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[str]:
+    """Spawn a dedicated runner whose harness subprocesses get a 10 s ceiling.
+
+    The harness scaffold reads ``HARNESS_TURN_ABSOLUTE_TIMEOUT_S`` /
+    ``HARNESS_TURN_TIMEOUT_S`` from its process environment at import
+    (``omnigent/runtime/harnesses/_scaffold.py``), and the runner's
+    ``_build_harness_spawn_env`` passes the runner's own environment through
+    to every spawned harness. A dedicated runner (same pattern as
+    ``stub_harness_runner`` in ``test_stop_button_interrupts_turn.py``) keeps
+    the override out of the shared ``live_server`` runner and out of
+    ``os.environ``.
+
+    Yields the runner id to bind sessions to.
+    """
+    from omnigent.runner.identity import token_bound_runner_id
+
+    runner_tmp = tmp_path_factory.mktemp("watchdog_runner")
+    log_path = runner_tmp / "runner.log"
+
+    binding_token = secrets.token_urlsafe(32)
+    runner_id = token_bound_runner_id(binding_token)
+    env = {
+        **os.environ,
+        "PYTHONPATH": f"{_REPO_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+        "OMNIGENT_RUNNER_ID": runner_id,
+        "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
+        "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
+        "RUNNER_SERVER_URL": live_server,
+        # Route the openai-agents harness at the mock LLM server.
+        "OPENAI_BASE_URL": f"{mock_llm_server_url}/v1",
+        "OPENAI_API_KEY": "mock-key",
+        "ANTHROPIC_API_KEY": "",
+        # The reproduction's time scaling: prod's 3 h absolute ceiling
+        # becomes 10 s; the idle watchdog stays far above the event cadence.
+        "HARNESS_TURN_ABSOLUTE_TIMEOUT_S": str(_ABSOLUTE_TIMEOUT_S),
+        "HARNESS_TURN_TIMEOUT_S": str(_IDLE_TIMEOUT_S),
+        # A fresh, empty config home: an ambient OMNIGENT_CONFIG_HOME (e.g.
+        # a CI harness config with env-ref'd gateway credentials) would make
+        # turn setup fail before the journey starts.
+        "OMNIGENT_CONFIG_HOME": str(runner_tmp / "config-home"),
+    }
+    (runner_tmp / "config-home").mkdir(exist_ok=True)
+    log_handle = open(log_path, "w")  # noqa: SIM115 — fd dup'd into child; closed below
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "omnigent.runner._entry"],
+        env=env,
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+    )
+    log_handle.close()  # child holds its own dup of the fd
+
+    deadline = time.monotonic() + _RUNNER_ONLINE_TIMEOUT_S
+    ready = False
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"short-watchdog runner exited early (code {proc.returncode}); "
+                f"log:\n{log_path.read_text()[-3000:]}"
+            )
+        try:
+            resp = httpx.get(f"{live_server}/v1/runners/{runner_id}/status", timeout=2)
+            if resp.status_code == 200 and resp.json().get("online") is True:
+                ready = True
+                break
+        except httpx.HTTPError:
+            pass
+        time.sleep(0.25)
+
+    if not ready:
+        proc.terminate()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=5)
+        raise RuntimeError(
+            f"short-watchdog runner did not register within "
+            f"{_RUNNER_ONLINE_TIMEOUT_S:.0f}s; log:\n{log_path.read_text()[-3000:]}"
+        )
+
+    try:
+        yield runner_id
+    finally:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+@pytest.fixture
+def watchdog_session(
+    live_server: str,
+    short_watchdog_runner: str,
+) -> Iterator[tuple[str, str, str]]:
+    """Create a session on the short-ceiling runner; yield (base, sid, model)."""
+    ws = Path(tempfile.mkdtemp(prefix="omnigent-e2e-abs-watchdog-"))
+    name = f"watchdog_probe_{uuid.uuid4().hex[:8]}"
+    model = f"watchdog-probe-{uuid.uuid4().hex[:8]}"
+
+    create_resp = httpx.post(
+        f"{live_server}/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={
+            "bundle": (
+                "agent.tar.gz",
+                _agent_bundle(name, model, str(ws)),
+                "application/gzip",
+            )
+        },
+        timeout=30.0,
+    )
+    create_resp.raise_for_status()
+    session_id = create_resp.json()["session_id"]
+
+    try:
+        httpx.patch(
+            f"{live_server}/v1/sessions/{session_id}",
+            json={"runner_id": short_watchdog_runner},
+            timeout=10.0,
+        ).raise_for_status()
+
+        # Wait for the runner-backed environment so the turn's sys_os_shell
+        # tool calls have a filesystem to run in.
+        env_resp = httpx.get(
+            f"{live_server}/v1/sessions/{session_id}/resources/environments/default",
+            timeout=10.0,
+        )
+        env_resp.raise_for_status()
+
+        yield (live_server, session_id, model)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        shutil.rmtree(ws, ignore_errors=True)
+
+
+def _queue_long_progressing_turn(mock_url: str, model: str) -> None:
+    """Script a turn that keeps emitting progress past the absolute ceiling.
+
+    Each tool-call round makes the harness emit real (non-heartbeat) events
+    — resetting the idle watchdog exactly as the bug report describes — while
+    the per-response ``delay`` stretches the turn's total duration beyond
+    ``_ABSOLUTE_TIMEOUT_S`` on LLM time alone.
+    """
+    responses: list[dict[str, object]] = [
+        {
+            "tool_calls": [
+                {
+                    "call_id": f"call_step_{step}",
+                    "name": "sys_os_shell",
+                    "arguments": json.dumps({"command": f'echo "progress step {step}"'}),
+                }
+            ],
+            "delay": _LLM_DELAY_S,
+        }
+        for step in range(1, _TOOL_ROUNDS + 1)
+    ]
+    responses.append({"text": _DONE_SENTINEL, "delay": _LLM_DELAY_S})
+    configure_mock_llm(mock_url, responses, key=model)
+    set_fallback_mock_llm(mock_url, model, _DONE_SENTINEL)
+
+
+def _poll_turn_outcome(base_url: str, session_id: str) -> tuple[bool, str | None, int]:
+    """Poll the transcript until the turn settles.
+
+    :returns: ``(completed, watchdog_error_message, function_call_count)`` —
+        ``completed`` when the final assistant sentinel landed;
+        ``watchdog_error_message`` when an ``error`` item mentioning the
+        absolute watchdog was persisted.
+    """
+    deadline = time.monotonic() + _TURN_SETTLE_TIMEOUT_S
+    completed = False
+    watchdog_error: str | None = None
+    call_count = 0
+    while time.monotonic() < deadline:
+        resp = httpx.get(f"{base_url}/v1/sessions/{session_id}/items?limit=200", timeout=10.0)
+        resp.raise_for_status()
+        items = resp.json()["data"]
+        call_count = 0
+        for item in items:
+            data = item.get("data") or {}
+            item_type = item.get("type")
+            if item_type == "function_call":
+                call_count += 1
+            elif item_type == "error":
+                message = str(item.get("message") or data.get("message") or "")
+                if "absolute watchdog" in message:
+                    watchdog_error = message
+            elif item_type == "message":
+                role = item.get("role") or data.get("role")
+                content = item.get("content") or data.get("content") or []
+                text = " ".join(
+                    str(part.get("text", "")) for part in content if isinstance(part, dict)
+                )
+                if role == "assistant" and _DONE_SENTINEL in text:
+                    completed = True
+        if completed or watchdog_error is not None:
+            break
+        time.sleep(1.0)
+    return completed, watchdog_error, call_count
+
+
+@pytest.mark.timeout(280)
+def test_actively_progressing_turn_survives_absolute_watchdog(
+    page: Page,
+    watchdog_session: tuple[str, str, str],
+    mock_llm_server_url: str,
+) -> None:
+    """A turn emitting steady progress must complete, not die at the ceiling.
+
+    On a build with the bug this fails at the ``watchdog_error``
+    assertion: the harness kills the still-emitting turn the moment its
+    cumulative duration crosses ``HARNESS_TURN_ABSOLUTE_TIMEOUT_S``, and the
+    chat shows the failure pill instead of the final assistant reply.
+    """
+    base_url, session_id, model = watchdog_session
+    _queue_long_progressing_turn(mock_llm_server_url, model)
+
+    page.goto(f"{base_url}/c/{session_id}")
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill("Work through the long multi-step task and report when done.")
+    page.get_by_role("button", name="Send", exact=True).click()
+
+    completed, watchdog_error, call_count = _poll_turn_outcome(base_url, session_id)
+
+    # The turn made real progress before it settled — this is what
+    # distinguishes the reported bug (an ACTIVE turn killed by the absolute
+    # ceiling) from a legitimately wedged turn the idle watchdog should kill.
+    assert call_count >= 1, (
+        f"Expected at least one executed tool call before the turn settled; "
+        f"got {call_count}. Without progress events this journey would not "
+        f"exercise the active-turn-vs-absolute-watchdog path."
+    )
+
+    # When the watchdog killed the turn, let the user-visible failure land
+    # on screen (the error pill) before failing — the recorded journey then
+    # ends on exactly what the user sees.
+    if watchdog_error is not None:
+        with contextlib.suppress(AssertionError):
+            expect(page.get_by_test_id("error-pill").first).to_be_visible(timeout=15_000)
+        page.wait_for_timeout(1_500)
+
+    # THE BUG: the absolute watchdog fails the turn despite ongoing progress.
+    assert watchdog_error is None, (
+        f"An actively-progressing turn was killed by the absolute turn "
+        f"watchdog after {call_count} executed tool call(s): {watchdog_error!r}. "
+        f"Turns that keep emitting real progress must not be failed solely "
+        f"because their cumulative duration crossed "
+        f"HARNESS_TURN_ABSOLUTE_TIMEOUT_S."
+    )
+
+    assert completed, (
+        f"The turn neither completed nor failed with the absolute-watchdog "
+        f"error within {_TURN_SETTLE_TIMEOUT_S:.0f}s — the journey never "
+        f"settled (mock LLM mis-scripted or harness never started)."
+    )
+
+    # The user-visible outcome: the final reply rendered, no error pill.
+    expect(
+        page.locator('[data-testid="message-bubble"][data-role="assistant"]').last
+    ).to_contain_text(_DONE_SENTINEL, timeout=30_000)
+    expect(page.get_by_test_id("error-pill")).to_have_count(0)

--- a/tests/runtime/harnesses/test_scaffold.py
+++ b/tests/runtime/harnesses/test_scaffold.py
@@ -378,10 +378,20 @@ def use_wedged_fast_heartbeat(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture
 def use_busy_absolute_cap(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Busy harness, 2s absolute ceiling below its ~3s runtime; idle high so only the cap fires."""
+    """Busy harness, 2s absolute ceiling below its ~3s runtime; idle high so it never trips."""
     monkeypatch.setenv("HARNESS_TEST_FIXTURE", "busy_progress")
-    # Idle high + reset on every emit → never trips; only the absolute cap can fire.
+    # Idle high + reset on every emit → never trips; progress extends the
+    # absolute ceiling, so the busy turn must outlive the 2s cap.
     monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "10")
+    monkeypatch.setenv("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "2")
+
+
+@pytest.fixture
+def use_busy_strict_absolute_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Busy harness, idle watchdog disabled: the 2s absolute ceiling is a strict cap."""
+    monkeypatch.setenv("HARNESS_TEST_FIXTURE", "busy_progress")
+    # Idle disabled → no progress-driven extension; only the absolute cap fires.
+    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "0")
     monkeypatch.setenv("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "2")
 
 
@@ -738,50 +748,138 @@ async def test_per_turn_watchdog_ignores_heartbeats(
     )
 
 
-async def test_per_turn_absolute_watchdog_caps_runaway_active_turn(
+async def test_actively_progressing_turn_outlives_absolute_ceiling(
     use_busy_absolute_cap: None,
     manager: HarnessProcessManager,
 ) -> None:
     """
-    The absolute ceiling fails a turn that keeps emitting but never ends.
+    Real progress extends the absolute ceiling: an active turn completes.
 
-    The idle watchdog never trips an actively-streaming turn (each emit
-    resets it), so a runaway-but-active loop needs the absolute backstop.
     The ``busy_progress`` harness emits every 0.1s for ~3s; with idle=10s
-    (reset on every emit → never trips) and absolute=2s, the absolute cap
-    must fire ~1s before the harness's natural completion.
+    and absolute=2s, every emit pushes the absolute deadline at least one
+    idle window past now, so the turn must run past the 2s cap and reach
+    ``response.completed`` — never be guillotined mid-stream for total
+    duration alone.
     """
     conv_id = "conv_busy_absolute_cap"
     client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
     body = {"type": "message", "role": "user", "model": "test-agent", "content": []}
     events: list[_ParsedSSEEvent] = []
-    # Above the 2s cap, below the ~3s natural completion's headroom and the
-    # suite timeout; 20s only guards an unrelated hang.
+    # Well above the harness's ~3s natural completion; guards only a hang.
     async with asyncio.timeout(20):
         async with client.stream("POST", f"/v1/sessions/{conv_id}/events", json=body) as response:
             async for event in _stream_iter(response):
                 events.append(event)
 
     event_types = [e.event for e in events]
-    # response.failed (not completed) proves the absolute ceiling fired
-    # before the harness's ~3s natural completion. response.completed would
-    # mean the cap didn't engage.
+    # response.completed (not failed) proves progress extended the ceiling
+    # past the turn's ~3s natural completion despite the 2s absolute cap.
+    assert event_types[-1] == "response.completed", (
+        f"An actively-emitting turn must outlive the absolute ceiling and "
+        f"complete; got {event_types[-1]!r} (full: {event_types!r})."
+    )
+    # Deltas streamed throughout — the turn was active the whole time.
+    assert "response.output_text.delta" in event_types, (
+        f"Expected progress deltas from the busy turn; got {event_types!r}."
+    )
+
+
+async def test_absolute_ceiling_is_strict_when_idle_watchdog_disabled(
+    use_busy_strict_absolute_cap: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """
+    With the idle watchdog disabled, the absolute ceiling is a hard cap.
+
+    No idle watchdog means no progress-driven extension, so the busy turn
+    (~3s runtime) must be failed at the 2s absolute ceiling — the ceiling
+    still backstops a runaway turn when it is the only watchdog left.
+    """
+    conv_id = "conv_busy_strict_absolute_cap"
+    client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    body = {"type": "message", "role": "user", "model": "test-agent", "content": []}
+    events: list[_ParsedSSEEvent] = []
+    async with asyncio.timeout(20):
+        async with client.stream("POST", f"/v1/sessions/{conv_id}/events", json=body) as response:
+            async for event in _stream_iter(response):
+                events.append(event)
+
+    event_types = [e.event for e in events]
     assert event_types[-1] == "response.failed", (
-        f"Absolute ceiling must fail a runaway-but-active turn; got "
+        f"With idle disabled the absolute ceiling must cap the turn; got "
         f"{event_types[-1]!r} (full: {event_types!r})."
     )
-    # The error must name the ABSOLUTE watchdog, not the idle one — proves
-    # the right ceiling tripped (idle was set high and reset by every emit).
+    # The error names the ABSOLUTE watchdog — the only one enabled.
     error = events[-1].data["response"]["error"]
     assert error is not None and "absolute" in error["message"], (
-        f"Failure must come from the absolute ceiling; got {error!r}. An "
-        f"'idle'-only message would mean the idle watchdog fired instead."
+        f"Failure must come from the absolute ceiling; got {error!r}."
     )
-    # Deltas streamed before the cap fired (it was actively emitting, not
-    # wedged) — distinguishes this from the idle/wedged path.
     assert "response.output_text.delta" in event_types, (
         f"Expected progress deltas before the absolute cap; got {event_types!r}."
     )
+
+
+async def test_turn_stalling_past_absolute_ceiling_fails_via_idle_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A turn that outlives the ceiling and then stalls still dies promptly.
+
+    Progress extends the absolute deadline only to one idle window past the
+    last emit, so once the turn goes quiet the idle watchdog (or the pushed
+    ceiling — whichever first) fails it within ~idle_timeout, preserving the
+    runaway backstop for a loop that stops making real progress.
+    """
+    from omnigent.runtime.harnesses import _scaffold
+
+    class _StallsAfterProgressApp(HarnessApp):
+        async def run_turn(self, request: Any, ctx: TurnContext) -> None:
+            """Emit past the absolute ceiling, then wedge forever."""
+            del request
+            from omnigent.server.schemas import OutputTextDeltaEvent
+
+            for i in range(8):  # 0.8s of steady progress > 0.5s ceiling
+                ctx.emit(
+                    OutputTextDeltaEvent(type="response.output_text.delta", delta=f"tick-{i} ")
+                )
+                await asyncio.sleep(0.1)
+            await asyncio.Event().wait()  # stall: no further progress
+
+    monkeypatch.setattr(_scaffold, "_TURN_IDLE_TIMEOUT_S", 1.0)
+    monkeypatch.setattr(_scaffold, "_TURN_ABSOLUTE_TIMEOUT_S", 0.5)
+
+    app = _StallsAfterProgressApp()
+    event_queue: asyncio.Queue[Any] = asyncio.Queue()
+    ctx = TurnContext(
+        response_id="resp_stall_after_progress",
+        event_queue=event_queue,
+        cancelled=asyncio.Event(),
+    )
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    # The stalled turn must fail within ~idle_timeout of its last emit —
+    # 5s guards only an unrelated hang.
+    async with asyncio.timeout(5):
+        with pytest.raises(RuntimeError) as excinfo:
+            await app._guarded_run_turn(None, ctx)  # type: ignore[arg-type]
+    elapsed = loop.time() - started
+    # The turn genuinely OUTLIVED the 0.5s absolute ceiling before it was
+    # failed — the old never-rescheduled ceiling would have killed it at
+    # ~0.5s with only ~5 of the 8 progress events emitted.
+    assert elapsed > 0.8, (
+        f"Turn was failed after {elapsed:.2f}s — at/under the 0.5s absolute "
+        f"ceiling, meaning progress did not extend it."
+    )
+    emitted = [
+        e
+        for e in iter(event_queue.get_nowait, None)
+        if getattr(e, "type", "") == "response.output_text.delta"
+    ]
+    assert len(emitted) == 8, (
+        f"All 8 progress events must land before the failure; got {len(emitted)}."
+    )
+    # The failure comes from the idle watchdog (the stall), not the ceiling.
+    assert "idle watchdog" in str(excinfo.value), str(excinfo.value)
 
 
 # ── Health probe ──────────────────────────────────────────────

--- a/tests/runtime/harnesses/test_scaffold.py
+++ b/tests/runtime/harnesses/test_scaffold.py
@@ -870,6 +870,13 @@ async def test_turn_stalling_past_absolute_ceiling_fails_via_idle_watchdog(
         f"Turn was failed after {elapsed:.2f}s — at/under the 0.5s absolute "
         f"ceiling, meaning progress did not extend it."
     )
+    # ...and the failure landed promptly: ~one idle window (1s) after the
+    # last emit at ~0.8s, with slack for a slow CI box. A stalled turn must
+    # not linger well past its extended deadline.
+    assert elapsed < 3.5, (
+        f"Stalled turn lingered {elapsed:.2f}s — the watchdog should fire "
+        f"within ~one idle window (1s) of the last progress event."
+    )
     emitted = [
         e
         for e in iter(event_queue.get_nowait, None)


### PR DESCRIPTION
## Related issue

Closes #5902 (Linear: [OMNI-5828](https://linear.app/omnigent/issue/OMNI-5828/bug-active-harness-turns-are-killed-after-3-hours-by-the-absolute))

## Summary

- A healthy, actively-emitting harness turn was forcibly failed the moment its cumulative duration crossed `HARNESS_TURN_ABSOLUTE_TIMEOUT_S` (3 h default) — long debugging/orchestration turns died mid-work with `turn exceeded the 10800s harness absolute watchdog`, even though every progress event kept resetting the idle watchdog.
- **Root cause:** `_guarded_run_turn` in `omnigent/runtime/harnesses/_scaffold.py` wrapped `run_turn` in an `asyncio.timeout` for the absolute ceiling that was **never rescheduled** — only the idle deadline moved on progress — so total wall-clock alone killed the turn regardless of activity.
- **Fix:** each real (non-heartbeat) progress event now also extends the absolute deadline to at least one idle window past now. An actively-progressing turn is never guillotined for running long; a turn that outlives the ceiling and then stalls is still failed within ~one idle window (the runaway backstop is preserved); with the idle watchdog disabled (`HARNESS_TURN_TIMEOUT_S <= 0`) the absolute ceiling remains a strict wall-clock cap. Both reschedules are guarded against a late emit racing a just-fired timeout.

```
before:  |-- progress ... progress ... progress --X  (killed at absolute ceiling)
after:   |-- progress ... progress ... progress ------- completes
         |-- progress ... [stalls] ----X               (idle watchdog, ~1 window later)
         |-- (idle wd disabled) -------X               (strict absolute cap, unchanged)
```

## Test Plan

- **e2e reproduction (fail→pass):** `tests/e2e_ui/chat/test_absolute_watchdog_spares_active_turn.py` drives the real journey (session on a scaffolded openai-agents harness, multi-step tool-call turn kept active past a 10 s-scaled absolute ceiling on a dedicated runner). On the unfixed tree it failed with `AssertionError: An actively-progressing turn was killed by the absolute turn watchdog after 2 executed tool call(s): 'turn exceeded the 10s harness absolute watchdog ...'`; on this branch the same journey completes and the test passes.
- **Unit tests** (`tests/runtime/harnesses/test_scaffold.py`):
  - `test_actively_progressing_turn_outlives_absolute_ceiling` — rewrite of the test that previously pinned the buggy behavior; fails on the unfixed scaffold, passes with the fix.
  - `test_absolute_ceiling_is_strict_when_idle_watchdog_disabled` — the runaway backstop still caps a turn when the absolute ceiling is the only watchdog.
  - `test_turn_stalling_past_absolute_ceiling_fails_via_idle_watchdog` — a turn that outlives the ceiling (all 8 progress events land, elapsed > the 0.5 s ceiling) and then stalls is failed by the idle watchdog.
- Full module green: `uv run --group test pytest tests/runtime/harnesses/test_scaffold.py` → 33 passed. Hostile-env re-run with `HARNESS_TURN_ABSOLUTE_TIMEOUT_S`/`HARNESS_TURN_TIMEOUT_S` exported also passes.

## Independent review

A different-vendor (codex) reviewer checked the diff pre-PR: no blocking or security findings; its one note (make the stall test prove the turn outlived the original ceiling) was addressed by asserting elapsed time, full event count, and the idle-watchdog error text.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Before (repro run: turn dies mid-work with the absolute-watchdog error pill) and after (same journey completes with the final assistant reply, no error pill) recordings are in the repro/resolve CI artifact bundles:
- Before: `recordings/.../before-absolute-watchdog-kills-active-turn.mp4` (repro-agent run [33438284756](https://github.com/omnigent-ai/omnigent-internal/actions/runs/33438284756) artifact `repro-bundle-33438284756`)
- After: `recordings/.../after-absolute-watchdog-spares-active-turn.webm` (this resolve run's artifact bundle)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The e2e test exercises the identical scaffold code path with the product's own env knob scaling the 3 h ceiling to 10 s; the unit tests cover the extension, the strict-cap fallback, and the stall backstop.

## Changelog

Long-running agent turns that keep making progress are no longer killed by the 3-hour absolute turn watchdog
