### PR TITLE
fix(server): seed builtin ACP CLI picker rows regardless of the server's PATH

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -744,16 +744,23 @@ def _ensure_default_acp_agents(
     agent_cache: Any,
 ) -> None:
     """
-    Seed a picker agent for each ACP harness set up on THIS server's host.
+    Seed a picker agent per builtin ACP CLI row and per configured ``acp:`` agent.
 
     Native harnesses seed a fixed ``<harness>-ui`` agent each
-    (:func:`_ensure_default_native_agents`). ACP agents are host config rather
-    than a fixed catalog, so seed one agent per user-configured ``acp:<slug>``
-    agent (``harness_is_configured("acp:...")`` treats "in config" as set up) and
-    per builtin ACP CLI harness whose binary is on PATH (its readiness gate). On a
-    host with no ACP setup — the common remote-server case, where the server holds
-    no ``acp:`` config — this seeds nothing. When both sources name the same
-    harness, the configured agent wins (see :func:`shadowed_builtin_acp_rows`).
+    (:func:`_ensure_default_native_agents`) unconditionally; the picker hides a row
+    the selected host cannot launch, reading that host's ``configured_harnesses``
+    readiness map. Builtin ACP CLI harnesses follow the same model, because the
+    vendor CLI runs on the *executing* host (the attached runner) rather than on the
+    server: gating the row on the server's own PATH left Devin and Grok missing from
+    the picker on every remote server, even when the runner had them installed.
+
+    User-configured ``acp:<slug>`` agents stay config-gated. Their launch command is
+    resolved from the *host's* own ``acp:`` block at spawn time, so a row naming a
+    slug the executing host does not define could never launch; surfacing those on a
+    remote server first needs the host to advertise its configured slugs.
+
+    When both sources name the same harness, the configured agent wins (see
+    :func:`shadowed_builtin_acp_rows`).
 
     Purely additive: it only adds picker rows and never touches native seeding.
     A malformed ``acp:`` block is logged and skipped, never fatal to startup
@@ -767,7 +774,6 @@ def _ensure_default_acp_agents(
     :param artifact_store: Store for agent bundles.
     :param agent_cache: Cache for loaded agent specs.
     """
-    from omnigent._platform import resolve_cli_binary
     from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 
     # (1) User-configured acp:<slug> agents — "set up" == present in config.
@@ -793,12 +799,12 @@ def _ensure_default_acp_agents(
             bundle_bytes=_build_acp_bundle(harness=f"acp:{agent.slug}", name=agent.slug),
         )
 
-    # (2) Builtin ACP CLI harnesses (e.g. grok) — "set up" == binary on PATH. Keyed
-    # by the catalog id (already a valid slug), not the display label. A row a
-    # configured agent already claims is skipped: both seed the same
-    # ``builtin_agent_id``, so the row would overwrite the user's chosen command.
-    for key, row in ACP_CLI_HARNESSES.items():
-        if key in shadowed or resolve_cli_binary(row.binary) is None:
+    # (2) Builtin ACP CLI harnesses — one row each, seeded like the natives because
+    # the vendor CLI runs on the executing host, not here. Keyed by the catalog id
+    # (already a valid slug), not the display label. A row a configured agent already
+    # claims is skipped: both seed the same ``builtin_agent_id``.
+    for key in ACP_CLI_HARNESSES:
+        if key in shadowed:
             continue
         _ensure_builtin_agent(
             agent_store,

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -1103,17 +1103,26 @@ def test_ensure_default_acp_agents_seeds_configured_agent(
     assert seed_stores.artifact_store.get(seeded.bundle_location) is not None
 
 
-def test_ensure_default_acp_agents_seeds_installed_builtin_cli(
+def test_ensure_default_acp_agents_seeds_builtin_cli_rows_without_a_local_binary(
     seed_stores: _SeedStores, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A builtin ACP CLI harness whose binary is on PATH seeds a picker built-in."""
+    """Every builtin ACP CLI row seeds even when no vendor CLI is on this host.
+
+    The vendor CLI runs on the *executing* host (the attached runner), not on the
+    server, so the server's own PATH says nothing about launchability. The picker
+    hides a row the selected host can't run via that host's ``configured_harnesses``
+    readiness map — the same way natives are seeded unconditionally and filtered.
+
+    **What breaks if this fails**: on a remote server (no vendor CLI in its
+    container) Devin and Grok vanish from the New Chat picker even though the Mac
+    runner attached to it has them installed — the row is never seeded, so no
+    per-host filter can bring it back.
+    """
     from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 
     monkeypatch.setattr("omnigent.onboarding.acp_auth.acp_agents", lambda *a, **k: [])
-    # Every builtin ACP CLI resolves on PATH in this test.
-    monkeypatch.setattr(
-        "omnigent._platform.resolve_cli_binary", lambda _b, **k: "/usr/local/bin/x"
-    )
+    # No vendor CLI resolves here — the remote-server / app-container shape.
+    monkeypatch.setattr("omnigent._platform.resolve_cli_binary", lambda _b, **k: None)
 
     server_app._ensure_default_acp_agents(
         seed_stores.agent_store, seed_stores.artifact_store, seed_stores.agent_cache
@@ -1121,7 +1130,7 @@ def test_ensure_default_acp_agents_seeds_installed_builtin_cli(
     # Keyed by the catalog id (a valid slug), not the display label.
     for key in ACP_CLI_HARNESSES:
         assert seed_stores.agent_store.get_by_name(key) is not None, (
-            f"installed builtin ACP CLI {key!r} was not seeded"
+            f"builtin ACP CLI {key!r} was not seeded"
         )
 
 
@@ -1174,13 +1183,17 @@ def test_ensure_default_acp_agents_configured_agent_beats_same_slug_builtin(
     assert load(dest).executor.config["harness"] == "acp:devin"
 
 
-def test_ensure_default_acp_agents_noop_when_nothing_set_up(
+def test_ensure_default_acp_agents_seeds_no_slug_rows_without_acp_config(
     seed_stores: _SeedStores, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """No configured agents + no installed builtin CLI → nothing seeded.
+    """An empty ``acp:`` block seeds no ``acp:<slug>`` row — only catalog rows.
 
-    **What breaks if this fails**: a remote server (no ``acp:`` config, ACP CLIs
-    absent) shows phantom ACP picker rows that can't launch there.
+    Unlike a builtin row, a configured agent's launch command is resolved from the
+    host's own ``acp:`` block at spawn time, so a slug this host never defined could
+    not launch anywhere. Only the fixed catalog rows are host-independent.
+
+    **What breaks if this fails**: the picker grows a row for a slug no config
+    defines, and choosing it fails at spawn with an unresolvable ACP command.
     """
     from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 
@@ -1190,9 +1203,13 @@ def test_ensure_default_acp_agents_noop_when_nothing_set_up(
     server_app._ensure_default_acp_agents(
         seed_stores.agent_store, seed_stores.artifact_store, seed_stores.agent_cache
     )
-    assert seed_stores.agent_store.get_by_name("devin") is None
-    for key in ACP_CLI_HARNESSES:
-        assert seed_stores.agent_store.get_by_name(key) is None
+    assert seed_stores.agent_store.get_by_name("kilocode") is None, (
+        "a slug absent from config must not be seeded"
+    )
+    seeded = {
+        key for key in ACP_CLI_HARNESSES if seed_stores.agent_store.get_by_name(key) is not None
+    }
+    assert seeded == set(ACP_CLI_HARNESSES), "catalog rows are host-independent and always seed"
 
 
 def test_ensure_default_acp_agents_survives_unreadable_config(


### PR DESCRIPTION
## Related issue

Closes #6065 (Tier A; Tier B — user-configured `acp:<slug>` agents — is scoped as a
follow-up on that issue).

## Summary

On a **remote** server, ACP harnesses never appeared in the New Chat picker — even when
the attached runner had the vendor CLI installed. Reproduced against a Databricks
`omnigents-*` app with a Mac runner that has `devin` installed and working: **Devin was
absent from the picker**, while the same Devin appears fine against a local server.

**Root cause — the gate was on the wrong host.** The picker lists *agents*
(`GET /v1/agents`), and the web then hides rows the selected host can't launch via
`harnessUnconfiguredOnHost` against that host's `configured_harnesses`. But seeding was
asymmetric in `omnigent/server/app.py`:

| family | seeded how | remote server |
|---|---|---|
| natives (claude/codex/pi) | `_ensure_default_native_agents` — loops `NATIVE_CODING_AGENTS`, **no host gating** | ✅ present |
| ACP (devin/grok) | `_ensure_default_acp_agents` — builtin rows gated on `resolve_cli_binary()` **on the server** | ❌ seeded nothing |

The vendor CLI runs on the **executing host** (the attached runner), not on the server —
`omnigent/runner/app.py` resolves it (`elif harness in ACP_CLI_HARNESSES:
_build_acp_cli_spawn_env(...)`), and `_build_acp_bundle` deliberately bakes nothing
host-specific because the command resolves at spawn time. So the server's own PATH says
nothing about launchability, and a row that is never seeded can't be recovered by any
per-host filter.

**Fix.** Seed the builtin ACP CLI catalog rows unconditionally, exactly like the natives,
and let the existing per-host readiness filter decide visibility. One gate removed; the
`shadowed` check (a user-configured agent wins over a same-slug row) is untouched.

User-configured `acp:<slug>` agents intentionally **stay** config-gated: their launch
command is resolved from the *host's* own `acp:` block at spawn time, so a row naming a
slug the executing host doesn't define could never launch. Surfacing those remotely needs
the host to advertise its slugs — Tier B on #6065.

<details>
<summary>Why this doesn't create phantom rows</summary>

The behavior the old gate protected against (a picker row that can't launch) is already
handled one layer up, the same way it is for every native harness:

- `devin`/`grok` readiness **is** properly binary-gated — stub `resolve_cli_binary` to
  return `None` and `_harness_availability` returns `False`.
- `configured_harness_map()` already emits a `devin` key, so
  `harnessUnconfiguredOnHost("devin", host)` resolves per host. Measured on a Mac runner
  with Devin installed: `{'devin': True, 'grok': True}`.
- With `hide_unconfigured` on the row is hidden; with it off the row renders with the
  same amber "needs setup" badge a native gets — and becomes discoverable/installable
  instead of silently absent.

So on a server whose runner lacks the CLI the row is filtered or badged, and on one whose
runner has it the row now works. No change to native seeding.
</details>

## Test Plan

`tests/server/test_app.py` — the two tests that encoded the server-host gate are rewritten
to the new contract:

- `..._seeds_builtin_cli_rows_without_a_local_binary` (was `..._seeds_installed_builtin_cli`)
  — with `resolve_cli_binary` stubbed to `None` (the app-container shape) **every** catalog
  row still seeds. This is the regression guard for the reported bug.
- `..._seeds_no_slug_rows_without_acp_config` (was `..._noop_when_nothing_set_up`) — an
  empty `acp:` block seeds no `acp:<slug>` row (asserted via `kilocode`) while the
  host-independent catalog rows all seed. Keeps the meaningful half of the old assertion.
- `..._configured_agent_beats_same_slug_builtin` unchanged and still green — the shadowing
  contract is untouched.

Runs:

- `pytest tests/server/test_app.py` → **55 passed**.
- `pytest tests/test_acp_cli_harnesses.py tests/onboarding/test_harness_readiness.py tests/cli/test_configure_models.py` → **180 passed**.
- `pytest tests/server/` (whole directory) → **3980 passed, 1 skipped, 3 xfailed, 0
  failures** in 18m27s, with one test deselected:
  `integration/test_external_runner_connects.py::test_external_runner_connects_to_local_server`
  is **pre-existing and environmental**, not from this change — it spawns a real runner
  subprocess and waits 60s for it to come online, and fails identically on a clean
  `origin/main` checkout on this machine (verified by A/B).
- `pre-commit` (ruff format, ruff check, pyrefly) clean; `uv.lock` untouched.

The per-host filter this fix relies on is already covered by
`tests/e2e_ui/chat/test_hide_unconfigured_harnesses.py`.

## Blast radius

The change is one removed condition, but it runs at server startup for every deployment,
so here is what was checked rather than assumed.

**What changes for a local server.** A user who has *neither* `devin` nor `grok`
installed now gets two extra picker rows where they previously had none. They are
**badged** ("needs setup"), not silently broken: `DEFAULT_HIDE_UNCONFIGURED_HARNESSES` is
`false`, and the documented design is that the picker "normally lists every harness and
badges the ones that aren't set up on the selected host". This is exactly how every
native already behaves — `_ensure_default_native_agents` seeds all of them
unconditionally — so this makes ACP consistent rather than special. It is a cosmetic
change worth a reviewer's explicit nod, and the one thing here that is a product call.

**Verified, not assumed:**

- The readiness signal exists locally: a real local host row reports **50 harness
  spellings including `devin` and `grok`**, so the picker filter has data to act on
  (checked by decoding `hosts.configured_harnesses` from a live DB).
- `devin`/`grok` readiness is genuinely binary-gated — stub `resolve_cli_binary` to
  `None` and `_harness_availability` returns `False`, so a host lacking the CLI badges
  or hides the row.
- Launch stays guarded: the harness rides the `host.launch_runner` frame precisely so
  the host can refuse an unconfigured harness *before* spawning, so a picked-but-absent
  CLI is a clean refusal, not a hung session.
- Smart Routing is untouched — `_installed_native_harnesses` only ever considers
  `AUTO_NATIVE_ROUTING_HARNESSES`, which these rows are not in.
- Old-runner compat: refs predating v0.12.0 already ship `configured_harness_map`, the
  `devin` catalog row, and the `hosts.configured_harnesses` column, so the compat-smoke
  configs (new server / old runner) still get a readiness map rather than falling open.
- `shadowed_builtin_acp_rows` is unchanged, so a user-configured agent still wins over a
  same-slug catalog row.
- No test anywhere asserts an exact agent-list length, and no doc describes the old
  server-host gate (the CHANGELOG is generated from PR bodies).

**Residual risks, stated plainly:**

- The cosmetic +2 badged rows above.
- The filter fails open by design (`if (!harness || !host?.configured_harnesses) return
  null`), so a host that reports no map at all shows the rows unbadged and relies on the
  pre-spawn refusal. That is pre-existing behavior for all natives; this adds two rows to
  the same path.
- Two extra `_build_acp_bundle` tarballs + artifact writes at startup and two extra agent
  rows per server. `_ensure_builtin_agent` is content-aware, so it is effectively a no-op
  after the first boot.

**Why the gate existed.** It was modeled on `harness_is_configured` — "seed what is set
up on this host" — when ACP first entered the picker, with the stated worry of "phantom
ACP picker rows that can't launch". Conservative and reasonable at the time; the flaw is
that the check ran on the wrong machine, conflating "the server's host" with "the host
that will run the harness". Those coincide only for a local server, which is why the bug
was invisible locally and total on a remote one. The anti-phantom intent is preserved —
it just belongs to the per-host readiness filter, which is where natives already get it.

**Alternative considered.** Seed a row only when some *connected* host reports the
harness available. Rejected: it makes seeding dynamic and host-connect-time rather than
startup-time, and races the picker before any host has connected — much larger surface
for the same visible outcome the readiness filter already produces.

## Demo

N/A — no frontend change. The picker rendering and its per-host filter are unchanged; this
only makes the server seed the agent row the filter then evaluates.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the diagnosis rather than the deployed fix: on a Mac with
`devin` installed I confirmed the runner reports `{'devin': True}` from
`configured_harness_map()` (so the server already has the readiness signal), that
`_harness_availability("devin")` correctly returns `False` when no binary resolves (so the
filter will hide the row where appropriate), and that `GET /v1/agents` is the only agent
surface (no create route, hence no client-side workaround). What is **not** automated is
the end-to-end check against a live remote server — attaching a Mac runner to a Databricks
`omnigents-*` app, opening New Chat, and seeing Devin listed and launching — which needs a
deployed server plus a real Devin turn.

## Changelog

Devin and Grok Build now appear in the New Chat picker when the connected host has them
installed, including on remote servers where the server itself has no vendor CLI.
