### PR TITLE
Fix automated titles for Codex sessions

### DIFF
--- a/omnigent/runner/background_titles/codex_native.py
+++ b/omnigent/runner/background_titles/codex_native.py
@@ -84,6 +84,7 @@ async def generate_background_title(context: BackgroundTitleContext) -> str | No
             "features.computer_use=false",
             "features.image_generation=false",
             "features.multi_agent=false",
+            "features.plugins=false",
             "features.tool_search=false",
         ):
             args.extend(("--config", override))

--- a/tests/runner/test_background_session_title.py
+++ b/tests/runner/test_background_session_title.py
@@ -661,6 +661,7 @@ async def test_codex_native_title_uses_ephemeral_tool_free_exec(
     assert "--skip-git-repo-check" in args
     assert args[args.index("--model") + 1] == "gpt-5.4-mini"
     assert "features.shell_tool=false" in args
+    assert "features.plugins=false" in args
     assert 'web_search="disabled"' in args
     assert all("sk-sentinel-do-not-use" not in arg for arg in args)
     assert "omnigent-codex-title-" in captured["kwargs"]["cwd"]


### PR DESCRIPTION
## Related issue

N/A — diagnosed from runner logs for failed automatic title generation.

## Summary

Codex's isolated background-title worker could start plugin marketplace setup even though it uses no plugins. That asynchronous setup raced temporary-directory cleanup, turning an otherwise successful title into a 502 response.

This disables plugins for the title worker. The normal Codex session remains unchanged.

ELI5: the title worker was starting an unnecessary background download and then removing its temporary room before the download finished. It now skips that download.

```text
title request -> isolated Codex worker -> plugins disabled -> title returned
```

## Test Plan

- `/Users/pat.sukprasert/git/omnigent/.venv/bin/pytest -q tests/runner/test_background_session_title.py` — 16 passed
- `/Users/pat.sukprasert/git/omnigent/.venv/bin/pyrefly check omnigent/runner/background_titles/codex_native.py` — 0 errors
- Ran a real `generate_background_title` smoke test with Codex; it returned `Debug Plugin Session Titles` without the temporary-directory cleanup exception.
- `git diff --check`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

See the real title-generation smoke test in the Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test verifies the isolated Codex invocation explicitly disables plugins. Manual verification exercised the real Codex title path and confirmed that it returned a title cleanly.

## Changelog

Codex sessions reliably receive automatic titles without plugin startup races.
