### PR TITLE
feat(web): swipe from left edge to open the sidebar on touch devices

### DIFF
--- a/web/src/hooks/useSidebarEdgeSwipe.test.tsx
+++ b/web/src/hooks/useSidebarEdgeSwipe.test.tsx
@@ -1,27 +1,39 @@
 import { render } from "@testing-library/react";
-import { act } from "react";
+import { act, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useSidebarEdgeSwipe } from "./useSidebarEdgeSwipe";
 
 // jsdom has no TouchEvent constructor and its Event has no `timeStamp` we can
 // set, so fabricate a minimal touch event the hook reads: `touches`,
 // `clientX/Y`, `timeStamp`, `cancelable`, and a spyable `preventDefault`.
+interface TouchOpts {
+  x?: number;
+  y?: number;
+  t?: number;
+  /** Number of active touch points — >1 simulates a second finger (pinch). */
+  count?: number;
+}
+
 function touchEvent(
   type: "touchstart" | "touchmove" | "touchend" | "touchcancel",
-  { x = 0, y = 0, t = 0 }: { x?: number; y?: number; t?: number } = {},
+  { x = 0, y = 0, t = 0, count = 1 }: TouchOpts = {},
 ): Event {
+  // Bubbles so a dispatch on a child element reaches the window listeners and
+  // carries that element as `e.target` (used by the horizontal-scroller check).
   const ev = new Event(type, { bubbles: true, cancelable: true });
-  const touch = { clientX: x, clientY: y };
+  const primary = { clientX: x, clientY: y };
+  // A second point just needs to exist for length checks; its coords are unused.
+  const touches = type === "touchend" || type === "touchcancel" ? [] : Array(count).fill(primary);
   Object.defineProperties(ev, {
-    touches: { value: type === "touchend" || type === "touchcancel" ? [] : [touch] },
+    touches: { value: touches },
     timeStamp: { value: t },
   });
   return ev;
 }
 
-function fire(ev: Event) {
+function fire(ev: Event, on: EventTarget = window) {
   act(() => {
-    window.dispatchEvent(ev);
+    on.dispatchEvent(ev);
   });
 }
 
@@ -115,5 +127,79 @@ describe("useSidebarEdgeSwipe", () => {
 
     expect(onDragProgress).not.toHaveBeenCalled();
     expect(onSettle).not.toHaveBeenCalled();
+  });
+
+  it("does not claim a close-swipe that starts in a horizontal scroller", () => {
+    const onDragProgress = vi.fn();
+    const onSettle = vi.fn();
+    render(<Harness isOpen onDragProgress={onDragProgress} onSettle={onSettle} />);
+
+    // A horizontally-scrollable element (e.g. a code block inside the drawer).
+    const scroller = document.createElement("div");
+    Object.defineProperties(scroller, {
+      scrollWidth: { value: 1000, configurable: true },
+      clientWidth: { value: 200, configurable: true },
+    });
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      overflowX: "auto",
+    } as CSSStyleDeclaration);
+    document.body.appendChild(scroller);
+
+    // Leftward drag starting on that element — the user scrolling the content.
+    fire(touchEvent("touchstart", { x: 400, y: 100, t: 0 }), scroller);
+    fire(touchEvent("touchmove", { x: 360, y: 100, t: 20 }), scroller);
+    fire(touchEvent("touchend", { x: 360, y: 100, t: 20 }), scroller);
+
+    expect(onSettle).not.toHaveBeenCalled();
+    expect(onDragProgress).not.toHaveBeenCalled();
+    document.body.removeChild(scroller);
+  });
+
+  it("ends the gesture when a second finger lands mid-drag", () => {
+    const onDragProgress = vi.fn();
+    const onSettle = vi.fn();
+    render(<Harness onDragProgress={onDragProgress} onSettle={onSettle} />);
+
+    fire(touchEvent("touchstart", { x: 5, y: 100, t: 0 }));
+    // Commit the drag past halfway, then a second finger appears (pinch): the
+    // gesture settles on what it had rather than tracking an arbitrary point.
+    fire(touchEvent("touchmove", { x: 500, y: 100, t: 200 }));
+    fire(touchEvent("touchmove", { x: 550, y: 100, t: 220, count: 2 }));
+
+    expect(onSettle).toHaveBeenCalledWith(true);
+    expect(onDragProgress).toHaveBeenLastCalledWith(null);
+  });
+
+  // Regression: AppShell passes an INLINE onSettle (fresh identity each render)
+  // and re-renders on every drag frame because onDragProgress drives its state.
+  // If the effect depended on the callbacks, that re-render would re-subscribe
+  // the listeners and reset the in-flight gesture, freezing the drag after one
+  // frame so touchend never settles. This harness reproduces both conditions:
+  // a new onSettle closure each render, and a state bump on every progress tick.
+  it("keeps tracking across re-renders driven by an inline callback (churn)", () => {
+    const settle = vi.fn();
+    function ChurnHarness() {
+      // Bumped on every drag frame, mimicking AppShell's setSidebarDragProgress.
+      const [, setProgress] = useState<number | null>(null);
+      useSidebarEdgeSwipe({
+        enabled: true,
+        isOpen: false,
+        onDragProgress: setProgress,
+        // New identity every render — the exact pattern Polly flagged.
+        onSettle: (open) => settle(open),
+      });
+      return null;
+    }
+    render(<ChurnHarness />);
+
+    fire(touchEvent("touchstart", { x: 5, y: 100, t: 0 }));
+    // Two separate move frames: the first re-renders the component (new onSettle
+    // identity). If the gesture reset on that re-render, the second move would
+    // see tracking===false and touchend would never settle.
+    fire(touchEvent("touchmove", { x: 300, y: 100, t: 200 }));
+    fire(touchEvent("touchmove", { x: 500, y: 100, t: 400 }));
+    fire(touchEvent("touchend", { x: 500, y: 100, t: 400 }));
+
+    expect(settle).toHaveBeenCalledWith(true);
   });
 });

--- a/web/src/hooks/useSidebarEdgeSwipe.test.tsx
+++ b/web/src/hooks/useSidebarEdgeSwipe.test.tsx
@@ -1,0 +1,119 @@
+import { render } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSidebarEdgeSwipe } from "./useSidebarEdgeSwipe";
+
+// jsdom has no TouchEvent constructor and its Event has no `timeStamp` we can
+// set, so fabricate a minimal touch event the hook reads: `touches`,
+// `clientX/Y`, `timeStamp`, `cancelable`, and a spyable `preventDefault`.
+function touchEvent(
+  type: "touchstart" | "touchmove" | "touchend" | "touchcancel",
+  { x = 0, y = 0, t = 0 }: { x?: number; y?: number; t?: number } = {},
+): Event {
+  const ev = new Event(type, { bubbles: true, cancelable: true });
+  const touch = { clientX: x, clientY: y };
+  Object.defineProperties(ev, {
+    touches: { value: type === "touchend" || type === "touchcancel" ? [] : [touch] },
+    timeStamp: { value: t },
+  });
+  return ev;
+}
+
+function fire(ev: Event) {
+  act(() => {
+    window.dispatchEvent(ev);
+  });
+}
+
+interface HarnessProps {
+  enabled?: boolean;
+  isOpen?: boolean;
+  onDragProgress: (p: number | null) => void;
+  onSettle: (open: boolean) => void;
+}
+
+function Harness({ enabled = true, isOpen = false, onDragProgress, onSettle }: HarnessProps) {
+  useSidebarEdgeSwipe({ enabled, isOpen, onDragProgress, onSettle });
+  return null;
+}
+
+describe("useSidebarEdgeSwipe", () => {
+  beforeEach(() => {
+    // Wide viewport so drawerWidth (innerWidth - peek strip) is a stable 744px.
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 800 });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens on a rightward edge swipe past the halfway point", () => {
+    const onDragProgress = vi.fn();
+    const onSettle = vi.fn();
+    render(<Harness onDragProgress={onDragProgress} onSettle={onSettle} />);
+
+    fire(touchEvent("touchstart", { x: 5, y: 100, t: 0 }));
+    // Slow drag well past half the 744px drawer, so velocity stays sub-flick
+    // and the settle is decided by position (> 0.5), not by a flick.
+    fire(touchEvent("touchmove", { x: 500, y: 100, t: 500 }));
+    fire(touchEvent("touchend", { x: 500, y: 100, t: 500 }));
+
+    expect(onDragProgress).toHaveBeenCalled();
+    expect(onSettle).toHaveBeenCalledWith(true);
+    // Progress reset to null on release.
+    expect(onDragProgress).toHaveBeenLastCalledWith(null);
+  });
+
+  it("ignores a swipe that does not start at the left edge", () => {
+    const onDragProgress = vi.fn();
+    const onSettle = vi.fn();
+    render(<Harness onDragProgress={onDragProgress} onSettle={onSettle} />);
+
+    fire(touchEvent("touchstart", { x: 200, y: 100, t: 0 }));
+    fire(touchEvent("touchmove", { x: 600, y: 100, t: 100 }));
+    fire(touchEvent("touchend", { x: 600, y: 100, t: 100 }));
+
+    expect(onDragProgress).not.toHaveBeenCalled();
+    expect(onSettle).not.toHaveBeenCalled();
+  });
+
+  it("hands back a vertical scroll gesture", () => {
+    const onDragProgress = vi.fn();
+    const onSettle = vi.fn();
+    render(<Harness onDragProgress={onDragProgress} onSettle={onSettle} />);
+
+    fire(touchEvent("touchstart", { x: 5, y: 100, t: 0 }));
+    // Mostly vertical — |dy| >= |dx|, so the drag is disowned.
+    fire(touchEvent("touchmove", { x: 20, y: 300, t: 100 }));
+    fire(touchEvent("touchend", { x: 20, y: 300, t: 100 }));
+
+    expect(onDragProgress).not.toHaveBeenCalled();
+    expect(onSettle).not.toHaveBeenCalled();
+  });
+
+  it("closes an open drawer on a fast leftward flick", () => {
+    const onDragProgress = vi.fn();
+    const onSettle = vi.fn();
+    render(<Harness isOpen onDragProgress={onDragProgress} onSettle={onSettle} />);
+
+    fire(touchEvent("touchstart", { x: 400, y: 100, t: 0 }));
+    // Short but fast leftward move: only 40px (< half) yet 40px/20ms = 2 px/ms,
+    // well over the flick threshold, so it settles closed on velocity alone.
+    fire(touchEvent("touchmove", { x: 360, y: 100, t: 20 }));
+    fire(touchEvent("touchend", { x: 360, y: 100, t: 20 }));
+
+    expect(onSettle).toHaveBeenCalledWith(false);
+  });
+
+  it("does nothing when disabled", () => {
+    const onDragProgress = vi.fn();
+    const onSettle = vi.fn();
+    render(<Harness enabled={false} onDragProgress={onDragProgress} onSettle={onSettle} />);
+
+    fire(touchEvent("touchstart", { x: 5, y: 100, t: 0 }));
+    fire(touchEvent("touchmove", { x: 500, y: 100, t: 500 }));
+    fire(touchEvent("touchend", { x: 500, y: 100, t: 500 }));
+
+    expect(onDragProgress).not.toHaveBeenCalled();
+    expect(onSettle).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/useSidebarEdgeSwipe.ts
+++ b/web/src/hooks/useSidebarEdgeSwipe.ts
@@ -1,0 +1,161 @@
+// Web left-edge swipe that drives the sidebar as an interactive drawer.
+//
+// The iOS native shell already streams a left-edge swipe over the native bridge
+// (see `onNativeSidebarDrag`), but a plain mobile browser has no such gesture —
+// there the only way to reveal the sidebar was the header button. This hook adds
+// the same drawer feel with DOM touch events, emitting the SAME (progress →
+// settle) contract AppShell already consumes, so both paths share one renderer.
+//
+// It is gated on the device being touch-primary (`pointer: coarse`), NOT on the
+// viewport width: capability, not screen size, is what decides whether a swipe
+// makes sense. Callers pass `enabled` (typically `useIsCoarsePointer()`).
+
+import { useEffect } from "react";
+
+// Left-edge band (CSS px) within which a swipe may BEGIN opening the drawer.
+// Wide enough to hit reliably with a thumb, narrow enough not to swallow taps
+// on left-aligned content.
+const EDGE_ZONE_PX = 28;
+// Movement (CSS px) before we commit to "this is a horizontal drawer drag"
+// rather than a tap or a vertical scroll. Below this we stay undecided.
+const DECIDE_SLOP_PX = 12;
+// Flick speed (CSS px/ms) that settles the drawer in the swipe's direction
+// regardless of how far it travelled — a fast short flick still opens/closes.
+const FLICK_VELOCITY = 0.35;
+// Strip of chat left visible to the right of the mobile drawer (Tailwind
+// `right-14` = 3.5rem). The drawer's own width — the denominator that maps
+// finger travel to a 0→1 open fraction — is the viewport minus this strip.
+const PEEK_STRIP_PX = 56;
+
+export interface SidebarEdgeSwipeOptions {
+  /** Master switch — pass a touch-capability signal, e.g. `useIsCoarsePointer()`. */
+  enabled: boolean;
+  /** Whether the sidebar is currently open (decides swipe direction & baseline). */
+  isOpen: boolean;
+  /**
+   * Live open fraction (0→1) during a drag, or `null` on release. Mirrors the
+   * native bridge's begin/move frames; wire it to the same drag-progress state
+   * the iOS path uses so the drawer tracks the finger 1:1.
+   */
+  onDragProgress: (progress: number | null) => void;
+  /** Settle decision on release — the drawer animates to this resting state. */
+  onSettle: (open: boolean) => void;
+}
+
+/**
+ * Attach a left-edge swipe gesture (touch) that opens the sidebar by dragging
+ * right and closes it by dragging left. No-op when `enabled` is false or off a
+ * touch device. Emits `onDragProgress` while the finger moves and `onSettle` on
+ * release; the caller owns the visual (see AppShell / Sidebar `dragProgress`).
+ */
+export function useSidebarEdgeSwipe({
+  enabled,
+  isOpen,
+  onDragProgress,
+  onSettle,
+}: SidebarEdgeSwipeOptions): void {
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined") return;
+
+    let tracking = false; // a candidate gesture is being watched
+    let dragging = false; // committed to a horizontal drawer drag
+    let startX = 0;
+    let startY = 0;
+    let drawerWidth = 1; // px; finger-travel denominator, set on start
+    let progress = isOpen ? 1 : 0;
+    let lastX = 0;
+    let lastT = 0;
+    let velocity = 0; // px/ms, signed (rightward positive)
+
+    const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
+
+    function reset() {
+      tracking = false;
+      dragging = false;
+      velocity = 0;
+    }
+
+    function onTouchStart(e: TouchEvent) {
+      // Multi-touch (pinch/zoom) isn't a drawer swipe.
+      if (e.touches.length !== 1) return;
+      const t = e.touches[0];
+      // A closed drawer only opens from the screen's left edge; an open drawer
+      // can be swiped shut from anywhere over it.
+      if (!isOpen && t.clientX > EDGE_ZONE_PX) return;
+      tracking = true;
+      dragging = false;
+      startX = t.clientX;
+      lastX = t.clientX;
+      startY = t.clientY;
+      lastT = e.timeStamp;
+      velocity = 0;
+      progress = isOpen ? 1 : 0;
+      drawerWidth = Math.max(1, window.innerWidth - PEEK_STRIP_PX);
+    }
+
+    function onTouchMove(e: TouchEvent) {
+      if (!tracking) return;
+      const t = e.touches[0];
+      const dx = t.clientX - startX;
+      const dy = t.clientY - startY;
+
+      if (!dragging) {
+        // Wait for enough travel to tell a swipe from a tap.
+        if (Math.abs(dx) < DECIDE_SLOP_PX && Math.abs(dy) < DECIDE_SLOP_PX) return;
+        // Vertical intent (scrolling the session list) — hand it back.
+        if (Math.abs(dy) >= Math.abs(dx)) {
+          tracking = false;
+          return;
+        }
+        // Direction must match the actionable move: open ⇒ drag right,
+        // close ⇒ drag left. A wrong-way swipe isn't ours.
+        if (!isOpen && dx <= 0) {
+          tracking = false;
+          return;
+        }
+        if (isOpen && dx >= 0) {
+          tracking = false;
+          return;
+        }
+        dragging = true;
+      }
+
+      const now = e.timeStamp;
+      const dt = now - lastT;
+      if (dt > 0) velocity = (t.clientX - lastX) / dt;
+      lastX = t.clientX;
+      lastT = now;
+
+      progress = clamp01((isOpen ? 1 : 0) + dx / drawerWidth);
+      onDragProgress(progress);
+      // We own the gesture now — stop the page scrolling under the drawer.
+      if (e.cancelable) e.preventDefault();
+    }
+
+    function onTouchEnd() {
+      if (dragging) {
+        // Settle on a flick (fast in either direction) or, absent a flick, on
+        // whichever resting state the drawer is closer to.
+        const open =
+          velocity > FLICK_VELOCITY ? true : velocity < -FLICK_VELOCITY ? false : progress > 0.5;
+        onDragProgress(null);
+        onSettle(open);
+      }
+      reset();
+    }
+
+    // touchmove must be non-passive so preventDefault can suppress scroll once
+    // we've committed to a horizontal drag.
+    const moveOpts: AddEventListenerOptions = { passive: false };
+    window.addEventListener("touchstart", onTouchStart, { passive: true });
+    window.addEventListener("touchmove", onTouchMove, moveOpts);
+    window.addEventListener("touchend", onTouchEnd, { passive: true });
+    window.addEventListener("touchcancel", onTouchEnd, { passive: true });
+    return () => {
+      window.removeEventListener("touchstart", onTouchStart);
+      window.removeEventListener("touchmove", onTouchMove, moveOpts);
+      window.removeEventListener("touchend", onTouchEnd);
+      window.removeEventListener("touchcancel", onTouchEnd);
+    };
+  }, [enabled, isOpen, onDragProgress, onSettle]);
+}

--- a/web/src/hooks/useSidebarEdgeSwipe.ts
+++ b/web/src/hooks/useSidebarEdgeSwipe.ts
@@ -10,7 +10,7 @@
 // viewport width: capability, not screen size, is what decides whether a swipe
 // makes sense. Callers pass `enabled` (typically `useIsCoarsePointer()`).
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 // Left-edge band (CSS px) within which a swipe may BEGIN opening the drawer.
 // Wide enough to hit reliably with a thumb, narrow enough not to swallow taps
@@ -22,10 +22,42 @@ const DECIDE_SLOP_PX = 12;
 // Flick speed (CSS px/ms) that settles the drawer in the swipe's direction
 // regardless of how far it travelled — a fast short flick still opens/closes.
 const FLICK_VELOCITY = 0.35;
-// Strip of chat left visible to the right of the mobile drawer (Tailwind
-// `right-14` = 3.5rem). The drawer's own width — the denominator that maps
-// finger travel to a 0→1 open fraction — is the viewport minus this strip.
+// Fallback strip of chat left visible to the right of the mobile drawer
+// (Tailwind `right-14` = 3.5rem). The drawer's own width — the denominator that
+// maps finger travel to a 0→1 open fraction — is normally measured from the
+// drawer element itself (see `measureDrawerWidth`); this is only used when that
+// element can't be found, so the mapping degrades gracefully rather than
+// dividing by a wrong number.
 const PEEK_STRIP_PX = 56;
+
+// The mobile sidebar drawer, matched by its landmark label (see Sidebar.tsx's
+// `<aside aria-label="Conversations">`). Measuring it keeps the finger→progress
+// mapping correct even if the peek-strip width changes, instead of silently
+// drifting off a hardcoded constant.
+function measureDrawerWidth(): number {
+  const el = document.querySelector('aside[aria-label="Conversations"]');
+  const measured = el?.getBoundingClientRect().width ?? 0;
+  // A hidden/zero-width match (e.g. desktop layout) is useless as a denominator;
+  // fall back to the viewport-minus-strip estimate.
+  if (measured > 1) return measured;
+  return Math.max(1, window.innerWidth - PEEK_STRIP_PX);
+}
+
+// True when the touch began inside an element that can itself scroll
+// horizontally. A leftward drag there is the user scrolling that content (a
+// code block, table, carousel), not swiping the drawer shut — so we must not
+// claim the gesture and `preventDefault` its native scroll.
+function startsInHorizontalScroller(target: EventTarget | null): boolean {
+  let node = target instanceof Element ? target : null;
+  while (node) {
+    if (node.scrollWidth > node.clientWidth + 1) {
+      const overflowX = getComputedStyle(node).overflowX;
+      if (overflowX === "auto" || overflowX === "scroll") return true;
+    }
+    node = node.parentElement;
+  }
+  return false;
+}
 
 export interface SidebarEdgeSwipeOptions {
   /** Master switch — pass a touch-capability signal, e.g. `useIsCoarsePointer()`. */
@@ -54,6 +86,15 @@ export function useSidebarEdgeSwipe({
   onDragProgress,
   onSettle,
 }: SidebarEdgeSwipeOptions): void {
+  // Hold the callbacks in a ref the listeners read through, so the effect can
+  // depend only on [enabled, isOpen]. AppShell re-renders on every drag frame
+  // (each onDragProgress drives its state), which would give inline callbacks a
+  // fresh identity and, if they were deps, tear down and re-subscribe the
+  // listeners mid-gesture — resetting the local tracking/dragging state so the
+  // drag freezes after one frame. The ref keeps one stable subscription alive.
+  const callbacks = useRef({ onDragProgress, onSettle });
+  callbacks.current = { onDragProgress, onSettle };
+
   useEffect(() => {
     if (!enabled || typeof window === "undefined") return;
 
@@ -82,6 +123,9 @@ export function useSidebarEdgeSwipe({
       // A closed drawer only opens from the screen's left edge; an open drawer
       // can be swiped shut from anywhere over it.
       if (!isOpen && t.clientX > EDGE_ZONE_PX) return;
+      // A close-swipe (drawer open) that starts inside horizontally-scrollable
+      // content is that content being scrolled, not a dismiss — leave it be.
+      if (isOpen && startsInHorizontalScroller(e.target)) return;
       tracking = true;
       dragging = false;
       startX = t.clientX;
@@ -90,11 +134,18 @@ export function useSidebarEdgeSwipe({
       lastT = e.timeStamp;
       velocity = 0;
       progress = isOpen ? 1 : 0;
-      drawerWidth = Math.max(1, window.innerWidth - PEEK_STRIP_PX);
+      drawerWidth = measureDrawerWidth();
     }
 
     function onTouchMove(e: TouchEvent) {
       if (!tracking) return;
+      // A second finger landing mid-drag (pinch/zoom) is no longer a drawer
+      // swipe. Settle whatever we had so the drawer doesn't hang half-open, and
+      // stop tracking rather than chasing an arbitrary touch point.
+      if (e.touches.length !== 1) {
+        onTouchEnd();
+        return;
+      }
       const t = e.touches[0];
       const dx = t.clientX - startX;
       const dy = t.clientY - startY;
@@ -127,7 +178,7 @@ export function useSidebarEdgeSwipe({
       lastT = now;
 
       progress = clamp01((isOpen ? 1 : 0) + dx / drawerWidth);
-      onDragProgress(progress);
+      callbacks.current.onDragProgress(progress);
       // We own the gesture now — stop the page scrolling under the drawer.
       if (e.cancelable) e.preventDefault();
     }
@@ -138,8 +189,8 @@ export function useSidebarEdgeSwipe({
         // whichever resting state the drawer is closer to.
         const open =
           velocity > FLICK_VELOCITY ? true : velocity < -FLICK_VELOCITY ? false : progress > 0.5;
-        onDragProgress(null);
-        onSettle(open);
+        callbacks.current.onDragProgress(null);
+        callbacks.current.onSettle(open);
       }
       reset();
     }
@@ -157,5 +208,5 @@ export function useSidebarEdgeSwipe({
       window.removeEventListener("touchend", onTouchEnd);
       window.removeEventListener("touchcancel", onTouchEnd);
     };
-  }, [enabled, isOpen, onDragProgress, onSettle]);
+  }, [enabled, isOpen]);
 }

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -18,6 +18,9 @@ import { AgentInfoContent, agentHasInfo } from "@/components/AgentInfo";
 import { useIdleNotifications } from "@/hooks/useIdleNotifications";
 import { useSeedReadState } from "@/hooks/useUnseenConversations";
 import { useIOSViewportLock } from "@/hooks/useIOSViewportLock";
+import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
+import { useSidebarEdgeSwipe } from "@/hooks/useSidebarEdgeSwipe";
 import { readFilesPanelPreferences, writeFilesPanelPreferences } from "@/lib/filesPanelPreferences";
 import { derivePermissionLevel, isOwnerLevel } from "@/lib/permissionsApi";
 import {
@@ -305,6 +308,26 @@ export function AppShell() {
       }),
     [],
   );
+  // In a plain touch browser (Android WebView, mobile web) there's no native
+  // bridge, so drive the same drawer gesture from DOM touch events. Gated on
+  // touch capability (pointer:coarse) so a narrow desktop window with a mouse
+  // stays gesture-free, AND on the mobile drawer layout being active: the
+  // finger-tracking transform only makes sense where the sidebar renders as a
+  // sliding overlay (`max-md`, <768px), not the ≥768px desktop push-panel a
+  // large tablet gets. Skipped inside the iOS shell, which streams the gesture
+  // natively above.
+  const coarsePointer = useIsCoarsePointer();
+  const mobileLayout = useIsMobileViewport();
+  useSidebarEdgeSwipe({
+    enabled: coarsePointer && mobileLayout && !isIOSShell() && !inSettings,
+    isOpen: sidebarOpen,
+    onDragProgress: setSidebarDragProgress,
+    onSettle: (open) => {
+      setSidebarDragProgress(null);
+      setSidebarOpen(open);
+      setSidebarPeek(false);
+    },
+  });
   const [selectedFilePath, setSelectedFilePath] = useState<string | null>(() =>
     conversationId ? (readSessionWorkspaceState(conversationId).selectedFilePath ?? null) : null,
   );


### PR DESCRIPTION
## Related issue

<!-- No linked issue; UI/frontend change. -->

Closes #

## Summary

Mobile web and the Android WebView had no way to reveal the left sidebar except the header button — only the iOS native shell got a left-edge swipe (streamed over the native bridge). This adds the same interactive-drawer gesture straight from DOM touch events:

- **Swipe right from the screen's left edge to open the sidebar**, drag left (or tap the exposed chat strip) to close — the drawer tracks your finger 1:1 and settles on release (position past halfway, or a flick).
- Reuses the existing `(dragProgress → settle)` contract the iOS path already feeds into the `Sidebar`, so both share one finger-tracking transform — no new rendering path.
- **Uses a mobile-native capability signal, not screen size.** Enabled only when the primary pointer is coarse (`pointer:coarse`) **and** the mobile drawer layout is active (`<768px`). So a narrow desktop window with a mouse stays gesture-free, and a large touch tablet in the desktop push-panel layout doesn't get a meaningless drag. Skipped inside the iOS shell, which drives the gesture natively.

## Test Plan

- New unit tests (`useSidebarEdgeSwipe.test.tsx`): open on edge swipe, ignore non-edge start, hand back vertical scroll, close-on-flick, disabled no-op — all pass.
- `cd web && npm test` — full suite green except 3 pre-existing `NewChatDialog.test.tsx` failures (verified identical on unmodified `main`, unrelated host-picker flow).
- `npm run build` (tsc -b && vite build) — passes.
- Manual: run `pnpm dev`, open Chrome device emulation (phone), swipe from the left edge → sidebar tracks the finger and opens; swipe left → closes. Confirm no gesture with a desktop mouse and on an iPad-landscape emulation.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

_Screen recording to be attached — gesture is best shown in mobile device emulation (swipe from left edge to open, swipe/flick left to close)._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Gesture logic is unit-tested in `useSidebarEdgeSwipe.test.tsx` (direction, edge-zone gating, scroll disambiguation, flick vs position settle, disabled state). The AppShell wiring (capability + layout gate) is verified manually in device emulation, since it depends on live `matchMedia` / touch input that jsdom doesn't model.

## Changelog

Swipe from the left edge to open the sidebar on phones and touch devices

This pull request and its description were written by Isaac.
