### PR TITLE
Set repro and resolve agents to xhigh effort

### DIFF
--- a/dev/repro-agent/config.yaml
+++ b/dev/repro-agent/config.yaml
@@ -52,6 +52,7 @@ description: >-
 executor:
   type: omnigent
   context_window: 1000000
+  reasoning_effort: xhigh
   config:
     harness: claude-sdk
 

--- a/dev/resolve-agent/config.yaml
+++ b/dev/resolve-agent/config.yaml
@@ -63,6 +63,7 @@ description: >-
 executor:
   type: omnigent
   context_window: 1000000
+  reasoning_effort: xhigh
   config:
     harness: claude-sdk
 


### PR DESCRIPTION
## Summary
- configure the repro agent to request `xhigh` Claude reasoning effort
- configure the resolve agent to request `xhigh` Claude reasoning effort
- retain automatic adaptive thinking for Databricks Fable models

## Validation
- loaded both agent bundles with `omnigent.spec.load` and verified `reasoning_effort == "xhigh"`