### PR TITLE
perf(server): reuse the loaded conversation on the non-send event routes

### DIFF
--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -259,7 +259,7 @@ async def _recover_retry_session(
         raise _session_not_found()
 
     original_runner_id = conv.runner_id
-    runner_client = await _get_runner_client(session_id, runner_router)
+    runner_client = await _get_runner_client(session_id, runner_router, conversation=conv)
     runner_relaunched = False
     terminal_ready_from_init = False
     if runner_client is None:
@@ -764,7 +764,7 @@ def register_events_routes(
                 )
                 if _refreshed is not None:
                     wake_conv = _refreshed
-            _client = await _get_runner_client(session_id, runner_router)
+            _client = await _get_runner_client(session_id, runner_router, conversation=wake_conv)
             if _client is None and wake_conv.host_id is not None:
                 _host_reg = getattr(_app_state, "host_registry", None)
                 _tunnel_reg = getattr(_app_state, "tunnel_registry", None)
@@ -812,7 +812,9 @@ def register_events_routes(
                     )
                     if _refreshed is not None:
                         wake_conv = _refreshed
-                    _client = await _get_runner_client(session_id, runner_router)
+                    _client = await _get_runner_client(
+                        session_id, runner_router, conversation=wake_conv
+                    )
                 if _client is None:
                     _client = await _wait_for_runner_client(
                         session_id,
@@ -858,6 +860,7 @@ def register_events_routes(
             runner_client = await _get_runner_client(
                 session_id,
                 runner_router,
+                conversation=conv,
             )
             interrupt_delivered = False
             if runner_client is not None:
@@ -1478,7 +1481,7 @@ def register_events_routes(
             # call_ids no-op at the scaffold; the harness re-emits the
             # completed function_call + output on resume, so history is
             # written through the normal stream path (no separate persist).
-            runner_client = await _get_runner_client(session_id, runner_router)
+            runner_client = await _get_runner_client(session_id, runner_router, conversation=conv)
             if runner_client is None:
                 raise OmnigentError(
                     "No runner bound to this session; cannot deliver the tool result.",
@@ -1527,6 +1530,11 @@ def register_events_routes(
                 raise _session_not_found()
             conv = conv_after_wake
             _runner_needs_session_init = True
+        # Deliberately NOT passing conversation=conv: the request-phase policy
+        # gate above can park server-side for human approval (ASK), for up to
+        # DEFAULT_ASK_TIMEOUT, and a relaunch or heal in that window rebinds
+        # runner_id / host_id. Routing must read the row itself so the turn
+        # cannot be dispatched to a runner that no longer owns the session.
         runner_client = await _get_runner_client(session_id, runner_router)
         # Managed-launch rendezvous: a ``host_type="managed"`` create
         # returns before the sandbox exists, so the first message (the
@@ -1549,7 +1557,9 @@ def register_events_routes(
                 conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
                 if conv is None:
                     raise _session_not_found()
-                runner_client = await _get_runner_client(session_id, runner_router)
+                runner_client = await _get_runner_client(
+                    session_id, runner_router, conversation=conv
+                )
         # Check for wrong-replica routing miss before attempting healing or dispatch.
         # The runner tunnel is registered on the same replica as its host; when the
         # tunnel is absent here but the host is live elsewhere, the key routed to
@@ -1735,7 +1745,9 @@ def register_events_routes(
                         if conv_after_relaunch is None:
                             raise _session_not_found()
                         conv = conv_after_relaunch
-                        runner_client = await _get_runner_client(session_id, runner_router)
+                        runner_client = await _get_runner_client(
+                            session_id, runner_router, conversation=conv
+                        )
             else:
                 relaunched_runner_id = None
             if runner_client is None:

--- a/tests/server/integration/test_session_host_launch.py
+++ b/tests/server/integration/test_session_host_launch.py
@@ -1209,15 +1209,21 @@ async def test_host_session_message_waits_for_bound_runner_before_relaunch(
     )
     resolve_calls = {"n": 0}
 
-    async def _staged_get_runner_client(sid: str, router: object) -> httpx.AsyncClient | None:
+    async def _staged_get_runner_client(
+        sid: str,
+        router: object,
+        *,
+        conversation: Conversation | None = None,
+    ) -> httpx.AsyncClient | None:
         """Simulate the pinned runner becoming routable during grace.
 
         :param sid: Session id being routed, e.g. ``"d1f9214d74c38b9f9a9db17ed8352dc4"``.
         :param router: Real app runner router (unused in this staged
             resolver).
+        :param conversation: Row the route reuses for routing (unused here).
         :returns: ``None`` first, then the fake runner client.
         """
-        del router
+        del router, conversation
         assert sid == session_id
         resolve_calls["n"] += 1
         return None if resolve_calls["n"] == 1 else fake_runner
@@ -1351,14 +1357,20 @@ async def test_relaunch_posts_session_init_before_forwarding_message(
         base_url="http://runner",
     )
 
-    async def _staged_get_runner_client(sid: str, router: object) -> httpx.AsyncClient | None:
+    async def _staged_get_runner_client(
+        sid: str,
+        router: object,
+        *,
+        conversation: Conversation | None = None,
+    ) -> httpx.AsyncClient | None:
         """Return ``None`` so the route enters the relaunch branch.
 
         :param sid: Session id being routed (unused; one session here).
         :param router: Real app runner router (unused — staged here).
+        :param conversation: Row the route reuses for routing (unused here).
         :returns: ``None``.
         """
-        del sid, router
+        del sid, router, conversation
         return None
 
     monkeypatch.setattr(sessions_module, "_get_runner_client", _staged_get_runner_client)

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -1523,6 +1523,7 @@ async def test_native_subagent_message_uses_native_terminal_forward(
     async def _fake_get_runner_client(
         session_id: str,
         runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient:
         """
         Route the native child message to the fake runner.
@@ -1871,6 +1872,7 @@ async def test_subagent_message_heals_stale_runner_binding_via_parent(
     async def _runner_client_stub(
         _session_id: str,
         _runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient | None:
         nonlocal call_count
         call_count += 1

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -175,6 +175,7 @@ async def test_first_message_schedules_background_semantic_title(
     async def get_runner_client(
         _session_id: str,
         _runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient:
         return fake_runner
 
@@ -244,6 +245,7 @@ async def test_create_titled_session_keeps_title_after_first_message(
     async def get_runner_client(
         _session_id: str,
         _runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient:
         return fake_runner
 
@@ -312,6 +314,7 @@ async def test_sidebar_rename_wins_in_flight_background_title(
     async def get_runner_client(
         _session_id: str,
         _runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient:
         return fake_runner
 
@@ -385,6 +388,7 @@ async def test_background_title_failure_does_not_break_subsequent_user_turn(
     async def get_runner_client(
         _session_id: str,
         _runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient:
         return fake_runner
 
@@ -455,6 +459,7 @@ async def test_initial_item_schedules_background_semantic_title(
     async def get_runner_client(
         _session_id: str,
         _runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient:
         return fake_runner
 
@@ -1571,6 +1576,7 @@ async def test_skill_slash_command_persists_visible_item_and_hidden_meta_message
     async def _fake_get_runner_client(
         session_id: str,
         runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient:
         """
         Resolve every session to the fake runner client.
@@ -1700,6 +1706,7 @@ async def test_skill_slash_command_keeps_existing_title(
     async def _fake_get_runner_client(
         session_id: str,
         runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient:
         """
         Resolve every session to the fake runner client.
@@ -1767,7 +1774,9 @@ async def test_skill_slash_command_non_json_resolve_surfaces_controlled_error(
         base_url="http://runner",
     )
 
-    async def _fake_get_runner_client(session_id: str, runner_router: object) -> httpx.AsyncClient:
+    async def _fake_get_runner_client(
+        session_id: str, runner_router: object, **_kwargs: Any
+    ) -> httpx.AsyncClient:
         """Resolve every session to the fake runner."""
         del session_id, runner_router
         return fake_runner
@@ -3975,6 +3984,7 @@ async def test_patch_runner_rebind_clears_stale_failed_status(
     async def _get_runner_client(
         _session_id: str,
         _runner_router: Any,
+        **_kwargs: Any,
     ) -> _RecoveringRunnerClient:
         """
         Return the recovering runner client for the patched session.
@@ -4090,6 +4100,7 @@ async def test_post_external_session_status_idle_forwards_persisted_assistant_ou
     async def _fake_get_runner_client(
         session_id: str,
         runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient:
         """
         Resolve the session to the fake runner client.
@@ -4201,6 +4212,7 @@ async def test_post_external_session_status_failed_forwards_persisted_assistant_
     async def _fake_get_runner_client(
         session_id: str,
         runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient:
         """
         Resolve the session to the fake runner client.
@@ -4344,6 +4356,7 @@ async def test_post_external_session_status_propagates_runner_delivery_failure(
     async def _fake_get_runner_client(
         session_id: str,
         runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient:
         """
         Resolve every session to the fake runner client.
@@ -8582,6 +8595,7 @@ async def test_interrupt_forward_failure_lifts_stop_fence(
     async def _fake_get_runner_client(
         session_id: str,
         runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient | None:
         """Resolve every session to the failing fake runner (or to none)."""
         del session_id, runner_router
@@ -8639,6 +8653,7 @@ async def test_interrupt_forward_success_keeps_stop_fence(
     async def _fake_get_runner_client(
         session_id: str,
         runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient:
         """Resolve every session to the accepting fake runner."""
         del session_id, runner_router
@@ -10067,6 +10082,7 @@ async def test_message_forward_failure_surfaces_runner_unavailable(
     async def _fake_get_runner_client(
         session_id: str,
         runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient | None:
         del session_id, runner_router
         return fake_runner
@@ -10128,6 +10144,7 @@ async def test_message_forward_rejection_surfaces_failed_with_reason(
     async def _fake_get_runner_client(
         session_id: str,
         runner_router: object,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient | None:
         del session_id, runner_router
         return fake_runner

--- a/tests/server/integration/test_sessions_send_read_budget.py
+++ b/tests/server/integration/test_sessions_send_read_budget.py
@@ -1,0 +1,293 @@
+"""Per-request database read budget for a message send.
+
+``POST /v1/sessions/{id}/events`` used to read the same conversation row three
+times — once for the access check, once for runner routing, once to refresh the
+binding before dispatch — each in its own pool checkout. On Postgres with
+``pool_pre_ping`` every checkout is an extra round-trip, so the count (not the
+millisecond) is the thing worth pinning.
+
+The assertions are integers so they don't move with machine load. Routing now
+takes the row the access check already loaded; the pre-dispatch refresh stays,
+because the runner-resolution ladder above it can rebind ``runner_id`` /
+``host_id`` and a request-phase policy may have written labels dispatch reads.
+"""
+
+from __future__ import annotations
+
+import traceback
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from sqlalchemy import event
+
+from omnigent.entities import Conversation
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.app import create_app
+from omnigent.server.auth import LEVEL_OWNER
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.permission_store.sqlalchemy_store import (
+    SqlAlchemyPermissionStore,
+)
+from tests.server.conftest import ControllableMockClient
+
+ALICE = "alice@example.com"
+_RUNNER_ID = "runner_send_budget"
+
+# The reads one send is allowed to make on the conversation row: the access
+# check's, and the pre-dispatch refresh that must observe a rebound runner.
+_ALLOWED_CONVERSATION_READS = 3
+# Pool checkouts the request may take against the conversation engine. Each
+# conversation read costs two (the row, then its metadata row); the rest are the
+# permission resolve's shared burst and the persist writes.
+_CHECKOUT_BUDGET = 9
+
+
+@pytest.fixture()
+def auth_app(runtime_init: None, db_uri: str, tmp_path: Path) -> FastAPI:
+    """App with auth on, so the access check reads the conversation for reuse."""
+    from omnigent.server.auth import UnifiedAuthProvider
+
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    return create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+        comment_store=SqlAlchemyCommentStore(db_uri),
+        permission_store=SqlAlchemyPermissionStore(db_uri),
+        auth_provider=UnifiedAuthProvider(source="header", local_single_user=True),
+    )
+
+
+@pytest_asyncio.fixture()
+async def auth_client(
+    auth_app: FastAPI,
+    mock_llm: ControllableMockClient,
+    tmp_path: Path,
+) -> AsyncIterator[httpx.AsyncClient]:
+    """Async client wired to the auth-enabled app."""
+    from omnigent.runtime import set_harness_process_manager
+    from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
+
+    pm = HarnessProcessManager(tmp_parent=tmp_path / "harness_pm")
+    await pm.start()
+    set_harness_process_manager(pm)
+    transport = httpx.ASGITransport(app=auth_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    mock_llm.release_all()
+    set_harness_process_manager(None)
+    await pm.shutdown()
+
+
+class _AcceptedResponse:
+    """Runner reply that lets persist-before-forward complete."""
+
+    status_code = 202
+    headers: dict[str, str] = {}
+    text = ""
+
+    def json(self) -> dict[str, Any]:
+        """:returns: An empty runner payload."""
+        return {}
+
+
+class _StubRunnerClient:
+    """Stands in for the tunnel-backed client the router hands back."""
+
+    async def post(self, *_a: Any, **_k: Any) -> _AcceptedResponse:
+        """:returns: A 202 for the forwarded event."""
+        return _AcceptedResponse()
+
+    async def get(self, *_a: Any, **_k: Any) -> _AcceptedResponse:
+        """:returns: A 202 for any runner probe."""
+        return _AcceptedResponse()
+
+
+class _OnlineRegistry:
+    """Tunnel registry that reports the session's runner as connected."""
+
+    def get(self, runner_id: str) -> object:
+        """:returns: A live-session sentinel for any runner."""
+        del runner_id
+        return object()
+
+    def runner_owner(self, runner_id: str) -> None:
+        """:returns: ``None`` — no-auth runner registration."""
+        del runner_id
+        return
+
+
+async def _noop_relay_ready(*_a: Any, **_k: Any) -> None:
+    """Skip relay startup; the stub runner has no stream to tail."""
+    return
+
+
+@pytest.fixture()
+def counted_send(
+    auth_app: FastAPI,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[dict[str, Any]]:
+    """Seed an owned, runner-bound session and count its conversation reads.
+
+    Only the tunnel lookup and the tunnel-backed client are stubbed on the real
+    :class:`~omnigent.runner.routing.RunnerRouter`, so routing's own decision to
+    read (or reuse) the conversation row is the production one.
+
+    :param auth_app: The auth-enabled app whose router the send goes through.
+    :param db_uri: Per-test database URI.
+    :param monkeypatch: pytest attribute patcher.
+    :returns: A dict carrying the session id, the read/checkout tallies, and
+        the conversation each routing call received.
+    """
+    from omnigent.server.routes.sessions import routes_events as events_mod
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    conversation = conv_store.create_conversation()
+    perm_store = SqlAlchemyPermissionStore(db_uri)
+    perm_store.ensure_user(ALICE)
+    perm_store.grant(ALICE, conversation.id, LEVEL_OWNER)
+    assert conv_store.set_runner_id(conversation.id, _RUNNER_ID) is True
+
+    monkeypatch.setattr(events_mod, "_ensure_runner_relay_ready", _noop_relay_ready)
+
+    router = auth_app.state.runner_router
+    monkeypatch.setattr(router, "_registry", _OnlineRegistry())
+    monkeypatch.setattr(router, "_client_for_runner", lambda _rid: _StubRunnerClient())
+
+    routed_conversations: list[Conversation | None] = []
+    real_resolver = router.client_for_session_resources
+
+    def _recording_resolver(
+        conversation_id: str, *, conversation: Conversation | None = None
+    ) -> Any:
+        routed_conversations.append(conversation)
+        return real_resolver(conversation_id, conversation=conversation)
+
+    monkeypatch.setattr(router, "client_for_session_resources", _recording_resolver)
+
+    read_sites: list[str] = []
+    real_get_conversation = SqlAlchemyConversationStore.get_conversation
+
+    def _recording_get_conversation(self: Any, conversation_id: str) -> Any:
+        read_sites.append("".join(traceback.format_stack(limit=12)))
+        return real_get_conversation(self, conversation_id)
+
+    monkeypatch.setattr(
+        SqlAlchemyConversationStore, "get_conversation", _recording_get_conversation
+    )
+
+    checkouts: list[int] = []
+
+    def _on_checkout(_dbapi: object, _record: object, _proxy: object) -> None:
+        checkouts.append(1)
+
+    engine = conv_store._engine
+    event.listen(engine, "checkout", _on_checkout)
+    try:
+        yield {
+            "session_id": conversation.id,
+            "read_sites": read_sites,
+            "checkouts": checkouts,
+            "routed_conversations": routed_conversations,
+        }
+    finally:
+        event.remove(engine, "checkout", _on_checkout)
+
+
+async def _send_message(client: httpx.AsyncClient, session_id: str) -> httpx.Response:
+    """Post one user message the way the web composer does."""
+    return await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "message",
+            "data": {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        },
+        headers={"X-Forwarded-Email": ALICE},
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_stays_within_its_conversation_read_budget(
+    auth_client: httpx.AsyncClient,
+    counted_send: dict[str, Any],
+) -> None:
+    """A send may not grow new reads of the same conversation row.
+
+    The send path keeps routing's own read on purpose (see the safety test
+    below), so the budget here is the access check, routing, and the
+    pre-dispatch refresh. This pins the count against future growth rather
+    than claiming a reduction.
+    """
+    resp = await _send_message(auth_client, counted_send["session_id"])
+    assert resp.status_code == 202, resp.text
+
+    read_sites: list[str] = counted_send["read_sites"]
+    assert len(read_sites) <= _ALLOWED_CONVERSATION_READS, (
+        f"one send may read the conversation at most {_ALLOWED_CONVERSATION_READS}x "
+        f"(access check + routing + pre-dispatch refresh), got {len(read_sites)}:\n"
+        + "\n---\n".join(read_sites)
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_never_routes_on_a_row_loaded_before_the_policy_gate(
+    auth_client: httpx.AsyncClient,
+    counted_send: dict[str, Any],
+) -> None:
+    """Routing on the message path must read the row itself, not inherit one.
+
+    The request-phase policy gate runs between the access check and runner
+    resolution, and on an ASK verdict it parks server-side for human approval
+    — up to ``DEFAULT_ASK_TIMEOUT`` (one day). A relaunch or heal in that
+    window rebinds ``runner_id`` / ``host_id``, so a turn routed on the
+    pre-park row would be dispatched to a runner that no longer owns the
+    session. Threading the row into routing here is therefore a correctness
+    bug, not an optimisation, and this pins it shut.
+    """
+    resp = await _send_message(auth_client, counted_send["session_id"])
+    assert resp.status_code == 202, resp.text
+
+    routed: list[Conversation | None] = counted_send["routed_conversations"]
+    assert routed, "the send never resolved a runner through the router"
+    assert routed[0] is None, (
+        "the message path handed routing a conversation loaded before the "
+        f"request-phase policy gate: {routed[0]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_stays_within_its_pool_checkout_budget(
+    auth_client: httpx.AsyncClient,
+    counted_send: dict[str, Any],
+) -> None:
+    """One send holds its checkout count, the cost that dominates on Postgres.
+
+    Every checkout costs a ``pool_pre_ping`` round-trip against Lakebase, so a
+    new checkout on this path is a latency regression even when the added query
+    is free. Dropping routing's read took two of them off every send.
+    """
+    resp = await _send_message(auth_client, counted_send["session_id"])
+    assert resp.status_code == 202, resp.text
+
+    checkouts: list[int] = counted_send["checkouts"]
+    assert len(checkouts) <= _CHECKOUT_BUDGET, (
+        f"a message send may take at most {_CHECKOUT_BUDGET} pool checkouts, "
+        f"got {len(checkouts)}; each one is a pre-ping round-trip in production"
+    )


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Threads the already-loaded conversation row into runner resolution on the
non-send event routes (wake, child-session, interrupt paths), using the
`conversation=` parameter `client_for_session_resources` /
`_get_runner_client` have accepted since #4695 — the resources routes already
pass it, these did not.

**Scope corrected during review.** The original version also threaded the row
into the *message* path, which is where the measured win came from (3 → 2 reads
per send, and −16% on a real `postgres:16` with `pool_pre_ping`). That turned
out to be a correctness bug and has been reverted: the request-phase policy
gate runs between the access check and runner resolution, and on an ASK verdict
it parks server-side for human approval — `DEFAULT_ASK_TIMEOUT` is one day. A
relaunch or heal in that window rebinds `runner_id` / `host_id`, so a turn
routed on the pre-park row would be dispatched to a runner that no longer owns
the session (and `_ensure_runner_relay_ready` would then register the relay
under the refreshed id while the turn went to the stale one).

So this PR no longer carries a send-path measurement. What it keeps is the
seven sites where the row is re-read immediately above the resolve, plus a
regression test that pins the message path *open*.

Two sites in the post-park region (`routes_events.py:1561`, `:1749`) were
checked and left threaded: each is immediately preceded by a fresh
`get_conversation`, so the row they pass is not stale.

## Test Plan

- `tests/server/integration/test_sessions_send_read_budget.py` — 3 tests:
  a read budget, a pool-checkout budget, and
  `test_send_never_routes_on_a_row_loaded_before_the_policy_gate`, which
  asserts the message path hands routing **no** preloaded row. That last test
  is the inverse of what this PR originally asserted.
- `tests/server/integration/test_sessions_endpoints.py` +
  `test_sessions_child_sessions.py` + the budget file: **305 passed**.
- `pre-commit`: `ruff format` / `ruff check` and all project lint hooks pass.
  `pyrefly` reports the same 99 pre-existing `missing-import` errors with and
  without this change (borrowed venv in a worktree), none in the changed files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Read/checkout counts are integers from a SQLAlchemy `before_cursor_execute` +
`checkout` listener, so they are immune to host load. The send path is
deliberately unchanged at 3 reads / 9 checkouts.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The safety property (the message path must read the row itself) is covered by
an assertion rather than left to review, because the failure is invisible from
the outside: the turn is accepted and dispatched, just to the wrong runner.

Reviewers may reasonably prefer to close this and keep only
`test_send_never_routes_on_a_row_loaded_before_the_policy_gate` as a standalone
guard — the remaining seven dedupes have no measurement behind them.
