### PR TITLE
perf(repl): stop polling the session snapshot once a second during a turn

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -16,6 +16,7 @@ import pathlib
 import re
 import sys
 import tempfile
+import time
 from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol, TextIO, TypeAlias
@@ -218,6 +219,14 @@ _LIST_ITEMS_PAGE_SIZE = 100
 # session's direct children) while sub-agents are active.
 _MAX_SUBAGENT_TREE_DEPTH = 3
 _SUBAGENT_POLL_SECONDS = 2.0
+
+# Turn-completion backstop. ``_stream_pump`` sets ``_turn_done`` from the
+# terminal ``session.status`` event; the snapshot poll only covers a terminal
+# event the stream could not deliver. A stream that is still delivering events
+# needs no snapshot, and each consecutive quiet snapshot doubles the wait.
+_BACKSTOP_MIN_INTERVAL_S = 1.0
+_BACKSTOP_MAX_INTERVAL_S = 5.0
+_BACKSTOP_STREAM_QUIET_S = 1.0
 
 
 def _load_startup_theme() -> TerminalTheme:
@@ -1396,6 +1405,9 @@ class _SessionsChatReplAdapter:
         self._last_total_tokens: int | None = None
         self._pending_local_tasks: dict[str, asyncio.Task[None]] = {}
         self._turn_done: asyncio.Event
+        # Monotonic stamp of the last event ``_stream_pump`` received. Proves the
+        # subscription is live, so the turn backstop can skip its snapshot poll.
+        self._last_stream_event_at: float = 0.0
         # FIFO counter: local sends are already echoed by ``on_input``,
         # so their ``session.input.consumed`` events are suppressed.
         self._pending_local_user_sends: int = 0
@@ -2191,6 +2203,7 @@ class _SessionsChatReplAdapter:
                         flush=True,
                     )
                 async for event in self._client.sessions.stream(self._session_id):
+                    self._last_stream_event_at = time.monotonic()
                     if isinstance(event, _StatusEv) and event.status in (
                         "idle",
                         "waiting",
@@ -2249,6 +2262,50 @@ class _SessionsChatReplAdapter:
                     )
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, max_backoff)
+
+    async def _await_turn_done(self, session_id: str) -> None:
+        """
+        Block until the running turn reaches a terminal state.
+
+        ``_stream_pump`` sets ``_turn_done`` from the terminal
+        ``session.status`` event, so the common path costs no extra
+        requests. The snapshot poll is a backstop for the two cases
+        the stream cannot cover: a terminal event published while the
+        subscription is reconnecting (the pub-sub has no replay), and
+        an httpx ASGI subscription that is not yet active because that
+        transport does not flush streaming body chunks eagerly.
+
+        A stream that is still delivering events will deliver the
+        terminal one too, so the poll fires only after
+        ``_BACKSTOP_STREAM_QUIET_S`` of stream silence, and backs off
+        to ``_BACKSTOP_MAX_INTERVAL_S`` while consecutive snapshots
+        keep reporting the turn running. ``GET /v1/sessions/{id}`` is
+        not cheap (it scales with conversation history), so a fixed
+        one-per-second cadence costs a multiple of the turn's own
+        dispatch work.
+
+        :param session_id: Session whose turn to wait for, e.g.
+            ``"conv_abc123"``.
+        :returns: None.
+        """
+        interval = _BACKSTOP_MIN_INTERVAL_S
+        while not self._turn_done.is_set():
+            try:
+                # Event.wait() is cancellation-safe (its finally block
+                # removes the waiter from Event._waiters), so no
+                # asyncio.shield() is needed — shield leaks orphaned
+                # Tasks on each timeout iteration.
+                await asyncio.wait_for(self._turn_done.wait(), timeout=interval)
+            except asyncio.TimeoutError:
+                if time.monotonic() - self._last_stream_event_at < _BACKSTOP_STREAM_QUIET_S:
+                    # Stream is live; it owns turn completion.
+                    interval = _BACKSTOP_MIN_INTERVAL_S
+                    continue
+                snap = await self._client.sessions.get(session_id)
+                if snap.status in ("idle", "failed"):
+                    self._turn_done.set()
+                else:
+                    interval = min(interval * 2.0, _BACKSTOP_MAX_INTERVAL_S)
 
     async def send(
         self,
@@ -2338,26 +2395,7 @@ class _SessionsChatReplAdapter:
             # Wait for the turn to complete. The stream pump sets
             # _turn_done when it sees session.status idle/failed;
             # the _on_event callback (when wired) also sets it.
-            #
-            # Fallback polling: httpx's ASGI transport does not
-            # flush streaming body chunks eagerly, so the pump's
-            # SSE subscription may not be active when the workflow
-            # publishes its terminal event (no-replay pub-sub).
-            # We poll the snapshot every second as a backstop.
-            while not self._turn_done.is_set():
-                try:
-                    # Event.wait() is cancellation-safe (its finally block
-                    # removes the waiter from Event._waiters), so no
-                    # asyncio.shield() is needed — shield leaks orphaned
-                    # Tasks on each timeout iteration.
-                    await asyncio.wait_for(
-                        self._turn_done.wait(),
-                        timeout=1.0,
-                    )
-                except asyncio.TimeoutError:
-                    snap = await self._client.sessions.get(session_id)
-                    if snap.status in ("idle", "failed"):
-                        self._turn_done.set()
+            await self._await_turn_done(session_id)
             # Yield a terminal event so callers iterating send()
             # observe completion. Rendering already happened via
             # _on_event.
@@ -2428,16 +2466,7 @@ class _SessionsChatReplAdapter:
                     flush=True,
                 )
             await self._client.sessions.post_event(session_id, event_payload)
-            while not self._turn_done.is_set():
-                try:
-                    await asyncio.wait_for(
-                        self._turn_done.wait(),
-                        timeout=1.0,
-                    )
-                except asyncio.TimeoutError:
-                    snap = await self._client.sessions.get(session_id)
-                    if snap.status in ("idle", "failed"):
-                        self._turn_done.set()
+            await self._await_turn_done(session_id)
             from omnigent_client._events import ResponseCompleted
             from omnigent_client._types import Response as SDKResponse
 

--- a/tests/repl/test_sessions_backstop_poll.py
+++ b/tests/repl/test_sessions_backstop_poll.py
@@ -1,0 +1,143 @@
+"""Tests for the REPL turn-completion backstop poll.
+
+``_SessionsChatReplAdapter.send`` waits for the turn's terminal
+``session.status`` event, which ``_stream_pump`` delivers. Because the
+pub-sub has no replay (and httpx's ASGI transport may not have the
+subscription active yet), the adapter also polls
+``GET /v1/sessions/{id}`` as a backstop.
+
+That snapshot is expensive and scales with conversation history, so the
+poll used to cost roughly one request per second of turn wall-clock —
+several times the dispatch work of the message that started the turn.
+These tests pin the three properties that keep it cheap *and* still a
+backstop, using request counts and a lower bound on elapsed time so
+they stay deterministic on a loaded box:
+
+1. A stream that is delivering events costs zero snapshots.
+2. Consecutive quiet snapshots back off instead of ticking at 1 Hz.
+3. A silent stream still ends the turn from the snapshot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omnigent.repl import _repl
+from omnigent.repl._repl import _SessionsChatReplAdapter
+
+pytestmark = pytest.mark.asyncio
+
+_SESSION_ID = "conv_backstop"
+
+
+@dataclass
+class _StubSnapshot:
+    """Minimal snapshot shape: the backstop only reads ``status``."""
+
+    status: str
+
+
+def _build_adapter(statuses: list[str]) -> tuple[_SessionsChatReplAdapter, list[float]]:
+    """
+    Build an adapter whose ``sessions.get`` is counted and timestamped.
+
+    :param statuses: Statuses to return from successive snapshot GETs;
+        the last one repeats if the backstop polls more times.
+    :returns: The adapter and the list that records a monotonic
+        timestamp per ``sessions.get`` call.
+    """
+    calls: list[float] = []
+
+    async def _get(session_id: str) -> _StubSnapshot:
+        assert session_id == _SESSION_ID
+        calls.append(time.monotonic())
+        return _StubSnapshot(status=statuses[min(len(calls) - 1, len(statuses) - 1)])
+
+    client = MagicMock()
+    client.sessions.get = AsyncMock(side_effect=_get)
+    adapter = _SessionsChatReplAdapter(
+        client=client,
+        agent_name="test-agent",
+        session_id=_SESSION_ID,
+    )
+    adapter._turn_done = asyncio.Event()
+    return adapter, calls
+
+
+async def test_live_stream_costs_no_backstop_snapshots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stream that delivered an event recently is never snapshotted.
+
+    The pump owns turn completion whenever the subscription is live, so
+    every backstop wake during a streaming turn must skip the GET. This
+    is the case the old fixed cadence paid for on every turn.
+    """
+    monkeypatch.setattr(_repl, "_BACKSTOP_MIN_INTERVAL_S", 0.01)
+    monkeypatch.setattr(_repl, "_BACKSTOP_MAX_INTERVAL_S", 0.01)
+    # Wide quiet window: one stamped event proves the stream live for the
+    # whole test, so scheduling jitter can't fake a stream stall.
+    monkeypatch.setattr(_repl, "_BACKSTOP_STREAM_QUIET_S", 30.0)
+
+    adapter, calls = _build_adapter(["running"])
+    adapter._last_stream_event_at = time.monotonic()
+
+    async def _finish_turn() -> None:
+        await asyncio.sleep(0.15)
+        adapter._turn_done.set()
+
+    finisher = asyncio.create_task(_finish_turn())
+    await adapter._await_turn_done(_SESSION_ID)
+    await finisher
+
+    # ~15 backstop wakes at a 0.01s interval, zero requests.
+    assert calls == []
+
+
+async def test_quiet_stream_backs_off_instead_of_ticking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Consecutive quiet snapshots double the wait up to the cap.
+
+    Asserted as a lower bound on elapsed time: the backed-off schedule
+    (1x + 2x + 4x + 8x-capped) cannot fit inside four fixed-interval
+    ticks, and load noise only inflates the measured span.
+    """
+    monkeypatch.setattr(_repl, "_BACKSTOP_MIN_INTERVAL_S", 0.05)
+    monkeypatch.setattr(_repl, "_BACKSTOP_MAX_INTERVAL_S", 0.40)
+
+    # Never stamped, so the stream reads as quiet from the first wake.
+    adapter, calls = _build_adapter(["running", "running", "running", "idle"])
+    started = time.monotonic()
+    await adapter._await_turn_done(_SESSION_ID)
+    elapsed = time.monotonic() - started
+
+    assert len(calls) == 4
+    # Backed off: 0.05 + 0.10 + 0.20 + 0.40 = 0.75s. A 0.05s fixed
+    # cadence would have reached the fourth poll by 0.20s.
+    assert elapsed >= 0.70, f"backstop did not back off (elapsed {elapsed:.3f}s)"
+
+
+@pytest.mark.parametrize("terminal_status", ["idle", "failed"])
+async def test_silent_stream_still_ends_turn_from_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    terminal_status: str,
+) -> None:
+    """The backstop still catches a terminal state the stream missed.
+
+    This is the case the poll exists for — a terminal event published
+    into a reconnect gap, or a subscription that never became active —
+    so the cheaper cadence must not turn into no backstop at all.
+    """
+    monkeypatch.setattr(_repl, "_BACKSTOP_MIN_INTERVAL_S", 0.01)
+
+    adapter, calls = _build_adapter([terminal_status])
+    await adapter._await_turn_done(_SESSION_ID)
+
+    assert len(calls) == 1
+    assert adapter._turn_done.is_set()


### PR DESCRIPTION
## Related issue

Closes #

## Summary

The REPL's turn-completion backstop polled `GET /v1/sessions/{id}` **once a second for the entire turn**. That snapshot is not a cheap read: measured in-process on an *empty* conversation it costs **42 SQL statements, 13 connection checkouts, 3 separate reads of the same `conversations` row, and 14.9 ms** — and it grows with conversation history. A 10 s turn paid 9 of them, so the backstop was doing more server work than the message send that started the turn. None of it shows up in the `warm_turn` benchmark journey, which is why it went unnoticed.

The poll cannot simply be deleted. `_stream_pump` sets `_turn_done` from the terminal `session.status` event, but the pub-sub has no replay, so a terminal event published while the subscription is reconnecting is lost forever; and httpx's ASGI transport does not flush streaming body chunks eagerly, so the subscription may not be active at all when the workflow publishes it. Without the backstop `send()` hangs in both cases.

So this keeps the backstop and makes it fire only when it can actually help:

- **Skip the snapshot while the stream is live.** `_stream_pump` stamps `_last_stream_event_at` on every event it receives. A stream that is still delivering events will deliver the terminal one too, so a wake within `_BACKSTOP_STREAM_QUIET_S` (1 s) of the last event does no I/O at all.
- **Back off while the stream is quiet.** Each consecutive snapshot that still reports the turn running doubles the wait, capped at `_BACKSTOP_MAX_INTERVAL_S` (5 s) — deliberately matching the stream pump's own max reconnect backoff, so the backstop cadence never lags the mechanism it backstops.
- The duplicated wait loop in `send()` and `send_skill_slash_command()` is folded into one `_await_turn_done()` helper (the two copies were byte-identical apart from a comment).

**Why this angle and not the endpoint.** The 42-statement snapshot is the deeper problem and fixing it would make *every* consumer of `GET /v1/sessions/{id}` cheaper, not just the REPL. It is also a much larger change in server code that two sibling PRs are currently touching, so it is filed as a follow-up below with the numbers measured here. This PR is the airtight half.

```
before                                  after
──────                                  ─────
t=1s  GET /v1/sessions/{id}  ─┐          stream delivering events?
t=2s  GET /v1/sessions/{id}   │            yes → no request
t=3s  GET /v1/sessions/{id}   │  42 SQL     no → GET, then 1s → 2s → 4s → 5s (cap)
 ...  ...                     │  each
t=Ns  GET /v1/sessions/{id}  ─┘
```

## Test Plan

### Counts (primary evidence)

One `GET /v1/sessions/{id}`, measured in-process against the real app via `httpx.ASGITransport` with a SQLAlchemy `before_cursor_execute` listener, on a freshly created session with **0 conversation items**:

| per snapshot request | count |
| --- | --- |
| SQL statements | **42** |
| connection checkouts (`PRAGMA foreign_keys`) | **13** |
| reads of the `conversations` row | **3** |
| wall time (in-process SQLite, no network) | **14.9 ms** |

Snapshot GETs for a fixed-duration turn, measured by driving `_await_turn_done` with a counting fake client at the shipped constants (1 s min / 5 s cap):

| 10 s turn | before | after |
| --- | --- | --- |
| stream delivering events (the normal case) | **9** | **0** |
| stream silent for the whole turn | **9** (t=1,2,3,4,5,6,7,8,9) | **3** (t=1,3,7) |

Extrapolated to the 30 s turn from the profile: 29 → 0 streaming, 29 → 7 silent. In server work, a 10 s streaming turn drops from ~378 SQL statements / ~117 connection checkouts / ~134 ms to zero.

### Tests

`tests/repl/test_sessions_backstop_poll.py` — three counter/bound-based guards, chosen so they are immune to this box's load noise:

1. `test_live_stream_costs_no_backstop_snapshots` — integer assert `calls == []` across ~15 backstop wakes while the stream is stamped live.
2. `test_quiet_stream_backs_off_instead_of_ticking` — asserts 4 snapshots and a **lower bound** on elapsed time (the 1x+2x+4x+8x-capped schedule cannot fit inside 4 fixed ticks). Load noise only inflates elapsed, so the bound can't flake.
3. `test_silent_stream_still_ends_turn_from_snapshot[idle|failed]` — the backstop still ends the turn from a snapshot, so the cheaper cadence can't decay into no backstop.

Prove-it-fails: restoring the old unconditional fixed-cadence body (keeping the new method and constants) fails guards 1 and 2 and passes 3, as designed:

```
FAILED test_live_stream_costs_no_backstop_snapshots
  assert [46427.29...] == []   # 15 requests instead of 0
FAILED test_quiet_stream_backs_off_instead_of_ticking
  AssertionError: backstop did not back off (elapsed 0.201s)
2 failed, 2 passed
```

```
$ python -m pytest tests/repl/test_sessions_backstop_poll.py \
    tests/repl/test_sessions_chat_adapter.py \
    tests/repl/test_repl_pending_model_override.py -q
43 passed

$ python -m pytest tests/e2e/test_remote_url_chat_fresh_session_2437.py -q
9 passed    # real end-to-end turns through the adapter, incl. the ASGI-transport
            # case the backstop exists for — turns still complete
```

`tests/server/integration/test_sessions_tunnel_three_layer.py` could not run in this environment (`ModuleNotFoundError: asgiref`, identical on a clean `origin/main`).

`pre-commit run --files omnigent/repl/_repl.py tests/repl/test_sessions_backstop_poll.py` is clean apart from pyrefly's pre-existing `missing-import` noise in a worktree without its own venv: **99 errors with these changes, 99 on a pristine `origin/main`, none in either changed file.**

### Follow-up (not in this PR)

`GET /v1/sessions/{id}` should stop reading the same document three times. The 42 statements above include 13 separate connection checkouts and 3 reads of one `conversations` row, on an empty conversation — independent layers of the snapshot handler each pull one field from the same document. Earlier profiling found the same smell on session start (the row read 4-5x per start). De-duplicating those reads would make every consumer cheaper — web, mobile, the host, and this backstop's remaining polls — and is worth its own PR. Adjacent, also out of scope here: turn-end accounting in `omnigent/server/routes/_sessions/orchestration.py` walks the spawn tree twice (~6 ms each); a sibling PR is already in that file.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covers the measurements above: the per-snapshot SQL/checkout/row counts came from an ad-hoc listener against the real app over `httpx.ASGITransport`, and the per-turn request counts from driving `_await_turn_done` at the shipped constants with a counting fake client (both harnesses were temporary and are not committed). The existing `tests/e2e/test_remote_url_chat_fresh_session_2437.py` suite is what proves turns still complete end to end, including the ASGI-transport case that the backstop exists for.
