### PR TITLE
fix(kubernetes): add env var override and docs for pod_ready_timeout_s

### DIFF
--- a/deploy/kubernetes/overlays/sandbox-runners/README.md
+++ b/deploy/kubernetes/overlays/sandbox-runners/README.md
@@ -211,6 +211,7 @@ writing nothing to disk — use HTTPS repository URLs. Details by provider match
 | `env` | Optional list of SERVER env-var names to inject as literal Pod env (prefer `secret_name` for credentials). |
 | `node_selector` | Optional extra node labels, merged with a default `kubernetes.io/arch: amd64` — set that key to `arm64` to schedule runners on arm64 nodes. |
 | `resources` | Optional `requests` / `limits` (`cpu` / `memory`) override. |
+| `pod_ready_timeout_s` | Optional override for how long to wait for a runner Pod to reach `Running` (schedule + image pull + init container) before failing the launch — default 90s. Raise it for deployments whose host image regularly takes longer to pull. Also settable via env: `OMNIGENT_K8S_POD_READY_TIMEOUT_S` (this key takes precedence when both are set). |
 | `in_cluster` | Optional cluster-config source: `true` (in-cluster SA only), `false` (kubeconfig only), omit (try in-cluster, then kubeconfig). |
 | `kubeconfig` | Optional kubeconfig path for the out-of-cluster fallback (env: `OMNIGENT_KUBERNETES_KUBECONFIG`). |
 | `pvc_mounts` | Optional pre-created PersistentVolumeClaims mounted into every runner Pod — see [Persistent storage mounts](#persistent-storage-mounts-pvc_mounts). |

--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -174,9 +174,17 @@ _INIT_CONTAINER_NAME: str = "workspace-prep"
 # image / clone its repo fails fast with a clear reason instead of as a generic
 # online timeout. Kept tight; a cold image pull is the usual slow case —
 # deployments whose host image regularly takes longer to pull can raise the
-# budget via ``sandbox.kubernetes.pod_ready_timeout_s``.
+# budget via ``sandbox.kubernetes.pod_ready_timeout_s``, or, when that isn't
+# set, via :data:`_POD_READY_TIMEOUT_ENV_VAR`.
 _POD_READY_TIMEOUT_S: int = 90
 _POD_READY_POLL_S: float = 2.0
+
+# Env var fallback for the pod-ready wait budget, mirroring
+# omnigent.onboarding.sandboxes.e2b.MAX_LIFETIME_ENV_VAR. Only consulted when
+# the launcher wasn't constructed with an explicit pod_ready_timeout_s (i.e.
+# sandbox.kubernetes.pod_ready_timeout_s is unset in the bundle) — the
+# explicit config key always wins when both are present.
+_POD_READY_TIMEOUT_ENV_VAR: str = "OMNIGENT_K8S_POD_READY_TIMEOUT_S"
 
 # Per-request client timeout for the blocking calls. Without it a stalled
 # apiserver socket blocks indefinitely and the wait deadline never fires.
@@ -287,6 +295,34 @@ def _ensure_sdk() -> None:
         raise click.ClickException(
             "The Kubernetes client is required for the 'kubernetes' sandbox "
             "provider. Install it with `pip install 'omnigent[kubernetes]'`."
+        ) from exc
+
+
+def _resolve_pod_ready_timeout_s(configured: int | None) -> int:
+    """
+    Resolve the pod-ready wait budget for :meth:`_wait_for_pod_running`.
+
+    Precedence: the explicit ``sandbox.kubernetes.pod_ready_timeout_s``
+    config value (``configured``, already parsed by the caller) wins when
+    set; otherwise :data:`_POD_READY_TIMEOUT_ENV_VAR` overrides the
+    :data:`_POD_READY_TIMEOUT_S` default, mirroring
+    ``omnigent.onboarding.sandboxes.e2b.resolve_max_lifetime_s``.
+
+    :param configured: The launcher's ``pod_ready_timeout_s`` constructor
+        argument, or ``None`` when the bundle didn't set it.
+    :returns: The timeout in seconds to wait for the Pod to reach ``Running``.
+    :raises click.ClickException: When the env override is not a number.
+    """
+    if configured is not None:
+        return configured
+    raw = os.environ.get(_POD_READY_TIMEOUT_ENV_VAR)
+    if raw is None:
+        return _POD_READY_TIMEOUT_S
+    try:
+        return int(float(raw))
+    except ValueError as exc:
+        raise click.ClickException(
+            f"{_POD_READY_TIMEOUT_ENV_VAR} must be a number of seconds"
         ) from exc
 
 
@@ -1448,11 +1484,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         from urllib3.exceptions import HTTPError
 
         core = self._load_core()
-        timeout_s = (
-            self._pod_ready_timeout_s
-            if self._pod_ready_timeout_s is not None
-            else _POD_READY_TIMEOUT_S
-        )
+        timeout_s = _resolve_pod_ready_timeout_s(self._pod_ready_timeout_s)
         deadline = time.monotonic() + timeout_s
         last_reason: str | None = None
         pod_name: str | None = None

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -508,6 +508,37 @@ def test_env_var_name_override_is_validated(monkeypatch: pytest.MonkeyPatch) -> 
         KubernetesSandboxLauncher()._resolve_namespace()
 
 
+def test_pod_ready_timeout_defaults_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no config and no env var, the hardcoded default wins."""
+    monkeypatch.delenv(k8s._POD_READY_TIMEOUT_ENV_VAR, raising=False)
+    assert k8s._resolve_pod_ready_timeout_s(None) == k8s._POD_READY_TIMEOUT_S
+
+
+def test_pod_ready_timeout_env_var_overrides_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no explicit config, the env var overrides the hardcoded default."""
+    monkeypatch.setenv(k8s._POD_READY_TIMEOUT_ENV_VAR, "300")
+    assert k8s._resolve_pod_ready_timeout_s(None) == 300
+
+
+def test_pod_ready_timeout_config_wins_over_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """sandbox.kubernetes.pod_ready_timeout_s takes precedence over the env var."""
+    monkeypatch.setenv(k8s._POD_READY_TIMEOUT_ENV_VAR, "300")
+    assert k8s._resolve_pod_ready_timeout_s(45) == 45
+
+
+def test_pod_ready_timeout_env_var_accepts_float_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A float-looking env value is accepted, matching the E2B lifetime resolver."""
+    monkeypatch.setenv(k8s._POD_READY_TIMEOUT_ENV_VAR, "120.0")
+    assert k8s._resolve_pod_ready_timeout_s(None) == 120
+
+
+def test_pod_ready_timeout_env_var_rejects_non_numeric(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A malformed env value fails fast with a clear error instead of a raw ValueError."""
+    monkeypatch.setenv(k8s._POD_READY_TIMEOUT_ENV_VAR, "not-a-number")
+    with pytest.raises(click.ClickException, match="must be a number of seconds"):
+        k8s._resolve_pod_ready_timeout_s(None)
+
+
 # ── SDK-driven tests (fake kubernetes client) ───────────────
 
 


### PR DESCRIPTION
## Related issue

Closes #5947

## Summary

`sandbox.kubernetes.pod_ready_timeout_s` already worked on `main` (it landed the day before this issue was filed), so the original bug report no longer reproduces there — it likely reproduced against the `v0.11.0` release tag. What was still genuinely missing, and what this PR fixes:

- An env var override, `OMNIGENT_K8S_POD_READY_TIMEOUT_S`, mirroring `OMNIGENT_E2B_MAX_LIFETIME_S` for E2B. Precedence: bundle config (`pod_ready_timeout_s`) > env var > the 90s hardcoded default.
- Documentation. `pod_ready_timeout_s` had zero mention in any `.md` file despite being fully wired — added it to the sandbox-runners README's config table, alongside the new env var.

`MANAGED_HOST_ONLINE_TIMEOUT_S` (the separate wait, after the pod is ready, for the host process inside it to come online) is also fully hardcoded with no override at all, but it's provider-agnostic and unrelated to what this issue asked for — filing it as its own follow-up issue rather than folding it into this PR.

## Test Plan

Confirmed the new unit tests fail against the pre-fix code — reverted `kubernetes.py` only, kept the tests, ran them: `AttributeError` on the missing env var constant plus failed precedence assertions, 5 failed / 4 passed. Restored the fix, all 5 passed. Full `test_kubernetes.py` suite: 80/80 green. Full `tests/onboarding/` suite: 1245/1246 green — the one failure (`test_databricks_config.py::test_databricks_sdk_installed_true_in_dev_env`) is pre-existing and unrelated, reproduced identically on unmodified `main`.

`ruff check`, `ruff format --check`, and `pyrefly check` all clean on the touched files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Precedence behavior, straight from the new tests:

```python
def test_pod_ready_timeout_config_wins_over_env_var(monkeypatch):
    monkeypatch.setenv(k8s._POD_READY_TIMEOUT_ENV_VAR, "300")
    assert k8s._resolve_pod_ready_timeout_s(45) == 45  # bundle config wins

def test_pod_ready_timeout_env_var_overrides_default(monkeypatch):
    monkeypatch.setenv(k8s._POD_READY_TIMEOUT_ENV_VAR, "300")
    assert k8s._resolve_pod_ready_timeout_s(None) == 300  # env var wins over default
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

5 new unit tests in `tests/onboarding/sandboxes/test_kubernetes.py` cover the resolver directly: default-when-unset, env-var-overrides-default, config-wins-over-env-var, float-string env values, and malformed env values raising `click.ClickException`. No e2e coverage added — the existing `_wait_for_pod_running` behavior (bounding the whole Job wait) is already covered by `test_configured_pod_ready_timeout_bounds_entire_job_wait`, which still passes unchanged since the resolver is a drop-in replacement for the inline ternary it replaced.

## Changelog

Kubernetes sandbox pod-ready wait can now be overridden with `OMNIGENT_K8S_POD_READY_TIMEOUT_S`, in addition to the existing `sandbox.kubernetes.pod_ready_timeout_s` config key (now documented)
