### PR TITLE
refactor(triage): colocate duplicate detection with v2

### DIFF
--- a/.github/triage_v2/src/issue_prioritization/duplicates.py
+++ b/.github/triage_v2/src/issue_prioritization/duplicates.py
@@ -320,9 +320,7 @@ def validate_duplicate_decision(
         """Keep only links the model is reasonably sure of and text agrees with."""
         if confidence < SIMILAR_MIN_CONFIDENCE:
             return []
-        return [
-            number for number in numbers if similarity.get(number, 0.0) >= SIMILAR_COSINE_FLOOR
-        ]
+        return [number for number in numbers if similarity.get(number, 0.0) >= SIMILAR_COSINE_FLOOR]
 
     decision = "none"
     if requested_decision == "duplicate" and duplicate_of is not None:

--- a/.github/triage_v2/tests/test_duplicates.py
+++ b/.github/triage_v2/tests/test_duplicates.py
@@ -1,7 +1,7 @@
 import unittest
 from typing import Any
 
-from issue_duplicates import (
+from issue_prioritization.duplicates import (
     AUTO_CLOSE_CONFIDENCE,
     CLOSE_COSINE_FLOOR,
     SIMILAR_MIN_CONFIDENCE,
@@ -564,8 +564,7 @@ class IssueDuplicatesTest(unittest.TestCase):
                 {
                     "number": 2304,
                     "title": (
-                        "Runner subprocess inherits host daemon cwd, breaking os_env "
-                        "cwd resolution"
+                        "Runner subprocess inherits host daemon cwd, breaking os_env cwd resolution"
                     ),
                     "body": (
                         "Runner subprocesses are spawned without cwd=<workspace>, so "

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -103,6 +103,12 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
+      - name: Set up Python
+        if: steps.creds.outputs.available == 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version-file: ".python-version"
+
       # ── Trusted context-gathering steps ──────────────────────────────
       # These run before the LLM and use the GitHub token directly.
       # The LLM never sees GH_TOKEN.
@@ -163,12 +169,12 @@ jobs:
             --json number,title,body,state,stateReason,url,createdAt,updatedAt,labels \
             > /tmp/corpus.json
 
-          PYTHONPATH=.github/scripts python3 <<'PYEOF'
+          PYTHONPATH=.github/triage_v2/src python3 <<'PYEOF'
           import json
           import os
           import pathlib
 
-          from issue_duplicates import extract_issue_references, rank_candidates
+          from issue_prioritization.duplicates import extract_issue_references, rank_candidates
 
           issue = json.loads(pathlib.Path("/tmp/issue.json").read_text())
           corpus = json.loads(pathlib.Path("/tmp/corpus.json").read_text())
@@ -191,12 +197,6 @@ jobs:
           PYEOF
 
       # ── LLM classification (no tools, no shell, no GH_TOKEN) ────────
-
-      - name: Set up Python
-        if: steps.creds.outputs.available == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version-file: ".python-version"
 
       - name: Set up uv
         if: steps.creds.outputs.available == 'true'
@@ -297,8 +297,8 @@ jobs:
           python3 <<'PYEOF'
           import json, pathlib, sys
 
-          sys.path.insert(0, ".github/scripts")
-          from issue_duplicates import format_candidates_for_prompt
+          sys.path.insert(0, ".github/triage_v2/src")
+          from issue_prioritization.duplicates import format_candidates_for_prompt
 
           issue = json.loads(pathlib.Path("/tmp/issue.json").read_text())
           dupes = json.loads(pathlib.Path("/tmp/duplicates.json").read_text())
@@ -429,10 +429,10 @@ jobs:
           # allowlists, and write gh commands to a script file.
           # All GitHub mutations are built in Python with proper escaping
           # — no eval, no shell interpolation of model output.
-          PYTHONPATH=.github/scripts python3 <<'PYEOF'
+          PYTHONPATH=.github/triage_v2/src python3 <<'PYEOF'
           import json, os, pathlib, sys, shlex
 
-          from issue_duplicates import (
+          from issue_prioritization.duplicates import (
               build_duplicate_comment,
               parse_triage_output,
               validate_duplicate_decision,


### PR DESCRIPTION
## Related issue

Linear: https://linear.app/omnigent/issue/OMNI-4269/make-sure-issues-contain-valid-steps-to-reproduce

## Summary

- Move the trusted duplicate-ranking and validation helper into the V2 package.
- Move its tests with it and update the legacy fallback workflow import path.
- Keep duplicate behavior and thresholds unchanged.

ELI5: this puts the duplicate logic beside its future owner before changing who calls it.

## Test Plan

- `uv run --frozen --project .github/triage_v2 pytest -q .github/triage_v2/tests` (141 passed, 3 subtests passed)
- `pre-commit run --all-files`

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The duplicate test suite moved with the implementation and runs unchanged.
