### PR TITLE
perf(runner): stop re-reading the bundle and history on session start

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -951,6 +951,21 @@ def _response_body_preview(resp: object, *, limit: int = 500) -> str:
     return ""
 
 
+@dataclasses.dataclass(frozen=True)
+class _LoadedHistory:
+    """One history read, with enough detail to tell empty from unreadable.
+
+    :param items: The converted history items, possibly partial when a
+        later page failed.
+    :param complete: ``True`` when every page read returned 200. ``False``
+        means the server was unreachable or refused a page, so an empty
+        ``items`` says nothing about the conversation.
+    """
+
+    items: list[_JsonObject]
+    complete: bool
+
+
 @dataclasses.dataclass
 @dataclasses.dataclass(frozen=True)
 class _SessionSnapshot:
@@ -2380,6 +2395,32 @@ def create_runner_app(
         str, asyncio.Task[ClaudeNativeUcodeConfig | None]
     ] = {}
 
+    def _session_spec_entry_for(
+        session_id: str,
+        agent_id: str | None,
+        sub_agent_name: str | None,
+    ) -> _SpecEntry | None:
+        """The session's cached bundle, when it is the one the caller wants.
+
+        Session init resolves the bundle once and caches the entry, already
+        swapped to the sub-agent's own spec; later readers in the same session
+        reuse it instead of re-fetching ``agent/contents``. Both identity
+        checks matter: a request naming a different agent, or a different
+        sub-agent than the cached entry was resolved for, still goes to the
+        resolver. An agent switch drops the cache outright.
+
+        :param session_id: Session/conversation identifier.
+        :param agent_id: Agent id the caller wants the spec for.
+        :param sub_agent_name: Sub-agent the caller wants the spec for, or
+            ``None`` for a top-level session.
+        :returns: The cached entry, or ``None`` when there is nothing to reuse.
+        """
+        if agent_id is None or _session_agent_ids.get(session_id) != agent_id:
+            return None
+        if _session_sub_agent_names.get(session_id) != sub_agent_name:
+            return None
+        return _session_spec_cache.get(session_id)
+
     async def _resolve_session_claude_launch_config(
         session_id: str,
     ) -> ClaudeNativeUcodeConfig | None:
@@ -3118,10 +3159,17 @@ def create_runner_app(
         sub_agent_name = body.sub_agent_name or await _recover_sub_agent_name(conversation_id)
         resolver_agent_id = body.agent_id or _session_agent_ids.get(conversation_id)
         resolver_cwd = await _session_runtime_cwd(conversation_id)
+        # The title request arrives right after session init, which already
+        # resolved (and cached) this session's bundle. Reuse that entry so the
+        # title does not re-fetch agent/contents for a spec that cannot have
+        # changed while the session stays on the same agent — an agent switch
+        # drops the cache, and the resolver still runs then.
+        cached_entry = _session_spec_entry_for(conversation_id, resolver_agent_id, sub_agent_name)
         try:
             effective_harness, spawn_env = await _resolve_harness_config(
                 agent_id=resolver_agent_id,
                 spec_resolver=spec_resolver,
+                resolved_entry=cached_entry,
                 session_id=conversation_id,
                 model_override=body.model_override,
                 harness_override=body.harness_override,
@@ -3136,6 +3184,7 @@ def create_runner_app(
                 resolved_harness, spawn_env = await _resolve_harness_config(
                     agent_id=resolver_agent_id,
                     spec_resolver=spec_resolver,
+                    resolved_entry=cached_entry,
                     session_id=conversation_id,
                     model_override=body.model_override,
                     harness_override=resolver_harness,
@@ -3680,9 +3729,16 @@ def create_runner_app(
             await _seed_last_server_item_id(session_id)
             history = []
         else:
-            history = await _load_history_as_input(session_id)
+            _loaded = await _load_history_pages(session_id)
+            history = _loaded.items
+            # Memoize a confirmed-empty history too. The first forwarded
+            # message reloads the items page whenever this map has no entry
+            # for the session, so leaving a fresh session out costs a second
+            # read of the page init just fetched. A read that failed
+            # empty-handed stays out so that path still retries it.
+            if _loaded.complete or history:
+                _session_histories[session_id] = history
         if history:
-            _session_histories[session_id] = history
             last = history[-1]
             last_type = last.get("type")
             last_role = last.get("role")
@@ -4023,6 +4079,28 @@ def create_runner_app(
         session_id: str,
         drop_item_id: str | None = None,
     ) -> list[_JsonObject]:
+        """Converted history for *session_id*, dropping *drop_item_id*.
+
+        :param session_id: Session/conversation identifier.
+        :param drop_item_id: Persisted item id to leave out, e.g. the
+            message the caller is about to append itself.
+        :returns: The converted history items.
+        """
+        return (await _load_history_pages(session_id, drop_item_id)).items
+
+    async def _load_history_pages(
+        session_id: str,
+        drop_item_id: str | None = None,
+    ) -> _LoadedHistory:
+        """Page the session's items and report whether the read completed.
+
+        :param session_id: Session/conversation identifier.
+        :param drop_item_id: Persisted item id to leave out.
+        :returns: The converted history plus a ``complete`` flag that is
+            ``False`` when a page read failed, so callers can tell an
+            empty conversation apart from an unreadable one.
+        """
+        complete = True
         all_items: list[_JsonObject] = []
         after_cursor: str | None = None
         while True:
@@ -4045,6 +4123,7 @@ def create_runner_app(
                         session_id,
                         extra={"session_id": session_id},
                     )
+                    complete = False
                     break
             except httpx.HTTPError:
                 _logger.warning(
@@ -4053,6 +4132,7 @@ def create_runner_app(
                     exc_info=True,
                     extra={"session_id": session_id},
                 )
+                complete = False
                 break
             page = resp.json()
             page_items = page.get("data", [])
@@ -4081,7 +4161,7 @@ def create_runner_app(
                     session_id=session_id,
                     server_client=server_client,
                 )
-        return converted
+        return _LoadedHistory(items=converted, complete=complete)
 
     def _convert_raw_items_to_input(
         items: list[_JsonObject],
@@ -10723,6 +10803,7 @@ async def _resolve_harness_config(
     *,
     agent_id: str | None,
     spec_resolver: SpecResolver | None,
+    resolved_entry: _SpecEntry | None = None,
     session_id: str | None = None,
     model_override: str | None = None,
     harness_override: str | None = None,
@@ -10733,6 +10814,12 @@ async def _resolve_harness_config(
 
     :param agent_id: Agent id to resolve the spec for.
     :param spec_resolver: Resolver that returns the spec for *agent_id*.
+    :param resolved_entry: The session's already-resolved bundle, when the
+        caller holds one. Used in place of *spec_resolver*, which would
+        otherwise re-fetch ``agent/contents`` for a spec the session
+        already resolved. Session-cached entries are swapped to the
+        sub-agent's own spec at resolution time, so *sub_agent_name* does
+        not apply to one and the swap below is skipped.
     :param session_id: Session/conversation id, threaded to the resolver.
     :param model_override: Per-session ``/model`` override, applied to the
         spawn-env model so it takes effect on the SDK harnesses.
@@ -10755,8 +10842,10 @@ async def _resolve_harness_config(
         cannot be resolved. Callers catch this to surface a clean error
         rather than spawning an invalid harness subprocess.
     """
-    if agent_id and spec_resolver:
+    spec_entry: _SpecEntry | None = resolved_entry
+    if spec_entry is None and agent_id and spec_resolver:
         spec_entry = await spec_resolver(agent_id, session_id)
+    if spec_entry is not None:
         spec = _unwrap_resolved_spec(spec_entry)
         workdir = _resolved_spec_workdir(spec_entry)
         if spec is not None:
@@ -10768,7 +10857,7 @@ async def _resolve_harness_config(
             # The child's bundle dir comes from the same resolution, so the
             # spawn-env below advertises the child's bundle — not the
             # parent's, whose skills and tools the child has no claim to.
-            if sub_agent_name:
+            if sub_agent_name and resolved_entry is None:
                 sub_entry = _native_runtime._resolve_sub_agent_spec_entry(
                     spec_entry, sub_agent_name
                 )

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -2772,3 +2772,148 @@ async def test_terminal_exit_cleanup_evicts_only_the_exited_instance(tmp_path: P
         "a successor registered under the same key must survive exit cleanup"
     )
     assert terminal_registry.get("conv_exit", "claude", "main") is successor
+
+
+@pytest.mark.asyncio
+async def test_session_start_reads_bundle_and_history_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session start reads ``agent/contents`` and ``items`` exactly once.
+
+    Sister to the concurrent-burst test above: that one pins the stampede
+    case, this one pins the sequential cold start a host-launched runner
+    actually walks — session init, the first forwarded message, and the
+    background-title request the server sends alongside it.
+
+    Two round trips used to be spent re-reading values init had already
+    fetched. Init loaded the (empty) history but only memoized a non-empty
+    one, so the first message re-paged ``items``; and the background-title
+    handler ran the HTTP spec resolver instead of the entry init cached,
+    re-fetching ``agent/contents``. Counting requests rather than timing
+    them keeps the guard immune to machine load.
+
+    :param tmp_path: Temporary runner workspace root.
+    :param monkeypatch: Stubs out the title harness turn, which is not under
+        test here — only the spec resolution that precedes it.
+    :returns: None.
+    """
+
+    async def _title(_context: object) -> str:
+        """
+        Stand in for the title harness turn.
+
+        :param _context: Background-title context (unused).
+        :returns: A fixed title.
+        """
+        return "A title"
+
+    monkeypatch.setattr("omnigent.runner.app.run_background_title", _title)
+
+    conv = "conv_once"
+    agent_id = "ag_once"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    counts: dict[str, int] = {"contents": 0, "items": 0}
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        """
+        Stub Omnigent server counting the two reads under test.
+
+        :param request: Outbound request from the runner.
+        :returns: An empty items page, the session snapshot, or ``{}``.
+        """
+        path = request.url.path
+        if request.method == "GET" and path == f"/v1/sessions/{conv}/items":
+            counts["items"] += 1
+            return httpx.Response(200, json={"data": [], "has_more": False})
+        if request.method == "GET" and path == f"/v1/sessions/{conv}":
+            return httpx.Response(
+                200,
+                json={"id": conv, "agent_id": agent_id, "workspace": str(workspace)},
+            )
+        return httpx.Response(200, json={})
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="once-agent",
+        executor=ExecutorSpec(config={"harness": "claude-sdk"}, model="m"),
+    )
+
+    async def _spec_resolver(resolved_agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """
+        Stand in for the HTTP bundle fetch, counting each ``agent/contents``.
+
+        :param resolved_agent_id: Agent id the caller wants the bundle for.
+        :param session_id: Session id (unused).
+        :returns: The minimal claude-sdk spec.
+        """
+        del resolved_agent_id, session_id
+        counts["contents"] += 1
+        return spec
+
+    harness_client = _ScriptedHarnessClient(
+        [
+            'data: {"type": "response.created", "response": {"id": "resp_1"}}\n\n',
+            'data: {"type": "response.completed", "response": {"id": "resp_1"}}\n\n',
+        ]
+    )
+    pm = _FakeProcessManager(harness_client)
+    server_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    )
+    app = create_runner_app(
+        runner_workspace=workspace,
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_spec_resolver,
+        server_client=server_client,
+    )
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as client:
+            created = await client.post(
+                "/v1/sessions",
+                json={"session_id": conv, "agent_id": agent_id},
+            )
+            assert created.status_code == 201, f"{created.status_code} {created.text}"
+            after_init = dict(counts)
+
+            turn = await client.post(
+                f"/v1/sessions/{conv}/events",
+                json={
+                    "type": "message",
+                    "role": "user",
+                    "agent_id": agent_id,
+                    "content": [{"type": "input_text", "text": "hi"}],
+                },
+            )
+            assert turn.status_code == 202, f"{turn.status_code} {turn.text}"
+            for _ in range(300):
+                if pm.get_client_calls:
+                    break
+                await asyncio.sleep(0.01)
+
+            titled = await client.post(
+                f"/v1/sessions/{conv}/background-title",
+                json={"prompt": "hi", "agent_id": agent_id},
+            )
+            # A 503 here would mean the spec never resolved, which would
+            # make the count below vacuous.
+            assert titled.status_code == 200, f"{titled.status_code} {titled.text}"
+    finally:
+        await server_client.aclose()
+
+    assert after_init == {"contents": 1, "items": 1}, (
+        f"session init must read the bundle and the history once each, got {after_init}"
+    )
+    assert counts["items"] == 1, (
+        f"expected one items read across the whole start, got {counts['items']}; "
+        f"2 means the first forwarded message re-paged the history init loaded"
+    )
+    assert counts["contents"] == 1, (
+        f"expected one agent/contents read across the whole start, got "
+        f"{counts['contents']}; 2 means the background title re-fetched the "
+        f"bundle instead of reusing the entry init cached"
+    )


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Every runner session start made two server round trips it did not need: it read
`GET /v1/sessions/{id}/agent/contents` twice and `GET /v1/sessions/{id}/items`
twice. Request count — not payload size — is what costs on a hosted deployment
(~28 ms of TCP+TLS on a fresh connection vs ~6 ms reused; 80–230 ms of edge
latency per request), so two duplicated reads are worth removing even though
they are ~9 ms each on loopback.

Both duplicates were a value being re-read rather than threaded forward:

- **`items`** — `_initialize_session` loads the history, then memoizes it only
  `if history:`. A brand-new session's history is empty, so nothing was
  memoized, and the first forwarded message hit the `conversation_id not in
  _session_histories` branch in `post_session_events` and re-paged `items`. That
  branch then drops `persisted_item_id` and appends the new message — i.e. it
  reconstructs exactly what init already had. Init now memoizes an empty
  history too, so the message takes the `append` branch the non-empty case
  always took.
- **`agent/contents`** — the background-title handler called
  `_resolve_harness_config` with the HTTP `spec_resolver`, which always issues
  the GET. The session's bundle was already resolved and cached by init (the
  same handler reads `_session_spec_cache` a few lines later for
  `session_spec=`). `_resolve_harness_config` now takes an optional
  `resolved_entry`, and the handler passes the cached entry.

**Where the diagnosis differed from the report that prompted this:** the second
`agent/contents` is *not* a second call inside `_initialize_session` — init
resolves the bundle exactly once and caches it correctly. Runner-side stack
traces put the second fetch in `POST /v1/sessions/{id}/background-title`, and
the second `items` in `POST /v1/sessions/{id}/events` (the first message), not
in init. Both still land inside a single cold session start, which is why the
per-route counters showed 2.00/init.

**Why deduping is safe here** (neither fetch can observe a change the first one
missed):

- The reused spec is guarded on identity: reuse requires the request's
  `agent_id` to equal the session's recorded agent *and* the requested
  sub-agent to equal the one the cached entry was resolved for. An agent switch
  calls `_invalidate_session_agent_state`, which drops `_session_spec_cache`
  outright, so a switched agent re-resolves. No new cache and no new lifetime
  is introduced — this reuses the existing per-session `_session_spec_cache`.
- The memoized history is only the *confirmed* one. `_load_history_as_input` is
  split into `_load_history_pages`, which reports whether every page read
  returned 200; a read that failed empty-handed is still left unmemoized so the
  message path retries it, exactly as today. A non-empty (possibly partial)
  read is memoized exactly as today.

One intended side effect worth a reviewer's eye: `_session_histories` now has an
entry for a session that has not seen a message yet, so the reconnect catch-up
sweep (`for session_id in list(_session_histories)`) covers such a session too.
For a genuinely empty conversation it pages once, finds nothing and `continue`s.
For a session whose first message was persisted while the tunnel was down it now
catches that message up — which is what the sweep exists for, and is guarded
against double-processing by the same `_active_turns` check the recovery path
uses.

## Test Plan

**Request counts, measured with `dev/benchmarks/omnigent/environment.py`
`BenchEnvironment(with_host=True)`** — a real server + `omni host` daemon +
mock LLM, driving `cold_start_first_delta` (create host-bound session → host
launches a fresh runner → runner boots, initializes, runs the first turn).
Counts come from the server's own per-route counter via
`GET /debug/server-metrics`, diffed around N cold starts, so they include
runner→server and host→server traffic. Integers, immune to machine load.

Before (N=4, and identical at N=1):

```
    8  (  2.00/init)  GET /v1/sessions/{session_id}/agent/contents
    8  (  2.00/init)  GET /v1/sessions/{session_id}/items
```

After (N=4, re-confirmed at N=6):

```
    4  (  1.00/init)  GET /v1/sessions/{session_id}/agent/contents
    4  (  1.00/init)  GET /v1/sessions/{session_id}/items
    6  (  1.00/init)  GET /v1/sessions/{session_id}/agent/contents   # N=6
    6  (  1.00/init)  GET /v1/sessions/{session_id}/items            # N=6
```

Every other route in the window is unchanged at 1.00/init (`POST /v1/sessions`,
`PATCH /v1/sessions/{id}`, `/events`, `/stream`, `/policies/evaluate`).

**Regression guard.** `tests/runner/test_session_start_reads_bundle_and_history_once`
(added to `tests/runner/test_session_resources.py`, beside the existing
concurrent-burst dedup test) drives init → first message → background-title
against a counting `httpx.MockTransport` and a counting spec resolver, and
asserts exactly one `agent/contents` and one `items`. Verified it fails on
`origin/main` for each half independently:

- whole change reverted → `expected one items read across the whole start, got 2`
- only the `resolved_entry` reuse reverted → `expected one agent/contents read
  across the whole start, got 2`

**Targeted suites** (green; only the files touching the changed internals — the
box is shared, so no broad runs):

```
pytest tests/runner/test_session_resources.py \
       tests/runner/test_background_session_title.py          # 77 passed
pytest tests/runner/test_runner_dispatch.py                   # 219 passed, 1 skipped
pytest tests/runner/test_sub_agent_bundle_isolation.py \
       tests/runner/test_native_subagent_harness_resolution.py \
       tests/runner/test_subagent_spec_swap_warning.py \
       tests/runner/test_subagent_harness_override.py \
       tests/runner/test_app_sessions_native_workflow_init.py   # 96 passed, 2 pre-existing
pytest tests/runner/test_app_sessions_native_workflow_messages.py \
       tests/runner/test_app_sessions_native_events_lifecycle.py \
       tests/runner/test_app_sessions_native_supervision.py  # 102 passed, 1 pre-existing
```

Three failures across those groups reproduce identically on a clean
`origin/main` checkout of this worktree, so they are environment, not this
change (each verified by checking out `origin/main`'s copy of the two files and
re-running):

- `test_sub_agent_bundle_isolation.py::test_spawn_env_{bundle_dir_is_the_child_bundle,omits_bundle_dir_when_child_has_none}[pi]`
  — `ModelResolutionError: no compatible model resolved from provider
  'databricks' for family 'claude'`; catalog discovery is unavailable here.
- `test_app_sessions_native_supervision.py::test_message_turn_lifecycle_status_suppressed_for_terminal_backed_harnesses[openai-agents-...]`
  — the box's `~/.codex/config.toml` pins a codex-only provider, so the
  `openai-agents` harness cannot resolve one.

`pre-commit run --files omnigent/runner/app.py tests/runner/test_session_resources.py`:
ruff format / ruff check / all repo guards pass. The `pyrefly` hook fails
identically before and after this change (99 pre-existing `missing-import`
errors from the shared venv used on this box); scoped to the two changed files
the error count is 18 both before and after.

## Follow-up, not in this PR

`_initialize_session` awaits three things in sequence that are only partly
dependent: the harness spawn (`process_manager.get_client`), the terminal
auto-create (native or REPL), and the history load. Profiling of a
host-launched cold start put these at roughly 336 ms, 52–138 ms and one
round trip respectively, and neither the terminal create nor the history load
needs the harness socket — so the tail could overlap.

It is deliberately not done here, because it is not trivially safe: the
recovery-turn decision at the end consumes the history *and* the spawn result,
and the terminal-pending / `session.status` events the two arms publish would
start interleaving in a different order than the web UI sees today. That wants
its own PR with its own event-ordering assertions.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the `BenchEnvironment` run above: a real server + host +
runner cold start, with the before/after per-route request counts read from the
server's own counter. The new unit test pins the counts so they cannot drift
back, and was confirmed to fail on `origin/main` for each of the two duplicate
reads separately.

## Changelog

Starting a session no longer makes two redundant server round trips, so the first
response arrives sooner on hosted deployments.
