### PR TITLE
fix(web): use forced theme for editor/terminal palette in managed omnigent

### DIFF
--- a/web/src/components/ProjectIconPicker.tsx
+++ b/web/src/components/ProjectIconPicker.tsx
@@ -6,10 +6,10 @@
 //     hover-revealed edit/remove affordances (the OMNI-3742 design).
 
 import { type CSSProperties, lazy, Suspense, useState } from "react";
-import { useTheme } from "next-themes";
 import { FolderIcon, Loader2Icon, PencilIcon, Trash2Icon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import { useUpdateProjectConfig } from "@/hooks/useConversations";
 import type { ProjectConfig } from "@/lib/projectsApi";
@@ -23,13 +23,13 @@ const loadEmojiData = async () => (await import("@emoji-mart/data")).default;
 
 /** A themed emoji-mart picker. Calls `onSelect` with the chosen unicode glyph. */
 export function EmojiPicker({ onSelect }: { onSelect: (native: string) => void }) {
-  const { resolvedTheme } = useTheme();
+  const mode = useResolvedThemeMode();
   return (
     <Suspense fallback={<div className="h-[420px] w-[352px]" aria-hidden />}>
       <Picker
         data={loadEmojiData}
         onEmojiSelect={(emoji: { native: string }) => onSelect(emoji.native)}
-        theme={resolvedTheme === "dark" ? "dark" : "light"}
+        theme={mode}
         navPosition="top"
         previewPosition="none"
         skinTonePosition="none"

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -10,7 +10,7 @@
 
 import { Loader2Icon } from "lucide-react";
 import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
-import { useTheme } from "next-themes";
+import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { copyText } from "@/lib/clipboard";
@@ -186,7 +186,7 @@ export function TerminalView({
   // Lets the close handler tell "stable connection finally dropped"
   // (reset the budget) from "re-dial died straight away" (burn it).
   const connectedAtRef = useRef<number | null>(null);
-  const { resolvedTheme } = useTheme();
+  const resolvedMode = useResolvedThemeMode();
   // Terminal theme is independent of the app theme: "auto" follows the app's
   // resolved appearance, while "light"/"dark" pin the terminal. Reading the
   // pref as state (seeded at mount, updated via the pub/sub) lets a Settings
@@ -195,7 +195,7 @@ export function TerminalView({
     readTerminalThemeMode(),
   );
   useEffect(() => subscribeTerminalTheme(setTerminalMode), []);
-  const isDark = resolveTerminalIsDark(terminalMode, resolvedTheme === "dark");
+  const isDark = resolveTerminalIsDark(terminalMode, resolvedMode === "dark");
   // Stable ref so the theme-update effect can reach the live session
   // without adding isDark to the attachSession deps (which would
   // reconnect the WebSocket on every theme change).

--- a/web/src/components/theme/useResolvedThemeMode.test.tsx
+++ b/web/src/components/theme/useResolvedThemeMode.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useResolvedThemeMode } from "./useResolvedThemeMode";
+
+// Controllable next-themes stub: each test sets what useTheme() returns.
+let themeReturn: { resolvedTheme?: string; forcedTheme?: string } = {};
+vi.mock("next-themes", () => ({ useTheme: () => themeReturn }));
+
+afterEach(() => {
+  themeReturn = {};
+});
+
+describe("useResolvedThemeMode", () => {
+  it("uses forcedTheme when resolvedTheme is unset (the embed case)", () => {
+    // The embed sets forcedTheme but next-themes leaves resolvedTheme unset —
+    // the exact managed regression: without the hook this normalized to light.
+    themeReturn = { forcedTheme: "dark", resolvedTheme: undefined };
+    const { result } = renderHook(() => useResolvedThemeMode());
+    expect(result.current).toBe("dark");
+  });
+
+  it("prefers forcedTheme over a conflicting resolvedTheme", () => {
+    themeReturn = { forcedTheme: "dark", resolvedTheme: "light" };
+    const { result } = renderHook(() => useResolvedThemeMode());
+    expect(result.current).toBe("dark");
+  });
+
+  it("falls back to resolvedTheme when no theme is forced (standalone)", () => {
+    themeReturn = { forcedTheme: undefined, resolvedTheme: "dark" };
+    const { result } = renderHook(() => useResolvedThemeMode());
+    expect(result.current).toBe("dark");
+  });
+
+  it("normalizes to light when neither is set", () => {
+    themeReturn = {};
+    const { result } = renderHook(() => useResolvedThemeMode());
+    expect(result.current).toBe("light");
+  });
+});

--- a/web/src/components/theme/useResolvedThemeMode.ts
+++ b/web/src/components/theme/useResolvedThemeMode.ts
@@ -1,0 +1,20 @@
+import { useTheme } from "next-themes";
+import { normalizeResolvedTheme, type ResolvedThemeMode } from "./themeMode";
+
+/**
+ * The concrete light/dark palette the app is rendering, honoring a forced theme.
+ *
+ * The managed/embedded island drives its palette with next-themes'
+ * `forcedTheme` (see `embed.tsx`), which — unlike a normal selection —
+ * does NOT feed back into `resolvedTheme`; there `resolvedTheme` stays
+ * unset and normalizes to light. Editor/terminal/3D themes that read
+ * `resolvedTheme` alone therefore render light on a dark embed. Prefer
+ * `forcedTheme` when present; standalone never sets it, so this is identical
+ * to reading `resolvedTheme` there.
+ *
+ * @returns Concrete `"light"` or `"dark"` mode to theme non-CSS surfaces with.
+ */
+export function useResolvedThemeMode(): ResolvedThemeMode {
+  const { resolvedTheme, forcedTheme } = useTheme();
+  return normalizeResolvedTheme(forcedTheme ?? resolvedTheme);
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -114,12 +114,8 @@ import { absoluteTime } from "@/lib/relativeTime";
 import { useNavigate } from "@/lib/routing";
 import { useSettingsRoute } from "@/shell/settingsNav";
 import { ImportSessionsPanel } from "@/shell/ImportSessionsPanel";
-import {
-  isThemeMode,
-  normalizeResolvedTheme,
-  normalizeThemeMode,
-  type ThemeMode,
-} from "@/components/theme/themeMode";
+import { isThemeMode, normalizeThemeMode, type ThemeMode } from "@/components/theme/themeMode";
+import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import {
   applyDesktopUiFontSize,
   applyUiFontFamily,
@@ -539,9 +535,9 @@ function WorkspacePanelDefaultControl() {
 }
 
 function ColorThemeControl() {
-  // Render each chip in the currently-resolved mode so it matches the app now.
-  const { resolvedTheme } = useTheme();
-  const isDark = normalizeResolvedTheme(resolvedTheme) === "dark";
+  // Render each chip in the currently-resolved mode so it matches the app now
+  // (honoring the embed's forced theme, not just next-themes' resolvedTheme).
+  const isDark = useResolvedThemeMode() === "dark";
   const [selection, setSelection] = useState<ThemeSelection>(() => readThemePalette());
   const [customTheme, setCustomTheme] = useState<CustomTheme>(() => readCustomTheme());
   const labelId = useId();

--- a/web/src/shell/ModelViewer.tsx
+++ b/web/src/shell/ModelViewer.tsx
@@ -10,14 +10,13 @@
 // geometry, materials, renderer, the animation frame, and the WebGL context are
 // all released so repeatedly opening model files can't leak GPU memory.
 
-import { useTheme } from "next-themes";
 import { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js";
 import { ThreeMFLoader } from "three/examples/jsm/loaders/3MFLoader.js";
 import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js";
-import { normalizeResolvedTheme } from "@/components/theme/themeMode";
+import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import { type FileContentResponse, fileContentToBlob } from "@/hooks/useFileContent";
 import {
   type ModelFormat,
@@ -228,8 +227,7 @@ export function ModelViewer({ data, path }: { data: FileContentResponse; path: s
   // Theme comes from the app's shared next-themes source (same hook Monaco and
   // the terminal use). `mode` is a stable "light"|"dark" string, so the theme
   // effect below re-runs only on an actual toggle.
-  const { resolvedTheme } = useTheme();
-  const mode = normalizeResolvedTheme(resolvedTheme);
+  const mode = useResolvedThemeMode();
 
   // The live scene, so the theme effect can recolor it without a rebuild, and
   // the latest theme, so the build effect can seed it without depending on the

--- a/web/src/shell/MonacoCodeEditor.tsx
+++ b/web/src/shell/MonacoCodeEditor.tsx
@@ -17,9 +17,8 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Editor, type EditorProps, type OnChange, type OnMount } from "@monaco-editor/react";
-import { useTheme } from "next-themes";
 import { AlertTriangleIcon, MessageSquareOffIcon } from "lucide-react";
-import { normalizeResolvedTheme } from "@/components/theme/themeMode";
+import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import {
   codeFontFamilyForEditor,
   readCodeFont,
@@ -220,8 +219,7 @@ function MonacoCodeEditorInner({
   pendingBodyRef,
 }: InnerProps) {
   const lang = detectLang(path);
-  const { resolvedTheme } = useTheme();
-  const monacoTheme = resolvedThemeToMonaco(normalizeResolvedTheme(resolvedTheme));
+  const monacoTheme = resolvedThemeToMonaco(useResolvedThemeMode());
 
   // Gate rendering until Shiki has registered the github themes + this file's
   // grammar, so the editor never flashes Monaco's default 'vs' theme.

--- a/web/src/shell/MonacoDiffViewer.tsx
+++ b/web/src/shell/MonacoDiffViewer.tsx
@@ -8,8 +8,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DiffEditor, type DiffEditorProps, type DiffOnMount } from "@monaco-editor/react";
-import { useTheme } from "next-themes";
-import { normalizeResolvedTheme } from "@/components/theme/themeMode";
+import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import {
   codeFontFamilyForEditor,
   readCodeFont,
@@ -73,8 +72,7 @@ export function MonacoDiffViewer({
 }: MonacoDiffViewerProps) {
   const canEdit = useCanEdit(conversationId);
   const lang = detectLang(path);
-  const { resolvedTheme } = useTheme();
-  const monacoTheme = resolvedThemeToMonaco(normalizeResolvedTheme(resolvedTheme));
+  const monacoTheme = resolvedThemeToMonaco(useResolvedThemeMode());
 
   // Gate rendering until Shiki has registered the github themes + this file's
   // grammar (so the diff never flashes Monaco's default 'vs' theme); surface an


### PR DESCRIPTION
## Related issue

N/A — no tracking issue (managed-omnigent dark-mode readability bug).

## Summary

In the **managed (embedded)** build, the Monaco file viewer rendered the **light** theme (`github-light`) on the dark app background — variable names, struct fields, params, and string literals came out near-black/navy and unreadable. Standalone was fine.

**Cause:** the embed drives its palette with next-themes **`forcedTheme`** (`embed.tsx`), which does **not** feed back into `resolvedTheme` — so in the embed `resolvedTheme` stays unset and normalizes to light. Every non-CSS surface that themes off `resolvedTheme` — Monaco code + diff viewers, the 3D `ModelViewer`, and the xterm terminal — therefore picked the light variant on a dark embed. (Chat code blocks were unaffected because they color via the `.dark` CSS class, not JS.)

**Fix:** add a shared `useResolvedThemeMode()` hook that prefers `forcedTheme ?? resolvedTheme`, and route the four consumers through it. Standalone never sets `forcedTheme`, so behavior there is **identical** — this only changes the embed.

## Test Plan

- Managed universe devloop in **dark mode**: opened a code file — variables/strings now render `github-dark` (readable) and the editor uses the `vs-dark` base (was `vs`). Confirmed via DevTools that Monaco's active theme flipped. Standalone unaffected.
- `tsc -p tsconfig.app.json --noEmit`, `oxlint`, `prettier --check` all clean; `MonacoCodeEditor` / `MonacoDiffViewer` / `ModelViewer` / `TerminalView` suites green (118 tests).

## Demo

Before: syntax-highlighted variables/strings dark grey/navy on the dark background (unreadable). After: readable github-dark colors. (Verified in the managed devloop; screen recording available on request.)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The bug only reproduces in the embedded island (where `forcedTheme` is set but `resolvedTheme` is not), which unit tests don't exercise, so it was verified manually in the managed devloop. The four consumers' existing suites cover that they still theme correctly off the resolved mode.

## Changelog

Fixed unreadable dark-mode syntax colors in the managed (embedded) code/file viewer.

This pull request and its description were written by Isaac.
