### PR TITLE
fix(codex-native): settle command approvals rejected by hook

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -3809,7 +3809,7 @@ async def _codex_elicitation_hook_result(
     :param client: HTTP client for Omnigent hook posts.
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
     :param event: Codex JSON-RPC request envelope.
-    :returns: Parsed JSON-RPC result payload, or ``None``.
+    :returns: Parsed JSON-RPC result, a safe command rejection, or ``None``.
     """
     method = event.get("method")
     request_id = event.get("id")
@@ -3827,6 +3827,10 @@ async def _codex_elicitation_hook_result(
             response.status_code,
             response.text[:512],
         )
+        # A malformed optional execpolicy decision must not leave Codex's
+        # command request unanswered and strand the active turn.
+        if method == _CODEX_COMMAND_EXECUTION_REQUEST_APPROVAL_METHOD:
+            return {"decision": "decline"}
         return None
     if not response.content:
         _logger.info(

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -4966,6 +4966,64 @@ def test_forwarder_sends_codex_command_approval_response_to_app_server(
     assert fake_client.responses == [(14, {"decision": "accept"})]
 
 
+def test_forwarder_declines_codex_command_when_approval_hook_rejects_request(
+    tmp_path: Path,
+) -> None:
+    """A rejected Omnigent hook must not leave Codex waiting forever."""
+    fake_client = _FakeCodexAppServerClient()
+    codex_event = {
+        "id": 14,
+        "method": "item/commandExecution/requestApproval",
+        "params": {
+            "threadId": "thread_123",
+            "turnId": "turn_123",
+            "itemId": "item_cmd",
+            "command": "date",
+            "availableDecisions": [
+                {
+                    "acceptWithExecpolicyAmendment": {
+                        "execpolicy_amendment": [],
+                    }
+                }
+            ],
+        },
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/sessions/conv_123/hooks/codex-elicitation-request"
+        assert json.loads(request.content) == codex_event
+        return httpx.Response(
+            400,
+            json={
+                "error": {
+                    "code": "invalid_input",
+                    "message": ("Codex execpolicy amendment must be a non-empty list of strings."),
+                }
+            },
+        )
+
+    async def run() -> None:
+        async with httpx.AsyncClient(
+            base_url="http://127.0.0.1:8000",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            elicitation_tracker = _elicitation_tracker()
+            await codex_native_forwarder._handle_event(
+                client,
+                session_id="conv_123",
+                bridge_dir=tmp_path,
+                usage_coalescer=_usage_coalescer(client),
+                elicitation_tracker=elicitation_tracker,
+                event=codex_event,
+                codex_client=fake_client,  # type: ignore[arg-type]
+            )
+            await elicitation_tracker.drain()
+
+    asyncio.run(run())
+
+    assert fake_client.responses == [(14, {"decision": "decline"})]
+
+
 def test_forwarder_routes_unregistered_child_command_approval_to_parent(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #5975

## Summary

- Return a safe `decline` response to Codex when Omnigent rejects a command-approval hook request.
- Prevent the active Codex turn from waiting forever after malformed optional execpolicy amendment data.
- Add a regression test through the forwarder's event-handling seam using the production 400 response.

ELI5: if Omnigent cannot process an approval request, it now tells Codex “no” instead of leaving Codex waiting for an answer that will never arrive.

```mermaid
flowchart LR
    A[Codex command approval] --> B[Omnigent hook]
    B -->|2xx| C[Forward hook decision]
    B -->|4xx/5xx| D[Reply decline]
    D --> E[Settle Codex request]
```

## Test Plan

- Verified the regression test failed before the fix: no response was sent to the fake Codex app-server client.
- `uv run --no-sync pytest -q tests/test_codex_native.py` — 245 passed.
- `uv run --no-sync pre-commit run --all-files` — all hooks passed.
- Applied the patch to the affected local 0.11.0 install and retried the same `ssh-keygen` command-approval path. Codex received `Rejected("rejected by user")`, the turn completed, the session returned to `idle`, and `active_response_id` cleared instead of remaining stuck.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Before: hook HTTP 400 left the app-server response list empty and the active turn stuck.

After: the forwarder sends `{"decision": "decline"}` for the same command-approval request, allowing the turn to settle. This was also verified against the original affected local session.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new regression test drives `_handle_event`, waits for the asynchronous elicitation tracker to drain, and asserts the exact JSON-RPC response returned to Codex. Manual verification used the original affected session after safely stopping its orphaned response and reconnecting the same persisted Codex thread.

## Changelog

Codex command-approval hook failures no longer leave active turns waiting indefinitely
