### PR TITLE
perf(host): register before probing harness capabilities

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -956,6 +956,10 @@ class HostProcess:
         self._configured_harnesses: dict[str, HarnessAvailability] | None = None
         self._gateway_inference: dict[str, bool] | None = None
         self._capabilities_initialized = False
+        # Tracks the startup capability probe so the readiness loop can tell
+        # "still probing" from "probed and found nothing", and skip refreshing
+        # alongside a probe already in flight.
+        self._capability_init_task: asyncio.Task[None] | None = None
         # Consecutive login-page redirects; reset by a successful upgrade.
         self._login_redirect_streak = 0
         # Reset by a successful upgrade or non-auth error; bounds fresh-host refresh retries.
@@ -2987,7 +2991,15 @@ class HostProcess:
             return None
 
     async def _initialize_capabilities(self) -> None:
-        """Build the initial capability snapshot once, before any handshake."""
+        """Build the initial capability snapshot once, off the connect path.
+
+        Probing shells out to four CLIs in series and imports the harness
+        modules, which measured 0.8-1.3s of a ~1.5s cold host start. The
+        metadata is advisory (``None`` means "unknown" on the wire, and the
+        launch-time check on this host is authoritative), so registration must
+        not wait on it: :meth:`run` starts this as a background task and
+        :meth:`_publish_capabilities` pushes the answer when it lands.
+        """
         if self._capabilities_initialized:
             return
         try:
@@ -3012,6 +3024,39 @@ class HostProcess:
         self._configured_harnesses = configured
         self._gateway_inference = gateway
         self._capabilities_initialized = True
+
+    async def _initialize_and_publish_capabilities(self) -> None:
+        """Probe capabilities in the background, then tell the live tunnel.
+
+        A hello sent before the probe finished reported readiness as unknown,
+        so the result is pushed as a readiness frame instead of waiting out
+        :data:`HARNESS_READINESS_REFRESH_INTERVAL_S`.
+        """
+        await self._initialize_capabilities()
+        await self._publish_capabilities()
+
+    async def _publish_capabilities(self) -> None:
+        """Push the current capability snapshot on the live tunnel, if any.
+
+        No-op when nothing is connected: the hello of the next connection
+        carries the snapshot. Best-effort — a send that loses a race with a
+        disconnect must not take the host down.
+        """
+        ws = self._ws
+        configured = self._configured_harnesses
+        if ws is None or configured is None:
+            return
+        try:
+            await ws.send(
+                encode_host_frame(
+                    HostHarnessReadinessFrame(
+                        configured_harnesses=configured,
+                        gateway_inference=self._gateway_inference,
+                    )
+                )
+            )
+        except Exception:  # noqa: BLE001 — advisory metadata, never fatal
+            _logger.debug("Could not publish host capabilities", exc_info=True)
 
     async def _lifecycle_monitor_loop(self) -> None:
         """Self-terminate once this daemon no longer owns its registry record.
@@ -3080,10 +3125,14 @@ class HostProcess:
             authorization / outdated server, or a loopback server that
             kept refusing connections (the local server is gone).
         """
-        # Capability probes may shell out or inspect local config, so perform
-        # them once during daemon initialization. They are advisory: a broken
-        # harness is reported as unknown and must not prevent registration.
-        await self._initialize_capabilities()
+        # Capability probes shell out to harness CLIs and import their
+        # modules, which dominated cold host start. They are advisory — a
+        # broken or unfinished probe is reported as unknown and must not delay
+        # registration — so they run alongside the connect instead of ahead of
+        # it, and push a readiness frame when they land.
+        self._capability_init_task = asyncio.create_task(
+            self._initialize_and_publish_capabilities(), name="host-capability-init"
+        )
 
         # Reap orphaned harness/tool grandchildren that reparent here when a
         # runner dies (this host is PID 1 in a container, or a subreaper
@@ -3291,6 +3340,11 @@ class HostProcess:
             # takeover paths that own it (this daemon may have been superseded).
             if self._lifecycle_lock is not None:
                 self._lifecycle_lock.release()
+            if self._capability_init_task is not None:
+                self._capability_init_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self._capability_init_task
+                self._capability_init_task = None
             if self._zygote_prestart_task is not None:
                 self._zygote_prestart_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -3570,6 +3624,10 @@ class HostProcess:
             raise HostConnectError(f"Could not encode host.hello: {exc}") from exc
         await ws.send(encoded_hello)
         self._ws = ws
+        if self._configured_harnesses != hello.configured_harnesses:
+            # The background probe landed while hello was on the wire, so the
+            # server holds the "unknown" this frame reported. Correct it now.
+            await self._publish_capabilities()
         # Reports raised while disconnected must wait until registration; the
         # server cannot route them before this connection owns the host.
         for runner_id, error in list(self._unreported_exits.items()):
@@ -3626,14 +3684,29 @@ class HostProcess:
         ws: websockets.asyncio.client.ClientConnection,
     ) -> None:
         """Refresh advisory capabilities without endangering the tunnel."""
-        configured = self._configured_harnesses
-        gateway = self._gateway_inference
         loop = asyncio.get_running_loop()
-        next_quick = loop.time() + HARNESS_READINESS_REFRESH_INTERVAL_S
+        # A probe that already settled as unknown is re-probed on the first
+        # tick rather than a full interval later, so the server is not left
+        # guessing. A probe still in flight is left to publish its own result.
+        settled_unknown = self._configured_harnesses is None and self._capabilities_initialized
+        next_quick = loop.time() + (
+            0.0 if settled_unknown else HARNESS_READINESS_REFRESH_INTERVAL_S
+        )
         next_full = loop.time() + HARNESS_READINESS_FULL_REFRESH_INTERVAL_S
         while True:
             await asyncio.sleep(max(0.0, min(next_quick, next_full) - loop.time()))
             now = loop.time()
+            # Registration no longer waits for the startup probe, so a tick can
+            # land while it is still running; refreshing here would run a
+            # second probe beside it. It publishes its own result when it lands.
+            init_task = self._capability_init_task
+            if init_task is not None and not init_task.done():
+                next_quick = now + HARNESS_READINESS_REFRESH_INTERVAL_S
+                continue
+            # Re-read each tick: the snapshot tracks what the server was last
+            # told, which the background probe may have pushed since.
+            configured = self._configured_harnesses
+            gateway = self._gateway_inference
             refresh_full = configured is None or now >= next_full
             if now >= next_quick:
                 next_quick = now + HARNESS_READINESS_REFRESH_INTERVAL_S
@@ -3663,10 +3736,8 @@ class HostProcess:
                         )
                     )
                 )
-                configured = new_configured
-                gateway = new_gateway
-                self._configured_harnesses = configured
-                self._gateway_inference = gateway
+                self._configured_harnesses = new_configured
+                self._gateway_inference = new_gateway
 
     def _raise_connection_error(self, frame: HostConnectionErrorFrame) -> None:
         """Raise the lifecycle exception requested by a server error frame."""

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -799,6 +799,11 @@ async def _cancel(task: asyncio.Task[None]) -> None:
         await task
 
 
+async def _noop_prewarm() -> None:
+    """Stand in for the model-options prewarm, which shells out to real CLIs."""
+    return
+
+
 def test_unavailable_harness_quick_probe_is_ttl_cached(monkeypatch: pytest.MonkeyPatch) -> None:
     """The quick probe resolves each unavailable harness once per TTL.
 
@@ -1319,6 +1324,197 @@ async def test_capability_probe_failure_does_not_block_registration(
     assert hello.configured_harnesses is None
     assert hello.gateway_inference == {"codex": False}
     assert "Permission denied: '/usr/local/bin/codex'" in capsys.readouterr().err
+
+
+class _OpenTunnel:
+    """Fake tunnel that stays open until the test closes it.
+
+    ``_FakeTunnel`` drops on first ``recv``, which tears down the post-hello
+    background tasks immediately. This one keeps serving so a test can observe
+    frames the host pushes while connected.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the frame log and the first-send / close signals."""
+        self.sent: list[str] = []
+        self.first_send = asyncio.Event()
+        self.closed = asyncio.Event()
+
+    async def send(self, data: str) -> None:
+        """Record an outbound frame and signal the first send.
+
+        :param data: Encoded frame text.
+        """
+        self.sent.append(data)
+        self.first_send.set()
+
+    async def recv(self) -> str:
+        """Block until the test closes the tunnel, then disconnect."""
+        await self.closed.wait()
+        raise ConnectionError("test disconnect")
+
+
+async def test_hello_is_sent_before_the_capability_probe_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Registration must not wait on capability discovery.
+
+    The startup probe shells out to four harness CLIs in series, which
+    measured 0.8-1.3s of a ~1.5s cold host start. It now runs alongside the
+    handshake, so hello registers the host with readiness unknown and the
+    probe's answer arrives as a readiness frame.
+
+    A 10ms heartbeat counts event-loop ticks: hello must land on the tick the
+    tunnel opened, long before the (deliberately much slower) probe returns.
+    """
+    host = _make_host_process()
+    monkeypatch.setattr(host, "_prewarm_model_options", _noop_prewarm)
+    release = asyncio.Event()
+    ticks = {"n": 0}
+
+    async def _heartbeat() -> None:
+        while True:
+            await asyncio.sleep(0.01)
+            ticks["n"] += 1
+
+    async def _blocked_configured(*, startup: bool) -> dict[str, bool]:
+        del startup
+        await release.wait()
+        return {"pi": True}
+
+    async def _blocked_gateway(*, startup: bool) -> dict[str, bool]:
+        del startup
+        await release.wait()
+        return {"codex": True}
+
+    monkeypatch.setattr(host, "_probe_configured_harnesses", _blocked_configured)
+    monkeypatch.setattr(host, "_probe_gateway_inference", _blocked_gateway)
+
+    beat = asyncio.create_task(_heartbeat())
+    init = asyncio.create_task(host._initialize_and_publish_capabilities())
+    tunnel = _OpenTunnel()
+    serve = asyncio.create_task(host._serve_frames(tunnel))  # type: ignore[arg-type]
+    try:
+        await asyncio.wait_for(tunnel.first_send.wait(), timeout=2.0)
+        hello_tick = ticks["n"]
+
+        hello = decode_host_frame(tunnel.sent[0])
+        assert isinstance(hello, HostHelloFrame)
+        # Registered as "unknown" — never as "nothing is configured".
+        assert hello.configured_harnesses is None
+        assert hello.gateway_inference is None
+        assert not host._capabilities_initialized
+
+        # The probe is still blocked several heartbeats after registration.
+        while ticks["n"] < hello_tick + 5:
+            await asyncio.sleep(0.01)
+        assert len(tunnel.sent) == 1
+
+        # Its answer reaches the server as soon as it lands, without waiting
+        # out HARNESS_READINESS_REFRESH_INTERVAL_S (left at its real 5s here).
+        release.set()
+        await asyncio.wait_for(init, timeout=2.0)
+        assert len(tunnel.sent) == 2
+        readiness = decode_host_frame(tunnel.sent[1])
+        assert isinstance(readiness, HostHarnessReadinessFrame)
+        assert readiness.configured_harnesses == {"pi": True}
+        assert readiness.gateway_inference == {"codex": True}
+    finally:
+        tunnel.closed.set()
+        with contextlib.suppress(ConnectionError):
+            await serve
+        await _cancel(beat)
+    _cleanup_host(host)
+
+
+async def test_capability_probe_landing_before_hello_needs_no_readiness_push(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A snapshot ready in time rides hello instead of a follow-up frame."""
+    host = _make_host_process()
+    monkeypatch.setattr(host, "_prewarm_model_options", _noop_prewarm)
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", lambda: {"pi": True})
+    monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", lambda: {"codex": True})
+
+    await host._initialize_and_publish_capabilities()
+    tunnel = _OpenTunnel()
+    serve = asyncio.create_task(host._serve_frames(tunnel))  # type: ignore[arg-type]
+    try:
+        await asyncio.wait_for(tunnel.first_send.wait(), timeout=2.0)
+        hello = decode_host_frame(tunnel.sent[0])
+        assert isinstance(hello, HostHelloFrame)
+        assert hello.configured_harnesses == {"pi": True}
+        # Nothing to correct, so no duplicate readiness frame.
+        await asyncio.sleep(0.05)
+        assert len(tunnel.sent) == 1
+    finally:
+        tunnel.closed.set()
+        with contextlib.suppress(ConnectionError):
+            await serve
+    _cleanup_host(host)
+
+
+async def test_settled_unknown_readiness_is_probed_without_a_refresh_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A startup probe that failed is retried on the loop's first tick.
+
+    ``HARNESS_READINESS_REFRESH_INTERVAL_S`` is left at its real 5s: a loop
+    that slept before its first probe would blow the 2s timeout below.
+    """
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", lambda: {"pi": True})
+    monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", lambda: {"codex": True})
+    host = _make_host_process()
+    host._configured_harnesses = None
+    host._gateway_inference = None
+    host._capabilities_initialized = True
+    ws = _RecordingWS()
+
+    task = asyncio.create_task(host._harness_readiness_loop(ws))  # type: ignore[arg-type]
+    try:
+        await asyncio.wait_for(ws.first_send.wait(), timeout=2.0)
+    finally:
+        await _cancel(task)
+
+    assert len(ws.sent) == 1
+    refresh = decode_host_frame(ws.sent[0])
+    assert isinstance(refresh, HostHarnessReadinessFrame)
+    assert refresh.configured_harnesses == {"pi": True}
+    _cleanup_host(host)
+
+
+async def test_refresh_loop_does_not_duplicate_an_in_flight_startup_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown readiness with the startup probe still running waits for it.
+
+    Probing again would double the four serial CLI execs for an answer already
+    on its way, so the loop only treats "unknown" as urgent once the startup
+    probe has settled.
+    """
+    calls = {"n": 0}
+
+    def _counted() -> dict[str, bool]:
+        calls["n"] += 1
+        return {"pi": True}
+
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", _counted)
+    monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", lambda: {"codex": True})
+    host = _make_host_process()
+    host._configured_harnesses = None
+    host._gateway_inference = None
+    host._capabilities_initialized = False
+    ws = _RecordingWS()
+
+    task = asyncio.create_task(host._harness_readiness_loop(ws))  # type: ignore[arg-type]
+    try:
+        await asyncio.sleep(0.2)
+    finally:
+        await _cancel(task)
+
+    assert calls["n"] == 0
+    assert ws.sent == []
+    _cleanup_host(host)
 
 
 async def test_hello_advertises_installed_version() -> None:


### PR DESCRIPTION
## Related issue

Closes #

## Summary

A cold `omnigent host` start spends most of its life invisible to the server. `run()` awaited `_initialize_capabilities()` **before** `_connect_and_serve()`, and that stage is dominated by four **strictly serial** CLI subprocesses (`claude --version` → `claude auth status` → `codex --version` → `gh auth token`) plus a concurrent thread importing `omnigent.claude_native` + `codex_native`. Measured on this box the stage is **635–1076 ms (median 1013 ms)** — the bulk of a ~1.5 s cold start — spent on metadata that is explicitly advisory.

This registers first and probes alongside the handshake:

- `run()` starts `_initialize_and_publish_capabilities()` as a background task. Hello goes out immediately, carrying `configured_harnesses = None` ("unknown") when the probe hasn't landed.
- The probe's answer is pushed as a `HostHarnessReadinessFrame` the moment it lands. `_serve_frames` also publishes right after registration when the probe finished *while hello was on the wire*, so no interleaving leaves the server holding a stale "unknown".
- `_harness_readiness_loop` no longer sleeps a full `HARNESS_READINESS_REFRESH_INTERVAL_S` (5 s) before its first probe when readiness has *settled* as unknown (i.e. the startup probe failed). Without this, the deferral would trade ~1 s of startup for up to 5 s of unknown state. A probe still **in flight** is deliberately left alone rather than duplicating its four CLI execs.
- The loop reads the shared snapshot each tick instead of carrying a stale local, so a map the background probe already published is not re-sent.

**ELI5:** the host used to interview every installed AI CLI before telling the server "I exist". Now it says hello first and sends the interview results a second later.

```
before:  spawn ──[ 4 serial CLI probes + harness imports ~1.0s ]──▶ connect ──▶ hello
after:   spawn ──▶ connect ──▶ hello                          (registered)
                └──[ probes ~1.0s ]──▶ host.harness_readiness  (map filled in)
```

### Why deferral is safe (verified before building, not assumed)

The wire protocol was already built for this, and I traced every consumer:

| Consumer | Behaviour on `None` |
|---|---|
| `HostHelloFrame.configured_harnesses` (`omnigent/host/frames.py`) | `\| None`, documented "``None`` means unknown … never treat ``None`` as *nothing is configured*" |
| `host_store.upsert_on_connect` → `SqlHost.configured_harnesses` | `None` → SQL `NULL`; `{}` → `"{}"`. **Null and empty stay distinct in the column.** |
| **Host selection / session routing** (`_available_auto_native_harnesses`, `omnigent/server/routes/_sessions/orchestration.py`) | `if not readiness: return list(AUTO_NATIVE_ROUTING_HARNESSES)` — **fails open**. An unknown map never excludes a host and never shrinks its candidate set. |
| Authoritative launch gate (`HostProcess._handle_launch`) | Calls `harness_is_configured(frame.harness)` **fresh at launch**, not from the cached map. An unconfigured harness is still refused with `harness_not_configured` (HTTP 412). |
| Web UI (`web/src/lib/harnessSetup.ts`) | `if (!harness \|\| !host?.configured_harnesses) return null;` → renders **unknown**: no "unconfigured" badge, host not hidden, launch not disabled |
| Web UI freshness | The readiness frame triggers `announce_hosts_changed` → `hosts_changed` over WS → `invalidateQueries(["hosts"])`. The filled-in map reaches the UI in ms, no manual refresh. |
| CLI (`omnigent host status`) | Does not render the map at all |

Nothing on the connect path needs the map synchronously, and `configured_harness_map()` has no process-level cache, so deferring moves no cost onto the first launch.

### Observable behaviour change

For roughly the first second of a **cold** host's life, the server may hold `configured_harnesses = None` instead of a populated map. That is the same fail-open state an older host or a failed probe already produces today; it renders as "unknown" rather than "unconfigured", and a harness that genuinely isn't configured is still refused at launch. Reconnects are unaffected — they reuse the cached snapshot and carry it in hello exactly as before.

The one honest caveat: during that window, auto-native routing considers both `claude-native` and `codex-native` candidates on that host. Worst case is a launch that fails loudly with `harness_not_configured` instead of routing to the configured harness — never a silent misroute, since the host-side launch check is authoritative.

## Test Plan

### Regression tests (`tests/host/test_connect.py`, 150 passed)

Four new tests, in the file's existing idiom:

1. **`test_hello_is_sent_before_the_capability_probe_finishes`** — the load-bearing one. Stubs both probes to block on an event and runs a **10 ms heartbeat coroutine counting event-loop ticks**: hello must land on the tick the tunnel opened, and still be the *only* frame sent 5 heartbeats later while the probe is blocked. Then releasing the probe produces the readiness frame — with `HARNESS_READINESS_REFRESH_INTERVAL_S` left at its **real 5 s**, so a push that waited for the refresh cadence could not pass. Ticks rather than wall-clock, so it can't go flaky on a loaded box.
2. **`test_capability_probe_landing_before_hello_needs_no_readiness_push`** — a snapshot ready in time rides hello and produces **no** duplicate frame.
3. **`test_settled_unknown_readiness_is_probed_without_a_refresh_interval`** — a failed startup probe is retried on the loop's first tick. Also leaves the interval at the real 5 s against a 2 s timeout.
4. **`test_refresh_loop_does_not_duplicate_an_in_flight_startup_probe`** — unknown readiness with the probe *still running* waits for it (asserts the probe fn is called **0** times), so the deferral doesn't double the four serial CLI execs.

**Prove-it-fails:** reverted `omnigent/host/connect.py` to `origin/main` and re-ran — test 3 fails with `TimeoutError` (the old loop slept 5 s before its first probe) and passes with the change. Tests 1–2 exercise methods that don't exist on main (the old `run()` awaited the probe outright).

```
$ pytest tests/host/test_connect.py -q
150 passed in 16.9s
$ pytest tests/host/test_frames.py tests/onboarding/test_harness_readiness.py tests/server/test_host_registry.py -q
151 passed   # one pre-existing env failure: opentelemetry.sdk not installed, identical on main
```

### Lint

`pre-commit run --files omnigent/host/connect.py tests/host/test_connect.py` — every hook passes. `pyrefly` reports **11 errors before and 11 after** on these two files (unchanged; they're `sdks/python-client` missing-import artifacts of this box's shared venv).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

### Measurements

**1. The cost being removed.** Real `_initialize_capabilities()` stage, fresh process per sample (the `gateway_inference` half is a one-time import, so it must not be measured twice in one process), under `flock /tmp/omnigent-profile.lock`, load average 4.97:

```
stage=635ms   configured=634ms   gateway=569ms
stage=1013ms  configured=1013ms  gateway=559ms
stage=1076ms  configured=1076ms  gateway=576ms
stage=638ms   configured=638ms   gateway=546ms
stage=1023ms  configured=1023ms  gateway=500ms
```

Median stage **1013 ms**, best **635 ms**. `configured_harness_map` (the four serial CLI execs) sets the stage length; `gateway_inference_map` (500–576 ms of harness imports) runs concurrently inside it. A further ~300 ms just to import the two modules precedes it.

**2. What registration now costs.** Interleaved A/B (alternating before/after per iteration so the box's drifting load hits both arms equally), n=11, driving the real `HostProcess` in-process against a fake tunnel and timestamping the actual `host.hello` frame. Probe latency stubbed to a fixed 1.0 s so the two arms differ *only* in ordering:

```
before (probe-then-hello):  best= 630.7 ms   median= 631.0 ms
after  (deferred):          best=   0.1 ms   median=   0.1 ms
delta median: 630.9 ms
```

Registration no longer scales with probe latency at all — the stage leaves the pre-hello critical path entirely rather than getting faster. Against the measured real probe cost that is **~1.0 s off median cold host start** (~635 ms in the best case), consistent with the paired spawn→`host.hello` A/B that motivated this (1866 → 1101 ms with probes stubbed).

Every number was taken under `flock /tmp/omnigent-profile.lock` with `PYTHONPATH` pinned to this worktree and `omnigent.__file__` printed to prove which tree loaded (several agents share this box).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the measurement work above: the real capability-probe stage timed in a fresh process, and the interleaved A/B on registration latency driving `HostProcess` in-process (cheapest way to exercise the connect path without onboarding or provider creds). I did **not** drive a live host daemon end-to-end against a real server — several other daemons run on this box and the in-process path covers the same code. The consumer audit in the Summary was done by reading the server, store, routing and web code rather than by observing a live host register with a null map.

## Changelog

Hosts now appear in the session picker about a second sooner on startup, with harness readiness filling in right after.
