### PR TITLE
ci: move the CI critical-path entry jobs (gate/setup/sidecar) to larger runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
   # scan; trusted authors / non-PR events pass through.
   gate:
     uses: ./.github/workflows/security-gate.yml
+    # Larger runner: the gate blocks every job below it (`needs: gate`), so
+    # keeping it on the saturated standard pool throttled the whole workflow.
+    with:
+      runner: ubuntu-latest-m
 
   pytest:
     name: Pytest (${{ matrix.group }})

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -62,6 +62,10 @@ jobs:
   # (security-gate.yml); trusted authors and non-PR events pass instantly.
   gate:
     uses: ./.github/workflows/security-gate.yml
+    # Larger runner: the gate blocks setup, build-sidecar, and the shards below
+    # it, so keeping it on the saturated standard pool throttled the workflow.
+    with:
+      runner: ubuntu-latest-m
 
   # Compute the shard matrix once. A skipped run (draft / fork pull_request)
   # yields an EMPTY matrix -> zero shard jobs -> no skipped placeholder check.
@@ -69,7 +73,9 @@ jobs:
   setup:
     name: setup
     needs: gate
-    runs-on: ubuntu-latest
+    # Larger runner: setup + build-sidecar sit upstream of the e2e-ui shards, so
+    # on the saturated standard pool they throttled the shards before they began.
+    runs-on: ubuntu-latest-m
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -101,7 +107,9 @@ jobs:
     name: build codex-parity sidecar
     needs: setup
     if: needs.setup.outputs.matrix != '{"include":[]}'
-    runs-on: ubuntu-latest
+    # Larger runner: on the critical path to the e2e-ui shards (they `needs`
+    # this), and the cold Rust build is CPU-parallel, so more cores help too.
+    runs-on: ubuntu-latest-m
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,13 +67,19 @@ jobs:
       (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
       github.event.label.name == 'skip-security-scan'
     uses: ./.github/workflows/security-gate.yml
+    # Larger runner: the gate blocks setup + the shards below it, so keeping it
+    # on the saturated standard pool throttled the whole workflow.
+    with:
+      runner: ubuntu-latest-m
 
   # Shard matrix (e2e-shard-matrix.sh, shared with e2e-ui.yml). Fork PRs run by
   # default; draft PRs resolve to an empty matrix.
   setup:
     name: setup
     needs: gate
-    runs-on: ubuntu-latest
+    # Larger runner: setup sits upstream of the e2e shards (which `needs: setup`),
+    # so on the saturated standard pool it throttled them before they could start.
+    runs-on: ubuntu-latest-m
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -15,6 +15,15 @@ name: Security Gate
 
 on:
   workflow_call:
+    inputs:
+      runner:
+        # Runner label for this gate job. Defaults to the standard pool; the
+        # heavy workflows (ci/e2e/e2e-ui) pass a larger-runner label so the gate
+        # -- the mandatory first job every dependent CI job `needs` -- is not
+        # throttled behind a saturated standard pool.
+        type: string
+        default: ubuntu-latest
+        required: false
 
 permissions:
   contents: read
@@ -22,7 +31,7 @@ permissions:
 jobs:
   gate:
     name: Security Gate
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 12
     steps:
       - name: Check out trust check from main


### PR DESCRIPTION
## Related issue

N/A — Test / CI change (no issue required per the PR template).

## Summary

Follow-up to #6018. After the pytest/e2e/e2e-ui test matrices moved to `ubuntu-latest-m`, the shards were still throttled by **upstream jobs left on the standard pool**: every dependent job `needs: gate` (the mandatory `security-gate.yml` first job), and the e2e/e2e-ui shards also `needs: setup` (and e2e-ui `needs: build-sidecar`). While the standard pool is saturated, those upstream jobs queue — so the shards never reach the larger-runner pool and the larger runner sits idle. **The standard pool becomes the throttle.**

This moves the whole critical path off standard, but only for the three heavy workflows:

- **`security-gate.yml`** gains a `runner` `workflow_call` input (default `ubuntu-latest`); `ci`/`e2e`/`e2e-ui` pass `ubuntu-latest-m`. The other **7 callers** (lint, docker-build, integration, web-tests, polly-review, security-scan, rerun-security-gate) keep the default and stay on standard — no change, no added cost there.
- **`e2e` / `e2e-ui` `setup`** and **`e2e-ui` `build-sidecar`** move to `ubuntu-latest-m`.

The gate is a short *waiter* (trust check, then poll for the Security Scan result), so for it this is **pool-separation** — escaping the standard concurrency cap — not a compute upgrade. Reversible per job.

## Test Plan

- YAML validated; pre-commit `check yaml syntax` + `no-hardcoded-models` pass on all four files.
- Verified the wiring: `security-gate` `runner` input defaults to `ubuntu-latest`; `ci`/`e2e`/`e2e-ui` gate calls pass `ubuntu-latest-m`; `setup`/`build-sidecar` on the three workflows now resolve to `ubuntu-latest-m`; the 7 other `security-gate` callers still resolve to `ubuntu-latest`.
- Behavioural check on this PR's own run: the gate + setup + shards should schedule on `ubuntu-latest-m` and CI should no longer stall waiting for a standard-pool slot at the gate.

## Demo

N/A — non-visual CI configuration change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No logic changes — only runner labels and a new optional `workflow_call` input with a default that preserves current behaviour for untouched callers. The same jobs run the same steps; verification is that they schedule on the intended runners (checked above) and stay green on this PR.

This pull request and its description were written by Isaac.
