### PR TITLE
ci: run the Security Scan on larger runners

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,7 +40,12 @@ concurrency:
 jobs:
   scan:
     name: Security Scan
-    runs-on: ubuntu-latest
+    # Larger runner: the per-workflow security gates poll THIS check and cannot
+    # proceed until it completes, so when it queued behind a saturated standard
+    # pool it stalled every gated CI workflow. Its own pool lets it start
+    # promptly -- it's fast once running (p90 ~0.4 min), so this is
+    # pool-separation, not a compute upgrade.
+    runs-on: ubuntu-latest-m
     timeout-minutes: 10
     env:
       # Route uv at PyPI for the semgrep fetch.


### PR DESCRIPTION
## Related issue

N/A — Test / CI change (no issue required per the PR template).

## Summary

Follow-up to #6027. The per-workflow security gates (`security-gate.yml`) poll the single **`Security Scan`** check and can't let dependent CI proceed until it completes. That scan's `scan` job ran on the **standard** pool — so while standard was saturated the scan *queued*, and every gate sat polling up to its ~9-minute timeout waiting for it.

The data made this concrete (24h): the gate's p90 is **9.8 min**, but the Security Scan itself runs in **~0.4 min** once it starts — the gap is the scan's queue wait on standard.

This moves the `scan` job to `ubuntu-latest-m` so it starts promptly out of its own pool; the gates then exit as soon as it finishes (≈1 min instead of ≈9 for untrusted PRs). It's **pool-separation, not a compute upgrade** — the scan is already fast once running. One job, once per PR, so the added cost is minimal.

## Test Plan

- YAML validated; pre-commit `check yaml syntax` + `no-hardcoded-models` pass.
- Verify post-merge from telemetry: `Security Gate` p90 should drop from ~9.8 min toward ~1 min for untrusted PRs, and the `Security Scan` job should schedule on `ubuntu-latest-m` without a standard-pool queue wait.

## Demo

N/A — non-visual CI configuration change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No logic changes — only the runner label on the single `scan` job. The scanner runs the same detectors on the same inputs; verification is that it schedules on the intended runner and that gate wall-time drops (checked post-merge in telemetry).

This pull request and its description were written by Isaac.
