### PR TITLE
perf(onboarding): overlap harness readiness probes and cache the CLI login verdict across processes

### DIFF
--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -35,6 +35,7 @@ when the credentials file is absent — see ``ambient._claude_login_detected``.)
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
@@ -57,6 +58,7 @@ from omnigent.opencode_native_client import (
     OPENCODE_MAX_VERSION_EXCLUSIVE,
     OPENCODE_MIN_VERSION,
 )
+from omnigent.process_logging import data_dir
 
 # Pi is not a configure-menu family (the menu is Claude + Codex), but the
 # first-run ``run`` flow falls back to it, so it has install metadata too.
@@ -774,6 +776,122 @@ _PROBE_CACHE_LOCK = threading.Lock()
 _LOGIN_PROBE_CACHE_TTL_S = 120.0
 _PROBE_CACHE_MAX_ENTRIES = 64
 
+# Per-target gates so concurrent cache misses don't each exec the CLI: the
+# readiness fan-out resolves many harness spellings at once and aliases of one
+# CLI (``claude-native`` / ``native-claude``) share a probe. The loser waits,
+# then reads the winner's cached answer.
+_PROBE_GATES: dict[object, threading.Lock] = {}
+
+
+def _probe_gate(token: object) -> threading.Lock:
+    """Return the lock serializing concurrent probes of the same target.
+
+    :param token: The probe's cache key — a binary signature for ``--version``,
+        a ``(key, binary)`` pair for the login status probe.
+    """
+    with _PROBE_CACHE_LOCK:
+        if len(_PROBE_GATES) >= _PROBE_CACHE_MAX_ENTRIES:
+            _PROBE_GATES.clear()
+        return _PROBE_GATES.setdefault(token, threading.Lock())
+
+
+# The in-process cache above only helps a daemon that stays up: a COLD host
+# start finds it empty and pays ``claude auth status`` (~0.6s on the measured
+# box) again. So positive verdicts are also mirrored to disk, keyed on the CLI's
+# ``(path, mtime_ns, size)`` exactly like the version cache, so an upgraded or
+# replaced binary re-probes.
+_PERSISTED_LOGIN_CACHE_NAME = "cli_login_probe_cache.json"
+# 15 min: covers a burst of cold daemon starts, and a login revoked outside
+# omnigent self-corrects within one working pause. A stale positive only
+# mislabels a picker badge — the launch gate is binary-only — and a login or
+# logout driven through omnigent invalidates immediately.
+_PERSISTED_LOGIN_TTL_S = 900.0
+_PERSISTED_LOGIN_CACHE_MAX_ENTRIES = 32
+
+
+def _persisted_login_cache_path() -> Path:
+    """Return the on-disk login-verdict cache file (honors ``OMNIGENT_DATA_DIR``)."""
+    return data_dir() / _PERSISTED_LOGIN_CACHE_NAME
+
+
+def _persisted_login_entry_key(key: str, binary: str) -> str | None:
+    """Return the disk-cache key for *key*'s verdict on this exact binary.
+
+    :returns: ``"<key>\\n<path>\\n<mtime_ns>\\n<size>"``, or ``None`` when the
+        binary cannot be stat'ed (caller then probes uncached).
+    """
+    sig = _binary_signature(binary)
+    if sig is None:
+        return None
+    path, mtime_ns, size = sig
+    return f"{key}\n{path}\n{mtime_ns}\n{size}"
+
+
+def _read_persisted_logins() -> dict[str, float]:
+    """Return the on-disk ``entry key -> expiry (epoch seconds)`` mapping.
+
+    A missing, unreadable, or malformed file reads as empty so a corrupted
+    cache degrades to probing rather than raising on the readiness path.
+    """
+    try:
+        payload = json.loads(_persisted_login_cache_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    return {
+        name: float(expiry)
+        for name, expiry in payload.items()
+        if isinstance(name, str)
+        and isinstance(expiry, (int, float))
+        and not isinstance(expiry, bool)
+    }
+
+
+def _write_persisted_logins(entries: dict[str, float]) -> None:
+    """Replace the on-disk cache atomically; a write failure is not fatal."""
+    path = _persisted_login_cache_path()
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_text(json.dumps(entries), encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError:
+        # A read-only / full data dir must never break a readiness refresh;
+        # the next probe simply runs the subprocess again.
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+
+
+def _persisted_login_fresh(key: str, binary: str) -> bool:
+    """Whether disk holds an unexpired positive verdict for this exact binary."""
+    entry_key = _persisted_login_entry_key(key, binary)
+    if entry_key is None:
+        return False
+    return time.time() < _read_persisted_logins().get(entry_key, 0.0)
+
+
+def _store_persisted_login(key: str, binary: str) -> None:
+    """Record a positive verdict on disk for :data:`_PERSISTED_LOGIN_TTL_S`."""
+    entry_key = _persisted_login_entry_key(key, binary)
+    if entry_key is None:
+        return
+    now = time.time()
+    entries = {name: expiry for name, expiry in _read_persisted_logins().items() if expiry > now}
+    entries[entry_key] = now + _PERSISTED_LOGIN_TTL_S
+    if len(entries) > _PERSISTED_LOGIN_CACHE_MAX_ENTRIES:
+        entries = {entry_key: entries[entry_key]}
+    _write_persisted_logins(entries)
+
+
+def _drop_persisted_logins(key: str) -> None:
+    """Forget every persisted verdict for *key* so a logout is never masked."""
+    prefix = f"{key}\n"
+    entries = _read_persisted_logins()
+    remaining = {name: expiry for name, expiry in entries.items() if not name.startswith(prefix)}
+    if len(remaining) != len(entries):
+        _write_persisted_logins(remaining)
+
 
 def _binary_signature(binary: str) -> tuple[str, int, int] | None:
     """Return *binary*'s identity signature for the version cache.
@@ -950,11 +1068,28 @@ def _harness_cli_version_string(
         :data:`READINESS_CLI_PROBE_TIMEOUT_S` on the readiness path.
     """
     sig = _binary_signature(binary)
-    if sig is not None:
+    if sig is None:
+        return _probe_harness_cli_version(binary, timeout)
+    with _PROBE_CACHE_LOCK:
+        cached = _VERSION_PROBE_CACHE.get(sig)
+    if cached is not None:
+        return cached
+    with _probe_gate(sig):
         with _PROBE_CACHE_LOCK:
             cached = _VERSION_PROBE_CACHE.get(sig)
         if cached is not None:
             return cached
+        version = _probe_harness_cli_version(binary, timeout)
+        if version is not None:
+            with _PROBE_CACHE_LOCK:
+                if len(_VERSION_PROBE_CACHE) >= _PROBE_CACHE_MAX_ENTRIES:
+                    _VERSION_PROBE_CACHE.clear()
+                _VERSION_PROBE_CACHE[sig] = version
+        return version
+
+
+def _probe_harness_cli_version(binary: str, timeout: float) -> str | None:
+    """Exec ``<binary> --version`` and return its parsed version, uncached."""
     try:
         completed = subprocess.run(
             [binary, "--version"],
@@ -965,15 +1100,7 @@ def _harness_cli_version_string(
         )
     except (OSError, subprocess.SubprocessError):
         return None
-    version = _parse_harness_cli_version(
-        (completed.stdout or "") + "\n" + (completed.stderr or "")
-    )
-    if version is not None and sig is not None:
-        with _PROBE_CACHE_LOCK:
-            if len(_VERSION_PROBE_CACHE) >= _PROBE_CACHE_MAX_ENTRIES:
-                _VERSION_PROBE_CACHE.clear()
-            _VERSION_PROBE_CACHE[sig] = version
-    return version
+    return _parse_harness_cli_version((completed.stdout or "") + "\n" + (completed.stderr or ""))
 
 
 def harness_install_command(key: str) -> list[str]:
@@ -1107,7 +1234,12 @@ def install_harness_cli(key: str) -> bool:
     return try_install_harness_cli(key).installed
 
 
-def harness_cli_logged_in(key: str, timeout: float = _DEFAULT_CLI_PROBE_TIMEOUT_S) -> bool:
+def harness_cli_logged_in(
+    key: str,
+    timeout: float = _DEFAULT_CLI_PROBE_TIMEOUT_S,
+    *,
+    use_persisted_cache: bool = False,
+) -> bool:
     """Return whether the harness CLI itself reports a usable login.
 
     Asks the CLI's own status command (``claude auth status`` /
@@ -1134,6 +1266,12 @@ def harness_cli_logged_in(key: str, timeout: float = _DEFAULT_CLI_PROBE_TIMEOUT_
         ``"openai"`` (Codex), or ``"gemini"`` (Antigravity, via ``agy models``).
     :param timeout: Seconds to wait for the status subprocess, e.g. ``10.0`` on
         the readiness path where a hung CLI must not stall the refresh.
+    :param use_persisted_cache: When true, a positive verdict is also served
+        from / written to the on-disk cache (:data:`_PERSISTED_LOGIN_TTL_S`), so
+        a cold host daemon doesn't re-exec the probe on every start. Opt-in: the
+        interactive ``configure`` surfaces and :func:`harness_login` stay live so
+        a user who just ran ``claude auth login``/``logout`` by hand sees the
+        real state immediately.
     :returns: ``True`` when the CLI reports a usable login; ``False`` when the
         key has no status command, the CLI binary is missing, the status
         process failed to spawn, or the CLI reports no login.
@@ -1149,13 +1287,50 @@ def harness_cli_logged_in(key: str, timeout: float = _DEFAULT_CLI_PROBE_TIMEOUT_
     # refresh is the ambient storm. Negatives always re-probe so a login
     # made a moment ago is seen immediately.
     cache_key = (key, binary)
+    if _cached_login_verdict(cache_key, use_persisted_cache=use_persisted_cache):
+        return True
+    with _probe_gate(cache_key):
+        # Re-check under the gate: a concurrent probe of the same CLI may have
+        # answered while we waited.
+        if _cached_login_verdict(cache_key, use_persisted_cache=use_persisted_cache):
+            return True
+        argv = [binary if key == GEMINI_FAMILY else spec.binary, *spec.status_args]
+        return _run_login_probe(
+            key,
+            binary,
+            argv,
+            spec.login_status_key,
+            timeout,
+            use_persisted_cache=use_persisted_cache,
+        )
+
+
+def _cached_login_verdict(cache_key: tuple[str, str], *, use_persisted_cache: bool) -> bool:
+    """Whether an unexpired positive verdict is already cached for *cache_key*."""
     with _PROBE_CACHE_LOCK:
         if time.monotonic() < _LOGIN_PROBE_CACHE.get(cache_key, 0.0):
             return True
-    argv_binary = binary if key == GEMINI_FAMILY else spec.binary
+    return use_persisted_cache and _persisted_login_fresh(*cache_key)
+
+
+def _run_login_probe(
+    key: str,
+    binary: str,
+    argv: list[str],
+    status_key: str | None,
+    timeout: float,
+    *,
+    use_persisted_cache: bool,
+) -> bool:
+    """Exec the CLI's status command and cache a positive verdict.
+
+    Split out of :func:`harness_cli_logged_in` so the cache lookup, the
+    single-flight gate, and the probe itself each stay readable.
+    """
+    cache_key = (key, binary)
     try:
         result = subprocess.run(
-            [argv_binary, *spec.status_args],
+            argv,
             check=False,
             timeout=timeout,
             capture_output=True,
@@ -1169,7 +1344,6 @@ def harness_cli_logged_in(key: str, timeout: float = _DEFAULT_CLI_PROBE_TIMEOUT_
     # harness has no JSON verdict (Codex's human line, agy's model list), so the
     # exit code is authoritative and stdout is never parsed — output that merely
     # happens to be JSON can't flip the verdict.
-    status_key = spec.login_status_key
     logged_in = result.returncode == 0
     if status_key is not None:
         try:
@@ -1183,6 +1357,8 @@ def harness_cli_logged_in(key: str, timeout: float = _DEFAULT_CLI_PROBE_TIMEOUT_
             if len(_LOGIN_PROBE_CACHE) >= _PROBE_CACHE_MAX_ENTRIES:
                 _LOGIN_PROBE_CACHE.clear()
             _LOGIN_PROBE_CACHE[cache_key] = time.monotonic() + _LOGIN_PROBE_CACHE_TTL_S
+        if use_persisted_cache:
+            _store_persisted_login(key, binary)
     return logged_in
 
 
@@ -1272,4 +1448,5 @@ def harness_logout(key: str) -> bool:
     with _PROBE_CACHE_LOCK:
         for cache_key in [k for k in _LOGIN_PROBE_CACHE if k[0] == key]:
             del _LOGIN_PROBE_CACHE[cache_key]
+    _drop_persisted_logins(key)
     return not harness_cli_logged_in(key)

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 
 import omnigent.onboarding.gemini_auth as _gemini_auth
 import omnigent.onboarding.kimi_auth as _kimi_auth
@@ -75,6 +76,11 @@ from omnigent.onboarding.provider_config import (
 # runtime), distinct from the CLI-wrapping ``antigravity-native`` (``agy``)
 # harness gated below on its binary plus an API key or OAuth credential.
 _logger = logging.getLogger(__name__)
+
+# Fan-out width for the readiness probes. Only a handful of harnesses actually
+# exec a subprocess; the rest resolve from local files, so a small pool covers
+# the slow ones without flooding a loaded machine with threads.
+_MAX_PROBE_WORKERS = 8
 
 _SDK_HARNESSES: frozenset[str] = frozenset(
     {"claude-sdk", "openai-agents", "openai-agents-sdk", "antigravity"}
@@ -450,9 +456,15 @@ def _cli_family_availability(canonical: str, install_key: str) -> HarnessAvailab
     # without depending on the probe resolving the CLI on PATH.
     if install_key == ANTHROPIC_FAMILY and _claude_managed_gateway_configured():
         return True
+    # ``use_persisted_cache``: this is the daemon's readiness path, and a cold
+    # daemon start would otherwise re-exec the (slow) status probe every time.
     return (
         True
-        if harness_cli_logged_in(install_key, timeout=READINESS_CLI_PROBE_TIMEOUT_S)
+        if harness_cli_logged_in(
+            install_key,
+            timeout=READINESS_CLI_PROBE_TIMEOUT_S,
+            use_persisted_cache=True,
+        )
         else "needs-auth"
     )
 
@@ -562,12 +574,36 @@ def configured_harness_map() -> dict[str, HarnessAvailability]:
     spellings.add(GOOSE_KEY)  # headless Goose (``goose acp``) gates on the goose binary
     spellings.add(HERMES_KEY)  # Hermes Agent wraps the ``hermes`` CLI
     spellings.add(COPILOT_KEY)
-    availability_cache: dict[tuple[str, ...], HarnessAvailability] = {}
-    result: dict[str, HarnessAvailability] = {}
+    keyed: dict[str, tuple[str, ...]] = {}
+    pending: dict[tuple[str, ...], str] = {}
     for spelling in spellings:
         canonical = _canonical_harness(spelling)
         cache_key = ("codex",) if _is_codex_family_harness(canonical) else ("harness", canonical)
-        if cache_key not in availability_cache:
-            availability_cache[cache_key] = _harness_availability(canonical)
-        result[spelling] = availability_cache[cache_key]
-    return result
+        keyed[spelling] = cache_key
+        pending.setdefault(cache_key, canonical)
+    availability_cache = _probe_availability(pending)
+    return {spelling: availability_cache[cache_key] for spelling, cache_key in keyed.items()}
+
+
+def _probe_availability(
+    pending: dict[tuple[str, ...], str],
+) -> dict[tuple[str, ...], HarnessAvailability]:
+    """Resolve one availability verdict per distinct probe, concurrently.
+
+    Each verdict execs its harness's own CLI (``claude auth status``,
+    ``codex --version``, ``gh auth token``, …) or reads local credential files,
+    and the probes are independent of each other — run serially they cost their
+    sum, which dominated the host daemon's cold-start readiness stage.
+
+    :param pending: Distinct probe key to the canonical harness that resolves it.
+    :returns: The verdict for every key in *pending*.
+    """
+    if len(pending) <= 1:
+        return {key: _harness_availability(canonical) for key, canonical in pending.items()}
+    workers = min(len(pending), _MAX_PROBE_WORKERS)
+    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="harness-probe") as pool:
+        futures = {
+            key: pool.submit(_harness_availability, canonical)
+            for key, canonical in pending.items()
+        }
+        return {key: future.result() for key, future in futures.items()}

--- a/tests/onboarding/conftest.py
+++ b/tests/onboarding/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+
 import pytest
 
 from omnigent.onboarding import harness_install
@@ -9,11 +11,16 @@ from omnigent.onboarding import harness_install
 
 @pytest.fixture(autouse=True)
 def _clear_probe_caches() -> None:
-    """Isolate the module-level CLI probe caches between tests.
+    """Isolate the CLI probe caches — in-process and on-disk — between tests.
 
     ``harness_cli_logged_in`` / ``_harness_cli_version_string`` cache
-    verdicts process-wide; a positive cached by one test's fake probe
-    would leak into the next test's counting assertions.
+    verdicts process-wide, and a logged-in verdict is also mirrored to
+    ``<data-dir>/cli_login_probe_cache.json`` so a cold host daemon skips the
+    probe; a positive left by one test's fake probe would leak into the next
+    test's counting assertions.
     """
     harness_install._LOGIN_PROBE_CACHE.clear()
     harness_install._VERSION_PROBE_CACHE.clear()
+    harness_install._PROBE_GATES.clear()
+    with contextlib.suppress(OSError):
+        harness_install._persisted_login_cache_path().unlink()

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -280,6 +282,172 @@ def test_logout_invalidates_login_probe_cache(
         "logout must invalidate the cached positive and confirm live"
     )
     assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY) is False
+
+
+def _persisted_cache_setup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> tuple[Path, list[list[str]]]:
+    """Point the disk cache at *tmp_path* and stub a real, logged-in claude CLI.
+
+    The persisted entry is keyed on the binary's ``(path, mtime_ns, size)``, so
+    the fake CLI has to be a file that actually exists.
+
+    :returns: ``(binary path, recorded probe argv list)``.
+    """
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+    binary = tmp_path / "claude"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(hi.shutil, "which", lambda name: str(binary))
+    runs: list[list[str]] = []
+
+    def _positive_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        runs.append(argv)
+        return subprocess.CompletedProcess(
+            args=argv, returncode=0, stdout='{"loggedIn": true}', stderr=""
+        )
+
+    monkeypatch.setattr(hi.subprocess, "run", _positive_run)
+    return binary, runs
+
+
+def test_persisted_login_cache_survives_a_cold_process(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A second cold probe of an unchanged binary skips ``auth status``.
+
+    The in-process cache starts empty on every host daemon, so without the
+    on-disk mirror each cold start re-paid the (slow) status subprocess.
+    """
+    binary, runs = _persisted_cache_setup(monkeypatch, tmp_path)
+
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY, use_persisted_cache=True) is True
+    # A fresh process starts with an empty in-process cache.
+    hi._LOGIN_PROBE_CACHE.clear()
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY, use_persisted_cache=True) is True
+    assert len(runs) == 1, "a cold process within the TTL must be served from disk"
+
+    # An upgraded binary must re-probe: the entry is keyed on its signature.
+    hi._LOGIN_PROBE_CACHE.clear()
+    binary.write_text("#!/bin/sh\n# upgraded\n", encoding="utf-8")
+    os.utime(binary, ns=(1, 1))
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY, use_persisted_cache=True) is True
+    assert len(runs) == 2, "a swapped binary must not reuse the old verdict"
+
+
+def test_persisted_login_cache_reprobes_after_ttl(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An expired persisted verdict re-probes, so a revoked login self-corrects."""
+    _persisted_cache_setup(monkeypatch, tmp_path)
+
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY, use_persisted_cache=True) is True
+    hi._LOGIN_PROBE_CACHE.clear()
+    hi._write_persisted_logins(dict.fromkeys(hi._read_persisted_logins(), 0.0))
+
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY, use_persisted_cache=True) is True
+    assert len(hi._read_persisted_logins()) == 1
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY, use_persisted_cache=True) is True
+
+
+def test_persisted_login_cache_is_opt_in(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Callers that don't opt in never read the disk cache.
+
+    The interactive ``configure`` surfaces and :func:`harness_login` must show
+    the live state, not a verdict recorded up to 15 minutes ago by the daemon.
+    """
+    _persisted_cache_setup(monkeypatch, tmp_path)
+
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY, use_persisted_cache=True) is True
+    hi._LOGIN_PROBE_CACHE.clear()
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY) is True
+    assert len(hi._read_persisted_logins()) == 1
+    hi._LOGIN_PROBE_CACHE.clear()
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY, use_persisted_cache=True) is True
+
+
+def test_persisted_login_cache_never_strands_a_fresh_login(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Not-logged-in is never persisted, so a login lands on the next probe.
+
+    A user's most likely next action after "not logged in" is to log in and
+    retry; a cached negative would report the fresh login as still missing.
+    """
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+    binary = tmp_path / "claude"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(hi.shutil, "which", lambda name: str(binary))
+    logged_in = False
+
+    def _stateful_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        body = '{"loggedIn": true}' if logged_in else '{"loggedIn": false}'
+        return subprocess.CompletedProcess(
+            args=argv, returncode=0 if logged_in else 1, stdout=body, stderr=""
+        )
+
+    monkeypatch.setattr(hi.subprocess, "run", _stateful_run)
+
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY, use_persisted_cache=True) is False
+    assert hi._read_persisted_logins() == {}
+    logged_in = True  # the user logs in and the daemon refreshes readiness
+    hi._LOGIN_PROBE_CACHE.clear()
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY, use_persisted_cache=True) is True
+
+
+def test_logout_invalidates_persisted_login_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A logout drops the persisted positive so no cold daemon revives it."""
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+    binary = tmp_path / "claude"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(hi.shutil, "which", lambda name: str(binary))
+    logged_in = True
+
+    def _stateful_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        nonlocal logged_in
+        if "logout" in argv:
+            logged_in = False
+            return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+        body = '{"loggedIn": true}' if logged_in else '{"loggedIn": false}'
+        return subprocess.CompletedProcess(
+            args=argv, returncode=0 if logged_in else 1, stdout=body, stderr=""
+        )
+
+    monkeypatch.setattr(hi.subprocess, "run", _stateful_run)
+
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY, use_persisted_cache=True) is True
+    assert hi._read_persisted_logins() != {}
+    assert hi.harness_logout(ANTHROPIC_FAMILY) is True
+    assert hi._read_persisted_logins() == {}
+    hi._LOGIN_PROBE_CACHE.clear()
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY, use_persisted_cache=True) is False
+
+
+def test_login_probe_runs_once_for_concurrent_callers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Concurrent probes of one CLI exec it once, not once per caller.
+
+    The readiness map resolves harness spellings in parallel and aliases of one
+    CLI (``claude-native`` / ``native-claude``) share a probe, so without a
+    single-flight gate the fan-out would double the very subprocesses these
+    caches exist to damp.
+    """
+    _binary, runs = _persisted_cache_setup(monkeypatch, tmp_path)
+    probe = hi.subprocess.run
+
+    def _slow_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        time.sleep(0.05)  # wide enough for the other callers to pile up
+        return probe(argv, **kwargs)
+
+    monkeypatch.setattr(hi.subprocess, "run", _slow_run)
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(hi.harness_cli_logged_in, ANTHROPIC_FAMILY) for _ in range(4)]
+        verdicts = [future.result() for future in futures]
+
+    assert verdicts == [True, True, True, True]
+    assert len(runs) == 1, "concurrent cache misses must share one probe"
 
 
 def test_version_probe_caches_by_binary_signature(

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import subprocess
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -523,6 +525,48 @@ def test_configured_harness_map_probes_codex_readiness_once(
     assert result["codex"] == "needs-auth"
     assert result["codex-native"] == "needs-auth"
     assert result["native-codex"] == "needs-auth"
+
+
+def test_configured_harness_map_probes_families_concurrently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Distinct harness probes overlap instead of running one after another.
+
+    Each probe execs a vendor CLI (``claude auth status`` alone measured ~0.6s),
+    so run serially the readiness stage cost their sum — which dominated the
+    host daemon's cold start.
+    """
+    import omnigent.onboarding.harness_readiness as hr
+
+    delay = 0.05
+    lock = threading.Lock()
+    live = 0
+    peak = 0
+    calls = 0
+
+    def _slow_probe(_canonical: str) -> bool:
+        nonlocal live, peak, calls
+        with lock:
+            live += 1
+            calls += 1
+            peak = max(peak, live)
+        time.sleep(delay)
+        with lock:
+            live -= 1
+        return True
+
+    monkeypatch.setattr(hr, "_harness_availability", _slow_probe)
+    started = time.monotonic()
+    result = configured_harness_map()
+    elapsed = time.monotonic() - started
+
+    assert calls > 1, "expected several distinct probes"
+    assert peak > 1, "probes ran one at a time"
+    assert elapsed < calls * delay / 2, (
+        f"{elapsed:.2f}s for {calls} probes is not meaningfully under their "
+        f"{calls * delay:.2f}s serial sum"
+    )
+    assert all(value is True for value in result.values())
 
 
 def test_kimi_readiness_keys_off_binary_and_credential(


### PR DESCRIPTION
## Related issue

Closes #

## Summary

The host daemon's capability-probe stage ran its harness family probes **strictly one after another**, and the slowest of them was re-paid on every cold daemon start:

```
claude --version    18 ms
claude auth status 589 ms   <- in-process cache only, so every cold start pays it again
codex --version     57 ms
gh auth token       49 ms
                  = 713 ms serial
```

That sum was the bulk of a ~1.5 s cold host-daemon start. Two independent fixes:

- **Overlap the probes.** `configured_harness_map()` now resolves its distinct probes on a small thread pool (`_MAX_PROBE_WORKERS = 8`), so the stage costs the *slowest* probe instead of their sum. The probes are independent — each execs its own vendor CLI or reads local credential files.
- **Cache the login verdict across processes.** A positive `harness_cli_logged_in` verdict is mirrored to `<data-dir>/cli_login_probe_cache.json`, keyed on the CLI binary's `(path, mtime_ns, size)` — exactly how the existing `--version` cache is keyed, so an upgraded or swapped binary re-probes — with a **15 minute TTL**.

Fanning out surfaced a second problem worth fixing here: two aliases of one CLI (`claude-native` / `native-claude` are distinct canonical spellings that resolve through the same `anthropic` probe) both missed the in-process cache and *each* exec'd the vendor CLI. The version and login caches now gate concurrent misses of the same target behind a per-target lock, so a fan-out still execs each CLI exactly once — the caches exist to damp subprocess churn and doubling it would have been a regression against that.

### Why 15 minutes, and why it is safe

| Risk | Mitigation |
| --- | --- |
| A revoked login reads as ready | Self-corrects within 15 min. The verdict only drives the **picker badge**; the launch gate (`harness_is_configured`) is binary-only, so a launch is never wrongly allowed or blocked by it, and a genuinely dead credential surfaces at the first turn. |
| A login/logout through omnigent looks stale | `harness_logout` drops the key's persisted entries before it confirms; `harness_login` and the interactive `configure` surfaces never *read* the persisted cache (reads are opt-in — only the daemon's readiness path opts in), so they always show the live state. |
| A user who was told "not logged in" logs in and retries | **Negative verdicts are never persisted** (unchanged from today's in-process behaviour), so the very next probe sees the fresh login. |
| A corrupt / unwritable cache file | Reads treat missing/malformed as empty and writes swallow `OSError`; either way the probe simply runs. |

```mermaid
flowchart LR
    A[readiness refresh] --> B{in-process cache?}
    B -- hit --> Z[logged in]
    B -- miss --> C{on-disk cache?<br/>same binary sig, TTL fresh}
    C -- hit --> Z
    C -- miss --> D[single-flight gate]
    D --> E[exec 'claude auth status']
    E -- positive --> F[write both caches] --> Z
    E -- negative --> N[cache nothing]
```

## Test Plan

**Measurements.** The four probes were replaced with stub CLIs on `PATH` that sleep their profiled durations (18 / 589 / 57 / 49 ms) and print realistic output, so the numbers are deterministic and no real `claude auth status` was invoked. Run inside an `OMNIGENT_CONFIG_HOME` / `OMNIGENT_DATA_DIR` / `HOME` sandbox under `flock /tmp/omnigent-profile.lock` on a 32-core box at load average ~10–16, best of 3.

Readiness stage in isolation (lazy imports already warm, caches cold — this is the probe cost itself):

| | before (`origin/main`) | after |
| --- | --- | --- |
| cold caches | **737 ms** | **621 ms** (= the 589 ms probe, no longer the sum) |
| second cold start, disk cache warm | 738 ms | **64 ms** |

Whole `configured_harness_map()` from a cold process (so it also includes ~500 ms of lazy imports, which now overlap the probes):

| | before | after |
| --- | --- | --- |
| cold disk cache | 1207 / 1253 / 1290 ms | 619 / 624 / 628 ms |
| warm disk cache | (n/a — none existed) | 537 / 549 / 564 ms |

Subprocess counts per cold start went `4 -> 4` (cold disk) and `4 -> 3` (warm disk, `claude auth status` gone), with no duplicate execs.

**Automated.**

```
python -m pytest tests/onboarding/test_harness_install.py tests/onboarding/test_harness_readiness.py \
                 tests/onboarding/test_ambient.py tests/onboarding/test_gemini_auth.py \
                 tests/test_harness_plugins.py tests/host/test_connect.py -k ...
```
310 + 17 passed. New tests were each confirmed to fail against `origin/main`'s source (the concurrency one fails on `assert peak > 1` → `assert 1 > 1`).

**Robustness.** 20 consecutive cold starts were run to check the newly-concurrent lazy imports inside the probes don't deadlock: 20/20 clean.

Two failures in the adjacent suites (`test_configured_harness_map_exposes_pi_native`, `tests/host/test_frames.py::test_encode_injects_traceparent_under_active_span`) reproduce identically on `origin/main` on this box — pre-existing and environment-dependent, not from this change.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

See the before/after tables in **Test Plan**.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover both fixes and the failure modes that make caching a login verdict risky:

- `test_configured_harness_map_probes_families_concurrently` — asserts probes **overlap** (peak concurrent entries > 1, wall time well under the serial sum), not a raw duration.
- `test_persisted_login_cache_survives_a_cold_process` — a second cold probe (cache cleared, same binary mtime) issues **no** `auth status`; a changed binary mtime/size re-probes.
- `test_persisted_login_cache_reprobes_after_ttl` — an expired entry re-probes.
- `test_persisted_login_cache_never_strands_a_fresh_login` — a negative is never written, so a login made right after "not logged in" is picked up on the next probe.
- `test_persisted_login_cache_is_opt_in` — callers that don't opt in never read the disk cache (guards the interactive `configure` / `harness_login` surfaces).
- `test_logout_invalidates_persisted_login_cache` — a logout drops the persisted positive.
- `test_login_probe_runs_once_for_concurrent_callers` — four concurrent probes of one CLI exec it once.

Manual verification beyond the measurements above: `configured_harness_map()` was run once against the real local config (with `OMNIGENT_DATA_DIR` redirected to a scratch dir, asserted before the call) to confirm the verdicts and the cache path are unchanged in a real environment.

**Not done, deliberately:** the persisted positive is not additionally invalidated on the *credential file's* mtime. That would shrink the stale window for a `claude auth logout` run outside omnigent to ~0 on Linux, but the credential path is platform-specific (macOS keeps it in the Keychain) and this module deliberately avoids depending on it — which is the whole reason the verdict comes from the CLI's own status command. The TTL plus explicit invalidation on omnigent-driven logout covers the realistic transitions.

## Changelog

Cold `omnigent` host starts no longer re-run the slow `claude auth status` check, and harness readiness checks now run in parallel.
