### PR TITLE
fix(web): strip markdown backticks from model picker labels

### DIFF
--- a/web/src/components/HarnessConfigControls.tsx
+++ b/web/src/components/HarnessConfigControls.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { SMART_ROUTING_LABEL } from "@/lib/agentLabels";
+import { plainModelLabel } from "@/lib/codexNativeModels";
 import { cn } from "@/lib/utils";
 
 // Sentinel Select values for the Model row. Radix requires a non-empty value,
@@ -38,7 +39,7 @@ interface NativeModelLabelFields {
 
 /** A catalog row's user-facing name: what the harness advertises, else its id. */
 export function nativeModelLabel(option: NativeModelLabelFields): string {
-  return option.displayName ?? option.id;
+  return option.displayName ? plainModelLabel(option.displayName) : option.id;
 }
 
 /**

--- a/web/src/components/scheduled/ModelEffortFields.tsx
+++ b/web/src/components/scheduled/ModelEffortFields.tsx
@@ -31,6 +31,7 @@ import {
   MODEL_SELECT_DEFAULT,
 } from "@/components/HarnessConfigControls";
 import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
+import { plainModelLabel } from "@/lib/codexNativeModels";
 import { CLAUDE_NATIVE_PERMISSION_MODES } from "@/lib/claudePermissionMode";
 import { useHostModelOptions } from "@/hooks/useHosts";
 
@@ -75,7 +76,10 @@ export function ModelEffortFields({
   );
   const modelOptions =
     hostModelOptions && hostModelOptions.length > 0
-      ? hostModelOptions.map((o) => ({ id: o.id, label: o.displayName ?? o.id }))
+      ? hostModelOptions.map((o) => ({
+          id: o.id,
+          label: o.displayName ? plainModelLabel(o.displayName) : o.id,
+        }))
       : CLAUDE_NATIVE_MODELS.map((m) => ({ id: m.id, label: m.label }));
 
   return (

--- a/web/src/lib/codexNativeModels.ts
+++ b/web/src/lib/codexNativeModels.ts
@@ -4,6 +4,23 @@ import type { NativeModelOption } from "./types";
 const CATALOG_PREFIXES = ["databricks-", "system.ai."] as const;
 
 /**
+ * Strip markdown backticks from a harness model label before it is shown.
+ *
+ * Some Claude Code releases print the active model name as markdown code
+ * (``Current model: `Opus 4.8 (1M context)```), and no real model name holds
+ * a backtick. The server-side probe already strips these, but a catalog
+ * persisted by an older probe (or binary) is served verbatim until it
+ * refreshes, so the picker would render the literal backticks. Sanitize at the
+ * render boundary so no stale label ever leaks them.
+ *
+ * @param label - The catalog's advertised label.
+ * @returns The label with any backticks removed.
+ */
+export function plainModelLabel(label: string): string {
+  return label.includes("`") ? label.replaceAll("`", "") : label;
+}
+
+/**
  * Fold a model id to the spelling Codex row ids compare in.
  *
  * Comparison only, never a value to send anywhere: Codex spells versions with

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -108,7 +108,11 @@ import {
 } from "@/lib/renderItems";
 import { getCurrentAuthorId } from "@/lib/identity";
 import { retrySession } from "@/lib/sessionsApi";
-import { codexEffortLevelsForModel, findNativeModelOption } from "@/lib/codexNativeModels";
+import {
+  codexEffortLevelsForModel,
+  findNativeModelOption,
+  plainModelLabel,
+} from "@/lib/codexNativeModels";
 import {
   composerAttachmentKey,
   consumePendingInitialPrompt,
@@ -3886,7 +3890,8 @@ export function formatStatusModelLabel(
   if (!raw) return null;
   const lower = raw.toLowerCase();
   const codexOption = findNativeModelOption(codexModelOptions, raw);
-  if (codexOption) return codexOption.displayName ?? codexOption.id;
+  if (codexOption)
+    return codexOption.displayName ? plainModelLabel(codexOption.displayName) : codexOption.id;
   // An alias-shaped id the session's catalog doesn't list (e.g. during
   // the pre-catalog window): render it friendly mechanically — "sonnet"
   // → "Sonnet", "sonnet_5" → "Sonnet 5", "sonnet[1m]" → "Sonnet

--- a/web/src/pages/modelPicker.test.ts
+++ b/web/src/pages/modelPicker.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 
+import { nativeModelLabel } from "@/components/HarnessConfigControls";
 import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
 import {
   codexEffortLevelsForModel,
   findNativeModelOption,
   isCodexNativeModel,
+  plainModelLabel,
 } from "@/lib/codexNativeModels";
 import type { NativeModelOption } from "@/lib/types";
 
@@ -155,5 +157,27 @@ describe("Codex model-list helpers", () => {
     // Both an unresolved model and an id Codex never advertised get nothing.
     expect(codexEffortLevelsForModel(CODEX_MODEL_OPTIONS, null)).toEqual([]);
     expect(codexEffortLevelsForModel(CODEX_MODEL_OPTIONS, "gpt-5.4")).toEqual([]);
+  });
+});
+
+describe("model label backtick sanitizing", () => {
+  it("strips the markdown backticks some Claude releases wrap the name in", () => {
+    // The CLI prints `Current model: `Opus 4.8 (1M context)`` as markdown code;
+    // a catalog persisted before the server started stripping them still serves
+    // the raw label, so the render boundary must not leak the backticks.
+    expect(plainModelLabel("`Opus 4.8 (1M context)`")).toBe("Opus 4.8 (1M context)");
+    expect(plainModelLabel("`Sonnet 5`")).toBe("Sonnet 5");
+  });
+
+  it("leaves a clean label untouched", () => {
+    expect(plainModelLabel("Opus 4.8 (1M context)")).toBe("Opus 4.8 (1M context)");
+  });
+
+  it("sanitizes the catalog display name through nativeModelLabel", () => {
+    expect(nativeModelLabel({ id: "opus[1m]", displayName: "`Opus 4.8 (1M context)`" })).toBe(
+      "Opus 4.8 (1M context)",
+    );
+    // No display name → the id shows verbatim.
+    expect(nativeModelLabel({ id: "claude-opus-4-8" })).toBe("claude-opus-4-8");
   });
 });

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -148,6 +148,7 @@ import {
   type SmartRoutingUnavailableCause,
 } from "@/lib/smartRoutingAvailability";
 import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
+import { plainModelLabel } from "@/lib/codexNativeModels";
 import {
   isAcpHarnessAgent,
   partitionAgentsByKind,
@@ -2331,7 +2332,7 @@ export function NewChatLandingScreen() {
           }))
         : (hostClaudeModelOptions ?? []).map((option) => ({
             id: option.id,
-            displayName: option.displayName ?? option.id,
+            displayName: option.displayName ? plainModelLabel(option.displayName) : option.id,
             // Keep the catalog's default marker: the Default row names the
             // model a bare launch truly runs, for claude exactly as codex.
             isDefault: option.isDefault,
@@ -2348,7 +2349,7 @@ export function NewChatLandingScreen() {
         ? []
         : (hostPiModelOptions ?? []).map((option) => ({
             id: option.id,
-            displayName: option.displayName ?? option.id,
+            displayName: option.displayName ? plainModelLabel(option.displayName) : option.id,
           })),
     [hostPiModelOptions, sandboxSelected],
   );


### PR DESCRIPTION
## Related issue

<!-- UI fix; no tracking issue. -->

Closes #

## Summary

- The Claude Code CLI prints its active model as markdown code (`Current model: \`Opus 4.8 (1M context)\``), so the **Configure Claude** model picker rendered the name wrapped in **literal backticks** (see the model dropdown in the screenshot below).
- The server-side probe already strips these (PR #5757), but a model catalog persisted by an older probe/binary is served verbatim until its TTL refresh, and the frontend rendered whatever label it received as plain text.
- Add a `plainModelLabel` sanitizer (`web/src/lib/codexNativeModels.ts`) and apply it at the render boundaries — the shared `nativeModelLabel` / `formatStatusModelLabel` helpers, plus the landing dialog and scheduled-task rows that build labels directly — so no stale catalog label ever leaks backticks into the UI.

## Test Plan

- `pnpm test src/pages/modelPicker.test.ts` — added unit tests for `plainModelLabel` (strips wrapping/embedded backticks, leaves clean labels untouched) and for `nativeModelLabel` sanitizing a catalog `displayName`. 10/10 pass.
- `pnpm type-check` and `pnpm lint` clean.
- Manual: open the **Configure Claude** dialog on a `claude-native` session and confirm the Model dropdown (selected trigger value + list items), the composer status chip, and the New Chat landing model picker all read `Opus 4.8 (1M context)` with no backticks.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Before (reported): the Model dropdown showed `` `Opus 4.8 (1M context)` `` with literal backticks. After: it renders `Opus 4.8 (1M context)`. Covered by the new unit tests in `modelPicker.test.ts`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the sanitizer and the `nativeModelLabel` render helper. Manual verification: the picker's selected value and list items, the composer status chip, and the landing dialog all render the label without backticks; the render-boundary approach is resilient to a stale cached catalog since it never assumes the server pre-stripped the label.

## Changelog

Model picker no longer shows literal backticks around Claude model names (e.g. `Opus 4.8 (1M context)`).

This pull request and its description were written by Isaac.
