### PR TITLE
perf(runner): keep the MCP SDK out of the runner import graph

### DIFF
--- a/omnigent/runner/_zygote.py
+++ b/omnigent/runner/_zygote.py
@@ -126,9 +126,25 @@ def _import_runner_graph() -> None:
     harness child forked via ``fork_harness`` shares that floor as well (the
     heaviest part is the fastapi/pydantic/omnigent-core graph the runner
     already holds, so this adds little resident cost).
+
+    The MCP SDK graph is deliberately excluded — see :func:`_import_mcp_graph`.
     """
     from omnigent.runner import _entry, app, native  # noqa: F401
     from omnigent.runtime.harnesses import _runner as _harness_runner  # noqa: F401
+
+
+def _import_mcp_graph() -> None:
+    """Import the MCP SDK graph (~300ms) so forked runners inherit it too.
+
+    Kept out of :func:`_import_runner_graph` because the zygote's own boot sits
+    on the first session-create's critical path, while a runner needs MCP only
+    once its spec connects to an MCP server. The serve loop warms it on its
+    first idle tick instead, so the cold start skips it and every session that
+    follows still gets it for free.
+    """
+    # ``omnigent.tools.mcp`` is what pulls the SDK in; the runner's own
+    # mcp_manager imports it (and ``mcp.types``) lazily from there.
+    from omnigent.tools import mcp  # noqa: F401
 
 
 def _wire_child_stdio(log_path: str | None) -> None:
@@ -335,6 +351,8 @@ class _ZygoteServer:
         # close (the daemon socket + all runner sockets).
         self._control_socks: set[socket.socket] = {control_sock}
         self._buffers: dict[int, bytearray] = {}
+        # Whether the deferred MCP graph warm-up has been attempted yet.
+        self._mcp_warmed = False
         self._sel.register(control_sock, selectors.EVENT_READ, "daemon")
         self._buffers[control_sock.fileno()] = bytearray()
 
@@ -344,13 +362,43 @@ class _ZygoteServer:
             while True:
                 self._reap()
                 # Timeout so idle periods still reap exited children promptly.
-                for key, _mask in self._sel.select(timeout=1.0):
+                ready = self._sel.select(timeout=1.0)
+                if not ready:
+                    self._warm_mcp_graph()
+                    continue
+                for key, _mask in ready:
                     # Only sockets are ever registered, so key.fileobj (typed
                     # HasFileno | int by selectors) is always a socket here.
                     if not self._on_readable(cast("socket.socket", key.fileobj), key.data):
                         return
         finally:
             self._sel.close()
+
+    def _warm_mcp_graph(self) -> None:
+        """Import the MCP graph once, on an idle tick, for later forks to share.
+
+        Runs in the main thread between requests rather than on a background
+        thread: the zygote's whole value is forking from a thread-free process.
+        A request landing mid-import waits no longer than it would have waited
+        for the same import during zygote boot.
+        """
+        if self._mcp_warmed:
+            return
+        self._mcp_warmed = True
+        try:
+            _import_mcp_graph()
+        except Exception as exc:  # noqa: BLE001 — a warm-up miss must not kill the server
+            print(f"warning: runner zygote could not warm the MCP graph: {exc}", file=sys.stderr)
+            return
+        if threading.active_count() != 1:  # pragma: no cover — defense in depth
+            names = [t.name for t in threading.enumerate()]
+            print(
+                f"warning: runner zygote gained threads while warming MCP: {names}",
+                file=sys.stderr,
+            )
+        # Keep the newly imported graph out of GC's tracked set, as after the
+        # initial import, so collections stay cheap and don't dirty shared pages.
+        gc.freeze()
 
     def _reap(self) -> None:
         """Non-blocking reap of any exited children into ``exit_codes``.

--- a/omnigent/runner/mcp_manager.py
+++ b/omnigent/runner/mcp_manager.py
@@ -10,16 +10,23 @@ import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import httpx
-from mcp.types import ElicitRequestParams, ElicitResult
-from mcp.types import Tool as McpToolDef
 
 from omnigent.debug_logging import runner_primary_session_id
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.spec.types import AgentSpec, MCPServerConfig, RetryPolicy
 from omnigent.tools.base import is_valid_tool_name
-from omnigent.tools.mcp import McpServerConnection
+
+if TYPE_CHECKING:
+    # Type-only: the MCP SDK graph costs ~300ms to import and is only needed
+    # once a spec actually connects to an MCP server, so every runtime use
+    # below imports it locally instead.
+    from mcp.types import ElicitRequestParams, ElicitResult
+    from mcp.types import Tool as McpToolDef
+
+    from omnigent.tools.mcp import McpServerConnection
 
 _logger = logging.getLogger(__name__)
 
@@ -268,6 +275,8 @@ class RunnerMcpManager:
             :param params: MCP elicitation params from the gateway.
             :returns: User verdict as an :class:`ElicitResult`.
             """
+            from mcp.types import ElicitResult
+
             if server_client is None:
                 _logger.warning(
                     "MCP elicitation callback: no Omnigent server client available — declining",
@@ -735,6 +744,8 @@ class RunnerMcpManager:
 
     async def _connect_server(self, server: _SharedServerEntry, spec_hash: str) -> None:
         """Connect one shared MCP server if needed."""
+        from omnigent.tools.mcp import McpServerConnection
+
         close_after_connect: McpServerConnection | None = None
         current_task = asyncio.current_task()
         try:

--- a/tests/runner/test_mcp_manager.py
+++ b/tests/runner/test_mcp_manager.py
@@ -29,7 +29,6 @@ from typing import Any
 import pytest
 from mcp.types import Tool as McpToolDef
 
-from omnigent.runner import mcp_manager as _mcp_manager_module
 from omnigent.runner.mcp_manager import (
     _POOL_SPEC_CAPACITY,
     McpSchemasResult,
@@ -38,6 +37,10 @@ from omnigent.runner.mcp_manager import (
     compute_spec_hash,
 )
 from omnigent.spec.types import AgentSpec, MCPServerConfig
+
+# The manager imports ``McpServerConnection`` lazily at connect time (keeping
+# the MCP SDK out of the runner import graph), so patches target its home.
+from omnigent.tools import mcp as _tools_mcp_module
 
 
 def _make_spec(*configs: MCPServerConfig) -> AgentSpec:
@@ -130,10 +133,7 @@ def patch_connection(
             """Forward to the per-config _FakeConn so tests can assert dispatch."""
             return await self._inner.call_tool(name, arguments)
 
-    monkeypatch.setattr(
-        "omnigent.runner.mcp_manager.McpServerConnection",
-        _PatchedConn,
-    )
+    monkeypatch.setattr(_tools_mcp_module, "McpServerConnection", _PatchedConn)
     # Tests script per-server behavior by mutating these dicts BEFORE
     # calling schemas_for; the closure above honors the script.
     conns["__raise_for__"] = raise_for  # type: ignore[assignment]
@@ -432,7 +432,7 @@ async def test_call_tool_connects_only_target_namespaced_server(
             calls.append((self._config.name, name, arguments))
             return "ok"
 
-    monkeypatch.setattr(_mcp_manager_module, "McpServerConnection", _TargetedConn)
+    monkeypatch.setattr(_tools_mcp_module, "McpServerConnection", _TargetedConn)
 
     spec = _make_spec(_make_config("used"), _make_config("unused"))
     manager = RunnerMcpManager()
@@ -516,7 +516,7 @@ async def test_lru_eviction_at_pool_capacity(
             """Unused in this test but required by the interface."""
             return ""
 
-    monkeypatch.setattr(_mcp_manager_module, "McpServerConnection", _CountingConn)
+    monkeypatch.setattr(_tools_mcp_module, "McpServerConnection", _CountingConn)
 
     manager = RunnerMcpManager()
     # Build capacity + 1 distinct specs (different server.name → different
@@ -574,7 +574,7 @@ async def test_prewarm_registers_without_connecting(
             """Unused in this test."""
             return ""
 
-    monkeypatch.setattr(_mcp_manager_module, "McpServerConnection", _CountingConn)
+    monkeypatch.setattr(_tools_mcp_module, "McpServerConnection", _CountingConn)
 
     spec = _make_spec(_make_config("slow"))
     manager = RunnerMcpManager()
@@ -625,7 +625,7 @@ async def test_shutdown_cancels_in_flight_schema_connect(
             """Unused."""
             return ""
 
-    monkeypatch.setattr(_mcp_manager_module, "McpServerConnection", _HangingConn)
+    monkeypatch.setattr(_tools_mcp_module, "McpServerConnection", _HangingConn)
 
     spec = _make_spec(_make_config("hangs"))
     manager = RunnerMcpManager()
@@ -676,7 +676,7 @@ async def test_evicted_spec_closes_late_completed_shared_connect(
         async def call_tool(self, name: str, arguments: dict[str, Any], **_kw: Any) -> str:
             return "ok"
 
-    monkeypatch.setattr(_mcp_manager_module, "McpServerConnection", _SlowConn)
+    monkeypatch.setattr(_tools_mcp_module, "McpServerConnection", _SlowConn)
 
     spec = _make_spec(_make_config("shared"))
     server_hash = compute_server_hash(spec.mcp_servers[0])
@@ -730,7 +730,7 @@ async def test_shared_connect_survives_one_spec_eviction_while_referenced(
         async def call_tool(self, name: str, arguments: dict[str, Any], **_kw: Any) -> str:
             return "ok"
 
-    monkeypatch.setattr(_mcp_manager_module, "McpServerConnection", _SlowConn)
+    monkeypatch.setattr(_tools_mcp_module, "McpServerConnection", _SlowConn)
 
     cfg_run = _make_config("shared")
     cfg_run.tools = ["run"]
@@ -824,7 +824,7 @@ async def test_stdio_cwd_threaded_to_connection(
             """Unused."""
             return ""
 
-    monkeypatch.setattr(_mcp_manager_module, "McpServerConnection", _CwdRecorder)
+    monkeypatch.setattr(_tools_mcp_module, "McpServerConnection", _CwdRecorder)
 
     spec = _make_spec(_make_config("jira"))
     project = Path("/tmp/some-project-root")

--- a/tests/runner/test_runner_import_graph.py
+++ b/tests/runner/test_runner_import_graph.py
@@ -1,0 +1,172 @@
+"""Import-graph guards for the runner: the MCP SDK stays out of it.
+
+The ``mcp`` package costs ~300ms to import (``mcp.types`` plus the FastMCP
+server graph its ``__init__`` pulls) and is only needed once a session's spec
+actually connects to an MCP server. It used to arrive unconditionally, via
+``runner/app.py`` -> ``proxy_mcp_manager`` -> ``mcp_manager``, and again at
+runtime because ``_entry.main()`` builds a ``RunnerMcpManager`` for every
+runner. That put it on the cold-zygote start that ``POST /v1/sessions`` awaits,
+and on the whole per-session import cost of any runner the zygote did not fork.
+
+Every assertion here runs in a fresh subprocess, the same way
+``tests/runner/test_identity.py`` guards ``runner.identity`` against FastAPI:
+the shared pytest session has long since imported ``mcp`` for the MCP tests
+themselves, so only a clean interpreter can tell whether the runner graph
+pulls it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import omnigent
+
+_OMNIGENT_ROOT = str(Path(omnigent.__file__).resolve().parent)
+_ECHO_SERVER = str(
+    Path(__file__).resolve().parents[1] / "tools" / "fixtures" / "echo_stdio_mcp_server.py"
+)
+
+# Reports the loaded tree plus whether the MCP SDK is resident. The tree line
+# is checked against this process's own ``omnigent``, so a probe that resolved a
+# different checkout fails loudly instead of silently "passing".
+_PREAMBLE = """
+import sys, threading
+
+import omnigent
+print("TREE", omnigent.__file__)
+
+
+def mcp_loaded():
+    return sorted(m for m in sys.modules if m == "mcp" or m.startswith("mcp."))
+"""
+
+
+def _probe(body: str, timeout: float = 300.0) -> list[str]:
+    """Run *body* in a fresh interpreter that resolves this checkout.
+
+    :param body: Probe source appended to the shared preamble.
+    :param timeout: Seconds to allow the probe.
+    :returns: The probe's stdout lines.
+    """
+    # Hand the child the same import roots as this process so it resolves
+    # ``omnigent`` to the code under test (worktree or installed package) — a
+    # bare ``-c`` subprocess otherwise misses pytest's rootdir sys.path entries.
+    child_env = {**os.environ, "PYTHONPATH": os.pathsep.join(p for p in sys.path if p)}
+    result = subprocess.run(
+        [sys.executable, "-c", _PREAMBLE + body],
+        env=child_env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    assert result.returncode == 0, f"probe failed:\n{result.stdout}\n{result.stderr}"
+    lines = result.stdout.strip().splitlines()
+    tree = next(line for line in lines if line.startswith("TREE "))
+    assert tree.removeprefix("TREE ").startswith(_OMNIGENT_ROOT), (
+        f"probe resolved a different omnigent than the code under test: {tree}"
+    )
+    return lines
+
+
+def test_runner_app_import_does_not_pull_the_mcp_sdk() -> None:
+    """``omnigent.runner.app`` must import with no ``mcp`` module resident."""
+    lines = _probe(
+        """
+import omnigent.runner.app  # noqa: F401
+print("MCP", mcp_loaded())
+"""
+    )
+    assert "MCP []" in lines, (
+        f"omnigent.runner.app pulled the MCP SDK into its import graph: {lines}"
+    )
+
+
+def test_building_the_runner_mcp_manager_does_not_pull_the_mcp_sdk() -> None:
+    """``_entry.main()`` builds one per runner, so construction must stay free.
+
+    Deferring the import in ``runner/app.py`` alone would have been undone here:
+    every runner instantiates ``RunnerMcpManager`` unconditionally at startup.
+    """
+    lines = _probe(
+        """
+from omnigent.runner.mcp_manager import RunnerMcpManager
+RunnerMcpManager()
+print("MCP", mcp_loaded())
+"""
+    )
+    assert "MCP []" in lines, f"constructing RunnerMcpManager imported the MCP SDK: {lines}"
+
+
+def test_zygote_pre_import_excludes_mcp_and_warms_it_separately() -> None:
+    """The zygote's boot-time graph skips MCP; its warm-up adds it, thread-free.
+
+    The zygote's own import sits on the first session-create's critical path, so
+    MCP is warmed later from the idle serve loop — which must stay
+    single-threaded, since that is the state every runner is forked from.
+    """
+    lines = _probe(
+        """
+from omnigent.runner._zygote import _import_mcp_graph, _import_runner_graph
+
+_import_runner_graph()
+print("BOOT", mcp_loaded())
+_import_mcp_graph()
+print("WARMED", bool(mcp_loaded()))
+print("THREADS", threading.active_count())
+"""
+    )
+    assert "BOOT []" in lines, f"the zygote pre-imported the MCP SDK: {lines}"
+    assert "WARMED True" in lines, f"the zygote warm-up did not import the MCP SDK: {lines}"
+    assert "THREADS 1" in lines, f"warming MCP started a thread, breaking fork safety: {lines}"
+
+
+def test_mcp_declaring_spec_still_works_from_an_mcp_free_runner_graph() -> None:
+    """End to end from a clean process: the deferred imports still resolve.
+
+    Boots the runner graph (no MCP resident), then drives a real stdio MCP
+    subprocess through ``RunnerMcpManager`` — exercising the lazily imported
+    ``McpServerConnection`` — and checks the SDK only arrives at that point.
+    """
+    lines = _probe(
+        f"""
+import asyncio, sys
+
+import omnigent.runner.app  # noqa: F401
+from omnigent.runner.mcp_manager import RunnerMcpManager
+from omnigent.spec.types import AgentSpec, MCPServerConfig
+
+print("BEFORE", mcp_loaded())
+spec = AgentSpec(
+    spec_version=1,
+    mcp_servers=[
+        MCPServerConfig(
+            name="echo-test",
+            transport="stdio",
+            command=sys.executable,
+            args=[{_ECHO_SERVER!r}],
+        )
+    ],
+)
+
+
+async def main():
+    manager = RunnerMcpManager()
+    try:
+        result = await manager.schemas_for(spec)
+        return sorted(result.tool_names), result.failures
+    finally:
+        await manager.shutdown()
+
+
+names, failures = asyncio.run(main())
+print("TOOLS", names, failures)
+print("AFTER", bool(mcp_loaded()))
+"""
+    )
+    assert "BEFORE []" in lines, f"the runner graph pulled the MCP SDK: {lines}"
+    tools = next(line for line in lines if line.startswith("TOOLS "))
+    assert "echo-test__echo" in tools, f"MCP-declaring spec lost its tool: {lines}"
+    assert "AFTER True" in lines, f"the real MCP connect never imported the SDK: {lines}"


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Importing `omnigent.runner.app` pulled the whole `mcp` package — `mcp.types`
plus the FastMCP *server* graph its `__init__` drags in (jsonschema, the auth
provider, the lowlevel server) — costing ~300ms of a 1.23s import graph,
unconditionally, whether or not a session's spec declares MCP servers.

It arrived twice over:

```
omnigent.runner.app                     1229ms cumulative
└── omnigent.runner.proxy_mcp_manager    530ms
    └── omnigent.runner.mcp_manager      297ms
        └── mcp (via mcp.types +
                 omnigent.tools.mcp)     ~300ms   ← paid by every runner
```

…and again at *runtime*, because `_entry.main()` builds a `RunnerMcpManager`
for every runner regardless of spec. Both hit user-visible paths:

1. The one-time **cold-zygote start**, which sits directly on
   `POST /v1/sessions`'s critical path (the server awaits the host's
   launch-result frame).
2. The **entire per-session import cost** for any runner the zygote did not
   fork: managed-sandbox runners, directly-`Popen`'d runners, and everything
   launched after the daemon latches `_harness_zygote_disabled`.

**What changed**

- `runner/mcp_manager.py` no longer needs the SDK to be *constructed*, only to
  *connect*. `ElicitRequestParams` and `Tool` are annotation-only (the module
  already has `from __future__ import annotations`) so they move under
  `TYPE_CHECKING`; `ElicitResult` and `McpServerConnection` are each used at
  exactly one runtime site and are imported there. Nothing else moved — no
  public API, no signature, no observable behavior changes, and
  `proxy_mcp_manager`/`app.py` are untouched: they simply stop dragging the SDK
  along transitively.
- `runner/_zygote.py` warms the MCP graph from the serve loop's **first idle
  tick** instead of during boot.

**ELI5.** The runner used to unpack the entire MCP toolbox on the way in the
door, every time, even for sessions that never open it. Now it leaves the
toolbox in the van, and the zygote — which is the van everyone shares — carries
it in during its first quiet moment, so it's already inside for everybody who
does need it.

**The zygote trade-off (deliberate).** `_import_runner_graph` exists precisely
so forked children inherit the heavy graph copy-on-write, so simply making MCP
lazy would have moved ~300ms off cold start and onto every MCP-using session's
first connect. Two options were considered:

- *Background thread after fork-ready* — **rejected.** The zygote must be
  thread-free to fork safely (forking from a multithreaded process risks child
  deadlocks) and asserts `threading.active_count() == 1` before serving. A
  warm-up thread would either trip that check or, worse, race a fork against
  the import lock.
- *Idle tick in the single-threaded serve loop* — **chosen.** `serve()` already
  wakes on a 1s `select` timeout to reap children; an empty ready-set now also
  warms MCP once, in the main thread, then re-`gc.freeze()`s. Fork safety is
  unchanged, and a request landing mid-import waits no longer than the same
  import already delayed *every* request during boot (the daemon's control
  timeout is 30s, so a ≤300ms stall is not observable).

Net effect: cold start and non-MCP runners get the full win; MCP-using
sessions on zygote-forked runners are no slower than before, because the graph
is resident by the time the second session forks. The one case that is slower
is a spec that connects to an MCP server on the *very first* session after
daemon boot, which pays the import at connect time instead of at zygote boot —
same work, later, once per daemon lifetime, on a path that is already spawning
subprocesses and doing network I/O.

```mermaid
sequenceDiagram
    participant S as Server
    participant D as Host daemon
    participant Z as Runner zygote
    participant R as Runner (forked)
    S->>D: POST /v1/sessions (awaits launch result)
    D->>Z: spawn + import runner graph
    Note over Z: 1217ms → 913ms<br/>(MCP no longer here)
    D->>Z: fork
    Z-->>R: runner #1 (no MCP import in _entry.main)
    Note over Z: serve loop goes idle<br/>→ warm MCP graph (~300ms)
    D->>Z: fork
    Z-->>R: runner #2+ inherits MCP copy-on-write
```

## Test Plan

Targeted suites, all green (`205 passed`):

```
cd <worktree>
python -m pytest \
  tests/runner/test_runner_import_graph.py \
  tests/runner/test_mcp_manager.py \
  tests/host/test_runner_zygote.py \
  tests/tools/test_mcp_stdio_e2e.py \
  tests/runner/test_proxy_mcp_manager.py \
  tests/runner/test_pending_approvals.py \
  tests/tools/test_mcp.py \
  tests/server/test_mcp_pool.py \
  tests/runner/test_identity.py
```

New regression guard — `tests/runner/test_runner_import_graph.py`, four
fresh-subprocess probes in the idiom of `tests/runner/test_identity.py` (the
shared pytest session imports `mcp` for the MCP tests themselves, so only a
clean interpreter can see the regression):

1. `import omnigent.runner.app` leaves no `mcp*` module in `sys.modules`.
2. Constructing a `RunnerMcpManager` — what `_entry.main()` does for every
   runner — also leaves it absent. Without this, deferring in `app.py` alone
   would have been silently undone at runtime.
3. The zygote's boot-time pre-import set excludes MCP, `_import_mcp_graph()`
   pulls it in, and doing so starts no threads (the fork-safety invariant).
4. **End to end:** from a process that started MCP-free, a spec declaring a
   real stdio MCP server (`tests/tools/fixtures/echo_stdio_mcp_server.py`)
   still discovers `echo-test__echo` through the lazily imported
   `McpServerConnection`, and the SDK only becomes resident at that point.

Prove-it-fails: with `omnigent/runner/{mcp_manager,_zygote}.py` stashed and the
new test in place, all four probes fail (probe 1 dumps the 80+ `mcp.*` modules
it found). With the fix, all four pass.

`tests/runner/test_mcp_manager.py` retargets its 8 `McpServerConnection`
monkeypatches from `omnigent.runner.mcp_manager` to `omnigent.tools.mcp`, the
class's canonical home — the manager now resolves it there at connect time, so
a patch on the manager module would no longer be seen. Same doubles, same
assertions.

`pre-commit run --files <changed files>`: ruff format, ruff check and every
other hook pass. `pyrefly` reports 99 errors in this sandbox, all
`missing-import` for `omnigent_client.*` and `opentelemetry.*` — identical
counts with the change stashed, i.e. pre-existing environment noise (the venv
belongs to a sibling worktree), none in the changed files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

`python -X importtime`, best-of-5, warm bytecode cache, serialized under a lock
so sibling agents don't pollute the numbers (load average ~11 on a 32-core box,
recorded beside each run):

| measurement | before | after | delta |
| --- | --- | --- | --- |
| `omnigent.runner.app` cumulative | 1229ms | 913ms | **-316ms (-26%)** |
| zygote pre-import set (`runner.{_entry,app,native}` + `runtime.harnesses._runner`) | 1217ms | 913ms | **-304ms (-25%)** |
| `omnigent.runner.mcp_manager` cumulative | 297ms | 4ms | -293ms |
| `mcp*` modules resident after `import omnigent.runner.app` | 84 | 0 | — |

Before/after were measured on the same tree by stashing only the two
`omnigent/` files, with `PYTHONPATH` pinned to the worktree and
`omnigent.__file__` printed each run to prove which checkout was loaded.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Existing tests cover this change
- [ ] Manual verification completed
- [ ] Not applicable

## Coverage notes

The import-graph guards are the point of the change and are asserted to fail
without it. Behavior preservation rests on the existing MCP suites
(`test_mcp_manager.py`, `test_mcp_stdio_e2e.py`, `test_mcp.py`,
`test_mcp_pool.py`, `test_proxy_mcp_manager.py`) plus the zygote's own
(`tests/host/test_runner_zygote.py`, which forks real runners through the
modified serve loop), and on the new end-to-end probe that drives a real stdio
MCP server from an MCP-free process.
