### PR TITLE
fix(electron): make links work in the embedded browser pane

### DIFF
--- a/web/electron/README.md
+++ b/web/electron/README.md
@@ -274,6 +274,10 @@ against its local Chromium, and the result is posted back.
   conversation's page keeps running when the user switches away; views are
   destroyed only on explicit close or window teardown. Each child view keeps
   `nodeIntegration:false, contextIsolation:true, sandbox:true`.
+  Page-initiated `window.open` / `target=_blank` never spawns a window: an
+  http(s) target navigates the same view in place (still allowlist-checked on
+  an agent-locked view), and right-click offers "Open Link in Browser" /
+  "Copy Link Address".
 - `src/browserViewBounds.js` — converts the placeholder's renderer CSS pixels to
   window device-independent pixels (they diverge after `Cmd+/Cmd-` zoom).
 - `src/main.js` — instantiates one registry **per shell window** and injects it

--- a/web/electron/src/browserViewRegistry.js
+++ b/web/electron/src/browserViewRegistry.js
@@ -29,6 +29,11 @@ function createBrowserViewRegistry({
   sendToRenderer, // (channel, payload) => mainWindow.webContents.send(...)
   getHostZoomFactor = () => 1,
   getHostDisplayScaleFactor = () => null,
+  // Desktop affordances for the pane's context menu; injected so the registry
+  // stays Electron-free. No-op defaults keep tests and non-menu hosts simple.
+  openUrlExternal = () => {}, // (url) => shell.openExternal(url)
+  copyTextToClipboard = () => {}, // (text) => clipboard.writeText(text)
+  showContextMenu = () => {}, // (items) => Menu.buildFromTemplate(items).popup(...)
   cap = DEFAULT_CAP,
 } = {}) {
   const entries = new Map(); // conversationId -> BrowserViewEntry
@@ -115,20 +120,82 @@ function createBrowserViewRegistry({
     });
     const entry = makeEntry(conversationId, view);
     entries.set(conversationId, entry);
-    denyChildWindowOpen(entry);
+    installWindowOpenPolicy(entry);
+    attachViewContextMenu(entry);
     attachAgentNavGuard(conversationId, entry);
     return { ok: true, entry, created: true };
   }
 
-  // SECURITY: a visited page must not spawn windows from the desktop shell.
-  // Deny every window.open / target=_blank on the child view (the safe default;
-  // unlike the main shell window we do NOT route to shell.openExternal, since an
-  // agent-visited page popping the user's real browser to an arbitrary URL is
-  // itself an abuse vector).
-  function denyChildWindowOpen(entry) {
+  // SECURITY: a visited page must not spawn windows from the desktop shell, so
+  // window.open / target=_blank still never creates a window here and is never
+  // routed to shell.openExternal (an agent-visited page popping the user's real
+  // browser to an arbitrary URL is itself an abuse vector). Instead an http(s)
+  // target navigates the SAME view in place — nothing the page couldn't already
+  // do with location.href — so a clicked link goes somewhere instead of dying
+  // silently. The agent nav guard cannot see this hop (will-navigate skips
+  // programmatic loadURL), so an agent-locked view is allowlist-checked here.
+  function installWindowOpenPolicy(entry) {
     const wc = entry.view && entry.view.webContents;
     if (!wc || typeof wc.setWindowOpenHandler !== "function") return;
-    wc.setWindowOpenHandler(() => ({ action: "deny" }));
+    wc.setWindowOpenHandler(({ url }) => {
+      let parsed;
+      try {
+        parsed = new URL(url);
+      } catch {
+        return { action: "deny" }; // unparseable URL — nothing safe to open
+      }
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        return { action: "deny" };
+      }
+      if (entry.agentNavLocked) {
+        const verdict = isAgentNavigationAllowed(url);
+        if (!verdict.ok) {
+          sendToRenderer("browser-nav-blocked", {
+            conversationId: entry.conversationId,
+            url,
+            error: verdict.error,
+          });
+          return { action: "deny" };
+        }
+      }
+      try {
+        wc.loadURL(url);
+      } catch {
+        /* view destroyed mid-click */
+      }
+      return { action: "deny" };
+    });
+  }
+
+  // Right-click menu for the child view — the shell window's own menu covers
+  // only the shell webContents, so without one a pane link can be neither
+  // opened externally nor copied. "Open Link in Browser" is user-chosen, so
+  // shell.openExternal is safe here (unlike the page-initiated path above).
+  // Items are plain data; the host (main.js) builds the actual Electron Menu.
+  function attachViewContextMenu(entry) {
+    const wc = entry.view && entry.view.webContents;
+    if (!wc || typeof wc.on !== "function") return;
+    wc.on("context-menu", (_event, params) => {
+      const items = [];
+      if (params.linkURL) {
+        if (/^https?:\/\//i.test(params.linkURL)) {
+          items.push({
+            label: "Open Link in Browser",
+            click: () => openUrlExternal(params.linkURL),
+          });
+        }
+        items.push({
+          label: "Copy Link Address",
+          click: () => copyTextToClipboard(params.linkURL),
+        });
+      }
+      if (typeof params.selectionText === "string" && params.selectionText.trim() !== "") {
+        if (items.length > 0) items.push({ type: "separator" });
+        items.push({ label: "Copy", click: () => wc.copy() });
+      }
+      if (items.length === 0) return;
+      showContextMenu(items);
+    });
   }
 
   // SECURITY (SSRF): enforce the agent-navigation allowlist on the child view's

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -2231,6 +2231,11 @@ function createBrowserRegistryForWindow(win) {
         return 1;
       }
     },
+    copyTextToClipboard: (text) => clipboard.writeText(text),
+    openUrlExternal: (url) => void shell.openExternal(url),
+    showContextMenu: (items) => {
+      Menu.buildFromTemplate(items).popup({ window: win });
+    },
   });
 }
 

--- a/web/electron/test/browserViewRegistry.test.js
+++ b/web/electron/test/browserViewRegistry.test.js
@@ -226,6 +226,11 @@ describe("browserViewRegistry — agent-navigation allowlist", () => {
 // can fire a redirect and assert whether it was cancelled (preventDefault).
 function makeEventCapturingRegistry() {
   const sent = []; // { channel, payload }
+  const loaded = []; // loadURL targets on the created view
+  const clipboardWrites = []; // copyTextToClipboard payloads
+  const externalOpens = []; // openUrlExternal payloads
+  const menus = []; // showContextMenu item lists
+  let copyCalls = 0; // webContents.copy() invocations
   let handlers; // { [event]: fn } for the single created view
   let windowOpenHandler;
   const registry = createBrowserViewRegistry({
@@ -234,8 +239,13 @@ function makeEventCapturingRegistry() {
       return {
         setBounds() {},
         webContents: {
-          loadURL() {},
+          loadURL(url) {
+            loaded.push(url);
+          },
           close() {},
+          copy() {
+            copyCalls += 1;
+          },
           removeListener() {},
           on(event, fn) {
             handlers[event] = fn;
@@ -251,10 +261,18 @@ function makeEventCapturingRegistry() {
     detachFromHost() {},
     sendToRenderer: (channel, payload) => sent.push({ channel, payload }),
     getHostZoomFactor: () => 1,
+    openUrlExternal: (url) => externalOpens.push(url),
+    copyTextToClipboard: (text) => clipboardWrites.push(text),
+    showContextMenu: (items) => menus.push(items),
   });
   return {
     registry,
     sent,
+    loaded,
+    clipboardWrites,
+    externalOpens,
+    menus,
+    copyCalls: () => copyCalls,
     fire: (event, targetUrl) => {
       const ev = {
         url: targetUrl,
@@ -266,6 +284,7 @@ function makeEventCapturingRegistry() {
       handlers[event](ev, targetUrl);
       return ev;
     },
+    fireContextMenu: (params) => handlers["context-menu"]({}, params),
     windowOpen: (url) => windowOpenHandler({ url }),
   };
 }
@@ -329,11 +348,87 @@ describe("browserViewRegistry — redirect/nav guard (SSRF: allowlist on every h
 });
 
 describe("browserViewRegistry — child window.open is denied (S3)", () => {
-  it("installs a window-open handler that denies every popup", () => {
+  it("never opens a window: every window.open target is answered with deny", () => {
     const { registry, windowOpen } = makeEventCapturingRegistry();
     registry.openOrNavigate("conv_1", "https://example.com/", undefined, { agent: true });
     assert.deepEqual(windowOpen("https://evil.example.com/popup"), { action: "deny" });
     assert.deepEqual(windowOpen("https://example.com/ok"), { action: "deny" });
+  });
+
+  it("navigates the SAME view in place for an http(s) link target", () => {
+    const { registry, windowOpen, loaded } = makeEventCapturingRegistry();
+    registry.openOrNavigate("conv_1", "https://example.com/", undefined, { agent: true });
+    loaded.length = 0; // ignore the initial openOrNavigate load
+    assert.deepEqual(windowOpen("https://example.com/linked-page"), { action: "deny" });
+    assert.deepEqual(loaded, ["https://example.com/linked-page"]);
+  });
+
+  it("blocks an agent-locked window.open to an internal host (no in-place nav)", () => {
+    const { registry, windowOpen, loaded, sent } = makeEventCapturingRegistry();
+    registry.openOrNavigate("conv_1", "https://example.com/", undefined, { agent: true });
+    loaded.length = 0;
+    assert.deepEqual(windowOpen("http://169.254.169.254/latest/meta-data/"), {
+      action: "deny",
+    });
+    assert.deepEqual(loaded, [], "no in-place navigation to a blocked host");
+    const blocked = sent.filter((s) => s.channel === "browser-nav-blocked");
+    assert.equal(blocked.length, 1, "the SSRF block surfaces to the renderer");
+  });
+
+  it("still denies non-web schemes with no in-place nav", () => {
+    const { registry, windowOpen, loaded } = makeEventCapturingRegistry();
+    registry.openOrNavigate("conv_1", "https://example.com/", undefined, { agent: true });
+    loaded.length = 0;
+    assert.deepEqual(windowOpen("file:///etc/passwd"), { action: "deny" });
+    assert.deepEqual(windowOpen("javascript:alert(1)"), { action: "deny" });
+    assert.deepEqual(loaded, []);
+  });
+});
+
+describe("browserViewRegistry — pane context menu", () => {
+  it("offers Open Link in Browser + Copy Link Address over a link", () => {
+    const { registry, fireContextMenu, menus, externalOpens, clipboardWrites } =
+      makeEventCapturingRegistry();
+    registry.openOrNavigate("conv_1", "https://example.com/", undefined, { agent: true });
+    fireContextMenu({ linkURL: "https://example.com/page", selectionText: "" });
+    assert.equal(menus.length, 1);
+    assert.deepEqual(
+      menus[0].map((item) => item.label),
+      ["Open Link in Browser", "Copy Link Address"],
+    );
+    menus[0][0].click();
+    menus[0][1].click();
+    assert.deepEqual(externalOpens, ["https://example.com/page"]);
+    assert.deepEqual(clipboardWrites, ["https://example.com/page"]);
+  });
+
+  it("omits Open Link in Browser for a non-web link but still offers Copy Link Address", () => {
+    const { registry, fireContextMenu, menus } = makeEventCapturingRegistry();
+    registry.openOrNavigate("conv_1", "https://example.com/", undefined, { agent: true });
+    fireContextMenu({ linkURL: "javascript:alert(1)", selectionText: "" });
+    assert.deepEqual(
+      menus[0].map((item) => item.label),
+      ["Copy Link Address"],
+    );
+  });
+
+  it("offers Copy over selected text and routes it to webContents.copy()", () => {
+    const { registry, fireContextMenu, menus, copyCalls } = makeEventCapturingRegistry();
+    registry.openOrNavigate("conv_1", "https://example.com/", undefined, { agent: true });
+    fireContextMenu({ linkURL: "", selectionText: "hello" });
+    assert.deepEqual(
+      menus[0].map((item) => item.label),
+      ["Copy"],
+    );
+    menus[0][0].click();
+    assert.equal(copyCalls(), 1);
+  });
+
+  it("shows nothing over dead space", () => {
+    const { registry, fireContextMenu, menus } = makeEventCapturingRegistry();
+    registry.openOrNavigate("conv_1", "https://example.com/", undefined, { agent: true });
+    fireContextMenu({ linkURL: "", selectionText: "   " });
+    assert.equal(menus.length, 0);
   });
 });
 


### PR DESCRIPTION
## Related issue

No tracking issue — reported in Slack (#apa-omnigent): in the desktop app, a link in the embedded browser pane could not be clicked open, did not redirect in the pane, and could not be copied. The same page in a real browser works fine, so this presented as desktop-only.

## Summary

The pane's `WebContentsView` blanket-denied every `window.open` / `target=_blank` (so clicking a link did nothing) and had no `context-menu` handler (so right-click gave no way to open or copy the link).

- An http(s) `window.open` / `target=_blank` target now navigates the **same view in place** — nothing the page couldn't already do with `location.href`. The popup window itself stays denied and is still never routed to `shell.openExternal` (the abuse vector the deny guarded against).
- The SSRF allowlist is re-checked on this hop for agent-locked views, because `will-navigate` does not fire for a programmatic `loadURL`.
- New right-click menu on the pane: **Open Link in Browser** / **Copy Link Address** over a link (Open is user-chosen, so `shell.openExternal` is safe here), **Copy** over a text selection.

## Test Plan

- `cd web/electron && node --test` — 290/293 pass; the 3 failures (`desktop_updater`, `omnigent_cli`, `server_manager`) are `Cannot find module 'js-yaml'` in a fresh worktree with no `node_modules`, and fail identically on unmodified `main`.
- New unit coverage in `test/browserViewRegistry.test.js`: in-place navigation for http(s) targets, SSRF block (no nav + `browser-nav-blocked`) for an agent-locked view opening an internal host, non-web schemes still denied, context-menu items and their actions.
- Manual check on a macOS desktop build from this branch (against a dev server): in the browser pane, clicking a `target=_blank` link navigates the pane in place; right-clicking a link shows Open Link in Browser / Copy Link Address (both work); right-clicking a text selection shows Copy. Plain same-tab links, the URL bar, and Back/Forward/Reload all still work.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the user-visible behavior on a real desktop build (macOS, Electron shell from this branch, connected to a dev server over the network): pane link click-through, the new right-click menu items, and toolbar regression checks. The window-open policy, SSRF re-check, and menu composition are unit-tested in `test/browserViewRegistry.test.js`.

## Changelog

Desktop browser pane: links can be clicked (the pane navigates to them) and right-clicked to open in your browser or copy the address
