### PR TITLE
fix(web): keep a just-created session in the sidebar until it's indexed

### DIFF
--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -19,7 +19,7 @@ import { type ReactNode, useCallback, useEffect, useRef } from "react";
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { useActiveConversationId } from "@/hooks/useActiveConversationId";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
-import { isSessionDeleting } from "@/hooks/useConversations";
+import { isSessionDeleting, markRecentlyCreated } from "@/hooks/useConversations";
 import {
   type ConversationsInfiniteData,
   type SessionListWireItem,
@@ -89,9 +89,12 @@ function applyItemsToCache(
       filters,
       isSessionDeleting,
     );
-    for (const id of inserted) {
-      const wire = itemsById.get(id);
-      if (wire?.project_id == null && !wire?.labels?.[PROJECT_LABEL_KEY]) foundAnywhere.add(id);
+    for (const row of inserted) {
+      if (row.project_id == null && !row.labels?.[PROJECT_LABEL_KEY]) foundAnywhere.add(row.id);
+      // Keep the new row in the list-fetch until the search index catches up,
+      // so the create-path refetch (or any reconcile) can't drop it before it's
+      // queryable — otherwise it flashes in and out. Mirrors the delete tombstone.
+      markRecentlyCreated(row);
     }
     if (next !== data) queryClient.setQueryData(key, next);
   }

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -30,6 +30,8 @@ import {
   useTogglePinnedConversation,
   fetchPinnedConversations,
   unmarkSessionsDeleting,
+  markRecentlyCreated,
+  clearRecentlyCreated,
   PINNED_CONVERSATIONS_KEY,
   type Conversation,
   type PinnedConversationsResult,
@@ -62,6 +64,8 @@ afterEach(() => {
   // settles, in module-level state that would otherwise leak into the next
   // test (which reuses the same ids against a fresh cache).
   unmarkSessionsDeleting();
+  // Same for the recently-created keep-alive.
+  clearRecentlyCreated();
 });
 
 describe("renameConversation", () => {
@@ -747,6 +751,71 @@ describe("useStopAndDeleteConversation cache eviction", () => {
     // The project list IS refreshed (DB-direct, no reindex race) so a project
     // emptied by the delete drops its now-empty folder without a reload.
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["projects"] });
+  });
+});
+
+describe("recently-created keep-alive", () => {
+  const listResponse = (ids: string[]) =>
+    mockResponse({
+      object: "list",
+      data: ids.map((id) => ({
+        id,
+        object: "conversation",
+        title: id,
+        created_at: 0,
+        updated_at: 1,
+      })),
+      first_id: ids[0] ?? null,
+      last_id: ids.at(-1) ?? null,
+      has_more: false,
+    });
+
+  it("keeps a just-created session in the first-page fetch until the index catches up", async () => {
+    // The session was just created and eagerly inserted, but the search-indexed
+    // list fetch lags and comes back without it.
+    markRecentlyCreated({
+      id: "conv_new",
+      object: "conversation",
+      title: "New",
+      created_at: 0,
+      updated_at: 9,
+      labels: {},
+      permission_level: null,
+    });
+    fetchMock.mockResolvedValueOnce(listResponse(["conv_old"]));
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useConversations("", true, {}), { wrapper });
+
+    // The lagging fetch omits conv_new, but the keep-alive prepends it so the
+    // row doesn't flash out of the sidebar.
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data!.pages[0].data.map((c) => c.id)).toEqual(["conv_new", "conv_old"]);
+  });
+
+  it("drops the keep-alive (no duplicate) once the fetch returns the row", async () => {
+    markRecentlyCreated({
+      id: "conv_new",
+      object: "conversation",
+      title: "New",
+      created_at: 0,
+      updated_at: 9,
+      labels: {},
+      permission_level: null,
+    });
+    // The index has caught up: the fetch now includes conv_new itself.
+    fetchMock.mockResolvedValueOnce(listResponse(["conv_new", "conv_old"]));
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useConversations("", true, {}), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    // No duplicate: the row appears once, from the server response.
+    expect(result.current.data!.pages[0].data.map((c) => c.id)).toEqual(["conv_new", "conv_old"]);
   });
 });
 

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -817,6 +817,81 @@ describe("recently-created keep-alive", () => {
     // No duplicate: the row appears once, from the server response.
     expect(result.current.data!.pages[0].data.map((c) => c.id)).toEqual(["conv_new", "conv_old"]);
   });
+
+  it("injects the fresh cache row, not the stale snapshot (no title revert)", async () => {
+    // Registered at create time with no title yet…
+    markRecentlyCreated({
+      id: "conv_new",
+      object: "conversation",
+      title: null,
+      created_at: 0,
+      updated_at: 9,
+      labels: {},
+      permission_level: null,
+    });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    // …but a WS frame has since titled it in another cached list variant.
+    queryClient.setQueryData(["conversations", "", false], {
+      pages: [
+        {
+          data: [
+            {
+              id: "conv_new",
+              object: "conversation",
+              title: "Auto Title",
+              created_at: 0,
+              updated_at: 9,
+              labels: {},
+              permission_level: null,
+            },
+          ],
+          first_id: "conv_new",
+          last_id: "conv_new",
+          has_more: false,
+        },
+      ],
+      pageParams: [undefined],
+    });
+    // The lagging fetch (this variant) still omits conv_new.
+    fetchMock.mockResolvedValueOnce(listResponse(["conv_old"]));
+
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useConversations("", true, {}), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    const injected = result.current.data!.pages[0].data.find((c) => c.id === "conv_new");
+    // The WS-confirmed title wins over the frozen snapshot's null title.
+    expect(injected?.title).toBe("Auto Title");
+  });
+
+  it("does not disarm the keep-alive when a sibling fetch already lists the row", async () => {
+    markRecentlyCreated({
+      id: "conv_new",
+      object: "conversation",
+      title: "New",
+      created_at: 0,
+      updated_at: 9,
+      labels: {},
+      permission_level: null,
+    });
+    // First list catches up (row present) — must NOT drop the global entry.
+    fetchMock.mockResolvedValueOnce(listResponse(["conv_new", "conv_old"]));
+    const qc1 = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result: r1 } = renderHook(() => useConversations("", true, {}), {
+      wrapper: ({ children }) => createElement(QueryClientProvider, { client: qc1 }, children),
+    });
+    await waitFor(() => expect(r1.current.data).toBeDefined());
+
+    // A second (still-lagging) list must still get the row from the keep-alive.
+    fetchMock.mockResolvedValueOnce(listResponse(["conv_old"]));
+    const qc2 = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result: r2 } = renderHook(() => useConversations("", true, {}), {
+      wrapper: ({ children }) => createElement(QueryClientProvider, { client: qc2 }, children),
+    });
+    await waitFor(() => expect(r2.current.data).toBeDefined());
+    expect(r2.current.data!.pages[0].data.map((c) => c.id)).toEqual(["conv_new", "conv_old"]);
+  });
 });
 
 describe("useRenameConversation cache patching", () => {

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -339,19 +339,24 @@ function withRecentlyCreated(
   searchQuery: string,
   project: string | undefined,
   includeArchived: boolean,
+  queryClient: QueryClient,
 ): ConversationsPage {
   if (after !== undefined || searchQuery || project || recentlyCreatedSessions.size === 0) {
     return page;
   }
   const present = new Set(page.data.map((c) => c.id));
   const inject: Conversation[] = [];
-  for (const [id, conv] of recentlyCreatedSessions) {
-    if (present.has(id)) {
-      recentlyCreatedSessions.delete(id);
-      continue;
-    }
-    if (conv.archived && !includeArchived) continue;
-    inject.push(conv);
+  for (const [id, snapshot] of recentlyCreatedSessions) {
+    // Already listed — skip (no duplicate). Don't drop the entry: a sibling
+    // list catching up first must not disarm the keep-alive for a still-lagging
+    // list; the 60s timer is the sole cleanup.
+    if (present.has(id)) continue;
+    // Inject the freshest copy: the cache row (kept current by WS overlays)
+    // beats the frozen snapshot, so a WS-confirmed title — or archive flag —
+    // isn't reverted by re-injecting stale data.
+    const row = findCachedConversationRow(queryClient, id) ?? snapshot;
+    if (row.archived && !includeArchived) continue;
+    inject.push(row);
   }
   if (inject.length === 0) return page;
   return { ...page, data: [...inject, ...page.data], first_id: inject[0].id };
@@ -403,11 +408,13 @@ async function fetchConversationsPage({
   searchQuery,
   includeArchived,
   project,
+  queryClient,
 }: {
   after?: string;
   searchQuery: string;
   includeArchived: boolean;
   project?: string;
+  queryClient: QueryClient;
 }): Promise<ConversationsPage> {
   // `updated_at` matches the sidebar's sort, which keeps server
   // pagination consistent with the visible order as the user scrolls.
@@ -447,7 +454,7 @@ async function fetchConversationsPage({
   // can't seed a stale value; a hostless row clears any prior mapping.
   for (const row of page.data) setSessionHost(row.id, row.host_id);
   return withoutDeletingSessions(
-    withRecentlyCreated(page, after, searchQuery, project, includeArchived),
+    withRecentlyCreated(page, after, searchQuery, project, includeArchived, queryClient),
   );
 }
 
@@ -489,6 +496,7 @@ export function useConversations(
   // enter the sidebar without making every consumer poll `/v1/sessions`.
   // If the socket is down, all consumers use a safety poll.
   const streamConnected = useSessionUpdatesConnected();
+  const queryClient = useQueryClient();
   return useInfiniteQuery({
     // Keep the base three-element key for the unfiltered callers (byte-for-byte
     // unchanged, so the sidebar / rename / push-delta paths are untouched); only
@@ -504,6 +512,7 @@ export function useConversations(
           searchQuery,
           includeArchived,
           project,
+          queryClient,
         });
       // Time the first full-list load per app session; skip pagination
       // (pageParam set) and every later fetch (poll / reconcile / invalidation).

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -302,6 +302,61 @@ function withoutDeletingSessions(page: ConversationsPage): ConversationsPage {
   };
 }
 
+// ── Recently-created keep-alive ───────────────────────────────────────
+//
+// The push stream inserts a just-created session into the sidebar instantly
+// (SessionUpdatesProvider → insertNewRowsIntoPages), but the create path also
+// fires a `["conversations"]` refetch, and on the search-indexed deployment
+// that fetch lags the write — so it comes back WITHOUT the new session and
+// replaces the cache, dropping the row until the index catches up (it flashes
+// in, then out). We keep the row in the first-page fetch until the index
+// reflects it — the additive mirror of the delete tombstone above.
+const recentlyCreatedSessions = new Map<string, Conversation>();
+
+/** Grace window for the server's async create reindex. */
+const CREATED_KEEPALIVE_MS = 60_000;
+
+/** Keep a just-created session in the first-page list fetch until it's indexed. */
+export function markRecentlyCreated(conv: Conversation): void {
+  recentlyCreatedSessions.set(conv.id, conv);
+  setTimeout(() => recentlyCreatedSessions.delete(conv.id), CREATED_KEEPALIVE_MS);
+}
+
+/** Clear the keep-alive map — exported for test cleanup (mirrors `unmarkSessionsDeleting`). */
+export function clearRecentlyCreated(): void {
+  recentlyCreatedSessions.clear();
+}
+
+/**
+ * Prepend recently-created rows the first page doesn't yet include (the index
+ * hasn't caught up). Only the unfiltered, unsearched first page — a create sorts
+ * newest-first. Once the fetch returns the row itself, the keep-alive is dropped.
+ * Applied before `withoutDeletingSessions`, so a create-then-delete stays gone.
+ */
+function withRecentlyCreated(
+  page: ConversationsPage,
+  after: string | undefined,
+  searchQuery: string,
+  project: string | undefined,
+  includeArchived: boolean,
+): ConversationsPage {
+  if (after !== undefined || searchQuery || project || recentlyCreatedSessions.size === 0) {
+    return page;
+  }
+  const present = new Set(page.data.map((c) => c.id));
+  const inject: Conversation[] = [];
+  for (const [id, conv] of recentlyCreatedSessions) {
+    if (present.has(id)) {
+      recentlyCreatedSessions.delete(id);
+      continue;
+    }
+    if (conv.archived && !includeArchived) continue;
+    inject.push(conv);
+  }
+  if (inject.length === 0) return page;
+  return { ...page, data: [...inject, ...page.data], first_id: inject[0].id };
+}
+
 /**
  * Fetch a single session as a sidebar-shaped ``Conversation`` object.
  *
@@ -391,7 +446,9 @@ async function fetchConversationsPage({
   // falling back to the modal. host_id is fixed for a session's life, so this
   // can't seed a stale value; a hostless row clears any prior mapping.
   for (const row of page.data) setSessionHost(row.id, row.host_id);
-  return withoutDeletingSessions(page);
+  return withoutDeletingSessions(
+    withRecentlyCreated(page, after, searchQuery, project, includeArchived),
+  );
 }
 
 /**

--- a/web/src/lib/sessionListCache.test.ts
+++ b/web/src/lib/sessionListCache.test.ts
@@ -456,7 +456,7 @@ describe("insertNewRowsIntoPages", () => {
     );
     expect(after!.pages[0].data.map((c) => c.id)).toEqual(["new", "a", "b"]);
     expect(after!.pages[0].first_id).toBe("new");
-    expect(inserted).toEqual(new Set(["new"]));
+    expect(inserted.map((c) => c.id)).toEqual(["new"]);
   });
 
   it("skips a row already present (idempotent)", () => {
@@ -467,7 +467,7 @@ describe("insertNewRowsIntoPages", () => {
       DEFAULT_FILTERS,
     );
     expect(after).toBe(before);
-    expect(inserted.size).toBe(0);
+    expect(inserted).toHaveLength(0);
   });
 
   it("skips search-filtered lists (membership unknown)", () => {
@@ -476,7 +476,7 @@ describe("insertNewRowsIntoPages", () => {
       searchQuery: "hi",
       includeArchived: false,
     });
-    expect(inserted.size).toBe(0);
+    expect(inserted).toHaveLength(0);
   });
 
   it("skips an archived row in a non-archived list", () => {
@@ -485,7 +485,7 @@ describe("insertNewRowsIntoPages", () => {
       searchQuery: "",
       includeArchived: false,
     });
-    expect(inserted.size).toBe(0);
+    expect(inserted).toHaveLength(0);
   });
 
   it("never inserts a sub-agent/child session (parent_session_id set)", () => {
@@ -495,7 +495,7 @@ describe("insertNewRowsIntoPages", () => {
       candidate("child", { parent_session_id: "parent" }),
       DEFAULT_FILTERS,
     );
-    expect(inserted.size).toBe(0);
+    expect(inserted).toHaveLength(0);
   });
 
   it("skips ids the caller excludes (e.g. a session being deleted)", () => {
@@ -506,6 +506,6 @@ describe("insertNewRowsIntoPages", () => {
       DEFAULT_FILTERS,
       (id) => id === "gone",
     );
-    expect(inserted.size).toBe(0);
+    expect(inserted).toHaveLength(0);
   });
 });

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -296,9 +296,8 @@ export function insertNewRowsIntoPages(
   candidates: Map<string, SessionListWireItem>,
   filters: ConversationListFilters,
   skip?: (id: string) => boolean,
-): { data: ConversationsInfiniteData | undefined; inserted: Set<string> } {
-  const inserted = new Set<string>();
-  if (!data || candidates.size === 0 || filters.searchQuery) return { data, inserted };
+): { data: ConversationsInfiniteData | undefined; inserted: Conversation[] } {
+  if (!data || candidates.size === 0 || filters.searchQuery) return { data, inserted: [] };
   const present = new Set<string>();
   for (const page of data.pages) for (const c of page.data) present.add(c.id);
   const rows: Conversation[] = [];
@@ -316,12 +315,11 @@ export function insertNewRowsIntoPages(
     };
     if (conv.parent_session_id != null || violatesKnownMembership(conv, filters)) continue;
     rows.push(conv);
-    inserted.add(id);
   }
-  if (rows.length === 0) return { data, inserted };
+  if (rows.length === 0) return { data, inserted: [] };
   const [first, ...rest] = data.pages;
   const nextFirst = { ...first, data: [...rows, ...first.data], first_id: rows[0].id };
-  return { data: { ...data, pages: [nextFirst, ...rest] }, inserted };
+  return { data: { ...data, pages: [nextFirst, ...rest] }, inserted: rows };
 }
 
 /**


### PR DESCRIPTION
## Related issue

Follow-up to #5929 (eagerly insert new sessions). Tracked in Linear [OMNI-5744](https://linear.app/omnigent/issue/OMNI-5744). No GitHub issue.

## Summary

Bug report: a new conversation **flashes into the sidebar, disappears for ~a second, then reappears** (roughly when the session gets auto-titled).

Root cause: #5929's eager insert paints the row instantly (from the `session_added` push, an authoritative store read), but the create path *also* fires a `["conversations"]` refetch — `chatStore.ts` `invalidateQueries(["conversations"])` right after `createSession` (landing/first-send), and `NewChatDialog.tsx` `refetchQueries(["conversations"])` (New Chat modal). On the search-indexed deployment that list fetch lags the write, so it comes back **without** the just-created session and replaces the cache — the row vanishes. It only reappears when the next WS `changed` frame (auto-title is usually the first) re-inserts it, by which time the index has caught up. In other words, the eager insert wasn't durable against a list refetch.

Fix: make it durable with a **recently-created keep-alive** — the additive mirror of the existing delete tombstone (`deletingSessionIds` / `withoutDeletingSessions`):

- `markRecentlyCreated(row)` records a just-created session (60s grace window).
- `fetchConversationsPage` prepends any recently-created id the first-page response doesn't yet include (index hasn't caught up), so **any** refetch — the create-path invalidate, a WS reconcile, or the poll — keeps the row.
- The keep-alive drops an id the moment the fetch returns it (no duplicate) or after the grace window, and is applied **before** `withoutDeletingSessions` so a create-then-delete stays gone.
- The WS handler (`SessionUpdatesProvider`) registers each brand-new inserted row; `insertNewRowsIntoPages` now returns the inserted rows so the caller can register them.

Scope is confined to the three files #5929 touched — no `chatStore` / `NewChatDialog` edits, no change to the create-path refetches themselves.

## ELI5

Before: the new chat popped into the list, then a slow "give me the full list" call came back (from a server index that hadn't caught up yet) and wiped it, so it blinked out until the next update re-added it. After: we hold the new row in the list until the server's list actually includes it, so it stays put.

## Test Plan

- `cd web && npx vitest run src/lib/sessionListCache.test.ts src/hooks/useConversations.test.ts src/hooks/SessionUpdatesProvider.test.tsx src/store/chatStore.test.ts` → 503 pass.
- `npx tsc -p tsconfig.app.json --noEmit` → clean (only the pre-existing unrelated `rehype-slug` error).
- Manual (on a search-indexed deployment): create a session → its row appears at the top and **stays** (no flash-out), through the create-path refetch, before it's ever titled.

## Demo

(Managed omnigent):

https://github.com/user-attachments/assets/0ee61fbf-9dc0-43b9-b828-f99f26678099

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New `useConversations.test.ts` cases: a lagging fetch (row absent) still surfaces the row via the keep-alive, and a caught-up fetch (row present) yields no duplicate and drops the keep-alive. `insertNewRowsIntoPages` tests updated for its new row-returning signature. The lagging-index self-heal is verified manually (unit tests mock the socket/fetch).

## Changelog

Newly-created sessions no longer briefly flash out of the sidebar before settling.