### PR TITLE
feat(dev): add cross-agent verification skill

### DIFF
--- a/.agents/skills/verify-omnigent/SKILL.md
+++ b/.agents/skills/verify-omnigent/SKILL.md
@@ -1,0 +1,522 @@
+---
+name: verify-omnigent
+description: Verifies every affected Omnigent product surface through fail-closed CLI, Electron, Playwright, server, and harness/client profiles, with optional live and Databricks/Universe compatibility checks. Use before implementation planning and before declaring an Omnigent change complete.
+---
+
+# Verify Omnigent
+
+Turn the feature request into proof obligations, then verify each affected
+product surface. Use unit and component tests as fast feedback, not as a
+substitute for a real CLI, Electron, browser, server, or client journey.
+
+## Plan before implementation
+
+Write this verification contract before changing code:
+
+```text
+Feature:
+Acceptance criteria:
+- Given <starting state>, when <user action>, then <observable result>.
+
+Affected surfaces:
+- desktop | cli | web-ui | server | harness-client
+
+Compatibility matrix:
+- current client / current server:
+- older client / new server:
+- new client / older server:
+- downstream Universe, if explicitly requested:
+
+Latency budget:
+- journey and measurement:
+- baseline:
+- maximum allowed regression:
+- if no baseline exists, state that limitation:
+
+Proof obligations:
+- profile or focused test for each acceptance criterion:
+- persistent/API read-back for each write:
+- negative proof for disabled or dry-run behavior:
+- credentialed, platform-specific, or downstream lanes that need explicit opt-in:
+```
+
+Do not start implementation with "tests pass" as the acceptance criterion.
+Name the user action, visible or API result, compatibility combinations, latency
+measurement, and evidence file that will prove each claim.
+
+Read [correctness.md](correctness.md). Write the observable invariant and its
+failure cases before choosing tests. Use the lowest test level that can falsify
+the claim. Do not add a standalone E2E test for a render-only condition already
+covered by a component test.
+
+## Choose the verification lanes
+
+Read the diff, then select every applicable local lane:
+
+- Any product or test code: run `quality-gates`. It runs pre-commit on changed
+  files, plus the full web format, lint, type-check, and production-build
+  commands when web code changed.
+- `web/**`: web unit tests plus the closest mapped Playwright journey.
+- `omnigent/server/**`, `omnigent/runtime/**`, or `sdks/**`: server/SDK tests,
+  the chat smoke journey, and compatibility checks.
+- DB models, store interfaces, or migrations: migration tests and a downstream
+  risk assessment. Run the Universe lane only when the user explicitly opts in.
+- auth, account-auth, identity, session authorization, sharing, permissions,
+  roles, login/registration pages, OIDC/account stores, or their client
+  surfaces: collaboration journeys plus the applicable server or UI lane and a
+  downstream risk assessment. Run the Universe lane only when explicitly asked.
+- scheduled tasks: run the automations profile, but preserve capability gating;
+  managed Databricks deployments intentionally disable automations.
+- user-visible render/load changes: record timings and the request waterfall
+  from the same Playwright journey before and after. Do not claim "no latency
+  regression" from a passing functional test.
+- CLI setup/onboarding changes: use the existing project
+  `.claude/skills/cli-setup-verify` PTY driver with isolated HOME, config, and
+  data directories.
+- harness adapter changes: run the relevant E2E skill plus
+  `tests/harness_bench`; use `--no-live` first and a real credentialed canary
+  only when the change warrants it.
+- desktop/mobile shell changes: run their Playwright/native wrapper journey in
+  addition to the shared web path.
+- deployment dry-runs: verify the promised non-effects on files, network,
+  browser launches, database state, and git refs.
+
+## Launch
+
+For the normal one-shot path, compare the checkout to the intended base:
+
+```bash
+OMNIGENT_VERIFY_ADAPTER=cursor \
+  .agents/skills/verify-omnigent/scripts/verify.sh auto --base-ref origin/main
+```
+
+Set `OMNIGENT_VERIFY_ADAPTER` to the invoking adapter: `cursor`,
+`claude-code`, `codex`, or `omnigent`. The value is self-reported in evidence;
+if it is absent or invalid, the manifest records `unspecified` or `invalid`
+and adds a limitation instead of guessing.
+
+`auto` resolves the merge base between `HEAD` and the requested base, reads
+committed branch changes from that branch point, then includes staged, unstaged,
+and untracked paths exactly once. It records why each lane was selected, runs
+required lanes sequentially, and writes a separate child manifest for each lane.
+A missing base ref, unresolved or ambiguous merge base, missing prerequisite,
+unmapped product path, missing child manifest, skipped required live probe, or
+failed lane makes the one-shot command nonzero. Set
+`OMNIGENT_VERIFY_BASE_REF` instead of `--base-ref` when the caller cannot pass an
+argument. The default base is `HEAD`.
+
+Before starting any selected lane, `auto` checks every selected lane's
+prerequisites. A blocker finalizes the parent and every selected child entry as
+`blocked`; it does not start a partial run. Required lanes then run fail-fast.
+If a required server, harness-client, or CLI step fails, `auto` reruns only that
+failed step at the unique merge base in a detached temporary worktree when
+dependency inputs match. Quality-gates, web-ui, and desktop exact-base
+comparisons are explicitly unsupported without isolated JavaScript dependencies
+and are classified `could_not_compare`; they are never presented as reproduced
+or PR-only failures. The
+classification is `pr_only_failure`, `baseline_reproduced`,
+`baseline_differs`, or `could_not_compare`. A reproduced baseline failure is
+still a required failure and never makes the parent pass. Partial execution is
+authorized by a private, signed, one-use request generated by that `auto` run;
+caller-supplied partial-execution environment variables are rejected. The
+comparison authenticates `steps.json` and its logs against the finalized child
+manifest and freshly generated profile commands before classifying anything.
+
+To verify another clean checkout without copying the skill into it, run the
+canonical script with an explicit repository root:
+
+```bash
+OMNIGENT_VERIFY_REPO_ROOT=/path/to/omnigent-checkout \
+OMNIGENT_VERIFY_ADAPTER=cursor \
+  .agents/skills/verify-omnigent/scripts/verify.sh auto --base-ref origin/main
+```
+
+Use `all-surfaces` only when you intentionally want every local,
+credential-free product lane:
+
+```bash
+OMNIGENT_VERIFY_ADAPTER=cursor \
+  .agents/skills/verify-omnigent/scripts/verify.sh all-surfaces
+```
+
+The script uses the repository's `tests/e2e_ui` fixtures. They build the real
+Vite bundle, start a mock OpenAI-compatible LLM, start `omnigent server` and a
+runner on random ports, and allocate a temporary SQLite DB and artifact
+directory. Readiness means `/health` is 200 and the fixture-owned runner reports
+online. No provider credentials are needed and product traffic stays on
+loopback. First-time dependency or browser setup can use package registries;
+`backend` intentionally installs into disposable virtual environments and
+therefore requires package-network access.
+
+Available profiles:
+
+- `auto`: select required product lanes from the diff against a configurable
+  base ref.
+- `all-surfaces`: run `quality-gates`, `server`, `harness-client`, `cli`,
+  `web-ui`, and `desktop` sequentially.
+- `quality-gates`: run pre-commit on changed files in a disposable worktree.
+  Pinned remote hook repositories are copied selectively from a trusted user
+  cache into the disposable runtime; a missing exact revision is an actionable
+  offline prerequisite. Changed verification, deploy, and Playwright evidence
+  contracts run explicitly. Web changes also run the full web format, lint,
+  type-check, and production-build binaries without package installation.
+- `prepare-hooks`: explicitly prepare the exact remote repositories and
+  revisions in `.pre-commit-config.yaml`, authenticate their trees, and
+  atomically publish them to `~/.cache/verify-omnigent/pre-commit`. This is a
+  distinct network-capable bootstrap operation, never verification evidence:
+  `.agents/skills/verify-omnigent/scripts/verify.sh prepare-hooks`.
+- `universe`: explicit non-syncing downstream preflight. It discovers a sibling
+  Universe checkout, compares its MAS pins with `--oss-ref` or the current OSS
+  `HEAD`, scopes affected patches with `--base-ref`, checks them in a temporary
+  tree, and runs applicable hermetic Bazel gates. It never syncs or edits
+  tracked Universe source; see the ignored-output limitation below.
+- `server`: app and API integration tests from the existing project
+  environment. It covers health, API-only landing, static routing, auth mode,
+  host routes, and app assembly without package-network access.
+- `backend`: opt-in clean-room API smoke against `/`, `/health`, `/docs`,
+  `/v1/agents`, and `/v1/sessions`. It installs into disposable environments
+  and requires package-network access.
+- `cli`: isolated PTY checks for config isolation, cold start, top-level help,
+  and server help. It requires macOS or Linux and never inherits the user's
+  HOME or credentials.
+- `web-ui`: web unit tests, type checking, and the real core Playwright journey.
+- `desktop`: Electron unit tests, JavaScript Electron Playwright journeys,
+  browser desktop-mode Playwright, and an unsigned package for the current
+  platform. Signing and notarization are not claimed.
+- `harness-client`: harness bench tests plus the credential-free offline
+  capability matrix. It does not claim a live turn.
+- `harness-live`: explicit credentialed canary for one harness. Set
+  `OMNIGENT_VERIFY_HARNESS`; optionally set
+  `OMNIGENT_VERIFY_DATABRICKS_PROFILE`. A skipped or missing basic turn fails.
+- `perf`: repeatable session-list, history-load, and time-to-first-token
+  benchmark with request-count and latency JSON. Pass `--base-ref REF` for a
+  bounded matched base/candidate comparison. Parent-owned defaults reject p50
+  or p99 regressions above 10%; override them explicitly with
+  `--max-p50-regression-percent` and `--max-p99-regression-percent`. Thresholds
+  emitted by benchmark code are ignored.
+- `smoke`: send a message through the real SPA, SSE, server, runner, and SDK
+  reducer.
+- `collaboration`: permission-modal controls, sharing lifecycle, read-only and
+  sharing-off behavior, realtime collaborator updates, and author attribution.
+- `automations`: Scheduled Tasks UI and REST persistence.
+- `db-migration-deploy`: focused database migration, store, and deployment
+  contracts. `auto` selects it only for DB/schema/store/deploy changes.
+- `perf`: is selected by `auto` only for mapped latency-sensitive session,
+  conversation, streaming, or benchmark paths; it is not added to a broad
+  `all-surfaces` run.
+- `core`: smoke, new-session UI, file autosave, and collaboration.
+- `full-ui`: all non-visual UI E2E tests.
+
+First-time setup:
+
+```bash
+uv sync --locked --extra all --extra dev
+CI=true pnpm install --frozen-lockfile
+uv run --no-sync playwright install chromium
+```
+
+## Doctor
+
+Run doctor for the exact profile you plan to drive:
+
+```bash
+OMNIGENT_VERIFY_ADAPTER=cursor \
+  .agents/skills/verify-omnigent/scripts/verify.sh doctor auto --base-ref origin/main
+```
+
+The target profile defaults to `smoke`. Doctor checks only that profile's
+requirements. `doctor auto` computes the same lane plan and checks every
+selected lane. `doctor all-surfaces` checks all six local lanes. Each blocker
+includes the exact setup command or platform requirement. Fix doctor failures
+before interpreting product failures. Doctor attempts also create and finalize
+evidence manifests.
+
+Doctor rejects `node_modules` metadata owned by another checkout. Verification
+never answers pnpm's purge prompt, installs packages, or repairs the dependency
+tree. Verification Vite builds use the supported `runner` config loader and
+run-owned output/runtime roots, so config loading never creates
+`node_modules/.vite-temp`.
+
+Run `.agents/skills/verify-omnigent/scripts/verify.sh prepare-tools` explicitly
+to prepare the exact `packageManager` pnpm pin. Preparation prefers an existing
+matching Corepack or pnpm tools package; only this explicit command may ask
+Corepack to obtain the exact pinned version when it is absent. It copies only
+that pnpm package into a sealed, atomically published user cache. Normal
+verification holds a shared cache lease while authenticating and staging the
+runtime into its disposable cache, prepends only that staged executable to
+`PATH`, and remains offline.
+
+Python verification commands use `uv run --no-sync`; quality steps use an
+isolated HOME and a private cache containing only exact configured remote hooks
+copied from the authenticated dedicated cache. Runtime caches stay outside
+persistent evidence and are verified deleted. Verification uses offline/frozen
+settings, `CI=true`, and no ambient credentials. Every non-credentialed doctor,
+direct lane, composite
+lane, child, and comparison uses the same environment allowlist. `harness-live`
+receives one labeled credential mode. When a Databricks profile is explicitly
+selected, verification copies only that profile into the disposable home and
+strips ambient OpenAI, Databricks token/host, Cursor, and other provider
+credentials. Without a profile, a complete ambient OpenAI pair takes precedence
+over a complete Databricks host/token pair; a Cursor API key is forwarded only
+for an explicitly selected Cursor harness when neither pair is present.
+`steps.json` records the mode used, never its values. Credential values are
+never recorded in evidence.
+Disposable runtime homes and caches are verified absent before evidence
+finalization and are never inventoried as persistent artifacts.
+
+Verifier control metadata and the authoritative pre-run snapshot live in a
+private parent-owned directory that product commands do not receive. Managed
+children cannot delete or replace the active manifest without forcing failure.
+Repository invariants include file bytes, dependency roots, build outputs,
+lockfiles, refs, raw/symbolic HEAD, and index identity. Shared dependency trees
+are recursively authenticated with kernel-controlled identity/change metadata.
+Potentially mutating quality hooks receive copy-on-write dependency trees, not
+writable links to the primary checkout; verification blocks when the platform
+cannot provide safe clone semantics.
+Tracked or otherwise visible symlinks that resolve outside the checkout block
+before execution. Verification Vite builds use a fresh run-owned output;
+the output and every ancestor are checked with `lstat` immediately before Vite
+can empty it.
+
+Never point verification at a user's dev server by default. The E2E harness
+rejects known dev ports because tests mutate sessions, files, permissions, and
+database state. Only use `--ui-base-url` for deliberate local debugging with
+`OMNIGENT_E2E_ALLOW_DEV_BASE_URL=1`, and never against production.
+
+## Drive
+
+1. Read [features/README.md](features/README.md) and choose every entry point
+   affected by the change.
+2. Run the smallest profile that exercises a real user path.
+3. Treat Playwright as the authoritative browser proof. Omnigent browser tools
+   are useful for exploratory debugging, but their output does not replace the
+   repository's Playwright journey.
+4. Use stable ARIA names, placeholders, and `data-testid` selectors already
+   present in `tests/e2e_ui`; do not use coordinates or tab order.
+5. For a bug, follow [repro-resolve.md](repro-resolve.md): reconstruct the
+   reported journey, reproduce live, give a verdict per symptom, then add or
+   strengthen a durable E2E test before fixing.
+6. After the focused proof, run `quality-gates` or the `auto` profile. Do not
+   declare a change verified while a merge-critical format, lint, type-check,
+   build, or pre-commit command is failing.
+
+### Launch the desktop app manually
+
+From the repository root of the exact branch or worktree under test:
+
+```bash
+just electron-dev
+```
+
+Use the real Electron shell for OS-level behavior such as menu accelerators,
+window focus, and SSO. A normal browser or Vite tab cannot verify Electron's
+main process. Record the worktree and the narrow manual action in the report;
+the automated `desktop` profile remains required.
+
+For browser/server compatibility, prefer additive API evolution:
+
+- New response fields must be optional to old clients.
+- Clients must default safely when a capability or field is absent.
+- Do not remove or reinterpret an endpoint/event until supported client
+  versions have aged out.
+- Keep TypeScript stream reducers behaviorally aligned with the Python SDK.
+- Gate UI affordances from `/v1/info`; the server must enforce the same rule.
+
+## Evidence
+
+Every attempted script run writes a collision-safe directory under
+`.artifacts/verify-omnigent/`. `manifest.json` is schema version 1 and is
+atomically rewritten while running and on success, failure, `INT`, `TERM`, or
+`HUP`. Final statuses are `passed`, `failed`, `interrupted`, or `blocked`; no
+normal or handled-signal exit may leave `running`. It records status, profile,
+reproducible argv with repository/run roots tokenized, the self-reported adapter,
+repository commit and dirty state, timestamps, JUnit-derived per-test results
+when available, cleanup confirmation, `downstream_universe.status`, explicit
+limitations, and every regular artifact's relative path, MIME type, SHA-256,
+byte count, and authority. It never embeds binary/base64 payloads or absolute
+artifact paths. Symlinks and unreadable or escaped files are excluded and
+reported as limitations. A strict before/after snapshot distinguishes existing
+dirty state from new changes, hashes lockfiles and dependency metadata, and
+forces a blocked/failed result if either snapshot is unreadable or verification
+mutates the checkout.
+
+Orchestration manifests add the changed-file decision and a `children` entry
+for every required lane before startup. Each entry records startup blockers,
+the child manifest's relative path, SHA-256, status, exit status, and any
+baseline classification. Parent finalization reconciles interrupted or stale
+children and records cleanup. The parent does not inventory or relabel child
+artifacts. Read the hashed child manifest for that lane's authoritative tests
+and artifacts.
+
+When `auto` or `all-surfaces` receives `--with-universe`, it adds the `universe`
+child. The child records source patch application separately from runtime proof.
+A pin mismatch records `downstream_universe.status=not_synced` and fails the
+required lane even when every source patch applies.
+
+`run.log` is the complete runner log. Composite profiles also write
+`steps.json` with each exact command and exit status. UI profiles request JUnit,
+screenshots, traces, and failure videos. Evidence is **test-bound** when the
+repository's pytest run owns the browser context and artifact lifecycle:
+
+- pytest-playwright `page` / `context` fixtures and direct synchronous
+  `browser.new_context()` / `browser.new_page()` calls share the plugin's
+  screenshot, trace, and failure-video recorder;
+- direct async `async_playwright()` browser launches are wrapped during a
+  verification run and capture screenshots, traces, and videos;
+- each observed browser context emits bounded, redacted console, page-error,
+  request, response, and request-failure metadata. It records method, resource
+  type, status, and query-free URL only—never headers or bodies. Text redaction
+  is heuristic, so the manifest tells recipients to review evidence before
+  sharing it outside the verification boundary;
+- trace ZIP sanitization streams each member under per-member, cumulative
+  expanded-byte, member-count, top-level, and nesting limits. A limit breach
+  removes the suspect context trace and fails evidence validation.
+
+Managed web and desktop profile runners pass only their run-owned
+`cleanup.json` path into nested pytest environments. A successful UI profile
+requires a versioned marker confirming completed pytest session cleanup and a
+zero pytest exit status; missing, malformed, stale, or cross-run markers fail
+the profile.
+
+Tests that create no browser remain normal tests and contribute JUnit results,
+not fabricated browser files. A UI command with exit status zero still fails
+verification when its JUnit report, context metadata, screenshot, or trace is
+missing. Missing failure video remains an explicit limitation.
+
+Browser-tool screenshots made outside pytest are **supplemental**. Place them
+under the run's `supplemental/` directory before finalization to inventory them
+as `supplemental-browser-tool`. They can explain exploratory work, but cannot
+replace or acquire the authority of a test-bound Playwright journey.
+
+A valid proof:
+
+- exercises the real user path, not internal setters or test-only endpoints;
+- captures both the action and resulting UI state;
+- reads back persistent/API side effects when the feature writes state;
+- uses mocks only at an existing production boundary, such as the E2E mock LLM;
+- records the exact profile and commit/worktree tested.
+
+For dry-run or disabled modes, assert what did not happen: no row, file, network
+call, grant, or ref mutation. Never trust a mode name alone.
+
+For UI latency, compare the same journey and environment. Capture navigation,
+time-to-interactive or user-visible completion, request count, and any new
+long-running main-thread work. If no baseline exists, report that limitation;
+do not invent a threshold.
+
+Run `.agents/skills/verify-omnigent/scripts/verify.sh perf` before and after
+changes to session listing, history, or turn startup. Compare `benchmark.json`
+by journey and backend, including p50/p99, `avg_http_requests_per_op`, and
+`network_routes`. Use a seeded corpus and the same database backend for
+meaningful release gates. Default SQLite is a low-noise development signal, not
+a production latency claim.
+
+For a first-class matched comparison:
+
+```bash
+.agents/skills/verify-omnigent/scripts/verify.sh perf --base-ref origin/main
+```
+
+The comparison records both commits, config and seed identity, p50/p99, request
+counts, routes, failures, backend, harness, and host identity. It blocks when
+those inputs do not match. Functional success is separate from latency: every
+journey must run, `runs_ok` must equal a positive `runs_total`, and every run
+must report `n_failures=0`. Without explicit applicable p50 and p99 regression
+thresholds, the comparison records deltas but remains blocked; it cannot produce
+a green verification result.
+
+## Report
+
+Report every acceptance criterion as `passed`, `failed`, or `not run`. Name the
+exact test and child manifest that support the result. Passing a broad profile
+does not prove a criterion unless one of its tests exercises that behavior.
+
+List manual-only checks separately. For each one, give the exact action, why
+automation cannot reproduce it, the automated precursor that already passed,
+and the failure signal the user should look for. Do not ask for a second manual
+pass after a test-only or history-only change when the product diff is
+unchanged.
+
+Separate correctness blockers from optional confidence checks. A skipped
+required lane is a blocker, not a pass with a caveat.
+
+`auto` ends with a compact terminal summary: selected lanes, child status and
+manifest path, baseline classification, cleanup, and the exact next command.
+Full command output remains in `run.log` and per-step logs.
+
+## Cleanup
+
+Pytest owns every server, runner, mock LLM, random port, temporary database, and
+artifact directory. Its fixture finalizers terminate only the PIDs they started
+and remove scratch state. Never kill by process name.
+
+Every command, lane child, and comparison helper runs in a dedicated managed
+session. The runner records descendants and also tracks an inherited private
+file descriptor so a fast double-fork into another session remains discoverable.
+On interruption or timeout it signals and reaps the recorded/marked tree with
+bounded TERM/KILL escalation, then atomically finalizes the manifest. A hostile
+child that deliberately closes every inherited descriptor before escaping can
+still outrun ancestry observation on platforms without cgroup/subreaper
+containment; verification does not claim a hard OS sandbox. Cleanup remains
+`unknown` unless
+pytest wrote its post-session marker. Rerun the focused profile once. Evidence
+under `.artifacts/verify-omnigent/` is intentionally preserved.
+
+## Optional Databricks compatibility
+
+The Universe lane is explicit opt-in. Local profiles do not discover or execute
+it, and record `universe=not_requested`. Credentialed CLI REPL, live harness
+turns, and Electron signing/notarization are also opt-in. `auto` and
+`all-surfaces` list them as `not_requested` with exact invocation guidance; they
+never call them unless passed `--with-universe`. Use `--oss-ref <commit>` when
+the requested commit is not the current checkout:
+
+```bash
+.agents/skills/verify-omnigent/scripts/verify.sh auto \
+  --base-ref origin/main --with-universe --oss-ref <commit>
+```
+
+Follow [compatibility.md](compatibility.md). Do not pin a Universe branch or
+assume its Python and UI vendor refs are equal.
+
+Local one-shot verification does not prove Windows-native packaging, real
+mobile software keyboards, credentialed provider or SSO flows,
+signing/notarization, managed Universe runtime on Linux, or production
+EStore/MySQL latency. Report these as `not run` unless the corresponding
+environment-specific proof was actually executed.
+
+The current Universe preflight still invokes Bazel in the selected live
+Universe checkout. Git state is checked, but ignored Bazel outputs are not fully
+isolated. A disposable Universe worktree/output-base redesign remains deferred;
+do not describe it as locally proved.
+
+## Helper
+
+`scripts/verify.sh` is the executable entry point:
+
+```bash
+.agents/skills/verify-omnigent/scripts/verify.sh \
+  <doctor|auto|all-surfaces|quality-gates|universe|server|backend|cli|web-ui|desktop|harness-client|harness-live|perf|db-migration-deploy|smoke|collaboration|automations|core|full-ui> \
+  [doctor-profile] [--base-ref REF] [--oss-ref REF] [--with-universe]
+```
+
+Cursor and Claude Code use thin project discovery adapters that point here.
+Codex launched by Omnigent only discovers bundle skills and host skills copied
+into its private `CODEX_HOME`; it does not scan this checkout's `.agents/skills`
+directory. Install the canonical directory into the host source, or copy it
+into an agent bundle:
+
+```bash
+.agents/skills/verify-omnigent/scripts/install-codex.sh --host
+.agents/skills/verify-omnigent/scripts/install-codex.sh --bundle ./path/to/agent
+```
+
+The host mode creates a symlink and refuses to overwrite an existing skill.
+The bundle mode copies the canonical skill at install time so uploaded bundles
+are self-contained; there is still one tracked canonical source. Installed
+scripts target the Git worktree from which they are invoked. When invocation is
+outside that worktree, set `OMNIGENT_VERIFY_REPO_ROOT` explicitly; installed
+paths are never treated as the product checkout.
+
+Keep [features/README.md](features/README.md) and its linked feature files
+current when routes, menus, capabilities, or supported deployment modes change.

--- a/.agents/skills/verify-omnigent/compatibility.md
+++ b/.agents/skills/verify-omnigent/compatibility.md
@@ -1,0 +1,159 @@
+# Databricks downstream compatibility lane
+
+Run this lane only when the user explicitly opts in and an OSS change can affect
+the vendored deployment in a sibling Universe checkout. Universe is a moving
+consumer, not the OSS source of truth. Read its current
+`agentbricks/mas/CLAUDE.md`, `agentbricks/mas/third_party/sync/README.md`, and
+pinned refs before checking it.
+
+## Compatibility matrix
+
+| OSS change | Downstream risk | Required evidence |
+|---|---|---|
+| API request/response, event, route, or capability | Vendored UI, server, and Lakebox clients advance independently | Old client/new server and new client/old server behavior; absent fields default safely; additive wire contract |
+| Store ABC or entity | Databricks, dual, and MySQL implementations can import but fail at runtime | Full MAS Python suite, including discovered store signature/abstract-method guards |
+| DB model or Alembic revision | Databricks MySQL DDL is owned by USM and deploys separately; the service runtime must never run Alembic | OSS Alembic remains valid; matching USM forward/rollback migration; USM-before-code rollout; old server remains usable after expansion |
+| Auth or permissions | Databricks resolves Barnacle request identity and stores ACLs in WHS, not OSS account or permission tables | Capability and server enforcement agree; anti-enumeration; owner/admin semantics; WHS UUID conversion and workspace-group behavior |
+| Sharing | Some accounts cap sharing at `restricted_read_only`; workspace-wide access may be disabled | `on`, `read_only`, `restricted_read_only`, and `off`; hidden/disabled UI matches rejected grants |
+| Automations | Managed MAS intentionally has no scheduler/store/router | `/v1/info.automations_enabled=false`; UI has no dead Automations route or calls |
+| Projects/other optional feature | Deployment may expose a structural capability only when its router/store exists | Capability false with old server; true only when endpoint answers |
+| Web dependency, host config, routing, or CSS | Universe vendors a separately pinned embeddable UI with host-owned fetch/WebSocket/router seams | Standalone build and embed build; host seam unchanged or backward-compatible; no second React/router; CSS remains scoped |
+| Runner/host protocol | Lakebox wheels are versioned separately from vendored server source | Current and supported older runner against new server; new runner against supported older server where applicable |
+| Dual-store behavior | Databricks can route sessions between EStore and MySQL | `mysqlEnabled` hides/shows the MySQL home correctly; `estoreReadOnly` rejects writes with usable migration/fork UX; cross-store forks retain the correct home |
+
+## Runtime discovery
+
+Use the read-only preflight from the OSS root:
+
+```bash
+.agents/skills/verify-omnigent/scripts/verify.sh universe \
+  --base-ref <PR-base> --oss-ref <commit>
+```
+
+It uses `UNIVERSE_ROOT` when set and otherwise checks the sibling `../universe`.
+It reads `UPSTREAM_REF` and `UI_UPSTREAM_REF` independently. Never change
+branches, sync vendors, regenerate patches, or deploy as part of verification.
+
+Python changes require `UPSTREAM_REF`, web/UI changes require
+`UI_UPSTREAM_REF`, and mixed changes require both pins to match the requested
+commit. A required mismatch records `not_synced` and exits nonzero. Clean
+application of affected local patches is source compatibility only. Runtime
+compatibility remains unproved until Universe vendors the requested commit and
+the mapped runtime targets pass.
+
+On Darwin, the lane runs checks that can produce valid test XML and records the
+remaining targets as blocked. MAS runtime targets can fail before test execution
+while compiling jemalloc against Linux `features.h`; the managed-host edge patch
+gate can fail during collection when psutil cannot import `_psutil_osx`. Run the
+blocked targets through the Linux/Bazel lane. Do not count a Bazel zero exit as
+proof unless the target's `test.xml` exists, parses, and records at least one
+test with no failures or errors.
+
+## Read-only/source checks
+
+Inspect the OSS diff against all three release axes: Python server/source,
+separately pinned embedded UI, and Lakebox runner/host wheels. For every changed
+public interface, check:
+
+- `third_party/omnigent*` consumers and local patches;
+- `python/omnigent_server` Databricks glue;
+- the host config mirror in the embedded UI integration;
+- USM MySQL migrations under `agentbricks/mas/db/omnigent/migrations`;
+- Lakebox wheel/version consumers when runner behavior changes.
+
+The Python and UI refs are deliberately independent, and Lakebox wheels are a
+third timeline. A green same-revision test does not prove staggered rollout
+safety.
+
+Automatic source mapping is explicit: `omnigent/**` and
+`sdks/python-client/**` select the Python pin; `web/**` and `sdks/ui/**` select
+the UI pin. Other paths do not gain an implicit Universe compatibility claim.
+
+`sync.sh sync --dry-run` lists intended patches but does not apply them. The
+preflight archives the requested OSS commit into a temporary directory and runs
+`git apply --check` there for each affected patch. It removes the temporary tree
+afterward and verifies that the Universe checkout's git status did not change.
+
+The current Bazel phase still runs in the selected live Universe checkout.
+Verification requires both checkouts to have no tracked or non-ignored
+untracked changes. Ignored generated outputs remain an explicit isolation
+limitation, but stable untracked inputs are never silently omitted from pin and
+patch selection.
+Git-status checks do not account for every ignored Bazel output or convenience
+symlink. Until a disposable Universe worktree with a temporary output base and
+symlink prefix is implemented, report this as an isolation limitation rather
+than a read-only filesystem proof.
+
+## Universe verification commands
+
+Run from the Universe root after it is stable:
+
+```bash
+agentbricks/mas/third_party/sync/sync.sh check
+bazel test //agentbricks/mas/python:all \
+  --tool_tag=ai-agent --test_output=errors \
+  --noshow_progress --noshow_loading_progress
+bazel build //agentbricks/mas/third_party/omnigent_ui:embed \
+  --tool_tag=ai-agent --noshow_progress --noshow_loading_progress
+bazel test //agentbricks/mas/third_party/omnigent_ui:bazel_lint_test \
+  --tool_tag=ai-agent --test_output=errors \
+  --noshow_progress --noshow_loading_progress
+```
+
+Do not run Bazel commands concurrently. Inspect `test.xml` for failures.
+
+For a DB change, additionally prove that schema rollout can precede binary
+rollout. Databricks USM owns DDL; the pod runtime must not invoke Alembic or
+`create_all`. Add matching USM forward and rollback migrations, run the required
+USM suites, and prove the old binary tolerates the expanded schema. The new
+binary may rely on a new column only after USM has completed. Contract/removal
+must be a later release.
+
+For auth and permissions, do not emulate OSS password/header account tables.
+Databricks resolves the caller from request context and maps session ACLs through
+WHS. Verify hex UUID16 MySQL session IDs map to WHS IDs, `can_approve` degrades
+safely where WHS cannot represent it, and workspace-wide access is a group
+grant, not the OSS `__public__` sentinel.
+
+For capability skew, probe the managed mount's `/v1/info`. Expected downstream
+invariants include:
+
+- `automations_enabled=false` and no calls to the 404ing scheduled-task routes;
+- `projects_enabled=true` only when the MySQL project router/store is wired;
+- sharing modes are SAFE-driven per request, and `public_sharing_enabled`
+  fails closed;
+- `/auth/users` and OSS Members administration are absent;
+- `/api/2.0/omnigent` remains primary while the plural legacy route and stored
+  `*.omnigentsession.json` names are preserved until coordinated migration.
+
+SAFE config changes ship in a separate PR from service code.
+
+For latency, OSS benchmark numbers are necessary but not sufficient. Check that
+the embedded UI adds no eager fetch/poll when a capability is disabled, that
+Databricks frontend poll intervals remain host-configurable, and that server
+heartbeat/liveness/rescan intervals remain internally consistent. Measure
+EStore/MySQL list fan-out with realistic data; an empty SQLite result cannot
+detect quota-amplifying reads or production round-trip cost.
+
+`verify.sh perf --base-ref <ref>` records a bounded local base/candidate
+comparison only when host, harness, backend, seed, config, and journey identity
+match. It includes p50/p99, total and per-operation request counts, routes, and
+failures. It blocks when no explicit applicable p50 and p99 regression
+thresholds were supplied. Even a matched SQLite result is not a production
+EStore/MySQL claim.
+
+For live managed-session verification, use LiteSwap and the current MAS
+instructions. Never use hot reload/rsync while testing a managed turn: restarting
+the pod drops the runner WebSocket tunnel and invalidates the result.
+
+## Stop conditions
+
+Do not call a change downstream-safe when:
+
+- it requires server and UI to update atomically;
+- a missing or unknown field crashes or enables an affordance;
+- a new store method or parameter is absent downstream;
+- a schema change has no separately deployable migration or rollback;
+- WHS/restricted-sharing behavior was represented only by OSS header/account auth;
+- EStore/MySQL dual-home behavior was tested against only one flag combination;
+- a passing functional test is the only latency evidence.

--- a/.agents/skills/verify-omnigent/correctness.md
+++ b/.agents/skills/verify-omnigent/correctness.md
@@ -1,0 +1,126 @@
+# Correctness strategy
+
+Use this guide to choose enough proof without creating tests that cost more than
+the behavior they protect.
+
+## State the property
+
+Write the claim as an observable invariant before choosing a test:
+
+```text
+Given:
+When:
+Then:
+Must not:
+```
+
+Include ordering, retries, persistence, and error behavior when they matter.
+"The page looks right" is not a correctness claim.
+
+## Use the lowest sufficient test level
+
+Choose the first level that can falsify the claim:
+
+1. **Pure function or render conditional.** Use a unit or component test. A
+   label selected from an existing prop does not need a new Playwright file.
+2. **Browser interaction or local persistence.** Use component tests plus the
+   closest existing Playwright journey. Extend that journey before adding a new
+   file.
+3. **Network, process, lifecycle, or concurrency boundary.** Add a focused real
+   journey. Examples include request ordering, remount recovery, Electron main
+   process behavior, host registration, streaming, and authentication.
+4. **Native behavior that automation cannot reproduce.** Keep automated
+   coverage for the browser or process event path, then name the narrow manual
+   check. Software keyboards, OS accelerators, signing, and real SSO can fall
+   into this category.
+
+A new E2E file must protect a failure that a lower-level test or an existing E2E
+cannot catch. Record that reason in the test docstring. If there is no such
+reason, do not add the file.
+
+## Prove failure modes, not only success
+
+For stateful work, assert the negative outcomes directly:
+
+- Count writes or requests to prove exactly-once behavior.
+- Record order to prove one message cannot overtake another.
+- Assert that cancellation stops retries.
+- Assert that a dry run creates no file, row, grant, request, or ref.
+- Test stale state, reload, remount, navigation, and final retry exhaustion.
+- For URL or authentication handling, test trusted and untrusted origins.
+
+Do not infer these properties from a final screenshot.
+
+## Reproduce bugs against the base
+
+For a regression fix, run the focused proof against the intended base when
+practical. The test should fail for the reported reason before the fix and pass
+after it. If the base cannot run, record the exact blocker and use captured
+production evidence or a minimal deterministic reproduction.
+
+## Handle unrelated failures with evidence
+
+Do not dismiss a failure because it looks unrelated. Run the same command in an
+unchanged base worktree. Classify it as pre-existing only when the same test
+fails with the same signature there. `auto` compares only failed steps at the
+unique merge base, with matched dependency inputs and a bounded timeout. Keep
+the failing logs from both runs. A matching base failure is
+`baseline_reproduced`, not a pass: the required lane remains failed until the
+repository-wide blocker is resolved or explicitly handled outside verification.
+The rerun request is private, signed, one-use evidence. Authenticate the
+finalized child `steps.json`, exact requested indices, regenerated profile
+commands, and execution-log hashes before using any comparison classification.
+Exact-base reproduction is currently supported for server, harness-client, and
+CLI lanes. Quality-gates, web-ui, and desktop remain `could_not_compare` until
+isolated JavaScript dependencies can be supplied without installs or shared-tree
+writes.
+
+## Check compatibility at changed boundaries
+
+When a client, server, database, or downstream package changes, verify the
+combinations that can exist during rollout:
+
+- current client with current server;
+- old client with new server;
+- new client with old server;
+- downstream Universe when explicitly requested and its pin includes the code.
+
+Missing fields must default safely. New server fields should be additive. A
+downstream source patch that applies is not runtime proof.
+
+## Finish with repository gates
+
+The `quality-gates` lane runs potentially fixing pre-commit hooks only in a
+disposable worktree, then runs non-mutating web format, lint, type-check, and
+production-build binaries. Every profile and doctor snapshots repository bytes,
+lockfiles, and dependency metadata before and after; unreadable snapshots or
+new mutations fail closed while unchanged pre-existing dirty state is retained.
+These checks do not replace behavioral tests, but a change is not verified when
+the same checks CI will run are still failing.
+
+Exact-base reproduction is limited to server, harness-client, and CLI.
+When the selected base commit equals `HEAD`, exact-base reproduction remains
+available only if the candidate contains uncommitted product/test changes; the
+baseline worktree still comes from the clean `HEAD` commit.
+JavaScript quality, browser UI, and desktop failures remain
+`could_not_compare`; a green parent cannot reinterpret that exclusion as
+baseline evidence. Text members of Playwright trace ZIPs receive deterministic
+credential-pattern redaction while preserving ZIP validity. Before evidence is
+finalized, every explicitly staged or allowlisted credential value is searched
+byte-for-byte through files and recursively through ZIP members; a matching
+artifact and any secret-bearing path components are removed and the run fails.
+Archive nesting beyond the bounded scanner fails closed. An unconfirmed removal
+is recorded as a privacy cleanup failure without reproducing the suspect path.
+This is not a claim that traces are
+generally sanitized: unnamed page secrets may evade heuristics, and image/video
+pixels are not OCR-scanned. Screenshots and videos receive only the known-value
+byte scan, which cannot detect visibly rendered credentials. Review captured
+evidence before sharing it outside the verification boundary.
+Browser network evidence covers only requests and responses observed by the
+instrumented Playwright context. It is not a packet capture and does not prove
+that unrelated processes or server-side dependencies made no network calls.
+
+UI profiles only pass when they produce JUnit results, browser context metadata,
+a screenshot, and a trace inside the run's evidence directory. Files in
+`/tmp`, an agent's private folder, or an unrelated browser session do not count
+as verification evidence.

--- a/.agents/skills/verify-omnigent/features/README.md
+++ b/.agents/skills/verify-omnigent/features/README.md
@@ -1,0 +1,25 @@
+# Omnigent verification feature map
+
+The primary surface is the web UI backed by the real Omnigent server and runner.
+Desktop and mobile wrap or reuse this UI; the CLI and SDKs are additional
+surfaces. Drive every affected entry point, not only the easiest one.
+
+| Feature | User entry points | Primary proof |
+|---|---|---|
+| [Chat and streaming](chat-and-streaming.md) | Existing chat, new-chat prompt, resumed session | User message and streamed assistant response render and persist |
+| [Start and manage sessions](session-lifecycle.md) | Landing composer, sidebar, fork/clone/switch | Correct session is created, selected, restored, and stopped |
+| [Approvals and policies](approvals-and-policies.md) | Chat card, inbox, standalone approval, agent info | Visible decision drains the real waiting request with correct scope |
+| [Files and comments](files-and-comments.md) | Workspace rail, file viewer/editor, comment inbox | Visible edit/comment survives read-back or reload |
+| [Collaboration and access](collaboration-and-access.md) | Share modal, link, collaborator session | UI affordance and server authorization agree at every permission level |
+| [Optional capabilities](optional-capabilities.md) | Projects, Automations, managed hosts, routing controls | `/v1/info`, visible UI, and callable endpoints agree |
+| [Harnesses and clients](harnesses-and-clients.md) | Harness picker, CLI, resumed cross-client session | Real adapter turn persists and renders with clean teardown |
+
+Cross-cutting checks:
+
+- Run chat smoke after changes to API events, SSE, reducers, runner protocol, or
+  server startup.
+- Run both web and Python reducer tests when event/block semantics change.
+- Exercise mobile/desktop wrappers when changing routing, deep links,
+  notifications, service workers, or host integration.
+- For user-visible performance, compare the same journey's timings and request
+  waterfall before and after. Functional success alone is insufficient.

--- a/.agents/skills/verify-omnigent/features/approvals-and-policies.md
+++ b/.agents/skills/verify-omnigent/features/approvals-and-policies.md
@@ -1,0 +1,35 @@
+# Approvals and policies
+
+## Sub-features
+
+- In-chat approval cards and standalone `/approve/{session}/{elicitation}` links
+- Approval inbox, approve/reject, persistent approvals, and delegation
+- AskUserQuestion and Exit Plan Mode forms
+- Server, agent, and session policy attachment and enforcement
+
+## How to get to it
+
+Trigger an action that policy marks `ASK`, then respond from the chat card,
+approval inbox, or standalone approval link. Open the agent-info popover or
+settings to inspect and change policies.
+
+## Driving it with Playwright
+
+Use focused tests under `tests/e2e_ui/approvals` and
+`tests/e2e_ui/agents/test_agent_info_popover.py`. Park a real permission request
+at the server boundary, assert the pending card contents, click the visible
+decision, and verify the waiting request receives the matching allow or deny
+result. For remembered approvals, trigger a second matching request and prove
+the intended scope, not a broader tool or domain, is bypassed.
+
+The observable end state is both a resolved UI card and a drained server-side
+elicitation with the exact decision.
+
+## Gotchas
+
+- Do not mock the approval card as already pending; park a real request.
+- Shared editors may reject without being allowed to approve.
+- WHS-backed Databricks permissions do not represent every OSS approval
+  delegation field; unsupported values must degrade safely.
+- A UI-only disabled state is insufficient; the server policy remains
+  authoritative.

--- a/.agents/skills/verify-omnigent/features/chat-and-streaming.md
+++ b/.agents/skills/verify-omnigent/features/chat-and-streaming.md
@@ -1,0 +1,34 @@
+# Chat and streaming
+
+## Sub-features
+
+- Composer send, queued/steered messages, stop and resume
+- SSE history hydration and live assistant output
+- Approval, elicitation, tool, reasoning, and native-harness blocks
+- Python SDK and TypeScript reducer behavioral parity
+
+## How to get to it
+
+Open an existing `/c/{session_id}` chat or type the first prompt on `/`. Send a
+message from the composer and observe user and assistant bubbles.
+
+## Driving it with Playwright
+
+Start with `scripts/verify.sh smoke`. Use the composer placeholder
+`Ask the agent anything…`, the exact `Send` button name, and
+`[data-testid="message-bubble"][data-role="assistant"]`. Assert non-empty
+assistant content, then reload and verify history when persistence is affected.
+Use the specialized tests under `tests/e2e_ui/chat`, `messages`, and `approvals`
+for changed event types.
+
+The observable end state is a rendered user action and assistant result backed
+by the session snapshot or SSE stream, not a spinner. For protocol changes,
+also prove a supported older client can ignore new fields or events safely.
+
+## Gotchas
+
+- The "Working…" shimmer is not an assistant response.
+- The UI reducer mirrors Python SDK behavior but has intentional web-only
+  context fields; preserve behavior, not byte-for-byte structure.
+- Mock the LLM boundary, not the server, runner, stream, or reducer.
+- A same-version pass does not prove staggered client/server rollout safety.

--- a/.agents/skills/verify-omnigent/features/collaboration-and-access.md
+++ b/.agents/skills/verify-omnigent/features/collaboration-and-access.md
@@ -1,0 +1,45 @@
+# Collaboration and access
+
+## Sub-features
+
+- Share link and workspace/public access toggle
+- User grants, read/edit/manage levels, approval delegation, and revoke
+- Presence, realtime messages, ownership, anti-enumeration, and attribution
+- Accounts/header auth in OSS; request-context and WHS identities downstream
+
+## How to get to it
+
+Open a session as its owner, choose **Share session**, grant another identity,
+and open the same link as that collaborator. Change or revoke access from the
+same modal.
+
+## Driving it with Playwright
+
+Run `scripts/verify.sh collaboration`. Drive **Share session** and the
+permissions dialog with separate browser contexts. At each level assert both
+the visible composer, read-only, or no-access state and the REST authorization
+result: ungranted or revoked users receive anti-enumerating 404s, readers cannot
+post, and editors can post only where policy permits.
+
+The profile requires the permissions and sharing journeys plus
+`tests/e2e_ui/collaboration/test_collab_realtime.py` and
+`tests/e2e_ui/collaboration/test_author_label.py`. Evidence preparation fails
+if any required journey is omitted from the command plan.
+
+The observable end state is agreement among `/v1/info`, visible controls,
+permission-store state, and server enforcement.
+
+Changes to `omnigent/server/routes/sessions/routes_core.py` or
+`routes_hooks.py` select this lane because those exact modules enforce session
+ownership, collaborator reads/writes, and permission-request authorization.
+Other files named `core` or `hooks` do not select collaboration by name alone.
+
+## Gotchas
+
+- Permission changes may require collaborator reload by design.
+- Single-user mode hides Share; sharing-off multi-user mode disables it with an
+  explanation.
+- Databricks `restricted_read_only` can also prohibit sharing sessions rooted at
+  home or filesystem root.
+- WHS workspace-wide access is a group grant, not OSS's `__public__` sentinel.
+- Treat auth or identity changes as downstream-sensitive even when OSS tests pass.

--- a/.agents/skills/verify-omnigent/features/files-and-comments.md
+++ b/.agents/skills/verify-omnigent/features/files-and-comments.md
@@ -1,0 +1,32 @@
+# Files and comments
+
+## Sub-features
+
+- Workspace file list, search, preview, edit, autosave, and diff
+- Markdown, HTML, PDF, notebook, code, and image rendering
+- Inline comments, actions, realtime updates, and inbox
+- Runner-unavailable and read-only degradation
+
+## How to get to it
+
+Open a chat with a filesystem-capable agent, expand the Workspace rail, select a
+file, and preview or edit it. Add comments from supported viewers or resolve
+them from the inbox.
+
+## Driving it with Playwright
+
+Use focused tests under `tests/e2e_ui/files` and `comments`;
+`scripts/verify.sh core` includes autosave. Open the rail by its `Workspace`
+accessible name and use existing viewer or test IDs. After editing, read the
+file through the resource API or reload the viewer. After commenting, read the
+comment endpoint and check realtime visibility.
+
+The observable end state is both visible UI and persisted runner/server state.
+
+## Gotchas
+
+- Direct runner resource paths require an `os_env`.
+- The default E2E runner lacks workspace affinity, so git diff is not available
+  without a dedicated fixture.
+- Runner 503s should degrade the UI rather than crash it.
+- Cleanup removes scratch files but must retain screenshots, traces, and logs.

--- a/.agents/skills/verify-omnigent/features/harnesses-and-clients.md
+++ b/.agents/skills/verify-omnigent/features/harnesses-and-clients.md
@@ -1,0 +1,35 @@
+# Harnesses and clients
+
+## Sub-features
+
+- Native and SDK Claude, Codex, Cursor, Pi, Hermes, and other adapters
+- Runner/host registration, tunnel, resume, interrupt, and approvals
+- Python SDK and web client event parsing
+- Polly/Debby orchestration and sub-agent wakeups
+
+## How to get to it
+
+Choose a harness while creating a session or launch it from the CLI, send a
+turn, respond to any native prompt, interrupt or resume, and return to the
+session from another supported client.
+
+## Driving it with Playwright
+
+Start with `tests/harness_bench --no-live` and the harness-specific project E2E
+skill. For a real canary, use an isolated server and credential source, launch
+the actual adapter, then use Playwright to prove the session's messages, status,
+prompts, and metadata render correctly. Keep provider and model time outside
+Omnigent latency claims; the performance profile uses a zero-latency mock LLM
+to isolate Omnigent overhead.
+
+The observable end state is a completed persisted turn whose UI blocks and
+metadata match the native or SDK events, plus clean runner/host teardown.
+
+## Gotchas
+
+- Never substitute a mocked adapter for the primary subject under test.
+- Unsupported or unavailable harnesses must report skipped, not passed.
+- Server source, embedded UI, and Lakebox runner/host wheels can all be on
+  different versions downstream.
+- Native harness process startup is vendor-controlled and excluded from the
+  Omnigent performance benchmark.

--- a/.agents/skills/verify-omnigent/features/optional-capabilities.md
+++ b/.agents/skills/verify-omnigent/features/optional-capabilities.md
@@ -1,0 +1,37 @@
+# Optional capabilities
+
+## Sub-features
+
+- Projects and project-grouped sessions
+- Automations / Scheduled Tasks
+- Managed sandboxes and host choices
+- Smart routing, dictation, auth/admin, and workspace-wide sharing
+
+## How to get to it
+
+Capabilities appear as routes, navigation items, composer controls, or settings
+only when the server advertises and supports them.
+
+## Driving it with Playwright
+
+For enabled behavior, run the focused journey, such as
+`scripts/verify.sh automations`, and read back the REST side effect. For disabled
+behavior, start a server with the capability absent or false and assert the
+navigation or control is absent or disabled and the unsupported endpoint is not
+called. Test an older `/v1/info` payload with the field omitted.
+
+The observable end state is a three-way invariant:
+
+1. `/v1/info` advertises the capability accurately.
+2. The UI safely defaults when the field is absent and exposes no dead affordance.
+3. The server endpoint enforces the same state.
+
+## Gotchas
+
+- Managed Databricks deliberately disables Automations because no scheduled-task
+  store, scheduler, or router is wired.
+- Projects downstream are structural: advertise them only when the router or
+  store exists.
+- SAFE and preview flags are per request; avoid process-global assumptions.
+- Adding an optional feature must not add eager startup requests, large initial
+  chunks, or blocking render work when the feature is disabled.

--- a/.agents/skills/verify-omnigent/features/session-lifecycle.md
+++ b/.agents/skills/verify-omnigent/features/session-lifecycle.md
@@ -1,0 +1,34 @@
+# Start and manage sessions
+
+## Sub-features
+
+- New-chat agent, host, directory, model, permission, and worktree choices
+- Sidebar selection, rename, pin, archive, search, stop, and reconnect
+- Fork, clone, agent switch, projects, and deep links
+- Local, connected-host, and managed-sandbox session types
+
+## How to get to it
+
+Open `/`, configure the landing composer, and send the first prompt. Manage the
+created session from the sidebar or chat header.
+
+## Driving it with Playwright
+
+Run `scripts/verify.sh core` for the broad path, then select focused tests under
+`tests/e2e_ui/start_session`, `sessions`, `fork_session`, and `agent_switch`.
+Prefer existing `data-testid` controls such as
+`new-chat-landing-agent-select`; verify the create request parameters and final
+`/c/{id}` route. For real creation changes, do not stop at a route-stubbed test.
+Include a real server and runner-bound journey.
+
+The observable end state is the intended session selected with the correct
+server-side metadata and a usable composer or explicit read-only/offline state.
+
+## Gotchas
+
+- The standard fixture runner is not a registered host; directory-picker tests
+  may stub host filesystem calls.
+- Managed Databricks sessions add launcher and Lakebox client timelines.
+- Do not use hot reload while turn-testing a managed session; it drops the
+  runner tunnel.
+- New launch fields must be optional across old clients, servers, and runners.

--- a/.agents/skills/verify-omnigent/repro-resolve.md
+++ b/.agents/skills/verify-omnigent/repro-resolve.md
@@ -1,0 +1,68 @@
+# Repro and resolve discipline
+
+Use this for reported bugs and compound regressions. The internal CI wrappers
+live in `omnigent-internal`; the actual `dev/repro-agent`, `dev/resolve-agent`,
+`dev/repro.py`, and `dev/resolve.py` may exist only on Omnigent `main`. Discover
+them before offering those commands. Do not assume every working branch carries
+the agents.
+
+## Reproduce before fixing
+
+1. Reconstruct the user journey and split compound reports into facets.
+2. Drive each facet live through the real app.
+3. Record one verdict per facet and an overall verdict:
+   `reproduced`, `not_reproduced`, `already_fixed`, or `needs_more_info`.
+4. Add or strengthen a durable E2E test that fails for the reproduced behavior.
+5. Only then implement and rerun the same journey.
+
+Use a fixed-shape JSON handoff:
+
+```json
+{
+  "bug_url": "...",
+  "verdict": "reproduced",
+  "facets": [],
+  "test": {},
+  "recordings": [],
+  "session_id": "...",
+  "journey": [],
+  "evidence": []
+}
+```
+
+The fields must describe actual evidence. An empty shape is not a successful
+handoff. Write the same object to `.omnigent/repro-handoff.json` when running
+the full repro agent.
+
+## Verify the resolution
+
+Rerun the authored regression test and the same live journey. Resolve outcomes
+are `fixed`, `partially_fixed`, `not_fixed`, `nothing_to_fix`, or
+`needs_more_info`. Preserve the original repro session identity and evidence;
+do not restart completed work merely because a streamed CLI connection ended.
+
+For remote Databricks App sessions, long SSE connections can be severed while
+the daemon-owned turn continues. Treat the session API and validated handoff as
+authoritative, not the launcher CLI exit code. Capture the announced
+`Omnigent session: <url>`, poll the session to a terminal or handoff state, and
+salvage the same session if the final handoff is missing.
+
+## Remote preflight
+
+Before driving a remote app, make an authenticated `GET /v1/me` request and
+require a direct 200 response. A redirect or auth failure means the instance is
+not worth driving. Use the app's own service principal where the deployment
+requires it; an unrelated deploy principal may be redirected despite broader
+workspace access.
+
+## Evidence bundle
+
+Retain:
+
+- the regression test patch and files;
+- Playwright screenshots, traces, and video;
+- run log and manifest;
+- repro and resolve handoffs;
+- session URL and exact tested revision.
+
+Never put credentials in the bundle.

--- a/.agents/skills/verify-omnigent/scripts/comparison.py
+++ b/.agents/skills/verify-omnigent/scripts/comparison.py
@@ -1,0 +1,1143 @@
+#!/usr/bin/env python3
+"""Run bounded exact-base failure and performance comparisons."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TypedDict
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from profile_runner import (
+    _changed_files,
+    _clone_dependency_path,
+    _electron_e2e_tests,
+    profile_steps,
+)
+from runtime_support import (
+    compare_snapshots,
+    inherited_managed_fds,
+    portable_argv,
+    repository_snapshot,
+    strict_environment,
+    terminate_group,
+)
+
+SCHEMA_VERSION = 1
+DEFAULT_MAX_P50_REGRESSION_PERCENT = 10.0
+DEFAULT_MAX_P99_REGRESSION_PERCENT = 10.0
+SUPPORTED_BENCHMARK_SCHEMA_VERSIONS = {6}
+COMPARABLE_LANES = {
+    "server",
+    "harness-client",
+    "cli",
+}
+DEPENDENCY_PATHS = (".venv",)
+DEPENDENCY_INPUTS = (
+    "pyproject.toml",
+    "uv.lock",
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "web/package.json",
+    "web/electron/package.json",
+)
+_ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+class ComparisonInterrupted(RuntimeError):
+    """Raised so signal delivery unwinds worktree and report contexts."""
+
+
+class _MetricPair(TypedDict):
+    base: object
+    candidate: object
+
+
+class _SuccessPair(TypedDict):
+    base: bool
+    candidate: bool
+
+
+class _BenchmarkRow(TypedDict):
+    journey: str
+    backend_match: bool
+    kind_match: bool
+    p50_ms: _MetricPair
+    p99_ms: _MetricPair
+    http_requests_per_op: _MetricPair
+    http_requests: _MetricPair
+    network_routes: _MetricPair
+    failures: _MetricPair
+    functional_success: _SuccessPair
+
+
+def _atomic_json(path: Path, value: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(value, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def _git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ("git", *args),
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _merge_base(repo_root: Path, base_ref: str) -> str:
+    base = _git(repo_root, "rev-parse", "--verify", f"{base_ref}^{{commit}}")
+    head = _git(repo_root, "rev-parse", "--verify", "HEAD^{commit}")
+    if base.returncode != 0 or head.returncode != 0:
+        raise RuntimeError(f"Base ref {base_ref!r} or HEAD is unavailable.")
+    result = _git(repo_root, "merge-base", "--all", base.stdout.strip(), head.stdout.strip())
+    values = result.stdout.splitlines()
+    if result.returncode != 0 or len(values) != 1:
+        raise RuntimeError(f"Base ref {base_ref!r} has no unique merge base with HEAD.")
+    return values[0]
+
+
+def _digest_bytes(value: bytes | None) -> str | None:
+    return hashlib.sha256(value).hexdigest() if value is not None else None
+
+
+def _dependency_identity(repo_root: Path, base_commit: str) -> dict[str, object]:
+    files: dict[str, dict[str, str | None]] = {}
+    for relative in DEPENDENCY_INPUTS:
+        current_path = repo_root / relative
+        current = current_path.read_bytes() if current_path.is_file() else None
+        base = subprocess.run(
+            ("git", "show", f"{base_commit}:{relative}"),
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+        )
+        base_bytes = base.stdout if base.returncode == 0 else None
+        files[relative] = {
+            "candidate_sha256": _digest_bytes(current),
+            "base_sha256": _digest_bytes(base_bytes),
+        }
+    return {
+        "matched": all(
+            value["candidate_sha256"] == value["base_sha256"] for value in files.values()
+        ),
+        "files": files,
+    }
+
+
+@contextlib.contextmanager
+def _base_worktree(
+    repo_root: Path,
+    base_commit: str,
+    cleanup: dict[str, object],
+) -> Iterator[Path]:
+    temporary = Path(tempfile.mkdtemp(prefix="omnigent-verify-base-"))
+    checkout = temporary / "checkout"
+    try:
+        result = subprocess.run(
+            ("git", "worktree", "add", "--detach", str(checkout), base_commit),
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.strip() or "git worktree add failed")
+        for relative in DEPENDENCY_PATHS:
+            source = repo_root / relative
+            target = checkout / relative
+            if not source.exists() or target.exists():
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            _clone_dependency_path(
+                source,
+                target,
+                source_root=repo_root,
+                target_root=checkout,
+            )
+        yield checkout
+    finally:
+        removed = True
+        detail = None
+        subprocess.run(
+            ("git", "worktree", "unlock", str(checkout)),
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        result = subprocess.run(
+            ("git", "worktree", "remove", "--force", str(checkout)),
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        removed = result.returncode == 0 or not checkout.exists()
+        detail = result.stderr.strip() or None
+        shutil.rmtree(temporary, ignore_errors=True)
+        prune = subprocess.run(
+            ("git", "worktree", "prune"),
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        removed = removed and prune.returncode == 0
+        if prune.returncode != 0:
+            detail = prune.stderr.strip() or "git worktree prune failed"
+        listed = subprocess.run(
+            ("git", "worktree", "list", "--porcelain"),
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        removed = (
+            removed and listed.returncode == 0 and f"worktree {checkout}" not in listed.stdout
+        )
+        cleanup.update(
+            {
+                "status": "completed" if removed and not temporary.exists() else "failed",
+                "detail": detail,
+            }
+        )
+
+
+def _bounded_run(
+    argv: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    log_path: Path,
+    timeout: float,
+) -> tuple[int, bool]:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w", encoding="utf-8") as log:
+        process = subprocess.Popen(
+            argv,
+            cwd=cwd,
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+            pass_fds=inherited_managed_fds(),
+        )
+        try:
+            return process.wait(timeout=timeout), False
+        except subprocess.TimeoutExpired:
+            terminate_group(process.pid)
+            process.wait()
+            return 124, True
+        finally:
+            if process.poll() is None:
+                terminate_group(process.pid)
+                process.wait()
+
+
+def _base_environment(run_dir: Path, checkout: Path) -> dict[str, str]:
+    python_roots = (
+        checkout,
+        checkout / "sdks" / "python-client",
+        checkout / "sdks" / "ui",
+    )
+    return strict_environment(
+        run_dir,
+        extra={
+            "OMNIGENT_VERIFY_REPO_ROOT": str(checkout),
+            "PYTHONPATH": os.pathsep.join(str(path) for path in python_roots),
+            "PYTHONSAFEPATH": "1",
+        },
+    )
+
+
+def _assert_base_import_identity(
+    checkout: Path,
+    run_dir: Path,
+    timeout: float,
+) -> None:
+    interpreter = checkout / ".venv" / "bin" / "python"
+    if not interpreter.is_file():
+        return
+    script = """import importlib
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1]).resolve()
+packages = {
+    "omnigent": root / "omnigent",
+    "omnigent_client": root / "sdks/python-client/omnigent_client",
+    "omnigent_ui_sdk": root / "sdks/ui/omnigent_ui_sdk",
+}
+for name, expected in packages.items():
+    if not expected.exists():
+        continue
+    module = importlib.import_module(name)
+    paths = list(getattr(module, "__path__", ()))
+    if getattr(module, "__file__", None):
+        paths.append(module.__file__)
+    if not paths:
+        raise RuntimeError(f"{name} has no filesystem identity")
+    for value in paths:
+        pathlib.Path(value).resolve().relative_to(root)
+    print(name, *paths)
+"""
+    status, timed_out = _bounded_run(
+        [str(interpreter), "-P", "-c", script, str(checkout)],
+        cwd=checkout,
+        env=_base_environment(run_dir, checkout),
+        log_path=run_dir / "base-import-identity.log",
+        timeout=min(timeout, 30),
+    )
+    if timed_out or status != 0:
+        raise RuntimeError("Base Omnigent import did not resolve inside the exact-base worktree.")
+
+
+def _authenticated_step_report(
+    child_manifest: Path,
+    lane: str,
+    repo_root: Path,
+    base_ref: str,
+    changed_files: tuple[str, ...] | None = None,
+    require_failure: bool = False,
+) -> tuple[dict[str, object], list[dict[str, object]]]:
+    manifest_raw = child_manifest.read_bytes()
+    manifest = json.loads(manifest_raw)
+    if (
+        not isinstance(manifest, dict)
+        or manifest.get("schema_version") != 1
+        or manifest.get("status") not in {"failed", "passed"}
+        or manifest.get("run", {}).get("profile") != lane
+    ):
+        raise RuntimeError("Child manifest is not finalized authenticated lane evidence.")
+    if require_failure and manifest.get("status") != "failed":
+        raise RuntimeError("Candidate child manifest does not record a failed lane.")
+    artifact = next(
+        (
+            item
+            for item in manifest.get("artifacts", [])
+            if isinstance(item, dict) and item.get("path") == "steps.json"
+        ),
+        None,
+    )
+    if not isinstance(artifact, dict) or not isinstance(artifact.get("sha256"), str):
+        raise RuntimeError("Child manifest does not authenticate steps.json.")
+    steps_path = child_manifest.parent / "steps.json"
+    raw = steps_path.read_bytes()
+    if hashlib.sha256(raw).hexdigest() != artifact["sha256"]:
+        raise RuntimeError("steps.json hash does not match the finalized child manifest.")
+    value = json.loads(raw)
+    if (
+        not isinstance(value, dict)
+        or value.get("schema_version") != 1
+        or value.get("profile") != lane
+        or value.get("status") not in {"failed", "passed"}
+    ):
+        raise RuntimeError("Step report schema or profile is invalid.")
+    steps = value.get("steps") if isinstance(value, dict) else None
+    if not isinstance(steps, list):
+        raise RuntimeError("Child produced no step report.")
+    changed = (
+        changed_files
+        if changed_files is not None
+        else (_changed_files(repo_root, base_ref) if lane == "quality-gates" else ())
+    )
+    resolved_run = child_manifest.parent.resolve()
+    run_dir_arg = os.fspath(resolved_run)
+    expected = profile_steps(
+        lane,
+        run_dir_arg,
+        base_ref=base_ref,
+        changed_files=changed,
+        electron_e2e_tests=_electron_e2e_tests(repo_root) if lane == "desktop" else (),
+        skill_root=str(Path(__file__).resolve().parent.parent),
+    )
+    seen: set[int] = set()
+    failed = [
+        step
+        for step in steps
+        if isinstance(step, dict)
+        and isinstance(step.get("source_step_index"), int)
+        and step.get("status") == "failed"
+    ]
+    for step in steps:
+        if not isinstance(step, dict):
+            raise RuntimeError("Step report contains a non-object step.")
+        index = step.get("source_step_index")
+        if not isinstance(index, int) or isinstance(index, bool) or index in seen:
+            raise RuntimeError("Step report contains a missing or duplicate source index.")
+        if index < 0 or index >= len(expected):
+            raise RuntimeError("Step report contains an out-of-range source index.")
+        seen.add(index)
+        trusted = expected[index]
+        expected_fields = {
+            "name": trusted.name,
+            "argv": portable_argv(
+                trusted.argv,
+                repo_root=repo_root,
+                run_dir=child_manifest.parent,
+                skill_root=Path(__file__).resolve().parent.parent,
+            ),
+            "environment": trusted.environment,
+            "cwd": trusted.cwd,
+            "isolated": trusted.isolated,
+        }
+        if any(step.get(key) != expected_value for key, expected_value in expected_fields.items()):
+            raise RuntimeError(f"Step {index} does not match the trusted profile definition.")
+        log = step.get("log")
+        log_hash = step.get("log_sha256")
+        if not isinstance(log, str) or not isinstance(log_hash, str):
+            raise RuntimeError(f"Step {index} has no authenticated execution log.")
+        log_path = (child_manifest.parent / log).resolve(strict=True)
+        log_path.relative_to(child_manifest.parent.resolve(strict=True))
+        if hashlib.sha256(log_path.read_bytes()).hexdigest() != log_hash:
+            raise RuntimeError(f"Step {index} execution log hash is invalid.")
+        if not isinstance(step.get("exit_status"), int) or step.get("status") not in {
+            "passed",
+            "failed",
+        }:
+            raise RuntimeError(f"Step {index} has no terminal execution result.")
+    return value, failed
+
+
+def _signature(step: dict[str, object], run_dir: Path, roots: tuple[Path, ...]) -> str:
+    relative = step.get("log")
+    if not isinstance(relative, str):
+        raise RuntimeError("Failed step has no bounded log.")
+    path = (run_dir / relative).resolve(strict=True)
+    path.relative_to(run_dir.resolve(strict=True))
+    text = _ANSI.sub("", path.read_text(encoding="utf-8", errors="replace"))
+    for root in roots:
+        text = text.replace(str(root), "<root>")
+    normalized = "\n".join(line.rstrip() for line in text.splitlines()).strip()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def compare_failure(
+    repo_root: Path,
+    skill_root: Path,
+    run_dir: Path,
+    lane: str,
+    base_ref: str,
+    child_manifest: Path,
+    timeout: float,
+    capability_file: Path,
+) -> tuple[dict[str, object], int]:
+    cleanup: dict[str, object] = {"status": "pending"}
+    limitations: list[str] = []
+    report: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "classification": "could_not_compare",
+        "lane": lane,
+        "base_ref": base_ref,
+        "base_commit": None,
+        "failed_step_indices": [],
+        "pr_signatures": {},
+        "base_signatures": {},
+        "base_manifest": None,
+        "base_manifest_sha256": None,
+        "dependency_identity": None,
+        "cleanup": cleanup,
+        "limitations": limitations,
+    }
+    output = run_dir / "baseline" / lane / "comparison.json"
+    before: dict[str, object] | None = None
+    try:
+        before = repository_snapshot(repo_root, deep_dependencies=True)
+        if lane not in COMPARABLE_LANES:
+            raise RuntimeError(f"Lane {lane!r} does not support exact-base comparison.")
+        base_commit = _merge_base(repo_root, base_ref)
+        head = _git(repo_root, "rev-parse", "HEAD").stdout.strip()
+        report["base_commit"] = base_commit
+        dependency_identity = _dependency_identity(repo_root, base_commit)
+        report["dependency_identity"] = dependency_identity
+        if dependency_identity.get("matched") is not True:
+            raise RuntimeError(
+                "Dependency inputs differ at the exact base; verification will not reuse "
+                "candidate dependencies or install replacements."
+            )
+        if base_commit == head:
+            local_changes = _changed_files(repo_root, "HEAD")
+            if not any(
+                path.startswith(
+                    (
+                        "omnigent/",
+                        "sdks/python-client/",
+                        "sdks/ui/",
+                        "web/",
+                        "tests/",
+                    )
+                )
+                for path in local_changes
+            ):
+                raise RuntimeError(
+                    "The requested base resolves to candidate HEAD without "
+                    "uncommitted product changes."
+                )
+        _, failed = _authenticated_step_report(
+            child_manifest,
+            lane,
+            repo_root,
+            base_ref,
+            require_failure=True,
+        )
+        if not failed:
+            raise RuntimeError("The PR failure did not identify a safely repeatable failed step.")
+        indices = sorted(
+            index for step in failed if isinstance(index := step.get("source_step_index"), int)
+        )
+        if not indices or len(indices) != len(set(indices)):
+            raise RuntimeError("The PR failed-step index set is empty or ambiguous.")
+        report["failed_step_indices"] = indices
+        child_run_dir = child_manifest.parent
+        report["pr_signatures"] = {
+            str(step["source_step_index"]): _signature(
+                step,
+                child_run_dir,
+                (repo_root, child_run_dir),
+            )
+            for step in failed
+        }
+
+        baseline_root = run_dir / "baseline" / lane
+        evidence_root = baseline_root / "evidence"
+        with _base_worktree(repo_root, base_commit, cleanup) as checkout:
+            env = _base_environment(baseline_root, checkout)
+            _assert_base_import_identity(checkout, baseline_root, timeout)
+            changed: tuple[str, ...] = ()
+            if lane == "quality-gates":
+                changed = _changed_files(repo_root, base_ref)
+                for value in changed:
+                    path = Path(value)
+                    if (
+                        path.is_absolute()
+                        or ".." in path.parts
+                        or value.startswith("-")
+                        or not (checkout / path).exists()
+                    ):
+                        raise RuntimeError(
+                            "A failed quality-gate step referenced an unsafe or PR-only path."
+                        )
+            request_path = baseline_root / "comparison-request.json"
+            request = {
+                "schema_version": 1,
+                "profile": lane,
+                "step_indices": indices,
+                "changed_files": list(changed) if lane == "quality-gates" else None,
+                "nonce": secrets.token_hex(32),
+                "issuer_pid": os.getpid(),
+            }
+            payload = json.dumps(request, sort_keys=True, separators=(",", ":")).encode()
+            request["signature"] = hmac.digest(
+                capability_file.read_bytes(),
+                payload,
+                "sha256",
+            ).hex()
+            _atomic_json(request_path, request)
+            request_path.chmod(0o600)
+            request_sha256 = hashlib.sha256(request_path.read_bytes()).hexdigest()
+            env.update(
+                {
+                    "OMNIGENT_VERIFY_ADAPTER": "baseline-comparison",
+                    "OMNIGENT_VERIFY_BASE_REF": "HEAD",
+                    "OMNIGENT_VERIFY_EVIDENCE_DIR": str(evidence_root),
+                    "OMNIGENT_VERIFY_REPO_ROOT": str(checkout),
+                    "OMNIGENT_VERIFY_SKILL_ROOT": str(skill_root),
+                    "OMNIGENT_VERIFY_STEP_TIMEOUT_SECONDS": str(timeout),
+                }
+            )
+            exit_status, timed_out = _bounded_run(
+                [
+                    str(skill_root / "scripts" / "verify.sh"),
+                    lane,
+                    "--comparison-request",
+                    str(request_path),
+                    "--comparison-capability",
+                    str(capability_file),
+                ],
+                cwd=checkout,
+                env=env,
+                log_path=baseline_root / "run.log",
+                timeout=timeout + 15,
+            )
+            report["base_exit_status"] = exit_status
+            report["timed_out"] = timed_out
+            manifests = list(evidence_root.glob("*/manifest.json"))
+            if len(manifests) != 1:
+                raise RuntimeError("Base comparison produced no unique finalized manifest.")
+            base_manifest = manifests[0]
+            base_value = json.loads(base_manifest.read_text(encoding="utf-8"))
+            report["base_manifest"] = base_manifest.relative_to(run_dir).as_posix()
+            report["base_manifest_sha256"] = hashlib.sha256(base_manifest.read_bytes()).hexdigest()
+            if timed_out or base_value.get("status") in {"blocked", "interrupted", "running"}:
+                raise RuntimeError(
+                    "Base comparison timed out or was blocked before the step completed."
+                )
+            base_report, base_failed = _authenticated_step_report(
+                base_manifest,
+                lane,
+                checkout,
+                "HEAD",
+                changed,
+            )
+            if (
+                base_report.get("comparison_request_sha256") != request_sha256
+                or base_report.get("requested_step_indices") != indices
+            ):
+                raise RuntimeError("Base comparison did not execute exactly the requested steps.")
+            base_steps = base_report.get("steps")
+            if not isinstance(base_steps, list):
+                raise RuntimeError("Base comparison did not return a step list.")
+            base_indices = sorted(
+                index
+                for step in base_steps
+                if isinstance(step, dict)
+                and isinstance(index := step.get("source_step_index"), int)
+            )
+            if base_indices != indices:
+                raise RuntimeError("Base comparison did not execute exactly the requested steps.")
+            if exit_status == 0 and base_value.get("status") == "passed":
+                report["classification"] = "pr_only_failure"
+            else:
+                if not base_failed:
+                    raise RuntimeError("Base failed without an authenticated failed step.")
+                report["base_signatures"] = {
+                    str(step["source_step_index"]): _signature(
+                        step,
+                        base_manifest.parent,
+                        (repo_root, checkout, base_manifest.parent),
+                    )
+                    for step in base_failed
+                }
+                report["classification"] = (
+                    "baseline_reproduced"
+                    if report["base_signatures"] == report["pr_signatures"]
+                    else "baseline_differs"
+                )
+    except (
+        OSError,
+        ValueError,
+        json.JSONDecodeError,
+        RuntimeError,
+        subprocess.SubprocessError,
+    ) as exc:
+        limitations.append(f"Exact-base comparison unavailable: {exc}")
+    finally:
+        try:
+            state_changes = (
+                ["initial repository snapshot was unavailable"]
+                if before is None
+                else compare_snapshots(
+                    before,
+                    repository_snapshot(repo_root, deep_dependencies=True),
+                )
+            )
+        except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+            state_changes = [f"final repository snapshot failed ({type(exc).__name__})"]
+        report["repository_unchanged"] = not state_changes
+        if state_changes:
+            report["classification"] = "could_not_compare"
+            limitations.append(
+                "Comparison repository invariant failed: " + "; ".join(state_changes)
+            )
+        if cleanup["status"] == "pending":
+            cleanup["status"] = "not_applicable"
+        if (
+            report["classification"] != "could_not_compare"
+            and cleanup.get("status") != "completed"
+        ):
+            report["classification"] = "could_not_compare"
+            limitations.append("Exact-base comparison cleanup was not confirmed complete.")
+        _atomic_json(output, report)
+    return report, 0 if report["classification"] != "could_not_compare" else 1
+
+
+def _safe_positive_int(config: dict[str, object], key: str) -> int:
+    value = config.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0 or value > 100_000:
+        raise RuntimeError(f"Candidate benchmark config {key!r} is invalid.")
+    return value
+
+
+def _failure_count(journey: dict[str, object]) -> int:
+    runs = journey.get("runs", [])
+    if not isinstance(runs, list):
+        return 0
+    return sum(
+        int(run.get("n_failures", 0))
+        for run in runs
+        if isinstance(run, dict) and isinstance(run.get("n_failures", 0), int)
+    )
+
+
+def _request_count(journey: dict[str, object]) -> int | None:
+    runs = journey.get("runs", [])
+    if not isinstance(runs, list):
+        return None
+    values: list[int] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        value = run.get("http_requests")
+        if isinstance(value, int) and not isinstance(value, bool):
+            values.append(value)
+    return sum(values) if values else None
+
+
+def _functional_success(journey: dict[str, object], configured_runs: object) -> bool:
+    summary = journey.get("summary")
+    runs = journey.get("runs")
+    if (
+        journey.get("skipped")
+        or journey.get("skipped_reason")
+        or not isinstance(summary, dict)
+        or not isinstance(runs, list)
+        or not runs
+        or not isinstance(configured_runs, int)
+        or isinstance(configured_runs, bool)
+        or configured_runs <= 0
+    ):
+        return False
+    runs_ok = summary.get("runs_ok")
+    runs_total = summary.get("runs_total")
+    if (
+        not isinstance(runs_ok, int)
+        or isinstance(runs_ok, bool)
+        or not isinstance(runs_total, int)
+        or isinstance(runs_total, bool)
+        or runs_total <= 0
+        or runs_ok != runs_total
+        or len(runs) != runs_total
+        or runs_total != configured_runs
+    ):
+        return False
+    successful = sum(
+        1
+        for run in runs
+        if isinstance(run, dict)
+        and isinstance(run.get("n_failures"), int)
+        and not isinstance(run.get("n_failures"), bool)
+        and run["n_failures"] == 0
+    )
+    return successful == runs_ok == configured_runs
+
+
+def _compare_benchmarks(
+    baseline: dict[str, object],
+    candidate: dict[str, object],
+    thresholds: tuple[float, float] | None = (
+        DEFAULT_MAX_P50_REGRESSION_PERCENT,
+        DEFAULT_MAX_P99_REGRESSION_PERCENT,
+    ),
+) -> dict[str, object]:
+    baseline_schema = baseline.get("schema_version")
+    candidate_schema = candidate.get("schema_version")
+    schema_match = (
+        baseline_schema == candidate_schema
+        and baseline_schema in SUPPORTED_BENCHMARK_SCHEMA_VERSIONS
+    )
+    config_match = baseline.get("config") == candidate.get("config")
+    baseline_config = baseline.get("config", {})
+    candidate_config = candidate.get("config", {})
+    backend_match = (
+        isinstance(baseline_config, dict)
+        and isinstance(candidate_config, dict)
+        and baseline_config.get("backend") == candidate_config.get("backend")
+    )
+    seed_match = (
+        backend_match
+        and isinstance(baseline_config, dict)
+        and baseline_config.get("backend") == "sqlite"
+    )
+    host_match = baseline.get("host") == candidate.get("host")
+    harness_match = baseline.get("harness") == candidate.get("harness")
+    base_journeys = baseline.get("journeys")
+    candidate_journeys = candidate.get("journeys")
+    journeys_match = (
+        isinstance(base_journeys, dict)
+        and isinstance(candidate_journeys, dict)
+        and set(base_journeys) == set(candidate_journeys)
+    )
+    rows: list[_BenchmarkRow] = []
+    if isinstance(base_journeys, dict) and isinstance(candidate_journeys, dict):
+        for name in sorted(set(base_journeys) & set(candidate_journeys)):
+            base = base_journeys[name]
+            current = candidate_journeys[name]
+            if not isinstance(base, dict) or not isinstance(current, dict):
+                continue
+            base_summary = base.get("summary", {})
+            current_summary = current.get("summary", {})
+            rows.append(
+                {
+                    "journey": name,
+                    "backend_match": base.get("backend") == current.get("backend"),
+                    "kind_match": base.get("kind") == current.get("kind"),
+                    "p50_ms": {
+                        "base": base_summary.get("avg_p50_ms"),
+                        "candidate": current_summary.get("avg_p50_ms"),
+                    },
+                    "p99_ms": {
+                        "base": base_summary.get("avg_p99_ms"),
+                        "candidate": current_summary.get("avg_p99_ms"),
+                    },
+                    "http_requests_per_op": {
+                        "base": base_summary.get("avg_http_requests_per_op"),
+                        "candidate": current_summary.get("avg_http_requests_per_op"),
+                    },
+                    "http_requests": {
+                        "base": _request_count(base),
+                        "candidate": _request_count(current),
+                    },
+                    "network_routes": {
+                        "base": base_summary.get("network_routes"),
+                        "candidate": current_summary.get("network_routes"),
+                    },
+                    "failures": {
+                        "base": _failure_count(base),
+                        "candidate": _failure_count(current),
+                    },
+                    "functional_success": {
+                        "base": _functional_success(
+                            base,
+                            baseline_config.get("runs")
+                            if isinstance(baseline_config, dict)
+                            else None,
+                        ),
+                        "candidate": _functional_success(
+                            current,
+                            candidate_config.get("runs")
+                            if isinstance(candidate_config, dict)
+                            else None,
+                        ),
+                    },
+                }
+            )
+    rows_match = bool(rows) and all(
+        row["backend_match"]
+        and row["kind_match"]
+        and row["functional_success"]["base"]
+        and row["functional_success"]["candidate"]
+        for row in rows
+    )
+    matched = (
+        schema_match
+        and config_match
+        and backend_match
+        and seed_match
+        and host_match
+        and harness_match
+        and journeys_match
+        and rows_match
+    )
+    threshold_passed = False
+    if matched and thresholds is not None:
+        p50_limit, p99_limit = thresholds
+        threshold_passed = all(
+            isinstance(row["p50_ms"]["base"], (int, float))
+            and isinstance(row["p50_ms"]["candidate"], (int, float))
+            and isinstance(row["p99_ms"]["base"], (int, float))
+            and isinstance(row["p99_ms"]["candidate"], (int, float))
+            and row["p50_ms"]["candidate"] <= row["p50_ms"]["base"] * (1 + p50_limit / 100)
+            and row["p99_ms"]["candidate"] <= row["p99_ms"]["base"] * (1 + p99_limit / 100)
+            for row in rows
+        )
+    return {
+        "matched": matched,
+        "schema_identity": {
+            "base": baseline_schema,
+            "candidate": candidate_schema,
+            "matched": schema_match,
+            "supported": sorted(SUPPORTED_BENCHMARK_SCHEMA_VERSIONS),
+        },
+        "config_match": config_match,
+        "backend_match": backend_match,
+        "host_match": host_match,
+        "harness_match": harness_match,
+        "journey_set_match": journeys_match,
+        "functional_success": rows_match,
+        "commit_identity": {
+            "base": baseline.get("git_sha"),
+            "candidate": candidate.get("git_sha"),
+        },
+        "seed_identity": {
+            "base": "fresh-disposable-sqlite",
+            "candidate": "fresh-disposable-sqlite",
+            "matched": seed_match,
+        },
+        "rows": rows,
+        "thresholds": (
+            {
+                "max_p50_regression_percent": thresholds[0],
+                "max_p99_regression_percent": thresholds[1],
+            }
+            if thresholds is not None
+            else None
+        ),
+        "no_regression_claim": threshold_passed,
+        "claim_reason": (
+            "Explicit applicable latency thresholds passed."
+            if threshold_passed
+            else (
+                "Matched comparison has no explicit applicable latency threshold."
+                if matched and thresholds is None
+                else (
+                    "One or more explicit latency thresholds failed."
+                    if matched
+                    else (
+                        "Settings, host, seed, backend, harness, or journey identity "
+                        "did not match."
+                    )
+                )
+            )
+        ),
+    }
+
+
+def compare_performance(
+    repo_root: Path,
+    run_dir: Path,
+    base_ref: str,
+    candidate_path: Path,
+    timeout: float,
+    thresholds: tuple[float, float] = (
+        DEFAULT_MAX_P50_REGRESSION_PERCENT,
+        DEFAULT_MAX_P99_REGRESSION_PERCENT,
+    ),
+) -> tuple[dict[str, object], int]:
+    benchmark_sha256: dict[str, object] = {"base": None, "candidate": None}
+    cleanup: dict[str, object] = {"status": "pending"}
+    limitations = ["Local SQLite is a development signal, not production latency evidence."]
+    report: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "blocked",
+        "base_ref": base_ref,
+        "base_commit": None,
+        "candidate_commit": None,
+        "dependency_identity": None,
+        "benchmark_sha256": benchmark_sha256,
+        "baseline_benchmark": "baseline-benchmark.json",
+        "candidate_benchmark": "benchmark.json",
+        "comparison": None,
+        "cleanup": cleanup,
+        "limitations": limitations,
+    }
+    output = run_dir / "performance-comparison.json"
+    before: dict[str, object] | None = None
+    try:
+        before = repository_snapshot(repo_root, deep_dependencies=True)
+        candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+        if not isinstance(candidate, dict):
+            raise RuntimeError("Candidate benchmark is not a JSON object.")
+        if candidate.get("schema_version") not in SUPPORTED_BENCHMARK_SCHEMA_VERSIONS:
+            raise RuntimeError("Candidate benchmark schema is unsupported.")
+        report["candidate_commit"] = candidate.get("git_sha")
+        benchmark_sha256["candidate"] = hashlib.sha256(candidate_path.read_bytes()).hexdigest()
+        config = candidate.get("config")
+        journeys = candidate.get("journeys")
+        if not isinstance(config, dict) or not isinstance(journeys, dict) or not journeys:
+            raise RuntimeError("Candidate benchmark lacks config or journeys.")
+        if config.get("backend") != "sqlite":
+            raise RuntimeError(
+                "Automatic base comparison currently supports disposable SQLite only."
+            )
+        base_commit = _merge_base(repo_root, base_ref)
+        report["base_commit"] = base_commit
+        candidate_head = _git(repo_root, "rev-parse", "--verify", "HEAD^{commit}")
+        if candidate_head.returncode != 0:
+            raise RuntimeError("Candidate HEAD commit is unavailable.")
+        candidate_head_sha = candidate_head.stdout.strip()
+        dependency_identity = _dependency_identity(repo_root, base_commit)
+        report["dependency_identity"] = dependency_identity
+        if dependency_identity.get("matched") is not True:
+            raise RuntimeError(
+                "Dependency inputs differ at the exact base; a matched benchmark "
+                "environment cannot be constructed without installation."
+            )
+        baseline_path = run_dir / "baseline-benchmark.json"
+        with _base_worktree(repo_root, base_commit, cleanup) as checkout:
+            _assert_base_import_identity(checkout, run_dir / "perf-baseline", timeout)
+            argv = [
+                "uv",
+                "run",
+                "--no-sync",
+                "dev/benchmarks/omnigent/run.py",
+                "--journeys",
+                ",".join(name for name in journeys if isinstance(name, str)),
+                "--iterations",
+                str(_safe_positive_int(config, "iterations")),
+                "--requests",
+                str(_safe_positive_int(config, "requests")),
+                "--concurrency",
+                str(_safe_positive_int(config, "concurrency")),
+                "--runs",
+                str(_safe_positive_int(config, "runs")),
+                "--warmup",
+                str(_safe_positive_int(config, "warmup")),
+                "--network-delay-ms",
+                str(float(config.get("network_delay_ms", 0.0))),
+                "--output",
+                str(baseline_path),
+            ]
+            exit_status, timed_out = _bounded_run(
+                argv,
+                cwd=checkout,
+                env=_base_environment(run_dir / "perf-baseline", checkout),
+                log_path=run_dir / "baseline-benchmark.log",
+                timeout=timeout,
+            )
+            if timed_out:
+                raise RuntimeError("Baseline benchmark timed out.")
+            if exit_status != 0 or not baseline_path.is_file():
+                raise RuntimeError(f"Baseline benchmark failed with exit status {exit_status}.")
+        baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+        if not isinstance(baseline, dict):
+            raise RuntimeError("Baseline benchmark is not a JSON object.")
+        benchmark_sha256["base"] = hashlib.sha256(baseline_path.read_bytes()).hexdigest()
+        comparison = _compare_benchmarks(baseline, candidate, thresholds)
+        commit_identity: dict[str, dict[str, object]] = {
+            "base": {
+                "expected": base_commit,
+                "observed": baseline.get("git_sha"),
+                "matched": baseline.get("git_sha") == base_commit,
+            },
+            "candidate": {
+                "expected": candidate_head_sha,
+                "observed": candidate.get("git_sha"),
+                "matched": candidate.get("git_sha") == candidate_head_sha,
+            },
+        }
+        comparison["commit_identity"] = commit_identity
+        if not all(value["matched"] is True for value in commit_identity.values()):
+            comparison["matched"] = False
+            comparison["claim_reason"] = (
+                "Benchmark commit identity did not match the exact base or candidate checkout."
+            )
+        report["comparison"] = comparison
+        report["status"] = (
+            "passed" if comparison["matched"] and comparison["no_regression_claim"] else "blocked"
+        )
+    except (
+        OSError,
+        ValueError,
+        json.JSONDecodeError,
+        RuntimeError,
+        subprocess.SubprocessError,
+    ) as exc:
+        limitations.append(f"Performance comparison unavailable: {exc}")
+    finally:
+        try:
+            state_changes = (
+                ["initial repository snapshot was unavailable"]
+                if before is None
+                else compare_snapshots(
+                    before,
+                    repository_snapshot(repo_root, deep_dependencies=True),
+                )
+            )
+        except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+            state_changes = [f"final repository snapshot failed ({type(exc).__name__})"]
+        report["repository_unchanged"] = not state_changes
+        if state_changes:
+            report["status"] = "blocked"
+            limitations.append(
+                "Comparison repository invariant failed: " + "; ".join(state_changes)
+            )
+        if cleanup["status"] == "pending":
+            cleanup["status"] = "not_applicable"
+        if report["status"] == "passed" and cleanup.get("status") != "completed":
+            report["status"] = "blocked"
+            limitations.append("Performance comparison cleanup was not confirmed complete.")
+        _atomic_json(output, report)
+    return report, 0 if report.get("status") == "passed" else 1
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="action", required=True)
+
+    baseline = subparsers.add_parser("baseline")
+    baseline.add_argument("--repo-root", type=Path, required=True)
+    baseline.add_argument("--skill-root", type=Path, required=True)
+    baseline.add_argument("--run-dir", type=Path, required=True)
+    baseline.add_argument("--lane", required=True)
+    baseline.add_argument("--base-ref", required=True)
+    baseline.add_argument("--child-manifest", type=Path, required=True)
+    baseline.add_argument("--timeout", type=float, default=600)
+    baseline.add_argument("--capability-file", type=Path, required=True)
+
+    perf = subparsers.add_parser("perf")
+    perf.add_argument("--repo-root", type=Path, required=True)
+    perf.add_argument("--run-dir", type=Path, required=True)
+    perf.add_argument("--base-ref", required=True)
+    perf.add_argument("--candidate", type=Path, required=True)
+    perf.add_argument("--timeout", type=float, default=900)
+    perf.add_argument(
+        "--max-p50-regression-percent",
+        type=float,
+        default=DEFAULT_MAX_P50_REGRESSION_PERCENT,
+    )
+    perf.add_argument(
+        "--max-p99-regression-percent",
+        type=float,
+        default=DEFAULT_MAX_P99_REGRESSION_PERCENT,
+    )
+    return parser
+
+
+def main() -> None:
+    def interrupt(signum: int, _frame: object) -> None:
+        raise ComparisonInterrupted(signal.Signals(signum).name)
+
+    for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+        signal.signal(signum, interrupt)
+    args = _parser().parse_args()
+    if args.action == "baseline":
+        _, status = compare_failure(
+            args.repo_root.resolve(),
+            args.skill_root.resolve(),
+            args.run_dir.resolve(),
+            args.lane,
+            args.base_ref,
+            args.child_manifest.resolve(),
+            args.timeout,
+            args.capability_file.resolve(),
+        )
+    else:
+        _, status = compare_performance(
+            args.repo_root.resolve(),
+            args.run_dir.resolve(),
+            args.base_ref,
+            args.candidate.resolve(),
+            args.timeout,
+            (
+                args.max_p50_regression_percent,
+                args.max_p99_regression_percent,
+            ),
+        )
+    raise SystemExit(status)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/verify-omnigent/scripts/evidence_manifest.py
+++ b/.agents/skills/verify-omnigent/scripts/evidence_manifest.py
@@ -1,0 +1,1932 @@
+#!/usr/bin/env python3
+"""Create and finalize portable verification evidence manifests."""
+
+from __future__ import annotations
+
+import argparse
+import binascii
+import configparser
+import hashlib
+import json
+import mimetypes
+import os
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+import zipfile
+import zlib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import BinaryIO, TypedDict, cast
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from runtime_support import (
+    cleanup_strict_environment,
+    compare_snapshots,
+    portable_argv,
+    repository_snapshot,
+)
+
+SCHEMA_VERSION = 1
+ADAPTER_ENV = "OMNIGENT_VERIFY_ADAPTER"
+UI_PROFILES = {
+    "smoke",
+    "collaboration",
+    "automations",
+    "core",
+    "full-ui",
+    "web-ui",
+    "desktop",
+}
+ORCHESTRATION_PROFILES = {"auto", "all-surfaces"}
+PYTEST_PROFILES = {*UI_PROFILES, "server", "harness-client", "db-migration-deploy"}
+SUPPORTED_BENCHMARK_SCHEMA_VERSIONS = {6}
+_TRACE_SECRET_PATTERNS = (
+    re.compile(r"(?i)(\bbearer\s+)[A-Za-z0-9._~+/=-]+"),
+    re.compile(
+        r"(?i)(\b(?:api[_-]?key|token|password|secret)\b"
+        r"\s*[:=]\s*)[A-Za-z0-9._~+/=-]+"
+    ),
+)
+_TRACE_SECRET_LITERAL = re.compile(
+    r"(?i)\b[A-Za-z0-9._~+/=-]*(?:secret|password|token)"
+    r"[A-Za-z0-9._~+/=-]*\b"
+)
+_SAFE_ADAPTER = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+FINAL_STATUSES = {"passed", "failed", "interrupted", "blocked"}
+MAX_ARTIFACT_BYTES = 512 * 1024 * 1024
+MAX_ARCHIVE_EXPANDED_BYTES = 1024 * 1024 * 1024
+MAX_ARCHIVE_MEMBERS = 10_000
+MAX_ARCHIVE_DEPTH = 4
+MAX_DECODE_BYTES = 64 * 1024 * 1024
+PRIVACY_FAILURE_MARKER = ".privacy-cleanup-failed.json"
+REQUIRED_PROFILE_TESTS: dict[str, frozenset[str]] = {
+    "collaboration": frozenset(
+        {
+            "tests/e2e_ui/collaboration/test_permissions_modal.py",
+            "tests/e2e_ui/collaboration/test_sharing_journey.py",
+            "tests/e2e_ui/collaboration/test_sharing_mode_off.py",
+            "tests/e2e_ui/collaboration/test_collab_realtime.py",
+            "tests/e2e_ui/collaboration/test_author_label.py",
+        }
+    )
+}
+
+
+class _RunRecord(TypedDict):
+    id: str
+    profile: str
+    doctor_profile: str
+    phase: str
+    command_argv: list[str]
+    selected_tests: list[str]
+
+
+class _Timestamps(TypedDict):
+    started_utc: str
+    finished_utc: str | None
+    duration_seconds: float | None
+
+
+class _Manifest(TypedDict, total=False):
+    schema_version: int
+    status: str
+    run: _RunRecord
+    adapter: dict[str, object]
+    repository: dict[str, object]
+    timestamps: _Timestamps
+    tests: list[dict[str, object]]
+    artifacts: list[dict[str, object]]
+    orchestration: object
+    children: list[dict[str, object]]
+    cleanup: dict[str, object]
+    downstream_universe: dict[str, object]
+    exit_status: int | None
+    signal: str | None
+    limitations: list[str]
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _atomic_write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(value, handle, indent=2, sort_keys=True, ensure_ascii=False)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+    try:
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _run_git(*args: str) -> subprocess.CompletedProcess[str] | None:
+    try:
+        return subprocess.run(
+            ["git", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _repository_state(limitations: list[str]) -> dict[str, object]:
+    commit_result = _run_git("rev-parse", "--verify", "HEAD")
+    status_result = _run_git("status", "--porcelain=v1", "--untracked-files=all")
+    if (
+        commit_result is None
+        or status_result is None
+        or commit_result.returncode != 0
+        or status_result.returncode != 0
+    ):
+        limitations.append("Repository commit or dirty state could not be read.")
+        return {"commit": None, "dirty": None, "status_sha256": None}
+
+    status = status_result.stdout.encode("utf-8")
+    return {
+        "commit": commit_result.stdout.strip(),
+        "dirty": bool(status),
+        "status_sha256": hashlib.sha256(status).hexdigest(),
+    }
+
+
+def _adapter_identity(limitations: list[str]) -> dict[str, object]:
+    raw = os.environ.get(ADAPTER_ENV, "").strip().lower()
+    if not raw:
+        limitations.append(
+            f"Adapter identity was not reported through {ADAPTER_ENV}; it is unspecified."
+        )
+        identity = "unspecified"
+    elif not _SAFE_ADAPTER.fullmatch(raw):
+        limitations.append(
+            f"Adapter identity from {ADAPTER_ENV} was invalid and was not recorded verbatim."
+        )
+        identity = "invalid"
+    else:
+        identity = raw
+    return {
+        "identity": identity,
+        "source": ADAPTER_ENV,
+        "self_reported": True,
+    }
+
+
+def _read_manifest(run_dir: Path) -> _Manifest:
+    path = run_dir / "manifest.json"
+    with path.open(encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict) or value.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"unsupported manifest at {path}")
+    if (
+        not isinstance(value.get("run"), dict)
+        or not isinstance(value.get("limitations"), list)
+        or not isinstance(value.get("children"), list)
+        or not isinstance(value.get("tests"), list)
+        or not isinstance(value.get("artifacts"), list)
+        or not isinstance(value.get("cleanup"), dict)
+    ):
+        raise ValueError(f"manifest at {path} has an invalid structure")
+    return cast("_Manifest", value)
+
+
+def _repository_snapshot_path(run_dir: Path) -> Path:
+    configured = os.environ.get("OMNIGENT_VERIFY_CONTROL_SNAPSHOT")
+    return Path(configured) if configured else run_dir / "repository-before.json"
+
+
+def initialize(run_dir: Path, profile: str, doctor_profile: str) -> None:
+    limitations: list[str] = [
+        "Process cleanup uses ancestry plus an inherited private descriptor, not a hard "
+        "OS sandbox; a hostile child that closes all inherited descriptors before a "
+        "sub-observation escape may evade cleanup."
+    ]
+    repository_root = Path(os.environ.get("OMNIGENT_VERIFY_REPO_ROOT", Path.cwd()))
+    try:
+        snapshot = repository_snapshot(
+            repository_root,
+            deep_dependencies=os.environ.get("OMNIGENT_VERIFY_DEEP_DEPENDENCY_SNAPSHOT") == "1",
+        )
+        _atomic_write_json(_repository_snapshot_path(run_dir), snapshot)
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        limitations.append(
+            f"Initial repository snapshot failed ({type(exc).__name__}); verification is blocked."
+        )
+    if profile == "harness-client":
+        limitations.append(
+            "The harness/client profile checks unit behavior and the offline capability matrix; "
+            "it does not claim a live harness turn. Run harness-live with "
+            "OMNIGENT_VERIFY_HARNESS set for credentialed proof."
+        )
+    elif profile == "cli":
+        limitations.append(
+            "Credentialed CLI REPL verification was not requested because it requires inherited "
+            "user credentials and relaxes HOME isolation."
+        )
+    elif profile == "desktop":
+        limitations.append(
+            "Electron signing and notarization were not requested; the profile builds an "
+            "unsigned current-platform package."
+        )
+    manifest: _Manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "running",
+        "run": {
+            "id": run_dir.name,
+            "profile": profile,
+            "doctor_profile": doctor_profile,
+            "phase": "initializing",
+            "command_argv": [],
+            "selected_tests": [],
+        },
+        "adapter": _adapter_identity(limitations),
+        "repository": _repository_state(limitations),
+        "timestamps": {
+            "started_utc": _utc_now(),
+            "finished_utc": None,
+            "duration_seconds": None,
+        },
+        "tests": [],
+        "artifacts": [],
+        "orchestration": None,
+        "children": [],
+        "cleanup": {"status": "pending", "details": []},
+        "downstream_universe": {"status": "not_requested"},
+        "exit_status": None,
+        "signal": None,
+        "limitations": limitations,
+    }
+    _atomic_write_json(run_dir / "manifest.json", manifest)
+
+
+def record_plan(run_dir: Path, plan_path: Path) -> None:
+    manifest = _read_manifest(run_dir)
+    with plan_path.open(encoding="utf-8") as handle:
+        plan = json.load(handle)
+    if not isinstance(plan, dict) or plan.get("schema_version") != 1:
+        raise ValueError(f"unsupported orchestration plan at {plan_path}")
+    manifest["orchestration"] = plan
+    for optional in plan.get("optional_lanes", []):
+        if not isinstance(optional, dict) or optional.get("status") != "not_requested":
+            continue
+        manifest["limitations"].append(
+            f"Optional lane {optional.get('lane', '<unknown>')} was not requested. "
+            f"Opt in: {optional.get('opt_in', '<unspecified>')}"
+        )
+    _atomic_write_json(run_dir / "manifest.json", manifest)
+
+
+def add_child(
+    run_dir: Path,
+    lane: str,
+    child_manifest: Path,
+    exit_status: int,
+) -> None:
+    manifest = _read_manifest(run_dir)
+    existing = next(
+        (
+            item
+            for item in manifest["children"]
+            if isinstance(item, dict) and item.get("lane") == lane
+        ),
+        {},
+    )
+    child: dict[str, object] = {
+        "lane": lane,
+        "required": True,
+        "manifest": None,
+        "manifest_sha256": None,
+        "status": "unavailable",
+        "exit_status": exit_status,
+    }
+    if isinstance(existing, dict) and "baseline_comparison" in existing:
+        child["baseline_comparison"] = existing["baseline_comparison"]
+    try:
+        resolved_run = run_dir.resolve(strict=True)
+        resolved_child = child_manifest.resolve(strict=True)
+        resolved_child.relative_to(resolved_run)
+        raw = child_manifest.read_bytes()
+        value = json.loads(raw)
+        if not isinstance(value, dict) or value.get("schema_version") != SCHEMA_VERSION:
+            raise ValueError("unsupported child manifest")
+        child.update(
+            {
+                "manifest": resolved_child.relative_to(resolved_run).as_posix(),
+                "manifest_sha256": hashlib.sha256(raw).hexdigest(),
+                "status": value.get("status", "unavailable"),
+                "exit_status": value.get("exit_status", exit_status),
+                "profile": value.get("run", {}).get("profile"),
+            }
+        )
+        if lane == "universe":
+            downstream = value.get("downstream_universe")
+            if isinstance(downstream, dict):
+                manifest["downstream_universe"] = downstream
+            else:
+                manifest["limitations"].append(
+                    "The Universe child manifest did not record downstream status."
+                )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        manifest["limitations"].append(
+            f"Required lane {lane} produced no valid child manifest ({type(exc).__name__})."
+        )
+    manifest["children"] = [
+        item
+        for item in manifest["children"]
+        if isinstance(item, dict) and item.get("lane") != lane
+    ]
+    manifest["children"].append(child)
+    _atomic_write_json(run_dir / "manifest.json", manifest)
+
+
+def register_children(run_dir: Path, lanes: list[str]) -> None:
+    manifest = _read_manifest(run_dir)
+    existing = {
+        item.get("lane"): item
+        for item in manifest["children"]
+        if isinstance(item, dict) and isinstance(item.get("lane"), str)
+    }
+    manifest["children"] = [
+        existing.get(
+            lane,
+            {
+                "lane": lane,
+                "required": True,
+                "manifest": None,
+                "manifest_sha256": None,
+                "status": "pending",
+                "exit_status": None,
+            },
+        )
+        for lane in lanes
+    ]
+    _atomic_write_json(run_dir / "manifest.json", manifest)
+
+
+def mark_child(run_dir: Path, lane: str, status: str, reason: str | None = None) -> None:
+    manifest = _read_manifest(run_dir)
+    found = False
+    for child in manifest["children"]:
+        if not isinstance(child, dict) or child.get("lane") != lane:
+            continue
+        child["status"] = status
+        if reason:
+            child["reason"] = reason
+        found = True
+        break
+    if not found:
+        raise ValueError(f"lane {lane!r} was not registered")
+    _atomic_write_json(run_dir / "manifest.json", manifest)
+
+
+def record_baseline(run_dir: Path, lane: str, comparison_path: Path) -> None:
+    manifest = _read_manifest(run_dir)
+    resolved_run = run_dir.resolve(strict=True)
+    resolved_comparison = comparison_path.resolve(strict=True)
+    resolved_comparison.relative_to(resolved_run)
+    raw = comparison_path.read_bytes()
+    comparison = json.loads(raw)
+    if not isinstance(comparison, dict) or comparison.get("schema_version") != 1:
+        raise ValueError("unsupported baseline comparison")
+    payload = {
+        "classification": comparison.get("classification", "could_not_compare"),
+        "comparison": resolved_comparison.relative_to(resolved_run).as_posix(),
+        "comparison_sha256": hashlib.sha256(raw).hexdigest(),
+        "base_manifest": comparison.get("base_manifest"),
+        "base_manifest_sha256": comparison.get("base_manifest_sha256"),
+        "cleanup": comparison.get("cleanup"),
+    }
+    for child in manifest["children"]:
+        if isinstance(child, dict) and child.get("lane") == lane:
+            child["baseline_comparison"] = payload
+            _atomic_write_json(run_dir / "manifest.json", manifest)
+            return
+    raise ValueError(f"lane {lane!r} was not registered")
+
+
+def prepare(
+    run_dir: Path,
+    phase: str,
+    command_argv: list[str],
+    selected_tests: list[str],
+) -> None:
+    manifest = _read_manifest(run_dir)
+    required_tests = REQUIRED_PROFILE_TESTS.get(manifest["run"]["profile"], frozenset())
+    missing_tests = sorted(required_tests.difference(selected_tests))
+    if missing_tests:
+        raise ValueError(
+            "selected tests omit required profile coverage: " + ", ".join(missing_tests)
+        )
+    manifest["run"]["phase"] = phase
+    manifest["run"]["command_argv"] = portable_argv(
+        command_argv,
+        repo_root=Path(os.environ.get("OMNIGENT_VERIFY_REPO_ROOT", Path.cwd())),
+        run_dir=run_dir,
+        skill_root=Path(os.environ["OMNIGENT_VERIFY_SKILL_ROOT"])
+        if os.environ.get("OMNIGENT_VERIFY_SKILL_ROOT")
+        else None,
+    )
+    manifest["run"]["selected_tests"] = selected_tests
+    _atomic_write_json(run_dir / "manifest.json", manifest)
+
+
+def _parse_junit(path: Path, limitations: list[str]) -> list[dict[str, object]]:
+    if not path.is_file():
+        limitations.append("No JUnit report was produced, so per-test results are unavailable.")
+        return []
+    try:
+        root = ET.parse(path).getroot()
+    except (ET.ParseError, OSError) as exc:
+        limitations.append(f"The JUnit report could not be parsed ({type(exc).__name__}).")
+        return []
+
+    results: list[dict[str, object]] = []
+    for case in root.iter("testcase"):
+        classname = case.attrib.get("classname", "")
+        name = case.attrib.get("name", "<unnamed>")
+        nodeid = f"{classname}::{name}" if classname else name
+        if case.find("error") is not None:
+            status = "error"
+        elif case.find("failure") is not None:
+            status = "failed"
+        elif case.find("skipped") is not None:
+            status = "skipped"
+        else:
+            status = "passed"
+        try:
+            duration = float(case.attrib.get("time", "0"))
+        except ValueError:
+            duration = None
+        results.append(
+            {
+                "nodeid": nodeid,
+                "status": status,
+                "duration_seconds": duration,
+            }
+        )
+    return results
+
+
+def _mime_type(path: Path) -> str:
+    overrides = {
+        ".json": "application/json",
+        ".log": "text/plain",
+        ".png": "image/png",
+        ".webm": "video/webm",
+        ".xml": "application/xml",
+        ".zip": "application/zip",
+    }
+    return (
+        overrides.get(path.suffix.lower())
+        or mimetypes.guess_type(path.name)[0]
+        or ("application/octet-stream")
+    )
+
+
+def _authority(relative_path: Path) -> str:
+    parts = relative_path.parts
+    if parts and parts[0] == "playwright":
+        return "playwright-test-bound"
+    if parts and parts[0] == "supplemental":
+        return "supplemental-browser-tool"
+    if relative_path.name == "junit.xml":
+        return "pytest-report"
+    if relative_path.name == "run.log":
+        return "verification-runner"
+    if relative_path.name == "cleanup.json":
+        return "pytest-cleanup-marker"
+    if relative_path.name == "benchmark.json":
+        return "omnigent-benchmark"
+    if relative_path.name == "baseline-benchmark.json":
+        return "omnigent-baseline-benchmark"
+    if relative_path.name == "performance-comparison.json":
+        return "omnigent-benchmark-comparison"
+    if parts and parts[0] == "baseline" and relative_path.name == "comparison.json":
+        return "verification-baseline-comparison"
+    if parts and parts[0] == "baseline" and relative_path.suffix == ".log":
+        return "verification-baseline-runner"
+    if relative_path.name == "steps.json":
+        return "verification-step-report"
+    if relative_path.name == "lane-plan.json":
+        return "verification-lane-plan"
+    if relative_path.name == "repository-before.json":
+        return "verification-repository-snapshot"
+    if relative_path.name in {"harness-matrix.json", "harness-live.json"}:
+        return "harness-bench-report"
+    if relative_path.name == "desktop-build.json":
+        return "electron-build-report"
+    if relative_path.name == "universe.json":
+        return "universe-compatibility-report"
+    if parts and parts[0] == "universe-bazel":
+        return "universe-bazel-output"
+    if parts and parts[0] == "cli":
+        return "cli-pty-evidence"
+    return "unclassified"
+
+
+def _artifact_inventory(
+    run_dir: Path,
+    limitations: list[str],
+    excluded: set[Path] | None = None,
+) -> list[dict[str, object]]:
+    artifacts: list[dict[str, object]] = []
+    secrets_to_find = _known_secret_values()
+    for path in sorted(run_dir.rglob("*")):
+        try:
+            relative_parts = path.relative_to(run_dir).parts
+            if relative_parts[:1] == ("children",):
+                continue
+            if relative_parts[:1] == ("baseline",) and "evidence" in relative_parts:
+                continue
+        except ValueError:
+            continue
+        if path == run_dir / "manifest.json" or path.name.startswith(".manifest.json."):
+            continue
+        if path.name == "comparison-capability":
+            continue
+        if path.name == PRIVACY_FAILURE_MARKER:
+            continue
+        if excluded and path.absolute() in excluded:
+            limitations.append("A suspect artifact was excluded from the inventory.")
+            continue
+        reference = _safe_artifact_reference(path, run_dir, secrets_to_find)
+        if reference.startswith("<redacted-artifact-"):
+            limitations.append(
+                f"Suspect artifact path {reference!r} was excluded from the inventory."
+            )
+            continue
+        if path.is_symlink():
+            limitations.append(f"Symlink artifact {reference!r} was excluded from the inventory.")
+            continue
+        if not path.is_file():
+            continue
+        try:
+            relative_path = path.relative_to(run_dir)
+            resolved = path.resolve(strict=True)
+            resolved.relative_to(run_dir.resolve(strict=True))
+        except (OSError, ValueError):
+            limitations.append("An artifact outside the evidence directory was excluded.")
+            continue
+        digest = hashlib.sha256()
+        size = 0
+        try:
+            with path.open("rb") as handle:
+                while chunk := handle.read(1024 * 1024):
+                    digest.update(chunk)
+                    size += len(chunk)
+        except OSError:
+            limitations.append(f"Artifact {reference!r} could not be read and was excluded.")
+            continue
+        artifacts.append(
+            {
+                "path": relative_path.as_posix(),
+                "mime": _mime_type(path),
+                "sha256": digest.hexdigest(),
+                "bytes": size,
+                "authority": _authority(relative_path),
+            }
+        )
+    return artifacts
+
+
+def _known_secret_values() -> tuple[bytes, ...]:
+    values = [
+        os.environ[key]
+        for key in ("OPENAI_API_KEY", "DATABRICKS_TOKEN", "CURSOR_API_KEY")
+        if os.environ.get(key)
+    ]
+    selected = os.environ.get("OMNIGENT_VERIFY_DATABRICKS_PROFILE")
+    config_path = os.environ.get("DATABRICKS_CONFIG_FILE")
+    if not config_path and os.environ.get("HOME"):
+        config_path = str(Path(os.environ["HOME"]) / ".databrickscfg")
+    if selected and config_path:
+        parser = configparser.ConfigParser(interpolation=None)
+        try:
+            parser.read(config_path, encoding="utf-8")
+            values.extend(
+                value
+                for key, value in parser.items(selected)
+                if any(word in key.lower() for word in ("token", "password", "secret")) and value
+            )
+        except (configparser.Error, OSError):
+            pass
+    return tuple(dict.fromkeys(value.encode() for value in values if value))
+
+
+def _stream_contains_secret(
+    handle: BinaryIO,
+    secrets_to_find: tuple[bytes, ...],
+    limit: int,
+) -> bool:
+    overlap = max((len(value) for value in secrets_to_find), default=1) - 1
+    previous = b""
+    consumed = 0
+    while chunk := handle.read(min(1024 * 1024, limit - consumed + 1)):
+        consumed += len(chunk)
+        if consumed > limit:
+            raise ValueError("artifact exceeds privacy scan limits")
+        payload = previous + chunk
+        if any(secret in payload for secret in secrets_to_find):
+            return True
+        previous = payload[-overlap:] if overlap else b""
+    return False
+
+
+def _archive_contains_secret(
+    archive: zipfile.ZipFile,
+    secrets_to_find: tuple[bytes, ...],
+    budget: dict[str, int],
+    *,
+    depth: int,
+) -> bool:
+    if depth > MAX_ARCHIVE_DEPTH:
+        raise ValueError("archive nesting exceeds privacy scan limit")
+    members = archive.infolist()
+    budget["members"] += len(members)
+    if budget["members"] > MAX_ARCHIVE_MEMBERS:
+        raise ValueError("archive member count exceeds privacy scan limit")
+    for info in members:
+        member = Path(info.filename)
+        if (
+            member.is_absolute()
+            or ".." in member.parts
+            or info.flag_bits & 0x1
+            or info.file_size < 0
+        ):
+            raise ValueError("archive contains an unsafe member")
+        budget["expanded"] += info.file_size
+        if budget["expanded"] > MAX_ARCHIVE_EXPANDED_BYTES:
+            raise ValueError("archive expanded bytes exceed privacy scan limit")
+        if info.is_dir():
+            continue
+        with (
+            archive.open(info) as source,
+            tempfile.SpooledTemporaryFile(max_size=1024 * 1024) as staged,
+        ):
+            matched = False
+            overlap = max((len(value) for value in secrets_to_find), default=1) - 1
+            previous = b""
+            consumed = 0
+            while chunk := source.read(1024 * 1024):
+                consumed += len(chunk)
+                if consumed > info.file_size:
+                    raise ValueError("archive member exceeded declared size")
+                payload = previous + chunk
+                if any(secret in payload for secret in secrets_to_find):
+                    matched = True
+                previous = payload[-overlap:] if overlap else b""
+                staged.write(chunk)
+            if consumed != info.file_size:
+                raise ValueError("archive member size did not match declaration")
+            if matched:
+                return True
+            staged.seek(0)
+            if zipfile.is_zipfile(staged):
+                staged.seek(0)
+                with zipfile.ZipFile(staged) as nested:
+                    if _archive_contains_secret(
+                        nested,
+                        secrets_to_find,
+                        budget,
+                        depth=depth + 1,
+                    ):
+                        return True
+    return False
+
+
+def _artifact_contains_secret(path: Path, secrets_to_find: tuple[bytes, ...]) -> bool:
+    size = path.stat().st_size
+    if size > MAX_ARTIFACT_BYTES:
+        raise ValueError("top-level artifact exceeds privacy scan limit")
+    if zipfile.is_zipfile(path):
+        with zipfile.ZipFile(path) as archive:
+            return _archive_contains_secret(
+                archive,
+                secrets_to_find,
+                {"members": 0, "expanded": 0},
+                depth=1,
+            )
+    with path.open("rb") as handle:
+        return _stream_contains_secret(handle, secrets_to_find, MAX_ARTIFACT_BYTES)
+
+
+def _redact_json_secrets(
+    value: object,
+    known: tuple[str, ...],
+    *,
+    sensitive: bool = False,
+) -> object:
+    if sensitive:
+        return "[redacted-sensitive-value]"
+    if isinstance(value, dict):
+        return {
+            key: _redact_json_secrets(
+                item,
+                known,
+                sensitive=any(
+                    word in str(key).lower()
+                    for word in ("token", "password", "secret", "api_key", "authorization")
+                ),
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_json_secrets(item, known) for item in value]
+    if isinstance(value, str):
+        for secret in known:
+            value = value.replace(secret, "[redacted-known-secret]")
+        for pattern in _TRACE_SECRET_PATTERNS:
+            value = pattern.sub(r"\1[redacted]", value)
+        return _TRACE_SECRET_LITERAL.sub("[redacted-secret-literal]", value)
+    return value
+
+
+def _redact_trace_text(text: str, known: tuple[str, ...]) -> str:
+    lines = text.splitlines()
+    if lines:
+        try:
+            parsed = [json.loads(line) for line in lines if line.strip()]
+        except json.JSONDecodeError:
+            parsed = []
+        if parsed and len(parsed) == len([line for line in lines if line.strip()]):
+            return "\n".join(
+                json.dumps(_redact_json_secrets(item, known), separators=(",", ":"))
+                for item in parsed
+            ) + ("\n" if text.endswith("\n") else "")
+    try:
+        parsed_document = json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    else:
+        return json.dumps(
+            _redact_json_secrets(parsed_document, known),
+            separators=(",", ":"),
+        )
+    for secret in known:
+        text = text.replace(secret, "[redacted-known-secret]")
+    for pattern in _TRACE_SECRET_PATTERNS:
+        text = pattern.sub(r"\1[redacted]", text)
+    return _TRACE_SECRET_LITERAL.sub("[redacted-secret-literal]", text)
+
+
+def _valid_png(path: Path) -> bool:
+    """Decode enough of an 8-bit Playwright PNG to prove nonempty image data."""
+    try:
+        if path.stat().st_size > MAX_DECODE_BYTES:
+            return False
+        payload = path.read_bytes()
+        if payload[:8] != b"\x89PNG\r\n\x1a\n":
+            return False
+        cursor = 8
+        ihdr: tuple[int, int, int, int, int] | None = None
+        compressed = bytearray()
+        ended = False
+        while cursor + 12 <= len(payload):
+            length = struct.unpack(">I", payload[cursor : cursor + 4])[0]
+            kind = payload[cursor + 4 : cursor + 8]
+            end = cursor + 12 + length
+            if end > len(payload):
+                return False
+            data = payload[cursor + 8 : cursor + 8 + length]
+            expected_crc = struct.unpack(">I", payload[cursor + 8 + length : end])[0]
+            if binascii.crc32(kind + data) & 0xFFFFFFFF != expected_crc:
+                return False
+            if kind == b"IHDR":
+                if ihdr is not None or length != 13:
+                    return False
+                width, height, depth, color, compression, filtering, interlace = struct.unpack(
+                    ">IIBBBBB", data
+                )
+                if (
+                    width <= 0
+                    or height <= 0
+                    or depth != 8
+                    or color not in {0, 2, 4, 6}
+                    or compression != 0
+                    or filtering != 0
+                    or interlace != 0
+                ):
+                    return False
+                ihdr = (width, height, depth, color, interlace)
+            elif kind == b"IDAT":
+                compressed.extend(data)
+            elif kind == b"IEND":
+                ended = length == 0
+                break
+            cursor = end
+        if ihdr is None or not compressed or not ended:
+            return False
+        width, height, _depth, color, _interlace = ihdr
+        channels = {0: 1, 2: 3, 4: 2, 6: 4}[color]
+        row_size = 1 + width * channels
+        expected = row_size * height
+        if expected > MAX_DECODE_BYTES:
+            return False
+        decoder = zlib.decompressobj()
+        decoded = decoder.decompress(bytes(compressed), expected + 1)
+        decoded += decoder.flush()
+        return (
+            len(decoded) == expected
+            and decoder.eof
+            and all(decoded[offset] <= 4 for offset in range(0, expected, row_size))
+        )
+    except (OSError, ValueError, struct.error, zlib.error):
+        return False
+
+
+def _valid_playwright_trace(path: Path) -> bool:
+    try:
+        if path.stat().st_size > MAX_ARTIFACT_BYTES:
+            return False
+        with zipfile.ZipFile(path) as archive:
+            members = archive.infolist()
+            if (
+                not members
+                or len(members) > MAX_ARCHIVE_MEMBERS
+                or sum(info.file_size for info in members) > MAX_ARCHIVE_EXPANDED_BYTES
+            ):
+                return False
+            trace = next(
+                (
+                    info
+                    for info in members
+                    if Path(info.filename).name == "trace.trace"
+                    and 0 < info.file_size <= MAX_DECODE_BYTES
+                ),
+                None,
+            )
+            if trace is None:
+                return False
+            with archive.open(trace) as handle:
+                payload = handle.read(trace.file_size + 1)
+            if len(payload) != trace.file_size:
+                return False
+            lines = [line for line in payload.decode("utf-8").splitlines() if line.strip()]
+            return bool(lines) and all(isinstance(json.loads(line), dict) for line in lines)
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError, zipfile.BadZipFile):
+        return False
+
+
+def _safe_artifact_reference(
+    path: Path,
+    run_dir: Path,
+    secrets_to_find: tuple[bytes, ...],
+) -> str:
+    raw = os.fsencode(path.relative_to(run_dir))
+    if any(secret in raw for secret in secrets_to_find):
+        return f"<redacted-artifact-{hashlib.sha256(raw).hexdigest()[:12]}>"
+    return path.relative_to(run_dir).as_posix()
+
+
+def _remove_artifact(path: Path, run_dir: Path) -> tuple[bool, str | None]:
+    try:
+        path.relative_to(run_dir)
+        parent = path.parent.resolve(strict=True)
+        parent.relative_to(run_dir.resolve(strict=True))
+        parent_stat = parent.stat()
+    except (OSError, ValueError):
+        return False, "unsafe artifact location"
+    original_mode = parent_stat.st_mode
+    changed_mode = False
+    restore_error = False
+    try:
+        try:
+            path.rmdir() if path.is_dir() and not path.is_symlink() else path.unlink()
+        except PermissionError:
+            if parent_stat.st_uid != os.getuid():
+                return False, "artifact parent is not owned by the verifier user"
+            parent.chmod(original_mode | 0o700)
+            changed_mode = True
+            path.rmdir() if path.is_dir() and not path.is_symlink() else path.unlink()
+    except OSError as exc:
+        return False, f"artifact removal failed ({type(exc).__name__})"
+    finally:
+        if changed_mode and parent.exists():
+            try:
+                parent.chmod(original_mode)
+            except OSError:
+                restore_error = True
+    if restore_error:
+        return False, "artifact parent permissions could not be restored"
+    if path.exists() or path.is_symlink():
+        return False, "artifact removal could not be confirmed"
+    return True, None
+
+
+def _mark_privacy_cleanup_failure(run_dir: Path) -> None:
+    _atomic_write_json(
+        run_dir / PRIVACY_FAILURE_MARKER,
+        {"schema_version": 1, "status": "failed"},
+    )
+
+
+def sanitize_trace_archives(
+    run_dir: Path,
+    suspect_paths: set[Path] | None = None,
+) -> list[str]:
+    """Redact text trace members; delete traces that cannot be transformed safely."""
+    blockers: list[str] = []
+    known = tuple(value.decode() for value in _known_secret_values())
+    for path in sorted(run_dir.rglob("*.zip")):
+        if "trace" not in path.name.lower() or path.is_symlink():
+            continue
+        temporary = path.with_name(f".{path.name}.privacy.tmp")
+        try:
+            if path.stat().st_size > MAX_ARTIFACT_BYTES:
+                raise ValueError("trace exceeds top-level artifact limit")
+            with (
+                zipfile.ZipFile(path, "r") as source,
+                zipfile.ZipFile(temporary, "w") as destination,
+            ):
+                seen: set[str] = set()
+                expanded = 0
+                members = source.infolist()
+                if len(members) > MAX_ARCHIVE_MEMBERS:
+                    raise ValueError("trace member count exceeds limit")
+                for info in members:
+                    member = Path(info.filename)
+                    if (
+                        info.filename in seen
+                        or member.is_absolute()
+                        or ".." in member.parts
+                        or info.flag_bits & 0x1
+                    ):
+                        raise ValueError("unsafe trace member")
+                    seen.add(info.filename)
+                    expanded += info.file_size
+                    if expanded > MAX_ARCHIVE_EXPANDED_BYTES:
+                        raise ValueError("trace expanded bytes exceed limit")
+                    if info.file_size > MAX_DECODE_BYTES:
+                        raise ValueError("trace member exceeds decode limit")
+                    with source.open(info) as member_source:
+                        payload = member_source.read(info.file_size + 1)
+                    if len(payload) != info.file_size:
+                        raise ValueError("trace member size did not match declaration")
+                    try:
+                        text = payload.decode("utf-8")
+                    except UnicodeDecodeError as exc:
+                        if any(value.encode() in payload for value in known):
+                            raise ValueError("known secret in binary trace member") from exc
+                        destination.writestr(info, payload)
+                        continue
+                    text = _redact_trace_text(text, known)
+                    destination.writestr(info, text.encode())
+            with zipfile.ZipFile(temporary, "r") as sanitized:
+                if sanitized.testzip() is not None:
+                    raise ValueError("invalid sanitized trace")
+            os.replace(temporary, path)
+        except (OSError, ValueError, zipfile.BadZipFile):
+            _mark_privacy_cleanup_failure(run_dir)
+            if suspect_paths is not None:
+                suspect_paths.add(path.absolute())
+            reference = _safe_artifact_reference(
+                path,
+                run_dir,
+                _known_secret_values(),
+            )
+            removed, error = _remove_artifact(path, run_dir)
+            outcome = "was deleted" if removed else f"removal was not confirmed ({error})"
+            blockers.append(
+                "PRIVACY CLEANUP FAILURE: "
+                f"trace artifact {reference!r} could not be privacy-transformed; {outcome}."
+            )
+        finally:
+            temporary.unlink(missing_ok=True)
+    return blockers
+
+
+def remove_known_secret_artifacts(
+    run_dir: Path,
+    suspect_paths: set[Path] | None = None,
+) -> list[str]:
+    """Delete artifacts containing explicitly known credentials, including ZIP members."""
+    secrets_to_find = _known_secret_values()
+    blockers: list[str] = []
+    for path in sorted(run_dir.rglob("*")):
+        if not path.is_file() or path.is_symlink():
+            continue
+        reference = _safe_artifact_reference(path, run_dir, secrets_to_find)
+        path_match = reference.startswith("<redacted-artifact-")
+        try:
+            matched = path_match or _artifact_contains_secret(path, secrets_to_find)
+        except (OSError, ValueError, zipfile.BadZipFile):
+            matched = True
+        if not matched:
+            continue
+        removed, error = _remove_artifact(path, run_dir)
+        if suspect_paths is not None:
+            suspect_paths.add(path.absolute())
+        if removed:
+            blockers.append(
+                f"Artifact {reference!r} contained or could expose an explicitly known "
+                "secret and was deleted."
+            )
+        else:
+            _mark_privacy_cleanup_failure(run_dir)
+            blockers.append(
+                "PRIVACY CLEANUP FAILURE: "
+                f"artifact {reference!r} contained or could expose an explicitly known "
+                f"secret; removal was not confirmed ({error})."
+            )
+    for path in sorted(
+        (item for item in run_dir.rglob("*") if item.is_dir() and not item.is_symlink()),
+        key=lambda item: len(item.parts),
+        reverse=True,
+    ):
+        reference = _safe_artifact_reference(path, run_dir, secrets_to_find)
+        if not reference.startswith("<redacted-artifact-"):
+            continue
+        removed, error = _remove_artifact(path, run_dir)
+        if not removed:
+            blockers.append(
+                "PRIVACY CLEANUP FAILURE: "
+                f"directory {reference!r} exposed a known secret in its path; "
+                f"removal was not confirmed ({error})."
+            )
+    return blockers
+
+
+def validate_required_outputs(run_dir: Path, profile: str) -> list[str]:
+    """Return blockers when a successful UI run lacks test-bound proof."""
+    suspect_paths: set[Path] = set()
+    privacy_blockers = [
+        *sanitize_trace_archives(run_dir, suspect_paths),
+        *remove_known_secret_artifacts(run_dir, suspect_paths),
+    ]
+    if privacy_blockers:
+        return privacy_blockers
+    if profile == "perf":
+        benchmark = run_dir / "benchmark.json"
+        if not benchmark.is_file():
+            return ["The performance run produced no benchmark.json."]
+        try:
+            value = json.loads(benchmark.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            return [f"benchmark.json is not valid JSON ({type(exc).__name__})."]
+        perf_blockers: list[str] = []
+        if (
+            not isinstance(value, dict)
+            or value.get("schema_version") not in SUPPORTED_BENCHMARK_SCHEMA_VERSIONS
+        ):
+            perf_blockers.append("benchmark.json has no supported schema version.")
+            return perf_blockers
+        if not value.get("git_sha"):
+            perf_blockers.append("benchmark.json has no commit identity.")
+        config = value.get("config")
+        if not isinstance(config, dict) or not config.get("backend"):
+            perf_blockers.append("benchmark.json has no backend/config identity.")
+        configured_runs = config.get("runs") if isinstance(config, dict) else None
+        if (
+            not isinstance(configured_runs, int)
+            or isinstance(configured_runs, bool)
+            or configured_runs <= 0
+        ):
+            perf_blockers.append("benchmark.json has no valid configured run count.")
+        journeys = value.get("journeys")
+        if not isinstance(journeys, dict) or not journeys:
+            perf_blockers.append("benchmark.json contains no journey results.")
+            return perf_blockers
+        for name, journey in journeys.items():
+            if not isinstance(journey, dict):
+                perf_blockers.append(f"Benchmark journey {name} is invalid.")
+                continue
+            summary = journey.get("summary")
+            if not isinstance(summary, dict):
+                perf_blockers.append(f"Benchmark journey {name} has no summary.")
+                continue
+            required = {
+                "avg_p50_ms",
+                "avg_p99_ms",
+                "avg_http_requests_per_op",
+                "network_routes",
+                "runs_ok",
+                "runs_total",
+            }
+            missing = sorted(required - summary.keys())
+            if missing:
+                perf_blockers.append(
+                    f"Benchmark journey {name} lacks required evidence: {', '.join(missing)}."
+                )
+                continue
+            runs_ok = summary.get("runs_ok")
+            runs_total = summary.get("runs_total")
+            if (
+                not isinstance(runs_ok, int)
+                or isinstance(runs_ok, bool)
+                or not isinstance(runs_total, int)
+                or isinstance(runs_total, bool)
+                or runs_total <= 0
+                or runs_ok != runs_total
+                or runs_total != configured_runs
+            ):
+                perf_blockers.append(
+                    f"Benchmark journey {name} did not complete every run "
+                    f"(runs_ok={runs_ok!r}, runs_total={runs_total!r})."
+                )
+            if journey.get("skipped") or journey.get("skipped_reason"):
+                perf_blockers.append(f"Benchmark journey {name} was skipped.")
+            runs = journey.get("runs")
+            if not isinstance(runs, list) or not runs:
+                perf_blockers.append(f"Benchmark journey {name} contains no run evidence.")
+                continue
+            successful_runs = sum(
+                1 for run in runs if isinstance(run, dict) and run.get("n_failures") == 0
+            )
+            if (
+                len(runs) != runs_total
+                or successful_runs != runs_ok
+                or len(runs) != configured_runs
+            ):
+                perf_blockers.append(
+                    f"Benchmark journey {name} run evidence contradicts configured "
+                    "and summarized counts."
+                )
+            for index, run in enumerate(runs):
+                failures = run.get("n_failures") if isinstance(run, dict) else None
+                if not isinstance(failures, int) or isinstance(failures, bool) or failures != 0:
+                    perf_blockers.append(
+                        f"Benchmark journey {name} run {index} has "
+                        f"n_failures={failures!r}; functional success is required."
+                    )
+        return perf_blockers
+    if profile not in UI_PROFILES:
+        return []
+    files = [
+        path
+        for path in (run_dir / "playwright").rglob("*")
+        if path.is_file() and not path.is_symlink()
+    ]
+    blockers: list[str] = []
+    junit = run_dir / "junit.xml"
+    executed_nodeids: dict[str, int] = {}
+    if not junit.is_file():
+        blockers.append("The UI run produced no JUnit report.")
+    else:
+        try:
+            root = ET.parse(junit).getroot()
+            for case in root.iter("testcase"):
+                if case.find("skipped") is None:
+                    properties = case.find("properties")
+                    identity_values = (
+                        [
+                            item.attrib.get("value")
+                            for item in properties.findall("property")
+                            if item.attrib.get("name") == "omnigent_nodeid_sha256"
+                        ]
+                        if properties is not None
+                        else []
+                    )
+                    context_values = (
+                        [
+                            item.attrib.get("value")
+                            for item in properties.findall("property")
+                            if item.attrib.get("name") == "omnigent_browser_context_count"
+                        ]
+                        if properties is not None
+                        else []
+                    )
+                    if (
+                        len(identity_values) != 1
+                        or not isinstance(identity_values[0], str)
+                        or not re.fullmatch(r"[0-9a-f]{64}", identity_values[0])
+                        or identity_values[0] in executed_nodeids
+                        or len(context_values) != 1
+                        or not isinstance(context_values[0], str)
+                        or not context_values[0].isdigit()
+                    ):
+                        blockers.append(
+                            "An executed UI case lacks one unique canonical node-id identity."
+                        )
+                        continue
+                    executed_nodeids[identity_values[0]] = int(context_values[0])
+        except (OSError, ET.ParseError):
+            blockers.append("The UI JUnit report is unreadable.")
+    if not executed_nodeids:
+        blockers.append("The UI run contains no executed Pytest test.")
+    expected_browser_tests = {
+        identity for identity, count in executed_nodeids.items() if count > 0
+    }
+    metadata_paths = [path for path in files if path.name == "metadata.json"]
+    if expected_browser_tests and not metadata_paths:
+        blockers.append("The UI run produced no browser context metadata.")
+    if expected_browser_tests and not any(path.suffix.lower() == ".png" for path in files):
+        blockers.append("The UI run produced no test-bound screenshot.")
+    if expected_browser_tests and not any(path.suffix.lower() == ".zip" for path in files):
+        blockers.append("The UI run produced no test-bound trace.")
+    valid_contexts = 0
+    covered_tests: set[str] = set()
+    for metadata_path in metadata_paths:
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            nodeid = metadata["nodeid"]
+            nodeid_sha256 = metadata["nodeid_sha256"]
+            if (
+                metadata.get("schema_version") != 1
+                or metadata.get("lifecycle") != "closed"
+                or metadata.get("context_style")
+                not in {"managed-sync", "direct-sync", "direct-async"}
+                or not isinstance(nodeid, str)
+                or not isinstance(nodeid_sha256, str)
+                or not re.fullmatch(r"[0-9a-f]{64}", nodeid_sha256)
+                or nodeid_sha256 not in executed_nodeids
+                or metadata_path.parent.parent.name != f"test-{nodeid_sha256[:20]}"
+                or not isinstance(metadata.get("events"), list)
+            ):
+                raise ValueError("invalid metadata identity")
+            context_files = [
+                path
+                for path in metadata_path.parent.rglob("*")
+                if path.is_file() and not path.is_symlink()
+            ]
+            screenshots = [path for path in context_files if path.suffix.lower() == ".png"]
+            traces = [path for path in context_files if path.suffix.lower() == ".zip"]
+            if not screenshots or not all(_valid_png(path) for path in screenshots):
+                raise ValueError("context has no screenshot")
+            if not traces or not all(_valid_playwright_trace(path) for path in traces):
+                raise ValueError("context has no trace")
+            covered_tests.add(nodeid_sha256)
+            valid_contexts += 1
+        except (KeyError, OSError, ValueError, json.JSONDecodeError):
+            blockers.append(
+                f"Browser context metadata is invalid or uncorrelated: "
+                f"{metadata_path.relative_to(run_dir)}."
+            )
+    if expected_browser_tests and valid_contexts == 0:
+        blockers.append("The UI run produced no authenticated complete browser context.")
+    if expected_browser_tests - covered_tests:
+        blockers.append("One or more executed UI tests have no correlated browser context.")
+    unexpected_browser_tests = covered_tests - expected_browser_tests
+    if unexpected_browser_tests:
+        blockers.append("Browser evidence is attributed to a browserless UI test.")
+    for identity, expected_count in executed_nodeids.items():
+        if expected_count == 0:
+            continue
+        actual_count = sum(
+            1
+            for metadata_path in metadata_paths
+            if metadata_path.parent.parent.name == f"test-{identity[:20]}"
+        )
+        if actual_count != expected_count:
+            blockers.append("An executed UI test has a mismatched browser context evidence count.")
+    return blockers
+
+
+def _orchestration_cleanup(manifest: _Manifest) -> dict[str, object]:
+    children = [item for item in manifest.get("children", []) if isinstance(item, dict)]
+    attempted = [item for item in children if item.get("manifest")]
+    details: list[str] = []
+    unknown = False
+    for child in attempted:
+        child_manifest = child.get("_loaded_manifest")
+        cleanup = child_manifest.get("cleanup") if isinstance(child_manifest, dict) else None
+        status = cleanup.get("status") if isinstance(cleanup, dict) else "unknown"
+        details.append(f"{child.get('lane')}: {status}")
+        if status not in {"completed", "not_applicable"}:
+            unknown = True
+        baseline = child.get("baseline_comparison")
+        baseline_cleanup = baseline.get("cleanup") if isinstance(baseline, dict) else None
+        if isinstance(baseline_cleanup, dict):
+            baseline_status = baseline_cleanup.get("status", "unknown")
+            details.append(f"{child.get('lane')} baseline worktree: {baseline_status}")
+            if baseline_status != "completed":
+                unknown = True
+    for child in children:
+        child.pop("_loaded_manifest", None)
+    if not attempted:
+        return {"status": "not_applicable", "details": details}
+    return {"status": "unknown" if unknown else "completed", "details": details}
+
+
+def _cleanup_state(
+    run_dir: Path,
+    profile: str,
+    signal_name: str | None,
+    manifest: _Manifest,
+) -> dict[str, object]:
+    if profile in ORCHESTRATION_PROFILES:
+        return _orchestration_cleanup(manifest)
+    if profile in {
+        "doctor",
+        "backend",
+        "quality-gates",
+        "server",
+        "db-migration-deploy",
+        "perf",
+        "cli",
+        "harness-client",
+        "harness-live",
+        "universe",
+    }:
+        return {"status": "not_applicable", "details": []}
+    marker = run_dir / "cleanup.json"
+    if marker.is_file():
+        try:
+            value = json.loads(marker.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            value = None
+        if isinstance(value, dict) and value.get("status") == "completed":
+            return {"status": "completed", "details": ["pytest session cleanup completed"]}
+    detail = (
+        "verification was interrupted before cleanup was confirmed"
+        if signal_name
+        else ("pytest did not confirm session cleanup")
+    )
+    return {"status": "unknown", "details": [detail]}
+
+
+def _append_artifact_limitations(
+    manifest: _Manifest,
+    artifacts: list[dict[str, object]],
+) -> None:
+    paths = [path for item in artifacts if isinstance(path := item.get("path"), str)]
+    if "run.log" not in paths:
+        manifest["limitations"].append("The expected verification runner log is missing.")
+    if manifest["run"]["profile"] == "perf" and "benchmark.json" not in paths:
+        manifest["limitations"].append("The performance profile produced no benchmark.json.")
+    if (
+        manifest["run"]["profile"]
+        in {
+            "quality-gates",
+            "perf",
+            "server",
+            "db-migration-deploy",
+            "cli",
+            "web-ui",
+            "desktop",
+            "harness-client",
+            "harness-live",
+            "universe",
+        }
+        and "steps.json" not in paths
+    ):
+        manifest["limitations"].append("The expected per-step command report is missing.")
+    unclassified = [
+        path
+        for item in artifacts
+        if item.get("authority") == "unclassified" and isinstance(path := item.get("path"), str)
+    ]
+    if unclassified:
+        manifest["limitations"].append(
+            "Some artifacts have unclassified authority: " + ", ".join(unclassified)
+        )
+    if manifest["run"]["profile"] not in UI_PROFILES:
+        return
+    manifest["limitations"].extend(
+        [
+            "Managed synchronous-context videos are retained only for failed tests; "
+            "successful managed tests rely on screenshots and traces.",
+            "Trace text receives deterministic known-pattern redaction, but unnamed page "
+            "secrets may evade heuristics; evidence is not generally sanitized.",
+            "Known credential values are byte-scanned through ZIP members, screenshots, "
+            "and videos. Image/video pixels are not OCR-scanned, so visibly rendered "
+            "unknown secrets remain outside this proof.",
+            "Network evidence is observed metadata only, not a complete HAR, and excludes "
+            "headers and bodies.",
+        ]
+    )
+    context_metadata = [path for path in paths if path.endswith("/metadata.json")]
+    if not context_metadata:
+        manifest["limitations"].append(
+            "No browser context metadata was produced; selected tests may not have created a "
+            "browser, or browser setup failed."
+        )
+        return
+    if not any(path.endswith(".png") for path in paths):
+        manifest["limitations"].append(
+            "Browser contexts ran, but no screenshot file was produced."
+        )
+    if not any(path.endswith(".zip") for path in paths):
+        manifest["limitations"].append("Browser contexts ran, but no trace file was produced.")
+    if manifest["status"] != "passed" and not any(path.endswith(".webm") for path in paths):
+        manifest["limitations"].append(
+            "The verification failed, but no browser video file was produced."
+        )
+
+
+def _append_orchestration_limitations(manifest: _Manifest) -> None:
+    orchestration = manifest.get("orchestration")
+    if not isinstance(orchestration, dict):
+        manifest["limitations"].append("The orchestration profile produced no lane decision.")
+        return
+    selected = orchestration.get("selected_lanes", [])
+    child_by_lane = {
+        child.get("lane"): child
+        for child in manifest.get("children", [])
+        if isinstance(child, dict)
+    }
+    for lane in selected:
+        child = child_by_lane.get(lane)
+        if child is None:
+            manifest["limitations"].append(f"Required lane {lane} has no child evidence manifest.")
+        elif child.get("status") != "passed":
+            manifest["limitations"].append(
+                f"Required lane {lane} did not pass; inspect {child.get('manifest') or 'run.log'}."
+            )
+
+
+def _reconcile_children(
+    run_dir: Path,
+    manifest: _Manifest,
+    parent_status: str,
+    parent_exit_status: int,
+    signal_name: str | None,
+) -> None:
+    orchestration = manifest.get("orchestration")
+    if not isinstance(orchestration, dict):
+        return
+    selected = orchestration.get("selected_lanes", [])
+    if not isinstance(selected, list):
+        return
+    by_lane = {
+        item.get("lane"): item
+        for item in manifest.get("children", [])
+        if isinstance(item, dict) and isinstance(item.get("lane"), str)
+    }
+    reconciled: list[dict[str, object]] = []
+    for lane in selected:
+        if not isinstance(lane, str):
+            continue
+        child = by_lane.get(
+            lane,
+            {
+                "lane": lane,
+                "required": True,
+                "manifest": None,
+                "manifest_sha256": None,
+                "status": "pending",
+                "exit_status": None,
+            },
+        )
+        manifests = sorted((run_dir / "children" / lane).glob("*/manifest.json"))
+        if len(manifests) == 1:
+            child_path = manifests[0]
+            try:
+                expected_sha256 = child.get("manifest_sha256")
+                reconciled_stale = False
+                child_value = json.loads(child_path.read_text(encoding="utf-8"))
+                if not isinstance(child_value, dict) or child_value.get("schema_version") != 1:
+                    raise ValueError("unsupported child manifest")
+                if child_value.get("status") == "running":
+                    child_status = "interrupted" if parent_status == "interrupted" else "failed"
+                    finalize(
+                        child_path.parent,
+                        child_status,
+                        parent_exit_status or 1,
+                        signal_name,
+                    )
+                    child_value = json.loads(child_path.read_text(encoding="utf-8"))
+                    reconciled_stale = True
+                    manifest["limitations"].append(
+                        f"Parent reconciliation finalized stale child {lane} as {child_status}."
+                    )
+                raw = child_path.read_bytes()
+                observed_sha256 = hashlib.sha256(raw).hexdigest()
+                if expected_sha256 is None and parent_status == "passed":
+                    raise ValueError("child manifest was never authenticated by the parent")
+                if (
+                    expected_sha256 is not None
+                    and expected_sha256 != observed_sha256
+                    and not reconciled_stale
+                ):
+                    raise ValueError("child manifest hash changed after registration")
+                if (
+                    child_value.get("run", {}).get("phase") != "finished"
+                    or child_value.get("run", {}).get("profile") != lane
+                ):
+                    raise ValueError("child manifest identity or finalization is invalid")
+                child.update(
+                    {
+                        "manifest": child_path.relative_to(run_dir).as_posix(),
+                        "manifest_sha256": observed_sha256,
+                        "status": child_value.get("status", "unavailable"),
+                        "exit_status": child_value.get("exit_status"),
+                        "profile": child_value.get("run", {}).get("profile"),
+                        "_loaded_manifest": child_value,
+                    }
+                )
+            except (OSError, ValueError, json.JSONDecodeError) as exc:
+                child["status"] = "unavailable"
+                child["reason"] = f"Child manifest could not be reconciled ({type(exc).__name__})."
+        elif len(manifests) > 1:
+            child["status"] = "unavailable"
+            child["reason"] = "Multiple child manifests were produced for one required lane."
+        elif not manifests:
+            if parent_status == "interrupted":
+                child["status"] = "interrupted"
+                child["exit_status"] = parent_exit_status
+                child["reason"] = "Parent orchestration was interrupted before child completion."
+            elif parent_status == "blocked":
+                child["status"] = "blocked"
+                child["exit_status"] = parent_exit_status
+                child["reason"] = "Prerequisite preflight blocked lane startup."
+            elif parent_status == "passed":
+                child["status"] = "unavailable"
+                child["exit_status"] = None
+                child["reason"] = "Required finalized child manifest is missing."
+            else:
+                child["status"] = "blocked"
+                child["exit_status"] = None
+                child["reason"] = "An earlier required lane failed before this lane started."
+        reconciled.append(child)
+    manifest["children"] = reconciled
+
+
+def _required_child_errors(manifest: _Manifest) -> list[str]:
+    orchestration = manifest.get("orchestration")
+    if not isinstance(orchestration, dict):
+        return ["orchestration decision is unavailable"]
+    selected = orchestration.get("selected_lanes")
+    children = manifest.get("children")
+    if not isinstance(selected, list) or not isinstance(children, list):
+        return ["required lane schema is invalid"]
+    errors = []
+    for lane in selected:
+        matches = [
+            child for child in children if isinstance(child, dict) and child.get("lane") == lane
+        ]
+        if len(matches) != 1:
+            errors.append(f"required lane {lane!r} has {len(matches)} child records")
+            continue
+        child = matches[0]
+        if (
+            child.get("status") != "passed"
+            or child.get("exit_status") != 0
+            or not child.get("manifest")
+            or not child.get("manifest_sha256")
+        ):
+            errors.append(f"required lane {lane!r} lacks successful authenticated evidence")
+        baseline = child.get("baseline_comparison")
+        if isinstance(baseline, dict) and baseline.get("cleanup", {}).get("status") != "completed":
+            errors.append(f"required lane {lane!r} baseline cleanup is incomplete")
+    return errors
+
+
+def finalize(
+    run_dir: Path,
+    status: str,
+    exit_status: int,
+    signal_name: str | None,
+) -> None:
+    manifest = _read_manifest(run_dir)
+    state_changes: list[str]
+    try:
+        before = json.loads(_repository_snapshot_path(run_dir).read_text(encoding="utf-8"))
+        repository_root = Path(os.environ.get("OMNIGENT_VERIFY_REPO_ROOT", Path.cwd()))
+        state_changes = compare_snapshots(
+            before,
+            repository_snapshot(
+                repository_root,
+                deep_dependencies=(
+                    os.environ.get("OMNIGENT_VERIFY_DEEP_DEPENDENCY_SNAPSHOT") == "1"
+                ),
+            ),
+        )
+    except (OSError, ValueError, json.JSONDecodeError, RuntimeError) as exc:
+        state_changes = [f"repository snapshot failed ({type(exc).__name__})"]
+    if state_changes:
+        status = "blocked" if manifest["run"]["profile"] == "doctor" else "failed"
+        exit_status = exit_status or 1
+        manifest["limitations"].append(
+            "Repository mutation invariant failed: " + "; ".join(state_changes)
+        )
+    manifest["status"] = status
+    manifest["exit_status"] = exit_status
+    manifest["signal"] = signal_name
+    manifest["run"]["phase"] = "finished"
+    manifest["timestamps"]["finished_utc"] = _utc_now()
+    try:
+        started_value = manifest["timestamps"]["started_utc"]
+        finished_value = manifest["timestamps"]["finished_utc"]
+        if finished_value is None:
+            raise ValueError("finished timestamp is missing")
+        started = datetime.fromisoformat(started_value.replace("Z", "+00:00"))
+        finished = datetime.fromisoformat(finished_value.replace("Z", "+00:00"))
+        manifest["timestamps"]["duration_seconds"] = round((finished - started).total_seconds(), 3)
+    except (TypeError, ValueError):
+        manifest["limitations"].append("Verification duration could not be calculated.")
+
+    if manifest["run"]["profile"] in ORCHESTRATION_PROFILES:
+        _reconcile_children(run_dir, manifest, status, exit_status, signal_name)
+        child_errors = _required_child_errors(manifest)
+        if child_errors and status == "passed":
+            status = "failed"
+            exit_status = exit_status or 1
+            manifest["status"] = status
+            manifest["exit_status"] = exit_status
+            manifest["limitations"].extend(child_errors)
+    if manifest["run"]["profile"] == "universe":
+        report_path = run_dir / "universe.json"
+        try:
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            if not isinstance(report, dict) or report.get("schema_version") != 1:
+                raise ValueError("unsupported Universe report")
+            manifest["downstream_universe"] = report
+            report_limitations = report.get("limitations", [])
+            if isinstance(report_limitations, list):
+                manifest["limitations"].extend(
+                    item for item in report_limitations if isinstance(item, str)
+                )
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            manifest["downstream_universe"] = {"status": "unavailable"}
+            manifest["limitations"].append(
+                f"The Universe report could not be loaded ({type(exc).__name__})."
+            )
+    if (run_dir / "junit.xml").is_file() or manifest["run"]["profile"] in UI_PROFILES:
+        manifest["tests"] = _parse_junit(run_dir / "junit.xml", manifest["limitations"])
+    if (
+        manifest["run"]["profile"] in PYTEST_PROFILES
+        and status == "passed"
+        and not any(test.get("status") != "skipped" for test in manifest["tests"])
+    ):
+        status = "failed"
+        exit_status = exit_status or 1
+        manifest["status"] = status
+        manifest["exit_status"] = exit_status
+        manifest["limitations"].append(
+            "The selected Pytest suite produced no non-skipped test evidence."
+        )
+    final_repository = _repository_state(manifest["limitations"])
+    manifest["repository"]["final_status_sha256"] = final_repository["status_sha256"]
+    manifest["repository"]["unchanged"] = not state_changes
+    if manifest["repository"]["unchanged"] is False:
+        manifest["limitations"].append("Repository status changed during verification.")
+    manifest["cleanup"] = _cleanup_state(
+        run_dir,
+        manifest["run"]["profile"],
+        signal_name,
+        manifest,
+    )
+    if manifest["run"]["profile"] == "perf":
+        comparison_path = run_dir / "performance-comparison.json"
+        if comparison_path.is_file():
+            try:
+                comparison = json.loads(comparison_path.read_text(encoding="utf-8"))
+                comparison_cleanup = comparison.get("cleanup")
+                if not isinstance(comparison_cleanup, dict):
+                    raise ValueError("missing cleanup")
+                manifest["cleanup"] = comparison_cleanup
+                if comparison_cleanup.get("status") != "completed" and status == "passed":
+                    status = "failed"
+                    exit_status = exit_status or 1
+                    manifest["status"] = status
+                    manifest["exit_status"] = exit_status
+                    manifest["limitations"].append(
+                        "Performance comparison cleanup was not confirmed complete."
+                    )
+            except (OSError, ValueError, json.JSONDecodeError) as exc:
+                manifest["cleanup"] = {"status": "unknown", "details": []}
+                if status == "passed":
+                    manifest["status"] = "failed"
+                    manifest["exit_status"] = exit_status or 1
+                manifest["limitations"].append(
+                    f"Performance cleanup evidence is invalid ({type(exc).__name__})."
+                )
+    try:
+        cleanup_strict_environment(run_dir, all_runs=True)
+    except (OSError, RuntimeError) as exc:
+        manifest["cleanup"] = {
+            "status": "failed",
+            "details": [f"sensitive runtime cleanup failed ({type(exc).__name__})"],
+        }
+        if manifest["status"] == "passed":
+            manifest["status"] = "failed"
+            manifest["exit_status"] = manifest["exit_status"] or 1
+        manifest["limitations"].append(
+            "Sensitive disposable runtime state may remain after verification."
+        )
+    suspect_paths: set[Path] = set()
+    privacy_blockers = [
+        *sanitize_trace_archives(run_dir, suspect_paths),
+        *remove_known_secret_artifacts(run_dir, suspect_paths),
+    ]
+    prior_privacy_failure = (run_dir / PRIVACY_FAILURE_MARKER).is_file()
+    if privacy_blockers:
+        manifest["status"] = "blocked" if manifest["run"]["profile"] == "doctor" else "failed"
+        manifest["exit_status"] = manifest["exit_status"] or 1
+        manifest["limitations"].extend(privacy_blockers)
+        cleanup_failures = [
+            item for item in privacy_blockers if item.startswith("PRIVACY CLEANUP FAILURE:")
+        ]
+        if cleanup_failures or prior_privacy_failure:
+            manifest["cleanup"] = {
+                "status": "failed",
+                "details": [
+                    "A suspect artifact could not be confirmed absent after privacy cleanup."
+                ],
+            }
+    elif prior_privacy_failure:
+        manifest["status"] = "blocked" if manifest["run"]["profile"] == "doctor" else "failed"
+        manifest["exit_status"] = manifest["exit_status"] or 1
+        manifest["cleanup"] = {
+            "status": "failed",
+            "details": ["A suspect artifact could not be privacy-transformed during this run."],
+        }
+        manifest["limitations"].append(
+            "PRIVACY CLEANUP FAILURE: a suspect artifact failed privacy transformation."
+        )
+    artifacts = _artifact_inventory(run_dir, manifest["limitations"], suspect_paths)
+    manifest["artifacts"] = artifacts
+    _append_artifact_limitations(manifest, artifacts)
+    if manifest["run"]["profile"] in ORCHESTRATION_PROFILES:
+        _append_orchestration_limitations(manifest)
+    manifest["limitations"] = list(dict.fromkeys(manifest["limitations"]))
+    _atomic_write_json(run_dir / "manifest.json", manifest)
+
+
+def _json_string_list(value: str) -> list[str]:
+    parsed = json.loads(value)
+    if not isinstance(parsed, list) or not all(isinstance(item, str) for item in parsed):
+        raise argparse.ArgumentTypeError("expected a JSON array of strings")
+    return parsed
+
+
+def print_summary(run_dir: Path) -> None:
+    manifest = _read_manifest(run_dir)
+    profile = manifest["run"]["profile"]
+    print(f"verification summary: {profile} {manifest['status']}")
+    try:
+        blocker_lines = [
+            line
+            for line in (run_dir / "run.log")
+            .read_text(
+                encoding="utf-8",
+                errors="replace",
+            )
+            .splitlines()
+            if "blocker:" in line.lower() or line.startswith("BLOCKER:")
+        ]
+    except OSError:
+        blocker_lines = []
+    for line in blocker_lines[-3:]:
+        print(line)
+    orchestration = manifest.get("orchestration")
+    if isinstance(orchestration, dict):
+        selected = orchestration.get("selected_lanes", [])
+        print("selected lanes: " + (", ".join(selected) if selected else "none"))
+        for child in manifest.get("children", []):
+            if not isinstance(child, dict):
+                continue
+            detail = f"- {child.get('lane')}: {child.get('status')}"
+            baseline = child.get("baseline_comparison")
+            if isinstance(baseline, dict):
+                detail += f" ({baseline.get('classification', 'could_not_compare')})"
+            detail += f" -> {child.get('manifest') or 'no child manifest'}"
+            print(detail)
+    cleanup = manifest.get("cleanup", {})
+    print(f"cleanup: {cleanup.get('status', 'unknown')}")
+    next_command = "none; verification passed"
+    failed_child = next(
+        (
+            child
+            for child in manifest.get("children", [])
+            if isinstance(child, dict) and child.get("status") != "passed"
+        ),
+        None,
+    )
+    if manifest["status"] == "blocked":
+        target = profile if profile != "doctor" else manifest["run"]["doctor_profile"]
+        next_command = f".agents/skills/verify-omnigent/scripts/verify.sh doctor {target}"
+        base_ref = orchestration.get("base_ref") if isinstance(orchestration, dict) else None
+        if target == "auto" and base_ref:
+            next_command += f" --base-ref {base_ref}"
+    elif failed_child is not None:
+        next_command = (
+            f".agents/skills/verify-omnigent/scripts/verify.sh {failed_child.get('lane')}"
+        )
+    elif manifest["status"] != "passed":
+        next_command = f".agents/skills/verify-omnigent/scripts/verify.sh {profile}"
+    print(f"next command: {next_command}")
+
+
+def assert_finalized(run_dir: Path, expected_status: str) -> None:
+    manifest = _read_manifest(run_dir)
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("finalized manifest schema is invalid")
+    if manifest.get("status") != expected_status:
+        raise ValueError(
+            f"finalized manifest status is {manifest.get('status')!r}, "
+            f"expected {expected_status!r}"
+        )
+    if manifest.get("run", {}).get("phase") != "finished":
+        raise ValueError("manifest did not reach the finished phase")
+    exit_status = manifest.get("exit_status")
+    if not isinstance(exit_status, int) or isinstance(exit_status, bool):
+        raise ValueError("finalized manifest exit status is invalid")
+    if expected_status == "passed" and exit_status != 0:
+        raise ValueError("passed manifest has a nonzero exit status")
+    if expected_status != "passed" and exit_status == 0:
+        raise ValueError("non-passed manifest has a zero exit status")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="action", required=True)
+
+    init_parser = subparsers.add_parser("init")
+    init_parser.add_argument("--run-dir", type=Path, required=True)
+    init_parser.add_argument("--profile", required=True)
+    init_parser.add_argument("--doctor-profile", required=True)
+
+    prepare_parser = subparsers.add_parser("prepare")
+    prepare_parser.add_argument("--run-dir", type=Path, required=True)
+    prepare_parser.add_argument("--phase", required=True)
+    prepare_parser.add_argument("--argv-json", type=_json_string_list, required=True)
+    prepare_parser.add_argument("--tests-json", type=_json_string_list, required=True)
+
+    plan_parser = subparsers.add_parser("record-plan")
+    plan_parser.add_argument("--run-dir", type=Path, required=True)
+    plan_parser.add_argument("--plan", type=Path, required=True)
+
+    child_parser = subparsers.add_parser("add-child")
+    child_parser.add_argument("--run-dir", type=Path, required=True)
+    child_parser.add_argument("--lane", required=True)
+    child_parser.add_argument("--child-manifest", type=Path, required=True)
+    child_parser.add_argument("--exit-status", type=int, required=True)
+
+    register_parser = subparsers.add_parser("register-children")
+    register_parser.add_argument("--run-dir", type=Path, required=True)
+    register_parser.add_argument("--lanes-json", type=_json_string_list, required=True)
+
+    mark_parser = subparsers.add_parser("mark-child")
+    mark_parser.add_argument("--run-dir", type=Path, required=True)
+    mark_parser.add_argument("--lane", required=True)
+    mark_parser.add_argument(
+        "--status",
+        choices=("pending", "running", "passed", "failed", "interrupted", "blocked"),
+        required=True,
+    )
+    mark_parser.add_argument("--reason")
+
+    baseline_parser = subparsers.add_parser("record-baseline")
+    baseline_parser.add_argument("--run-dir", type=Path, required=True)
+    baseline_parser.add_argument("--lane", required=True)
+    baseline_parser.add_argument("--comparison", type=Path, required=True)
+
+    validate_parser = subparsers.add_parser("validate")
+    validate_parser.add_argument("--run-dir", type=Path, required=True)
+    validate_parser.add_argument("--profile", required=True)
+
+    finalize_parser = subparsers.add_parser("finalize")
+    finalize_parser.add_argument("--run-dir", type=Path, required=True)
+    finalize_parser.add_argument(
+        "--status",
+        choices=sorted(FINAL_STATUSES),
+        required=True,
+    )
+    finalize_parser.add_argument("--exit-status", type=int, required=True)
+    finalize_parser.add_argument("--signal")
+
+    assert_parser = subparsers.add_parser("assert-finalized")
+    assert_parser.add_argument("--run-dir", type=Path, required=True)
+    assert_parser.add_argument("--expected-status", choices=sorted(FINAL_STATUSES), required=True)
+
+    summary_parser = subparsers.add_parser("summary")
+    summary_parser.add_argument("--run-dir", type=Path, required=True)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    if args.action == "init":
+        initialize(args.run_dir, args.profile, args.doctor_profile)
+    elif args.action == "prepare":
+        prepare(args.run_dir, args.phase, args.argv_json, args.tests_json)
+    elif args.action == "record-plan":
+        record_plan(args.run_dir, args.plan)
+    elif args.action == "add-child":
+        add_child(args.run_dir, args.lane, args.child_manifest, args.exit_status)
+    elif args.action == "register-children":
+        register_children(args.run_dir, args.lanes_json)
+    elif args.action == "mark-child":
+        mark_child(args.run_dir, args.lane, args.status, args.reason)
+    elif args.action == "record-baseline":
+        record_baseline(args.run_dir, args.lane, args.comparison)
+    elif args.action == "validate":
+        blockers = validate_required_outputs(args.run_dir, args.profile)
+        for blocker in blockers:
+            print(f"verification blocker: {blocker}", file=sys.stderr)
+        raise SystemExit(1 if blockers else 0)
+    elif args.action == "finalize":
+        finalize(args.run_dir, args.status, args.exit_status, args.signal)
+    elif args.action == "assert-finalized":
+        assert_finalized(args.run_dir, args.expected_status)
+    else:
+        print_summary(args.run_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/verify-omnigent/scripts/install-codex.sh
+++ b/.agents/skills/verify-omnigent/scripts/install-codex.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${OMNIGENT_VERIFY_REPO_ROOT:-}" ]]; then
+  repo_root="$OMNIGENT_VERIFY_REPO_ROOT"
+elif repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null)"; then
+  :
+else
+  echo "install-codex: run from the target Git checkout or set OMNIGENT_VERIFY_REPO_ROOT" >&2
+  exit 2
+fi
+repo_root="$(cd "$repo_root" && pwd)"
+source_dir="$repo_root/.agents/skills/verify-omnigent"
+if [[ ! -f "$source_dir/scripts/verify.sh" ]]; then
+  echo "install-codex: target checkout has no canonical verify-omnigent skill: $repo_root" >&2
+  exit 2
+fi
+mode="${1:---host}"
+
+usage() {
+  echo "usage: $0 [--host [SKILLS_DIR] | --bundle AGENT_BUNDLE_DIR]" >&2
+}
+
+install_link() {
+  local skills_dir="$1"
+  local target="$skills_dir/verify-omnigent"
+  mkdir -p "$skills_dir"
+  if [[ -L "$target" && "$(readlink "$target")" == "$source_dir" ]]; then
+    echo "verify-omnigent already installed: $target"
+    return
+  fi
+  if [[ -e "$target" || -L "$target" ]]; then
+    echo "refusing to replace existing Codex skill: $target" >&2
+    return 1
+  fi
+  ln -s "$source_dir" "$target"
+  echo "installed verify-omnigent for Codex: $target"
+}
+
+install_copy() {
+  local bundle_dir="$1"
+  local target="$bundle_dir/skills/verify-omnigent"
+  if [[ ! -f "$bundle_dir/config.yaml" && ! -f "$bundle_dir/agent.yaml" ]]; then
+    echo "not an Omnigent agent bundle (missing config.yaml or agent.yaml): $bundle_dir" >&2
+    return 1
+  fi
+  if [[ -e "$target" || -L "$target" ]]; then
+    echo "refusing to replace existing bundled skill: $target" >&2
+    return 1
+  fi
+  mkdir -p "$bundle_dir/skills"
+  python3 -c \
+    'import shutil, sys; shutil.copytree(sys.argv[1], sys.argv[2], symlinks=False)' \
+    "$source_dir" "$target"
+  echo "copied verify-omnigent into agent bundle: $target"
+}
+
+case "$mode" in
+  --host)
+    [[ "$#" -le 2 ]] || {
+      usage
+      exit 2
+    }
+    install_link "${2:-$HOME/.codex/skills}"
+    ;;
+  --bundle)
+    [[ "$#" -eq 2 ]] || {
+      usage
+      exit 2
+    }
+    install_copy "$2"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/.agents/skills/verify-omnigent/scripts/orchestration.py
+++ b/.agents/skills/verify-omnigent/scripts/orchestration.py
@@ -1,0 +1,673 @@
+#!/usr/bin/env python3
+"""Select fail-closed Omnigent verification lanes from repository changes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+
+LANE_ORDER = (
+    "quality-gates",
+    "server",
+    "harness-client",
+    "cli",
+    "web-ui",
+    "desktop",
+    "automations",
+    "collaboration",
+    "db-migration-deploy",
+    "perf",
+)
+ALL_SURFACES = frozenset(
+    (
+        "quality-gates",
+        "server",
+        "harness-client",
+        "cli",
+        "web-ui",
+        "desktop",
+        "automations",
+        "collaboration",
+    )
+)
+
+OPTIONAL_LANES = (
+    {
+        "lane": "disposable-backend-install",
+        "status": "not_requested",
+        "reason": "A clean-room dependency install needs package-network access.",
+        "opt_in": ".agents/skills/verify-omnigent/scripts/verify.sh backend",
+    },
+    {
+        "lane": "harness-live",
+        "status": "not_requested",
+        "reason": "Live harness turns need a selected adapter and gateway credentials.",
+        "opt_in": (
+            "OMNIGENT_VERIFY_HARNESS=<name> "
+            ".agents/skills/verify-omnigent/scripts/verify.sh harness-live"
+        ),
+    },
+    {
+        "lane": "cli-live-repl",
+        "status": "not_requested",
+        "reason": "The credentialed CLI REPL writes diagnostics under the inherited HOME.",
+        "opt_in": (
+            "Follow .claude/skills/cli-setup-verify/SKILL.md and run repl-commands "
+            "with --inherit-home only after accepting that write boundary."
+        ),
+    },
+    {
+        "lane": "electron-release",
+        "status": "not_requested",
+        "reason": "Signing and notarization need Apple release credentials.",
+        "opt_in": (
+            "Set the credentials documented in web/electron/README.md, then run "
+            "pnpm --dir web/electron run build:mac:release -- --publish never"
+        ),
+    },
+    {
+        "lane": "downstream-universe",
+        "status": "not_requested",
+        "reason": "Downstream compatibility reads a sibling checkout and remains explicit opt-in.",
+        "opt_in": (
+            ".agents/skills/verify-omnigent/scripts/verify.sh auto "
+            "--with-universe --oss-ref <commit>"
+        ),
+    },
+)
+
+_VERIFICATION_PREFIXES = (
+    ".agents/skills/verify-omnigent/",
+    ".claude/skills/verify-omnigent/",
+    ".cursor/skills/verify-omnigent/",
+    "tests/verify_omnigent/",
+)
+_DESKTOP_PREFIXES = (
+    "web/electron/",
+    "tests/e2e_ui/desktop/",
+    "tests/e2e_ui/browser/",
+)
+_CLI_PREFIXES = (
+    "omnigent/onboarding/",
+    "omnigent/repl/",
+    "tests/cli/",
+    "tests/onboarding/",
+    ".claude/skills/cli-setup-verify/",
+)
+_HARNESS_PREFIXES = (
+    "integrations/",
+    "omnigent/inner/",
+    "omnigent/runtime/harnesses/",
+    "omnigent/runner/",
+    "omnigent/host/",
+    "sdks/",
+    "tests/host/",
+    "tests/harness_bench/",
+    "tests/inner/",
+    "tests/frontends/",
+    "tests/e2e/",
+)
+_SERVER_PREFIXES = (
+    "integrations/",
+    "omnigent/server/",
+    "omnigent/runtime/",
+    "omnigent/db/",
+    "omnigent/stores/",
+    "omnigent/entities/",
+    "tests/server/",
+    "tests/runtime/",
+    "tests/db/",
+    "tests/stores/",
+    "deploy/",
+    "tests/deploy/",
+)
+_CLI_FILES = {
+    "omnigent/cli.py",
+    "omnigent/_terminal_picker_theme.py",
+    "scripts/install_oss.sh",
+}
+_HARNESS_FILES = {
+    "omnigent/claude_model_vocabulary.py",
+    "omnigent/gateway_inference.py",
+    "omnigent/model_fallbacks.py",
+    "tests/test_claude_native_bridge.py",
+    "tests/test_gateway_inference.py",
+}
+_SERVER_FILES = {
+    "omnigent/gateway_inference.py",
+    "omnigent/host/identity.py",
+    "omnigent/runner/identity.py",
+    "tests/test_gateway_inference.py",
+}
+_QUALITY_ONLY_FILES = {
+    ".gitignore",
+    ".pre-commit-config.yaml",
+    "scripts/barrier1_apply_check.sh",
+    "scripts/verify_smart_routing.sh",
+}
+_SHARED_PYTHON_FILES = {
+    "pyproject.toml",
+    "uv.lock",
+    "uv.toml",
+    "setup.py",
+}
+_SHARED_WEB_FILES = {
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+}
+_SETUP_WEB_BUILD_TEST_FILES = {
+    "tests/test_setup_web_ui_build.py",
+}
+_SHARED_PLAYWRIGHT_EVIDENCE_FILES = {
+    "tests/e2e_ui/conftest.py",
+    "tests/e2e_ui/playwright_evidence.py",
+    "tests/e2e_ui/test_evidence_contract.py",
+}
+_AUTOMATION_PREFIXES = (
+    "omnigent/automations/",
+    "omnigent/server/routes/scheduled",
+    "omnigent/stores/scheduled",
+    "tests/e2e_ui/scheduled/",
+    "tests/server/integration/test_scheduled",
+    "tests/stores/test_scheduled",
+    "tests/runner/test_scheduled",
+)
+_COLLABORATION_PREFIXES = (
+    "omnigent/server/routes/sharing",
+    "omnigent/server/routes/permissions",
+    "omnigent/server/routes/sessions/routes_permissions",
+    "omnigent/server/routes/account_auth/",
+    "omnigent/server/routes/accounts_auth/",
+    "omnigent/server/routes/auth/",
+    "omnigent/server/routes/identity/",
+    "omnigent/server/routes/roles/",
+    "omnigent/server/routes/session_authorization/",
+    "tests/e2e_ui/auth/",
+    "tests/e2e_ui/collaboration/",
+    "tests/e2e/test_sharing",
+    "tests/e2e/test_managed_runner_http_auth",
+    "tests/integration/test_sharing",
+    "tests/server/integration/test_accounts_auth",
+    "tests/server/integration/test_oidc",
+    "tests/server/routes/test_auth",
+    "tests/server/test_accounts",
+    "tests/server/test_admin_list",
+    "tests/server/test_device_auth",
+    "tests/server/test_identity_migration",
+    "tests/server/test_oidc",
+    "tests/server/routes/test_sessions_sharing",
+)
+_COLLABORATION_FILES = {
+    "omnigent/entities/account.py",
+    "omnigent/entities/permission.py",
+    "omnigent/host/identity.py",
+    "omnigent/runner/identity.py",
+    "omnigent/server/accounts_bootstrap.py",
+    "omnigent/server/accounts_config.py",
+    "omnigent/server/accounts_secret.py",
+    "omnigent/server/accounts_store.py",
+    "omnigent/server/auth.py",
+    "omnigent/server/identity_migration.py",
+    "omnigent/server/oidc.py",
+    "omnigent/server/oidc_access.py",
+    "omnigent/server/permissions.py",
+    "omnigent/server/routes/_auth_helpers.py",
+    "omnigent/server/routes/_session_create_validation.py",
+    "omnigent/server/routes/accounts_auth.py",
+    "omnigent/server/routes/auth.py",
+    "omnigent/server/routes/device_auth.py",
+    "omnigent/server/routes/session_policies.py",
+    "omnigent/server/routes/sessions/routes_core.py",
+    "omnigent/server/routes/sessions/routes_hooks.py",
+    "sdks/python-client/omnigent_client/_client.py",
+    "tests/e2e_ui/sessions/test_sidebar_ownership_gating.py",
+    "tests/entities/test_permission.py",
+    "tests/server/integration/test_runner_ownership.py",
+    "tests/server/integration/test_sessions_permission_request_hook.py",
+    "tests/server/integration/test_sessions_permissions.py",
+    "tests/server/routes/test_accounts_auth_helpers.py",
+    "tests/server/routes/test_shell_permission_gate.py",
+    "tests/server/test_permissions.py",
+    "tests/stores/test_permission_store.py",
+    "web/src/components/PermissionsModal.tsx",
+    "web/src/components/PermissionsModal.test.tsx",
+    "web/src/components/PermissionsModal.safety.test.tsx",
+    "web/src/hooks/usePermissions.ts",
+    "web/src/hooks/usePermissions.test.tsx",
+    "web/src/lib/identity.ts",
+    "web/src/lib/identity.test.ts",
+    "web/src/lib/accountsApi.ts",
+    "web/src/lib/accountsApi.test.ts",
+    "web/src/lib/permissionsApi.ts",
+    "web/src/lib/permissionsApi.test.ts",
+    "web/src/hooks/useIsAdmin.ts",
+    "web/src/hooks/useMe.ts",
+    "web/src/pages/LoginPage.tsx",
+    "web/src/pages/LoginPage.test.tsx",
+    "web/src/pages/MembersPage.tsx",
+    "web/src/pages/MembersPage.test.tsx",
+    "web/src/pages/RegisterPage.tsx",
+    "web/src/pages/RegisterPage.test.tsx",
+    "web/src/pages/SetupPage.tsx",
+    "web/src/pages/SetupPage.test.tsx",
+}
+_DB_DEPLOY_PREFIXES = (
+    "omnigent/db/",
+    "omnigent/stores/",
+    "deploy/",
+    "tests/db/test_migration",
+    "tests/deploy/",
+)
+_PERF_SENSITIVE_PREFIXES = (
+    "dev/benchmarks/omnigent/",
+    "omnigent/server/routes/sessions",
+    "omnigent/server/routes/conversations",
+    "omnigent/runtime/stream",
+    "tests/benchmarks/",
+)
+_QUALITY_PREFIXES = (
+    ".github/workflows/",
+    "deploy/",
+    "examples/",
+    "omnigent/",
+    "scripts/",
+    "sdks/",
+    "tests/",
+    "web/",
+)
+_IGNORED_PREFIXES = (
+    "designs/",
+    "docs/",
+)
+_IGNORED_FILES = {
+    "AGENTS.md",
+    "CLAUDE.md",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "README.md",
+}
+
+
+def _under(path: str, prefixes: tuple[str, ...]) -> bool:
+    return any(path.startswith(prefix) for prefix in prefixes)
+
+
+def _add_reason(
+    reasons: dict[str, list[str]],
+    lane: str,
+    path: str,
+    explanation: str,
+) -> None:
+    reasons[lane].append(f"{path}: {explanation}")
+
+
+def select_lanes(changed_files: list[str]) -> dict[str, object]:
+    """Map changed files to every applicable local verification lane."""
+    normalized = sorted(
+        dict.fromkeys(
+            path[2:] if path.startswith("./") else path for path in changed_files if path
+        )
+    )
+    reasons: dict[str, list[str]] = {lane: [] for lane in LANE_ORDER}
+    blockers: list[str] = []
+
+    for path in normalized:
+        path_parts = Path(path).parts
+        if Path(path).is_absolute() or ".." in path_parts or path.startswith("-"):
+            blockers.append(
+                f"Unsafe changed path {path!r} cannot be passed to verification tools."
+            )
+            continue
+        if "/__pycache__/" in path or path.endswith((".pyc", ".pyo")):
+            continue
+        if _under(path, _VERIFICATION_PREFIXES):
+            for lane in (lane for lane in LANE_ORDER if lane != "perf"):
+                if not reasons[lane]:
+                    _add_reason(
+                        reasons,
+                        lane,
+                        path,
+                        "the canonical verification path can change this lane",
+                    )
+            continue
+
+        matched = False
+        if _under(path, _DESKTOP_PREFIXES) or path == ".github/workflows/electron-build.yml":
+            _add_reason(reasons, "desktop", path, "Electron shell or desktop journey changed")
+            matched = True
+        if path.startswith("web/") and not path.startswith("web/electron/"):
+            _add_reason(reasons, "web-ui", path, "browser UI code or tests changed")
+            matched = True
+        if path.startswith("tests/e2e_ui/") and not _under(path, _DESKTOP_PREFIXES):
+            _add_reason(reasons, "web-ui", path, "browser journey infrastructure changed")
+            matched = True
+        if path in _SHARED_PLAYWRIGHT_EVIDENCE_FILES:
+            _add_reason(reasons, "desktop", path, "shared Playwright evidence changed")
+            matched = True
+        if path in _SETUP_WEB_BUILD_TEST_FILES:
+            matched = True
+        if _under(path, _CLI_PREFIXES) or path in _CLI_FILES or path.endswith("_cli.py"):
+            _add_reason(reasons, "cli", path, "CLI setup, onboarding, or terminal flow changed")
+            matched = True
+        if (
+            _under(path, _HARNESS_PREFIXES)
+            or path in _HARNESS_FILES
+            or (
+                path.startswith("omnigent/")
+                and ("native" in Path(path).name or "harness" in Path(path).name)
+            )
+        ):
+            _add_reason(
+                reasons, "harness-client", path, "harness, runner, host, or client changed"
+            )
+            matched = True
+        if _under(path, _SERVER_PREFIXES) or path in _SERVER_FILES:
+            _add_reason(
+                reasons, "server", path, "server, runtime, storage, or deployment code changed"
+            )
+            matched = True
+        if _under(path, _AUTOMATION_PREFIXES):
+            _add_reason(reasons, "automations", path, "scheduled-task behavior changed")
+            matched = True
+        if _under(path, _COLLABORATION_PREFIXES) or path in _COLLABORATION_FILES:
+            _add_reason(
+                reasons,
+                "collaboration",
+                path,
+                "authentication, identity, sharing, or permission behavior changed",
+            )
+            matched = True
+        if _under(path, _DB_DEPLOY_PREFIXES):
+            _add_reason(
+                reasons,
+                "db-migration-deploy",
+                path,
+                "database migration, schema, store, or deployment behavior changed",
+            )
+            matched = True
+        if _under(path, _PERF_SENSITIVE_PREFIXES):
+            _add_reason(reasons, "perf", path, "latency-sensitive request path changed")
+            matched = True
+        if path in _QUALITY_ONLY_FILES:
+            matched = True
+        if path in _SHARED_PYTHON_FILES:
+            for lane in ("server", "harness-client", "cli"):
+                _add_reason(reasons, lane, path, "shared Python dependency or build input changed")
+            matched = True
+        if path in _SHARED_WEB_FILES:
+            for lane in ("web-ui", "desktop"):
+                _add_reason(
+                    reasons, lane, path, "shared JavaScript dependency or workspace input changed"
+                )
+            matched = True
+        if (
+            matched
+            or _under(path, _QUALITY_PREFIXES)
+            or path in _SHARED_PYTHON_FILES
+            or path in _SHARED_WEB_FILES
+        ):
+            _add_reason(
+                reasons,
+                "quality-gates",
+                path,
+                "changed product or test code must pass repository quality checks",
+            )
+
+        if matched:
+            continue
+        if path in _IGNORED_FILES or _under(path, _IGNORED_PREFIXES):
+            continue
+        blockers.append(
+            f"{path} did not map to a verification lane. Add an explicit mapping or "
+            "run all-surfaces."
+        )
+
+    decisions: list[dict[str, object]] = []
+    selected_lanes: list[str] = []
+    for lane in LANE_ORDER:
+        selected = bool(reasons[lane])
+        if selected:
+            selected_lanes.append(lane)
+        decisions.append(
+            {
+                "lane": lane,
+                "status": "selected" if selected else "not_applicable",
+                "reasons": reasons[lane] or ["No changed file mapped to this lane."],
+            }
+        )
+    return {
+        "changed_files": normalized,
+        "selected_lanes": selected_lanes,
+        "decisions": decisions,
+        "blockers": blockers,
+    }
+
+
+def changed_files(repo_root: Path, base_ref: str) -> tuple[list[str], list[str]]:
+    """Return branch-point changes plus tracked local and untracked files."""
+    base = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{base_ref}^{{commit}}"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if base.returncode != 0:
+        return [], [
+            f"Base ref {base_ref!r} is unavailable. Fetch it or set "
+            "OMNIGENT_VERIFY_BASE_REF to an existing commit."
+        ]
+
+    head = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD^{commit}"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if head.returncode != 0:
+        return [], ["HEAD is unavailable; changed-file discovery cannot continue."]
+
+    merge_base = subprocess.run(
+        ["git", "merge-base", "--all", base.stdout.strip(), head.stdout.strip()],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    merge_bases = merge_base.stdout.splitlines()
+    if merge_base.returncode != 0 or len(merge_bases) != 1:
+        detail = merge_base.stderr.strip()
+        suffix = f" ({detail})" if detail else ""
+        return [], [
+            f"Base ref {base_ref!r} has no unique merge base with HEAD{suffix}. "
+            "Fetch the complete history or choose the PR base ref."
+        ]
+
+    commands = (
+        (
+            "git",
+            "diff",
+            "--name-status",
+            "-z",
+            "--find-renames",
+            "--find-copies-harder",
+            "--diff-filter=ACDMRTUXB",
+            merge_bases[0],
+            head.stdout.strip(),
+            "--",
+        ),
+        (
+            "git",
+            "diff",
+            "--name-status",
+            "-z",
+            "--find-renames",
+            "--find-copies-harder",
+            "--diff-filter=ACDMRTUXB",
+            "HEAD",
+            "--",
+        ),
+        (
+            "git",
+            "diff",
+            "--name-status",
+            "-z",
+            "--find-renames",
+            "--find-copies-harder",
+            "--diff-filter=ACDMRTUXB",
+            "--",
+        ),
+        ("git", "ls-files", "-z", "--others", "--exclude-standard"),
+    )
+    results = [
+        subprocess.run(
+            command,
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+        )
+        for command in commands
+    ]
+    failures = [
+        result.stderr.decode("utf-8", "replace").strip() or "git changed-file discovery failed"
+        for result in results
+        if result.returncode != 0
+    ]
+    if failures:
+        return [], failures
+    paths: list[str] = []
+    for index, result in enumerate(results):
+        fields = [os.fsdecode(raw) for raw in result.stdout.split(b"\0") if raw]
+        if index == len(results) - 1:
+            paths.extend(fields)
+            continue
+        cursor = 0
+        while cursor < len(fields):
+            status = fields[cursor]
+            cursor += 1
+            path_count = 2 if status[:1] in {"R", "C"} else 1
+            if cursor + path_count > len(fields):
+                return [], ["git returned malformed name-status output"]
+            paths.extend(fields[cursor : cursor + path_count])
+            cursor += path_count
+    return list(dict.fromkeys(paths)), []
+
+
+def build_plan(
+    repo_root: Path,
+    profile: str,
+    base_ref: str,
+    with_universe: bool = False,
+) -> dict[str, object]:
+    if profile == "all-surfaces":
+        selected = [lane for lane in LANE_ORDER if lane in ALL_SURFACES]
+        selection = {
+            "changed_files": [],
+            "selected_lanes": selected,
+            "decisions": [
+                {
+                    "lane": lane,
+                    "status": "selected",
+                    "reasons": ["Explicit all-surfaces verification was requested."],
+                }
+                for lane in selected
+            ],
+            "blockers": [],
+        }
+    else:
+        files, discovery_blockers = changed_files(repo_root, base_ref)
+        selection = select_lanes(files)
+        selected_blockers = selection.get("blockers")
+        if not isinstance(selected_blockers, list) or not all(
+            isinstance(item, str) for item in selected_blockers
+        ):
+            raise RuntimeError("lane selection returned invalid blockers")
+        selection["blockers"] = [*discovery_blockers, *selected_blockers]
+    if with_universe:
+        selected_lanes = selection.get("selected_lanes")
+        decisions = selection.get("decisions")
+        if not isinstance(selected_lanes, list) or not isinstance(decisions, list):
+            raise RuntimeError("lane selection returned invalid lists")
+        selected_lanes.append("universe")
+        decisions.append(
+            {
+                "lane": "universe",
+                "status": "selected",
+                "reasons": ["Explicit downstream Universe verification was requested."],
+            }
+        )
+    return {
+        "schema_version": 1,
+        "profile": profile,
+        "base_ref": base_ref if profile == "auto" else None,
+        **selection,
+        "optional_lanes": [
+            dict(item)
+            for item in OPTIONAL_LANES
+            if not (with_universe and item["lane"] == "downstream-universe")
+        ],
+    }
+
+
+def _atomic_write(path: Path, value: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(value, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--profile", choices=("auto", "all-surfaces"), required=True)
+    parser.add_argument("--base-ref", default="HEAD")
+    parser.add_argument("--with-universe", action="store_true")
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    plan = build_plan(
+        args.repo_root.resolve(),
+        args.profile,
+        args.base_ref,
+        args.with_universe,
+    )
+    _atomic_write(args.output, plan)
+    selected_lanes = plan.get("selected_lanes")
+    decisions = plan.get("decisions")
+    blockers = plan.get("blockers")
+    if (
+        not isinstance(selected_lanes, list)
+        or not all(isinstance(item, str) for item in selected_lanes)
+        or not isinstance(decisions, list)
+        or not all(isinstance(item, dict) for item in decisions)
+        or not isinstance(blockers, list)
+        or not all(isinstance(item, str) for item in blockers)
+    ):
+        raise RuntimeError("verification plan has an invalid schema")
+    print("verification lanes: " + (", ".join(selected_lanes) if selected_lanes else "none"))
+    for decision in decisions:
+        print(f"  {decision['lane']}: {decision['status']}")
+        reasons = decision.get("reasons")
+        if not isinstance(reasons, list):
+            raise RuntimeError("verification decision has invalid reasons")
+        for reason in reasons:
+            print(f"    - {reason}")
+    for blocker in blockers:
+        print(f"BLOCKER: {blocker}")
+    raise SystemExit(3 if blockers else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/verify-omnigent/scripts/profile_runner.py
+++ b/.agents/skills/verify-omnigent/scripts/profile_runner.py
@@ -1,0 +1,1349 @@
+#!/usr/bin/env python3
+"""Run the grounded command sequence for one Omnigent verification profile."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import hmac
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from runtime_support import (
+    CREDENTIAL_MODE_ENV,
+    compare_snapshots,
+    inherited_managed_fds,
+    playwright_browser_snapshot,
+    portable_argv,
+    repository_snapshot,
+    strict_environment,
+    terminate_group,
+)
+
+
+@dataclass(frozen=True)
+class Step:
+    name: str
+    argv: tuple[str, ...]
+    environment: dict[str, str] = field(default_factory=dict)
+    cwd: str = "."
+    isolated: bool = False
+
+
+def _ui_pytest(
+    tests: tuple[str, ...],
+    run_dir: str,
+) -> tuple[str, ...]:
+    return (
+        "uv",
+        "run",
+        "--no-sync",
+        "pytest",
+        *tests,
+        "-v",
+        "-m",
+        "not visual",
+        "--screenshot=on",
+        "--tracing=on",
+        "--video=retain-on-failure",
+        "-o",
+        "junit_family=legacy",
+        f"--output={run_dir}/playwright",
+        f"--junitxml={run_dir}/junit.xml",
+    )
+
+
+def profile_steps(
+    profile: str,
+    run_dir: str,
+    harness: str | None = None,
+    databricks_profile: str | None = None,
+    base_ref: str = "HEAD",
+    oss_ref: str = "HEAD",
+    changed_files: tuple[str, ...] = (),
+    electron_e2e_tests: tuple[str, ...] = (),
+    skill_root: str = ".agents/skills/verify-omnigent",
+) -> list[Step]:
+    """Construct commands from checked-in CLI, Electron, UI, and bench assets."""
+    if profile == "quality-gates":
+        files = tuple(sorted(dict.fromkeys(changed_files)))
+        pre_commit_scope = ("--files", *files) if files else ("--all-files",)
+        steps = [
+            Step(
+                "Pre-commit checks",
+                (
+                    "uv",
+                    "run",
+                    "--no-sync",
+                    "pre-commit",
+                    "run",
+                    *pre_commit_scope,
+                ),
+                isolated=True,
+            )
+        ]
+        web_changed = not files or any(
+            path.startswith(("tests/e2e_ui/", "web/"))
+            or path
+            in {
+                "package.json",
+                "pnpm-lock.yaml",
+                "pnpm-workspace.yaml",
+                "tests/test_setup_web_ui_build.py",
+            }
+            for path in files
+        )
+        if web_changed:
+            steps.extend(
+                [
+                    Step(
+                        "Web format check",
+                        ("node_modules/.bin/prettier", "--check", "."),
+                        cwd="web",
+                    ),
+                    Step(
+                        "Web lint",
+                        ("node_modules/.bin/oxlint", "--deny-warnings", "."),
+                        cwd="web",
+                    ),
+                    Step(
+                        "Web type check",
+                        ("node_modules/.bin/tsc", "-b", "--noEmit"),
+                        cwd="web",
+                    ),
+                    Step(
+                        "Web production build",
+                        (
+                            "node",
+                            "node_modules/vite/bin/vite.js",
+                            "build",
+                            "--configLoader",
+                            "runner",
+                            "--outDir",
+                            f"{run_dir}/build/web-quality",
+                        ),
+                        cwd="web",
+                    ),
+                ]
+            )
+        selected_contracts = {
+            path
+            for path in files
+            if path.endswith(".py")
+            and path.startswith(("tests/verify_omnigent/", "tests/deploy/"))
+        }
+        if any(
+            path.startswith(
+                (
+                    ".agents/skills/verify-omnigent/",
+                    ".claude/skills/verify-omnigent/",
+                    ".cursor/skills/verify-omnigent/",
+                )
+            )
+            for path in files
+        ):
+            selected_contracts.add("tests/verify_omnigent")
+        if any(path.startswith("deploy/databricks/") and path.endswith(".py") for path in files):
+            selected_contracts.add("tests/deploy/test_databricks_deploy_dry_run.py")
+        if any(
+            path.startswith(("tests/harness_bench/", "dev/benchmarks/omnigent/")) for path in files
+        ):
+            selected_contracts.update(
+                (
+                    "tests/harness_bench/test_bench.py",
+                    "tests/benchmarks/test_benchmark_smoke.py",
+                )
+            )
+        if selected_contracts:
+            steps.append(
+                Step(
+                    "Selected verification and deploy contracts",
+                    (
+                        "uv",
+                        "run",
+                        "--no-sync",
+                        "pytest",
+                        *sorted(selected_contracts),
+                        "-q",
+                    ),
+                )
+            )
+        evidence_contract = "tests/e2e_ui/test_evidence_contract.py"
+        evidence_implementation_changed = any(
+            path
+            in {
+                "tests/e2e_ui/conftest.py",
+                "tests/e2e_ui/playwright_evidence.py",
+                evidence_contract,
+            }
+            for path in files
+        )
+        if evidence_implementation_changed:
+            steps.append(
+                Step(
+                    "Playwright evidence contract",
+                    _ui_pytest((evidence_contract,), run_dir),
+                )
+            )
+        return steps
+    if profile == "perf":
+        return [
+            Step(
+                "Performance benchmark",
+                (
+                    "uv",
+                    "run",
+                    "--no-sync",
+                    "dev/benchmarks/omnigent/run.py",
+                    "--journeys",
+                    "list_sessions,load_conversation_history,time_to_first_token",
+                    "--iterations",
+                    "25",
+                    "--runs",
+                    "3",
+                    "--output",
+                    f"{run_dir}/benchmark.json",
+                ),
+            ),
+        ]
+    if profile == "server":
+        return [
+            Step(
+                "Server API and app integration",
+                (
+                    "uv",
+                    "run",
+                    "--no-sync",
+                    "pytest",
+                    "tests/server/test_app.py",
+                    "tests/server/integration/test_app.py",
+                    "-q",
+                    f"--junitxml={run_dir}/junit.xml",
+                ),
+            ),
+        ]
+    if profile == "db-migration-deploy":
+        return [
+            Step(
+                "Database migration and deploy contracts",
+                (
+                    "uv",
+                    "run",
+                    "--no-sync",
+                    "pytest",
+                    "tests/db",
+                    "tests/stores",
+                    "tests/deploy",
+                    "-q",
+                    f"--junitxml={run_dir}/junit.xml",
+                ),
+            ),
+        ]
+    if profile == "cli":
+        driver = ".claude/skills/cli-setup-verify/verify_cli.py"
+        common = (".venv/bin/python", driver, "--repo", ".")
+        return [
+            Step(
+                "CLI isolation",
+                (
+                    *common,
+                    "--scenario",
+                    "check-isolation",
+                    "--artifacts",
+                    f"{run_dir}/cli/isolation",
+                ),
+            ),
+            Step(
+                "CLI cold start",
+                (
+                    *common,
+                    "--scenario",
+                    "cold-start",
+                    "--strip-path",
+                    "--artifacts",
+                    f"{run_dir}/cli/cold-start",
+                ),
+            ),
+            Step(
+                "CLI top-level help",
+                (
+                    *common,
+                    "--scenario",
+                    "help-snapshot",
+                    "--artifacts",
+                    f"{run_dir}/cli/help",
+                ),
+            ),
+            Step(
+                "CLI server help",
+                (
+                    *common,
+                    "--scenario",
+                    "help-snapshot",
+                    "--subcommand",
+                    "server",
+                    "--artifacts",
+                    f"{run_dir}/cli/server-help",
+                ),
+            ),
+        ]
+    if profile == "web-ui":
+        return [
+            Step("Web unit tests", ("node_modules/.bin/vitest", "run"), cwd="web"),
+            Step(
+                "Web type check",
+                ("node_modules/.bin/tsc", "-b", "--noEmit"),
+                cwd="web",
+            ),
+            Step(
+                "Web core journey",
+                _ui_pytest(
+                    (
+                        "tests/e2e_ui/chat/test_smoke.py",
+                        "tests/e2e_ui/start_session/test_start_session.py",
+                        "tests/e2e_ui/files/test_file_autosave.py",
+                        "tests/e2e_ui/collaboration/test_permissions_modal.py",
+                        "tests/e2e_ui/collaboration/test_sharing_mode_off.py",
+                    ),
+                    run_dir,
+                ),
+            ),
+        ]
+    if profile == "desktop":
+        steps = [
+            Step(
+                "Electron unit tests",
+                ("node", "--test"),
+                cwd="web/electron",
+            ),
+            Step(
+                "Web production build",
+                (
+                    "node",
+                    "node_modules/vite/bin/vite.js",
+                    "build",
+                    "--configLoader",
+                    "runner",
+                    "--outDir",
+                    f"{run_dir}/build/web-desktop",
+                ),
+                cwd="web",
+            ),
+        ]
+        if electron_e2e_tests:
+            steps.append(
+                Step(
+                    "Electron JavaScript Playwright journeys",
+                    ("node", "--test", "--test-concurrency=1", *electron_e2e_tests),
+                )
+            )
+        steps.extend(
+            [
+                Step(
+                    "Browser desktop-mode Playwright journeys",
+                    _ui_pytest(
+                        ("tests/e2e_ui/desktop", "tests/e2e_ui/browser"),
+                        run_dir,
+                    ),
+                ),
+                Step(
+                    "Electron overlay build",
+                    (
+                        "node",
+                        "node_modules/vite/bin/vite.js",
+                        "build",
+                        "--configLoader",
+                        "runner",
+                        "--config",
+                        "vite.update-overlay.config.ts",
+                        "--outDir",
+                        f"{run_dir}/build/electron-overlay",
+                    ),
+                    cwd="web",
+                ),
+                Step(
+                    "Electron current-platform package",
+                    (
+                        "node_modules/.bin/electron-builder",
+                        "--publish",
+                        "never",
+                        f"--config.directories.output={run_dir}/build/electron-package",
+                    ),
+                    {"CSC_IDENTITY_AUTO_DISCOVERY": "false"},
+                    cwd="web/electron",
+                ),
+            ]
+        )
+        return steps
+    if profile == "harness-client":
+        return [
+            Step(
+                "Harness bench tests",
+                (
+                    "uv",
+                    "run",
+                    "--no-sync",
+                    "pytest",
+                    "tests/harness_bench",
+                    "-q",
+                    f"--junitxml={run_dir}/junit.xml",
+                ),
+            ),
+            Step(
+                "Offline harness capability matrix",
+                (
+                    "uv",
+                    "run",
+                    "--no-sync",
+                    "python",
+                    "-m",
+                    "tests.harness_bench",
+                    "--no-live",
+                    "--json",
+                    "--report",
+                    f"{run_dir}/harness-matrix.json",
+                ),
+            ),
+        ]
+    if profile == "harness-live":
+        if not harness:
+            raise ValueError("OMNIGENT_VERIFY_HARNESS is required for harness-live")
+        command = [
+            "uv",
+            "run",
+            "--no-sync",
+            "python",
+            "-m",
+            "tests.harness_bench",
+            "--live",
+            "--harness",
+            harness,
+            "--json",
+            "--report",
+            f"{run_dir}/harness-live.json",
+        ]
+        if databricks_profile:
+            command.extend(("--profile", databricks_profile))
+        return [
+            Step("Live harness capability probe", tuple(command)),
+        ]
+    if profile == "universe":
+        return [
+            Step(
+                "Universe downstream preflight",
+                (
+                    "python3",
+                    f"{skill_root}/scripts/universe_preflight.py",
+                    "--repo-root",
+                    ".",
+                    "--run-dir",
+                    run_dir,
+                    "--base-ref",
+                    base_ref,
+                    "--oss-ref",
+                    oss_ref,
+                ),
+            )
+        ]
+    raise ValueError(f"unsupported composite profile: {profile}")
+
+
+def _atomic_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(value, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def _validate_live_harness_report(path: Path) -> str | None:
+    try:
+        report = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return f"Live harness report is unavailable ({type(exc).__name__})."
+    harnesses = report.get("harnesses") if isinstance(report, dict) else None
+    if not isinstance(harnesses, list) or not harnesses:
+        return "Live harness report contains no harness result."
+    for harness in harnesses:
+        if not isinstance(harness, dict):
+            return "Live harness report contains an invalid harness result."
+        if harness.get("skipped_reason"):
+            return f"Harness was unavailable: {harness['skipped_reason']}"
+        cells = harness.get("cells")
+        if not isinstance(cells, list):
+            return "Live harness report contains no capability cells."
+        basic = next(
+            (
+                cell
+                for cell in cells
+                if isinstance(cell, dict) and cell.get("dimension") == "basic_turn"
+            ),
+            None,
+        )
+        if basic is None or basic.get("observed") != "supported":
+            observed = basic.get("observed") if isinstance(basic, dict) else "missing"
+            return f"Required live basic turn did not pass (observed={observed})."
+    return None
+
+
+def _validate_offline_harness_report(path: Path) -> str | None:
+    try:
+        report = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return f"Offline harness report is unavailable ({type(exc).__name__})."
+    if not isinstance(report, dict) or report.get("schema_version") != 1:
+        return "Offline harness report has an unsupported schema."
+    harnesses = report.get("harnesses")
+    expected_dimensions = report.get("dimensions")
+    if not isinstance(harnesses, list) or not harnesses:
+        return "Offline harness report contains no harness results."
+    if (
+        not isinstance(expected_dimensions, list)
+        or not expected_dimensions
+        or not all(isinstance(item, str) and item for item in expected_dimensions)
+        or len(set(expected_dimensions)) != len(expected_dimensions)
+        or "basic_turn" not in expected_dimensions
+    ):
+        return "Offline harness report has no supported capability dimension contract."
+    if report.get("has_drift") is not False:
+        return "Offline harness report does not confirm a drift-free declared matrix."
+    for harness in harnesses:
+        if not isinstance(harness, dict) or not isinstance(harness.get("harness"), str):
+            return "Offline harness report contains an invalid harness result."
+        cells = harness.get("cells")
+        if not isinstance(cells, list) or not cells:
+            return f"Offline harness {harness['harness']} contains no capability cells."
+        dimensions = [cell.get("dimension") for cell in cells if isinstance(cell, dict)]
+        if len(dimensions) != len(cells) or dimensions != expected_dimensions:
+            return f"Offline harness {harness['harness']} has incomplete capability cells."
+        if any(
+            cell.get("observed") not in {"skipped", "not_applicable"}
+            or cell.get("declared")
+            not in {"supported", "unsupported", "partial", "not_applicable", "unknown"}
+            for cell in cells
+        ):
+            return f"Offline harness {harness['harness']} has invalid offline verdicts."
+    return None
+
+
+def _desktop_build_report(run_dir: Path) -> str | None:
+    dist = run_dir / "build" / "electron-package"
+    outputs = []
+    if dist.is_dir():
+        for path in sorted(dist.rglob("*")):
+            if not path.is_file() or path.is_symlink():
+                continue
+            digest = hashlib.sha256()
+            size = 0
+            with path.open("rb") as handle:
+                while chunk := handle.read(1024 * 1024):
+                    digest.update(chunk)
+                    size += len(chunk)
+            outputs.append(
+                {
+                    "path": path.relative_to(run_dir).as_posix(),
+                    "bytes": size,
+                    "sha256": digest.hexdigest(),
+                }
+            )
+    _atomic_json(
+        run_dir / "desktop-build.json",
+        {
+            "schema_version": 1,
+            "outputs": outputs,
+            "limitation": None,
+        },
+    )
+    if not outputs:
+        return "Electron packaging produced no regular file in the run-owned output directory."
+    return None
+
+
+def _changed_files(repo_root: Path, base_ref: str) -> tuple[str, ...]:
+    base = subprocess.run(
+        ("git", "rev-parse", "--verify", f"{base_ref}^{{commit}}"),
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if base.returncode != 0:
+        reason = base.stderr.strip() or f"base ref {base_ref!r} is unavailable"
+        raise RuntimeError(reason)
+
+    head = subprocess.run(
+        ("git", "rev-parse", "--verify", "HEAD^{commit}"),
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if head.returncode != 0:
+        reason = head.stderr.strip() or "HEAD is unavailable"
+        raise RuntimeError(reason)
+
+    merge_base = subprocess.run(
+        ("git", "merge-base", "--all", base.stdout.strip(), head.stdout.strip()),
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    merge_bases = merge_base.stdout.splitlines()
+    if merge_base.returncode != 0 or len(merge_bases) != 1:
+        reason = merge_base.stderr.strip() or (
+            f"base ref {base_ref!r} has no unique merge base with HEAD"
+        )
+        raise RuntimeError(reason)
+
+    commands = (
+        (
+            "git",
+            "diff",
+            "--name-status",
+            "-z",
+            "--find-renames",
+            "--find-copies-harder",
+            "--diff-filter=ACDMRTUXB",
+            merge_bases[0],
+            head.stdout.strip(),
+            "--",
+        ),
+        (
+            "git",
+            "diff",
+            "--cached",
+            "--name-status",
+            "-z",
+            "--find-renames",
+            "--find-copies-harder",
+            "--diff-filter=ACDMRTUXB",
+            "HEAD",
+            "--",
+        ),
+        (
+            "git",
+            "diff",
+            "--name-status",
+            "-z",
+            "--find-renames",
+            "--find-copies-harder",
+            "--diff-filter=ACDMRTUXB",
+            "--",
+        ),
+        ("git", "ls-files", "-z", "--others", "--exclude-standard"),
+    )
+    files: list[str] = []
+    for index, command in enumerate(commands):
+        result = subprocess.run(
+            command,
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            reason = (
+                result.stderr.decode("utf-8", "replace").strip()
+                or "git changed-file discovery failed"
+            )
+            raise RuntimeError(reason)
+        fields = [os.fsdecode(raw) for raw in result.stdout.split(b"\0") if raw]
+        if index == len(commands) - 1:
+            files.extend(fields)
+            continue
+        cursor = 0
+        while cursor < len(fields):
+            status = fields[cursor]
+            cursor += 1
+            path_count = 2 if status[:1] in {"R", "C"} else 1
+            if cursor + path_count > len(fields):
+                raise RuntimeError("git returned malformed name-status output")
+            files.extend(fields[cursor : cursor + path_count])
+            cursor += path_count
+    return tuple(dict.fromkeys(files))
+
+
+def _electron_e2e_tests(repo_root: Path) -> tuple[str, ...]:
+    root = repo_root / "web" / "electron" / "e2e"
+    return tuple(
+        path.relative_to(repo_root).as_posix()
+        for path in sorted(root.glob("*.e2e.js"))
+        if path.is_file()
+    )
+
+
+def _validate_changed_paths(paths: tuple[str, ...]) -> tuple[str, ...]:
+    for value in paths:
+        path = Path(value)
+        if not value or path.is_absolute() or ".." in path.parts or value.startswith("-"):
+            raise RuntimeError(f"unsafe changed path {value!r}")
+    return paths
+
+
+_DEPENDENCY_PATHS = (
+    ".venv",
+    "node_modules",
+    "web/node_modules",
+    "web/electron/node_modules",
+)
+
+
+def _cow_copy(source: Path, target: Path) -> None:
+    if sys.platform == "darwin":
+        argv = ("cp", "-cR", str(source), str(target))
+    elif sys.platform.startswith("linux"):
+        argv = ("cp", "--reflink=always", "-a", str(source), str(target))
+    else:
+        raise RuntimeError(
+            f"Safe copy-on-write dependency isolation is unsupported on {sys.platform}."
+        )
+    subprocess.run(argv, check=True, capture_output=True)
+
+
+def _rebase_pnpm_shims(
+    source: Path,
+    target: Path,
+    *,
+    source_root: Path,
+    target_root: Path,
+) -> None:
+    marker = "# cmd-shim-target="
+    for shim in target.rglob("*"):
+        if shim.is_symlink() or not shim.is_file() or ".bin" not in shim.parts:
+            continue
+        try:
+            text = shim.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        target_line = next(
+            (line[len(marker) :] for line in text.splitlines() if line.startswith(marker)),
+            None,
+        )
+        if target_line is None:
+            continue
+        virtual_store = target_line.find("/node_modules/.pnpm/")
+        if virtual_store < 0:
+            continue
+        relative_package = target_line[virtual_store + 1 :]
+        local_package = source_root / relative_package
+        if not local_package.exists():
+            shim.unlink()
+            continue
+        rebased_package = target_root / relative_package
+        source_shim = source / shim.relative_to(target)
+        old_relative = os.path.relpath(target_line, source_shim.parent)
+        new_relative = os.path.relpath(rebased_package, shim.parent)
+        old_checkout = target_line[:virtual_store]
+        rebased = text.replace(str(source_root), str(target_root))
+        rebased = rebased.replace(old_checkout, str(target_root))
+        rebased = rebased.replace(old_relative, new_relative)
+        shim.write_text(rebased, encoding="utf-8")
+
+
+def _rebase_pnpm_metadata(target: Path) -> None:
+    metadata = target / ".modules.yaml"
+    virtual_store = target / ".pnpm"
+    if not metadata.is_file() or not virtual_store.is_dir():
+        return
+    try:
+        value = json.loads(metadata.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError("pnpm dependency metadata is unreadable") from exc
+    if not isinstance(value, dict) or not isinstance(value.get("virtualStoreDir"), str):
+        raise RuntimeError("pnpm dependency metadata has no virtual store identity")
+    value["virtualStoreDir"] = ".pnpm"
+    metadata.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _clone_dependency_path(
+    source: Path,
+    target: Path,
+    *,
+    source_root: Path | None = None,
+    target_root: Path | None = None,
+) -> None:
+    source_root = (source_root or source.parent).resolve(strict=True)
+    target_root = (target_root or target.parent).resolve(strict=True)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    _cow_copy(source, target)
+    if target.is_symlink() or not target.exists():
+        raise RuntimeError("Dependency isolation did not create an independent tree.")
+
+    for link in (path for path in target.rglob("*") if path.is_symlink()):
+        source_link = source / link.relative_to(target)
+        source_target = (source_link.parent / os.readlink(source_link)).resolve(strict=False)
+        try:
+            relative_target = source_target.relative_to(source_root)
+            rebased = target_root / relative_target
+            link.unlink()
+            link.symlink_to(
+                os.path.relpath(rebased, link.parent.resolve()),
+                target_is_directory=source_target.is_dir(),
+            )
+            continue
+        except ValueError:
+            pass
+        # pnpm can leave workspace links pointing at an equivalent virtual-store
+        # path in the checkout where install was run. Rebase that package identity
+        # to this checkout when the same package exists locally.
+        for index, part in enumerate(source_target.parts):
+            if part != "node_modules":
+                continue
+            local_equivalent = source_root.joinpath(*source_target.parts[index:])
+            if not local_equivalent.exists():
+                continue
+            rebased = target_root.joinpath(*source_target.parts[index:])
+            link.unlink()
+            link.symlink_to(
+                os.path.relpath(rebased, link.parent.resolve()),
+                target_is_directory=local_equivalent.is_dir(),
+            )
+            break
+        else:
+            try:
+                source_target = source_link.resolve(strict=True)
+            except OSError as exc:
+                raise RuntimeError(
+                    f"External dependency symlink cannot be safely cloned: "
+                    f"{source_link.relative_to(source)}"
+                ) from exc
+            if (
+                source.name == ".venv"
+                and source_link.parent == source / "bin"
+                and source_target.parent.name == "bin"
+                and source_target.name.startswith("python")
+            ):
+                runtime = target / ".python-runtime"
+                if not runtime.exists():
+                    _cow_copy(source_target.parent.parent, runtime)
+                link.unlink()
+                link.symlink_to(os.path.relpath(runtime / "bin" / source_target.name, link.parent))
+                continue
+            link.unlink()
+            _cow_copy(source_target, link)
+    _rebase_pnpm_metadata(target)
+    _rebase_pnpm_shims(
+        source,
+        target,
+        source_root=source_root,
+        target_root=target_root,
+    )
+
+
+def _controlled_environment(
+    repo_root: Path,
+    run_dir: Path,
+    profile: str,
+    overrides: dict[str, str],
+) -> dict[str, str]:
+    trusted_overrides = dict(overrides)
+    if profile in {"server", "harness-client", "harness-live", "cli", "perf", "web-ui", "desktop"}:
+        trusted_overrides["PYTHONPATH"] = str(repo_root.resolve())
+    if profile in {
+        "smoke",
+        "collaboration",
+        "automations",
+        "core",
+        "full-ui",
+        "web-ui",
+        "desktop",
+    }:
+        trusted_overrides["OMNIGENT_WEB_UI_DIST"] = str(
+            (run_dir / "build" / "e2e-web-ui").resolve()
+        )
+    if profile in {"web-ui", "desktop"}:
+        expected_marker = (run_dir / "cleanup.json").resolve()
+        inherited_marker = os.environ.get("OMNIGENT_VERIFY_CLEANUP_MARKER")
+        if inherited_marker is not None and Path(inherited_marker).resolve() != expected_marker:
+            raise RuntimeError("UI cleanup marker is not owned by this verification run")
+        trusted_overrides["OMNIGENT_VERIFY_CLEANUP_MARKER"] = str(expected_marker)
+    return strict_environment(
+        run_dir,
+        extra={
+            "OMNIGENT_VERIFY_REPO_ROOT": str(repo_root),
+            "OMNIGENT_VERIFY_RUN_DIR": str(run_dir),
+            **trusted_overrides,
+        },
+        credentialed=profile == "harness-live",
+        pre_commit=profile == "quality-gates",
+    )
+
+
+def _validate_ui_cleanup_marker(run_dir: Path) -> str | None:
+    marker = run_dir / "cleanup.json"
+    if marker.is_symlink() or not marker.is_file():
+        return "UI pytest did not create its run-owned cleanup marker"
+    try:
+        value = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return "UI pytest cleanup marker is malformed"
+    if (
+        not isinstance(value, dict)
+        or value.get("schema_version") != 1
+        or value.get("status") != "completed"
+        or value.get("exit_status") != 0
+    ):
+        return "UI pytest cleanup marker does not confirm completed cleanup"
+    return None
+
+
+def _copy_working_changes(repo_root: Path, checkout: Path) -> None:
+    diff = subprocess.run(
+        ("git", "diff", "--binary", "HEAD", "--"),
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    )
+    if diff.stdout:
+        subprocess.run(
+            ("git", "apply", "--binary", "--whitespace=nowarn", "-"),
+            cwd=checkout,
+            input=diff.stdout,
+            check=True,
+            capture_output=True,
+        )
+    untracked = subprocess.run(
+        ("git", "ls-files", "--others", "--exclude-standard", "-z"),
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    ).stdout.split(b"\0")
+    for raw in untracked:
+        if not raw:
+            continue
+        relative = Path(os.fsdecode(raw))
+        if relative.is_absolute() or ".." in relative.parts:
+            raise RuntimeError("git returned an unsafe untracked path")
+        source = repo_root / relative
+        target = checkout / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_symlink():
+            target.symlink_to(os.readlink(source))
+        elif source.is_file():
+            shutil.copy2(source, target)
+
+
+@contextlib.contextmanager
+def _isolated_checkout(repo_root: Path, cleanup: dict[str, object]) -> Iterator[Path]:
+    temporary = Path(tempfile.mkdtemp(prefix="omnigent-verify-quality-"))
+    checkout = temporary / "checkout"
+    added = False
+    try:
+        subprocess.run(
+            ("git", "worktree", "add", "--detach", str(checkout), "HEAD"),
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+        )
+        added = True
+        _copy_working_changes(repo_root, checkout)
+        for relative in _DEPENDENCY_PATHS:
+            source = repo_root / relative
+            target = checkout / relative
+            if not source.exists() or target.exists():
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            _clone_dependency_path(
+                source,
+                target,
+                source_root=repo_root,
+                target_root=checkout,
+            )
+        isolated_root = checkout.resolve(strict=True)
+        for relative in _DEPENDENCY_PATHS:
+            dependency = checkout / relative
+            if not dependency.exists():
+                continue
+            for link in (path for path in dependency.rglob("*") if path.is_symlink()):
+                try:
+                    link.resolve(strict=False).relative_to(isolated_root)
+                except ValueError as exc:
+                    raise RuntimeError(
+                        f"Dependency symlink remains outside isolated checkout: "
+                        f"{link.relative_to(checkout)}"
+                    ) from exc
+        yield checkout
+    finally:
+        removed = True
+        if added:
+            result = subprocess.run(
+                ("git", "worktree", "remove", "--force", str(checkout)),
+                cwd=repo_root,
+                check=False,
+                capture_output=True,
+            )
+            removed = result.returncode == 0
+        shutil.rmtree(temporary, ignore_errors=True)
+        prune = subprocess.run(
+            ("git", "worktree", "prune"),
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+        )
+        removed = removed and prune.returncode == 0
+        cleanup["status"] = "completed" if removed and not temporary.exists() else "failed"
+
+
+def _safe_request_path(value: str) -> bool:
+    path = Path(value)
+    return (
+        bool(value)
+        and not path.is_absolute()
+        and ".." not in path.parts
+        and not value.startswith("-")
+    )
+
+
+def _load_request(
+    path: Path | None,
+    capability_path: Path | None,
+    profile: str,
+) -> tuple[set[int] | None, tuple[str, ...] | None, str | None]:
+    if path is None:
+        if capability_path is not None:
+            raise RuntimeError("comparison capability was supplied without a request")
+        return None, None, None
+    if capability_path is None:
+        raise RuntimeError("comparison request has no orchestration capability")
+    if path.is_symlink() or capability_path.is_symlink():
+        raise RuntimeError("comparison request paths cannot be symlinks")
+    resolved = path.resolve(strict=True)
+    resolved_capability = capability_path.resolve(strict=True)
+    metadata = resolved.stat()
+    capability_metadata = resolved_capability.stat()
+    if not resolved.is_file() or metadata.st_uid != os.getuid():
+        raise RuntimeError("comparison request is not an owned regular file")
+    if (
+        not resolved_capability.is_file()
+        or capability_metadata.st_uid != os.getuid()
+        or capability_metadata.st_mode & 0o077
+    ):
+        raise RuntimeError("comparison capability is not a private owned regular file")
+    if metadata.st_mode & 0o077:
+        raise RuntimeError("comparison request permissions are not private")
+    resolved.relative_to(resolved_capability.parent.parent)
+    raw = resolved.read_bytes()
+    value = json.loads(raw)
+    resolved.unlink()
+    if not isinstance(value, dict) or value.get("schema_version") != 1:
+        raise RuntimeError("comparison request schema is invalid")
+    if value.get("profile") != profile:
+        raise RuntimeError("comparison request profile does not match")
+    indices = value.get("step_indices")
+    if (
+        not isinstance(indices, list)
+        or not indices
+        or not all(
+            isinstance(item, int) and not isinstance(item, bool) and item >= 0 for item in indices
+        )
+        or len(indices) != len(set(indices))
+    ):
+        raise RuntimeError("comparison request step indices are invalid")
+    changed = value.get("changed_files")
+    if changed is not None and (
+        not isinstance(changed, list)
+        or not all(isinstance(item, str) and _safe_request_path(item) for item in changed)
+    ):
+        raise RuntimeError("comparison request changed paths are invalid")
+    nonce = value.get("nonce")
+    if not isinstance(nonce, str) or len(nonce) < 32:
+        raise RuntimeError("comparison request capability is invalid")
+    signature = value.pop("signature", None)
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    expected_signature = hmac.digest(resolved_capability.read_bytes(), payload, "sha256").hex()
+    if not isinstance(signature, str) or not hmac.compare_digest(signature, expected_signature):
+        raise RuntimeError("comparison request signature is invalid")
+    return (
+        set(indices),
+        tuple(changed) if changed is not None else None,
+        hashlib.sha256(raw).hexdigest(),
+    )
+
+
+def _terminate_process(active: subprocess.Popen[str], signum: int = signal.SIGTERM) -> None:
+    if active.poll() is not None:
+        return
+    terminate_group(active.pid, signum)
+    active.wait()
+
+
+def run_profile(
+    repo_root: Path,
+    run_dir: Path,
+    profile: str,
+    request_file: Path | None = None,
+    capability_file: Path | None = None,
+) -> int:
+    relative_run_dir = os.fspath(run_dir.resolve())
+    base_ref = os.environ.get("OMNIGENT_VERIFY_BASE_REF", "HEAD")
+    selected_indices, changed_override, request_sha256 = _load_request(
+        request_file,
+        capability_file,
+        profile,
+    )
+    changed_files = (
+        changed_override
+        if changed_override is not None
+        else (_changed_files(repo_root, base_ref) if profile == "quality-gates" else ())
+    )
+    skill_root = os.environ.get(
+        "OMNIGENT_VERIFY_SKILL_ROOT",
+        ".agents/skills/verify-omnigent",
+    )
+    steps = profile_steps(
+        profile,
+        relative_run_dir,
+        harness=os.environ.get("OMNIGENT_VERIFY_HARNESS"),
+        databricks_profile=os.environ.get("OMNIGENT_VERIFY_DATABRICKS_PROFILE"),
+        base_ref=base_ref,
+        oss_ref=os.environ.get("OMNIGENT_VERIFY_OSS_REF", "HEAD"),
+        changed_files=_validate_changed_paths(changed_files),
+        electron_e2e_tests=_electron_e2e_tests(repo_root) if profile == "desktop" else (),
+        skill_root=skill_root,
+    )
+    report: dict[str, object] = {
+        "schema_version": 1,
+        "profile": profile,
+        "status": "running",
+        "comparison_request_sha256": request_sha256,
+        "requested_step_indices": sorted(selected_indices)
+        if selected_indices is not None
+        else None,
+        "steps": [],
+    }
+    report_path = run_dir / "steps.json"
+    if profile in {"web-ui", "desktop"}:
+        (run_dir / "cleanup.json").unlink(missing_ok=True)
+    _atomic_json(report_path, report)
+    active: subprocess.Popen[str] | None = None
+    try:
+        before = repository_snapshot(repo_root, deep_dependencies=True)
+        browser_before = (
+            playwright_browser_snapshot() if profile in {"web-ui", "desktop"} else None
+        )
+        if profile in {"web-ui", "desktop"} and browser_before is None:
+            raise RuntimeError("verified Playwright browser installation is unavailable")
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        report["status"] = "failed"
+        report["state_unchanged"] = False
+        report["state_error"] = f"Initial repository snapshot failed ({type(exc).__name__}): {exc}"
+        _atomic_json(report_path, report)
+        return 1
+    timeout_seconds = float(os.environ.get("OMNIGENT_VERIFY_STEP_TIMEOUT_SECONDS", "1800"))
+    if selected_indices is not None and not selected_indices.issubset(range(len(steps))):
+        raise RuntimeError("comparison request contains out-of-range step indices")
+
+    def forward_signal(signum: int, _frame: object) -> None:
+        if active is not None and active.poll() is None:
+            _terminate_process(active, signum)
+        report["status"] = "interrupted"
+        try:
+            report["state_unchanged"] = not compare_snapshots(
+                before,
+                repository_snapshot(repo_root, deep_dependencies=True),
+            )
+        except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+            report["state_unchanged"] = False
+            report["state_error"] = (
+                f"Final repository snapshot failed ({type(exc).__name__}): {exc}"
+            )
+        _atomic_json(report_path, report)
+        raise SystemExit(128 + signum)
+
+    for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+        signal.signal(signum, forward_signal)
+
+    first_failure = 0
+    step_results = report["steps"]
+    assert isinstance(step_results, list)
+    for index, step in enumerate(steps):
+        if selected_indices is not None and index not in selected_indices:
+            continue
+        step_log = run_dir / "step-logs" / f"{index:02d}.log"
+        step_log.parent.mkdir(parents=True, exist_ok=True)
+        result = {
+            "source_step_index": index,
+            "name": step.name,
+            "argv": portable_argv(
+                step.argv,
+                repo_root=repo_root,
+                run_dir=run_dir,
+                skill_root=Path(skill_root),
+            ),
+            "environment": step.environment,
+            "cwd": step.cwd,
+            "isolated": step.isolated,
+            "log": step_log.relative_to(run_dir).as_posix(),
+            "status": "running",
+            "exit_status": None,
+        }
+        step_results.append(result)
+        _atomic_json(report_path, report)
+        print(f"==> {step.name}", flush=True)
+        isolation_cleanup: dict[str, object] = {"status": "not_applicable"}
+        try:
+            manager = (
+                _isolated_checkout(repo_root, isolation_cleanup)
+                if step.isolated
+                else contextlib.nullcontext(repo_root)
+            )
+            with manager as execution_root:
+                cwd = execution_root / step.cwd
+                with step_log.open("w", encoding="utf-8") as log:
+                    controlled_env = _controlled_environment(
+                        repo_root,
+                        run_dir,
+                        profile,
+                        step.environment,
+                    )
+                    if profile == "harness-live":
+                        credential_mode = controlled_env.get(CREDENTIAL_MODE_ENV)
+                        if not credential_mode:
+                            raise RuntimeError("harness-live has no deliberate credential mode")
+                        result["credential_mode"] = credential_mode
+                    started_process = subprocess.Popen(
+                        step.argv,
+                        cwd=cwd,
+                        env=controlled_env,
+                        stdout=log,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        start_new_session=True,
+                        pass_fds=inherited_managed_fds(),
+                    )
+                    active = started_process
+                    try:
+                        exit_status = started_process.wait(timeout=timeout_seconds)
+                    except subprocess.TimeoutExpired:
+                        _terminate_process(started_process)
+                        exit_status = 124
+                        result["timed_out"] = True
+                    finally:
+                        active = None
+        except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+            exit_status = 1
+            result["reason"] = f"Step startup failed ({type(exc).__name__}): {exc}"
+            with step_log.open("a", encoding="utf-8") as log:
+                log.write(f"{result['reason']}\n")
+        result["isolation_cleanup"] = isolation_cleanup["status"]
+        output = step_log.read_text(encoding="utf-8", errors="replace")
+        print(output, end="" if output.endswith("\n") or not output else "\n")
+        result["exit_status"] = exit_status
+        result["status"] = "passed" if exit_status == 0 else "failed"
+        result["log_sha256"] = hashlib.sha256(step_log.read_bytes()).hexdigest()
+        if isolation_cleanup["status"] == "failed":
+            result["status"] = "failed"
+            result["exit_status"] = 1
+            result["reason"] = "The isolated quality worktree was not cleaned up."
+            exit_status = 1
+        if exit_status != 0 and first_failure == 0:
+            first_failure = exit_status
+        _atomic_json(report_path, report)
+
+    validation_error = None
+    if selected_indices is None:
+        if profile in {"web-ui", "desktop"} and first_failure == 0:
+            validation_error = _validate_ui_cleanup_marker(run_dir)
+        if profile == "harness-live" and first_failure == 0:
+            validation_error = _validate_live_harness_report(run_dir / "harness-live.json")
+        elif profile == "harness-client" and first_failure == 0:
+            validation_error = _validate_offline_harness_report(run_dir / "harness-matrix.json")
+        elif profile == "desktop" and first_failure == 0 and validation_error is None:
+            validation_error = _desktop_build_report(run_dir)
+    if validation_error:
+        print(f"verification blocker: {validation_error}", file=sys.stderr)
+        step_results.append(
+            {
+                "name": "Evidence validation",
+                "argv": [],
+                "environment": {},
+                "status": "failed",
+                "exit_status": 1,
+                "reason": validation_error,
+            }
+        )
+        first_failure = 1
+
+    try:
+        after = repository_snapshot(repo_root, deep_dependencies=True)
+        state_errors = compare_snapshots(before, after)
+        if profile in {"web-ui", "desktop"}:
+            browser_after = playwright_browser_snapshot()
+            if browser_before != browser_after:
+                state_errors.append("Playwright browser installation changed")
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        state_errors = [f"final repository snapshot failed ({type(exc).__name__}): {exc}"]
+    report["state_unchanged"] = not state_errors
+    if state_errors:
+        state_error = "; ".join(state_errors)
+        report["state_error"] = state_error
+        print(f"verification blocker: {state_error}", file=sys.stderr)
+        step_results.append(
+            {
+                "name": "Repository state invariant",
+                "argv": [],
+                "environment": {},
+                "status": "failed",
+                "exit_status": 1,
+                "reason": state_error,
+            }
+        )
+        first_failure = 1
+    report["status"] = "passed" if first_failure == 0 else "failed"
+    _atomic_json(report_path, report)
+    return first_failure
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--profile",
+        choices=(
+            "quality-gates",
+            "perf",
+            "server",
+            "db-migration-deploy",
+            "cli",
+            "web-ui",
+            "desktop",
+            "harness-client",
+            "harness-live",
+            "universe",
+        ),
+        required=True,
+    )
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--run-dir", type=Path, required=True)
+    parser.add_argument("--request-file", type=Path)
+    parser.add_argument("--capability-file", type=Path)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    raise SystemExit(
+        run_profile(
+            args.repo_root.resolve(),
+            args.run_dir.resolve(),
+            args.profile,
+            args.request_file,
+            args.capability_file,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/verify-omnigent/scripts/runtime_support.py
+++ b/.agents/skills/verify-omnigent/scripts/runtime_support.py
@@ -1,0 +1,1655 @@
+#!/usr/bin/env python3
+"""Strict environments, repository guards, and managed process trees."""
+
+from __future__ import annotations
+
+import argparse
+import atexit
+import configparser
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+import pwd
+import re
+import secrets
+import shutil
+import signal
+import sqlite3
+import stat
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+LOCKFILES = (
+    "uv.lock",
+    "pnpm-lock.yaml",
+    "package-lock.json",
+    "yarn.lock",
+)
+PROTECTED_DEPENDENCY_PATHS = (
+    "node_modules/.modules.yaml",
+    "web/node_modules/.bin/prettier",
+    "web/node_modules/.bin/oxlint",
+    "web/node_modules/.bin/tsc",
+    "web/node_modules/.bin/vite",
+    "web/node_modules/.bin/vitest",
+    "web/electron/node_modules/.bin/electron-builder",
+    ".venv/bin/python",
+    ".venv/bin/omnigent",
+    ".venv/pyvenv.cfg",
+)
+PROTECTED_DEPENDENCY_ROOTS = (
+    ".venv",
+    "node_modules",
+    "web/node_modules",
+    "web/electron/node_modules",
+)
+PROTECTED_BUILD_PATHS = (
+    "web/dist",
+    "web/electron/dist",
+)
+INTERNAL_ENV_KEYS = {
+    "OMNIGENT_VERIFY_PARTIAL_COMPARISON",
+    "OMNIGENT_VERIFY_ONLY_STEP_INDICES",
+    "OMNIGENT_VERIFY_CHANGED_FILES_JSON",
+    "OMNIGENT_VERIFY_DISABLE_BASELINE",
+    "OMNIGENT_VERIFY_INTERNAL_REQUEST",
+    "OMNIGENT_VERIFY_CONTROL_SNAPSHOT",
+    "OMNIGENT_VERIFY_DEEP_DEPENDENCY_SNAPSHOT",
+}
+_BASE_ENV_KEYS = (
+    "PATH",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TMPDIR",
+    "SYSTEMROOT",
+    "COMSPEC",
+    "PATHEXT",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+)
+_EXTRA_ENV_KEYS = {
+    "CSC_IDENTITY_AUTO_DISCOVERY",
+    "OMNIGENT_VERIFY_ADAPTER",
+    "OMNIGENT_VERIFY_BASE_REF",
+    "OMNIGENT_VERIFY_CLEANUP_MARKER",
+    "OMNIGENT_VERIFY_DATABRICKS_PROFILE",
+    "OMNIGENT_VERIFY_EVIDENCE_DIR",
+    "OMNIGENT_VERIFY_HARNESS",
+    "OMNIGENT_VERIFY_OSS_REF",
+    "OMNIGENT_VERIFY_REPO_ROOT",
+    "OMNIGENT_VERIFY_RUN_DIR",
+    "OMNIGENT_WEB_UI_DIST",
+    "OMNIGENT_VERIFY_SKILL_ROOT",
+    "OMNIGENT_VERIFY_STEP_TIMEOUT_SECONDS",
+    "PORT",
+    "PYTHONPATH",
+    "PYTHONSAFEPATH",
+    "UNIVERSE_ROOT",
+}
+MANAGED_FD_ENV = "OMNIGENT_VERIFY_MANAGED_FD"
+CREDENTIAL_MODE_ENV = "OMNIGENT_VERIFY_CREDENTIAL_MODE"
+
+
+def atomic_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(value, handle, indent=2, sort_keys=True, ensure_ascii=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def atomic_bytes(path: Path, value: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp")
+    with temporary.open("wb") as handle:
+        handle.write(value)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def portable_argv(
+    argv: list[str] | tuple[str, ...],
+    *,
+    repo_root: Path,
+    run_dir: Path,
+    skill_root: Path | None = None,
+    home: Path | None = None,
+) -> list[str]:
+    replacements = [
+        (os.fspath(run_dir.resolve()), "<run-dir>"),
+        (os.fspath(repo_root.resolve()), "<repo-root>"),
+    ]
+    if skill_root is not None:
+        replacements.extend(
+            {
+                (os.fspath(skill_root.absolute()), "<skill-root>"),
+                (os.fspath(skill_root.resolve()), "<skill-root>"),
+            }
+        )
+    raw_home = os.environ.get("HOME")
+    effective_home = home or (Path(raw_home).expanduser() if raw_home else None)
+    if effective_home is not None:
+        replacements.append((os.fspath(effective_home.resolve()), "<home>"))
+    replacements.sort(key=lambda item: len(item[0]), reverse=True)
+    portable = []
+    for value in argv:
+        for root, token in replacements:
+            value = value.replace(root, token)
+        portable.append(value)
+    return portable
+
+
+def _git_bytes(repo_root: Path, *args: str) -> bytes:
+    result = subprocess.run(
+        ("git", *args),
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        raise RuntimeError(detail or f"git {' '.join(args)} failed")
+    return result.stdout
+
+
+def _git_optional_bytes(repo_root: Path, *args: str) -> bytes | None:
+    result = subprocess.run(
+        ("git", *args),
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+    )
+    return result.stdout if result.returncode == 0 else None
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _path_identity(path: Path) -> dict[str, object]:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return {"kind": "missing", "mode": None, "sha256": None}
+    mode = stat.S_IMODE(metadata.st_mode)
+    if path.is_symlink():
+        target = os.readlink(path)
+        digest = hashlib.sha256(os.fsencode(target))
+        try:
+            resolved = path.resolve(strict=True)
+            if resolved.is_file():
+                digest.update(b"\0")
+                with resolved.open("rb") as handle:
+                    while chunk := handle.read(1024 * 1024):
+                        digest.update(chunk)
+        except OSError as exc:
+            raise RuntimeError(
+                f"dependency symlink {path} could not be resolved ({type(exc).__name__})"
+            ) from exc
+        kind = "symlink"
+        sha256 = digest.hexdigest()
+    elif path.is_file():
+        kind = "file"
+        sha256 = _file_sha256(path)
+    elif path.is_dir():
+        kind = "directory"
+        sha256 = hashlib.sha256(b"").hexdigest()
+    else:
+        kind = "other"
+        sha256 = hashlib.sha256(b"").hexdigest()
+    return {
+        "kind": kind,
+        "mode": mode,
+        "size": metadata.st_size,
+        "mtime_ns": metadata.st_mtime_ns,
+        "sha256": sha256,
+    }
+
+
+def _tree_identity(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {"kind": "missing", "entries": {}}
+    if not path.is_dir():
+        return {"kind": "not-directory", "entries": {".": _path_identity(path)}}
+    entries: dict[str, object] = {}
+    for child in sorted(path.rglob("*")):
+        entries[child.relative_to(path).as_posix()] = _path_identity(child)
+    return {"kind": "directory", "entries": entries}
+
+
+def _tree_metadata_identity(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {"kind": "missing", "sha256": None, "entries": 0}
+    digest = hashlib.sha256()
+    count = 0
+    pending = [path]
+    while pending:
+        current = pending.pop()
+        metadata = current.lstat()
+        relative = current.relative_to(path)
+        kind = "link" if current.is_symlink() else "dir" if current.is_dir() else "file"
+        target = os.readlink(current) if current.is_symlink() else ""
+        record = (
+            os.fsencode(relative)
+            + b"\0"
+            + kind.encode()
+            + b"\0"
+            + str(metadata.st_mode).encode()
+            + b"\0"
+            + str(metadata.st_size).encode()
+            + b"\0"
+            + str(metadata.st_mtime_ns).encode()
+            + b"\0"
+            + str(metadata.st_ctime_ns).encode()
+            + b"\0"
+            + os.fsencode(target)
+            + b"\0"
+        )
+        digest.update(record)
+        count += 1
+        if kind == "dir":
+            pending.extend(sorted(current.iterdir(), reverse=True))
+    return {"kind": "tree", "sha256": digest.hexdigest(), "entries": count}
+
+
+def _browser_executables(root: Path) -> tuple[Path, ...]:
+    patterns = (
+        "chromium-*/chrome-mac*/Chromium.app/Contents/MacOS/Chromium",
+        "chromium-*/chrome-mac*/Google Chrome for Testing.app/Contents/MacOS/"
+        "Google Chrome for Testing",
+        "chromium-*/chrome-linux*/chrome",
+        "chromium-*/chrome-win*/chrome.exe",
+        "chromium_headless_shell-*/chrome-headless-shell-mac*/chrome-headless-shell",
+        "chromium_headless_shell-*/chrome-headless-shell-linux*/chrome-headless-shell",
+        "chromium_headless_shell-*/chrome-headless-shell-win*/chrome-headless-shell.exe",
+    )
+    return tuple(
+        sorted(
+            path
+            for pattern in patterns
+            for path in root.glob(pattern)
+            if path.is_file() and os.access(path, os.X_OK)
+        )
+    )
+
+
+def verified_playwright_browsers_path(
+    source: dict[str, str] | None = None,
+) -> Path | None:
+    """Resolve an existing browser cache without exposing the caller's HOME."""
+    effective_source = dict(os.environ) if source is None else source
+    candidates: list[Path] = []
+    configured = effective_source.get("PLAYWRIGHT_BROWSERS_PATH")
+    if configured and configured != "0":
+        candidates.append(Path(configured).expanduser())
+    home = effective_source.get("HOME")
+    if home:
+        home_path = Path(home)
+        candidates.extend(
+            (
+                home_path / "Library" / "Caches" / "ms-playwright",
+                home_path / ".cache" / "ms-playwright",
+            )
+        )
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError:
+            continue
+        if resolved.is_dir() and _browser_executables(resolved):
+            return resolved
+    return None
+
+
+def _pnpm_cache_destination() -> Path | None:
+    override = os.environ.get("OMNIGENT_VERIFY_PNPM_CACHE_ROOT")
+    if override:
+        return Path(override)
+    try:
+        account_home = Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except (KeyError, OSError):
+        return None
+    return account_home / ".cache" / "verify-omnigent" / "pnpm"
+
+
+@contextlib.contextmanager
+def _pnpm_cache_lock(cache_root: Path, *, exclusive: bool) -> Iterator[None]:
+    parent = cache_root.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    lock_path = parent / ".pnpm.verify-omnigent.lock"
+    descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def pinned_pnpm_version(repo_root: Path) -> str:
+    package = json.loads((repo_root / "package.json").read_text(encoding="utf-8"))
+    declared = package.get("packageManager") if isinstance(package, dict) else None
+    if (
+        not isinstance(declared, str)
+        or not declared.startswith("pnpm@")
+        or not declared.removeprefix("pnpm@")
+        or any(character.isspace() for character in declared)
+    ):
+        raise RuntimeError("package.json must declare an exact packageManager pnpm version")
+    version = declared.removeprefix("pnpm@")
+    if any(character in version for character in "*^~<>=|"):
+        raise RuntimeError("package.json packageManager pnpm version must be exact")
+    return version
+
+
+def _tree_content_identity(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in (root, *sorted(root.rglob("*"))):
+        relative = "." if path == root else path.relative_to(root).as_posix()
+        metadata = path.lstat()
+        digest.update(relative.encode("utf-8"))
+        digest.update(f"\0{metadata.st_mode:o}\0{metadata.st_size}\0".encode())
+        if path.is_symlink():
+            digest.update(os.fsencode(os.readlink(path)))
+        elif path.is_file():
+            with path.open("rb") as handle:
+                while chunk := handle.read(1024 * 1024):
+                    digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validated_pnpm_cache(cache_root: Path) -> tuple[Path, dict[str, object]] | None:
+    try:
+        resolved = cache_root.resolve(strict=True)
+        root_stat = resolved.stat()
+        seal_path = resolved / "omnigent-prepared-pnpm.json"
+        seal_stat = seal_path.stat()
+        seal = json.loads(seal_path.read_text(encoding="utf-8"))
+        if (
+            root_stat.st_uid != os.getuid()
+            or seal_stat.st_uid != os.getuid()
+            or root_stat.st_mode & 0o022
+            or seal_stat.st_mode & 0o022
+            or not isinstance(seal, dict)
+            or seal.get("schema_version") != 1
+            or seal.get("package_manager") != "pnpm"
+            or not isinstance(seal.get("version"), str)
+        ):
+            return None
+        version = seal["version"]
+        runtime = resolved / version
+        executable = runtime / "bin" / "pnpm"
+        if (
+            not runtime.is_dir()
+            or not executable.is_file()
+            or not os.access(executable, os.X_OK)
+            or seal.get("tree") != _tree_metadata_identity(runtime)
+            or seal.get("content_sha256") != _tree_content_identity(runtime)
+        ):
+            return None
+        return resolved, seal
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def verified_pnpm_tools_root() -> Path | None:
+    destination = _pnpm_cache_destination()
+    if destination is None:
+        return None
+    with _pnpm_cache_lock(destination, exclusive=False):
+        validated = _validated_pnpm_cache(destination)
+        return validated[0] if validated is not None else None
+
+
+def _local_pnpm_candidates(version: str) -> tuple[Path, ...]:
+    try:
+        account_home = Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except (KeyError, OSError):
+        return ()
+    candidates = (
+        account_home / ".cache" / "node" / "corepack" / "v1" / "pnpm" / version,
+        account_home / "Library" / "Caches" / "node" / "corepack" / "v1" / "pnpm" / version,
+        account_home / "Library" / "pnpm" / ".tools" / "pnpm" / version / "node_modules" / "pnpm",
+        account_home
+        / ".local"
+        / "share"
+        / "pnpm"
+        / ".tools"
+        / "pnpm"
+        / version
+        / "node_modules"
+        / "pnpm",
+    )
+    return tuple(candidates)
+
+
+def _valid_local_pnpm_package(candidate: Path, version: str) -> bool:
+    try:
+        resolved = candidate.resolve(strict=True)
+        metadata = json.loads((resolved / "package.json").read_text(encoding="utf-8"))
+        executable = resolved / "bin" / "pnpm.mjs"
+        stat = resolved.stat()
+        return (
+            resolved.is_dir()
+            and stat.st_uid == os.getuid()
+            and not stat.st_mode & 0o022
+            and isinstance(metadata, dict)
+            and metadata.get("name") == "pnpm"
+            and metadata.get("version") == version
+            and executable.is_file()
+        )
+    except (OSError, json.JSONDecodeError):
+        return False
+
+
+def prepare_pnpm_cache(
+    repo_root: Path,
+    staging: Path,
+    *,
+    candidates: tuple[Path, ...] | None = None,
+    allow_download: bool = False,
+) -> dict[str, object]:
+    version = pinned_pnpm_version(repo_root)
+    available = candidates if candidates is not None else _local_pnpm_candidates(version)
+    package = next(
+        (
+            candidate.resolve()
+            for candidate in available
+            if _valid_local_pnpm_package(candidate, version)
+        ),
+        None,
+    )
+    if package is None and allow_download:
+        subprocess.run(
+            ("corepack", "prepare", f"pnpm@{version}"),
+            cwd=repo_root,
+            check=True,
+        )
+        package = next(
+            (
+                candidate.resolve()
+                for candidate in _local_pnpm_candidates(version)
+                if _valid_local_pnpm_package(candidate, version)
+            ),
+            None,
+        )
+    if package is None:
+        raise RuntimeError(
+            f"pnpm {version} is not in a supported local cache; "
+            "Corepack preparation did not produce it"
+        )
+    runtime = staging / version
+    copied_package = runtime / "package"
+    runtime.mkdir(parents=True)
+    shutil.copytree(package, copied_package, symlinks=False)
+    binary = runtime / "bin" / "pnpm"
+    binary.parent.mkdir()
+    binary.write_text(
+        '#!/bin/sh\nexec node "$(dirname "$0")/../package/bin/pnpm.mjs" "$@"\n',
+        encoding="utf-8",
+    )
+    binary.chmod(0o755)
+    for path in (runtime, *runtime.rglob("*")):
+        with contextlib.suppress(OSError):
+            path.chmod(path.stat().st_mode & ~0o022)
+    actual = subprocess.run(
+        (os.fspath(binary), "--version"),
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if actual != version:
+        raise RuntimeError(f"prepared pnpm reported {actual!r}, expected {version!r}")
+    seal: dict[str, object] = {
+        "schema_version": 1,
+        "package_manager": "pnpm",
+        "version": version,
+        "tree": _tree_metadata_identity(runtime),
+        "content_sha256": _tree_content_identity(runtime),
+    }
+    atomic_json(staging / "omnigent-prepared-pnpm.json", seal)
+    return seal
+
+
+def publish_pnpm_cache(staging: Path, destination: Path) -> None:
+    with _pnpm_cache_lock(destination, exclusive=True):
+        try:
+            staging = staging.resolve(strict=True)
+            parent = destination.parent.resolve(strict=True)
+            staging.relative_to(parent)
+        except (OSError, ValueError) as exc:
+            raise RuntimeError("pnpm staging cache is outside its publication root") from exc
+        if _validated_pnpm_cache(staging) is None:
+            raise RuntimeError("pnpm staging cache failed authentication")
+        previous = destination.resolve(strict=True) if destination.is_symlink() else None
+        if destination.exists() and not destination.is_symlink():
+            raise RuntimeError("refusing a non-atomic pnpm cache destination")
+        pointer = parent / f".pnpm.pointer.{secrets.token_hex(8)}"
+        pointer.symlink_to(staging.name, target_is_directory=True)
+        published = False
+        try:
+            os.replace(pointer, destination)
+            published = True
+            if destination.resolve(strict=True) != staging:
+                raise RuntimeError("published pnpm cache pointer does not resolve to staging")
+        except Exception:
+            pointer.unlink(missing_ok=True)
+            if published:
+                if previous is None:
+                    destination.unlink(missing_ok=True)
+                else:
+                    rollback = parent / f".pnpm.rollback.{secrets.token_hex(8)}"
+                    rollback.symlink_to(previous.name, target_is_directory=True)
+                    os.replace(rollback, destination)
+            raise
+        if (
+            previous is not None
+            and previous != staging
+            and previous.parent == parent
+            and previous.name.startswith("pnpm.version.")
+        ):
+            with contextlib.suppress(OSError):
+                shutil.rmtree(previous)
+
+
+def _stage_pnpm_tools(repo_root: Path, destination: Path) -> Path | None:
+    cache_root = _pnpm_cache_destination()
+    if cache_root is None:
+        return None
+    expected = pinned_pnpm_version(repo_root)
+    with _pnpm_cache_lock(cache_root, exclusive=False):
+        validated = _validated_pnpm_cache(cache_root)
+        if validated is None or validated[1].get("version") != expected:
+            return None
+        source = validated[0] / expected
+        target = destination / expected
+        if target.exists():
+            if _tree_content_identity(target) != validated[1].get("content_sha256"):
+                raise RuntimeError("existing staged pnpm runtime failed tree authentication")
+            return destination
+        shutil.copytree(source, target, symlinks=False)
+        if _tree_content_identity(target) != validated[1].get("content_sha256"):
+            shutil.rmtree(destination, ignore_errors=True)
+            raise RuntimeError("staged pnpm runtime failed tree authentication")
+    return destination
+
+
+def playwright_browser_snapshot(
+    source: dict[str, str] | None = None,
+) -> dict[str, object] | None:
+    root = verified_playwright_browsers_path(source)
+    if root is None:
+        return None
+    return {
+        "root": os.fspath(root),
+        "installations": sorted(path.name for path in root.iterdir()),
+        "markers": {
+            marker.relative_to(root).as_posix(): _path_identity(marker)
+            for installation in sorted(root.iterdir())
+            if installation.is_dir()
+            for name in ("INSTALLATION_COMPLETE", "DEPENDENCIES_VALIDATED")
+            if (marker := installation / name).is_file()
+        },
+        "executables": {
+            path.relative_to(root).as_posix(): _path_identity(path)
+            for path in _browser_executables(root)
+        },
+    }
+
+
+def _configured_remote_hooks(repo_root: Path) -> list[tuple[str, str]]:
+    config_path = repo_root / ".pre-commit-config.yaml"
+    if not config_path.is_file():
+        raise RuntimeError("Repository has no .pre-commit-config.yaml.")
+    config = config_path.read_text(encoding="utf-8")
+    hooks: list[tuple[str, str]] = []
+    current_repo: str | None = None
+    for line in config.splitlines():
+        repo_match = re.match(r"^\s*-\s+repo:\s*([^\s#]+)", line)
+        if repo_match:
+            current_repo = repo_match.group(1)
+            continue
+        rev_match = re.match(r"^\s+rev:\s*([^\s#]+)", line)
+        if rev_match and current_repo is not None and current_repo not in {"local", "meta"}:
+            hooks.append((current_repo, rev_match.group(1)))
+            current_repo = None
+    return hooks
+
+
+def _pre_commit_cache_roots(source: dict[str, str]) -> list[Path]:
+    roots = []
+    if source.get("PRE_COMMIT_HOME"):
+        roots.append(Path(source["PRE_COMMIT_HOME"]))
+    if source.get("HOME"):
+        home = Path(source["HOME"])
+        roots.extend(
+            (
+                home / ".cache/verify-omnigent/pre-commit",
+                home / ".cache/pre-commit",
+                home / "Library/Caches/pre-commit",
+            )
+        )
+    return list(dict.fromkeys(roots))
+
+
+def seal_pre_commit_cache(repo_root: Path, cache_root: Path) -> dict[str, object]:
+    configured = _configured_remote_hooks(repo_root)
+    entries = []
+    database = cache_root / "db.db"
+    if configured and not database.is_file():
+        raise RuntimeError("Prepared pre-commit cache has no db.db.")
+    with sqlite3.connect(database) as connection:
+        for repo, rev in configured:
+            row = connection.execute(
+                "SELECT path FROM repos WHERE repo = ? AND ref = ?",
+                (repo, rev),
+            ).fetchone()
+            if not row or not isinstance(row[0], str):
+                raise RuntimeError(f"Prepared cache lacks {repo}@{rev}.")
+            path = Path(row[0]).resolve(strict=True)
+            path.relative_to(cache_root.resolve(strict=True))
+            entries.append(
+                {
+                    "repo": repo,
+                    "rev": rev,
+                    "path": str(path),
+                    "tree": _tree_metadata_identity(path),
+                }
+            )
+    seal = {
+        "schema_version": 1,
+        "config_sha256": hashlib.sha256(
+            (repo_root / ".pre-commit-config.yaml").read_bytes()
+        ).hexdigest(),
+        "hooks": entries,
+    }
+    atomic_json(cache_root / "omnigent-prepared-hooks.json", seal)
+    return seal
+
+
+@contextlib.contextmanager
+def _hook_cache_lock(cache_root: Path, *, exclusive: bool) -> Iterator[None]:
+    """Lease a published cache, or serialize its publication and collection."""
+    parent = cache_root.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    lock_path = parent / ".pre-commit.verify-omnigent.lock"
+    descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def publish_pre_commit_cache(repo_root: Path, staging: Path, destination: Path) -> None:
+    """Atomically publish a fully sealed version directory through a cache pointer."""
+    with _hook_cache_lock(destination, exclusive=True):
+        staging = staging.resolve(strict=True)
+        parent = destination.parent.resolve(strict=True)
+        staging.relative_to(parent)
+        seal_path = staging / "omnigent-prepared-hooks.json"
+        if not seal_path.is_file():
+            raise RuntimeError("Staging cache is not sealed.")
+        seal = json.loads(seal_path.read_text(encoding="utf-8"))
+        expected_config = hashlib.sha256(
+            (repo_root / ".pre-commit-config.yaml").read_bytes()
+        ).hexdigest()
+        if (
+            not isinstance(seal, dict)
+            or seal.get("schema_version") != 1
+            or seal.get("config_sha256") != expected_config
+        ):
+            raise RuntimeError("Staging cache seal does not match the repository config.")
+        for repo, rev in _configured_remote_hooks(repo_root):
+            with sqlite3.connect(staging / "db.db") as connection:
+                row = connection.execute(
+                    "SELECT path FROM repos WHERE repo = ? AND ref = ?",
+                    (repo, rev),
+                ).fetchone()
+            if (
+                not row
+                or not isinstance(row[0], str)
+                or not _authenticated_pre_commit_entry(
+                    repo_root,
+                    staging,
+                    repo,
+                    rev,
+                    Path(row[0]).resolve(strict=True),
+                )
+            ):
+                raise RuntimeError(f"Staging cache failed authentication for {repo}@{rev}.")
+        previous_target: Path | None = None
+        if destination.is_symlink():
+            previous_target = destination.resolve(strict=True)
+        elif destination.exists():
+            raise RuntimeError("Refusing non-atomic migration of a legacy hook-cache directory.")
+        pointer = parent / f".pre-commit.pointer.{secrets.token_hex(8)}"
+        pointer.symlink_to(staging.name, target_is_directory=True)
+        published = False
+        try:
+            os.replace(pointer, destination)
+            published = True
+            if destination.resolve(strict=True) != staging:
+                raise RuntimeError("Published cache pointer does not resolve to staging.")
+        except Exception:
+            pointer.unlink(missing_ok=True)
+            if published and previous_target is not None:
+                rollback = parent / f".pre-commit.rollback.{secrets.token_hex(8)}"
+                rollback.symlink_to(previous_target.name, target_is_directory=True)
+                os.replace(rollback, destination)
+            raise
+        if (
+            previous_target is not None
+            and previous_target != staging
+            and previous_target.parent == parent
+            and previous_target.name.startswith("pre-commit.version.")
+        ):
+            # A stale version is safer than rolling the pointer back or dangling it.
+            with contextlib.suppress(OSError):
+                shutil.rmtree(previous_target)
+
+
+def _authenticated_pre_commit_entry(
+    repo_root: Path,
+    cache_root: Path,
+    repo: str,
+    rev: str,
+    candidate: Path,
+) -> bool:
+    try:
+        seal = json.loads(
+            (cache_root / "omnigent-prepared-hooks.json").read_text(encoding="utf-8")
+        )
+        expected_config = hashlib.sha256(
+            (repo_root / ".pre-commit-config.yaml").read_bytes()
+        ).hexdigest()
+        if (
+            not isinstance(seal, dict)
+            or seal.get("schema_version") != 1
+            or seal.get("config_sha256") != expected_config
+        ):
+            return False
+        entry = next(
+            (
+                item
+                for item in seal.get("hooks", [])
+                if isinstance(item, dict)
+                and item.get("repo") == repo
+                and item.get("rev") == rev
+                and item.get("path") == str(candidate)
+            ),
+            None,
+        )
+        return isinstance(entry, dict) and entry.get("tree") == _tree_metadata_identity(candidate)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return False
+
+
+def _stage_configured_pre_commit_cache(
+    repo_root: Path,
+    destination: Path,
+    source: dict[str, str],
+) -> None:
+    configured = _configured_remote_hooks(repo_root)
+    if not configured:
+        return
+    roots = _pre_commit_cache_roots(source)
+    with contextlib.ExitStack() as leases:
+        for cache_root in roots:
+            leases.enter_context(_hook_cache_lock(cache_root, exclusive=False))
+        selected: list[tuple[str, str, Path]] = []
+        for repo, rev in configured:
+            match: Path | None = None
+            for cache_root in roots:
+                database = cache_root / "db.db"
+                if not database.is_file():
+                    continue
+                resolved_cache = cache_root.resolve(strict=True)
+                cache_stat = resolved_cache.stat()
+                database_stat = database.stat()
+                if (
+                    cache_stat.st_uid != os.getuid()
+                    or database_stat.st_uid != os.getuid()
+                    or cache_stat.st_mode & 0o022
+                    or database_stat.st_mode & 0o022
+                ):
+                    continue
+                with sqlite3.connect(database) as connection:
+                    row = connection.execute(
+                        "SELECT path FROM repos WHERE repo = ? AND ref = ?",
+                        (repo, rev),
+                    ).fetchone()
+                if row and isinstance(row[0], str):
+                    candidate = Path(row[0]).resolve(strict=True)
+                    candidate.relative_to(resolved_cache)
+                    if candidate.is_dir() and _authenticated_pre_commit_entry(
+                        repo_root,
+                        resolved_cache,
+                        repo,
+                        rev,
+                        candidate,
+                    ):
+                        match = candidate
+                        break
+            if match is None:
+                raise RuntimeError(
+                    f"Configured pre-commit hook {repo}@{rev} is not prepared "
+                    "in a trusted user cache."
+                )
+            selected.append((repo, rev, match))
+        destination.mkdir(parents=True, exist_ok=True)
+        database = destination / "db.db"
+        with sqlite3.connect(database) as connection:
+            connection.execute(
+                "CREATE TABLE IF NOT EXISTS repos "
+                "(repo TEXT NOT NULL, ref TEXT NOT NULL, path TEXT NOT NULL, "
+                "PRIMARY KEY (repo, ref))"
+            )
+            connection.execute(
+                "CREATE TABLE IF NOT EXISTS configs (path TEXT NOT NULL PRIMARY KEY)"
+            )
+            for index, (repo, rev, source_path) in enumerate(selected):
+                staged = destination / f"repo-{index}"
+                shutil.copytree(source_path, staged, symlinks=False)
+                source_bytes = os.fsencode(source_path)
+                staged_bytes = os.fsencode(staged)
+                for path in staged.rglob("*"):
+                    if not path.is_file() or path.is_symlink() or path.stat().st_size > 1_000_000:
+                        continue
+                    payload = path.read_bytes()
+                    if b"\0" not in payload and source_bytes in payload:
+                        path.write_bytes(payload.replace(source_bytes, staged_bytes))
+                connection.execute(
+                    "INSERT INTO repos(repo, ref, path) VALUES (?, ?, ?)",
+                    (repo, rev, str(staged)),
+                )
+
+
+def repository_snapshot(
+    repo_root: Path,
+    *,
+    deep_dependencies: bool = False,
+) -> dict[str, object]:
+    repo_root = repo_root.resolve(strict=True)
+    status = _git_bytes(repo_root, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+    listed = _git_bytes(
+        repo_root,
+        "ls-files",
+        "-z",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+    )
+    paths = [os.fsdecode(raw) for raw in listed.split(b"\0") if raw]
+    entries: dict[str, object] = {}
+    for relative in paths:
+        value = Path(relative)
+        if value.is_absolute() or ".." in value.parts:
+            raise RuntimeError(f"git returned unsafe path {relative!r}")
+        path = repo_root / value
+        try:
+            if path.is_symlink():
+                try:
+                    path.resolve(strict=True).relative_to(repo_root)
+                except (OSError, ValueError) as exc:
+                    raise RuntimeError(
+                        f"tracked or visible symlink {relative!r} escapes the checkout"
+                    ) from exc
+            entries[relative] = _path_identity(path)
+        except OSError as exc:
+            raise RuntimeError(
+                f"repository path {relative!r} could not be hashed ({type(exc).__name__})"
+            ) from exc
+    lockfiles: dict[str, object] = {}
+    for relative in LOCKFILES:
+        path = repo_root / relative
+        lockfiles[relative] = _path_identity(path) if path.exists() else None
+    protected: dict[str, object] = {}
+    for relative in PROTECTED_DEPENDENCY_PATHS:
+        path = repo_root / relative
+        protected[relative] = _path_identity(path) if path.exists() else None
+    protected_roots = {
+        relative: _path_identity(repo_root / relative) if (repo_root / relative).exists() else None
+        for relative in PROTECTED_DEPENDENCY_ROOTS
+    }
+    protected_trees = (
+        {
+            relative: _tree_metadata_identity(repo_root / relative)
+            for relative in PROTECTED_DEPENDENCY_ROOTS
+        }
+        if deep_dependencies
+        else None
+    )
+    refs = _git_bytes(
+        repo_root,
+        "for-each-ref",
+        "--format=%(refname)%00%(objectname)%00",
+    )
+    head = _git_optional_bytes(repo_root, "rev-parse", "--verify", "HEAD^{commit}")
+    index_entries = _git_bytes(repo_root, "ls-files", "--stage", "-z")
+    index_diff = _git_bytes(repo_root, "diff", "--cached", "--binary", "--full-index", "--")
+    index_identity = {
+        "entries_sha256": hashlib.sha256(index_entries).hexdigest(),
+        "diff_sha256": hashlib.sha256(index_diff).hexdigest(),
+    }
+    head_path = Path(os.fsdecode(_git_bytes(repo_root, "rev-parse", "--git-path", "HEAD")).strip())
+    if not head_path.is_absolute():
+        head_path = repo_root / head_path
+    head_file_identity = _path_identity(head_path)
+    head_file_identity.pop("mtime_ns", None)
+    symbolic_head = _git_optional_bytes(repo_root, "symbolic-ref", "-q", "HEAD")
+    build_outputs = {
+        relative: _tree_identity(repo_root / relative) for relative in PROTECTED_BUILD_PATHS
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status_sha256": hashlib.sha256(status).hexdigest(),
+        "entries": entries,
+        "lockfiles": lockfiles,
+        "protected_dependencies": protected,
+        "protected_dependency_roots": protected_roots,
+        "protected_dependency_trees": protected_trees,
+        "protected_build_outputs": build_outputs,
+        "git_identity": {
+            "refs_sha256": hashlib.sha256(refs).hexdigest(),
+            "head_sha256": hashlib.sha256(head).hexdigest() if head is not None else None,
+            "head_file": head_file_identity,
+            "symbolic_head": (
+                os.fsdecode(symbolic_head).strip() if symbolic_head is not None else None
+            ),
+            "index": index_identity,
+        },
+    }
+
+
+def compare_snapshots(before: dict[str, object], after: dict[str, object]) -> list[str]:
+    if (
+        before.get("schema_version") != SCHEMA_VERSION
+        or after.get("schema_version") != SCHEMA_VERSION
+    ):
+        return ["repository snapshot schema is invalid"]
+    changes: list[str] = []
+    if before.get("status_sha256") != after.get("status_sha256"):
+        changes.append("git status changed")
+    before_entries = before.get("entries")
+    after_entries = after.get("entries")
+    if not isinstance(before_entries, dict) or not isinstance(after_entries, dict):
+        return [*changes, "repository file snapshot is unreadable"]
+    changed_paths = sorted(
+        path
+        for path in set(before_entries) | set(after_entries)
+        if before_entries.get(path) != after_entries.get(path)
+    )
+    if changed_paths:
+        preview = ", ".join(repr(path) for path in changed_paths[:20])
+        suffix = "" if len(changed_paths) <= 20 else f" (+{len(changed_paths) - 20} more)"
+        changes.append(f"repository bytes changed: {preview}{suffix}")
+    before_locks = before.get("lockfiles")
+    after_locks = after.get("lockfiles")
+    if not isinstance(before_locks, dict) or not isinstance(after_locks, dict):
+        changes.append("lockfile snapshot is unreadable")
+    else:
+        changed_locks = [
+            path for path in LOCKFILES if before_locks.get(path) != after_locks.get(path)
+        ]
+        if changed_locks:
+            changes.append("lockfiles changed: " + ", ".join(changed_locks))
+    before_dependencies = before.get("protected_dependencies")
+    after_dependencies = after.get("protected_dependencies")
+    if not isinstance(before_dependencies, dict) or not isinstance(after_dependencies, dict):
+        changes.append("dependency metadata snapshot is unreadable")
+    else:
+        changed_dependencies = [
+            path
+            for path in PROTECTED_DEPENDENCY_PATHS
+            if before_dependencies.get(path) != after_dependencies.get(path)
+        ]
+        if changed_dependencies:
+            changes.append("dependency metadata changed: " + ", ".join(changed_dependencies))
+    before_roots = before.get("protected_dependency_roots")
+    after_roots = after.get("protected_dependency_roots")
+    if not isinstance(before_roots, dict) or not isinstance(after_roots, dict):
+        changes.append("dependency root snapshot is unreadable")
+    else:
+        changed_roots = [
+            path
+            for path in PROTECTED_DEPENDENCY_ROOTS
+            if before_roots.get(path) != after_roots.get(path)
+        ]
+        if changed_roots:
+            changes.append("dependency roots changed: " + ", ".join(changed_roots))
+    before_trees = before.get("protected_dependency_trees")
+    after_trees = after.get("protected_dependency_trees")
+    if before_trees is None and after_trees is None:
+        pass
+    elif not isinstance(before_trees, dict) or not isinstance(after_trees, dict):
+        changes.append("dependency tree snapshot is unreadable")
+    else:
+        changed_trees = [
+            path
+            for path in PROTECTED_DEPENDENCY_ROOTS
+            if before_trees.get(path) != after_trees.get(path)
+        ]
+        if changed_trees:
+            changes.append("dependency trees changed: " + ", ".join(changed_trees))
+    before_builds = before.get("protected_build_outputs")
+    after_builds = after.get("protected_build_outputs")
+    if not isinstance(before_builds, dict) or not isinstance(after_builds, dict):
+        changes.append("build output snapshot is unreadable")
+    else:
+        changed_builds = [
+            path
+            for path in PROTECTED_BUILD_PATHS
+            if before_builds.get(path) != after_builds.get(path)
+        ]
+        if changed_builds:
+            changes.append("build outputs changed: " + ", ".join(changed_builds))
+    if before.get("git_identity") != after.get("git_identity"):
+        changes.append("Git refs, HEAD, or index changed")
+    return changes
+
+
+def strict_environment(
+    run_dir: Path,
+    *,
+    source: dict[str, str] | None = None,
+    extra: dict[str, str] | None = None,
+    credentialed: bool = False,
+    pre_commit: bool = False,
+) -> dict[str, str]:
+    _ = pre_commit
+    effective_source = dict(os.environ) if source is None else source
+    group_root, environment_root = _strict_environment_paths(run_dir)
+    home = environment_root / "home"
+    reusing_environment = (
+        environment_root.is_dir()
+        and effective_source.get("HOME") is not None
+        and Path(effective_source["HOME"]).resolve() == home.resolve()
+    )
+    if environment_root.exists() and not reusing_environment:
+        shutil.rmtree(environment_root)
+    if environment_root.exists() and not reusing_environment:
+        raise RuntimeError(f"Sensitive runtime state survived cleanup: {environment_root}")
+    group_root.mkdir(parents=True, exist_ok=True)
+    atexit.register(cleanup_strict_environment, run_dir)
+    cache = environment_root / "cache"
+    config = environment_root / "config"
+    data = environment_root / "data"
+    temp = environment_root / "tmp"
+    for path in (home, cache, config, data, temp):
+        path.mkdir(parents=True, exist_ok=True)
+    env = {key: effective_source[key] for key in _BASE_ENV_KEYS if key in effective_source}
+    if effective_source.get(MANAGED_FD_ENV):
+        env[MANAGED_FD_ENV] = effective_source[MANAGED_FD_ENV]
+    browser_root = verified_playwright_browsers_path(effective_source)
+    repo_root = Path(
+        (extra or {}).get(
+            "OMNIGENT_VERIFY_REPO_ROOT",
+            effective_source.get("OMNIGENT_VERIFY_REPO_ROOT", str(Path.cwd())),
+        )
+    )
+    pnpm_tools_root = (
+        _stage_pnpm_tools(repo_root, cache / "pnpm-tools")
+        if (repo_root / "package.json").is_file()
+        else None
+    )
+    pre_commit_home = cache / "pre-commit"
+    pre_commit_home.mkdir(parents=True, exist_ok=True)
+    if pre_commit and not (pre_commit_home / "db.db").is_file():
+        repo_root = Path(
+            (extra or {}).get(
+                "OMNIGENT_VERIFY_REPO_ROOT",
+                effective_source.get("OMNIGENT_VERIFY_REPO_ROOT", str(Path.cwd())),
+            )
+        )
+        _stage_configured_pre_commit_cache(repo_root, pre_commit_home, effective_source)
+    env.update(
+        {
+            "CI": "true",
+            "HOME": str(home),
+            "XDG_CACHE_HOME": str(cache),
+            "XDG_CONFIG_HOME": str(config),
+            "XDG_DATA_HOME": str(data),
+            "TMPDIR": str(temp),
+            "PRE_COMMIT_HOME": str(pre_commit_home),
+            "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0",
+            "NO_COLOR": "1",
+            "NPM_CONFIG_AUDIT": "false",
+            "NPM_CONFIG_FUND": "false",
+            "NPM_CONFIG_OFFLINE": "true",
+            "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+            "PIP_NO_INDEX": "1",
+            "PNPM_CONFIG_CONFIRM_MODULES_PURGE": "false",
+            "PNPM_CONFIG_FROZEN_LOCKFILE": "true",
+            "PNPM_CONFIG_OFFLINE": "true",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "UV_FROZEN": "1",
+            "UV_NO_SYNC": "1",
+            "UV_OFFLINE": "1",
+        }
+    )
+    if browser_root is not None:
+        env["PLAYWRIGHT_BROWSERS_PATH"] = os.fspath(browser_root)
+    if pnpm_tools_root is not None:
+        env["OMNIGENT_VERIFY_TRUSTED_PNPM_TOOLS_ROOT"] = os.fspath(pnpm_tools_root)
+        version = pinned_pnpm_version(repo_root)
+        env["PATH"] = os.pathsep.join(
+            (
+                os.fspath(pnpm_tools_root / version / "bin"),
+                env.get("PATH", ""),
+            )
+        ).rstrip(os.pathsep)
+    if credentialed:
+        selected_profile = (extra or {}).get(
+            "OMNIGENT_VERIFY_DATABRICKS_PROFILE"
+        ) or effective_source.get("OMNIGENT_VERIFY_DATABRICKS_PROFILE")
+        if selected_profile:
+            source_config = Path(
+                effective_source.get(
+                    "DATABRICKS_CONFIG_FILE",
+                    str(Path(effective_source.get("HOME", "")) / ".databrickscfg"),
+                )
+            )
+            parser = configparser.RawConfigParser()
+            if not source_config.is_file() or not parser.read(source_config):
+                raise RuntimeError(
+                    f"Selected Databricks profile {selected_profile!r} has no readable config."
+                )
+            if not parser.has_section(selected_profile):
+                raise RuntimeError(
+                    f"Selected Databricks profile {selected_profile!r} does not exist."
+                )
+            staged = configparser.RawConfigParser()
+            staged.add_section(selected_profile)
+            for key, value in parser.items(selected_profile, raw=True):
+                staged.set(selected_profile, key, value)
+            staged_path = home / ".databrickscfg"
+            if source_config.resolve() != staged_path.resolve():
+                with staged_path.open("w", encoding="utf-8") as handle:
+                    staged.write(handle)
+                staged_path.chmod(0o600)
+            env["DATABRICKS_CONFIG_FILE"] = str(staged_path)
+            env["DATABRICKS_CONFIG_PROFILE"] = selected_profile
+            env[CREDENTIAL_MODE_ENV] = "databricks-profile"
+        else:
+            harness = (extra or {}).get("OMNIGENT_VERIFY_HARNESS") or effective_source.get(
+                "OMNIGENT_VERIFY_HARNESS"
+            )
+            if effective_source.get("OPENAI_API_KEY") and effective_source.get("OPENAI_BASE_URL"):
+                env.update(
+                    {
+                        "OPENAI_API_KEY": effective_source["OPENAI_API_KEY"],
+                        "OPENAI_BASE_URL": effective_source["OPENAI_BASE_URL"],
+                        CREDENTIAL_MODE_ENV: "openai-environment",
+                    }
+                )
+            elif effective_source.get("DATABRICKS_HOST") and effective_source.get(
+                "DATABRICKS_TOKEN"
+            ):
+                env.update(
+                    {
+                        "DATABRICKS_HOST": effective_source["DATABRICKS_HOST"],
+                        "DATABRICKS_TOKEN": effective_source["DATABRICKS_TOKEN"],
+                        CREDENTIAL_MODE_ENV: "databricks-environment",
+                    }
+                )
+            elif (
+                harness and harness.startswith("cursor") and effective_source.get("CURSOR_API_KEY")
+            ):
+                env.update(
+                    {
+                        "CURSOR_API_KEY": effective_source["CURSOR_API_KEY"],
+                        CREDENTIAL_MODE_ENV: "cursor-api-key",
+                    }
+                )
+    for key, value in (extra or {}).items():
+        if key not in _EXTRA_ENV_KEYS:
+            raise RuntimeError(f"environment override {key!r} is not allowlisted")
+        env[key] = value
+    return env
+
+
+def _strict_environment_paths(run_dir: Path) -> tuple[Path, Path]:
+    resolved = run_dir.resolve()
+    manifest_ancestors = [
+        ancestor
+        for ancestor in (resolved, *resolved.parents)
+        if (ancestor / "manifest.json").is_file()
+    ]
+    verification_root = manifest_ancestors[-1] if manifest_ancestors else resolved
+    group_key = hashlib.sha256(os.fsencode(verification_root)).hexdigest()[:24]
+    run_key = hashlib.sha256(os.fsencode(resolved)).hexdigest()[:24]
+    group_root = Path(tempfile.gettempdir()) / f"omnigent-verify-runtime.{group_key}"
+    return group_root, group_root / run_key
+
+
+def cleanup_strict_environment(run_dir: Path, *, all_runs: bool = False) -> None:
+    group_root, environment_root = _strict_environment_paths(run_dir)
+    target = group_root if all_runs else environment_root
+    if target.exists():
+        shutil.rmtree(target)
+    if target.exists():
+        raise RuntimeError(f"Sensitive runtime state survived cleanup: {target}")
+    with contextlib.suppress(OSError):
+        group_root.rmdir()
+
+
+def _group_exists(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def terminate_group(pgid: int, requested: int = signal.SIGTERM) -> None:
+    for signum, grace in ((requested, 1.0), (signal.SIGTERM, 2.0), (signal.SIGKILL, 2.0)):
+        if not _group_exists(pgid):
+            return
+        try:
+            os.killpg(pgid, signum)
+        except PermissionError:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.kill(pgid, signum)
+        except ProcessLookupError:
+            return
+        deadline = time.monotonic() + grace
+        while _group_exists(pgid) and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+
+def _process_table() -> dict[int, tuple[int, int]]:
+    result = subprocess.run(
+        ("ps", "-axo", "pid=,ppid=,pgid="),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return {}
+    table: dict[int, tuple[int, int]] = {}
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) != 3:
+            continue
+        try:
+            pid, ppid, pgid = (int(value) for value in fields)
+        except ValueError:
+            continue
+        table[pid] = (ppid, pgid)
+    return table
+
+
+def _refresh_descendants(root_pid: int, known: set[int]) -> dict[int, tuple[int, int]]:
+    table = _process_table()
+    parents = {root_pid, *known}
+    changed = True
+    while changed:
+        changed = False
+        for pid, (ppid, _pgid) in table.items():
+            if pid not in known and ppid in parents:
+                known.add(pid)
+                parents.add(pid)
+                changed = True
+    return table
+
+
+def _marker_holders(marker: Path) -> set[int]:
+    holders: set[int] = set()
+    if sys.platform.startswith("linux") and Path("/proc").is_dir():
+        marker_stat = marker.stat()
+        for process_dir in Path("/proc").iterdir():
+            if not process_dir.name.isdigit():
+                continue
+            for descriptor in (process_dir / "fd").glob("*"):
+                try:
+                    target_stat = descriptor.stat()
+                except OSError:
+                    continue
+                if (
+                    target_stat.st_dev == marker_stat.st_dev
+                    and target_stat.st_ino == marker_stat.st_ino
+                ):
+                    holders.add(int(process_dir.name))
+                    break
+    elif sys.platform == "darwin":
+        result = subprocess.run(
+            ("/usr/sbin/lsof", "-F", "p", "--", str(marker)),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        holders.update(
+            int(line[1:])
+            for line in result.stdout.splitlines()
+            if line.startswith("p") and line[1:].isdigit()
+        )
+    holders.discard(os.getpid())
+    return holders
+
+
+def terminate_process_tree(
+    root_pid: int,
+    descendants: set[int],
+    requested: int = signal.SIGTERM,
+    marker: Path | None = None,
+) -> None:
+    own_pgid = os.getpgrp()
+    for signum, grace in ((requested, 1.0), (signal.SIGTERM, 1.0), (signal.SIGKILL, 2.0)):
+        table = _refresh_descendants(root_pid, descendants)
+        if marker is not None:
+            descendants.update(_marker_holders(marker))
+        alive = {pid for pid in descendants if pid in table}
+        groups = {
+            pgid
+            for pid in {root_pid, *alive}
+            if (entry := table.get(pid)) is not None
+            and (pgid := entry[1]) > 0
+            and pgid != own_pgid
+        }
+        for pgid in groups:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(pgid, signum)
+        for pid in {root_pid, *alive}:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.kill(pid, signum)
+        deadline = time.monotonic() + grace
+        while time.monotonic() < deadline:
+            table = _refresh_descendants(root_pid, descendants)
+            if marker is not None:
+                descendants.update(_marker_holders(marker))
+            if root_pid not in table and not any(pid in table for pid in descendants):
+                return
+            time.sleep(0.05)
+
+
+def managed_run(
+    argv: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    log_path: Path,
+    timeout: float | None,
+    result_path: Path,
+    console_fd: int | None = None,
+) -> int:
+    if not argv:
+        raise RuntimeError("managed command argv is empty")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    received_signal: int | None = None
+
+    def receive_signal(signum: int, _frame: object) -> None:
+        nonlocal received_signal
+        received_signal = signum
+
+    previous = {
+        signum: signal.signal(signum, receive_signal)
+        for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
+    }
+    started = time.monotonic()
+    timed_out = False
+    process: subprocess.Popen[bytes] | None = None
+    reader: threading.Thread | None = None
+    descendants: set[int] = set()
+    marker_path = result_path.with_name(f".process-tree.{secrets.token_hex(12)}")
+    marker_descriptor = os.open(marker_path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with log_path.open("wb") as log:
+            child_env = dict(env)
+            child_env[MANAGED_FD_ENV] = str(marker_descriptor)
+            process = subprocess.Popen(
+                argv,
+                cwd=cwd,
+                env=child_env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                pass_fds=(marker_descriptor,),
+            )
+            assert process.stdout is not None
+            process_stdout = process.stdout
+
+            def copy_output() -> None:
+                try:
+                    while chunk := process_stdout.read(64 * 1024):
+                        log.write(chunk)
+                        log.flush()
+                        with contextlib.suppress(OSError):
+                            sys.stdout.buffer.write(chunk)
+                            sys.stdout.buffer.flush()
+                        if console_fd is not None:
+                            with contextlib.suppress(OSError):
+                                os.write(console_fd, chunk)
+                except (OSError, ValueError):
+                    return
+
+            reader = threading.Thread(target=copy_output, daemon=True)
+            reader.start()
+            while True:
+                _refresh_descendants(process.pid, descendants)
+                if process.poll() is not None:
+                    break
+                if received_signal is not None:
+                    terminate_process_tree(
+                        process.pid,
+                        descendants,
+                        received_signal,
+                        marker_path,
+                    )
+                    break
+                if timeout is not None and time.monotonic() - started >= timeout:
+                    timed_out = True
+                    terminate_process_tree(process.pid, descendants, marker=marker_path)
+                    break
+                time.sleep(0.05)
+            exit_status = process.wait(timeout=1)
+            table = _refresh_descendants(process.pid, descendants)
+            descendants.update(_marker_holders(marker_path))
+            if _group_exists(process.pid) or any(pid in table for pid in descendants):
+                terminate_process_tree(process.pid, descendants, marker=marker_path)
+            process.stdout.close()
+            reader.join(timeout=1)
+    finally:
+        os.close(marker_descriptor)
+        marker_path.unlink(missing_ok=True)
+        for signum, handler in previous.items():
+            signal.signal(signum, handler)
+    if timed_out:
+        exit_status = 124
+    elif received_signal is not None:
+        exit_status = 128 + received_signal
+    atomic_json(
+        result_path,
+        {
+            "schema_version": SCHEMA_VERSION,
+            "exit_status": exit_status,
+            "signal": signal.Signals(received_signal).name.removeprefix("SIG")
+            if received_signal
+            else None,
+            "timed_out": timed_out,
+        },
+    )
+    return exit_status
+
+
+def inherited_managed_fds(source: dict[str, str] | None = None) -> tuple[int, ...]:
+    """Return the validated verifier marker descriptor inherited by this process."""
+    effective_source = dict(os.environ) if source is None else source
+    raw = effective_source.get(MANAGED_FD_ENV)
+    if raw is None:
+        return ()
+    try:
+        descriptor = int(raw)
+        os.fstat(descriptor)
+    except (OSError, ValueError):
+        return ()
+    return (descriptor,)
+
+
+def _parse_extra(values: list[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for item in values:
+        key, separator, value = item.partition("=")
+        if not separator:
+            raise RuntimeError(f"invalid environment override {item!r}")
+        result[key] = value
+    return result
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    snapshot = subparsers.add_parser("snapshot")
+    snapshot.add_argument("--repo-root", type=Path, required=True)
+    snapshot.add_argument("--output", type=Path, required=True)
+    snapshot.add_argument("--deep-dependencies", action="store_true")
+    check = subparsers.add_parser("check")
+    check.add_argument("--repo-root", type=Path, required=True)
+    check.add_argument("--before", type=Path, required=True)
+    check.add_argument("--deep-dependencies", action="store_true")
+    seal = subparsers.add_parser("seal-pre-commit-cache")
+    seal.add_argument("--repo-root", type=Path, required=True)
+    seal.add_argument("--cache-root", type=Path, required=True)
+    publish = subparsers.add_parser("publish-pre-commit-cache")
+    publish.add_argument("--repo-root", type=Path, required=True)
+    publish.add_argument("--staging", type=Path, required=True)
+    publish.add_argument("--destination", type=Path, required=True)
+    prepare_pnpm = subparsers.add_parser("prepare-pnpm-cache")
+    prepare_pnpm.add_argument("--repo-root", type=Path, required=True)
+    prepare_pnpm.add_argument("--staging", type=Path, required=True)
+    prepare_pnpm.add_argument("--allow-download", action="store_true")
+    publish_pnpm = subparsers.add_parser("publish-pnpm-cache")
+    publish_pnpm.add_argument("--staging", type=Path, required=True)
+    publish_pnpm.add_argument("--destination", type=Path, required=True)
+    run = subparsers.add_parser("run")
+    run.add_argument("--run-dir", type=Path, required=True)
+    run.add_argument("--cwd", type=Path, required=True)
+    run.add_argument("--log", type=Path, required=True)
+    run.add_argument("--result", type=Path, required=True)
+    run.add_argument("--timeout", type=float)
+    run.add_argument("--credentialed", action="store_true")
+    run.add_argument("--console-fd", type=int)
+    run.add_argument("--set-env", action="append", default=[])
+    run.add_argument("argv", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    if args.action == "snapshot":
+        atomic_json(
+            args.output,
+            repository_snapshot(
+                args.repo_root,
+                deep_dependencies=args.deep_dependencies,
+            ),
+        )
+        return
+    if args.action == "check":
+        before = json.loads(args.before.read_text(encoding="utf-8"))
+        changes = compare_snapshots(
+            before,
+            repository_snapshot(
+                args.repo_root,
+                deep_dependencies=args.deep_dependencies,
+            ),
+        )
+        for change in changes:
+            print(f"verification blocker: {change}", file=sys.stderr)
+        raise SystemExit(1 if changes else 0)
+    if args.action == "seal-pre-commit-cache":
+        seal = seal_pre_commit_cache(args.repo_root, args.cache_root)
+        print(json.dumps(seal, sort_keys=True))
+        return
+    if args.action == "publish-pre-commit-cache":
+        publish_pre_commit_cache(args.repo_root, args.staging, args.destination)
+        return
+    if args.action == "prepare-pnpm-cache":
+        seal = prepare_pnpm_cache(
+            args.repo_root,
+            args.staging,
+            allow_download=args.allow_download,
+        )
+        print(json.dumps(seal, sort_keys=True))
+        return
+    if args.action == "publish-pnpm-cache":
+        publish_pnpm_cache(args.staging, args.destination)
+        return
+    argv = list(args.argv)
+    if argv[:1] == ["--"]:
+        argv = argv[1:]
+    env = strict_environment(
+        args.run_dir,
+        extra=_parse_extra(args.set_env),
+        credentialed=args.credentialed,
+        pre_commit=any("pre-commit" in value or value == "quality-gates" for value in argv),
+    )
+    manifest_path = args.run_dir / "manifest.json"
+    manifest_before = (
+        manifest_path.read_bytes()
+        if manifest_path.is_file() and not manifest_path.is_symlink()
+        else None
+    )
+    status = managed_run(
+        argv,
+        cwd=args.cwd,
+        env=env,
+        log_path=args.log,
+        timeout=args.timeout,
+        result_path=args.result,
+        console_fd=args.console_fd,
+    )
+    if manifest_before is not None:
+        try:
+            manifest_after = manifest_path.read_bytes()
+        except OSError:
+            manifest_after = None
+        if manifest_after != manifest_before or manifest_path.is_symlink():
+            atomic_bytes(manifest_path, manifest_before)
+            print(
+                "verification blocker: verifier manifest was modified by a managed child",
+                file=sys.stderr,
+            )
+            result = json.loads(args.result.read_text(encoding="utf-8"))
+            result["control_metadata_tampered"] = True
+            result["exit_status"] = 125
+            atomic_json(args.result, result)
+            status = 125
+    try:
+        cleanup_strict_environment(args.run_dir, all_runs=True)
+    except (OSError, RuntimeError) as exc:
+        print(
+            f"verification blocker: sensitive runtime cleanup failed ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        result = json.loads(args.result.read_text(encoding="utf-8"))
+        result["runtime_cleanup"] = {"status": "failed"}
+        result["exit_status"] = 125
+        atomic_json(args.result, result)
+        status = 125
+    raise SystemExit(status)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/verify-omnigent/scripts/universe_preflight.py
+++ b/.agents/skills/verify-omnigent/scripts/universe_preflight.py
@@ -1,0 +1,676 @@
+#!/usr/bin/env python3
+"""Run read-only source and Bazel checks against a sibling Universe checkout."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import subprocess
+import tarfile
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+BAZEL_FLAGS = (
+    "--tool_tag=ai-agent",
+    "--test_output=errors",
+    "--noshow_progress",
+    "--noshow_loading_progress",
+)
+VENDORED_INVARIANT_TARGET = "//agentbricks/mas/python:test_vendored_invariants"
+HOST_PATCH_TARGETS = {
+    "//agentbricks/mas/python:test_host_slice_key_gate_patch",
+    "//agentbricks/mas/python:test_managed_host_edge_bearer_patch",
+}
+HOST_RUNTIME_TARGETS = {
+    "//agentbricks/mas/python:test_arca_sandbox_launcher",
+    "//agentbricks/mas/python:test_databricks_host_store",
+    "//agentbricks/mas/python:test_databricks_host_store_managed",
+    "//agentbricks/mas/python:test_lakebox_sandbox_launcher",
+}
+HOST_ID_PATHS = {
+    "omnigent/cli.py",
+    "omnigent/host/connect.py",
+    "omnigent/host/identity.py",
+    "omnigent/server/routes/host_tunnel.py",
+}
+_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _atomic_json(path: Path, value: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(value, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def _run(
+    argv: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        cwd=cwd,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _resolve_commit(repo_root: Path, ref: str) -> tuple[str | None, str | None]:
+    result = _run(["git", "rev-parse", "--verify", f"{ref}^{{commit}}"], cwd=repo_root)
+    value = result.stdout.strip().lower()
+    if result.returncode != 0 or not _SHA.fullmatch(value):
+        detail = result.stderr.strip() or f"{ref!r} did not resolve to a commit"
+        return None, detail
+    return value, None
+
+
+def _read_pin(path: Path) -> tuple[str | None, str | None]:
+    try:
+        value = path.read_text(encoding="utf-8").strip().lower()
+    except OSError as exc:
+        return None, f"{path.name} could not be read ({type(exc).__name__})"
+    if not _SHA.fullmatch(value):
+        return None, f"{path.name} does not contain a full commit SHA"
+    return value, None
+
+
+def discover_universe(repo_root: Path, explicit: str | None) -> tuple[Path | None, str | None]:
+    """Find a Universe checkout without searching outside the OSS checkout's parent."""
+    candidate = Path(explicit).expanduser() if explicit else repo_root.parent / "universe"
+    try:
+        candidate = candidate.resolve(strict=True)
+    except OSError:
+        return None, f"Universe checkout was not found at {candidate}"
+    pin = candidate / "agentbricks" / "mas" / "third_party" / "sync" / "UPSTREAM_REF"
+    if not pin.is_file():
+        return None, f"{candidate.name} is not a MAS Universe checkout"
+    return candidate, None
+
+
+def _changed_files(
+    repo_root: Path,
+    base: str,
+    requested: str,
+    pathspec: str | None = None,
+) -> tuple[list[str], str | None]:
+    argv = [
+        "git",
+        "diff",
+        "--name-status",
+        "-z",
+        "--find-renames",
+        "--find-copies-harder",
+        "--diff-filter=ACDMRTUXB",
+        base,
+        requested,
+    ]
+    if pathspec:
+        argv.extend(("--", pathspec))
+    result = subprocess.run(argv, cwd=repo_root, check=False, capture_output=True)
+    if result.returncode != 0:
+        return (
+            [],
+            result.stderr.decode("utf-8", "replace").strip() or "changed-file discovery failed",
+        )
+    fields = [os.fsdecode(raw) for raw in result.stdout.split(b"\0") if raw]
+    paths: list[str] = []
+    cursor = 0
+    while cursor < len(fields):
+        status = fields[cursor]
+        cursor += 1
+        path_count = 2 if status[:1] in {"R", "C"} else 1
+        if cursor + path_count > len(fields):
+            return [], "git returned malformed name-status output"
+        paths.extend(fields[cursor : cursor + path_count])
+        cursor += path_count
+    return sorted(dict.fromkeys(paths)), None
+
+
+def _merge_base(repo_root: Path, base: str, requested: str) -> tuple[str | None, str | None]:
+    result = subprocess.run(
+        ["git", "merge-base", "--all", base, requested],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    values = result.stdout.splitlines()
+    if result.returncode != 0 or len(values) != 1:
+        detail = result.stderr.strip()
+        return None, detail or "base and requested refs have no unique merge base"
+    return values[0], None
+
+
+def _patch_for_path(patches_root: Path, changed_path: str) -> Path | None:
+    mappings = (
+        ("omnigent/", "omnigent/"),
+        ("sdks/python-client/omnigent_client/", "omnigent_client/omnigent_client/"),
+        ("sdks/ui/omnigent_ui_sdk/", "omnigent_ui_sdk/omnigent_ui_sdk/"),
+        ("web/", "omnigent_ui/"),
+    )
+    for source_prefix, patch_prefix in mappings:
+        if changed_path.startswith(source_prefix):
+            relative = changed_path.removeprefix(source_prefix)
+            candidate = patches_root / f"{patch_prefix}{relative}.patch"
+            return candidate if candidate.is_file() else None
+    return None
+
+
+def _required_sync_pins(changed_files: list[str]) -> list[str]:
+    required = []
+    if any(path.startswith(("omnigent/", "sdks/python-client/")) for path in changed_files):
+        required.append("python")
+    if any(path.startswith(("web/", "sdks/ui/")) for path in changed_files):
+        required.append("ui")
+    return required
+
+
+def relevant_patches(
+    patches_root: Path,
+    python_changes: list[str],
+    ui_changes: list[str],
+) -> list[Path]:
+    patches = {
+        patch
+        for path in [*python_changes, *ui_changes]
+        if (patch := _patch_for_path(patches_root, path)) is not None
+    }
+    return sorted(patches)
+
+
+def check_patch_apply(
+    repo_root: Path,
+    requested_commit: str,
+    patches: list[Path],
+    patches_root: Path,
+) -> dict[str, object]:
+    """Check patches against an archived commit, never the live Universe tree."""
+    if not patches:
+        return {"status": "not_applicable", "checks": []}
+
+    checks: list[dict[str, object]] = []
+    with tempfile.TemporaryDirectory(prefix="omnigent-universe-apply-") as temporary:
+        tree = Path(temporary) / "tree"
+        tree.mkdir()
+        archive = Path(temporary) / "upstream.tar"
+        with archive.open("wb") as handle:
+            exported = subprocess.run(
+                ["git", "archive", "--format=tar", requested_commit],
+                cwd=repo_root,
+                check=False,
+                stdout=handle,
+                stderr=subprocess.PIPE,
+            )
+        if exported.returncode != 0:
+            return {
+                "status": "unavailable",
+                "checks": [],
+                "reason": exported.stderr.decode("utf-8", "replace").strip(),
+            }
+        with tarfile.open(archive) as tar:
+            tar.extractall(tree, filter="data")
+
+        for patch in patches:
+            result = _run(["git", "apply", "--check", "-p1", str(patch)], cwd=tree)
+            checks.append(
+                {
+                    "patch": patch.relative_to(patches_root).as_posix(),
+                    "status": "passed" if result.returncode == 0 else "failed",
+                    "exit_status": result.returncode,
+                    "detail": result.stderr.strip() or None,
+                }
+            )
+    return {
+        "status": "passed" if all(item["status"] == "passed" for item in checks) else "failed",
+        "checks": checks,
+    }
+
+
+def classify_darwin_blocker(text: str) -> str | None:
+    lowered = text.lower()
+    if "jemalloc" in lowered and "features.h" in lowered:
+        return "darwin_jemalloc_features_h"
+    if "_psutil_osx" in lowered:
+        return "darwin_psutil_extension"
+    return None
+
+
+def parse_bazel_test_result(
+    *,
+    exit_status: int,
+    xml_path: Path,
+    output: str,
+    system: str,
+) -> dict[str, object]:
+    """Require both a zero Bazel exit and a non-empty passing test.xml."""
+    blocker = classify_darwin_blocker(output) if system == "Darwin" else None
+    if not xml_path.is_file():
+        return {
+            "status": "blocked" if blocker else "failed",
+            "exit_status": exit_status,
+            "tests": 0,
+            "failures": 0,
+            "errors": 0,
+            "blocker": blocker,
+            "reason": "Bazel produced no test.xml; zero tests were proven.",
+        }
+    try:
+        root = ET.parse(xml_path).getroot()
+    except (ET.ParseError, OSError) as exc:
+        return {
+            "status": "failed",
+            "exit_status": exit_status,
+            "tests": 0,
+            "failures": 0,
+            "errors": 1,
+            "blocker": blocker,
+            "reason": f"test.xml could not be parsed ({type(exc).__name__}).",
+        }
+
+    cases = list(root.iter("testcase"))
+    tests = len(cases)
+    failures = sum(case.find("failure") is not None for case in cases)
+    errors = sum(case.find("error") is not None for case in cases)
+    skipped = sum(case.find("skipped") is not None for case in cases)
+    xml_text = ET.tostring(root, encoding="unicode")
+    blocker = blocker or (classify_darwin_blocker(xml_text) if system == "Darwin" else None)
+    executed = tests - skipped
+    if exit_status == 0 and executed > 0 and failures == 0 and errors == 0:
+        status = "passed"
+        reason = None
+    elif blocker:
+        status = "blocked"
+        reason = "A known Darwin build or collection blocker prevented the test."
+    elif tests == 0:
+        status = "failed"
+        reason = "test.xml recorded zero tests."
+    elif executed == 0:
+        status = "failed"
+        reason = "test.xml recorded no non-skipped tests."
+    else:
+        status = "failed"
+        reason = "Bazel or the recorded test cases failed."
+    return {
+        "status": status,
+        "exit_status": exit_status,
+        "tests": tests,
+        "failures": failures,
+        "errors": errors,
+        "skipped": skipped,
+        "blocker": blocker,
+        "reason": reason,
+    }
+
+
+def _target_name(target: str) -> str:
+    return target.rsplit(":", 1)[-1]
+
+
+def _target_xml(universe_root: Path, target: str) -> Path:
+    package, name = target.removeprefix("//").split(":", 1)
+    return universe_root / "bazel-testlogs" / package / name / "test.xml"
+
+
+def _run_bazel_test(
+    universe_root: Path,
+    target: str,
+    output_dir: Path,
+    system: str,
+) -> dict[str, object]:
+    log_path = output_dir / f"{_target_name(target)}.log"
+    env = {**os.environ, "TMPDIR": "/tmp"}
+    result = _run(["bazel", "test", target, *BAZEL_FLAGS], cwd=universe_root, env=env)
+    output = result.stdout + result.stderr
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(output, encoding="utf-8")
+    parsed = parse_bazel_test_result(
+        exit_status=result.returncode,
+        xml_path=_target_xml(universe_root, target),
+        output=output,
+        system=system,
+    )
+    parsed.update(
+        {
+            "target": target,
+            "log": f"universe-bazel/{log_path.name}",
+            "test_xml": (f"bazel-testlogs/{target.removeprefix('//').replace(':', '/')}/test.xml"),
+        }
+    )
+    return parsed
+
+
+def _git_status_digest(repo_root: Path) -> tuple[str | None, str | None]:
+    result = _run(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        return None, result.stderr.strip() or "git status failed"
+    return hashlib.sha256(result.stdout.encode("utf-8")).hexdigest(), None
+
+
+def _dirty_paths(repo_root: Path, *, include_untracked: bool) -> tuple[list[str], str | None]:
+    result = subprocess.run(
+        [
+            "git",
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all" if include_untracked else "--untracked-files=no",
+        ],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return [], result.stderr.decode("utf-8", "replace").strip() or "git status failed"
+    entries = [raw for raw in result.stdout.split(b"\0") if raw]
+    paths = [os.fsdecode(entry[3:]) for entry in entries if len(entry) >= 4]
+    return paths, None
+
+
+def _blocked_target(target: str, blocker: str) -> dict[str, object]:
+    return {
+        "target": target,
+        "status": "blocked",
+        "exit_status": None,
+        "tests": 0,
+        "failures": 0,
+        "errors": 0,
+        "skipped": 0,
+        "blocker": blocker,
+        "reason": "Run this target on the supported Linux/Bazel lane.",
+        "log": None,
+        "test_xml": None,
+    }
+
+
+def run_preflight(
+    repo_root: Path,
+    run_dir: Path,
+    oss_ref: str,
+    base_ref: str,
+    universe_override: str | None,
+    system: str,
+) -> tuple[dict[str, object], int]:
+    limitations: list[str] = []
+    requested_oss: dict[str, object] = {
+        "ref": oss_ref,
+        "commit": None,
+        "base_ref": base_ref,
+        "base_commit": None,
+        "merge_base": None,
+    }
+    source_patch_apply: dict[str, object] = {"status": "unavailable", "checks": []}
+    bazel_results: list[dict[str, object]] = []
+    bazel: dict[str, object] = {"tests": bazel_results}
+    runtime: dict[str, object] = {"status": "unverified", "targets": []}
+    report: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "failed",
+        "requested_oss": requested_oss,
+        "pins": {"python": None, "ui": None},
+        "sync": {"status": "unknown"},
+        "source_patch_apply": source_patch_apply,
+        "bazel": bazel,
+        "runtime_compatibility": runtime,
+        "checkout_unchanged": None,
+        "limitations": limitations,
+    }
+    oss_tracked_dirty, tracked_dirty_error = _dirty_paths(repo_root, include_untracked=False)
+    oss_dirty, dirty_error = _dirty_paths(repo_root, include_untracked=True)
+    if tracked_dirty_error or dirty_error or oss_tracked_dirty or oss_dirty:
+        limitations.append(
+            "OSS checkout has tracked or non-ignored untracked changes; commit, stash, "
+            "or ignore generated outputs before Universe verification."
+        )
+        return report, 2
+    requested, error = _resolve_commit(repo_root, oss_ref)
+    if error or requested is None:
+        limitations.append(f"Requested OSS ref could not be resolved: {error}")
+        return report, 2
+    requested_oss["commit"] = requested
+    base, error = _resolve_commit(repo_root, base_ref)
+    if error or base is None:
+        limitations.append(f"OSS base ref could not be resolved: {error}")
+        return report, 2
+    requested_oss["base_commit"] = base
+    merge_base, error = _merge_base(repo_root, base, requested)
+    if error or merge_base is None:
+        limitations.append(f"OSS refs have no unique merge base: {error}")
+        return report, 2
+    requested_oss["merge_base"] = merge_base
+
+    universe_root, error = discover_universe(repo_root, universe_override)
+    if error or universe_root is None:
+        limitations.append(error or "Universe checkout discovery failed.")
+        report["status"] = "unavailable"
+        return report, 2
+    report["checkout"] = universe_root.name
+    universe_dirty, dirty_error = _dirty_paths(universe_root, include_untracked=True)
+    if dirty_error or universe_dirty:
+        limitations.append(
+            "Universe checkout has tracked or non-ignored untracked changes; "
+            "start from a clean checkout."
+        )
+        report["status"] = "unavailable"
+        return report, 2
+    all_changes, change_error = _changed_files(repo_root, merge_base, requested)
+    python_changes = [
+        path for path in all_changes if path.startswith(("omnigent/", "sdks/python-client/"))
+    ]
+    ui_changes = [path for path in all_changes if path.startswith(("web/", "sdks/ui/"))]
+    if not python_changes and not ui_changes and change_error is None:
+        report["changed_files"] = []
+        report["sync"] = {
+            "status": "not_applicable",
+            "requested_commit": requested,
+            "required_pins": [],
+            "mismatched_pins": [],
+            "vendored_python_commit": None,
+            "vendored_ui_commit": None,
+        }
+        source_patch_apply.update({"status": "not_applicable", "checks": []})
+        runtime.update({"status": "not_applicable", "targets": []})
+        bazel_results.clear()
+        report["checkout_unchanged"] = True
+        report["status"] = "not_applicable"
+        limitations.append(
+            "The requested OSS diff changes only verification or deployment support; "
+            "Universe Python and UI pins are not applicable."
+        )
+        return report, 0
+    sync_root = universe_root / "agentbricks" / "mas" / "third_party" / "sync"
+    python_pin, pin_error = _read_pin(sync_root / "UPSTREAM_REF")
+    ui_pin, ui_error = _read_pin(sync_root / "UI_UPSTREAM_REF")
+    report["pins"] = {"python": python_pin, "ui": ui_pin}
+    if pin_error or ui_error:
+        limitations.extend(error for error in (pin_error, ui_error) if error)
+        report["status"] = "unavailable"
+        return report, 2
+    assert requested is not None and python_pin is not None and ui_pin is not None
+
+    if change_error:
+        limitations.append(f"Source change discovery failed: {change_error}")
+    else:
+        report["changed_files"] = sorted(dict.fromkeys([*python_changes, *ui_changes]))
+        patches_root = sync_root / "local-patches"
+        patches = relevant_patches(patches_root, python_changes, ui_changes)
+        source_patch_apply = check_patch_apply(
+            repo_root,
+            requested,
+            patches,
+            patches_root,
+        )
+        report["source_patch_apply"] = source_patch_apply
+        if source_patch_apply["status"] in {"failed", "unavailable"}:
+            limitations.append(
+                "One or more affected Universe patches could not be applied to "
+                "the requested OSS commit."
+            )
+
+    pin_values = {"python": python_pin, "ui": ui_pin}
+    required_pins = [
+        (name, pin_values[name]) for name in _required_sync_pins([*python_changes, *ui_changes])
+    ]
+    mismatched_pins = [name for name, pin in required_pins if pin != requested]
+    sync_status = "synced" if not mismatched_pins else "not_synced"
+    report["sync"] = {
+        "status": sync_status,
+        "requested_commit": requested,
+        "required_pins": [name for name, _pin in required_pins],
+        "mismatched_pins": mismatched_pins,
+        "vendored_python_commit": python_pin,
+        "vendored_ui_commit": ui_pin,
+    }
+    if sync_status == "not_synced":
+        limitations.append(
+            "Universe pins required by the changed Python/UI surfaces are not synced "
+            "to the requested OSS commit."
+        )
+
+    before_status, status_error = _git_status_digest(universe_root)
+    if status_error:
+        limitations.append(f"Universe checkout state could not be read: {status_error}")
+
+    changed_value = report.get("changed_files", [])
+    changed = set(changed_value) if isinstance(changed_value, list) else set()
+    patch_targets = {VENDORED_INVARIANT_TARGET}
+    runtime_targets: set[str] = set()
+    if changed & HOST_ID_PATHS:
+        patch_targets.update(HOST_PATCH_TARGETS)
+        runtime_targets.update(HOST_RUNTIME_TARGETS)
+
+    output_dir = run_dir / "universe-bazel"
+    for target in sorted(patch_targets):
+        if (
+            system == "Darwin"
+            and target == "//agentbricks/mas/python:test_managed_host_edge_bearer_patch"
+        ):
+            bazel_results.append(_blocked_target(target, "darwin_psutil_extension"))
+            continue
+        bazel_results.append(_run_bazel_test(universe_root, target, output_dir, system))
+    for result in bazel_results:
+        if result["status"] != "passed":
+            limitations.append(
+                f"{result['target']} did not pass: {result.get('reason') or result['status']}"
+            )
+
+    if sync_status == "not_synced":
+        runtime["status"] = "not_synced"
+        runtime["targets"] = sorted(runtime_targets)
+    elif not runtime_targets:
+        runtime["status"] = "unverified"
+        limitations.append("No focused downstream runtime target is mapped for these OSS paths.")
+    elif system == "Darwin":
+        runtime["status"] = "blocked"
+        runtime["targets"] = [
+            _blocked_target(target, "darwin_jemalloc_features_h")
+            for target in sorted(runtime_targets)
+        ]
+        limitations.append(
+            "Darwin MAS runtime targets are blocked before test execution by the known "
+            "jemalloc/features.h toolchain failure. Run this profile on Linux."
+        )
+    else:
+        runtime_results = [
+            _run_bazel_test(universe_root, target, output_dir, system)
+            for target in sorted(runtime_targets)
+        ]
+        runtime["targets"] = runtime_results
+        runtime["status"] = (
+            "passed" if all(item["status"] == "passed" for item in runtime_results) else "failed"
+        )
+        for result in runtime_results:
+            if result["status"] != "passed":
+                limitations.append(
+                    f"{result['target']} did not pass: {result.get('reason') or result['status']}"
+                )
+
+    after_status, after_error = _git_status_digest(universe_root)
+    if after_error:
+        limitations.append(f"Final Universe checkout state could not be read: {after_error}")
+    report["checkout_unchanged"] = (
+        before_status is not None and after_status is not None and before_status == after_status
+    )
+    if report["checkout_unchanged"] is False:
+        limitations.append("Universe checkout status changed during verification.")
+
+    source_status = source_patch_apply["status"]
+    bazel_failed = any(item["status"] == "failed" for item in bazel_results)
+    if source_status in {"failed", "unavailable"}:
+        report["status"] = "source_incompatible"
+    elif bazel_failed or report["checkout_unchanged"] is False:
+        report["status"] = "failed"
+    elif sync_status == "not_synced":
+        report["status"] = "not_synced"
+    elif runtime["status"] == "blocked":
+        report["status"] = "blocked"
+    elif runtime["status"] == "passed":
+        report["status"] = "passed"
+    else:
+        report["status"] = "unverified"
+    return report, 0 if report.get("status") == "passed" else 1
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--run-dir", type=Path, required=True)
+    parser.add_argument("--oss-ref", default="HEAD")
+    parser.add_argument("--base-ref", default="HEAD")
+    parser.add_argument("--universe-root")
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    run_dir = args.run_dir.resolve()
+    try:
+        report, exit_status = run_preflight(
+            args.repo_root.resolve(),
+            run_dir,
+            args.oss_ref,
+            args.base_ref,
+            args.universe_root or os.environ.get("UNIVERSE_ROOT"),
+            platform.system(),
+        )
+    except (OSError, subprocess.SubprocessError, tarfile.TarError) as exc:
+        report = {
+            "schema_version": SCHEMA_VERSION,
+            "status": "failed",
+            "source_patch_apply": {"status": "unavailable", "checks": []},
+            "runtime_compatibility": {"status": "unverified", "targets": []},
+            "limitations": [f"Universe preflight failed ({type(exc).__name__}): {exc}"],
+        }
+        exit_status = 2
+    _atomic_json(run_dir / "universe.json", report)
+    source = report.get("source_patch_apply")
+    runtime = report.get("runtime_compatibility")
+    if not isinstance(source, dict) or not isinstance(runtime, dict):
+        raise RuntimeError("Universe report has an invalid schema")
+    print(
+        "universe: "
+        f"status={report['status']} "
+        f"source={source['status']} "
+        f"runtime={runtime['status']}"
+    )
+    raise SystemExit(exit_status)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/verify-omnigent/scripts/verify.sh
+++ b/.agents/skills/verify-omnigent/scripts/verify.sh
@@ -1,0 +1,1390 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+invocation_cwd="$PWD"
+skill_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -n "${OMNIGENT_VERIFY_REPO_ROOT:-}" ]]; then
+  repo_root="$OMNIGENT_VERIFY_REPO_ROOT"
+elif repo_root="$(git -C "$invocation_cwd" rev-parse --show-toplevel 2>/dev/null)"; then
+  :
+elif repo_root="$(git -C "$skill_root" rev-parse --show-toplevel 2>/dev/null)" &&
+  [[ "$skill_root" == "$repo_root/.agents/skills/verify-omnigent" ]]; then
+  :
+else
+  echo "verify-omnigent: target checkout is ambiguous; run from its Git worktree or set OMNIGENT_VERIFY_REPO_ROOT" >&2
+  exit 2
+fi
+repo_root="$(cd "$repo_root" && pwd)"
+export OMNIGENT_VERIFY_SKILL_ROOT="$skill_root"
+cd "$repo_root"
+
+profile="${1:-doctor}"
+if [[ "$#" -gt 0 ]]; then
+  shift
+fi
+doctor_profile="smoke"
+if [[ "$profile" == "doctor" && "$#" -gt 0 && "${1:-}" != "--base-ref" ]]; then
+  doctor_profile="$1"
+  shift
+fi
+base_ref="${OMNIGENT_VERIFY_BASE_REF:-HEAD}"
+oss_ref="${OMNIGENT_VERIFY_OSS_REF:-HEAD}"
+with_universe=0
+comparison_request=""
+comparison_capability=""
+max_p50_regression_percent="10"
+max_p99_regression_percent="10"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --base-ref)
+      if [[ "$#" -lt 2 ]]; then
+        echo "verify-omnigent: --base-ref needs a value" >&2
+        exit 2
+      fi
+      base_ref="$2"
+      shift 2
+      ;;
+    --oss-ref)
+      if [[ "$#" -lt 2 ]]; then
+        echo "verify-omnigent: --oss-ref needs a value" >&2
+        exit 2
+      fi
+      oss_ref="$2"
+      shift 2
+      ;;
+    --with-universe)
+      with_universe=1
+      shift
+      ;;
+    --max-p50-regression-percent|--max-p99-regression-percent)
+      if [[ "$#" -lt 2 ]] ||
+        ! python3 -c 'import math,sys; value=float(sys.argv[1]); assert math.isfinite(value) and 0 <= value <= 1000' "$2" 2>/dev/null; then
+        echo "verify-omnigent: $1 needs a finite value between 0 and 1000" >&2
+        exit 2
+      fi
+      if [[ "$1" == "--max-p50-regression-percent" ]]; then
+        max_p50_regression_percent="$2"
+      else
+        max_p99_regression_percent="$2"
+      fi
+      shift 2
+      ;;
+    --comparison-request)
+      if [[ "$#" -lt 2 ]]; then
+        echo "verify-omnigent: --comparison-request needs a value" >&2
+        exit 2
+      fi
+      comparison_request="$2"
+      shift 2
+      ;;
+    --comparison-capability)
+      if [[ "$#" -lt 2 ]]; then
+        echo "verify-omnigent: --comparison-capability needs a value" >&2
+        exit 2
+      fi
+      comparison_capability="$2"
+      shift 2
+      ;;
+    *)
+      echo "verify-omnigent: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+manifest_doctor_profile="$doctor_profile"
+if [[ "$profile" != "doctor" ]]; then
+  manifest_doctor_profile="$profile"
+fi
+evidence_root="${OMNIGENT_VERIFY_EVIDENCE_DIR:-$repo_root/.artifacts/verify-omnigent}"
+manifest_helper="$skill_root/scripts/evidence_manifest.py"
+orchestration_helper="$skill_root/scripts/orchestration.py"
+profile_runner="$skill_root/scripts/profile_runner.py"
+universe_preflight="$skill_root/scripts/universe_preflight.py"
+comparison_helper="$skill_root/scripts/comparison.py"
+runtime_helper="$skill_root/scripts/runtime_support.py"
+verify_script="$skill_root/scripts/verify.sh"
+if [[ "$profile" == "prepare-hooks" ]]; then
+  cache_root="$HOME/.cache/verify-omnigent/pre-commit"
+  cache_parent="$(dirname "$cache_root")"
+  mkdir -p "$cache_parent"
+  chmod 700 "$cache_parent"
+  staging_cache="$(mktemp -d "$cache_parent/pre-commit.version.XXXXXX")"
+  # shellcheck disable=SC2329 # EXIT trap callback
+  cleanup_preparation() {
+    rm -rf "$staging_cache"
+  }
+  trap cleanup_preparation EXIT
+  PRE_COMMIT_HOME="$staging_cache" uv run --no-sync pre-commit install-hooks \
+    --config "$repo_root/.pre-commit-config.yaml"
+  chmod -R go-w "$staging_cache"
+  python3 "$runtime_helper" seal-pre-commit-cache \
+    --repo-root "$repo_root" \
+    --cache-root "$staging_cache" >/dev/null
+  python3 "$runtime_helper" publish-pre-commit-cache \
+    --repo-root "$repo_root" \
+    --staging "$staging_cache" \
+    --destination "$cache_root"
+  staging_cache=""
+  trap - EXIT
+  echo "Prepared and authenticated configured pre-commit hooks in $cache_root"
+  exit 0
+fi
+if [[ "$profile" == "prepare-tools" ]]; then
+  cache_root="$HOME/.cache/verify-omnigent/pnpm"
+  cache_parent="$(dirname "$cache_root")"
+  mkdir -p "$cache_parent"
+  chmod 700 "$cache_parent"
+  staging_cache="$(mktemp -d "$cache_parent/pnpm.version.XXXXXX")"
+  # shellcheck disable=SC2329 # EXIT trap callback
+  cleanup_tool_preparation() {
+    rm -rf "$staging_cache"
+  }
+  trap cleanup_tool_preparation EXIT
+  python3 "$runtime_helper" prepare-pnpm-cache \
+    --repo-root "$repo_root" \
+    --staging "$staging_cache" \
+    --allow-download >/dev/null
+  python3 "$runtime_helper" publish-pnpm-cache \
+    --staging "$staging_cache" \
+    --destination "$cache_root"
+  staging_cache=""
+  trap - EXIT
+  echo "Prepared authenticated pnpm from the exact packageManager pin."
+  exit 0
+fi
+run_dir=""
+run_id=""
+run_status="failed"
+final_exit_status=1
+received_signal=""
+child_pid=""
+logging_started=0
+finalized=0
+managed_counter=0
+initial_snapshot=""
+initial_snapshot_sha256=""
+control_dir=""
+
+# shellcheck disable=SC2329 # EXIT/finalization callback
+cleanup_control_dir() {
+  if [[ -n "$control_dir" ]]; then
+    rm -rf "$control_dir"
+    control_dir=""
+  fi
+}
+
+reject_internal_control() {
+  local name="$1"
+  local present="$2"
+  if [[ "$present" == "set" ]]; then
+    echo "verify-omnigent: caller-supplied internal control $name is forbidden" >&2
+    exit 2
+  fi
+}
+reject_internal_control \
+  OMNIGENT_VERIFY_PARTIAL_COMPARISON "${OMNIGENT_VERIFY_PARTIAL_COMPARISON+set}"
+reject_internal_control \
+  OMNIGENT_VERIFY_ONLY_STEP_INDICES "${OMNIGENT_VERIFY_ONLY_STEP_INDICES+set}"
+reject_internal_control \
+  OMNIGENT_VERIFY_CHANGED_FILES_JSON "${OMNIGENT_VERIFY_CHANGED_FILES_JSON+set}"
+reject_internal_control \
+  OMNIGENT_VERIFY_DISABLE_BASELINE "${OMNIGENT_VERIFY_DISABLE_BASELINE+set}"
+reject_internal_control \
+  OMNIGENT_VERIFY_INTERNAL_REQUEST "${OMNIGENT_VERIFY_INTERNAL_REQUEST+set}"
+reject_internal_control \
+  OMNIGENT_VERIFY_CONTROL_SNAPSHOT "${OMNIGENT_VERIFY_CONTROL_SNAPSHOT+set}"
+reject_internal_control \
+  OMNIGENT_VERIFY_DEEP_DEPENDENCY_SNAPSHOT \
+  "${OMNIGENT_VERIFY_DEEP_DEPENDENCY_SNAPSHOT+set}"
+if [[ -n "$comparison_request" ]]; then
+  case "$profile" in
+    quality-gates | server | harness-client | cli | web-ui | desktop) ;;
+    *)
+      echo "verify-omnigent: comparison requests are unsupported for profile $profile" >&2
+      exit 2
+      ;;
+  esac
+fi
+if [[ ( -n "$comparison_request" && -z "$comparison_capability" ) ||
+  ( -z "$comparison_request" && -n "$comparison_capability" ) ]]; then
+  echo "verify-omnigent: comparison request and capability must be supplied together" >&2
+  exit 2
+fi
+
+usage() {
+  echo "usage: $0 <prepare-hooks|doctor|auto|all-surfaces|quality-gates|universe|server|backend|db-migration-deploy|cli|web-ui|desktop|harness-client|harness-live|perf|smoke|collaboration|automations|core|full-ui> [doctor-profile] [--base-ref REF] [--oss-ref REF] [--with-universe]" >&2
+}
+
+json_array() {
+  python3 -c 'import json, sys; print(json.dumps(sys.argv[1:]))' "$@"
+}
+
+run_dir_argument() {
+  python3 - "$run_dir" "$repo_root" <<'PY'
+import os
+import sys
+from pathlib import Path
+
+run = Path(sys.argv[1]).resolve()
+repo = Path(sys.argv[2]).resolve()
+try:
+    print(run.relative_to(repo))
+except ValueError:
+    print(os.fspath(run))
+PY
+}
+
+# shellcheck disable=SC2329 # finalization callback
+stop_logging() {
+  if [[ "$logging_started" -ne 1 ]]; then
+    return
+  fi
+  exec 1>&3 2>&4
+  logging_started=0
+}
+
+# shellcheck disable=SC2329 # signal/finalization callback
+terminate_child() {
+  local target_pid="$1"
+  local requested_signal="${2:-TERM}"
+  local attempt
+
+  if ! kill -0 "$target_pid" 2>/dev/null; then
+    wait "$target_pid" 2>/dev/null || true
+    return
+  fi
+  kill "-$requested_signal" "$target_pid" 2>/dev/null || true
+  for ((attempt = 0; attempt < 20; attempt++)); do
+    if ! kill -0 "$target_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.05
+  done
+  if kill -0 "$target_pid" 2>/dev/null; then
+    kill -TERM "$target_pid" 2>/dev/null || true
+    for ((attempt = 0; attempt < 100; attempt++)); do
+      if ! kill -0 "$target_pid" 2>/dev/null; then
+        break
+      fi
+      sleep 0.05
+    done
+  fi
+  if kill -0 "$target_pid" 2>/dev/null; then
+    kill -KILL "$target_pid" 2>/dev/null || true
+  fi
+  wait "$target_pid" 2>/dev/null || true
+}
+
+managed_probe() {
+  managed_counter=$((managed_counter + 1))
+  local result_path="$run_dir/managed/probe-${managed_counter}.json"
+  local log_path="$run_dir/managed/probe-${managed_counter}.log"
+  local -a args
+  args=(
+    python3 "$runtime_helper" run
+    --console-fd 3
+    --run-dir "$run_dir"
+    --cwd "$repo_root"
+    --log "$log_path"
+    --result "$result_path"
+    --timeout 120
+    --set-env "OMNIGENT_VERIFY_REPO_ROOT=$repo_root"
+    --set-env "OMNIGENT_VERIFY_RUN_DIR=$run_dir"
+    --set-env "OMNIGENT_VERIFY_SKILL_ROOT=$skill_root"
+  )
+  if [[ "$profile" == "harness-live" || "$doctor_profile" == "harness-live" ]]; then
+    args+=(--credentialed)
+    if [[ -n "${OMNIGENT_VERIFY_DATABRICKS_PROFILE:-}" ]]; then
+      args+=(--set-env "OMNIGENT_VERIFY_DATABRICKS_PROFILE=$OMNIGENT_VERIFY_DATABRICKS_PROFILE")
+    fi
+  fi
+  args+=(-- "$@")
+  if [[ -n "${managed_stdin_file:-}" ]]; then
+    "${args[@]}" <"$managed_stdin_file" &
+  else
+    "${args[@]}" </dev/null &
+  fi
+  child_pid=$!
+  local status=0
+  wait "$child_pid" || status=$?
+  child_pid=""
+  return "$status"
+}
+
+managed_probe_script() {
+  local input_path="$run_dir/managed/stdin-$((managed_counter + 1)).txt"
+  mkdir -p "${input_path%/*}"
+  cat >"$input_path"
+  local status=0
+  managed_stdin_file="$input_path" managed_probe "$@" || status=$?
+  rm -f "$input_path"
+  return "$status"
+}
+
+check_repository_state() {
+  if [[ -z "$initial_snapshot" ]]; then
+    echo "verification blocker: initial repository snapshot is unavailable" >&2
+    return 1
+  fi
+  local current_snapshot_sha256
+  current_snapshot_sha256="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$initial_snapshot" 2>/dev/null)" ||
+    {
+      echo "verification blocker: protected initial repository snapshot is unreadable" >&2
+      return 1
+    }
+  if [[ "$current_snapshot_sha256" != "$initial_snapshot_sha256" ]]; then
+    echo "verification blocker: protected initial repository snapshot was replaced" >&2
+    return 1
+  fi
+  python3 "$runtime_helper" check \
+    --repo-root "$repo_root" \
+    --before "$initial_snapshot" \
+    --deep-dependencies
+}
+
+# shellcheck disable=SC2329 # EXIT trap callback
+finalize_run() {
+  local shell_status=$?
+  local -a finalize_args
+  local finalize_ok=1
+  if [[ "$finalized" -eq 1 || -z "$run_dir" ]]; then
+    return
+  fi
+  finalized=1
+  trap - EXIT INT TERM HUP
+
+  if [[ -n "$child_pid" ]] && kill -0 "$child_pid" 2>/dev/null; then
+    terminate_child "$child_pid" TERM
+  fi
+  stop_logging
+  if [[ -n "${orchestration_capability:-}" ]]; then
+    rm -f "$orchestration_capability"
+  fi
+  if [[ -z "$received_signal" && "$run_status" != "passed" && "$final_exit_status" -eq 1 ]]; then
+    final_exit_status="$shell_status"
+  fi
+  if [[ -n "$initial_snapshot_sha256" ]]; then
+    local observed_snapshot_sha256=""
+    observed_snapshot_sha256="$(
+      python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' \
+        "$initial_snapshot" 2>/dev/null
+    )" || true
+    if [[ "$observed_snapshot_sha256" != "$initial_snapshot_sha256" ]]; then
+      echo "verify-omnigent: protected initial snapshot was tampered with" >&2
+      cp "$control_dir/repository-before.backup.json" "$initial_snapshot"
+      run_status="failed"
+      final_exit_status=1
+    fi
+  fi
+
+  finalize_args=(
+    python3 "$manifest_helper" finalize
+    --run-dir "$run_dir"
+    --status "$run_status"
+    --exit-status "$final_exit_status"
+  )
+  if [[ -n "$received_signal" ]]; then
+    finalize_args+=(--signal "$received_signal")
+  fi
+  "${finalize_args[@]}" || {
+    echo "verify-omnigent: failed to finalize manifest" >&2
+    finalize_ok=0
+  }
+  if [[ "$finalize_ok" -eq 1 ]] &&
+    ! python3 "$manifest_helper" assert-finalized \
+      --run-dir "$run_dir" --expected-status "$run_status"; then
+    echo "verify-omnigent: finalized manifest validation failed" >&2
+    finalize_ok=0
+  fi
+  if [[ "$finalize_ok" -ne 1 ]]; then
+    run_status="failed"
+    final_exit_status=1
+  fi
+  python3 "$manifest_helper" summary --run-dir "$run_dir" || true
+  printf 'OMNIGENT_VERIFY_SUMMARY schema=1 status=%s profile=%s run_id=%s manifest=%s\n' \
+    "$run_status" "$profile" "$run_id" "$run_dir/manifest.json"
+  cleanup_control_dir
+  exit "$final_exit_status"
+}
+
+# shellcheck disable=SC2329 # INT/TERM/HUP trap callback
+handle_signal() {
+  local signal_name="$1"
+  local signal_status="$2"
+  received_signal="$signal_name"
+  run_status="interrupted"
+  final_exit_status="$signal_status"
+  if [[ -n "$child_pid" ]] && kill -0 "$child_pid" 2>/dev/null; then
+    terminate_child "$child_pid" "$signal_name"
+    child_pid=""
+  fi
+  exit "$signal_status"
+}
+
+doctor() {
+  local target_profile="$1"
+
+  require_file pyproject.toml "Restore the repository pyproject.toml." || return $?
+  require_file "$skill_root/features/README.md" \
+    "Restore the canonical verify-omnigent feature map." || return $?
+  require_file "$skill_root/features/approvals-and-policies.md" \
+    "Restore the approvals verification contract." || return $?
+  require_file "$skill_root/features/harnesses-and-clients.md" \
+    "Restore the harness verification contract." || return $?
+  require_file "$manifest_helper" "Restore scripts/evidence_manifest.py." || return $?
+  require_file "$orchestration_helper" "Restore scripts/orchestration.py." || return $?
+  require_file "$profile_runner" "Restore scripts/profile_runner.py." || return $?
+  require_file "$universe_preflight" "Restore scripts/universe_preflight.py." || return $?
+  require_file "$comparison_helper" "Restore scripts/comparison.py." || return $?
+
+  case "$target_profile" in
+    quality-gates)
+      require_command uv "Install uv and run: uv sync --locked --extra all --extra dev" || return $?
+      require_file .pre-commit-config.yaml "Restore the repository pre-commit configuration." ||
+        return $?
+      managed_probe uv run --no-sync pre-commit --version || {
+        echo "doctor blocker: pre-commit or an authenticated exact remote-hook cache is unavailable. Run: .agents/skills/verify-omnigent/scripts/verify.sh prepare-hooks" >&2
+        return 1
+      }
+      local requirements_path="$run_dir/quality-requirements.json"
+      managed_probe_script python3 - "$profile_runner" "$repo_root" "$base_ref" "$requirements_path" <<'PY'
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+runner_path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("verify_profile_runner", runner_path)
+if spec is None or spec.loader is None:
+    raise SystemExit("doctor blocker: profile runner could not be loaded")
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+repo = Path(sys.argv[2])
+files = module._changed_files(repo, sys.argv[3])
+steps = module.profile_steps("quality-gates", "doctor", changed_files=files)
+binaries = sorted(
+    {
+        f"{step.cwd}/{step.argv[0]}".removeprefix("./")
+        for step in steps
+        if "node_modules/.bin/" in step.argv[0]
+    }
+)
+Path(sys.argv[4]).write_text(json.dumps(binaries) + "\n", encoding="utf-8")
+PY
+      require_file "$requirements_path" \
+        "The quality prerequisite plan could not be generated." || return $?
+      managed_probe python3 -c \
+        'import json,sys; value=json.load(open(sys.argv[1], encoding="utf-8")); raise SystemExit(0 if isinstance(value,list) and all(isinstance(item,str) for item in value) else 1)' \
+        "$requirements_path" || {
+        echo "doctor blocker: quality prerequisite plan is invalid." >&2
+        return 1
+      }
+      local -a quality_binaries=()
+      while IFS= read -r binary; do
+        quality_binaries+=("$binary")
+      done < <(
+        python3 - "$requirements_path" <<'PY'
+import json
+import sys
+
+for value in json.load(open(sys.argv[1], encoding="utf-8")):
+    print(value)
+PY
+      )
+      if [[ "${#quality_binaries[@]}" -gt 0 ]]; then
+        require_command pnpm "Install the pnpm version declared in package.json." || return $?
+        require_command node "Install Node 22.12 or newer and put node on PATH." || return $?
+        check_node_version || return $?
+        check_pnpm_version || return $?
+        check_pnpm_install_state || return $?
+        local binary
+        for binary in "${quality_binaries[@]}"; do
+          require_executable "$binary" "Run: CI=true pnpm install --frozen-lockfile" || return $?
+        done
+      fi
+      ;;
+    backend)
+      require_file scripts/backend-smoke.sh "Restore scripts/backend-smoke.sh." || return $?
+      require_command python3 "Install Python 3.12 or newer and put python3 on PATH." || return $?
+      require_command git "Install git and put it on PATH." || return $?
+      require_command curl "Install curl and put it on PATH." || return $?
+      managed_probe_script python3 - <<'PY'
+import sys
+
+if sys.version_info < (3, 12):
+    raise SystemExit(
+        "doctor blocker: backend smoke requires python3 >= 3.12. "
+        "Install Python 3.12 or newer and retry."
+    )
+PY
+      local status=$?
+      [[ "$status" -eq 0 ]] || return "$status"
+      ;;
+    server)
+      require_command uv "Install uv and run: uv sync --locked --extra all --extra dev" || return $?
+      require_file tests/server/test_app.py "Restore tests/server/test_app.py." || return $?
+      require_file tests/server/integration/test_app.py \
+        "Restore tests/server/integration/test_app.py." || return $?
+      managed_probe uv run --no-sync python -c "import httpx, omnigent" || {
+        echo "doctor blocker: server test imports failed. Run: uv sync --locked --extra all --extra dev" >&2
+        return 1
+      }
+      ;;
+    db-migration-deploy)
+      require_command uv "Install uv and run: uv sync --locked --extra all --extra dev" || return $?
+      require_directory tests/db "Restore tests/db migration contracts." || return $?
+      require_directory tests/stores "Restore tests/stores contracts." || return $?
+      require_directory tests/deploy "Restore tests/deploy contracts." || return $?
+      ;;
+    perf)
+      require_file dev/benchmarks/omnigent/run.py \
+        "Restore dev/benchmarks/omnigent/run.py." || return $?
+      require_command uv "Install uv and run: uv sync --locked --extra all --extra dev" || return $?
+      managed_probe_script uv run --no-sync python - <<'PY'
+from pathlib import Path
+
+import httpx
+import omnigent
+
+print(f"omnigent={Path(omnigent.__file__).resolve()}")
+print(f"httpx={httpx.__version__}")
+PY
+      local status=$?
+      [[ "$status" -eq 0 ]] || return "$status"
+      ;;
+    smoke | collaboration | automations | core | full-ui | web-ui)
+      doctor_ui || return $?
+      if [[ "$target_profile" == "web-ui" ]]; then
+        require_file web/package.json "Restore web/package.json." || return $?
+        require_directory web/node_modules \
+          "Run: pnpm install --frozen-lockfile --filter web" || return $?
+        require_executable web/node_modules/.bin/vitest \
+          "Run: CI=true pnpm install --frozen-lockfile" || return $?
+        require_executable web/node_modules/.bin/tsc \
+          "Run: CI=true pnpm install --frozen-lockfile" || return $?
+      fi
+      ;;
+    desktop)
+      doctor_ui || return $?
+      require_file web/electron/package.json "Restore web/electron/package.json." || return $?
+      require_directory web/node_modules \
+        "Run: pnpm install --frozen-lockfile --filter web" || return $?
+      require_directory web/electron/node_modules \
+        "Run: pnpm install --frozen-lockfile --filter web/electron" || return $?
+      require_executable web/electron/node_modules/.bin/electron-builder \
+        "Run: CI=true pnpm install --frozen-lockfile" || return $?
+      if python3 - <<'PY'
+from pathlib import Path
+
+raise SystemExit(0 if any(Path("web/electron/e2e").glob("*.e2e.js")) else 1)
+PY
+      then
+        managed_probe node -e \
+          'require.resolve("electron", {paths: ["web/electron"]}); require.resolve("playwright", {paths: ["web/electron"]})' || {
+          echo "doctor blocker: Electron E2E files exist, but Node playwright and electron are not both importable from web/electron. Provision the dependencies documented in web/electron/e2e/README.md; a skipped native journey is not a pass." >&2
+          return 1
+        }
+      fi
+      ;;
+    cli)
+      case "$(uname -s)" in
+        Darwin | Linux) ;;
+        *)
+          echo "doctor blocker: the CLI PTY driver requires macOS or Linux. Run this lane on a POSIX host." >&2
+          return 1
+          ;;
+      esac
+      require_file .claude/skills/cli-setup-verify/verify_cli.py \
+        "Restore the checked-in CLI setup driver." || return $?
+      require_file .venv/bin/python \
+        "Run: uv sync --locked --extra all --extra dev" || return $?
+      require_file .venv/bin/omnigent \
+        "Run: uv sync --locked --extra all --extra dev" || return $?
+      managed_probe_script .venv/bin/python - <<'PY'
+import pexpect
+
+print(f"pexpect={pexpect.__version__}")
+PY
+      ;;
+    harness-client | harness-live)
+      require_command uv "Install uv and run: uv sync --locked --extra all --extra dev" || return $?
+      require_file tests/harness_bench/__main__.py \
+        "Restore the checked-in harness bench." || return $?
+      managed_probe uv run --no-sync python -m tests.harness_bench --list >/dev/null || {
+        echo "doctor blocker: harness bench imports failed. Run: uv sync --locked --extra all --extra dev" >&2
+        return 1
+      }
+      if [[ "$target_profile" == "harness-live" ]]; then
+        if [[ -z "${OMNIGENT_VERIFY_HARNESS:-}" ]]; then
+          echo "doctor blocker: set OMNIGENT_VERIFY_HARNESS to one name from: uv run --no-sync python -m tests.harness_bench --list" >&2
+          return 1
+        fi
+        managed_probe_script uv run --no-sync python - "${OMNIGENT_VERIFY_DATABRICKS_PROFILE:-}" <<'PY'
+import sys
+from tests.harness_bench.runtime_env import bench_creds_skip_reason
+
+profile = sys.argv[1] or None
+reason = bench_creds_skip_reason(profile)
+if reason:
+    raise SystemExit(
+        "doctor blocker: live harness credentials are unavailable: "
+        f"{reason}. Configure ambient OPENAI_* credentials or set "
+        "OMNIGENT_VERIFY_DATABRICKS_PROFILE."
+    )
+PY
+      fi
+      ;;
+    universe)
+      local universe_root_path="${UNIVERSE_ROOT:-$repo_root/../universe}"
+      require_file "$skill_root/compatibility.md" \
+        "Restore the downstream compatibility contract." || return $?
+      require_file "$universe_root_path/agentbricks/mas/third_party/sync/UPSTREAM_REF" \
+        "Set UNIVERSE_ROOT to a Universe checkout containing agentbricks/mas." || return $?
+      require_file "$universe_root_path/agentbricks/mas/third_party/sync/UI_UPSTREAM_REF" \
+        "Restore the MAS UI upstream pin." || return $?
+      require_command python3 "Install Python 3.12 or newer and put python3 on PATH." || return $?
+      require_command git "Install git and put it on PATH." || return $?
+      require_command bazel "Install the Universe Bazel launcher and put it on PATH." || return $?
+      managed_probe python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)' || {
+        echo "doctor blocker: Universe preflight requires python3 >= 3.12." >&2
+        return 1
+      }
+      if [[ "$(uname -s)" == "Darwin" ]]; then
+        echo "doctor note: Darwin can run source and hermetic checks; MAS runtime proof requires Linux because of known jemalloc/features.h and psutil/_psutil_osx blockers."
+      fi
+      ;;
+    auto | all-surfaces)
+      doctor_orchestration "$target_profile" || return $?
+      ;;
+    doctor)
+      echo "doctor blocker: choose a concrete profile after doctor." >&2
+      return 2
+      ;;
+    *)
+      usage
+      return 2
+      ;;
+  esac
+
+  echo "doctor: $target_profile ready"
+}
+
+require_file() {
+  local path="$1"
+  local remediation="$2"
+  if [[ ! -f "$path" ]]; then
+    echo "doctor blocker: missing file $path. $remediation" >&2
+    return 1
+  fi
+}
+
+require_directory() {
+  local path="$1"
+  local remediation="$2"
+  if [[ ! -d "$path" ]]; then
+    echo "doctor blocker: missing directory $path. $remediation" >&2
+    return 1
+  fi
+}
+
+require_executable() {
+  local path="$1"
+  local remediation="$2"
+  if [[ ! -x "$path" ]]; then
+    echo "doctor blocker: missing executable $path. $remediation" >&2
+    return 1
+  fi
+}
+
+require_command() {
+  local name="$1"
+  local remediation="$2"
+  if ! command -v "$name" >/dev/null; then
+    echo "doctor blocker: command $name is unavailable. $remediation" >&2
+    return 1
+  fi
+}
+
+check_pnpm_install_state() {
+  managed_probe_script python3 - "$repo_root" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1]).resolve()
+metadata = root / "node_modules" / ".modules.yaml"
+if metadata.exists():
+    try:
+        value = json.loads(metadata.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(
+            "doctor blocker: node_modules metadata is unreadable "
+            f"({type(exc).__name__}). Run: CI=true pnpm install --frozen-lockfile"
+        )
+    raw_virtual_store = value.get("virtualStoreDir")
+    if not isinstance(raw_virtual_store, str):
+        raise SystemExit(
+            "doctor blocker: node_modules metadata has no virtualStoreDir. "
+            "Run: CI=true pnpm install --frozen-lockfile"
+        )
+    actual = (metadata.parent / raw_virtual_store).resolve()
+    expected = (root / "node_modules" / ".pnpm").resolve()
+    if actual != expected:
+        raise SystemExit(
+            "doctor blocker: node_modules belongs to a different checkout "
+            f"({actual}). Run: CI=true pnpm install --frozen-lockfile"
+        )
+    raise SystemExit(0)
+
+bins = root / "web" / "node_modules" / ".bin"
+if not bins.is_dir() or not any(bins.iterdir()):
+    raise SystemExit(
+        "doctor blocker: no validated JavaScript dependency tree is available. "
+        "Run: CI=true pnpm install --frozen-lockfile"
+    )
+for binary in bins.iterdir():
+    try:
+        binary.resolve(strict=True).relative_to(root)
+    except (OSError, ValueError):
+        raise SystemExit(
+            f"doctor blocker: {binary} resolves outside this checkout. "
+            "Run: CI=true pnpm install --frozen-lockfile"
+        )
+PY
+}
+
+check_node_version() {
+  managed_probe_script node - <<'JS'
+const [major, minor] = process.versions.node.split(".").map(Number);
+if (major < 22 || (major === 22 && minor < 12)) {
+  console.error(
+    `doctor blocker: Node ${process.versions.node} is unsupported. Install Node 22.12 or newer.`,
+  );
+  process.exit(1);
+}
+JS
+}
+
+check_pnpm_version() {
+  managed_probe_script python3 - <<'PY'
+import json
+import os
+import subprocess
+from pathlib import Path
+
+package = json.load(open("package.json", encoding="utf-8"))
+declared = package.get("packageManager")
+if not isinstance(declared, str) or not declared.startswith("pnpm@"):
+    raise SystemExit("doctor blocker: package.json has no exact packageManager pnpm version")
+expected = declared.removeprefix("pnpm@")
+tools_value = os.environ.get("OMNIGENT_VERIFY_TRUSTED_PNPM_TOOLS_ROOT")
+if not tools_value:
+    raise SystemExit(
+        f"doctor blocker: authenticated pnpm {expected} is not prepared. Run: "
+        ".agents/skills/verify-omnigent/scripts/verify.sh prepare-tools"
+    )
+tools = Path(tools_value).resolve(strict=True)
+executable = (tools / expected / "bin" / "pnpm").resolve(strict=True)
+executable.relative_to(tools)
+actual = subprocess.run(
+    [str(executable), "--version"],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout.strip()
+if actual != expected:
+    raise SystemExit(
+        f"doctor blocker: pnpm {actual} does not match package.json ({expected}). "
+        "Run: .agents/skills/verify-omnigent/scripts/verify.sh prepare-tools"
+    )
+PY
+}
+
+doctor_ui() {
+      require_file tests/e2e_ui/conftest.py "Restore tests/e2e_ui/conftest.py." || return $?
+      require_file tests/e2e_ui/playwright_evidence.py \
+        "Restore tests/e2e_ui/playwright_evidence.py." || return $?
+      require_command uv "Install uv and run: uv sync --locked --extra all --extra dev" || return $?
+      require_command node "Install Node 22.12 or newer and put node on PATH." || return $?
+      check_node_version || return $?
+      check_pnpm_version || return $?
+      check_pnpm_install_state || return $?
+      require_executable web/node_modules/.bin/prettier \
+        "Run: CI=true pnpm install --frozen-lockfile" || return $?
+      require_executable web/node_modules/.bin/oxlint \
+        "Run: CI=true pnpm install --frozen-lockfile" || return $?
+      require_executable web/node_modules/.bin/tsc \
+        "Run: CI=true pnpm install --frozen-lockfile" || return $?
+      require_file web/node_modules/vite/bin/vite.js \
+        "Run: CI=true pnpm install --frozen-lockfile" || return $?
+      managed_probe_script uv run --no-sync python - <<'PY'
+from pathlib import Path
+
+import httpx
+import omnigent
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as playwright:
+    chromium = Path(playwright.chromium.executable_path)
+    if not chromium.is_file():
+        raise SystemExit(
+            "Playwright Chromium is missing. "
+            "Run: uv run --no-sync playwright install chromium"
+        )
+
+print(f"omnigent={Path(omnigent.__file__).resolve()}")
+print(f"chromium={chromium}")
+print(f"httpx={httpx.__version__}")
+PY
+      local status=$?
+      [[ "$status" -eq 0 ]] || return "$status"
+      managed_probe node --version || return $?
+      managed_probe pnpm --version || return $?
+}
+
+doctor_orchestration() {
+  local target_profile="$1"
+  local plan_path="$run_dir/lane-plan.json"
+  local -a plan_args selected_lanes
+  plan_args=(
+    python3 "$orchestration_helper"
+    --repo-root "$repo_root"
+    --profile "$target_profile"
+    --base-ref "$base_ref"
+    --output "$plan_path"
+  )
+  if [[ "$with_universe" -eq 1 ]]; then
+    plan_args+=(--with-universe)
+  fi
+  local plan_status=0
+  "${plan_args[@]}" || plan_status=$?
+  if [[ -f "$plan_path" ]]; then
+    python3 "$manifest_helper" record-plan --run-dir "$run_dir" --plan "$plan_path"
+  fi
+  [[ "$plan_status" -eq 0 ]] || return "$plan_status"
+  selected_lanes=()
+  while IFS= read -r lane; do
+    selected_lanes+=("$lane")
+  done < <(
+    python3 - "$plan_path" <<'PY'
+import json
+import sys
+
+for lane in json.load(open(sys.argv[1], encoding="utf-8"))["selected_lanes"]:
+    print(lane)
+PY
+  )
+  local lane
+  for lane in "${selected_lanes[@]}"; do
+    doctor "$lane" || return $?
+  done
+}
+
+mkdir -p "$evidence_root"
+safe_profile="$(
+  python3 -c 'import re, sys; print(re.sub(r"[^A-Za-z0-9_-]", "_", sys.argv[1])[:40] or "attempt")' \
+    "$profile"
+)"
+run_dir="$(
+  mktemp -d "$evidence_root/$(date -u +%Y%m%dT%H%M%SZ)-${safe_profile}.XXXXXX"
+)"
+run_id="${run_dir##*/}"
+mkdir -p "$run_dir/playwright"
+control_dir="$(mktemp -d "${TMPDIR:-/tmp}/omnigent-verify-control.XXXXXX")"
+chmod 700 "$control_dir"
+cp "$skill_root/scripts/"*.py "$control_dir/"
+runtime_helper="$control_dir/runtime_support.py"
+manifest_helper="$control_dir/evidence_manifest.py"
+initial_snapshot="$control_dir/repository-before.json"
+export OMNIGENT_VERIFY_CONTROL_SNAPSHOT="$initial_snapshot"
+export OMNIGENT_VERIFY_DEEP_DEPENDENCY_SNAPSHOT=1
+trap cleanup_control_dir EXIT
+python3 "$manifest_helper" init \
+  --run-dir "$run_dir" \
+  --profile "$profile" \
+  --doctor-profile "$manifest_doctor_profile"
+
+exec 3>&1 4>&2
+trap finalize_run EXIT
+trap 'handle_signal INT 130' INT
+trap 'handle_signal TERM 143' TERM
+trap 'handle_signal HUP 129' HUP
+exec >>"$run_dir/run.log" 2>&1
+logging_started=1
+if [[ ! -f "$initial_snapshot" ]] &&
+  ! python3 "$runtime_helper" snapshot \
+    --repo-root "$repo_root" \
+    --output "$initial_snapshot" \
+    --deep-dependencies; then
+  run_status="blocked"
+  final_exit_status=1
+  exit "$final_exit_status"
+fi
+initial_snapshot_sha256="$(
+  python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' \
+    "$initial_snapshot"
+)"
+cp "$initial_snapshot" "$control_dir/repository-before.backup.json"
+orchestration_capability=""
+if [[ "$profile" == "auto" ]]; then
+  orchestration_capability="$run_dir/environment/comparison-capability"
+  python3 - "$orchestration_capability" <<'PY'
+import os
+import secrets
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+path.parent.mkdir(parents=True, exist_ok=True)
+descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(descriptor, "wb") as handle:
+    handle.write(secrets.token_bytes(32))
+    handle.flush()
+    os.fsync(handle.fileno())
+PY
+fi
+
+if [[ "$profile" == "doctor" ]]; then
+  doctor_argv=(doctor "$doctor_profile")
+  if [[ "$doctor_profile" == "auto" ]]; then
+    doctor_argv+=(--base-ref "$base_ref")
+  fi
+  if [[ "$doctor_profile" == "auto" || "$doctor_profile" == "all-surfaces" ]]; then
+    if [[ "$with_universe" -eq 1 ]]; then
+      doctor_argv+=(--with-universe --oss-ref "$oss_ref")
+    fi
+  elif [[ "$doctor_profile" == "universe" ]]; then
+    doctor_argv+=(--base-ref "$base_ref" --oss-ref "$oss_ref")
+  fi
+  python3 "$manifest_helper" prepare \
+    --run-dir "$run_dir" \
+    --phase doctor \
+    --argv-json "$(json_array "${doctor_argv[@]}")" \
+    --tests-json '[]'
+  set +e
+  doctor "$doctor_profile"
+  final_exit_status=$?
+  set -e
+  if [[ "$final_exit_status" -eq 0 ]]; then
+    set +e
+    check_repository_state
+    final_exit_status=$?
+    set -e
+  fi
+  if [[ "$final_exit_status" -eq 0 ]]; then
+    run_status="passed"
+  else
+    run_status="blocked"
+  fi
+  exit "$final_exit_status"
+fi
+
+if [[ "$profile" == "auto" || "$profile" == "all-surfaces" ]]; then
+  plan_path="$run_dir/lane-plan.json"
+  plan_args=(
+    python3 "$orchestration_helper"
+    --repo-root "$repo_root"
+    --profile "$profile"
+    --base-ref "$base_ref"
+    --output "$plan_path"
+  )
+  if [[ "$with_universe" -eq 1 ]]; then
+    plan_args+=(--with-universe)
+  fi
+  set +e
+  "${plan_args[@]}"
+  plan_status=$?
+  set -e
+  if [[ -f "$plan_path" ]]; then
+    python3 "$manifest_helper" record-plan --run-dir "$run_dir" --plan "$plan_path"
+  fi
+  selected_lanes=()
+  while IFS= read -r lane; do
+    selected_lanes+=("$lane")
+  done < <(
+    python3 - "$plan_path" <<'PY'
+import json
+import sys
+
+for lane in json.load(open(sys.argv[1], encoding="utf-8"))["selected_lanes"]:
+    print(lane)
+PY
+  )
+  orchestration_argv=(orchestrate "$profile")
+  if [[ "$profile" == "auto" ]]; then
+    orchestration_argv+=(--base-ref "$base_ref")
+  fi
+  if [[ "$with_universe" -eq 1 ]]; then
+    orchestration_argv+=(--with-universe --oss-ref "$oss_ref")
+  fi
+  python3 "$manifest_helper" prepare \
+    --run-dir "$run_dir" \
+    --phase orchestration \
+    --argv-json "$(json_array "${orchestration_argv[@]}")" \
+    --tests-json "$(json_array "${selected_lanes[@]}")"
+  python3 "$manifest_helper" register-children \
+    --run-dir "$run_dir" \
+    --lanes-json "$(json_array "${selected_lanes[@]}")"
+  if [[ "$plan_status" -ne 0 ]]; then
+    run_status="blocked"
+    final_exit_status="$plan_status"
+    exit "$final_exit_status"
+  fi
+
+  prerequisite_status=0
+  for lane in "${selected_lanes[@]}"; do
+    echo "==> prerequisite check: $lane"
+    set +e
+    doctor "$lane"
+    lane_doctor_status=$?
+    set -e
+    if [[ "$lane_doctor_status" -ne 0 ]]; then
+      prerequisite_status="$lane_doctor_status"
+      break
+    fi
+  done
+  if [[ "$prerequisite_status" -ne 0 ]]; then
+    run_status="blocked"
+    final_exit_status="$prerequisite_status"
+    exit "$final_exit_status"
+  fi
+
+  orchestration_status=0
+  for lane in "${selected_lanes[@]}"; do
+    child_root="$run_dir/children/$lane"
+    mkdir -p "$child_root"
+    echo "==> required lane: $lane"
+    python3 "$manifest_helper" mark-child \
+      --run-dir "$run_dir" \
+      --lane "$lane" \
+      --status running
+    set +e
+    child_argv=("$lane")
+    if [[ "$lane" == "universe" ]]; then
+      child_argv+=(--base-ref "$base_ref" --oss-ref "$oss_ref")
+    fi
+    child_command=(
+      python3 "$runtime_helper" run
+      --console-fd 3
+      --run-dir "$run_dir"
+      --cwd "$repo_root"
+      --log "$run_dir/managed/child-$lane.log"
+      --result "$run_dir/managed/child-$lane.json"
+      --set-env "OMNIGENT_VERIFY_ADAPTER=${OMNIGENT_VERIFY_ADAPTER:-unspecified}"
+      --set-env "OMNIGENT_VERIFY_BASE_REF=$base_ref"
+      --set-env "OMNIGENT_VERIFY_EVIDENCE_DIR=$child_root"
+      --set-env "OMNIGENT_VERIFY_REPO_ROOT=$repo_root"
+      -- "$verify_script" "${child_argv[@]}"
+    )
+    "${child_command[@]}" &
+    child_pid=$!
+    wait "$child_pid"
+    lane_status=$?
+    child_pid=""
+    set -e
+    child_manifest="$(
+      python3 - "$child_root" <<'PY'
+import sys
+from pathlib import Path
+
+manifests = list(Path(sys.argv[1]).glob("*/manifest.json"))
+if len(manifests) == 1:
+    print(manifests[0])
+PY
+    )"
+    if [[ -z "$child_manifest" ]]; then
+      child_manifest="$child_root/missing-manifest.json"
+      if [[ "$lane_status" -eq 0 ]]; then
+        lane_status=1
+      fi
+    elif [[ "$(
+      python3 - "$child_manifest" <<'PY'
+import json
+import sys
+
+print(json.load(open(sys.argv[1], encoding="utf-8")).get("status", "unavailable"))
+PY
+    )" != "passed" && "$lane_status" -eq 0 ]]; then
+      lane_status=1
+    fi
+    python3 "$manifest_helper" add-child \
+      --run-dir "$run_dir" \
+      --lane "$lane" \
+      --child-manifest "$child_manifest" \
+      --exit-status "$lane_status"
+    if [[ "$lane_status" -ne 0 && "$orchestration_status" -eq 0 ]]; then
+      orchestration_status="$lane_status"
+      if [[ "$profile" == "auto" && -n "$child_manifest" && -f "$child_manifest" ]]; then
+        comparison_path="$run_dir/baseline/$lane/comparison.json"
+        comparison_command=(
+          python3 "$runtime_helper" run
+          --console-fd 3
+          --run-dir "$run_dir"
+          --cwd "$repo_root"
+          --log "$run_dir/managed/baseline-$lane.log"
+          --result "$run_dir/managed/baseline-$lane.json"
+          --timeout "${OMNIGENT_VERIFY_BASELINE_TIMEOUT_SECONDS:-600}"
+          --set-env "OMNIGENT_VERIFY_REPO_ROOT=$repo_root"
+          -- python3 "$comparison_helper" baseline
+          --repo-root "$repo_root"
+          --skill-root "$skill_root"
+          --run-dir "$run_dir"
+          --lane "$lane"
+          --base-ref "$base_ref"
+          --child-manifest "$child_manifest"
+          --timeout "${OMNIGENT_VERIFY_BASELINE_TIMEOUT_SECONDS:-600}"
+          --capability-file "$orchestration_capability"
+        )
+        set +e
+        "${comparison_command[@]}" &
+        child_pid=$!
+        wait "$child_pid"
+        comparison_status=$?
+        child_pid=""
+        set -e
+        if [[ -f "$comparison_path" ]]; then
+          python3 "$manifest_helper" record-baseline \
+            --run-dir "$run_dir" \
+            --lane "$lane" \
+            --comparison "$comparison_path"
+        elif [[ "$comparison_status" -eq 0 ]]; then
+          orchestration_status=1
+        fi
+      fi
+      break
+    fi
+  done
+  final_exit_status="$orchestration_status"
+  if [[ "$final_exit_status" -eq 0 ]]; then
+    set +e
+    check_repository_state
+    final_exit_status=$?
+    set -e
+    if [[ "$final_exit_status" -eq 0 ]]; then
+      run_status="passed"
+    fi
+  fi
+  exit "$final_exit_status"
+fi
+
+set +e
+doctor "$profile"
+doctor_status=$?
+set -e
+if [[ "$doctor_status" -ne 0 ]]; then
+  run_status="blocked"
+  final_exit_status="$doctor_status"
+  exit "$final_exit_status"
+fi
+
+case "$profile" in
+  backend)
+    port="$(
+      python3 - <<'PY'
+import socket
+
+with socket.socket() as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+    )"
+    command=(env "PORT=$port" scripts/backend-smoke.sh)
+    tests=("backend API smoke")
+    ;;
+  smoke)
+    tests=(tests/e2e_ui/chat/test_smoke.py)
+    ;;
+  collaboration)
+    tests=(
+      tests/e2e_ui/collaboration/test_permissions_modal.py
+      tests/e2e_ui/collaboration/test_sharing_journey.py
+      tests/e2e_ui/collaboration/test_sharing_mode_off.py
+      tests/e2e_ui/collaboration/test_collab_realtime.py
+      tests/e2e_ui/collaboration/test_author_label.py
+    )
+    ;;
+  automations)
+    tests=(tests/e2e_ui/scheduled/test_scheduled_tasks_page.py)
+    ;;
+  core)
+    tests=(
+      tests/e2e_ui/chat/test_smoke.py
+      tests/e2e_ui/start_session/test_start_session.py
+      tests/e2e_ui/files/test_file_autosave.py
+      tests/e2e_ui/collaboration/test_permissions_modal.py
+      tests/e2e_ui/collaboration/test_sharing_mode_off.py
+    )
+    ;;
+  full-ui)
+    tests=(tests/e2e_ui)
+    ;;
+  quality-gates | perf | server | db-migration-deploy | cli | web-ui | desktop | harness-client | harness-live | universe)
+    relative_run_dir="$(run_dir_argument)"
+    command=(
+      python3 "$profile_runner"
+      --profile "$profile"
+      --repo-root .
+      --run-dir "$relative_run_dir"
+    )
+    if [[ -n "$comparison_request" ]]; then
+      command+=(
+        --request-file "$comparison_request"
+        --capability-file "$comparison_capability"
+      )
+    fi
+    tests=("$profile profile steps")
+    if [[ "$profile" == "web-ui" || "$profile" == "desktop" ]]; then
+      export OMNIGENT_VERIFY_RUN_DIR="$run_dir"
+      export OMNIGENT_VERIFY_CLEANUP_MARKER="$run_dir/cleanup.json"
+    elif [[ "$profile" == "quality-gates" ]]; then
+      export OMNIGENT_VERIFY_BASE_REF="$base_ref"
+    elif [[ "$profile" == "universe" ]]; then
+      export OMNIGENT_VERIFY_BASE_REF="$base_ref"
+      export OMNIGENT_VERIFY_OSS_REF="$oss_ref"
+    fi
+    ;;
+  *)
+    usage
+    final_exit_status=2
+    exit "$final_exit_status"
+    ;;
+esac
+
+relative_run_dir="$(run_dir_argument)"
+if [[ "$profile" != "backend" && "$profile" != "server" && "$profile" != "perf" &&
+  "$profile" != "db-migration-deploy" &&
+  "$profile" != "universe" &&
+  "$profile" != "quality-gates" &&
+  "$profile" != "cli" && "$profile" != "web-ui" && "$profile" != "desktop" &&
+  "$profile" != "harness-client" && "$profile" != "harness-live" ]]; then
+  command=(
+    uv run --no-sync pytest "${tests[@]}" -v -m "not visual"
+    --screenshot=on
+    --tracing=on
+    --video=retain-on-failure
+    -o junit_family=legacy
+    "--output=$relative_run_dir/playwright"
+    "--junitxml=$relative_run_dir/junit.xml"
+  )
+  export OMNIGENT_VERIFY_RUN_DIR="$run_dir"
+  export OMNIGENT_VERIFY_CLEANUP_MARKER="$run_dir/cleanup.json"
+fi
+
+python3 "$manifest_helper" prepare \
+  --run-dir "$run_dir" \
+  --phase verification \
+  --argv-json "$(json_array "${command[@]}")" \
+  --tests-json "$(json_array "${tests[@]}")"
+
+managed_command=(
+  python3 "$runtime_helper" run
+  --console-fd 3
+  --run-dir "$run_dir"
+  --cwd "$repo_root"
+  --log "$run_dir/managed/verification.log"
+  --result "$run_dir/managed/verification.json"
+  --timeout "${OMNIGENT_VERIFY_LANE_TIMEOUT_SECONDS:-3600}"
+  --set-env "OMNIGENT_VERIFY_ADAPTER=${OMNIGENT_VERIFY_ADAPTER:-unspecified}"
+  --set-env "OMNIGENT_VERIFY_BASE_REF=$base_ref"
+  --set-env "OMNIGENT_VERIFY_EVIDENCE_DIR=$evidence_root"
+  --set-env "OMNIGENT_VERIFY_OSS_REF=$oss_ref"
+  --set-env "OMNIGENT_VERIFY_REPO_ROOT=$repo_root"
+  --set-env "OMNIGENT_VERIFY_RUN_DIR=$run_dir"
+  --set-env "OMNIGENT_VERIFY_SKILL_ROOT=$skill_root"
+)
+if [[ -n "${OMNIGENT_VERIFY_STEP_TIMEOUT_SECONDS:-}" ]]; then
+  managed_command+=(
+    --set-env "OMNIGENT_VERIFY_STEP_TIMEOUT_SECONDS=$OMNIGENT_VERIFY_STEP_TIMEOUT_SECONDS"
+  )
+fi
+if [[ "$profile" == "harness-live" ]]; then
+  managed_command+=(--credentialed)
+fi
+if [[ "$profile" == "smoke" || "$profile" == "collaboration" ||
+  "$profile" == "automations" || "$profile" == "core" ||
+  "$profile" == "full-ui" || "$profile" == "web-ui" ||
+  "$profile" == "desktop" ]]; then
+  managed_command+=(
+    --set-env "OMNIGENT_WEB_UI_DIST=$run_dir/build/e2e-web-ui"
+  )
+fi
+if [[ -n "${OMNIGENT_VERIFY_HARNESS:-}" ]]; then
+  managed_command+=(--set-env "OMNIGENT_VERIFY_HARNESS=$OMNIGENT_VERIFY_HARNESS")
+fi
+if [[ -n "${OMNIGENT_VERIFY_DATABRICKS_PROFILE:-}" ]]; then
+  managed_command+=(
+    --set-env "OMNIGENT_VERIFY_DATABRICKS_PROFILE=$OMNIGENT_VERIFY_DATABRICKS_PROFILE"
+  )
+fi
+if [[ "$profile" == "universe" && -n "${UNIVERSE_ROOT:-}" ]]; then
+  managed_command+=(--set-env "UNIVERSE_ROOT=$UNIVERSE_ROOT")
+fi
+if [[ "$profile" == "web-ui" || "$profile" == "desktop" ||
+  "$profile" == "smoke" || "$profile" == "collaboration" ||
+  "$profile" == "automations" || "$profile" == "core" || "$profile" == "full-ui" ]]; then
+  managed_command+=(
+    --set-env "OMNIGENT_VERIFY_CLEANUP_MARKER=$run_dir/cleanup.json"
+  )
+fi
+if [[ "$profile" == "backend" ]]; then
+  managed_command+=(--set-env "PORT=$port")
+fi
+managed_command+=(-- "${command[@]}")
+set +e
+"${managed_command[@]}" &
+child_pid=$!
+wait "$child_pid"
+final_exit_status=$?
+child_pid=""
+set -e
+
+if [[ "$final_exit_status" -eq 0 ]]; then
+  if [[ -n "$comparison_request" ]]; then
+    final_exit_status=0
+  else
+    set +e
+    python3 "$manifest_helper" validate --run-dir "$run_dir" --profile "$profile"
+    final_exit_status=$?
+    set -e
+  fi
+  if [[ "$final_exit_status" -eq 0 ]]; then
+    if [[ "$profile" == "perf" && "$base_ref" != "HEAD" ]]; then
+      perf_comparison_command=(
+        python3 "$runtime_helper" run
+        --console-fd 3
+        --run-dir "$run_dir"
+        --cwd "$repo_root"
+        --log "$run_dir/managed/performance-comparison.log"
+        --result "$run_dir/managed/performance-comparison.json"
+        --timeout "${OMNIGENT_VERIFY_PERF_TIMEOUT_SECONDS:-900}"
+        --set-env "OMNIGENT_VERIFY_REPO_ROOT=$repo_root"
+        -- python3 "$comparison_helper" perf
+        --repo-root "$repo_root"
+        --run-dir "$run_dir"
+        --base-ref "$base_ref"
+        --candidate "$run_dir/benchmark.json"
+        --timeout "${OMNIGENT_VERIFY_PERF_TIMEOUT_SECONDS:-900}"
+        --max-p50-regression-percent "$max_p50_regression_percent"
+        --max-p99-regression-percent "$max_p99_regression_percent"
+      )
+      set +e
+      "${perf_comparison_command[@]}" &
+      child_pid=$!
+      wait "$child_pid"
+      final_exit_status=$?
+      child_pid=""
+      set -e
+    fi
+    if [[ "$final_exit_status" -eq 0 ]]; then
+      set +e
+      check_repository_state
+      final_exit_status=$?
+      set -e
+      if [[ "$final_exit_status" -eq 0 ]]; then
+        run_status="passed"
+      fi
+    fi
+  fi
+fi
+exit "$final_exit_status"

--- a/.claude/skills/verify-omnigent/SKILL.md
+++ b/.claude/skills/verify-omnigent/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: verify-omnigent
+description: Verifies affected Omnigent changes through fail-closed quality, Playwright, Electron, CLI, server, harness, and optional Universe lanes. Use before implementation planning and before declaring an Omnigent change complete.
+---
+
+# Verify Omnigent
+
+Read and follow the canonical
+[cross-agent skill](../../../.agents/skills/verify-omnigent/SKILL.md). Resolve
+its relative links and scripts from `.agents/skills/verify-omnigent/`.
+When invoking its verification script from Claude Code, set
+`OMNIGENT_VERIFY_ADAPTER=claude-code`.

--- a/.cursor/skills/verify-omnigent/SKILL.md
+++ b/.cursor/skills/verify-omnigent/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: verify-omnigent
+description: Verifies affected Omnigent changes through fail-closed quality, Playwright, Electron, CLI, server, harness, and optional Universe lanes. Use before implementation planning and before declaring an Omnigent change complete.
+---
+
+# Verify Omnigent
+
+Read and follow the canonical
+[cross-agent skill](../../../.agents/skills/verify-omnigent/SKILL.md). Resolve
+its relative links and scripts from `.agents/skills/verify-omnigent/`.
+When invoking its verification script from Cursor, set
+`OMNIGENT_VERIFY_ADAPTER=cursor`.

--- a/.gitignore
+++ b/.gitignore
@@ -33,11 +33,29 @@ omnigent/_build_info.py
 !web/.storybook/
 !web/.storybook/**
 
+# Exception: track cross-agent project skills.
+!.agents/
+.agents/*
+!.agents/skills/
+!.agents/skills/**
+.agents/skills/verify-omnigent/**/__pycache__/
+
 # Exception: track .claude/skills/ (project-wide dev-time skills for Claude Code).
 # The .*/ rule above would otherwise exclude everything under .claude/.
 !.claude/
 .claude/*
 !.claude/skills/
+!.claude/skills/**
+
+# Exception: track Cursor's thin adapter to the canonical cross-agent skill.
+!.cursor/
+.cursor/*
+!.cursor/skills/
+!.cursor/skills/**
+
+# Reassert generated Python ignores after hidden skill-tree negations.
+**/__pycache__/
+**/*.py[cod]
 
 # Local helper scripts
 run-ap-chat.sh
@@ -67,6 +85,7 @@ dev/omnidev/target/
 # Playwright test run output (screenshots, traces, videos).
 test-results/
 output/playwright/
+.artifacts/verify-omnigent/
 
 # Visual-snapshot failure output (actual/expected/diff PNGs from the UI diff
 # gate). Regenerated each run; only the baseline under

--- a/deploy/databricks/README.md
+++ b/deploy/databricks/README.md
@@ -266,6 +266,13 @@ routine redeploys only ever update in place.
 ## Common deploy modes
 
 ```bash
+# Preview only: print the resolved plan (ordered steps, deploy version,
+# config) and exit 0. No build, no file writes, no bundle or API calls.
+uv run python deploy/databricks/deploy.py --dry-run ...
+
+# Preview a redeploy of the wheels already in dist/.
+uv run python deploy/databricks/deploy.py --dry-run --skip-build ...
+
 # Iterate without rebuilding wheels (reuses dist/; useful when you only
 # changed app.py / app.yaml). Skips the clean-tree check.
 uv run python deploy/databricks/deploy.py --skip-build --allow-dirty ...

--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -710,6 +710,18 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Resolve the deploy plan — ordered steps, the deploy version "
+            "each one lands, and the config the bundle would apply — print "
+            "it as a table, and exit 0. Makes no API calls and mutates "
+            "nothing: no build, no version stamp, no file writes, no "
+            "bundle deploy/run. Combine with --skip-build to preview a "
+            "redeploy of the wheels already in dist/."
+        ),
+    )
+    parser.add_argument(
         "--skip-build",
         action="store_true",
         help="Reuse existing dist/ wheels — skip the npm + uv build.",
@@ -918,6 +930,13 @@ def _grant_failure_detail(exc: subprocess.CalledProcessError) -> str:
     return _SECRET_ECHO_RE.sub(r"\1<redacted>", first_line)[:200]
 
 
+def _validate_volume_name(value: str) -> tuple[str, str, str]:
+    parts = value.split(".")
+    if len(parts) != 3 or any(not part or part.strip() != part for part in parts):
+        raise SystemExit(f"--volume-name {value!r} must be catalog.schema.volume")
+    return parts[0], parts[1], parts[2]
+
+
 def _ensure_app_sp_uc_traversal(
     args: argparse.Namespace,
     app_sp: str | None,
@@ -940,10 +959,7 @@ def _ensure_app_sp_uc_traversal(
         _log("app SP not resolved yet; skipping UC traversal grants")
         return
 
-    parts = args.volume_name.split(".")
-    if len(parts) != 3:
-        raise SystemExit(f"--volume-name {args.volume_name!r} must be catalog.schema.volume")
-    catalog, schema_only, _ = parts
+    catalog, schema_only, _ = _validate_volume_name(args.volume_name)
     schema_fqn = f"{catalog}.{schema_only}"
 
     import json as _json
@@ -974,14 +990,197 @@ def _ensure_app_sp_uc_traversal(
             _log(f"warning: {priv} grant on {fqn} failed ({_grant_failure_detail(exc)})")
 
 
+def _reused_wheels() -> list[Path]:
+    """Wheels in ``dist/`` to redeploy under ``--skip-build``.
+
+    :returns: Sorted wheel paths from ``dist/``.
+    :raises SystemExit: If ``dist/`` holds no wheels.
+    """
+    wheels = sorted((_repo_root() / "dist").glob("*.whl"))
+    if not wheels:
+        raise SystemExit("--skip-build was set but dist/ has no wheels to redeploy")
+    return wheels
+
+
+@dataclass(frozen=True)
+class _DeployStep:
+    """One ordered action the deploy performs.
+
+    :param action: What the deploy does, e.g. ``"bundle deploy"``.
+    :param target: What it acts on, e.g. the app or bundle resource name.
+    :param version: Deploy version the step lands, or ``""`` when the
+        step carries no version (grants, resize, smoke check).
+    :param notes: Short qualifier, e.g. ``"skipped if already matching"``.
+    """
+
+    action: str
+    target: str
+    version: str = ""
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class _DeployPlan:
+    """Fully resolved deploy, with nothing built, uploaded, or mutated.
+
+    :param base_version: On-disk version from the top-level pyproject.
+    :param deploy_version: Version this deploy stamps into every wheel.
+    :param version_source: How ``deploy_version`` was resolved, e.g.
+        ``"reuse dist/ wheels"``.
+    :param config: Ordered ``(key, value)`` rows the deploy applies —
+        bundle vars plus the out-of-band app settings.
+    :param steps: Ordered actions the deploy performs.
+    """
+
+    base_version: str
+    deploy_version: str
+    version_source: str
+    config: list[tuple[str, str]]
+    steps: list[_DeployStep]
+
+
+def _resolve_version(args: argparse.Namespace) -> tuple[str, str, str]:
+    """Resolve the deploy version without building or writing anything.
+
+    :param args: Parsed CLI args.
+    :returns: ``(base_version, deploy_version, version_source)``.
+    :raises SystemExit: If ``--version`` conflicts with reused wheels.
+    """
+    base = _read_base_version()
+    if not args.skip_build:
+        return base, _compute_deploy_version(base, args.version), "computed"
+    wheels = _reused_wheels()
+    classified = _classify_wheels(wheels)
+    if classified.oversize:
+        names = ", ".join(wheel.name for wheel in classified.oversize)
+        raise SystemExit(f"reused wheel is over 10 MB and cannot be deployed: {names}")
+    wheel_version = _derive_deploy_version_from_wheels(wheels)
+    if args.version and args.version != wheel_version:
+        raise SystemExit(
+            f"--version {args.version!r} does not match reused wheel version {wheel_version!r}"
+        )
+    return base, wheel_version, "reuse dist/ wheels"
+
+
+def _resolve_plan(args: argparse.Namespace) -> _DeployPlan:
+    """Resolve the full deploy plan. Read-only: no API calls, no writes.
+
+    Both the real deploy and ``--dry-run`` go through here, so the
+    printed plan can't drift from what a real deploy would do.
+
+    :param args: Parsed CLI args.
+    :returns: The resolved plan.
+    """
+    _validate_volume_name(args.volume_name)
+    base_version, deploy_version, version_source = _resolve_version(args)
+
+    # Read the bundle vars back off the real `--var` argv the deploy
+    # passes, so a var added there shows up in the plan automatically.
+    bundle_vars = _bundle_vars(args)
+    config = [
+        (pair.split("=", 1)[0], pair.split("=", 1)[1]) for pair in bundle_vars if pair != "--var"
+    ]
+    config += [
+        ("compute_size", args.compute_size),
+        ("bundle target", args.target),
+        ("profile", args.profile or "(env-based auth)"),
+    ]
+
+    wheel_source = (
+        f"reuse dist/ ({', '.join(w.name for w in _reused_wheels())})"
+        if args.skip_build
+        else "build.sh" + (" (SKIP_WEB_UI=1)" if args.skip_web_ui else "")
+    )
+    steps = [
+        _DeployStep("resolve wheels", wheel_source, deploy_version),
+        _DeployStep(
+            "sync wheels", "deploy/databricks/src/", deploy_version, "sweeps stale wheels"
+        ),
+        _DeployStep("write uv files", "src/pyproject.toml + src/uv.lock", deploy_version),
+        _DeployStep(
+            "bundle deployment bind",
+            f"{_BUNDLE_RESOURCE_KEY} → {args.app_name}",
+            "",
+            "no-op if bound",
+        ),
+        _DeployStep(
+            "app resize", args.app_name, "", f"→ {args.compute_size}, skipped if matching"
+        ),
+        _DeployStep(f"bundle deploy --target {args.target}", args.app_name, deploy_version),
+        _DeployStep(
+            f"bundle run {_BUNDLE_RESOURCE_KEY} --target {args.target}",
+            args.app_name,
+            deploy_version,
+            "restarts the app",
+        ),
+        _DeployStep(
+            "UC traversal grants", args.volume_name, "", "USE_CATALOG + USE_SCHEMA to app SP"
+        ),
+    ]
+    if not args.no_smoke_check:
+        steps.append(
+            _DeployStep(
+                "smoke-check",
+                f"{args.app_url or '<resolved app URL>'}/health",
+                "",
+                "polls up to 60s",
+            )
+        )
+    return _DeployPlan(base_version, deploy_version, version_source, config, steps)
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
+    """Render ``rows`` as a fixed-width text table, header + rule first."""
+    widths = [
+        max(len(h), *(len(row[i]) for row in rows)) if rows else len(h)
+        for i, h in enumerate(headers)
+    ]
+    lines = ["  ".join(h.ljust(widths[i]) for i, h in enumerate(headers)).rstrip()]
+    lines.append("  ".join("-" * w for w in widths))
+    for row in rows:
+        lines.append("  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)).rstrip())
+    return lines
+
+
+def _render_plan(plan: _DeployPlan) -> str:
+    """Format a resolved plan as a human-readable table."""
+    lines = [
+        "dry run: resolved deploy plan. Nothing is built, uploaded, or mutated.",
+        "",
+        f"deploy version: {plan.deploy_version}  "
+        f"(base {plan.base_version}, {plan.version_source})",
+        "",
+        "config changes:",
+    ]
+    lines += [
+        f"  {line}" for line in _render_table(["key", "value"], [[k, v] for k, v in plan.config])
+    ]
+    lines += ["", "steps, in order:"]
+    rows = [
+        [str(i), step.action, step.target, step.version or "-", step.notes or "-"]
+        for i, step in enumerate(plan.steps, start=1)
+    ]
+    lines += [
+        f"  {line}" for line in _render_table(["#", "action", "target", "version", "notes"], rows)
+    ]
+    return "\n".join(lines) + "\n"
+
+
 def main() -> int:
     args = _parse_args()
+
+    if args.dry_run:
+        # Resolve and print, then stop — before the env scrub, the
+        # clean-tree git calls, and anything that touches the workspace.
+        print(_render_plan(_resolve_plan(args)), end="", flush=True)
+        return 0
+
     _clear_env_vars()
     _assert_clean_tree(skip=args.allow_dirty)
 
-    base_version = _read_base_version()
-    deploy_version = _compute_deploy_version(base_version, args.version)
-    _log(f"deploy version: {deploy_version} (base: {base_version})")
+    plan = _resolve_plan(args)
+    deploy_version = plan.deploy_version
+    _log(f"deploy version: {deploy_version} (base: {plan.base_version}, {plan.version_source})")
 
     backups: dict[Path, str] = {}
     try:
@@ -990,18 +1189,7 @@ def main() -> int:
             backups = _stamp_versions(deploy_version)
             wheels = _build_wheels(skip_web_ui=args.skip_web_ui)
         else:
-            dist = _repo_root() / "dist"
-            wheels = sorted(dist.glob("*.whl"))
-            if not wheels:
-                raise SystemExit("--skip-build was set but dist/ has no wheels to redeploy")
-            wheel_version = _derive_deploy_version_from_wheels(wheels)
-            if args.version and args.version != wheel_version:
-                raise SystemExit(
-                    f"--version {args.version!r} does not match reused wheel "
-                    f"version {wheel_version!r}"
-                )
-            deploy_version = wheel_version
-            _log(f"deploy version from reused wheels: {deploy_version}")
+            wheels = _reused_wheels()
             _log(f"reusing wheels: {[w.name for w in wheels]}")
     finally:
         if backups and not args.keep_version_bump:

--- a/tests/deploy/test_databricks_deploy_dry_run.py
+++ b/tests/deploy/test_databricks_deploy_dry_run.py
@@ -1,0 +1,247 @@
+"""Guard: `deploy.py --dry-run` resolves a plan but mutates nothing.
+
+The dry-run path must reuse the real version/config resolution and
+print a plan, then exit 0 before any build, file write, subprocess, or
+SDK/API call happens.
+"""
+
+from __future__ import annotations
+
+import argparse
+import types
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+_deploy = import_module("deploy.databricks.deploy")
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    base: dict[str, object] = {
+        "app_name": "omnigent",
+        "lakebase_branch": "projects/omnigent/branches/production",
+        "lakebase_database": "projects/omnigent/branches/production/databases/db",
+        "volume_name": "main.omnigent.artifacts",
+        "compute_size": "LARGE",
+        "otel_table_schema": "main.omnigent_logs",
+        "features": "",
+        "target": "prod",
+        "profile": None,
+        "version": None,
+        "dry_run": True,
+        "skip_build": False,
+        "skip_web_ui": False,
+        "app_url": None,
+        "no_smoke_check": False,
+        "keep_version_bump": False,
+        "allow_dirty": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+@pytest.fixture
+def _no_mutations(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Blow up if dry-run reaches anything that builds, writes, or calls out."""
+
+    def _boom_subprocess(*_a: object, **_k: object) -> None:
+        raise AssertionError("subprocess.run must not run in dry-run mode")
+
+    monkeypatch.setattr(_deploy.subprocess, "run", _boom_subprocess)
+
+    for name in (
+        "_clear_env_vars",
+        "_assert_clean_tree",
+        "_clean_build_artifacts",
+        "_stamp_versions",
+        "_build_wheels",
+        "_ensure_bound",
+        "_ensure_compute_size",
+        "_ensure_app_sp_uc_traversal",
+        "_smoke_check",
+        "write_uv_dependency_files",
+    ):
+
+        def _make(fn_name: str) -> object:
+            def _boom(*_a: object, **_k: object) -> None:
+                raise AssertionError(f"{fn_name} must not run in dry-run mode")
+
+            return _boom
+
+        monkeypatch.setattr(_deploy, name, _make(name))
+
+
+def test_dry_run_makes_no_api_calls_and_exits_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    _no_mutations: None,
+) -> None:
+    """No WorkspaceClient is constructed, and the command exits 0."""
+
+    def _boom_client(*_a: object, **_k: object) -> None:
+        raise AssertionError("WorkspaceClient must not be constructed in dry-run mode")
+
+    # The SDK is late-imported inside main(), so stub the module the
+    # import would resolve to rather than patching an attribute.
+    sdk = types.ModuleType("databricks.sdk")
+    sdk.WorkspaceClient = _boom_client  # type: ignore[attr-defined]
+    pkg = types.ModuleType("databricks")
+    pkg.sdk = sdk  # type: ignore[attr-defined]
+    monkeypatch.setitem(_deploy.sys.modules, "databricks", pkg)
+    monkeypatch.setitem(_deploy.sys.modules, "databricks.sdk", sdk)
+
+    monkeypatch.setattr(_deploy, "_parse_args", lambda: _args())
+
+    assert _deploy.main() == 0
+    assert capsys.readouterr().out
+
+
+@pytest.mark.parametrize("volume_name", ["catalog.schema", "catalog..volume", ".schema.volume"])
+def test_dry_run_rejects_malformed_volume_before_any_operation(
+    monkeypatch: pytest.MonkeyPatch,
+    _no_mutations: None,
+    volume_name: str,
+) -> None:
+    monkeypatch.setattr(
+        _deploy,
+        "_parse_args",
+        lambda: _args(volume_name=volume_name),
+    )
+
+    with pytest.raises(SystemExit, match=r"catalog\.schema\.volume"):
+        _deploy.main()
+
+
+def test_dry_run_prints_resolved_version_and_config(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    _no_mutations: None,
+) -> None:
+    """The table carries the resolved version, bundle vars, and ordered steps."""
+    monkeypatch.setattr(_deploy, "_read_base_version", lambda: "0.1.0")
+    monkeypatch.setattr(_deploy, "_compute_deploy_version", lambda base, explicit: "0.1.0.post42")
+    monkeypatch.setattr(_deploy, "_parse_args", lambda: _args())
+
+    assert _deploy.main() == 0
+    out = capsys.readouterr().out
+
+    assert "dry run" in out.lower()
+    assert "0.1.0.post42" in out
+    assert "app_name" in out and "omnigent" in out
+    assert "volume_name" in out and "main.omnigent.artifacts" in out
+    assert "bundle deploy --target prod" in out
+    assert "bundle run omnigent --target prod" in out
+
+
+def test_dry_run_reuses_wheel_version_when_skipping_build(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    _no_mutations: None,
+) -> None:
+    """--skip-build derives the version from dist/ instead of stamping a new one."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    for prefix in _deploy._WHEEL_PREFIXES:
+        (dist / f"{prefix}0.1.0.post7-py3-none-any.whl").touch()
+
+    monkeypatch.setattr(_deploy, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(_deploy, "_read_base_version", lambda: "0.1.0")
+    monkeypatch.setattr(_deploy, "_parse_args", lambda: _args(skip_build=True))
+
+    assert _deploy.main() == 0
+    out = capsys.readouterr().out
+    assert "0.1.0.post7" in out
+    assert "reuse dist/ wheels" in out
+
+
+def test_dry_run_rejects_version_mismatch_with_reused_wheels(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _no_mutations: None,
+) -> None:
+    """An explicit --version that contradicts dist/ fails in dry-run too."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    for prefix in _deploy._WHEEL_PREFIXES:
+        (dist / f"{prefix}0.1.0.post7-py3-none-any.whl").touch()
+
+    monkeypatch.setattr(_deploy, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(_deploy, "_read_base_version", lambda: "0.1.0")
+    monkeypatch.setattr(
+        _deploy, "_parse_args", lambda: _args(skip_build=True, version="0.1.0.post9")
+    )
+
+    with pytest.raises(SystemExit, match="does not match reused wheel version"):
+        _deploy.main()
+
+
+@pytest.mark.parametrize(
+    ("size", "should_pass"),
+    [
+        (_deploy._WORKSPACE_WHEEL_LIMIT_BYTES, True),
+        (_deploy._WORKSPACE_WHEEL_LIMIT_BYTES + 1, False),
+    ],
+)
+def test_skip_build_dry_run_applies_real_wheel_size_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _no_mutations: None,
+    size: int,
+    should_pass: bool,
+) -> None:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    for index, prefix in enumerate(_deploy._WHEEL_PREFIXES):
+        wheel = dist / f"{prefix}0.1.0.post7-py3-none-any.whl"
+        wheel.touch()
+        if index == 0:
+            with wheel.open("wb") as handle:
+                handle.truncate(size)
+    monkeypatch.setattr(_deploy, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(_deploy, "_read_base_version", lambda: "0.1.0")
+    monkeypatch.setattr(_deploy, "_parse_args", lambda: _args(skip_build=True))
+
+    if should_pass:
+        assert _deploy.main() == 0
+    else:
+        with pytest.raises(SystemExit, match="over 10 MB"):
+            _deploy.main()
+
+
+def test_dry_run_omits_smoke_check_step_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    _no_mutations: None,
+) -> None:
+    """The plan reflects --no-smoke-check, so it matches the real run's steps."""
+    monkeypatch.setattr(_deploy, "_parse_args", lambda: _args(no_smoke_check=True))
+
+    assert _deploy.main() == 0
+    assert "smoke-check" not in capsys.readouterr().out
+
+
+def test_without_dry_run_the_real_path_still_runs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Sanity check that --dry-run is opt-in: omitting it reaches the deploy."""
+    reached: list[str] = []
+    monkeypatch.setattr(_deploy, "_clear_env_vars", lambda: reached.append("env"))
+    monkeypatch.setattr(_deploy, "_assert_clean_tree", lambda skip: reached.append("tree"))
+    monkeypatch.setattr(_deploy, "_read_base_version", lambda: "0.1.0")
+    monkeypatch.setattr(_deploy, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(_deploy, "_clean_build_artifacts", lambda: reached.append("clean"))
+    monkeypatch.setattr(_deploy, "_stamp_versions", lambda version: {})
+
+    def _boom_build(**_k: object) -> None:
+        reached.append("build")
+        raise SystemExit("stop here")
+
+    monkeypatch.setattr(_deploy, "_build_wheels", _boom_build)
+    monkeypatch.setattr(_deploy, "_parse_args", lambda: _args(dry_run=False))
+
+    with pytest.raises(SystemExit):
+        _deploy.main()
+    assert reached == ["env", "tree", "clean", "build"]

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -33,6 +33,7 @@ pytest tmp dir so the test never touches the user's default
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import io
 import json
 import os
@@ -43,6 +44,7 @@ import socket
 import subprocess
 import sys
 import tarfile
+import tempfile
 import textwrap
 import time
 from collections.abc import Generator, Iterator
@@ -53,7 +55,9 @@ from typing import Any
 import filelock
 import httpx
 import pytest
-from playwright.sync_api import APIResponse, Error, Locator, Page, Route, expect
+from _pytest.nodes import Node
+from playwright.async_api import BrowserType as AsyncBrowserType
+from playwright.sync_api import APIResponse, Browser, Error, Locator, Page, Route, expect
 
 from tests._helpers.compat import apply_server_env, compat_server_cwd, server_executable
 from tests.codex_parity.helpers import ev_assistant_message, ev_completed, ev_response_created
@@ -61,6 +65,11 @@ from tests.codex_parity.sidecar_harness import (
     CodexResponsesSidecar,
     build_sidecar_bin,
     start_codex_responses_sidecar,
+)
+from tests.e2e_ui.playwright_evidence import (
+    VERIFY_RUN_DIR_ENV,
+    AsyncEvidenceBrowser,
+    SyncEvidenceBrowser,
 )
 from tests.e2e_ui.url_safety import DEV_PORTS, unsafe_ui_base_url_reason
 
@@ -141,7 +150,11 @@ def switch_markdown_view_mode(page: Page, file_viewer: Locator, mode: str) -> No
 # type (which other tests depend on).
 _server_state: dict[str, int | str] = {}
 _WEB_DIR = _REPO_ROOT / "web"
-_BUILD_OUTPUT = _REPO_ROOT / "omnigent" / "server" / "static" / "web-ui"
+_BUILD_OUTPUT = Path(
+    os.environ.get("OMNIGENT_WEB_UI_DIST")
+    or (_REPO_ROOT / "omnigent" / "server" / "static" / "web-ui")
+)
+_BROWSER_CONTEXT_COUNT_KEY = pytest.StashKey[int]()
 
 # ``omnigent server --agent`` runs the spec through the strict
 # validator at registration time (no shim defaults applied), so the
@@ -296,6 +309,71 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _record_canonical_nodeid(
+    request: pytest.FixtureRequest,
+    record_property: Any,
+) -> Iterator[None]:
+    request.node.stash[_BROWSER_CONTEXT_COUNT_KEY] = 0
+    record_property(
+        "omnigent_nodeid_sha256",
+        hashlib.sha256(request.node.nodeid.encode("utf-8")).hexdigest(),
+    )
+    yield
+    record_property(
+        "omnigent_browser_context_count",
+        str(request.node.stash[_BROWSER_CONTEXT_COUNT_KEY]),
+    )
+
+
+def _mark_browser_context(node: Node) -> None:
+    node.stash[_BROWSER_CONTEXT_COUNT_KEY] = node.stash.get(_BROWSER_CONTEXT_COUNT_KEY, 0) + 1
+
+
+def _validate_vite_output(output: Path, trusted_root: Path) -> None:
+    output = output.absolute()
+    trusted_root = trusted_root.absolute()
+    try:
+        output.relative_to(trusted_root)
+    except ValueError:
+        pytest.fail("Verification UI output must be inside its trusted root.")
+    current = output
+    while True:
+        if current.is_symlink():
+            pytest.fail(f"Refusing Vite output through symlink: {current}")
+        if current.exists() and current == output and not current.is_dir():
+            pytest.fail(f"Vite output exists but is not a directory: {current}")
+        if current == trusted_root:
+            return
+        if current.parent == current:
+            pytest.fail("Vite output is not below its trusted root.")
+        current = current.parent
+
+
+def _vite_build_lock_path() -> Path:
+    return Path(tempfile.gettempdir()) / "omnigent-vite-build.lock"
+
+
+def _vite_build_command(vite: Path, output: Path) -> list[str]:
+    """Build without Vite's bundled config loader writing below node_modules."""
+    return [
+        "node",
+        str(vite),
+        "build",
+        "--configLoader",
+        "runner",
+        "--outDir",
+        str(output),
+        "--emptyOutDir",
+    ]
+
+
+def _assert_spa_build(output: Path) -> None:
+    index = output / "index.html"
+    if not index.is_file() or index.stat().st_size == 0:
+        pytest.fail(f"Vite build did not produce a nonempty {index}")
+
+
 def pytest_configure(config: pytest.Config) -> None:
     """Fail fast on unsafe e2e-ui harness options.
 
@@ -361,6 +439,73 @@ def browser_context_args(
     return {**browser_context_args}
 
 
+@pytest.fixture
+def browser(
+    browser: Browser,
+    browser_context_args: dict[str, Any],
+    _artifacts_recorder: Any,
+    request: pytest.FixtureRequest,
+) -> Iterator[SyncEvidenceBrowser]:
+    """Record plugin-managed and directly-created synchronous contexts alike."""
+    evidence_browser = SyncEvidenceBrowser(
+        browser,
+        _artifacts_recorder,
+        request.node.nodeid,
+        browser_context_args,
+        lambda: _mark_browser_context(request.node),
+    )
+    yield evidence_browser
+    evidence_browser.close_contexts()
+
+
+@pytest.fixture
+def new_context(
+    browser: SyncEvidenceBrowser,
+    request: pytest.FixtureRequest,
+) -> Iterator[Any]:
+    """Create managed contexts through the same evidence-aware Browser facade."""
+    context_args: dict[str, Any] = {}
+    marker = next(request.node.iter_markers("browser_context_args"), None)
+    if marker is not None:
+        context_args.update(marker.kwargs)
+    contexts: list[Any] = []
+
+    def create_context(**kwargs: Any) -> Any:
+        context = browser._create_context("managed-sync", **{**context_args, **kwargs})
+        contexts.append(context)
+        return context
+
+    yield create_context
+    for context in contexts:
+        if context in browser._contexts:
+            context.close()
+
+
+@pytest.fixture(autouse=True)
+def _capture_direct_async_contexts(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Wrap direct async Playwright launches without forcing a browser launch."""
+    if not os.environ.get(VERIFY_RUN_DIR_ENV):
+        return
+    original_launch = AsyncBrowserType.launch
+
+    async def launch_with_evidence(
+        browser_type: AsyncBrowserType,
+        *args: Any,
+        **kwargs: Any,
+    ) -> AsyncEvidenceBrowser:
+        browser = await original_launch(browser_type, *args, **kwargs)
+        return AsyncEvidenceBrowser(
+            browser,
+            request.node.nodeid,
+            lambda: _mark_browser_context(request.node),
+        )
+
+    monkeypatch.setattr(AsyncBrowserType, "launch", launch_with_evidence)
+
+
 def _validate_ui_base_url(base_url: str) -> None:
     reason = unsafe_ui_base_url_reason(base_url)
     if reason is None or os.environ.get(_ALLOW_DEV_BASE_URL_ENV) == "1":
@@ -407,6 +552,21 @@ def pytest_collection_modifyitems(
     if not 1 <= group <= splits:
         raise pytest.UsageError(f"--group must be between 1 and {splits}")
     items[:] = items[group - 1 :: splits]
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Atomically confirm that pytest reached session cleanup."""
+    marker_value = os.environ.get("OMNIGENT_VERIFY_CLEANUP_MARKER")
+    if not marker_value:
+        return
+    marker = Path(marker_value)
+    temporary = marker.with_name(f".{marker.name}.{os.getpid()}.tmp")
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    temporary.write_text(
+        json.dumps({"schema_version": 1, "status": "completed", "exit_status": exitstatus}) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, marker)
 
 
 def _register_agent_yaml(
@@ -777,29 +937,31 @@ def built_spa(request: pytest.FixtureRequest) -> None:
     if request.config.getoption("--ui-skip-build"):
         return
 
-    lock_path = _WEB_DIR / ".build.lock"
+    run_dir_value = os.environ.get("OMNIGENT_VERIFY_RUN_DIR")
+    if run_dir_value:
+        run_dir = Path(run_dir_value).absolute()
+        output = _BUILD_OUTPUT.absolute()
+    else:
+        run_dir = _REPO_ROOT
+        output = _BUILD_OUTPUT.absolute()
+    _validate_vite_output(output, run_dir)
+
+    lock_path = _vite_build_lock_path()
     with filelock.FileLock(str(lock_path), timeout=600):
-        # pnpm frozen-lockfile uses the root workspace lockfile, which
-        # keeps the pinned tree matching CI and avoids re-resolving the
-        # React peer conflicts that used to require --legacy-peer-deps.
-        # COREPACK_ENABLE_DOWNLOAD_PROMPT=0 keeps a corepack `pnpm` shim
-        # from blocking on its download confirmation under captured
-        # pytest output, which reads as a hung test run.
-        env = {**os.environ, "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"}
+        _validate_vite_output(output, run_dir)
+        vite = _WEB_DIR / "node_modules" / "vite" / "bin" / "vite.js"
+        if not vite.is_file():
+            pytest.fail(
+                "Web dependencies are not provisioned. Run: CI=true pnpm install --frozen-lockfile"
+            )
         subprocess.run(
-            ["pnpm", "install", "--frozen-lockfile", "--filter", "web"],
-            cwd=_REPO_ROOT,
+            _vite_build_command(vite, output),
+            cwd=_WEB_DIR,
             check=True,
             stdin=subprocess.DEVNULL,
-            env=env,
         )
-        subprocess.run(
-            ["pnpm", "--filter", "web", "run", "build"],
-            cwd=_REPO_ROOT,
-            check=True,
-            stdin=subprocess.DEVNULL,
-            env=env,
-        )
+
+    _assert_spa_build(output)
 
 
 def _spawn_runner_against_external_server(

--- a/tests/e2e_ui/playwright_evidence.py
+++ b/tests/e2e_ui/playwright_evidence.py
@@ -1,0 +1,589 @@
+"""Test-bound Playwright evidence for managed and directly-created contexts."""
+
+from __future__ import annotations
+
+import configparser
+import hashlib
+import io
+import json
+import os
+import re
+import secrets
+import shutil
+import time
+import zipfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from playwright.async_api import Browser as AsyncBrowser
+from playwright.async_api import BrowserContext as AsyncBrowserContext
+from playwright.sync_api import Browser, BrowserContext
+
+VERIFY_RUN_DIR_ENV = "OMNIGENT_VERIFY_RUN_DIR"
+_MAX_EVENTS = 2_000
+_MAX_TEXT = 1_000
+MAX_TRACE_ARCHIVE_BYTES = 512 * 1024 * 1024
+MAX_TRACE_MEMBER_BYTES = 64 * 1024 * 1024
+MAX_TRACE_EXPANDED_BYTES = 1024 * 1024 * 1024
+MAX_TRACE_MEMBERS = 10_000
+MAX_TRACE_ARCHIVE_DEPTH = 4
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)\b(bearer\s+)[A-Za-z0-9._~+/=-]+"),
+    re.compile(r"(?i)\b(api[_-]?key|token|password|secret)(\s*[:=]\s*)\S+"),
+    re.compile(r"\b(?:sk|pk)-[A-Za-z0-9_-]{12,}\b"),
+)
+_LONG_BLOB = re.compile(r"(?<![A-Za-z0-9+/=])[A-Za-z0-9+/=]{80,}(?![A-Za-z0-9+/=])")
+_HIGH_ENTROPY_SEGMENT = re.compile(r"^[A-Za-z0-9._~+=-]{24,}$")
+_LOCAL_PATH = re.compile(r"(?:(?:/Users|/home)/[^/\s]+|[A-Za-z]:\\Users\\[^\\\s]+)[^\s]*")
+_TRACE_SECRET_PATTERNS = (
+    re.compile(r"(?i)(\bbearer\s+)[A-Za-z0-9._~+/=-]+"),
+    re.compile(
+        r"(?i)(\b(?:api[_-]?key|token|password|secret)\b"
+        r"\s*[:=]\s*)[A-Za-z0-9._~+/=-]+"
+    ),
+)
+_TRACE_SECRET_LITERAL = re.compile(
+    r"(?i)\b[A-Za-z0-9._~+/=-]*(?:secret|password|token)"
+    r"[A-Za-z0-9._~+/=-]*\b"
+)
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(value, handle, indent=2, sort_keys=True, ensure_ascii=False)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def redact_url(raw_url: str) -> str:
+    """Retain routing metadata without credentials, queries, fragments, or bodies."""
+    try:
+        parsed = urlsplit(raw_url)
+    except ValueError:
+        return "<redacted-url>"
+    if parsed.scheme in {"data", "blob"}:
+        return f"{parsed.scheme}:[redacted]"
+    if parsed.scheme == "file":
+        return "file:///[redacted]"
+    if not parsed.scheme:
+        return raw_url.split("?", 1)[0].split("#", 1)[0][:_MAX_TEXT]
+    hostname = parsed.hostname or ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    netloc = hostname
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+    segments = []
+    for segment in parsed.path.split("/"):
+        if _HIGH_ENTROPY_SEGMENT.fullmatch(segment) or any(
+            pattern.search(segment) for pattern in _SECRET_PATTERNS
+        ):
+            digest = hashlib.sha256(segment.encode("utf-8")).hexdigest()[:12]
+            segments.append(f"<redacted-{digest}>")
+        else:
+            segments.append(redact_text(segment))
+    return urlunsplit((parsed.scheme, netloc, "/".join(segments)[:_MAX_TEXT], "", ""))
+
+
+def redact_text(raw_text: object) -> str:
+    """Bound and redact diagnostic text before it reaches an evidence file."""
+    text = str(raw_text)
+    for pattern in _SECRET_PATTERNS:
+        if pattern.pattern.startswith("(?i)\\b(bearer"):
+            text = pattern.sub(r"\1[redacted]", text)
+        elif "api[_-]?key" in pattern.pattern:
+            text = pattern.sub(r"\1\2[redacted]", text)
+        else:
+            text = pattern.sub("[redacted-secret]", text)
+    text = _LONG_BLOB.sub("[redacted-blob]", text)
+    text = _LOCAL_PATH.sub("<local-path>", text)
+    text = re.sub(
+        r"https?://[^\s\"')]+",
+        lambda match: redact_url(match.group(0)),
+        text,
+    )
+    if len(text) > _MAX_TEXT:
+        return f"{text[:_MAX_TEXT]}…[truncated]"
+    return text
+
+
+def _known_secret_values() -> tuple[str, ...]:
+    values = [
+        os.environ[key]
+        for key in ("OPENAI_API_KEY", "DATABRICKS_TOKEN", "CURSOR_API_KEY")
+        if os.environ.get(key)
+    ]
+    config_path = os.environ.get("DATABRICKS_CONFIG_FILE")
+    selected = os.environ.get("DATABRICKS_CONFIG_PROFILE")
+    if config_path and selected:
+        parser = configparser.ConfigParser(interpolation=None)
+        try:
+            parser.read(config_path, encoding="utf-8")
+            values.extend(
+                value
+                for key, value in parser.items(selected)
+                if any(word in key.lower() for word in ("token", "password", "secret")) and value
+            )
+        except (configparser.Error, OSError):
+            pass
+    return tuple(dict.fromkeys(values))
+
+
+def _redact_json_secrets(value: Any, known: tuple[str, ...], *, sensitive: bool = False) -> Any:
+    if sensitive:
+        return "[redacted-sensitive-value]"
+    if isinstance(value, dict):
+        return {
+            key: _redact_json_secrets(
+                item,
+                known,
+                sensitive=any(
+                    word in str(key).lower()
+                    for word in ("token", "password", "secret", "api_key", "authorization")
+                ),
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_json_secrets(item, known) for item in value]
+    if isinstance(value, str):
+        for secret in known:
+            value = value.replace(secret, "[redacted-known-secret]")
+        for pattern in _TRACE_SECRET_PATTERNS:
+            value = pattern.sub(r"\1[redacted]", value)
+        return _TRACE_SECRET_LITERAL.sub("[redacted-secret-literal]", value)
+    return value
+
+
+def _redact_trace_text(text: str, known: tuple[str, ...]) -> str:
+    lines = text.splitlines()
+    if lines:
+        try:
+            parsed = [json.loads(line) for line in lines if line.strip()]
+        except json.JSONDecodeError:
+            parsed = []
+        if parsed and len(parsed) == len([line for line in lines if line.strip()]):
+            return "\n".join(
+                json.dumps(_redact_json_secrets(item, known), separators=(",", ":"))
+                for item in parsed
+            ) + ("\n" if text.endswith("\n") else "")
+    try:
+        parsed_document = json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    else:
+        return json.dumps(
+            _redact_json_secrets(parsed_document, known),
+            separators=(",", ":"),
+        )
+    for secret in known:
+        text = text.replace(secret, "[redacted-known-secret]")
+    for pattern in _TRACE_SECRET_PATTERNS:
+        text = pattern.sub(r"\1[redacted]", text)
+    return _TRACE_SECRET_LITERAL.sub("[redacted-secret-literal]", text)
+
+
+def _sanitize_trace_zip(
+    source: zipfile.ZipFile,
+    destination: zipfile.ZipFile,
+    known: tuple[str, ...],
+    budget: dict[str, int],
+    *,
+    depth: int,
+) -> None:
+    if depth > MAX_TRACE_ARCHIVE_DEPTH:
+        raise ValueError("trace archive nesting exceeds limit")
+    members = source.infolist()
+    budget["members"] += len(members)
+    if budget["members"] > MAX_TRACE_MEMBERS:
+        raise ValueError("trace archive member count exceeds limit")
+    seen: set[str] = set()
+    for info in members:
+        member = Path(info.filename)
+        if (
+            info.filename in seen
+            or member.is_absolute()
+            or ".." in member.parts
+            or info.flag_bits & 0x1
+            or info.file_size < 0
+        ):
+            raise ValueError("unsafe trace member")
+        seen.add(info.filename)
+        if info.file_size > MAX_TRACE_MEMBER_BYTES:
+            raise ValueError("trace archive member exceeds limit")
+        budget["expanded"] += info.file_size
+        if budget["expanded"] > MAX_TRACE_EXPANDED_BYTES:
+            raise ValueError("trace archive expanded bytes exceed limit")
+        if info.is_dir():
+            destination.writestr(info, b"")
+            continue
+        payload = bytearray()
+        with source.open(info) as member_source:
+            while chunk := member_source.read(1024 * 1024):
+                if (
+                    len(payload) + len(chunk) > info.file_size
+                    or len(payload) + len(chunk) > MAX_TRACE_MEMBER_BYTES
+                ):
+                    raise ValueError("trace archive member exceeded declared size")
+                payload.extend(chunk)
+        if len(payload) != info.file_size:
+            raise ValueError("trace archive member size did not match declaration")
+        sanitized = bytes(payload)
+        nested_source_buffer = io.BytesIO(sanitized)
+        if zipfile.is_zipfile(nested_source_buffer):
+            nested_source_buffer.seek(0)
+            nested_destination_buffer = io.BytesIO()
+            with (
+                zipfile.ZipFile(nested_source_buffer, "r") as nested_source,
+                zipfile.ZipFile(
+                    nested_destination_buffer,
+                    "w",
+                    compression=zipfile.ZIP_DEFLATED,
+                ) as nested_destination,
+            ):
+                _sanitize_trace_zip(
+                    nested_source,
+                    nested_destination,
+                    known,
+                    budget,
+                    depth=depth + 1,
+                )
+            sanitized = nested_destination_buffer.getvalue()
+            if len(sanitized) > MAX_TRACE_MEMBER_BYTES:
+                raise ValueError("sanitized nested trace archive exceeds member limit")
+        else:
+            try:
+                text = sanitized.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                if any(value.encode() in sanitized for value in known):
+                    raise ValueError("known secret in binary trace member") from exc
+            else:
+                sanitized = _redact_trace_text(text, known).encode("utf-8")
+        if any(value.encode() in sanitized for value in known):
+            raise ValueError("known secret survived trace redaction")
+        destination.writestr(info, sanitized)
+
+
+def _sanitize_trace_archive(path: Path) -> None:
+    """Bound and redact a trace ZIP in one streaming transformation."""
+    if path.stat().st_size > MAX_TRACE_ARCHIVE_BYTES:
+        raise ValueError("trace archive exceeds top-level size limit")
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    known = _known_secret_values()
+    try:
+        with (
+            zipfile.ZipFile(path, "r") as source,
+            zipfile.ZipFile(temporary, "w", compression=zipfile.ZIP_DEFLATED) as destination,
+        ):
+            _sanitize_trace_zip(
+                source,
+                destination,
+                known,
+                {"members": 0, "expanded": 0},
+                depth=1,
+            )
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _test_directory(run_dir: Path, nodeid: str) -> Path:
+    digest = hashlib.sha256(nodeid.encode("utf-8")).hexdigest()
+    return run_dir / "playwright" / f"test-{digest[:20]}"
+
+
+class ContextMetadata:
+    """Collect bounded, redacted browser metadata for one test context."""
+
+    def __init__(self, nodeid: str, style: str, context_dir: Path | None) -> None:
+        self.nodeid = redact_text(nodeid)
+        self.nodeid_sha256 = hashlib.sha256(nodeid.encode("utf-8")).hexdigest()
+        self.style = style
+        self.context_dir = context_dir
+        self.started = time.monotonic()
+        self.events: list[dict[str, Any]] = []
+        self.limitations = [
+            "Request and response headers and bodies are intentionally not captured.",
+            "Console and page-error text is bounded and redacted heuristically.",
+        ]
+        self._truncated = False
+
+    @property
+    def enabled(self) -> bool:
+        return self.context_dir is not None
+
+    def add(self, event_type: str, **metadata: object) -> None:
+        if not self.enabled:
+            return
+        if len(self.events) >= _MAX_EVENTS:
+            self._truncated = True
+            return
+        self.events.append(
+            {
+                "type": event_type,
+                "elapsed_ms": round((time.monotonic() - self.started) * 1_000, 3),
+                **metadata,
+            }
+        )
+
+    def attach_page(self, page: Any) -> None:
+        if not self.enabled:
+            return
+        page.on(
+            "console",
+            lambda message: self.add(
+                "console",
+                level=redact_text(message.type),
+                text=redact_text(message.text),
+            ),
+        )
+        page.on(
+            "pageerror",
+            lambda error: self.add("page_error", message=redact_text(error)),
+        )
+        page.on(
+            "request",
+            lambda request: self.add(
+                "request",
+                method=redact_text(request.method),
+                resource_type=redact_text(request.resource_type),
+                url=redact_url(request.url),
+            ),
+        )
+        page.on(
+            "response",
+            lambda response: self.add(
+                "response",
+                method=redact_text(response.request.method),
+                resource_type=redact_text(response.request.resource_type),
+                status=int(response.status),
+                url=redact_url(response.url),
+            ),
+        )
+        page.on(
+            "requestfailed",
+            lambda request: self.add(
+                "request_failed",
+                method=redact_text(request.method),
+                resource_type=redact_text(request.resource_type),
+                url=redact_url(request.url),
+                failure=redact_text(request.failure or ""),
+            ),
+        )
+
+    def write(self) -> None:
+        if self.context_dir is None:
+            return
+        if self._truncated:
+            self.limitations.append(f"Browser metadata was capped at {_MAX_EVENTS} events.")
+        _atomic_json(
+            self.context_dir / "metadata.json",
+            {
+                "schema_version": 1,
+                "nodeid": self.nodeid,
+                "nodeid_sha256": self.nodeid_sha256,
+                "context_style": self.style,
+                "lifecycle": "closed",
+                "events": self.events,
+                "limitations": self.limitations,
+            },
+        )
+
+
+def _evidence_context_dir(nodeid: str, index: int) -> Path | None:
+    raw_run_dir = os.environ.get(VERIFY_RUN_DIR_ENV)
+    if not raw_run_dir:
+        return None
+    run_dir = Path(raw_run_dir).resolve()
+    test_dir = _test_directory(run_dir, nodeid)
+    test_dir.mkdir(parents=True, exist_ok=True)
+    for _ in range(100):
+        context_dir = test_dir / f"context-{index}-{secrets.token_hex(12)}"
+        try:
+            context_dir.mkdir()
+        except FileExistsError:
+            continue
+        return context_dir
+    raise RuntimeError("Could not allocate a unique Playwright evidence directory.")
+
+
+class SyncEvidenceBrowser:
+    """Function-scoped Browser facade that records every created context."""
+
+    def __init__(
+        self,
+        browser: Browser,
+        artifacts_recorder: Any,
+        nodeid: str,
+        context_args: dict[str, Any],
+        mark_context: Callable[[], None],
+    ) -> None:
+        self._browser = browser
+        self._artifacts_recorder = artifacts_recorder
+        self._nodeid = nodeid
+        self._context_args = context_args
+        self._mark_context = mark_context
+        self._contexts: list[BrowserContext] = []
+        self._context_count = 0
+
+    def _create_context(self, style: str, **kwargs: Any) -> BrowserContext:
+        self._context_count += 1
+        self._mark_context()
+        metadata = ContextMetadata(
+            self._nodeid,
+            style,
+            _evidence_context_dir(self._nodeid, self._context_count),
+        )
+        options = {**self._context_args, **kwargs}
+        context = self._browser.new_context(**options)
+        context.on("page", metadata.attach_page)
+        original_close = context.close
+
+        def close(*args: Any, **close_kwargs: Any) -> None:
+            if context in self._contexts:
+                self._contexts.remove(context)
+                trace_count = len(getattr(self._artifacts_recorder, "_traces", ()))
+                screenshot_count = len(getattr(self._artifacts_recorder, "_screenshots", ()))
+                self._artifacts_recorder.on_will_close_browser_context(context)
+                if metadata.context_dir is not None:
+                    recorder_artifacts = (
+                        (
+                            "trace",
+                            getattr(self._artifacts_recorder, "_traces", ())[trace_count:],
+                            ".zip",
+                        ),
+                        (
+                            "screenshot",
+                            getattr(self._artifacts_recorder, "_screenshots", ())[
+                                screenshot_count:
+                            ],
+                            ".png",
+                        ),
+                    )
+                    for kind, sources, suffix in recorder_artifacts:
+                        for index, source in enumerate(sources, start=1):
+                            source_path = Path(source)
+                            recorder_root = Path(
+                                self._artifacts_recorder._pw_artifacts_folder.name
+                            ).resolve(strict=True)
+                            resolved_source = source_path.resolve(strict=True)
+                            resolved_source.relative_to(recorder_root)
+                            if resolved_source.is_file() and not source_path.is_symlink():
+                                destination = (
+                                    metadata.context_dir / f"recorder-{kind}-{index}{suffix}"
+                                )
+                                shutil.copyfile(resolved_source, destination)
+                                if kind == "trace":
+                                    try:
+                                        _sanitize_trace_archive(destination)
+                                    except (OSError, ValueError, zipfile.BadZipFile) as exc:
+                                        destination.unlink(missing_ok=True)
+                                        metadata.limitations.append(
+                                            "Trace privacy transformation failed "
+                                            f"({type(exc).__name__}); trace was deleted."
+                                        )
+                metadata.write()
+            original_close(*args, **close_kwargs)
+
+        object.__setattr__(context, "close", close)
+        self._contexts.append(context)
+        self._artifacts_recorder.on_did_create_browser_context(context)
+        return context
+
+    def new_context(self, **kwargs: Any) -> BrowserContext:
+        return self._create_context("direct-sync", **kwargs)
+
+    def new_page(self, **kwargs: Any) -> Any:
+        return self.new_context(**kwargs).new_page()
+
+    def close_contexts(self) -> None:
+        for context in self._contexts.copy():
+            context.close()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._browser, name)
+
+
+class AsyncEvidenceBrowser:
+    """Async Browser facade for tests that launch Playwright directly."""
+
+    def __init__(
+        self,
+        browser: AsyncBrowser,
+        nodeid: str,
+        mark_context: Callable[[], None],
+    ) -> None:
+        self._browser = browser
+        self._nodeid = nodeid
+        self._mark_context = mark_context
+        self._contexts: list[AsyncBrowserContext] = []
+        self._context_count = 0
+
+    async def new_context(self, **kwargs: Any) -> AsyncBrowserContext:
+        self._context_count += 1
+        self._mark_context()
+        context_dir = _evidence_context_dir(self._nodeid, self._context_count)
+        if context_dir is not None and "record_video_dir" not in kwargs:
+            kwargs["record_video_dir"] = str(context_dir / "videos")
+        context = await self._browser.new_context(**kwargs)
+        metadata = ContextMetadata(self._nodeid, "direct-async", context_dir)
+        context.on("page", metadata.attach_page)
+        if context_dir is not None:
+            await context.tracing.start(screenshots=True, snapshots=True, sources=True)
+        original_close = context.close
+
+        async def close(*args: Any, **close_kwargs: Any) -> None:
+            if context in self._contexts:
+                self._contexts.remove(context)
+                if context_dir is not None:
+                    for index, page in enumerate(context.pages, start=1):
+                        try:
+                            await page.screenshot(
+                                path=context_dir / f"screenshot-{index}.png",
+                                full_page=True,
+                                timeout=5_000,
+                            )
+                        except Exception as exc:
+                            metadata.limitations.append(
+                                f"Screenshot capture failed ({type(exc).__name__})."
+                            )
+                    try:
+                        trace_path = context_dir / "trace.zip"
+                        await context.tracing.stop(path=trace_path)
+                        _sanitize_trace_archive(trace_path)
+                    except Exception as exc:
+                        (context_dir / "trace.zip").unlink(missing_ok=True)
+                        metadata.limitations.append(
+                            "Trace capture or privacy transformation failed "
+                            f"({type(exc).__name__}); trace was deleted."
+                        )
+                await original_close(*args, **close_kwargs)
+                metadata.write()
+                return
+            await original_close(*args, **close_kwargs)
+
+        object.__setattr__(context, "close", close)
+        self._contexts.append(context)
+        return context
+
+    async def new_page(self, **kwargs: Any) -> Any:
+        context = await self.new_context(**kwargs)
+        return await context.new_page()
+
+    async def close(self, *args: Any, **kwargs: Any) -> None:
+        for context in self._contexts.copy():
+            await context.close()
+        await self._browser.close(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._browser, name)

--- a/tests/e2e_ui/test_evidence_contract.py
+++ b/tests/e2e_ui/test_evidence_contract.py
@@ -1,0 +1,132 @@
+"""Small browser probes for every Playwright context style used by this suite."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import threading
+import zipfile
+from collections.abc import Coroutine
+from pathlib import Path
+from typing import Any
+
+import pytest
+from playwright.async_api import async_playwright
+from playwright.sync_api import Browser, Page
+
+from tests.e2e_ui.conftest import _validate_vite_output, _vite_build_lock_path
+from tests.e2e_ui.playwright_evidence import VERIFY_RUN_DIR_ENV, _sanitize_trace_archive
+
+
+def test_managed_page_fixture_is_evidence_bound(page: Page) -> None:
+    page.goto("data:text/html,<title>managed</title>")
+    page.evaluate("console.log('token=managed-secret-value')")
+    page.evaluate("setTimeout(() => { throw new Error('managed page error'); }, 0)")
+    page.wait_for_timeout(50)
+    assert page.title() == "managed"
+
+
+def test_vite_output_symlink_cannot_delete_external_data(tmp_path: Path) -> None:
+    trusted = tmp_path / "run"
+    external = tmp_path / "external"
+    trusted.mkdir()
+    external.mkdir()
+    sentinel = external / "keep.txt"
+    sentinel.write_text("untouched\n", encoding="utf-8")
+    output = trusted / "build"
+    output.symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(pytest.fail.Exception, match="symlink"):
+        _validate_vite_output(output, trusted)
+
+    assert sentinel.read_text(encoding="utf-8") == "untouched\n"
+
+
+def test_vite_build_lock_is_outside_checkout() -> None:
+    lock = _vite_build_lock_path().resolve()
+
+    assert not lock.is_relative_to(Path(__file__).resolve().parents[2])
+
+
+def test_direct_sync_context_is_evidence_bound(browser: Browser) -> None:
+    context = browser.new_context()
+    page = context.new_page()
+    try:
+        page.goto("data:text/html,<title>direct-sync</title>")
+        page.evaluate("console.warn('api_key=direct-sync-secret')")
+        assert page.title() == "direct-sync"
+    finally:
+        context.close()
+
+
+def test_direct_async_context_is_evidence_bound() -> None:
+    _run_in_fresh_loop(_drive_direct_async_context())
+
+
+async def _drive_direct_async_context() -> None:
+    async with async_playwright() as playwright:
+        browser = await playwright.chromium.launch()
+        page = await browser.new_page()
+        try:
+            await page.goto("data:text/html,<title>direct-async</title>")
+            await page.evaluate("console.error('Bearer direct-async-secret')")
+            assert await page.title() == "direct-async"
+        finally:
+            await browser.close()
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    error: list[BaseException] = []
+
+    def run() -> None:
+        try:
+            asyncio.run(coro)
+        except BaseException as exc:
+            error.append(exc)
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    thread.join(timeout=30)
+    assert not thread.is_alive(), "async Playwright evidence probe timed out"
+    if error:
+        raise error[0]
+
+
+def test_evidence_plugin_does_not_require_a_browser() -> None:
+    raw_run_dir = os.environ.get(VERIFY_RUN_DIR_ENV)
+    if raw_run_dir:
+        run_dir = Path(raw_run_dir)
+        metadata_files = list((run_dir / "playwright").glob("**/metadata.json"))
+        metadata = [json.loads(path.read_text(encoding="utf-8")) for path in metadata_files]
+        assert {item["context_style"] for item in metadata} >= {
+            "managed-sync",
+            "direct-sync",
+            "direct-async",
+        }
+        assert len(list((run_dir / "playwright").glob("**/*.png"))) >= 3
+        assert len(list((run_dir / "playwright").glob("**/*.zip"))) >= 3
+        assert list((run_dir / "playwright").glob("**/*.webm"))
+        serialized = json.dumps(metadata)
+        assert "managed-secret-value" not in serialized
+        assert "direct-sync-secret" not in serialized
+        assert "direct-async-secret" not in serialized
+        markers = (
+            b"managed-secret-value",
+            b"direct-sync-secret",
+            b"direct-async-secret",
+        )
+        for trace in run_dir.rglob("*.zip"):
+            _sanitize_trace_archive(trace)
+        for path in run_dir.rglob("*"):
+            if not path.is_file():
+                continue
+            payload = path.read_bytes()
+            assert not any(marker in payload for marker in markers)
+            if path.suffix == ".zip":
+                with zipfile.ZipFile(path) as archive:
+                    assert archive.testzip() is None
+                    for member in archive.infolist():
+                        payload = archive.read(member)
+                        assert not any(marker in payload for marker in markers)
+    assert True

--- a/tests/harness_bench/report.py
+++ b/tests/harness_bench/report.py
@@ -252,6 +252,8 @@ def _skip_lines(matrix: BenchMatrix) -> list[str]:
 def render_json(matrix: BenchMatrix) -> str:
     """Render *matrix* as indented JSON (stable key order) for tooling."""
     payload = {
+        "dimensions": [name for name, _title in _matrix_dimensions(matrix)],
+        "schema_version": 1,
         "harnesses": [_report_json(r) for r in matrix.reports],
         "has_drift": matrix.has_drift,
     }

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -287,6 +287,8 @@ async def test_offline_render_produces_matrix() -> None:
     assert "`claude-sdk [full-server]`" in md
     assert "`claude-native [native]`" in md
     payload = json.loads(render_json(matrix))
+    assert payload["schema_version"] == 1
+    assert payload["dimensions"]
     assert {h["harness"] for h in payload["harnesses"]} == {p.harness for p in _OFFICIAL}
     by_harness = {h["harness"]: h for h in payload["harnesses"]}
     assert by_harness["claude-sdk"]["resolved_transport"] == "full-server"

--- a/tests/verify_omnigent/conftest.py
+++ b/tests/verify_omnigent/conftest.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+def _remove_fsmonitor_state(repo: Path) -> None:
+    """Stop only this disposable repo's daemon and remove its IPC state."""
+    subprocess.run(
+        ["git", "-c", "core.fsmonitor=true", "fsmonitor--daemon", "stop"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    for name in ("fsmonitor--daemon", "fsmonitor--daemon.ipc"):
+        result = subprocess.run(
+            ["git", "-c", "core.fsmonitor=false", "rev-parse", "--git-path", name],
+            cwd=repo,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            continue
+        state = Path(result.stdout.strip())
+        if not state.is_absolute():
+            state = repo / state
+        with contextlib.suppress(FileNotFoundError):
+            if state.is_dir() and not state.is_symlink():
+                shutil.rmtree(state)
+            else:
+                state.unlink()
+
+
+@pytest.fixture(autouse=True)
+def _disable_fsmonitor_for_fixture_repos(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[None]:
+    """Disable inherited fsmonitor before any disposable-repo Git command."""
+    count = int(os.environ.get("GIT_CONFIG_COUNT", "0"))
+    monkeypatch.setenv("GIT_CONFIG_COUNT", str(count + 1))
+    monkeypatch.setenv(f"GIT_CONFIG_KEY_{count}", "core.fsmonitor")
+    monkeypatch.setenv(f"GIT_CONFIG_VALUE_{count}", "false")
+    yield
+    for git_entry in tmp_path.rglob(".git"):
+        _remove_fsmonitor_state(git_entry.parent)

--- a/tests/verify_omnigent/fixtures/bazel_all_skipped.xml
+++ b/tests/verify_omnigent/fixtures/bazel_all_skipped.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="all-skipped" tests="2" failures="0" errors="0" skipped="2">
+  <testcase classname="fixture" name="first">
+    <skipped />
+  </testcase>
+  <testcase classname="fixture" name="second">
+    <skipped />
+  </testcase>
+</testsuite>

--- a/tests/verify_omnigent/fixtures/bazel_passing.xml
+++ b/tests/verify_omnigent/fixtures/bazel_passing.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="host_slice_key" tests="2" failures="0" errors="0" skipped="0">
+  <testcase classname="HostSliceKeyGatePatchTest" name="test_marker_present" time="0.01" />
+  <testcase classname="HostSliceKeyGatePatchTest" name="test_gate_defaults_off" time="0.02" />
+</testsuite>

--- a/tests/verify_omnigent/fixtures/bazel_psutil_error.xml
+++ b/tests/verify_omnigent/fixtures/bazel_psutil_error.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="collection" tests="1" failures="0" errors="1" skipped="0">
+  <testcase classname="" name="agentbricks/mas/python/tests/test_managed_host_edge_bearer_patch.py" time="0">
+    <error message="ImportError">ImportError: cannot import name '_psutil_osx' from partially initialized module 'psutil'</error>
+  </testcase>
+</testsuite>

--- a/tests/verify_omnigent/fixtures/bazel_zero_test_jemalloc.log
+++ b/tests/verify_omnigent/fixtures/bazel_zero_test_jemalloc.log
@@ -1,0 +1,4 @@
+ERROR: Compiling src/zone.c failed
+jemalloc_internal_defs.h:145:10: fatal error: 'features.h' file not found
+ERROR: Build did NOT complete successfully
+Executed 0 out of 3 tests: 1 fails to build and 2 were skipped.

--- a/tests/verify_omnigent/fixtures/pin_mismatch.json
+++ b/tests/verify_omnigent/fixtures/pin_mismatch.json
@@ -1,0 +1,4 @@
+{
+  "requested": "f0b161505fb1271808c8c289f7595f60f7da4a3c",
+  "vendored": "5f0177417ccaff9824edfc2305bcfa85d99daf96"
+}

--- a/tests/verify_omnigent/test_comparison.py
+++ b/tests/verify_omnigent/test_comparison.py
@@ -1,0 +1,827 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib.util
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HELPER = _REPO_ROOT / ".agents" / "skills" / "verify-omnigent" / "scripts" / "comparison.py"
+
+
+def _load_helper() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("verify_comparison", _HELPER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    previous = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.dont_write_bytecode = previous
+    return module
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _commit(repo: Path, message: str) -> None:
+    _git(repo, "add", ".")
+    _git(
+        repo,
+        "-c",
+        "user.name=Fixture",
+        "-c",
+        "user.email=fixture@example.com",
+        "commit",
+        "-qm",
+        message,
+    )
+
+
+def _comparison_repo(tmp_path: Path, base_behavior: str) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "behavior.txt").write_text(base_behavior + "\n", encoding="utf-8")
+    _commit(repo, "base")
+    _git(repo, "switch", "-q", "-c", "pr")
+    (repo / "candidate.txt").write_text("candidate\n", encoding="utf-8")
+    _commit(repo, "candidate")
+    (repo / "candidate.txt").write_text("dirty candidate\n", encoding="utf-8")
+    (repo / "untracked.txt").write_text("preserve me\n", encoding="utf-8")
+    return repo
+
+
+def _fake_skill(tmp_path: Path) -> Path:
+    skill = tmp_path / "skill"
+    script = skill / "scripts" / "verify.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+behavior = Path("behavior.txt").read_text(encoding="utf-8").strip()
+if behavior == "timeout":
+    time.sleep(60)
+if behavior == "no-manifest":
+    raise SystemExit(2)
+root = Path(os.environ["OMNIGENT_VERIFY_EVIDENCE_DIR"]) / "base-run"
+logs = root / "step-logs"
+logs.mkdir(parents=True)
+passed = behavior == "pass"
+log = logs / "00.log"
+log.write_text(("base passed" if passed else behavior) + "\\n")
+request_path = Path(sys.argv[sys.argv.index("--comparison-request") + 1])
+request_raw = request_path.read_bytes()
+request = json.loads(request_raw)
+request_path.unlink()
+step = {
+    "source_step_index": 0,
+    "name": "Server API and app integration",
+    "argv": [
+        "uv", "run", "--no-sync", "pytest", "tests/server/test_app.py",
+        "tests/server/integration/test_app.py", "-q",
+        "--junitxml=<run-dir>/junit.xml",
+    ],
+    "environment": {},
+    "cwd": ".",
+    "isolated": False,
+    "status": "passed" if passed else "failed",
+    "exit_status": 0 if passed else 1,
+    "log": "step-logs/00.log",
+    "log_sha256": __import__("hashlib").sha256(log.read_bytes()).hexdigest(),
+}
+steps_path = root / "steps.json"
+steps_path.write_text(json.dumps({
+    "schema_version": 1,
+    "profile": sys.argv[1],
+    "status": "passed" if passed else "failed",
+    "comparison_request_sha256": __import__("hashlib").sha256(request_raw).hexdigest(),
+    "requested_step_indices": request["step_indices"],
+    "steps": [step],
+}) + "\\n")
+(root / "manifest.json").write_text(json.dumps({
+    "schema_version": 1,
+    "status": "passed" if passed else "failed",
+    "exit_status": 0 if passed else 1,
+    "run": {"profile": sys.argv[1]},
+    "cleanup": {"status": "not_applicable", "details": []},
+    "artifacts": [{
+        "path": "steps.json",
+        "sha256": __import__("hashlib").sha256(steps_path.read_bytes()).hexdigest(),
+    }],
+}) + "\\n")
+raise SystemExit(0 if passed else 1)
+""",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    return skill
+
+
+def _pr_child(tmp_path: Path, signature: str) -> Path:
+    child = tmp_path / "pr-child"
+    logs = child / "step-logs"
+    logs.mkdir(parents=True)
+    (logs / "00.log").write_text(signature + "\n", encoding="utf-8")
+    log_hash = hashlib.sha256((logs / "00.log").read_bytes()).hexdigest()
+    steps_path = child / "steps.json"
+    steps_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "profile": "server",
+                "status": "failed",
+                "steps": [
+                    {
+                        "source_step_index": 0,
+                        "name": "Server API and app integration",
+                        "argv": [
+                            "uv",
+                            "run",
+                            "--no-sync",
+                            "pytest",
+                            "tests/server/test_app.py",
+                            "tests/server/integration/test_app.py",
+                            "-q",
+                            "--junitxml=<run-dir>/junit.xml",
+                        ],
+                        "environment": {},
+                        "cwd": ".",
+                        "isolated": False,
+                        "status": "failed",
+                        "exit_status": 1,
+                        "log": "step-logs/00.log",
+                        "log_sha256": log_hash,
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest = child / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "failed",
+                "exit_status": 1,
+                "run": {"profile": "server"},
+                "artifacts": [
+                    {
+                        "path": "steps.json",
+                        "sha256": hashlib.sha256(steps_path.read_bytes()).hexdigest(),
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _capability(run_dir: Path) -> Path:
+    path = run_dir / "environment" / "comparison-capability"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(os.urandom(32))
+    path.chmod(0o600)
+    return path
+
+
+@pytest.mark.parametrize(
+    ("base_behavior", "candidate_signature", "classification"),
+    [
+        ("pass", "candidate failure", "pr_only_failure"),
+        ("same failure", "same failure", "baseline_reproduced"),
+        ("different failure", "candidate failure", "baseline_differs"),
+    ],
+)
+def test_exact_base_failure_classification_and_cleanup(
+    tmp_path: Path,
+    base_behavior: str,
+    candidate_signature: str,
+    classification: str,
+) -> None:
+    helper = _load_helper()
+    repo = _comparison_repo(tmp_path, base_behavior)
+    skill = _fake_skill(tmp_path)
+    child = _pr_child(tmp_path, candidate_signature)
+    run_dir = tmp_path / "run"
+    capability = _capability(run_dir)
+    status_before = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    worktrees_before = _git(repo, "worktree", "list", "--porcelain")
+
+    report, exit_status = helper.compare_failure(
+        repo,
+        skill,
+        run_dir,
+        "server",
+        "main",
+        child,
+        2,
+        capability,
+    )
+
+    assert exit_status == 0
+    assert report["classification"] == classification
+    assert report["cleanup"]["status"] == "completed"
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == status_before
+    assert (repo / "untracked.txt").read_text(encoding="utf-8") == "preserve me\n"
+    assert _git(repo, "worktree", "list", "--porcelain") == worktrees_before
+
+
+def test_head_baseline_classifies_uncommitted_product_failure(tmp_path: Path) -> None:
+    helper = _load_helper()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "behavior.txt").write_text("pass\n", encoding="utf-8")
+    (repo / "omnigent").mkdir()
+    (repo / "omnigent/change.py").write_text("BASE = True\n", encoding="utf-8")
+    _commit(repo, "base")
+    (repo / "behavior.txt").write_text("candidate failure\n", encoding="utf-8")
+    (repo / "omnigent/change.py").write_text("BASE = False\n", encoding="utf-8")
+    skill = _fake_skill(tmp_path)
+    child = _pr_child(tmp_path, "candidate failure")
+    run_dir = tmp_path / "run"
+
+    report, exit_status = helper.compare_failure(
+        repo,
+        skill,
+        run_dir,
+        "server",
+        "HEAD",
+        child,
+        2,
+        _capability(run_dir),
+    )
+
+    assert exit_status == 0
+    assert report["classification"] == "pr_only_failure"
+    assert report["base_commit"] == _git(repo, "rev-parse", "HEAD")
+    assert report["cleanup"]["status"] == "completed"
+
+
+@pytest.mark.parametrize("base_behavior", ["timeout", "no-manifest"])
+def test_exact_base_comparison_failure_is_bounded_and_cleaned(
+    tmp_path: Path,
+    base_behavior: str,
+) -> None:
+    helper = _load_helper()
+    repo = _comparison_repo(tmp_path, base_behavior)
+    skill = _fake_skill(tmp_path)
+    child = _pr_child(tmp_path, "candidate failure")
+    run_dir = tmp_path / "run"
+    capability = _capability(run_dir)
+
+    report, exit_status = helper.compare_failure(
+        repo,
+        skill,
+        run_dir,
+        "server",
+        "main",
+        child,
+        0.1,
+        capability,
+    )
+
+    assert exit_status != 0
+    assert report["classification"] == "could_not_compare"
+    assert report["cleanup"]["status"] == "completed"
+    worktrees = _git(repo, "worktree", "list").splitlines()
+    assert not any("omnigent-verify-base-" in line for line in worktrees)
+
+
+def test_successful_classification_is_rejected_when_cleanup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    repo = _comparison_repo(tmp_path, "pass")
+    skill = _fake_skill(tmp_path)
+    child = _pr_child(tmp_path, "candidate failure")
+    run_dir = tmp_path / "run"
+    original = helper._base_worktree
+
+    @contextlib.contextmanager
+    def failed_cleanup(
+        repo_root: Path,
+        base_commit: str,
+        cleanup: dict[str, object],
+    ) -> Iterator[Path]:
+        with original(repo_root, base_commit, cleanup) as checkout:
+            yield checkout
+        cleanup["status"] = "failed"
+
+    monkeypatch.setattr(helper, "_base_worktree", failed_cleanup)
+
+    report, exit_status = helper.compare_failure(
+        repo,
+        skill,
+        run_dir,
+        "server",
+        "main",
+        child,
+        2,
+        _capability(run_dir),
+    )
+
+    assert exit_status != 0
+    assert report["classification"] == "could_not_compare"
+    assert report["cleanup"]["status"] == "failed"
+    assert "omnigent-verify-base-" not in _git(repo, "worktree", "list")
+
+
+def test_tampered_step_report_cannot_forge_baseline_classification(tmp_path: Path) -> None:
+    helper = _load_helper()
+    repo = _comparison_repo(tmp_path, "pass")
+    skill = _fake_skill(tmp_path)
+    child = _pr_child(tmp_path, "candidate failure")
+    steps = child.parent / "steps.json"
+    value = json.loads(steps.read_text(encoding="utf-8"))
+    value["steps"][0]["source_step_index"] = 999
+    steps.write_text(json.dumps(value), encoding="utf-8")
+    run_dir = tmp_path / "run"
+
+    report, exit_status = helper.compare_failure(
+        repo,
+        skill,
+        run_dir,
+        "server",
+        "main",
+        child,
+        2,
+        _capability(run_dir),
+    )
+
+    assert exit_status != 0
+    assert report["classification"] == "could_not_compare"
+    assert "hash does not match" in " ".join(report["limitations"])
+
+
+@pytest.mark.parametrize("lane", ["quality-gates", "web-ui", "desktop"])
+def test_unsupported_js_comparisons_are_never_misclassified(
+    tmp_path: Path,
+    lane: str,
+) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "run"
+
+    report, status = helper.compare_failure(
+        _REPO_ROOT,
+        _REPO_ROOT / ".agents/skills/verify-omnigent",
+        run_dir,
+        lane,
+        "HEAD",
+        tmp_path / "unused-manifest.json",
+        1,
+        _capability(run_dir),
+    )
+
+    assert status != 0
+    assert report["classification"] == "could_not_compare"
+    assert "does not support exact-base comparison" in " ".join(report["limitations"])
+
+
+@pytest.mark.parametrize("tamper", ["out-of-range", "command", "empty"])
+def test_rehashed_manifest_tampering_still_cannot_forge_classification(
+    tmp_path: Path,
+    tamper: str,
+) -> None:
+    helper = _load_helper()
+    repo = _comparison_repo(tmp_path, "pass")
+    skill = _fake_skill(tmp_path)
+    child = _pr_child(tmp_path, "candidate failure")
+    steps_path = child.parent / "steps.json"
+    steps = json.loads(steps_path.read_text(encoding="utf-8"))
+    if tamper == "out-of-range":
+        steps["steps"][0]["source_step_index"] = 999
+    elif tamper == "command":
+        steps["steps"][0]["argv"] = ["attacker-controlled"]
+    else:
+        steps["steps"] = []
+    steps_path.write_text(json.dumps(steps), encoding="utf-8")
+    manifest = json.loads(child.read_text(encoding="utf-8"))
+    manifest["artifacts"][0]["sha256"] = hashlib.sha256(steps_path.read_bytes()).hexdigest()
+    child.write_text(json.dumps(manifest), encoding="utf-8")
+    run_dir = tmp_path / "run"
+
+    report, status = helper.compare_failure(
+        repo,
+        skill,
+        run_dir,
+        "server",
+        "main",
+        child,
+        2,
+        _capability(run_dir),
+    )
+
+    assert status != 0
+    assert report["classification"] == "could_not_compare"
+
+
+def test_base_worktree_never_links_primary_node_modules(tmp_path: Path) -> None:
+    helper = _load_helper()
+    repo = tmp_path / "dependency-repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / ".gitignore").write_text("node_modules/\n", encoding="utf-8")
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    _commit(repo, "base")
+    metadata = repo / "node_modules" / ".modules.yaml"
+    metadata.parent.mkdir()
+    metadata.write_bytes(b'{"virtualStoreDir":".pnpm"}\n')
+    primary_link = repo / "node_modules" / "package"
+    primary_link.symlink_to("../store/package")
+    before_metadata = metadata.read_bytes()
+    before_link = os.readlink(primary_link)
+    cleanup: dict[str, object] = {}
+
+    with helper._base_worktree(repo, _git(repo, "rev-parse", "HEAD"), cleanup) as checkout:
+        assert not (checkout / "node_modules").exists()
+
+    assert metadata.read_bytes() == before_metadata
+    assert os.readlink(primary_link) == before_link
+    assert cleanup["status"] == "completed"
+
+
+def test_base_worktree_clones_candidate_venv_without_write_through(tmp_path: Path) -> None:
+    helper = _load_helper()
+    repo = tmp_path / "dependency-repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    _commit(repo, "base")
+    candidate_file = repo / ".venv/lib/python/site-packages/pkg.py"
+    candidate_file.parent.mkdir(parents=True)
+    candidate_file.write_text("candidate = True\n", encoding="utf-8")
+    cleanup: dict[str, object] = {}
+
+    with helper._base_worktree(repo, _git(repo, "rev-parse", "HEAD"), cleanup) as checkout:
+        cloned = checkout / ".venv/lib/python/site-packages/pkg.py"
+        assert cloned.is_file()
+        assert not (checkout / ".venv").is_symlink()
+        cloned.write_text("base write\n", encoding="utf-8")
+
+    assert candidate_file.read_text(encoding="utf-8") == "candidate = True\n"
+    assert cleanup["status"] == "completed"
+
+
+def test_base_import_identity_rejects_candidate_editable_path(tmp_path: Path) -> None:
+    helper = _load_helper()
+    checkout = tmp_path / "base"
+    candidate = tmp_path / "candidate"
+    for root, identity in ((checkout, "base"), (candidate, "candidate")):
+        package = root / "omnigent"
+        package.mkdir(parents=True)
+        (package / "__init__.py").write_text(f"IDENTITY = {identity!r}\n", encoding="utf-8")
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(checkout / ".venv")],
+        check=True,
+    )
+    interpreter = checkout / ".venv/bin/python"
+    site_packages = subprocess.run(
+        [str(interpreter), "-c", "import site; print(site.getsitepackages()[0])"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    Path(site_packages, "candidate-editable.pth").write_text(
+        f"import sys; sys.path.insert(0, {str(candidate)!r})\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="did not resolve inside"):
+        helper._assert_base_import_identity(checkout, tmp_path / "run", 10)
+
+
+def test_comparison_signal_cleans_child_process_and_worktree(tmp_path: Path) -> None:
+    repo = _comparison_repo(tmp_path, "timeout")
+    skill = _fake_skill(tmp_path)
+    child = _pr_child(tmp_path, "candidate failure")
+    run_dir = tmp_path / "run"
+    capability = _capability(run_dir)
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(_HELPER),
+            "baseline",
+            "--repo-root",
+            str(repo),
+            "--skill-root",
+            str(skill),
+            "--run-dir",
+            str(run_dir),
+            "--lane",
+            "server",
+            "--base-ref",
+            "main",
+            "--child-manifest",
+            str(child),
+            "--timeout",
+            "60",
+            "--capability-file",
+            str(capability),
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if "omnigent-verify-base-" in _git(repo, "worktree", "list"):
+            break
+        time.sleep(0.05)
+    started = time.monotonic()
+    process.send_signal(signal.SIGTERM)
+    process.communicate(timeout=10)
+
+    assert time.monotonic() - started < 10
+    assert process.returncode != 0
+    report = json.loads(
+        (run_dir / "baseline" / "server" / "comparison.json").read_text(encoding="utf-8")
+    )
+    assert report["classification"] == "could_not_compare"
+    assert report["cleanup"]["status"] == "completed"
+    assert "omnigent-verify-base-" not in _git(repo, "worktree", "list")
+
+
+def test_comparison_subprocess_propagates_managed_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    marker = tmp_path / "marker"
+    descriptor = os.open(marker, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        monkeypatch.setenv("OMNIGENT_VERIFY_MANAGED_FD", str(descriptor))
+        status, timed_out = helper._bounded_run(
+            [
+                sys.executable,
+                "-c",
+                "import os; os.fstat(int(os.environ['OMNIGENT_VERIFY_MANAGED_FD']))",
+            ],
+            cwd=tmp_path,
+            env=dict(os.environ),
+            log_path=tmp_path / "comparison.log",
+            timeout=5,
+        )
+    finally:
+        os.close(descriptor)
+
+    assert status == 0
+    assert timed_out is False
+
+
+def _benchmark(*, backend: str = "sqlite", p50: float = 1.0) -> dict[str, Any]:
+    return {
+        "schema_version": 6,
+        "git_sha": "a" * 40,
+        "host": {"platform": "test", "python": "3.12", "cpu_count": 1},
+        "harness": "http-only",
+        "config": {
+            "iterations": 25,
+            "requests": 500,
+            "concurrency": 1,
+            "runs": 1,
+            "warmup": 10,
+            "with_runner": False,
+            "backend": backend,
+            "network_delay_ms": 0.0,
+        },
+        "journeys": {
+            "list_sessions": {
+                "backend": backend,
+                "kind": "latency",
+                "runs": [{"n_failures": 0, "http_requests": 25}],
+                "summary": {
+                    "avg_p50_ms": p50,
+                    "avg_p99_ms": p50 * 2,
+                    "avg_http_requests_per_op": 1.0,
+                    "network_routes": [
+                        {"route": "GET /v1/sessions", "requests": 75, "per_op": 1.0}
+                    ],
+                    "runs_ok": 1,
+                    "runs_total": 1,
+                },
+            }
+        },
+    }
+
+
+def test_performance_comparison_requires_matched_identity_and_never_invents_threshold() -> None:
+    helper = _load_helper()
+    matched = helper._compare_benchmarks(_benchmark(), _benchmark(p50=1.2))
+    mismatched = helper._compare_benchmarks(_benchmark(), _benchmark(backend="mysql"))
+    unsupported_seed = helper._compare_benchmarks(
+        _benchmark(backend="mysql"),
+        _benchmark(backend="mysql"),
+    )
+
+    assert matched["matched"] is True
+    assert matched["rows"][0]["p50_ms"] == {"base": 1.0, "candidate": 1.2}
+    assert matched["rows"][0]["p99_ms"] == {"base": 2.0, "candidate": 2.4}
+    assert matched["rows"][0]["http_requests_per_op"]["candidate"] == 1.0
+    assert matched["rows"][0]["http_requests"]["candidate"] == 25
+    assert matched["rows"][0]["network_routes"]["candidate"][0]["route"] == "GET /v1/sessions"
+    assert matched["no_regression_claim"] is False
+    assert mismatched["matched"] is False
+    assert "did not match" in mismatched["claim_reason"]
+    assert unsupported_seed["matched"] is False
+    assert unsupported_seed["seed_identity"]["matched"] is False
+
+
+def test_performance_comparison_enforces_explicit_applicable_thresholds() -> None:
+    helper = _load_helper()
+    passing = _benchmark(p50=1.05)
+    passing["verification_thresholds"] = {
+        "max_p50_regression_percent": 10,
+        "max_p99_regression_percent": 10,
+    }
+    failing = _benchmark(p50=1.2)
+    failing["verification_thresholds"] = passing["verification_thresholds"]
+
+    passed = helper._compare_benchmarks(_benchmark(), passing)
+    failed = helper._compare_benchmarks(_benchmark(), failing)
+
+    assert passed["matched"] is True
+    assert passed["no_regression_claim"] is True
+    assert failed["matched"] is True
+    assert failed["no_regression_claim"] is False
+
+
+def test_performance_schema_must_be_supported_and_equal() -> None:
+    helper = _load_helper()
+    unsupported = _benchmark()
+    unsupported["schema_version"] = 999
+
+    comparison = helper._compare_benchmarks(_benchmark(), unsupported)
+
+    assert comparison["matched"] is False
+    assert comparison["schema_identity"] == {
+        "base": 6,
+        "candidate": 999,
+        "matched": False,
+        "supported": [6],
+    }
+    assert comparison["no_regression_claim"] is False
+
+
+def test_performance_comparison_rejects_contradictory_run_counts() -> None:
+    helper = _load_helper()
+    contradictory = _benchmark()
+    summary = contradictory["journeys"]["list_sessions"]["summary"]
+    summary["runs_ok"] = 2
+    summary["runs_total"] = 2
+
+    comparison = helper._compare_benchmarks(_benchmark(), contradictory)
+
+    assert comparison["matched"] is False
+    assert comparison["rows"][0]["functional_success"]["candidate"] is False
+    assert comparison["no_regression_claim"] is False
+
+
+def test_extreme_latency_regression_never_returns_green() -> None:
+    helper = _load_helper()
+    without_threshold = _benchmark(p50=1_000)
+    with_threshold = _benchmark(p50=1_000)
+    with_threshold["verification_thresholds"] = {
+        "max_p50_regression_percent": 1_000_000,
+        "max_p99_regression_percent": 1_000_000,
+    }
+
+    unscored = helper._compare_benchmarks(_benchmark(p50=1), without_threshold)
+    failed = helper._compare_benchmarks(_benchmark(p50=1), with_threshold)
+
+    assert unscored["rows"][0]["p50_ms"] == {"base": 1, "candidate": 1_000}
+    assert unscored["rows"][0]["p99_ms"] == {"base": 2, "candidate": 2_000}
+    assert unscored["no_regression_claim"] is False
+    assert "thresholds failed" in unscored["claim_reason"]
+    assert failed["no_regression_claim"] is False
+    assert "thresholds failed" in failed["claim_reason"]
+    assert failed["thresholds"] == {
+        "max_p50_regression_percent": 10,
+        "max_p99_regression_percent": 10,
+    }
+
+
+@pytest.mark.parametrize("defect", ["skipped", "partial", "failed-operation"])
+def test_performance_comparison_requires_functional_success(defect: str) -> None:
+    helper = _load_helper()
+    candidate = _benchmark()
+    journey = candidate["journeys"]["list_sessions"]
+    if defect == "skipped":
+        journey["skipped_reason"] = "fixture"
+    elif defect == "partial":
+        journey["summary"]["runs_ok"] = 0
+    else:
+        journey["runs"][0]["n_failures"] = 1
+
+    comparison = helper._compare_benchmarks(_benchmark(), candidate)
+
+    assert comparison["matched"] is False
+    assert comparison["functional_success"] is False
+
+
+def test_matched_performance_comparison_runs_at_exact_base(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    repo = tmp_path / "perf-repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    for relative, content in {
+        "pyproject.toml": "[project]\nname='fixture'\n",
+        "uv.lock": "version = 1\n",
+        "package.json": '{"name":"fixture","packageManager":"pnpm@11.15.1"}\n',
+        "pnpm-lock.yaml": "lockfileVersion: 9\n",
+        "pnpm-workspace.yaml": "packages: []\n",
+        "web/package.json": '{"name":"web"}\n',
+        "web/electron/package.json": '{"name":"electron"}\n',
+        "dev/benchmarks/omnigent/run.py": "# synthetic benchmark\n",
+    }.items():
+        path = repo / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    _commit(repo, "base")
+    _git(repo, "switch", "-q", "-c", "pr")
+    (repo / "product.py").write_text("changed = True\n", encoding="utf-8")
+    _commit(repo, "candidate")
+    candidate = _benchmark()
+    candidate["git_sha"] = _git(repo, "rev-parse", "HEAD")
+    run_dir = tmp_path / "perf-run"
+    run_dir.mkdir()
+    candidate_path = run_dir / "benchmark.json"
+    candidate_path.write_text(json.dumps(candidate), encoding="utf-8")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_uv = bin_dir / "uv"
+    fake_uv.write_text(
+        f"""#!/usr/bin/env python3
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+report = json.loads({json.dumps(json.dumps(_benchmark()))})
+report["git_sha"] = subprocess.run(
+    ["git", "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+).stdout.strip()
+output = Path(sys.argv[sys.argv.index("--output") + 1])
+output.write_text(json.dumps(report) + "\\n", encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv(
+        "OMNIGENT_VERIFY_PNPM_CACHE_ROOT",
+        str(tmp_path / "unprepared-pnpm-cache"),
+    )
+
+    report, exit_status = helper.compare_performance(
+        repo,
+        run_dir,
+        "main",
+        candidate_path,
+        2,
+    )
+
+    assert exit_status == 0
+    assert report["status"] == "passed"
+    assert report["comparison"]["matched"] is True
+    assert report["comparison"]["commit_identity"]["base"]["matched"] is True
+    assert report["comparison"]["commit_identity"]["candidate"]["matched"] is True
+    assert report["comparison"]["no_regression_claim"] is True
+    assert report["base_commit"] != report["candidate_commit"]
+    assert report["benchmark_sha256"]["base"]
+    assert report["benchmark_sha256"]["candidate"]
+    assert report["cleanup"]["status"] == "completed"

--- a/tests/verify_omnigent/test_evidence_manifest.py
+++ b/tests/verify_omnigent/test_evidence_manifest.py
@@ -1,0 +1,975 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import importlib.util
+import io
+import json
+import struct
+import sys
+import zipfile
+import zlib
+from pathlib import Path
+from types import ModuleType
+from typing import Any, cast
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HELPER = (
+    _REPO_ROOT / ".agents" / "skills" / "verify-omnigent" / "scripts" / "evidence_manifest.py"
+)
+
+
+def _load_helper() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("verify_evidence_manifest", _HELPER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    previous = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.dont_write_bytecode = previous
+    return module
+
+
+def _manifest(run_dir: Path) -> dict[str, Any]:
+    value = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return cast("dict[str, Any]", value)
+
+
+def _write_trace(path: Path, payload: str = '{"type":"fixture"}\n') -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("trace.trace", payload)
+
+
+def _png() -> bytes:
+    def chunk(kind: bytes, payload: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(payload))
+            + kind
+            + payload
+            + struct.pack(">I", binascii.crc32(kind + payload) & 0xFFFFFFFF)
+        )
+
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(b"\0\x00\x00\x00\xff"))
+        + chunk(b"IEND", b"")
+    )
+
+
+def test_manifest_is_atomic_relative_hashed_and_finalized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "outside-checkout" / "run-1"
+    run_dir.mkdir(parents=True)
+    fake_home = tmp_path / "fake-home"
+    installed_skill = fake_home / ".claude/skills/verify-omnigent"
+    monkeypatch.setenv("OMNIGENT_VERIFY_ADAPTER", "cursor")
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("OMNIGENT_VERIFY_SKILL_ROOT", str(installed_skill))
+
+    helper.initialize(run_dir, "smoke", "smoke")
+    helper.prepare(
+        run_dir,
+        "verification",
+        [
+            "uv",
+            "run",
+            "pytest",
+            f"--output={run_dir}/playwright",
+            str(installed_skill / "scripts/helper.py"),
+        ],
+        ["tests/e2e_ui/test_evidence_contract.py"],
+    )
+    payload = _png()
+    screenshot = run_dir / "playwright" / "test" / "screenshot.png"
+    screenshot.parent.mkdir(parents=True)
+    screenshot.write_bytes(payload)
+    (run_dir / "playwright" / "test" / "metadata.json").write_text(
+        '{"schema_version": 1}\n',
+        encoding="utf-8",
+    )
+    _write_trace(run_dir / "playwright" / "test" / "trace.zip")
+    (run_dir / "run.log").write_text("ok\n", encoding="utf-8")
+    (run_dir / "cleanup.json").write_text(
+        '{"schema_version": 1, "status": "completed"}\n',
+        encoding="utf-8",
+    )
+    (run_dir / "junit.xml").write_text(
+        """\
+<testsuite tests="2">
+  <testcase classname="tests.e2e_ui.test_contract" name="test_pass" time="0.25" />
+  <testcase classname="tests.e2e_ui.test_contract" name="test_skip" time="0">
+    <skipped />
+  </testcase>
+</testsuite>
+""",
+        encoding="utf-8",
+    )
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+    (run_dir / "escaped-link").symlink_to(outside)
+
+    helper.finalize(run_dir, "passed", 0, None)
+
+    manifest = _manifest(run_dir)
+    assert manifest["schema_version"] == 1
+    assert manifest["status"] == "passed"
+    assert manifest["adapter"]["identity"] == "cursor"
+    assert manifest["cleanup"]["status"] == "completed"
+    assert [result["status"] for result in manifest["tests"]] == ["passed", "skipped"]
+    screenshot_item = next(
+        item for item in manifest["artifacts"] if item["path"].endswith("screenshot.png")
+    )
+    assert screenshot_item == {
+        "path": "playwright/test/screenshot.png",
+        "mime": "image/png",
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "bytes": len(payload),
+        "authority": "playwright-test-bound",
+    }
+    assert all(not Path(item["path"]).is_absolute() for item in manifest["artifacts"])
+    assert not any(item["path"] == "escaped-link" for item in manifest["artifacts"])
+    serialized = json.dumps(manifest)
+    assert str(run_dir) not in serialized
+    assert str(fake_home) not in serialized
+    assert manifest["run"]["command_argv"][-2:] == [
+        "--output=<run-dir>/playwright",
+        "<skill-root>/scripts/helper.py",
+    ]
+    assert base64.b64encode(payload).decode("ascii") not in serialized
+    assert not list(run_dir.glob(".manifest.json.*.tmp"))
+
+
+def test_collaboration_prepare_rejects_omitted_semantic_journeys(tmp_path: Path) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "collaboration"
+    run_dir.mkdir()
+    helper.initialize(run_dir, "collaboration", "collaboration")
+    required = set(helper.REQUIRED_PROFILE_TESTS["collaboration"])
+    omitted = "tests/e2e_ui/collaboration/test_author_label.py"
+
+    with pytest.raises(ValueError, match="omit required profile coverage"):
+        helper.prepare(
+            run_dir,
+            "verification",
+            ["uv", "run", "pytest"],
+            sorted(required - {omitted}),
+        )
+
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["run"]["selected_tests"] == []
+    helper.prepare(run_dir, "verification", ["uv", "run", "pytest"], sorted(required))
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert set(manifest["run"]["selected_tests"]) == required
+
+
+def test_interrupted_manifest_fails_closed_on_missing_outputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    monkeypatch.delenv("OMNIGENT_VERIFY_ADAPTER", raising=False)
+
+    helper.initialize(run_dir, "smoke", "smoke")
+    helper.finalize(run_dir, "interrupted", 143, "TERM")
+
+    manifest = _manifest(run_dir)
+    assert manifest["status"] == "interrupted"
+    assert manifest["signal"] == "TERM"
+    assert manifest["cleanup"]["status"] == "unknown"
+    assert manifest["tests"] == []
+    assert manifest["adapter"]["identity"] == "unspecified"
+    assert any("No JUnit report" in item for item in manifest["limitations"])
+    assert any("No browser context metadata" in item for item in manifest["limitations"])
+
+
+def test_ui_output_validation_requires_test_bound_evidence(tmp_path: Path) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    missing = helper.validate_required_outputs(run_dir, "web-ui")
+    assert "JUnit" in " ".join(missing)
+
+    nodeid = "tests/e2e_ui/test_example.py::test_real"
+    nodeid_sha256 = hashlib.sha256(nodeid.encode()).hexdigest()
+    (run_dir / "junit.xml").write_text(
+        "<testsuite tests='1'><testcase name='test_real'><properties>"
+        f"<property name='omnigent_nodeid_sha256' value='{nodeid_sha256}'/>"
+        "<property name='omnigent_browser_context_count' value='1'/>"
+        "</properties></testcase></testsuite>\n",
+        encoding="utf-8",
+    )
+    supplemental = run_dir / "supplemental"
+    supplemental.mkdir()
+    (supplemental / "metadata.json").write_text('{"schema_version": 1}\n', encoding="utf-8")
+    (supplemental / "screenshot.png").write_bytes(b"png")
+    _write_trace(supplemental / "trace.zip")
+    assert len(helper.validate_required_outputs(run_dir, "web-ui")) == 6
+
+    context = run_dir / "playwright" / f"test-{nodeid_sha256[:20]}" / "context-1"
+    context.mkdir(parents=True)
+    (context / "metadata.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "nodeid": nodeid,
+                "nodeid_sha256": nodeid_sha256,
+                "context_style": "managed-sync",
+                "lifecycle": "closed",
+                "events": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (context / "screenshot.png").write_bytes(_png())
+    _write_trace(context / "trace.zip")
+
+    assert helper.validate_required_outputs(run_dir, "web-ui") == []
+
+
+def test_parameterized_ui_cases_require_exact_individual_contexts(tmp_path: Path) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    nodeids = [
+        "tests/e2e_ui/test_example.py::test_case[alpha-one]",
+        "tests/e2e_ui/test_example.py::test_case[alpha-two]",
+    ]
+    identities = [hashlib.sha256(nodeid.encode()).hexdigest() for nodeid in nodeids]
+    cases = "".join(
+        f"<testcase name='test_case[{index}]'><properties>"
+        f"<property name='omnigent_nodeid_sha256' value='{identity}'/>"
+        "<property name='omnigent_browser_context_count' value='1'/>"
+        "</properties></testcase>"
+        for index, identity in enumerate(identities)
+    )
+    (run_dir / "junit.xml").write_text(
+        f"<testsuite tests='2'>{cases}</testsuite>",
+        encoding="utf-8",
+    )
+    context = run_dir / "playwright" / f"test-{identities[0][:20]}" / "context-1"
+    context.mkdir(parents=True)
+    (context / "metadata.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "nodeid": nodeids[0],
+                "nodeid_sha256": identities[0],
+                "context_style": "managed-sync",
+                "lifecycle": "closed",
+                "events": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (context / "screenshot.png").write_bytes(_png())
+    _write_trace(context / "trace.zip")
+
+    blockers = helper.validate_required_outputs(run_dir, "web-ui")
+
+    assert "One or more executed UI tests have no correlated browser context." in blockers
+
+
+def test_mixed_ui_suite_allows_only_declared_browserless_cases(tmp_path: Path) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "mixed"
+    run_dir.mkdir()
+    browser_nodeid = "tests/e2e_ui/test_example.py::test_browser"
+    browser_id = hashlib.sha256(browser_nodeid.encode()).hexdigest()
+    browserless_nodeid = "tests/e2e_ui/test_example.py::test_browserless"
+    browserless_id = hashlib.sha256(browserless_nodeid.encode()).hexdigest()
+    (run_dir / "junit.xml").write_text(
+        "<testsuite tests='2'>"
+        "<testcase name='test_browser'><properties>"
+        f"<property name='omnigent_nodeid_sha256' value='{browser_id}'/>"
+        "<property name='omnigent_browser_context_count' value='1'/>"
+        "</properties></testcase>"
+        "<testcase name='test_browserless'><properties>"
+        f"<property name='omnigent_nodeid_sha256' value='{browserless_id}'/>"
+        "<property name='omnigent_browser_context_count' value='0'/>"
+        "</properties></testcase></testsuite>",
+        encoding="utf-8",
+    )
+    context = run_dir / "playwright" / f"test-{browser_id[:20]}" / "context-1"
+    context.mkdir(parents=True)
+    (context / "metadata.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "nodeid": browser_nodeid,
+                "nodeid_sha256": browser_id,
+                "context_style": "managed-sync",
+                "lifecycle": "closed",
+                "events": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (context / "screenshot.png").write_bytes(_png())
+    trace = context / "trace.zip"
+    _write_trace(trace)
+
+    assert helper.validate_required_outputs(run_dir, "full-ui") == []
+    trace.unlink()
+    assert any(
+        "invalid or uncorrelated" in blocker
+        for blocker in helper.validate_required_outputs(run_dir, "full-ui")
+    )
+
+
+def test_all_skipped_pytest_profile_cannot_finalize_passed(tmp_path: Path) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "server"
+    run_dir.mkdir()
+    helper.initialize(run_dir, "server", "server")
+    (run_dir / "run.log").write_text("pytest skipped\n", encoding="utf-8")
+    (run_dir / "junit.xml").write_text(
+        '<testsuite tests="1" skipped="1">'
+        '<testcase name="test_skip"><skipped/></testcase></testsuite>',
+        encoding="utf-8",
+    )
+
+    helper.finalize(run_dir, "passed", 0, None)
+
+    manifest = _manifest(run_dir)
+    assert manifest["status"] == "failed"
+    assert manifest["exit_status"] != 0
+    assert any("no non-skipped test" in item for item in manifest["limitations"])
+
+
+def test_candidate_filenames_do_not_forge_ui_evidence(tmp_path: Path) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "ui"
+    context = run_dir / "playwright/test-forged/context-1"
+    context.mkdir(parents=True)
+    (context / "metadata.json").write_text('{"schema_version": 1}\n', encoding="utf-8")
+    (context / "screenshot.png").write_bytes(b"fake")
+    _write_trace(context / "trace.zip")
+    (run_dir / "junit.xml").write_text(
+        '<testsuite tests="1"><testcase name="test_real"/></testsuite>',
+        encoding="utf-8",
+    )
+
+    blockers = helper.validate_required_outputs(run_dir, "web-ui")
+
+    assert any("invalid or uncorrelated" in blocker for blocker in blockers)
+
+
+def test_perf_manifest_validates_and_hashes_current_benchmark(tmp_path: Path) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "perf-run"
+    run_dir.mkdir()
+    benchmark = {
+        "schema_version": 6,
+        "git_sha": "a" * 40,
+        "host": {"platform": "test"},
+        "harness": "http-only",
+        "config": {"backend": "sqlite", "runs": 3},
+        "journeys": {
+            "list_sessions": {
+                "runs": [{"n_failures": 0}, {"n_failures": 0}, {"n_failures": 0}],
+                "summary": {
+                    "avg_p50_ms": 1.0,
+                    "avg_p99_ms": 2.0,
+                    "avg_http_requests_per_op": 1.0,
+                    "network_routes": [],
+                    "runs_ok": 3,
+                    "runs_total": 3,
+                },
+            }
+        },
+    }
+    payload = (json.dumps(benchmark) + "\n").encode()
+
+    helper.initialize(run_dir, "perf", "perf")
+    (run_dir / "benchmark.json").write_bytes(payload)
+    (run_dir / "steps.json").write_text('{"status":"passed"}\n', encoding="utf-8")
+    (run_dir / "run.log").write_text("benchmark passed\n", encoding="utf-8")
+
+    assert helper.validate_required_outputs(run_dir, "perf") == []
+    helper.finalize(run_dir, "passed", 0, None)
+
+    manifest = _manifest(run_dir)
+    artifact = next(item for item in manifest["artifacts"] if item["path"] == "benchmark.json")
+    assert artifact["authority"] == "omnigent-benchmark"
+    assert artifact["sha256"] == hashlib.sha256(payload).hexdigest()
+    assert manifest["status"] == "passed"
+
+
+@pytest.mark.parametrize(
+    "defect",
+    ["skipped", "partial", "failed-operation", "contradictory"],
+)
+def test_perf_manifest_rejects_incomplete_functional_runs(
+    tmp_path: Path,
+    defect: str,
+) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / defect
+    run_dir.mkdir()
+    runs: list[dict[str, object]] = [{"n_failures": 0}]
+    summary: dict[str, object] = {
+        "avg_p50_ms": 1.0,
+        "avg_p99_ms": 2.0,
+        "avg_http_requests_per_op": 1.0,
+        "network_routes": [],
+        "runs_ok": 1,
+        "runs_total": 1,
+    }
+    journey: dict[str, object] = {"runs": runs, "summary": summary}
+    if defect == "skipped":
+        journey["skipped_reason"] = "fixture"
+    elif defect == "partial":
+        summary["runs_ok"] = 0
+    elif defect == "failed-operation":
+        runs[0]["n_failures"] = 1
+    else:
+        summary["runs_total"] = 2
+        summary["runs_ok"] = 2
+    (run_dir / "benchmark.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 6,
+                "git_sha": "a" * 40,
+                "config": {"backend": "sqlite", "runs": 1},
+                "journeys": {"fixture": journey},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert helper.validate_required_outputs(run_dir, "perf")
+
+
+def test_perf_manifest_propagates_failed_comparison_cleanup(tmp_path: Path) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "perf"
+    run_dir.mkdir()
+    helper.initialize(run_dir, "perf", "perf")
+    (run_dir / "run.log").write_text("comparison passed before cleanup\n", encoding="utf-8")
+    (run_dir / "performance-comparison.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "passed",
+                "cleanup": {"status": "failed", "worktree": "removed"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    helper.finalize(run_dir, "passed", 0, None)
+
+    manifest = _manifest(run_dir)
+    assert manifest["status"] == "failed"
+    assert manifest["exit_status"] != 0
+    assert manifest["cleanup"]["status"] == "failed"
+
+
+def test_known_secret_inside_nested_trace_archive_is_deleted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    secret = "fake-explicit-credential-value"
+    nested_buffer = io.BytesIO()
+    with zipfile.ZipFile(nested_buffer, "w") as nested:
+        nested.writestr("trace.trace", f'{{"token":"{secret}"}}\n')
+    trace = run_dir / "trace.zip"
+    with zipfile.ZipFile(trace, "w") as outer:
+        outer.writestr("resources/nested.zip", nested_buffer.getvalue())
+    monkeypatch.setenv("DATABRICKS_TOKEN", secret)
+
+    blockers = helper.validate_required_outputs(run_dir, "server")
+
+    assert blockers
+    assert not trace.exists()
+    assert secret not in " ".join(blockers)
+
+
+def test_trace_text_redaction_preserves_zip_and_rehashes_artifact(tmp_path: Path) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    trace = run_dir / "trace.zip"
+    with zipfile.ZipFile(trace, "w") as archive:
+        archive.writestr(
+            "trace.trace",
+            '{"message":"token=managed-secret-value"}\n',
+        )
+        archive.writestr("resources/source.txt", "direct-sync-secret\n")
+    before = hashlib.sha256(trace.read_bytes()).hexdigest()
+
+    assert helper.sanitize_trace_archives(run_dir) == []
+
+    with zipfile.ZipFile(trace) as archive:
+        assert archive.testzip() is None
+        payload = b"".join(archive.read(item) for item in archive.infolist())
+    assert b"managed-secret-value" not in payload
+    assert b"direct-sync-secret" not in payload
+    inventory = helper._artifact_inventory(run_dir, [])
+    assert inventory[0]["sha256"] == hashlib.sha256(trace.read_bytes()).hexdigest()
+    assert inventory[0]["sha256"] != before
+
+
+def test_five_level_nested_archive_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    monkeypatch.setenv("DATABRICKS_TOKEN", "known-depth-scan-secret")
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    payload = b"clean"
+    for depth in range(6):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as archive:
+            archive.writestr(f"level-{depth}.zip", payload)
+        payload = buffer.getvalue()
+    outer = run_dir / "deep.zip"
+    outer.write_bytes(payload)
+
+    blockers = helper.remove_known_secret_artifacts(run_dir)
+
+    assert blockers
+    assert not outer.exists()
+
+
+def test_zip_bomb_shaped_archive_is_rejected_before_expansion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    monkeypatch.setattr(helper, "MAX_ARCHIVE_EXPANDED_BYTES", 1024)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    bomb = run_dir / "bomb.zip"
+    with zipfile.ZipFile(bomb, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("large.txt", b"A" * 4096)
+
+    blockers = helper.remove_known_secret_artifacts(run_dir)
+
+    assert blockers
+    assert not bomb.exists()
+
+
+def test_oversized_top_level_artifact_is_failed_and_removed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    monkeypatch.setattr(helper, "MAX_ARTIFACT_BYTES", 8)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    artifact = run_dir / "oversized.bin"
+    artifact.write_bytes(b"x" * 9)
+
+    blockers = helper.remove_known_secret_artifacts(run_dir)
+
+    assert blockers
+    assert not artifact.exists()
+
+
+def test_secret_path_is_redacted_and_removed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    helper = _load_helper()
+    secret = "filename-secret-marker"
+    monkeypatch.setenv("DATABRICKS_TOKEN", secret)
+    run_dir = tmp_path / "run"
+    artifact = run_dir / f"directory-{secret}" / f"file-{secret}.txt"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("otherwise clean\n", encoding="utf-8")
+
+    blockers = helper.remove_known_secret_artifacts(run_dir)
+
+    assert blockers
+    assert not artifact.exists()
+    assert not artifact.parent.exists()
+    assert secret not in " ".join(blockers)
+    assert "<redacted-artifact-" in " ".join(blockers)
+
+
+def test_unremovable_secret_artifact_reports_cleanup_failure_without_leak(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    secret = "unremovable-secret-marker"
+    monkeypatch.setenv("DATABRICKS_TOKEN", secret)
+    monkeypatch.setenv("OMNIGENT_VERIFY_ADAPTER", "cursor")
+    monkeypatch.setenv("OMNIGENT_VERIFY_REPO_ROOT", str(_REPO_ROOT))
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    helper.initialize(run_dir, "backend", "backend")
+    helper.prepare(run_dir, "verification", ["fixture"], [])
+    artifact = run_dir / f"{secret}.txt"
+    artifact.write_text(secret, encoding="utf-8")
+    original_unlink = Path.unlink
+
+    def deny_unlink(path: Path, missing_ok: bool = False) -> None:
+        if path == artifact:
+            raise PermissionError("simulated")
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", deny_unlink)
+
+    blockers = helper.remove_known_secret_artifacts(run_dir)
+
+    assert artifact.exists()
+    assert any(item.startswith("PRIVACY CLEANUP FAILURE:") for item in blockers)
+    assert secret not in " ".join(blockers)
+    limitations: list[str] = []
+    inventory = helper._artifact_inventory(run_dir, limitations)
+    assert all(secret not in item["path"] for item in inventory)
+    assert secret not in " ".join(limitations)
+    helper.finalize(run_dir, "passed", 0, None)
+    manifest_text = (run_dir / "manifest.json").read_text(encoding="utf-8")
+    manifest = json.loads(manifest_text)
+    assert manifest["status"] == "failed"
+    assert manifest["cleanup"]["status"] == "failed"
+    assert secret not in manifest_text
+
+
+def test_failed_trace_sanitization_is_privacy_failure_and_excluded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    trace = run_dir / "trace.zip"
+    trace.write_bytes(b"not a zip")
+    real_unlink = Path.unlink
+
+    def deny_trace(path: Path, missing_ok: bool = False) -> None:
+        if path == trace:
+            raise PermissionError("private filesystem detail")
+        real_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", deny_trace)
+    suspect: set[Path] = set()
+    blockers = helper.sanitize_trace_archives(run_dir, suspect)
+    limitations: list[str] = []
+    inventory = helper._artifact_inventory(run_dir, limitations, suspect)
+
+    assert blockers and blockers[0].startswith("PRIVACY CLEANUP FAILURE:")
+    assert "private filesystem detail" not in " ".join(blockers)
+    assert all(item["path"] != "trace.zip" for item in inventory)
+    assert "trace.zip" not in " ".join(limitations)
+
+
+def test_deleted_failed_trace_still_marks_final_privacy_cleanup_failed(
+    tmp_path: Path,
+) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    helper.initialize(run_dir, "backend", "backend")
+    trace = run_dir / "trace.zip"
+    trace.write_bytes(b"not a zip")
+
+    blockers = helper.validate_required_outputs(run_dir, "backend")
+    assert blockers and not trace.exists()
+    helper.finalize(run_dir, "passed", 0, None)
+
+    manifest = _manifest(run_dir)
+    assert manifest["status"] == "failed"
+    assert manifest["cleanup"]["status"] == "failed"
+    assert all(item["path"] != "trace.zip" for item in manifest["artifacts"])
+
+
+def test_trace_json_sensitive_values_are_recursively_redacted(tmp_path: Path) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    trace = run_dir / "trace.zip"
+    with zipfile.ZipFile(trace, "w") as archive:
+        archive.writestr(
+            "trace.trace",
+            '{"token":"page-secret","nested":{"password":"nested-secret"},'
+            '"items":[{"api_key":"array-secret"}]}\n',
+        )
+
+    assert helper.sanitize_trace_archives(run_dir) == []
+
+    with zipfile.ZipFile(trace) as archive:
+        document = json.loads(archive.read("trace.trace"))
+        assert archive.testzip() is None
+    assert document["token"] == "[redacted-sensitive-value]"
+    assert document["nested"]["password"] == "[redacted-sensitive-value]"
+    assert document["items"][0]["api_key"] == "[redacted-sensitive-value]"
+
+
+def test_ui_evidence_decodes_png_and_requires_useful_trace(tmp_path: Path) -> None:
+    helper = _load_helper()
+    assert helper._valid_png(tmp_path / "missing.png") is False
+    png = tmp_path / "screenshot.png"
+    png.write_bytes(_png())
+    assert helper._valid_png(png) is True
+    png.write_bytes(b"\x89PNG\r\n\x1a\n")
+    assert helper._valid_png(png) is False
+
+    trace = tmp_path / "trace.zip"
+    with zipfile.ZipFile(trace, "w") as archive:
+        archive.writestr("resources/empty.txt", b"")
+    assert helper._valid_playwright_trace(trace) is False
+    _write_trace(trace, '{"type":"before"}\n{"type":"after"}\n')
+    assert helper._valid_playwright_trace(trace) is True
+
+
+def test_surviving_sensitive_runtime_state_forces_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "server"
+    run_dir.mkdir()
+    helper.initialize(run_dir, "server", "server")
+    (run_dir / "run.log").write_text("tests passed\n", encoding="utf-8")
+    (run_dir / "junit.xml").write_text(
+        "<testsuite tests='1'><testcase name='test_pass'/></testsuite>",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        helper,
+        "cleanup_strict_environment",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("simulated retained credential cache")
+        ),
+    )
+
+    helper.finalize(run_dir, "passed", 0, None)
+
+    manifest = _manifest(run_dir)
+    assert manifest["status"] == "failed"
+    assert manifest["exit_status"] != 0
+    assert manifest["cleanup"]["status"] == "failed"
+
+
+def test_parent_manifest_hashes_children_without_flattening_their_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    parent = tmp_path / "parent"
+    child = parent / "children" / "server" / "server-run"
+    child.mkdir(parents=True)
+    monkeypatch.setenv("OMNIGENT_VERIFY_ADAPTER", "cursor")
+
+    helper.initialize(parent, "auto", "auto")
+    plan_path = parent / "lane-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "profile": "auto",
+                "base_ref": "HEAD",
+                "changed_files": ["omnigent/server/app.py"],
+                "selected_lanes": ["server"],
+                "decisions": [
+                    {
+                        "lane": "server",
+                        "status": "selected",
+                        "reasons": ["omnigent/server/app.py: server changed"],
+                    }
+                ],
+                "blockers": [],
+                "optional_lanes": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    helper.record_plan(parent, plan_path)
+
+    helper.initialize(child, "server", "server")
+    (child / "run.log").write_text("server passed\n", encoding="utf-8")
+    (child / "server-proof.json").write_text('{"ok": true}\n', encoding="utf-8")
+    (child / "junit.xml").write_text(
+        '<testsuite tests="1"><testcase classname="server" name="test_ok"/></testsuite>',
+        encoding="utf-8",
+    )
+    helper.finalize(child, "passed", 0, None)
+    child_bytes = (child / "manifest.json").read_bytes()
+
+    helper.add_child(parent, "server", child / "manifest.json", 0)
+    (parent / "run.log").write_text("orchestration passed\n", encoding="utf-8")
+    helper.finalize(parent, "passed", 0, None)
+
+    manifest = _manifest(parent)
+    assert manifest["children"] == [
+        {
+            "lane": "server",
+            "required": True,
+            "manifest": "children/server/server-run/manifest.json",
+            "manifest_sha256": hashlib.sha256(child_bytes).hexdigest(),
+            "status": "passed",
+            "exit_status": 0,
+            "profile": "server",
+        }
+    ]
+    assert all(not item["path"].startswith("children/") for item in manifest["artifacts"])
+    assert not any("server-proof.json" in item["path"] for item in manifest["artifacts"])
+
+
+@pytest.mark.parametrize("tamper", ["delete", "corrupt", "duplicate"])
+def test_parent_pass_fails_when_required_child_evidence_is_invalid(
+    tmp_path: Path,
+    tamper: str,
+) -> None:
+    helper = _load_helper()
+    parent = tmp_path / "parent"
+    child = parent / "children/cli/child"
+    child.mkdir(parents=True)
+    helper.initialize(parent, "auto", "auto")
+    _record_parent_plan(helper, parent, ["cli"])
+    helper.initialize(child, "cli", "cli")
+    (child / "run.log").write_text("cli passed\n", encoding="utf-8")
+    helper.finalize(child, "passed", 0, None)
+    helper.add_child(parent, "cli", child / "manifest.json", 0)
+    child_manifest = child / "manifest.json"
+    if tamper == "delete":
+        child_manifest.unlink()
+    elif tamper == "corrupt":
+        child_manifest.write_text("{}\n", encoding="utf-8")
+    else:
+        duplicate = parent / "children/cli/duplicate"
+        duplicate.mkdir()
+        (duplicate / "manifest.json").write_bytes(child_manifest.read_bytes())
+    (parent / "run.log").write_text("parent attempted pass\n", encoding="utf-8")
+
+    helper.finalize(parent, "passed", 0, None)
+
+    manifest = _manifest(parent)
+    assert manifest["status"] == "failed"
+    assert manifest["exit_status"] != 0
+    assert manifest["children"][0]["status"] == "unavailable"
+
+
+def test_missing_required_child_is_recorded_as_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    run_dir = tmp_path / "parent"
+    run_dir.mkdir()
+    monkeypatch.setenv("OMNIGENT_VERIFY_ADAPTER", "cursor")
+    helper.initialize(run_dir, "all-surfaces", "all-surfaces")
+    helper.add_child(
+        run_dir,
+        "desktop",
+        run_dir / "children" / "desktop" / "missing.json",
+        1,
+    )
+
+    manifest = _manifest(run_dir)
+    assert manifest["children"][0]["status"] == "unavailable"
+    assert any("no valid child manifest" in item for item in manifest["limitations"])
+
+
+def test_universe_child_status_is_propagated_to_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    parent = tmp_path / "parent"
+    child = parent / "children" / "universe" / "universe-run"
+    child.mkdir(parents=True)
+    monkeypatch.setenv("OMNIGENT_VERIFY_ADAPTER", "cursor")
+
+    helper.initialize(parent, "auto", "auto")
+    helper.initialize(child, "universe", "universe")
+    report = {
+        "schema_version": 1,
+        "status": "not_synced",
+        "sync": {"status": "not_synced"},
+        "source_patch_apply": {"status": "passed", "checks": []},
+        "runtime_compatibility": {"status": "not_synced", "targets": []},
+        "limitations": ["Universe pin differs from the requested OSS commit."],
+    }
+    (child / "universe.json").write_text(
+        json.dumps(report),
+        encoding="utf-8",
+    )
+    (child / "run.log").write_text("not synced\n", encoding="utf-8")
+    helper.finalize(child, "failed", 1, None)
+
+    helper.add_child(parent, "universe", child / "manifest.json", 1)
+
+    manifest = _manifest(parent)
+    assert manifest["downstream_universe"]["status"] == "not_synced"
+    assert manifest["downstream_universe"]["source_patch_apply"]["status"] == "passed"
+    assert manifest["children"][0]["manifest_sha256"]
+
+
+def _record_parent_plan(helper: ModuleType, parent: Path, lanes: list[str]) -> None:
+    plan_path = parent / "lane-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "profile": "auto",
+                "base_ref": "main",
+                "changed_files": ["omnigent/server/app.py"],
+                "selected_lanes": lanes,
+                "decisions": [],
+                "blockers": [],
+                "optional_lanes": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    helper.record_plan(parent, plan_path)
+    helper.register_children(parent, lanes)
+
+
+def test_blocked_parent_finalizes_every_selected_child(tmp_path: Path) -> None:
+    helper = _load_helper()
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    helper.initialize(parent, "auto", "auto")
+    _record_parent_plan(helper, parent, ["quality-gates", "server"])
+
+    helper.finalize(parent, "blocked", 1, None)
+
+    manifest = _manifest(parent)
+    assert manifest["status"] == "blocked"
+    assert [child["status"] for child in manifest["children"]] == ["blocked", "blocked"]
+    assert all(child["status"] != "running" for child in manifest["children"])
+    json.loads((parent / "manifest.json").read_text(encoding="utf-8"))
+    assert not list(parent.glob(".manifest.json.*.tmp"))
+
+
+def test_parent_reconciles_stale_running_child_after_interrupt(tmp_path: Path) -> None:
+    helper = _load_helper()
+    parent = tmp_path / "parent"
+    child = parent / "children" / "server" / "server-run"
+    child.mkdir(parents=True)
+    helper.initialize(parent, "auto", "auto")
+    _record_parent_plan(helper, parent, ["server"])
+    helper.initialize(child, "server", "server")
+
+    helper.finalize(parent, "interrupted", 143, "TERM")
+
+    parent_manifest = _manifest(parent)
+    child_manifest = _manifest(child)
+    assert parent_manifest["status"] == "interrupted"
+    assert parent_manifest["children"][0]["status"] == "interrupted"
+    assert child_manifest["status"] == "interrupted"
+    assert child_manifest["signal"] == "TERM"
+    assert child_manifest["cleanup"]["status"] == "not_applicable"
+    assert parent_manifest["cleanup"]["status"] == "completed"

--- a/tests/verify_omnigent/test_orchestration.py
+++ b/tests/verify_omnigent/test_orchestration.py
@@ -1,0 +1,2235 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / ".agents" / "skills" / "verify-omnigent" / "scripts"
+
+
+def _load(name: str) -> ModuleType:
+    path = _SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"verify_omnigent_{name}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    previous = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.dont_write_bytecode = previous
+    return module
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _fsmonitor_daemon_pids() -> set[int]:
+    result = subprocess.run(
+        ["ps", "-axo", "pid=,command="],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return {
+        int(line.split(None, 1)[0])
+        for line in result.stdout.splitlines()
+        if "fsmonitor--daemon run" in line
+    }
+
+
+def _commit(repo: Path, message: str) -> None:
+    _git(repo, "add", ".")
+    _git(
+        repo,
+        "-c",
+        "user.name=Fixture",
+        "-c",
+        "user.email=fixture@example.com",
+        "commit",
+        "-qm",
+        message,
+    )
+
+
+def _diverged_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    for path in ("tracked-staged.txt", "tracked-unstaged.txt"):
+        (repo / path).write_text("base\n", encoding="utf-8")
+    _commit(repo, "base")
+
+    _git(repo, "switch", "-q", "-c", "pr")
+    pr_only = repo / "omnigent" / "pr_only.py"
+    pr_only.parent.mkdir()
+    pr_only.write_text("PR_ONLY = True\n", encoding="utf-8")
+    _commit(repo, "pr change")
+
+    _git(repo, "switch", "-q", "main")
+    base_only = repo / "web" / "base_only.ts"
+    base_only.parent.mkdir()
+    base_only.write_text("export const baseOnly = true;\n", encoding="utf-8")
+    _commit(repo, "newer base change")
+
+    _git(repo, "switch", "-q", "pr")
+    (repo / "tracked-staged.txt").write_text("staged\n", encoding="utf-8")
+    _git(repo, "add", "tracked-staged.txt")
+    (repo / "tracked-unstaged.txt").write_text("unstaged\n", encoding="utf-8")
+    untracked = repo / "tests" / "host" / "test_untracked.py"
+    untracked.parent.mkdir(parents=True)
+    untracked.write_text("def test_placeholder(): pass\n", encoding="utf-8")
+    return repo
+
+
+def test_disposable_repos_do_not_leak_fsmonitor_daemons(tmp_path: Path) -> None:
+    before = _fsmonitor_daemon_pids()
+    for index in range(3):
+        repo = tmp_path / f"fsmonitor-{index}"
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "main")
+        assert _git(repo, "config", "--bool", "core.fsmonitor") == "false"
+        _git(repo, "status", "--porcelain=v1")
+    time.sleep(0.2)
+    assert _fsmonitor_daemon_pids() - before == set()
+
+
+def test_changed_files_select_every_applicable_lane() -> None:
+    helper = _load("orchestration")
+    plan = helper.select_lanes(
+        [
+            "omnigent/server/app.py",
+            "omnigent/cli.py",
+            "sdks/python-client/omnigent_client/client.py",
+            "web/src/App.tsx",
+            "web/electron/src/main.js",
+        ]
+    )
+
+    assert plan["selected_lanes"] == [
+        "quality-gates",
+        "server",
+        "harness-client",
+        "cli",
+        "web-ui",
+        "desktop",
+    ]
+    assert plan["blockers"] == []
+    assert all(
+        decision["reasons"] != ["No changed file mapped to this lane."]
+        for decision in plan["decisions"]
+        if decision["status"] == "selected"
+    )
+
+
+def test_integrations_map_and_unknown_product_paths_fail_closed() -> None:
+    helper = _load("orchestration")
+
+    integration = helper.select_lanes(["integrations/slack/src/omnigent_slack/app.py"])
+    unknown = helper.select_lanes(["config/new-runtime-surface.yaml"])
+
+    assert integration["selected_lanes"] == [
+        "quality-gates",
+        "server",
+        "harness-client",
+    ]
+    assert integration["blockers"] == []
+    assert unknown["selected_lanes"] == []
+    assert "did not map to a verification lane" in unknown["blockers"][0]
+
+
+def test_executable_config_maps_to_quality_and_unknown_text_blocks() -> None:
+    helper = _load("orchestration")
+
+    config = helper.select_lanes([".pre-commit-config.yaml"])
+    unknown = helper.select_lanes(["notes/internal-state.txt"])
+
+    assert config["selected_lanes"] == ["quality-gates"]
+    assert config["blockers"] == []
+    assert unknown["selected_lanes"] == []
+    assert unknown["blockers"]
+
+
+def test_strict_environment_reuses_verified_browser_cache(tmp_path: Path) -> None:
+    helper = _load("runtime_support")
+    home = tmp_path / "real-home"
+    browser = (
+        home
+        / "Library/Caches/ms-playwright/chromium-123/chrome-mac-arm64"
+        / "Chromium.app/Contents/MacOS/Chromium"
+    )
+    browser.parent.mkdir(parents=True)
+    browser.write_bytes(b"chromium")
+    browser.chmod(0o755)
+    marker = home / "Library/Caches/ms-playwright/chromium-123/INSTALLATION_COMPLETE"
+    marker.write_text("installed\n", encoding="utf-8")
+
+    env = helper.strict_environment(
+        tmp_path / "run",
+        source={"HOME": str(home), "PATH": "/usr/bin:/bin"},
+    )
+
+    assert env["HOME"] != str(home)
+    assert env["PLAYWRIGHT_BROWSERS_PATH"] == str(home / "Library/Caches/ms-playwright")
+    assert not (tmp_path / "run/environment/cache/playwright").exists()
+    before = helper.playwright_browser_snapshot(env)
+    marker.write_text("mutated\n", encoding="utf-8")
+    assert helper.playwright_browser_snapshot(env) != before
+
+
+def test_dependency_binary_mutation_invalidates_snapshot(tmp_path: Path) -> None:
+    helper = _load("runtime_support")
+    repo = tmp_path / "repo"
+    binary = repo / "web/node_modules/.bin/vite"
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"before")
+    _git(repo, "init", "-q", "-b", "main")
+    before = helper.repository_snapshot(repo)
+
+    binary.write_bytes(b"after")
+    changes = helper.compare_snapshots(before, helper.repository_snapshot(repo))
+
+    assert any("dependency metadata changed" in change for change in changes)
+
+
+def test_nested_dependency_mutation_invalidates_deep_snapshot(tmp_path: Path) -> None:
+    helper = _load("runtime_support")
+    repo = tmp_path / "repo"
+    nested = repo / ".venv/lib/python/site-packages/package/module.py"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("before\n", encoding="utf-8")
+    _git(repo, "init", "-q", "-b", "main")
+    before = helper.repository_snapshot(repo, deep_dependencies=True)
+
+    nested.write_text("after\n", encoding="utf-8")
+    changes = helper.compare_snapshots(
+        before,
+        helper.repository_snapshot(repo, deep_dependencies=True),
+    )
+
+    assert "dependency trees changed: .venv" in changes
+
+
+def test_detach_at_same_commit_changes_git_identity(tmp_path: Path) -> None:
+    helper = _load("runtime_support")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
+    _commit(repo, "base")
+    before = helper.repository_snapshot(repo)
+
+    _git(repo, "switch", "--detach", "-q")
+    changes = helper.compare_snapshots(before, helper.repository_snapshot(repo))
+
+    assert "Git refs, HEAD, or index changed" in changes
+
+
+def test_staged_index_content_changes_git_identity(tmp_path: Path) -> None:
+    helper = _load("runtime_support")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    tracked = repo / "tracked.txt"
+    tracked.write_text("before\n", encoding="utf-8")
+    _commit(repo, "base")
+    before = helper.repository_snapshot(repo)
+    tracked.write_text("after\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+
+    after = helper.repository_snapshot(repo)
+
+    assert before["git_identity"]["index"] != after["git_identity"]["index"]
+    assert "Git refs, HEAD, or index changed" in helper.compare_snapshots(before, after)
+
+
+def test_repository_snapshot_does_not_create_git_objects(tmp_path: Path) -> None:
+    helper = _load("runtime_support")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    _commit(repo, "base")
+    (repo / "staged.txt").write_text("new staged content\n", encoding="utf-8")
+    _git(repo, "add", "staged.txt")
+    objects = repo / ".git" / "objects"
+    before = {path.relative_to(objects) for path in objects.rglob("*") if path.is_file()}
+
+    helper.repository_snapshot(repo)
+
+    after = {path.relative_to(objects) for path in objects.rglob("*") if path.is_file()}
+    assert after == before
+
+
+def test_local_pre_commit_uses_empty_disposable_cache(tmp_path: Path) -> None:
+    helper = _load("runtime_support")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".pre-commit-config.yaml").write_text(
+        "repos:\n  - repo: local\n    hooks: []\n",
+        encoding="utf-8",
+    )
+    home = tmp_path / "home"
+    source = home / ".cache/pre-commit"
+    source.mkdir(parents=True)
+    (source / "db.db").write_bytes(b"database")
+    hook = source / "repo123/hook.py"
+    hook.parent.mkdir()
+    hook.write_text("original\n", encoding="utf-8")
+    run_dir = tmp_path / "run"
+
+    env = helper.strict_environment(
+        run_dir,
+        source={"HOME": str(home), "PATH": os.environ["PATH"]},
+        extra={"OMNIGENT_VERIFY_REPO_ROOT": str(repo)},
+        pre_commit=True,
+    )
+    private_cache = Path(env["PRE_COMMIT_HOME"])
+
+    assert not private_cache.is_relative_to(run_dir)
+    assert list(private_cache.iterdir()) == []
+    assert hook.read_text(encoding="utf-8") == "original\n"
+    helper.cleanup_strict_environment(run_dir)
+    assert not private_cache.exists()
+
+
+def test_remote_pre_commit_stages_only_exact_configured_revision(tmp_path: Path) -> None:
+    helper = _load("runtime_support")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    remote = "https://example.invalid/configured-hooks"
+    revision = "v1.2.3"
+    (repo / ".pre-commit-config.yaml").write_text(
+        f"repos:\n  - repo: {remote}\n    rev: {revision}\n    hooks: []\n",
+        encoding="utf-8",
+    )
+    home = tmp_path / "home"
+    cache = home / ".cache/pre-commit"
+    configured = cache / "repo-configured"
+    unrelated = cache / "repo-unrelated"
+    configured.mkdir(parents=True)
+    unrelated.mkdir(parents=True)
+    (configured / "hook.py").write_text("configured\n", encoding="utf-8")
+    (unrelated / "secret.txt").write_text("unrelated-global-marker\n", encoding="utf-8")
+    with sqlite3.connect(cache / "db.db") as connection:
+        connection.execute(
+            "CREATE TABLE repos "
+            "(repo TEXT NOT NULL, ref TEXT NOT NULL, path TEXT NOT NULL, "
+            "PRIMARY KEY (repo, ref))"
+        )
+        connection.executemany(
+            "INSERT INTO repos(repo, ref, path) VALUES (?, ?, ?)",
+            [
+                (remote, revision, str(configured)),
+                ("https://example.invalid/unrelated", "v9", str(unrelated)),
+            ],
+        )
+    helper.seal_pre_commit_cache(repo, cache)
+    run_dir = tmp_path / "run"
+
+    env = helper.strict_environment(
+        run_dir,
+        source={"HOME": str(home), "PATH": os.environ["PATH"]},
+        extra={"OMNIGENT_VERIFY_REPO_ROOT": str(repo)},
+        pre_commit=True,
+    )
+    private_cache = Path(env["PRE_COMMIT_HOME"])
+
+    assert list(private_cache.glob("repo-*/hook.py"))
+    assert not list(private_cache.rglob("secret.txt"))
+    helper.cleanup_strict_environment(run_dir)
+    assert not private_cache.exists()
+
+
+def test_prepared_remote_system_hook_runs_from_disposable_cache(tmp_path: Path) -> None:
+    helper = _load("runtime_support")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    remote = "https://example.invalid/prepared-hooks"
+    revision = "v1"
+    (repo / ".pre-commit-config.yaml").write_text(
+        f"repos:\n  - repo: {remote}\n    rev: {revision}\n"
+        "    hooks:\n      - id: offline-check\n",
+        encoding="utf-8",
+    )
+    (repo / "tracked.txt").write_text("safe\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    home = tmp_path / "home"
+    cache = home / ".cache/pre-commit"
+    prepared = cache / "repo-prepared"
+    prepared.mkdir(parents=True)
+    (prepared / ".pre-commit-hooks.yaml").write_text(
+        "- id: offline-check\n"
+        "  name: offline check\n"
+        f"  entry: {sys.executable} -c 'raise SystemExit(0)'\n"
+        "  language: system\n"
+        "  pass_filenames: false\n",
+        encoding="utf-8",
+    )
+    with sqlite3.connect(cache / "db.db") as connection:
+        connection.execute(
+            "CREATE TABLE repos "
+            "(repo TEXT NOT NULL, ref TEXT NOT NULL, path TEXT NOT NULL, "
+            "PRIMARY KEY (repo, ref))"
+        )
+        connection.execute(
+            "INSERT INTO repos(repo, ref, path) VALUES (?, ?, ?)",
+            (remote, revision, str(prepared)),
+        )
+    helper.seal_pre_commit_cache(repo, cache)
+    run_dir = tmp_path / "run"
+    env = helper.strict_environment(
+        run_dir,
+        source={"HOME": str(home), "PATH": os.environ["PATH"]},
+        extra={"OMNIGENT_VERIFY_REPO_ROOT": str(repo)},
+        pre_commit=True,
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pre_commit", "run", "--all-files"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    helper.cleanup_strict_environment(run_dir)
+    assert result.returncode == 0, result.stderr
+    assert not Path(env["PRE_COMMIT_HOME"]).exists()
+
+
+def test_hook_cache_publication_failure_preserves_last_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load("runtime_support")
+    parent = tmp_path / "cache"
+    parent.mkdir()
+    previous = parent / "pre-commit.version.previous"
+    previous.mkdir()
+    (previous / "marker").write_text("last-valid\n", encoding="utf-8")
+    destination = parent / "pre-commit"
+    destination.symlink_to(previous.name, target_is_directory=True)
+    staging = parent / "pre-commit.version.new"
+    staging.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".pre-commit-config.yaml").write_text("repos: []\n", encoding="utf-8")
+    helper.seal_pre_commit_cache(repo, staging)
+    real_replace = os.replace
+
+    def fail_publish(source: str | Path, target: str | Path) -> None:
+        if Path(source).name.startswith(".pre-commit.pointer."):
+            raise OSError("simulated publication failure")
+        real_replace(source, target)
+
+    monkeypatch.setattr(os, "replace", fail_publish)
+
+    with pytest.raises(OSError, match="simulated"):
+        helper.publish_pre_commit_cache(repo, staging, destination)
+
+    assert (destination / "marker").read_text(encoding="utf-8") == "last-valid\n"
+    assert destination.resolve() == previous
+    assert staging.exists()
+
+
+def test_hook_cache_publication_waits_for_active_reader_lease(tmp_path: Path) -> None:
+    helper = _load("runtime_support")
+    parent = tmp_path / "cache"
+    parent.mkdir()
+    destination = parent / "pre-commit"
+    previous = parent / "pre-commit.version.previous"
+    previous.mkdir()
+    destination.symlink_to(previous.name, target_is_directory=True)
+    staging = parent / "pre-commit.version.new"
+    staging.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".pre-commit-config.yaml").write_text("repos: []\n", encoding="utf-8")
+    helper.seal_pre_commit_cache(repo, staging)
+    published = threading.Event()
+
+    def publish() -> None:
+        helper.publish_pre_commit_cache(repo, staging, destination)
+        published.set()
+
+    with helper._hook_cache_lock(destination, exclusive=False):
+        thread = threading.Thread(target=publish)
+        thread.start()
+        time.sleep(0.1)
+        assert not published.is_set()
+    thread.join(timeout=5)
+
+    assert published.is_set()
+    assert destination.resolve() == staging
+
+
+def test_hook_cache_gc_failure_keeps_new_active_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load("runtime_support")
+    parent = tmp_path / "cache"
+    parent.mkdir()
+    previous = parent / "pre-commit.version.previous"
+    previous.mkdir()
+    destination = parent / "pre-commit"
+    destination.symlink_to(previous.name, target_is_directory=True)
+    staging = parent / "pre-commit.version.new"
+    staging.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".pre-commit-config.yaml").write_text("repos: []\n", encoding="utf-8")
+    helper.seal_pre_commit_cache(repo, staging)
+    real_rmtree = helper.shutil.rmtree
+
+    def fail_old(path: Path, *args: object, **kwargs: object) -> None:
+        if Path(path) == previous:
+            raise OSError("simulated stale GC failure")
+        real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(helper.shutil, "rmtree", fail_old)
+    helper.publish_pre_commit_cache(repo, staging, destination)
+
+    assert destination.resolve() == staging
+    assert previous.exists()
+
+
+def test_credentialed_environment_profile_strips_conflicting_ambient_credentials(
+    tmp_path: Path,
+) -> None:
+    helper = _load("runtime_support")
+    home = tmp_path / "real-home"
+    home.mkdir()
+    source_config = home / ".databrickscfg"
+    source_config.write_text(
+        "[selected]\nhost = https://selected.invalid\ntoken = fake-selected-marker\n"
+        "[other]\nhost = https://other.invalid\ntoken = fake-other-marker\n",
+        encoding="utf-8",
+    )
+    run_dir = tmp_path / "run"
+    env = helper.strict_environment(
+        run_dir,
+        source={
+            "HOME": str(home),
+            "PATH": os.environ["PATH"],
+            "CURSOR_API_KEY": "fake-cursor-marker",
+            "OPENAI_API_KEY": "fake-openai-marker",
+            "OPENAI_BASE_URL": "https://ambient-openai.invalid",
+            "DATABRICKS_HOST": "https://ambient-databricks.invalid",
+            "DATABRICKS_TOKEN": "fake-databricks-marker",
+        },
+        extra={
+            "OMNIGENT_VERIFY_DATABRICKS_PROFILE": "selected",
+            "OMNIGENT_VERIFY_HARNESS": "cursor",
+        },
+        credentialed=True,
+    )
+
+    staged = Path(env["DATABRICKS_CONFIG_FILE"])
+    text = staged.read_text(encoding="utf-8")
+    assert env["DATABRICKS_CONFIG_PROFILE"] == "selected"
+    assert env["OMNIGENT_VERIFY_CREDENTIAL_MODE"] == "databricks-profile"
+    assert (
+        not {
+            "CURSOR_API_KEY",
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+            "DATABRICKS_HOST",
+            "DATABRICKS_TOKEN",
+        }
+        & env.keys()
+    )
+    assert "fake-selected-marker" in text
+    assert "fake-other-marker" not in text
+    assert not staged.is_relative_to(run_dir)
+    assert not any(
+        "fake-selected-marker" in path.read_text(encoding="utf-8", errors="ignore")
+        for path in run_dir.rglob("*")
+        if path.is_file()
+    )
+    helper.cleanup_strict_environment(run_dir)
+    assert not staged.exists()
+
+
+@pytest.mark.parametrize(
+    ("source", "harness", "mode", "present", "absent"),
+    [
+        (
+            {
+                "OPENAI_API_KEY": "fake-openai-marker",
+                "OPENAI_BASE_URL": "https://openai.invalid",
+                "DATABRICKS_HOST": "https://ignored.invalid",
+                "DATABRICKS_TOKEN": "fake-ignored-marker",
+            },
+            "claude-sdk",
+            "openai-environment",
+            {"OPENAI_API_KEY", "OPENAI_BASE_URL"},
+            {"DATABRICKS_HOST", "DATABRICKS_TOKEN", "CURSOR_API_KEY"},
+        ),
+        (
+            {
+                "DATABRICKS_HOST": "https://databricks.invalid",
+                "DATABRICKS_TOKEN": "fake-databricks-marker",
+                "CURSOR_API_KEY": "fake-ignored-marker",
+            },
+            "claude-sdk",
+            "databricks-environment",
+            {"DATABRICKS_HOST", "DATABRICKS_TOKEN"},
+            {"OPENAI_API_KEY", "OPENAI_BASE_URL", "CURSOR_API_KEY"},
+        ),
+        (
+            {"CURSOR_API_KEY": "fake-cursor-marker"},
+            "cursor",
+            "cursor-api-key",
+            {"CURSOR_API_KEY"},
+            {
+                "OPENAI_API_KEY",
+                "OPENAI_BASE_URL",
+                "DATABRICKS_HOST",
+                "DATABRICKS_TOKEN",
+            },
+        ),
+    ],
+)
+def test_credentialed_environment_labels_non_profile_mode_used(
+    tmp_path: Path,
+    source: dict[str, str],
+    harness: str,
+    mode: str,
+    present: set[str],
+    absent: set[str],
+) -> None:
+    helper = _load("runtime_support")
+    run_dir = tmp_path / mode
+    env = helper.strict_environment(
+        run_dir,
+        source={"PATH": os.environ["PATH"], **source},
+        extra={"OMNIGENT_VERIFY_HARNESS": harness},
+        credentialed=True,
+    )
+
+    assert env["OMNIGENT_VERIFY_CREDENTIAL_MODE"] == mode
+    assert present <= env.keys()
+    assert not absent & env.keys()
+    helper.cleanup_strict_environment(run_dir)
+    assert not any(run_dir.rglob("*"))
+
+
+def test_nested_credentialed_environment_preserves_selected_profile(tmp_path: Path) -> None:
+    helper = _load("runtime_support")
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    (real_home / ".databrickscfg").write_text(
+        "[selected]\nhost = https://selected.invalid\ntoken = nested-fake-marker\n",
+        encoding="utf-8",
+    )
+    run_dir = tmp_path / "run"
+    overrides = {
+        "OMNIGENT_VERIFY_DATABRICKS_PROFILE": "selected",
+        "OMNIGENT_VERIFY_HARNESS": "claude-sdk",
+    }
+    outer = helper.strict_environment(
+        run_dir,
+        source={
+            "HOME": str(real_home),
+            "PATH": os.environ["PATH"],
+            "OPENAI_API_KEY": "ambient-openai-marker",
+            "OPENAI_BASE_URL": "https://ambient.invalid",
+            "DATABRICKS_HOST": "https://ambient-databricks.invalid",
+            "DATABRICKS_TOKEN": "ambient-databricks-marker",
+        },
+        extra=overrides,
+        credentialed=True,
+    )
+    staged = Path(outer["DATABRICKS_CONFIG_FILE"])
+
+    nested = helper.strict_environment(
+        run_dir,
+        source=outer,
+        extra=overrides,
+        credentialed=True,
+    )
+
+    assert Path(nested["DATABRICKS_CONFIG_FILE"]) == staged
+    assert "nested-fake-marker" in staged.read_text(encoding="utf-8")
+    helper.cleanup_strict_environment(run_dir)
+    assert not staged.exists()
+
+
+def test_runtime_cleanup_verifies_sensitive_state_is_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load("runtime_support")
+    run_dir = tmp_path / "run"
+    env = helper.strict_environment(
+        run_dir,
+        source={"PATH": os.environ["PATH"]},
+    )
+    home = Path(env["HOME"])
+    real_rmtree = helper.shutil.rmtree
+    monkeypatch.setattr(helper.shutil, "rmtree", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="survived cleanup"):
+        helper.cleanup_strict_environment(run_dir)
+
+    monkeypatch.setattr(helper.shutil, "rmtree", real_rmtree)
+    helper.cleanup_strict_environment(run_dir)
+    assert not home.exists()
+
+
+def test_ignored_build_output_mutation_invalidates_snapshot(tmp_path: Path) -> None:
+    helper = _load("runtime_support")
+    repo = tmp_path / "repo"
+    output = repo / "web/dist/index.js"
+    output.parent.mkdir(parents=True)
+    output.write_bytes(b"before")
+    (repo / ".gitignore").write_text("web/dist/\n", encoding="utf-8")
+    _git(repo, "init", "-q", "-b", "main")
+    _commit(repo, "base")
+    before = helper.repository_snapshot(repo)
+
+    output.write_bytes(b"after")
+    changes = helper.compare_snapshots(before, helper.repository_snapshot(repo))
+
+    assert any("build outputs changed" in change for change in changes)
+
+
+def test_cli_profile_imports_code_from_target_checkout(tmp_path: Path) -> None:
+    runner = _load("profile_runner")
+    repo = tmp_path / "base-checkout"
+    package = repo / "omnigent"
+    driver = repo / ".claude/skills/cli-setup-verify/verify_cli.py"
+    python = repo / ".venv/bin/python"
+    package.mkdir(parents=True)
+    driver.parent.mkdir(parents=True)
+    python.parent.mkdir(parents=True)
+    (package / "__init__.py").write_text("IDENTITY = 'base-checkout'\n", encoding="utf-8")
+    driver.write_text(
+        "import omnigent\nprint(omnigent.IDENTITY, omnigent.__file__)\n",
+        encoding="utf-8",
+    )
+    python.symlink_to(Path(sys.executable))
+    (repo / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    _git(repo, "init", "-q", "-b", "main")
+    _commit(repo, "base")
+    run_dir = tmp_path / "run"
+
+    status = runner.run_profile(repo, run_dir, "cli")
+
+    assert status == 0
+    report = json.loads((run_dir / "steps.json").read_text(encoding="utf-8"))
+    assert len(report["steps"]) == 4
+    for step in report["steps"]:
+        output = (run_dir / step["log"]).read_text(encoding="utf-8")
+        assert "base-checkout" in output
+        assert str(repo / "omnigent/__init__.py") in output
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".agents/skills/other/scripts/__pycache__/helper.cpython-312.pyc",
+        ".claude/skills/other/__pycache__/helper.pyc",
+        ".cursor/skills/other/generated.pyo",
+    ],
+)
+def test_hidden_skill_bytecode_remains_ignored_after_negations(path: str) -> None:
+    result = subprocess.run(
+        ["git", "check-ignore", "--no-index", "-q", path],
+        cwd=_REPO_ROOT,
+        check=False,
+    )
+    assert result.returncode == 0
+
+
+def test_host_tests_map_to_the_host_harness_and_quality_lanes() -> None:
+    helper = _load("orchestration")
+    plan = helper.select_lanes(
+        [
+            "tests/host/test_connect.py",
+            "tests/host/test_identity.py",
+        ]
+    )
+
+    assert plan["selected_lanes"] == ["quality-gates", "harness-client"]
+    assert plan["blockers"] == []
+
+
+def test_routing_runtime_files_have_explicit_surface_mappings() -> None:
+    helper = _load("orchestration")
+    plan = helper.select_lanes(
+        [
+            "omnigent/gateway_inference.py",
+            "omnigent/inner/hook_scripts/subagent_router.py",
+            "omnigent/smart_routing_cli.py",
+            "scripts/verify_smart_routing.sh",
+            "tests/test_gateway_inference.py",
+        ]
+    )
+
+    assert plan["blockers"] == []
+    assert plan["selected_lanes"] == [
+        "quality-gates",
+        "server",
+        "harness-client",
+        "cli",
+    ]
+
+
+def test_setup_web_build_test_maps_to_full_web_quality_only() -> None:
+    helper = _load("orchestration")
+    runner = _load("profile_runner")
+
+    plan = helper.select_lanes(["tests/test_setup_web_ui_build.py"])
+    steps = runner.profile_steps(
+        "quality-gates",
+        ".artifacts/run",
+        changed_files=("tests/test_setup_web_ui_build.py",),
+    )
+
+    assert plan["selected_lanes"] == ["quality-gates"]
+    assert plan["blockers"] == []
+    assert any(
+        step.argv[:3] == ("node", "node_modules/vite/bin/vite.js", "build") for step in steps
+    )
+
+
+def test_quality_steps_execute_only_selected_meta_contracts() -> None:
+    runner = _load("profile_runner")
+    changed = (
+        "tests/verify_omnigent/test_comparison.py",
+        "tests/deploy/test_databricks_deploy_dry_run.py",
+        "tests/e2e_ui/test_evidence_contract.py",
+    )
+
+    steps = runner.profile_steps("quality-gates", "/tmp/run", changed_files=changed)
+    commands = [step.argv for step in steps]
+
+    contract = next(
+        command for command in commands if "tests/verify_omnigent/test_comparison.py" in command
+    )
+    assert "tests/deploy/test_databricks_deploy_dry_run.py" in contract
+    assert any(
+        "tests/e2e_ui/test_evidence_contract.py" in command and "--tracing=on" in command
+        for command in commands
+    )
+
+    ordinary = runner.profile_steps(
+        "quality-gates",
+        "/tmp/run",
+        changed_files=("omnigent/server/app.py",),
+    )
+    assert not any(
+        any(
+            focused in argument
+            for focused in (
+                "tests/verify_omnigent",
+                "tests/deploy",
+                "tests/e2e_ui/test_evidence_contract.py",
+                "tests/harness_bench/test_bench.py",
+                "tests/benchmarks/test_benchmark_smoke.py",
+            )
+        )
+        for step in ordinary
+        for argument in step.argv
+    )
+
+
+@pytest.mark.parametrize(
+    ("implementation", "expected"),
+    [
+        (
+            ".agents/skills/verify-omnigent/scripts/evidence_manifest.py",
+            "tests/verify_omnigent",
+        ),
+        ("deploy/databricks/deploy.py", "tests/deploy/test_databricks_deploy_dry_run.py"),
+        ("tests/e2e_ui/conftest.py", "tests/e2e_ui/test_evidence_contract.py"),
+        ("tests/e2e_ui/playwright_evidence.py", "tests/e2e_ui/test_evidence_contract.py"),
+        ("tests/harness_bench/report.py", "tests/harness_bench/test_bench.py"),
+        (
+            "dev/benchmarks/omnigent/run.py",
+            "tests/benchmarks/test_benchmark_smoke.py",
+        ),
+    ],
+)
+def test_quality_implementation_changes_run_focused_contracts(
+    implementation: str,
+    expected: str,
+) -> None:
+    runner = _load("profile_runner")
+
+    steps = runner.profile_steps(
+        "quality-gates",
+        "/tmp/run",
+        changed_files=(implementation,),
+    )
+
+    assert any(expected in step.argv for step in steps)
+
+
+def test_shared_playwright_evidence_maps_web_and_desktop() -> None:
+    helper = _load("orchestration")
+
+    plan = helper.select_lanes(["tests/e2e_ui/playwright_evidence.py"])
+
+    assert "web-ui" in plan["selected_lanes"]
+    assert "desktop" in plan["selected_lanes"]
+
+
+def test_all_verification_vite_builds_use_runner_config_loader() -> None:
+    runner = _load("profile_runner")
+    commands = [
+        step.argv
+        for profile, changed_files in (
+            ("quality-gates", ("web/src/App.tsx",)),
+            ("desktop", None),
+        )
+        for step in runner.profile_steps(profile, "/evidence/run", changed_files=changed_files)
+        if step.argv[:3] == ("node", "node_modules/vite/bin/vite.js", "build")
+    ]
+
+    assert len(commands) == 3
+    assert all(command[command.index("--configLoader") + 1] == "runner" for command in commands)
+    assert all(
+        command[command.index("--outDir") + 1].startswith("/evidence/run/") for command in commands
+    )
+
+
+def test_representative_vite_build_preserves_source_node_modules(
+    tmp_path: Path,
+) -> None:
+    helper = _load("runtime_support")
+    from tests.e2e_ui import conftest as ui_conftest
+
+    source = tmp_path / "source"
+    vite = source / "web/node_modules/vite/bin/vite.js"
+    vite.parent.mkdir(parents=True)
+    vite.write_text(
+        """const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+const nodeModules = path.resolve(__dirname, "../..");
+if (!args.includes("--configLoader") || args[args.indexOf("--configLoader") + 1] !== "runner") {
+  fs.mkdirSync(path.join(nodeModules, ".vite-temp"));
+  process.exit(9);
+}
+const output = args[args.indexOf("--outDir") + 1];
+fs.mkdirSync(output, {recursive: true});
+fs.writeFileSync(path.join(output, "index.html"), "built");
+const cache = path.join(process.env.TMPDIR, "vite-cache");
+fs.mkdirSync(cache);
+fs.writeFileSync(path.join(cache, "config.lock"), "run-owned");
+""",
+        encoding="utf-8",
+    )
+    run_dir = tmp_path / "evidence/run"
+    run_dir.mkdir(parents=True)
+    output = run_dir / "build/e2e-web-ui"
+    before = helper._tree_identity(source / "web/node_modules")
+    env = helper.strict_environment(
+        run_dir,
+        source={"PATH": os.environ["PATH"]},
+    )
+
+    subprocess.run(
+        ui_conftest._vite_build_command(vite, output),
+        cwd=source / "web",
+        env=env,
+        check=True,
+    )
+    lock = Path(
+        subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from tests.e2e_ui.conftest import _vite_build_lock_path; "
+                "path=_vite_build_lock_path(); path.write_text('run-owned'); print(path)",
+            ],
+            cwd=Path(__file__).resolve().parents[2],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
+
+    assert helper._tree_identity(source / "web/node_modules") == before
+    assert not (source / "web/node_modules/.vite-temp").exists()
+    assert (output / "index.html").is_file()
+    cache = Path(env["TMPDIR"]) / "vite-cache"
+    assert cache.is_relative_to(Path(env["TMPDIR"]))
+    assert lock.is_relative_to(Path(env["TMPDIR"]))
+    assert (cache / "config.lock").is_file()
+    assert lock.is_file()
+    helper.cleanup_strict_environment(run_dir)
+    assert not cache.exists()
+    assert not lock.exists()
+    assert (output / "index.html").is_file()
+
+
+def test_real_vite_runner_loader_does_not_write_source_node_modules(
+    tmp_path: Path,
+) -> None:
+    helper = _load("runtime_support")
+    repo_root = Path(__file__).resolve().parents[2]
+    candidates = sorted(
+        (repo_root / "node_modules/.pnpm").glob("vite@*/node_modules/vite/bin/vite.js")
+    )
+    if not candidates:
+        pytest.skip("offline Vite package is unavailable")
+    project = tmp_path / "project"
+    (project / "node_modules").mkdir(parents=True)
+    (project / "index.html").write_text('<main id="app"></main>\n', encoding="utf-8")
+    config = project / "vite.config.mjs"
+    config.write_text("export default { build: { minify: false } };\n", encoding="utf-8")
+    run_dir = tmp_path / "evidence"
+    run_dir.mkdir()
+    output = run_dir / "build"
+    before = helper._tree_metadata_identity(repo_root / "node_modules")
+    env = helper.strict_environment(run_dir, source={"PATH": os.environ["PATH"]})
+
+    subprocess.run(
+        [
+            "node",
+            str(candidates[-1]),
+            "build",
+            "--configLoader",
+            "runner",
+            "--config",
+            str(config),
+            "--outDir",
+            str(output),
+            "--emptyOutDir",
+        ],
+        cwd=project,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert helper._tree_metadata_identity(repo_root / "node_modules") == before
+    assert not (project / "node_modules/.vite-temp").exists()
+    assert (output / "index.html").is_file()
+    helper.cleanup_strict_environment(run_dir)
+
+
+def _fake_pnpm_package(root: Path, version: str) -> Path:
+    package = root / f"pnpm-{version}"
+    (package / "bin").mkdir(parents=True)
+    (package / "package.json").write_text(
+        json.dumps({"name": "pnpm", "version": version}),
+        encoding="utf-8",
+    )
+    (package / "bin/pnpm.mjs").write_text(
+        f"console.log({json.dumps(version)});\n",
+        encoding="utf-8",
+    )
+    return package
+
+
+def _pnpm_repo(root: Path, version: str = "11.15.1") -> Path:
+    repo = root / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text(
+        json.dumps({"packageManager": f"pnpm@{version}"}),
+        encoding="utf-8",
+    )
+    return repo
+
+
+def _publish_fake_pnpm(
+    helper: ModuleType,
+    repo: Path,
+    candidate: Path,
+    cache_parent: Path,
+    name: str,
+) -> Path:
+    staging = cache_parent / f"pnpm.version.{name}"
+    helper.prepare_pnpm_cache(repo, staging, candidates=(candidate,))
+    destination = cache_parent / "pnpm"
+    helper.publish_pnpm_cache(staging, destination)
+    return destination
+
+
+def test_strict_environment_requires_authenticated_exact_pnpm(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load("runtime_support")
+    repo = _pnpm_repo(tmp_path)
+    destination = tmp_path / "cache/pnpm"
+    monkeypatch.setattr(helper, "_pnpm_cache_destination", lambda: destination)
+
+    env = helper.strict_environment(
+        tmp_path / "run",
+        source={"PATH": os.environ["PATH"]},
+        extra={"OMNIGENT_VERIFY_REPO_ROOT": str(repo)},
+    )
+
+    assert "OMNIGENT_VERIFY_TRUSTED_PNPM_TOOLS_ROOT" not in env
+    verify_script = (
+        Path(__file__).resolve().parents[2] / ".agents/skills/verify-omnigent/scripts/verify.sh"
+    ).read_text(encoding="utf-8")
+    assert ".agents/skills/verify-omnigent/scripts/verify.sh prepare-tools" in verify_script
+    helper.cleanup_strict_environment(tmp_path / "run")
+
+
+def test_pnpm_preparation_rejects_wrong_version(tmp_path: Path) -> None:
+    helper = _load("runtime_support")
+    repo = _pnpm_repo(tmp_path)
+    wrong = _fake_pnpm_package(tmp_path / "local", "11.15.0")
+
+    with pytest.raises(RuntimeError, match="not in a supported local cache"):
+        helper.prepare_pnpm_cache(
+            repo,
+            tmp_path / "cache/pnpm.version.wrong",
+            candidates=(wrong,),
+        )
+
+
+def test_tampered_pnpm_cache_is_not_staged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load("runtime_support")
+    repo = _pnpm_repo(tmp_path)
+    candidate = _fake_pnpm_package(tmp_path / "local", "11.15.1")
+    cache_parent = tmp_path / "cache"
+    cache_parent.mkdir()
+    destination = _publish_fake_pnpm(helper, repo, candidate, cache_parent, "sealed")
+    monkeypatch.setattr(helper, "_pnpm_cache_destination", lambda: destination)
+    published = destination.resolve(strict=True)
+    (published / "11.15.1/package/bin/pnpm.mjs").write_text(
+        "console.log('tampered');\n",
+        encoding="utf-8",
+    )
+
+    assert helper.verified_pnpm_tools_root() is None
+    env = helper.strict_environment(
+        tmp_path / "run",
+        source={"PATH": os.environ["PATH"]},
+        extra={"OMNIGENT_VERIFY_REPO_ROOT": str(repo)},
+    )
+    assert "OMNIGENT_VERIFY_TRUSTED_PNPM_TOOLS_ROOT" not in env
+    helper.cleanup_strict_environment(tmp_path / "run")
+
+
+def test_concurrent_pnpm_publication_and_strict_readers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load("runtime_support")
+    repo = _pnpm_repo(tmp_path)
+    candidate = _fake_pnpm_package(tmp_path / "local", "11.15.1")
+    cache_parent = tmp_path / "cache"
+    cache_parent.mkdir()
+    destination = _publish_fake_pnpm(helper, repo, candidate, cache_parent, "seed")
+    monkeypatch.setattr(helper, "_pnpm_cache_destination", lambda: destination)
+
+    def publish(index: int) -> str:
+        _publish_fake_pnpm(helper, repo, candidate, cache_parent, f"writer-{index}")
+        return "published"
+
+    def read(index: int) -> str:
+        run_dir = tmp_path / f"run-{index}"
+        run_dir.mkdir()
+        env = helper.strict_environment(
+            run_dir,
+            source={"PATH": os.environ["PATH"]},
+            extra={"OMNIGENT_VERIFY_REPO_ROOT": str(repo)},
+        )
+        result = subprocess.run(
+            ["pnpm", "--version"],
+            cwd=repo,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        helper.cleanup_strict_environment(run_dir)
+        return result
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = [executor.submit(publish if index < 3 else read, index) for index in range(8)]
+    assert [future.result() for future in futures].count("11.15.1") == 5
+    assert helper.verified_pnpm_tools_root() == destination.resolve(strict=True)
+
+
+def test_strict_environment_executes_prepared_pinned_pnpm(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load("runtime_support")
+    repo = _pnpm_repo(tmp_path)
+    candidate = _fake_pnpm_package(tmp_path / "local", "11.15.1")
+    cache_parent = tmp_path / "cache"
+    cache_parent.mkdir()
+    destination = _publish_fake_pnpm(helper, repo, candidate, cache_parent, "success")
+    monkeypatch.setattr(helper, "_pnpm_cache_destination", lambda: destination)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    env = helper.strict_environment(
+        run_dir,
+        source={"PATH": os.environ["PATH"]},
+        extra={"OMNIGENT_VERIFY_REPO_ROOT": str(repo)},
+    )
+
+    trusted = Path(env["OMNIGENT_VERIFY_TRUSTED_PNPM_TOOLS_ROOT"])
+    assert trusted.is_relative_to(helper._strict_environment_paths(run_dir)[1])
+    assert (
+        subprocess.run(
+            ["pnpm", "--version"],
+            cwd=repo,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        == "11.15.1"
+    )
+    helper.cleanup_strict_environment(run_dir)
+    assert not trusted.exists()
+
+
+def test_verification_changes_select_all_lanes_and_unknown_product_paths_block() -> None:
+    helper = _load("orchestration")
+    verification = helper.select_lanes([".agents/skills/verify-omnigent/scripts/verify.sh"])
+    assert verification["selected_lanes"] == [lane for lane in helper.LANE_ORDER if lane != "perf"]
+
+    unknown = helper.select_lanes(["tests/tools/test_new_unmapped_surface.py"])
+    assert unknown["selected_lanes"] == ["quality-gates"]
+    assert "did not map to a verification lane" in unknown["blockers"][0]
+
+
+def test_targeted_risk_surfaces_select_focused_auto_lanes() -> None:
+    helper = _load("orchestration")
+    plan = helper.select_lanes(
+        [
+            "tests/e2e_ui/scheduled/test_scheduled_tasks_page.py",
+            "tests/e2e_ui/collaboration/test_sharing_journey.py",
+            "tests/db/test_migration_workspace.py",
+            "deploy/databricks/deploy.py",
+            "omnigent/server/routes/sessions.py",
+        ]
+    )
+
+    assert {"automations", "collaboration", "db-migration-deploy", "perf"} <= set(
+        plan["selected_lanes"]
+    )
+    assert plan["blockers"] == []
+
+
+@pytest.mark.parametrize(
+    ("path", "required"),
+    [
+        (
+            "omnigent/server/routes/accounts_auth.py",
+            {"quality-gates", "server", "collaboration"},
+        ),
+        (
+            "omnigent/server/routes/sessions/routes_permissions.py",
+            {"quality-gates", "server", "collaboration", "perf"},
+        ),
+        (
+            "omnigent/server/routes/roles/assign.py",
+            {"quality-gates", "server", "collaboration"},
+        ),
+        (
+            "omnigent/host/identity.py",
+            {"quality-gates", "server", "harness-client", "collaboration"},
+        ),
+        (
+            "sdks/python-client/omnigent_client/_client.py",
+            {"quality-gates", "harness-client", "collaboration"},
+        ),
+        (
+            "web/src/lib/permissionsApi.ts",
+            {"quality-gates", "web-ui", "collaboration"},
+        ),
+        (
+            "web/src/pages/LoginPage.tsx",
+            {"quality-gates", "web-ui", "collaboration"},
+        ),
+        (
+            "omnigent/server/oidc.py",
+            {"quality-gates", "server", "collaboration"},
+        ),
+        (
+            "omnigent/server/accounts_store.py",
+            {"quality-gates", "server", "collaboration"},
+        ),
+        (
+            "omnigent/server/routes/session_policies.py",
+            {"quality-gates", "server", "collaboration"},
+        ),
+        (
+            "tests/e2e_ui/auth/test_device_grant_reauth.py",
+            {"quality-gates", "web-ui", "collaboration"},
+        ),
+        (
+            "omnigent/server/routes/sessions/routes_core.py",
+            {"quality-gates", "server", "perf", "collaboration"},
+        ),
+        (
+            "omnigent/server/routes/sessions/routes_hooks.py",
+            {"quality-gates", "server", "perf", "collaboration"},
+        ),
+        (
+            "tests/server/integration/test_sessions_permission_request_hook.py",
+            {"quality-gates", "server", "collaboration"},
+        ),
+        (
+            "tests/e2e_ui/sessions/test_sidebar_ownership_gating.py",
+            {"quality-gates", "web-ui", "collaboration"},
+        ),
+    ],
+)
+def test_auth_and_access_paths_select_collaboration(
+    path: str,
+    required: set[str],
+) -> None:
+    helper = _load("orchestration")
+    plan = helper.select_lanes([path])
+
+    assert required <= set(plan["selected_lanes"])
+    assert plan["blockers"] == []
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "omnigent/runtime/identity_map.py",
+        "omnigent/runtime/hooks.py",
+        "omnigent/server/core.py",
+        "omnigent/server/routes/authenticity_metrics.py",
+        "omnigent/server/routes/sessions/routes_events.py",
+        "web/src/components/IdentityBadge.tsx",
+    ],
+)
+def test_unrelated_identity_like_names_do_not_select_collaboration(path: str) -> None:
+    helper = _load("orchestration")
+    plan = helper.select_lanes([path])
+
+    assert "collaboration" not in plan["selected_lanes"]
+
+
+def test_changed_files_exclude_base_only_changes(tmp_path: Path) -> None:
+    orchestration = _load("orchestration")
+    repo = _diverged_repo(tmp_path)
+
+    files, blockers = orchestration.changed_files(repo, "main")
+
+    assert blockers == []
+    assert "web/base_only.ts" not in files
+
+
+def test_changed_files_preserve_nul_delimited_special_names(tmp_path: Path) -> None:
+    orchestration = _load("orchestration")
+    repo = tmp_path / "special-paths"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    _commit(repo, "base")
+    _git(repo, "switch", "-q", "-c", "pr")
+    names = (
+        "omnigent/server/line\nbreak.py",
+        "omnigent/server/tab\tname.py",
+        'omnigent/server/"quote"\\name.py',
+    )
+    for name in names:
+        path = repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("changed = True\n", encoding="utf-8")
+    _commit(repo, "special paths")
+
+    files, blockers = orchestration.changed_files(repo, "main")
+    plan = orchestration.select_lanes(files)
+    runner = _load("profile_runner")
+    scoped = runner._changed_files(repo, "main")
+    quality_steps = runner.profile_steps(
+        "quality-gates",
+        "run",
+        changed_files=scoped,
+    )
+
+    assert blockers == []
+    assert set(names).issubset(files)
+    assert set(names).issubset(scoped)
+    assert set(names).issubset(quality_steps[0].argv)
+    assert "server" in plan["selected_lanes"]
+    assert plan["blockers"] == []
+
+
+def test_changed_files_include_both_rename_and_copy_paths(tmp_path: Path) -> None:
+    orchestration = _load("orchestration")
+    runner = _load("profile_runner")
+    repo = tmp_path / "renames"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    implementation = repo / "omnigent/server/name with\nnewline.py"
+    implementation.parent.mkdir(parents=True)
+    implementation.write_text("value = 1\n", encoding="utf-8")
+    _commit(repo, "base")
+    base = _git(repo, "rev-parse", "HEAD")
+    destination = repo / "docs" / "renamed with space.md"
+    destination.parent.mkdir()
+    implementation.rename(destination)
+    _git(repo, "add", "-A")
+    _commit(repo, "rename implementation to docs")
+    copied = repo / "omnigent/server/copied file.py"
+    copied.write_text(destination.read_text(encoding="utf-8"), encoding="utf-8")
+    _git(repo, "add", copied.relative_to(repo).as_posix())
+
+    files, blockers = orchestration.changed_files(repo, base)
+    scoped = runner._changed_files(repo, base)
+
+    assert blockers == []
+    assert "omnigent/server/name with\nnewline.py" in files
+    assert "docs/renamed with space.md" in files
+    assert "omnigent/server/copied file.py" in files
+    assert set(files) == set(scoped)
+
+
+def test_changed_files_include_pr_only_changes(tmp_path: Path) -> None:
+    orchestration = _load("orchestration")
+    repo = _diverged_repo(tmp_path)
+
+    files, blockers = orchestration.changed_files(repo, "main")
+
+    assert blockers == []
+    assert "omnigent/pr_only.py" in files
+
+
+def test_changed_files_include_each_local_path_once(tmp_path: Path) -> None:
+    orchestration = _load("orchestration")
+    runner = _load("profile_runner")
+    repo = _diverged_repo(tmp_path)
+
+    files, blockers = orchestration.changed_files(repo, "main")
+    runner_files = runner._changed_files(repo, "main")
+
+    assert blockers == []
+    assert {
+        "tracked-staged.txt",
+        "tracked-unstaged.txt",
+        "tests/host/test_untracked.py",
+    } <= set(files)
+    assert len(files) == len(set(files))
+    assert set(runner_files) == set(files)
+    assert len(runner_files) == len(set(runner_files))
+
+
+def test_changed_files_fail_closed_for_missing_base(tmp_path: Path) -> None:
+    orchestration = _load("orchestration")
+    runner = _load("profile_runner")
+    repo = _diverged_repo(tmp_path)
+
+    files, blockers = orchestration.changed_files(repo, "missing-base")
+
+    assert files == []
+    assert blockers and "unavailable" in blockers[0]
+    with pytest.raises(RuntimeError):
+        runner._changed_files(repo, "missing-base")
+
+
+def test_changed_files_fail_closed_without_merge_base(tmp_path: Path) -> None:
+    orchestration = _load("orchestration")
+    runner = _load("profile_runner")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "main.txt").write_text("main\n", encoding="utf-8")
+    _commit(repo, "main")
+    _git(repo, "switch", "--orphan", "disconnected")
+    (repo / "main.txt").unlink(missing_ok=True)
+    (repo / "disconnected.txt").write_text("disconnected\n", encoding="utf-8")
+    _commit(repo, "disconnected")
+
+    files, blockers = orchestration.changed_files(repo, "main")
+
+    assert files == []
+    assert blockers and "no unique merge base" in blockers[0]
+    with pytest.raises(RuntimeError, match="no unique merge base"):
+        runner._changed_files(repo, "main")
+
+
+def test_all_surfaces_is_explicit_and_keeps_live_lanes_not_requested(tmp_path: Path) -> None:
+    helper = _load("orchestration")
+    plan = helper.build_plan(tmp_path, "all-surfaces", "unused")
+
+    assert plan["selected_lanes"] == [
+        lane for lane in helper.LANE_ORDER if lane in helper.ALL_SURFACES
+    ]
+    assert all(decision["status"] == "selected" for decision in plan["decisions"])
+    assert {lane["status"] for lane in plan["optional_lanes"]} == {"not_requested"}
+    assert {lane["lane"] for lane in plan["optional_lanes"]} >= {
+        "harness-live",
+        "cli-live-repl",
+        "electron-release",
+        "downstream-universe",
+    }
+
+
+def test_universe_lane_requires_explicit_opt_in(tmp_path: Path) -> None:
+    helper = _load("orchestration")
+
+    default = helper.build_plan(tmp_path, "all-surfaces", "unused")
+    opted_in = helper.build_plan(
+        tmp_path,
+        "all-surfaces",
+        "unused",
+        with_universe=True,
+    )
+
+    assert "universe" not in default["selected_lanes"]
+    assert opted_in["selected_lanes"][-1] == "universe"
+    assert not any(lane["lane"] == "downstream-universe" for lane in opted_in["optional_lanes"])
+    assert opted_in["decisions"][-1]["status"] == "selected"
+
+
+@pytest.mark.parametrize(
+    ("profile", "expected"),
+    [
+        (
+            "quality-gates",
+            ("uv", "run", "--no-sync", "pre-commit", "run"),
+        ),
+        (
+            "server",
+            ("uv", "run", "--no-sync", "pytest", "tests/server/test_app.py"),
+        ),
+        (
+            "db-migration-deploy",
+            ("uv", "run", "--no-sync", "pytest", "tests/db", "tests/stores", "tests/deploy"),
+        ),
+        ("cli", (".venv/bin/python", ".claude/skills/cli-setup-verify/verify_cli.py")),
+        ("web-ui", ("node_modules/.bin/vitest", "run")),
+        ("desktop", ("node", "--test")),
+        (
+            "harness-client",
+            ("uv", "run", "--no-sync", "pytest", "tests/harness_bench"),
+        ),
+        (
+            "universe",
+            (
+                "python3",
+                ".agents/skills/verify-omnigent/scripts/universe_preflight.py",
+            ),
+        ),
+    ],
+)
+def test_profile_commands_are_grounded_in_checked_in_assets(
+    profile: str,
+    expected: tuple[str, ...],
+) -> None:
+    runner = _load("profile_runner")
+    steps = runner.profile_steps(profile, ".artifacts/run")
+
+    assert steps
+    assert any(step.argv[: len(expected)] == expected for step in steps)
+    assert all("/Users/" not in argument for step in steps for argument in step.argv)
+
+
+def test_web_quality_gate_matches_merge_critical_commands() -> None:
+    runner = _load("profile_runner")
+    steps = runner.profile_steps(
+        "quality-gates",
+        ".artifacts/run",
+        changed_files=("web/src/App.tsx", "tests/e2e_ui/chat/test_smoke.py"),
+    )
+
+    commands = [step.argv for step in steps]
+    assert commands[0] == (
+        "uv",
+        "run",
+        "--no-sync",
+        "pre-commit",
+        "run",
+        "--files",
+        "tests/e2e_ui/chat/test_smoke.py",
+        "web/src/App.tsx",
+    )
+    assert ("node_modules/.bin/prettier", "--check", ".") in commands
+    assert ("node_modules/.bin/oxlint", "--deny-warnings", ".") in commands
+    assert ("node_modules/.bin/tsc", "-b", "--noEmit") in commands
+    assert any(
+        command[:3] == ("node", "node_modules/vite/bin/vite.js", "build") for command in commands
+    )
+
+
+def test_desktop_report_supports_external_evidence_root(tmp_path: Path) -> None:
+    runner = _load("profile_runner")
+    run_dir = tmp_path / "external-evidence" / "run"
+    package = run_dir / "build/electron-package/app.bin"
+    package.parent.mkdir(parents=True)
+    package.write_bytes(b"package")
+
+    error = runner._desktop_build_report(run_dir)
+
+    assert error is None
+    report = json.loads((run_dir / "desktop-build.json").read_text(encoding="utf-8"))
+    assert report["outputs"][0]["path"] == "build/electron-package/app.bin"
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        ({}, "unsupported schema"),
+        ({"schema_version": 1, "harnesses": []}, "no harness results"),
+        (
+            {
+                "schema_version": 1,
+                "has_drift": False,
+                "dimensions": ["basic_turn"],
+                "harnesses": [{"harness": "codex", "cells": []}],
+            },
+            "no capability cells",
+        ),
+    ],
+)
+def test_offline_harness_report_fails_closed(
+    tmp_path: Path,
+    payload: dict[str, object],
+    error: str,
+) -> None:
+    runner = _load("profile_runner")
+    report = tmp_path / "harness-matrix.json"
+    report.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert error in runner._validate_offline_harness_report(report)
+
+
+def test_offline_harness_report_requires_expected_cells(tmp_path: Path) -> None:
+    runner = _load("profile_runner")
+    report = tmp_path / "harness-matrix.json"
+    report.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "has_drift": False,
+                "dimensions": ["basic_turn"],
+                "harnesses": [
+                    {
+                        "harness": "codex",
+                        "cells": [
+                            {
+                                "dimension": "basic_turn",
+                                "observed": "skipped",
+                                "declared": "supported",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert runner._validate_offline_harness_report(report) is None
+
+
+def test_python_quality_gate_does_not_require_web_build() -> None:
+    runner = _load("profile_runner")
+    steps = runner.profile_steps(
+        "quality-gates",
+        ".artifacts/run",
+        changed_files=("omnigent/server/app.py",),
+    )
+
+    assert len(steps) == 1
+    assert steps[0].argv[-2:] == ("--files", "omnigent/server/app.py")
+
+
+def test_desktop_profile_runs_real_electron_playwright_journeys() -> None:
+    runner = _load("profile_runner")
+    steps = runner.profile_steps(
+        "desktop",
+        ".artifacts/run",
+        electron_e2e_tests=(
+            "web/electron/e2e/desktop_api_url_recovery.e2e.js",
+            "web/electron/e2e/desktop_settings_shortcut.e2e.js",
+        ),
+    )
+
+    commands = [step.argv for step in steps]
+    assert any(
+        command[:3] == ("node", "node_modules/vite/bin/vite.js", "build") for command in commands
+    )
+    assert (
+        "node",
+        "--test",
+        "--test-concurrency=1",
+        "web/electron/e2e/desktop_api_url_recovery.e2e.js",
+        "web/electron/e2e/desktop_settings_shortcut.e2e.js",
+    ) in commands
+
+
+def test_live_harness_report_fails_closed_on_skipped_basic_turn(tmp_path: Path) -> None:
+    runner = _load("profile_runner")
+    report = tmp_path / "harness-live.json"
+    report.write_text(
+        json.dumps(
+            {
+                "harnesses": [
+                    {
+                        "harness": "cursor",
+                        "skipped_reason": "cursor is not installed",
+                        "cells": [],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert "unavailable" in runner._validate_live_harness_report(report)
+
+
+def test_universe_profile_propagates_requested_refs() -> None:
+    runner = _load("profile_runner")
+    step = runner.profile_steps(
+        "universe",
+        ".artifacts/run",
+        base_ref="origin/main",
+        oss_ref="pr-head",
+    )[0]
+
+    assert step.argv[-4:] == ("--base-ref", "origin/main", "--oss-ref", "pr-head")
+
+
+def _runner_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "runner-repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / ".pre-commit-config.yaml").write_text(
+        "repos:\n  - repo: local\n    hooks: []\n",
+        encoding="utf-8",
+    )
+    (repo / "uv.lock").write_text("locked\n", encoding="utf-8")
+    (repo / "pnpm-lock.yaml").write_text("lockfileVersion: 9\n", encoding="utf-8")
+    _commit(repo, "base")
+    return repo
+
+
+def test_harness_live_nested_runtime_keeps_profile_until_step_finishes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load("runtime_support")
+    runner = _load("profile_runner")
+    repo = _runner_repo(tmp_path)
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    (real_home / ".databrickscfg").write_text(
+        "[selected]\nhost = https://selected.invalid\ntoken = harness-fake-marker\n",
+        encoding="utf-8",
+    )
+    run_dir = tmp_path / "harness-live-run"
+    run_dir.mkdir()
+    outer = helper.strict_environment(
+        run_dir,
+        source={
+            "HOME": str(real_home),
+            "PATH": os.environ["PATH"],
+            "OPENAI_API_KEY": "ambient-openai-marker",
+            "OPENAI_BASE_URL": "https://ambient.invalid",
+            "DATABRICKS_HOST": "https://ambient-databricks.invalid",
+            "DATABRICKS_TOKEN": "ambient-databricks-marker",
+        },
+        extra={
+            "OMNIGENT_VERIFY_DATABRICKS_PROFILE": "selected",
+            "OMNIGENT_VERIFY_HARNESS": "claude-sdk",
+        },
+        credentialed=True,
+    )
+    staged = Path(outer["DATABRICKS_CONFIG_FILE"])
+    monkeypatch.setattr(os, "environ", outer)
+    monkeypatch.setattr(
+        runner,
+        "profile_steps",
+        lambda *_args, **_kwargs: [
+            runner.Step(
+                "Read staged profile",
+                (
+                    sys.executable,
+                    "-c",
+                    "import json, os, pathlib; "
+                    "value=pathlib.Path(os.environ['DATABRICKS_CONFIG_FILE']).read_text(); "
+                    "report={'harnesses':[{'cells':["
+                    "{'dimension':'basic_turn','observed':'supported'}]}]}; "
+                    "(pathlib.Path(os.environ['OMNIGENT_VERIFY_RUN_DIR']) / "
+                    "'harness-live.json').write_text(json.dumps(report)); "
+                    "forbidden={'OPENAI_API_KEY','OPENAI_BASE_URL',"
+                    "'DATABRICKS_HOST','DATABRICKS_TOKEN','CURSOR_API_KEY'}; "
+                    "valid=('token = ' in value and "
+                    "os.environ.get('DATABRICKS_CONFIG_PROFILE') == 'selected' and "
+                    "os.environ.get('OMNIGENT_VERIFY_CREDENTIAL_MODE') == "
+                    "'databricks-profile' and not forbidden.intersection(os.environ)); "
+                    "raise SystemExit(0 if valid else 9)",
+                ),
+            )
+        ],
+    )
+
+    result = runner.run_profile(repo, run_dir, "harness-live")
+
+    assert result == 0
+    report = json.loads((run_dir / "steps.json").read_text(encoding="utf-8"))
+    assert report["steps"][0]["credential_mode"] == "databricks-profile"
+    helper.cleanup_strict_environment(run_dir)
+    assert not staged.exists()
+    assert "harness-fake-marker" not in (run_dir / "steps.json").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("exit_status", [0, 9])
+def test_profile_runner_preserves_status_and_lockfiles_on_success_and_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exit_status: int,
+) -> None:
+    runner = _load("profile_runner")
+    repo = _runner_repo(tmp_path)
+    run_dir = tmp_path / f"run-{exit_status}"
+    run_dir.mkdir()
+    before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    before_lock = (repo / "uv.lock").read_bytes()
+    monkeypatch.setattr(
+        runner,
+        "profile_steps",
+        lambda *_args, **_kwargs: [
+            runner.Step(
+                "Synthetic step",
+                (sys.executable, "-c", f"raise SystemExit({exit_status})"),
+            )
+        ],
+    )
+
+    result = runner.run_profile(repo, run_dir, "server")
+
+    assert result == exit_status
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
+    assert (repo / "uv.lock").read_bytes() == before_lock
+    report = json.loads((run_dir / "steps.json").read_text(encoding="utf-8"))
+    assert report["state_unchanged"] is True
+
+
+def test_mutating_pre_commit_runs_only_in_disposable_worktree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load("profile_runner")
+    repo = _runner_repo(tmp_path)
+    run_dir = tmp_path / "isolated-run"
+    run_dir.mkdir()
+    before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    before_lock = (repo / "uv.lock").read_bytes()
+    monkeypatch.setattr(
+        runner,
+        "profile_steps",
+        lambda *_args, **_kwargs: [
+            runner.Step(
+                "Synthetic mutating hook",
+                (
+                    sys.executable,
+                    "-c",
+                    "from pathlib import Path; Path('uv.lock').write_text('rewritten\\n')",
+                ),
+                isolated=True,
+            )
+        ],
+    )
+
+    result = runner.run_profile(repo, run_dir, "quality-gates")
+
+    assert result == 0
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
+    assert (repo / "uv.lock").read_bytes() == before_lock
+    report = json.loads((run_dir / "steps.json").read_text(encoding="utf-8"))
+    assert report["steps"][0]["isolation_cleanup"] == "completed"
+    assert report["state_unchanged"] is True
+
+
+def test_isolated_quality_step_cannot_mutate_shared_venv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load("profile_runner")
+    repo = _runner_repo(tmp_path)
+    (repo / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    _commit(repo, "ignore environment")
+    (repo / ".venv").mkdir()
+    original = repo / ".venv/original.bin"
+    original.write_bytes(b"original dependency bytes\n")
+    original_hash = hashlib.sha256(original.read_bytes()).hexdigest()
+    run_dir = tmp_path / "isolated-venv-run"
+    run_dir.mkdir()
+    monkeypatch.setattr(
+        runner,
+        "profile_steps",
+        lambda *_args, **_kwargs: [
+            runner.Step(
+                "Synthetic environment mutation",
+                (
+                    sys.executable,
+                    "-c",
+                    "from pathlib import Path; "
+                    "Path('.venv/original.bin').write_text('changed'); "
+                    "Path('.venv/marker.txt').write_text('isolated')",
+                ),
+                isolated=True,
+            )
+        ],
+    )
+
+    result = runner.run_profile(repo, run_dir, "quality-gates")
+
+    assert result == 0
+    assert not (repo / ".venv/marker.txt").exists()
+    assert hashlib.sha256(original.read_bytes()).hexdigest() == original_hash
+    report = json.loads((run_dir / "steps.json").read_text(encoding="utf-8"))
+    assert report["state_unchanged"] is True
+
+
+def test_isolated_quality_supports_normal_pnpm_links_without_mutating_source(
+    tmp_path: Path,
+) -> None:
+    runner = _load("profile_runner")
+    source_root = tmp_path / "source"
+    target_root = tmp_path / "target"
+    package = source_root / "node_modules/.pnpm/pkg@1/node_modules/pkg"
+    package.mkdir(parents=True)
+    original = package / "index.js"
+    original.write_text("module.exports = 'original'\n", encoding="utf-8")
+    dangling = source_root / "node_modules/.pnpm/node_modules/typebox"
+    dangling.parent.mkdir(parents=True)
+    dangling.symlink_to("../../typebox@1.1.38")
+    modules_metadata = source_root / "node_modules/.modules.yaml"
+    modules_metadata.write_text(
+        json.dumps({"virtualStoreDir": ("../../../.worktrees/omnigent/stale/node_modules/.pnpm")}),
+        encoding="utf-8",
+    )
+    original_metadata = modules_metadata.read_text(encoding="utf-8")
+    workspace_link = source_root / "web/node_modules/pkg"
+    workspace_link.parent.mkdir(parents=True)
+    workspace_link.symlink_to("../../node_modules/.pnpm/pkg@1/node_modules/pkg")
+    stale_checkout_link = source_root / "web/node_modules/pkg-stale-layout"
+    stale_checkout_link.symlink_to(
+        "../../../.worktrees/omnigent/stale/node_modules/.pnpm/pkg@1/node_modules/pkg"
+    )
+    shim = source_root / "web/node_modules/.bin/pkg"
+    shim.parent.mkdir()
+    stale_shim_target = (
+        tmp_path / ".worktrees/omnigent/stale/node_modules/.pnpm/pkg@1/node_modules/pkg/index.js"
+    )
+    stale_shim_relative = os.path.relpath(stale_shim_target, shim.parent)
+    shim.write_text(
+        "#!/bin/sh\n"
+        f'exec node "$basedir/{stale_shim_relative}"\n'
+        f"# cmd-shim-target={stale_shim_target}\n",
+        encoding="utf-8",
+    )
+    original_shim = shim.read_text(encoding="utf-8")
+    target_root.mkdir()
+
+    runner._clone_dependency_path(
+        source_root / "node_modules",
+        target_root / "node_modules",
+        source_root=source_root,
+        target_root=target_root,
+    )
+    runner._clone_dependency_path(
+        source_root / "web/node_modules",
+        target_root / "web/node_modules",
+        source_root=source_root,
+        target_root=target_root,
+    )
+
+    isolated = target_root / "web/node_modules/pkg/index.js"
+    assert isolated.resolve().is_relative_to(target_root)
+    assert (
+        (target_root / "web/node_modules/pkg-stale-layout/index.js")
+        .resolve()
+        .is_relative_to(target_root)
+    )
+    isolated_dangling = target_root / "node_modules/.pnpm/node_modules/typebox"
+    assert isolated_dangling.is_symlink()
+    assert isolated_dangling.resolve(strict=False).is_relative_to(target_root)
+    isolated_metadata = json.loads(
+        (target_root / "node_modules/.modules.yaml").read_text(encoding="utf-8")
+    )
+    assert isolated_metadata["virtualStoreDir"] == ".pnpm"
+    isolated_shim = target_root / "web/node_modules/.bin/pkg"
+    assert str(target_root) in isolated_shim.read_text(encoding="utf-8")
+    assert ".worktrees/omnigent/stale" not in isolated_shim.read_text(encoding="utf-8")
+    isolated.write_text("changed\n", encoding="utf-8")
+    assert original.read_text(encoding="utf-8") == "module.exports = 'original'\n"
+    assert os.readlink(workspace_link) == "../../node_modules/.pnpm/pkg@1/node_modules/pkg"
+    assert shim.read_text(encoding="utf-8") == original_shim
+    assert modules_metadata.read_text(encoding="utf-8") == original_metadata
+
+
+def test_isolated_venv_clones_external_python_runtime(tmp_path: Path) -> None:
+    runner = _load("profile_runner")
+    source_root = tmp_path / "source"
+    target_root = tmp_path / "target"
+    runtime = tmp_path / "python-runtime"
+    runtime_python = runtime / "bin/python3.12"
+    runtime_python.parent.mkdir(parents=True)
+    runtime_python.write_text("python-runtime\n", encoding="utf-8")
+    runtime_library = runtime / "lib/libpython3.12.dylib"
+    runtime_library.parent.mkdir()
+    runtime_library.write_text("runtime-library\n", encoding="utf-8")
+    source_python = source_root / ".venv/bin/python"
+    source_python.parent.mkdir(parents=True)
+    source_python.symlink_to(runtime_python)
+    target_root.mkdir()
+
+    runner._clone_dependency_path(
+        source_root / ".venv",
+        target_root / ".venv",
+        source_root=source_root,
+        target_root=target_root,
+    )
+
+    isolated_python = target_root / ".venv/bin/python"
+    assert isolated_python.resolve(strict=True).is_relative_to(target_root)
+    isolated_library = target_root / ".venv/.python-runtime/lib/libpython3.12.dylib"
+    assert isolated_library.read_text(encoding="utf-8") == "runtime-library\n"
+    isolated_library.write_text("changed\n", encoding="utf-8")
+    assert runtime_library.read_text(encoding="utf-8") == "runtime-library\n"
+
+
+def test_profile_runner_times_out_and_finalizes_step_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load("profile_runner")
+    repo = _runner_repo(tmp_path)
+    run_dir = tmp_path / "timeout-run"
+    run_dir.mkdir()
+    monkeypatch.setenv("OMNIGENT_VERIFY_STEP_TIMEOUT_SECONDS", "0.05")
+    monkeypatch.setattr(
+        runner,
+        "profile_steps",
+        lambda *_args, **_kwargs: [
+            runner.Step(
+                "Synthetic timeout",
+                (sys.executable, "-c", "import time; time.sleep(60)"),
+            )
+        ],
+    )
+
+    assert runner.run_profile(repo, run_dir, "server") == 124
+    report = json.loads((run_dir / "steps.json").read_text(encoding="utf-8"))
+    assert report["status"] == "failed"
+    assert report["steps"][0]["timed_out"] is True
+    assert report["steps"][0]["exit_status"] == 124
+
+
+def test_managed_marker_reaches_profile_step_and_cleans_fast_daemon(
+    tmp_path: Path,
+) -> None:
+    helper = _load("runtime_support")
+    repo = _runner_repo(tmp_path)
+    run_dir = tmp_path / "managed-profile"
+    run_dir.mkdir()
+    ready = tmp_path / "daemon.pid"
+    driver = tmp_path / "driver.py"
+    driver.write_text(
+        f"""\
+import os
+import sys
+from pathlib import Path
+sys.path.insert(0, {str(_SCRIPTS)!r})
+import profile_runner
+
+code = '''import os,time
+from pathlib import Path
+fd=int(os.environ["OMNIGENT_VERIFY_MANAGED_FD"])
+os.fstat(fd)
+first=os.fork()
+if first == 0:
+    os.setsid()
+    second=os.fork()
+    if second > 0:
+        os._exit(0)
+    Path({str(ready)!r}).write_text(str(os.getpid()))
+    time.sleep(60)
+os.waitpid(first, 0)
+'''
+profile_runner.profile_steps = lambda *_args, **_kwargs: [
+    profile_runner.Step("nested daemon", (sys.executable, "-c", code))
+]
+raise SystemExit(profile_runner.run_profile(
+    Path({str(repo)!r}), Path({str(run_dir)!r}), "server"
+))
+""",
+        encoding="utf-8",
+    )
+    result = tmp_path / "managed-result.json"
+    status = helper.managed_run(
+        [sys.executable, str(driver)],
+        cwd=repo,
+        env={"PATH": os.environ["PATH"]},
+        log_path=tmp_path / "managed.log",
+        timeout=15,
+        result_path=result,
+    )
+
+    assert status == 0
+    assert ready.is_file()
+    daemon_pid = int(ready.read_text(encoding="utf-8"))
+    with pytest.raises(ProcessLookupError):
+        os.kill(daemon_pid, 0)
+
+
+def test_ambient_partial_controls_cannot_skip_profile_evidence_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load("profile_runner")
+    repo = _runner_repo(tmp_path)
+    run_dir = tmp_path / "partial-run"
+    run_dir.mkdir()
+    monkeypatch.setenv("OMNIGENT_VERIFY_PARTIAL_COMPARISON", "1")
+    monkeypatch.setenv("OMNIGENT_VERIFY_ONLY_STEP_INDICES", "0")
+    monkeypatch.setattr(
+        runner,
+        "profile_steps",
+        lambda *_args, **_kwargs: [
+            runner.Step("Previously failing step", (sys.executable, "-c", "pass"))
+        ],
+    )
+    monkeypatch.setattr(runner, "_desktop_build_report", lambda *_args: "evidence required")
+
+    assert runner.run_profile(repo, run_dir, "desktop") == 1
+    report = json.loads((run_dir / "steps.json").read_text(encoding="utf-8"))
+    assert report["status"] == "failed"
+    assert any(step.get("name") == "Evidence validation" for step in report["steps"])
+
+
+@pytest.mark.parametrize("profile", ["web-ui", "desktop"])
+@pytest.mark.parametrize(
+    ("marker_state", "expected_status"),
+    [
+        ("completed", 0),
+        ("missing", 1),
+        ("malformed", 1),
+    ],
+)
+def test_ui_profile_runner_requires_run_owned_completed_cleanup_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    profile: str,
+    marker_state: str,
+    expected_status: int,
+) -> None:
+    helper = _load("runtime_support")
+    runner = _load("profile_runner")
+    repo = _runner_repo(tmp_path)
+    run_dir = tmp_path / f"{profile}-{marker_state}"
+    run_dir.mkdir()
+    marker = run_dir / "cleanup.json"
+    monkeypatch.setenv("OMNIGENT_VERIFY_CLEANUP_MARKER", str(marker))
+    if marker_state == "completed":
+        command = (
+            "import json, os; from pathlib import Path; "
+            "Path(os.environ['OMNIGENT_VERIFY_CLEANUP_MARKER']).write_text("
+            "json.dumps({'schema_version': 1, 'status': 'completed', 'exit_status': 0}))"
+        )
+    elif marker_state == "malformed":
+        command = (
+            "import os; from pathlib import Path; "
+            "Path(os.environ['OMNIGENT_VERIFY_CLEANUP_MARKER']).write_text('{')"
+        )
+    else:
+        command = "pass"
+    monkeypatch.setattr(
+        runner,
+        "profile_steps",
+        lambda *_args, **_kwargs: [
+            runner.Step("Synthetic UI pytest", (sys.executable, "-c", command))
+        ],
+    )
+    monkeypatch.setattr(runner, "playwright_browser_snapshot", lambda: {"verified": True})
+    monkeypatch.setattr(runner, "_desktop_build_report", lambda *_args: None)
+
+    result = runner.run_profile(repo, run_dir, profile)
+
+    assert result == expected_status
+    report = json.loads((run_dir / "steps.json").read_text(encoding="utf-8"))
+    assert report["status"] == ("passed" if expected_status == 0 else "failed")
+    if expected_status:
+        assert any(step.get("name") == "Evidence validation" for step in report["steps"])
+    helper.cleanup_strict_environment(run_dir)
+
+
+@pytest.mark.parametrize("profile", ["web-ui", "desktop"])
+def test_ui_profile_rejects_cleanup_marker_owned_by_another_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    profile: str,
+) -> None:
+    runner = _load("profile_runner")
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    monkeypatch.setenv(
+        "OMNIGENT_VERIFY_CLEANUP_MARKER",
+        str(tmp_path / "other-run" / "cleanup.json"),
+    )
+
+    with pytest.raises(RuntimeError, match="not owned"):
+        runner._controlled_environment(tmp_path, run_dir, profile, {})
+
+
+def test_comparison_request_requires_valid_private_capability(
+    tmp_path: Path,
+) -> None:
+    runner = _load("profile_runner")
+    request = tmp_path / "request.json"
+    capability = tmp_path / "capability"
+    capability.write_bytes(b"x" * 32)
+    capability.chmod(0o600)
+    request.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "profile": "server",
+                "step_indices": [0],
+                "changed_files": None,
+                "nonce": "n" * 64,
+                "signature": "forged",
+            }
+        ),
+        encoding="utf-8",
+    )
+    request.chmod(0o600)
+
+    with pytest.raises(RuntimeError, match="signature is invalid"):
+        runner._load_request(request, capability, "server")

--- a/tests/verify_omnigent/test_playwright_evidence.py
+++ b/tests/verify_omnigent/test_playwright_evidence.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from tests.e2e_ui import playwright_evidence
+from tests.e2e_ui.playwright_evidence import ContextMetadata, redact_text, redact_url
+
+
+def test_browser_metadata_redacts_secrets_paths_queries_and_inline_bodies(
+    tmp_path: Path,
+) -> None:
+    assert (
+        redact_url("https://user:password@example.test/v1/items?token=secret#fragment")
+        == "https://example.test/v1/items"
+    )
+    assert redact_url("data:text/plain,secret-body") == "data:[redacted]"
+    redacted = redact_text(
+        "Bearer abc.def.ghi api_key=super-secret "
+        "https://example.test/path?token=query /Users/alice/private/file.txt"
+    )
+    assert "abc.def.ghi" not in redacted
+    assert "super-secret" not in redacted
+    assert "token=query" not in redacted
+    assert "/Users/alice" not in redacted
+
+    metadata = ContextMetadata("tests/test_contract.py::test_it", "direct-sync", tmp_path)
+    metadata.add(
+        "request",
+        method="GET",
+        resource_type="fetch",
+        url=redact_url("https://example.test/v1/items?token=secret"),
+    )
+    metadata.write()
+    payload = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
+    serialized = json.dumps(payload)
+    assert all("headers" not in event and "body" not in event for event in payload["events"])
+    assert "token=secret" not in serialized
+
+
+def test_url_segments_and_parametrized_nodeids_are_digest_redacted(tmp_path: Path) -> None:
+    token = "sk-" + "A" * 48
+    redacted_url = redact_url(f"https://example.test/sessions/{token}/messages")
+    assert token not in redacted_url
+    assert "<redacted-" in redacted_url
+
+    metadata = ContextMetadata(
+        f"tests/test_secret.py::test_case[token={token}]",
+        "direct-sync",
+        tmp_path,
+    )
+    metadata.write()
+    payload = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
+    assert token not in payload["nodeid"]
+    assert len(payload["nodeid_sha256"]) == 64
+
+
+def test_concurrent_browser_launches_allocate_unique_evidence_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(playwright_evidence.VERIFY_RUN_DIR_ENV, str(tmp_path))
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        paths = list(
+            pool.map(
+                lambda _index: playwright_evidence._evidence_context_dir(
+                    "test_same_node",
+                    1,
+                ),
+                range(32),
+            )
+        )
+
+    assert all(path is not None and path.is_dir() for path in paths)
+    assert len({path.name for path in paths if path is not None}) == 32
+
+
+def _zip_bytes(members: dict[str, bytes]) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, payload in members.items():
+            archive.writestr(name, payload)
+    return output.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("limits", "payload", "message"),
+    [
+        (
+            {"MAX_TRACE_ARCHIVE_BYTES": 1},
+            _zip_bytes({"trace.trace": b"x"}),
+            "top-level size limit",
+        ),
+        (
+            {"MAX_TRACE_MEMBER_BYTES": 8},
+            _zip_bytes({"trace.trace": b"x" * 9}),
+            "member exceeds limit",
+        ),
+        (
+            {"MAX_TRACE_MEMBERS": 2},
+            _zip_bytes({"a": b"1", "b": b"2", "c": b"3"}),
+            "member count exceeds limit",
+        ),
+        (
+            {"MAX_TRACE_EXPANDED_BYTES": 5},
+            _zip_bytes({"a": b"123", "b": b"456"}),
+            "expanded bytes exceed limit",
+        ),
+        (
+            {"MAX_TRACE_ARCHIVE_DEPTH": 1},
+            _zip_bytes({"nested.zip": _zip_bytes({"trace.trace": b"nested"})}),
+            "nesting exceeds limit",
+        ),
+    ],
+)
+def test_trace_sanitization_rejects_bounded_archive_limits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    limits: dict[str, int],
+    payload: bytes,
+    message: str,
+) -> None:
+    trace = tmp_path / "trace.zip"
+    trace.write_bytes(payload)
+    for name, value in limits.items():
+        monkeypatch.setattr(playwright_evidence, name, value)
+
+    with pytest.raises(ValueError, match=message):
+        playwright_evidence._sanitize_trace_archive(trace)
+
+    assert trace.read_bytes() == payload
+    assert not list(tmp_path.glob(".trace.zip.*.tmp"))

--- a/tests/verify_omnigent/test_universe_preflight.py
+++ b/tests/verify_omnigent/test_universe_preflight.py
@@ -1,0 +1,469 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HELPER = (
+    _REPO_ROOT / ".agents" / "skills" / "verify-omnigent" / "scripts" / "universe_preflight.py"
+)
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load_helper() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("verify_universe_preflight", _HELPER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    previous = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.dont_write_bytecode = previous
+    return module
+
+
+def test_pin_mismatch_records_not_synced_without_runtime_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    pins = json.loads((_FIXTURES / "pin_mismatch.json").read_text(encoding="utf-8"))
+    universe = tmp_path / "universe"
+    sync = universe / "agentbricks" / "mas" / "third_party" / "sync"
+    (sync / "local-patches").mkdir(parents=True)
+    (sync / "UPSTREAM_REF").write_text(pins["vendored"], encoding="utf-8")
+    (sync / "UI_UPSTREAM_REF").write_text(pins["vendored"], encoding="utf-8")
+
+    monkeypatch.setattr(
+        helper,
+        "_resolve_commit",
+        lambda _root, _ref: (pins["requested"], None),
+    )
+    monkeypatch.setattr(
+        helper,
+        "_changed_files",
+        lambda *_args: (["omnigent/server/app.py"], None),
+    )
+    monkeypatch.setattr(helper, "_merge_base", lambda *_args: (pins["requested"], None))
+    monkeypatch.setattr(helper, "_git_status_digest", lambda _root: ("stable", None))
+    monkeypatch.setattr(helper, "_dirty_paths", lambda *_args, **_kwargs: ([], None))
+    monkeypatch.setattr(
+        helper,
+        "_run_bazel_test",
+        lambda _root, target, _output, _system: {
+            "target": target,
+            "status": "passed",
+            "tests": 1,
+            "failures": 0,
+            "errors": 0,
+        },
+    )
+
+    report, exit_status = helper.run_preflight(
+        _REPO_ROOT,
+        tmp_path / "run",
+        "requested",
+        "base",
+        str(universe),
+        "Linux",
+    )
+
+    assert exit_status != 0
+    assert report["status"] == "not_synced"
+    assert report["sync"]["status"] == "not_synced"
+    assert report["runtime_compatibility"]["status"] == "not_synced"
+    assert not any(
+        isinstance(target, dict) and target.get("status") == "passed"
+        for target in report["runtime_compatibility"]["targets"]
+    )
+
+
+def test_dirty_oss_product_change_blocks_universe_proof(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    monkeypatch.setattr(
+        helper,
+        "_dirty_paths",
+        lambda root, **_kwargs: (["web/src/dirty.ts"], None) if root == tmp_path else ([], None),
+    )
+
+    report, exit_status = helper.run_preflight(
+        tmp_path,
+        tmp_path / "run",
+        "HEAD",
+        "HEAD",
+        None,
+        "Linux",
+    )
+
+    assert exit_status != 0
+    assert "tracked or non-ignored untracked" in " ".join(report["limitations"])
+
+
+def test_dirty_universe_checkout_blocks_before_bazel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    oss = tmp_path / "oss"
+    universe = tmp_path / "universe"
+    sync = universe / "agentbricks/mas/third_party/sync"
+    sync.mkdir(parents=True)
+    (sync / "UPSTREAM_REF").write_text("a" * 40, encoding="utf-8")
+    monkeypatch.setattr(helper, "_resolve_commit", lambda *_args: ("a" * 40, None))
+    monkeypatch.setattr(helper, "_merge_base", lambda *_args: ("a" * 40, None))
+    monkeypatch.setattr(
+        helper,
+        "_dirty_paths",
+        lambda root, **_kwargs: (
+            (["agentbricks/mas/dirty.py"], None) if root == universe else ([], None)
+        ),
+    )
+
+    report, exit_status = helper.run_preflight(
+        oss,
+        tmp_path / "run",
+        "HEAD",
+        "HEAD",
+        str(universe),
+        "Linux",
+    )
+
+    assert exit_status != 0
+    assert report["status"] == "unavailable"
+    assert "non-ignored untracked" in " ".join(report["limitations"])
+
+
+@pytest.mark.parametrize("relative", [".bazelrc", "agentbricks/mas/new_source.py"])
+def test_untracked_universe_inputs_are_dirty(tmp_path: Path, relative: str) -> None:
+    helper = _load_helper()
+    repo = tmp_path / "universe"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("fixture\n", encoding="utf-8")
+
+    dirty, error = helper._dirty_paths(repo, include_untracked=True)
+
+    assert error is None
+    assert relative in dirty
+
+
+def test_ignored_universe_output_is_not_dirty(tmp_path: Path) -> None:
+    helper = _load_helper()
+    repo = tmp_path / "universe"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    (repo / ".gitignore").write_text("bazel-out/\n", encoding="utf-8")
+    subprocess.run(["git", "add", ".gitignore"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=fixture@example.com",
+            "commit",
+            "-qm",
+            "base",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    output = repo / "bazel-out/generated.txt"
+    output.parent.mkdir()
+    output.write_text("generated\n", encoding="utf-8")
+
+    dirty, error = helper._dirty_paths(repo, include_untracked=True)
+
+    assert error is None
+    assert dirty == []
+
+
+@pytest.mark.parametrize(
+    ("changed", "expected"),
+    [
+        (["omnigent/server/app.py"], ["python"]),
+        (["web/src/App.tsx"], ["ui"]),
+        (["omnigent/server/app.py", "web/src/App.tsx"], ["python", "ui"]),
+        (["deploy/databricks/deploy.py"], []),
+    ],
+)
+def test_changed_surfaces_select_their_universe_pins(
+    changed: list[str],
+    expected: list[str],
+) -> None:
+    helper = _load_helper()
+
+    assert helper._required_sync_pins(changed) == expected
+
+
+def test_verification_or_deploy_only_diff_is_not_applicable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = _load_helper()
+    pins = "a" * 40
+    universe = tmp_path / "universe"
+    sync = universe / "agentbricks" / "mas" / "third_party" / "sync"
+    (sync / "local-patches").mkdir(parents=True)
+    (sync / "UPSTREAM_REF").write_text(pins, encoding="utf-8")
+    monkeypatch.setattr(helper, "_resolve_commit", lambda *_args: (pins, None))
+    monkeypatch.setattr(helper, "_merge_base", lambda *_args: (pins, None))
+    monkeypatch.setattr(
+        helper,
+        "_changed_files",
+        lambda *_args: (["deploy/databricks/deploy.py"], None),
+    )
+    monkeypatch.setattr(helper, "_dirty_paths", lambda *_args, **_kwargs: ([], None))
+
+    def reject_bazel(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise AssertionError("Bazel must not run")
+
+    monkeypatch.setattr(helper, "_run_bazel_test", reject_bazel)
+
+    report, status = helper.run_preflight(
+        tmp_path / "oss",
+        tmp_path / "run",
+        "HEAD",
+        "HEAD",
+        str(universe),
+        "Linux",
+    )
+
+    assert status == 0
+    assert report["status"] == "not_applicable"
+    assert report["sync"]["required_pins"] == []
+    assert report["runtime_compatibility"]["status"] == "not_applicable"
+
+
+def test_passing_bazel_xml_requires_positive_test_count() -> None:
+    helper = _load_helper()
+    result = helper.parse_bazel_test_result(
+        exit_status=0,
+        xml_path=_FIXTURES / "bazel_passing.xml",
+        output="PASSED",
+        system="Linux",
+    )
+
+    assert result["status"] == "passed"
+    assert result["tests"] == 2
+    assert result["failures"] == 0
+    assert result["errors"] == 0
+
+
+def test_all_skipped_bazel_xml_fails() -> None:
+    helper = _load_helper()
+
+    result = helper.parse_bazel_test_result(
+        exit_status=0,
+        xml_path=_FIXTURES / "bazel_all_skipped.xml",
+        output="PASSED",
+        system="Linux",
+    )
+
+    assert result["status"] == "failed"
+    assert result["skipped"] == 2
+    assert result["reason"] == "test.xml recorded no non-skipped tests."
+
+
+def test_diverged_ref_change_discovery_uses_merge_base(tmp_path: Path) -> None:
+    helper = _load_helper()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    _commit = [
+        "git",
+        "-c",
+        "user.name=Fixture",
+        "-c",
+        "user.email=fixture@example.com",
+        "commit",
+        "-qm",
+    ]
+    subprocess.run([*_commit, "base"], cwd=repo, check=True)
+    subprocess.run(["git", "switch", "-q", "-c", "requested"], cwd=repo, check=True)
+    (repo / "requested.py").write_text("requested\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run([*_commit, "requested"], cwd=repo, check=True)
+    requested = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(["git", "switch", "-q", "main"], cwd=repo, check=True)
+    (repo / "base-only.py").write_text("base only\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run([*_commit, "base-only"], cwd=repo, check=True)
+    main = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    merge_base, error = helper._merge_base(repo, main, requested)
+    assert error is None and merge_base is not None
+    changed, error = helper._changed_files(repo, merge_base, requested)
+
+    assert error is None
+    assert changed == ["requested.py"]
+
+
+def test_universe_change_discovery_preserves_special_filenames(tmp_path: Path) -> None:
+    helper = _load_helper()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=fixture@example.com",
+            "commit",
+            "-qm",
+            "base",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    special = 'web/src/line\nbreak\tquote"\\name.ts'
+    path = repo / special
+    path.parent.mkdir(parents=True)
+    path.write_text("changed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=fixture@example.com",
+            "commit",
+            "-qm",
+            "change",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    files, error = helper._changed_files(repo, base, head, "web")
+
+    assert error is None
+    assert files == [special]
+
+
+def test_zero_test_jemalloc_failure_is_a_darwin_blocker(tmp_path: Path) -> None:
+    helper = _load_helper()
+    output = (_FIXTURES / "bazel_zero_test_jemalloc.log").read_text(encoding="utf-8")
+
+    result = helper.parse_bazel_test_result(
+        exit_status=1,
+        xml_path=tmp_path / "missing.xml",
+        output=output,
+        system="Darwin",
+    )
+
+    assert result["status"] == "blocked"
+    assert result["tests"] == 0
+    assert result["blocker"] == "darwin_jemalloc_features_h"
+    assert "zero tests" in result["reason"]
+
+
+def test_psutil_collection_error_is_a_darwin_blocker() -> None:
+    helper = _load_helper()
+    result = helper.parse_bazel_test_result(
+        exit_status=1,
+        xml_path=_FIXTURES / "bazel_psutil_error.xml",
+        output="",
+        system="Darwin",
+    )
+
+    assert result["status"] == "blocked"
+    assert result["tests"] == 1
+    assert result["errors"] == 1
+    assert result["blocker"] == "darwin_psutil_extension"
+
+
+def test_patch_apply_check_uses_temporary_tree(tmp_path: Path) -> None:
+    helper = _load_helper()
+    repo = tmp_path / "oss"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    source = repo / "omnigent" / "host" / "connect.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("value = 'upstream'\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=fixture@example.com",
+            "commit",
+            "-qm",
+            "fixture",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    patches_root = tmp_path / "patches"
+    patch = patches_root / "omnigent" / "host" / "connect.py.patch"
+    patch.parent.mkdir(parents=True)
+    patch.write_text(
+        """\
+diff --git a/omnigent/host/connect.py b/omnigent/host/connect.py
+--- a/omnigent/host/connect.py
++++ b/omnigent/host/connect.py
+@@ -1 +1 @@
+-value = 'upstream'
++value = 'downstream'
+""",
+        encoding="utf-8",
+    )
+
+    result = helper.check_patch_apply(repo, commit, [patch], patches_root)
+
+    assert result["status"] == "passed"
+    assert source.read_text(encoding="utf-8") == "value = 'upstream'\n"

--- a/tests/verify_omnigent/test_verify_script.py
+++ b/tests/verify_omnigent/test_verify_script.py
@@ -1,0 +1,1322 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import json
+import os
+import shutil
+import signal
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SKILL_ROOT = _REPO_ROOT / ".agents" / "skills" / "verify-omnigent"
+
+
+def _stage_repo(tmp_path: Path, backend_body: str) -> tuple[Path, Path]:
+    root = tmp_path / "repo"
+    scripts = root / ".agents" / "skills" / "verify-omnigent" / "scripts"
+    features = scripts.parent / "features"
+    backend = root / "scripts" / "backend-smoke.sh"
+    scripts.mkdir(parents=True)
+    features.mkdir()
+    backend.parent.mkdir()
+    shutil.copy2(_SKILL_ROOT / "scripts" / "verify.sh", scripts / "verify.sh")
+    shutil.copy2(
+        _SKILL_ROOT / "scripts" / "evidence_manifest.py",
+        scripts / "evidence_manifest.py",
+    )
+    shutil.copy2(
+        _SKILL_ROOT / "scripts" / "orchestration.py",
+        scripts / "orchestration.py",
+    )
+    shutil.copy2(
+        _SKILL_ROOT / "scripts" / "profile_runner.py",
+        scripts / "profile_runner.py",
+    )
+    shutil.copy2(
+        _SKILL_ROOT / "scripts" / "universe_preflight.py",
+        scripts / "universe_preflight.py",
+    )
+    shutil.copy2(
+        _SKILL_ROOT / "scripts" / "comparison.py",
+        scripts / "comparison.py",
+    )
+    shutil.copy2(
+        _SKILL_ROOT / "scripts" / "runtime_support.py",
+        scripts / "runtime_support.py",
+    )
+    for name in ("README.md", "approvals-and-policies.md", "harnesses-and-clients.md"):
+        (features / name).write_text("# contract\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text("[project]\nname='fixture'\n", encoding="utf-8")
+    backend.write_text(
+        f"#!/usr/bin/env bash\nset -euo pipefail\n{backend_body}\n",
+        encoding="utf-8",
+    )
+    (scripts / "verify.sh").chmod(0o755)
+    (scripts / "evidence_manifest.py").chmod(0o755)
+    (scripts / "orchestration.py").chmod(0o755)
+    (scripts / "profile_runner.py").chmod(0o755)
+    (scripts / "universe_preflight.py").chmod(0o755)
+    (scripts / "comparison.py").chmod(0o755)
+    (scripts / "runtime_support.py").chmod(0o755)
+    backend.chmod(0o755)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=fixture@example.com",
+            "commit",
+            "-qm",
+            "fixture",
+        ],
+        cwd=root,
+        check=True,
+    )
+    return root, scripts / "verify.sh"
+
+
+def _run(
+    root: Path,
+    script: Path,
+    evidence_root: Path,
+    *args: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "OMNIGENT_VERIFY_ADAPTER": "codex",
+        "OMNIGENT_VERIFY_EVIDENCE_DIR": str(evidence_root),
+        **(extra_env or {}),
+    }
+    return subprocess.run(
+        [str(script), *args],
+        cwd=root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=90,
+    )
+
+
+def _only_manifest(evidence_root: Path) -> dict[str, Any]:
+    manifests = list(evidence_root.glob("*/manifest.json"))
+    assert len(manifests) == 1
+    value = json.loads(manifests[0].read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return cast("dict[str, Any]", value)
+
+
+def test_verify_script_finalizes_passing_and_failing_runs(tmp_path: Path) -> None:
+    passing_root, passing_script = _stage_repo(tmp_path / "passing", 'echo "backend passed"')
+    passing_evidence = tmp_path / "passing-evidence"
+    passed = _run(passing_root, passing_script, passing_evidence, "backend")
+    assert passed.returncode == 0, passed.stderr
+    passed_manifest = _only_manifest(passing_evidence)
+    assert passed_manifest["status"] == "passed"
+    assert passed_manifest["exit_status"] == 0
+    assert passed_manifest["adapter"]["identity"] == "codex"
+    assert passed_manifest["run"]["command_argv"][0] == "env"
+    assert passed_manifest["run"]["command_argv"][1].startswith("PORT=")
+    assert passed_manifest["run"]["command_argv"][2:] == ["scripts/backend-smoke.sh"]
+    assert "OMNIGENT_VERIFY_SUMMARY schema=1 status=passed" in passed.stdout
+
+    failing_root, failing_script = _stage_repo(tmp_path / "failing", 'echo "nope"; exit 7')
+    failing_evidence = tmp_path / "failing-evidence"
+    failed = _run(failing_root, failing_script, failing_evidence, "backend")
+    assert failed.returncode == 7
+    failed_manifest = _only_manifest(failing_evidence)
+    assert failed_manifest["status"] == "failed"
+    assert failed_manifest["exit_status"] == 7
+    assert "OMNIGENT_VERIFY_SUMMARY schema=1 status=failed" in failed.stdout
+
+
+def test_manifest_finalize_failure_forces_nonzero_and_never_claims_passed(
+    tmp_path: Path,
+) -> None:
+    root, script = _stage_repo(tmp_path, 'echo "backend passed"')
+    helper = script.parent / "evidence_manifest.py"
+    real_helper = helper.with_name("evidence_manifest_real.py")
+    helper.rename(real_helper)
+    helper.write_text(
+        """#!/usr/bin/env python3
+import os
+import sys
+
+if sys.argv[1:2] == ["finalize"]:
+    raise SystemExit(9)
+os.execv(
+    sys.executable,
+    [
+        sys.executable,
+        os.path.join(os.path.dirname(__file__), "evidence_manifest_real.py"),
+        *sys.argv[1:],
+    ],
+)
+""",
+        encoding="utf-8",
+    )
+
+    result = _run(root, script, tmp_path / "evidence", "backend")
+
+    assert result.returncode != 0
+    assert "failed to finalize manifest" in result.stderr
+    assert "status=passed" not in result.stdout
+
+
+def test_installed_skill_resolves_invocation_checkout_for_link_and_copy(
+    tmp_path: Path,
+) -> None:
+    canonical_root, canonical_script = _stage_repo(
+        tmp_path / "canonical",
+        'echo "canonical backend"',
+    )
+    target_root, _ = _stage_repo(tmp_path / "target", 'echo "target backend"')
+    installed_root = tmp_path / "installed"
+    installed_root.mkdir()
+    linked = installed_root / "linked"
+    linked.symlink_to(canonical_script.parent.parent, target_is_directory=True)
+    copied = installed_root / "copied"
+    shutil.copytree(canonical_script.parent.parent, copied)
+
+    for name, installed in (("linked", linked), ("copied", copied)):
+        env = {
+            key: value for key, value in os.environ.items() if key != "OMNIGENT_VERIFY_REPO_ROOT"
+        }
+        env.update(
+            {
+                "OMNIGENT_VERIFY_ADAPTER": "codex",
+                "OMNIGENT_VERIFY_EVIDENCE_DIR": str(tmp_path / f"{name}-evidence"),
+            }
+        )
+        result = subprocess.run(
+            [str(installed / "scripts/verify.sh"), "backend"],
+            cwd=target_root,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=20,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "target backend" in result.stdout
+        assert "canonical backend" not in result.stdout
+
+    assert canonical_root != target_root
+
+
+def test_verify_script_doctor_writes_manifest(tmp_path: Path) -> None:
+    root, script = _stage_repo(tmp_path, 'echo "unused"')
+    evidence_root = tmp_path / "evidence"
+    result = _run(root, script, evidence_root, "doctor", "backend")
+    assert result.returncode == 0, result.stderr
+    manifest = _only_manifest(evidence_root)
+    assert manifest["status"] == "passed"
+    assert manifest["run"]["phase"] == "finished"
+    assert manifest["run"]["command_argv"] == ["doctor", "backend"]
+    assert manifest["cleanup"]["status"] == "not_applicable"
+
+
+def test_direct_profile_receives_only_strict_run_environment(tmp_path: Path) -> None:
+    body = """python3 - <<'PY'
+import json
+import os
+import zipfile
+from pathlib import Path
+
+keys = [
+    "HOME",
+    "PRE_COMMIT_HOME",
+    "PLAYWRIGHT_BROWSERS_PATH",
+    "AWS_SECRET_ACCESS_KEY",
+    "TEST_SECRET",
+]
+Path(os.environ["OMNIGENT_VERIFY_RUN_DIR"], "child-env.json").write_text(
+    json.dumps({key: os.environ.get(key) for key in keys}),
+    encoding="utf-8",
+)
+PY"""
+    root, script = _stage_repo(tmp_path, body)
+    evidence_root = tmp_path / "evidence"
+    result = _run(
+        root,
+        script,
+        evidence_root,
+        "backend",
+        extra_env={
+            "AWS_SECRET_ACCESS_KEY": "must-not-leak",
+            "TEST_SECRET": "must-not-leak",
+            "PRE_COMMIT_HOME": "/real/pre-commit",
+            "PLAYWRIGHT_BROWSERS_PATH": "/real/playwright",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    run_dir = next(evidence_root.iterdir())
+    child_env = json.loads((run_dir / "child-env.json").read_text(encoding="utf-8"))
+    assert not Path(child_env["HOME"]).is_relative_to(run_dir)
+    assert not Path(child_env["PRE_COMMIT_HOME"]).is_relative_to(run_dir)
+    assert "omnigent-verify-runtime." in child_env["HOME"]
+    assert not Path(child_env["HOME"]).exists()
+    assert child_env["PLAYWRIGHT_BROWSERS_PATH"] != "/real/playwright"
+    assert (
+        child_env["PLAYWRIGHT_BROWSERS_PATH"] is None
+        or Path(child_env["PLAYWRIGHT_BROWSERS_PATH"]).is_dir()
+    )
+    assert child_env["AWS_SECRET_ACCESS_KEY"] is None
+    assert child_env["TEST_SECRET"] is None
+
+
+@pytest.mark.parametrize(
+    "profile",
+    ["smoke", "collaboration", "automations", "core", "full-ui"],
+)
+def test_direct_ui_profiles_receive_run_owned_web_dist(
+    tmp_path: Path,
+    profile: str,
+) -> None:
+    root, script = _stage_repo(tmp_path, "exit 2")
+    script.write_text(
+        script.read_text(encoding="utf-8").replace('doctor "$profile"', "true", 1),
+        encoding="utf-8",
+    )
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_uv = bin_dir / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import hashlib
+import binascii
+import json
+import os
+import struct
+import zipfile
+import zlib
+from pathlib import Path
+
+run = Path(os.environ["OMNIGENT_VERIFY_RUN_DIR"])
+dist = Path(os.environ["OMNIGENT_WEB_UI_DIST"])
+(run / "ui-env.json").write_text(json.dumps({"dist": str(dist)}), encoding="utf-8")
+nodeid = "tests/e2e_ui/test_fixture.py::test_case[param-one]"
+identity = hashlib.sha256(nodeid.encode()).hexdigest()
+context = run / "playwright" / f"test-{identity[:20]}" / "context-1"
+context.mkdir(parents=True)
+(context / "metadata.json").write_text(json.dumps({
+    "schema_version": 1,
+    "nodeid": nodeid,
+    "nodeid_sha256": identity,
+    "context_style": "managed-sync",
+    "lifecycle": "closed",
+    "events": [],
+}), encoding="utf-8")
+def png_chunk(kind, payload):
+    return (
+        struct.pack(">I", len(payload)) + kind + payload
+        + struct.pack(">I", binascii.crc32(kind + payload) & 0xffffffff)
+    )
+(context / "screenshot.png").write_bytes(
+    b"\\x89PNG\\r\\n\\x1a\\n"
+    + png_chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0))
+    + png_chunk(b"IDAT", zlib.compress(b"\\0\\0\\0\\0\\xff"))
+    + png_chunk(b"IEND", b"")
+)
+with zipfile.ZipFile(context / "trace.zip", "w") as archive:
+    archive.writestr("trace.trace", '{"type":"fixture"}\\n')
+(run / "junit.xml").write_text(
+    "<testsuite tests='1'><testcase name='test_case[param-one]'><properties>"
+    f"<property name='omnigent_nodeid_sha256' value='{identity}'/>"
+    "<property name='omnigent_browser_context_count' value='1'/>"
+    "</properties></testcase></testsuite>",
+    encoding="utf-8",
+)
+(run / "cleanup.json").write_text(
+    '{"schema_version":1,"status":"completed"}',
+    encoding="utf-8",
+)
+""",
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+    evidence = tmp_path / "external-evidence"
+
+    result = _run(
+        root,
+        script,
+        evidence,
+        profile,
+        extra_env={"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    run_dir = next(evidence.iterdir())
+    child = json.loads((run_dir / "ui-env.json").read_text(encoding="utf-8"))
+    assert child["dist"] == str(run_dir / "build/e2e-web-ui")
+    if profile == "collaboration":
+        manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+        assert set(manifest["run"]["selected_tests"]) == {
+            "tests/e2e_ui/collaboration/test_permissions_modal.py",
+            "tests/e2e_ui/collaboration/test_sharing_journey.py",
+            "tests/e2e_ui/collaboration/test_sharing_mode_off.py",
+            "tests/e2e_ui/collaboration/test_collab_realtime.py",
+            "tests/e2e_ui/collaboration/test_author_label.py",
+        }
+
+
+def test_source_mutation_forces_failed_manifest_and_nonzero_exit(tmp_path: Path) -> None:
+    root, script = _stage_repo(
+        tmp_path,
+        "printf 'mutated\\n' >> pyproject.toml",
+    )
+    evidence_root = tmp_path / "evidence"
+
+    result = _run(root, script, evidence_root, "backend")
+
+    assert result.returncode != 0
+    manifest = _only_manifest(evidence_root)
+    assert manifest["status"] == "failed"
+    assert manifest["repository"]["unchanged"] is False
+    assert "Repository mutation invariant failed" in " ".join(manifest["limitations"])
+
+
+def test_deleted_active_manifest_is_restored_and_fails_closed(tmp_path: Path) -> None:
+    root, script = _stage_repo(
+        tmp_path,
+        'rm -f "$OMNIGENT_VERIFY_RUN_DIR/manifest.json"',
+    )
+    evidence = tmp_path / "evidence"
+
+    result = _run(root, script, evidence, "backend")
+
+    assert result.returncode != 0
+    manifest = _only_manifest(evidence)
+    assert manifest["status"] == "failed"
+    assert "manifest was modified by a managed child" in result.stdout
+
+
+def test_regenerated_exposed_snapshot_cannot_hide_source_mutation(tmp_path: Path) -> None:
+    body = """printf 'mutated\\n' >> pyproject.toml
+python3 .agents/skills/verify-omnigent/scripts/runtime_support.py snapshot \
+  --repo-root . \
+  --output "$OMNIGENT_VERIFY_RUN_DIR/repository-before.json"
+"""
+    root, script = _stage_repo(tmp_path, body)
+    evidence = tmp_path / "evidence"
+
+    result = _run(root, script, evidence, "backend")
+
+    assert result.returncode != 0
+    manifest = _only_manifest(evidence)
+    assert manifest["status"] == "failed"
+    assert manifest["repository"]["unchanged"] is False
+
+
+def test_git_ref_creation_fails_repository_invariant(tmp_path: Path) -> None:
+    root, script = _stage_repo(tmp_path, "git tag verifier-leaked-ref")
+    evidence = tmp_path / "evidence"
+    try:
+        result = _run(root, script, evidence, "backend")
+
+        assert result.returncode != 0
+        manifest = _only_manifest(evidence)
+        assert manifest["status"] == "failed"
+        assert manifest["repository"]["unchanged"] is False
+        assert "verifier-leaked-ref" in _git(root, "tag", "--list")
+    finally:
+        subprocess.run(
+            ["git", "tag", "-d", "verifier-leaked-ref"],
+            cwd=root,
+            check=False,
+            capture_output=True,
+        )
+
+
+def test_tracked_symlink_escaping_checkout_blocks_before_execution(
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path / "outside.txt"
+    outside.write_text("original\n", encoding="utf-8")
+    root, script = _stage_repo(
+        tmp_path / "fixture",
+        'printf "changed\\n" > escaped.txt',
+    )
+    escaped = root / "escaped.txt"
+    escaped.symlink_to(outside)
+    subprocess.run(["git", "add", "escaped.txt"], cwd=root, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=fixture@example.com",
+            "commit",
+            "-qm",
+            "tracked external symlink",
+        ],
+        cwd=root,
+        check=True,
+    )
+
+    result = _run(root, script, tmp_path / "evidence", "backend")
+
+    assert result.returncode != 0
+    assert outside.read_text(encoding="utf-8") == "original\n"
+    run_dir = next((tmp_path / "evidence").iterdir())
+    assert "escapes the checkout" in (run_dir / "run.log").read_text(encoding="utf-8")
+
+
+def test_verify_script_can_target_clean_external_checkout(tmp_path: Path) -> None:
+    _, script = _stage_repo(tmp_path / "canonical", 'echo "wrong checkout"; exit 9')
+    target = tmp_path / "target"
+    backend = target / "scripts" / "backend-smoke.sh"
+    backend.parent.mkdir(parents=True)
+    (target / "pyproject.toml").write_text(
+        "[project]\nname='external-fixture'\n",
+        encoding="utf-8",
+    )
+    backend.write_text(
+        '#!/usr/bin/env bash\nset -euo pipefail\necho "external checkout passed"\n',
+        encoding="utf-8",
+    )
+    backend.chmod(0o755)
+    subprocess.run(["git", "init", "-q"], cwd=target, check=True)
+    subprocess.run(["git", "add", "."], cwd=target, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=fixture@example.com",
+            "commit",
+            "-qm",
+            "fixture",
+        ],
+        cwd=target,
+        check=True,
+    )
+    evidence_root = tmp_path / "evidence"
+
+    result = _run(
+        target,
+        script,
+        evidence_root,
+        "backend",
+        extra_env={"OMNIGENT_VERIFY_REPO_ROOT": str(target)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "external checkout passed" in result.stdout
+    manifest = _only_manifest(evidence_root)
+    assert manifest["status"] == "passed"
+    assert manifest["repository"]["dirty"] is False
+
+
+def test_doctor_fails_closed_with_exact_missing_prerequisite(
+    tmp_path: Path,
+) -> None:
+    root, script = _stage_repo(tmp_path, 'echo "unused"')
+    (root / "scripts" / "backend-smoke.sh").unlink()
+    evidence_root = tmp_path / "evidence"
+
+    result = _run(root, script, evidence_root, "doctor", "backend")
+
+    assert result.returncode != 0
+    assert "missing file scripts/backend-smoke.sh" in result.stdout
+    manifest = _only_manifest(evidence_root)
+    assert manifest["status"] == "blocked"
+    assert manifest["exit_status"] != 0
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "OMNIGENT_VERIFY_PARTIAL_COMPARISON",
+        "OMNIGENT_VERIFY_ONLY_STEP_INDICES",
+        "OMNIGENT_VERIFY_CHANGED_FILES_JSON",
+        "OMNIGENT_VERIFY_DISABLE_BASELINE",
+    ],
+)
+def test_caller_supplied_internal_controls_are_rejected(
+    tmp_path: Path,
+    name: str,
+) -> None:
+    root, script = _stage_repo(tmp_path, 'echo "must not run"; exit 99')
+    evidence_root = tmp_path / "evidence"
+
+    result = _run(
+        root,
+        script,
+        evidence_root,
+        "backend",
+        extra_env={name: "1"},
+    )
+
+    assert result.returncode == 2
+    assert f"caller-supplied internal control {name} is forbidden" in result.stderr
+    assert not list(evidence_root.glob("*/manifest.json"))
+
+
+@pytest.mark.parametrize(
+    ("signum", "signal_name", "exit_status"),
+    [
+        (signal.SIGINT, "INT", 130),
+        (signal.SIGTERM, "TERM", 143),
+        (signal.SIGHUP, "HUP", 129),
+    ],
+)
+def test_verify_script_finalizes_interrupted_run(
+    tmp_path: Path,
+    signum: int,
+    signal_name: str,
+    exit_status: int,
+) -> None:
+    ready = tmp_path / "ready"
+    backend_body = f"""python3 - {str(ready)!r} <<'PY' &
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+for value in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+    signal.signal(value, signal.SIG_IGN)
+Path(sys.argv[1]).write_text(str(os.getpid()), encoding="utf-8")
+time.sleep(60)
+PY
+wait"""
+    root, script = _stage_repo(
+        tmp_path,
+        backend_body,
+    )
+    evidence_root = tmp_path / "evidence"
+    env = {
+        **os.environ,
+        "OMNIGENT_VERIFY_ADAPTER": "claude-code",
+        "OMNIGENT_VERIFY_EVIDENCE_DIR": str(evidence_root),
+    }
+    process = subprocess.Popen(
+        [str(script), "backend"],
+        cwd=root,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    deadline = time.monotonic() + 10
+    while not ready.exists() and time.monotonic() < deadline:
+        time.sleep(0.05)
+    if not ready.exists():
+        process.kill()
+        pytest.fail("fake backend did not start")
+    process.send_signal(signum)
+    stdout, stderr = process.communicate(timeout=10)
+
+    assert process.returncode == exit_status, stderr
+    manifest = _only_manifest(evidence_root)
+    assert manifest["status"] == "interrupted"
+    assert manifest["signal"] == signal_name
+    assert manifest["exit_status"] == exit_status
+    assert "OMNIGENT_VERIFY_SUMMARY schema=1 status=interrupted" in stdout
+    descendant_pid = int(ready.read_text(encoding="utf-8"))
+    with pytest.raises(ProcessLookupError):
+        os.kill(descendant_pid, 0)
+
+
+@pytest.mark.parametrize(
+    ("signum", "signal_name", "exit_status"),
+    [
+        (signal.SIGINT, "INT", 130),
+        (signal.SIGTERM, "TERM", 143),
+        (signal.SIGHUP, "HUP", 129),
+    ],
+)
+def test_verify_kills_signal_ignoring_descendant_in_escaped_session(
+    tmp_path: Path,
+    signum: int,
+    signal_name: str,
+    exit_status: int,
+) -> None:
+    ready = tmp_path / "escaped-ready"
+    backend_body = f"""python3 - {str(ready)!r} <<'PY'
+import subprocess
+import sys
+from pathlib import Path
+
+code = '''import signal
+import time
+for value in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+    signal.signal(value, signal.SIG_IGN)
+time.sleep(60)
+'''
+child = subprocess.Popen([sys.executable, "-c", code], start_new_session=True)
+Path(sys.argv[1]).write_text(str(child.pid), encoding="utf-8")
+child.wait()
+PY"""
+    root, script = _stage_repo(tmp_path, backend_body)
+    evidence_root = tmp_path / "evidence"
+    process = subprocess.Popen(
+        [str(script), "backend"],
+        cwd=root,
+        env={
+            **os.environ,
+            "OMNIGENT_VERIFY_ADAPTER": "claude-code",
+            "OMNIGENT_VERIFY_EVIDENCE_DIR": str(evidence_root),
+        },
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    descendant_pid: int | None = None
+    try:
+        deadline = time.monotonic() + 10
+        while not ready.exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        if not ready.exists():
+            pytest.fail("escaped descendant did not start")
+        descendant_pid = int(ready.read_text(encoding="utf-8"))
+        time.sleep(0.25)
+        process.send_signal(signum)
+        stdout, stderr = process.communicate(timeout=12)
+
+        assert process.returncode == exit_status, stderr
+        manifest = _only_manifest(evidence_root)
+        assert manifest["status"] == "interrupted"
+        assert manifest["signal"] == signal_name
+        assert "OMNIGENT_VERIFY_SUMMARY schema=1 status=interrupted" in stdout
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            try:
+                os.kill(descendant_pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail(f"escaped descendant {descendant_pid} survived")
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+        if descendant_pid is not None:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(descendant_pid, signal.SIGKILL)
+
+
+@pytest.mark.parametrize(
+    ("signum", "signal_name", "exit_status"),
+    [
+        (signal.SIGINT, "INT", 130),
+        (signal.SIGTERM, "TERM", 143),
+        (signal.SIGHUP, "HUP", 129),
+    ],
+)
+def test_verify_kills_fast_double_forked_session(
+    tmp_path: Path,
+    signum: int,
+    signal_name: str,
+    exit_status: int,
+) -> None:
+    ready = tmp_path / "double-fork-ready"
+    backend_body = f"""python3 - {str(ready)!r} <<'PY'
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+first = os.fork()
+if first == 0:
+    os.setsid()
+    second = os.fork()
+    if second > 0:
+        os._exit(0)
+    for value in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+        signal.signal(value, signal.SIG_IGN)
+    Path(sys.argv[1]).write_text(str(os.getpid()), encoding="utf-8")
+    time.sleep(60)
+    os._exit(0)
+time.sleep(60)
+PY"""
+    root, script = _stage_repo(tmp_path, backend_body)
+    evidence_root = tmp_path / "evidence"
+    process = subprocess.Popen(
+        [str(script), "backend"],
+        cwd=root,
+        env={
+            **os.environ,
+            "OMNIGENT_VERIFY_ADAPTER": "claude-code",
+            "OMNIGENT_VERIFY_EVIDENCE_DIR": str(evidence_root),
+        },
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    descendant_pid: int | None = None
+    try:
+        deadline = time.monotonic() + 10
+        while not ready.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert ready.exists()
+        descendant_pid = int(ready.read_text(encoding="utf-8"))
+        process.send_signal(signum)
+        stdout, stderr = process.communicate(timeout=12)
+        assert process.returncode == exit_status, stderr
+        manifest = _only_manifest(evidence_root)
+        assert manifest["status"] == "interrupted"
+        assert manifest["signal"] == signal_name
+        assert "status=interrupted" in stdout
+        with pytest.raises(ProcessLookupError):
+            os.kill(descendant_pid, 0)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+        if descendant_pid is not None:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(descendant_pid, signal.SIGKILL)
+
+
+def test_codex_installer_supports_host_and_bundle_sources(tmp_path: Path) -> None:
+    installer = _SKILL_ROOT / "scripts" / "install-codex.sh"
+    host_skills = tmp_path / "home" / ".codex" / "skills"
+    host = subprocess.run(
+        [str(installer), "--host", str(host_skills)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert host.returncode == 0, host.stderr
+    installed = host_skills / "verify-omnigent"
+    assert installed.is_symlink()
+    assert installed.resolve() == _SKILL_ROOT.resolve()
+
+    bundle = tmp_path / "agent"
+    bundle.mkdir()
+    (bundle / "config.yaml").write_text("spec_version: 1\nname: fixture\n", encoding="utf-8")
+    copied = subprocess.run(
+        [str(installer), "--bundle", str(bundle)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert copied.returncode == 0, copied.stderr
+    bundled_skill = bundle / "skills" / "verify-omnigent"
+    assert not bundled_skill.is_symlink()
+    assert (bundled_skill / "SKILL.md").is_file()
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _commit(repo: Path, message: str) -> None:
+    _git(repo, "add", ".")
+    _git(
+        repo,
+        "-c",
+        "user.name=Fixture",
+        "-c",
+        "user.email=fixture@example.com",
+        "commit",
+        "-qm",
+        message,
+    )
+
+
+def _stage_auto_repo(
+    tmp_path: Path,
+    *,
+    base_behavior: str,
+    candidate_behavior: str,
+) -> tuple[Path, Path, dict[str, str]]:
+    root = tmp_path / "repo"
+    root.mkdir()
+    skill = root / ".agents" / "skills" / "verify-omnigent"
+    shutil.copytree(_SKILL_ROOT, skill)
+    for script in (skill / "scripts").iterdir():
+        if script.suffix in {".py", ".sh"}:
+            script.chmod(0o755)
+    (root / "tests" / "server" / "integration").mkdir(parents=True)
+    (root / "tests" / "server" / "test_app.py").write_text("# fixture\n", encoding="utf-8")
+    (root / "tests" / "server" / "integration" / "test_app.py").write_text(
+        "# fixture\n",
+        encoding="utf-8",
+    )
+    (root / "omnigent" / "server").mkdir(parents=True)
+    (root / "omnigent" / "server" / "change.py").write_text("BASE = True\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text("[project]\nname='fixture'\n", encoding="utf-8")
+    (root / "package.json").write_text(
+        '{"name":"fixture","packageManager":"pnpm@11.15.1"}\n',
+        encoding="utf-8",
+    )
+    (root / "pnpm-lock.yaml").write_text("lockfileVersion: 9\n", encoding="utf-8")
+    (root / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    (root / ".pre-commit-config.yaml").write_text("repos: []\n", encoding="utf-8")
+    (root / ".gitignore").write_text(
+        "node_modules/\n.artifacts/\n__pycache__/\n*.pyc\n",
+        encoding="utf-8",
+    )
+    modules = root / "node_modules"
+    (modules / ".pnpm").mkdir(parents=True)
+    (modules / ".modules.yaml").write_text(
+        '{"virtualStoreDir": ".pnpm", "packageManager": "pnpm@11.15.1"}\n',
+        encoding="utf-8",
+    )
+    behavior = root / "docs" / "behavior.txt"
+    behavior.parent.mkdir()
+    behavior.write_text(base_behavior + "\n", encoding="utf-8")
+    bin_dir = root / "fixture-bin"
+    bin_dir.mkdir()
+    uv = bin_dir / "uv"
+    uv.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+args="$*"
+if [[ "$args" == *"pre-commit --version"* ]]; then
+  echo "pre-commit 4.0"
+  exit 0
+fi
+if [[ "$args" == *"python -c"* ]]; then
+  exit 0
+fi
+if [[ "$args" == *"pre-commit run"* ]]; then
+  echo "synthetic pre-commit passed"
+  exit 0
+fi
+if [[ "$args" == *"pytest tests/server/test_app.py"* ]]; then
+  behavior="$(< docs/behavior.txt)"
+  if [[ "$behavior" == "pass" ]]; then
+    for arg in "$@"; do
+      if [[ "$arg" == --junitxml=* ]]; then
+        junit="${arg#--junitxml=}"
+        mkdir -p "$(dirname "$junit")"
+        printf '%s\n' '<testsuite tests="1"><testcase name="test_server"/></testsuite>' >"$junit"
+      fi
+    done
+    echo "synthetic server passed"
+    exit 0
+  fi
+  if [[ "$behavior" == "sleep" ]]; then
+    sleep 60
+  fi
+  echo "server failure"
+  exit 1
+fi
+echo "unexpected uv invocation: $args" >&2
+exit 2
+""",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+    node = bin_dir / "node"
+    node.write_text(
+        """#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then echo "v24.0.0"; fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    node.chmod(0o755)
+    pnpm = bin_dir / "pnpm"
+    pnpm.write_text("#!/usr/bin/env bash\necho 11.15.1\n", encoding="utf-8")
+    pnpm.chmod(0o755)
+    _git(root, "init", "-q", "-b", "main")
+    _commit(root, "base")
+    _git(root, "switch", "-q", "-c", "pr")
+    behavior.write_text(candidate_behavior + "\n", encoding="utf-8")
+    (root / "omnigent" / "server" / "change.py").write_text(
+        "BASE = False\n",
+        encoding="utf-8",
+    )
+    _commit(root, "candidate")
+    return (
+        root,
+        skill / "scripts" / "verify.sh",
+        {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"},
+    )
+
+
+def test_synthetic_auto_success_finalizes_every_child(tmp_path: Path) -> None:
+    root, script, env = _stage_auto_repo(
+        tmp_path,
+        base_behavior="pass",
+        candidate_behavior="pass",
+    )
+    evidence = tmp_path / "evidence"
+
+    result = _run(root, script, evidence, "auto", "--base-ref", "main", extra_env=env)
+
+    assert result.returncode == 0, result.stdout
+    manifest = _only_manifest(evidence)
+    assert manifest["status"] == "passed"
+    assert [child["status"] for child in manifest["children"]] == ["passed", "passed"]
+    assert manifest["cleanup"]["status"] == "completed"
+    assert "selected lanes: quality-gates, server" in result.stdout
+
+
+def test_quality_doctor_checks_only_selected_web_prerequisites(tmp_path: Path) -> None:
+    root, script, env = _stage_auto_repo(
+        tmp_path,
+        base_behavior="pass",
+        candidate_behavior="pass",
+    )
+    shutil.rmtree(root / "node_modules")
+    (root / "fixture-bin" / "node").unlink()
+    (root / "fixture-bin" / "pnpm").unlink()
+    env["PATH"] = f"{root / 'fixture-bin'}:{Path(sys.executable).parent}:/usr/bin:/bin"
+    evidence = tmp_path / "python-only-evidence"
+
+    python_only = _run(
+        root,
+        script,
+        evidence,
+        "doctor",
+        "quality-gates",
+        "--base-ref",
+        "main",
+        extra_env=env,
+    )
+
+    assert python_only.returncode == 0, python_only.stdout
+    (root / "web").mkdir()
+    (root / "web" / "change.ts").write_text("export const changed = true;\n", encoding="utf-8")
+    web_evidence = tmp_path / "web-evidence"
+    web = _run(
+        root,
+        script,
+        web_evidence,
+        "doctor",
+        "quality-gates",
+        "--base-ref",
+        "main",
+        extra_env=env,
+    )
+    assert web.returncode != 0
+    assert "command pnpm is unavailable" in web.stdout
+
+
+def test_quality_doctor_ignores_path_pnpm_until_tools_are_prepared(
+    tmp_path: Path,
+) -> None:
+    root, script, env = _stage_auto_repo(
+        tmp_path,
+        base_behavior="pass",
+        candidate_behavior="pass",
+    )
+    (root / "web").mkdir()
+    (root / "web" / "change.ts").write_text("export const changed = true;\n", encoding="utf-8")
+    (root / "fixture-bin" / "pnpm").write_text(
+        "#!/usr/bin/env bash\necho 99.0.0\n",
+        encoding="utf-8",
+    )
+    env["OMNIGENT_VERIFY_PNPM_CACHE_ROOT"] = str(tmp_path / "empty-pnpm-cache")
+
+    result = _run(
+        root,
+        script,
+        tmp_path / "evidence",
+        "doctor",
+        "quality-gates",
+        "--base-ref",
+        "main",
+        extra_env=env,
+    )
+
+    assert result.returncode != 0
+    assert "99.0.0" not in result.stdout
+    assert ".agents/skills/verify-omnigent/scripts/verify.sh prepare-tools" in result.stdout
+
+
+def test_quality_doctor_uses_prepared_pnpm_instead_of_path_shim(
+    tmp_path: Path,
+) -> None:
+    root, script, env = _stage_auto_repo(
+        tmp_path,
+        base_behavior="pass",
+        candidate_behavior="pass",
+    )
+    (root / "web").mkdir()
+    (root / "web" / "change.ts").write_text("export const changed = true;\n", encoding="utf-8")
+    (root / "fixture-bin" / "pnpm").write_text(
+        "#!/usr/bin/env bash\necho 99.0.0\n",
+        encoding="utf-8",
+    )
+    (root / "fixture-bin" / "node").write_text(
+        "#!/usr/bin/env bash\n"
+        'if [[ "${1:-}" == "--version" ]]; then echo "v24.0.0"; exit 0; fi\n'
+        'if [[ "${1:-}" == *pnpm.mjs ]]; then echo 11.15.1; exit 0; fi\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    helper_path = root / ".agents/skills/verify-omnigent/scripts/runtime_support.py"
+    spec = importlib.util.spec_from_file_location("doctor_pnpm_runtime", helper_path)
+    assert spec and spec.loader
+    helper = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(helper)
+    package = tmp_path / "local-pnpm"
+    (package / "bin").mkdir(parents=True)
+    (package / "package.json").write_text(
+        json.dumps({"name": "pnpm", "version": "11.15.1"}),
+        encoding="utf-8",
+    )
+    (package / "bin/pnpm.mjs").write_text("console.log('11.15.1');\n", encoding="utf-8")
+    cache_parent = tmp_path / "cache"
+    cache_parent.mkdir()
+    staging = cache_parent / "pnpm.version.prepared"
+    helper.prepare_pnpm_cache(root, staging, candidates=(package,))
+    destination = cache_parent / "pnpm"
+    helper.publish_pnpm_cache(staging, destination)
+    env["OMNIGENT_VERIFY_PNPM_CACHE_ROOT"] = str(destination)
+
+    result = _run(
+        root,
+        script,
+        tmp_path / "evidence",
+        "doctor",
+        "quality-gates",
+        "--base-ref",
+        "main",
+        extra_env=env,
+    )
+
+    assert "99.0.0" not in result.stdout
+    assert "prepare-tools" not in result.stdout
+    assert "pnpm 11.15.1 does not match" not in result.stdout
+
+
+def test_prepare_hooks_builds_authenticated_dedicated_cache(tmp_path: Path) -> None:
+    root, script = _stage_repo(tmp_path, "true")
+    remote = "https://example.invalid/pre-commit-hooks"
+    revision = "v4.6.0"
+    (root / ".pre-commit-config.yaml").write_text(
+        f"repos:\n  - repo: {remote}\n    rev: {revision}\n    hooks:\n      - id: fixture\n",
+        encoding="utf-8",
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    uv = fake_bin / "uv"
+    uv.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os, pathlib, sqlite3\n"
+        "cache=pathlib.Path(os.environ['PRE_COMMIT_HOME'])\n"
+        "prepared=cache/'repo-prepared'\n"
+        "prepared.mkdir(parents=True)\n"
+        "(prepared/'.pre-commit-hooks.yaml').write_text("
+        '"- id: fixture\\n  name: fixture\\n  entry: true\\n  language: system\\n")\n'
+        "with sqlite3.connect(cache/'db.db') as db:\n"
+        " db.execute('CREATE TABLE repos "
+        "(repo TEXT NOT NULL, ref TEXT NOT NULL, path TEXT NOT NULL, "
+        "PRIMARY KEY (repo, ref))')\n"
+        f" db.execute('INSERT INTO repos VALUES (?, ?, ?)', "
+        f"({remote!r}, {revision!r}, str(prepared)))\n",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = _run(
+        root,
+        script,
+        tmp_path / "unused-evidence",
+        "prepare-hooks",
+        extra_env={"HOME": str(home), "PATH": f"{fake_bin}:{os.environ['PATH']}"},
+    )
+
+    cache = home / ".cache/verify-omnigent/pre-commit"
+    assert result.returncode == 0, result.stderr
+    seal = json.loads((cache / "omnigent-prepared-hooks.json").read_text())
+    assert [(item["repo"], item["rev"]) for item in seal["hooks"]] == [(remote, revision)]
+    assert not (tmp_path / "unused-evidence").exists()
+
+    with sqlite3.connect(cache / "db.db") as connection:
+        prepared = Path(connection.execute("SELECT path FROM repos").fetchone()[0])
+    (prepared / "tampered.txt").write_text("tampered\n", encoding="utf-8")
+    helper_path = root / ".agents/skills/verify-omnigent/scripts/runtime_support.py"
+    spec = importlib.util.spec_from_file_location("prepared_runtime_support", helper_path)
+    assert spec and spec.loader
+    helper = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(helper)
+    with pytest.raises(RuntimeError, match="not prepared"):
+        helper.strict_environment(
+            tmp_path / "run",
+            source={"HOME": str(home), "PATH": os.environ["PATH"]},
+            extra={"OMNIGENT_VERIFY_REPO_ROOT": str(root)},
+            pre_commit=True,
+        )
+    helper.cleanup_strict_environment(tmp_path / "run")
+
+
+def test_quality_doctor_names_exact_hook_preparation_command(tmp_path: Path) -> None:
+    root, script, env = _stage_auto_repo(
+        tmp_path,
+        base_behavior="pass",
+        candidate_behavior="pass",
+    )
+    (root / ".pre-commit-config.yaml").write_text(
+        "repos:\n"
+        "  - repo: https://example.invalid/hooks\n"
+        "    rev: v1\n"
+        "    hooks:\n"
+        "      - id: fixture\n",
+        encoding="utf-8",
+    )
+    home = tmp_path / "empty-home"
+    home.mkdir()
+
+    result = _run(
+        root,
+        script,
+        tmp_path / "evidence",
+        "doctor",
+        "quality-gates",
+        "--base-ref",
+        "main",
+        extra_env={**env, "HOME": str(home)},
+    )
+
+    assert result.returncode != 0
+    assert ".agents/skills/verify-omnigent/scripts/verify.sh prepare-hooks" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("base_behavior", "classification"),
+    [("pass", "pr_only_failure"), ("fail", "baseline_reproduced")],
+)
+def test_auto_classifies_exact_base_failure_without_waiving_it(
+    tmp_path: Path,
+    base_behavior: str,
+    classification: str,
+) -> None:
+    root, script, env = _stage_auto_repo(
+        tmp_path,
+        base_behavior=base_behavior,
+        candidate_behavior="fail",
+    )
+    evidence = tmp_path / "evidence"
+
+    result = _run(root, script, evidence, "auto", "--base-ref", "main", extra_env=env)
+
+    assert result.returncode != 0
+    manifest = _only_manifest(evidence)
+    assert manifest["status"] == "failed"
+    server = next(child for child in manifest["children"] if child["lane"] == "server")
+    assert server["status"] == "failed"
+    assert server["baseline_comparison"]["classification"] == classification
+    comparison = json.loads(
+        (next(evidence.glob("*")) / server["baseline_comparison"]["comparison"]).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert comparison["cleanup"]["status"] == "completed"
+
+
+def test_auto_blocks_before_lanes_when_prerequisite_is_missing(tmp_path: Path) -> None:
+    root, script, env = _stage_auto_repo(
+        tmp_path,
+        base_behavior="pass",
+        candidate_behavior="pass",
+    )
+    (root / "tests" / "server" / "test_app.py").unlink()
+    evidence = tmp_path / "evidence"
+
+    result = _run(root, script, evidence, "auto", "--base-ref", "main", extra_env=env)
+
+    assert result.returncode != 0
+    assert "Restore tests/server/test_app.py" in result.stdout
+    manifest = _only_manifest(evidence)
+    assert manifest["status"] == "blocked"
+    assert all(child["status"] == "blocked" for child in manifest["children"])
+    assert all(child["manifest"] is None for child in manifest["children"])
+
+
+def test_doctor_auto_records_plan_blocker_as_blocked(tmp_path: Path) -> None:
+    root, script, env = _stage_auto_repo(
+        tmp_path,
+        base_behavior="pass",
+        candidate_behavior="pass",
+    )
+    unknown = root / "tests" / "tools" / "test_unknown_surface.py"
+    unknown.parent.mkdir(parents=True)
+    unknown.write_text("# unmapped fixture\n", encoding="utf-8")
+    _commit(root, "add unmapped path")
+    evidence = tmp_path / "evidence"
+
+    result = _run(
+        root,
+        script,
+        evidence,
+        "doctor",
+        "auto",
+        "--base-ref",
+        "main",
+        extra_env=env,
+    )
+
+    assert result.returncode != 0
+    assert _only_manifest(evidence)["status"] == "blocked"
+    assert "next command:" in result.stdout
+
+
+def test_interrupted_auto_finalizes_parent_and_active_child(tmp_path: Path) -> None:
+    root, script, env = _stage_auto_repo(
+        tmp_path,
+        base_behavior="pass",
+        candidate_behavior="sleep",
+    )
+    evidence = tmp_path / "evidence"
+    process = subprocess.Popen(
+        [str(script), "auto", "--base-ref", "main"],
+        cwd=root,
+        env={**os.environ, **env, "OMNIGENT_VERIFY_EVIDENCE_DIR": str(evidence)},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 45
+    parent_path: Path | None = None
+    while time.monotonic() < deadline:
+        manifests = list(evidence.glob("*/manifest.json"))
+        if manifests:
+            parent_path = manifests[0]
+            value = json.loads(parent_path.read_text(encoding="utf-8"))
+            server = next(
+                (child for child in value.get("children", []) if child.get("lane") == "server"),
+                None,
+            )
+            child_manifests = list(parent_path.parent.glob("children/server/*/manifest.json"))
+            if server and server.get("status") == "running" and child_manifests:
+                break
+        time.sleep(0.05)
+    else:
+        process.kill()
+        pytest.fail("synthetic server lane did not start")
+    process.terminate()
+    stdout, stderr = process.communicate(timeout=30)
+
+    assert process.returncode == 143, stderr
+    assert parent_path is not None
+    parent = json.loads(parent_path.read_text(encoding="utf-8"))
+    assert parent["status"] == "interrupted"
+    assert all(child["status"] != "running" for child in parent["children"])
+    server = next(child for child in parent["children"] if child["lane"] == "server")
+    child = json.loads((parent_path.parent / server["manifest"]).read_text(encoding="utf-8"))
+    assert child["status"] == "interrupted"
+    assert "status=interrupted" in stdout

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -220,7 +220,7 @@ export default defineConfig({
   plugins: [safariLookbehindWorkarounds(), react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
   test: {
@@ -261,7 +261,7 @@ export default defineConfig({
   build: {
     // default baseline is Safari 16.4+; iPadOS 15 can't parse dep regex lookbehinds (#1978)
     target: ["chrome111", "edge111", "firefox114", "safari15", "ios15"],
-    outDir: path.resolve(__dirname, "../omnigent/server/static/web-ui"),
+    outDir: path.resolve(import.meta.dirname, "../omnigent/server/static/web-ui"),
     emptyOutDir: true,
     rollupOptions: {
       output: {

--- a/web/vite.embed.config.ts
+++ b/web/vite.embed.config.ts
@@ -253,7 +253,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
   // React reads process.env.NODE_ENV; replace at build time so the bundle
@@ -262,7 +262,7 @@ export default defineConfig({
     "process.env.NODE_ENV": JSON.stringify("production"),
   },
   build: {
-    outDir: path.resolve(__dirname, "./dist-embed"),
+    outDir: path.resolve(import.meta.dirname, "./dist-embed"),
     emptyOutDir: true,
     cssCodeSplit: false,
     // Emit source maps so downstream bundlers embedding this build (e.g. the
@@ -271,7 +271,7 @@ export default defineConfig({
     // omnigent-embed.js:<line>. Consumed at the host build via source-map-loader.
     sourcemap: true,
     lib: {
-      entry: path.resolve(__dirname, "./src/embed.tsx"),
+      entry: path.resolve(import.meta.dirname, "./src/embed.tsx"),
       formats: ["es"],
     },
     rollupOptions: {

--- a/web/vite.update-overlay.config.ts
+++ b/web/vite.update-overlay.config.ts
@@ -29,15 +29,15 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
   build: {
     // Ship straight into the Electron package so electron-builder picks it up.
-    outDir: path.resolve(__dirname, "./electron/overlay"),
+    outDir: path.resolve(import.meta.dirname, "./electron/overlay"),
     emptyOutDir: true,
     rollupOptions: {
-      input: path.resolve(__dirname, "./update-overlay.html"),
+      input: path.resolve(import.meta.dirname, "./update-overlay.html"),
     },
   },
 });


### PR DESCRIPTION
## Related issue

N/A — developer tooling and test infrastructure.

## Summary

- Add one portable verification skill for Cursor, Claude Code, Codex, and Omnigent.
- Select required CLI, server, web, desktop, collaboration, automation, harness, deployment, and performance lanes from the actual diff.
- Fail closed on missing prerequisites/evidence, skipped required tests, repository mutation, unsafe credentials, or unsupported comparisons.

ELI5: `verify.sh auto` looks at what changed, runs the real product journeys that matter, and produces hashed evidence instead of treating a generic test pass as proof.

```text
diff -> lane selection -> doctor -> real journeys -> validated evidence
                         \-> blocker/failure -> nonzero exit
```

## Test Plan

- `245 passed`: `tests/verify_omnigent`
- `11 passed`: Databricks deploy dry-run tests
- `78 passed, 15 skipped`: harness matrix tests (credential/plugin-gated skips)
- `6 passed`: Playwright evidence contracts
- Web type-check, oxlint, Prettier, and Vite runner-loader production build
- Ruff, ShellCheck, Bash syntax, and `git diff --check`
- Isolated live certification: collaboration 15/15 and smoke 1/1, with passed manifests and unchanged `node_modules`

Known base issue: `uv lock --check` currently reports that the untouched `origin/main` lockfile needs updating; this PR does not change `pyproject.toml` or `uv.lock`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Run:

```bash
OMNIGENT_VERIFY_ADAPTER=cursor \
  .agents/skills/verify-omnigent/scripts/verify.sh auto --base-ref origin/main
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified isolated collaboration and smoke journeys end to end. Live credentials, signing/notarization, production latency, and opt-in Universe execution remain explicit separate lanes.
