### PR TITLE
ci: run the pytest, E2E, and E2E-UI suites on larger runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,11 @@ jobs:
     name: Pytest (${{ matrix.group }})
     needs: gate
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubuntu-latest
+    # Larger runner: this 16-shard matrix is the biggest single consumer of
+    # standard-runner slots, so moving it to the separate larger-runner pool
+    # frees the saturated standard pool for every other workflow. The shards
+    # run `pytest -n 8`, which is CPU-parallel, so more vCPUs also cut wall time.
+    runs-on: ubuntu-latest-m
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -147,7 +147,12 @@ jobs:
     # them. Fork PRs DO run (mock LLM, no secrets) -- same as ci.yml.
     # `ready_for_review` re-fires when a draft is converted.
     needs: [setup, build-sidecar]
-    runs-on: ubuntu-latest
+    # Larger runner: this 4-shard suite is a top consumer of standard-runner
+    # slots, so moving it to the separate larger-runner pool cuts its queue
+    # wait and frees standard slots for other workflows. The 16 GB RAM also
+    # eases the native-CLI render-parity tests (browser + Claude/Codex CLIs +
+    # tmux panes + mock server) that press hard on the 7 GB standard runner.
+    runs-on: ubuntu-latest-m
     timeout-minutes: 25
     strategy:
       # One red shard shouldn't cancel siblings -- we want every shard's signal.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -103,7 +103,10 @@ jobs:
     # Draft PRs resolve to an EMPTY matrix in `setup`, so no shard runs for
     # them. Fork PRs DO run (mock LLM, no secrets) -- same as ci.yml.
     needs: setup
-    runs-on: ubuntu-latest
+    # Larger runner: this 4-shard suite is a top consumer of standard-runner
+    # slots; moving it to the separate larger-runner pool cuts its queue wait
+    # and frees standard slots for other workflows.
+    runs-on: ubuntu-latest-m
     # Job-level cap (composite-action run steps can't set timeout-minutes):
     # ~30 min of tests + setup, replacing the old per-step 30-min backstop.
     timeout-minutes: 35


### PR DESCRIPTION
## Related issue

N/A — Test / CI change (no issue required per the PR template).

## Summary

Moves the three heaviest consumers of **standard** GitHub-hosted runner slots onto the `ubuntu-latest-m` larger-runner pool (4-core / 16 GB, its own concurrency allowance), to relieve the standard-pool queue that's driving CI latency.

- **Why:** the standard pool saturates around ~130 concurrent jobs, so PR bursts queue behind it — measured queue-wait p99 reached ~44 min while job **execution** stayed flat (~6 min p90). The latency is **queueing, not slow tests**.
- **What moves** (the sharded test executors only):
  - `ci.yml` → `pytest` matrix (16 shards). `pytest -n 8` is CPU-parallel, so 4 cores also cut wall time.
  - `e2e-ui.yml` → `e2e-ui` (4-shard Playwright). 16 GB RAM eases the native-CLI render-parity tests (browser + Claude/Codex CLIs + tmux + mock server) that press hard on the 7 GB standard runner.
  - `e2e.yml` → `e2e` (4-shard).
- **What stays on standard:** every `gate`, `setup`, `build-sidecar`, `stores-*`, `codex-parity`, and `coverage-report` job — low volume, low contention.

## Cost

Larger runners are metered even on public repos: `ubuntu-latest-m` is 4-core → ~$0.016/min. Gross upper bound across the three lanes is **~$115K/yr** before speedup / cache-hit / cancel-in-progress savings. This is a deliberate, **reversible** trade (one line per lane back to `ubuntu-latest`) to unblock the team now; we'll watch the bill and scale down per-lane if it runs hot, and revisit the Enterprise upgrade (free standard pool 60→500) once unblocked.

## Test Plan

- YAML validated (`yaml.safe_load`) and pre-commit `check yaml syntax` / `no-hardcoded-models` pass on all three files.
- Behavioural check is on this PR's own CI run: confirm the `Pytest (*)`, `E2E UI Tests (shard *)`, and `E2E Tests (shard *)` jobs schedule on `ubuntu-latest-m`, stay green, and don't regress per-shard wall time.

## Demo

N/A — non-visual CI configuration change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No test logic changes — only the runner label on the pytest, e2e-ui, and e2e matrices. The same suites run unchanged; verification is that the jobs schedule on the new runner and stay green on this PR.

This pull request and its description were written by Isaac.
