### PR TITLE
fix(web): enlarge mobile toolbar icon buttons to 44px tap targets

### DIFF
--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -416,14 +416,14 @@ export function ChatHeader({
                 // copy of it. Kept everywhere else, where it is the ONLY way to
                 // reopen a collapsed sidebar.
                 className={cn(
-                  "chat-header-sidebar-toggle text-muted-foreground hover:text-foreground md:size-6",
+                  "chat-header-sidebar-toggle text-muted-foreground hover:text-foreground max-md:size-11 md:size-6",
                   MOBILE_GLASS_PILL,
                 )}
                 onPointerEnter={onPeekSidebar}
                 onPointerDown={cancelPeek}
                 onPointerLeave={cancelPeek}
               >
-                <PanelLeftIcon className="size-4" />
+                <PanelLeftIcon className="size-4 max-md:size-5" />
               </Button>
             </TooltipTrigger>
             {/* Bottom placement keeps the tooltip clear of the macOS
@@ -487,9 +487,9 @@ export function ChatHeader({
                 size="icon"
                 aria-label="Session actions"
                 data-testid="session-actions-menu"
-                className="text-muted-foreground hover:text-foreground md:hidden max-md:rounded-full"
+                className="text-muted-foreground hover:text-foreground md:hidden max-md:size-11 max-md:rounded-full"
               >
-                <EllipsisVerticalIcon className="size-4" />
+                <EllipsisVerticalIcon className="size-4 max-md:size-5" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className={cn("min-w-44", MOBILE_GLASS_SURFACE)}>

--- a/web/src/shell/Sidebar.mobileDrawer.test.tsx
+++ b/web/src/shell/Sidebar.mobileDrawer.test.tsx
@@ -239,6 +239,6 @@ describe("mobile sidebar drawer", () => {
     // hiding its title and state badge and blocking the tap target.
     renderSidebar();
 
-    expect(screen.getByRole("navigation")).toHaveClass("max-md:pb-14");
+    expect(screen.getByRole("navigation")).toHaveClass("max-md:pb-16");
   });
 });

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1044,7 +1044,7 @@ export function Sidebar({
                 // chip is a non-scrolling sibling pinned bottom-right, so
                 // without a gutter the last row's always-visible kebab parks
                 // underneath it and can't be tapped.
-                className="relative flex-1 overflow-y-auto px-2 pt-4 pb-3 [scrollbar-width:none] max-md:pb-14 [&::-webkit-scrollbar]:hidden"
+                className="relative flex-1 overflow-y-auto px-2 pt-4 pb-3 [scrollbar-width:none] max-md:pb-16 [&::-webkit-scrollbar]:hidden"
               >
                 <ConversationList
                   conversationsQuery={conversationsQuery}

--- a/web/src/shell/SidebarHeaderActions.tsx
+++ b/web/src/shell/SidebarHeaderActions.tsx
@@ -102,9 +102,9 @@ export function SidebarHeaderActions({
  * mobile breakpoint) and these stay flat 24px ghost icons in the header row.
  */
 const SIDEBAR_FLOAT_BUTTON =
-  "sidebar-glass-chip size-6 text-muted-foreground hover:text-foreground max-md:size-9 max-md:rounded-full max-md:text-foreground";
+  "sidebar-glass-chip size-6 text-muted-foreground hover:text-foreground max-md:size-11 max-md:rounded-full max-md:text-foreground";
 
-const SIDEBAR_FLOAT_ICON = "ui-icon max-md:size-[18px]";
+const SIDEBAR_FLOAT_ICON = "ui-icon max-md:size-[22px]";
 
 /**
  * Search (command palette) icon button.


### PR DESCRIPTION
## Related issue

N/A — small UX tweak.

## Summary

On mobile, several toolbar icon buttons were smaller than the iOS-recommended 44px minimum tap target, making them fiddly to hit (per user feedback comparing against the ChatGPT mobile app):

- Sidebar **Search** and **Settings** glass chips: 36px → **44px** (icons 18px → 22px).
- Chat-header **sidebar toggle** and **session-actions kebab**: 40px → **44px** (icons 16px → 20px).
- Widened the sidebar list's bottom padding (`pb-14` → `pb-16`) so the last row's kebab still clears the enlarged floating Settings chip.

All sizing changes are scoped to the mobile breakpoint (`max-md:`); desktop is unchanged.

## Test Plan

Open the web app in a mobile viewport (~390px — Chrome DevTools device toolbar or a real phone) and confirm the four buttons are larger and comfortably tappable: Search (top of sidebar drawer), Settings (bottom-right float), sidebar toggle + three-dots session menu (chat header). Scroll the session list to the bottom and confirm the last row's kebab isn't hidden under the Settings chip. Resize past 768px to confirm desktop sizing is unchanged.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

_See the `ui-preview` build for a live preview of the mobile layout._

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Purely a CSS/Tailwind sizing change on the mobile breakpoint — verified visually in a mobile viewport as described in the Test Plan. No logic changed, so no automated coverage added.

## Changelog

Bigger, easier-to-tap mobile toolbar buttons (search, settings, sidebar toggle, session menu)

This pull request and its description were written by Isaac.
