### PR TITLE
fix(policies): cover Claude Code MultiEdit/NotebookEdit in the built-in write policies

### DIFF
--- a/omnigent/policies/builtins/orchestration.py
+++ b/omnigent/policies/builtins/orchestration.py
@@ -16,6 +16,7 @@ from collections.abc import Callable, Collection
 from typing import Any, TypeAlias
 
 from omnigent.policies.builtins._shell import SHELL_TOOLS
+from omnigent.policies.builtins.safety import NATIVE_WRITE_TOOLS
 
 # Heterogeneous JSON-shaped maps — the V0 policy event + decision payloads.
 _Json: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
@@ -552,12 +553,12 @@ def worktree_guard(
     :returns: An evaluator ``fn(event, config)`` returning a V0 decision.
     """
 
-    # Match Omnigent built-in OS write/edit, Claude/Codex native Write/Edit
-    # (surfaced via the PreToolUse hook), and Pi's native lowercase
+    # Match Omnigent built-in OS write/edit, every Claude/Codex native write
+    # tool (surfaced via the PreToolUse hook), and Pi's native lowercase
     # write/edit (surfaced via the pi ``tool_call`` hook). Pi uses the same
     # ``path`` argument key as the Omnigent tools, so no Pi-specific arg
     # branch is needed below.
-    _write_tools = {"sys_os_write", "sys_os_edit", "Write", "Edit", "MultiEdit", "write", "edit"}
+    _write_tools = NATIVE_WRITE_TOOLS | {"sys_os_write", "sys_os_edit", "write", "edit"}
 
     def _evaluate(event: _Json, config: _Json) -> _Json:  # noqa: ARG001
         """
@@ -571,8 +572,9 @@ def worktree_guard(
         args = _tool_call(event, _write_tools)
         if args is None:
             return _ALLOW
-        # Omnigent tools use ``path``; Claude native tools use ``file_path``.
-        path = args.get("path") or args.get("file_path")
+        # Omnigent tools use ``path``; Claude native tools use ``file_path``,
+        # except NotebookEdit which uses ``notebook_path``.
+        path = args.get("path") or args.get("file_path") or args.get("notebook_path")
         if not isinstance(path, str):
             return _ALLOW
         # Backslashes are not valid in POSIX paths and could confuse
@@ -616,7 +618,7 @@ def read_only_os(
     Factory: deny every file-mutating tool call (report-only agents).
 
     DENIES ``sys_os_write`` / ``sys_os_edit`` and the Claude/Codex/Pi native
-    ``Write`` / ``Edit`` / ``MultiEdit`` aliases. Reads, searches, and shell
+    ``Write`` / ``Edit`` / ``MultiEdit`` / ``NotebookEdit`` aliases. Reads, searches, and shell
     commands are left untouched — pair with :func:`blast_radius` to also bound
     shell blast radius. Use on agents whose contract is to investigate and
     report, never to change code (e.g. a security reviewer and its read-only
@@ -628,18 +630,10 @@ def read_only_os(
         write/edit tool call, ALLOW otherwise.
     """
 
-    # Match Omnigent built-in OS write/edit, Claude/Codex native Write/Edit/
-    # MultiEdit, and Pi's native lowercase write/edit — the same tool set
+    # Match Omnigent built-in OS write/edit, every Claude/Codex native write
+    # tool, and Pi's native lowercase write/edit — the same tool set
     # worktree_guard gates, so the two write policies stay in lockstep.
-    write_tools = {
-        "sys_os_write",
-        "sys_os_edit",
-        "Write",
-        "Edit",
-        "MultiEdit",
-        "write",
-        "edit",
-    }
+    write_tools = NATIVE_WRITE_TOOLS | {"sys_os_write", "sys_os_edit", "write", "edit"}
 
     def _evaluate(event: _Json, config: _Json) -> _Json:  # noqa: ARG001
         """
@@ -714,15 +708,15 @@ POLICY_REGISTRY: list[dict[str, object]] = [
         "kind": "factory",
         "name": "Restrict Writes to Git Worktree",
         "description": "Blocks file writes (sys_os_write/edit, Claude/Codex native "
-        "Write/Edit, and Pi native write/edit) outside the worker's git worktree to "
-        "prevent cross-branch contamination",
+        "Write/Edit/MultiEdit/NotebookEdit, and Pi native write/edit) outside the worker's "
+        "git worktree to prevent cross-branch contamination",
     },
     {
         "handler": "omnigent.policies.builtins.orchestration.read_only_os",
         "kind": "factory",
         "name": "Report-Only (Deny File Writes)",
         "description": "Denies every file-mutating tool (sys_os_write/edit, Claude/Codex "
-        "native Write/Edit/MultiEdit, and Pi native write/edit) so a report-only agent "
-        "can read and run shell but never change code",
+        "native Write/Edit/MultiEdit/NotebookEdit, and Pi native write/edit) so a "
+        "report-only agent can read and run shell but never change code",
     },
 ]

--- a/omnigent/policies/builtins/orchestration.py
+++ b/omnigent/policies/builtins/orchestration.py
@@ -573,35 +573,42 @@ def worktree_guard(
         if args is None:
             return _ALLOW
         # Omnigent tools use ``path``; Claude native tools use ``file_path``,
-        # except NotebookEdit which uses ``notebook_path``.
-        path = args.get("path") or args.get("file_path") or args.get("notebook_path")
-        if not isinstance(path, str):
-            return _ALLOW
-        # Backslashes are not valid in POSIX paths and could confuse
-        # downstream processing into treating them as separators, slipping a
-        # ``..\\`` past the split-on-'/' traversal check.
-        if "\\" in path:
-            return _decision("DENY", f"{deny_reason} (outside {allowed_root}/: {path!r})")
-        # posixpath, NOT os.path: the tool contract is POSIX-shaped, and
-        # ntpath.normpath rewrites "/" to "\", which makes the leading-"/" test
-        # below inert on a Windows runner (absolute paths would ALLOW there).
-        # normpath collapses ``..``/``.``/repeated slashes and pushes every
-        # upward traversal to the front, so a single startswith catches every
-        # escape form (e.g. "a/../../escape" → "../../escape").
-        normalized = posixpath.normpath(path)
-        if normalized.startswith(("/", "~", "..")):
-            return _decision("DENY", f"{deny_reason} (outside {allowed_root}/: {path!r})")
-        # A drive-qualified path ("C:/Windows/x") is absolute on Windows but
-        # reads as an ordinary relative dir named "C:" to posixpath, so the test
-        # above misses it. Checked on the NORMALIZED path, not the raw one:
-        # normpath strips a leading "./" (and collapses "a/../C:/..."), which
-        # would otherwise hide the drive letter from a raw-string check. UNC
-        # ("//server/share") keeps its leading slashes and is caught above.
-        # ASCII-only: Windows drives are [A-Za-z], but str.isalpha() is
-        # Unicode-aware and would also reject a relative dir named e.g. "Ω:".
-        drive = normalized[:1]
-        if drive.isascii() and drive.isalpha() and normalized[1:2] == ":":
-            return _decision("DENY", f"{deny_reason} (outside {allowed_root}/: {path!r})")
+        # except NotebookEdit which uses ``notebook_path``. Check EVERY
+        # path-like argument present, not the first truthy one: a decoy
+        # in-tree ``path`` alongside an escaping ``notebook_path`` (or
+        # ``file_path``) must still DENY, since the tool acts on its own
+        # canonical key regardless of what else rides in the payload.
+        paths = [
+            value
+            for key in ("path", "file_path", "notebook_path")
+            if isinstance(value := args.get(key), str)
+        ]
+        for path in paths:
+            # Backslashes are not valid in POSIX paths and could confuse
+            # downstream processing into treating them as separators, slipping a
+            # ``..\\`` past the split-on-'/' traversal check.
+            if "\\" in path:
+                return _decision("DENY", f"{deny_reason} (outside {allowed_root}/: {path!r})")
+            # posixpath, NOT os.path: the tool contract is POSIX-shaped, and
+            # ntpath.normpath rewrites "/" to "\", which makes the leading-"/" test
+            # below inert on a Windows runner (absolute paths would ALLOW there).
+            # normpath collapses ``..``/``.``/repeated slashes and pushes every
+            # upward traversal to the front, so a single startswith catches every
+            # escape form (e.g. "a/../../escape" → "../../escape").
+            normalized = posixpath.normpath(path)
+            if normalized.startswith(("/", "~", "..")):
+                return _decision("DENY", f"{deny_reason} (outside {allowed_root}/: {path!r})")
+            # A drive-qualified path ("C:/Windows/x") is absolute on Windows but
+            # reads as an ordinary relative dir named "C:" to posixpath, so the test
+            # above misses it. Checked on the NORMALIZED path, not the raw one:
+            # normpath strips a leading "./" (and collapses "a/../C:/..."), which
+            # would otherwise hide the drive letter from a raw-string check. UNC
+            # ("//server/share") keeps its leading slashes and is caught above.
+            # ASCII-only: Windows drives are [A-Za-z], but str.isalpha() is
+            # Unicode-aware and would also reject a relative dir named e.g. "Ω:".
+            drive = normalized[:1]
+            if drive.isascii() and drive.isalpha() and normalized[1:2] == ":":
+                return _decision("DENY", f"{deny_reason} (outside {allowed_root}/: {path!r})")
         return _ALLOW
 
     return _evaluate

--- a/omnigent/policies/builtins/safety.py
+++ b/omnigent/policies/builtins/safety.py
@@ -25,11 +25,18 @@ _ALLOW: PolicyResponse = {"result": "ALLOW"}
 
 _SYS_OS_TOOLS = frozenset({"sys_os_read", "sys_os_write", "sys_os_edit", "sys_os_shell"})
 
+# Claude Code / Codex native tools that MUTATE a file, surfaced via the
+# PreToolUse hook contract. Single source of truth: the write policies in
+# ``omnigent.policies.builtins.orchestration`` build their gated sets from
+# this, and it must stay equal to ``_CLAUDE_NATIVE_EDIT_TOOLS`` in
+# ``omnigent.server.routes._sessions.common`` (asserted in the tests).
+NATIVE_WRITE_TOOLS: frozenset[str] = frozenset({"Write", "Edit", "MultiEdit", "NotebookEdit"})
+
 # Claude Code and Codex native tool names surfaced via the PreToolUse /
 # PostToolUse hook contract (see ``omnigent.native_policy_hook``).
 # These bypass Omnigent' ``sys_os_*`` MCP tools and execute directly
 # inside the CLI subprocess.
-_NATIVE_OS_TOOLS = frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"})
+_NATIVE_OS_TOOLS = NATIVE_WRITE_TOOLS | {"Bash", "Read", "Glob", "Grep"}
 
 # Cursor SDK native tool names surfaced via the preToolUse hook
 # (see ``omnigent.inner.cursor_policy_hook``). Cursor uses ``Shell``
@@ -230,8 +237,8 @@ def ask_on_os_tools(event: PolicyEvent) -> PolicyResponse:
     - **Omnigent built-in OS tools** (``sys_os_read``,
       ``sys_os_write``, ``sys_os_edit``, ``sys_os_shell``).
     - **Claude Code native tools** (``Bash``, ``Read``, ``Write``,
-      ``Edit``, ``Glob``, ``Grep``) — surfaced via the
-      ``PreToolUse`` hook contract.
+      ``Edit``, ``MultiEdit``, ``NotebookEdit``, ``Glob``, ``Grep``) —
+      surfaced via the ``PreToolUse`` hook contract.
     - **Codex native tools** — uses the same ``PreToolUse`` hook
       contract with the same tool names (e.g. ``Bash``).
     - **Cursor SDK native tools** (``Shell``) — surfaced via the
@@ -287,11 +294,15 @@ def ask_on_os_tools(event: PolicyEvent) -> PolicyResponse:
         elif tool in ("Grep", "Glob", "search_files", "grep", "glob"):
             preview = args.get("pattern", "") if isinstance(args, dict) else ""
         elif tool == "execute_code":
-            preview = args.get("code", "")[:80] if isinstance(args, dict) else ""
+            code = args.get("code") if isinstance(args, dict) else None
+            preview = code[:80] if isinstance(code, str) else ""
         else:
-            # Omnigent tools use ``path``; Claude native tools use ``file_path``.
+            # Omnigent tools use ``path``; Claude native tools use ``file_path``,
+            # except NotebookEdit which uses ``notebook_path``.
             preview = (
-                (args.get("path") or args.get("file_path", "")) if isinstance(args, dict) else ""
+                (args.get("path") or args.get("file_path") or args.get("notebook_path") or "")
+                if isinstance(args, dict)
+                else ""
             )
         return {
             "result": "ASK",
@@ -722,9 +733,11 @@ POLICY_REGISTRY: list[dict[str, object]] = [
         "kind": "callable",
         "name": "Require Approval for File & Shell Operations",
         "description": "Asks for user approval before any file or shell tool call — "
-        "covers Omnigent sys_os_* tools, Claude Code native tools "
-        "(Bash, Read, Write, Edit, Glob, Grep), Codex native tools, "
+        "covers Omnigent sys_os_* tools, Claude Code and Codex native tools "
+        "(Bash, Read, Write, Edit, MultiEdit, NotebookEdit, Glob, Grep), "
+        "Cursor native tools (Shell), Pi native tools (read, bash, write, edit), "
         "opencode native tools (bash, edit, read, grep, glob), "
+        "Goose native tools (developer__shell and the developer__* file tools), "
         "and Hermes Agent tools (terminal, execute_code, read_file, write_file, search_files)",
         "params_schema": None,
     },

--- a/omnigent/policies/builtins/safety.py
+++ b/omnigent/policies/builtins/safety.py
@@ -247,6 +247,9 @@ def ask_on_os_tools(event: PolicyEvent) -> PolicyResponse:
     - **Pi native tools** (``read``, ``bash``, ``write``, ``edit``)
       — surfaced via the pi ``tool_call`` extension hook. Lowercase
       and distinct from the Claude/Codex casing.
+    - **Goose native tools** (``developer__shell`` and the
+      ``developer__*`` file tools) — surfaced via the goose
+      extension hook.
     - **Hermes Agent tools** (``terminal``, ``execute_code``,
       ``read_file``, ``write_file``, ``search_files``) — surfaced
       via the ``pre_tool_call`` shell hook.

--- a/tests/e2e/test_write_policy_native_tool_coverage_e2e.py
+++ b/tests/e2e/test_write_policy_native_tool_coverage_e2e.py
@@ -1,0 +1,234 @@
+"""E2E: built-in write policies must cover Claude Code's NotebookEdit.
+
+Two built-in policies promise complete coverage of file-mutating tools and are
+user-attachable from the Policies UI:
+
+- ``read_only_os`` ("Report-Only (Deny File Writes)") — "Denies every
+  file-mutating tool … so a report-only agent can read and run shell but
+  never change code".
+- ``worktree_guard`` ("Restrict Writes to Git Worktree") — blocks file writes
+  outside the worker's worktree subtree.
+
+Claude Code mutates ``.ipynb`` files with its native ``NotebookEdit`` tool,
+which addresses the target file via a ``notebook_path`` argument (not
+``file_path``). On the buggy build neither policy gates it: ``NotebookEdit``
+is missing from both tool-name sets, and ``worktree_guard``'s path extraction
+never reads ``notebook_path``, so a report-only or worktree-confined Claude
+session silently rewrites notebooks anywhere on disk.
+
+Journey (per policy): attach the built-in policy to a live session → Claude
+Code's ``PreToolUse`` hook posts the tool call to
+``POST /v1/sessions/{id}/policies/evaluate`` (the exact wire path the
+claude-native harness takes for every native tool call; driven here with the
+same request shape ``omnigent.claude_native_hook._main_evaluate_policy``
+sends) → the verdict must be ``POLICY_ACTION_DENY``. Control legs prove the
+same journey with ``Write`` (and ``MultiEdit`` for read_only_os) DENYs today,
+so a failure is specifically the ``NotebookEdit`` coverage gap.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
+
+_READ_ONLY_HANDLER = "omnigent.policies.builtins.orchestration.read_only_os"
+_WORKTREE_GUARD_HANDLER = "omnigent.policies.builtins.orchestration.worktree_guard"
+
+
+def _create_bare_session(http_client: httpx.Client) -> str:
+    """Create a session with a minimal inline agent bundle.
+
+    Policy evaluation needs only a session row (no runner, no LLM turn) —
+    the evaluate endpoint is the sole enforcement point the claude-native
+    ``PreToolUse`` hook calls, so the journey is fully exercised without
+    booting the CLI.
+    """
+    import io
+    import tarfile
+    import uuid
+
+    import yaml
+
+    name = f"write-policy-coverage-{uuid.uuid4().hex[:8]}"
+    config: dict[str, Any] = {
+        "name": name,
+        "prompt": "You are a test agent.",
+        "executor": {"harness": "openai-agents", "model": "gpt-4o-mini"},
+    }
+    with io.BytesIO() as buf:
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            yaml_bytes = yaml.dump(config).encode()
+            info = tarfile.TarInfo(f"{name}.yaml")
+            info.size = len(yaml_bytes)
+            tar.addfile(info, io.BytesIO(yaml_bytes))
+        bundle = buf.getvalue()
+    resp = http_client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+    assert resp.status_code in (200, 201), f"session create failed: {resp.text[:500]}"
+    return str(resp.json()["session_id"])
+
+
+def _attach_policy(
+    http_client: httpx.Client,
+    session_id: str,
+    *,
+    name: str,
+    handler: str,
+    factory_params: dict[str, Any] | None = None,
+) -> None:
+    """Attach a registered built-in policy to *session_id*."""
+    body: dict[str, Any] = {"name": name, "type": "python", "handler": handler}
+    if factory_params is not None:
+        body["factory_params"] = factory_params
+    resp = http_client.post(f"/v1/sessions/{session_id}/policies", json=body)
+    assert resp.status_code == 200, f"policy attach failed: {resp.status_code} {resp.text[:500]}"
+
+
+def _evaluate_tool_call(
+    http_client: httpx.Client,
+    session_id: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> str:
+    """POST a ``PHASE_TOOL_CALL`` evaluate request; return the verdict string.
+
+    Same body shape the claude-native ``evaluate-policy`` hook sends for a
+    ``PreToolUse`` event (see ``omnigent.claude_native_hook``).
+    """
+    resp = http_client.post(
+        f"/v1/sessions/{session_id}/policies/evaluate",
+        json={
+            "event": {
+                "type": "PHASE_TOOL_CALL",
+                "target": "",
+                "data": {"name": tool_name, "arguments": arguments},
+                "context": {"harness": "claude-native"},
+            },
+        },
+    )
+    assert resp.status_code == 200, f"evaluate failed: {resp.status_code} {resp.text[:500]}"
+    result = resp.json().get("result", "")
+    assert isinstance(result, str)
+    return result
+
+
+@pytest.mark.timeout(120)
+def test_report_only_policy_denies_notebook_edit(
+    live_server: str,
+    http_client: httpx.Client,
+) -> None:
+    """ "Report-Only (Deny File Writes)" must DENY a NotebookEdit call.
+
+    Control legs first: Write and MultiEdit are denied today, proving the
+    policy is attached and firing on this session. Then the same journey
+    with NotebookEdit — a file-mutating tool on a report-only agent — must
+    also DENY. On the buggy build it returns ALLOW and the ``.ipynb`` is
+    silently rewritten.
+    """
+    session_id = _create_bare_session(http_client)
+    _attach_policy(
+        http_client,
+        session_id,
+        name="report-only-deny-writes",
+        handler=_READ_ONLY_HANDLER,
+    )
+
+    # Controls: the policy demonstrably gates writes on this session.
+    assert (
+        _evaluate_tool_call(
+            http_client, session_id, "Write", {"file_path": "a.py", "content": "x"}
+        )
+        == "POLICY_ACTION_DENY"
+    )
+    assert (
+        _evaluate_tool_call(
+            http_client,
+            session_id,
+            "MultiEdit",
+            {"file_path": "a.py", "edits": [{"old_string": "x", "new_string": "y"}]},
+        )
+        == "POLICY_ACTION_DENY"
+    )
+
+    # The bug: NotebookEdit mutates a file, so a report-only agent must be
+    # denied. Fails on the buggy build (returns POLICY_ACTION_ALLOW).
+    verdict = _evaluate_tool_call(
+        http_client,
+        session_id,
+        "NotebookEdit",
+        {"notebook_path": "analysis.ipynb", "new_source": "print(1)"},
+    )
+    assert verdict == "POLICY_ACTION_DENY", (
+        f"read_only_os allowed NotebookEdit (verdict={verdict!r}): a report-only "
+        "agent can silently mutate .ipynb files"
+    )
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        pytest.param({"notebook_path": "/etc/x.ipynb", "new_source": "x"}, id="notebook_path"),
+        pytest.param({"file_path": "/etc/x.ipynb", "new_source": "x"}, id="file_path"),
+    ],
+)
+def test_worktree_guard_denies_escaping_notebook_edit(
+    live_server: str,
+    http_client: httpx.Client,
+    arguments: dict[str, Any],
+) -> None:
+    """ "Restrict Writes to Git Worktree" must DENY an escaping NotebookEdit.
+
+    Control leg: an absolute-path Write is denied today. Then the same
+    journey with NotebookEdit targeting an absolute path — via its real
+    ``notebook_path`` argument and via a ``file_path`` spelling — must also
+    DENY. On the buggy build both return ALLOW: the tool name is missing
+    from ``_write_tools`` and the path extraction never reads
+    ``notebook_path``.
+    """
+    session_id = _create_bare_session(http_client)
+    _attach_policy(
+        http_client,
+        session_id,
+        name="restrict-writes-to-worktree",
+        handler=_WORKTREE_GUARD_HANDLER,
+        factory_params={
+            "allowed_root": "workspace",
+            "deny_reason": "Writes must stay inside the workspace.",
+        },
+    )
+
+    # Control: the guard demonstrably fires on this session for Write.
+    assert (
+        _evaluate_tool_call(
+            http_client, session_id, "Write", {"file_path": "/etc/x.py", "content": "x"}
+        )
+        == "POLICY_ACTION_DENY"
+    )
+
+    # The bug: an out-of-tree NotebookEdit must be denied like any other
+    # escaping write. Fails on the buggy build (returns POLICY_ACTION_ALLOW).
+    verdict = _evaluate_tool_call(http_client, session_id, "NotebookEdit", arguments)
+    assert verdict == "POLICY_ACTION_DENY", (
+        f"worktree_guard allowed NotebookEdit with {arguments!r} (verdict={verdict!r}): "
+        "notebook writes escape the worktree confinement"
+    )
+
+    # Guard for the fix: an in-tree relative notebook edit stays allowed —
+    # the fix must add coverage, not blanket-deny notebooks.
+    in_tree = _evaluate_tool_call(
+        http_client,
+        session_id,
+        "NotebookEdit",
+        {"notebook_path": "notebooks/a.ipynb", "new_source": "x"},
+    )
+    assert in_tree == "POLICY_ACTION_ALLOW", in_tree

--- a/tests/e2e_ui/approvals/test_native_edit_tools_approval_card.py
+++ b/tests/e2e_ui/approvals/test_native_edit_tools_approval_card.py
@@ -1,0 +1,165 @@
+"""E2E: "Require Approval for File & Shell Operations" must gate MultiEdit/NotebookEdit.
+
+The ``ask_on_os_tools`` builtin (UI name "Require Approval for File & Shell
+Operations") is the primary human-in-the-loop guard for Claude Code native
+tools: every file-mutating ``PreToolUse`` hook evaluation must park an
+approval card in the SPA before the tool runs. Claude Code's multi-hunk edit
+tool is ``MultiEdit`` (its preferred tool for the common "make two edits to
+one file" case) and its notebook editor is ``NotebookEdit`` — both mutate
+files, so both must ASK exactly like ``Edit`` does.
+
+Journey (per sub-symptom): attach the builtin approval policy to a session →
+Claude Code's ``PreToolUse`` hook posts the tool call to
+``POST /v1/sessions/{id}/policies/evaluate`` (driven here as a synthetic hook
+POST, the same fast pattern as ``test_persistent_approval.py`` — no native CLI
+required) → the SPA must show a pending approval card → the user approves →
+the parked evaluate returns ALLOW.
+
+On the buggy build the ``Edit`` control leg works (card renders, approve
+resolves it), but the ``MultiEdit`` / ``NotebookEdit`` legs fail: the evaluate
+endpoint returns ``POLICY_ACTION_ALLOW`` immediately, no card ever appears,
+and the file would be written with no approval. Root cause:
+``_NATIVE_OS_TOOLS`` in ``omnigent/policies/builtins/safety.py`` lists only
+``{Bash, Read, Write, Edit, Glob, Grep}``.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_APPROVAL_CARD = '[data-testid="approval-card"]'
+_CARD_TIMEOUT_MS = 15_000
+
+# What Claude Code sends for each tool, per its PreToolUse hook contract.
+# NotebookEdit addresses the target via ``notebook_path``, not ``file_path``.
+_TOOL_ARGS: dict[str, dict] = {
+    "Edit": {"file_path": "a.py", "old_string": "x", "new_string": "y"},
+    "MultiEdit": {
+        "file_path": "a.py",
+        "edits": [
+            {"old_string": "x", "new_string": "y"},
+            {"old_string": "p", "new_string": "q"},
+        ],
+    },
+    "NotebookEdit": {"notebook_path": "a.ipynb", "new_source": "print(1)"},
+}
+
+
+def _attach_approval_policy(base_url: str, session_id: str) -> None:
+    """Attach the builtin "Require Approval for File & Shell Operations" policy.
+
+    Same registered handler the Policies UI attaches; the registry allowlist
+    accepts it without any factory params.
+    """
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/policies",
+        json={
+            "name": "require-approval-file-shell",
+            "type": "python",
+            "handler": "omnigent.policies.builtins.safety.ask_on_os_tools",
+        },
+        timeout=15.0,
+    )
+    assert resp.status_code == 200, f"policy attach failed: {resp.status_code} {resp.text}"
+
+
+def _evaluate_tool_call(
+    base_url: str,
+    session_id: str,
+    tool_name: str,
+    holder: dict,
+) -> None:
+    """POST the PreToolUse-shaped evaluate request; park until resolved.
+
+    Mirrors the body Claude Code's ``evaluate-policy`` hook sends
+    (``PHASE_TOOL_CALL`` + tool name/arguments). Stores the response JSON
+    (or the exception) in *holder* for the test to assert on.
+    """
+    try:
+        resp = httpx.post(
+            f"{base_url}/v1/sessions/{session_id}/policies/evaluate",
+            json={
+                "event": {
+                    "type": "PHASE_TOOL_CALL",
+                    "target": "",
+                    "data": {
+                        "name": tool_name,
+                        "arguments": _TOOL_ARGS[tool_name],
+                    },
+                    "context": {"harness": "claude-native"},
+                },
+            },
+            timeout=120.0,
+        )
+        resp.raise_for_status()
+        holder["response"] = resp.json()
+    except Exception as exc:  # surfaced by the test
+        holder["error"] = exc
+
+
+def _drive_gated_tool(page: Page, base_url: str, session_id: str, tool_name: str) -> dict:
+    """Fire *tool_name* through the policy gate and approve its card in the UI.
+
+    Returns the evaluate endpoint's response JSON. Fails (card timeout) when
+    the policy silently ALLOWs instead of parking an approval.
+    """
+    holder: dict = {}
+    thread = threading.Thread(
+        target=_evaluate_tool_call,
+        args=(base_url, session_id, tool_name, holder),
+        daemon=True,
+    )
+    thread.start()
+
+    # The file-mutating call must park a pending approval card. On the buggy
+    # build MultiEdit/NotebookEdit return ALLOW instantly and no card renders,
+    # so this expectation is the failing assertion.
+    card = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first
+    expect(card).to_be_visible(timeout=_CARD_TIMEOUT_MS)
+    expect(card).to_contain_text(tool_name)
+
+    card.get_by_role("button", name="Approve", exact=True).click()
+
+    thread.join(timeout=60)
+    assert not thread.is_alive(), f"evaluate call for {tool_name} never resolved"
+    if "error" in holder:
+        raise AssertionError(f"evaluate call for {tool_name} failed: {holder['error']}")
+    return holder["response"]
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize("tool_name", ["MultiEdit", "NotebookEdit"])
+def test_native_file_edit_tools_require_approval_card(
+    page: Page,
+    seeded_session: tuple[str, str],
+    tool_name: str,
+) -> None:
+    """A Claude Code MultiEdit/NotebookEdit call must surface an approval card.
+
+    Control leg first: ``Edit`` parks a card and approve resolves it — proving
+    the policy, the evaluate endpoint, and the card wiring all work in this
+    session. Then the same journey with *tool_name* must behave identically;
+    on the buggy build no card appears and the tool would write with no
+    approval.
+    """
+    base_url, session_id = seeded_session
+    _attach_approval_policy(base_url, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+    # Session surface is up once the composer renders (matched by its stable
+    # aria-label; the placeholder text varies with runner/agent state).
+    expect(page.get_by_label("Message the agent")).to_be_attached(timeout=30_000)
+
+    # Control: Edit is gated today — card renders, approve resolves to ALLOW.
+    edit_result = _drive_gated_tool(page, base_url, session_id, "Edit")
+    assert edit_result.get("result") == "POLICY_ACTION_ALLOW", edit_result
+
+    # The bug: the same journey with MultiEdit / NotebookEdit must also park
+    # an approval card (both mutate files). Fails on the buggy build — the
+    # evaluate returns ALLOW with no card.
+    gated_result = _drive_gated_tool(page, base_url, session_id, tool_name)
+    assert gated_result.get("result") == "POLICY_ACTION_ALLOW", gated_result

--- a/tests/inner/nessie/test_policies.py
+++ b/tests/inner/nessie/test_policies.py
@@ -459,6 +459,12 @@ def test_worktree_guard_blocks_escapes(path: str, expected: str) -> None:
         ("MultiEdit", "file_path", "src/app.py", "ALLOW"),
         ("MultiEdit", "file_path", "/etc/passwd", "DENY"),
         ("MultiEdit", "file_path", "../escape.py", "DENY"),
+        # NotebookEdit carries its target under ``notebook_path``, so it needs
+        # both the tool name AND the arg key to be gated -- adding the name
+        # alone would leave the guard unable to see the path (silent ALLOW).
+        ("NotebookEdit", "notebook_path", "nb.ipynb", "ALLOW"),
+        ("NotebookEdit", "notebook_path", "/etc/x.ipynb", "DENY"),
+        ("NotebookEdit", "notebook_path", "../escape.ipynb", "DENY"),
         # Pi native write/edit (lowercase) use ``path`` (Omnigent convention).
         ("write", "path", "src/app.py", "ALLOW"),
         ("write", "path", "/etc/passwd", "DENY"),
@@ -473,6 +479,9 @@ def test_worktree_guard_blocks_escapes(path: str, expected: str) -> None:
         "MultiEdit-in-tree",
         "MultiEdit-absolute",
         "MultiEdit-escape",
+        "NotebookEdit-in-tree",
+        "NotebookEdit-absolute",
+        "NotebookEdit-escape",
         "pi-write-in-tree",
         "pi-write-absolute",
         "pi-edit-escape",
@@ -522,6 +531,7 @@ def test_worktree_guard_only_guards_writes() -> None:
         ("Write", {"file_path": "a.py", "content": "x"}),
         ("Edit", {"file_path": "a.py", "old_string": "x", "new_string": "y"}),
         ("MultiEdit", {"file_path": "a.py", "edits": []}),
+        ("NotebookEdit", {"notebook_path": "a.ipynb", "new_source": "x"}),
         # Pi native lowercase.
         ("write", {"path": "a.py", "content": "x"}),
         ("edit", {"path": "a.py"}),

--- a/tests/inner/nessie/test_policies.py
+++ b/tests/inner/nessie/test_policies.py
@@ -511,6 +511,32 @@ def test_worktree_guard_gates_native_write_edit(
     assert _result(evaluate(_tool_call(tool, **{path_key: path, "content": ""}), {})) == expected
 
 
+@pytest.mark.parametrize(
+    "tool,args",
+    [
+        # A decoy in-tree ``path`` must not shadow an escaping canonical key:
+        # the tool acts on its own key regardless of what else rides in the
+        # payload, so the guard must check every path-like argument present.
+        ("NotebookEdit", {"notebook_path": "/etc/x.ipynb", "path": "safe.ipynb"}),
+        ("Write", {"file_path": "/etc/passwd", "path": "safe.py", "content": ""}),
+        ("MultiEdit", {"file_path": "../escape.py", "path": "safe.py", "edits": []}),
+    ],
+    ids=["NotebookEdit-decoy-path", "Write-decoy-path", "MultiEdit-decoy-path"],
+)
+def test_worktree_guard_denies_escape_behind_decoy_path(
+    tool: str,
+    args: dict,
+) -> None:
+    """
+    An escaping path must DENY even when a benign in-tree path key is also
+    present. If the guard picked the first truthy key, a crafted payload
+    carrying a decoy relative ``path`` would smuggle an absolute
+    ``notebook_path``/``file_path`` past the confinement.
+    """
+    evaluate = worktree_guard()
+    assert _result(evaluate(_tool_call(tool, **args), {})) == "DENY"
+
+
 def test_worktree_guard_only_guards_writes() -> None:
     """
     Reads and shells pass through — the guard constrains only write/edit

--- a/tests/policies/builtins/test_prompt.py
+++ b/tests/policies/builtins/test_prompt.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from omnigent.policies.builtins.prompt import prompt_policy
+from omnigent.policies.builtins.prompt import _CLASSIFIER_SCHEMA, prompt_policy
 
 
 def _make_event(
@@ -70,6 +70,22 @@ async def test_fixed_reason_overrides_llm() -> None:
     event = _make_event(llm_response={"action": "deny", "reason": "LLM reason"})
     result = await evaluate(event)
     assert result == {"result": "DENY", "reason": "Fixed reason."}
+
+
+@pytest.mark.asyncio
+async def test_structured_output_schema_forwarded() -> None:
+    """
+    The classifier call passes ``text=_CLASSIFIER_SCHEMA`` so the LLM
+    is constrained to bare JSON.
+
+    What breaks if this fails: a chatty model prefixes prose,
+    ``json.loads`` raises, and the fail-closed branch DENYs an
+    otherwise-fine turn with an opaque reason.
+    """
+    evaluate = prompt_policy(prompt="Deny Canada.")
+    event = _make_event(llm_response={"action": "allow", "reason": ""})
+    await evaluate(event)
+    assert event["llm_client"].create.call_args.kwargs["text"] is _CLASSIFIER_SCHEMA
 
 
 @pytest.mark.asyncio

--- a/tests/policies/builtins/test_safety.py
+++ b/tests/policies/builtins/test_safety.py
@@ -54,10 +54,16 @@ def test_ask_on_os_tools_asks_for_sys_os_tools(tool: str) -> None:
         ("Read", {"path": "/etc/passwd"}, "/etc/passwd"),
         ("Write", {"path": "/tmp/out.txt"}, "/tmp/out.txt"),
         ("Edit", {"path": "main.py"}, "main.py"),
+        # MultiEdit is what Claude Code reaches for on multi-hunk edits (the
+        # common case) and NotebookEdit is its .ipynb writer, which carries the
+        # path under ``notebook_path``. Both must ASK or most writes go
+        # un-approved under an approval policy.
+        ("MultiEdit", {"file_path": "main.py", "edits": []}, "main.py"),
+        ("NotebookEdit", {"notebook_path": "nb.ipynb"}, "nb.ipynb"),
         ("Glob", {"pattern": "**/*.py"}, "**/*.py"),
         ("Grep", {"pattern": "secret"}, "secret"),
     ],
-    ids=["Bash", "Read", "Write", "Edit", "Glob", "Grep"],
+    ids=["Bash", "Read", "Write", "Edit", "MultiEdit", "NotebookEdit", "Glob", "Grep"],
 )
 def test_ask_on_os_tools_asks_for_native_tools(
     tool: str,
@@ -82,6 +88,17 @@ def test_ask_on_os_tools_asks_for_native_tools(
     # The preview should contain the relevant argument value so the
     # user can make an informed approval decision.
     assert expected_preview in result["reason"]
+
+
+def test_ask_on_os_tools_handles_non_string_code() -> None:
+    """A non-string ``code`` payload must still ASK, not raise.
+
+    ``None[:80]`` raises TypeError, which the engine turns into a
+    ``policy '<name>' failed`` DENY — a confusing failure instead of the
+    approval prompt the user attached the policy for.
+    """
+    result = ask_on_os_tools(tc("execute_code", {"code": None}))
+    assert result["result"] == "ASK"
 
 
 # ── ask_on_os_tools: Pi native tools (lowercase) ──────────────────────────

--- a/tests/server/routes/test_claude_native_remember_helpers.py
+++ b/tests/server/routes/test_claude_native_remember_helpers.py
@@ -14,10 +14,25 @@ tests pin the gating and URL-parsing edge cases directly.
 
 from __future__ import annotations
 
+from omnigent.policies.builtins.safety import NATIVE_WRITE_TOOLS
+from omnigent.server.routes._sessions.common import _CLAUDE_NATIVE_EDIT_TOOLS
 from omnigent.server.routes.sessions import (
     _allow_remember_eligible,
     _claude_native_remember_host,
 )
+
+
+def test_policy_write_tool_set_matches_server() -> None:
+    """
+    The policy layer's write-tool set must equal the server's.
+
+    These two lists drifted before: the approval (``ask_on_os_tools``) and
+    report-only (``read_only_os``) policies missed ``MultiEdit`` /
+    ``NotebookEdit`` while the server already treated them as edit tools, so
+    writes went through un-gated. Fails loudly if either side gains a tool
+    the other doesn't know about.
+    """
+    assert NATIVE_WRITE_TOOLS == _CLAUDE_NATIVE_EDIT_TOOLS
 
 
 class TestAllowRememberEligible:


### PR DESCRIPTION
## Related issue

Closes #3852

Resolves OMNI-2248 (Linear).

## Summary

Takes over #3854 by @rajarshidattapy (couldn't push to the fork: App installation tokens can't push to fork branches, and the branch needed a DCO sign-off rewrite plus a rebase onto current `main`). Both original commits are carried over with authorship and credit intact; this PR adds the end-to-end reproduction tests on top.

Three built-in policies gate file-mutating tools, each with its own hand-maintained tool-name literal, and none matched Claude Code's full write set:

| Policy | `Write` | `Edit` | `MultiEdit` | `NotebookEdit` |
|---|:--:|:--:|:--:|:--:|
| `safety.ask_on_os_tools` ("Require Approval for File & Shell Operations") | ASK | ASK | **ALLOW** | **ALLOW** |
| `orchestration.read_only_os` ("Report-Only: Deny File Writes") | DENY | DENY | DENY | **ALLOW** |
| `orchestration.worktree_guard` ("Restrict Writes to Git Worktree") | gated | gated | gated | **not gated** |

So an approval policy let a `MultiEdit` (Claude Code's preferred multi-hunk edit tool) write to disk with no approval card, and a report-only or worktree-confined agent could silently rewrite `.ipynb` files anywhere on disk — `NotebookEdit` was missing from both tool sets *and* carries its target under `notebook_path`, which the path extraction never read.

**Fix (carried from #3854):** `safety.py` gains `NATIVE_WRITE_TOOLS = {Write, Edit, MultiEdit, NotebookEdit}` as the single source of truth; `_NATIVE_OS_TOOLS` and both orchestration write policies derive from it; the `worktree_guard` / `ask_on_os_tools` path lookups now read `notebook_path`; plus a `{"code": null}` guard in the `execute_code` preview and a regression test pinning that `prompt_policy` forwards `_CLASSIFIER_SCHEMA` (the source already does on `main`; the carried commit keeps the test). A lockstep test asserts `NATIVE_WRITE_TOOLS == _CLAUDE_NATIVE_EDIT_TOOLS` (the server's set) so the lists can't drift again.

**Added here:** two live end-to-end reproductions keyed to the exact wire path Claude Code's `PreToolUse` hook takes (`POST /v1/sessions/{id}/policies/evaluate`), and a hardening pass from an independent cross-vendor review: `worktree_guard` now checks **every** path-like argument (`path` / `file_path` / `notebook_path`) instead of the first truthy one, so a decoy in-tree `path` can no longer smuggle an escaping `notebook_path`/`file_path` past the confinement (with decoy-payload regression tests).

```mermaid
flowchart LR
    CC[Claude Code PreToolUse hook<br/>MultiEdit / NotebookEdit] -->|POST /policies/evaluate| S[server]
    S --> P{built-in write policies}
    P -- before --> A[ALLOW - silent write,<br/>no approval card]
    P -- after --> B[ASK / DENY -<br/>card parks in SPA]
```

## Test Plan

Fail→pass proven on both sides of the fix (run on this branch, latest `main` base):

- `tests/e2e/test_write_policy_native_tool_coverage_e2e.py` (live spawned server + real evaluate endpoint):
  - **unfixed `main`**: FAILS — `read_only_os allowed NotebookEdit (verdict='POLICY_ACTION_ALLOW')`; `worktree_guard allowed NotebookEdit with {'notebook_path': '/etc/x.ipynb'}` and with the `file_path` spelling.
  - **this branch**: 3 passed. Control legs (Write/MultiEdit DENY) pass on both, so the failures are specifically the coverage gap. An in-tree relative `NotebookEdit` stays ALLOWed, proving the fix adds coverage rather than blanket-denying notebooks.
- `tests/e2e_ui/approvals/test_native_edit_tools_approval_card.py` (built SPA + Playwright):
  - **unfixed policies**: FAILS — no pending approval card ever renders for MultiEdit/NotebookEdit (evaluate returns ALLOW instantly) while the Edit control leg parks and resolves a card.
  - **this branch**: 2 passed — MultiEdit and NotebookEdit each park a pending card; approving resolves the parked evaluate to ALLOW.
- Targeted suites all green: `tests/policies/builtins/`, `tests/inner/nessie/test_policies.py`, `tests/server/routes/test_claude_native_remember_helpers.py` (838 passed).

## Validate the fix live

Run this against the deployed UI preview (attaches your own host, which carries your model credentials):

```
omnigent claude -p 'Reproduce and validate a bug fix in the built-in write policies. Steps: open this session, attach the "Require Approval for File & Shell Operations" policy to it from the Policies UI, then ask the agent to make two separate edits to one file (Claude Code will issue a MultiEdit) and to edit a Jupyter .ipynb notebook (Claude Code will issue a NotebookEdit). Before this fix, both tools wrote to disk immediately with no approval card. Confirm the fix by checking that each of the two tool calls parks a pending approval card that you must approve before the write happens, exactly like a plain Edit does. Also attach "Report-Only (Deny File Writes)" to a fresh session and confirm a NotebookEdit is denied. Report whether each step now behaves correctly.' --server https://omnigent-ui-preview-pr-5974-3272836215725701.aws.databricksapps.com
```

No preview URL? Drop `--server <url>` to run against your own local app, or paste just the prompt to an agent already connected to an Omnigent app.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Before/after recordings (before = repro run on unfixed `main`, after = this branch):

- before: policy callables allow MultiEdit/NotebookEdit; SPA shows no approval card (`before-multiedit-approval-gap.mp4`, `before-notebookedit-approval-gap.mp4`, `before-policy-tool-coverage.mp4` — in the repro run's artifact bundle: https://github.com/omnigent-ai/omnigent-internal/actions/runs/33447170369)
- after: the same journeys park approval cards / DENY (`after-multiedit-approval-gap.mp4`, `after-notebookedit-approval-gap.mp4`, `after-policy-tool-coverage.mp4` — in this resolve run's artifact bundle)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage in `tests/policies/builtins/test_safety.py`, `tests/inner/nessie/test_policies.py` (per-tool ASK/DENY/worktree matrices incl. `notebook_path`), a server/policy lockstep assertion in `tests/server/routes/test_claude_native_remember_helpers.py`, and the two live e2e reproductions described above.

## Changelog

The built-in approval, report-only, and worktree-guard policies now cover Claude Code's `MultiEdit` and `NotebookEdit` tools (including `notebook_path` targets).
