### PR TITLE
ci: re-evaluate Merge Ready when E2E UI Required flips green

### DIFF
--- a/.github/workflows/e2e-ui-required.yml
+++ b/.github/workflows/e2e-ui-required.yml
@@ -45,6 +45,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      actions: write   # dispatch a Merge Ready re-evaluation when this flips green
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -75,3 +76,21 @@ jobs:
         run: |
           : "${E2E_UI_JUDGE_MODEL:?Set OMNIGENT_CI_E2E_JUDGE_MODEL repository variable}"
           bash .github/scripts/e2e-ui-required/check.sh
+
+      # Merge Ready (the single required gating check) does NOT re-evaluate when
+      # this check flips green: E2E UI Required isn't in Merge Ready's
+      # workflow_run trigger list, and its check_run only wakes Merge Ready for
+      # DCO. So when a `skip-e2e-ui-test` waiver (or a newly pushed test) turns
+      # this check green, the PR would otherwise sit BLOCKED with every check
+      # already green. Nudge Merge Ready to re-post its status. Only on success --
+      # a red gate must stay blocking, and Merge Ready ignores a workflow_dispatch
+      # re-eval that isn't fully green anyway.
+      - name: Re-evaluate Merge Ready
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh workflow run merge-ready.yml -R "$REPO" -f pr="$PR" \
+            || echo "::warning::could not dispatch Merge Ready re-evaluation for #$PR"


### PR DESCRIPTION
## Related issue

N/A — Test / CI change (no issue required per the PR template).

## Summary

Fixes PRs sitting `BLOCKED` with every check green, seen on #6038.

- **Root cause:** `Merge Ready` is the single required gating check and only posts green after *re-evaluating* on one of its triggers — a fixed `workflow_run` list (CI, Lint, Docker build, E2E UI Tests, E2E Tests, Integration Tests, UI Snapshot) plus `check_run` completions, and the `check_run` path only acts on **DCO**. `E2E UI Required` is in **neither**. So when a `skip-e2e-ui-test` waiver (or a newly pushed e2e_ui test) turns that required check green, **nothing wakes Merge Ready** — it never re-posts, and the PR stays `BLOCKED` even though every check now passes.
- **Fix:** when `E2E UI Required` concludes **green**, it now dispatches a Merge Ready re-evaluation for the PR. Localized to `e2e-ui-required.yml` (adds `actions: write` + a single `gh workflow run merge-ready.yml -f pr=<n>` step); Merge Ready's own gating logic is untouched.
- **Safety:** only fires on `success()` — a red gate stays blocking — and a `workflow_dispatch` Merge Ready re-eval posts only when *everything* is green (it never paints red), so this can't force a status.

## Test Plan

- YAML validated; pre-commit `check yaml syntax` + `no-hardcoded-models` pass.
- Reproduced the stuck state on #6038 (E2E UI Required green via `skip-e2e-ui-test`, but Merge Ready never re-posted → `BLOCKED`); a manual `merge-ready.yml` dispatch re-posted `Merge Ready: success` and unblocked it — which is exactly what this step now automates.

## Demo

N/A — non-visual CI configuration change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Workflow-only change (one added step + a permission). Verified by reproducing the stuck-PR state on #6038 and confirming a Merge Ready re-dispatch clears it; this step performs that dispatch automatically when the gate flips green.

This pull request and its description were written by Isaac.
