### PR TITLE
fix(web): give same-named image attachments distinct optimistic ids

### DIFF
--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -3310,6 +3310,54 @@ describe("chatStore — send (file attachments)", () => {
     ]);
   });
 
+  it("gives same-named attachments distinct optimistic ids", async () => {
+    // Pasted screenshots all arrive named "image.png". The optimistic
+    // "pending:" placeholder must key on File identity, not the name, or the
+    // two blocks collide on one id — React dedupes on the shared render key
+    // and strands a ghost chip until a refresh swaps in the server ids.
+    useChatStore.setState({
+      conversationId: "conv_existing",
+      abortController: new AbortController(),
+    });
+
+    // Hold the upload open so we can inspect the optimistic bubble before
+    // real ids land.
+    let releaseUpload: () => void = () => {};
+    const uploadGate = new Promise<void>((resolve) => {
+      releaseUpload = resolve;
+    });
+    let uploadSeq = 0;
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/sessions/conv_existing/resources/files")) {
+        await uploadGate;
+        uploadSeq += 1;
+        return mockResponse({
+          id: `file_real_${uploadSeq}`,
+          name: "image.png",
+          metadata: { filename: "image.png", bytes: 10, created_at: 0 },
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const a = new File(["a"], "image.png", { type: "image/png" });
+    const b = new File(["b"], "image.png", { type: "image/png" });
+    const sendPromise = useChatStore.getState().send("two shots", "agent_xyz", [a, b]);
+
+    // Optimistic bubble, before the upload resolves: two image blocks with
+    // distinct placeholder ids so both chips render.
+    const optimistic = useChatStore.getState().pendingUserMessages[0]!.content;
+    const imageIds = optimistic
+      .filter((c) => c.type === "input_image")
+      .map((c) => (c as { file_id: string }).file_id);
+    expect(imageIds).toHaveLength(2);
+    expect(new Set(imageIds).size).toBe(2);
+
+    releaseUpload();
+    await sendPromise;
+  });
+
   it("preserves the real file_id through a text-only consumed event", async () => {
     // End-to-end claude-native: upload → text-only consumed event →
     // promoted bubble must carry the real id so UserBubble takes the

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -108,6 +108,7 @@ import type {
   SkillSummary,
 } from "@/lib/types";
 import { uploadFile } from "@/lib/filesApi";
+import { attachmentKey } from "@/lib/attachments";
 import type { ActiveResponse } from "./types";
 import { supportsEffortControl } from "@/lib/sessionCapabilities";
 import { claudePermissionModeFromSession } from "@/lib/claudePermissionMode";
@@ -1596,9 +1597,15 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     const tempId = `pend_${pendingSeq}`;
     const pendingFileBlocks: MessageContentBlock[] = (files ?? []).map((file) => {
       const filename = file.name || "image.png";
+      // Key the placeholder id on the File's stable identity, not its name:
+      // pasted screenshots all arrive named "image.png", so a name-derived
+      // id would collide across attachments and strand a ghost chip (React
+      // dedupes on the shared key) until a refresh replaces it with the
+      // server's unique file_id.
+      const fileId = `pending:${attachmentKey(file)}`;
       return file.type.startsWith("image/")
-        ? { type: "input_image" as const, file_id: `pending:${filename}`, filename }
-        : { type: "input_file" as const, file_id: `pending:${filename}`, filename };
+        ? { type: "input_image" as const, file_id: fileId, filename }
+        : { type: "input_file" as const, file_id: fileId, filename };
     });
     const content: MessageContentBlock[] = [
       ...pendingFileBlocks,


### PR DESCRIPTION
## Related issue

Closes #

## Summary

When you send a chat message with images — especially **pasted** screenshots — a stray `image.png` chip appeared at the first position of the message and only disappeared after a page refresh.

Root cause is in `send()` (`web/src/store/chatStore.ts`): each optimistic file block got `file_id: pending:${filename}`. Every image pasted from the clipboard is named `image.png` by the browser, so when a message carried two or more pasted images their placeholder blocks all collided on the same `file_id` (`pending:image.png`). `UserBubble` renders each image keyed by `img.file_id`, so the duplicate React keys made React dedupe the blocks — leaving one ghost chip stranded. On refresh the server snapshot supplied unique real `file_id`s, so the ghost vanished.

Fix: key the placeholder id on the `File`'s stable identity via the existing `attachmentKey()` (`pending:attachment-N`) instead of its display name. The `filename` field still carries the label, so the chip text is unchanged — only the collision is removed.

## Test Plan

- `cd web && npm test` — passes (the only failures are 3 pre-existing, unrelated failures in `NewChatDialog.test.tsx`, confirmed failing on a clean tree without this change).
- `cd web && npm run build` — passes (`tsc -b && vite build`).
- Added regression test `gives same-named attachments distinct optimistic ids` in `chatStore.test.ts`: holds the upload open and asserts two same-named files get two distinct optimistic `file_id`s.

Manual:
1. Run the web UI (`just dev`).
2. Open a chat, take two screenshots and **paste both** into the composer (both are named `image.png`), then send.
3. Before: an extra `image.png` chip lingers at the front until refresh. After: only the two real image previews render, and nothing changes on refresh.

## Demo

N/A — optimistic-rendering fix; behaviour described in the Test Plan. The stray chip is transient and clears on refresh, so a static screenshot doesn't capture it well.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a unit test that inspects the optimistic pending state (before upload resolves) for two same-named files and asserts distinct `file_id`s. Manually verified by pasting two screenshots into the composer and confirming no stray `image.png` chip appears (and nothing changes on refresh).

## Changelog

Sending a message with multiple pasted images no longer shows a stray `image.png` placeholder that disappeared on refresh

This pull request and its description were written by Isaac.