### PR TITLE
fix(policies): warn when a RESPONSE-phase policy is unreachable on claude-sdk

### DIFF
--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -87,6 +87,7 @@ from omnigent.server.routes._sessions.orchestration import (
 from omnigent.server.schemas import (
     ElicitationRequestParams,
 )
+from omnigent.spec import AgentSpec
 from omnigent.spec.types import (
     Phase,
     PolicyAction,
@@ -125,6 +126,172 @@ def _create_route_decision_id(
             if isinstance(decision_id, str) and decision_id:
                 return decision_id
     return None
+
+
+# Harnesses whose LLM-phase round trip (PHASE_LLM_REQUEST / PHASE_LLM_RESPONSE via
+# this route) never also posts the assistant message back through
+# ``POST .../events``. Phase.RESPONSE is only ever evaluated from that POST (see
+# ``_evaluate_output_policy`` in ``_sessions/helpers.py``), so a RESPONSE-phase
+# policy declared on one of these harnesses is structurally unreachable, not just
+# advisory. Confirmed on ``claude-sdk`` (omnigent-ai/omnigent#5939): a complete
+# session's access log shows exactly one ``POST .../events`` — the user's own
+# message — regardless of how many assistant turns follow.
+_HARNESSES_WITHOUT_RESPONSE_PHASE_DELIVERY: frozenset[str] = frozenset({"claude-sdk"})
+
+# Session ids already warned about an unreachable RESPONSE-phase policy, so the
+# warning fires once per session rather than once per LLM round trip. Unbounded
+# but session ids are naturally bounded by process lifetime; a restart clears it.
+_warned_unreachable_response_policy_sessions: set[str] = set()
+
+
+def _unreachable_response_phase_policy_names(spec: AgentSpec) -> list[str]:
+    """
+    Names of *spec*'s guardrail policies bound to ``Phase.RESPONSE``.
+
+    Only catches policies where that's knowable statically: a declarative
+    policy's ``on:`` (explicit, or the ``[request, response]`` default when
+    omitted — see ``_parse_policy_base_fields``). Every policy the spec
+    parser accepts today is ``type: function`` (``type: prompt`` was
+    removed), and a function policy's ``on:`` is discarded at parse time
+    regardless of what the bundle author wrote — the callable self-selects
+    phases at runtime by inspecting the event it's called with. So this
+    finds nothing on any bundle constructible today; it exists so a
+    reintroduced declarative policy type (or the legacy shape, if some
+    caller still constructs one directly rather than through the parser)
+    is caught precisely instead of falling through to the general caveat
+    in :func:`_warn_if_response_phase_policy_unreachable`.
+
+    :param spec: The agent's parsed spec.
+    :returns: Policy names bound to ``Phase.RESPONSE``, in declaration
+        order. Empty if none, or if the spec has no guardrails.
+    """
+    guardrails = spec.guardrails
+    if guardrails is None or guardrails.policies is None:
+        return []
+    return [
+        policy.name
+        for policy in guardrails.policies
+        if policy.on is not None and any(selector.phase == Phase.RESPONSE for selector in policy.on)
+    ]
+
+
+def _self_selecting_policy_names(spec: AgentSpec) -> list[str]:
+    """
+    Names of *spec*'s guardrail policies with no statically-declared
+    ``on:`` — i.e. every ``type: function`` policy, which self-selects
+    which event types it handles at runtime (see
+    :func:`_unreachable_response_phase_policy_names`).
+
+    These are exactly the policies :func:`_warn_if_response_phase_policy_unreachable`
+    can't clear or convict: unlike a policy with an explicit, RESPONSE-free
+    ``on:`` (provably unaffected), a self-selecting policy might act on a
+    ``response`` event and this harness will never give it the chance to
+    find out.
+
+    :param spec: The agent's parsed spec.
+    :returns: Policy names with ``on is None``, in declaration order.
+        Empty if none, or if the spec has no guardrails.
+    """
+    guardrails = spec.guardrails
+    if guardrails is None or guardrails.policies is None:
+        return []
+    return [policy.name for policy in guardrails.policies if policy.on is None]
+
+
+def _warn_if_response_phase_policy_unreachable(
+    *, session_id: str, phase: Phase, spec: AgentSpec
+) -> None:
+    """
+    Log once if *spec*'s guardrails include a policy this session's
+    harness can never deliver a RESPONSE-phase event to
+    (omnigent-ai/omnigent#5939).
+
+    Called from the LLM-phase round trip (``PHASE_LLM_REQUEST`` /
+    ``PHASE_LLM_RESPONSE``) rather than refusing the session outright:
+    the gap is real and worth surfacing loudly, but a hard refusal would
+    break every existing bundle that happens to use the ``[request,
+    response]`` default on one of these harnesses, most of which also
+    declare a working ``llm_response`` or ``tool_call`` policy alongside
+    it. A once-per-session warning is the minimum bar the issue asks for
+    ("Silently advisory is the worst of the three").
+
+    Three-way split, because which policies are actually affected is only
+    sometimes knowable ahead of time:
+
+    - :func:`_unreachable_response_phase_policy_names` names policies
+      whose ``on:`` is statically known to include ``response``
+      (currently only a theoretical case — the only policy type the spec
+      parser accepts today, ``type: function``, discards ``on:`` and
+      self-selects its phase at runtime; a reintroduced declarative type
+      would light this path back up for free). When it finds names, one
+      warning line accuses them by name.
+    - :func:`_self_selecting_policy_names` names policies whose phase
+      isn't statically known at all — every ``type: function`` policy,
+      which is the actual case for every bundle constructible today.
+      These can't be cleared or convicted, so a second warning line
+      names them as a caveat rather than an accusation.
+    - A policy with an explicit ``on:`` that provably excludes
+      ``response`` is neither — it's cleared, and never mentioned.
+      If every policy clears, nothing is logged at all: there's nothing
+      to warn about.
+
+    :param session_id: Session/conversation identifier.
+    :param phase: The phase this evaluation call was for. Only
+        ``LLM_REQUEST`` / ``LLM_RESPONSE`` are checked — those are what
+        confirm we're on a harness's own LLM round trip, as opposed to
+        the message-POST path that (when reached) evaluates
+        ``Phase.RESPONSE`` correctly on its own.
+    :param spec: The agent's parsed spec.
+    """
+    if phase not in (Phase.LLM_REQUEST, Phase.LLM_RESPONSE):
+        return
+    if session_id in _warned_unreachable_response_policy_sessions:
+        return
+    harness = spec.executor.config.get("harness") or spec.executor.type
+    if harness not in _HARNESSES_WITHOUT_RESPONSE_PHASE_DELIVERY:
+        return
+    guardrails = spec.guardrails
+    if guardrails is None or not guardrails.policies:
+        return
+    unreachable = _unreachable_response_phase_policy_names(spec)
+    unknowable = _self_selecting_policy_names(spec)
+    if not unreachable and not unknowable:
+        # Every policy has an explicit on: that provably excludes
+        # response — nothing here could be affected either way.
+        return
+    _warned_unreachable_response_policy_sessions.add(session_id)
+    if unreachable:
+        _logger.warning(
+            "policy_response_phase_unreachable: session %s (harness=%s) declares "
+            "RESPONSE-phase polic%s %s. This harness's LLM round trip never "
+            "evaluates Phase.RESPONSE, and the separate evaluator that would "
+            "(_evaluate_output_policy) only runs when the assistant message is "
+            "posted back through POST .../events, which this harness does not do. "
+            "%s will not be enforced for this session — output the policy is meant "
+            "to gate may reach the user unchecked.",
+            session_id,
+            harness,
+            "y" if len(unreachable) == 1 else "ies",
+            unreachable,
+            "This policy" if len(unreachable) == 1 else "These policies",
+        )
+    if unknowable:
+        _logger.warning(
+            "policy_response_phase_unreachable: session %s (harness=%s) has "
+            "self-selecting polic%s %s configured, and this harness's LLM round "
+            "trip never evaluates Phase.RESPONSE — the separate evaluator that "
+            "would (_evaluate_output_policy) only runs when the assistant "
+            "message is posted back through POST .../events, which this harness "
+            "does not do. If any of %s gates on event type 'response' rather "
+            "than 'llm_response', it will never fire for this session; this "
+            "can't be confirmed from the spec alone since function-type "
+            "policies self-select their phase at runtime.",
+            session_id,
+            harness,
+            "y" if len(unknowable) == 1 else "ies",
+            unknowable,
+            "it" if len(unknowable) == 1 else "them",
+        )
 
 
 def register_hooks_routes(
@@ -811,6 +978,9 @@ def register_hooks_routes(
             )
 
         engine = _build_engine(conv)
+        _warn_if_response_phase_policy_unreachable(
+            session_id=session_id, phase=phase, spec=loaded.spec
+        )
         # Use the turn-initiating human's identity (persisted at forward time)
         # so per-user policies gate on the correct actor even when the HTTP
         # caller is the runner's service-account credential.  Falls back to

--- a/tests/server/integration/test_response_phase_policy_warning_e2e.py
+++ b/tests/server/integration/test_response_phase_policy_warning_e2e.py
@@ -1,0 +1,190 @@
+"""
+End-to-end test for the RESPONSE-phase-unreachable warning
+(omnigent-ai/omnigent#5939), through the real
+``POST /v1/sessions/{id}/policies/evaluate`` route rather than calling
+the detection functions directly.
+
+A ``claude-sdk`` agent whose guardrails declare a policy has that
+policy's ``response``-phase handling (if any) silently never
+evaluated: this harness's own turn loop only ever asks this route for
+``PHASE_LLM_REQUEST`` / ``PHASE_LLM_RESPONSE``, and the separate route
+that would ask for ``PHASE_RESPONSE`` (``POST .../events`` with an
+assistant message) is never reached in this topology. This confirms
+the real route logs a loud warning instead of doing nothing.
+
+The only policy type the spec parser accepts today is ``type:
+function`` (``type: prompt`` was removed — see
+``_parse_policy_spec``), and a function policy self-selects which
+event types it handles at runtime rather than declaring them in
+``on:``, so these tests exercise the general-caveat warning tier, not
+the (currently unreachable via the parser) precise-names tier that
+``tests/server/routes/test_response_phase_policy_warning.py`` covers
+directly against a hand-built spec.
+
+Uses the shared ``client`` fixture from ``tests/server/conftest.py``
+(real stores + mock LLM), same as the sibling
+``test_sessions_policy_evaluate.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.server.helpers import create_test_agent
+
+pytestmark = pytest.mark.asyncio
+
+
+def _tripwire_policy(event: dict[str, Any]) -> dict[str, Any]:
+    """Self-selecting policy that would deny a ``response`` event
+    containing a marker — mirrors the issue's own repro
+    (``tripwire_policy.py``). Never actually reached by the LLM-phase
+    round trip this test drives, which is exactly the bug: the
+    function is declared and would act on ``response``, but nothing
+    ever calls it with one in this topology."""
+    if event.get("type") != "response":
+        return {"result": "ALLOW"}
+    return {"result": "DENY", "reason": "tripwire hit"}
+
+
+async def _create_session(client: httpx.AsyncClient, agent_id: str) -> str:
+    resp = await client.post("/v1/sessions", json={"agent_id": agent_id})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _llm_response_payload() -> dict[str, object]:
+    return {
+        "event": {
+            "type": "PHASE_LLM_RESPONSE",
+            "data": {"model": "gpt-4o", "text_preview": "Hello!", "tool_calls_count": 0},
+            "context": {},
+        },
+    }
+
+
+async def test_claude_sdk_session_with_guardrails_warns_on_llm_response_call(
+    client: httpx.AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A claude-sdk agent with any guardrail policy logs the general-caveat
+    unreachable-response-phase warning the first time an LLM-phase
+    evaluation call comes in for its session — the realistic case today,
+    since every constructible policy is ``type: function`` and
+    self-selects its phase, so the exact affected policy can't be named
+    without executing it.
+    """
+    agent = await create_test_agent(
+        client,
+        executor={"type": "omnigent", "config": {"harness": "claude-sdk"}},
+        guardrails={
+            "policies": {
+                "tripwire": {
+                    "type": "function",
+                    "function": f"{__name__}._tripwire_policy",
+                },
+            },
+        },
+    )
+    session_id = await _create_session(client, agent["id"])
+
+    with caplog.at_level(logging.WARNING):
+        resp = await client.post(
+            f"/v1/sessions/{session_id}/policies/evaluate",
+            json=_llm_response_payload(),
+        )
+    assert resp.status_code == 200
+
+    matching = [r for r in caplog.records if "policy_response_phase_unreachable" in r.getMessage()]
+    assert matching, f"expected the warning, got: {[r.getMessage() for r in caplog.records]}"
+    assert session_id in matching[0].getMessage()
+    assert "claude-sdk" in matching[0].getMessage()
+
+
+async def test_second_llm_call_in_same_session_does_not_warn_again(
+    client: httpx.AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The warning fires once per session, not once per round trip."""
+    agent = await create_test_agent(
+        client,
+        executor={"type": "omnigent", "config": {"harness": "claude-sdk"}},
+        guardrails={
+            "policies": {
+                "tripwire": {
+                    "type": "function",
+                    "function": f"{__name__}._tripwire_policy",
+                },
+            },
+        },
+    )
+    session_id = await _create_session(client, agent["id"])
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(2):
+            resp = await client.post(
+                f"/v1/sessions/{session_id}/policies/evaluate",
+                json=_llm_response_payload(),
+            )
+            assert resp.status_code == 200
+
+    matching = [r for r in caplog.records if "policy_response_phase_unreachable" in r.getMessage()]
+    assert len(matching) == 1, f"expected exactly one warning, got {len(matching)}: {matching}"
+
+
+async def test_codex_session_with_same_guardrails_does_not_warn(
+    client: httpx.AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    The same guardrails on a harness not known to have this gap (codex)
+    must not trigger the warning — it's scoped to harnesses confirmed to
+    skip the message-POST path, not a blanket "any guardrails" alarm.
+    """
+    agent = await create_test_agent(
+        client,
+        executor={"type": "omnigent", "config": {"harness": "codex"}},
+        guardrails={
+            "policies": {
+                "tripwire": {
+                    "type": "function",
+                    "function": f"{__name__}._tripwire_policy",
+                },
+            },
+        },
+    )
+    session_id = await _create_session(client, agent["id"])
+
+    with caplog.at_level(logging.WARNING):
+        resp = await client.post(
+            f"/v1/sessions/{session_id}/policies/evaluate",
+            json=_llm_response_payload(),
+        )
+    assert resp.status_code == 200
+    assert not any("policy_response_phase_unreachable" in r.getMessage() for r in caplog.records)
+
+
+async def test_claude_sdk_session_without_guardrails_does_not_warn(
+    client: httpx.AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A claude-sdk agent with no guardrails at all has nothing to warn
+    about."""
+    agent = await create_test_agent(
+        client,
+        executor={"type": "omnigent", "config": {"harness": "claude-sdk"}},
+    )
+    session_id = await _create_session(client, agent["id"])
+
+    with caplog.at_level(logging.WARNING):
+        resp = await client.post(
+            f"/v1/sessions/{session_id}/policies/evaluate",
+            json=_llm_response_payload(),
+        )
+    assert resp.status_code == 200
+    assert not any("policy_response_phase_unreachable" in r.getMessage() for r in caplog.records)

--- a/tests/server/routes/test_response_phase_policy_warning.py
+++ b/tests/server/routes/test_response_phase_policy_warning.py
@@ -1,0 +1,249 @@
+"""Tests for the RESPONSE-phase-unreachable warning (omnigent-ai/omnigent#5939).
+
+A ``claude-sdk`` session's LLM-phase round trip (``PHASE_LLM_REQUEST`` /
+``PHASE_LLM_RESPONSE`` via ``POST .../policies/evaluate``) never also posts
+the assistant's message back through ``POST .../events``, so a guardrail
+policy that would act on a ``response`` event is declared but structurally
+never evaluated for that session — see the issue for the full trace.
+
+The spec parser only accepts ``type: function`` policies today (``type:
+prompt`` was removed), and a function policy discards whatever ``on:`` the
+bundle author wrote and self-selects its handled event types at runtime —
+so in practice we can never statically prove a given policy DOES act on
+``response``, only that a policy with an explicit, RESPONSE-free ``on:``
+does NOT. These tests cover all three outcomes
+(:func:`_unreachable_response_phase_policy_names`,
+:func:`_self_selecting_policy_names`) and the once-per-session warning
+trigger (:func:`_warn_if_response_phase_policy_unreachable`) in isolation,
+without spinning up the full route/DB stack.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from omnigent.server.routes.sessions.routes_hooks import (
+    _self_selecting_policy_names,
+    _unreachable_response_phase_policy_names,
+    _warn_if_response_phase_policy_unreachable,
+    _warned_unreachable_response_policy_sessions,
+)
+from omnigent.spec import AgentSpec
+from omnigent.spec.types import ExecutorSpec, GuardrailsSpec, Phase, PhaseSelector, PolicySpec
+
+
+def _spec(
+    *,
+    harness: str = "claude-sdk",
+    policies: list[PolicySpec] | None = None,
+    no_guardrails: bool = False,
+) -> AgentSpec:
+    """Build a minimal AgentSpec for these tests.
+
+    :param harness: Value written to ``executor.config["harness"]``.
+    :param policies: Policies to attach via a fresh ``GuardrailsSpec``.
+        ``None`` builds a ``GuardrailsSpec`` with no ``policies:`` key
+        (the "labels only, no policies" case).
+    :param no_guardrails: When true, ``guardrails`` is ``None`` entirely
+        (no ``guardrails:`` block in the bundle at all).
+    :returns: A populated :class:`AgentSpec`.
+    """
+    guardrails = None if no_guardrails else GuardrailsSpec(policies=policies)
+    return AgentSpec(
+        spec_version=1,
+        name="test-agent",
+        executor=ExecutorSpec(config={"harness": harness}),
+        guardrails=guardrails,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_warned_sessions():
+    """Isolate the module-level dedup set between tests."""
+    _warned_unreachable_response_policy_sessions.clear()
+    yield
+    _warned_unreachable_response_policy_sessions.clear()
+
+
+# ── _unreachable_response_phase_policy_names ────────────────────
+
+
+def test_finds_policy_with_explicit_response_phase():
+    policy = PolicySpec(name="redact_pii", on=[PhaseSelector(phase=Phase.RESPONSE)])
+    spec = _spec(policies=[policy])
+    assert _unreachable_response_phase_policy_names(spec) == ["redact_pii"]
+
+
+def test_finds_policy_bound_to_multiple_phases_including_response():
+    policy = PolicySpec(
+        name="redact_pii",
+        on=[PhaseSelector(phase=Phase.REQUEST), PhaseSelector(phase=Phase.RESPONSE)],
+    )
+    spec = _spec(policies=[policy])
+    assert _unreachable_response_phase_policy_names(spec) == ["redact_pii"]
+
+
+def test_ignores_policy_scoped_to_other_phases_only():
+    policy = PolicySpec(name="gate_tools", on=[PhaseSelector(phase=Phase.TOOL_CALL)])
+    spec = _spec(policies=[policy])
+    assert _unreachable_response_phase_policy_names(spec) == []
+
+
+def test_ignores_self_selecting_policy_since_on_is_discarded_at_parse_time():
+    # Real function-type policy instances always have on=None regardless of
+    # what the bundle YAML wrote (see _parse_policy_base_fields) — this
+    # models that, rather than a real function policy self-selecting
+    # "response" at runtime, which is undetectable statically.
+    policy = PolicySpec(name="tripwire", on=None)
+    spec = _spec(policies=[policy])
+    assert _unreachable_response_phase_policy_names(spec) == []
+
+
+def test_no_guardrails_returns_empty():
+    spec = _spec(no_guardrails=True)
+    assert _unreachable_response_phase_policy_names(spec) == []
+
+
+def test_guardrails_with_labels_but_no_policies_returns_empty():
+    # policies defaults to None on GuardrailsSpec — a bundle that only
+    # declares `guardrails.labels` and no `policies:` key hits this.
+    spec = _spec(policies=None)
+    assert _unreachable_response_phase_policy_names(spec) == []
+
+
+def test_preserves_declaration_order_for_multiple_matches():
+    policies = [
+        PolicySpec(name="first", on=[PhaseSelector(phase=Phase.RESPONSE)]),
+        PolicySpec(name="second", on=[PhaseSelector(phase=Phase.RESPONSE)]),
+    ]
+    spec = _spec(policies=policies)
+    assert _unreachable_response_phase_policy_names(spec) == ["first", "second"]
+
+
+# ── _self_selecting_policy_names ────────────────────────────────
+
+
+def test_finds_self_selecting_policy():
+    policy = PolicySpec(name="tripwire", on=None)
+    spec = _spec(policies=[policy])
+    assert _self_selecting_policy_names(spec) == ["tripwire"]
+
+
+def test_ignores_policy_with_explicit_on():
+    policy = PolicySpec(name="gate_tools", on=[PhaseSelector(phase=Phase.TOOL_CALL)])
+    spec = _spec(policies=[policy])
+    assert _self_selecting_policy_names(spec) == []
+
+
+def test_self_selecting_no_guardrails_returns_empty():
+    spec = _spec(no_guardrails=True)
+    assert _self_selecting_policy_names(spec) == []
+
+
+# ── _warn_if_response_phase_policy_unreachable ──────────────────
+
+
+def test_warns_naming_policy_with_explicit_response_phase(caplog):
+    spec = _spec(
+        harness="claude-sdk",
+        policies=[PolicySpec(name="redact_pii", on=[PhaseSelector(phase=Phase.RESPONSE)])],
+    )
+    with caplog.at_level(logging.WARNING):
+        _warn_if_response_phase_policy_unreachable(
+            session_id="conv_1", phase=Phase.LLM_RESPONSE, spec=spec
+        )
+    matching = [r for r in caplog.records if "redact_pii" in r.getMessage()]
+    assert matching, (
+        f"expected a warning naming redact_pii, got: {[r.getMessage() for r in caplog.records]}"
+    )
+    assert "conv_1" in matching[0].getMessage()
+    assert "claude-sdk" in matching[0].getMessage()
+
+
+def test_warns_as_caveat_for_self_selecting_policy(caplog):
+    spec = _spec(
+        harness="claude-sdk",
+        policies=[PolicySpec(name="tripwire", on=None)],
+    )
+    with caplog.at_level(logging.WARNING):
+        _warn_if_response_phase_policy_unreachable(
+            session_id="conv_1", phase=Phase.LLM_RESPONSE, spec=spec
+        )
+    matching = [r for r in caplog.records if "tripwire" in r.getMessage()]
+    got = [r.getMessage() for r in caplog.records]
+    assert matching, f"expected a caveat warning naming tripwire, got: {got}"
+    assert "self-select" in matching[0].getMessage()
+
+
+def test_does_not_warn_when_every_policy_provably_excludes_response(caplog):
+    # gate_tools has an explicit on: that names only TOOL_CALL — provably
+    # not affected, and it's the only policy, so there's nothing to caveat
+    # either.
+    spec = _spec(
+        policies=[PolicySpec(name="gate_tools", on=[PhaseSelector(phase=Phase.TOOL_CALL)])]
+    )
+    with caplog.at_level(logging.WARNING):
+        _warn_if_response_phase_policy_unreachable(
+            session_id="conv_1", phase=Phase.LLM_RESPONSE, spec=spec
+        )
+    assert not any("policy_response_phase_unreachable" in r.getMessage() for r in caplog.records)
+
+
+def test_second_call_for_same_session_does_not_warn_again(caplog):
+    spec = _spec(policies=[PolicySpec(name="tripwire", on=None)])
+    with caplog.at_level(logging.WARNING):
+        _warn_if_response_phase_policy_unreachable(
+            session_id="conv_1", phase=Phase.LLM_REQUEST, spec=spec
+        )
+        _warn_if_response_phase_policy_unreachable(
+            session_id="conv_1", phase=Phase.LLM_RESPONSE, spec=spec
+        )
+    matching = [r for r in caplog.records if "tripwire" in r.getMessage()]
+    assert len(matching) == 1, f"expected exactly one warning, got {len(matching)}: {matching}"
+
+
+def test_different_sessions_each_get_their_own_warning(caplog):
+    spec = _spec(policies=[PolicySpec(name="tripwire", on=None)])
+    with caplog.at_level(logging.WARNING):
+        _warn_if_response_phase_policy_unreachable(
+            session_id="conv_1", phase=Phase.LLM_RESPONSE, spec=spec
+        )
+        _warn_if_response_phase_policy_unreachable(
+            session_id="conv_2", phase=Phase.LLM_RESPONSE, spec=spec
+        )
+    matching = [r for r in caplog.records if "tripwire" in r.getMessage()]
+    assert len(matching) == 2
+
+
+def test_does_not_warn_for_unaffected_harness(caplog):
+    spec = _spec(
+        harness="codex",
+        policies=[PolicySpec(name="tripwire", on=None)],
+    )
+    with caplog.at_level(logging.WARNING):
+        _warn_if_response_phase_policy_unreachable(
+            session_id="conv_1", phase=Phase.LLM_RESPONSE, spec=spec
+        )
+    assert not any("tripwire" in r.getMessage() for r in caplog.records)
+
+
+def test_does_not_warn_for_non_llm_phase(caplog):
+    # A TOOL_CALL round trip isn't the signal we key off of — only the
+    # LLM-phase round trip confirms we're on this harness's own path.
+    spec = _spec(policies=[PolicySpec(name="tripwire", on=None)])
+    with caplog.at_level(logging.WARNING):
+        _warn_if_response_phase_policy_unreachable(
+            session_id="conv_1", phase=Phase.TOOL_CALL, spec=spec
+        )
+    assert not any("tripwire" in r.getMessage() for r in caplog.records)
+
+
+def test_does_not_warn_with_no_guardrails(caplog):
+    spec = _spec(no_guardrails=True)
+    with caplog.at_level(logging.WARNING):
+        _warn_if_response_phase_policy_unreachable(
+            session_id="conv_1", phase=Phase.LLM_RESPONSE, spec=spec
+        )
+    assert not any("policy_response_phase_unreachable" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Related issue

Closes #5939

## Summary

An agent's guardrails can declare a policy meant to gate the assistant's final response. On the claude-sdk harness, that policy is silently never evaluated: the harness's own LLM round trip only ever asks for `PHASE_LLM_REQUEST` / `PHASE_LLM_RESPONSE`, and the separate route that would evaluate `Phase.RESPONSE` (`_evaluate_output_policy`, triggered by the assistant's message being POSTed back through `POST .../events`) is never reached in this topology.

I traced the full delivery path first (server → runner → harness → executor) to rule out a plumbing bug — every hop that carries a DENY verdict checks out correctly. The real problem is structural: the assistant's answer streams to the client token by token as it's generated, and the `LLM_RESPONSE` policy check only runs after the full stream completes, by design (see the existing comment above the check in `inner/claude_sdk_executor.py`). So even a correct DENY at that point can only stop the turn from completing cleanly, not un-show text the client already streamed live. Actually enforcing this would mean buffering the entire response before showing any of it — a real feature with its own tradeoffs (streaming UX, multiple client surfaces), out of scope here. This PR is the smaller, honest half: stop the guardrail from silently doing nothing, without claiming to fix the streaming gap itself.

Warns once per session, naming the affected policy when that's knowable (a declarative policy with an explicit or defaulted `on: [response]`) and as a caveat when it isn't — which is every policy constructible today, since the only policy type the spec parser accepts, `type: function`, discards `on:` and self-selects its handled event types at runtime. A policy with an explicit `on:` that provably excludes `response` is cleared and never mentioned.

## Test Plan

Confirmed against the real `POST /v1/sessions/{id}/policies/evaluate` route, not just the detection functions in isolation: with the fix reverted the new end-to-end tests fail (no warning fires), and with it restored they pass. Full existing policy test suite still green: `tests/server/routes/test_sessions_policy.py`, `tests/server/integration/test_sessions_policy_evaluate.py`, `test_sessions_policy_evaluate_read_only.py`, `test_policy_deny_lifecycle_e2e.py`, `test_policy_ask_lifecycle_e2e.py` — 52 tests, all green.

`ruff check`, `ruff format --check`, and `pyrefly check` all clean on the touched file.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The warning as it actually fires, from the new e2e test hitting the real route:

```
policy_response_phase_unreachable: session conv_xyz (harness=claude-sdk) has
self-selecting policy 'tripwire' configured, and this harness's LLM round
trip never evaluates Phase.RESPONSE — the separate evaluator that would
(_evaluate_output_policy) only runs when the assistant message is posted
back through POST .../events, which this harness does not do. If any of it
gates on event type 'response' rather than 'llm_response', it will never
fire for this session; this can't be confirmed from the spec alone since
function-type policies self-select their phase at runtime.
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`tests/server/routes/test_response_phase_policy_warning.py` unit-tests the two detection helpers and the warning trigger directly against hand-built specs (covers the currently-theoretical "precise name" tier, which needs a declarative policy type the parser no longer accepts). `tests/server/integration/test_response_phase_policy_warning_e2e.py` drives the real route end to end with an actual `type: function` policy — the realistic case for every bundle constructible today — and is what caught that my first version (detecting only explicit `on: [response]`) would never fire in practice, which is why the fix has two warning tiers instead of one.

## Changelog

Warn once per session when a claude-sdk agent's guardrails include a policy that can never receive a RESPONSE-phase event in this harness, instead of silently doing nothing
