### PR TITLE
perf(runner): remember a definitive mint refusal instead of re-probing it four times per start

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import gc
+import hashlib
 import logging
 import os
 import signal
@@ -67,6 +68,27 @@ _logger = logging.getLogger(__name__)
 # shares the proxy bearer, even after RUNNER_INITIAL_AUTH_TOKEN has been
 # popped from the environment.
 _runner_auth_factory: Callable[[], str | None] | None = None
+
+# Mint attempts the server definitively refused, keyed by
+# ``(mint_url, proxy-bearer digest)``. Whether a server mints at all is a
+# property of its auth configuration, so the refusal is remembered and later
+# probes skip the blocking POST. Only definitive refusals land here; a
+# transient failure must keep installing a retrying factory.
+_declined_mint_probes: set[tuple[str, str]] = set()
+
+
+def _declined_mint_probe_cache() -> set[tuple[str, str]]:
+    """Return the process-wide declined-mint cache.
+
+    Read through the canonical module so the runner's ``__main__`` copy of this
+    file and later importers share one cache — the same split
+    :func:`_set_runner_auth_factory` exists for.
+
+    :returns: The mutable set of definitively-refused mint attempts.
+    """
+    import omnigent.runner._entry as canonical
+
+    return canonical._declined_mint_probes
 
 
 def _set_runner_auth_factory(factory: Callable[[], str | None] | None) -> None:
@@ -716,11 +738,25 @@ def _make_managed_mint_factory(
         bare requests. A post-install 401/403 with no still-valid cache
         latches ``proxy_auth_failed`` instead, which
         :class:`_InitialAuthTokenFactory` answers by re-resolving SDK/OIDC.
+
+    A definitive refusal is remembered per ``(mint_url, proxy bearer)`` for the
+    life of the process, so the several startup callers that each build a
+    factory pay for the probe once rather than once apiece. Transient failures
+    are never remembered.
     """
     from omnigent.runner.identity import token_bound_runner_id
 
     runner_id = token_bound_runner_id(binding_token)
     mint_url = f"{server_url.rstrip('/')}/v1/runners/{runner_id}/token"
+
+    # Reuse a refusal already learned for this exact attempt rather than
+    # spending another blocking round trip on it. ``mint_url`` already carries
+    # the server URL and the binding-token digest; the proxy bearer joins the
+    # key because an Apps OAuth redirect depends on which bearer was presented.
+    declined_probes = _declined_mint_probe_cache()
+    probe_key = (mint_url, hashlib.sha256((proxy_bearer or "").encode()).hexdigest())
+    if probe_key in declined_probes:
+        return None
 
     # Construction probe. Decline to install the factory ONLY when the
     # server definitively will not mint for this runner — HTTP 400 (no auth
@@ -734,7 +770,12 @@ def _make_managed_mint_factory(
         mint_url, server_url, binding_token, proxy_bearer=proxy_bearer
     )
     factory()
-    if factory.declined or factory.proxy_auth_failed:
+    if factory.declined:
+        declined_probes.add(probe_key)
+        return None
+    if factory.proxy_auth_failed:
+        # Not remembered: the presented bearer died, which a caller answers by
+        # re-resolving SDK/OIDC. It says nothing about whether the server mints.
         return None
     return factory
 

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -74,6 +74,21 @@ def _ensure_subprocess_pythonpath(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PYTHONPATH", new_path)
 
 
+@pytest.fixture(autouse=True)
+def _reset_declined_mint_probes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give each test a fresh managed-mint refusal cache.
+
+    ``_make_managed_mint_factory`` remembers a definitive refusal for the life
+    of the process, so without this a test that drives the refusal would make
+    every later test using the same server URL and binding token see a cached
+    "no" instead of probing.
+
+    :param monkeypatch: Pytest monkeypatch fixture; restores the cache at
+        teardown.
+    """
+    monkeypatch.setattr("omnigent.runner._entry._declined_mint_probes", set())
+
+
 def _drain_session_event_queue(queue: asyncio.Queue[Any] | None) -> list[dict[str, Any]]:
     """
     Drain and return every dict item currently on a runner session queue.

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -539,6 +539,95 @@ def test_managed_mint_factory_no_factory_when_server_definitively_refuses(
     assert _make_managed_mint_factory("https://s.example.com", "btok") is None
 
 
+def test_definitive_mint_refusal_is_not_reprobed_by_later_factory_builds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A remembered refusal makes later factory builds issue no mint request.
+
+    Several startup call sites each build an auth token factory. On a server
+    that never mints (no auth provider, or header/proxy auth mode) the outer
+    factory resolves to ``None``, so the process-wide singleton is never
+    installed and every one of those calls re-runs resolution — re-probing the
+    mint endpoint with a blocking POST, before the tunnel is even up, for a
+    refusal this process already learned.
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :returns: None.
+    """
+    from omnigent.inner.databricks_executor import DatabricksAuthError
+
+    mint_calls: list[int] = []
+
+    def _refuses(
+        mint_url: str, server_url: str, binding_token: str, **_kw: object
+    ) -> tuple[str, float]:
+        """Reject the mint the way a no-auth / header-mode server does (400)."""
+        del server_url, binding_token
+        mint_calls.append(1)
+        request = httpx.Request("POST", mint_url)
+        raise httpx.HTTPStatusError(
+            "unsupported", request=request, response=httpx.Response(400, request=request)
+        )
+
+    def _no_sdk(profile: str | None = None) -> tuple[Any, str]:
+        """Stand in for _resolve_databricks_auth with no credentials."""
+        raise DatabricksAuthError("no Databricks credentials configured")
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://omnigent.example.com")
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "host-binding-token")
+    monkeypatch.setenv("OMNIGENT_RUNNER_DELEGATED_AUTH", "1")
+    monkeypatch.delenv(RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url, **_kw: None)
+    monkeypatch.setattr("omnigent.inner.databricks_executor._resolve_databricks_auth", _no_sdk)
+    monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _refuses)
+
+    # One probe learns the refusal — including for the delegated-mint fallback
+    # the same call would otherwise re-probe after credential discovery fails.
+    assert _make_auth_token_factory() is None
+    assert mint_calls == [1]
+
+    # Every later startup call site reuses it: no further request.
+    assert _make_auth_token_factory() is None
+    assert _make_auth_token_factory() is None
+    assert _make_auth_token_factory() is None
+    assert mint_calls == [1]
+
+
+def test_transient_mint_failure_is_not_remembered_across_factory_builds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only definitive refusals are remembered; a boot blip is re-probed.
+
+    A transient failure installs a factory armed to retry, and a later build
+    must probe again rather than inherit a cached "no" — otherwise one blip at
+    boot would leave the runner unauthenticated until process restart.
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :returns: None.
+    """
+    calls: list[int] = []
+
+    def _blip_then_mint(
+        mint_url: str, server_url: str, binding_token: str, **_kw: object
+    ) -> tuple[str, float]:
+        """Fail the first probe with a connection error, then mint."""
+        del mint_url, server_url, binding_token
+        calls.append(1)
+        if len(calls) == 1:
+            raise httpx.ConnectError("mint endpoint unreachable at boot")
+        return ("jwt-1", time.time() + 1800)
+
+    monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _blip_then_mint)
+
+    first = _make_managed_mint_factory("https://s.example.com", "btok")
+    assert first is not None  # installed despite the boot blip
+
+    second = _make_managed_mint_factory("https://s.example.com", "btok")
+    assert second is not None  # the blip was not cached as a refusal
+    assert second() == "jwt-1"
+    assert len(calls) == 2  # failed probe + the probe that succeeded
+
+
 def test_managed_mint_factory_installs_for_retry_on_transient_boot_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Four separate runner-startup call sites each build an auth token factory
(`_make_auth_token_factory`: `runner/_entry.py` ×2, `runner/app.py`,
`runner/native/orchestration.py`). On a server that **cannot** mint a runner
token, every one of them re-ran credential resolution *and* re-probed the mint
endpoint with a blocking `httpx` POST — before the tunnel is even up.

The bug is a gap between two pieces of existing logic:

- `_make_managed_mint_factory` ends with a construction probe and returns
  `None` on a definitive refusal.
- `_make_auth_token_factory` installs the process-wide `_runner_auth_factory`
  singleton only when it *has* a factory, and the short-circuit gate requires
  `_runner_auth_factory is not None`.

So when the outer factory resolves to `None` — no OIDC token, no Databricks
credential, and no mint — the singleton is never installed, the gate never
fires, and calls 2..N repeat the whole probe. This is the steady state of the
local dev server (`auth_provider is None`) and of **header/proxy auth mode**
(`server/routes/runner_tunnel.py`); both answer
`POST /v1/runners/{id}/token` with HTTP 400. In a proxied deployment those are
four real network round trips per runner start.

The fix memoizes the refusal. A *definitive* refusal (400 no-auth/header mode,
404 on an older server, an Apps OAuth redirect ahead of the app) is a property
of server configuration, so it is recorded and later builds return `None`
without touching the network.

```
before                                   after
call 1 -> POST /token -> 400 ---.        call 1 -> POST /token -> 400 --> remember
call 2 -> POST /token -> 400    |        call 2 -> (cache hit) -> None
call 3 -> POST /token -> 400    |-- 4x   call 3 -> (cache hit) -> None
call 4 -> POST /token -> 400 ---'        call 4 -> (cache hit) -> None
```

**ELI5:** the runner asks the server "will you issue me a token?" four times
during startup, gets the same "no, I'm not configured for that" four times, and
waits for each answer. Now it remembers the first "no".

**What is deliberately *not* cached:**

- **Transient failures** (network blip, 5xx, timeout) still install a factory
  armed to re-mint. Caching them would let one blip at boot leave the runner
  unauthenticated until process restart — the exact regression the existing
  `declined`-latch tests were written for.
- **`proxy_auth_failed`** (mint 401/403). That means the *presented bearer*
  died, which `_InitialAuthTokenFactory` answers by re-resolving SDK/OIDC. It
  says nothing about whether the server mints.

**Why memoize rather than "install the factory and latch `declined`"** (the
other option considered): installing a declined factory changes what
`_make_auth_token_factory() is not None` means to its callers, and the damage is
concrete — `_make_auth_token_factory` returns early on the first non-`None`
delegated factory, so a runner that has a real OIDC/Databricks credential *and*
a non-minting server would get a permanently dead factory instead of its
working credential. It would also silence `_InitialAuthTokenFactory`'s terminal
"no credential available" log, which keys off `self._fallback_factory is None`.
Memoizing changes only how many times the same question is asked.

**Cache key:** `(mint_url, sha256(proxy_bearer))`. `mint_url` already embeds the
server URL and the binding-token digest (`token_bound_runner_id` is a sha256 of
the binding token), so that covers the `(mint_url, binding_token)` identity. The
proxy bearer is in the key because the Apps-redirect flavour of "definitive"
depends on *which* bearer was presented — without it, a bare probe that got
bounced by the Apps front door could wrongly veto a later probe carrying a valid
host bearer. Keyed this way, a remembered "no" can only ever replace a
byte-identical request. The bearer is hashed so a process-lifetime global holds
no credential material.

The cache is read through the canonical module, so the runner's `__main__` copy
of `_entry.py` and later importers share one cache (the same module-identity
split `_set_runner_auth_factory` already exists for).

## Test Plan

**Regression tests** (`tests/runner/test_runner_entry.py`, extending the
existing mint-factory tests in their idiom — they monkeypatch
`_mint_managed_owner_token`, the function that performs the POST):

- `test_definitive_mint_refusal_is_not_reprobed_by_later_factory_builds` —
  four `_make_auth_token_factory()` calls in the profiled configuration
  (binding token present, no OIDC token, no Databricks credential, server 400s)
  issue exactly **one** mint request in total.
- `test_transient_mint_failure_is_not_remembered_across_factory_builds` — a
  connect error at the boot probe still installs a factory, **and** the next
  build re-probes and installs rather than inheriting a cached "no".

`tests/runner/conftest.py` gains an autouse fixture giving each test a fresh
cache — without it the existing "server definitively refuses" test would poison
every later test that reuses the same server URL and binding token.

**Prove-it-fails:** with only the memo neutered (cache lookup replaced by a
fresh set, i.e. exactly today's behaviour) the new test fails
`assert [1, 1] == [1]` — showing that today even a *single*
`_make_auth_token_factory()` call probes twice when the delegated-mint marker is
set, because the same call re-probes in its post-credential-discovery fallback.

**Commands** (`origin/main`-clean, run individually on a loaded box):

```
pytest tests/runner/test_runner_entry.py                    # 100 passed
pytest tests/e2e/test_managed_runner_http_auth.py           # 2 passed (real mint, real sockets)
pytest tests/test_native_policy_hook.py \
       tests/inner/test_pi_native_executor.py \
       tests/runner/test_app_pi_native_model.py             # 62 passed
pre-commit run --files omnigent/runner/_entry.py \
       tests/runner/conftest.py tests/runner/test_runner_entry.py
```

`ruff format` / `ruff check` and the project lint hooks pass. `pyrefly` reports
99 `missing-import` errors — byte-identical on a pristine `origin/main` tree in
this environment (a borrowed venv), none of them in the changed files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

**Where the number comes from.** Profiling 32 host-launched runner starts on the
real stack measured exactly **4** `POST /v1/runners/{id}/token` requests per
runner start, **all HTTP 400**, on every launch — **132 ms p50 / 227 ms p95**
with the runner zygote (**550 ms** without it), all of it before the tunnel
connects, ~22% of the 602 ms fork→online window.

**Reproduced in isolation.** A harness stands up a stdlib HTTP server that
returns HTTP 400 to the mint POST (exactly what a no-auth-provider or
header-mode server sends), points `RUNNER_SERVER_URL` at it, sets the binding
token, and stubs OIDC/Databricks resolution to "no credential" — the profiled
configuration. It then times the four runner-startup `_make_auth_token_factory()`
builds, 20 iterations, cache cleared between iterations, under
`flock /tmp/omnigent-profile.lock`:

| | mint requests per runner start | wall time for the 4 builds (p50) | (p95) |
|---|---|---|---|
| before | **4** | **113.3 ms** | 177.9 ms |
| after  | **1** | **27.2 ms** | 37.6 ms |

~86 ms p50 / ~140 ms p95 off runner startup **on loopback**, where the network
is free: the per-probe cost is a fresh `httpx.Client`, the Databricks routing
header resolution, and the POST. In a proxied deployment each avoided probe is
additionally a real TLS round trip through the Apps front door, which is where
the profiler's 132 ms p50 / 227 ms p95 lives.

Measured with `/home/harry.yao/o8/.venv/bin/python` against this worktree
(verified via `omnigent.__file__`), box load average 6-8 for both runs, same
harness and same process for before/after (`before` = this commit's source with
the cache lookup reverted).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

The existing `_make_managed_mint_factory` suite already pins the semantics this
change must preserve — transient probe failure installs a factory, the factory
recovers on the next call, a post-install 400 latches `declined` and callbacks
go out bare, a mint 403 latches `proxy_auth_failed` and is not treated as a
server refusal — and all of it still passes, including the real-socket e2e
`tests/e2e/test_managed_runner_http_auth.py`.

**One intentional behaviour difference:** after a definitive refusal, a later
factory build in the *same process* no longer re-probes, so a server that starts
without an auth provider and later gains one will not be picked up by a
long-lived runner. That is consistent with today's design — an installed factory
already latches `declined` permanently for the process — and flipping that
server config requires a server restart, which drops the tunnel and takes the
runner with it.

## Changelog

Runner startup no longer spends four doomed token-mint round trips before its
tunnel connects.
