### PR TITLE
fix(claude-native): dismiss stranded compaction spinner on /compact refusal

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -2411,7 +2411,7 @@ def read_transcript_items_since_with_position(
         line_cursor=read_result.line_cursor,
         byte_offset=read_result.byte_offset,
         current_response_id=active_response_id,
-        items=items,
+        items=_dedupe_compact_noop_echo(items),
         latest_usage=latest_usage,
         latest_model=latest_model,
         latest_custom_title=latest_custom_title,
@@ -2505,7 +2505,7 @@ def read_transcript_items_from_offset(
         line_cursor=read_result.line_cursor,
         byte_offset=read_result.byte_offset,
         current_response_id=active_response_id,
-        items=items,
+        items=_dedupe_compact_noop_echo(items),
         latest_usage=latest_usage,
         latest_model=latest_model,
         latest_custom_title=latest_custom_title,
@@ -5765,6 +5765,7 @@ def _transcript_items_from_entry(
             entry,
             line_number=line_number,
             record_offset=record_offset,
+            agent_name=agent_name,
             current_response_id=current_response_id,
         )
     message = entry.get("message")
@@ -5877,19 +5878,53 @@ _COMPACT_NOOP_STDOUT_MARKERS: tuple[str, ...] = (
 )
 
 
-def _is_compact_noop_stdout(content: str) -> bool:
+def _dedupe_compact_noop_echo(
+    items: list[ClaudeTranscriptItem],
+) -> list[ClaudeTranscriptItem]:
     """
-    Whether a ``local_command`` record is a ``/compact`` "nothing to compact" refusal.
+    Drop the bare ``/compact`` echo when its refusal item is in the same batch.
+
+    Claude records a declined ``/compact`` as two records: the command echo
+    (a ``slash_command`` item with no output) and a standalone stdout record
+    (surfaced as the ``is_compact_noop`` item carrying the refusal text). They
+    are written together and normally read in one poll, so rendering both
+    yields two "Command compact" bubbles. Keep only the refusal item — it
+    carries the message — so the web shows a single bubble like the terminal.
+
+    :param items: Items parsed from one read batch, in order.
+    :returns: The items with any redundant bare ``/compact`` echo removed;
+        unchanged when the batch holds no ``is_compact_noop`` item.
+    """
+    if not any(item.is_compact_noop for item in items):
+        return items
+    return [
+        item
+        for item in items
+        if not (
+            not item.is_compact_noop
+            and item.item_type == "slash_command"
+            and item.data.get("name") == "compact"
+            and not item.data.get("output")
+        )
+    ]
+
+
+def _compact_noop_stdout(content: str) -> str | None:
+    """
+    Return the ``/compact`` "nothing to compact" refusal text, if this is one.
 
     :param content: Raw ``local_command`` record ``content``, expected to hold a
         ``<local-command-stdout>`` block.
-    :returns: ``True`` when the stdout matches a known compact-refusal marker.
+    :returns: The stdout text (e.g. "Not enough messages to compact.") when it
+        matches a known compact-refusal marker, else ``None``.
     """
     stdout_match = _COMMAND_STDOUT_RE.search(content)
     if stdout_match is None:
-        return False
-    lowered = stdout_match.group(1).lower()
-    return any(marker in lowered for marker in _COMPACT_NOOP_STDOUT_MARKERS)
+        return None
+    stdout = stdout_match.group(1)
+    if any(marker in stdout.lower() for marker in _COMPACT_NOOP_STDOUT_MARKERS):
+        return stdout.strip()
+    return None
 
 
 # Markers that prefix a ``role=user`` record produced by Claude
@@ -6080,6 +6115,7 @@ def _local_command_transcript_items_from_entry(
     *,
     line_number: int,
     record_offset: int | None,
+    agent_name: str,
     current_response_id: str | None,
 ) -> tuple[str | None, list[ClaudeTranscriptItem]]:
     """
@@ -6096,6 +6132,7 @@ def _local_command_transcript_items_from_entry(
     :param line_number: One-based transcript line number.
     :param record_offset: Byte offset where the transcript record
         starts, or ``None`` for legacy line-cursor reads.
+    :param agent_name: Agent/model name stamped on surfaced items.
     :param current_response_id: Response id for an in-progress shell
         command group, if the input record was parsed in an earlier
         line.
@@ -6108,14 +6145,23 @@ def _local_command_transcript_items_from_entry(
     source_key = _transcript_source_key(entry, line_number, record_offset)
     # A ``/compact`` refusal ("Not enough messages to compact.") lands as a
     # standalone ``local_command`` stdout record, separate from the
-    # ``/compact`` command echo. Surface it as a flagged, non-rendering item
-    # so the forwarder can dismiss the stranded "Compacting…" spinner.
-    if _is_compact_noop_stdout(content):
+    # ``/compact`` command echo. Surface it as a ``slash_command`` item
+    # carrying the refusal as ``output`` — so the web shows the same message
+    # Claude did — and flag it so the forwarder also dismisses the stranded
+    # "Compacting…" spinner.
+    compact_noop = _compact_noop_stdout(content)
+    if compact_noop is not None:
         return current_response_id, [
             ClaudeTranscriptItem(
                 source_id=_source_id(source_key, 0, "compact_noop"),
                 item_type="slash_command",
-                data={"kind": "command", "name": "compact"},
+                data={
+                    "agent": agent_name,
+                    "kind": "command",
+                    "name": "compact",
+                    "arguments": "",
+                    "output": compact_noop,
+                },
                 response_id=current_response_id or _response_id_from_source(source_key),
                 is_compact_noop=True,
             )

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -436,6 +436,13 @@ class ClaudeTranscriptItem:
         :func:`omnigent.claude_native_forwarder._forward_available_items`)
         instead of rendering the summary as a user bubble. Defaults to
         ``False`` for every ordinary transcript item.
+    :param is_compact_noop: ``True`` when this item was parsed from the
+        ``<local-command-stdout>`` record Claude writes when it declines a
+        ``/compact`` (e.g. "Not enough messages to compact."). No real
+        compaction runs, so no ``isCompactSummary`` / ``SessionStart
+        source=compact`` completion signal follows; the forwarder uses this
+        flag to dismiss the stranded "Compacting…" spinner. Never rendered
+        as a bubble. Defaults to ``False``.
     """
 
     source_id: str
@@ -443,6 +450,7 @@ class ClaudeTranscriptItem:
     data: _JsonObject
     response_id: str
     is_compact_summary: bool = False
+    is_compact_noop: bool = False
 
 
 @dataclass(frozen=True)
@@ -5854,6 +5862,36 @@ _TASK_NOTIFICATION_REQUIRED_MARKERS: tuple[str, ...] = (
     "</task-notification>",
 )
 
+# Substrings Claude Code writes to a ``/compact`` command's
+# ``<local-command-stdout>`` when it declines to compact (context too small
+# to summarize). Claude fires the ``PreCompact`` hook — which raises the web
+# "Compacting conversation…" spinner — BEFORE deciding there's nothing to do,
+# then aborts without any ``isCompactSummary`` / ``SessionStart
+# source=compact`` completion signal, so the spinner is stranded. Matched
+# case-insensitively so the forwarder can dismiss the spinner.
+_COMPACT_NOOP_STDOUT_MARKERS: tuple[str, ...] = (
+    # Observed refusal text.
+    "not enough messages to compact",
+    # Defensive variant against wording drift.
+    "nothing to compact",
+)
+
+
+def _is_compact_noop_stdout(content: str) -> bool:
+    """
+    Whether a ``local_command`` record is a ``/compact`` "nothing to compact" refusal.
+
+    :param content: Raw ``local_command`` record ``content``, expected to hold a
+        ``<local-command-stdout>`` block.
+    :returns: ``True`` when the stdout matches a known compact-refusal marker.
+    """
+    stdout_match = _COMMAND_STDOUT_RE.search(content)
+    if stdout_match is None:
+        return False
+    lowered = stdout_match.group(1).lower()
+    return any(marker in lowered for marker in _COMPACT_NOOP_STDOUT_MARKERS)
+
+
 # Markers that prefix a ``role=user`` record produced by Claude
 # Code's CLI scaffolding (not user-typed content). ``<command-
 # name>`` is handled separately by the slash-command parser;
@@ -6068,6 +6106,20 @@ def _local_command_transcript_items_from_entry(
     if not isinstance(content, str) or not content:
         return current_response_id, []
     source_key = _transcript_source_key(entry, line_number, record_offset)
+    # A ``/compact`` refusal ("Not enough messages to compact.") lands as a
+    # standalone ``local_command`` stdout record, separate from the
+    # ``/compact`` command echo. Surface it as a flagged, non-rendering item
+    # so the forwarder can dismiss the stranded "Compacting…" spinner.
+    if _is_compact_noop_stdout(content):
+        return current_response_id, [
+            ClaudeTranscriptItem(
+                source_id=_source_id(source_key, 0, "compact_noop"),
+                item_type="slash_command",
+                data={"kind": "command", "name": "compact"},
+                response_id=current_response_id or _response_id_from_source(source_key),
+                is_compact_noop=True,
+            )
+        ]
     fallback_response_id = _response_id_from_source(source_key)
     response_id = (
         fallback_response_id

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -69,9 +69,13 @@ _MAX_PERSISTED_COMPACTION_SEQS = 16
 # — BEFORE deciding there's nothing to do, then aborts without ever writing
 # an ``isCompactSummary`` record or firing the ``SessionStart source=compact``
 # completion hook. Without an explicit dismissal the spinner is stranded.
-# Matched case-insensitively against the slash-command ``output``.
+# Matched case-insensitively against the slash-command ``output``; brittle to
+# upstream wording, so it's a substring match over the observed refusal plus a
+# defensive variant. Widen this list if Claude Code rephrases the refusal.
 _COMPACTION_NOOP_OUTPUT_MARKERS: tuple[str, ...] = (
+    # Observed refusal text.
     "not enough messages to compact",
+    # Defensive variant against wording drift.
     "nothing to compact",
 )
 

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -579,6 +579,13 @@ class _ForwardDedupeState:
     # prevents the limiter from recovering.
     cost_retry_not_before: float = 0.0
     cost_retry_failures: int = 0
+    # Set when the transcript phase sees a ``/compact`` refusal
+    # (``is_compact_noop``). The spinner dismissal is DEFERRED until after the
+    # hook phase runs, because the ``PreCompact`` hook (which raises the
+    # spinner via ``in_progress``) can land in the SAME poll as the refusal
+    # and is forwarded after transcript items — dismissing first would clear
+    # nothing and then the hook would strand a fresh spinner.
+    pending_compaction_dismiss: bool = False
 
 
 @dataclass(frozen=True)
@@ -996,6 +1003,17 @@ async def forward_claude_transcript_to_session(
                             # (the user-message reset only fires on the next turn).
                             response_id=state.current_response_id,
                         )
+                        # Deferred ``/compact``-refusal dismissal: runs AFTER
+                        # the hook phase so the ``failed`` post always follows
+                        # the ``PreCompact`` ``in_progress`` that raised the
+                        # spinner, even when both land in this same poll.
+                        if dedupe.pending_compaction_dismiss:
+                            dedupe.pending_compaction_dismiss = False
+                            await _maybe_dismiss_stranded_compaction_spinner(
+                                client,
+                                session_id=current_session_id,
+                                bridge_dir=bridge_dir,
+                            )
                         subagent_state = await _forward_available_subagents(
                             client=client,
                             parent_session_id=current_session_id,
@@ -3423,15 +3441,14 @@ async def _forward_available_items(
             continue
         # ``/compact`` refusal ("Not enough messages to compact."). Claude
         # fired ``PreCompact`` (raising the spinner) but declined to compact,
-        # so no completion signal follows and the spinner is stranded. Dismiss
-        # it here; the item itself still forwards below as a normal
-        # ``slash_command`` bubble carrying the refusal text, so the web shows
-        # the same message Claude did. Best-effort — a failed dismissal POST
-        # is logged, not retried (there is nothing durable to persist).
+        # so no completion signal follows and the spinner is stranded. Defer
+        # the dismissal (see ``pending_compaction_dismiss``) — the raising
+        # ``PreCompact`` hook can land in the SAME poll and is forwarded AFTER
+        # this transcript phase, so dismissing now would clear nothing and
+        # leave a fresh spinner. The item itself still forwards below as a
+        # normal ``slash_command`` bubble carrying the refusal text.
         if item.is_compact_noop:
-            await _maybe_dismiss_stranded_compaction_spinner(
-                client, session_id=session_id, bridge_dir=bridge_dir
-            )
+            dedupe.pending_compaction_dismiss = True
         if skip_user_messages and item.item_type == "message" and item.data.get("role") == "user":
             seen_source_ids.append(item.source_id)
             seen.add(item.source_id)

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -579,13 +579,19 @@ class _ForwardDedupeState:
     # prevents the limiter from recovering.
     cost_retry_not_before: float = 0.0
     cost_retry_failures: int = 0
-    # Set when the transcript phase sees a ``/compact`` refusal
-    # (``is_compact_noop``). The spinner dismissal is DEFERRED until after the
-    # hook phase runs, because the ``PreCompact`` hook (which raises the
-    # spinner via ``in_progress``) can land in the SAME poll as the refusal
-    # and is forwarded after transcript items — dismissing first would clear
-    # nothing and then the hook would strand a fresh spinner.
-    pending_compaction_dismiss: bool = False
+    # The ``PreCompact`` ``seq`` to dismiss when the transcript phase sees a
+    # ``/compact`` refusal (``is_compact_noop``), else ``None``. The dismissal
+    # is DEFERRED until after the hook phase, because the ``PreCompact`` hook
+    # (which raises the spinner via ``in_progress``) is forwarded after
+    # transcript items in the same poll — dismissing first would clear nothing
+    # and then the hook would strand a fresh spinner. Scoped to the specific
+    # seq (not a bare flag) and cleared every poll: the prescan mints the
+    # token before the transcript phase and Claude writes ``PreCompact``
+    # before the refusal stdout, so the refused compaction's token is already
+    # pending when the refusal is seen. Keying to that seq stops a refusal
+    # whose ``PreCompact`` was missed from later hijacking an unrelated
+    # genuine compaction's token.
+    pending_compaction_dismiss_seq: int | None = None
 
 
 @dataclass(frozen=True)
@@ -1006,20 +1012,20 @@ async def forward_claude_transcript_to_session(
                         # Deferred ``/compact``-refusal dismissal: runs AFTER
                         # the hook phase so the ``failed`` post always follows
                         # the ``PreCompact`` ``in_progress`` that raised the
-                        # spinner, even when both land in this same poll. The
-                        # flag stays ARMED across polls until a pending token is
-                        # actually found and dismissed, so a ``PreCompact`` that
-                        # only becomes visible in a LATER poll than the refusal
-                        # transcript item still gets dismissed rather than
-                        # stranding the spinner.
-                        if dedupe.pending_compaction_dismiss:
-                            dismissed = await _maybe_dismiss_stranded_compaction_spinner(
+                        # spinner, even when both land in this same poll. Scoped
+                        # to the refused compaction's own seq and consumed here
+                        # (one-shot, cleared unconditionally) so a stale arm can
+                        # never dismiss a later genuine compaction's spinner or
+                        # discard its boundary token.
+                        if dedupe.pending_compaction_dismiss_seq is not None:
+                            dismiss_seq = dedupe.pending_compaction_dismiss_seq
+                            dedupe.pending_compaction_dismiss_seq = None
+                            await _maybe_dismiss_stranded_compaction_spinner(
                                 client,
                                 session_id=current_session_id,
                                 bridge_dir=bridge_dir,
+                                seq=dismiss_seq,
                             )
-                            if dismissed:
-                                dedupe.pending_compaction_dismiss = False
                         subagent_state = await _forward_available_subagents(
                             client=client,
                             parent_session_id=current_session_id,
@@ -3448,13 +3454,19 @@ async def _forward_available_items(
         # ``/compact`` refusal ("Not enough messages to compact."). Claude
         # fired ``PreCompact`` (raising the spinner) but declined to compact,
         # so no completion signal follows and the spinner is stranded. Defer
-        # the dismissal (see ``pending_compaction_dismiss``) — the raising
+        # the dismissal (see ``pending_compaction_dismiss_seq``) — the raising
         # ``PreCompact`` hook can land in the SAME poll and is forwarded AFTER
         # this transcript phase, so dismissing now would clear nothing and
-        # leave a fresh spinner. The item itself still forwards below as a
-        # normal ``slash_command`` bubble carrying the refusal text.
+        # leave a fresh spinner. Scope it to the refused compaction's OWN
+        # pending seq (already minted by the prescan, since Claude writes
+        # ``PreCompact`` before the refusal stdout) so it can never dismiss a
+        # later genuine compaction. If no token is pending the ``PreCompact``
+        # was missed and no spinner is up — nothing to dismiss. The item still
+        # forwards below as a ``slash_command`` bubble carrying the text.
         if item.is_compact_noop:
-            dedupe.pending_compaction_dismiss = True
+            refused = _read_compaction_state(bridge_dir).pending
+            if refused is not None:
+                dedupe.pending_compaction_dismiss_seq = refused.seq
         if skip_user_messages and item.item_type == "message" and item.data.get("role") == "user":
             seen_source_ids.append(item.source_id)
             seen.add(item.source_id)
@@ -5241,9 +5253,9 @@ async def _note_transcript_summary_without_token(bridge_dir: Path) -> None:
     await asyncio.to_thread(_mutate)
 
 
-async def _discard_pending_compaction(bridge_dir: Path) -> bool:
+async def _discard_pending_compaction(bridge_dir: Path, seq: int) -> bool:
     """
-    Drop an in-flight ``PreCompact`` token that will never complete.
+    Drop the in-flight ``PreCompact`` token for ``seq`` that will never complete.
 
     Called when a ``/compact`` refusal ("Not enough messages to compact.")
     is observed: Claude fired ``PreCompact`` (raising the spinner) but then
@@ -5251,14 +5263,20 @@ async def _discard_pending_compaction(bridge_dir: Path) -> bool:
     pending token so a later, genuine compaction reconciles cleanly, and
     closes any completion-ack window.
 
+    Scoped to ``seq``: only the token the refusal belongs to is dropped. A
+    later, genuine compaction (a higher seq) is left untouched, so a stale or
+    mis-paired refusal can never discard a live compaction's boundary token.
+
     :param bridge_dir: Native Claude bridge directory.
-    :returns: ``True`` when a pending token was cleared, ``False`` when
-        there was nothing pending (so the caller skips the dismissal post).
+    :param seq: The refused compaction's ``PreCompact`` seq to drop.
+    :returns: ``True`` when the pending token for ``seq`` was cleared,
+        ``False`` when no such token is pending (so the caller skips the
+        dismissal post).
     """
 
     def _mutate() -> bool:
         state = _read_compaction_state(bridge_dir)
-        if state.pending is None:
+        if state.pending is None or state.pending.seq != seq:
             return False
         _write_compaction_state(
             bridge_dir,
@@ -5281,13 +5299,14 @@ async def _maybe_dismiss_stranded_compaction_spinner(
     *,
     session_id: str,
     bridge_dir: Path,
-) -> bool:
+    seq: int,
+) -> None:
     """
     Dismiss the "Compacting…" spinner when Claude declines to compact.
 
-    Called for the flagged ``is_compact_noop`` transcript item (the
-    ``/compact`` "Not enough messages to compact." refusal). Claude fired
-    ``PreCompact`` first, so the forwarder already posted
+    Called after the hook phase for a ``/compact`` refusal
+    (``is_compact_noop``) whose own ``PreCompact`` seq is ``seq``. Claude
+    fired ``PreCompact`` first, so the forwarder already posted
     ``external_compaction_status: in_progress`` and the web UI is showing
     the spinner. No ``isCompactSummary`` record or ``SessionStart
     source=compact`` hook follows a refusal, so without this the spinner is
@@ -5295,22 +5314,19 @@ async def _maybe_dismiss_stranded_compaction_spinner(
     ``response.compaction.failed`` → remove the loading block) and drop the
     dangling ``PreCompact`` token. Best-effort — logged, not raised.
 
+    No-op when ``seq`` is no longer the pending token (the ``PreCompact`` was
+    missed so no spinner is up, or an unrelated compaction has since
+    superseded it) — that's the guard against dismissing a genuine
+    compaction's spinner or discarding its boundary token.
+
     :param client: Omnigent HTTP client.
     :param session_id: Omnigent session/conversation id, e.g. ``"conv_abc123"``.
     :param bridge_dir: Native Claude bridge directory.
-    :returns: ``True`` when a pending token was found and the ``failed``
-        dismissal was posted; ``False`` when there was no pending token yet
-        (the ``PreCompact`` has not been observed) so the caller keeps the
-        deferred-dismiss flag armed for a later poll. Also ``True`` on a
-        failed POST — the token is consumed and retrying is pointless.
+    :param seq: The refused compaction's own ``PreCompact`` seq.
+    :returns: None.
     """
-    # Only dismiss when there is actually an in-flight PreCompact token — the
-    # refusal spinner we raised. A refusal with no pending token means the
-    # ``PreCompact`` has not been observed yet (or the spinner already
-    # resolved), so a ``failed`` post would be spurious; signal the caller to
-    # keep the flag armed and retry next poll.
-    if not await _discard_pending_compaction(bridge_dir):
-        return False
+    if not await _discard_pending_compaction(bridge_dir, seq):
+        return
     try:
         await _post_external_compaction_status(
             client,
@@ -5326,7 +5342,6 @@ async def _maybe_dismiss_stranded_compaction_spinner(
             exc_info=True,
             extra={"session_id": session_id},
         )
-    return True
 
 
 async def _claim_standalone_completion(bridge_dir: Path) -> int | None:

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -63,6 +63,18 @@ _HOOKS_FILE = "hooks.jsonl"
 # surviving a cursor rewind that re-reads an already-persisted summary.
 _MAX_PERSISTED_COMPACTION_SEQS = 16
 
+# Substrings Claude Code writes to a ``/compact`` command's stdout when it
+# declines to compact (context too small to summarize). Claude fires the
+# ``PreCompact`` hook — which raises the "Compacting conversation…" spinner
+# — BEFORE deciding there's nothing to do, then aborts without ever writing
+# an ``isCompactSummary`` record or firing the ``SessionStart source=compact``
+# completion hook. Without an explicit dismissal the spinner is stranded.
+# Matched case-insensitively against the slash-command ``output``.
+_COMPACTION_NOOP_OUTPUT_MARKERS: tuple[str, ...] = (
+    "not enough messages to compact",
+    "nothing to compact",
+)
+
 # Cap on the in-memory ``(message_id, index)`` dedupe ring for streamed
 # deltas. The byte offset already prevents re-reading on the normal
 # path; this guards the rare truncation/rewind case where the deltas
@@ -3537,6 +3549,9 @@ async def _forward_available_items(
             return updated
         retry_tracker.clear(retry_key)
         await _maybe_sync_effort_from_slash_command(client, session_id=session_id, item=item)
+        await _maybe_dismiss_stranded_compaction_spinner(
+            client, session_id=session_id, bridge_dir=bridge_dir, item=item
+        )
         seen.add(item.source_id)
         seen_source_ids.append(item.source_id)
         updated = TranscriptForwardState(
@@ -4541,15 +4556,16 @@ async def _post_external_compaction_status(
     "Compacting conversation…" spinner while Claude runs the real
     compaction in the terminal. ``"in_progress"`` is sent from the
     ``PreCompact`` hook and ``"completed"`` from the post-compaction
-    ``SessionStart`` (``source == "compact"``) hook. The Omnigent server maps
+    ``SessionStart`` (``source == "compact"``) hook; ``"failed"`` dismisses a
+    stranded spinner when Claude declined to compact. The Omnigent server maps
     these to the ``response.compaction.in_progress`` /
-    ``response.compaction.completed`` SSE events the web client already
-    renders.
+    ``response.compaction.completed`` / ``response.compaction.failed`` SSE
+    events the web client already renders.
 
     :param client: Omnigent HTTP client.
     :param session_id: Omnigent session/conversation id.
-    :param status: Compaction status value, ``"in_progress"`` or
-        ``"completed"``.
+    :param status: Compaction status value, ``"in_progress"``,
+        ``"completed"``, or ``"failed"``.
     :returns: None.
     :raises httpx.HTTPError: If the Omnigent request fails or is rejected.
     """
@@ -5204,6 +5220,110 @@ async def _note_transcript_summary_without_token(bridge_dir: Path) -> None:
         )
 
     await asyncio.to_thread(_mutate)
+
+
+def _is_compaction_noop_output(output: object) -> bool:
+    """
+    Whether a ``/compact`` slash-command output is a "nothing to compact" refusal.
+
+    Claude Code declines to compact when the context is too small to
+    summarize, writing e.g. "Not enough messages to compact." to the
+    command's stdout. Matched case-insensitively against the known markers.
+
+    :param output: The ``slash_command`` item's ``output`` value, if any.
+    :returns: ``True`` when the output signals Claude declined to compact.
+    """
+    if not isinstance(output, str):
+        return False
+    lowered = output.lower()
+    return any(marker in lowered for marker in _COMPACTION_NOOP_OUTPUT_MARKERS)
+
+
+async def _discard_pending_compaction(bridge_dir: Path) -> bool:
+    """
+    Drop an in-flight ``PreCompact`` token that will never complete.
+
+    Called when a ``/compact`` refusal ("Not enough messages to compact.")
+    is observed: Claude fired ``PreCompact`` (raising the spinner) but then
+    aborted, so neither completion signal will ever arrive. Clears the
+    pending token so a later, genuine compaction reconciles cleanly, and
+    closes any completion-ack window.
+
+    :param bridge_dir: Native Claude bridge directory.
+    :returns: ``True`` when a pending token was cleared, ``False`` when
+        there was nothing pending (so the caller skips the dismissal post).
+    """
+
+    def _mutate() -> bool:
+        state = _read_compaction_state(bridge_dir)
+        if state.pending is None:
+            return False
+        _write_compaction_state(
+            bridge_dir,
+            CompactionForwardState(
+                pending=None,
+                last_seq=state.last_seq,
+                persisted_seqs=state.persisted_seqs,
+                last_precompact_cursor=state.last_precompact_cursor,
+                expect_completion_ack=False,
+                expect_completion_ack_seq=0,
+            ),
+        )
+        return True
+
+    return await asyncio.to_thread(_mutate)
+
+
+async def _maybe_dismiss_stranded_compaction_spinner(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+    item: ClaudeTranscriptItem,
+) -> None:
+    """
+    Dismiss the "Compacting…" spinner when Claude declines to compact.
+
+    A ``/compact`` that Claude refuses ("Not enough messages to compact.")
+    still fires ``PreCompact`` first, so the forwarder already posted
+    ``external_compaction_status: in_progress`` and the web UI is showing
+    the spinner. No ``isCompactSummary`` record or ``SessionStart
+    source=compact`` hook follows a refusal, so without this the spinner is
+    stranded forever. Post ``failed`` (which the web UI maps to
+    ``response.compaction.failed`` → remove the loading block) and drop the
+    dangling ``PreCompact`` token. Best-effort — logged, not raised.
+
+    :param client: Omnigent HTTP client.
+    :param session_id: Omnigent session/conversation id, e.g. ``"conv_abc123"``.
+    :param item: A just-forwarded item; only a ``/compact`` ``slash_command``
+        whose ``output`` signals a refusal triggers the dismissal.
+    :returns: None.
+    """
+    if item.item_type != "slash_command" or item.data.get("name") != "compact":
+        return
+    if not _is_compaction_noop_output(item.data.get("output")):
+        return
+    # Only dismiss when there is actually an in-flight PreCompact token — the
+    # refusal spinner we raised. A refusal with no pending token means the
+    # spinner was never raised (or already resolved), so a ``failed`` post
+    # would be spurious.
+    if not await _discard_pending_compaction(bridge_dir):
+        return
+    try:
+        await _post_external_compaction_status(
+            client,
+            session_id=session_id,
+            status="failed",
+        )
+    except httpx.HTTPError:
+        _logger.warning(
+            "Failed to dismiss stranded compaction spinner after a /compact refusal; "
+            "session=%s bridge_dir=%s",
+            session_id,
+            bridge_dir,
+            exc_info=True,
+            extra={"session_id": session_id},
+        )
 
 
 async def _claim_standalone_completion(bridge_dir: Path) -> int | None:

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -63,22 +63,6 @@ _HOOKS_FILE = "hooks.jsonl"
 # surviving a cursor rewind that re-reads an already-persisted summary.
 _MAX_PERSISTED_COMPACTION_SEQS = 16
 
-# Substrings Claude Code writes to a ``/compact`` command's stdout when it
-# declines to compact (context too small to summarize). Claude fires the
-# ``PreCompact`` hook — which raises the "Compacting conversation…" spinner
-# — BEFORE deciding there's nothing to do, then aborts without ever writing
-# an ``isCompactSummary`` record or firing the ``SessionStart source=compact``
-# completion hook. Without an explicit dismissal the spinner is stranded.
-# Matched case-insensitively against the slash-command ``output``; brittle to
-# upstream wording, so it's a substring match over the observed refusal plus a
-# defensive variant. Widen this list if Claude Code rephrases the refusal.
-_COMPACTION_NOOP_OUTPUT_MARKERS: tuple[str, ...] = (
-    # Observed refusal text.
-    "not enough messages to compact",
-    # Defensive variant against wording drift.
-    "nothing to compact",
-)
-
 # Cap on the in-memory ``(message_id, index)`` dedupe ring for streamed
 # deltas. The byte offset already prevents re-reading on the normal
 # path; this guards the rare truncation/rewind case where the deltas
@@ -3437,6 +3421,30 @@ async def _forward_available_items(
             )
             await _write_forward_state_async(bridge_dir, updated)
             continue
+        # ``/compact`` refusal ("Not enough messages to compact."). Claude
+        # fired ``PreCompact`` (raising the spinner) but declined to compact,
+        # so no completion signal follows and the spinner is stranded. Dismiss
+        # it and never render this marker as a bubble. Best-effort — a failed
+        # dismissal POST is logged, not retried (unlike a compaction boundary,
+        # there is nothing durable to persist).
+        if item.is_compact_noop:
+            await _maybe_dismiss_stranded_compaction_spinner(
+                client, session_id=session_id, bridge_dir=bridge_dir
+            )
+            seen.add(item.source_id)
+            seen_source_ids.append(item.source_id)
+            updated = TranscriptForwardState(
+                transcript_path=state.transcript_path,
+                line_cursor=state.line_cursor,
+                byte_offset=state.byte_offset,
+                current_response_id=current_response_id,
+                seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
+                cursor_fingerprint=state.cursor_fingerprint,
+                settled_response_id=dedupe.settled_response_id,
+                pending_settled_response_id=dedupe.pending_settled_response_id,
+            )
+            await _write_forward_state_async(bridge_dir, updated)
+            continue
         if skip_user_messages and item.item_type == "message" and item.data.get("role") == "user":
             seen_source_ids.append(item.source_id)
             seen.add(item.source_id)
@@ -3553,9 +3561,6 @@ async def _forward_available_items(
             return updated
         retry_tracker.clear(retry_key)
         await _maybe_sync_effort_from_slash_command(client, session_id=session_id, item=item)
-        await _maybe_dismiss_stranded_compaction_spinner(
-            client, session_id=session_id, bridge_dir=bridge_dir, item=item
-        )
         seen.add(item.source_id)
         seen_source_ids.append(item.source_id)
         updated = TranscriptForwardState(
@@ -5226,23 +5231,6 @@ async def _note_transcript_summary_without_token(bridge_dir: Path) -> None:
     await asyncio.to_thread(_mutate)
 
 
-def _is_compaction_noop_output(output: object) -> bool:
-    """
-    Whether a ``/compact`` slash-command output is a "nothing to compact" refusal.
-
-    Claude Code declines to compact when the context is too small to
-    summarize, writing e.g. "Not enough messages to compact." to the
-    command's stdout. Matched case-insensitively against the known markers.
-
-    :param output: The ``slash_command`` item's ``output`` value, if any.
-    :returns: ``True`` when the output signals Claude declined to compact.
-    """
-    if not isinstance(output, str):
-        return False
-    lowered = output.lower()
-    return any(marker in lowered for marker in _COMPACTION_NOOP_OUTPUT_MARKERS)
-
-
 async def _discard_pending_compaction(bridge_dir: Path) -> bool:
     """
     Drop an in-flight ``PreCompact`` token that will never complete.
@@ -5283,13 +5271,13 @@ async def _maybe_dismiss_stranded_compaction_spinner(
     *,
     session_id: str,
     bridge_dir: Path,
-    item: ClaudeTranscriptItem,
 ) -> None:
     """
     Dismiss the "Compacting…" spinner when Claude declines to compact.
 
-    A ``/compact`` that Claude refuses ("Not enough messages to compact.")
-    still fires ``PreCompact`` first, so the forwarder already posted
+    Called for the flagged ``is_compact_noop`` transcript item (the
+    ``/compact`` "Not enough messages to compact." refusal). Claude fired
+    ``PreCompact`` first, so the forwarder already posted
     ``external_compaction_status: in_progress`` and the web UI is showing
     the spinner. No ``isCompactSummary`` record or ``SessionStart
     source=compact`` hook follows a refusal, so without this the spinner is
@@ -5299,14 +5287,9 @@ async def _maybe_dismiss_stranded_compaction_spinner(
 
     :param client: Omnigent HTTP client.
     :param session_id: Omnigent session/conversation id, e.g. ``"conv_abc123"``.
-    :param item: A just-forwarded item; only a ``/compact`` ``slash_command``
-        whose ``output`` signals a refusal triggers the dismissal.
+    :param bridge_dir: Native Claude bridge directory.
     :returns: None.
     """
-    if item.item_type != "slash_command" or item.data.get("name") != "compact":
-        return
-    if not _is_compaction_noop_output(item.data.get("output")):
-        return
     # Only dismiss when there is actually an in-flight PreCompact token — the
     # refusal spinner we raised. A refusal with no pending token means the
     # spinner was never raised (or already resolved), so a ``failed`` post

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -3424,27 +3424,14 @@ async def _forward_available_items(
         # ``/compact`` refusal ("Not enough messages to compact."). Claude
         # fired ``PreCompact`` (raising the spinner) but declined to compact,
         # so no completion signal follows and the spinner is stranded. Dismiss
-        # it and never render this marker as a bubble. Best-effort — a failed
-        # dismissal POST is logged, not retried (unlike a compaction boundary,
-        # there is nothing durable to persist).
+        # it here; the item itself still forwards below as a normal
+        # ``slash_command`` bubble carrying the refusal text, so the web shows
+        # the same message Claude did. Best-effort — a failed dismissal POST
+        # is logged, not retried (there is nothing durable to persist).
         if item.is_compact_noop:
             await _maybe_dismiss_stranded_compaction_spinner(
                 client, session_id=session_id, bridge_dir=bridge_dir
             )
-            seen.add(item.source_id)
-            seen_source_ids.append(item.source_id)
-            updated = TranscriptForwardState(
-                transcript_path=state.transcript_path,
-                line_cursor=state.line_cursor,
-                byte_offset=state.byte_offset,
-                current_response_id=current_response_id,
-                seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
-                cursor_fingerprint=state.cursor_fingerprint,
-                settled_response_id=dedupe.settled_response_id,
-                pending_settled_response_id=dedupe.pending_settled_response_id,
-            )
-            await _write_forward_state_async(bridge_dir, updated)
-            continue
         if skip_user_messages and item.item_type == "message" and item.data.get("role") == "user":
             seen_source_ids.append(item.source_id)
             seen.add(item.source_id)

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -1006,14 +1006,20 @@ async def forward_claude_transcript_to_session(
                         # Deferred ``/compact``-refusal dismissal: runs AFTER
                         # the hook phase so the ``failed`` post always follows
                         # the ``PreCompact`` ``in_progress`` that raised the
-                        # spinner, even when both land in this same poll.
+                        # spinner, even when both land in this same poll. The
+                        # flag stays ARMED across polls until a pending token is
+                        # actually found and dismissed, so a ``PreCompact`` that
+                        # only becomes visible in a LATER poll than the refusal
+                        # transcript item still gets dismissed rather than
+                        # stranding the spinner.
                         if dedupe.pending_compaction_dismiss:
-                            dedupe.pending_compaction_dismiss = False
-                            await _maybe_dismiss_stranded_compaction_spinner(
+                            dismissed = await _maybe_dismiss_stranded_compaction_spinner(
                                 client,
                                 session_id=current_session_id,
                                 bridge_dir=bridge_dir,
                             )
+                            if dismissed:
+                                dedupe.pending_compaction_dismiss = False
                         subagent_state = await _forward_available_subagents(
                             client=client,
                             parent_session_id=current_session_id,
@@ -5275,7 +5281,7 @@ async def _maybe_dismiss_stranded_compaction_spinner(
     *,
     session_id: str,
     bridge_dir: Path,
-) -> None:
+) -> bool:
     """
     Dismiss the "Compacting…" spinner when Claude declines to compact.
 
@@ -5292,14 +5298,19 @@ async def _maybe_dismiss_stranded_compaction_spinner(
     :param client: Omnigent HTTP client.
     :param session_id: Omnigent session/conversation id, e.g. ``"conv_abc123"``.
     :param bridge_dir: Native Claude bridge directory.
-    :returns: None.
+    :returns: ``True`` when a pending token was found and the ``failed``
+        dismissal was posted; ``False`` when there was no pending token yet
+        (the ``PreCompact`` has not been observed) so the caller keeps the
+        deferred-dismiss flag armed for a later poll. Also ``True`` on a
+        failed POST — the token is consumed and retrying is pointless.
     """
     # Only dismiss when there is actually an in-flight PreCompact token — the
     # refusal spinner we raised. A refusal with no pending token means the
-    # spinner was never raised (or already resolved), so a ``failed`` post
-    # would be spurious.
+    # ``PreCompact`` has not been observed yet (or the spinner already
+    # resolved), so a ``failed`` post would be spurious; signal the caller to
+    # keep the flag armed and retry next poll.
     if not await _discard_pending_compaction(bridge_dir):
-        return
+        return False
     try:
         await _post_external_compaction_status(
             client,
@@ -5315,6 +5326,7 @@ async def _maybe_dismiss_stranded_compaction_spinner(
             exc_info=True,
             extra={"session_id": session_id},
         )
+    return True
 
 
 async def _claim_standalone_completion(bridge_dir: Path) -> int | None:

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -1064,13 +1064,14 @@ def test_read_transcript_items_since_flags_compact_summary(tmp_path: Path) -> No
 )
 def test_read_transcript_items_since_flags_compact_noop(tmp_path: Path, stdout: str) -> None:
     """
-    A ``/compact`` refusal stdout record is flagged, not rendered as a bubble.
+    A ``/compact`` refusal stdout record is surfaced with its text.
 
     When Claude declines ``/compact`` (context too small), it writes the
     refusal to a standalone ``local_command`` stdout record — separate from
-    the ``/compact`` command echo. The bridge must surface it as a single
-    non-rendering ``slash_command`` item with ``is_compact_noop=True`` so the
-    forwarder can dismiss the stranded "Compacting…" spinner.
+    the ``/compact`` command echo. The bridge must surface it as a
+    ``slash_command`` item flagged ``is_compact_noop=True`` (so the forwarder
+    dismisses the stranded "Compacting…" spinner) carrying the refusal text as
+    ``output`` (so the web shows the same message Claude did).
     """
     transcript_path = tmp_path / "session.jsonl"
     transcript_path.write_text(
@@ -1111,10 +1112,16 @@ def test_read_transcript_items_since_flags_compact_noop(tmp_path: Path, stdout: 
         agent_name="claude-native-ui",
     )
 
-    noop = [item for item in items if item.is_compact_noop]
-    assert len(noop) == 1, f"expected one compact-noop item, got {items!r}"
-    assert noop[0].item_type == "slash_command"
-    assert noop[0].data["name"] == "compact"
+    # Exactly one bubble: the bare ``/compact`` echo is deduped away so the
+    # web shows a single "Command compact" row (like the terminal), and it
+    # carries the refusal text as ``output``.
+    compact_items = [item for item in items if item.data.get("name") == "compact"]
+    assert len(compact_items) == 1, f"expected one /compact bubble, got {items!r}"
+    noop = compact_items[0]
+    assert noop.is_compact_noop is True
+    assert noop.item_type == "slash_command"
+    assert noop.data["kind"] == "command"
+    assert noop.data["output"] == stdout.strip()
 
 
 def test_read_transcript_items_since_keeps_real_bash_local_command(tmp_path: Path) -> None:

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -1055,6 +1055,99 @@ def test_read_transcript_items_since_flags_compact_summary(tmp_path: Path) -> No
 
 
 @pytest.mark.parametrize(
+    "stdout",
+    [
+        "Not enough messages to compact.",
+        "not enough messages to compact",
+        "Nothing to compact.",
+    ],
+)
+def test_read_transcript_items_since_flags_compact_noop(tmp_path: Path, stdout: str) -> None:
+    """
+    A ``/compact`` refusal stdout record is flagged, not rendered as a bubble.
+
+    When Claude declines ``/compact`` (context too small), it writes the
+    refusal to a standalone ``local_command`` stdout record — separate from
+    the ``/compact`` command echo. The bridge must surface it as a single
+    non-rendering ``slash_command`` item with ``is_compact_noop=True`` so the
+    forwarder can dismiss the stranded "Compacting…" spinner.
+    """
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "user",
+                        "uuid": "compact-cmd",
+                        "message": {
+                            "role": "user",
+                            "content": (
+                                "<command-name>/compact</command-name>\n"
+                                "            <command-message>compact</command-message>\n"
+                                "            <command-args></command-args>"
+                            ),
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "system",
+                        "subtype": "local_command",
+                        "uuid": "compact-stdout",
+                        "isMeta": False,
+                        "content": f"<local-command-stdout>{stdout}</local-command-stdout>",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    _cursor, _current_response_id, items = read_transcript_items_since(
+        transcript_path,
+        0,
+        agent_name="claude-native-ui",
+    )
+
+    noop = [item for item in items if item.is_compact_noop]
+    assert len(noop) == 1, f"expected one compact-noop item, got {items!r}"
+    assert noop[0].item_type == "slash_command"
+    assert noop[0].data["name"] == "compact"
+
+
+def test_read_transcript_items_since_keeps_real_bash_local_command(tmp_path: Path) -> None:
+    """
+    A non-refusal ``local_command`` stdout is not mistaken for a compact noop.
+
+    A shell ``!cmd`` record still surfaces as a terminal command, never a
+    flagged compact-noop item.
+    """
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "type": "system",
+                "subtype": "local_command",
+                "uuid": "bash-1",
+                "content": ("<bash-input>echo hi</bash-input>\n<bash-stdout>hi</bash-stdout>"),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    _cursor, _current_response_id, items = read_transcript_items_since(
+        transcript_path,
+        0,
+        agent_name="claude-native-ui",
+    )
+
+    assert all(not item.is_compact_noop for item in items), items
+
+
+@pytest.mark.parametrize(
     "raw_text",
     [
         "Prompt is too long",

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5588,32 +5588,7 @@ async def test_effort_sync_swallows_patch_failure() -> None:
     assert captured[0].method == "PATCH"
 
 
-def _compact_slash_command_item(*, output: str | None) -> ClaudeTranscriptItem:
-    """
-    Build a ``/compact`` ``slash_command`` item carrying stdout.
-
-    :param output: The ``<local-command-stdout>`` text, or ``None`` for a
-        compaction that actually ran (no refusal stdout).
-    :returns: A ``slash_command`` item shaped like the bridge emits.
-    """
-    data: dict[str, Any] = {
-        "agent": "claude",
-        "kind": "command",
-        "name": "compact",
-        "arguments": "",
-    }
-    if output is not None:
-        data["output"] = output
-    return ClaudeTranscriptItem(
-        source_id="rec01:0:slash_command",
-        item_type="slash_command",
-        data=data,
-        response_id="resp_1",
-    )
-
-
 async def _run_dismiss_stranded_spinner(
-    item: ClaudeTranscriptItem,
     *,
     bridge_dir: Path,
     status: int = 200,
@@ -5621,7 +5596,6 @@ async def _run_dismiss_stranded_spinner(
     """
     Drive ``_maybe_dismiss_stranded_compaction_spinner`` against a mock AP.
 
-    :param item: Transcript item to feed the helper.
     :param bridge_dir: Bridge dir holding the compaction state.
     :param status: HTTP status the mock endpoint returns.
     :returns: Every request the helper issued, in order.
@@ -5637,20 +5611,12 @@ async def _run_dismiss_stranded_spinner(
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
         await forwarder._maybe_dismiss_stranded_compaction_spinner(
-            client, session_id="conv_x", bridge_dir=bridge_dir, item=item
+            client, session_id="conv_x", bridge_dir=bridge_dir
         )
     return captured
 
 
-@pytest.mark.parametrize(
-    "output",
-    [
-        "Not enough messages to compact.",
-        "not enough messages to compact",
-        "Nothing to compact.",
-    ],
-)
-async def test_compact_refusal_dismisses_stranded_spinner(output: str, tmp_path: Path) -> None:
+async def test_compact_refusal_dismisses_stranded_spinner(tmp_path: Path) -> None:
     """
     A ``/compact`` refusal posts ``failed`` and drops the pending token.
 
@@ -5665,9 +5631,7 @@ async def test_compact_refusal_dismisses_stranded_spinner(output: str, tmp_path:
         bridge_dir, claude_session_id="claude-1", transcript_path="/t/session.jsonl"
     )
 
-    captured = await _run_dismiss_stranded_spinner(
-        _compact_slash_command_item(output=output), bridge_dir=bridge_dir
-    )
+    captured = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir)
 
     assert captured == [
         _CapturedRequest(
@@ -5690,34 +5654,9 @@ async def test_compact_refusal_without_pending_token_no_ops(tmp_path: Path) -> N
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
 
-    captured = await _run_dismiss_stranded_spinner(
-        _compact_slash_command_item(output="Not enough messages to compact."),
-        bridge_dir=bridge_dir,
-    )
+    captured = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir)
 
     assert captured == [], f"expected no POST without a pending token, got {captured!r}"
-
-
-async def test_successful_compact_does_not_dismiss_spinner(tmp_path: Path) -> None:
-    """
-    A ``/compact`` that actually ran must NOT post ``failed``.
-
-    A real compaction carries no refusal stdout; the pending token is
-    consumed by the ``isCompactSummary`` completion path, not dropped here.
-    """
-    bridge_dir = tmp_path / "bridge"
-    bridge_dir.mkdir()
-    await forwarder._note_precompact(
-        bridge_dir, claude_session_id="claude-1", transcript_path="/t/session.jsonl"
-    )
-
-    captured = await _run_dismiss_stranded_spinner(
-        _compact_slash_command_item(output=None), bridge_dir=bridge_dir
-    )
-
-    assert captured == [], f"expected no failed POST for a real compaction, got {captured!r}"
-    # Token left intact for the completion path to consume.
-    assert forwarder._read_compaction_state(bridge_dir).pending is not None
 
 
 async def test_compact_refusal_swallows_post_failure(tmp_path: Path) -> None:
@@ -5728,11 +5667,7 @@ async def test_compact_refusal_swallows_post_failure(tmp_path: Path) -> None:
         bridge_dir, claude_session_id="claude-1", transcript_path="/t/session.jsonl"
     )
 
-    captured = await _run_dismiss_stranded_spinner(
-        _compact_slash_command_item(output="Not enough messages to compact."),
-        bridge_dir=bridge_dir,
-        status=503,
-    )
+    captured = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir, status=503)
 
     # Attempted once, the 503 swallowed. The token is still cleared (the
     # spinner-owning PreCompact will never complete regardless).

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5691,13 +5691,14 @@ async def _run_dismiss_stranded_spinner(
     *,
     bridge_dir: Path,
     status: int = 200,
-) -> list[_CapturedRequest]:
+) -> tuple[list[_CapturedRequest], bool]:
     """
     Drive ``_maybe_dismiss_stranded_compaction_spinner`` against a mock AP.
 
     :param bridge_dir: Bridge dir holding the compaction state.
     :param status: HTTP status the mock endpoint returns.
-    :returns: Every request the helper issued, in order.
+    :returns: ``(captured requests in order, dismissed)`` where ``dismissed``
+        is the helper's return — ``True`` when a pending token was found.
     """
     captured: list[_CapturedRequest] = []
 
@@ -5709,10 +5710,10 @@ async def _run_dismiss_stranded_spinner(
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
-        await forwarder._maybe_dismiss_stranded_compaction_spinner(
+        dismissed = await forwarder._maybe_dismiss_stranded_compaction_spinner(
             client, session_id="conv_x", bridge_dir=bridge_dir
         )
-    return captured
+    return captured, dismissed
 
 
 async def test_compact_refusal_dismisses_stranded_spinner(tmp_path: Path) -> None:
@@ -5730,8 +5731,9 @@ async def test_compact_refusal_dismisses_stranded_spinner(tmp_path: Path) -> Non
         bridge_dir, claude_session_id="claude-1", transcript_path="/t/session.jsonl"
     )
 
-    captured = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir)
+    captured, dismissed = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir)
 
+    assert dismissed is True
     assert captured == [
         _CapturedRequest(
             method="POST",
@@ -5745,17 +5747,54 @@ async def test_compact_refusal_dismisses_stranded_spinner(tmp_path: Path) -> Non
 
 async def test_compact_refusal_without_pending_token_no_ops(tmp_path: Path) -> None:
     """
-    A refusal with no in-flight ``PreCompact`` posts nothing.
+    A refusal with no in-flight ``PreCompact`` posts nothing and stays armed.
 
-    No pending token means the spinner was never raised (or already
-    resolved), so a ``failed`` post would be spurious.
+    No pending token means the ``PreCompact`` has not been observed yet, so a
+    ``failed`` post would be spurious. The helper returns ``False`` so the
+    caller keeps its deferred-dismiss flag armed for a later poll.
     """
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
 
-    captured = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir)
+    captured, dismissed = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir)
 
+    assert dismissed is False
     assert captured == [], f"expected no POST without a pending token, got {captured!r}"
+
+
+async def test_compact_refusal_dismisses_when_precompact_arrives_later(tmp_path: Path) -> None:
+    """
+    A refusal seen before its ``PreCompact`` stays armed, then dismisses.
+
+    Guards the cross-poll inversion: if the refusal transcript item is read
+    in a poll BEFORE the ``PreCompact`` hook becomes visible, the first
+    dismissal attempt finds no token and returns ``False`` (caller keeps the
+    flag armed). Once the ``PreCompact`` mints the token, a later attempt
+    posts ``failed`` — so the spinner is never stranded.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    # Poll N: refusal observed first, no PreCompact token yet.
+    captured, dismissed = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir)
+    assert dismissed is False
+    assert captured == []
+
+    # Poll N+k: PreCompact finally lands and mints the pending token.
+    await forwarder._note_precompact(
+        bridge_dir, claude_session_id="claude-1", transcript_path="/t/session.jsonl"
+    )
+    captured, dismissed = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir)
+
+    assert dismissed is True
+    assert captured == [
+        _CapturedRequest(
+            method="POST",
+            path="/v1/sessions/conv_x/events",
+            body={"type": "external_compaction_status", "data": {"status": "failed"}},
+        )
+    ], f"expected the deferred failed POST once the token appeared, got {captured!r}"
+    assert forwarder._read_compaction_state(bridge_dir).pending is None
 
 
 async def test_compact_refusal_swallows_post_failure(tmp_path: Path) -> None:
@@ -5766,10 +5805,12 @@ async def test_compact_refusal_swallows_post_failure(tmp_path: Path) -> None:
         bridge_dir, claude_session_id="claude-1", transcript_path="/t/session.jsonl"
     )
 
-    captured = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir, status=503)
+    captured, dismissed = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir, status=503)
 
-    # Attempted once, the 503 swallowed. The token is still cleared (the
-    # spinner-owning PreCompact will never complete regardless).
+    # Attempted once, the 503 swallowed. Returns True (token consumed, no
+    # point retrying) and the token is cleared (the spinner-owning PreCompact
+    # will never complete regardless).
+    assert dismissed is True
     assert len(captured) == 1
     assert captured[0].method == "POST"
     assert forwarder._read_compaction_state(bridge_dir).pending is None

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5588,6 +5588,159 @@ async def test_effort_sync_swallows_patch_failure() -> None:
     assert captured[0].method == "PATCH"
 
 
+def _compact_slash_command_item(*, output: str | None) -> ClaudeTranscriptItem:
+    """
+    Build a ``/compact`` ``slash_command`` item carrying stdout.
+
+    :param output: The ``<local-command-stdout>`` text, or ``None`` for a
+        compaction that actually ran (no refusal stdout).
+    :returns: A ``slash_command`` item shaped like the bridge emits.
+    """
+    data: dict[str, Any] = {
+        "agent": "claude",
+        "kind": "command",
+        "name": "compact",
+        "arguments": "",
+    }
+    if output is not None:
+        data["output"] = output
+    return ClaudeTranscriptItem(
+        source_id="rec01:0:slash_command",
+        item_type="slash_command",
+        data=data,
+        response_id="resp_1",
+    )
+
+
+async def _run_dismiss_stranded_spinner(
+    item: ClaudeTranscriptItem,
+    *,
+    bridge_dir: Path,
+    status: int = 200,
+) -> list[_CapturedRequest]:
+    """
+    Drive ``_maybe_dismiss_stranded_compaction_spinner`` against a mock AP.
+
+    :param item: Transcript item to feed the helper.
+    :param bridge_dir: Bridge dir holding the compaction state.
+    :param status: HTTP status the mock endpoint returns.
+    :returns: Every request the helper issued, in order.
+    """
+    captured: list[_CapturedRequest] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Record the request and return a canned response."""
+        body = json.loads(request.content.decode("utf-8")) if request.content else None
+        captured.append(_CapturedRequest(method=request.method, path=request.url.path, body=body))
+        return httpx.Response(status, json={"queued": False})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
+        await forwarder._maybe_dismiss_stranded_compaction_spinner(
+            client, session_id="conv_x", bridge_dir=bridge_dir, item=item
+        )
+    return captured
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "Not enough messages to compact.",
+        "not enough messages to compact",
+        "Nothing to compact.",
+    ],
+)
+async def test_compact_refusal_dismisses_stranded_spinner(output: str, tmp_path: Path) -> None:
+    """
+    A ``/compact`` refusal posts ``failed`` and drops the pending token.
+
+    Claude fired ``PreCompact`` (raising the spinner) but declined to
+    compact, so no completion signal follows. The forwarder must dismiss
+    the "Compacting…" spinner with ``external_compaction_status: failed``
+    and clear the dangling ``PreCompact`` token.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    await forwarder._note_precompact(
+        bridge_dir, claude_session_id="claude-1", transcript_path="/t/session.jsonl"
+    )
+
+    captured = await _run_dismiss_stranded_spinner(
+        _compact_slash_command_item(output=output), bridge_dir=bridge_dir
+    )
+
+    assert captured == [
+        _CapturedRequest(
+            method="POST",
+            path="/v1/sessions/conv_x/events",
+            body={"type": "external_compaction_status", "data": {"status": "failed"}},
+        )
+    ], f"expected one failed compaction-status POST, got {captured!r}"
+    # Dangling token cleared so a later genuine compaction reconciles cleanly.
+    assert forwarder._read_compaction_state(bridge_dir).pending is None
+
+
+async def test_compact_refusal_without_pending_token_no_ops(tmp_path: Path) -> None:
+    """
+    A refusal with no in-flight ``PreCompact`` posts nothing.
+
+    No pending token means the spinner was never raised (or already
+    resolved), so a ``failed`` post would be spurious.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    captured = await _run_dismiss_stranded_spinner(
+        _compact_slash_command_item(output="Not enough messages to compact."),
+        bridge_dir=bridge_dir,
+    )
+
+    assert captured == [], f"expected no POST without a pending token, got {captured!r}"
+
+
+async def test_successful_compact_does_not_dismiss_spinner(tmp_path: Path) -> None:
+    """
+    A ``/compact`` that actually ran must NOT post ``failed``.
+
+    A real compaction carries no refusal stdout; the pending token is
+    consumed by the ``isCompactSummary`` completion path, not dropped here.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    await forwarder._note_precompact(
+        bridge_dir, claude_session_id="claude-1", transcript_path="/t/session.jsonl"
+    )
+
+    captured = await _run_dismiss_stranded_spinner(
+        _compact_slash_command_item(output=None), bridge_dir=bridge_dir
+    )
+
+    assert captured == [], f"expected no failed POST for a real compaction, got {captured!r}"
+    # Token left intact for the completion path to consume.
+    assert forwarder._read_compaction_state(bridge_dir).pending is not None
+
+
+async def test_compact_refusal_swallows_post_failure(tmp_path: Path) -> None:
+    """A failed dismissal POST is best-effort — attempted, logged, never raised."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    await forwarder._note_precompact(
+        bridge_dir, claude_session_id="claude-1", transcript_path="/t/session.jsonl"
+    )
+
+    captured = await _run_dismiss_stranded_spinner(
+        _compact_slash_command_item(output="Not enough messages to compact."),
+        bridge_dir=bridge_dir,
+        status=503,
+    )
+
+    # Attempted once, the 503 swallowed. The token is still cleared (the
+    # spinner-owning PreCompact will never complete regardless).
+    assert len(captured) == 1
+    assert captured[0].method == "POST"
+    assert forwarder._read_compaction_state(bridge_dir).pending is None
+
+
 def test_usage_from_status_state_surfaces_cumulative_cost() -> None:
     """
     ``_usage_from_status_state`` surfaces ``total_cost_usd`` as

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -1701,6 +1701,105 @@ async def test_forwarder_posts_compaction_in_progress_on_precompact_hook(
 
 
 @pytest.mark.asyncio
+async def test_compact_refusal_in_progress_precedes_failed_same_poll(
+    tmp_path: Path,
+) -> None:
+    """
+    A same-poll ``/compact`` refusal posts ``in_progress`` BEFORE ``failed``.
+
+    Regression for the stranded spinner: the ``PreCompact`` hook (→
+    ``in_progress``, which raises the spinner) is forwarded AFTER transcript
+    items each poll, and Claude writes the refusal (transcript) and the
+    ``PreCompact`` (hook) close enough to land in one poll. If the dismissal
+    fired during the transcript phase it would clear nothing, then the hook
+    would raise a spinner that never clears. The dismissal is deferred to
+    after the hook phase, so the ordered posts are ``in_progress`` then
+    ``failed`` — a net-dismissed spinner.
+    """
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    # The two records Claude writes for a declined /compact: the command echo
+    # and the standalone refusal stdout.
+    transcript_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "user",
+                        "uuid": "compact-cmd",
+                        "message": {
+                            "role": "user",
+                            "content": (
+                                "<command-name>/compact</command-name>\n<command-args></command-args>"
+                            ),
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "system",
+                        "subtype": "local_command",
+                        "uuid": "compact-stdout",
+                        "isMeta": False,
+                        "content": (
+                            "<local-command-stdout>Not enough messages to compact."
+                            "</local-command-stdout>"
+                        ),
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "claude-session",
+            "transcript_path": str(transcript_path),
+        },
+    )
+    record_hook_event(
+        bridge_dir,
+        {"hook_event_name": "PreCompact", "session_id": "claude-session"},
+    )
+    server, thread, base_url = _start_recording_server()
+    task = asyncio.create_task(
+        forward_claude_transcript_to_session(
+            base_url=base_url,
+            headers={},
+            session_id="conv_abc",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            start_at_end=False,
+            poll_interval_s=0.01,
+        )
+    )
+    try:
+        # Collect compaction-status posts until both edges are seen.
+        statuses: list[str] = []
+        deadline = asyncio.get_running_loop().time() + 5.0
+        while "failed" not in statuses and asyncio.get_running_loop().time() < deadline:
+            request = await _get_recorded_request(server)
+            if request["body"].get("type") == "external_compaction_status":
+                statuses.append(request["body"]["data"]["status"])
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5.0)
+
+    # in_progress (spinner raised by the hook) must land before failed
+    # (the deferred dismissal), so the net effect is a dismissed spinner.
+    assert statuses == ["in_progress", "failed"], (
+        f"expected in_progress then failed, got {statuses!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_forwarder_posts_compaction_completed_on_compact_session_start(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5690,15 +5690,16 @@ async def test_effort_sync_swallows_patch_failure() -> None:
 async def _run_dismiss_stranded_spinner(
     *,
     bridge_dir: Path,
+    seq: int,
     status: int = 200,
-) -> tuple[list[_CapturedRequest], bool]:
+) -> list[_CapturedRequest]:
     """
     Drive ``_maybe_dismiss_stranded_compaction_spinner`` against a mock AP.
 
     :param bridge_dir: Bridge dir holding the compaction state.
+    :param seq: The refused compaction's ``PreCompact`` seq to dismiss.
     :param status: HTTP status the mock endpoint returns.
-    :returns: ``(captured requests in order, dismissed)`` where ``dismissed``
-        is the helper's return — ``True`` when a pending token was found.
+    :returns: Every request the helper issued, in order.
     """
     captured: list[_CapturedRequest] = []
 
@@ -5710,30 +5711,30 @@ async def _run_dismiss_stranded_spinner(
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
-        dismissed = await forwarder._maybe_dismiss_stranded_compaction_spinner(
-            client, session_id="conv_x", bridge_dir=bridge_dir
+        await forwarder._maybe_dismiss_stranded_compaction_spinner(
+            client, session_id="conv_x", bridge_dir=bridge_dir, seq=seq
         )
-    return captured, dismissed
+    return captured
 
 
 async def test_compact_refusal_dismisses_stranded_spinner(tmp_path: Path) -> None:
     """
-    A ``/compact`` refusal posts ``failed`` and drops the pending token.
+    A ``/compact`` refusal posts ``failed`` and drops the refused token.
 
     Claude fired ``PreCompact`` (raising the spinner) but declined to
     compact, so no completion signal follows. The forwarder must dismiss
     the "Compacting…" spinner with ``external_compaction_status: failed``
-    and clear the dangling ``PreCompact`` token.
+    and clear the dangling ``PreCompact`` token for that seq.
     """
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
     await forwarder._note_precompact(
         bridge_dir, claude_session_id="claude-1", transcript_path="/t/session.jsonl"
     )
+    seq = forwarder._read_compaction_state(bridge_dir).pending.seq
 
-    captured, dismissed = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir)
+    captured = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir, seq=seq)
 
-    assert dismissed is True
     assert captured == [
         _CapturedRequest(
             method="POST",
@@ -5747,54 +5748,41 @@ async def test_compact_refusal_dismisses_stranded_spinner(tmp_path: Path) -> Non
 
 async def test_compact_refusal_without_pending_token_no_ops(tmp_path: Path) -> None:
     """
-    A refusal with no in-flight ``PreCompact`` posts nothing and stays armed.
+    A refusal whose ``PreCompact`` was missed posts nothing.
 
-    No pending token means the ``PreCompact`` has not been observed yet, so a
-    ``failed`` post would be spurious. The helper returns ``False`` so the
-    caller keeps its deferred-dismiss flag armed for a later poll.
+    No pending token means the ``PreCompact`` was never observed, so no
+    spinner is up and a ``failed`` post would be spurious.
     """
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
 
-    captured, dismissed = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir)
+    captured = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir, seq=1)
 
-    assert dismissed is False
     assert captured == [], f"expected no POST without a pending token, got {captured!r}"
 
 
-async def test_compact_refusal_dismisses_when_precompact_arrives_later(tmp_path: Path) -> None:
+async def test_compact_refusal_does_not_dismiss_a_different_compaction(tmp_path: Path) -> None:
     """
-    A refusal seen before its ``PreCompact`` stays armed, then dismisses.
+    A stale refusal seq never dismisses a later genuine compaction's token.
 
-    Guards the cross-poll inversion: if the refusal transcript item is read
-    in a poll BEFORE the ``PreCompact`` hook becomes visible, the first
-    dismissal attempt finds no token and returns ``False`` (caller keeps the
-    flag armed). Once the ``PreCompact`` mints the token, a later attempt
-    posts ``failed`` — so the spinner is never stranded.
+    Regression for the flag-leak hazard: a refusal armed for seq N must not
+    fire against a fresh seq N+1 minted by a subsequent real ``/compact`` —
+    doing so would clear that live spinner and discard its boundary token.
     """
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
-
-    # Poll N: refusal observed first, no PreCompact token yet.
-    captured, dismissed = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir)
-    assert dismissed is False
-    assert captured == []
-
-    # Poll N+k: PreCompact finally lands and mints the pending token.
+    # A genuine, later compaction is pending (seq 1); the refusal we're
+    # flushing was armed for a missed earlier compaction (seq 0).
     await forwarder._note_precompact(
         bridge_dir, claude_session_id="claude-1", transcript_path="/t/session.jsonl"
     )
-    captured, dismissed = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir)
+    live_seq = forwarder._read_compaction_state(bridge_dir).pending.seq
 
-    assert dismissed is True
-    assert captured == [
-        _CapturedRequest(
-            method="POST",
-            path="/v1/sessions/conv_x/events",
-            body={"type": "external_compaction_status", "data": {"status": "failed"}},
-        )
-    ], f"expected the deferred failed POST once the token appeared, got {captured!r}"
-    assert forwarder._read_compaction_state(bridge_dir).pending is None
+    captured = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir, seq=live_seq - 1)
+
+    assert captured == [], f"a stale refusal seq must post nothing, got {captured!r}"
+    # The genuine compaction's token is untouched.
+    assert forwarder._read_compaction_state(bridge_dir).pending.seq == live_seq
 
 
 async def test_compact_refusal_swallows_post_failure(tmp_path: Path) -> None:
@@ -5804,13 +5792,12 @@ async def test_compact_refusal_swallows_post_failure(tmp_path: Path) -> None:
     await forwarder._note_precompact(
         bridge_dir, claude_session_id="claude-1", transcript_path="/t/session.jsonl"
     )
+    seq = forwarder._read_compaction_state(bridge_dir).pending.seq
 
-    captured, dismissed = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir, status=503)
+    captured = await _run_dismiss_stranded_spinner(bridge_dir=bridge_dir, seq=seq, status=503)
 
-    # Attempted once, the 503 swallowed. Returns True (token consumed, no
-    # point retrying) and the token is cleared (the spinner-owning PreCompact
-    # will never complete regardless).
-    assert dismissed is True
+    # Attempted once, the 503 swallowed. The token is still cleared (the
+    # spinner-owning PreCompact will never complete regardless).
     assert len(captured) == 1
     assert captured[0].method == "POST"
     assert forwarder._read_compaction_state(bridge_dir).pending is None


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- Fixes the "Compacting conversation…" spinner staying on screen forever in a **claude-native** session when the user runs `/compact` but Claude replies **"Not enough messages to compact."**
- Root cause: Claude Code fires its `PreCompact` hook *before* deciding whether there's anything to compact. The forwarder maps that hook to `external_compaction_status: in_progress` → the spinner. On a refusal Claude aborts without writing an `isCompactSummary` record or firing the `SessionStart source=compact` hook — the two signals that normally dismiss the spinner — so it's stranded.
- Fix: the forwarder now detects the refusal from the `/compact` slash-command's stdout, posts `external_compaction_status: failed` (which the web UI already maps to `response.compaction.failed` → remove the loading block), and drops the dangling `PreCompact` token so a later genuine compaction reconciles cleanly. Best-effort and guarded to only fire when a spinner is actually in flight.

### ELI5

You press "compact". The app immediately shows a "compacting…" spinner. But the assistant looks at the chat, decides it's too short to bother, and quietly walks away — never telling the app it's done. The spinner spins forever. This change makes the app notice "oh, it declined" and turn the spinner off.

```
/compact typed
   │
   ▼
PreCompact hook ──► external_compaction_status: in_progress ──► 🌀 spinner shown
   │
   ├─ enough context ─► isCompactSummary / SessionStart(compact) ─► completed ─► ✅ (existing)
   │
   └─ "Not enough messages to compact." (refusal, no completion signal)
             │
             ▼   (NEW)
      detect refusal in /compact stdout ──► external_compaction_status: failed ──► spinner removed
```

## Test Plan

- `python -m pytest tests/test_claude_native_forwarder.py -k "compact or effort_sync"` — 23 passed.
- Added 6 unit tests: refusal variants dismiss + clear token, no-op without a pending token, real compaction (no refusal stdout) leaves the token intact, and best-effort swallow of a failed dismissal POST.
- `ruff format` / `ruff check` / `pyrefly` clean (pre-commit hooks pass).

**Manual check:** in a claude-native session with only a message or two of context, run `/compact` from the web UI. The "Compacting conversation…" shimmer should appear briefly and then disappear (no permanent marker) once Claude replies "Not enough messages to compact." — instead of hanging forever. A `/compact` on a longer conversation should still show the spinner and settle into the "Conversation compacted" checkmark.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The spinner is driven entirely by the backend forwarder (no `web/` files changed); the fix is covered by unit tests and the manual check above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the honest end-to-end check because the stranded spinner is a web-UI symptom driven by the SSE the forwarder emits; the new unit tests pin the forwarder's exact behavior (posts `failed`, clears the token, no false positives on a real compaction), and the web side already handles `response.compaction.failed` (existing `compaction_failed` store handler).

## Changelog

Fixed the "Compacting conversation…" spinner getting stuck when Claude Code declines a `/compact` with too little context

This pull request and its description were written by Isaac.
