### PR TITLE
fix(codex): pass service-principal M2M credentials through the env filter

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -505,6 +505,15 @@ def _clean_codex_env(extra_allow: Iterable[str] = ()) -> dict[str, str]:
             "PYTHONUTF8",
             "DATABRICKS_BEARER",  # explicit CI/integration bearer used by auth.command
             "DATABRICKS_CODEX_TOKEN",  # env_key in ~/.codex/config.toml's DB provider
+            # Service-principal M2M credentials, so a Databricks-gateway
+            # ``auth.command`` can mint an OAuth token from the SP on each
+            # refresh. Only DATABRICKS_BEARER survived before, forcing a
+            # pre-minted (expiring) token or an inlined secret; these let the
+            # standard client-credentials mint work on a non-interactive host.
+            # DATABRICKS_CONFIG_PROFILE / DATABRICKS_TOKEN are deliberately NOT
+            # here (they stay host secrets, gated behind env_passthrough).
+            "DATABRICKS_CLIENT_ID",
+            "DATABRICKS_CLIENT_SECRET",
             *_CODEX_OMNIGENT_LAUNCH_ENV_VARS,
         ),
         deny_exact=_CODEX_ENV_DENY_EXACT,

--- a/tests/test_agent_spawn_env_canary.py
+++ b/tests/test_agent_spawn_env_canary.py
@@ -240,6 +240,26 @@ def test_deny_exact_beats_a_matching_prefix(hostile_env):
     assert env["OPENAI_BASE_URL"] == "https://x"
 
 
+def test_codex_passes_service_principal_m2m_credentials(hostile_env):
+    """codex's own builder must let the SP M2M pair through, so a
+    Databricks-gateway ``auth.command`` can mint an OAuth token on refresh.
+    The canaried DATABRICKS_CONFIG_PROFILE / DATABRICKS_TOKEN must still not."""
+    from omnigent.inner.codex_executor import _clean_codex_env
+
+    src = {
+        **hostile_env,
+        "DATABRICKS_CLIENT_ID": "sp-app-id",
+        "DATABRICKS_CLIENT_SECRET": "sp-secret",
+    }
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("os.environ", src)
+        env = _clean_codex_env()
+    assert env["DATABRICKS_CLIENT_ID"] == "sp-app-id"
+    assert env["DATABRICKS_CLIENT_SECRET"] == "sp-secret"
+    assert "DATABRICKS_CONFIG_PROFILE" not in env
+    assert "DATABRICKS_TOKEN" not in env
+
+
 def test_source_is_never_mutated(hostile_env):
     before = dict(hostile_env)
     clean_agent_env(allow_prefixes=("QWEN_",), source=hostile_env)


### PR DESCRIPTION
## Problem

The codex subprocess env allowlist (`_clean_codex_env` in `omnigent/inner/codex_executor.py`) filters `os.environ` down to a safe set. It kept `DATABRICKS_BEARER` and `DATABRICKS_CODEX_TOKEN` but **stripped `DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET`**.

As a result, a Databricks AI Gateway `auth.command` running *inside* the codex process cannot mint an OAuth token from a service principal — the client-credentials pair it needs is gone by the time the command runs. The only credential that survived was a pre-minted `DATABRICKS_BEARER`, which expires (~1h) and isn't refreshed, so operators were forced into either a stale-token workaround or inlining the SP secret literally into the auth command.

This blocks **non-interactive M2M hosts** (no browser OAuth, no PAT) — e.g. a coding-agent host that authenticates purely from a service principal.

Note the Claude harness is unaffected: it does not run through this allowlist, so the SP env vars already reach it.

## Fix

Allow the SP client-credentials pair (`DATABRICKS_CLIENT_ID`, `DATABRICKS_CLIENT_SECRET`) through the codex filter, alongside the existing `DATABRICKS_BEARER`. A gateway `auth.command` can now do the standard client-credentials mint on each refresh with no secret inlining.

`DATABRICKS_CONFIG_PROFILE` and `DATABRICKS_TOKEN` are **deliberately left out** of the allowlist — they remain host secrets gated behind the spec's `os_env.sandbox.env_passthrough` escape hatch, matching the intent encoded in `tests/test_agent_spawn_env_canary.py` (they stay in `CANARY_SECRETS`).

## Test

Adds `test_codex_passes_service_principal_m2m_credentials` to the spawn-env canary suite: drives the real `_clean_codex_env` builder against a planted environment and asserts the SP pair survives while `DATABRICKS_CONFIG_PROFILE` / `DATABRICKS_TOKEN` do not. Full `tests/test_agent_spawn_env_canary.py` (40) and `tests/inner/test_codex_executor.py` (124) pass locally.

This pull request and its description were written by Isaac.