### PR TITLE
perf(host): defer heavy imports out of the host-connect graph

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3261,7 +3261,7 @@ def _build_host_daemon_env(
         such as ``None`` / ``""`` for local daemon mode.
     :returns: Environment dict for ``subprocess.Popen``.
     """
-    from omnigent.host.connect import (
+    from omnigent.host.runner_env import (
         _RUNNER_ENV_ALLOWLIST,
         _RUNNER_ENV_ALLOWLIST_PREFIXES,
     )

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -27,7 +27,7 @@ from typing import Any, Literal, Protocol, SupportsIndex, SupportsInt, cast
 import websockets.asyncio.client
 from websockets.exceptions import ConnectionClosed, InvalidStatus, InvalidURI
 
-from omnigent._platform import IS_POSIX, WINDOWS_ENV_PASSTHROUGH
+from omnigent._platform import IS_POSIX
 from omnigent.cli_invocation import cli_invocation
 from omnigent.debug_logging import (
     ORIGIN_WORKSPACE_ID_ENV_VAR,
@@ -90,13 +90,12 @@ from omnigent.host.git_worktree import (
     remove_worktree,
 )
 from omnigent.host.identity import HostIdentity, load_or_create_host_identity
+from omnigent.host.runner_env import (
+    _RUNNER_ENV_ALLOWLIST,
+    _RUNNER_ENV_ALLOWLIST_PREFIXES,
+)
 from omnigent.host.runner_zygote import ZygoteManager, ZygoteRunnerProc, ZygoteUnavailable
 from omnigent.inner import _proc
-from omnigent.onboarding.harness_auth import (
-    adopt_env_credential,
-    detect_adoptable_credentials,
-    store_harness_credential,
-)
 from omnigent.onboarding.harness_install import (
     harness_cli_installed,
     harness_setup_hint,
@@ -109,7 +108,6 @@ from omnigent.onboarding.harness_readiness import (
 )
 from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, OPENAI_FAMILY
 from omnigent.process_logging import (
-    LOG_TTY_FD_ENV_VAR,
     PROCESS_LOG_FILE_ENV_VAR,
     child_logging_popen_kwargs,
     configure_process_logging,
@@ -406,205 +404,6 @@ _SILENT_CONNECT_ESCALATE_ATTEMPTS = 10
 # Capability discovery is advisory and must not delay the host channel forever.
 _HOST_CAPABILITY_INIT_TIMEOUT_S = 15.0
 
-# Host-environment variables a spawned runner is allowed to inherit.
-# Deliberately an allowlist (not ``{**os.environ}``): the host runs as the
-# user, so its environment holds the user's personal secrets (API keys,
-# tokens). A runner has no need for those — agent credentials and config
-# come from the agent spec, not the host owner's shell (spec
-# self-containment). Anything an agent
-# legitimately needs must flow through its spec's env config. Limited to
-# process essentials (PATH/HOME/shell/locale/temp) and TLS trust stores so
-# the runner's outbound HTTPS still works.
-_RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
-    {
-        "PATH",
-        "PYTHONPATH",
-        "HOME",
-        "USER",
-        "LOGNAME",
-        "SHELL",
-        "TMPDIR",
-        "TZ",
-        "TERM",
-        "TERMINFO",
-        "TERMINFO_DIRS",
-        "LANG",
-        "SSL_CERT_FILE",
-        "SSL_CERT_DIR",
-        "REQUESTS_CA_BUNDLE",
-        "CURL_CA_BUNDLE",
-        "NODE_EXTRA_CA_CERTS",
-        # Force UTF-8 I/O on Windows. Without this, Python on Windows defaults
-        # to the system ANSI code page (e.g. cp1252), causing UnicodeEncodeError
-        # when the host daemon / runner prints Unicode characters such as "✓" or
-        # "↑" in connection status messages — which kills the tunnel in an
-        # infinite reconnect loop. Safe to propagate: a non-secret interpreter
-        # flag. No-op on POSIX where UTF-8 is the default.
-        "PYTHONUTF8",
-        # Environment descriptor baked into the sandbox host image
-        # (deploy/docker/Dockerfile `host` target), never set on
-        # laptops. Claude Code refuses --dangerously-skip-permissions
-        # under root unless this devcontainer-convention flag is set,
-        # and sandbox containers run as root — without it the
-        # claude-sdk harness cannot start inside managed sandboxes.
-        "IS_SANDBOX",
-        # Databricks config selectors are not bearer secrets. They must
-        # reach host-spawned runners so native harnesses resolve the same
-        # profile/config file the host resolved (e.g. a spec-declared
-        # executor.profile propagated into the daemon's env).
-        "DATABRICKS_CONFIG_PROFILE",
-        "DATABRICKS_CONFIG_FILE",
-        # DATABRICKS_AUTH_STORAGE selects the token-storage backend ("secure"
-        # OS keychain vs "plaintext" JSON cache) — also a non-secret selector.
-        # Without it a runner falls back to the ~/.databrickscfg [__settings__]
-        # auth_storage default and can resolve a DIFFERENT token store than the
-        # host/daemon (which inherits it via the daemon env's DATABRICKS_ prefix
-        # in cli.py). That mismatch makes the runner read an empty/stale store
-        # and fail to mint a token — the runner tunnel is rejected with HTTP 401
-        # even though the host authenticated fine.
-        "DATABRICKS_AUTH_STORAGE",
-        # Runtime config/data-dir selection. These are filesystem PATHS, not
-        # secrets, so they're safe to propagate to the host owner's own
-        # daemon/runner subprocesses. They MUST propagate so the whole local
-        # chain (CLI → daemon → local server → runner) agrees:
-        #   - OMNIGENT_CONFIG_HOME: where config.yaml / provider config live,
-        #     so the runner resolves the same providers the CLI configured.
-        #   - OMNIGENT_DATA_DIR: where the sqlite db + pidfile live, so the
-        #     CLI doesn't read the local-server pidfile from one dir while the
-        #     daemon writes it to another (that mismatch timed out discovery).
-        # OMNIGENT_DATABASE_URI is intentionally NOT here — it may embed a
-        # DB password, so it's propagated to the local daemon only (see
-        # cli._ensure_host_daemon), never to a (possibly hosted) runner.
-        "OMNIGENT_CONFIG_HOME",
-        "OMNIGENT_DATA_DIR",
-        # Auth provider selection. The env-unset default was flipped
-        # to "accounts", so the whole CLI → daemon → local-server chain has
-        # to agree on the mode. Without this, the daemon strips
-        # OMNIGENT_AUTH_PROVIDER and the daemon-spawned local server
-        # silently boots in accounts mode while the CLI thinks it's talking
-        # to a header-mode server — every CLI request 401s (e.g. the
-        # test_run_omnigent_resumption suite). Not a secret; safe to propagate to
-        # any subprocess.
-        "OMNIGENT_AUTH_PROVIDER",
-        # Multi-user opt-in switch (create_auth_provider): OMNIGENT_AUTH_ENABLED
-        # turns the env-unset header/local default into accounts (or oidc, when
-        # OMNIGENT_OIDC_* is set); =0 opts back out. Must propagate down the
-        # CLI → daemon → local-server chain or `omnigent run`/`connect` would
-        # spawn the wrong auth mode while the operator set the switch on the CLI.
-        # Not a secret.
-        "OMNIGENT_AUTH_ENABLED",
-        # Process logging controls. These are diagnostics knobs, not secrets.
-        "OMNIGENT_LOG_LEVEL",
-        "OMNIGENT_LOG_TO_STDERR",
-        LOG_TTY_FD_ENV_VAR,
-        # Debug-log sink config + creds (OMNI-4198). The runner uploads its OWN
-        # process logs to the debug-logs table, so it needs these — including the
-        # service-principal secret. That is the one deliberate exception to the
-        # "no secrets" rule: it is the app's SP creds for log upload (not a user
-        # secret), and the runner is a trusted child. Without them the runner's
-        # sink never arms and runner logs never reach the table.
-        "OMNIGENT_DEBUG_LOG_CLIENT_ID",
-        "OMNIGENT_DEBUG_LOG_CLIENT_SECRET",
-        "OMNIGENT_DEBUG_LOG_WORKSPACE_URL",
-        "OMNIGENT_DEBUG_LOG_ENDPOINT",
-        # Secret-store backend selector. The CLI's `configure harnesses` stores
-        # pasted API keys via the file backend when this is set (headless /
-        # locked-keyring hosts), writing `keychain:<name>` refs. The runner
-        # RESOLVES those refs, so it must pick the SAME backend — otherwise it
-        # falls back to the OS keyring and fails with "no stored secret named
-        # …" for a key the CLI just saved to the file. Not a secret (a boolean
-        # flag); safe to propagate.
-        "OMNIGENT_DISABLE_KEYRING",
-        # claude-sdk sandbox bypass flag. A diagnostic knob (not a
-        # secret — a plain boolean) read inside the harness to decide
-        # whether to wrap the brain CLI in sandbox-exec. Without it in
-        # the allowlist the daemon→runner env strip drops it, so a bare
-        # ``OMNIGENT_CLAUDE_SDK_NO_SANDBOX=1 omnigent run …`` had no
-        # effect (the operator also had to set
-        # ``OMNIGENT_RUNNER_ENV_PASSTHROUGH=OMNIGENT_CLAUDE_SDK_NO_SANDBOX``).
-        # Safe to propagate: not a secret.
-        "OMNIGENT_CLAUDE_SDK_NO_SANDBOX",
-        # Native-Claude launcher plugin selector: the entry-point NAME of a
-        # launcher registered in the ``omnigent.claude_launcher`` group (e.g.
-        # ``isaac``). Read by omnigent.claude_launcher.resolve_claude_launch in
-        # the managed-host runner (``_auto_create_claude_terminal``) to wrap the
-        # Claude launch through a downstream binary (e.g. Databricks' isaac).
-        # The daemon→runner env strip would otherwise drop it, leaving the
-        # runner on the default launch. Safe to propagate: not a secret, just a
-        # plugin name.
-        "OMNIGENT_CLAUDE_LAUNCHER",
-        # Testing knob: override the context window size for compaction
-        # trigger threshold. Not a secret — a plain integer.
-        "AP_CONTEXT_WINDOW_OVERRIDE",
-        # Claude Code's Bedrock-mode switch: a non-secret boolean flag that
-        # turns on AWS Bedrock / Bedrock-compatible gateway mode. The matching
-        # credential (AWS_BEARER_TOKEN_BEDROCK) and endpoint
-        # (ANTHROPIC_BEDROCK_BASE_URL) are NOT here: they are credentials and
-        # live in HARNESS_CREDENTIAL_ENV_VARS, mirroring ANTHROPIC_API_KEY /
-        # ANTHROPIC_BASE_URL. Safe to propagate: not a secret.
-        "CLAUDE_CODE_USE_BEDROCK",
-        # Claude Code's Bedrock-auth-skip switch: a non-secret boolean flag
-        # that disables AWS SigV4 auth so Claude Code can talk to a LiteLLM
-        # proxy fronting Bedrock. Without it the runner attempts native AWS
-        # auth, which fails for non-AWS proxies. Same rationale as
-        # CLAUDE_CODE_USE_BEDROCK above. Safe to propagate: not a secret.
-        "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
-        # Non-secret Claude Code flags the native-claude provider path reads from
-        # os.environ. If stripped, the runner re-adds CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1,
-        # which turns off MCP tool search and loads every tool schema eagerly.
-        "CLAUDE_CODE_USE_GATEWAY",
-        "ENABLE_TOOL_SEARCH",
-        # Kubernetes config path. A filesystem path (typically
-        # ``~/.kube/config``), not a bearer secret — the file *contains*
-        # cluster certs/tokens but the env var is just a path string,
-        # analogous to ``HOME``. Without it, ``kubectl`` / helm / k9s
-        # inside the agent's shell fall back to the default path which may
-        # not match what the host owner configured (e.g. a non-standard
-        # kubeconfig location or a colon-separated multi-file list).
-        "KUBECONFIG",
-        # ssh-agent socket path. Same class as KUBECONFIG above: a path to a
-        # unix socket, not a bearer secret. Without it every runner-spawned
-        # context (sys_os_shell, terminal panes, coding sub-agents) loses
-        # ssh-agent auth, so git-over-SSH and SSH-cert-authenticated tooling
-        # fail with "dial unix: missing address".
-        "SSH_AUTH_SOCK",
-        # Telemetry master opt-in. MUST propagate, or the daemon-spawned runner
-        # (and the harness it spawns) never see OMNIGENT_TELEMETRY_ENABLED, so
-        # telemetry.init() no-ops there and omni-runner / omni-harness export
-        # nothing — inheriting OTEL_* alone is no longer enough now that
-        # telemetry is opt-in. Not a secret (a boolean). The OMNIGENT_OTEL_*
-        # knobs (capture-content, FastAPI toggle) ride the prefix allowlist below.
-        "OMNIGENT_TELEMETRY_ENABLED",
-        # Opaque request-routing headers (dev/test): a JSON header map folded by
-        # cli_auth.databricks_request_headers into every client→server connection
-        # so a request pins to a specific server instance/replica. Must reach the
-        # spawned runner so its tunnel + server callbacks route to the SAME
-        # instance the host registered on — otherwise the host lands on the
-        # selected instance while its runners fall back to the default one.
-        # Routing config, not a secret; unset in prod. Allowlisting it forwards it
-        # host→runner intrinsically, so the setter need not also list it in
-        # OMNIGENT_RUNNER_ENV_PASSTHROUGH.
-        "OMNIGENT_DATABRICKS_EXTRA_HEADERS",
-        # The operator's env-forwarding control var itself. Without it here, the
-        # var is stripped before it reaches the daemon in --server mode (the
-        # remote daemon prefixes are DATABRICKS_ + LC_/MLFLOW_/OTEL_/OMNIGENT_OTEL_,
-        # not plain OMNIGENT_), so _build_runner_env never sees the names it lists
-        # and the whole passthrough is a no-op remotely. It carries only env var
-        # NAMES, not secrets, so allowlisting it leaks nothing on its own.
-        # (Literal, not RUNNER_ENV_PASSTHROUGH_ENV_VAR, which is defined below.)
-        "OMNIGENT_RUNNER_ENV_PASSTHROUGH",
-        # Keep host and spawned-runner routing decisions aligned when the
-        # host-slice-key kill switch is explicitly disabled.
-        "OMNIGENT_HOST_SLICE_KEY_ENABLED",
-    }
-    # Windows system / profile constants (SYSTEMROOT is mandatory for Winsock,
-    # USERPROFILE for Path.home(), etc.); a no-op on POSIX. See _platform.
-    | set(WINDOWS_ENV_PASSTHROUGH)
-)
-# Allowed by prefix: locale family (``LC_*``), MLflow, and OpenTelemetry config —
-# both the standard ``OTEL_*`` vars and Omnigent's ``OMNIGENT_OTEL_*`` knobs
-# (capture-content, FastAPI toggle) so they reach the runner/harness too.
-_RUNNER_ENV_ALLOWLIST_PREFIXES: tuple[str, ...] = ("LC_", "MLFLOW_", "OTEL_", "OMNIGENT_OTEL_")
 
 # Harness credential / endpoint env vars forwarded host→runner when
 # present. These are the names the harnesses themselves resolve —
@@ -2434,6 +2233,15 @@ class HostProcess:
         :returns: Result with ``status`` ``"ok"``/``"failed"``, refreshed
             readiness on success, and a non-secret reason on failure.
         """
+        # Imported here, not at module scope: the credential writer is a heavy
+        # import and only the rare store-secret / detect-credentials frames reach
+        # it, while this module loads on every host-daemon start.
+        from omnigent.onboarding.harness_auth import (
+            adopt_env_credential,
+            detect_adoptable_credentials,
+            store_harness_credential,
+        )
+
         # Resolve the harness to a provider family, re-checking the allowlist.
         # claude→anthropic, codex→openai; pi consumes both and prefers anthropic
         # (its first fallback family), so a typed pi key lands on anthropic.
@@ -2527,6 +2335,8 @@ class HostProcess:
         :param frame: The detect request (carries only a request id).
         :returns: Result frame with the non-secret credential descriptors.
         """
+        from omnigent.onboarding.harness_auth import detect_adoptable_credentials
+
         detected = detect_adoptable_credentials()
         return HostDetectCredentialsResultFrame(
             request_id=frame.request_id,

--- a/omnigent/host/runner_env.py
+++ b/omnigent/host/runner_env.py
@@ -1,0 +1,215 @@
+"""Env-var allowlist for host-spawned runner processes.
+
+A deliberately tiny leaf module: both the host daemon
+(:mod:`omnigent.host.connect`, which builds a runner's environment) and the CLI
+helper that builds the host daemon's own environment need these two constants,
+and the CLI must not pay for the whole host-connect import tree to read them.
+Depends only on the import-cheap :mod:`omnigent._platform` /
+:mod:`omnigent.process_logging` leaves.
+"""
+
+from __future__ import annotations
+
+from omnigent._platform import WINDOWS_ENV_PASSTHROUGH
+from omnigent.process_logging import LOG_TTY_FD_ENV_VAR
+
+# Host-environment variables a spawned runner is allowed to inherit.
+# Deliberately an allowlist (not ``{**os.environ}``): the host runs as the
+# user, so its environment holds the user's personal secrets (API keys,
+# tokens). A runner has no need for those — agent credentials and config
+# come from the agent spec, not the host owner's shell (spec
+# self-containment). Anything an agent
+# legitimately needs must flow through its spec's env config. Limited to
+# process essentials (PATH/HOME/shell/locale/temp) and TLS trust stores so
+# the runner's outbound HTTPS still works.
+_RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "PATH",
+        "PYTHONPATH",
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "TMPDIR",
+        "TZ",
+        "TERM",
+        "TERMINFO",
+        "TERMINFO_DIRS",
+        "LANG",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        "NODE_EXTRA_CA_CERTS",
+        # Force UTF-8 I/O on Windows. Without this, Python on Windows defaults
+        # to the system ANSI code page (e.g. cp1252), causing UnicodeEncodeError
+        # when the host daemon / runner prints Unicode characters such as "✓" or
+        # "↑" in connection status messages — which kills the tunnel in an
+        # infinite reconnect loop. Safe to propagate: a non-secret interpreter
+        # flag. No-op on POSIX where UTF-8 is the default.
+        "PYTHONUTF8",
+        # Environment descriptor baked into the sandbox host image
+        # (deploy/docker/Dockerfile `host` target), never set on
+        # laptops. Claude Code refuses --dangerously-skip-permissions
+        # under root unless this devcontainer-convention flag is set,
+        # and sandbox containers run as root — without it the
+        # claude-sdk harness cannot start inside managed sandboxes.
+        "IS_SANDBOX",
+        # Databricks config selectors are not bearer secrets. They must
+        # reach host-spawned runners so native harnesses resolve the same
+        # profile/config file the host resolved (e.g. a spec-declared
+        # executor.profile propagated into the daemon's env).
+        "DATABRICKS_CONFIG_PROFILE",
+        "DATABRICKS_CONFIG_FILE",
+        # DATABRICKS_AUTH_STORAGE selects the token-storage backend ("secure"
+        # OS keychain vs "plaintext" JSON cache) — also a non-secret selector.
+        # Without it a runner falls back to the ~/.databrickscfg [__settings__]
+        # auth_storage default and can resolve a DIFFERENT token store than the
+        # host/daemon (which inherits it via the daemon env's DATABRICKS_ prefix
+        # in cli.py). That mismatch makes the runner read an empty/stale store
+        # and fail to mint a token — the runner tunnel is rejected with HTTP 401
+        # even though the host authenticated fine.
+        "DATABRICKS_AUTH_STORAGE",
+        # Runtime config/data-dir selection. These are filesystem PATHS, not
+        # secrets, so they're safe to propagate to the host owner's own
+        # daemon/runner subprocesses. They MUST propagate so the whole local
+        # chain (CLI → daemon → local server → runner) agrees:
+        #   - OMNIGENT_CONFIG_HOME: where config.yaml / provider config live,
+        #     so the runner resolves the same providers the CLI configured.
+        #   - OMNIGENT_DATA_DIR: where the sqlite db + pidfile live, so the
+        #     CLI doesn't read the local-server pidfile from one dir while the
+        #     daemon writes it to another (that mismatch timed out discovery).
+        # OMNIGENT_DATABASE_URI is intentionally NOT here — it may embed a
+        # DB password, so it's propagated to the local daemon only (see
+        # cli._ensure_host_daemon), never to a (possibly hosted) runner.
+        "OMNIGENT_CONFIG_HOME",
+        "OMNIGENT_DATA_DIR",
+        # Auth provider selection. The env-unset default was flipped
+        # to "accounts", so the whole CLI → daemon → local-server chain has
+        # to agree on the mode. Without this, the daemon strips
+        # OMNIGENT_AUTH_PROVIDER and the daemon-spawned local server
+        # silently boots in accounts mode while the CLI thinks it's talking
+        # to a header-mode server — every CLI request 401s (e.g. the
+        # test_run_omnigent_resumption suite). Not a secret; safe to propagate to
+        # any subprocess.
+        "OMNIGENT_AUTH_PROVIDER",
+        # Multi-user opt-in switch (create_auth_provider): OMNIGENT_AUTH_ENABLED
+        # turns the env-unset header/local default into accounts (or oidc, when
+        # OMNIGENT_OIDC_* is set); =0 opts back out. Must propagate down the
+        # CLI → daemon → local-server chain or `omnigent run`/`connect` would
+        # spawn the wrong auth mode while the operator set the switch on the CLI.
+        # Not a secret.
+        "OMNIGENT_AUTH_ENABLED",
+        # Process logging controls. These are diagnostics knobs, not secrets.
+        "OMNIGENT_LOG_LEVEL",
+        "OMNIGENT_LOG_TO_STDERR",
+        LOG_TTY_FD_ENV_VAR,
+        # Debug-log sink config + creds (OMNI-4198). The runner uploads its OWN
+        # process logs to the debug-logs table, so it needs these — including the
+        # service-principal secret. That is the one deliberate exception to the
+        # "no secrets" rule: it is the app's SP creds for log upload (not a user
+        # secret), and the runner is a trusted child. Without them the runner's
+        # sink never arms and runner logs never reach the table.
+        "OMNIGENT_DEBUG_LOG_CLIENT_ID",
+        "OMNIGENT_DEBUG_LOG_CLIENT_SECRET",
+        "OMNIGENT_DEBUG_LOG_WORKSPACE_URL",
+        "OMNIGENT_DEBUG_LOG_ENDPOINT",
+        # Secret-store backend selector. The CLI's `configure harnesses` stores
+        # pasted API keys via the file backend when this is set (headless /
+        # locked-keyring hosts), writing `keychain:<name>` refs. The runner
+        # RESOLVES those refs, so it must pick the SAME backend — otherwise it
+        # falls back to the OS keyring and fails with "no stored secret named
+        # …" for a key the CLI just saved to the file. Not a secret (a boolean
+        # flag); safe to propagate.
+        "OMNIGENT_DISABLE_KEYRING",
+        # claude-sdk sandbox bypass flag. A diagnostic knob (not a
+        # secret — a plain boolean) read inside the harness to decide
+        # whether to wrap the brain CLI in sandbox-exec. Without it in
+        # the allowlist the daemon→runner env strip drops it, so a bare
+        # ``OMNIGENT_CLAUDE_SDK_NO_SANDBOX=1 omnigent run …`` had no
+        # effect (the operator also had to set
+        # ``OMNIGENT_RUNNER_ENV_PASSTHROUGH=OMNIGENT_CLAUDE_SDK_NO_SANDBOX``).
+        # Safe to propagate: not a secret.
+        "OMNIGENT_CLAUDE_SDK_NO_SANDBOX",
+        # Native-Claude launcher plugin selector: the entry-point NAME of a
+        # launcher registered in the ``omnigent.claude_launcher`` group (e.g.
+        # ``isaac``). Read by omnigent.claude_launcher.resolve_claude_launch in
+        # the managed-host runner (``_auto_create_claude_terminal``) to wrap the
+        # Claude launch through a downstream binary (e.g. Databricks' isaac).
+        # The daemon→runner env strip would otherwise drop it, leaving the
+        # runner on the default launch. Safe to propagate: not a secret, just a
+        # plugin name.
+        "OMNIGENT_CLAUDE_LAUNCHER",
+        # Testing knob: override the context window size for compaction
+        # trigger threshold. Not a secret — a plain integer.
+        "AP_CONTEXT_WINDOW_OVERRIDE",
+        # Claude Code's Bedrock-mode switch: a non-secret boolean flag that
+        # turns on AWS Bedrock / Bedrock-compatible gateway mode. The matching
+        # credential (AWS_BEARER_TOKEN_BEDROCK) and endpoint
+        # (ANTHROPIC_BEDROCK_BASE_URL) are NOT here: they are credentials and
+        # live in HARNESS_CREDENTIAL_ENV_VARS, mirroring ANTHROPIC_API_KEY /
+        # ANTHROPIC_BASE_URL. Safe to propagate: not a secret.
+        "CLAUDE_CODE_USE_BEDROCK",
+        # Claude Code's Bedrock-auth-skip switch: a non-secret boolean flag
+        # that disables AWS SigV4 auth so Claude Code can talk to a LiteLLM
+        # proxy fronting Bedrock. Without it the runner attempts native AWS
+        # auth, which fails for non-AWS proxies. Same rationale as
+        # CLAUDE_CODE_USE_BEDROCK above. Safe to propagate: not a secret.
+        "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+        # Non-secret Claude Code flags the native-claude provider path reads from
+        # os.environ. If stripped, the runner re-adds CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1,
+        # which turns off MCP tool search and loads every tool schema eagerly.
+        "CLAUDE_CODE_USE_GATEWAY",
+        "ENABLE_TOOL_SEARCH",
+        # Kubernetes config path. A filesystem path (typically
+        # ``~/.kube/config``), not a bearer secret — the file *contains*
+        # cluster certs/tokens but the env var is just a path string,
+        # analogous to ``HOME``. Without it, ``kubectl`` / helm / k9s
+        # inside the agent's shell fall back to the default path which may
+        # not match what the host owner configured (e.g. a non-standard
+        # kubeconfig location or a colon-separated multi-file list).
+        "KUBECONFIG",
+        # ssh-agent socket path. Same class as KUBECONFIG above: a path to a
+        # unix socket, not a bearer secret. Without it every runner-spawned
+        # context (sys_os_shell, terminal panes, coding sub-agents) loses
+        # ssh-agent auth, so git-over-SSH and SSH-cert-authenticated tooling
+        # fail with "dial unix: missing address".
+        "SSH_AUTH_SOCK",
+        # Telemetry master opt-in. MUST propagate, or the daemon-spawned runner
+        # (and the harness it spawns) never see OMNIGENT_TELEMETRY_ENABLED, so
+        # telemetry.init() no-ops there and omni-runner / omni-harness export
+        # nothing — inheriting OTEL_* alone is no longer enough now that
+        # telemetry is opt-in. Not a secret (a boolean). The OMNIGENT_OTEL_*
+        # knobs (capture-content, FastAPI toggle) ride the prefix allowlist below.
+        "OMNIGENT_TELEMETRY_ENABLED",
+        # Opaque request-routing headers (dev/test): a JSON header map folded by
+        # cli_auth.databricks_request_headers into every client→server connection
+        # so a request pins to a specific server instance/replica. Must reach the
+        # spawned runner so its tunnel + server callbacks route to the SAME
+        # instance the host registered on — otherwise the host lands on the
+        # selected instance while its runners fall back to the default one.
+        # Routing config, not a secret; unset in prod. Allowlisting it forwards it
+        # host→runner intrinsically, so the setter need not also list it in
+        # OMNIGENT_RUNNER_ENV_PASSTHROUGH.
+        "OMNIGENT_DATABRICKS_EXTRA_HEADERS",
+        # The operator's env-forwarding control var itself. Without it here, the
+        # var is stripped before it reaches the daemon in --server mode (the
+        # remote daemon prefixes are DATABRICKS_ + LC_/MLFLOW_/OTEL_/OMNIGENT_OTEL_,
+        # not plain OMNIGENT_), so _build_runner_env never sees the names it lists
+        # and the whole passthrough is a no-op remotely. It carries only env var
+        # NAMES, not secrets, so allowlisting it leaks nothing on its own.
+        # (Literal, not omnigent.host.connect.RUNNER_ENV_PASSTHROUGH_ENV_VAR,
+        # which would be a circular import back into the host daemon.)
+        "OMNIGENT_RUNNER_ENV_PASSTHROUGH",
+        # Keep host and spawned-runner routing decisions aligned when the
+        # host-slice-key kill switch is explicitly disabled.
+        "OMNIGENT_HOST_SLICE_KEY_ENABLED",
+    }
+    # Windows system / profile constants (SYSTEMROOT is mandatory for Winsock,
+    # USERPROFILE for Path.home(), etc.); a no-op on POSIX. See _platform.
+    | set(WINDOWS_ENV_PASSTHROUGH)
+)
+# Allowed by prefix: locale family (``LC_*``), MLflow, and OpenTelemetry config —
+# both the standard ``OTEL_*`` vars and Omnigent's ``OMNIGENT_OTEL_*`` knobs
+# (capture-content, FastAPI toggle) so they reach the runner/harness too.
+_RUNNER_ENV_ALLOWLIST_PREFIXES: tuple[str, ...] = ("LC_", "MLFLOW_", "OTEL_", "OMNIGENT_OTEL_")

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -59,7 +59,6 @@ from omnigent.env_credentials import (
 )
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_aliases import canonicalize_harness
-from omnigent.spec.parser import check_unresolved_env_vars
 
 _logger = logging.getLogger(__name__)
 
@@ -552,6 +551,11 @@ def resolve_secret(ref: str) -> str:
         # verbatim to a harness/SDK, where the padding fails auth.
         return value.strip()
     # Bare inline reference, e.g. "$ANTHROPIC_API_KEY" or a literal value.
+    # Imported here, not at module scope: the spec parser is a heavy import and
+    # only the credential-resolution paths need it, while this module is on the
+    # host/CLI startup import graph.
+    from omnigent.spec.parser import check_unresolved_env_vars
+
     expanded = expand_envvars_with_omnigent_prefix(ref)
     check_unresolved_env_vars(ref, expanded)
     return expanded
@@ -601,6 +605,8 @@ def _expand(key: str, value: str) -> str:
     :returns: The expanded value, e.g. ``"sk-or-..."``.
     :raises OmnigentError: If a referenced variable is unset.
     """
+    from omnigent.spec.parser import check_unresolved_env_vars
+
     expanded = expand_envvars_with_omnigent_prefix(value)
     check_unresolved_env_vars(key, expanded)
     return expanded

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -2774,6 +2774,7 @@ def test_handle_store_secret_key_writes_and_returns_readiness(
     green) without a reconnect.
     """
     import omnigent.host.connect as connect
+    import omnigent.onboarding.harness_auth as harness_auth
     from omnigent.onboarding.harness_auth import StoreCredentialResult
 
     calls: list[dict[str, object]] = []
@@ -2782,7 +2783,7 @@ def test_handle_store_secret_key_writes_and_returns_readiness(
         calls.append(kwargs)
         return StoreCredentialResult(True, "anthropic", None)
 
-    monkeypatch.setattr(connect, "store_harness_credential", _store)
+    monkeypatch.setattr(harness_auth, "store_harness_credential", _store)
     monkeypatch.setattr(connect, "configured_harness_map", lambda: {"claude-native": True})
 
     host = _make_host_process()
@@ -2816,6 +2817,7 @@ def test_handle_store_secret_pi_maps_to_anthropic_family(
 ) -> None:
     """Pi (which consumes both families) writes to its preferred anthropic family."""
     import omnigent.host.connect as connect
+    import omnigent.onboarding.harness_auth as harness_auth
     from omnigent.onboarding.harness_auth import StoreCredentialResult
 
     seen: dict[str, object] = {}
@@ -2824,7 +2826,7 @@ def test_handle_store_secret_pi_maps_to_anthropic_family(
         seen.update(kwargs)
         return StoreCredentialResult(True, "anthropic", None)
 
-    monkeypatch.setattr(connect, "store_harness_credential", _store)
+    monkeypatch.setattr(harness_auth, "store_harness_credential", _store)
     monkeypatch.setattr(connect, "configured_harness_map", lambda: {"pi": True})
 
     host = _make_host_process()
@@ -2840,6 +2842,7 @@ def test_handle_store_secret_adopt_calls_adopt_core(
 ) -> None:
     """An adopt request references an env var via the adopt core."""
     import omnigent.host.connect as connect
+    import omnigent.onboarding.harness_auth as harness_auth
     from omnigent.onboarding.harness_auth import DetectedCredential, StoreCredentialResult
 
     seen: dict[str, object] = {}
@@ -2848,9 +2851,9 @@ def test_handle_store_secret_adopt_calls_adopt_core(
         seen.update(kwargs)
         return StoreCredentialResult(True, "openai", None)
 
-    monkeypatch.setattr(connect, "adopt_env_credential", _adopt)
+    monkeypatch.setattr(harness_auth, "adopt_env_credential", _adopt)
     monkeypatch.setattr(
-        connect,
+        harness_auth,
         "detect_adoptable_credentials",
         lambda: [
             DetectedCredential(family="openai", source="$OPENAI_API_KEY", env_var="OPENAI_API_KEY")
@@ -2880,6 +2883,7 @@ def test_handle_store_secret_pi_adopt_uses_detected_family_not_harness(
     detected family instead.
     """
     import omnigent.host.connect as connect
+    import omnigent.onboarding.harness_auth as harness_auth
     from omnigent.onboarding.harness_auth import DetectedCredential, StoreCredentialResult
 
     seen: dict[str, object] = {}
@@ -2888,9 +2892,9 @@ def test_handle_store_secret_pi_adopt_uses_detected_family_not_harness(
         seen.update(kwargs)
         return StoreCredentialResult(True, "openai", None)
 
-    monkeypatch.setattr(connect, "adopt_env_credential", _adopt)
+    monkeypatch.setattr(harness_auth, "adopt_env_credential", _adopt)
     monkeypatch.setattr(
-        connect,
+        harness_auth,
         "detect_adoptable_credentials",
         lambda: [
             DetectedCredential(family="openai", source="$OPENAI_API_KEY", env_var="OPENAI_API_KEY")
@@ -2918,16 +2922,16 @@ def test_handle_store_secret_adopt_refuses_undetected_env_var(
     an arbitrary set env var (a DB password, an unrelated secret) and have it
     persisted as a provider credential and sent to the vendor endpoint as auth.
     """
-    import omnigent.host.connect as connect
+    import omnigent.onboarding.harness_auth as harness_auth
     from omnigent.onboarding.harness_auth import DetectedCredential
 
     def _must_not_write(**kwargs: object) -> object:
         raise AssertionError("adopt core reached for an undetected env var")
 
-    monkeypatch.setattr(connect, "adopt_env_credential", _must_not_write)
+    monkeypatch.setattr(harness_auth, "adopt_env_credential", _must_not_write)
     # Detect surfaces only ANTHROPIC_API_KEY; the request names a different var.
     monkeypatch.setattr(
-        connect,
+        harness_auth,
         "detect_adoptable_credentials",
         lambda: [
             DetectedCredential(
@@ -2949,12 +2953,12 @@ def test_handle_store_secret_adopt_refuses_undetected_env_var(
 
 def test_handle_store_secret_rejects_non_ui_harness(monkeypatch: pytest.MonkeyPatch) -> None:
     """A harness outside the UI-auth families is refused without a write."""
-    import omnigent.host.connect as connect
+    import omnigent.onboarding.harness_auth as harness_auth
 
     def _must_not_write(**kwargs: object) -> object:
         raise AssertionError("credential core reached for a non-UI-auth harness")
 
-    monkeypatch.setattr(connect, "store_harness_credential", _must_not_write)
+    monkeypatch.setattr(harness_auth, "store_harness_credential", _must_not_write)
     host = _make_host_process()
     result = host._handle_store_secret(
         HostStoreSecretFrame(request_id="c4", harness="cursor", kind="key", secret_value="x")
@@ -2965,11 +2969,11 @@ def test_handle_store_secret_rejects_non_ui_harness(monkeypatch: pytest.MonkeyPa
 
 def test_handle_store_secret_surfaces_core_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     """A core write failure surfaces its non-secret reason as ``failed``."""
-    import omnigent.host.connect as connect
+    import omnigent.onboarding.harness_auth as harness_auth
     from omnigent.onboarding.harness_auth import StoreCredentialResult
 
     monkeypatch.setattr(
-        connect,
+        harness_auth,
         "store_harness_credential",
         lambda **k: StoreCredentialResult(False, None, "a gateway requires a base_url"),
     )
@@ -2986,11 +2990,11 @@ def test_handle_detect_credentials_returns_non_secret_descriptors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The detect handler returns the core's descriptors as plain dicts."""
-    import omnigent.host.connect as connect
+    import omnigent.onboarding.harness_auth as harness_auth
     from omnigent.onboarding.harness_auth import DetectedCredential
 
     monkeypatch.setattr(
-        connect,
+        harness_auth,
         "detect_adoptable_credentials",
         lambda: [DetectedCredential("anthropic", "$ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY")],
     )

--- a/tests/host/test_connect_import_graph.py
+++ b/tests/host/test_connect_import_graph.py
@@ -1,0 +1,129 @@
+"""Guard the lazy import seams that keep ``omnigent.host.connect`` cheap.
+
+Importing the host connector is one of the two dominant stages of a cold
+``omnigent host`` start, and three eager module-scope imports used to inflate
+it: the credential writer (``onboarding.harness_auth``), the spec parser
+reached through ``onboarding.provider_config``, and — from the other side — the
+CLI's own daemon-env helper importing the whole connector just to read two
+frozensets.
+
+Each edge is now deferred: ``harness_auth`` loads inside the rare
+``host.store_secret`` / ``host.detect_credentials`` handlers, ``spec.parser``
+inside the credential-resolution helpers, and the runner env allowlist lives in
+the leaf module :mod:`omnigent.host.runner_env`. Without these assertions the
+edges grow back silently, so each probe runs in a fresh subprocess (an
+unrelated test in the same session can otherwise pre-import the heavy module
+and mask the regression).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+# Hand each child the same import roots as this process so it resolves
+# ``omnigent`` to the code under test (worktree or installed package).
+_CHILD_ENV = {**os.environ, "PYTHONPATH": os.pathsep.join(p for p in sys.path if p)}
+
+
+def _assert_absent_after_import(light: str, heavy: str) -> None:
+    """Import *light* in a fresh interpreter and assert *heavy* stayed unloaded.
+
+    :param light: Module the hot path imports, e.g. ``"omnigent.host.connect"``.
+    :param heavy: Module that must NOT be dragged in, e.g.
+        ``"omnigent.onboarding.harness_auth"``.
+    :returns: None.
+    """
+    probe = (
+        f"import sys, {light}\n"
+        f"assert {heavy!r} not in sys.modules, "
+        f"{f'{heavy} was imported eagerly by {light}'!r}\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        env=_CHILD_ENV,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        f"importing {light} pulled in {heavy}; the lazy import seam "
+        f"regressed. stderr:\n{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("light", "heavy"),
+    [
+        # The credential writer is only needed by the rare store_secret /
+        # detect_credentials frames, not by every host-daemon start.
+        ("omnigent.host.connect", "omnigent.onboarding.harness_auth"),
+        # provider_config reaches the spec parser only when resolving a secret.
+        ("omnigent.onboarding.provider_config", "omnigent.spec.parser"),
+        # ... and neither of connect's two routes to it may reinstate the edge.
+        ("omnigent.onboarding.harness_readiness", "omnigent.spec.parser"),
+        ("omnigent.host.connect", "omnigent.spec.parser"),
+        # The runner env allowlist must stay a leaf the CLI can read cheaply.
+        ("omnigent.host.runner_env", "omnigent.host.connect"),
+    ],
+)
+def test_host_connect_import_graph_stays_lazy(light: str, heavy: str) -> None:
+    """Each light module loads without dragging in its heavy neighbour.
+
+    :param light: The module on the startup path.
+    :param heavy: The module that must stay unloaded.
+    :returns: None.
+    """
+    _assert_absent_after_import(light, heavy)
+
+
+def test_build_host_daemon_env_does_not_import_host_connect() -> None:
+    """``_build_host_daemon_env`` reads the allowlist without loading the connector.
+
+    The helper used to import ``omnigent.host.connect`` inside its body purely
+    to read two frozensets, paying the whole connector import tree on the first
+    call during ``omnigent host`` startup.
+
+    :returns: None.
+    """
+    probe = (
+        "import sys\n"
+        "from omnigent.cli import _build_host_daemon_env\n"
+        "_build_host_daemon_env(server_url=None)\n"
+        "_build_host_daemon_env(server_url='https://example.databricksapps.com')\n"
+        "assert 'omnigent.host.connect' not in sys.modules, "
+        "'_build_host_daemon_env imported the host connector'\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        env=_CHILD_ENV,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        f"_build_host_daemon_env pulled in omnigent.host.connect; the "
+        f"runner_env leaf-module seam regressed. stderr:\n{result.stderr}"
+    )
+
+
+def test_connect_still_re_exports_the_runner_env_allowlist() -> None:
+    """Moving the allowlist to a leaf module kept ``connect``'s names identical.
+
+    :returns: None.
+    """
+    from omnigent.host import runner_env
+    from omnigent.host.connect import (
+        _RUNNER_ENV_ALLOWLIST,
+        _RUNNER_ENV_ALLOWLIST_PREFIXES,
+    )
+
+    assert _RUNNER_ENV_ALLOWLIST is runner_env._RUNNER_ENV_ALLOWLIST
+    assert _RUNNER_ENV_ALLOWLIST_PREFIXES is runner_env._RUNNER_ENV_ALLOWLIST_PREFIXES
+    # Spot-check the contract the allowlist exists to enforce: process
+    # essentials in, host-owner provider secrets out.
+    assert {"PATH", "HOME"} <= _RUNNER_ENV_ALLOWLIST
+    assert "ANTHROPIC_API_KEY" not in _RUNNER_ENV_ALLOWLIST


### PR DESCRIPTION
## Related issue

Closes #

## Summary

`import omnigent.host.connect` is one of the two dominant stages of a cold `omnigent host` start. Three eager module-scope imports carried most of its cost — each a heavy module loaded for something only a rare code path needs:

- **`onboarding/provider_config.py`** imported `omnigent.spec.parser` at module scope for `check_unresolved_env_vars`, which is used only in the two credential-resolution helpers (`resolve_secret`, `_expand`). The parser alone was ~121 ms of the connect tree, reached via both `provider_config` and `harness_readiness`.
- **`host/connect.py`** imported `onboarding.harness_auth` eagerly, though only the rare `host.store_secret` / `host.detect_credentials` frame handlers call it.
- **`_build_host_daemon_env`** in `cli.py` imported the whole `host.connect` tree inside its body purely to read two frozensets, paying ~103 ms on the first call during daemon startup.

The first two become function-scope imports. For the third, the runner env allowlist moves to a new leaf module `omnigent/host/runner_env.py` that depends only on the import-cheap `_platform` / `process_logging` leaves, so both the host daemon and the CLI helper read it without loading the connector.

```
before                                   after
  cli._build_host_daemon_env               cli._build_host_daemon_env
    └─> host.connect  (whole tree)           └─> host.runner_env  (leaf, ~0 ms)
          ├─> onboarding.harness_auth
          │     └─> provider_config       host.connect
          │           └─> spec.parser       ├─ harness_auth   -> deferred into the
          └─> harness_readiness             │                    store_secret /
                └─> provider_config         │                    detect_credentials
                      └─> spec.parser       │                    handlers
                                            └─ provider_config
                                                 └─ spec.parser -> deferred into
                                                                   resolve_secret /
                                                                   _expand
```

No public API or observable behavior changes: `host.connect` re-exports `_RUNNER_ENV_ALLOWLIST` / `_RUNNER_ENV_ALLOWLIST_PREFIXES`, and the allowlist contents are byte-identical to `main` (verified by evaluating `main`'s AST node for both constants and comparing the resulting frozensets — 62 names, equal).

## Test Plan

**Measurements.** `python -X importtime`, best-of-5 on a warm bytecode cache, same worktree before/after via `git stash`, serialized under `flock` (load avg ~7 both runs):

| | before | after |
|---|---|---|
| `omnigent.host.connect` cumulative (best) | 398.6 ms | **268.4 ms** |
| `omnigent.host.connect` cumulative (median) | 434.8 ms | **274.0 ms** |
| `_build_host_daemon_env` first call | 102.9 ms best / 106.6 ms median | **0.3 ms** |

Per-module cumulative inside the connect tree:

| module | before | after |
|---|---|---|
| `onboarding.harness_auth` | 143.6 ms | **absent** |
| `onboarding.provider_config` | 126.1 ms | 5.6 ms |
| `spec.parser` | 121.4 ms | **absent** |

**Guard test.** `tests/host/test_connect_import_graph.py` asserts, in fresh subprocesses, that each heavy module stays out of `sys.modules` after importing the light one, plus that `_build_host_daemon_env` runs without loading the connector and that `connect` still re-exports the allowlist. Proven to fail on the pre-change source: **6 of its 7 tests fail** when the `omnigent/` changes are stashed out.

**Targeted suites** (all green; `tests/cli/test_backend.py::test_databricks_preflight_refresh_handles_duplicate_workspace_profiles` fails identically on `origin/main` and is unrelated):

```
pytest tests/host/test_connect.py tests/host/test_connect_import_graph.py \
       tests/host/test_cli_host.py tests/cli/test_backend.py \
       tests/onboarding/test_provider_config.py tests/onboarding/test_harness_auth.py \
       tests/onboarding/test_harness_readiness.py tests/onboarding/test_provider_selection.py \
       tests/onboarding/test_providers.py tests/spec/test_parser.py \
       tests/llms/test_init_lazy_imports.py tests/runner/test_identity.py
```

`pre-commit run --files <changed files>`: ruff format / ruff check and all repo-specific hooks pass. (pyrefly reports the same 99 pre-existing errors on `origin/main` in this environment — none in the touched files.)

**To verify manually:** start a host daemon and confirm it still connects, then exercise the two deferred paths — in the web UI, open the model/credential panel for a host (drives `host.detect_credentials`) and add an API key for Claude or Codex (drives `host.store_secret`); the readiness badge should flip yellow → green without a reconnect, and `~/.omnigent/config.yaml` should gain a `providers:` entry referencing the keychain rather than the raw secret. Also confirm a spawned runner still receives the allowlisted env (e.g. `OMNIGENT_RUNNER_ENV_PASSTHROUGH=MY_VAR omnigent host` and check `MY_VAR` reaches the runner).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new `tests/host/test_connect_import_graph.py` is the regression guard for all three seams — without it these import edges grow back silently. It was validated by prove-it-fails: 6 of 7 tests fail on the pre-change source.

Manual verification covered the import-cost claims themselves (the `-X importtime` and first-call timings above, each taken best-of-5 on a warm bytecode cache with the measurement serialized under `flock` and the loaded tree confirmed via `omnigent.__file__`), and the allowlist-equivalence check against `origin/main`. Behavior of the deferred code paths is covered by the existing `tests/host/test_connect.py` store-secret / detect-credentials tests, which were repointed to patch `onboarding.harness_auth` (the definition site) instead of the name `host.connect` no longer binds at module scope.
