### PR TITLE
perf(runtime): keep the server router out of harness children

### DIFF
--- a/omnigent/runtime/_globals.py
+++ b/omnigent/runtime/_globals.py
@@ -29,6 +29,10 @@ if TYPE_CHECKING:
     from omnigent.tools import ToolManager
     from omnigent.tools.base import ToolContext
 
+    # Materialized on first read by ``__getattr__`` below; declared here so
+    # callers still see the concrete type.
+    _caps: RuntimeCaps
+
 _conversation_store: ConversationStore | None = None
 _agent_store: AgentStore | None = None
 _agent_cache: AgentCache | None = None
@@ -36,7 +40,6 @@ _file_store: FileStore | None = None
 _artifact_store: ArtifactStore | None = None
 _comment_store: CommentStore | None = None
 _policy_store: PolicyStore | None = None
-_caps: RuntimeCaps = RuntimeCaps()
 
 # Server-resident tmux terminal registry. Initialized in
 # :func:`init` and accessed via ``get_terminal_registry()`` in
@@ -165,6 +168,23 @@ class DispatchCapability:
 # the entry and must surface a clear error rather than silently
 # dispatching on stale state.
 _dispatch_capabilities: dict[str, DispatchCapability] = {}
+
+
+def __getattr__(name: str) -> RuntimeCaps:
+    """Build the default caps on first read instead of at import time.
+
+    ``RuntimeCaps``' ``routing_settings`` default is supplied by
+    ``omnigent.server.smart_routing``, so constructing one here at module
+    scope dragged that server module — and its import graph — into every
+    process that touches ``omnigent.runtime``, harness subprocesses included.
+    Deferring the construction keeps the read identical while leaving the
+    server import to whoever actually reads the routing knobs.
+    """
+    if name == "_caps":
+        caps = RuntimeCaps()
+        globals()["_caps"] = caps
+        return caps
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def init(

--- a/tests/runtime/harnesses/test_runner_import_graph.py
+++ b/tests/runtime/harnesses/test_runner_import_graph.py
@@ -1,0 +1,92 @@
+"""Guard: the harness subprocess entrypoint stays free of the server router.
+
+``omnigent/runtime/_globals.py`` built a default
+:class:`~omnigent.runtime.caps.RuntimeCaps` at module scope, and that default's
+``routing_settings`` is supplied by ``omnigent.server.smart_routing`` — so every
+process that touched ``omnigent.runtime``, harness children included, loaded the
+server routing module and the graph behind it just to fill a field it never
+read. ``_globals.__getattr__`` defers the construction to first read; these
+tests fail if the edge grows back, and pin the behaviour the deferral has to
+preserve.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+_FORBIDDEN = "omnigent.server.smart_routing"
+
+_PROBE = (
+    "import sys\n"
+    "import {module}\n"
+    "loaded = sorted(m for m in sys.modules if m.startswith('omnigent.server'))\n"
+    "assert {forbidden!r} not in loaded, (\n"
+    "    'a server module is back in the client import graph; '\n"
+    "    'loaded omnigent.server modules: ' + repr(loaded)\n"
+    ")\n"
+)
+
+
+def _assert_no_server_router(module: str) -> None:
+    """Import *module* in a fresh interpreter and fail if it loads the router.
+
+    A subprocess, not ``sys.modules`` surgery: the pytest session has long since
+    imported the server for other tests, so only a clean interpreter shows what
+    a real harness child pays for.
+    """
+    # Hand the child the same import roots as this process so it resolves
+    # ``omnigent`` to the code under test (worktree or installed package).
+    child_env = {**os.environ, "PYTHONPATH": os.pathsep.join(p for p in sys.path if p)}
+
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE.format(module=module, forbidden=_FORBIDDEN)],
+        env=child_env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        f"importing {module} pulled in {_FORBIDDEN} (the lazy default caps "
+        f"regressed). stderr:\n{result.stderr}"
+    )
+
+
+def test_harness_runner_import_stays_free_of_smart_routing() -> None:
+    """The harness subprocess entrypoint must import no server routing module."""
+    _assert_no_server_router("omnigent.runtime.harnesses._runner")
+
+
+def test_runtime_import_stays_free_of_smart_routing() -> None:
+    """The same edge one level up: importing the runtime stays client-only."""
+    _assert_no_server_router("omnigent.runtime")
+
+
+def test_get_caps_still_returns_default_routing_settings() -> None:
+    """Deferring the construction must not change what callers read."""
+    from omnigent.runtime import get_caps
+    from omnigent.runtime.caps import RuntimeCaps
+    from omnigent.server.smart_routing import RoutingSettings
+
+    caps = get_caps()
+    assert isinstance(caps, RuntimeCaps)
+    assert caps.routing_settings == RoutingSettings()
+
+
+def test_caps_is_readable_as_a_module_attribute() -> None:
+    """``from omnigent.runtime._globals import _caps`` is a live call site."""
+    from omnigent.runtime import get_caps
+    from omnigent.runtime._globals import _caps
+
+    assert _caps is get_caps()
+
+
+def test_unknown_globals_attribute_still_raises_attribute_error() -> None:
+    """The module ``__getattr__`` must not swallow typos."""
+    from omnigent.runtime import _globals
+
+    with pytest.raises(AttributeError, match="no_such_global"):
+        _globals.no_such_global  # noqa: B018


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Every harness subprocess was importing a *server* module. `omnigent/runtime/_globals.py`
built the process-default `RuntimeCaps` at module scope, and that dataclass' `routing_settings`
field takes its default from `omnigent.server.smart_routing` — so merely importing
`omnigent.runtime` executed the server routing module and the whole graph behind it
(`model_fallbacks` → `onboarding.provider_config` → `spec.parser`), purely to fill in a field
the child never reads.

- `_globals` now defers building the default caps to first read via a PEP 562 module
  `__getattr__`, the same idiom already used for the lazy `omnigent.runner` package
  `__init__` and `omnigent/llms/__init__.py`. Whoever actually reads the routing knobs pays
  for the server import.
- No public API change: `get_caps()` and `from omnigent.runtime._globals import _caps` both
  still yield a `RuntimeCaps` whose `routing_settings` is an all-defaults `RoutingSettings`.
  A `TYPE_CHECKING` declaration keeps the concrete type visible to type checkers.
- Adds a subprocess import-graph guard so the edge cannot silently grow back.

ELI5: the harness child was unpacking the entire server toolbox just to read one default
setting off the lid. Now it only opens the toolbox if something actually asks for the setting.

```
before:  runtime._globals ──> runtime.caps ──> server.smart_routing ──> model_fallbacks
         (module scope:                                                  └─> onboarding.provider_config
          RuntimeCaps())                                                     └─> spec.parser ──> fastapi

after:   runtime._globals ──> runtime.caps          (server.smart_routing reached only on
         (no instantiation at import)                first read of _caps, i.e. on the server)
```

## Test Plan

New guard: `tests/runtime/harnesses/test_runner_import_graph.py` — two subprocess probes
(fresh interpreter, so an unrelated test in the same session cannot mask the regression)
plus three behaviour-preservation tests.

Prove-it-fails: with the `_globals.py` change stashed, both probes fail —

```
AssertionError: importing omnigent.runtime.harnesses._runner pulled in
omnigent.server.smart_routing (the lazy default caps regressed). stderr:
  AssertionError: a server module is back in the client import graph;
  loaded omnigent.server modules: ['omnigent.server', 'omnigent.server.smart_routing']
```

Targeted suites, all green:

```
pytest tests/runtime/harnesses/test_runner_import_graph.py     5 passed
pytest tests/runtime/test_caps.py tests/test_reasoning_effort.py \
       tests/tools/test_manager.py tests/cli/test_build_routing_client.py   114 passed
pytest tests/runtime/harnesses/test_runner.py tests/host/test_runner_zygote.py   52 passed
pytest tests/server/test_smart_routing.py tests/server/test_routing_oss_fallback.py \
       tests/server/test_subagent_routing.py   306 passed, 8 failed
```

Plus the whole `tests/runtime` tree (telemetry and credentials modules excluded — they need
the `opentelemetry` / `databricks` extras this environment lacks): **1216 passed, 3 failed**.

Every failure above is pre-existing on the base commit in this environment, verified by
re-running each with `omnigent/runtime/_globals.py` restored from `origin/main`:

- the 8 `tests/server/test_smart_routing.py` ambient-credential failures are
  `ModuleNotFoundError: No module named 'databricks'`;
- the 3 `tests/runtime/test_*_spawn_env.py` failures read the developer's real
  `~/.codex/config.toml` and ambient gateway credentials.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

`python -X importtime`, cumulative µs, best-of-3, warm bytecode, same box and comparable
load average (~5.8) for both arms:

| entry point | before | after | delta |
| --- | --- | --- | --- |
| `import omnigent.runtime` | 254.8 ms | 19.3 ms | **−235.5 ms (13×)** |
| `import omnigent.runtime.harnesses._runner` | 501.8 ms | 408.3 ms | −93.5 ms (−19%) |

`omnigent.server.smart_routing` (244 ms cumulative) and the whole `omnigent.server` package
leave the harness child's import graph entirely — after the change a fresh
`import omnigent.runtime.harnesses._runner` loads *zero* `omnigent.server.*` modules.

The `_runner` figure improves less than the removed subtree suggests, and that is worth being
precise about: `_runner.py` does `import uvicorn` / `from fastapi import FastAPI` itself
(it *is* the harness HTTP server), so ~230 ms of FastAPI/uvicorn that `importtime` previously
attributed to the `smart_routing` subtree — because that is where those modules were first
reached — is genuinely required by `_runner` and is simply billed directly now. That FastAPI
cost on the harness-child path is a separate, larger issue and is untouched here.

The full 235 ms is saved for every process that imports `omnigent.runtime` without otherwise
needing FastAPI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: measured `-X importtime` for both entry points before and after (numbers
above), and confirmed in a fresh interpreter that `import omnigent.runtime.harnesses._runner`
leaves `sys.modules` with no `omnigent.server.*` entry while `get_caps().routing_settings`
still equals `RoutingSettings()`. The existing `_caps`-patching tests
(`tests/server/test_smart_routing.py`, `tests/tools/test_manager.py`,
`tests/test_reasoning_effort.py`) cover the accessor paths through the new module
`__getattr__`.
