### PR TITLE
ci: revert public CI lanes to free standard runners (Enterprise 500)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,20 +39,12 @@ jobs:
   # scan; trusted authors / non-PR events pass through.
   gate:
     uses: ./.github/workflows/security-gate.yml
-    # Larger runner: the gate blocks every job below it (`needs: gate`), so
-    # keeping it on the saturated standard pool throttled the whole workflow.
-    with:
-      runner: ubuntu-latest-m
 
   pytest:
     name: Pytest (${{ matrix.group }})
     needs: gate
     if: ${{ !github.event.pull_request.draft }}
-    # Larger runner: this 16-shard matrix is the biggest single consumer of
-    # standard-runner slots, so moving it to the separate larger-runner pool
-    # frees the saturated standard pool for every other workflow. The shards
-    # run `pytest -n 8`, which is CPU-parallel, so more vCPUs also cut wall time.
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -62,10 +62,6 @@ jobs:
   # (security-gate.yml); trusted authors and non-PR events pass instantly.
   gate:
     uses: ./.github/workflows/security-gate.yml
-    # Larger runner: the gate blocks setup, build-sidecar, and the shards below
-    # it, so keeping it on the saturated standard pool throttled the workflow.
-    with:
-      runner: ubuntu-latest-m
 
   # Compute the shard matrix once. A skipped run (draft / fork pull_request)
   # yields an EMPTY matrix -> zero shard jobs -> no skipped placeholder check.
@@ -73,9 +69,7 @@ jobs:
   setup:
     name: setup
     needs: gate
-    # Larger runner: setup + build-sidecar sit upstream of the e2e-ui shards, so
-    # on the saturated standard pool they throttled the shards before they began.
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -107,9 +101,7 @@ jobs:
     name: build codex-parity sidecar
     needs: setup
     if: needs.setup.outputs.matrix != '{"include":[]}'
-    # Larger runner: on the critical path to the e2e-ui shards (they `needs`
-    # this), and the cold Rust build is CPU-parallel, so more cores help too.
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -155,12 +147,7 @@ jobs:
     # them. Fork PRs DO run (mock LLM, no secrets) -- same as ci.yml.
     # `ready_for_review` re-fires when a draft is converted.
     needs: [setup, build-sidecar]
-    # Larger runner: this 4-shard suite is a top consumer of standard-runner
-    # slots, so moving it to the separate larger-runner pool cuts its queue
-    # wait and frees standard slots for other workflows. The 16 GB RAM also
-    # eases the native-CLI render-parity tests (browser + Claude/Codex CLIs +
-    # tmux panes + mock server) that press hard on the 7 GB standard runner.
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
       # One red shard shouldn't cancel siblings -- we want every shard's signal.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,19 +67,13 @@ jobs:
       (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
       github.event.label.name == 'skip-security-scan'
     uses: ./.github/workflows/security-gate.yml
-    # Larger runner: the gate blocks setup + the shards below it, so keeping it
-    # on the saturated standard pool throttled the whole workflow.
-    with:
-      runner: ubuntu-latest-m
 
   # Shard matrix (e2e-shard-matrix.sh, shared with e2e-ui.yml). Fork PRs run by
   # default; draft PRs resolve to an empty matrix.
   setup:
     name: setup
     needs: gate
-    # Larger runner: setup sits upstream of the e2e shards (which `needs: setup`),
-    # so on the saturated standard pool it throttled them before they could start.
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -109,10 +103,7 @@ jobs:
     # Draft PRs resolve to an EMPTY matrix in `setup`, so no shard runs for
     # them. Fork PRs DO run (mock LLM, no secrets) -- same as ci.yml.
     needs: setup
-    # Larger runner: this 4-shard suite is a top consumer of standard-runner
-    # slots; moving it to the separate larger-runner pool cuts its queue wait
-    # and frees standard slots for other workflows.
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     # Job-level cap (composite-action run steps can't set timeout-minutes):
     # ~30 min of tests + setup, replacing the old per-step 30-min backstop.
     timeout-minutes: 35

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,17 +43,13 @@ jobs:
   # (see security-gate.yml); trusted authors / non-PR events pass instantly.
   gate:
     uses: ./.github/workflows/security-gate.yml
-    # Larger runner: keep the gate off the saturated standard pool so it can't
-    # throttle the integration jobs below it (matches ci/e2e/e2e-ui).
-    with:
-      runner: ubuntu-latest-m
 
   # Harness matrix (integration-matrix.sh). Fork PRs run by default; draft PRs
   # resolve to an empty matrix.
   setup:
     name: setup
     needs: gate
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -80,7 +76,7 @@ jobs:
     # leg runs (and thus no skipped placeholder check). Fork PRs DO run (mock
     # LLM, no secrets) -- same as ci.yml.
     needs: setup
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     # Per-leg ceiling; inner test step caps at 25 min, rest covers install +
     # junit upload. Legs run in parallel; longest gates wall-time.
     timeout-minutes: 30

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,12 +40,7 @@ concurrency:
 jobs:
   scan:
     name: Security Scan
-    # Larger runner: the per-workflow security gates poll THIS check and cannot
-    # proceed until it completes, so when it queued behind a saturated standard
-    # pool it stalled every gated CI workflow. Its own pool lets it start
-    # promptly -- it's fast once running (p90 ~0.4 min), so this is
-    # pool-separation, not a compute upgrade.
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       # Route uv at PyPI for the semgrep fetch.

--- a/.github/workflows/server-compat.yml
+++ b/.github/workflows/server-compat.yml
@@ -65,7 +65,7 @@ jobs:
   resolve-latest:
     name: Resolve latest stable tag
     # PRs: always. Schedule/dispatch: always.
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       latest_tag: ${{ steps.tag.outputs.latest_tag }}
@@ -93,7 +93,7 @@ jobs:
   compat-smoke-config1:
     name: "Compat smoke – Config 1 (new server / old runner ${{ needs.resolve-latest.outputs.latest_tag }})"
     needs: resolve-latest
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -110,7 +110,7 @@ jobs:
   compat-smoke-config2:
     name: "Compat smoke – Config 2 (new runner / old server ${{ needs.resolve-latest.outputs.latest_tag }})"
     needs: resolve-latest
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -127,7 +127,7 @@ jobs:
   compat-smoke-ui-config-a:
     name: "Compat smoke – UI Config A (new SPA / old server ${{ needs.resolve-latest.outputs.latest_tag }})"
     needs: resolve-latest
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
       - name: Checkout
@@ -144,7 +144,7 @@ jobs:
   compat-smoke-ui-config-b:
     name: "Compat smoke – UI Config B (old SPA ${{ needs.resolve-latest.outputs.latest_tag }} / new server)"
     needs: resolve-latest
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
       - name: Checkout
@@ -168,7 +168,7 @@ jobs:
     # The full pairwise matrix is expensive — skip it on PR triggers (the
     # fast smoke jobs above cover the PR case).
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       e2e_matrix: ${{ steps.matrix.outputs.e2e_matrix }}
@@ -192,7 +192,7 @@ jobs:
   backcompat-e2e:
     name: Backcompat e2e (server ${{ matrix.server }} / runner ${{ matrix.runner }}, shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
     needs: setup
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     # Job-level cap (composite run steps can't set timeout-minutes); mirrors
     # e2e.yml's ~30-min test budget + setup + up to two old-build installs.
     timeout-minutes: 45
@@ -231,7 +231,7 @@ jobs:
   backcompat-integration:
     name: Backcompat integration (server ${{ matrix.server }} / runner ${{ matrix.runner }}, ${{ matrix.harness }})
     needs: setup
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -261,7 +261,7 @@ jobs:
   setup-ui:
     name: setup-ui
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       ui_matrix: ${{ steps.matrix.outputs.ui_matrix }}
@@ -282,7 +282,7 @@ jobs:
   backcompat-e2e-ui:
     name: "Backcompat e2e-ui (Config ${{ matrix.config }}: ${{ matrix.config == 'A' && matrix.server || matrix.ui }}, shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})"
     needs: setup-ui
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Related issue

N/A — Test / CI change (no issue required per the PR template).

## Summary

Now that we're on **GitHub Enterprise**, standard-runner concurrency is **500** (up from Team's 60) and standard runners are **free for public repos**. The reason we moved these lanes to the paid `ubuntu-latest-m` pool — escaping the 60 cap — no longer applies: 500 comfortably absorbs the ~130 peak, **for free**.

- Reverts `runs-on` → `ubuntu-latest` across the public workflows: **ci, e2e, e2e-ui, security-scan, server-compat, integration**.
- Drops the gate `runner: ubuntu-latest-m` inputs so the security gate runs on standard again.
- **Kept intact** (independently valuable): the gate-poll reduction (#6046), the trusted-CI-bot scan/poll skip (#6053 — `should-scan.sh` + the `security-gate` `runner` input remains as a knob), Merge Ready re-eval (#6049), and the Sync PR Priority trigger trim (#6019).
- **Unaffected:** the private `omnigent-internal` repro/resolve agent lane (`omnigent-resolvers`) — that's paid either way and stays isolated.

Drops the **`Actions Linux 4-core` bill** for the public repo (~$4K/mo at the observed rate). `-m` can be re-added per lane later only where 4-core wall-time speed specifically earns the cost.

## Test Plan

- YAML validated; pre-commit `check yaml syntax` + `no-hardcoded-models` pass. `security-gate.yml` intentionally unchanged.
- **After merge, confirm the 500 concurrency holds under load** — watch that standard-pool queue-wait does *not* regress toward the old 40-min tails. If for any reason the free pool didn't rise to 500, re-adding `-m` is a one-line-per-lane re-revert.

## Demo

N/A — non-visual CI configuration change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Runner-label-only revert across six workflows; same suites run unchanged. Verification is that jobs schedule on `ubuntu-latest` and standard-pool queue-wait stays low under Enterprise's 500 ceiling.

This pull request and its description were written by Isaac.
