### PR TITLE
Keep resolve actions bot-attributed with fork pushes

### DIFF
--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -717,18 +717,15 @@ can land a fix depends on where its branch lives:
   - If `maintainerCanModify` is true and
     `git config --get omnigent.forkPushTokenFile` names a readable file, preserve
     the contributor's branch. Keep the App token exported as `GH_TOKEN` for all
-    visible actions. For the push only, read the fork token inside a non-traced
-    shell command, push directly to the exact fork repo/branch, then unset it:
+    visible actions. For the push only, use CI's credential-isolating helper:
     ```bash
-    token_file="$(git config --get omnigent.forkPushTokenFile)"
-    fork_token="$(cat "$token_file")"
-    git push "https://x-access-token:${fork_token}@github.com/<owner>/<repo>.git" \
-      "HEAD:refs/heads/<head-branch>"
-    unset fork_token
+    omnigent-push-fork --repo <owner>/<repo> --branch <head-branch>
     ```
-    Never print the URL, enable shell tracing, persist this URL as a remote, or
-    use the fork token for `gh pr comment`/`review`/`create`; those commands must
-    remain bot-attributed through the App token.
+    The helper uses `GIT_ASKPASS`, clears the checkout's App-token extraheader
+    only for that push, and keeps the maintainer token out of command arguments,
+    remote URLs, and git's failure output. Never read or copy the token file
+    yourself, and never use it for `gh pr comment`/`review`/`create`; those
+    commands must remain bot-attributed through the App token.
   - **If the fork PR needs a fix** and maintainer edits are disabled, the token
     file is absent, or the isolated push returns a real permission error →
     **take over: open your own PR**

--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -609,6 +609,12 @@ gh auth setup-git   # route git pushes through gh's credential helper with this 
   the command output. **Never** substitute a guess like "token expired" or "PAT
   is read-only" — those are false and drop the hand-off silently. Only a real,
   quoted failure goes in `maintainer_review`.
+- CI may also configure `omnigent.forkPushTokenFile`. That is a separate
+  maintainer credential for one purpose only: pushing a fix to an existing fork
+  PR whose author enabled maintainer edits. Never export it as `GH_TOKEN` and
+  never pass it to `gh`; PR creation, comments, reviews, labels, and every other
+  visible action must continue using the App token so GitHub attributes them to
+  `omni-resolve-agent[bot]`.
 
 Once the set is genuinely green:
 
@@ -704,12 +710,28 @@ can land a fix depends on where its branch lives:
   → you have write access. Push fixes the same as the author path, then re-check.
   Say in your review comments that you pushed, so the author isn't surprised.
 - **Fork PR** (the head branch is on a contributor's fork, `head.repo.fork ==
-  true`) → you **cannot** push to it. An App installation token is scoped to
-  `omnigent-ai/omnigent` only; GitHub does not honor "allow edits from maintainers"
-  for an App token (that grant is for maintainer *users*), so a push to the fork
-  branch is rejected. **Do not attempt the push** — it will always fail. Instead:
-  - **If the fork PR needs a fix** (repro test fails against it, CI is red from its
-    diff, or Polly flags a real blocking defect) → **take over: open your own PR**
+  true`) → the App token cannot push there, but CI may provide an isolated
+  maintainer credential specifically for that transport. Read
+  `maintainerCanModify`, `headRepositoryOwner`, `headRepository`, and
+  `headRefName` from `gh pr view`.
+  - If `maintainerCanModify` is true and
+    `git config --get omnigent.forkPushTokenFile` names a readable file, preserve
+    the contributor's branch. Keep the App token exported as `GH_TOKEN` for all
+    visible actions. For the push only, read the fork token inside a non-traced
+    shell command, push directly to the exact fork repo/branch, then unset it:
+    ```bash
+    token_file="$(git config --get omnigent.forkPushTokenFile)"
+    fork_token="$(cat "$token_file")"
+    git push "https://x-access-token:${fork_token}@github.com/<owner>/<repo>.git" \
+      "HEAD:refs/heads/<head-branch>"
+    unset fork_token
+    ```
+    Never print the URL, enable shell tracing, persist this URL as a remote, or
+    use the fork token for `gh pr comment`/`review`/`create`; those commands must
+    remain bot-attributed through the App token.
+  - **If the fork PR needs a fix** and maintainer edits are disabled, the token
+    file is absent, or the isolated push returns a real permission error →
+    **take over: open your own PR**
     that includes their work plus your fix. This is the same mechanic as the
     "approach is wrong" escape hatch (Step 2A), but the reason is different — the
     approach is fine, you just can't push the fix to a fork. Build it so the
@@ -727,7 +749,7 @@ can land a fix depends on where its branch lives:
       yours and close it **as the very next commands — before you emit the interim
       handoff (Step 3.5) and before you start driving Step 4**:
       ```
-      gh pr comment <fork-pr> --body 'Superseded by #<your-pr> — I took this over to add a fix I could not push to your fork (App tokens can’t push to forks). Your commits are carried over with credit. Thanks @<author>!'
+      gh pr comment <fork-pr> --body 'Superseded by #<your-pr> — I took this over to add a fix because maintainer fork updates were unavailable. Your commits are carried over with credit. Thanks @<author>!'
       gh pr close <fork-pr>
       ```
       Do **not** defer this to the end of Step 4: the session can drop mid-turn


### PR DESCRIPTION
## Related issue

N/A — resolve-agent credential attribution fix.

## Summary

- Keep the GitHub App token as `GH_TOKEN` for PR creation, comments, reviews, labels, and every other visible action.
- When CI provides `omnigent.forkPushTokenFile`, use its maintainer credential only for the exact one-shot `git push` to a fork branch with maintainer edits enabled.
- Retain the existing same-repo takeover fallback when maintainer fork updates are unavailable.

ELI5: the resolve bot signs and speaks for itself; the maintainer key is used only as a hidden key to open the contributor fork's git door.

Producer-side credential wiring: https://github.com/omnigent-ai/omnigent-internal/pull/200

## Test Plan

- Ran `uv tool run pre-commit run --files dev/resolve-agent/AGENTS.md`.
- Verified the fork path never exports the maintainer credential as `GH_TOKEN` or passes it to `gh`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The operating procedure now explicitly separates bot-attributed GitHub actions from the isolated fork-push transport credential.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This changes the resolve-agent operating contract. The internal workflow PR contains the executable wiring and regression assertions; this PR documents the required credential use inside the agent.
