### PR TITLE
ci: cut Security Gate polling API calls to avoid GITHUB_TOKEN exhaustion

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -77,18 +77,25 @@ jobs:
             echo "::warning::Security Scan is awaiting maintainer approval (action_required); proceeding (fail-open). It will re-gate on the next push or maintainer approval event."
             exit 0
           fi
+          # Poll on a 30s cadence (was 5s), fetching the whole check-runs payload
+          # ONCE per tick and reading every field from it locally -- instead of a
+          # 5s busy-poll that also re-fetched the endpoint 3x on completion. This
+          # gate runs once per untrusted PR across ~10 gated workflows, all drawing
+          # on the shared per-repo GITHUB_TOKEN budget (1000 req/hr); the tight poll
+          # drained it and 403'd whole PRs' checks. Now ~18 calls per gate instead
+          # of up to ~110 (poll 108x + 3x on completion) -- roughly a 6x cut.
           q='[.check_runs[] | select(.name=="Security Scan")] | sort_by(.started_at) | last'
           conclusion=""
           details_url=""
-          for _ in $(seq 1 108); do  # up to ~9 min (108 * 5s)
-            status=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq "$q | .status" 2>/dev/null || echo "")
-            if [ "$status" = "completed" ]; then
-              conclusion=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq "$q | .conclusion")
+          for _ in $(seq 1 18); do  # up to ~9 min (18 * 30s)
+            runs=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" 2>/dev/null || echo "")
+            if [ -n "$runs" ] && [ "$(jq -r "$q | .status // empty" <<<"$runs")" = "completed" ]; then
+              conclusion=$(jq -r "$q | .conclusion // empty" <<<"$runs")
               # The scan's own run page -- where the findings/annotations live.
-              details_url=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq "$q | .html_url")
+              details_url=$(jq -r "$q | .html_url // empty" <<<"$runs")
               break
             fi
-            sleep 5
+            sleep 30
           done
           if [ -z "$conclusion" ]; then
             echo "::warning::Security Scan check did not complete in time; proceeding (fail-open)."


### PR DESCRIPTION
## Related issue

N/A — Test / CI change (no issue required per the PR template).

## Summary

Fixes the `403: API rate limit exceeded for installation` cascade seen on PRs (e.g. #5989).

- **Root cause (confirmed from the failing run):** the per-workflow Security Gate polls the shared `Security Scan` check for untrusted PRs on a **5-second** busy-poll for up to ~9 min (108 iterations) and re-fetches the endpoint **3×** on completion — up to **~110 `gh api` calls per gate**. That gate runs once per untrusted PR across **~10 gated workflows**, all drawing on the **same per-repo `GITHUB_TOKEN` budget (1,000 req/hr, shared across the whole repo)**. A burst drained it → `403`, which cascaded: the Security Scan's own `gh pr diff` 403'd and every gate polling it failed, taking down a whole PR's checks at once.
- **This change:** fetch the check-runs payload **once per tick** and read every field locally, and widen the cadence **5s → 30s** (18 iterations, same ~9-min ceiling). Drops a gate from ~110 calls to **~18** — roughly a **6× cut** on the hot path — for ≤30s of extra completion-detection latency (negligible vs CI wall time).

**Follow-ups (not here):** collapse the ~10 per-workflow gates that each poll the same check into one shared gate (a further ~10× cut), and give high-volume automation its own GitHub App so it stops sharing the `GITHUB_TOKEN`/repo budget.

## Test Plan

- YAML validated; pre-commit `check yaml syntax` + `no-hardcoded-models` pass.
- Behaviour is unchanged (same fields, same fail-open + block-on-failure logic); only the request cadence and per-tick fetch count change. Verify post-merge that untrusted-PR gates still gate correctly and that `403` rate-limit failures drop.

## Demo

N/A — non-visual CI configuration change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Shell-only change inside a workflow step (poll cadence + single-fetch); no unit-testable code path. The gate's decision logic (fail-open on timeout, block on a non-passing scan) is unchanged.

This pull request and its description were written by Isaac.
