### PR TITLE
ci(security): skip scan + gate polling for trusted CI bots

### DIFF
--- a/.github/scripts/security-scan/should-scan.sh
+++ b/.github/scripts/security-scan/should-scan.sh
@@ -38,6 +38,9 @@
 #
 # Env in:  EVENT_NAME          (github.event_name)
 #          AUTHOR_ASSOCIATION  (github.event.pull_request.author_association)
+#          PR_AUTHOR           (github.event.pull_request.user.login; trusted-CI-bot
+#                               allowlist, checked without an API call so the gate
+#                               pollers short-circuit too)
 #          MAINTAINERS         (space-separated, from merge-ready/load-maintainers.sh;
 #                               optional -- used only to trust private-membership
 #                               maintainer AUTHORS, not for the label waiver)
@@ -102,6 +105,22 @@ author_is_maintainer() {
   done
   return 1
 }
+
+# Trusted CI bots (omni-resolve-agent, omnigent-ci) open SAME-REPO PRs from a
+# trusted internal pipeline via their GitHub App, and every such PR is still
+# gated by Maintainer Approval + human review before merge. The PR author login
+# is set by GitHub and is not settable from PR contents, and a fork PR's author
+# is never one of these bots. Checked from PR_AUTHOR with NO API call, so this
+# short-circuits the per-workflow gate pollers too (they pass no token) -- not
+# just the scan -- sparing the shared GITHUB_TOKEN budget their high PR volume
+# was exhausting. Add a login here only for a bot whose PRs are trusted to skip
+# the diff scan.
+TRUSTED_BOTS="omni-resolve-agent[bot] omnigent-ci[bot]"
+if [[ -n "${PR_AUTHOR:-}" ]]; then
+  for bot in $TRUSTED_BOTS; do
+    [[ "$PR_AUTHOR" == "$bot" ]] && { emit false "trusted CI bot ($PR_AUTHOR)"; exit 0; }
+  done
+fi
 
 case "${AUTHOR_ASSOCIATION:-}" in
   OWNER | MEMBER | COLLABORATOR)

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -46,6 +46,9 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          # Trusted-CI-bot allowlist in should-scan.sh; GitHub-set, not
+          # PR-controlled. Lets the gate skip polling for bot PRs with no token.
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           # Before the scanner lands on main the scripts are absent there --
           # proceed (fail-open) so the introducing PR is not bricked.

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -73,6 +73,8 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          # Trusted-CI-bot allowlist in should-scan.sh (GitHub-set, not PR-controlled).
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           # For the skip-security-scan label waiver + author check (read-only).
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Related issue

N/A — Test / CI change (no issue required per the PR template).

## Summary

Follow-up to #6046 — the `403: API rate limit exceeded for installation` cascade **still occurs** (confirmed after #6046 merged, on PRs #6048/#5917).

- **Confirmed root cause:** untrusted PRs run the full Security Scan **plus** get polled by ~8 per-workflow gates, all drawing on the shared per-repo `GITHUB_TOKEN` budget (1,000 req/hr). The **dominant driver is the resolve-agent**: its **~43 open same-repo PRs** are classified *untrusted* (`author_association: NONE`), so every push runs the scan and every gated workflow polls it. That drains the budget until the Scan's own `gh pr diff` 403s — which fails the scan and cascades to every gate.
- **Fix:** trust the internal CI bots (`omni-resolve-agent[bot]`, `omnigent-ci[bot]`) in `should-scan.sh` so their **same-repo** PRs skip the scan and the gate polling.

## Why this is safe

- The PR **author login is set by GitHub** and is **not settable from PR contents**; a **fork PR's author is never** one of these bots (forks come from the fork owner's account). So the allowlist can't be spoofed by an attacker.
- Every bot PR is **still gated by `Maintainer Approval` + human review** before merge — trusting it only skips the *diff scan*, not the merge gate.
- **Community/fork PRs are unaffected** — they still scan. Verified by running `should-scan.sh` directly:
  - `omni-resolve-agent[bot]` → `scan=false` (trusted CI bot)
  - `omnigent-ci[bot]` → `scan=false` (trusted CI bot)
  - a community author (`NONE`, no token) → **`scan=true`** (still scanned)
  - `MEMBER` → `scan=false` (unchanged)
- Checked from a new `PR_AUTHOR` env (`github.event.pull_request.user.login`) with **no API call**, so it also short-circuits the token-less **gate pollers** — the whole point (sparing the `GITHUB_TOKEN` budget), not just the scan.

## Test Plan

- `bash -n` + 4 direct `should-scan.sh` runs (above) confirm the decision matrix.
- YAML validated; pre-commit `check yaml syntax` + `no-hardcoded-models` pass.
- Post-merge: the resolve-agent's PRs should show the Security Scan `Trust gate` emitting `scan=false (trusted CI bot ...)`, no `Fetch PR diff`, and no gate polling — and the `403` rate should drop sharply.

## Demo

N/A — non-visual CI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Security-trust change to a shell gate; verified by running `should-scan.sh` across the bot / community / maintainer cases (results above). The trust decision keys only on the GitHub-set PR author login, which is not attacker-controllable.

This pull request and its description were written by Isaac.
