### PR TITLE
perf(server): skip the request-phase policy engine when no policy applies

### DIFF
--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -219,6 +219,7 @@ def any_policies_apply(
     conversation_id: str,
     default_policies: list[PolicySpec] | None,
     policy_store: PolicyStore | None,
+    root_conversation_id: str | None,
     phase: Phase | None = None,
     tool_name: str | None = None,
 ) -> bool:
@@ -237,6 +238,11 @@ def any_policies_apply(
     :param default_policies: Server-wide policies from ``RuntimeCaps``.
     :param policy_store: Session-scoped policy store; ``None`` means no DB
         policies are configured.
+    :param root_conversation_id: Root of this conversation's tree, so an
+        inherited root policy is counted (see :func:`build_policy_engine`).
+        Required rather than defaulted: omitting it silently under-reports for
+        sub-agents, which is a fail-open. Pass ``None`` only when the
+        conversation is genuinely a root or no row is available.
     :param phase: The evaluation phase, if known.
     :param tool_name: The tool being called (for ``PHASE_TOOL_CALL`` events).
     :returns: ``False`` when the engine would have an empty policy list and
@@ -257,6 +263,14 @@ def any_policies_apply(
     # this is a cache hit on any call after the first for this session.
     if _load_session_policy_specs(conversation_id, policy_store):
         return True
+    # Sub-agents inherit the root session's policies, so a child carrying none
+    # of its own still runs the parent's — a guardrail added to a top-level
+    # session governs the sub-agents it spawns. Unlike build_policy_engine this
+    # takes the root unverified: for a pure "would anything fire" check a wrong
+    # root can only over-report, which leaves the caller evaluating.
+    if root_conversation_id is not None and root_conversation_id != conversation_id:
+        if _load_session_policy_specs(root_conversation_id, policy_store):
+            return True
     return False
 
 

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -88,6 +88,7 @@ from omnigent.runtime.policies.approval import (
 from omnigent.runtime.policies.builder import (
     _sum_subtree_usage,
     ancestor_ids_from_tree,
+    any_policies_apply,
     load_session_tree,
     load_session_usage,
 )
@@ -6898,11 +6899,20 @@ async def _evaluate_input_policy(
     spec = await asyncio.to_thread(_load_agent_spec_for_session, conv, agent_store)
     if spec is None:
         return None
-    # Skip only when there are no agent guardrails AND no server-wide
-    # default policies AND no session policies. Without this, default/
-    # session policies (e.g. deny_pii_in_llm_request added via the UI)
-    # are silently skipped for agents without a guardrails: YAML block.
-    if not spec.guardrails and not get_caps().default_policies and get_policy_store() is None:
+    # Skip only when no policy could fire: no agent guardrail policies, no
+    # server-wide defaults (YAML or DB) and no session policies. Reads the
+    # builder's own invalidation-based caches, so a policy added mid-session is
+    # honored on the very next message. Declared labels still build the engine —
+    # it seeds their initial values.
+    declares_labels = bool(spec.guardrails and spec.guardrails.labels)
+    if not declares_labels and not any_policies_apply(
+        spec=spec,
+        conversation_id=session_id,
+        default_policies=get_caps().default_policies,
+        policy_store=get_policy_store(),
+        root_conversation_id=conv.root_conversation_id,
+        phase=Phase.REQUEST,
+    ):
         return None
 
     # Text-like attachments (e.g. an uploaded CSV) arrive as ``input_file`` blocks

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -768,6 +768,7 @@ def register_hooks_routes(
             conversation_id=session_id,
             default_policies=_caps.default_policies,
             policy_store=get_policy_store(),
+            root_conversation_id=conv.root_conversation_id if conv is not None else None,
             phase=phase,
             tool_name=data.get("name") if isinstance(data, dict) else None,
         ):

--- a/tests/runtime/policies/test_builder_session_policies.py
+++ b/tests/runtime/policies/test_builder_session_policies.py
@@ -22,6 +22,7 @@ from omnigent.runtime.policies.builder import (
     _load_default_policy_specs,
     _load_session_policy_specs,
     _stored_policy_to_spec,
+    any_policies_apply,
     build_policy_engine,
     invalidate_default_policy_specs_cache,
     invalidate_session_policy_specs_cache,
@@ -31,6 +32,7 @@ from omnigent.spec.types import (
     FunctionPolicySpec,
     FunctionRef,
     GuardrailsSpec,
+    Phase,
 )
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
@@ -403,6 +405,56 @@ def test_subagent_inherits_root_session_policies(db_uri: str) -> None:
     assert "root_guard" in names, f"root session policy not inherited by sub-agent; got {names}"
     # Root policy should come before the ask_on_add_policy sentinel.
     assert names.index("root_guard") < names.index("__ask_on_add_policy")
+
+
+def test_any_policies_apply_sees_the_root_policy_a_subagent_inherits(db_uri: str) -> None:
+    """The fast-path check must agree with the engine about inherited policies.
+
+    ``any_policies_apply`` gates whether the engine is built at all, so a
+    sub-agent whose only applicable policy lives on the root must still report
+    ``True``. Reporting ``False`` here silently disables a guardrail the parent
+    session configured — a fail-open, not a slow path.
+
+    :param db_uri: Per-test SQLite URI.
+    """
+    handler = "tests.resources.examples._shared.tool_functions.block_long_sleep"
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    root_conv = conv_store.create_conversation()
+    child_conv = conv_store.create_conversation(
+        parent_conversation_id=root_conv.id,
+        kind="sub_agent",
+    )
+
+    policy_store = SqlAlchemyPolicyStore(db_uri)
+    policy_store.create(
+        policy_id="c6de31de238a26c347a7c3d8d5a74c3a",
+        session_id=root_conv.id,
+        name="root_guard",
+        type="python",
+        handler=handler,
+    )
+
+    child = conv_store.get_conversation(child_conv.id)
+    assert child is not None
+
+    # The engine the check stands in for does carry the inherited policy.
+    engine = build_policy_engine(
+        spec=_make_minimal_spec(),
+        conversation_id=child_conv.id,
+        conversation_store=conv_store,
+        policy_store=policy_store,
+    )
+    assert "root_guard" in [p.spec.name for p in engine.policies]
+
+    assert any_policies_apply(
+        spec=_make_minimal_spec(),
+        conversation_id=child_conv.id,
+        default_policies=None,
+        policy_store=policy_store,
+        root_conversation_id=child.root_conversation_id,
+        phase=Phase.REQUEST,
+    ), "fast path missed the root policy the sub-agent inherits"
 
 
 def test_subagent_deduplicates_same_name_policy(db_uri: str) -> None:

--- a/tests/server/routes/test_sessions_policy.py
+++ b/tests/server/routes/test_sessions_policy.py
@@ -17,6 +17,7 @@ import pytest
 from omnigent.entities import Conversation, ConversationItem
 from omnigent.entities.agent import Agent, LoadedAgent
 from omnigent.entities.conversation import FunctionCallData
+from omnigent.entities.policy import Policy as StoredPolicy
 from omnigent.policies.types import PolicyAction, PolicyResult
 from omnigent.server.routes.sessions import (
     _build_evaluation_context,
@@ -210,6 +211,7 @@ _CACHE_PATCH = "omnigent.server.routes.sessions.get_agent_cache"
 _ENGINE_PATCH = "omnigent.server.routes.sessions.build_policy_engine"
 _HOLD_GATE_PATCH = "omnigent.server.routes.sessions._hold_native_ask_gate"
 _STREAM_PATCH = "omnigent.server.routes.sessions.session_stream"
+_TREE_PATCH = "omnigent.runtime.policies.builder.load_verified_session_tree"
 
 
 @pytest.mark.asyncio
@@ -448,19 +450,29 @@ def _make_user_message_body(
 
 
 def _make_spec_with_guardrails() -> AgentSpec:
-    """Build an AgentSpec with a guardrails block (but no policies).
+    """Build an AgentSpec declaring one guardrail policy.
 
-    The presence of ``guardrails`` triggers policy engine
-    construction; the empty policy list means ALLOW by default.
+    A policy must actually be declared: with none, the input gate
+    short-circuits via ``any_policies_apply`` and never builds an engine,
+    so a test that stubs the engine would assert on a code path the
+    request never reaches.
 
-    :returns: AgentSpec with guardrails enabled.
+    :returns: AgentSpec with one function policy declared.
     """
-    from omnigent.spec.types import GuardrailsSpec
+    from omnigent.spec.types import FunctionPolicySpec, FunctionRef, GuardrailsSpec
 
     return AgentSpec(
         spec_version=1,
         name="test-agent",
-        guardrails=GuardrailsSpec(),
+        guardrails=GuardrailsSpec(
+            policies=[
+                FunctionPolicySpec(
+                    name="test_policy",
+                    on=None,
+                    function=FunctionRef(path="tests.fake.policy"),
+                )
+            ]
+        ),
     )
 
 
@@ -638,6 +650,175 @@ async def test_input_no_guardrails_skips_policy():
         )
 
     assert result is None
+
+
+@dataclass
+class _FakePolicyStore:
+    """Minimal policy store for the input-gate fast-path tests.
+
+    :param session_policies: Rows returned for ``list_for_session``.
+    :param default_policies: Rows returned for ``list_defaults``.
+    """
+
+    session_policies: list[StoredPolicy] = field(default_factory=list)
+    default_policies: list[StoredPolicy] = field(default_factory=list)
+
+    def list_for_session(self, session_id: str) -> list[StoredPolicy]:
+        """Return this session's stored policies.
+
+        :param session_id: Session id, e.g. ``"sess_1"``.
+        :returns: The configured session rows.
+        """
+        return list(self.session_policies)
+
+    def list_defaults(self) -> list[StoredPolicy]:
+        """Return server-wide default policies.
+
+        :returns: The configured default rows.
+        """
+        return list(self.default_policies)
+
+
+def _make_stored_policy(name: str, session_id: str | None) -> StoredPolicy:
+    """Build an enabled python-handler stored policy row.
+
+    :param name: Policy name, e.g. ``"deny_pii"``.
+    :param session_id: Owning session, or ``None`` for a default policy.
+    :returns: A :class:`Policy` entity the builder can convert to a spec.
+    """
+    return StoredPolicy(
+        id=f"pol_{name}",
+        name=name,
+        session_id=session_id,
+        scope="session" if session_id else "default",
+        created_at=1,
+        type="python",
+        handler="tests.fake.policy",
+    )
+
+
+@pytest.fixture
+def policy_store(monkeypatch: pytest.MonkeyPatch):
+    """Install an empty policy store and reset the builder's spec caches.
+
+    A store is always configured in a real deployment, so these tests must
+    run with one bound; the module-level spec caches are process-wide, so
+    they are cleared on entry and exit to keep the tests hermetic.
+
+    :param monkeypatch: pytest patcher, used to bind the runtime global.
+    :returns: The installed :class:`_FakePolicyStore`.
+    """
+    store = _FakePolicyStore()
+    monkeypatch.setattr("omnigent.runtime._globals._policy_store", store)
+    _clear_policy_spec_caches()
+    yield store
+    _clear_policy_spec_caches()
+
+
+def _clear_policy_spec_caches() -> None:
+    """Evict the builder's default/session policy-spec caches."""
+    from omnigent.runtime.policies.builder import (
+        invalidate_default_policy_specs_cache,
+        invalidate_session_policy_specs_cache,
+    )
+
+    invalidate_default_policy_specs_cache()
+    invalidate_session_policy_specs_cache("sess_1")
+
+
+@pytest.mark.asyncio
+async def test_input_no_policies_skips_engine_and_tree_scan(policy_store):
+    """A configured-but-empty policy store must not build an engine.
+
+    The gate used to skip only when ``get_policy_store() is None`` — never
+    true in a real deployment — so every user message built an engine and
+    paid its O(spawn-tree) scan even with zero policies anywhere.
+    """
+    conv_store = _FakeConversationStore()
+    agent_store = _FakeAgentStore(agent=_make_agent())
+    conv = conv_store.get_conversation("sess_1")
+    body = _make_user_message_body()
+
+    loaded = LoadedAgent(spec=_make_spec_no_guardrails(), workdir="/tmp/fake")
+
+    with (
+        patch(_CACHE_PATCH) as mock_cache,
+        patch(_ENGINE_PATCH) as mock_build,
+        patch(_TREE_PATCH) as mock_tree,
+    ):
+        mock_cache.return_value.load.return_value = loaded
+        result = await _evaluate_input_policy(
+            _FakeRequest(),
+            "sess_1",
+            conv,
+            body,
+            conv_store,
+            agent_store,
+            None,
+        )
+
+    assert result is None
+    mock_build.assert_not_called()
+    mock_tree.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_input_policy_added_mid_session_is_enforced(policy_store):
+    """A policy created after the session is live still gates the next message.
+
+    Guards the fast path against caching a stale "no policies" verdict: the
+    first message legitimately skips, and once a session policy exists (with
+    the store's cache invalidated, as the CRUD routes do) the very next
+    message must reach the engine and be denied.
+    """
+    conv_store = _FakeConversationStore()
+    agent_store = _FakeAgentStore(agent=_make_agent())
+    conv = conv_store.get_conversation("sess_1")
+    body = _make_user_message_body()
+
+    loaded = LoadedAgent(spec=_make_spec_no_guardrails(), workdir="/tmp/fake")
+    deny_result = PolicyResult(action=PolicyAction.DENY, reason="Denied mid-session")
+
+    async def _eval(_ctx: Any) -> PolicyResult:
+        return deny_result
+
+    async def _evaluate_once() -> tuple[dict[str, Any] | None, bool]:
+        """Run the input gate once against the current store contents.
+
+        :returns: ``(verdict, engine_was_built)`` — the verdict dict (or
+            ``None`` on allow/skip) and whether an engine was constructed.
+        """
+        with (
+            patch(_CACHE_PATCH) as mock_cache,
+            patch(_ENGINE_PATCH) as mock_build,
+        ):
+            mock_cache.return_value.load.return_value = loaded
+            mock_engine = mock_build.return_value
+            mock_engine.evaluate = _eval
+            mock_engine.apply_label_writes = lambda x: None
+            verdict = await _evaluate_input_policy(
+                _FakeRequest(),
+                "sess_1",
+                conv,
+                body,
+                conv_store,
+                agent_store,
+                None,
+            )
+            return verdict, mock_build.called
+
+    # No policies yet: the message is allowed without an engine build.
+    assert await _evaluate_once() == (None, False)
+
+    # A policy is added mid-session, exactly as POST /sessions/{id}/policies does.
+    policy_store.session_policies.append(_make_stored_policy("deny_all", "sess_1"))
+    _clear_policy_spec_caches()
+
+    verdict, built = await _evaluate_once()
+    assert built is True
+    assert verdict is not None
+    assert verdict["verdict"] == "deny"
+    assert verdict["reason"] == "Denied mid-session"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- `_evaluate_input_policy` (the REQUEST-phase gate on `POST /v1/sessions/{id}/events`) gated its fast path on `get_policy_store() is None` — never true in a real deployment, since a policy store is always configured. So **every user message** built a full `PolicyEngine`, and `build_policy_engine` loads and verifies the entire spawn tree. Profiled at **6.0 ms of a 26.9 ms handler**, growing with tree size, so long-lived and heavily forked sessions pay the most.
- Gate on `any_policies_apply` instead — the same check the sibling `PreToolUse` hook endpoint (`routes_hooks.py`) already uses for the identical work.
- One deliberate difference from the sibling: an agent that declares guardrail **labels** still builds the engine, because engine construction is what seeds their `initial` values (observable via `GET /v1/sessions/{id}`). Only enforcement work is skipped, nothing else.

### Why the skip is provably equivalent (security-relevant path)

With zero applicable policies, `build_policy_engine` still returns a non-empty engine: it unconditionally appends the injected `__ask_on_add_policy` guard. That guard's callable (`omnigent.policies.builtins.safety.ask_on_add_policy`) returns `ALLOW` immediately when `event["type"] != "tool_call"`. A REQUEST-phase evaluation is never a tool call (`ctx.tool_name` is `None` here), so `evaluate()` returns `ALLOW` with no `set_labels` and no `state_updates`, and `_evaluate_input_policy` returns `None` — exactly what the skip does. `any_policies_apply` also refuses to fast-path `sys_add_policy` `TOOL_CALL` events, which this call site cannot produce; `phase=Phase.REQUEST` is passed explicitly.

**No verdict is cached.** `any_policies_apply` reads the builder's own caches: session policies use an *invalidation-based* LRU that the policy CRUD routes and `sys_add_policy` evict on every mutation (no TTL), and DB default policies use the same 30 s TTL cache `build_policy_engine` itself reads. So a policy added while a session is live is enforced on the very next message — there is no window in which a stale "no policies" verdict can outlive a policy being added. Test 2 below pins exactly that.

### Not in scope (follow-up)

The turn-end accounting inside the first-delta → `response.completed` gap walks the spawn tree twice more (`load_session_usage` and `_publish_subtree_cost_to_ancestors`, both in the `response.completed` branch of the relay loop, ~6 ms each). Those are **not** policy work — they compute the subtree cost/token roll-up for the client's `session.usage` badge and for each ancestor's stream. They cannot be gated on "no policies apply" without breaking the cost indicator, so they are left alone here and want their own change (e.g. coalescing the two walks onto one tree load, or reusing the tree already loaded upstream).

## Test Plan

Two regression tests added to `tests/server/routes/test_sessions_policy.py`, both asserting on **calls**, not timing:

1. `test_input_no_policies_skips_engine_and_tree_scan` — with a policy store bound but empty, `build_policy_engine` and `load_verified_session_tree` are both `assert_not_called()`.
2. `test_input_policy_added_mid_session_is_enforced` — first message legitimately skips (no engine built); a session policy is then added and the spec cache invalidated exactly as `POST /v1/sessions/{id}/policies` does; the very next message reaches the engine and is denied.

Both fail on `origin/main` (test 1: engine built; test 2: the first message is already denied), and pass with the fix.

`_make_spec_with_guardrails()` now declares an actual policy. Previously it returned `GuardrailsSpec()` with an empty policy list and relied on the bare presence of a `guardrails:` block to force an engine build — a spec that, correctly, no longer builds one. Same idiom as the existing note in `tests/server/integration/test_sessions_policy_evaluate.py`.

Targeted suites, all green (`--venv` from a sibling worktree; run from the branch worktree so pytest's path injection picks up this source):

```
python -m pytest tests/server/routes/test_sessions_policy.py \
  tests/server/integration/test_sessions_policy_evaluate.py \
  tests/server/integration/test_sessions_policy_evaluate_read_only.py \
  tests/server/integration/test_policy_deny_yaml_tools_e2e.py \
  tests/server/integration/test_policy_ask_yaml_tools_e2e.py \
  tests/test_native_policy_hook.py
# 99 passed

python -m pytest tests/server/integration/test_policy_crud_e2e.py \
  tests/server/integration/test_policy_deny_lifecycle_e2e.py \
  tests/server/integration/test_policy_ask_lifecycle_e2e.py \
  tests/server/integration/test_policy_composition_e2e.py \
  tests/server/integration/test_policy_contextual_labels_e2e.py \
  tests/server/integration/test_policy_detect_thrashing_e2e.py \
  tests/server/integration/test_session_policy_routes.py \
  tests/server/integration/test_default_policy_routes.py \
  tests/server/integration/test_oidc_default_policies.py
# 61 passed
```

`pre-commit run --files <changed files>`: `ruff format`, `ruff check` and every other hook pass. `pyrefly` reports 99 `missing-import` errors, byte-identical to a pristine `origin/main` on the same files (a worktree without its own venv), and **zero** of them are in the changed files.

### Manual verification

To see the gate itself: start a server with no policies configured, send a message in an agent session with no `guardrails:` block, and confirm the turn behaves identically. Then add a session policy that denies the message (`POST /v1/sessions/{id}/policies`, or the UI's guardrails panel) **without restarting the server or the session**, send the same message again, and confirm it is now denied — that is the mid-session pickup this change must not break.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Counter-based measurement of the work the skip removes — SQL statements executed, which is immune to a loaded box. Real `SqlAlchemyConversationStore` + `SqlAlchemyPolicyStore` on SQLite, an agent with no policies, an empty policy store; comparing `build_policy_engine(...)` (what every message paid) against `any_policies_apply(...)` (what it pays now), steady state after cache warm-up, 20 reps:

| spawn tree | before | after |
| --- | --- | --- |
| 1 conversation | 3 SQL / 2.3 ms | 0 SQL / 0.006 ms |
| 1 + 40 sub-agents | 3 SQL / 4.0 ms | 0 SQL / 0.004 ms |
| 1 + 200 sub-agents | 12 SQL / 18.0 ms | 0 SQL / 0.003 ms |

The 200-child row is the paged-tree path (extra confirming reads) and shows the O(tree) growth the profile predicted. The first message of a session pays 2 SQL to warm the policy caches, then 0 thereafter. Wall-clock numbers were taken under `flock /tmp/omnigent-profile.lock` on a 32-core box at load average ~9; the SQL counts are the load-independent claim.

Handler-level context from the profile this came from: 6.0 ms of a 26.9 ms `POST /v1/sessions/{id}/events`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The two new unit tests are the regression guard for both halves of the change: that no engine is built when nothing can fire, and that a policy added mid-session is still enforced. Existing coverage carries the rest — the request-phase ALLOW / DENY / ASK-approve / ASK-decline tests in `tests/server/routes/test_sessions_policy.py`, the request-phase gate tests in `tests/server/integration/test_sessions_policy_evaluate_read_only.py`, and the policy CRUD / deny / ask / composition lifecycle e2e suites (160 tests total, listed above). Manual verification is the mid-session-policy walkthrough in the Test Plan, which exercises the real store and cache invalidation rather than a fake.

## Changelog

Sending a message is faster in sessions with no policies configured — the server no longer sets up policy enforcement it will not use.
