### PR TITLE
fix(claude-sdk): keep a bundle's own skill invocable under skills: none

### DIFF
--- a/omnigent/inner/bundle_skills.py
+++ b/omnigent/inner/bundle_skills.py
@@ -78,8 +78,8 @@ def bundle_skill_names(bundle_dir: Path) -> list[str]:
     Used to seed the SDK's ``skills`` allowlist with a bundle's own
     skills when ``skills_filter: none`` would otherwise leave them
     listed (via ``--plugin-dir``) but unable to actually invoke the
-    native ``Skill`` tool (omnigent-ai/omnigent#5946) — an empty
-    allowlist blocks every skill, bundled or host.
+    native ``Skill`` tool — an empty allowlist blocks every skill,
+    bundled or host.
 
     Deliberately tolerant: a bundle only reaches a harness after the
     spec parser already validated every ``SKILL.md`` strictly, so a

--- a/omnigent/inner/bundle_skills.py
+++ b/omnigent/inner/bundle_skills.py
@@ -167,7 +167,10 @@ def claude_native_skill_args(
       sources), so no ``--setting-sources`` is emitted.
     - ``"none"`` → ``--setting-sources ""`` suppresses host-skill
       discovery; bundle skills loaded via ``--plugin-dir`` are
-      unaffected and remain visible.
+      unaffected and remain visible. Unlike the SDK path, no allowlist
+      seeding is needed here: the CLI has no per-name allowlist flag,
+      so nothing blocks the plugin skills (the SDK's empty ``skills``
+      list is what the executor's seeding works around).
     - ``list[str]`` → treated like ``"all"`` for host sources (the SDK
       uses ``setting_sources=None`` for the list case). The CLI has no
       per-name skill allowlist flag, so the named subset is not

--- a/omnigent/inner/bundle_skills.py
+++ b/omnigent/inner/bundle_skills.py
@@ -116,6 +116,35 @@ def bundle_skill_names(bundle_dir: Path) -> list[str]:
     return names
 
 
+def bundle_plugin_name(bundle_dir: Path, agent_name: str | None) -> str:
+    """
+    Resolve the plugin name Claude Code will label this bundle's skills
+    with (the ``<plugin>`` half of ``<plugin>:<skill>``).
+
+    Prefers the ``name`` recorded in the bundle's own
+    ``.claude-plugin/plugin.json`` — a user-supplied manifest may carry a
+    name that differs from the agent's display name, and the CLI labels
+    skills by the manifest, not the agent. Falls back to the same
+    ``agent_name or bundle_dir.name`` default that
+    :func:`ensure_bundle_plugin_manifest` writes, so both agree when the
+    manifest was auto-generated (or is unreadable).
+
+    :param bundle_dir: Materialized agent-bundle root.
+    :param agent_name: Agent display name, or ``None``.
+    :returns: The plugin name to build ``<plugin>:<skill>`` entries with.
+    """
+    manifest_path = bundle_dir / ".claude-plugin" / "plugin.json"
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        manifest = None
+    if isinstance(manifest, dict):
+        name = manifest.get("name")
+        if isinstance(name, str) and name:
+            return name
+    return agent_name or bundle_dir.name
+
+
 def claude_native_skill_args(
     bundle_dir: Path | None,
     *,

--- a/omnigent/inner/bundle_skills.py
+++ b/omnigent/inner/bundle_skills.py
@@ -15,7 +15,18 @@ to the real ``claude`` binary.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
+
+import yaml
+
+# Matches ``_FRONTMATTER_RE`` in ``omnigent.spec.parser`` — kept as a
+# separate copy here (rather than importing the parser's private regex)
+# since this module intentionally stays a lightweight, best-effort reader:
+# by the time a bundle reaches a harness it already passed the parser's
+# strict validation, so a skill directory that fails this tolerant read
+# is skipped rather than treated as an error.
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n(.*)", re.DOTALL)
 
 
 def ensure_bundle_plugin_manifest(
@@ -57,6 +68,52 @@ def ensure_bundle_plugin_manifest(
         )
         + "\n",
     )
+
+
+def bundle_skill_names(bundle_dir: Path) -> list[str]:
+    """
+    Read the ``name`` frontmatter field out of each of the bundle's
+    ``skills/<dir>/SKILL.md`` files.
+
+    Used to seed the SDK's ``skills`` allowlist with a bundle's own
+    skills when ``skills_filter: none`` would otherwise leave them
+    listed (via ``--plugin-dir``) but unable to actually invoke the
+    native ``Skill`` tool (omnigent-ai/omnigent#5946) — an empty
+    allowlist blocks every skill, bundled or host.
+
+    Deliberately tolerant: a bundle only reaches a harness after the
+    spec parser already validated every ``SKILL.md`` strictly, so a
+    directory that fails this lightweight re-read (missing file, bad
+    YAML, no ``name`` key) is skipped rather than raised — this is a
+    best-effort enrichment at turn time, not spec validation.
+
+    :param bundle_dir: Materialized agent-bundle root.
+    :returns: Skill names in directory-listing order, e.g.
+        ``["code-review", "feature-brainstorming"]``. Empty when the
+        bundle has no ``skills/`` directory or no readable skills.
+    """
+    skills_dir = bundle_dir / "skills"
+    if not skills_dir.is_dir():
+        return []
+    names: list[str] = []
+    for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
+        try:
+            text = skill_md.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        match = _FRONTMATTER_RE.match(text)
+        if not match:
+            continue
+        try:
+            frontmatter = yaml.safe_load(match.group(1))
+        except yaml.YAMLError:
+            continue
+        if not isinstance(frontmatter, dict):
+            continue
+        name = frontmatter.get("name")
+        if isinstance(name, str) and name:
+            names.append(name)
+    return names
 
 
 def claude_native_skill_args(

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -1398,8 +1398,8 @@ def _resolve_skills_option(
       remain listed — but an empty ``skills`` allowlist also
       blocks them from being *invoked*, so the caller
       (:meth:`ClaudeSDKExecutor.run_turn`) re-seeds this result's
-      ``skills`` with the bundle's own skill names before use
-      (omnigent-ai/omnigent#5946). This function's return value
+      ``skills`` with the bundle's own skill names before use.
+      This function's return value
       alone is not the final word for ``"none"``.
     - ``list[str]`` → ``skills=[names]``, ``setting_sources=None``.
       Only the named subset is in the model's listing; the SDK's
@@ -1441,7 +1441,7 @@ def _seed_bundle_skills_when_hermetic(
     allowlist, which blocks the ``Skill`` tool outright — including
     for the bundle's OWN skills, which are still listed (via
     ``--plugin-dir``, wired by the caller) but then can never actually
-    be invoked (omnigent-ai/omnigent#5946). Every other *resolved*
+    be invoked. Every other *resolved*
     value (``"all"``, or an explicit list of names) is returned
     unchanged: this only affects the specific ``skills=[]`` shape that
     ``"none"`` produces.
@@ -1586,8 +1586,7 @@ class ClaudeSDKExecutor(Executor):
                 ``"none"`` — the allowlist is seeded with the
                 bundle's own skill names so opting out of host
                 skills doesn't also disable the agent's own bundled
-                skill (omnigent-ai/omnigent#5946). Defaults to
-                ``"all"``.
+                skill. Defaults to ``"all"``.
             api_key_helper: Shell command the Claude CLI will invoke to
                 retrieve a bearer token, e.g.
                 ``"printf %s sk-ant-..."`` (set by the harness when

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -47,7 +47,11 @@ from omnigent._platform import resolve_cli_binary, stable_user_id
 from omnigent.cli_invocation import cli_invocation
 from omnigent.databricks_ai_gateway import is_databricks_ai_gateway_url
 from omnigent.inner import _proc
-from omnigent.inner.bundle_skills import bundle_skill_names, ensure_bundle_plugin_manifest
+from omnigent.inner.bundle_skills import (
+    bundle_plugin_name,
+    bundle_skill_names,
+    ensure_bundle_plugin_manifest,
+)
 from omnigent.inner.hook_scripts import subagent_router
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
@@ -1458,10 +1462,11 @@ def _seed_bundle_skills_when_hermetic(
         against ``"none"`` to scope this to the hermetic case.
     :param bundle_dir: Materialized agent-bundle root, or ``None``
         when the agent ships no bundle.
-    :param agent_name: Agent display name, used the same way
-        :func:`omnigent.inner.bundle_skills.ensure_bundle_plugin_manifest`
-        does to build the plugin-qualified name — falls back to the
-        bundle directory's basename when unset.
+    :param agent_name: Agent display name, used by
+        :func:`omnigent.inner.bundle_skills.bundle_plugin_name` as the
+        fallback when the bundle's ``.claude-plugin/plugin.json`` carries
+        no usable ``name`` — the manifest's own name wins otherwise,
+        since that is the label the CLI qualifies plugin skills with.
     :returns: *resolved* unchanged, or a new :class:`_ResolvedSkills`
         with ``skills`` seeded from the bundle's own skill names.
     """
@@ -1470,7 +1475,7 @@ def _seed_bundle_skills_when_hermetic(
     skill_names = bundle_skill_names(bundle_dir)
     if not skill_names:
         return resolved
-    plugin_name = agent_name or bundle_dir.name
+    plugin_name = bundle_plugin_name(bundle_dir, agent_name)
     seeded: list[str] = []
     for name in skill_names:
         seeded.append(name)

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -47,7 +47,7 @@ from omnigent._platform import resolve_cli_binary, stable_user_id
 from omnigent.cli_invocation import cli_invocation
 from omnigent.databricks_ai_gateway import is_databricks_ai_gateway_url
 from omnigent.inner import _proc
-from omnigent.inner.bundle_skills import ensure_bundle_plugin_manifest
+from omnigent.inner.bundle_skills import bundle_skill_names, ensure_bundle_plugin_manifest
 from omnigent.inner.hook_scripts import subagent_router
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
@@ -1394,8 +1394,13 @@ def _resolve_skills_option(
       the ``Skill`` tool listing AND the scope-based discovery
       are suppressed: no host skills appear in the system
       prompt or as invokable. Bundled skills (loaded via
-      ``--plugin-dir``) are unaffected by ``setting_sources``
-      and remain visible.
+      ``--plugin-dir``) are unaffected by ``setting_sources`` and
+      remain listed — but an empty ``skills`` allowlist also
+      blocks them from being *invoked*, so the caller
+      (:meth:`ClaudeSDKExecutor.run_turn`) re-seeds this result's
+      ``skills`` with the bundle's own skill names before use
+      (omnigent-ai/omnigent#5946). This function's return value
+      alone is not the final word for ``"none"``.
     - ``list[str]`` → ``skills=[names]``, ``setting_sources=None``.
       Only the named subset is in the model's listing; the SDK's
       auto-default still loads user and project sources for
@@ -1418,6 +1423,59 @@ def _resolve_skills_option(
     if isinstance(skills_filter, list):
         return _ResolvedSkills(skills=list(skills_filter), setting_sources=None)
     return None
+
+
+def _seed_bundle_skills_when_hermetic(
+    resolved: _ResolvedSkills,
+    *,
+    skills_filter: str | list[str],
+    bundle_dir: pathlib.Path | None,
+    agent_name: str | None,
+) -> _ResolvedSkills:
+    """
+    Re-seed a hermetic (``"none"``) skills resolution with the bundle's
+    own skill names, so they stay invocable through the native
+    ``Skill`` tool.
+
+    ``_resolve_skills_option("none")`` returns an empty ``skills``
+    allowlist, which blocks the ``Skill`` tool outright — including
+    for the bundle's OWN skills, which are still listed (via
+    ``--plugin-dir``, wired by the caller) but then can never actually
+    be invoked (omnigent-ai/omnigent#5946). Every other *resolved*
+    value (``"all"``, or an explicit list of names) is returned
+    unchanged: this only affects the specific ``skills=[]`` shape that
+    ``"none"`` produces.
+
+    Both the bare skill name and the plugin-qualified
+    ``<plugin>:<name>`` form are added for each skill, since the CLI's
+    exact matching convention for a plugin-provided skill isn't part
+    of the SDK's public contract; an unmatched extra allowlist entry
+    is inert.
+
+    :param resolved: The ``_resolve_skills_option`` result to
+        (possibly) re-seed.
+    :param skills_filter: The spec's raw ``skills_filter``, checked
+        against ``"none"`` to scope this to the hermetic case.
+    :param bundle_dir: Materialized agent-bundle root, or ``None``
+        when the agent ships no bundle.
+    :param agent_name: Agent display name, used the same way
+        :func:`omnigent.inner.bundle_skills.ensure_bundle_plugin_manifest`
+        does to build the plugin-qualified name — falls back to the
+        bundle directory's basename when unset.
+    :returns: *resolved* unchanged, or a new :class:`_ResolvedSkills`
+        with ``skills`` seeded from the bundle's own skill names.
+    """
+    if skills_filter != "none" or bundle_dir is None:
+        return resolved
+    skill_names = bundle_skill_names(bundle_dir)
+    if not skill_names:
+        return resolved
+    plugin_name = agent_name or bundle_dir.name
+    seeded: list[str] = []
+    for name in skill_names:
+        seeded.append(name)
+        seeded.append(f"{plugin_name}:{name}")
+    return _ResolvedSkills(skills=seeded, setting_sources=resolved.setting_sources)
 
 
 class ClaudeSDKExecutor(Executor):
@@ -1522,14 +1580,14 @@ class ClaudeSDKExecutor(Executor):
             skills_filter: Host-skill filter (``"all"`` / ``"none"`` /
                 ``list[str]``). Maps to the SDK's ``skills`` option:
                 ``"all"`` → enable every host-discovered skill,
-                ``"none"`` → empty list (no host skills exposed),
-                list of names → only the named skills. Bundled
-                skills loaded via ``bundle_dir`` are subject to the
-                same listing filter (so ``"none"`` hides every skill
-                from the model, bundled or host); agents that want
-                bundled skills always visible while opting out of
-                host skills should set this to a list naming their
-                bundled skills explicitly. Defaults to ``"all"``.
+                ``"none"`` → no host skills exposed, list of names →
+                only the named skills. Bundled skills loaded via
+                ``bundle_dir`` stay listed AND invocable under
+                ``"none"`` — the allowlist is seeded with the
+                bundle's own skill names so opting out of host
+                skills doesn't also disable the agent's own bundled
+                skill (omnigent-ai/omnigent#5946). Defaults to
+                ``"all"``.
             api_key_helper: Shell command the Claude CLI will invoke to
                 retrieve a bearer token, e.g.
                 ``"printf %s sk-ant-..."`` (set by the harness when
@@ -2421,6 +2479,12 @@ class ClaudeSDKExecutor(Executor):
         # this is belt-and-suspenders).
         resolved = _resolve_skills_option(self._skills_filter) or _ResolvedSkills(
             skills="all", setting_sources=None
+        )
+        resolved = _seed_bundle_skills_when_hermetic(
+            resolved,
+            skills_filter=self._skills_filter,
+            bundle_dir=self._bundle_dir,
+            agent_name=self._agent_name,
         )
         # Bundle skills are exposed via the SDK's plugin mechanism.
         # The bundle's ``<bundle>/skills/<dir>/SKILL.md`` files are

--- a/tests/e2e/omnigent/test_claude_sdk_skills_none_bundle_skill.py
+++ b/tests/e2e/omnigent/test_claude_sdk_skills_none_bundle_skill.py
@@ -1,4 +1,4 @@
-"""E2E — bundled skill invocation under ``skills: none`` (omnigent-ai/omnigent#5946).
+"""E2E — bundled skill invocation under ``skills: none``.
 
 Drives ``ClaudeSDKExecutor.run_turn()`` directly (in-process, real
 ``claude`` CLI binary) against a bundle whose spec sets ``skills:
@@ -110,7 +110,7 @@ def test_bundled_skill_is_invocable_under_skills_none(
     for key, value in mock_credentials_env.items():
         monkeypatch.setenv(key, value)
     monkeypatch.setenv("ANTHROPIC_BASE_URL", mock_llm_server_url)
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "mock-key")
+    monkeypatch.setenv("OMNIGENT_CLAUDE_SDK_NO_SANDBOX", "1")
 
     executor = ClaudeSDKExecutor(
         bundle_dir=skill_bundle,
@@ -118,6 +118,7 @@ def test_bundled_skill_is_invocable_under_skills_none(
         skills_filter="none",
         model=model,
         permission_mode="bypassPermissions",
+        api_key_helper="printf %s mock-key",
         cwd="/tmp",
     )
 
@@ -147,6 +148,6 @@ def test_bundled_skill_is_invocable_under_skills_none(
     completion = skill_completions[0]
     assert completion.status == ToolCallStatus.SUCCESS, (
         f"bundled skill was denied by the skills allowlist under skills:none "
-        f"(the #5946 regression) — result: {completion.result!r}"
+        f"— result: {completion.result!r}"
     )
     assert "not in this session's skills allowlist" not in (completion.error or "")

--- a/tests/e2e/omnigent/test_claude_sdk_skills_none_bundle_skill.py
+++ b/tests/e2e/omnigent/test_claude_sdk_skills_none_bundle_skill.py
@@ -1,0 +1,152 @@
+"""E2E — bundled skill invocation under ``skills: none`` (omnigent-ai/omnigent#5946).
+
+Drives ``ClaudeSDKExecutor.run_turn()`` directly (in-process, real
+``claude`` CLI binary) against a bundle whose spec sets ``skills:
+none`` and ships a single skill under ``skills/my-skill/SKILL.md``.
+The mock LLM server is scripted to have the model call the native
+``Skill`` tool for that skill — exercising the real CLI binary's own
+skill-allowlist enforcement, not just the Python-side translation
+logic.
+
+Two responses are queued per run: the CLI makes an unrelated
+preliminary model call before the scripted user turn is processed (a
+generic warm-up request, observed empirically — the first queued
+response is otherwise silently consumed by it), so a plain-text
+response absorbs that first request and the real assertion targets
+the second.
+
+**What breaks if this fails:** ``ClaudeSDKExecutor``'s ``skills:
+none`` handling regresses so the agent's own bundled skill goes back
+to being listed-but-uninvokable, silently defeating the fix in
+``_seed_bundle_skills_when_hermetic`` — reproduced live pre-fix with
+the exact reported error, ``Skill my-skill is not in this session's
+skills allowlist``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from shutil import which
+
+import pytest
+
+from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+from omnigent.inner.executor import ToolCallComplete, ToolCallStatus
+from tests.e2e.omnigent.conftest import configure_mock_llm, reset_mock_llm, set_fallback_mock_llm
+
+_MODEL_PREFIX = "mock-skills-none-bundle"
+_RUN_TIMEOUT_SEC = 60
+
+
+@pytest.fixture
+def claude_sdk_available() -> bool:
+    """True when the ``claude`` CLI binary is present on PATH.
+
+    Unlike the subprocess-based per-harness characterization tests,
+    this test drives ``ClaudeSDKExecutor`` in-process against the
+    CURRENT interpreter's ``claude_agent_sdk`` (the test's own venv,
+    which is the omnigent venv itself for this test tree) — so only
+    the ``claude`` binary needs a presence check.
+    """
+    return which("claude") is not None
+
+
+@pytest.fixture
+def skill_bundle(tmp_path: Path) -> Path:
+    """A minimal bundle: ``skills: none``, one bundled skill named ``my-skill``."""
+    bundle = tmp_path / "skill-test-agent"
+    (bundle / "skills" / "my-skill").mkdir(parents=True)
+    (bundle / "skills" / "my-skill" / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A trivial test skill that just says a magic word.\n"
+        "---\n"
+        "\n"
+        "When invoked, respond with exactly the word: SKILLINVOKED\n"
+    )
+    return bundle
+
+
+def test_bundled_skill_is_invocable_under_skills_none(
+    mock_credentials_env: dict[str, str],
+    mock_llm_server_url: str,
+    claude_sdk_available: bool,
+    skill_bundle: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    With ``skills: none``, the agent's own bundled skill still gets
+    invoked successfully through the real ``claude`` CLI's own
+    skill-allowlist enforcement — the model's ``Skill`` tool_use for
+    ``my-skill`` is NOT denied.
+
+    Pre-fix, the CLI's allowlist (triggered by the empty ``skills=[]``
+    that ``"none"`` used to produce unconditionally) rejects the call
+    with "not in this session's skills allowlist", surfaced here as a
+    :class:`ToolCallComplete` with ``status=ERROR``.
+    """
+    if not claude_sdk_available:
+        pytest.skip(
+            "claude-sdk harness prerequisites missing: the 'claude' CLI "
+            "binary must be present on PATH. Skipping — binary absent."
+        )
+
+    model = f"{_MODEL_PREFIX}-{uuid.uuid4().hex[:8]}"
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            # Absorbs an observed unrelated preliminary model call the
+            # CLI makes before processing the scripted user turn.
+            {"text": "preflight"},
+            {"tool_calls": [{"name": "Skill", "arguments": '{"skill": "my-skill"}'}]},
+        ],
+        key=model,
+    )
+    set_fallback_mock_llm(mock_llm_server_url, model, "done")
+
+    for key, value in mock_credentials_env.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", mock_llm_server_url)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "mock-key")
+
+    executor = ClaudeSDKExecutor(
+        bundle_dir=skill_bundle,
+        agent_name="skill-test-agent",
+        skills_filter="none",
+        model=model,
+        permission_mode="bypassPermissions",
+        cwd="/tmp",
+    )
+
+    async def _run() -> list[object]:
+        events: list[object] = []
+        async for ev in executor.run_turn(
+            [
+                {
+                    "role": "user",
+                    "content": (
+                        "Use the Skill tool right now to invoke the skill named 'my-skill'."
+                    ),
+                }
+            ],
+            [],
+            "You are a test agent.",
+        ):
+            events.append(ev)
+        return events
+
+    events = asyncio.run(asyncio.wait_for(_run(), timeout=_RUN_TIMEOUT_SEC))
+
+    skill_completions = [
+        ev for ev in events if isinstance(ev, ToolCallComplete) and ev.name == "Skill"
+    ]
+    assert skill_completions, f"expected a Skill ToolCallComplete event, got: {events}"
+    completion = skill_completions[0]
+    assert completion.status == ToolCallStatus.SUCCESS, (
+        f"bundled skill was denied by the skills allowlist under skills:none "
+        f"(the #5946 regression) — result: {completion.result!r}"
+    )
+    assert "not in this session's skills allowlist" not in (completion.error or "")

--- a/tests/e2e_ui/chat/test_skills_none_bundled_skill_invocable.py
+++ b/tests/e2e_ui/chat/test_skills_none_bundled_skill_invocable.py
@@ -229,9 +229,9 @@ def test_skills_none_allows_invoking_bundled_skill(
 
             # Turn settles: the scripted final text lands and the working
             # indicator clears.
-            expect(
-                page.locator(_ASSISTANT).filter(has_text=_DONE_TEXT).first
-            ).to_be_visible(timeout=240_000)
+            expect(page.locator(_ASSISTANT).filter(has_text=_DONE_TEXT).first).to_be_visible(
+                timeout=240_000
+            )
             expect(page.locator(_WORKING)).to_have_count(0, timeout=60_000)
 
             # ── The reproduction assertion ──────────────────────────────

--- a/tests/e2e_ui/chat/test_skills_none_bundled_skill_invocable.py
+++ b/tests/e2e_ui/chat/test_skills_none_bundled_skill_invocable.py
@@ -1,0 +1,272 @@
+"""UI journey: ``skills: none`` must not block the agent's own bundled skill.
+
+A claude-sdk agent whose bundle ships ``skills/<name>/SKILL.md`` and sets
+``skills: none`` (the hermetic host-skill filter) must still be able to
+invoke its own bundled skill through the CLI's native ``Skill`` tool.
+``skills: none`` exists to keep the *host's* ``~/.claude/skills`` and
+``<cwd>/.claude/skills`` out of the session — the bundle's own skills ride
+``--plugin-dir`` and are promised to remain usable (see
+``_resolve_skills_option`` in ``omnigent/inner/claude_sdk_executor.py``).
+
+Journey driven here, on the real web SPA against a live server + runner
+and the real claude CLI pointed at the mock Anthropic endpoint:
+
+1. bundle a claude-sdk agent with ``skills: none`` plus its own
+   ``skills/<name>/SKILL.md``, and start a session on it
+2. ask the agent to run that bundled skill
+3. the model calls the native ``Skill`` tool with the bundled skill's name
+4. observable failure: the tool call is rejected with
+   ``<tool_use_error>Skill <name> is not in this session's skills
+   allowlist</tool_use_error>`` — the agent's own skill is visible but
+   not invokable, and the model carries on without it
+
+Regression guard: the final assertion (the ``Skill`` tool invocation of
+the bundled skill succeeds — no allowlist rejection) FAILS on the current
+build and passes once bundled skills are exempt from (or seeded into) the
+SDK's empty ``skills=[]`` allowlist under ``skills: none``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+import uuid
+from typing import Any
+
+import httpx
+import pytest
+import yaml
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import (
+    _ensure_runner_online,
+    _server_state,
+    configure_mock_llm,
+    reset_mock_llm,
+)
+
+_COMPOSER = "Send a message…"
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+_WORKING = '[data-testid="working-indicator"]'
+
+# Unforgeable skill name: the unique suffix cannot be hallucinated, so any
+# occurrence in the captured LLM traffic is genuinely this test's skill.
+_SKILL_NAME = "probe-brew-tea-x7k3f9"
+_SKILL_MARKER = "BREW_TEA_MARKER_x7k3f9"
+_DONE_TEXT = "SKILL_ATTEMPT_FINISHED"
+
+
+def _build_bundle(name: str, mock_llm_base_url: str) -> bytes:
+    """Build a strict-format claude-sdk bundle with one bundled skill.
+
+    Uses the strict ``config.yaml`` (spec_version 1) format so the server's
+    parser discovers ``skills/<dir>/SKILL.md`` into ``agent_spec.skills`` —
+    the exact shape the bug report describes (bundle ships the skill,
+    ``skills: none`` filters host skills). ``executor.auth`` routes the
+    claude CLI's ``ANTHROPIC_BASE_URL`` at the mock server.
+
+    :param name: Agent name (unique per test run).
+    :param mock_llm_base_url: Mock server base URL WITHOUT ``/v1`` (the
+        Anthropic SDK appends ``/v1/messages`` itself).
+    :returns: The ``.tar.gz`` bundle bytes for multipart upload.
+    """
+    config = {
+        "spec_version": 1,
+        "name": name,
+        "prompt": "You are a tester agent. Do exactly what the user asks.",
+        "skills": "none",
+        "executor": {
+            "type": "omnigent",
+            "model": "claude-sonnet-4-20250514",
+            "config": {"harness": "claude-sdk"},
+            "auth": {
+                "type": "api_key",
+                "api_key": "mock-key",
+                "base_url": mock_llm_base_url,
+            },
+        },
+    }
+    skill_md = (
+        f"---\nname: {_SKILL_NAME}\ndescription: Bundled probe skill for the "
+        f"skills-none regression test.\n---\n\n# Probe skill\n\n"
+        f"When invoked output the literal string {_SKILL_MARKER}.\n"
+    )
+    with io.BytesIO() as buf:
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            yaml_bytes = yaml.safe_dump(config, sort_keys=False).encode()
+            info = tarfile.TarInfo("config.yaml")
+            info.size = len(yaml_bytes)
+            tar.addfile(info, io.BytesIO(yaml_bytes))
+            md = skill_md.encode()
+            info = tarfile.TarInfo(f"skills/{_SKILL_NAME}/SKILL.md")
+            info.size = len(md)
+            tar.addfile(info, io.BytesIO(md))
+        return buf.getvalue()
+
+
+def _create_session(base_url: str, runner_id: str, mock_llm_server_url: str) -> str:
+    """Upload the bundle, create the session, and bind it to the runner.
+
+    :param base_url: Live server base URL.
+    :param runner_id: Token-bound runner id to PATCH-bind.
+    :param mock_llm_server_url: Mock server base URL (no ``/v1``).
+    :returns: The new session id.
+    """
+    name = f"skills-none-probe-{uuid.uuid4().hex[:8]}"
+    bundle = _build_bundle(name, mock_llm_server_url)
+    create_resp = httpx.post(
+        f"{base_url}/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        timeout=30.0,
+    )
+    create_resp.raise_for_status()
+    session_id = create_resp.json()["session_id"]
+    patch_resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"runner_id": runner_id},
+        timeout=10.0,
+    )
+    patch_resp.raise_for_status()
+    return session_id
+
+
+def _send(page: Page, text: str) -> None:
+    """Type *text* into the composer and click Send."""
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible()
+    composer.fill(text)
+    page.get_by_role("button", name="Send", exact=True).click()
+
+
+def _skill_tool_results(reqs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract the tool_result blocks answering native ``Skill`` tool_use calls.
+
+    Walks every captured Anthropic ``/v1/messages`` request: maps assistant
+    ``tool_use`` blocks named ``Skill`` (with this test's skill as input) to
+    their ids, then collects the user-role ``tool_result`` blocks that
+    reference those ids. The CLI resends the cumulative conversation each
+    call, so duplicates are deduped by ``tool_use_id``.
+
+    :param reqs: Captured request bodies from ``GET /mock/requests``.
+    :returns: One tool_result dict per distinct Skill invocation.
+    """
+    skill_use_ids: set[str] = set()
+    results: dict[str, dict[str, Any]] = {}
+    for req in reqs:
+        for msg in req.get("messages") or []:
+            content = msg.get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if (
+                    msg.get("role") == "assistant"
+                    and block.get("type") == "tool_use"
+                    and block.get("name") == "Skill"
+                    and (block.get("input") or {}).get("skill") == _SKILL_NAME
+                ):
+                    skill_use_ids.add(str(block.get("id")))
+                if (
+                    msg.get("role") == "user"
+                    and block.get("type") == "tool_result"
+                    and str(block.get("tool_use_id")) in skill_use_ids
+                ):
+                    results[str(block.get("tool_use_id"))] = block
+    return list(results.values())
+
+
+@pytest.mark.timeout(600)
+def test_skills_none_allows_invoking_bundled_skill(
+    page: Page,
+    live_server: str,
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Native ``Skill`` invocation of the bundle's own skill must succeed.
+
+    The mock scripts the model to call the ``Skill`` tool on the bundled
+    skill; the claude CLI executes the call and sends the tool_result back
+    on its next API call, where this test captures it. On the current build
+    that result is ``<tool_use_error>Skill <name> is not in this session's
+    skills allowlist</tool_use_error>`` — the reported bug.
+    """
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    try:
+        runner_id = str(_server_state["runner_id"])
+        reset_mock_llm(mock_llm_server_url)
+        session_id = _create_session(live_server, runner_id, mock_llm_server_url)
+        try:
+            token = f"skillsnone-{uuid.uuid4().hex[:6]}"
+            # Three identical Skill tool_call entries, not one: the CLI
+            # spawns side API calls at turn start (session title, etc.)
+            # that route to the same match-queue and can consume the first
+            # entry — extra Skill invocations are harmless (each yields its
+            # own tool_result; the assertion dedupes by tool_use_id).
+            configure_mock_llm(
+                mock_llm_server_url,
+                [
+                    {
+                        "tool_calls": [
+                            {
+                                "call_id": f"toolu_{uuid.uuid4().hex[:10]}",
+                                "name": "Skill",
+                                "arguments": json.dumps({"skill": _SKILL_NAME}),
+                            }
+                        ]
+                    }
+                ]
+                * 3
+                + [{"text": _DONE_TEXT}] * 10,
+                match=token,
+            )
+
+            page.goto(f"{live_server}/c/{session_id}")
+
+            _send(page, f"Run your bundled skill {_SKILL_NAME} now. {token}")
+
+            # Turn settles: the scripted final text lands and the working
+            # indicator clears.
+            expect(
+                page.locator(_ASSISTANT).filter(has_text=_DONE_TEXT).first
+            ).to_be_visible(timeout=240_000)
+            expect(page.locator(_WORKING)).to_have_count(0, timeout=60_000)
+
+            # ── The reproduction assertion ──────────────────────────────
+            # The CLI echoed the Skill call's tool_result back to the model;
+            # read it off the mock's captured requests.
+            reqs_resp = httpx.get(f"{mock_llm_server_url}/mock/requests", timeout=10.0)
+            reqs_resp.raise_for_status()
+            captured = reqs_resp.json()
+            reqs = captured.get("requests", []) if isinstance(captured, dict) else captured
+
+            results = _skill_tool_results(reqs)
+            assert results, (
+                "the model's native Skill tool_use for the bundled skill never "
+                "produced a tool_result in the captured LLM traffic — the turn "
+                "did not exercise the Skill tool"
+            )
+            rejected = [
+                r
+                for r in results
+                if r.get("is_error") or "skills allowlist" in json.dumps(r, default=str)
+            ]
+            assert not rejected, (
+                f"skills: none blocked the agent's own bundled skill: the native "
+                f"Skill tool invocation of {_SKILL_NAME!r} was rejected with "
+                f"{json.dumps(rejected[0], default=str)[:500]} — bundled skills "
+                f"(loaded via --plugin-dir) must remain invokable when the spec "
+                f"only filters HOST skills"
+            )
+        finally:
+            httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+    finally:
+        if respawned is not None:
+            respawned.terminate()
+            try:
+                respawned.wait(timeout=5)
+            except Exception:  # best-effort teardown
+                respawned.kill()
+                respawned.wait(timeout=5)

--- a/tests/e2e_ui/chat/test_skills_none_bundled_skill_invocable.py
+++ b/tests/e2e_ui/chat/test_skills_none_bundled_skill_invocable.py
@@ -21,9 +21,9 @@ and the real claude CLI pointed at the mock Anthropic endpoint:
    not invokable, and the model carries on without it
 
 Regression guard: the final assertion (the ``Skill`` tool invocation of
-the bundled skill succeeds — no allowlist rejection) FAILS on the current
-build and passes once bundled skills are exempt from (or seeded into) the
-SDK's empty ``skills=[]`` allowlist under ``skills: none``.
+the bundled skill succeeds — no allowlist rejection) fails whenever the
+executor stops seeding bundled skills into the SDK's otherwise-empty
+``skills=[]`` allowlist under ``skills: none``.
 """
 
 from __future__ import annotations

--- a/tests/inner/test_bundle_skills.py
+++ b/tests/inner/test_bundle_skills.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from omnigent.inner.bundle_skills import (
+    bundle_skill_names,
     claude_native_skill_args,
     ensure_bundle_plugin_manifest,
 )
@@ -130,3 +131,76 @@ def test_claude_native_skill_args_bundle_without_skills_dir(tmp_path: Path) -> N
     """
     (tmp_path / "no_skills").mkdir()
     assert "--plugin-dir" not in claude_native_skill_args(tmp_path / "no_skills")
+
+
+def _write_skill(bundle: Path, dir_name: str, *, name: str, description: str = "desc") -> None:
+    """Write ``<bundle>/skills/<dir_name>/SKILL.md`` with the given frontmatter."""
+    skill_dir = bundle / "skills" / dir_name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\nBody.\n"
+    )
+
+
+def test_bundle_skill_names_reads_frontmatter_name(tmp_path: Path) -> None:
+    """
+    The returned name comes from the frontmatter ``name`` field, not the
+    directory name — they may differ, per ``SkillSpec``'s own docstring.
+    """
+    _write_skill(tmp_path, "on-disk-dir", name="feature-brainstorming")
+    assert bundle_skill_names(tmp_path) == ["feature-brainstorming"]
+
+
+def test_bundle_skill_names_multiple_skills_sorted_by_dir(tmp_path: Path) -> None:
+    """Multiple skills are all returned, in directory-listing (sorted) order."""
+    _write_skill(tmp_path, "b-dir", name="skill-b")
+    _write_skill(tmp_path, "a-dir", name="skill-a")
+    assert bundle_skill_names(tmp_path) == ["skill-a", "skill-b"]
+
+
+def test_bundle_skill_names_no_skills_dir_returns_empty(tmp_path: Path) -> None:
+    """A bundle with no ``skills/`` directory at all returns ``[]``, not an error."""
+    assert bundle_skill_names(tmp_path) == []
+
+
+def test_bundle_skill_names_empty_skills_dir_returns_empty(tmp_path: Path) -> None:
+    """An empty ``skills/`` directory (no subdirectories) returns ``[]``."""
+    (tmp_path / "skills").mkdir()
+    assert bundle_skill_names(tmp_path) == []
+
+
+def test_bundle_skill_names_skips_missing_frontmatter(tmp_path: Path) -> None:
+    """
+    A ``SKILL.md`` with no ``---`` frontmatter delimiters is skipped, not
+    raised — this is a best-effort read, not spec validation (the parser
+    already validated strictly before the bundle ever reached this code).
+    """
+    skill_dir = tmp_path / "skills" / "broken"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("Just plain text, no frontmatter.\n")
+    assert bundle_skill_names(tmp_path) == []
+
+
+def test_bundle_skill_names_skips_missing_name_field(tmp_path: Path) -> None:
+    """Frontmatter present but missing the required ``name`` key is skipped."""
+    skill_dir = tmp_path / "skills" / "no-name"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\ndescription: no name here\n---\n\nBody.\n")
+    assert bundle_skill_names(tmp_path) == []
+
+
+def test_bundle_skill_names_skips_invalid_yaml(tmp_path: Path) -> None:
+    """Malformed YAML frontmatter is skipped rather than raising."""
+    skill_dir = tmp_path / "skills" / "bad-yaml"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: [unclosed\n---\n\nBody.\n")
+    assert bundle_skill_names(tmp_path) == []
+
+
+def test_bundle_skill_names_partial_failure_keeps_valid_ones(tmp_path: Path) -> None:
+    """One broken SKILL.md doesn't take down the whole bundle's skill list."""
+    _write_skill(tmp_path, "good", name="good-skill")
+    broken_dir = tmp_path / "skills" / "broken"
+    broken_dir.mkdir(parents=True)
+    (broken_dir / "SKILL.md").write_text("no frontmatter here\n")
+    assert bundle_skill_names(tmp_path) == ["good-skill"]

--- a/tests/inner/test_bundle_skills.py
+++ b/tests/inner/test_bundle_skills.py
@@ -240,3 +240,16 @@ def test_bundle_plugin_name_ignores_malformed_manifest(tmp_path: Path) -> None:
     assert bundle_plugin_name(tmp_path, "display-name") == "display-name"
     (manifest_dir / "plugin.json").write_text(json.dumps(["not", "a", "dict"]))
     assert bundle_plugin_name(tmp_path, None) == tmp_path.name
+
+
+def test_frontmatter_regex_matches_spec_parser() -> None:
+    """
+    The tolerant reader's frontmatter regex is a deliberate copy of the
+    spec parser's; if the parser's grammar ever changes, this copy must
+    follow or the two would disagree on which SKILL.md files parse.
+    """
+    from omnigent.inner import bundle_skills
+    from omnigent.spec import parser
+
+    assert bundle_skills._FRONTMATTER_RE.pattern == parser._FRONTMATTER_RE.pattern
+    assert bundle_skills._FRONTMATTER_RE.flags == parser._FRONTMATTER_RE.flags

--- a/tests/inner/test_bundle_skills.py
+++ b/tests/inner/test_bundle_skills.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from omnigent.inner.bundle_skills import (
+    bundle_plugin_name,
     bundle_skill_names,
     claude_native_skill_args,
     ensure_bundle_plugin_manifest,
@@ -204,3 +205,38 @@ def test_bundle_skill_names_partial_failure_keeps_valid_ones(tmp_path: Path) -> 
     broken_dir.mkdir(parents=True)
     (broken_dir / "SKILL.md").write_text("no frontmatter here\n")
     assert bundle_skill_names(tmp_path) == ["good-skill"]
+
+
+def test_bundle_plugin_name_prefers_manifest_name(tmp_path: Path) -> None:
+    """
+    A user-authored manifest whose ``name`` differs from the agent's
+    display name wins: the CLI labels plugin skills by the manifest, so
+    the ``<plugin>:<skill>`` allowlist entries must use that name or the
+    qualified form never matches.
+    """
+    manifest_dir = tmp_path / ".claude-plugin"
+    manifest_dir.mkdir()
+    (manifest_dir / "plugin.json").write_text(json.dumps({"name": "custom-plugin"}))
+    assert bundle_plugin_name(tmp_path, "display-name") == "custom-plugin"
+
+
+def test_bundle_plugin_name_falls_back_to_agent_name(tmp_path: Path) -> None:
+    """No manifest present: fall back to the agent display name."""
+    assert bundle_plugin_name(tmp_path, "display-name") == "display-name"
+
+
+def test_bundle_plugin_name_falls_back_to_basename_without_agent(tmp_path: Path) -> None:
+    """No manifest and no agent name: fall back to the bundle basename."""
+    assert bundle_plugin_name(tmp_path, None) == tmp_path.name
+
+
+def test_bundle_plugin_name_ignores_malformed_manifest(tmp_path: Path) -> None:
+    """A manifest that is not JSON (or has no usable name) is skipped."""
+    manifest_dir = tmp_path / ".claude-plugin"
+    manifest_dir.mkdir()
+    (manifest_dir / "plugin.json").write_text("{not json")
+    assert bundle_plugin_name(tmp_path, "display-name") == "display-name"
+    (manifest_dir / "plugin.json").write_text(json.dumps({"name": ""}))
+    assert bundle_plugin_name(tmp_path, "display-name") == "display-name"
+    (manifest_dir / "plugin.json").write_text(json.dumps(["not", "a", "dict"]))
+    assert bundle_plugin_name(tmp_path, None) == tmp_path.name

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -1845,6 +1845,172 @@ class TestSkillsFilterTranslation(unittest.TestCase):
         self.assertIsNone(_resolve_skills_option("bogus"))
 
 
+class TestSeedBundleSkillsWhenHermetic(unittest.TestCase):
+    """
+    ``skills: none`` must not also disable the agent's own bundled
+    skill (omnigent-ai/omnigent#5946).
+
+    ``_resolve_skills_option("none")`` alone produces an empty
+    ``skills`` allowlist, which blocks the native ``Skill`` tool
+    outright — including for a skill loaded from the bundle itself
+    via ``--plugin-dir``, which stays *listed* but becomes
+    permanently un-invokable. ``_seed_bundle_skills_when_hermetic``
+    is the fix: it re-seeds that empty allowlist with the bundle's
+    own skill names, read straight off ``<bundle_dir>/skills/*/SKILL.md``.
+    """
+
+    def _bundle(self, tmp_path, skills: dict[str, str]):
+        """Write ``<tmp_path>/skills/<dir>/SKILL.md`` for each entry.
+
+        :param skills: Maps a skill's on-disk directory name to the
+            ``name`` it declares in its frontmatter (may differ, per
+            :class:`SkillSpec`'s own docstring).
+        """
+        import pathlib
+
+        bundle_dir = pathlib.Path(tmp_path)
+        for dir_name, frontmatter_name in skills.items():
+            skill_dir = bundle_dir / "skills" / dir_name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                f"---\nname: {frontmatter_name}\ndescription: A test skill.\n---\n\nBody.\n"
+            )
+        return bundle_dir
+
+    def test_none_with_bundle_skill_seeds_both_name_forms(self) -> None:
+        """The empty ``"none"`` allowlist is replaced with bare + plugin-qualified names."""
+        import tempfile
+
+        from omnigent.inner.claude_sdk_executor import (
+            _ResolvedSkills,
+            _seed_bundle_skills_when_hermetic,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle_dir = self._bundle(tmp, {"my-skill-dir": "my-skill"})
+            resolved = _seed_bundle_skills_when_hermetic(
+                _ResolvedSkills(skills=[], setting_sources=[]),
+                skills_filter="none",
+                bundle_dir=bundle_dir,
+                agent_name="testagent",
+            )
+        self.assertEqual(resolved.skills, ["my-skill", "testagent:my-skill"])
+        # setting_sources stays [] — host discovery is still suppressed,
+        # only the skills allowlist changes.
+        self.assertEqual(resolved.setting_sources, [])
+
+    def test_agent_name_none_falls_back_to_bundle_dir_basename(self) -> None:
+        """Matches ``ensure_bundle_plugin_manifest``'s own fallback for the qualified name."""
+        import tempfile
+
+        from omnigent.inner.claude_sdk_executor import (
+            _ResolvedSkills,
+            _seed_bundle_skills_when_hermetic,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle_dir = self._bundle(tmp, {"my-skill-dir": "my-skill"})
+            resolved = _seed_bundle_skills_when_hermetic(
+                _ResolvedSkills(skills=[], setting_sources=[]),
+                skills_filter="none",
+                bundle_dir=bundle_dir,
+                agent_name=None,
+            )
+        self.assertIn(f"{bundle_dir.name}:my-skill", resolved.skills)
+
+    def test_multiple_bundle_skills_all_seeded(self) -> None:
+        """Every bundled skill gets both name forms, not just the first."""
+        import tempfile
+
+        from omnigent.inner.claude_sdk_executor import (
+            _ResolvedSkills,
+            _seed_bundle_skills_when_hermetic,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle_dir = self._bundle(tmp, {"a-dir": "skill-a", "b-dir": "skill-b"})
+            resolved = _seed_bundle_skills_when_hermetic(
+                _ResolvedSkills(skills=[], setting_sources=[]),
+                skills_filter="none",
+                bundle_dir=bundle_dir,
+                agent_name="agent",
+            )
+        self.assertEqual(
+            set(resolved.skills),
+            {"skill-a", "agent:skill-a", "skill-b", "agent:skill-b"},
+        )
+
+    def test_no_bundle_dir_returns_resolved_unchanged(self) -> None:
+        """An agent with no bundle (``bundle_dir=None``) is untouched."""
+        from omnigent.inner.claude_sdk_executor import (
+            _ResolvedSkills,
+            _seed_bundle_skills_when_hermetic,
+        )
+
+        original = _ResolvedSkills(skills=[], setting_sources=[])
+        resolved = _seed_bundle_skills_when_hermetic(
+            original, skills_filter="none", bundle_dir=None, agent_name="agent"
+        )
+        self.assertIs(resolved, original)
+
+    def test_bundle_with_no_skills_dir_returns_resolved_unchanged(self) -> None:
+        """A bundle directory that ships no ``skills/`` at all is a no-op, not an error."""
+        import pathlib
+        import tempfile
+
+        from omnigent.inner.claude_sdk_executor import (
+            _ResolvedSkills,
+            _seed_bundle_skills_when_hermetic,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            original = _ResolvedSkills(skills=[], setting_sources=[])
+            resolved = _seed_bundle_skills_when_hermetic(
+                original,
+                skills_filter="none",
+                bundle_dir=pathlib.Path(tmp),
+                agent_name="agent",
+            )
+        self.assertIs(resolved, original)
+
+    def test_filter_all_is_untouched_even_with_bundle_skills(self) -> None:
+        """Only the ``"none"`` shape is re-seeded — ``"all"`` and explicit lists pass through."""
+        import tempfile
+
+        from omnigent.inner.claude_sdk_executor import (
+            _ResolvedSkills,
+            _seed_bundle_skills_when_hermetic,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle_dir = self._bundle(tmp, {"my-skill-dir": "my-skill"})
+            original = _ResolvedSkills(skills="all", setting_sources=None)
+            resolved = _seed_bundle_skills_when_hermetic(
+                original, skills_filter="all", bundle_dir=bundle_dir, agent_name="agent"
+            )
+        self.assertIs(resolved, original)
+
+    def test_filter_list_is_untouched_even_with_bundle_skills(self) -> None:
+        """An explicit list filter already names its own skills — not re-seeded."""
+        import tempfile
+
+        from omnigent.inner.claude_sdk_executor import (
+            _ResolvedSkills,
+            _seed_bundle_skills_when_hermetic,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle_dir = self._bundle(tmp, {"my-skill-dir": "my-skill"})
+            original = _ResolvedSkills(skills=["explicit"], setting_sources=None)
+            resolved = _seed_bundle_skills_when_hermetic(
+                original,
+                skills_filter=["explicit"],
+                bundle_dir=bundle_dir,
+                agent_name="agent",
+            )
+        self.assertIs(resolved, original)
+
+
 # ---------------------------------------------------------------------------
 # Tests: StreamEvent-based streaming
 # ---------------------------------------------------------------------------

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -1899,6 +1899,31 @@ class TestSeedBundleSkillsWhenHermetic(unittest.TestCase):
         # only the skills allowlist changes.
         self.assertEqual(resolved.setting_sources, [])
 
+    def test_manifest_name_wins_over_agent_name(self) -> None:
+        """A bundle's own ``.claude-plugin/plugin.json`` name qualifies the
+        seeded ``plugin:skill`` entries — the CLI labels plugin skills by
+        the manifest, not the agent display name."""
+        import json as _json
+        import tempfile
+
+        from omnigent.inner.claude_sdk_executor import (
+            _ResolvedSkills,
+            _seed_bundle_skills_when_hermetic,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle_dir = self._bundle(tmp, {"my-skill-dir": "my-skill"})
+            manifest_dir = bundle_dir / ".claude-plugin"
+            manifest_dir.mkdir()
+            (manifest_dir / "plugin.json").write_text(_json.dumps({"name": "custom-plugin"}))
+            resolved = _seed_bundle_skills_when_hermetic(
+                _ResolvedSkills(skills=[], setting_sources=[]),
+                skills_filter="none",
+                bundle_dir=bundle_dir,
+                agent_name="testagent",
+            )
+        self.assertEqual(resolved.skills, ["my-skill", "custom-plugin:my-skill"])
+
     def test_agent_name_none_falls_back_to_bundle_dir_basename(self) -> None:
         """Matches ``ensure_bundle_plugin_manifest``'s own fallback for the qualified name."""
         import tempfile

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -1848,7 +1848,7 @@ class TestSkillsFilterTranslation(unittest.TestCase):
 class TestSeedBundleSkillsWhenHermetic(unittest.TestCase):
     """
     ``skills: none`` must not also disable the agent's own bundled
-    skill (omnigent-ai/omnigent#5946).
+    skill.
 
     ``_resolve_skills_option("none")`` alone produces an empty
     ``skills`` allowlist, which blocks the native ``Skill`` tool


### PR DESCRIPTION
## Related issue

Closes #5946

## Summary

`skills_filter: none` is meant to hide host-discovered skills (`~/.claude/skills`, project `.claude/skills`) so an agent behaves identically in any workspace. On `claude-sdk` it maps to an empty skills allowlist for the Claude CLI's native `Skill` tool, and an empty allowlist blocks the tool outright with no exception — so the one skill a bundle actually ships stays listed (via `--plugin-dir`) but can never be invoked. The model reads the denial as "not available" and improvises, with nothing in the logs marking it as a misconfiguration.

I decompiled the CLI's own allowlist check to find the exact gate rather than guess from the SDK's docs, and reproduced the reported error live end to end — not just at the Python translation layer — by driving `ClaudeSDKExecutor.run_turn` against the real `claude` binary with a bundled skill under `skills: none`: `Skill my-skill is not in this session's skills allowlist`, verbatim the issue's report.

Fix: when the filter is `"none"`, seed the allowlist with the bundle's own skill names instead of leaving it empty, so those specific skills stay invocable while host skills — the actual point of `"none"` — stay excluded. Both the bare name and the plugin-qualified `plugin:name` form are added per skill, since the CLI's exact matching convention for a plugin-provided skill isn't part of the SDK's public contract and an unmatched extra allowlist entry is inert.

## Why this approach and not the others

The issue names three possible fixes. I picked the narrowest one that actually restores the documented behavior, but wanted to flag the other two here:

- **Let plugin-provided skills bypass the allowlist gate entirely.** Would need the CLI to distinguish "gate exists because nothing was granted" from "gate exists and denies plugin skills too" — that's not how the allowlist is structured from what I could tell decompiling it, so this would need a CLI-side change, not something omnigent can do from its side of the SDK.
- **Only fix the docstring/error message.** Honest about the limitation, much smaller diff — but leaves the agent's own bundled skill permanently unusable under `skills: none`, which is the actual complaint in the issue (a bundle shipping exactly one skill it needs and never being able to call it).

Seeding the allowlist felt like the right level: it makes `"none"` mean what its own docstring already claimed ("bundled skills remain visible") instead of only explaining why it doesn't.

One open question I couldn't resolve with certainty: whether the CLI matches a plugin skill by its bare name or the `plugin:name` form. I tried to verify this directly against the real Anthropic API through the SDK's streaming client, but hit an unrelated auth error specific to that channel from a nested session and didn't want to burn more time chasing an auth quirk unrelated to the actual question. Seeding both forms sidesteps needing a definitive answer — happy to narrow it to one if someone here knows the convention.

## Test Plan

Reverted just the source (kept the new tests): 5 new tests fail — `AttributeError` on the missing helper plus failed precedence assertions. Restored the fix: all pass. Full `tests/inner/test_claude_sdk_executor.py` + `tests/inner/test_bundle_skills.py`: 157 passed.

The new e2e test (`tests/e2e/omnigent/test_claude_sdk_skills_none_bundle_skill.py`) drives the real `claude` CLI binary against a mock backend, not just the Python translation logic — same story: fails with the exact reported error pre-fix, passes post-fix.

`ruff check`, `ruff format --check`, and `pyrefly check` all clean on the touched files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The actual denial, reproduced live pre-fix by driving the executor directly against the real CLI binary:

```
ToolCallComplete(name='Skill', status=ERROR,
  result="<tool_use_error>Skill my-skill is not in this session's skills allowlist</tool_use_error>")
```

Same call, post-fix:

```
ToolCallComplete(name='Skill', status=SUCCESS, result='Launching skill: my-skill')
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`tests/inner/test_bundle_skills.py` covers `bundle_skill_names` directly (frontmatter parsing, multiple skills, missing/malformed SKILL.md files skipped rather than raised). `tests/inner/test_claude_sdk_executor.py` covers `_seed_bundle_skills_when_hermetic` in isolation (both name forms seeded, `agent_name=None` fallback, every filter value other than `"none"` left untouched). The e2e test is what actually caught this needed live verification in the first place — the Python-level unit tests alone can't observe whether the CLI's real allowlist enforcement accepts the seeded names, only that `ClaudeAgentOptions.skills` gets the right list handed to it.

## Changelog

A `claude-sdk` agent's own bundled skill stays invokable under `skills: none`, instead of being listed but permanently blocked

## Issues

Resolves [OMNI-5849](https://linear.app/omnigent/issue/OMNI-5849/skills-none-makes-the-agents-own-bundled-skill-visible-but-not)
