### PR TITLE
fix(qwen-native): wake parent when sub-agent turn ends

### DIFF
--- a/omnigent/qwen_native_forwarder.py
+++ b/omnigent/qwen_native_forwarder.py
@@ -26,9 +26,10 @@ Event shapes consumed (others are ignored defensively):
   these as web elicitation cards. This forwarder ignores them (they carry no
   transcript prose to mirror).
 
-Status (``running``/``idle``) is intentionally NOT posted here: the runner's
-PTY-activity watcher owns those edges for qwen-native (see
-:mod:`omnigent.runner.app`), exactly as for goose-/cursor-native.
+The terminating ``result`` record posts ``external_session_status`` (``idle``
+for success, ``failed`` otherwise). This is the authoritative turn-completion
+edge used to deliver a headless sub-agent's result to its parent; PTY activity
+remains the source of non-terminal UI status.
 
 This module also hosts the **compaction mirror** (:func:`supervise_qwen_compaction_mirror`).
 qwen compaction (its *compression*) is invisible on the ``--json-file`` stream
@@ -57,6 +58,7 @@ from pathlib import Path
 
 import httpx
 
+from omnigent._native_post_delivery import post_external_session_status
 from omnigent.inner.native_attachments import ATTACHMENT_MARKER_STRIP_PATTERN
 from omnigent.qwen_native_bridge import events_file_path
 
@@ -161,6 +163,14 @@ class _MirrorItem:
     response_id: str
 
 
+@dataclass(frozen=True)
+class _TerminalStatus:
+    """Terminal session status derived from qwen's per-turn ``result`` record."""
+
+    status: str
+    output: str | None
+
+
 def _text_from_content(content: object) -> str:
     """Join the ``text`` blocks of a stream-json message ``content`` array.
 
@@ -221,10 +231,20 @@ def _event_to_item(event: dict[str, object], agent_name: str) -> _MirrorItem | N
     )
 
 
+def _event_to_terminal_status(event: dict[str, object]) -> _TerminalStatus | None:
+    """Map qwen's terminating ``result`` record to the shared native status edge."""
+    if event.get("type") != "result":
+        return None
+    result = event.get("result")
+    output = result.strip() if isinstance(result, str) and result.strip() else None
+    succeeded = event.get("subtype") == "success" and event.get("is_error") is not True
+    return _TerminalStatus(status="idle" if succeeded else "failed", output=output)
+
+
 def _read_new_events(
     events_file: Path, offset: int, seen: Container[str], agent_name: str
-) -> tuple[list[_MirrorItem], int]:
-    """Read NDJSON lines past *offset*, returning new mirror items + the new offset.
+) -> tuple[list[_MirrorItem], list[_TerminalStatus], int]:
+    """Read NDJSON lines past *offset*, returning items, terminal edges, and offset.
 
     Detects a truncated/recreated event file (``size < offset``) and rewinds to 0.
     Only fully terminated lines (ending in ``\\n``) are consumed; a trailing
@@ -233,24 +253,25 @@ def _read_new_events(
     try:
         size = events_file.stat().st_size
     except OSError:
-        return [], offset
+        return [], [], offset
     if size < offset:
         offset = 0  # file truncated by a relaunched terminal
     if size == offset:
-        return [], offset
+        return [], [], offset
     try:
         with open(events_file, "rb") as fh:
             fh.seek(offset)
             data = fh.read(size - offset)
     except OSError:
-        return [], offset
+        return [], [], offset
     # Only consume up to the last newline; keep any trailing partial line.
     last_nl = data.rfind(b"\n")
     if last_nl == -1:
-        return [], offset  # no complete line yet
+        return [], [], offset  # no complete line yet
     consumed = data[: last_nl + 1]
     new_offset = offset + len(consumed)
     items: list[_MirrorItem] = []
+    terminal_statuses: list[_TerminalStatus] = []
     for raw in consumed.split(b"\n"):
         raw = raw.strip()
         if not raw:
@@ -264,7 +285,10 @@ def _read_new_events(
         item = _event_to_item(event, agent_name)
         if item is not None and item.uuid not in seen:
             items.append(item)
-    return items, new_offset
+        terminal_status = _event_to_terminal_status(event)
+        if terminal_status is not None:
+            terminal_statuses.append(terminal_status)
+    return items, terminal_statuses, new_offset
 
 
 async def _post_conversation_item(
@@ -323,13 +347,20 @@ async def forward_qwen_events_to_session(
     async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         while True:
             try:
-                items, new_offset = await asyncio.to_thread(
+                items, terminal_statuses, new_offset = await asyncio.to_thread(
                     _read_new_events, target, offset, seen, agent_name
                 )
                 for item in items:
                     await _post_conversation_item(client, session_id=session_id, item=item)
                     seen[item.uuid] = None
-                if new_offset != offset or items:
+                for terminal_status in terminal_statuses:
+                    await post_external_session_status(
+                        client,
+                        session_id=session_id,
+                        status=terminal_status.status,
+                        output=terminal_status.output,
+                    )
+                if new_offset != offset or items or terminal_statuses:
                     offset = new_offset
                     _write_state(
                         bridge_dir,

--- a/tests/test_qwen_native_forwarder.py
+++ b/tests/test_qwen_native_forwarder.py
@@ -134,7 +134,7 @@ def test_could_not_load_marker_stripped() -> None:
 def test_read_new_events_incremental_and_partial_line(tmp_path: Path) -> None:
     f = tmp_path / "out.ndjson"
     f.write_bytes(_ev_bytes(_user_ev("u1", "q")))
-    items, off = _read_new_events(f, 0, set(), _AGENT)
+    items, _, off = _read_new_events(f, 0, set(), _AGENT)
     assert [i.uuid for i in items] == ["u1"]
     assert off == f.stat().st_size
 
@@ -145,7 +145,7 @@ def test_read_new_events_incremental_and_partial_line(tmp_path: Path) -> None:
         complete_size = f.stat().st_size
         fh.write(b'{"type":"assistant","uuid":"a2"')  # no newline yet
         fh.flush()
-    items, off2 = _read_new_events(f, off, {"u1"}, _AGENT)
+    items, _, off2 = _read_new_events(f, off, {"u1"}, _AGENT)
     assert [i.uuid for i in items] == ["a1"]
     # Offset stops at the last newline — the partial line is not consumed.
     assert off2 == complete_size
@@ -155,20 +155,20 @@ def test_read_new_events_detects_truncation(tmp_path: Path) -> None:
     f = tmp_path / "out.ndjson"
     # A long first line so the stale offset exceeds the post-truncation size.
     f.write_bytes(_ev_bytes(_user_ev("u1", "first message, intentionally long " * 4)))
-    _, off = _read_new_events(f, 0, set(), _AGENT)
+    _, _, off = _read_new_events(f, 0, set(), _AGENT)
     assert off > 0
     # A relaunched terminal truncates + writes a shorter line; size < offset
     # must rewind so the fresh content is not skipped.
     f.write_bytes(_ev_bytes(_user_ev("u2", "fresh")))
     assert f.stat().st_size < off
-    items, _ = _read_new_events(f, off, set(), _AGENT)
+    items, _, _ = _read_new_events(f, off, set(), _AGENT)
     assert [i.uuid for i in items] == ["u2"]
 
 
 def test_malformed_line_tolerated(tmp_path: Path) -> None:
     f = tmp_path / "out.ndjson"
     f.write_bytes(b"not json\n" + _ev_bytes(_user_ev("u1", "ok")))
-    items, _ = _read_new_events(f, 0, set(), _AGENT)
+    items, _, _ = _read_new_events(f, 0, set(), _AGENT)
     assert [i.uuid for i in items] == ["u1"]
 
 
@@ -531,6 +531,52 @@ async def test_forward_loop_posts_new_events_and_persists(
     state = _read_state(bridge)
     assert state.offset > 0
     assert "u1" in (state.seen_uuids or [])
+
+
+async def test_forward_loop_posts_terminal_status_for_success_and_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bridge = tmp_path / "bridge"
+    bridge.mkdir()
+    events_file_path(bridge).write_bytes(
+        _ev_bytes({"type": "result", "subtype": "success", "result": "Done"})
+        + _ev_bytes(
+            {
+                "type": "result",
+                "subtype": "error_during_execution",
+                "is_error": True,
+                "result": "Tool failed",
+            }
+        )
+    )
+    posted: list[tuple[str, str | None]] = []
+
+    async def _fake_status(
+        _client: object, *, session_id: str, status: str, output: str | None = None
+    ) -> None:
+        assert session_id == "conv"
+        posted.append((status, output))
+
+    monkeypatch.setattr(fwd, "post_external_session_status", _fake_status)
+    task = asyncio.create_task(
+        fwd.forward_qwen_events_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv",
+            bridge_dir=bridge,
+            agent_name=_AGENT,
+            poll_interval_s=0.01,
+        )
+    )
+    for _ in range(200):
+        if len(posted) == 2:
+            break
+        await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        _ = await task
+
+    assert posted == [("idle", "Done"), ("failed", "Tool failed")]
 
 
 async def test_compaction_mirror_seeds_at_eof_and_posts_new(


### PR DESCRIPTION
## Related issue

N/A — live-reproduced native sub-agent completion defect.

## Summary

- Treat qwen's terminating stream-json `result` record as the authoritative turn-end edge.
- Post the shared `external_session_status` event as `idle` on success or `failed` otherwise, carrying qwen's final result text as parent-inbox output.
- Leave the generic runner parent-wake path unchanged.

ELI5: qwen saved its answer but never rang the parent's doorbell. Its existing final `result` record now rings the same doorbell used by the other native harnesses.

```text
qwen result NDJSON
        |
        v
qwen native forwarder
        |
        v
external_session_status (idle/failed + output)
        |
        v
existing runner parent-inbox wake
```

## Test Plan

- `OMNIGENT_SKIP_WEB_UI=true uv run pytest -q tests/test_qwen_native_forwarder.py` — 37 passed.
- `pre-commit run --files omnigent/qwen_native_forwarder.py tests/test_qwen_native_forwarder.py` — passed.
- `SKIP=web-prettier,web-theme-palette-generation,web-oxlint,web-tsc,vscode-tsc pre-commit run --all-files` — all applicable repository hooks passed; frontend-only hooks were skipped because this backend-only diff changes no frontend files and the local Node build cannot run the repository's TypeScript-stripping hook.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — non-visual backend lifecycle fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression test drives the real qwen forward loop over success and failure `result` records and asserts the shared status helper receives `idle`/`failed` with the corresponding output.

## Changelog

Qwen-native sub-agents now notify and return their final answer to the parent orchestrator when a turn finishes.
