### PR TITLE
fix(qwen-native): wake parent when sub-agent turn ends

### DIFF
--- a/omnigent/qwen_native_forwarder.py
+++ b/omnigent/qwen_native_forwarder.py
@@ -56,7 +56,7 @@ import logging
 import os
 import re
 import time
-from collections.abc import Container, Iterable
+from collections.abc import Collection, Container, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -360,7 +360,7 @@ def _read_new_events(
 def _read_new_forward_events(
     events_file: Path,
     offset: int,
-    seen: Container[str],
+    seen: Collection[str],
     agent_name: str,
     last_assistant_text: str,
     last_assistant_stop_reason: str | None = None,

--- a/omnigent/qwen_native_forwarder.py
+++ b/omnigent/qwen_native_forwarder.py
@@ -56,7 +56,7 @@ import logging
 import os
 import re
 import time
-from collections.abc import Collection, Container, Iterable
+from collections.abc import Collection, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -296,6 +296,8 @@ def _event_to_terminal(
             or last_assistant_stop_reason == "tool_use"
         ):
             return None
+        # message_stop carries no error channel: a v0.21 turn that dies is
+        # surfaced by the runner's terminal-exit watcher, not this edge.
         failed = False
         output = last_assistant_text or None
     else:
@@ -309,52 +311,6 @@ def _event_to_terminal(
         output=output,
         response_id=f"qwen:{uuid}",
     )
-
-
-def _read_new_events(
-    events_file: Path, offset: int, seen: Container[str], agent_name: str
-) -> tuple[list[_MirrorItem], int]:
-    """Read NDJSON lines past *offset*, returning new mirror items + the new offset.
-
-    Detects a truncated/recreated event file (``size < offset``) and rewinds to 0.
-    Only fully terminated lines (ending in ``\\n``) are consumed; a trailing
-    partial line is left for the next poll by not advancing past it.
-    """
-    try:
-        size = events_file.stat().st_size
-    except OSError:
-        return [], offset
-    if size < offset:
-        offset = 0  # file truncated by a relaunched terminal
-    if size == offset:
-        return [], offset
-    try:
-        with open(events_file, "rb") as fh:
-            fh.seek(offset)
-            data = fh.read(size - offset)
-    except OSError:
-        return [], offset
-    # Only consume up to the last newline; keep any trailing partial line.
-    last_nl = data.rfind(b"\n")
-    if last_nl == -1:
-        return [], offset  # no complete line yet
-    consumed = data[: last_nl + 1]
-    new_offset = offset + len(consumed)
-    items: list[_MirrorItem] = []
-    for raw in consumed.split(b"\n"):
-        raw = raw.strip()
-        if not raw:
-            continue
-        try:
-            event = json.loads(raw.decode("utf-8"))
-        except (ValueError, UnicodeDecodeError):
-            continue  # tolerate a malformed line rather than stalling the tail
-        if not isinstance(event, dict):
-            continue
-        item = _event_to_item(event, agent_name)
-        if item is not None and item.uuid not in seen:
-            items.append(item)
-    return items, new_offset
 
 
 def _read_new_forward_events(
@@ -659,7 +615,7 @@ def _compaction_status_from_record(record: dict[str, object]) -> str | None:
 def _read_new_compaction_statuses(recording: Path, offset: int) -> tuple[list[str], int]:
     """Read NDJSON lines past *offset*, returning new compaction statuses + offset.
 
-    Same tail discipline as :func:`_read_new_events` (truncation rewind, only
+    Same tail discipline as :func:`_read_new_forward_events` (truncation rewind, only
     newline-terminated lines consumed), but scoped to ``chat_compression`` records.
     """
     try:

--- a/omnigent/qwen_native_forwarder.py
+++ b/omnigent/qwen_native_forwarder.py
@@ -10,7 +10,7 @@ empty because nothing mirrors the transcript back into the session.
 This module is that missing mirror — the qwen analog of
 :mod:`omnigent.goose_native_forwarder`. Where goose has to scrape a SQLite store,
 qwen emits a structured **stream-json event stream** (verified Anthropic-shaped
-against ``qwen`` v0.18.1): we tail the ``--json-file`` NDJSON by byte offset and
+against ``qwen`` v0.18.1 and v0.21.14): we tail the ``--json-file`` NDJSON by byte offset and
 POST each new ``user`` / ``assistant`` message as an ``external_conversation_item``
 event (which also seeds the session title).
 
@@ -26,9 +26,14 @@ Event shapes consumed (others are ignored defensively):
   these as web elicitation cards. This forwarder ignores them (they carry no
   transcript prose to mirror).
 
-Status (``running``/``idle``) is intentionally NOT posted here: the runner's
-PTY-activity watcher owns those edges for qwen-native (see
-:mod:`omnigent.runner.app`), exactly as for goose-/cursor-native.
+Qwen v0.18 emits a terminating top-level ``result`` record. Qwen v0.21.14 no
+longer emits that record; it ends each model invocation with a nested
+``stream_event.message_stop``. For v0.21, a ``message_stop`` is terminal only
+when the preceding assistant message is not a ``tool_use`` stop — tool-use
+cycles continue with tool-result events and another model invocation. The
+forwarder posts ``external_session_status`` from either real turn boundary with
+the last assistant text, while the runner's PTY watcher remains a read-only UI
+signal.
 
 This module also hosts the **compaction mirror** (:func:`supervise_qwen_compaction_mirror`).
 qwen compaction (its *compression*) is invisible on the ``--json-file`` stream
@@ -108,6 +113,10 @@ class _ForwardState:
 
     offset: int = 0
     seen_uuids: list[str] | None = None
+    last_assistant_text: str = ""
+    # ``None`` means no assistant message is awaiting its ``message_stop``;
+    # ``""`` represents qwen's JSON null/missing terminal stop reason.
+    last_assistant_stop_reason: str | None = None
 
 
 def _read_state(bridge_dir: Path) -> _ForwardState:
@@ -122,6 +131,16 @@ def _read_state(bridge_dir: Path) -> _ForwardState:
     return _ForwardState(
         offset=offset if isinstance(offset, int) and offset >= 0 else 0,
         seen_uuids=[u for u in seen if isinstance(u, str)] if isinstance(seen, list) else [],
+        last_assistant_text=(
+            data.get("last_assistant_text")
+            if isinstance(data.get("last_assistant_text"), str)
+            else ""
+        ),
+        last_assistant_stop_reason=(
+            data.get("last_assistant_stop_reason")
+            if isinstance(data.get("last_assistant_stop_reason"), str)
+            else None
+        ),
     )
 
 
@@ -135,7 +154,14 @@ def _write_state(bridge_dir: Path, state: _ForwardState) -> bool:
         # _DEDUP_WINDOW uuids — the ones a relaunch re-read is most likely to hit.
         seen = (state.seen_uuids or [])[-_DEDUP_WINDOW:]
         tmp.write_text(
-            json.dumps({"offset": state.offset, "seen_uuids": seen}),
+            json.dumps(
+                {
+                    "offset": state.offset,
+                    "seen_uuids": seen,
+                    "last_assistant_text": state.last_assistant_text,
+                    "last_assistant_stop_reason": state.last_assistant_stop_reason,
+                }
+            ),
             encoding="utf-8",
         )
         os.replace(tmp, bridge_dir / _STATE_FILE)
@@ -158,6 +184,16 @@ class _MirrorItem:
     uuid: str
     item_type: str
     item_data: dict[str, object]
+    response_id: str
+
+
+@dataclass
+class _TerminalStatus:
+    """One authoritative qwen turn-completion record."""
+
+    uuid: str
+    status: str
+    output: str | None
     response_id: str
 
 
@@ -221,6 +257,60 @@ def _event_to_item(event: dict[str, object], agent_name: str) -> _MirrorItem | N
     )
 
 
+def _assistant_stop_reason(event: dict[str, object]) -> str | None:
+    """Return the stop reason from a top-level assistant event.
+
+    ``None`` means *not an assistant event*. Qwen serializes a successful final
+    answer with a JSON null (and older fixtures omit the key), represented here
+    as ``""`` so it remains distinguishable from no assistant context.
+    """
+    if event.get("type") != "assistant":
+        return None
+    message = event.get("message")
+    if not isinstance(message, dict):
+        return None
+    stop_reason = message.get("stop_reason")
+    return stop_reason if isinstance(stop_reason, str) else ""
+
+
+def _event_to_terminal(
+    event: dict[str, object],
+    last_assistant_text: str,
+    last_assistant_stop_reason: str | None = None,
+) -> _TerminalStatus | None:
+    """Convert qwen's version-specific terminating record to session status."""
+    event_type = event.get("type")
+    if event_type == "result":
+        # Qwen's result builder permits caller-defined success subtypes;
+        # is_error is the protocol's authoritative discriminator.
+        failed = event.get("is_error") is True
+        result = event.get("result")
+        result_text = result.strip() if isinstance(result, str) else ""
+        output = result_text or last_assistant_text or None
+    elif event_type == "stream_event":
+        stream_event = event.get("event")
+        if (
+            not isinstance(stream_event, dict)
+            or stream_event.get("type") != "message_stop"
+            or last_assistant_stop_reason is None
+            or last_assistant_stop_reason == "tool_use"
+        ):
+            return None
+        failed = False
+        output = last_assistant_text or None
+    else:
+        return None
+    uuid = event.get("uuid")
+    if not isinstance(uuid, str) or not uuid:
+        return None
+    return _TerminalStatus(
+        uuid=uuid,
+        status="failed" if failed else "idle",
+        output=output,
+        response_id=f"qwen:{uuid}",
+    )
+
+
 def _read_new_events(
     events_file: Path, offset: int, seen: Container[str], agent_name: str
 ) -> tuple[list[_MirrorItem], int]:
@@ -267,6 +357,84 @@ def _read_new_events(
     return items, new_offset
 
 
+def _read_new_forward_events(
+    events_file: Path,
+    offset: int,
+    seen: Container[str],
+    agent_name: str,
+    last_assistant_text: str,
+    last_assistant_stop_reason: str | None = None,
+) -> tuple[list[_MirrorItem | _TerminalStatus], int, str, str | None]:
+    """Read mirror items and terminal records in wire order past *offset*."""
+    try:
+        size = events_file.stat().st_size
+    except OSError:
+        return [], offset, last_assistant_text, last_assistant_stop_reason
+    if size < offset:
+        offset = 0
+        last_assistant_text = ""
+        last_assistant_stop_reason = None
+    if size == offset:
+        return [], offset, last_assistant_text, last_assistant_stop_reason
+    try:
+        with open(events_file, "rb") as fh:
+            fh.seek(offset)
+            data = fh.read(size - offset)
+    except OSError:
+        return [], offset, last_assistant_text, last_assistant_stop_reason
+    last_nl = data.rfind(b"\n")
+    if last_nl == -1:
+        return [], offset, last_assistant_text, last_assistant_stop_reason
+    consumed = data[: last_nl + 1]
+    new_offset = offset + len(consumed)
+    actions: list[_MirrorItem | _TerminalStatus] = []
+    encountered = set(seen)
+    for raw in consumed.split(b"\n"):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            event = json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            continue
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") == "user":
+            last_assistant_stop_reason = None
+        assistant_stop_reason = _assistant_stop_reason(event)
+        if assistant_stop_reason is not None:
+            last_assistant_stop_reason = assistant_stop_reason
+        item = _event_to_item(event, agent_name)
+        if item is not None and item.uuid not in encountered:
+            actions.append(item)
+            encountered.add(item.uuid)
+            last_assistant_text = _assistant_text_after_action(last_assistant_text, item)
+            continue
+        terminal = _event_to_terminal(event, last_assistant_text, last_assistant_stop_reason)
+        if terminal is not None and terminal.uuid not in encountered:
+            actions.append(terminal)
+            encountered.add(terminal.uuid)
+            last_assistant_text = ""
+            last_assistant_stop_reason = None
+    return actions, new_offset, last_assistant_text, last_assistant_stop_reason
+
+
+def _assistant_text_after_action(current: str, action: _MirrorItem | _TerminalStatus) -> str:
+    """Return the assistant buffer after one successfully delivered action."""
+    if isinstance(action, _TerminalStatus):
+        return ""
+    role = action.item_data.get("role")
+    if role == "user":
+        return ""
+    if role != "assistant":
+        return current
+    content = action.item_data.get("content")
+    if not isinstance(content, list) or not content or not isinstance(content[0], dict):
+        return current
+    text = content[0].get("text")
+    return text if isinstance(text, str) else current
+
+
 async def _post_conversation_item(
     client: httpx.AsyncClient, *, session_id: str, item: _MirrorItem
 ) -> None:
@@ -283,6 +451,47 @@ async def _post_conversation_item(
         },
     )
     resp.raise_for_status()
+
+
+async def _post_external_session_status(
+    client: httpx.AsyncClient, *, session_id: str, terminal: _TerminalStatus
+) -> None:
+    """POST one authoritative qwen terminal edge."""
+    data: dict[str, object] = {
+        "status": terminal.status,
+        "response_id": terminal.response_id,
+    }
+    if terminal.output is not None:
+        data["output"] = terminal.output
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={"type": "external_session_status", "data": data},
+    )
+    resp.raise_for_status()
+
+
+async def _deliver_forward_actions(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+    state: _ForwardState,
+    actions: list[_MirrorItem | _TerminalStatus],
+) -> None:
+    """Deliver actions in order and durably commit each successful POST."""
+    seen = _new_seen(state.seen_uuids)
+    for action in actions:
+        if isinstance(action, _MirrorItem):
+            await _post_conversation_item(client, session_id=session_id, item=action)
+        else:
+            await _post_external_session_status(client, session_id=session_id, terminal=action)
+        seen[action.uuid] = None
+        state.seen_uuids = list(seen)
+        state.last_assistant_text = _assistant_text_after_action(state.last_assistant_text, action)
+        # Keep the prior offset until every action from this read is delivered.
+        # On a later POST failure, retry re-reads the batch but skips each
+        # already-delivered uuid while retaining the assistant output.
+        _write_state(bridge_dir, state)
 
 
 async def forward_qwen_events_to_session(
@@ -314,27 +523,39 @@ async def forward_qwen_events_to_session(
     :returns: Never normally returns; cancel the task to stop it.
     """
     target = events_file or events_file_path(bridge_dir)
-    persisted = _read_state(bridge_dir)
-    offset = persisted.offset
-    seen = _new_seen(persisted.seen_uuids)
+    state = _read_state(bridge_dir)
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     from omnigent.cli_auth import open_server_client
 
     async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         while True:
             try:
-                items, new_offset = await asyncio.to_thread(
-                    _read_new_events, target, offset, seen, agent_name
+                (
+                    actions,
+                    new_offset,
+                    next_assistant_text,
+                    next_assistant_stop_reason,
+                ) = await asyncio.to_thread(
+                    _read_new_forward_events,
+                    target,
+                    state.offset,
+                    _new_seen(state.seen_uuids),
+                    agent_name,
+                    state.last_assistant_text,
+                    state.last_assistant_stop_reason,
                 )
-                for item in items:
-                    await _post_conversation_item(client, session_id=session_id, item=item)
-                    seen[item.uuid] = None
-                if new_offset != offset or items:
-                    offset = new_offset
-                    _write_state(
-                        bridge_dir,
-                        _ForwardState(offset=offset, seen_uuids=list(seen)),
-                    )
+                await _deliver_forward_actions(
+                    client,
+                    session_id=session_id,
+                    bridge_dir=bridge_dir,
+                    state=state,
+                    actions=actions,
+                )
+                if new_offset != state.offset or actions:
+                    state.offset = new_offset
+                    state.last_assistant_text = next_assistant_text
+                    state.last_assistant_stop_reason = next_assistant_stop_reason
+                    _write_state(bridge_dir, state)
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/omnigent/qwen_native_permissions.py
+++ b/omnigent/qwen_native_permissions.py
@@ -174,7 +174,7 @@ def _control_response_request_id(event: dict[str, object]) -> str | None:
 def _read_new_control_events(events_file: Path, offset: int) -> tuple[list[_ControlEvent], int]:
     """Read NDJSON lines past *offset*, returning control events + the new offset.
 
-    Mirrors :func:`omnigent.qwen_native_forwarder._read_new_events`: detects a
+    Mirrors :func:`omnigent.qwen_native_forwarder._read_new_forward_events`: detects a
     truncated/recreated file (``size < offset`` → rewind to 0), consumes only
     fully terminated lines, and leaves a trailing partial line for the next poll.
     Only control-plane events (``control_request`` / ``control_response``) are

--- a/tests/e2e/test_qwen_native_subagent_wake_e2e.py
+++ b/tests/e2e/test_qwen_native_subagent_wake_e2e.py
@@ -98,7 +98,14 @@ def _ambient_free_environ() -> dict[str, str]:
         k: v
         for k, v in os.environ.items()
         if not k.startswith(("OMNIGENT_RUNNER_", "OMNIGENT_HOST_"))
-        and k not in ("RUNNER_SERVER_URL", "OMNIGENT_REMOTE_AUTH_TOKEN")
+        and k
+        not in (
+            "RUNNER_SERVER_URL",
+            "OMNIGENT_REMOTE_AUTH_TOKEN",
+            # An inherited process-log path may point at another process's
+            # (possibly unwritable) log dir and crash the spawned runner.
+            "OMNIGENT_PROCESS_LOG_FILE",
+        )
     }
 
 

--- a/tests/e2e/test_qwen_native_subagent_wake_e2e.py
+++ b/tests/e2e/test_qwen_native_subagent_wake_e2e.py
@@ -1,0 +1,473 @@
+"""End-to-end: a qwen-native sub-agent's completed turn must wake its parent.
+
+A parent orchestrator dispatches a qwen-native sub-agent via
+``sys_session_send`` and goes idle. The child runs headlessly (the runner owns
+its tmux pane), finishes its turn, and its answer is persisted to the child
+transcript. The runner must then deliver the result to the parent's inbox and
+post the ``[System: ... waiting in inbox]`` wake notice so the idle parent
+takes a continuation turn and surfaces the result — the same contract the
+claude-/codex-/cursor-/kimi-native forwarders honor via an
+``external_session_status`` terminal edge.
+
+The reported bug: the qwen-native forwarder mirrors
+the child's transcript but never posts a terminal ``external_session_status``,
+so a *successful* qwen child finishes silently — the parent sits on
+"dispatched, waiting" forever and only a manual bump reveals the result. The
+failure edge is unaffected (a child that dies at launch DOES wake the parent),
+which this test exploits: it drives the SUCCESS path and asserts the wake.
+
+Requires a runnable ``qwen`` CLI (skipped otherwise). Point
+``OMNIGENT_QWEN_PATH`` at a raw qwen binary if the PATH one wraps/overrides
+``OPENAI_BASE_URL`` (the child must reach this test's mock LLM).
+
+Excluded from default ``pytest`` runs via ``--ignore=tests/e2e``. Invoke
+with::
+
+    pytest tests/e2e/test_qwen_native_subagent_wake_e2e.py -v --timeout=900
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import secrets
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tarfile
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml
+
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN, token_bound_runner_id
+from tests._helpers.compat import apply_runner_env, apply_server_env
+from tests.e2e.conftest import configure_mock_llm, reset_mock_llm
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The auto-wake notice is emitted ONLY by the runner's auto-wake path
+# (``_format_subagent_wake_notice``); the sys_read_inbox drain message does not
+# contain it, so its presence is an auto-wake-specific signal.
+_WAKE_NOTICE_SIGNATURE = "waiting in inbox"
+_CHILD_MARKER = "QWEN_SUBAGENT_DONE_MARKER"
+_CONTINUATION_MARKER = "CONTINUATION_MARKER"
+
+_PARENT_MODEL = "mock-qwen-wake-parent"
+# The qwen TUI reads its model from OPENAI_MODEL/QWEN_MODEL in the runner env;
+# this key routes the child's mock-LLM requests to its own queue.
+_CHILD_MODEL = "mock-qwen-wake-child"
+
+_HEALTH_TIMEOUT_S = 90.0
+# qwen boots a real TUI in tmux, then runs one mock-LLM turn.
+_CHILD_ANSWER_TIMEOUT_S = 300.0
+# Once the child's answer is in its transcript, the wake should follow almost
+# immediately (the forwarder tails the child's event file sub-second). A
+# generous window avoids flaking on a slow box while still failing decisively.
+_WAKE_TIMEOUT_S = 120.0
+_POLL_INTERVAL_S = 2.0
+
+_LOOPBACK_NO_PROXY = "localhost,127.0.0.1"
+
+pytestmark = [pytest.mark.timeout(900, method="signal")]
+
+
+def _qwen_cli() -> str | None:
+    """Resolve the qwen binary the runner will launch, or ``None`` if absent."""
+    override = os.environ.get("OMNIGENT_QWEN_PATH", "").strip()
+    if override:
+        return override if Path(override).exists() else None
+    return shutil.which("qwen")
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _ambient_free_environ() -> dict[str, str]:
+    """``os.environ`` minus ambient runner/host identity vars (hermetic stack)."""
+    return {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith(("OMNIGENT_RUNNER_", "OMNIGENT_HOST_"))
+        and k not in ("RUNNER_SERVER_URL", "OMNIGENT_REMOTE_AUTH_TOKEN")
+    }
+
+
+def _merged_no_proxy(env: dict[str, str]) -> str:
+    existing = env.get("NO_PROXY") or env.get("no_proxy") or ""
+    parts = [p for p in existing.split(",") if p]
+    for host in _LOOPBACK_NO_PROXY.split(","):
+        if host not in parts:
+            parts.append(host)
+    return ",".join(parts)
+
+
+# Proxy-blind client: CI forces an egress proxy via HTTP(S)_PROXY env vars
+# that must not intercept loopback requests to the spawned server.
+_client = httpx.Client(trust_env=False, timeout=30.0)
+
+
+@pytest.fixture
+def qwen_wake_rig(
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str, Path]]:
+    """Server + runner wired to the mock LLM, with qwen-native launchable.
+
+    The runner env carries ``OPENAI_BASE_URL`` → mock LLM and
+    ``OPENAI_MODEL``/``QWEN_MODEL`` → the child queue key, so the qwen TUI the
+    runner launches for the sub-agent completes its turn against the mock.
+    ``OMNIGENT_RUNNER_WORKSPACE`` is set because the runner-owned qwen terminal
+    requires a workspace to launch headlessly.
+
+    :returns: ``(base_url, runner_id, runner_log_path)``.
+    """
+    if _qwen_cli() is None:
+        pytest.skip("qwen CLI is required for the qwen-native sub-agent wake repro")
+
+    work = tmp_path_factory.mktemp("qwen_subagent_wake")
+    artifacts = work / "artifacts"
+    workspace = work / "ws"
+    home_dir = work / "home"
+    for path in (artifacts, workspace, home_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    binding_token = secrets.token_urlsafe(32)
+    runner_id = token_bound_runner_id(binding_token)
+
+    shared_env = _ambient_free_environ()
+    shared_env.update(
+        {
+            "OPENAI_API_KEY": "mock-key",
+            "OPENAI_BASE_URL": f"{mock_llm_server_url}/v1",
+        }
+    )
+    shared_env["NO_PROXY"] = _merged_no_proxy(shared_env)
+    shared_env["no_proxy"] = shared_env["NO_PROXY"]
+
+    server_env = {**shared_env, "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token}
+    apply_server_env(server_env, _REPO_ROOT)
+
+    runner_env = apply_runner_env(
+        {
+            **shared_env,
+            "OMNIGENT_RUNNER_ID": runner_id,
+            "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
+            "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
+            "RUNNER_SERVER_URL": base_url,
+            "OMNIGENT_RUNNER_WORKSPACE": str(workspace),
+            # HOME is redirected so an ambient ~/.qwen/settings.json can't
+            # override the env-configured mock auth/model (qwen prefers its
+            # user settings over env when both exist).
+            "HOME": str(home_dir),
+            # The qwen TUI the runner spawns inherits these; they pin its model
+            # to the child's mock queue.
+            "OPENAI_MODEL": _CHILD_MODEL,
+            "QWEN_MODEL": _CHILD_MODEL,
+            "QWEN_CODE_DISABLE_UPDATE_CHECK": "1",
+        }
+    )
+    qwen_path = _qwen_cli()
+    assert qwen_path is not None  # guarded by the skip above
+    runner_env["OMNIGENT_QWEN_PATH"] = qwen_path
+    # PYTHONPATH must also resolve the workspace SDKs (omnigent_client) for the
+    # runner's tunnel bootstrap; extend rather than replace what apply_server_env
+    # composed for the server.
+    sdk_path = str(_REPO_ROOT / "sdks" / "python-client")
+    existing_pp = runner_env.get("PYTHONPATH") or server_env.get("PYTHONPATH", "")
+    runner_env["PYTHONPATH"] = os.pathsep.join(
+        p for p in (str(_REPO_ROOT), sdk_path, existing_pp) if p
+    )
+
+    server_log = work / "server.log"
+    runner_log = work / "runner.log"
+    server_handle = server_log.open("w")
+    runner_handle = runner_log.open("w")
+    server_proc: subprocess.Popen[bytes] | None = None
+    runner_proc: subprocess.Popen[bytes] | None = None
+    try:
+        server_proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "omnigent.cli",
+                "server",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--database-uri",
+                f"sqlite:///{work}/test.db",
+                "--artifact-location",
+                str(artifacts),
+            ],
+            env=server_env,
+            stdout=server_handle,
+            stderr=subprocess.STDOUT,
+            cwd=str(_REPO_ROOT),
+        )
+        runner_proc = subprocess.Popen(
+            [sys.executable, "-m", "omnigent.runner._entry"],
+            env=runner_env,
+            stdout=runner_handle,
+            stderr=subprocess.STDOUT,
+            cwd=str(_REPO_ROOT),
+        )
+
+        deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+        online = False
+        while time.monotonic() < deadline:
+            if server_proc.poll() is not None or runner_proc.poll() is not None:
+                break
+            try:
+                if _client.get(f"{base_url}/health", timeout=2).status_code == 200:
+                    status = _client.get(f"{base_url}/v1/runners/{runner_id}/status", timeout=2)
+                    if status.status_code == 200 and status.json().get("online"):
+                        online = True
+                        break
+            except httpx.HTTPError:
+                pass
+            time.sleep(0.5)
+        if not online:
+            raise RuntimeError(
+                "qwen sub-agent wake rig did not come online within "
+                f"{_HEALTH_TIMEOUT_S:.0f}s.\nServer log:\n{server_log.read_text()[-3000:]}\n"
+                f"Runner log:\n{runner_log.read_text()[-3000:]}"
+            )
+        yield (base_url, runner_id, runner_log)
+    finally:
+        for proc in (runner_proc, server_proc):
+            if proc is not None and proc.poll() is None:
+                proc.send_signal(signal.SIGTERM)
+        for proc in (runner_proc, server_proc):
+            if proc is not None:
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=5)
+        server_handle.close()
+        runner_handle.close()
+
+
+def _parent_config() -> dict:
+    """Orchestrator spec (dict) with a qwen-native sub-agent tool."""
+    return {
+        "name": "qwen-wake-parent",
+        "prompt": (
+            "You are an orchestrator. Dispatch the qwencoder sub-agent via "
+            "sys_session_send when asked, and report its result when woken."
+        ),
+        "executor": {
+            "harness": "openai-agents",
+            "model": _PARENT_MODEL,
+            "auth": {
+                "type": "api_key",
+                "api_key": "mock-key",
+                # Placeholder; rewritten per-rig in _register_parent.
+                "base_url": "http://mock",
+            },
+        },
+        "tools": {
+            "qwencoder": {
+                "type": "agent",
+                "description": "Qwen coding sub-agent (qwen-native harness).",
+                "executor": {"harness": "qwen-native"},
+                "prompt": "You are a qwen coding sub-agent.",
+            }
+        },
+    }
+
+
+def _register_parent(base_url: str, mock_llm_server_url: str) -> str:
+    """Upload the orchestrator agent and return its durable agent id."""
+    config = _parent_config()
+    config["executor"]["auth"]["base_url"] = f"{mock_llm_server_url}/v1"
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = yaml.dump(config).encode()
+        info = tarfile.TarInfo("qwen-wake-parent.yaml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    resp = _client.post(
+        f"{base_url}/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", buf.getvalue(), "application/gzip")},
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+    if resp.status_code not in (200, 201, 409):
+        raise RuntimeError(f"agent register failed: {resp.status_code} {resp.text[:500]}")
+    listing = _client.get(
+        f"{base_url}/v1/sessions", params={"agent_name": "qwen-wake-parent", "limit": 1}
+    )
+    listing.raise_for_status()
+    return str(listing.json()["data"][0]["agent_id"])
+
+
+def _configure_queues(mock_llm_server_url: str) -> None:
+    """Queue the parent's dispatch → ack → continuation and the child's answer."""
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_1",
+                        "name": "sys_session_send",
+                        "arguments": json.dumps(
+                            {
+                                "agent": "qwencoder",
+                                "title": "qwen-task",
+                                "args": "Say the completion marker.",
+                            }
+                        ),
+                    }
+                ],
+            },
+            {"text": "Dispatched the qwen sub-agent, waiting for its result."},
+            # Only reachable via the auto-wake continuation turn.
+            {"text": f"{_CONTINUATION_MARKER}: the qwen sub-agent returned {_CHILD_MARKER}"},
+        ],
+        key=_PARENT_MODEL,
+    )
+    # qwen issues several chat-completions calls per turn (main + auxiliary
+    # extractors); keep the queue deep so every call sees the marker text.
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": f"Task complete. {_CHILD_MARKER}"}] * 8,
+        key=_CHILD_MODEL,
+    )
+
+
+def _session_items_blob(base_url: str, session_id: str) -> str:
+    resp = _client.get(f"{base_url}/v1/sessions/{session_id}")
+    resp.raise_for_status()
+    return json.dumps(resp.json().get("items", []))
+
+
+def _child_id_from_dispatch(base_url: str, session_id: str) -> str | None:
+    """Pull the child conversation id out of the sys_session_send tool output."""
+    resp = _client.get(f"{base_url}/v1/sessions/{session_id}")
+    resp.raise_for_status()
+    for item in resp.json().get("items", []):
+        data = item.get("data") or {}
+        output = data.get("output") or item.get("output") or ""
+        if isinstance(output, str) and "conversation_id" in output:
+            try:
+                return str(json.loads(output)["conversation_id"])
+            except (ValueError, KeyError):
+                continue
+    return None
+
+
+def test_qwen_native_subagent_completion_wakes_parent(
+    qwen_wake_rig: tuple[str, str, Path],
+    mock_llm_server_url: str,
+) -> None:
+    """A completed qwen-native sub-agent turn must auto-wake the idle parent.
+
+    Journey:
+    1. The user asks the orchestrator to dispatch its qwen-native sub-agent.
+    2. The dispatch turn ends; the child runs headlessly and finishes its turn
+       (its answer is persisted to the child transcript — observed here).
+    3. With NO further user input, the parent must receive the auto-wake
+       notice and take the continuation turn that surfaces the result.
+
+    While the bug is live, step 3 never happens for a SUCCESSFUL child (the
+    qwen forwarder posts no terminal ``external_session_status``), so the wake
+    assertion fails after proving the child had answered.
+    """
+    base_url, runner_id, runner_log = qwen_wake_rig
+    _configure_queues(mock_llm_server_url)
+
+    agent_id = _register_parent(base_url, mock_llm_server_url)
+    create = _client.post(
+        f"{base_url}/v1/sessions",
+        json={"agent_id": agent_id},
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+    create.raise_for_status()
+    session_id = str(create.json()["id"])
+    bind = _client.patch(f"{base_url}/v1/sessions/{session_id}", json={"runner_id": runner_id})
+    bind.raise_for_status()
+
+    send = _client.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={
+            "type": "message",
+            "data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Dispatch the qwencoder sub-agent."}],
+            },
+        },
+    )
+    assert send.status_code == 202, f"send rejected: {send.status_code} {send.text}"
+
+    # ── Step 2: wait for the child to be minted and ANSWER (success path). ──
+    child_id: str | None = None
+    child_answered = False
+    child_error: str | None = None
+    deadline = time.monotonic() + _CHILD_ANSWER_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if child_id is None:
+            child_id = _child_id_from_dispatch(base_url, session_id)
+        if child_id is not None:
+            child_snap = _client.get(f"{base_url}/v1/sessions/{child_id}")
+            if child_snap.status_code == 200:
+                child_body = child_snap.json()
+                child_blob = json.dumps(child_body.get("items", []))
+                if _CHILD_MARKER in child_blob:
+                    child_answered = True
+                    break
+                if child_body.get("status") == "failed":
+                    child_error = json.dumps(child_body.get("last_task_error"))
+                    break
+        time.sleep(_POLL_INTERVAL_S)
+
+    assert child_error is None, (
+        "qwen-native child failed to launch/run — this exercises the (working) "
+        f"failure-wake edge, not the bug under test: {child_error}\n"
+        f"runner log tail:\n{runner_log.read_text()[-2000:]}"
+    )
+    assert child_answered, (
+        f"qwen-native child (session {child_id}) never persisted its answer within "
+        f"{_CHILD_ANSWER_TIMEOUT_S:.0f}s — cannot reach the completion-wake edge.\n"
+        f"runner log tail:\n{runner_log.read_text()[-2000:]}"
+    )
+
+    # ── Step 3: the completion must wake the parent with NO further input. ──
+    wake_seen = False
+    continuation_seen = False
+    deadline = time.monotonic() + _WAKE_TIMEOUT_S
+    while time.monotonic() < deadline:
+        blob = _session_items_blob(base_url, session_id)
+        wake_seen = wake_seen or (_WAKE_NOTICE_SIGNATURE in blob)
+        continuation_seen = continuation_seen or (_CONTINUATION_MARKER in blob)
+        if wake_seen and continuation_seen:
+            break
+        time.sleep(_POLL_INTERVAL_S)
+
+    assert wake_seen, (
+        f"qwen-native sub-agent {child_id} completed its turn (its answer "
+        f"{_CHILD_MARKER!r} is persisted in the child transcript) but the parent "
+        f"session {session_id} never received the auto-wake notice "
+        f"({_WAKE_NOTICE_SIGNATURE!r}) within {_WAKE_TIMEOUT_S:.0f}s — the "
+        "completion never woke the parent orchestrator. "
+        "claude-/codex-native children wake the parent on the same journey."
+    )
+    assert continuation_seen, (
+        f"The wake notice arrived but the parent never took the continuation turn "
+        f"surfacing {_CONTINUATION_MARKER!r} in session {session_id}."
+    )

--- a/tests/test_qwen_native_forwarder.py
+++ b/tests/test_qwen_native_forwarder.py
@@ -39,7 +39,6 @@ from omnigent.qwen_native_forwarder import (
     _ForwardState,
     _new_seen,
     _read_new_compaction_statuses,
-    _read_new_events,
     _read_new_forward_events,
     _read_state,
     _write_state,
@@ -140,7 +139,7 @@ def test_could_not_load_marker_stripped() -> None:
 def test_read_new_events_incremental_and_partial_line(tmp_path: Path) -> None:
     f = tmp_path / "out.ndjson"
     f.write_bytes(_ev_bytes(_user_ev("u1", "q")))
-    items, off = _read_new_events(f, 0, set(), _AGENT)
+    items, off, _, _ = _read_new_forward_events(f, 0, set(), _AGENT, "")
     assert [i.uuid for i in items] == ["u1"]
     assert off == f.stat().st_size
 
@@ -151,7 +150,7 @@ def test_read_new_events_incremental_and_partial_line(tmp_path: Path) -> None:
         complete_size = f.stat().st_size
         fh.write(b'{"type":"assistant","uuid":"a2"')  # no newline yet
         fh.flush()
-    items, off2 = _read_new_events(f, off, {"u1"}, _AGENT)
+    items, off2, _, _ = _read_new_forward_events(f, off, {"u1"}, _AGENT, "")
     assert [i.uuid for i in items] == ["a1"]
     # Offset stops at the last newline — the partial line is not consumed.
     assert off2 == complete_size
@@ -161,20 +160,20 @@ def test_read_new_events_detects_truncation(tmp_path: Path) -> None:
     f = tmp_path / "out.ndjson"
     # A long first line so the stale offset exceeds the post-truncation size.
     f.write_bytes(_ev_bytes(_user_ev("u1", "first message, intentionally long " * 4)))
-    _, off = _read_new_events(f, 0, set(), _AGENT)
+    _, off, _, _ = _read_new_forward_events(f, 0, set(), _AGENT, "")
     assert off > 0
     # A relaunched terminal truncates + writes a shorter line; size < offset
     # must rewind so the fresh content is not skipped.
     f.write_bytes(_ev_bytes(_user_ev("u2", "fresh")))
     assert f.stat().st_size < off
-    items, _ = _read_new_events(f, off, set(), _AGENT)
+    items, _, _, _ = _read_new_forward_events(f, off, set(), _AGENT, "")
     assert [i.uuid for i in items] == ["u2"]
 
 
 def test_malformed_line_tolerated(tmp_path: Path) -> None:
     f = tmp_path / "out.ndjson"
     f.write_bytes(b"not json\n" + _ev_bytes(_user_ev("u1", "ok")))
-    items, _ = _read_new_events(f, 0, set(), _AGENT)
+    items, _, _, _ = _read_new_forward_events(f, 0, set(), _AGENT, "")
     assert [i.uuid for i in items] == ["u1"]
 
 

--- a/tests/test_qwen_native_forwarder.py
+++ b/tests/test_qwen_native_forwarder.py
@@ -2,7 +2,8 @@
 
 These cover the logic that diverges from goose-native: appending JSONL commands
 to qwen's ``--input-file`` and parsing its ``--json-file`` stream-json events.
-The event shapes are pinned to ``qwen`` v0.18.1 (see ``docs/QWEN_NATIVE_DESIGN.md``).
+The event shapes cover qwen v0.18.1 and v0.21.14 (see
+``docs/QWEN_NATIVE_DESIGN.md``).
 """
 
 from __future__ import annotations
@@ -39,6 +40,7 @@ from omnigent.qwen_native_forwarder import (
     _new_seen,
     _read_new_compaction_statuses,
     _read_new_events,
+    _read_new_forward_events,
     _read_state,
     _write_state,
     clear_qwen_bridge_state,
@@ -55,12 +57,16 @@ def _user_ev(uuid: str, text: str) -> dict:
     }
 
 
-def _asst_ev(uuid: str, content: list[dict]) -> dict:
+def _asst_ev(uuid: str, content: list[dict], stop_reason: str | None = None) -> dict:
     return {
         "type": "assistant",
         "uuid": uuid,
-        "message": {"role": "assistant", "content": content},
+        "message": {"role": "assistant", "content": content, "stop_reason": stop_reason},
     }
+
+
+def _message_stop_ev(uuid: str) -> dict:
+    return {"type": "stream_event", "uuid": uuid, "event": {"type": "message_stop"}}
 
 
 def _ev_bytes(obj: dict) -> bytes:
@@ -170,6 +176,218 @@ def test_malformed_line_tolerated(tmp_path: Path) -> None:
     f.write_bytes(b"not json\n" + _ev_bytes(_user_ev("u1", "ok")))
     items, _ = _read_new_events(f, 0, set(), _AGENT)
     assert [i.uuid for i in items] == ["u1"]
+
+
+def test_forward_events_preserve_item_then_terminal_output_order(tmp_path: Path) -> None:
+    """The structured result wakes only after its assistant item is available."""
+    events = tmp_path / "out.ndjson"
+    events.write_bytes(
+        _ev_bytes(_user_ev("u1", "question"))
+        + _ev_bytes(_asst_ev("a1", [{"type": "text", "text": "final answer"}]))
+        + _ev_bytes(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "uuid": "r1",
+            }
+        )
+    )
+
+    actions, offset, buffered, stop_reason = _read_new_forward_events(events, 0, set(), _AGENT, "")
+
+    assert [type(action) for action in actions] == [
+        fwd._MirrorItem,
+        fwd._MirrorItem,
+        fwd._TerminalStatus,
+    ]
+    terminal = actions[-1]
+    assert isinstance(terminal, fwd._TerminalStatus)
+    assert terminal.status == "idle"
+    assert terminal.output == "final answer"
+    assert offset == events.stat().st_size
+    assert buffered == ""
+    assert stop_reason is None
+
+
+def test_forward_events_terminal_without_pty_idle_and_failure(tmp_path: Path) -> None:
+    """Wire-protocol results terminate success and error turns without PTY edges."""
+    events = tmp_path / "out.ndjson"
+    events.write_bytes(
+        _ev_bytes(_asst_ev("a1", [{"type": "text", "text": "partial answer"}]))
+        + _ev_bytes(
+            {
+                "type": "result",
+                "subtype": "error_during_execution",
+                "is_error": True,
+                "result": "tool failed",
+                "uuid": "r1",
+            }
+        )
+    )
+
+    actions, _, _, _ = _read_new_forward_events(events, 0, set(), _AGENT, "")
+
+    terminal = actions[-1]
+    assert isinstance(terminal, fwd._TerminalStatus)
+    assert terminal.status == "failed"
+    assert terminal.output == "tool failed"
+
+
+def test_qwen_021_message_stop_completes_final_text_turn(tmp_path: Path) -> None:
+    """Qwen 0.21.14 uses message_stop instead of a top-level result record."""
+    events = tmp_path / "out.ndjson"
+    events.write_bytes(
+        _ev_bytes(_asst_ev("a1", [{"type": "text", "text": "final answer"}]))
+        + _ev_bytes(_message_stop_ev("stop-1"))
+    )
+
+    actions, _, buffered, stop_reason = _read_new_forward_events(events, 0, set(), _AGENT, "")
+
+    assert [type(action) for action in actions] == [
+        fwd._MirrorItem,
+        fwd._TerminalStatus,
+    ]
+    terminal = actions[-1]
+    assert isinstance(terminal, fwd._TerminalStatus)
+    assert terminal.status == "idle"
+    assert terminal.output == "final answer"
+    assert terminal.response_id == "qwen:stop-1"
+    assert buffered == ""
+    assert stop_reason is None
+
+
+def test_qwen_021_message_stop_skips_tool_use_and_completes_final_turn(tmp_path: Path) -> None:
+    """An intermediate tool-use message_stop must not terminalize the child."""
+    events = tmp_path / "out.ndjson"
+    events.write_bytes(
+        _ev_bytes(
+            _asst_ev(
+                "a-tool",
+                [{"type": "tool_use", "id": "call-1", "name": "read_file"}],
+                stop_reason="tool_use",
+            )
+        )
+        + _ev_bytes(_message_stop_ev("stop-tool"))
+        + _ev_bytes(
+            {
+                "type": "user",
+                "uuid": "tool-result",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "call-1"}],
+                },
+            }
+        )
+        + _ev_bytes(_asst_ev("a-final", [{"type": "text", "text": "done"}]))
+        + _ev_bytes(_message_stop_ev("stop-final"))
+    )
+
+    actions, _, _, _ = _read_new_forward_events(events, 0, set(), _AGENT, "")
+    terminals = [action for action in actions if isinstance(action, fwd._TerminalStatus)]
+
+    assert [terminal.uuid for terminal in terminals] == ["stop-final"]
+    assert terminals[0].output == "done"
+
+
+def test_qwen_021_message_stop_context_survives_poll_boundary(tmp_path: Path) -> None:
+    """Assistant and message_stop can land in separate forwarder polls."""
+    events = tmp_path / "out.ndjson"
+    events.write_bytes(_ev_bytes(_asst_ev("a1", [{"type": "text", "text": "answer"}])))
+
+    first, offset, buffered, stop_reason = _read_new_forward_events(events, 0, set(), _AGENT, "")
+    assert [action.uuid for action in first] == ["a1"]
+    assert buffered == "answer"
+    assert stop_reason == ""
+
+    with open(events, "ab") as fh:
+        fh.write(_ev_bytes(_message_stop_ev("stop-1")))
+
+    second, _, buffered, stop_reason = _read_new_forward_events(
+        events,
+        offset,
+        {"a1"},
+        _AGENT,
+        buffered,
+        stop_reason,
+    )
+    assert [action.uuid for action in second] == ["stop-1"]
+    terminal = second[0]
+    assert isinstance(terminal, fwd._TerminalStatus)
+    assert terminal.output == "answer"
+    assert buffered == ""
+    assert stop_reason is None
+
+
+def test_qwen_021_truncation_resets_persisted_assistant_context(tmp_path: Path) -> None:
+    """A fresh event file must not inherit assistant context from a prior process."""
+    state = _ForwardState(
+        offset=10_000,
+        seen_uuids=[],
+        last_assistant_text="stale answer",
+        last_assistant_stop_reason="tool_use",
+    )
+    assert _write_state(tmp_path, state) is True
+    persisted = _read_state(tmp_path)
+
+    events = tmp_path / "out.ndjson"
+    events.write_bytes(
+        _ev_bytes(_asst_ev("a-fresh", [{"type": "text", "text": "fresh answer"}]))
+        + _ev_bytes(_message_stop_ev("stop-fresh"))
+    )
+    assert events.stat().st_size < persisted.offset
+
+    actions, _, buffered, stop_reason = _read_new_forward_events(
+        events,
+        persisted.offset,
+        set(persisted.seen_uuids or []),
+        _AGENT,
+        persisted.last_assistant_text,
+        persisted.last_assistant_stop_reason,
+    )
+
+    terminals = [action for action in actions if isinstance(action, fwd._TerminalStatus)]
+    assert len(terminals) == 1
+    assert terminals[0].output == "fresh answer"
+    assert buffered == ""
+    assert stop_reason is None
+
+
+def test_result_is_error_is_authoritative_for_custom_success_subtype() -> None:
+    terminal = fwd._event_to_terminal(
+        {
+            "type": "result",
+            "subtype": "success_with_warnings",
+            "is_error": False,
+            "result": "completed with warnings",
+            "uuid": "r-warning",
+        },
+        "",
+    )
+
+    assert terminal is not None
+    assert terminal.status == "idle"
+    assert terminal.output == "completed with warnings"
+
+
+def test_forward_events_dedup_and_genuinely_empty_result(tmp_path: Path) -> None:
+    """Duplicate results stay suppressed and output-free success stays explicit."""
+    events = tmp_path / "out.ndjson"
+    result = {
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "uuid": "r-empty",
+    }
+    events.write_bytes(_ev_bytes(result) + _ev_bytes(result))
+
+    actions, _, _, _ = _read_new_forward_events(events, 0, {"r-empty"}, _AGENT, "")
+    assert actions == []
+
+    actions, _, _, _ = _read_new_forward_events(events, 0, set(), _AGENT, "")
+    terminals = [action for action in actions if isinstance(action, fwd._TerminalStatus)]
+    assert len(terminals) == 1
+    assert all(terminal.output is None for terminal in terminals)
 
 
 # --- Compaction mirror (chat-recording tail) -------------------------------
@@ -322,11 +540,18 @@ def test_bridge_submit_and_confirmation_append_jsonl(tmp_path: Path) -> None:
 
 
 def test_forward_state_roundtrip_and_clear(tmp_path: Path) -> None:
-    state = _ForwardState(offset=123, seen_uuids=["a", "b"])
+    state = _ForwardState(
+        offset=123,
+        seen_uuids=["a", "b"],
+        last_assistant_text="buffered answer",
+        last_assistant_stop_reason="tool_use",
+    )
     assert _write_state(tmp_path, state) is True
     loaded = _read_state(tmp_path)
     assert loaded.offset == 123
     assert loaded.seen_uuids == ["a", "b"]
+    assert loaded.last_assistant_text == "buffered answer"
+    assert loaded.last_assistant_stop_reason == "tool_use"
     # Clearing resets the cursor so a re-created terminal starts clean.
     clear_qwen_bridge_state(tmp_path)
     cleared = _read_state(tmp_path)
@@ -491,6 +716,91 @@ async def test_post_conversation_item_shape() -> None:
         "item_data": {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
         "response_id": "qwen:u1",
     }
+
+
+async def test_post_external_session_status_shape() -> None:
+    client = _RecordingClient()
+    terminal = fwd._TerminalStatus(
+        uuid="r1", status="idle", output="answer", response_id="qwen:r1"
+    )
+
+    await fwd._post_external_session_status(  # type: ignore[arg-type]
+        client, session_id="conv_1", terminal=terminal
+    )
+
+    _, body = client.posts[0]
+    assert body == {
+        "type": "external_session_status",
+        "data": {"status": "idle", "response_id": "qwen:r1", "output": "answer"},
+    }
+
+
+async def test_partial_batch_failure_retries_only_terminal_with_buffered_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    events = tmp_path / "out.ndjson"
+    events.write_bytes(
+        _ev_bytes(_asst_ev("a1", [{"type": "text", "text": "durable answer"}]))
+        + _ev_bytes(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "uuid": "r1",
+            }
+        )
+    )
+    state = _ForwardState(offset=0, seen_uuids=[], last_assistant_text="")
+    item_posts: list[str] = []
+    terminal_posts: list[str | None] = []
+
+    async def _post_item(_client: object, *, session_id: str, item: object) -> None:
+        item_posts.append(item.uuid)  # type: ignore[attr-defined]
+
+    async def _post_terminal(_client: object, *, session_id: str, terminal: object) -> None:
+        if not terminal_posts:
+            terminal_posts.append(None)
+            raise httpx.ConnectError("terminal unavailable")
+        terminal_posts.append(terminal.output)  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(fwd, "_post_conversation_item", _post_item)
+    monkeypatch.setattr(fwd, "_post_external_session_status", _post_terminal)
+    actions, _, _, _ = _read_new_forward_events(events, 0, set(), _AGENT, "")
+
+    with pytest.raises(httpx.ConnectError, match="terminal unavailable"):
+        await fwd._deliver_forward_actions(  # type: ignore[arg-type]
+            object(), session_id="conv", bridge_dir=tmp_path, state=state, actions=actions
+        )
+
+    persisted = _read_state(tmp_path)
+    assert persisted.offset == 0
+    assert persisted.seen_uuids == ["a1"]
+    assert persisted.last_assistant_text == "durable answer"
+    retry_actions, retry_offset, _, _ = _read_new_forward_events(
+        events,
+        persisted.offset,
+        set(persisted.seen_uuids or []),
+        _AGENT,
+        persisted.last_assistant_text,
+        persisted.last_assistant_stop_reason,
+    )
+    assert [action.uuid for action in retry_actions] == ["r1"]
+
+    await fwd._deliver_forward_actions(  # type: ignore[arg-type]
+        object(),
+        session_id="conv",
+        bridge_dir=tmp_path,
+        state=persisted,
+        actions=retry_actions,
+    )
+    persisted.offset = retry_offset
+    assert _write_state(tmp_path, persisted) is True
+
+    assert item_posts == ["a1"]
+    assert terminal_posts == [None, "durable answer"]
+    final = _read_state(tmp_path)
+    assert final.seen_uuids == ["a1", "r1"]
+    assert final.last_assistant_text == ""
 
 
 async def test_forward_loop_posts_new_events_and_persists(


### PR DESCRIPTION
## Related issue

Fixes #6050

## Summary

- Handle both qwen v0.18's top-level `result` boundary and qwen v0.21.14's nested `stream_event.message_stop` boundary.
- Suppress intermediate `message_stop` records after `stop_reason=tool_use`, persisting assistant stop state across polling boundaries until the real turn end.
- Post `external_session_status` as `idle` on success or `failed` otherwise, carrying qwen's final assistant text as parent-inbox output.
- Leave the generic runner parent-wake path unchanged.

ELI5: qwen saved its answer but never rang the parent's doorbell. Both old and current qwen versions now ring it at their respective real turn-end signals, without ringing early while a tool call is still running.

```text
qwen v0.18 result OR v0.21.14 final message_stop
        |
        v
qwen native forwarder
        |
        v
external_session_status (idle/failed + output)
        |
        v
existing runner parent-inbox wake
```

## Test Plan

- `UV_NO_SYNC=1 uv run pytest -q tests/test_qwen_native_forwarder.py` on a Linux-filesystem checkout — 45 passed.
- `pre-commit run --files omnigent/qwen_native_forwarder.py tests/test_qwen_native_forwarder.py` — passed.
- `SKIP=web-prettier,web-theme-palette-generation,web-oxlint,web-tsc,vscode-tsc pre-commit run --all-files` — all applicable repository hooks passed; frontend-only hooks were skipped because this backend-only diff changes no frontend files and the local Node build cannot run the repository's TypeScript-stripping hook.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — non-visual backend lifecycle fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression coverage exercises v0.18 success/failure `result` records, v0.21.14 final `message_stop`, suppression after `stop_reason=tool_use`, persisted stop state across polling boundaries, ordered delivery, deduplication, and retry behavior.

## Changelog

Qwen-native sub-agents now notify and return their final answer to the parent orchestrator when a turn finishes.