### PR TITLE
Always select chat input when switching to a session

### DIFF
--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -496,6 +496,7 @@ describe("TerminalSession", () => {
     onInput?: () => void,
     clipboardEnabled = true,
     onClipboardRequest?: (text: string) => void,
+    focusOnConnect = true,
   ) {
     const states: ConnectionState[] = [];
     const container = document.createElement("div");
@@ -509,6 +510,7 @@ describe("TerminalSession", () => {
       onInput,
       clipboardEnabled,
       onClipboardRequest,
+      focusOnConnect,
     );
     return { session, states, container, socket: FakeWebSocket.instances.at(-1)! };
   }
@@ -526,6 +528,31 @@ describe("TerminalSession", () => {
       (m) => typeof m === "string" && m.includes('"type":"resize"'),
     );
     expect(resizeFrame).toBeDefined();
+    session.dispose();
+  });
+
+  it("grabs keyboard focus on open when focusOnConnect is set", () => {
+    // WHY: a foreground surface should claim the keyboard as it comes up.
+    const { socket, session } = makeSession();
+    const term = (session as unknown as { term: Terminal }).term;
+    const focusSpy = vi.spyOn(term, "focus");
+
+    socket.open();
+
+    expect(focusSpy).toHaveBeenCalled();
+    session.dispose();
+  });
+
+  it("does not grab focus on open when focusOnConnect is false", () => {
+    // WHY: the workspace-rail shell connects in the background on a session
+    // switch — it must not yank focus off the chat composer.
+    const { socket, session } = makeSession(undefined, undefined, true, undefined, false);
+    const term = (session as unknown as { term: Terminal }).term;
+    const focusSpy = vi.spyOn(term, "focus");
+
+    socket.open();
+
+    expect(focusSpy).not.toHaveBeenCalled();
     session.dispose();
   });
 

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -494,6 +494,13 @@ export class TerminalSession {
   private readonly onClipboardRequest?: TerminalClipboardListener;
   /** Whether this visible, interactive attach may write the local clipboard. */
   private clipboardEnabled: boolean;
+  /**
+   * Whether to grab keyboard focus when the WS opens. True for a primary
+   * interactive surface the user is looking at; false for a secondary attach
+   * (the workspace-rail shell) so a background connect never yanks focus off
+   * the chat composer. See {@link focus} for the explicit-focus path.
+   */
+  private focusOnConnect: boolean;
   /** ``performance.now()`` of the last keystroke; gates clipboard writes. */
   private lastUserInputAt = 0;
   /** Guards {@link dispose} so calling it twice is a safe no-op. */
@@ -524,6 +531,7 @@ export class TerminalSession {
    * :param onInput: Called when user input is sent to the terminal.
    * :param clipboardEnabled: Whether tmux copies may write the local clipboard.
    * :param onClipboardRequest: Receives validated tmux copy-mode text.
+   * :param focusOnConnect: Whether to grab keyboard focus on WS-open.
    */
   constructor(
     container: HTMLElement,
@@ -534,8 +542,10 @@ export class TerminalSession {
     onInput?: TerminalInputListener,
     clipboardEnabled = true,
     onClipboardRequest?: TerminalClipboardListener,
+    focusOnConnect = true,
   ) {
     this.clipboardEnabled = clipboardEnabled;
+    this.focusOnConnect = focusOnConnect;
     this.onClipboardRequest = onClipboardRequest;
     // Read the user's code-font preference (Settings → Appearance) at
     // construction; a mid-session change is applied live via setFont(). The
@@ -608,7 +618,7 @@ export class TerminalSession {
         // dimensions before the user sees the default 80×24 followed
         // by a reflow.
         this.sendResize();
-        this.term.focus();
+        if (this.focusOnConnect) this.term.focus();
         onState({ kind: "connected" });
       },
       { signal },

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -103,6 +103,15 @@ interface TerminalViewProps {
    */
   active?: boolean;
   /**
+   * Whether the terminal grabs keyboard focus when its WS connects. Defaults
+   * to ``active`` — a foreground surface claims the keyboard as it comes up.
+   * The workspace-rail shell overrides this to false so a shell restored on a
+   * session switch connects in the background without yanking focus off the
+   * chat composer; it stays fully interactive (clipboard, reconnect) either
+   * way. It still grabs focus on the reveal edge and on an explicit open.
+   */
+  focusOnConnect?: boolean;
+  /**
    * Loopback attach URL advertised by the session's runner (from the
    * terminal resource's ``metadata.direct_attach_url``). When set, each
    * connection attempt probes it first and uses it if the listener
@@ -123,6 +132,7 @@ export function TerminalView({
   onResume,
   resumePending = false,
   active = true,
+  focusOnConnect = active,
   directAttachUrl,
 }: TerminalViewProps) {
   const [state, setState] = useState<ConnectionState>({ kind: "connecting" });
@@ -211,6 +221,8 @@ export function TerminalView({
   onInputRef.current = onInput;
   const activeRef = useRef(active);
   activeRef.current = active;
+  const focusOnConnectRef = useRef(focusOnConnect);
+  focusOnConnectRef.current = focusOnConnect;
   // Track whether this terminal has already tried a keyless re-dial after a
   // 4400 wrong-replica close. If keyless still fails with 4400, the host is
   // genuinely unreachable — stop retrying.
@@ -571,6 +583,7 @@ export function TerminalView({
           notifyInput,
           !readOnly && activeRef.current,
           notifyClipboardRequest,
+          focusOnConnectRef.current,
         );
         sessionRef.current = terminalSession;
         // Relay-connected with a direct URL on offer: negotiate the

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -325,6 +325,12 @@ export function AppShell() {
   const [selectedTerminalKey, setSelectedTerminalKey] = useState<string | null>(() =>
     conversationId ? (readSessionWorkspaceState(conversationId).selectedTerminalKey ?? null) : null,
   );
+  // The one shell key the user just opened by an explicit gesture (clicking a
+  // tab / creating a "+"→Shell). Its rail xterm may grab keyboard focus when it
+  // connects; a shell merely *restored* on a session switch may not — switching
+  // sessions keeps focus in the chat composer. Cleared once consumed and on
+  // every session switch.
+  const autoFocusTerminalKeyRef = useRef<string | null>(null);
   // Whether the workspace rail is maximized (covers the full content region,
   // hiding the chat column). Session-transient — a fresh visit starts docked.
   const [rightPanelMaximized, setRightPanelMaximized] = useState(false);
@@ -944,6 +950,7 @@ export function AppShell() {
       setRightRailTab("files");
       setSelectedFilePath(null);
       setOpenFiles([]);
+      autoFocusTerminalKeyRef.current = null;
       setSelectedTerminalKey(null);
       setPanelInitialKeyState(null);
       stateConvRef.current = null;
@@ -989,6 +996,7 @@ export function AppShell() {
     // effect clears that selection if its terminal no longer exists once this
     // session's list loads. A restored shell selection must not coexist with a
     // file selection (one content slot).
+    autoFocusTerminalKeyRef.current = null;
     setSelectedTerminalKey(nextSelected ? null : (persisted.selectedTerminalKey ?? null));
     // A maximized rail is transient too — the incoming session starts docked.
     // If we were maximized, restore the sidebar we collapsed on entry (the
@@ -1431,6 +1439,7 @@ export function AppShell() {
       // just focuses it and reveals the rail. The selection is sticky (never
       // pruned off the list), so a fresh create that's still landing stays
       // selected and its xterm surfaces the instant the terminal appears.
+      autoFocusTerminalKeyRef.current = key;
       setSelectedTerminalKey(key);
       setSelectedFilePath(null);
       setFileViewerCommentsOpen(false);
@@ -1971,6 +1980,10 @@ export function AppShell() {
                     openTerminalTab={openTerminalTab}
                     openTerminals={openTerminals}
                     selectedTerminalKey={selectedTerminalKey}
+                    autoFocusSelectedTerminal={
+                      autoFocusTerminalKeyRef.current !== null &&
+                      autoFocusTerminalKeyRef.current === selectedTerminalKey
+                    }
                     closingTerminalKey={closingTerminalKey}
                     onCloseTerminal={requestCloseTerminal}
                     maximized={rightPanelMaximized}

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -510,10 +510,15 @@ function RailTerminalView({
   conversationId,
   terminalKey,
   readOnly,
+  autoFocus,
 }: {
   conversationId: string;
   terminalKey: string;
   readOnly: boolean;
+  /** Grab keyboard focus when the WS connects. Only for a shell the user just
+   *  opened by hand — a shell restored on a session switch leaves focus in the
+   *  chat composer. */
+  autoFocus: boolean;
 }) {
   const { terminals } = useTerminals(conversationId);
   const { setTerminalConnectionState, markTerminalActive } = useTerminalStatuses(terminals);
@@ -531,6 +536,7 @@ function RailTerminalView({
         sessionId={conversationId}
         terminalId={terminal.id}
         readOnly={readOnly}
+        focusOnConnect={autoFocus}
         directAttachUrl={terminal.directAttachUrl}
         onStateChange={(state) => setTerminalConnectionState(terminal.id, state)}
         onActivity={() => markTerminalActive(terminal.id)}
@@ -604,6 +610,11 @@ interface WorkspacePanelProps {
   openTerminals: string[];
   /** Active shell tab key, or null when no shell tab is selected. */
   selectedTerminalKey: string | null;
+  /** Whether the selected shell was just opened by an explicit user gesture
+   *  (clicking a tab / "+"→Shell) and so may grab keyboard focus on connect.
+   *  False when the shell is merely restored on a session switch — then focus
+   *  stays in the chat composer. */
+  autoFocusSelectedTerminal?: boolean;
   /** Tab key whose close (terminal kill) is in flight — rendered greyed and
    *  non-interactive until it disappears. Null when no close is pending. */
   closingTerminalKey?: string | null;
@@ -672,6 +683,7 @@ export function WorkspacePanel({
   openTerminalTab,
   openTerminals,
   selectedTerminalKey,
+  autoFocusSelectedTerminal = false,
   closingTerminalKey,
   onCloseTerminal,
   maximized,
@@ -934,6 +946,7 @@ export function WorkspacePanel({
             conversationId={conversationId}
             terminalKey={selectedTerminalKey}
             readOnly={!isOwnerLevel(permissionLevel)}
+            autoFocus={autoFocusSelectedTerminal}
           />
         ) : selectedFilePath !== null ? (
           <FileViewer


### PR DESCRIPTION
## Related issue

Closes https://linear.app/omnigent/issue/OMNI-5882/always-select-chat-input-when-switching-to-a-session

<!-- Tracked in Jira as OMNI-5882 (no matching GitHub issue). -->

## Summary

Switching to a session that already had a shell open in the right-side workspace
rail moved keyboard focus into that shell, so typing went to the terminal
instead of the chat composer. This restores the expected behaviour: switching
sessions keeps focus in the chat input.

- The rail shell's xterm grabbed focus on every WebSocket connect
  (`TerminalSession` focused unconditionally on `open`). On a session switch the
  rail shell re-attaches in the background, so that connect yanked focus off the
  composer.
- The WS-open focus is now gated by a `focusOnConnect` flag. The rail shell only
  requests it when the user **explicitly opens** the shell (clicking a shell tab
  or `+`→Shell) — a shell merely *restored* on a session switch connects in the
  background without taking focus.
- `active` is left untouched for the rail (it also gates clipboard bridging and
  background reconnect), so the shell stays fully interactive either way — you
  can still click into it and type/copy as before.

**ELI5:** The side terminal used to "grab the microphone" every time it
reconnected. Now it only grabs it when *you* open it, not when you switch to a
session that happens to have one open — so what you type keeps going to the chat
box.

```
Switch session (rail shell already open)
        │
        ▼
  rail shell re-attaches (WS open)
        │
   focusOnConnect?
    ┌───┴────┐
   yes       no  ◄── session-switch restore (autoFocusTerminalKey cleared)
    │         │
 term.focus() │      focus stays in chat composer  ✅
 (only on an  └───────────────────────────────────►
  explicit open: tab click / +→Shell)
```

## Test Plan

Manual (Electron desktop):

1. Open a session, open a shell in the right rail, click into the chat composer.
2. Switch sessions in the sidebar and type immediately → text lands in **chat**,
   not the shell. ✅
3. Click a rail shell tab (or create one via `+`→Shell) → it takes focus and you
   can type in it right away. ✅
4. Click into the shell, switch away and back → focus stays in chat on the
   switch; the shell is still usable (type, copy) after clicking it. ✅

Automated:

- `npx vitest run src/components/blocks/TerminalSession.test.ts` — 40 pass
  (2 new: WS-open focuses when `focusOnConnect` is set; does **not** focus when
  it is false).
- `npx vitest run src/shell/WorkspacePanel.test.tsx` — 37 pass.
- `npx tsc -p tsconfig.app.json --noEmit` — clean.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Focus behaviour is hard to convey in a still image; the Test Plan steps above
reproduce the before/after. Happy to attach a short screen recording if a
reviewer wants one.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added two unit tests around the new `focusOnConnect` gate in `TerminalSession`
(the smallest thing that fails if the gate breaks). The end-to-end focus routing
across a session switch spans AppShell → WorkspacePanel → TerminalView →
TerminalSession and depends on real DOM focus, so it was verified manually per
the Test Plan.

## Changelog

Switching sessions no longer moves keyboard focus into an open workspace-rail
shell — typing stays in the chat input.
