### PR TITLE
perf(runner): keep tool dispatch out of the runner import graph

### DIFF
--- a/omnigent/runner/proxy_mcp_manager.py
+++ b/omnigent/runner/proxy_mcp_manager.py
@@ -34,7 +34,7 @@ import httpx
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.runner import pending_approvals
 from omnigent.runner.mcp_manager import McpSchemasResult
-from omnigent.runner.tool_dispatch import MCP_PROXY_CALL_TIMEOUT_S
+from omnigent.runner.tool_timeouts import MCP_PROXY_CALL_TIMEOUT_S
 from omnigent.spec.types import AgentSpec
 
 _logger = logging.getLogger(__name__)

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -60,6 +60,11 @@ from omnigent.model_override import (
     validate_model_override,
 )
 from omnigent.native_coding_agents import public_agent_name
+from omnigent.runner.tool_timeouts import (  # noqa: F401  (re-exported)
+    MCP_PROXY_CALL_TIMEOUT_S,
+    MCP_PROXY_FORWARD_TIMEOUT_S,
+    RUNNER_EXECUTION_TIMEOUT_S as _RUNNER_EXECUTION_TIMEOUT_S,
+)
 from omnigent.runtime import pending_elicitations
 from omnigent.session_lifecycle import (
     CLOSED_LABEL_KEY,
@@ -167,7 +172,6 @@ def _string_mapping(value: object) -> dict[str, str] | None:
 
 _INBOX_OUTPUT_MAX_CHARS = 12000
 _OS_ENV_SHELL_DEFAULT_TIMEOUT_S = 120.0
-_RUNNER_EXECUTION_TIMEOUT_S = 7200.0
 _SUBAGENT_POLICY_STATUSES = frozenset({"completed", "failed"})
 _SUBAGENT_INBOX_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
 _SUBAGENT_POLICY_FAILURE_OUTPUT = "[Result suppressed by policy: policy evaluation failed]"
@@ -181,14 +185,6 @@ _SESSION_WRAPPER_LABEL_KEY = "omnigent.wrapper"
 # still fails out promptly. Guarded by tests/test_ask_timeout_infinite.py.
 _ASK_GATE_DELIVERY_READ_TIMEOUT_S: float = 86400.0
 _ASK_GATE_DELIVERY_TIMEOUT = httpx.Timeout(_ASK_GATE_DELIVERY_READ_TIMEOUT_S, connect=30.0)
-
-# Read timeouts for the two MCP-proxy hops that carry a tool call back to the
-# runner (runner → Omnigent server → runner). ``sys_os_shell`` accepts caller-provided
-# timeouts, so these must sit above the runner's execution timeout rather than
-# only above the 120-second shell default. Keep the outer hop larger so the
-# AP→runner leg fails first with the more specific error when the proxy wedges.
-MCP_PROXY_FORWARD_TIMEOUT_S = _RUNNER_EXECUTION_TIMEOUT_S + 30.0
-MCP_PROXY_CALL_TIMEOUT_S = _RUNNER_EXECUTION_TIMEOUT_S + 60.0
 
 
 @dataclass(frozen=True)

--- a/omnigent/runner/tool_timeouts.py
+++ b/omnigent/runner/tool_timeouts.py
@@ -1,0 +1,26 @@
+"""Timeout constants shared by runner tool dispatch and the MCP proxy.
+
+A dependency-free leaf module so a caller that only needs one of these
+numbers does not pull ``omnigent.runner.tool_dispatch`` — and the
+``omnigent.tools`` / ``omnigent_client`` graph behind it — into its import
+graph. ``runner/proxy_mcp_manager.py`` is imported eagerly by
+``runner/app.py``, so that cost would land on every runner start and on the
+runner zygote's pre-import set.
+
+``tool_dispatch`` re-exports these names, so existing imports from there
+keep resolving.
+"""
+
+from __future__ import annotations
+
+# Wall-clock budget the runner allows a single agent execution.
+RUNNER_EXECUTION_TIMEOUT_S = 7200.0
+
+# Read timeouts for the two MCP-proxy hops that carry a tool call back to the
+# runner (runner → Omnigent server → runner). ``sys_os_shell`` accepts
+# caller-provided timeouts, so these must sit above the runner's execution
+# timeout rather than only above the 120-second shell default. Keep the outer
+# hop larger so the AP→runner leg fails first with the more specific error when
+# the proxy wedges.
+MCP_PROXY_FORWARD_TIMEOUT_S = RUNNER_EXECUTION_TIMEOUT_S + 30.0
+MCP_PROXY_CALL_TIMEOUT_S = RUNNER_EXECUTION_TIMEOUT_S + 60.0

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -9067,7 +9067,7 @@ async def _handle_mcp_tools_call(
     if runner_client is None:
         return _mcp_error_response(rpc_id, -32000, f"No runner bound for session {session_id!r}")
     try:
-        from omnigent.runner.tool_dispatch import MCP_PROXY_FORWARD_TIMEOUT_S
+        from omnigent.runner.tool_timeouts import MCP_PROXY_FORWARD_TIMEOUT_S
 
         exec_resp = await runner_client.post(
             f"/v1/sessions/{session_id}/mcp/execute",

--- a/tests/runner/test_runner_import_graph.py
+++ b/tests/runner/test_runner_import_graph.py
@@ -1,0 +1,132 @@
+"""Import-graph guards for the runner: tool dispatch stays out of it.
+
+``runner/tool_dispatch.py`` costs ~220ms to import — it reaches
+``omnigent.tools`` -> ``omnigent.tools.local`` -> ``omnigent_client`` — and the
+runner only needs it once a turn actually dispatches a tool. It used to arrive
+unconditionally anyway: ``runner/proxy_mcp_manager.py`` imported one float from
+it (``MCP_PROXY_CALL_TIMEOUT_S``) and ``runner/app.py`` imports
+``proxy_mcp_manager`` eagerly. That put it on the cold-zygote start that
+``POST /v1/sessions`` awaits, and on the whole per-session import cost of any
+runner the zygote did not fork. The constants now live in the leaf module
+``runner/tool_timeouts.py``.
+
+Every assertion here runs in a fresh subprocess, the same way
+``tests/runner/test_identity.py`` guards ``runner.identity`` against FastAPI:
+the shared pytest session has long since imported ``tool_dispatch`` for the
+dispatch tests themselves, so only a clean interpreter can tell whether the
+runner graph pulls it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import omnigent
+
+_OMNIGENT_ROOT = str(Path(omnigent.__file__).resolve().parent)
+
+# Reports the loaded tree plus the modules the dispatch graph would bring in.
+# The tree line is checked against this process's own ``omnigent``, so a probe
+# that resolved a different checkout fails loudly instead of silently
+# "passing".
+_PREAMBLE = """
+import sys
+
+import omnigent
+print("TREE", omnigent.__file__)
+
+
+def dispatch_loaded():
+    # ``omnigent.tools`` itself resolves its submodules lazily (PEP 562), so
+    # only the heavy ones below matter.
+    roots = (
+        "omnigent.runner.tool_dispatch",
+        "omnigent.tools.manager",
+        "omnigent.tools.local",
+        "omnigent_client",
+    )
+    return sorted(
+        m for m in sys.modules if any(m == r or m.startswith(r + ".") for r in roots)
+    )
+"""
+
+
+def _probe(body: str, timeout: float = 300.0) -> list[str]:
+    """Run *body* in a fresh interpreter that resolves this checkout.
+
+    :param body: Probe source appended to the shared preamble.
+    :param timeout: Seconds to allow the probe.
+    :returns: The probe's stdout lines.
+    """
+    # Hand the child the same import roots as this process so it resolves
+    # ``omnigent`` to the code under test (worktree or installed package) — a
+    # bare ``-c`` subprocess otherwise misses pytest's rootdir sys.path entries.
+    child_env = {**os.environ, "PYTHONPATH": os.pathsep.join(p for p in sys.path if p)}
+    result = subprocess.run(
+        [sys.executable, "-c", _PREAMBLE + body],
+        env=child_env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    assert result.returncode == 0, f"probe failed:\n{result.stdout}\n{result.stderr}"
+    lines = result.stdout.strip().splitlines()
+    tree = next(line for line in lines if line.startswith("TREE "))
+    assert tree.removeprefix("TREE ").startswith(_OMNIGENT_ROOT), (
+        f"probe resolved a different omnigent than the code under test: {tree}"
+    )
+    return lines
+
+
+def test_runner_app_import_does_not_pull_tool_dispatch() -> None:
+    """``omnigent.runner.app`` must import with no dispatch graph resident."""
+    lines = _probe(
+        """
+import omnigent.runner.app  # noqa: F401
+print("DISPATCH", dispatch_loaded())
+"""
+    )
+    assert "DISPATCH []" in lines, (
+        f"omnigent.runner.app pulled tool_dispatch into its import graph: {lines}"
+    )
+
+
+def test_zygote_pre_import_excludes_tool_dispatch() -> None:
+    """The zygote's boot graph skips dispatch, so forked runners start lighter.
+
+    Covers the wider graph the zygote imports (``_entry`` and the native
+    harness modules as well as ``app``): a deferral made only in ``app.py``
+    would be silently undone by any of the others importing dispatch eagerly.
+    """
+    lines = _probe(
+        """
+from omnigent.runner._zygote import _import_runner_graph
+
+_import_runner_graph()
+print("DISPATCH", dispatch_loaded())
+"""
+    )
+    assert "DISPATCH []" in lines, f"the zygote pre-imported tool_dispatch: {lines}"
+
+
+def test_proxy_mcp_manager_import_does_not_pull_tool_dispatch() -> None:
+    """The proxy manager needs one timeout constant, not the dispatch module."""
+    lines = _probe(
+        """
+from omnigent.runner.proxy_mcp_manager import ProxyMcpManager  # noqa: F401
+print("DISPATCH", dispatch_loaded())
+"""
+    )
+    assert "DISPATCH []" in lines, f"proxy_mcp_manager pulled tool_dispatch: {lines}"
+
+
+def test_tool_dispatch_still_re_exports_the_timeout_constants() -> None:
+    """Moving the constants must not break callers importing them from before."""
+    from omnigent.runner import tool_dispatch, tool_timeouts
+
+    assert tool_dispatch.MCP_PROXY_CALL_TIMEOUT_S == tool_timeouts.MCP_PROXY_CALL_TIMEOUT_S
+    assert tool_dispatch.MCP_PROXY_FORWARD_TIMEOUT_S == tool_timeouts.MCP_PROXY_FORWARD_TIMEOUT_S
+    assert tool_dispatch._RUNNER_EXECUTION_TIMEOUT_S == tool_timeouts.RUNNER_EXECUTION_TIMEOUT_S


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Importing `omnigent.runner.app` pulled `runner/tool_dispatch.py` — ~220ms, mostly
`omnigent.tools` -> `omnigent.tools.local` -> `omnigent_client` (~179ms) — in order to read a
single float. `runner/proxy_mcp_manager.py` imported `MCP_PROXY_CALL_TIMEOUT_S` from it at module
scope and used it at exactly one call site, and `runner/app.py` imports `proxy_mcp_manager`
eagerly. The runner only needs dispatch once a turn actually dispatches a tool, so the cost was
unconditional: it sat on the cold-zygote start the server awaits inside `POST /v1/sessions`, on the
zygote's pre-import set, and on the whole per-session import cost of any runner the zygote did not
fork.

- The constant is derived (`_RUNNER_EXECUTION_TIMEOUT_S + 60.0`), so the base moves with it: all
  three timeouts now live in the dependency-free leaf module `runner/tool_timeouts.py`, which
  `tool_dispatch` re-exports so existing imports from there keep resolving (no public API change).
- The server's MCP forward hop takes `MCP_PROXY_FORWARD_TIMEOUT_S` from the leaf module too, rather
  than importing the whole dispatch module inside a request.
- Follow-up to the MCP-deferral work on the same import graph
  (`perf/runner-defer-mcp-imports`, "keep the MCP SDK out of the runner import graph"). The two
  **stack**: that PR removed the `mcp` SDK (~300ms) from the graph, this one removes the
  `tool_dispatch` / `omnigent_client` branch (~150ms measured). They touch different edges
  (`proxy_mcp_manager` -> `mcp_manager` vs `proxy_mcp_manager` -> `tool_dispatch`) and both add
  guards to `tests/runner/test_runner_import_graph.py`, which will need a trivial merge.

```
before:  runner/app.py ─┬─> proxy_mcp_manager ──> tool_dispatch ──> omnigent.tools.manager
                        │        (one float:            220ms          -> omnigent.tools.local
                        │     MCP_PROXY_CALL_TIMEOUT_S)                -> omnigent_client (179ms)
after:   runner/app.py ─┴─> proxy_mcp_manager ──> tool_timeouts   (leaf, no imports)
                                 tool_dispatch is imported only when a tool is dispatched
```

## Test Plan

Targeted suites, all green (`python -m pytest -p no:randomly`):

```
tests/runner/test_runner_import_graph.py      (new)
tests/runner/test_proxy_mcp_manager.py        (pins the constant is still used as the read timeout)
tests/test_ask_timeout.py                     (other tool_dispatch timeout constants)
tests/runner/test_tool_dispatch_timer.py
tests/runner/test_policy_tool_dispatch.py
tests/server/integration/test_mcp_proxy.py
=> 43 passed
```

New regression guard `tests/runner/test_runner_import_graph.py` (fresh-subprocess probes, the
`tests/runner/test_identity.py` idiom — each probe re-checks it resolved the tree under test):

- `import omnigent.runner.app` leaves `tool_dispatch` / `omnigent.tools.manager` /
  `omnigent.tools.local` / `omnigent_client` out of `sys.modules`
- importing `proxy_mcp_manager` alone does the same
- the zygote's whole boot graph (`_import_runner_graph()`, i.e. `_entry` + `app` + `native` + the
  harness runner) does the same — a deferral made only in `app.py` would otherwise be silently
  undone by another pre-imported module reaching dispatch, which is exactly the trap the MCP PR hit
- `tool_dispatch` still re-exports the three constants with identical values

Prove-it-fails: with only the `omnigent/` changes reverted, the three import probes fail
(`DISPATCH ['omnigent.runner.tool_dispatch', 'omnigent.tools.local', ...]`) and the re-export test
still passes.

Also verified by hand that nothing else depends on the constants living in `tool_dispatch`: the only
other references are `tests/runner/test_proxy_mcp_manager.py` (via the re-export, untouched) and the
server's lazy import, which this PR repoints.

`pre-commit run --files <changed files>`: ruff format / ruff check / secret scan / the repo's
custom hooks all pass. `pyrefly` reports 99 pre-existing `missing-import` errors
(`omnigent_client.*`, `opentelemetry.*`) in a worktree without its own venv — byte-identical count
with this change reverted, and none of them in the changed files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Measured on one tree (`python -X importtime -c "import omnigent.runner.app"`), three interleaved
before/after blocks of three runs each so box load (32 cores, load average 4-6, several concurrent
agents) hits both arms equally. "before" = only the `omnigent/` files reverted:

| | `import omnigent.runner.app` | modules |
|---|---|---|
| before | 1230, 1253, 1262, 1263, 1286, 1301, 1373 ms (median 1262) | 1029 |
| after | 1099, 1102, 1104, 1105, 1110, 1112, 1118, 1153 ms (median 1108) | 989 |

~150ms off a 1.26s graph (~12%). The zygote's full boot graph (`_import_runner_graph()`) goes
1049 -> 1009 modules, with `tool_dispatch`, `omnigent.tools.manager`, `omnigent.tools.local` and
`omnigent_client` all absent afterwards.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the import measurement above: repeated `-X importtime` runs and
`sys.modules` inspection on the same worktree, alternating the `omnigent/` diff in and out, plus a
direct trace of which module first imports `tool_dispatch` during `import omnigent.runner.app`
(it was `proxy_mcp_manager`, and after the change nothing does). Behaviour coverage is unchanged:
the constants keep their values, `ProxyMcpManager` still passes `MCP_PROXY_CALL_TIMEOUT_S` as its
read timeout (pinned by the existing `tests/runner/test_proxy_mcp_manager.py` assertions, which
still import it from `tool_dispatch` and therefore exercise the re-export), and the server's MCP
forward hop keeps the same timeout value.
