### PR TITLE
fix(web): show the sub-agent's own name in the child session breadcrumb

### DIFF
--- a/tests/e2e_ui/agents/test_subagent_breadcrumb_identity.py
+++ b/tests/e2e_ui/agents/test_subagent_breadcrumb_identity.py
@@ -1,0 +1,75 @@
+"""E2E: a sub-agent session's header breadcrumb identifies the sub-agent.
+
+A child session dispatched from a parent bundle (``sys_session_send``, or a
+direct create with ``sub_agent_name``) is bound to the PARENT bundle's agent
+row, so the bound agent's name is the parent's (e.g. ``joke_director``).
+The header breadcrumb's identity segment must show the child's own
+``sub_agent_name`` (e.g. ``comic_one``) — before the fix it rendered the
+bound agent's name, so every sub-agent masqueraded as its parent and the
+generic "Sub-agent" caption was gone too.
+
+This is the lightweight half of the nightly journey in
+``test_subagent_navigation.py``: instead of a full dispatch + relay turn, the
+child is created directly through the API with ``parent_session_id`` +
+``sub_agent_name`` set (the same shape the runner's spawn path posts), then
+the page navigates straight into it.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.agents.conftest import JokeSubagentsSession
+
+
+@pytest.mark.timeout(300)
+def test_child_breadcrumb_shows_subagent_name_not_parent_agent(
+    page: Page,
+    joke_subagents_session: JokeSubagentsSession,
+) -> None:
+    """The child header names the sub-agent, not the parent bundle's agent.
+
+    :param page: Playwright page fixture.
+    :param joke_subagents_session: Parent session bound to the two-comedian
+        joke-director bundle (its declared sub-agents make ``sub_agent_name``
+        creates valid); no LLM turn is dispatched.
+    :returns: None.
+    """
+    chat = joke_subagents_session
+
+    # The child binds to the parent's agent row — fetch its id.
+    agent_resp = httpx.get(
+        f"{chat.base_url}/v1/sessions/{chat.session_id}/agent",
+        timeout=10.0,
+    )
+    agent_resp.raise_for_status()
+    agent_id = agent_resp.json()["id"]
+
+    # Create the sub-agent child the way a dispatch does: bound to the parent
+    # bundle's agent, with the child's own identity in ``sub_agent_name``.
+    child_resp = httpx.post(
+        f"{chat.base_url}/v1/sessions",
+        json={
+            "agent_id": agent_id,
+            "parent_session_id": chat.session_id,
+            "sub_agent_name": "comic_one",
+            "title": "comic_one",
+        },
+        timeout=10.0,
+    )
+    child_resp.raise_for_status()
+    child_id = child_resp.json()["id"]
+
+    page.goto(f"{chat.base_url}/c/{child_id}")
+
+    # The child still climbs out via the parent link…
+    expect(page.get_by_role("link", name="Back to parent session")).to_be_visible(timeout=30_000)
+
+    # …and its identity segment names the SUB-AGENT. Scoped to the breadcrumb
+    # nav so a stray "comic_one" elsewhere on the page can't satisfy it.
+    breadcrumb = page.get_by_role("navigation", name="Conversation")
+    expect(breadcrumb.get_by_text("comic_one", exact=True)).to_be_visible()
+    # The parent bundle's agent name must NOT be shown as the child's identity.
+    expect(breadcrumb.get_by_text("joke_director", exact=True)).not_to_be_visible()

--- a/tests/e2e_ui/agents/test_subagent_navigation.py
+++ b/tests/e2e_ui/agents/test_subagent_navigation.py
@@ -105,16 +105,20 @@ def test_two_joke_subagents_appear_and_navigate(
     target_row = rows.first
     child_session_id = target_row.get_attribute("data-child-session-id")
     assert child_session_id, "subagent row is missing data-child-session-id"
+    target_name = target_row.locator("span.font-medium").first.inner_text()
+    assert target_name in {"comic_one", "comic_two"}, target_name
     target_row.click()
     page.wait_for_url(re.compile(re.escape(f"/c/{child_session_id}")))
 
     # The header carries the back-to-parent affordance: a "Back to parent
-    # session" link pointing at the parent conversation, beside the
-    # "Sub-agent" identity caption.
+    # session" link pointing at the parent conversation, beside the child's
+    # own sub-agent identity (the comedian's name — NOT the parent bundle's
+    # agent name, which is what the bound-agent row carries).
     back_link = page.get_by_role("link", name="Back to parent session")
     expect(back_link).to_be_visible(timeout=30_000)
     expect(back_link).to_have_attribute("href", re.compile(re.escape(f"/c/{chat.session_id}")))
-    expect(page.get_by_text("Sub-agent", exact=True)).to_be_visible()
+    breadcrumb = page.get_by_role("navigation", name="Conversation")
+    expect(breadcrumb.get_by_text(target_name, exact=True)).to_be_visible()
 
     # Following it returns to the parent session.
     back_link.click()

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1875,6 +1875,7 @@ export function AppShell() {
                     }
                   }}
                   isChildSession={isChildSession}
+                  subAgentName={activeSession?.subAgentName ?? null}
                   conversationId={conversationId}
                   actionConversation={actionConversation}
                   conversationTitle={headerConversationTitle}

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -60,6 +60,7 @@ const mobileMenu = {
 function renderHeader(props: {
   sidebarOpen: boolean;
   isChildSession?: boolean;
+  subAgentName?: string | null;
   conversationId?: string;
   actionConversation?: Conversation | null;
   conversationTitle?: string | null;
@@ -86,6 +87,7 @@ function renderHeader(props: {
             sidebarOpen={props.sidebarOpen}
             onOpenSidebar={props.onOpenSidebar ?? (() => {})}
             isChildSession={props.isChildSession ?? false}
+            subAgentName={props.subAgentName ?? null}
             // Defaults to no active session: PresenceAvatars / AgentInfoButton /
             // right-panel toggle / rail entries all gate on conversationId and
             // stay unmounted, isolating the left-slot affordances under test.
@@ -260,6 +262,38 @@ describe("ChatHeader — conversation breadcrumb", () => {
     expect(screen.getByText("check-account-eligibility")).toBeInTheDocument();
   });
 
+  it("names the session's own sub-agent, not the parent bundle's agent row", () => {
+    // A `sys_session_send` child is bound to its PARENT bundle's agent row,
+    // so boundAgent.name is the parent's name. The session's own
+    // sub_agent_name must win, or the child masquerades as its parent.
+    renderHeader({
+      sidebarOpen: true,
+      conversationId: "child-9",
+      isChildSession: true,
+      subAgentName: "comic_one",
+      conversationTitle: "Joke night",
+      titleLinkTo: "/c/parent-123",
+      boundAgent: { id: "a1", name: "joke_director" },
+    });
+    expect(screen.getByText("comic_one")).toBeInTheDocument();
+    expect(screen.queryByText("joke_director")).toBeNull();
+  });
+
+  it("falls back past a blank sub_agent_name to the bound agent's name", () => {
+    // An empty/whitespace sub_agent_name must not render a blank identity
+    // segment — the fallback chain continues to boundAgent.name.
+    renderHeader({
+      sidebarOpen: true,
+      conversationId: "child-9",
+      isChildSession: true,
+      subAgentName: "  ",
+      conversationTitle: "Fix the login bug",
+      titleLinkTo: "/c/parent-123",
+      boundAgent: { id: "a1", name: "check-account-eligibility" },
+    });
+    expect(screen.getByText("check-account-eligibility")).toBeInTheDocument();
+  });
+
   it("names the product, not the internal wrapper row, on a native sub-agent", () => {
     // A Claude Code Task child is bound to its parent's `claude-native-ui`
     // agent — an Omnigent internal the server hides everywhere else
@@ -275,6 +309,24 @@ describe("ChatHeader — conversation breadcrumb", () => {
     });
     expect(screen.getByText("Claude Code")).toBeInTheDocument();
     expect(screen.queryByText("claude-native-ui")).toBeNull();
+  });
+
+  it("prefers the vendor product name over sub_agent_name on a native sub-agent", () => {
+    // A native child carries BOTH a wrapper label and a sub_agent_name; the
+    // product name (matching the Agents rail and composer) outranks the raw
+    // sub-agent identifier.
+    renderHeader({
+      sidebarOpen: true,
+      conversationId: "child-9",
+      isChildSession: true,
+      subAgentName: "general-purpose",
+      conversationTitle: "Fix the login bug",
+      titleLinkTo: "/c/parent-123",
+      boundAgent: { id: "a1", name: "claude-native-ui" },
+      wrapperLabel: "claude-code-native-ui-subagent",
+    });
+    expect(screen.getByText("Claude Code")).toBeInTheDocument();
+    expect(screen.queryByText("general-purpose")).toBeNull();
   });
 
   it("falls back to a 'Sub-agent' segment before the agent snapshot loads", () => {

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -101,6 +101,12 @@ interface ChatHeaderProps {
   onOpenSidebar: (peek?: boolean) => void;
   /** Whether the active session is a sub-agent (appends its identity). */
   isChildSession: boolean;
+  /**
+   * The session's own ``sub_agent_name`` — identifies a dispatched sub-agent
+   * in the breadcrumb. ``null`` when the session has none (top-level, or an
+   * Add-Agent child bound to its own agent).
+   */
+  subAgentName?: string | null;
   /** Active session id, or undefined on the landing composer. */
   conversationId: string | undefined;
   /** Owner-managed top-level row backing the title-adjacent action menu. */
@@ -189,6 +195,7 @@ export function ChatHeader({
   sidebarOpen,
   onOpenSidebar,
   isChildSession,
+  subAgentName,
   conversationId,
   actionConversation = null,
   conversationTitle,
@@ -446,6 +453,7 @@ export function ChatHeader({
             titleSlot={titleSlot ?? undefined}
             titleLinkTo={titleLinkTo}
             isChildSession={isChildSession}
+            subAgentName={subAgentName}
             boundAgent={boundAgent}
             wrapperLabel={wrapperLabel}
             actions={isMobile ? undefined : (conversationMenu ?? undefined)}

--- a/web/src/shell/ConversationBreadcrumb.tsx
+++ b/web/src/shell/ConversationBreadcrumb.tsx
@@ -28,6 +28,7 @@ export function ConversationBreadcrumb({
   titleSlot,
   titleLinkTo,
   isChildSession,
+  subAgentName,
   boundAgent,
   wrapperLabel,
   actions,
@@ -54,6 +55,12 @@ export function ConversationBreadcrumb({
   titleLinkTo?: string;
   /** Whether the active session is a sub-agent (appends its identity). */
   isChildSession: boolean;
+  /**
+   * The session's own `sub_agent_name` — the dispatched sub-agent's identity
+   * (e.g. a `sys_session_send` child of a bundle). Preferred over
+   * `boundAgent.name`, which for such children is the *parent* bundle's row.
+   */
+  subAgentName?: string | null;
   /** The bound agent — names the sub-agent segment. */
   boundAgent: Agent | undefined;
   /** The session's `omnigent.wrapper` label — names a native sub-agent's vendor. */
@@ -66,11 +73,16 @@ export function ConversationBreadcrumb({
   // A native sub-agent (a Claude Code Task, a Codex collab thread) is bound to
   // its parent's `<vendor>-native-ui` row, so its agent name is an internal the
   // server itself hides (`public_agent_name`). Name the product instead,
-  // matching the Agents rail and the composer. Every other sub-agent keeps its
-  // own agent name, which is already human-readable. Only the sub-agent segment
-  // reads this, so it stays behind `isChildSession`.
-  const subAgentName = isChildSession
-    ? (nativeCodingAgentForSubagentWrapper(wrapperLabel)?.displayName ?? boundAgent?.name ?? null)
+  // matching the Agents rail and the composer. Otherwise prefer the session's
+  // own `sub_agent_name`: a `sys_session_send` child is bound to its parent
+  // bundle's agent row, so `boundAgent.name` would misidentify it as the
+  // parent. `boundAgent.name` remains the fallback for the Add-Agent flow,
+  // where the child is bound to its own agent and `sub_agent_name` is null.
+  const subAgentSegment = isChildSession
+    ? (nativeCodingAgentForSubagentWrapper(wrapperLabel)?.displayName ??
+      (subAgentName?.trim() || null) ??
+      boundAgent?.name ??
+      null)
     : null;
   // iOS/Android native chrome already identifies the session. Restore the
   // compact "< Back" climb-out there; web / Electron keep the parent name.
@@ -139,7 +151,7 @@ export function ConversationBreadcrumb({
           <span className="flex min-w-0 items-center gap-1.5">
             <BotIcon className="size-4 shrink-0 text-muted-foreground" />
             <span className="truncate font-semibold text-foreground">
-              {subAgentName ?? "Sub-agent"}
+              {subAgentSegment ?? "Sub-agent"}
             </span>
           </span>
         </>


### PR DESCRIPTION
## Related issue

Closes #5098

Resolves OMNI-4226 (Linear): nightly failure in the E2E UI tests.

## Summary

- **Root cause:** a child (sub-agent) session dispatched from a parent bundle is bound to the *parent's* agent row, so `ConversationBreadcrumb` — which derived the sub-agent identity segment from `boundAgent.name` — showed the parent agent's name (e.g. `joke_director`) for every dispatched sub-agent. The title-bar rework that introduced the breadcrumb (OMNI-3743) removed the previous literal "Sub-agent" caption, which is what the nightly `test_two_joke_subagents_appear_and_navigate` asserted, so the nightly shard has been red since.
- **Fix:** plumb the session's own `subAgentName` (already on the session snapshot, `sub_agent_name` on the wire) from `AppShell` → `ChatHeader` → `ConversationBreadcrumb`. The identity segment now prefers: native vendor product name (unchanged) → the session's own `sub_agent_name` → `boundAgent.name` (the Add-Agent child flow, where the child is bound to its own agent and `sub_agent_name` is null) → the "Sub-agent" fallback. Blank/whitespace `sub_agent_name` falls through rather than rendering an empty segment.
- **Tests:** aligned the nightly journey's assertion with the real identity (the clicked comedian's name, scoped to the breadcrumb nav), added a lightweight e2e regression test (`test_subagent_breadcrumb_identity.py`) that exercises the parent-bound child shape directly without an LLM turn, and added unit tests for the new precedence in `ChatHeader.test.tsx`.

ELI5: when you clicked into a sub-agent's chat, the header said it was the *parent* agent. Now it names the sub-agent you actually opened.

```
before:  [folder] / parent title / joke_director      (parent's name — wrong)
after:   [folder] / parent title / comic_one          (the child's own identity)
```

## Test Plan

Fail→pass proof (all run against a local server + mock LLM, SPA rebuilt per side):

- `tests/e2e_ui/agents/test_subagent_navigation.py::test_two_joke_subagents_appear_and_navigate` (the failing nightly test): **fails on unfixed main** at `expect(page.get_by_text("Sub-agent", exact=True)).to_be_visible()` — ARIA snapshot shows the child breadcrumb reading `joke_director` — and **passes with the fix** (breadcrumb reads `comic_one`, asserted via the updated identity check).
- `tests/e2e_ui/agents/test_subagent_breadcrumb_identity.py` (new): **fails on unfixed main** (breadcrumb shows the parent bundle's agent name) and **passes with the fix**.
- `web/src/shell/ChatHeader.test.tsx`: new precedence tests fail on unfixed code, pass with the fix; all 35 tests green. `AppShell.test.tsx` (113 tests) green.
- `tsc --noEmit`, `oxlint`, `prettier --check`, and a full SPA build are clean.

## Independent review

A cross-vendor (codex) reviewer checked the diff before this PR opened: no blocking or security findings; its one non-blocking note (blank `sub_agent_name` bypassing the fallback chain) was addressed with a `trim()` guard and a unit test.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

**After (fixed):** the child session's breadcrumb names the sub-agent (`comic_one`), beside the Back-to-parent link:

![after: breadcrumb names the sub-agent](https://raw.githubusercontent.com/omnigent-ai/omnigent/assets/subagent-breadcrumb-identity-demo/after-breadcrumb-frame.png)

**Before (bug):** the same child session's breadcrumb read the parent agent's name (`joke_director`):

![before: breadcrumb shows the parent agent's name](https://raw.githubusercontent.com/omnigent-ai/omnigent/assets/subagent-breadcrumb-identity-demo/before-frame.png)

Full recordings (all on the `assets/subagent-breadcrumb-identity-demo` branch):
- [after-subagent-navigation.mp4](https://github.com/omnigent-ai/omnigent/raw/assets/subagent-breadcrumb-identity-demo/after-subagent-navigation.mp4) — the full nightly journey on the fixed build: dispatch two comedians → open Agents rail → click a comedian row → header names the comedian → back to parent
- [after-breadcrumb-identity.mp4](https://github.com/omnigent-ai/omnigent/raw/assets/subagent-breadcrumb-identity-demo/after-breadcrumb-identity.mp4) — the new regression test: direct child create → breadcrumb names `comic_one`, not `joke_director`
- [before-evidence-summary.mp4](https://github.com/omnigent-ai/omnigent/raw/assets/subagent-breadcrumb-identity-demo/before-evidence-summary.mp4) — the repro run's before-fix evidence clip (from `repro-bundle-33454758790`)

## Validate the fix live

Run this against the deployed UI preview once the `<!-- ui-preview -->` comment posts its URL (attaches your own host, which carries your model credentials):

```
omnigent claude -p 'Reproduce and validate a bug fix. Steps: create a session with an agent that declares sub-agents (e.g. an orchestrator bundle), ask it to dispatch a task to one sub-agent, open the Agents rail on the right, and click the sub-agent row to open the child session. Before this fix, the chat header breadcrumb identity segment showed the PARENT agent name for the child session. Confirm the fix by checking that the header breadcrumb now shows the sub-agent'\''s own name (the dispatched sub-agent identity), with a "Back to parent session" link beside it. Report whether each step now behaves correctly.' --server https://omnigent-ui-preview-pr-5988-3272836215725701.aws.databricksapps.com
```

To validate without the preview, drop the `--server …` flag to run against your own local app.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The nightly e2e journey covers the full dispatch → rail → child-navigation path; the new lightweight e2e test covers the breadcrumb identity without an LLM turn (so it runs in the PR gate); unit tests pin the precedence order (vendor product name > sub_agent_name > bound agent name > "Sub-agent") including the blank-name fallback.

## Changelog

Sub-agent sessions now show the sub-agent's own name in the chat header breadcrumb instead of the parent agent's name
