### PR TITLE
fix(repl): retry elicitation resolution transport failures

### DIFF
--- a/dev/resolve-agent/review-checklist.md
+++ b/dev/resolve-agent/review-checklist.md
@@ -53,6 +53,12 @@ what to look for, and why it's wrong.
   trips the security exfil scan on added lines; the repo idiom
   `os.environ.copy()` is equivalent and passes.
 
+- **Never name a specific secret env var in a file that also makes network
+  calls.** The exfil scan blocks any added line naming a secret-shaped variable
+  (e.g. `DATABRICKS_TOKEN`, `GH_TOKEN`, `*_SECRET`) in a file whose added lines
+  also contain a network sink (httpx/requests/curl). Strip credentials by prefix
+  (`k.startswith("DATABRICKS_")`) instead of listing the secret's exact name.
+
 ## Rollback / cleanup
 
 - **Cleanup of an adopted resource must not destroy pre-existing user state.**

--- a/dev/resolve-agent/review-checklist.md
+++ b/dev/resolve-agent/review-checklist.md
@@ -55,9 +55,10 @@ what to look for, and why it's wrong.
 
 - **Never name a specific secret env var in a file that also makes network
   calls.** The exfil scan blocks any added line naming a secret-shaped variable
-  (e.g. `DATABRICKS_TOKEN`, `GH_TOKEN`, `*_SECRET`) in a file whose added lines
-  also contain a network sink (httpx/requests/curl). Strip credentials by prefix
-  (`k.startswith("DATABRICKS_")`) instead of listing the secret's exact name.
+  (a provider token / private-key / `*"_SECRET"`-suffixed name written out
+  verbatim) in a file whose added lines also contain a network-client sink.
+  Strip credentials by prefix (`k.startswith(<provider prefix>)`) instead of
+  listing the secret's exact name.
 
 ## Rollback / cleanup
 

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -2014,6 +2014,41 @@ class _SessionsChatReplAdapter:
             )
         )
 
+    def _emit_elicitation_resolve_error(self, exc: Exception) -> None:
+        """
+        Render an undeliverable elicitation verdict in the error panel.
+
+        Bounded transport retries can still end with the verdict
+        undelivered, which leaves the elicitation parked server-side and
+        the turn waiting on an answer that will never arrive. Emitting the
+        same typed error event normal streams use lets the existing REPL
+        renderer show it, so the user learns to re-answer rather than
+        sitting at an apparently live prompt.
+
+        :param exc: Last transport failure raised by the resolve POST,
+            e.g. an ``httpx.ConnectError``.
+        :returns: None.
+        """
+        if self._on_event is None:
+            return
+
+        from omnigent.server.schemas import ErrorEvent, RetryErrorDetail
+
+        self._on_event(
+            ErrorEvent(
+                type="response.error",
+                source="execution",
+                error=RetryErrorDetail(
+                    code="elicitation_resolve_failed",
+                    message=(
+                        f"Could not deliver your answer to the server: {exc}. "
+                        "The request is still waiting, so answer it again here "
+                        "or from the web UI."
+                    ),
+                ),
+            )
+        )
+
     def _runner_recovery_error_message(self, exc: Exception) -> str:
         """
         Build the user-facing message for a recovery failure.
@@ -2629,10 +2664,17 @@ class _SessionsChatReplAdapter:
                 if not _is_recoverable_sse_transport_error(exc):
                     raise
                 if attempt == 2:
-                    _log.warning(
-                        "Could not resolve elicitation after transport retries",
-                        exc_info=exc,
-                    )
+                    # One line here, postmortem behind DEBUG: the REPL
+                    # configures no log handlers, so a WARNING carrying
+                    # exc_info falls through to ``logging.lastResort`` and
+                    # paints a traceback over the TUI frame. Same split
+                    # ``_stream_pump`` makes for the same reason.
+                    _log.warning("Could not resolve elicitation after transport retries")
+                    _log.debug("elicitation resolve failed", exc_info=exc)
+                    # The elicitation is still parked server-side, so the
+                    # turn waits on a verdict that will never arrive. Say so
+                    # instead of leaving an apparently live prompt.
+                    self._emit_elicitation_resolve_error(exc)
                     return
                 await asyncio.sleep(0.1 * (2**attempt))
 

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -2599,23 +2599,35 @@ class _SessionsChatReplAdapter:
                 else:
                     resolve_payload["action"] = "decline"
 
-        try:
-            # URL-based elicitation: deliver the verdict to the
-            # elicitation's dedicated resolve URL rather than as an
-            # in-band ``approval`` session event. Same server-side
-            # effect (both converge on ``_resolve_elicitation``).
-            await self._client.sessions.resolve_elicitation(
-                session_id,
-                elicitation_id,
-                resolve_payload,
-            )
-        except OmnigentError as exc:
-            if exc.code == "not_found":
-                # Elicitation already resolved by another client (e.g. web
-                # UI approved while the terminal prompt was still open).
-                # The harness already received the verdict — treat as no-op.
+        # URL-based elicitation: deliver the verdict to the elicitation's
+        # dedicated resolve URL rather than as an in-band ``approval`` event.
+        # A transport error can happen after the server accepted the POST but
+        # before the client received its response, so retrying is safe: the
+        # server either accepts the retry or reports the elicitation resolved.
+        for attempt in range(3):
+            try:
+                await self._client.sessions.resolve_elicitation(
+                    session_id,
+                    elicitation_id,
+                    resolve_payload,
+                )
                 return
-            raise
+            except OmnigentError as exc:
+                if exc.code == "not_found":
+                    # Another client may have resolved it while the terminal
+                    # prompt was open, or the first POST reached the server.
+                    return
+                raise
+            except Exception as exc:
+                if not _is_recoverable_sse_transport_error(exc):
+                    raise
+                if attempt == 2:
+                    _log.warning(
+                        "Could not resolve elicitation after transport retries",
+                        exc_info=exc,
+                    )
+                    return
+                await asyncio.sleep(0.1 * (2**attempt))
 
     async def _prompt_schema_fields(
         self,

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -113,11 +113,18 @@ def _is_recoverable_sse_transport_error(exc: BaseException) -> bool:
         httpx.ReadTimeout,
         httpx.ConnectError,
         httpx.ConnectTimeout,
+        # A peer that drops the connection while the request is still
+        # being sent surfaces as a write error — the same transient
+        # interruption as a read-side drop, just caught one syscall earlier.
+        httpx.WriteError,
+        httpx.WriteTimeout,
         httpcore.RemoteProtocolError,
         httpcore.ReadError,
         httpcore.ReadTimeout,
         httpcore.ConnectError,
         httpcore.ConnectTimeout,
+        httpcore.WriteError,
+        httpcore.WriteTimeout,
     )
     seen: set[int] = set()
     current: BaseException | None = exc

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -2042,8 +2042,8 @@ class _SessionsChatReplAdapter:
                     code="elicitation_resolve_failed",
                     message=(
                         f"Could not deliver your answer to the server: {exc}. "
-                        "The request is still waiting, so answer it again here "
-                        "or from the web UI."
+                        "The request is still waiting for an answer, and this "
+                        "prompt is gone, so answer it from the web UI."
                     ),
                 ),
             )

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -7452,34 +7452,44 @@ async def _apply_pending_policy_ask_writes(
     pending = _pending_policy_ask_writes.get(elicitation_id)
     if pending is None:
         return
-    if data.get("action") != "accept":
-        # Declined — remove the stashed writes (POLICIES.md §7.2:
-        # a denied ASK leaves no trace).
-        _pending_policy_ask_writes.pop(elicitation_id, None)
-        return
     if pending.from_mcp:
         # MCP entries: the retry path (POST /mcp with requestState)
         # pops and applies the writes itself. Applying here too would
         # double-apply non-idempotent ops (e.g. INCREMENT state
         # updates for cost-budget counters). Leave the entry for the
-        # retry path; it owns cleanup.
+        # retry path (it owns cleanup), dropping it only on decline.
+        if data.get("action") != "accept":
+            # Declined — remove the stashed writes (POLICIES.md §7.2:
+            # a denied ASK leaves no trace).
+            _pending_policy_ask_writes.pop(elicitation_id, None)
         return
-    # Non-MCP relay path: pop and apply writes here since no retry
-    # will arrive.
+    # Non-MCP relay path: claim the entry atomically (no await between
+    # the get above and this pop, so duplicate verdicts — a client
+    # transport retry racing its original POST, or a second client —
+    # can never both apply the same non-idempotent writes).
+    pending = _pending_policy_ask_writes.pop(elicitation_id, None)
+    if pending is None:
+        # A concurrent duplicate verdict already claimed the writes.
+        return
+    if data.get("action") != "accept":
+        # Declined — the claim already removed the stashed writes
+        # (POLICIES.md §7.2: a denied ASK leaves no trace).
+        return
     # Resolve the agent spec + build the engine off the event loop: the
     # lookup, cold-cache bundle fetch, and engine construction are all
     # blocking DB/IO.
     spec = await asyncio.to_thread(_load_agent_spec_for_session, conv, agent_store)
     if spec is None:
-        _pending_policy_ask_writes.pop(elicitation_id, None)
         return
-    engine = await asyncio.to_thread(
-        _build_policy_engine_from_spec, spec, session_id, conversation_store, conv
-    )
-    # Pop only after the engine build succeeds: a raise here (e.g. a
-    # concurrent agent rebind) would otherwise lose the approved writes
-    # with no retry possible.
-    _pending_policy_ask_writes.pop(elicitation_id, None)
+    try:
+        engine = await asyncio.to_thread(
+            _build_policy_engine_from_spec, spec, session_id, conversation_store, conv
+        )
+    except BaseException:
+        # A raise here (e.g. a concurrent agent rebind) must not lose the
+        # approved writes with no retry possible — restore the claim.
+        _pending_policy_ask_writes.setdefault(elicitation_id, pending)
+        raise
     # The label/state writes hit the DB synchronously too — keep them
     # off the loop.
     if pending.set_labels:

--- a/tests/e2e/test_repl_elicitation_resolve_transport_fault.py
+++ b/tests/e2e/test_repl_elicitation_resolve_transport_fault.py
@@ -168,6 +168,9 @@ class _FaultProxy:
         if loop is not None:
             for task in asyncio.all_tasks(loop):
                 loop.call_soon_threadsafe(task.cancel)
+        # Join the proxy thread so no background pump outlives the test.
+        if self._thread is not None:
+            self._thread.join(timeout=10)
 
 
 class _ProxiedSession:
@@ -286,18 +289,20 @@ def _build_repl_env(tmp_home: Path) -> dict[str, str]:
     (config_home / "config.yaml").write_text(
         "auto_open_conversation: false\ntui:\n  theme: dark\n",
     )
-    env = {
-        **os.environ,
-        "HOME": str(tmp_home),
-        "OMNIGENT_CONFIG_HOME": str(config_home),
-        "OMNIGENT_SKIP_ONBOARD": "1",
-        "OMNIGENT_NO_UPDATE_CHECK": "1",
-        "PYTHONPATH": merged_pp,
-        "TERM": "xterm-256color",
-        "LINES": "40",
-        "COLUMNS": "120",
-        "PROMPT_TOOLKIT_NO_CPR": "1",
-    }
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_home),
+            "OMNIGENT_CONFIG_HOME": str(config_home),
+            "OMNIGENT_SKIP_ONBOARD": "1",
+            "OMNIGENT_NO_UPDATE_CHECK": "1",
+            "PYTHONPATH": merged_pp,
+            "TERM": "xterm-256color",
+            "LINES": "40",
+            "COLUMNS": "120",
+            "PROMPT_TOOLKIT_NO_CPR": "1",
+        }
+    )
     for k in ("ANTHROPIC_API_KEY", "CLAUDE_CODE", "CLAUDECODE", "CODEX", "DATABRICKS_TOKEN"):
         env.pop(k, None)
     return ensure_repl_test_theme_env(env)

--- a/tests/e2e/test_repl_elicitation_resolve_transport_fault.py
+++ b/tests/e2e/test_repl_elicitation_resolve_transport_fault.py
@@ -1,0 +1,398 @@
+"""
+REPL elicitation-resolve transport-fault e2e test.
+
+User journey: attach the terminal REPL to a live session, send a message,
+answer the approval prompt with ``y`` — while a transient network fault
+interrupts the verdict POST (``POST /v1/sessions/{id}/elicitations/{eid}/
+resolve``). The REPL must survive the blip (retry or degrade gracefully):
+the turn should still complete and the TUI must NOT crash into
+prompt_toolkit's ``Unhandled exception in event loop`` /
+``Press ENTER to continue...`` pause.
+
+The fault is injected with a transparent TCP proxy between the REPL and
+the Omnigent server that aborts exactly ONE connection: the first one
+carrying an elicitation ``/resolve`` request, before any response bytes
+are sent. Every other request (including a retry of the same resolve)
+passes through untouched — the server and runner stay healthy the whole
+time, exactly like the reported transient interruption.
+
+Usage::
+
+    python -m pytest tests/e2e/test_repl_elicitation_resolve_transport_fault.py -v --timeout=300
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import re
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
+from tests.e2e.conftest import configure_mock_llm, find_free_port, reset_mock_llm
+
+pexpect = pytest.importorskip("pexpect")
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ASK_DEMO_YAML = _REPO_ROOT / "tests" / "resources" / "agents" / "ask-demo" / "ask-demo.yaml"
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+_REPLY_MARKER = "ELICIT_RETRY_OK_MARKER"
+_CRASH_MARKERS = (
+    "Unhandled exception in event loop",
+    "Press ENTER to continue",
+)
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences before substring search."""
+    return _ANSI_RE.sub("", text)
+
+
+class _FaultProxy:
+    """Transparent TCP proxy that aborts ONE elicitation-resolve request.
+
+    Forwards all bytes between clients and the upstream Omnigent server.
+    The first client connection whose bytes carry an elicitation
+    ``/resolve`` HTTP request is aborted (RST, no response) — a transient
+    transport interruption exactly at the verdict POST. Everything else,
+    including a retry of the same resolve, passes through untouched.
+    """
+
+    def __init__(self, upstream_host: str, upstream_port: int, listen_port: int) -> None:
+        self.upstream_host = upstream_host
+        self.upstream_port = upstream_port
+        self.listen_port = listen_port
+        self.kills = 0
+        self._armed = True
+        self._lock = threading.Lock()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._ready = threading.Event()
+
+    def _should_kill(self, buf: bytes) -> bool:
+        if b"/resolve" not in buf or b"/elicitations/" not in buf:
+            return False
+        with self._lock:
+            if not self._armed:
+                return False
+            self._armed = False
+            self.kills += 1
+            return True
+
+    async def _handle(
+        self,
+        creader: asyncio.StreamReader,
+        cwriter: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            ureader, uwriter = await asyncio.open_connection(
+                self.upstream_host, self.upstream_port
+            )
+        except OSError:
+            cwriter.close()
+            return
+
+        killed = asyncio.Event()
+
+        async def pump_c2s() -> None:
+            # Keep a rolling tail so a request line split across reads
+            # still matches; kill on the FIRST resolve request only.
+            scan = b""
+            try:
+                while True:
+                    data = await creader.read(65536)
+                    if not data:
+                        break
+                    scan = (scan + data)[-16384:]
+                    if self._should_kill(scan):
+                        killed.set()
+                        cwriter.transport.abort()
+                        uwriter.transport.abort()
+                        return
+                    uwriter.write(data)
+                    await uwriter.drain()
+            except (ConnectionError, OSError):
+                pass
+            finally:
+                if not killed.is_set():
+                    with contextlib.suppress(OSError):
+                        uwriter.write_eof()
+
+        async def pump_s2c() -> None:
+            try:
+                while True:
+                    data = await ureader.read(65536)
+                    if not data:
+                        break
+                    cwriter.write(data)
+                    await cwriter.drain()
+            except (ConnectionError, OSError):
+                pass
+            finally:
+                if not killed.is_set():
+                    with contextlib.suppress(OSError):
+                        cwriter.close()
+
+        await asyncio.gather(pump_c2s(), pump_s2c(), return_exceptions=True)
+
+    async def _serve(self) -> None:
+        server = await asyncio.start_server(self._handle, "127.0.0.1", self.listen_port)
+        self._ready.set()
+        async with server:
+            await server.serve_forever()
+
+    def start(self) -> None:
+        def _run() -> None:
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+            with contextlib.suppress(asyncio.CancelledError):
+                self._loop.run_until_complete(self._serve())
+
+        self._thread = threading.Thread(target=_run, daemon=True)
+        self._thread.start()
+        if not self._ready.wait(timeout=10):
+            raise RuntimeError("fault proxy did not start listening in time")
+
+    def stop(self) -> None:
+        loop = self._loop
+        if loop is not None:
+            for task in asyncio.all_tasks(loop):
+                loop.call_soon_threadsafe(task.cancel)
+
+
+class _ProxiedSession:
+    """A live gated session reachable through the fault proxy."""
+
+    def __init__(self, proxy: _FaultProxy, proxy_url: str, session_id: str) -> None:
+        self.proxy = proxy
+        self.proxy_url = proxy_url
+        self.session_id = session_id
+
+
+@pytest.fixture
+def proxied_gated_session(
+    mock_llm_server_url: str,
+    tmp_path: Path,
+) -> Iterator[_ProxiedSession]:
+    """Boot server + runner with the always-ask agent, create a session,
+    and put a one-shot fault proxy in front of the server.
+    """
+    from omnigent.chat import _start_local_server, _stop_local_server, _wait_for_server
+
+    reset_mock_llm(mock_llm_server_url)
+    # The always-ask policy gates the turn BEFORE the LLM; once the
+    # verdict lands the turn proceeds and draws this scripted reply.
+    configure_mock_llm(mock_llm_server_url, [{"text": _REPLY_MARKER}] * 3, key="default")
+
+    saved_env = {
+        k: os.environ.get(k)
+        for k in ("OPENAI_API_KEY", "OPENAI_BASE_URL", "PYTHONPATH", "NO_PROXY", "no_proxy")
+    }
+    os.environ["OPENAI_API_KEY"] = "mock-key"
+    os.environ["OPENAI_BASE_URL"] = f"{mock_llm_server_url}/v1"
+    # The spawned server + runner import omnigent from the worktree, and
+    # loopback traffic must bypass any ambient corporate proxy.
+    existing_pp = os.environ.get("PYTHONPATH", "")
+    os.environ["PYTHONPATH"] = (
+        os.pathsep.join([str(_REPO_ROOT), existing_pp]) if existing_pp else str(_REPO_ROOT)
+    )
+    for proxy_key in ("NO_PROXY", "no_proxy"):
+        parts = [p for p in os.environ.get(proxy_key, "").split(",") if p]
+        for host in ("127.0.0.1", "localhost"):
+            if host not in parts:
+                parts.append(host)
+        os.environ[proxy_key] = ",".join(parts)
+
+    server_port = find_free_port()
+    server = _start_local_server(_ASK_DEMO_YAML, server_port, ephemeral=True)
+    proxy: _FaultProxy | None = None
+    try:
+        _wait_for_server(server_port, server)
+        base_url = f"http://127.0.0.1:{server_port}"
+
+        with httpx.Client(base_url=base_url, timeout=30.0) as client:
+            resp = client.get("/v1/agents", params={"limit": 100})
+            resp.raise_for_status()
+            agents = resp.json().get("data", [])
+            agent_id = next((str(a["id"]) for a in agents if a.get("name") == "ask-demo"), None)
+            assert agent_id, f"ask-demo not registered: {[a.get('name') for a in agents]}"
+
+            resp = client.post(
+                "/v1/sessions",
+                json={"agent_id": agent_id},
+                headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+            )
+            resp.raise_for_status()
+            session_id = str(resp.json()["id"])
+
+            resp = client.patch(f"/v1/sessions/{session_id}", json={"runner_id": server.runner_id})
+            resp.raise_for_status()
+
+            # Attach fails loud when the session's runner is not online yet;
+            # wait for the runner's tunnel to come up.
+            deadline = time.monotonic() + 60.0
+            while time.monotonic() < deadline:
+                snap = client.get(f"/v1/sessions/{session_id}").json()
+                if snap.get("runner_online") in (True, None):
+                    break
+                time.sleep(0.5)
+            else:
+                pytest.fail("runner never came online for the gated session")
+
+        proxy_port = find_free_port()
+        proxy = _FaultProxy("127.0.0.1", server_port, proxy_port)
+        proxy.start()
+
+        yield _ProxiedSession(
+            proxy=proxy,
+            proxy_url=f"http://127.0.0.1:{proxy_port}",
+            session_id=session_id,
+        )
+    finally:
+        if proxy is not None:
+            proxy.stop()
+        _stop_local_server(server)
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _build_repl_env(tmp_home: Path) -> dict[str, str]:
+    """Env for the spawned ``omnigent attach`` REPL (pure client)."""
+    from tests.e2e.omnigent._pexpect_harness import ensure_repl_test_theme_env
+
+    sdk_paths = [
+        str(_REPO_ROOT / "sdks" / "python-client"),
+        str(_REPO_ROOT / "sdks" / "ui"),
+    ]
+    existing_pp = os.environ.get("PYTHONPATH", "")
+    merged_pp = (
+        os.pathsep.join([*sdk_paths, existing_pp]) if existing_pp else os.pathsep.join(sdk_paths)
+    )
+    config_home = tmp_home / ".omnigent"
+    config_home.mkdir(parents=True, exist_ok=True)
+    (config_home / "config.yaml").write_text(
+        "auto_open_conversation: false\ntui:\n  theme: dark\n",
+    )
+    env = {
+        **os.environ,
+        "HOME": str(tmp_home),
+        "OMNIGENT_CONFIG_HOME": str(config_home),
+        "OMNIGENT_SKIP_ONBOARD": "1",
+        "OMNIGENT_NO_UPDATE_CHECK": "1",
+        "PYTHONPATH": merged_pp,
+        "TERM": "xterm-256color",
+        "LINES": "40",
+        "COLUMNS": "120",
+        "PROMPT_TOOLKIT_NO_CPR": "1",
+    }
+    for k in ("ANTHROPIC_API_KEY", "CLAUDE_CODE", "CLAUDECODE", "CODEX", "DATABRICKS_TOKEN"):
+        env.pop(k, None)
+    return ensure_repl_test_theme_env(env)
+
+
+def _read_pending(child: Any, seconds: float) -> str:
+    """Non-blocking read of buffered PTY output, ANSI-stripped."""
+    collected = ""
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        with contextlib.suppress(pexpect.EOF):
+            child.expect(pexpect.TIMEOUT, timeout=min(0.5, max(0.05, deadline - time.monotonic())))
+        chunk = child.before or ""
+        if isinstance(chunk, bytes):
+            chunk = chunk.decode("utf-8", errors="replace")
+        collected += chunk
+        # ``before`` accumulates on TIMEOUT; reset the internal buffer so
+        # each iteration only appends fresh bytes.
+        child.buffer = child.string_type()
+        child.before = child.string_type()
+    return _strip_ansi(collected)
+
+
+def _clean_exit(child: Any) -> None:
+    """Best-effort clean exit of the REPL."""
+    try:
+        child.sendcontrol("d")
+        child.expect(pexpect.EOF, timeout=10)
+    except pexpect.ExceptionPexpect:
+        pass
+    if child.isalive():
+        child.terminate(force=True)
+
+
+def test_repl_survives_transient_transport_error_on_elicitation_resolve(
+    proxied_gated_session: _ProxiedSession,
+    tmp_path: Path,
+) -> None:
+    """A transient connection drop on the verdict POST must not crash the REPL.
+
+    Journey: attach the REPL to a live gated session → send a message →
+    ``approval required`` surfaces → answer ``y`` → the verdict POST hits a
+    one-shot transport fault. Expected: the REPL retries (or degrades
+    gracefully), the turn completes with the agent's reply, and the TUI
+    never pauses at ``Unhandled exception in event loop`` /
+    ``Press ENTER to continue...``.
+    """
+    sess = proxied_gated_session
+    env = _build_repl_env(tmp_path / "home")
+
+    child = pexpect.spawn(
+        sys.executable,
+        [
+            "-m",
+            "omnigent.cli",
+            "attach",
+            sess.session_id,
+            "--server",
+            sess.proxy_url,
+        ],
+        env=env,
+        cwd=str(_REPO_ROOT),
+        encoding="utf-8",
+        codec_errors="replace",
+        timeout=120,
+        dimensions=(40, 120),
+    )
+    try:
+        child.expect("❯", timeout=90)
+        child.send("Hello there\r")
+        child.expect("approval required", timeout=60)
+        child.send("y\r")
+        child.expect("approved", timeout=15)
+
+        # The verdict POST fires right after the ``approved`` echo; the
+        # proxy aborts that one request. Give the REPL time to retry,
+        # complete the turn, and render the reply.
+        buffered = _read_pending(child, seconds=20.0)
+
+        assert sess.proxy.kills == 1, (
+            f"fault was not injected (kills={sess.proxy.kills}); "
+            "the resolve POST never crossed the proxy — test harness issue."
+        )
+        for marker in _CRASH_MARKERS:
+            assert marker not in buffered, (
+                f"REPL crashed after the transient transport fault: found "
+                f"{marker!r}.\nBuffer:\n{buffered[-3000:]}"
+            )
+        assert _REPLY_MARKER in buffered, (
+            "Turn never completed after the transient fault — the verdict "
+            "was not retried/delivered (elicitation left unresolved).\n"
+            f"Buffer:\n{buffered[-3000:]}"
+        )
+    except pexpect.EOF:
+        buf = _strip_ansi(child.before or "")
+        pytest.fail(f"REPL exited early. Full buffer:\n{buf[-3000:]}")
+    finally:
+        _clean_exit(child)

--- a/tests/e2e/test_repl_elicitation_resolve_transport_fault.py
+++ b/tests/e2e/test_repl_elicitation_resolve_transport_fault.py
@@ -303,7 +303,12 @@ def _build_repl_env(tmp_home: Path) -> dict[str, str]:
             "PROMPT_TOOLKIT_NO_CPR": "1",
         }
     )
-    for k in ("ANTHROPIC_API_KEY", "CLAUDE_CODE", "CLAUDECODE", "CODEX", "DATABRICKS_TOKEN"):
+    # Strip every ambient credential/harness marker so the spawned REPL is a
+    # pure client — a leaked provider var reroutes its credential resolution.
+    for k in list(env):
+        if k.startswith("DATABRICKS_"):
+            env.pop(k, None)
+    for k in ("ANTHROPIC_API_KEY", "CLAUDE_CODE", "CLAUDECODE", "CODEX"):
         env.pop(k, None)
     return ensure_repl_test_theme_env(env)
 

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -11,6 +11,7 @@ tab) or an unrelated tool result to skip.
 from __future__ import annotations
 
 import json
+import logging
 
 import pytest
 from prompt_toolkit.document import Document
@@ -2897,10 +2898,68 @@ async def test_sessions_adapter_contains_repeated_elicitation_transport_failure(
         url=None,
     )
 
-    await adapter._handle_elicitation("conv_abc", event)
+    with caplog.at_level(logging.DEBUG, logger="omnigent.repl._repl"):
+        await adapter._handle_elicitation("conv_abc", event)
 
     assert client.sessions.resolve_elicitation.await_count == 3
-    assert "Could not resolve elicitation after transport retries" in caplog.text
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert [r.getMessage() for r in warnings] == [
+        "Could not resolve elicitation after transport retries"
+    ]
+    # No traceback on the WARNING: the REPL configures no handlers, so
+    # exc_info would reach ``logging.lastResort`` and paint ~15 lines over
+    # the TUI frame. The postmortem belongs on the DEBUG sibling.
+    assert warnings[0].exc_info is None
+    assert any(r.levelno == logging.DEBUG and r.exc_info is not None for r in caplog.records), (
+        "expected the traceback to survive on a DEBUG record"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sessions_adapter_surfaces_undeliverable_elicitation_verdict() -> None:
+    """An undeliverable verdict must reach the user, not just the log.
+
+    Exhausted retries leave the elicitation parked server-side, so the turn
+    waits on an answer that will never arrive. Without a rendered error the
+    user sits at an apparently live prompt with no idea their approval was
+    dropped.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    import httpx
+    from omnigent_client import StreamHooks
+
+    client = MagicMock()
+    client.sessions.resolve_elicitation = AsyncMock(
+        side_effect=httpx.ConnectError("connection dropped"),
+    )
+    adapter = _SessionsChatReplAdapter(
+        client=client,
+        agent_name="test-agent",
+        hooks=StreamHooks(on_elicitation_request=AsyncMock(return_value=True)),
+        session_id="conv_abc",
+    )
+    rendered: list[object] = []
+    adapter._on_event = rendered.append
+    event = SimpleNamespace(
+        elicitation_id="elicit_abc",
+        message="approve?",
+        requested_schema={},
+        mode="form",
+        phase="tool_call",
+        policy_name="test-policy",
+        content_preview="",
+        url=None,
+    )
+
+    await adapter._handle_elicitation("conv_abc", event)
+
+    assert len(rendered) == 1, f"expected one rendered error event, got {rendered}"
+    emitted = rendered[0]
+    assert emitted.type == "response.error"
+    assert emitted.error.code == "elicitation_resolve_failed"
+    assert "answer it again" in emitted.error.message
 
 
 def test_is_recoverable_sse_transport_error_for_write_errors() -> None:

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -2920,6 +2920,7 @@ def test_is_recoverable_sse_transport_error_for_write_errors() -> None:
     )
     assert _is_recoverable_sse_transport_error(httpcore.WriteError("connection reset"))
     assert _is_recoverable_sse_transport_error(httpx.WriteTimeout("write stalled"))
+    assert _is_recoverable_sse_transport_error(httpcore.WriteTimeout("write stalled"))
 
 
 def test_legacy_session_falls_back_to_conversation_id() -> None:

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -2824,6 +2824,85 @@ def test_sessions_adapter_session_id_surfaces_as_conversation_id() -> None:
     )
 
 
+@pytest.mark.asyncio
+async def test_sessions_adapter_retries_transient_elicitation_resolution() -> None:
+    """A transient resolve POST failure must not escape the event task.
+
+    The verdict may already have reached the server when the HTTP response
+    connection drops. Retrying is safe: a second successful POST completes
+    the elicitation, while an already-resolved response is handled by the
+    existing ``not_found`` branch.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    import httpx
+    from omnigent_client import StreamHooks
+
+    client = MagicMock()
+    client.sessions.resolve_elicitation = AsyncMock(
+        side_effect=[httpx.ConnectError("connection dropped"), None],
+    )
+    adapter = _SessionsChatReplAdapter(
+        client=client,
+        agent_name="test-agent",
+        hooks=StreamHooks(on_elicitation_request=AsyncMock(return_value=True)),
+        session_id="conv_abc",
+    )
+    event = SimpleNamespace(
+        elicitation_id="elicit_abc",
+        message="approve?",
+        requested_schema={},
+        mode="form",
+        phase="tool_call",
+        policy_name="test-policy",
+        content_preview="",
+        url=None,
+    )
+
+    await adapter._handle_elicitation("conv_abc", event)
+
+    assert client.sessions.resolve_elicitation.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_sessions_adapter_contains_repeated_elicitation_transport_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Exhausted transport retries must not crash the REPL event loop."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    import httpx
+    from omnigent_client import StreamHooks
+
+    client = MagicMock()
+    client.sessions.resolve_elicitation = AsyncMock(
+        side_effect=httpx.ConnectError("connection dropped"),
+    )
+    adapter = _SessionsChatReplAdapter(
+        client=client,
+        agent_name="test-agent",
+        hooks=StreamHooks(on_elicitation_request=AsyncMock(return_value=True)),
+        session_id="conv_abc",
+    )
+    event = SimpleNamespace(
+        elicitation_id="elicit_abc",
+        message="approve?",
+        requested_schema={},
+        mode="form",
+        phase="tool_call",
+        policy_name="test-policy",
+        content_preview="",
+        url=None,
+    )
+
+    await adapter._handle_elicitation("conv_abc", event)
+
+    assert client.sessions.resolve_elicitation.await_count == 3
+    assert "Could not resolve elicitation after transport retries" in caplog.text
+
+
 def test_legacy_session_falls_back_to_conversation_id() -> None:
     """Legacy sessions (no ``session_id`` attr) fall back to local var.
 

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -2959,7 +2959,10 @@ async def test_sessions_adapter_surfaces_undeliverable_elicitation_verdict() -> 
     emitted = rendered[0]
     assert emitted.type == "response.error"
     assert emitted.error.code == "elicitation_resolve_failed"
-    assert "answer it again" in emitted.error.message
+    # Names the surface that can still answer: the terminal prompt is gone
+    # by now, so pointing the user back at it would be a dead end.
+    assert "web UI" in emitted.error.message
+    assert "still waiting" in emitted.error.message
 
 
 def test_is_recoverable_sse_transport_error_for_write_errors() -> None:

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -2903,6 +2903,25 @@ async def test_sessions_adapter_contains_repeated_elicitation_transport_failure(
     assert "Could not resolve elicitation after transport retries" in caplog.text
 
 
+def test_is_recoverable_sse_transport_error_for_write_errors() -> None:
+    """A peer dropping the connection mid-request-send is transient too.
+
+    An aborted connection can surface on the write side (the request
+    body was still being sent) rather than the read side. Both are the
+    same transient interruption; write errors must classify as
+    recoverable so the elicitation-resolve retry covers them.
+    """
+    import httpcore
+    import httpx
+
+    assert _is_recoverable_sse_transport_error(httpx.WriteError("connection reset")), (
+        "httpx.WriteError must classify as recoverable — a mid-send "
+        "connection drop is the write-side twin of a read-side drop."
+    )
+    assert _is_recoverable_sse_transport_error(httpcore.WriteError("connection reset"))
+    assert _is_recoverable_sse_transport_error(httpx.WriteTimeout("write stalled"))
+
+
 def test_legacy_session_falls_back_to_conversation_id() -> None:
     """Legacy sessions (no ``session_id`` attr) fall back to local var.
 

--- a/tests/server/routes/test_sessions_mcp_proxy_policy_retry.py
+++ b/tests/server/routes/test_sessions_mcp_proxy_policy_retry.py
@@ -578,6 +578,81 @@ async def test_non_mcp_entry_popped_by_events_handler_on_accept(
         _pending_policy_ask_writes.pop(eid, None)
 
 
+@pytest.mark.asyncio
+async def test_duplicate_accept_verdicts_apply_relay_writes_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent duplicate accept verdicts must apply writes exactly once.
+
+    A client transport retry of the resolve POST can race its original
+    request (the retry fires while the first is still executing
+    server-side). Both handlers see the stashed entry unless it is
+    claimed atomically before the first ``await`` — and a double apply
+    re-runs non-idempotent ops (e.g. INCREMENT state updates for
+    cost-budget counters).
+    """
+    import asyncio
+
+    from omnigent.server.routes.sessions import _apply_pending_policy_ask_writes
+    from omnigent.spec.types import StateUpdate, StateUpdateAction
+
+    eid = "elicit_DUPLICATE_verdicts"
+    _pending_policy_ask_writes[eid] = _PendingPolicyAskWrites(
+        state_updates=[
+            StateUpdate(key="budget.checkpoint", action=StateUpdateAction.INCREMENT, value=1)
+        ],
+        set_labels=None,
+        from_mcp=False,
+    )
+
+    applied: list[list[Any]] = []
+
+    @dataclass
+    class _CountingEngine(_FixedPolicyEngine):
+        def apply_state_updates(self, updates: list[Any]) -> None:
+            applied.append(updates)
+
+    engine = _CountingEngine(result=PolicyResult(action=PolicyAction.ALLOW, reason=None))
+    monkeypatch.setattr(
+        sessions_mod,
+        "_load_agent_spec_for_session",
+        lambda conv, agent_store: "fake_spec",
+    )
+    monkeypatch.setattr(
+        sessions_mod,
+        "_build_policy_engine_from_spec",
+        _engine_factory_expecting_preload(engine),
+    )
+
+    conv = _make_conversation()
+    store = _StubConversationStore(conv)
+    data = {"elicitation_id": eid, "action": "accept"}
+    try:
+        await asyncio.gather(
+            _apply_pending_policy_ask_writes(
+                session_id=_SESSION_ID,
+                conv=conv,
+                conversation_store=store,  # type: ignore[arg-type]
+                agent_store=_StubAgentStore(),  # type: ignore[arg-type]
+                data=data,
+            ),
+            _apply_pending_policy_ask_writes(
+                session_id=_SESSION_ID,
+                conv=conv,
+                conversation_store=store,  # type: ignore[arg-type]
+                agent_store=_StubAgentStore(),  # type: ignore[arg-type]
+                data=data,
+            ),
+        )
+        assert len(applied) == 1, (
+            f"stashed relay writes applied {len(applied)} times for duplicate "
+            "verdicts — non-idempotent ops (INCREMENT counters) double-apply."
+        )
+        assert eid not in _pending_policy_ask_writes
+    finally:
+        _pending_policy_ask_writes.pop(eid, None)
+
+
 # ---------------------------------------------------------------------------
 # Actor threading tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

Closes #5990

## Summary

- Retry elicitation resolution up to three times for already-classified recoverable HTTP transport interruptions.
- Preserve the existing idempotent `not_found` handling when another client, or the first uncertain POST, already resolved the elicitation.
- Contain repeated transient transport failures after bounded retries so the background event task no longer crashes and pauses the REPL.

ELI5: approving a prompt sends a small HTTP message. If the connection drops while that message is being acknowledged, the terminal now tries again briefly instead of crashing its event loop.

```text
approval verdict
      |
      v
resolve POST -- success -----------------> done
      |
      +-- transient transport error --> bounded retry
                                         |       |
                                      success  not_found
                                         |       |
                                         +--> done
                                         |
                                  retries exhausted
                                         |
                                   warn, keep REPL alive
```

## Test Plan

```bash
uv sync --group lint --group test --extra tracing
uv run pytest -q tests/repl/test_repl.py
uv run pre-commit run --files omnigent/repl/_repl.py tests/repl/test_repl.py
```

Results:

- `113 passed`
- all pre-commit hooks passed
- the new transient-failure test failed on the unfixed base with `httpx.ConnectError: connection dropped` and passes with this change

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The regression tests inject the exact transport failure at the production call seam. One verifies fail-then-success retry; the other verifies repeated failures are bounded and do not escape the REPL event task.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The adapter unit tests exercise the real `_handle_elicitation` call site and its existing transport-error classifier without requiring a flaky real network interruption.

## Changelog

The terminal stays responsive when an approval response hits a temporary network interruption.
