### PR TITLE
perf(harness): probe the harness bind window tightly, then back off

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -31,7 +31,7 @@ import sys
 import tempfile
 import time
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -162,10 +162,19 @@ _RELEASE_GRACE_S = 5.0
 # forever.
 _SPAWN_READY_TIMEOUT_S = 30.0
 
-# Polling interval while waiting for the socket to appear. Short
-# enough that fast spawns return quickly; not so short that we
-# hammer the filesystem.
+# Steady polling interval while waiting for the socket to appear.
+# Short enough that a slow spawn returns quickly; not so short that we
+# hammer the filesystem for the whole ready timeout.
 _SPAWN_POLL_INTERVAL_S = 0.05
+
+# Bind is the longest stage of session init, and it lands somewhere in a
+# few hundred milliseconds — a window the steady cadence quantizes, so
+# readiness is seen up to a full interval after it happened. Probe
+# tightly across that window instead (a local socket probe is a syscall,
+# not a request), then ease off to the steady cadence for the tail.
+_SPAWN_POLL_TIGHT_INTERVAL_S = 0.01
+_SPAWN_POLL_TIGHT_WINDOW_S = 1.0
+_SPAWN_POLL_BACKOFF_FACTOR = 1.5
 
 # httpx's default read timeout (5s) is too short for SSE streams
 # that pause for tens of seconds during tool dispatch round-trips
@@ -271,6 +280,28 @@ def _resolve_module_path(harness: str) -> str:
     )
 
 
+def _spawn_poll_intervals() -> Iterator[float]:
+    """
+    Yield successive sleeps between harness bind probes.
+
+    Holds :data:`_SPAWN_POLL_TIGHT_INTERVAL_S` across the window where
+    bind normally lands, then grows geometrically to the steady
+    :data:`_SPAWN_POLL_INTERVAL_S` cadence, so a spawn that is stuck
+    rides out its ready timeout without a hot loop. Infinite: the caller
+    stops on its own deadline.
+
+    :returns: Iterator of sleep durations in seconds, e.g.
+        ``0.01, 0.01, ... 0.015, 0.0225, ... 0.05, 0.05``.
+    """
+    interval = _SPAWN_POLL_TIGHT_INTERVAL_S
+    elapsed = 0.0
+    while True:
+        yield interval
+        elapsed += interval
+        if elapsed >= _SPAWN_POLL_TIGHT_WINDOW_S:
+            interval = min(interval * _SPAWN_POLL_BACKOFF_FACTOR, _SPAWN_POLL_INTERVAL_S)
+
+
 async def _wait_for_bind(
     process: asyncio.subprocess.Process,
     endpoint: _HarnessEndpoint,
@@ -298,6 +329,7 @@ async def _wait_for_bind(
     """
     loop = asyncio.get_running_loop()
     deadline = loop.time() + _SPAWN_READY_TIMEOUT_S
+    intervals = _spawn_poll_intervals()
     while True:
         if process.returncode is not None:
             # Subprocess inherits stderr so the failure message
@@ -324,7 +356,7 @@ async def _wait_for_bind(
                 f"{conversation_id!r} did not bind its endpoint "
                 f"within {_SPAWN_READY_TIMEOUT_S:.0f}s"
             )
-        await asyncio.sleep(_SPAWN_POLL_INTERVAL_S)
+        await asyncio.sleep(next(intervals))
 
 
 async def _can_connect_uds(socket_path: Path) -> bool:

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -1595,3 +1595,104 @@ async def test_shutdown_during_spawn_leaves_no_live_process(
         await _cancel_pending(get_task, shutdown_task)
         # Idempotent if the test already shut down; still safe if it failed early.
         await manager.shutdown()
+
+
+def test_spawn_poll_intervals_probe_the_bind_window_tightly() -> None:
+    """
+    Bind probes stay tight across the window where bind lands, then ease off.
+
+    Harness bind is the longest stage of session init and completes a few
+    hundred milliseconds in, so a flat cadence reports readiness up to a
+    full interval late. The schedule must therefore hold a sub-cadence
+    interval across that whole window — not merely open tight and ramp
+    past it — while still bounding the probe count over the full ready
+    timeout, so a stuck spawn never degenerates into a hot loop.
+    """
+    from omnigent.runtime.harnesses import process_manager as pm_mod
+
+    intervals = pm_mod._spawn_poll_intervals()
+    tight = pm_mod._SPAWN_POLL_TIGHT_INTERVAL_S
+    steady = pm_mod._SPAWN_POLL_INTERVAL_S
+
+    assert tight < steady
+
+    # Probe the schedule out to the ready timeout, recording when each
+    # probe would happen and how long the caller waits at that point.
+    elapsed = 0.0
+    probes: list[tuple[float, float]] = []
+    while elapsed < pm_mod._SPAWN_READY_TIMEOUT_S:
+        interval = next(intervals)
+        probes.append((elapsed, interval))
+        elapsed += interval
+
+    waits = [interval for _, interval in probes]
+    assert waits[0] == tight
+    assert waits == sorted(waits)
+    assert max(waits) == steady
+
+    # Readiness anywhere inside the tight window costs at most one tight
+    # interval of dead time, instead of up to a full steady cadence.
+    in_window = [interval for at, interval in probes if at < pm_mod._SPAWN_POLL_TIGHT_WINDOW_S]
+    assert max(in_window) == tight
+
+    # The tail must not keep paying the tight price: covering the ready
+    # timeout stays within a small factor of the flat cadence's probe
+    # count, so a future edit cannot turn this into a hot loop.
+    flat_probes = pm_mod._SPAWN_READY_TIMEOUT_S / steady
+    assert len(probes) < 2 * flat_probes
+
+
+async def test_wait_for_bind_sees_a_late_bind_without_a_cadence_delay() -> None:
+    """
+    A bind that lands mid-window is observed promptly, not on a coarse tick.
+
+    The stub becomes connectable partway through the bind window — the
+    shape of a real harness spawn, and deliberately not on a multiple of
+    the steady cadence. The waiter must probe many times across that
+    window (so readiness is seen within one tight interval of happening)
+    rather than a handful of times at the steady cadence, which used to
+    add up to a full interval of dead time to every session init.
+    """
+    from omnigent.runtime.harnesses import process_manager as pm_mod
+
+    bind_delay_s = 0.28
+    ready_at = time.monotonic() + bind_delay_s
+
+    class _StubProcess:
+        """Stands in for a runner subprocess that is still starting up."""
+
+        returncode = None
+
+    class _StubEndpoint:
+        """Endpoint that starts accepting connections at ``ready_at``."""
+
+        def __init__(self) -> None:
+            self.probes = 0
+            self.hardened = False
+
+        async def can_connect(self) -> bool:
+            self.probes += 1
+            return time.monotonic() >= ready_at
+
+        def harden(self) -> None:
+            self.hardened = True
+
+    endpoint = _StubEndpoint()
+    await pm_mod._wait_for_bind(
+        _StubProcess(),  # type: ignore[arg-type]
+        endpoint,  # type: ignore[arg-type]
+        _TEST_HARNESS_NAME,
+        "conv_bind_latency",
+    )
+
+    lateness = time.monotonic() - ready_at
+    assert endpoint.hardened
+    assert lateness < pm_mod._SPAWN_POLL_INTERVAL_S
+    # Half the probes the tight cadence allows for, so an overloaded CI box
+    # oversleeping every interval still passes — but the steady cadence
+    # (which would probe ~6 times here) cannot.
+    steady_probes = bind_delay_s / pm_mod._SPAWN_POLL_INTERVAL_S
+    assert endpoint.probes > 2 * steady_probes, (
+        f"only {endpoint.probes} probes across a {bind_delay_s * 1000:.0f}ms bind — "
+        "the wait is back on a coarse tick"
+    )


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Waiting for a spawned harness to bind its Unix socket is the longest single
stage of session init, and `_wait_for_bind` polled it on a flat 50 ms cadence.
Readiness was therefore *reported* up to a full interval after it actually
happened, with nothing happening in the gap — pure dead time added to every
session's first turn.

- `omnigent/runtime/harnesses/process_manager.py` now probes on a schedule
  instead of a constant: hold a 10 ms interval across the first second (where
  bind lands — a local socket probe is a syscall, not a request), then grow
  geometrically back to the 50 ms steady cadence for the tail. A spawn that is
  genuinely stuck still rides out its `_SPAWN_READY_TIMEOUT_S` (30 s,
  unchanged) on a comparable number of probes rather than a hot loop.
- Measured over 12 real spawns of the fixture harness: **average dead time
  25.6 ms → 4.0 ms** (p50 26.6 → 4.2 ms, worst 44.7 → 9.1 ms).
- Deliberately *not* just a smaller constant. A flat 10 ms poll would be ~3000
  probes over the 30 s timeout; the tight window plus backoff keeps the tail
  within a small factor of today's probe count, and a new unit test asserts
  that bound so a future edit can't turn it into a hot loop.

Timeouts, error messages and every failure path are untouched.

### Why the tight *window* and not just a tight *start*

Dead time equals the poll interval **at the moment readiness lands**, so a
schedule that opens tight and ramps geometrically buys nothing here: with a
1.5× ramp the interval is already at the 50 ms ceiling by t ≈ 170 ms, long
before bind completes at 200–700 ms. The interval has to stay small *across*
the window where the event happens. Hence: tight interval held for the bind
window, backoff only for the pathological tail.

```
bind at ~700ms:
  flat 50ms      |....|....|....|....| ... probe at 700, 750  → up to 50ms late
  tight 10ms/1s  |.|.|.|.|.|.|.|.|.|.| ... probe every 10ms   → up to 10ms late
  (after 1s)     backoff 10 → 15 → 22 → 34 → 50ms, holds at 50ms to the timeout
```

## Scope: what this PR does *not* change

**The CLI's runner-readiness poll (`wait_for_runner_online`) was already fixed
on main** by #5190 (`daemon_poll_intervals`: opens at 100 ms, ramps 1.5× to the
500 ms cadence), so there is nothing left to do there in this PR's terms. For
the record, with a runner that comes online at 602 ms p50 the schedule probes at
t = 0, 100, 250, 475, 812 ms, so it reports readiness at 812 ms — **~210 ms of
residual dead time at p50**, down from ~400 ms under the old flat 500 ms poll.

Closing that remaining 210 ms needs the event-driven signal, not a tuned
constant: a bounded long-poll on `GET /v1/runners/{runner_id}/status` (e.g. an
optional `wait_s`) riding `TunnelRegistry.wait_for_runner`, which already owns
the "runner connected" future and already bounds its waiters
(`_max_connect_waiters_per_runner` / `_max_connect_waiters_total`, with an
overflow path that degrades to a plain sleep). **Out of scope here**, and not
because of the line count:

- It has to race the `host.runner_exited` crash report the way
  `_wait_for_runner_client_impl` does, or a dead runner is reported one full
  `wait_s` later than today — a regression on the failure path that gates every
  native-harness launch.
- Its correctness depends on the long-poll landing on the replica that holds
  the runner's tunnel (the registry is per-replica). Today's fast poll has the
  same dependency, but holding a request open for seconds makes any
  slice-routing or rollout edge case much more visible, and I can't exercise
  multi-replica routing from a single-process dev box.

I'd rather land the measurable local win and do the long-poll as its own
change, with its own tests for the crash-report race and the routing path.

**`omnigent/server/managed_hosts.py` (`_ONLINE_POLL_INTERVAL_S = 1.0`) is left
alone.** It is the same *shape*, but the same-shaped fix does nothing there: a
managed sandbox registers seconds after launch, by which point any tight-open
ramp has long since reached its ceiling — the dead time is still ~1 interval.
Improving that one means either a lower steady ceiling (4× the DB probes for up
to the full 120 s budget) or an event-driven registration signal, and neither is
profiled. Noting it rather than cargo-culting the change.

## Test Plan

New unit tests in `tests/runtime/harnesses/test_process_manager.py`, written in
the idiom of the existing `daemon_poll_intervals` schedule test:

- `test_spawn_poll_intervals_probe_the_bind_window_tightly` — pure, no clock.
  Asserts the schedule holds a sub-cadence interval across the *whole* bind
  window (not merely opening tight), is monotonic, never exceeds the steady
  cadence, and covers the 30 s ready timeout in under 2× the flat cadence's
  probe count (the hot-loop guard).
- `test_wait_for_bind_sees_a_late_bind_without_a_cadence_delay` — stubbed
  endpoint that starts accepting connections 280 ms in (deliberately not a
  multiple of the steady cadence). Asserts the waiter probed far more times
  than the steady cadence would across that window, so readiness is seen within
  one tight interval of happening.

Both tests were confirmed to **fail** against the old flat cadence (constants
temporarily set back to `tight = 0.05`, `window = 0.0`):

```
E       assert 0.05 < 0.05
E       AssertionError: only 7 probes across a 280ms bind — the wait is back on a coarse tick
2 failed, 40 deselected
```

Full targeted file green on the change:

```
$ python -m pytest tests/runtime/harnesses/test_process_manager.py -q
42 passed in 45.07s
```

`pre-commit run --files omnigent/runtime/harnesses/process_manager.py
tests/runtime/harnesses/test_process_manager.py` — ruff format, ruff check and
all lint hooks pass. `pyrefly` reports 99 pre-existing `missing-import` errors
from my dev box's borrowed virtualenv (`opentelemetry.*` not installed there);
**zero** of them are in either changed file.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

**How the numbers were measured.** A script drove 12 real harness spawns
through `HarnessProcessManager.get_client` with the fixture harness
(`tests.runtime.harnesses._test_harness`, a real uvicorn subprocess on a real
UDS), with the probe interval forced to 1 ms so the *true* bind time is captured
to within a millisecond. Each measured bind time was then scored against both
schedules analytically (when does this schedule first probe at/after t?), which
avoids attributing the schedule's cost to run-to-run spawn noise. Run under
`flock /tmp/omnigent-profile.lock`; load average 15.97 on a 32-core shared box,
so absolute bind times run high — the dead-time deltas are what matter.

```
bind samples (n=12): min=655ms p50=698ms max=737ms
  all: 655, 659, 661, 663, 673, 677, 698, 699, 708, 726, 735, 737 ms

flat 50ms (before)       dead time: p50= 26.6ms  mean= 25.6ms  max= 44.7ms
tight 10ms/1s (after)    dead time: p50=  4.2ms  mean=  4.0ms  max=  9.1ms
```

Probe cost for that ~700 ms bind: ~70 cheap local probes instead of ~14
(`stat` + `connect` on a Unix socket). Over a full 30 s stuck spawn the schedule
issues ~684 probes vs ~600 today.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The 42 existing tests in `tests/runtime/harnesses/test_process_manager.py` all
spawn real runner subprocesses through this exact wait, so they cover the
correctness of the change (bind detection, crash-during-spawn, the 30 s timeout
path, mid-spawn cancellation); the two new tests cover the cadence itself.
Manual verification is the 12-spawn measurement in the Demo section — the
latency win is a wall-clock property and is deliberately *not* asserted as a
timing test, since wall-clock assertions on shared CI would be flaky; the
regression guard is the probe-count assertion instead.
