### PR TITLE
ci: move Backwards-Compat + Integration Tests to larger runners

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,13 +43,17 @@ jobs:
   # (see security-gate.yml); trusted authors / non-PR events pass instantly.
   gate:
     uses: ./.github/workflows/security-gate.yml
+    # Larger runner: keep the gate off the saturated standard pool so it can't
+    # throttle the integration jobs below it (matches ci/e2e/e2e-ui).
+    with:
+      runner: ubuntu-latest-m
 
   # Harness matrix (integration-matrix.sh). Fork PRs run by default; draft PRs
   # resolve to an empty matrix.
   setup:
     name: setup
     needs: gate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -76,7 +80,7 @@ jobs:
     # leg runs (and thus no skipped placeholder check). Fork PRs DO run (mock
     # LLM, no secrets) -- same as ci.yml.
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     # Per-leg ceiling; inner test step caps at 25 min, rest covers install +
     # junit upload. Legs run in parallel; longest gates wall-time.
     timeout-minutes: 30

--- a/.github/workflows/server-compat.yml
+++ b/.github/workflows/server-compat.yml
@@ -65,7 +65,7 @@ jobs:
   resolve-latest:
     name: Resolve latest stable tag
     # PRs: always. Schedule/dispatch: always.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     timeout-minutes: 5
     outputs:
       latest_tag: ${{ steps.tag.outputs.latest_tag }}
@@ -93,7 +93,7 @@ jobs:
   compat-smoke-config1:
     name: "Compat smoke – Config 1 (new server / old runner ${{ needs.resolve-latest.outputs.latest_tag }})"
     needs: resolve-latest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -110,7 +110,7 @@ jobs:
   compat-smoke-config2:
     name: "Compat smoke – Config 2 (new runner / old server ${{ needs.resolve-latest.outputs.latest_tag }})"
     needs: resolve-latest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -127,7 +127,7 @@ jobs:
   compat-smoke-ui-config-a:
     name: "Compat smoke – UI Config A (new SPA / old server ${{ needs.resolve-latest.outputs.latest_tag }})"
     needs: resolve-latest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     timeout-minutes: 25
     steps:
       - name: Checkout
@@ -144,7 +144,7 @@ jobs:
   compat-smoke-ui-config-b:
     name: "Compat smoke – UI Config B (old SPA ${{ needs.resolve-latest.outputs.latest_tag }} / new server)"
     needs: resolve-latest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     timeout-minutes: 25
     steps:
       - name: Checkout
@@ -168,7 +168,7 @@ jobs:
     # The full pairwise matrix is expensive — skip it on PR triggers (the
     # fast smoke jobs above cover the PR case).
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     timeout-minutes: 5
     outputs:
       e2e_matrix: ${{ steps.matrix.outputs.e2e_matrix }}
@@ -192,7 +192,7 @@ jobs:
   backcompat-e2e:
     name: Backcompat e2e (server ${{ matrix.server }} / runner ${{ matrix.runner }}, shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     # Job-level cap (composite run steps can't set timeout-minutes); mirrors
     # e2e.yml's ~30-min test budget + setup + up to two old-build installs.
     timeout-minutes: 45
@@ -231,7 +231,7 @@ jobs:
   backcompat-integration:
     name: Backcompat integration (server ${{ matrix.server }} / runner ${{ matrix.runner }}, ${{ matrix.harness }})
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -261,7 +261,7 @@ jobs:
   setup-ui:
     name: setup-ui
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     timeout-minutes: 5
     outputs:
       ui_matrix: ${{ steps.matrix.outputs.ui_matrix }}
@@ -282,7 +282,7 @@ jobs:
   backcompat-e2e-ui:
     name: "Backcompat e2e-ui (Config ${{ matrix.config }}: ${{ matrix.config == 'A' && matrix.server || matrix.ui }}, shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})"
     needs: setup-ui
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     timeout-minutes: 45
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Related issue

N/A — Test / CI change (no issue required per the PR template).

## Summary

The **standard** GitHub-hosted pool is pinned at its **Team-plan ceiling (~60 concurrent)**, so the heavy lanes still on it queue behind that cap — items observed **queued 8+ min**. After CI/E2E/E2E-UI moved to `ubuntu-latest-m`, the remaining heavy standard-pool lanes are **Backwards-Compat** and **Integration Tests** (both run the e2e/integration suites — same profile as the lanes already moved).

- **`server-compat.yml` (Backwards-Compat):** all jobs → `ubuntu-latest-m`. It's **not** a security-gate caller, so no gate change.
- **`integration.yml` (Integration Tests):** `setup` + `integration` → `ubuntu-latest-m`, and its `gate` now passes `runner: ubuntu-latest-m` so the gate isn't itself a standard-pool throttle for the jobs below it (matches ci/e2e/e2e-ui from #6027).

This is queue/burst relief on the shared org pool, consistent with the earlier migrations. Cost: these lanes now bill on `-m` (~$0.016/min); Backwards-Compat is paths-filtered + scheduled (not every PR), Integration runs per non-web PR.

## Test Plan

- YAML validated; pre-commit `check yaml syntax` + `no-hardcoded-models` pass.
- Job graph unchanged (only `runs-on` + the integration gate `runner` input). Verify on this PR's run that the jobs schedule on `ubuntu-latest-m`, and that standard-pool queue-wait for the remaining workflows eases.

## Demo

N/A — non-visual CI configuration change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Runner-label-only change across two workflows (plus one reusable-gate `runner` input). Same suites run unchanged; verification is that jobs schedule on the intended runner and stay green on this PR.

This pull request and its description were written by Isaac.
