### PR TITLE
Fix automatic scroll-to-top on mobile views

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1933,6 +1933,10 @@ function MainAgentSurface({
     if (!isIOSShell()) return;
     return () => setNativeServerSwitcherHidden(true);
   }, []);
+  // Keys the transcript so a warm switch (no hydration remount) still re-runs
+  // its mount-only scroll-to-bottom and anchor capture. Store id, not the URL
+  // prop, which leads the mirrored blocks by a commit (see the switchTo effect).
+  const activeConversationId = useChatStore((s) => s.conversationId);
   // The conversation's scroll container + the StickToBottom controls needed to
   // override its bottom-lock, lifted out of the context by
   // ConversationScrollRefBridge so the pinned-but-unmasked JumpToTopButton can
@@ -2111,7 +2115,10 @@ function MainAgentSurface({
             ChatHeader overlay's controls (geometry in index.css). Dropped
             when the Plan accordion is pinned above — its solid bar already
             occludes content scrolling past the viewport's top edge. */}
-            <Conversation className={cn(!hasTasks && "chat-scroll-fade", "flex-1")}>
+            <Conversation
+              key={activeConversationId ?? "landing"}
+              className={cn(!hasTasks && "chat-scroll-fade", "flex-1")}
+            >
               {/* Override ConversationContent's default spacing so the thread keeps
               16px side gutters and consecutive agent turns read as one thread.
               The left inset grows *continuously* as the conversation area


### PR DESCRIPTION
## Related issue

Closes https://linear.app/omnigent/issue/OMNI-5888/mobile-scrolls-to-top-sometimes

## Summary

Switching between conversations sometimes left the transcript scrolled to the
top instead of pinned to the newest message — most visible on mobile.

`ChatPage` stays mounted across `/c/:a` → `/c/:b` (the route has no `key`), so a
conversation switch is a **warm switch**: the `<Conversation>` (StickToBottom)
subtree is reused, not remounted. Its scroll-to-bottom and anchor capture are
**mount-only**, so on a warm switch they never re-run and the new transcript
inherits the previous one's scroll offset — often the top.

This keys the `<Conversation>` on the active conversation id so React remounts
it on every switch, re-running the mount-only scroll-to-bottom (and anchor
capture). The key reads the **store** `conversationId`, not the URL prop: the
URL leads the store by a commit, and the transcript's blocks mirror the store —
keying on the store id keeps the remount in sync with the content it renders
(and `?? "landing"` keys the empty landing state).

### ELI5

Two chats open in the same window frame. When you jump from chat A to chat B,
the frame is reused, so the "scroll to the bottom when the chat opens" step —
which only runs the first time the frame appears — is skipped, and you're left
wherever chat A happened to be (usually the top). Giving each chat its own
`key` makes React treat "open chat B" as a fresh frame, so the scroll-to-bottom
runs again.

```
Before (warm switch):
  /c/A ──navigate──▶ /c/B     <Conversation> reused → mount effect skipped → stale scroll (top)

After (keyed on store id):
  /c/A ──navigate──▶ /c/B     key A → key B → <Conversation> remounts → scroll-to-bottom re-runs
```

## Test Plan

Manual, on a mobile viewport / iOS shell:

1. Open a conversation with enough history to scroll, scroll up to the top.
2. Switch to another conversation (sidebar), then back.
3. Each opened conversation now lands pinned at the newest message instead of
   at the top.
4. Sanity-checked desktop: switching conversations and the landing → chat
   transition still open at the bottom; sending a message still snaps to the
   newest bubble.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

<!-- Attach a short mobile screen recording: scroll to top in chat A, switch to
chat B and back, showing each opens at the bottom. -->

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Scroll/mount timing on the real StickToBottom container and the iOS shell isn't
meaningfully exercised in jsdom, so this was verified manually per the Test Plan
(warm switch on mobile, plus desktop regression checks). No automated coverage
added.

## Changelog

Switching conversations on mobile now opens the transcript at the newest message instead of sometimes jumping to the top
