### PR TITLE
perf(server): stamp a per-turn policy verdict on the runner frame

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -6727,6 +6727,12 @@ def create_runner_app(
                 _model_override,
                 extra={"session_id": conv},
             )
+        # Per-turn policy verdict from the server. Relayed, never decided here:
+        # only a literal ``False`` (the server established that no policy could
+        # fire for this turn) is forwarded, so an absent or malformed hint
+        # leaves the harness evaluating as before.
+        if msg_body.get("policies_apply") is False:
+            harness_body["policies_apply"] = False
         # Resolve the effort for this turn — an explicit per-event value, else
         # the session's remembered one — then deliver only what this harness can
         # accept. The persisted effort is validated at create against the union

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -131,6 +131,12 @@ class ExecutorAdapter(HarnessApp):
         # current turn's ctx, not turn 1's dead ctx.
         self._current_ctx: TurnContext | None = None
         self._current_agent: str | None = None
+        # Per-turn policy verdict the server stamped on this turn's dispatch.
+        # False only when the server established that no policy could fire,
+        # which lets the turn-start LLM_REQUEST gate skip its round-trip.
+        # Read off self (not closure-captured) because the policy bridge is
+        # installed once and must see the current turn's value.
+        self._policies_apply = True
         # FIFO queue of inner-SDK tool-use ids from ToolCallRequest events. Drained by
         # _stable_tool_executor so each dispatch reuses the same call_id as the inline
         # observed event, letting BlockStream dedupe the two renders into one.
@@ -198,6 +204,8 @@ class ExecutorAdapter(HarnessApp):
             executor._policy_evaluator = self._stable_policy_evaluator  # type: ignore[attr-defined]
         self._current_ctx = ctx
         self._current_agent = request.model
+        # Only a literal False skips a gate; absent/True/malformed evaluate.
+        self._policies_apply = request.policies_apply is not False
         # Clear per-turn state so stale entries from an errored prior turn don't bleed through.
         self._pending_mcp_call_ids.clear()
         # Reset orphan counter: measures only post-bind orphans (no intervening clean turn).
@@ -667,6 +675,14 @@ class ExecutorAdapter(HarnessApp):
         """Stable bridge for policy evaluation; routes through ``ctx.evaluate_policy``.
 
         Fails closed (DENY) for tool-call phases when no turn context is active.
+
+        Skips the round-trip for the turn-start ``PHASE_LLM_REQUEST`` gate when
+        the server stamped ``policies_apply: false`` on this turn — it already
+        computed that the answer is ALLOW, microseconds earlier, with the same
+        primitive its ``/policies/evaluate`` handler uses. Every later gate
+        (``PHASE_LLM_RESPONSE``, ``PHASE_TOOL_CALL``, ``PHASE_TOOL_RESULT``)
+        fires seconds to minutes after dispatch and still round-trips, so a
+        policy added mid-turn is enforced.
         """
         ctx = self._current_ctx
         if ctx is None:
@@ -688,6 +704,8 @@ class ExecutorAdapter(HarnessApp):
                     f"No active turn context; failing closed for {phase}." if fail_closed else None
                 ),
             )
+        if phase == "PHASE_LLM_REQUEST" and not self._policies_apply:
+            return PolicyVerdictPayload(action="POLICY_ACTION_ALLOW")
         evaluation_id = f"poleval_{secrets.token_hex(16)}"
         return await ctx.evaluate_policy(evaluation_id, phase, data)
 

--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -219,6 +219,7 @@ def any_policies_apply(
     conversation_id: str,
     default_policies: list[PolicySpec] | None,
     policy_store: PolicyStore | None,
+    root_conversation_id: str | None,
     phase: Phase | None = None,
     tool_name: str | None = None,
 ) -> bool:
@@ -237,6 +238,11 @@ def any_policies_apply(
     :param default_policies: Server-wide policies from ``RuntimeCaps``.
     :param policy_store: Session-scoped policy store; ``None`` means no DB
         policies are configured.
+    :param root_conversation_id: Root of this conversation's tree, so an
+        inherited root policy is counted (see :func:`build_policy_engine`).
+        Required rather than defaulted: omitting it silently under-reports for
+        sub-agents, which is a fail-open. Pass ``None`` only when the
+        conversation is genuinely a root or no row is available.
     :param phase: The evaluation phase, if known.
     :param tool_name: The tool being called (for ``PHASE_TOOL_CALL`` events).
     :returns: ``False`` when the engine would have an empty policy list and
@@ -257,6 +263,14 @@ def any_policies_apply(
     # this is a cache hit on any call after the first for this session.
     if _load_session_policy_specs(conversation_id, policy_store):
         return True
+    # Sub-agents inherit the root session's policies, so a child carrying none
+    # of its own still runs the parent's — a guardrail added to a top-level
+    # session governs the sub-agents it spawns. Unlike build_policy_engine this
+    # takes the root unverified: for a pure "would anything fire" check a wrong
+    # root can only over-report, which leaves the caller evaluating.
+    if root_conversation_id is not None and root_conversation_id != conversation_id:
+        if _load_session_policy_specs(root_conversation_id, policy_store):
+            return True
     return False
 
 

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -88,6 +88,7 @@ from omnigent.runtime.policies.approval import (
 from omnigent.runtime.policies.builder import (
     _sum_subtree_usage,
     ancestor_ids_from_tree,
+    any_policies_apply,
     load_session_tree,
     load_session_usage,
 )
@@ -6898,11 +6899,20 @@ async def _evaluate_input_policy(
     spec = await asyncio.to_thread(_load_agent_spec_for_session, conv, agent_store)
     if spec is None:
         return None
-    # Skip only when there are no agent guardrails AND no server-wide
-    # default policies AND no session policies. Without this, default/
-    # session policies (e.g. deny_pii_in_llm_request added via the UI)
-    # are silently skipped for agents without a guardrails: YAML block.
-    if not spec.guardrails and not get_caps().default_policies and get_policy_store() is None:
+    # Skip only when no policy could fire: no agent guardrail policies, no
+    # server-wide defaults (YAML or DB) and no session policies. Reads the
+    # builder's own invalidation-based caches, so a policy added mid-session is
+    # honored on the very next message. Declared labels still build the engine —
+    # it seeds their initial values.
+    declares_labels = bool(spec.guardrails and spec.guardrails.labels)
+    if not declares_labels and not any_policies_apply(
+        spec=spec,
+        conversation_id=session_id,
+        default_policies=get_caps().default_policies,
+        policy_store=get_policy_store(),
+        root_conversation_id=conv.root_conversation_id,
+        phase=Phase.REQUEST,
+    ):
         return None
 
     # Text-like attachments (e.g. an uploaded CSV) arrive as ``input_file`` blocks

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -4758,6 +4758,7 @@ async def _forward_event_to_runner(
     file_store: FileStore | None = None,
     artifact_store: ArtifactStore | None = None,
     has_mcp_servers: bool = False,
+    policies_apply: bool = True,
     created_by: str | None = None,
     host_store: HostStore | None = None,
 ) -> str:
@@ -4786,6 +4787,11 @@ async def _forward_event_to_runner(
         ``has_mcp_servers`` hint so ``proxy_stream`` knows to load
         the agent spec and initialise :class:`ProxyMcpManager` for
         this turn. ``False`` by default (agents without MCP servers).
+    :param policies_apply: The server's per-turn policy verdict. ``False``
+        means it recomputed, just now, that no policy could fire for this
+        turn, letting the harness skip the turn-start LLM_REQUEST
+        round-trip. Stamped on the runner body only when ``False``;
+        absent means evaluate. ``True`` by default.
     :param created_by: Authenticated identity of the posting actor,
         recorded on the persisted item for attribution.
     :param host_store: Host registrations, read only to learn whether this
@@ -4818,6 +4824,10 @@ async def _forward_event_to_runner(
     # harness don't have access to the server's file store — the
     # LLM endpoint needs the actual content, not an internal ID.
     forwarded_data = dict(body.data)
+    # ``body.data`` is client-supplied and is splatted into the runner body
+    # below, so a forged key here would disable a security control. The
+    # server's own verdict is the only source of this hint.
+    forwarded_data.pop("policies_apply", None)
     if (
         file_store is not None
         and artifact_store is not None
@@ -4879,6 +4889,12 @@ async def _forward_event_to_runner(
         # resolved copy — id-based dedup, not a role/content guess.
         "persisted_item_id": persisted_items[0].id,
     }
+    # Per-turn policy verdict for the harness's turn-start LLM_REQUEST gate.
+    # Stamped only when the server established that nothing would fire —
+    # absent means evaluate, so every other dispatch path (scheduled fires,
+    # sub-agent forwards) keeps the round-trip without opting in.
+    if policies_apply is False:
+        runner_body["policies_apply"] = False
     # Persist the turn-initiating actor so /policies/evaluate and MCP
     # tools/call can read it back on any server replica.  Skip system-driven
     # forwards (sub-agent results, parent-wake carry created_by=None) — they
@@ -5468,6 +5484,7 @@ async def _dispatch_session_event_to_runner_impl(
     file_store: FileStore | None,
     artifact_store: ArtifactStore | None,
     has_mcp_servers: bool = False,
+    policies_apply: bool = True,
     created_by: str | None = None,
     runner_router: RunnerRouter | None = None,
     native_terminal_ready: bool = False,
@@ -5525,6 +5542,10 @@ async def _dispatch_session_event_to_runner_impl(
     :param has_mcp_servers: ``True`` when the agent spec declares at
         least one MCP server. Forwarded to the runner as the
         ``has_mcp_servers`` hint. ``False`` by default.
+    :param policies_apply: The server's per-turn policy verdict, forwarded
+        to the runner as the ``policies_apply`` hint. ``False`` lets the
+        harness skip the turn-start LLM_REQUEST round-trip. ``True`` by
+        default (evaluate).
     :param created_by: Authenticated identity of the posting actor,
         e.g. ``"alice@example.com"``. On the non-native path it is
         recorded directly on the persisted item. On the claude-native
@@ -5769,6 +5790,7 @@ async def _dispatch_session_event_to_runner_impl(
         file_store=file_store,
         artifact_store=artifact_store,
         has_mcp_servers=has_mcp_servers,
+        policies_apply=policies_apply,
         created_by=created_by,
         host_store=host_store,
     )

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -6,7 +6,7 @@ import asyncio
 import secrets
 import weakref
 from collections.abc import Callable
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import httpx
 from fastapi import (
@@ -220,10 +220,54 @@ from omnigent.telemetry.events import TurnEndEvent as _TelTurnEndEvent
 from omnigent.telemetry.installation_id import get_installation_id as _get_installation_id
 from omnigent.tools.client_specified import parse_client_side_tool_specs
 
+if TYPE_CHECKING:
+    from omnigent.spec.types import AgentSpec
+
 _retry_recovery_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
     weakref.WeakValueDictionary()
 )
 _retry_recovery_tasks: dict[str, asyncio.Task[dict[str, bool | str]]] = {}
+
+
+def _policy_hint_for_dispatch(
+    spec: AgentSpec, session_id: str, root_conversation_id: str | None
+) -> bool:
+    """Return the per-turn ``policies_apply`` hint stamped on a runner forward.
+
+    The server stays the sole decider: this asks the same
+    :func:`omnigent.runtime.policies.builder.any_policies_apply` primitive that
+    ``POST /policies/evaluate`` consults, microseconds before dispatch, and the
+    runner only relays the answer. Fails safe — any error returns ``True``, so
+    the turn keeps its round-trip and the gate is enforced as before.
+
+    :param spec: The loaded agent spec for this session.
+    :param session_id: Conversation id, e.g. ``"conv_abc123"``.
+    :param root_conversation_id: Root of this session's tree, so a sub-agent
+        still reports ``True`` for a guardrail its parent session configured.
+    :returns: ``False`` only when no policy could fire for this turn.
+    """
+    from omnigent.server.routes import sessions as _sf
+
+    try:
+        return bool(
+            _sf.any_policies_apply(
+                spec=spec,
+                conversation_id=session_id,
+                default_policies=_sf.get_caps().default_policies,
+                policy_store=_sf.get_policy_store(),
+                root_conversation_id=root_conversation_id,
+                phase=None,
+                tool_name=None,
+            )
+        )
+    except Exception:
+        _logger.warning(
+            "policies_apply hint computation failed for session=%s; "
+            "keeping the per-turn policy round-trip",
+            session_id,
+            exc_info=True,
+        )
+        return True
 
 
 def _retry_recovery_lock(session_id: str) -> asyncio.Lock:
@@ -1851,6 +1895,13 @@ def register_events_routes(
         # asyncio.to_thread wrapper covers the rare cold-cache path
         # where the bundle is extracted from disk for the first time.
         _has_mcp_servers = False
+        # Per-turn policy verdict for the runner's turn-start LLM_REQUEST
+        # gate. Recomputed from scratch on every dispatch with the same
+        # primitive POST /policies/evaluate uses, so a policy added
+        # mid-session is picked up on the next turn. True unless the
+        # server positively established that nothing would fire — an
+        # unreadable spec or any failure keeps the round-trip.
+        _policies_apply = True
         if _agent is not None and agent_cache is not None and _agent.bundle_location:
             try:
                 _loaded_agent = await asyncio.to_thread(
@@ -1859,6 +1910,11 @@ def register_events_routes(
                     _agent.bundle_location,
                 )
                 _has_mcp_servers = bool(_loaded_agent.spec.mcp_servers)
+                _policies_apply = _policy_hint_for_dispatch(
+                    _loaded_agent.spec,
+                    session_id,
+                    conv.root_conversation_id,
+                )
             except Exception:
                 _logger.warning(
                     "Failed to load agent spec for MCP hint for session=%s",
@@ -1916,6 +1972,7 @@ def register_events_routes(
             file_store=file_store,
             artifact_store=artifact_store,
             has_mcp_servers=_has_mcp_servers,
+            policies_apply=_policies_apply,
             created_by=created_by,
             runner_router=runner_router,
             native_terminal_ready=native_terminal_ready,

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -768,6 +768,7 @@ def register_hooks_routes(
             conversation_id=session_id,
             default_policies=_caps.default_policies,
             policy_store=get_policy_store(),
+            root_conversation_id=conv.root_conversation_id if conv is not None else None,
             phase=phase,
             tool_name=data.get("name") if isinstance(data, dict) else None,
         ):

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -980,6 +980,10 @@ class CreateResponseRequest(BaseModel):
         e.g. ``"openai/gpt-5.4-mini"``. Distinct from ``model``
         (agent name). Substitutes for the spec's ``llm.model`` for
         this single request. Drives the REPL's ``/model`` command.
+    :param policies_apply: Server-stamped per-turn policy verdict.
+        ``False`` means no policy could fire for this turn, so the
+        turn-start ``PHASE_LLM_REQUEST`` gate skips its round-trip to
+        the server. Absent, ``True``, or malformed all mean evaluate.
     :param context_management: Compaction strategy objects,
         e.g. ``[{"type": "compaction", ...}]``.
     :param temperature: Ignored — agent controls this. Silently
@@ -1035,6 +1039,12 @@ class CreateResponseRequest(BaseModel):
     # Per-request LLM model override (distinct from ``model``, which
     # carries the agent name). See class docstring for semantics.
     model_override: str | None = None
+    # Per-turn policy verdict stamped by the server: ``False`` means the
+    # server recomputed, just before dispatch, that no policy could fire
+    # for this turn, so the turn-start LLM_REQUEST gate can skip its
+    # round-trip. Anything else — absent, ``True``, or a malformed value
+    # the validator below flattens to ``None`` — means evaluate.
+    policies_apply: bool | None = None
     # Compaction strategy objects, e.g. [{"type": "compaction", ...}]
     context_management: list[dict[str, Any]] | None = None
     # Ignored fields — agent controls these; silently dropped.
@@ -1049,6 +1059,20 @@ class CreateResponseRequest(BaseModel):
     parallel_tool_calls: bool | None = None
     max_tool_calls: int | None = None
     top_logprobs: int | None = None
+
+    @field_validator("policies_apply", mode="before")
+    @classmethod
+    def _only_literal_false_skips_policies(cls, value: object) -> bool | None:
+        """Normalize the policy hint so only a literal ``False`` can skip a gate.
+
+        A malformed hint must never disable a security control, and it must
+        not 422 the turn either. Everything that is not exactly ``False``
+        becomes ``None``, which the harness reads as "evaluate".
+
+        :param value: The raw hint as it arrived on the wire.
+        :returns: ``False`` for a literal ``False``, else ``None``.
+        """
+        return False if value is False else None
 
     @model_validator(mode="after")
     def _require_model_for_new_conversations(self) -> CreateResponseRequest:

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -27,6 +27,7 @@ import pytest
 
 from omnigent.inner.executor import Executor
 from omnigent.runtime.harnesses import _HARNESS_MODULES
+from omnigent.runtime.harnesses._scaffold import PolicyVerdictPayload, TurnContext
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
 
 _TEST_HARNESS_NAME = "executor_adapter_fixture"
@@ -2255,6 +2256,215 @@ async def test_policy_evaluator_no_active_turn_context_is_phase_aware() -> None:
         verdict = await adapter._stable_policy_evaluator(advisory_phase, {})
         assert verdict.action == "POLICY_ACTION_ALLOW", advisory_phase
         assert verdict.reason is None, advisory_phase
+
+
+# ── Server-stamped per-turn policy hint (``policies_apply``) ──
+#
+# The server recomputes ``any_policies_apply`` microseconds before it dispatches
+# a turn and stamps ``policies_apply: false`` on the frame only when nothing
+# could fire. These tests count the round-trips the adapter's policy bridge
+# makes so a regression that skipped an enforced gate — or stopped skipping the
+# provably-ALLOW one — fails here.
+
+
+class _CountingPolicyTurnContext(TurnContext):
+    """Real :class:`TurnContext` whose ``evaluate_policy`` counts and scripts.
+
+    Subclasses the production context (rather than stubbing it) so the adapter
+    exercises the same object it uses in a live turn; only the server round-trip
+    is replaced by a counter and a scripted verdict.
+    """
+
+    def __init__(self, action: str = "POLICY_ACTION_ALLOW", **kwargs: Any) -> None:
+        """Initialize the counting context.
+
+        :param action: Verdict every scripted evaluation returns, e.g.
+            ``"POLICY_ACTION_DENY"``.
+        :param kwargs: Forwarded to :class:`TurnContext`.
+        """
+        super().__init__(**kwargs)
+        self._scripted_action = action
+        self.evaluated_phases: list[str] = []
+
+    async def evaluate_policy(
+        self, evaluation_id: str, phase: str, data: dict[str, Any]
+    ) -> PolicyVerdictPayload:
+        """Record the round-trip and return the scripted verdict."""
+        self.evaluated_phases.append(phase)
+        return PolicyVerdictPayload(
+            action=self._scripted_action,
+            reason="scripted" if self._scripted_action == "POLICY_ACTION_DENY" else None,
+        )
+
+
+def _counting_ctx(action: str = "POLICY_ACTION_ALLOW") -> _CountingPolicyTurnContext:
+    """Build a counting turn context with fresh asyncio primitives."""
+    import asyncio as _aio
+
+    return _CountingPolicyTurnContext(
+        action=action,
+        response_id="resp_policy",
+        event_queue=_aio.Queue(),
+        cancelled=_aio.Event(),
+    )
+
+
+def _policy_gate_executor(phases: tuple[str, ...]) -> Any:
+    """Return an :class:`Executor` that fires the adapter's bridge at *phases*.
+
+    Stands in for the inner SDK executors, which call the adapter-installed
+    ``_policy_evaluator`` at each enforcement phase and abort the turn on DENY.
+
+    :param phases: Phases to evaluate, in order.
+    :returns: An executor class ready for ``executor_factory``.
+    """
+    from omnigent.inner.executor import (
+        Executor,
+        ExecutorConfig,
+        ExecutorError,
+        Message,
+        ToolSpec,
+        TurnComplete,
+    )
+
+    class _PolicyGateExecutor(Executor):
+        async def run_turn(
+            self,
+            messages: list[Message],
+            tools: list[ToolSpec],
+            system_prompt: str,
+            config: ExecutorConfig | None = None,
+        ):
+            evaluator = getattr(self, "_policy_evaluator", None)
+            assert evaluator is not None, "adapter did not install the policy bridge"
+            for phase in phases:
+                verdict = await evaluator(phase, {"model": "mock"})
+                if verdict.action == "POLICY_ACTION_DENY":
+                    yield ExecutorError(message=f"{phase} denied by policy: {verdict.reason}")
+                    return
+            yield TurnComplete(response="ok")
+
+    return _PolicyGateExecutor
+
+
+@pytest.mark.asyncio
+async def test_llm_request_gate_skips_round_trip_when_server_stamps_no_policies() -> None:
+    """``policies_apply: false`` drops the turn-start LLM_REQUEST round-trip.
+
+    This is the whole point of the hint: the server already computed, with the
+    same primitive its ``/policies/evaluate`` handler uses, that the answer for
+    this turn is ALLOW. Counting zero evaluations for LLM_REQUEST is the
+    regression guard for the saved request per turn.
+    """
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.server.schemas import CreateResponseRequest
+
+    adapter = ExecutorAdapter(executor_factory=_policy_gate_executor(("PHASE_LLM_REQUEST",)))
+    ctx = _counting_ctx()
+    await adapter.run_turn(
+        CreateResponseRequest(model="agent", input="hi", policies_apply=False),
+        ctx,
+    )
+    assert ctx.evaluated_phases == [], (
+        "the server stamped policies_apply=false, so the turn-start gate must "
+        f"not round-trip; it evaluated {ctx.evaluated_phases}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_later_gates_still_round_trip_when_llm_request_is_skipped() -> None:
+    """Only LLM_REQUEST is skipped; every later gate still asks the server.
+
+    LLM_RESPONSE, TOOL_CALL and TOOL_RESULT fire seconds to minutes after
+    dispatch, so a dispatch-time snapshot is not good enough for them — a
+    policy added mid-turn (including the engine's always-injected
+    ``sys_add_policy`` ASK) must still be enforced.
+    """
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.server.schemas import CreateResponseRequest
+
+    later = ("PHASE_LLM_RESPONSE", "PHASE_TOOL_CALL", "PHASE_TOOL_RESULT")
+    adapter = ExecutorAdapter(
+        executor_factory=_policy_gate_executor(("PHASE_LLM_REQUEST", *later))
+    )
+    ctx = _counting_ctx()
+    await adapter.run_turn(
+        CreateResponseRequest(model="agent", input="hi", policies_apply=False),
+        ctx,
+    )
+    assert ctx.evaluated_phases == list(later)
+
+
+@pytest.mark.parametrize(
+    "hint",
+    [
+        pytest.param({}, id="absent"),
+        pytest.param({"policies_apply": True}, id="true"),
+        pytest.param({"policies_apply": "banana"}, id="malformed-string"),
+        pytest.param({"policies_apply": 0}, id="malformed-int"),
+        pytest.param({"policies_apply": {"nested": 1}}, id="malformed-object"),
+        pytest.param({"policies_apply": None}, id="explicit-null"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_absent_or_malformed_hint_still_evaluates(hint: dict[str, Any]) -> None:
+    """Anything but a literal ``false`` keeps the round-trip — fail-safe.
+
+    A hint the server never sent (non-web dispatch paths such as scheduled
+    fires) or one that arrived garbled must never disable a control, and must
+    not fail the turn either.
+    """
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.server.schemas import CreateResponseRequest
+
+    adapter = ExecutorAdapter(executor_factory=_policy_gate_executor(("PHASE_LLM_REQUEST",)))
+    ctx = _counting_ctx()
+    await adapter.run_turn(CreateResponseRequest(model="agent", input="hi", **hint), ctx)
+    assert ctx.evaluated_phases == ["PHASE_LLM_REQUEST"]
+
+
+@pytest.mark.asyncio
+async def test_deny_verdict_blocks_the_turn_when_policies_apply() -> None:
+    """With policies in play the gate round-trips and a DENY blocks the turn.
+
+    Pairs with the skip tests: proves the round-trip the hint preserves is the
+    one that actually stops a turn, so "0 evaluations" can only ever mean "the
+    server said nothing would fire".
+    """
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.server.schemas import CreateResponseRequest
+
+    adapter = ExecutorAdapter(executor_factory=_policy_gate_executor(("PHASE_LLM_REQUEST",)))
+    ctx = _counting_ctx(action="POLICY_ACTION_DENY")
+    with pytest.raises(RuntimeError, match="PHASE_LLM_REQUEST denied by policy"):
+        await adapter.run_turn(CreateResponseRequest(model="agent", input="hi"), ctx)
+    assert ctx.evaluated_phases == ["PHASE_LLM_REQUEST"]
+
+
+@pytest.mark.asyncio
+async def test_policy_hint_does_not_leak_into_the_next_turn() -> None:
+    """The hint is per-turn: a skipped turn must not disarm the next one.
+
+    The policy bridge is installed once and closure-captured by the inner SDK,
+    so the flag is read off the adapter at call time. If it were captured
+    per-turn instead, a session whose first turn had no policies would keep
+    skipping the gate after a policy was added.
+    """
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.server.schemas import CreateResponseRequest
+
+    adapter = ExecutorAdapter(executor_factory=_policy_gate_executor(("PHASE_LLM_REQUEST",)))
+    skipped = _counting_ctx()
+    await adapter.run_turn(
+        CreateResponseRequest(model="agent", input="hi", policies_apply=False),
+        skipped,
+    )
+    assert skipped.evaluated_phases == []
+
+    # Next turn: a policy now exists, so the server stops stamping the hint.
+    enforced = _counting_ctx()
+    await adapter.run_turn(CreateResponseRequest(model="agent", input="hi"), enforced)
+    assert enforced.evaluated_phases == ["PHASE_LLM_REQUEST"]
 
 
 class _CancelFlag:

--- a/tests/runtime/policies/test_builder_session_policies.py
+++ b/tests/runtime/policies/test_builder_session_policies.py
@@ -22,6 +22,7 @@ from omnigent.runtime.policies.builder import (
     _load_default_policy_specs,
     _load_session_policy_specs,
     _stored_policy_to_spec,
+    any_policies_apply,
     build_policy_engine,
     invalidate_default_policy_specs_cache,
     invalidate_session_policy_specs_cache,
@@ -31,6 +32,7 @@ from omnigent.spec.types import (
     FunctionPolicySpec,
     FunctionRef,
     GuardrailsSpec,
+    Phase,
 )
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
@@ -403,6 +405,56 @@ def test_subagent_inherits_root_session_policies(db_uri: str) -> None:
     assert "root_guard" in names, f"root session policy not inherited by sub-agent; got {names}"
     # Root policy should come before the ask_on_add_policy sentinel.
     assert names.index("root_guard") < names.index("__ask_on_add_policy")
+
+
+def test_any_policies_apply_sees_the_root_policy_a_subagent_inherits(db_uri: str) -> None:
+    """The fast-path check must agree with the engine about inherited policies.
+
+    ``any_policies_apply`` gates whether the engine is built at all, so a
+    sub-agent whose only applicable policy lives on the root must still report
+    ``True``. Reporting ``False`` here silently disables a guardrail the parent
+    session configured — a fail-open, not a slow path.
+
+    :param db_uri: Per-test SQLite URI.
+    """
+    handler = "tests.resources.examples._shared.tool_functions.block_long_sleep"
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    root_conv = conv_store.create_conversation()
+    child_conv = conv_store.create_conversation(
+        parent_conversation_id=root_conv.id,
+        kind="sub_agent",
+    )
+
+    policy_store = SqlAlchemyPolicyStore(db_uri)
+    policy_store.create(
+        policy_id="c6de31de238a26c347a7c3d8d5a74c3a",
+        session_id=root_conv.id,
+        name="root_guard",
+        type="python",
+        handler=handler,
+    )
+
+    child = conv_store.get_conversation(child_conv.id)
+    assert child is not None
+
+    # The engine the check stands in for does carry the inherited policy.
+    engine = build_policy_engine(
+        spec=_make_minimal_spec(),
+        conversation_id=child_conv.id,
+        conversation_store=conv_store,
+        policy_store=policy_store,
+    )
+    assert "root_guard" in [p.spec.name for p in engine.policies]
+
+    assert any_policies_apply(
+        spec=_make_minimal_spec(),
+        conversation_id=child_conv.id,
+        default_policies=None,
+        policy_store=policy_store,
+        root_conversation_id=child.root_conversation_id,
+        phase=Phase.REQUEST,
+    ), "fast path missed the root policy the sub-agent inherits"
 
 
 def test_subagent_deduplicates_same_name_policy(db_uri: str) -> None:

--- a/tests/server/integration/test_sessions_policy_evaluate.py
+++ b/tests/server/integration/test_sessions_policy_evaluate.py
@@ -24,6 +24,7 @@ Uses the shared ``client`` fixture from ``tests/server/conftest.py``
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +35,7 @@ from fastapi import FastAPI
 
 from omnigent.runtime import get_caps, session_stream
 from omnigent.runtime.caps import RuntimeCaps
+from omnigent.runtime.harnesses._scaffold import TurnContext
 from omnigent.server.routes import sessions as sessions_routes
 from omnigent.spec.types import FunctionPolicySpec, FunctionRef
 from omnigent.stores.conversation_store.sqlalchemy_store import (
@@ -121,6 +123,18 @@ def _deny_large_llm_request(event: dict[str, Any]) -> dict[str, Any]:
             "reason": f"LLM request too large: {count} messages",
         }
     return {"result": "ALLOW"}
+
+
+def _deny_all_llm_requests(event: dict[str, Any]) -> dict[str, Any]:
+    """
+    Policy that denies every LLM request.
+
+    :param event: V0 event dict.
+    :returns: DENY for ``llm_request``, ALLOW for every other phase.
+    """
+    if event.get("type") != "llm_request":
+        return {"result": "ALLOW"}
+    return {"result": "DENY", "reason": "LLM calls are blocked by admin policy."}
 
 
 def _deny_llm_response_with_pii(event: dict[str, Any]) -> dict[str, Any]:
@@ -1362,6 +1376,412 @@ async def test_policy_evaluate_gates_every_first_party_tool_result_shape(
         assert resp.json()["result"] == "POLICY_ACTION_DENY", (
             f"{why}: the tool-scoped policy did not see a tool name — {resp.text[:160]}"
         )
+
+
+# ── Server-stamped per-turn policy hint (``policies_apply``) ──
+#
+# The turn-start ``PHASE_LLM_REQUEST`` gate provably returns ALLOW when no
+# policy could fire, so the server recomputes ``any_policies_apply`` just
+# before it dispatches a turn and stamps ``policies_apply: false`` on the frame
+# it already sends. The harness then skips that one round-trip.
+#
+# These tests count REAL ``POST /policies/evaluate`` requests against the live
+# app: they capture the frame the server forwards, hand it to the production
+# :class:`ExecutorAdapter`, and route the adapter's policy bridge at the real
+# route. That is the same number the benchmark's per-route counter reports
+# (``warm_turn``: 3.0 → 2.0 requests/op).
+
+
+# The data the inner executors send at the LLM_REQUEST gate — see the
+# identical block in ``openai_agents_sdk_executor`` / ``claude_sdk_executor``.
+_LLM_REQUEST_GATE_DATA: dict[str, Any] = {
+    "model": "gpt-4o",
+    "messages_count": 2,
+    "tools_count": 0,
+    "system_prompt_preview": "You are a helpful assistant.",
+    "last_user_message": "hi",
+}
+
+
+class _EvaluateCountingTurnContext(TurnContext):
+    """Turn context whose policy bridge really POSTs ``/policies/evaluate``.
+
+    Stands in for the runner's interception of
+    ``policy_evaluation.requested`` — same destination, same body shape — so
+    ``evaluations`` counts actual HTTP evaluations, not stubbed calls.
+    """
+
+    def __init__(self, client: httpx.AsyncClient, session_id: str, **kwargs: Any) -> None:
+        """Wire the context at a live test client.
+
+        :param client: Client bound to the app under test.
+        :param session_id: Session the turn belongs to.
+        :param kwargs: Forwarded to :class:`TurnContext`.
+        """
+        super().__init__(**kwargs)
+        self._client = client
+        self._session_id = session_id
+        self.evaluations: list[str] = []
+
+    async def evaluate_policy(self, evaluation_id: str, phase: str, data: dict[str, Any]) -> Any:
+        """POST the evaluation to the real route and return its verdict."""
+        from omnigent.runtime.harnesses._scaffold import PolicyVerdictPayload
+
+        self.evaluations.append(phase)
+        resp = await self._client.post(
+            f"/v1/sessions/{self._session_id}/policies/evaluate",
+            json={"event": {"type": phase, "data": data, "context": {}}},
+        )
+        assert resp.status_code == 200, resp.text
+        payload = resp.json()
+        return PolicyVerdictPayload(action=payload["result"], reason=payload.get("reason"))
+
+
+def _fake_runner(
+    forwarded: list[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> httpx.AsyncClient:
+    """Route every session's runner client at a capture-only fake runner.
+
+    :param forwarded: List each forwarded ``/events`` body is appended to.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: The fake client; the caller must ``aclose()`` it.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path.endswith("/events"):
+            forwarded.append(json.loads(request.content))
+        return httpx.Response(202, json={"queued": True})
+
+    fake = httpx.AsyncClient(transport=httpx.MockTransport(_handler), base_url="http://runner")
+
+    async def _resolve(session_id: str, runner_router: object) -> httpx.AsyncClient:
+        del session_id, runner_router
+        return fake
+
+    monkeypatch.setattr(sessions_routes, "_get_runner_client", _resolve)
+    return fake
+
+
+async def _dispatch_turn(
+    client: httpx.AsyncClient,
+    session_id: str,
+    forwarded: list[dict[str, Any]],
+    data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """POST a user message and return the frame the server forwarded.
+
+    :param client: Client bound to the app under test.
+    :param session_id: Session to dispatch into.
+    :param forwarded: Capture list from :func:`_fake_runner`.
+    :param data: Event ``data`` payload; defaults to a plain text message.
+    :returns: The forwarded runner body for this dispatch.
+    """
+    before = len(forwarded)
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "message",
+            "data": data or {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    assert len(forwarded) == before + 1, "the server forwarded no frame to the runner"
+    return forwarded[-1]
+
+
+async def _run_llm_request_gate(
+    client: httpx.AsyncClient,
+    session_id: str,
+    runner_body: dict[str, Any],
+) -> _EvaluateCountingTurnContext:
+    """Drive the turn-start policy gate off a captured runner frame.
+
+    Rebuilds the harness-bound event from the frame the server sent (the
+    runner relays ``policies_apply`` unchanged — it only ever copies a literal
+    ``false`` across) and runs it through the production
+    :class:`ExecutorAdapter`, whose inner executor fires the LLM_REQUEST gate.
+
+    :param client: Client bound to the app under test.
+    :param session_id: Session the turn belongs to.
+    :param runner_body: The frame captured from the runner forward.
+    :returns: The context, whose ``evaluations`` is the request count.
+    :raises RuntimeError: When the gate denies, aborting the turn.
+    """
+    from omnigent.inner.executor import (
+        Executor,
+        ExecutorConfig,
+        ExecutorError,
+        Message,
+        ToolSpec,
+        TurnComplete,
+    )
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.runtime.harnesses._scaffold import MessageEvent
+
+    class _LlmRequestGateExecutor(Executor):
+        async def run_turn(
+            self,
+            messages: list[Message],
+            tools: list[ToolSpec],
+            system_prompt: str,
+            config: ExecutorConfig | None = None,
+        ):
+            evaluator = getattr(self, "_policy_evaluator", None)
+            assert evaluator is not None
+            verdict = await evaluator("PHASE_LLM_REQUEST", _LLM_REQUEST_GATE_DATA)
+            if verdict.action == "POLICY_ACTION_DENY":
+                yield ExecutorError(message=f"LLM call denied by policy: {verdict.reason}")
+                return
+            yield TurnComplete(response="ok")
+
+    request = MessageEvent(**runner_body).to_create_request()
+    ctx = _EvaluateCountingTurnContext(
+        client,
+        session_id,
+        response_id="resp_gate",
+        event_queue=asyncio.Queue(),
+        cancelled=asyncio.Event(),
+    )
+    adapter = ExecutorAdapter(executor_factory=lambda: _LlmRequestGateExecutor())
+    await adapter.run_turn(request, ctx)
+    return ctx
+
+
+async def test_turn_start_gate_makes_zero_evaluate_calls_with_no_policies(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No policies anywhere → the turn makes zero ``/policies/evaluate`` calls.
+
+    The saved request per turn. The server stamps ``policies_apply: false``
+    because it just recomputed that nothing would fire; the harness honours it
+    and never asks. If the hint stopped being stamped (or stopped being
+    honoured) the count goes back to 1 and this fails.
+    """
+    forwarded: list[dict[str, Any]] = []
+    fake = _fake_runner(forwarded, monkeypatch)
+    try:
+        agent = await create_test_agent(client)
+        session_id = await _create_session(client, agent["id"])
+        runner_body = await _dispatch_turn(client, session_id, forwarded)
+        assert runner_body["policies_apply"] is False
+        ctx = await _run_llm_request_gate(client, session_id, runner_body)
+    finally:
+        await fake.aclose()
+    assert ctx.evaluations == [], (
+        f"a no-policy turn must not round-trip the turn-start gate; it evaluated {ctx.evaluations}"
+    )
+
+
+async def test_turn_start_gate_evaluates_and_blocks_with_a_deny_policy(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A DENY policy keeps the round-trip and actually blocks the turn.
+
+    Proves the skip is not a blanket disarm: with a policy configured the
+    server does not stamp the hint, the gate asks, the answer is DENY, and the
+    turn aborts. If the fast path ever fired here, the LLM call would proceed.
+    """
+    _patch_default_policies(monkeypatch, f"{__name__}._deny_all_llm_requests")
+    forwarded: list[dict[str, Any]] = []
+    fake = _fake_runner(forwarded, monkeypatch)
+    try:
+        agent = await create_test_agent(client)
+        session_id = await _create_session(client, agent["id"])
+        runner_body = await _dispatch_turn(client, session_id, forwarded)
+        assert "policies_apply" not in runner_body, (
+            "a session with a default policy must not be stamped as policy-free"
+        )
+        with pytest.raises(RuntimeError, match="denied by policy"):
+            await _run_llm_request_gate(client, session_id, runner_body)
+    finally:
+        await fake.aclose()
+
+
+@pytest.fixture()
+def policy_store_app(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> FastAPI:
+    """App wired to a real policy store, so session-policy CRUD is mounted.
+
+    The shared ``client`` app runs without one (which is what makes it the
+    no-policy case). Registering the store on the runtime globals too is what
+    lets ``any_policies_apply`` — and therefore the dispatch-time hint — see a
+    policy created through the CRUD route.
+    """
+    from omnigent.runtime.agent_cache import AgentCache
+    from omnigent.server.app import create_app
+    from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+    from omnigent.stores.artifact_store.local import LocalArtifactStore
+    from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+    from omnigent.stores.policy_store.sqlalchemy_store import SqlAlchemyPolicyStore
+
+    store = SqlAlchemyPolicyStore(db_uri)
+    monkeypatch.setattr("omnigent.runtime._globals._policy_store", store)
+    # Same artifact dir the ``runtime_init`` fixture registered globally, so a
+    # bundle uploaded through this app is loadable via the runtime facade.
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    return create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(artifact_store=artifact_store, cache_dir=tmp_path / "cache"),
+        policy_store=store,
+    )
+
+
+@pytest_asyncio.fixture()
+async def policy_store_client(
+    policy_store_app: FastAPI,
+    mock_llm: Any,
+    tmp_path: Path,
+) -> Any:
+    """Async client against the policy-store-enabled app."""
+    from omnigent.runtime import set_harness_process_manager
+    from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
+
+    pm = HarnessProcessManager(tmp_parent=tmp_path / "policy_harness_pm")
+    await pm.start()
+    set_harness_process_manager(pm)
+    transport = httpx.ASGITransport(app=policy_store_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    mock_llm.release_all()
+    set_harness_process_manager(None)
+    await pm.shutdown()
+
+
+async def test_session_policy_created_mid_session_re_arms_the_gate(
+    policy_store_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A policy added mid-session is enforced on the very next turn.
+
+    The hint is recomputed from scratch on every dispatch against the same
+    cache-coherent primitive ``/policies/evaluate`` uses, and the session-policy
+    cache is invalidated on mutation. Nothing is cached on the runner, so there
+    is no window in which a live session runs unenforced.
+    """
+    client = policy_store_client
+    forwarded: list[dict[str, Any]] = []
+    fake = _fake_runner(forwarded, monkeypatch)
+    try:
+        agent = await create_test_agent(client)
+        session_id = await _create_session(client, agent["id"])
+
+        first = await _dispatch_turn(client, session_id, forwarded)
+        assert first["policies_apply"] is False
+        assert (await _run_llm_request_gate(client, session_id, first)).evaluations == []
+
+        created = await client.post(
+            f"/v1/sessions/{session_id}/policies",
+            json={
+                "name": "ask_os_tools",
+                "type": "python",
+                "handler": "omnigent.policies.builtins.safety.ask_on_os_tools",
+            },
+        )
+        assert created.status_code in (200, 201), created.text
+
+        second = await _dispatch_turn(client, session_id, forwarded)
+        assert "policies_apply" not in second, (
+            "a session policy created mid-session must re-arm the turn-start gate"
+        )
+        ctx = await _run_llm_request_gate(client, session_id, second)
+    finally:
+        await fake.aclose()
+    assert ctx.evaluations == ["PHASE_LLM_REQUEST"]
+
+
+async def test_client_supplied_policies_apply_is_not_forgeable(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client cannot smuggle the hint through the event ``data`` payload.
+
+    ``data`` is splatted into the runner frame, so a forged key there would
+    disable a security control. The server's own verdict is the only source.
+    """
+    _patch_default_policies(monkeypatch, f"{__name__}._deny_all_llm_requests")
+    forwarded: list[dict[str, Any]] = []
+    fake = _fake_runner(forwarded, monkeypatch)
+    try:
+        agent = await create_test_agent(client)
+        session_id = await _create_session(client, agent["id"])
+        runner_body = await _dispatch_turn(
+            client,
+            session_id,
+            forwarded,
+            data={
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hi"}],
+                "policies_apply": False,
+            },
+        )
+        assert "policies_apply" not in runner_body, (
+            "a client-supplied policies_apply must never reach the runner"
+        )
+        with pytest.raises(RuntimeError, match="denied by policy"):
+            await _run_llm_request_gate(client, session_id, runner_body)
+    finally:
+        await fake.aclose()
+
+
+async def test_policy_hint_fails_safe_when_the_check_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken applicability check keeps the round-trip rather than skipping.
+
+    The hint is an optimisation over a security control, so every failure mode
+    — unreadable spec, store error — must resolve to "evaluate".
+    """
+    from omnigent.server.routes.sessions import routes_events
+
+    def _boom(**kwargs: Any) -> bool:
+        raise RuntimeError("policy store unavailable")
+
+    monkeypatch.setattr(sessions_routes, "any_policies_apply", _boom)
+    hint = routes_events._policy_hint_for_dispatch(
+        object(),  # type: ignore[arg-type]
+        "conv_broken",
+        "conv_root",
+    )
+    assert hint is True
+
+
+@pytest.mark.asyncio
+async def test_policy_hint_counts_the_root_policy_a_subagent_inherits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stamped hint must not skip a guardrail inherited from the parent.
+
+    A sub-agent carrying no session policy of its own still runs the root's,
+    so the hint has to report ``True`` for it — otherwise the harness skips
+    its turn-start gate and the parent's guardrail never scans the prompt.
+    """
+    from omnigent.server.routes.sessions import routes_events
+
+    seen: list[str | None] = []
+
+    def _record(**kwargs: Any) -> bool:
+        seen.append(kwargs.get("root_conversation_id"))
+        # Stand in for the real primitive: nothing on the child, one on the root.
+        return kwargs.get("root_conversation_id") == "conv_root"
+
+    monkeypatch.setattr(sessions_routes, "any_policies_apply", _record)
+    hint = routes_events._policy_hint_for_dispatch(
+        object(),  # type: ignore[arg-type]
+        "conv_child",
+        "conv_root",
+    )
+    assert seen == ["conv_root"], f"root was not forwarded to the check; got {seen}"
+    assert hint is True
 
 
 _EVALUATE_USER = "alice@example.com"

--- a/tests/server/routes/test_sessions_policy.py
+++ b/tests/server/routes/test_sessions_policy.py
@@ -17,6 +17,7 @@ import pytest
 from omnigent.entities import Conversation, ConversationItem
 from omnigent.entities.agent import Agent, LoadedAgent
 from omnigent.entities.conversation import FunctionCallData
+from omnigent.entities.policy import Policy as StoredPolicy
 from omnigent.policies.types import PolicyAction, PolicyResult
 from omnigent.server.routes.sessions import (
     _build_evaluation_context,
@@ -210,6 +211,7 @@ _CACHE_PATCH = "omnigent.server.routes.sessions.get_agent_cache"
 _ENGINE_PATCH = "omnigent.server.routes.sessions.build_policy_engine"
 _HOLD_GATE_PATCH = "omnigent.server.routes.sessions._hold_native_ask_gate"
 _STREAM_PATCH = "omnigent.server.routes.sessions.session_stream"
+_TREE_PATCH = "omnigent.runtime.policies.builder.load_verified_session_tree"
 
 
 @pytest.mark.asyncio
@@ -448,19 +450,29 @@ def _make_user_message_body(
 
 
 def _make_spec_with_guardrails() -> AgentSpec:
-    """Build an AgentSpec with a guardrails block (but no policies).
+    """Build an AgentSpec declaring one guardrail policy.
 
-    The presence of ``guardrails`` triggers policy engine
-    construction; the empty policy list means ALLOW by default.
+    A policy must actually be declared: with none, the input gate
+    short-circuits via ``any_policies_apply`` and never builds an engine,
+    so a test that stubs the engine would assert on a code path the
+    request never reaches.
 
-    :returns: AgentSpec with guardrails enabled.
+    :returns: AgentSpec with one function policy declared.
     """
-    from omnigent.spec.types import GuardrailsSpec
+    from omnigent.spec.types import FunctionPolicySpec, FunctionRef, GuardrailsSpec
 
     return AgentSpec(
         spec_version=1,
         name="test-agent",
-        guardrails=GuardrailsSpec(),
+        guardrails=GuardrailsSpec(
+            policies=[
+                FunctionPolicySpec(
+                    name="test_policy",
+                    on=None,
+                    function=FunctionRef(path="tests.fake.policy"),
+                )
+            ]
+        ),
     )
 
 
@@ -638,6 +650,175 @@ async def test_input_no_guardrails_skips_policy():
         )
 
     assert result is None
+
+
+@dataclass
+class _FakePolicyStore:
+    """Minimal policy store for the input-gate fast-path tests.
+
+    :param session_policies: Rows returned for ``list_for_session``.
+    :param default_policies: Rows returned for ``list_defaults``.
+    """
+
+    session_policies: list[StoredPolicy] = field(default_factory=list)
+    default_policies: list[StoredPolicy] = field(default_factory=list)
+
+    def list_for_session(self, session_id: str) -> list[StoredPolicy]:
+        """Return this session's stored policies.
+
+        :param session_id: Session id, e.g. ``"sess_1"``.
+        :returns: The configured session rows.
+        """
+        return list(self.session_policies)
+
+    def list_defaults(self) -> list[StoredPolicy]:
+        """Return server-wide default policies.
+
+        :returns: The configured default rows.
+        """
+        return list(self.default_policies)
+
+
+def _make_stored_policy(name: str, session_id: str | None) -> StoredPolicy:
+    """Build an enabled python-handler stored policy row.
+
+    :param name: Policy name, e.g. ``"deny_pii"``.
+    :param session_id: Owning session, or ``None`` for a default policy.
+    :returns: A :class:`Policy` entity the builder can convert to a spec.
+    """
+    return StoredPolicy(
+        id=f"pol_{name}",
+        name=name,
+        session_id=session_id,
+        scope="session" if session_id else "default",
+        created_at=1,
+        type="python",
+        handler="tests.fake.policy",
+    )
+
+
+@pytest.fixture
+def policy_store(monkeypatch: pytest.MonkeyPatch):
+    """Install an empty policy store and reset the builder's spec caches.
+
+    A store is always configured in a real deployment, so these tests must
+    run with one bound; the module-level spec caches are process-wide, so
+    they are cleared on entry and exit to keep the tests hermetic.
+
+    :param monkeypatch: pytest patcher, used to bind the runtime global.
+    :returns: The installed :class:`_FakePolicyStore`.
+    """
+    store = _FakePolicyStore()
+    monkeypatch.setattr("omnigent.runtime._globals._policy_store", store)
+    _clear_policy_spec_caches()
+    yield store
+    _clear_policy_spec_caches()
+
+
+def _clear_policy_spec_caches() -> None:
+    """Evict the builder's default/session policy-spec caches."""
+    from omnigent.runtime.policies.builder import (
+        invalidate_default_policy_specs_cache,
+        invalidate_session_policy_specs_cache,
+    )
+
+    invalidate_default_policy_specs_cache()
+    invalidate_session_policy_specs_cache("sess_1")
+
+
+@pytest.mark.asyncio
+async def test_input_no_policies_skips_engine_and_tree_scan(policy_store):
+    """A configured-but-empty policy store must not build an engine.
+
+    The gate used to skip only when ``get_policy_store() is None`` — never
+    true in a real deployment — so every user message built an engine and
+    paid its O(spawn-tree) scan even with zero policies anywhere.
+    """
+    conv_store = _FakeConversationStore()
+    agent_store = _FakeAgentStore(agent=_make_agent())
+    conv = conv_store.get_conversation("sess_1")
+    body = _make_user_message_body()
+
+    loaded = LoadedAgent(spec=_make_spec_no_guardrails(), workdir="/tmp/fake")
+
+    with (
+        patch(_CACHE_PATCH) as mock_cache,
+        patch(_ENGINE_PATCH) as mock_build,
+        patch(_TREE_PATCH) as mock_tree,
+    ):
+        mock_cache.return_value.load.return_value = loaded
+        result = await _evaluate_input_policy(
+            _FakeRequest(),
+            "sess_1",
+            conv,
+            body,
+            conv_store,
+            agent_store,
+            None,
+        )
+
+    assert result is None
+    mock_build.assert_not_called()
+    mock_tree.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_input_policy_added_mid_session_is_enforced(policy_store):
+    """A policy created after the session is live still gates the next message.
+
+    Guards the fast path against caching a stale "no policies" verdict: the
+    first message legitimately skips, and once a session policy exists (with
+    the store's cache invalidated, as the CRUD routes do) the very next
+    message must reach the engine and be denied.
+    """
+    conv_store = _FakeConversationStore()
+    agent_store = _FakeAgentStore(agent=_make_agent())
+    conv = conv_store.get_conversation("sess_1")
+    body = _make_user_message_body()
+
+    loaded = LoadedAgent(spec=_make_spec_no_guardrails(), workdir="/tmp/fake")
+    deny_result = PolicyResult(action=PolicyAction.DENY, reason="Denied mid-session")
+
+    async def _eval(_ctx: Any) -> PolicyResult:
+        return deny_result
+
+    async def _evaluate_once() -> tuple[dict[str, Any] | None, bool]:
+        """Run the input gate once against the current store contents.
+
+        :returns: ``(verdict, engine_was_built)`` — the verdict dict (or
+            ``None`` on allow/skip) and whether an engine was constructed.
+        """
+        with (
+            patch(_CACHE_PATCH) as mock_cache,
+            patch(_ENGINE_PATCH) as mock_build,
+        ):
+            mock_cache.return_value.load.return_value = loaded
+            mock_engine = mock_build.return_value
+            mock_engine.evaluate = _eval
+            mock_engine.apply_label_writes = lambda x: None
+            verdict = await _evaluate_input_policy(
+                _FakeRequest(),
+                "sess_1",
+                conv,
+                body,
+                conv_store,
+                agent_store,
+                None,
+            )
+            return verdict, mock_build.called
+
+    # No policies yet: the message is allowed without an engine build.
+    assert await _evaluate_once() == (None, False)
+
+    # A policy is added mid-session, exactly as POST /sessions/{id}/policies does.
+    policy_store.session_policies.append(_make_stored_policy("deny_all", "sess_1"))
+    _clear_policy_spec_caches()
+
+    verdict, built = await _evaluate_once()
+    assert built is True
+    assert verdict is not None
+    assert verdict["verdict"] == "deny"
+    assert verdict["reason"] == "Denied mid-session"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

N/A — `Refactor / chore` (performance), no issue required per the template.

## Summary

Every turn paid an unconditional runner→server round-trip to
`POST /v1/sessions/{id}/policies/evaluate` for the turn-start `PHASE_LLM_REQUEST`
policy gate — including sessions with no policies at all, where the answer is
provably `ALLOW`. Measured with the `warm_turn` benchmark (sqlite, an agent
bundle that declares no guardrails), that one gate was **1.0 of the 3.0 HTTP
requests per turn**.

The server already sends exactly one per-turn frame to the runner
(`POST /v1/sessions/{id}/events`), and already stamps runner hints on it
(`has_mcp_servers`, `harness_override`, `model_override`, `persisted_item_id`).
This change follows the `has_mcp_servers` precedent exactly:

- **`routes_events.py`** — beside the existing `has_mcp_servers` computation
  (where the agent spec is already loaded), recompute `any_policies_apply` and
  stamp `policies_apply=false` on the frame **only** when nothing could fire.
- **`orchestration.py`** — thread one `policies_apply: bool = True` kwarg through
  `_dispatch_session_event_to_runner_impl` → `_forward_event_to_runner`.
- **`runner/app.py`** — relay a literal `false` onto the harness body.
- **`_executor_adapter.py`** — record the per-turn flag on `run_turn` and return
  `POLICY_ACTION_ALLOW` immediately, **for `PHASE_LLM_REQUEST` only**.

**Result: `warm_turn` 3.0 → 2.0 HTTP requests/op.** The `policies/evaluate` route
disappears from the per-route counter entirely.

<details>
<summary>ELI5 + diagram</summary>

The runner used to phone the server at the start of every turn to ask "may I call
the LLM?", even for sessions where the server had nothing to enforce and the
answer was always yes. The server already sends the runner a message to start the
turn, so it now writes the answer on that message — but only when it has just
checked and knows the answer is yes, and only for that one question.

```mermaid
sequenceDiagram
    participant C as Client
    participant S as Server
    participant R as Runner
    participant H as Harness
    C->>S: POST /events (message)
    Note over S: any_policies_apply(...)<br/>µs before dispatch
    S->>R: POST /events {..., policies_apply: false}
    R->>H: message {policies_apply: false}
    rect rgb(240,240,240)
    Note over H: LLM_REQUEST gate:<br/>skipped (was: POST /policies/evaluate)
    end
    H->>H: LLM call
    H->>S: POST /policies/evaluate (LLM_RESPONSE)
    H->>S: POST /policies/evaluate (TOOL_CALL)
    H->>S: POST /policies/evaluate (TOOL_RESULT)
```

Before, the greyed box was a full HTTP round-trip. Every gate below it still is.
</details>

### Why enforcement is not weakened

This is the part worth reviewing carefully. The argument, explicitly:

1. **The server remains the sole decider.** It computes the verdict itself, with
   the *same* `any_policies_apply` primitive its own `/policies/evaluate` handler
   uses as a fast path — the same caches, the same `sys_add_policy` carve-out.
   The runner never decides anything.
2. **Microseconds, not minutes.** The verdict is computed immediately before
   dispatch, and the gate it covers fires immediately after. A dispatch-time
   snapshot is no staler than today's round-trip.
3. **Nothing is cached on the runner.** There is no TTL and no invalidation
   channel to get wrong. The verdict is recomputed from scratch on *every* send,
   so a policy created mid-session is picked up on the very next turn. (This is
   also why the rejected alternative — a runner-side "no policies apply" cache
   with push invalidation — is not merely risky but wrong: the tunnel registry is
   per server replica, so a policy created on replica A could not invalidate a
   runner tunnelled to replica B.)
4. **The skip covers exactly one gate, whose answer would provably have been
   ALLOW.** `LLM_RESPONSE`, `TOOL_CALL` and `TOOL_RESULT` fire seconds to minutes
   after dispatch and still round-trip. That also keeps the engine's
   unconditionally injected `_ASK_ON_ADD_POLICY_SPEC` intact —
   `TOOL_CALL(sys_add_policy)` is never fast-pathed.
5. **Fail-safe by construction.** A missing, `true`, or malformed hint means
   *evaluate*. Absent is what every non-web dispatch path (`scheduled/fire.py`,
   sub-agent forwards) yields, so those are unchanged. A `CreateResponseRequest`
   validator flattens anything that is not a literal `False` to `None`, so a
   garbled hint neither disables the control nor 422s the turn. Any failure
   computing the hint (unreadable spec, store error) returns `True`.
6. **The hint is not client-forgeable.** `body.data` is client-supplied and is
   splatted into the runner frame, so `policies_apply` is popped from it before
   the frame is built. The server's own verdict is the only source. (This is the
   reason the rejected alternative of smuggling the hint through `body.data` was
   not viable.)

Deliberately **not** done here: the Claude-family harnesses also gate
`PHASE_LLM_RESPONSE` unconditionally, which is a second round-trip per turn. That
hint has to be computed later in the turn and belongs in its own change.

## Test Plan

New regression guards assert on a **counter** of real `policies/evaluate` calls,
not on timings.

`tests/server/integration/test_sessions_policy_evaluate.py` — boots the real app,
captures the frame the server forwards to the runner, then hands that frame to
the production `ExecutorAdapter` with its policy bridge pointed at the real
`POST /policies/evaluate` route, so the count is of actual HTTP evaluations:

- `test_turn_start_gate_makes_zero_evaluate_calls_with_no_policies` — **0** calls.
- `test_turn_start_gate_evaluates_and_blocks_with_a_deny_policy` — hint not
  stamped, gate round-trips, and the turn is **actually blocked** (`RuntimeError:
  … denied by policy`).
- `test_session_policy_created_mid_session_re_arms_the_gate` — first turn 0 calls;
  after a `POST /v1/sessions/{id}/policies`, the next turn is **1** call.
- `test_client_supplied_policies_apply_is_not_forgeable` — a forged
  `data.policies_apply: false` never reaches the runner, and the DENY still fires.
- `test_policy_hint_fails_safe_when_the_check_raises` — a raising applicability
  check yields `True`.

`tests/runtime/harnesses/test_executor_adapter.py`:

- `test_llm_request_gate_skips_round_trip_when_server_stamps_no_policies` — 0
  evaluations.
- `test_later_gates_still_round_trip_when_llm_request_is_skipped` —
  `LLM_RESPONSE` / `TOOL_CALL` / `TOOL_RESULT` all still evaluate.
- `test_absent_or_malformed_hint_still_evaluates` — parametrized over absent,
  `true`, `"banana"`, `0`, `{}`, `null`.
- `test_deny_verdict_blocks_the_turn_when_policies_apply`.
- `test_policy_hint_does_not_leak_into_the_next_turn` — the bridge is
  closure-captured once, so the flag must be read off the adapter per turn.

**Prove-it-fails:** with the `omnigent/` changes reverted (`git checkout --`) and
the tests kept, 7 of the new tests fail; restored, all pass.

```
cd <repo> && python -m pytest \
  tests/server/integration/test_sessions_policy_evaluate.py \
  tests/runtime/harnesses/test_executor_adapter.py
# 91 passed
```

Also green on the suites that touch the same dispatch path:

```
python -m pytest tests/server/integration/test_sessions_endpoints.py \
                 tests/server/routes/test_subagent_block_wake.py     # 254 passed
python -m pytest tests/runner/test_runner_dispatch.py \
                 tests/runner/test_suppress_recovery_turn.py         # 221 passed, 1 skipped
```

`pre-commit run --files <changed>`: ruff format / ruff check / all custom lints
pass. `pyrefly` reports 99 errors both with and without this change (all
pre-existing `missing-import` in `omnigent/runtime/telemetry.py` and
`sdks/python-client/`, from a borrowed venv); 0 errors in every file this PR
touches.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

`dev/benchmarks/omnigent/run.py --journeys warm_turn` (real server + runner +
mock LLM in-process, sqlite, per-route counter from
`GET /debug/server-metrics`), same box, same flags, under `flock`:

**Before** — 3.0 requests/op:

```
warm_turn   Mean ms 116.4   HTTP/op 3.0
  GET  /v1/sessions/{session_id}/stream              1.0/op
  POST /v1/sessions/{session_id}/events              1.0/op
  POST /v1/sessions/{session_id}/policies/evaluate   1.0/op
```

**After** — 2.0 requests/op:

```
warm_turn   Mean ms  90.9   HTTP/op 2.0
  GET  /v1/sessions/{session_id}/stream              1.0/op
  POST /v1/sessions/{session_id}/events              1.0/op
```

The `policies/evaluate` row is gone, not merely smaller. Wall-clock (116 ms →
91 ms on loopback) is incidental — the counter is the claim, and it scales with
real network latency.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = the benchmark run above (`warm_turn`, before/after request
counts and per-route breakdown), plus the reverted-source prove-it-fails cycle
confirming the new tests actually guard the change rather than passing
vacuously.

Not covered automatically: the runner's one-line relay of the hint
(`runner/app.py`) is exercised transitively — the server-side test drives the
frame the runner would relay, and the relay is identity for this field. A live
runner path is covered by the benchmark run rather than by a unit test.

## Note on sequencing

This is a **follow-up** to the `perf/server-skip-empty-policy-engine` work, which
added the `any_policies_apply` fast path inside the `/policies/evaluate` handler.
That change made the round-trip cheap; this one removes it. It reuses that exact
primitive and touches **disjoint lines** of `omnigent/runtime/policies/builder.py`
consumers, so the two do not conflict — but this PR should land after it.

## Changelog

Turns no longer make a policy-evaluation round-trip when the session has no policies configured.
