### PR TITLE
docs(changelog): fix broken code span in v0.11.0 host-stop entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ website under `/releases`.
 - [Feature] Scheduled tasks can now set a per-firing cost budget (`max_cost_usd`) that caps LLM spend on each run (#4791)
 - [Bug fix] Sub-agent inbox wake notices no longer repeat the same "results waiting in inbox" line while a parent's results sit undrained. (#4803)
 - [Chore] Cache session access checks briefly to cut per-event database load on active sessions (#4820)
-- [Chore] `omnigent host` conflict error now shows the exact `omnigent host stop --server (#4821)
+- [Chore] `omnigent host` conflict error now shows the exact `omnigent host stop` command to run (#4821)
 - [Bug fix] Resuming a conversation no longer fails with `string indices must be integers` when the history contains a plain-text assistant message (#4824)
 - [UI / Bug fix / Feature] Cmd/Ctrl+N now starts a new session, including in the macOS desktop app without opening another app window. (#4840)
 - [Bug fix] Agent and session discovery tools now page large catalogs through an opaque cursor, or return a bounded diagnostic when the smallest page cannot fit. (#4892)


### PR DESCRIPTION
> **Note:** Draft test PR opened to exercise OpenUI's PR view. The diff itself is a real, correct one-line fix, but it's fine to close this once the view has been validated.

## Related issue

N/A — `Docs` change, so no issue is required per the template.

## Summary

The v0.11.0 changelog entry for #4821 had an unclosed backtick and a truncated sentence:

> `omnigent host` conflict error now shows the exact \`omnigent host stop --server (#4821)

This closes the code span and completes the line to match the actual behavior — the conflict error prints the exact `omnigent host stop` command to run (`_host_stop_command` in `omnigent/cli.py` appends `--server <target>` only when the user passed one, so the general phrasing is "`omnigent host stop` command").

## Test Plan

- Verified the corrected line renders as valid Markdown (balanced code span, complete sentence).
- Cross-checked the wording against `omnigent/cli.py:_host_stop_command` and its tests in `tests/host/test_cli_host.py`.
- Note: `pre-commit` could not be run locally in this sandbox (no network access to fetch hook environments from PyPI). The change is a single-line Markdown edit with no whitespace/EOF impact; CI runs the same checks.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Docs-only fix to an already-released changelog entry; no code path changes, so automated coverage does not apply.

This pull request and its description were written by Isaac.