### PR TITLE
ci: drop the redundant synchronize trigger from Sync PR Priority

### DIFF
--- a/.github/workflows/sync-pr-priority.yml
+++ b/.github/workflows/sync-pr-priority.yml
@@ -7,11 +7,14 @@ name: Sync PR Priority
 # files; it edits labels through the API.
 
 on:
+  # No `synchronize`: priority is derived from the linked issue's label and the
+  # PR body's closing reference, so pushing a new commit can't change it --
+  # re-running on every push was pure waste. The `edited` event still catches a
+  # closing link added/changed after open, and `issues` catches label changes.
   pull_request_target:
     types:
       - opened
       - edited
-      - synchronize
       - reopened
       - ready_for_review
   issues:


### PR DESCRIPTION
## Related issue

N/A — Test / CI change (no issue required per the PR template).

## Summary

- `Sync PR Priority` mirrors a linked issue's priority label (P0–P3) onto the PR that closes it. That priority comes entirely from the **linked issue's label** and the **PR body's closing reference** — neither of which a code push can change.
- It was triggering on `pull_request_target: synchronize`, i.e. **every push on every open PR**, re-running work that can't produce a different result. This drops `synchronize`.
- Behaviour-neutral: `edited` still catches a `closes #n` link added/changed after open, and the `issues` `labeled`/`unlabeled` events still catch priority changes on the issue.

## Test Plan

- YAML validated (`yaml.safe_load`) and pre-commit `check yaml syntax` passes.
- Verify post-merge: `Sync PR Priority` run count per day drops noticeably, with no change to priority-label accuracy on PRs (label still applies on open, on body edits that add a link, and when the linked issue's priority changes).

## Demo

N/A — non-visual CI configuration change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Trigger-only change to a workflow; no code path is added or altered, so there is nothing to unit-test. The remaining triggers (`opened`, `edited`, `reopened`, `ready_for_review`, `issues`, `workflow_dispatch`) still cover every case in which the synced priority could actually change.

This pull request and its description were written by Isaac.
