### PR TITLE
Reject non-product agent recordings

### DIFF
--- a/dev/recording-lanes.md
+++ b/dev/recording-lanes.md
@@ -3,12 +3,13 @@
 Shared reference for **repro-agent** and **resolve-agent**. Both film the same
 kinds of journeys on the same surfaces; only *which* clip they produce differs:
 
-- **repro-agent** films the reproduction — a `reproduced` facet yields a
-  **`before`** clip (the test FAILS, showing the live bug); an `already_fixed`
-  facet yields a **`fixed`** clip (the test PASSES on the running build).
-- **resolve-agent** films the resolution — after the fix, the recovered test now
-  PASSES, and that passing run is the **`after`** clip (the human-visible half of
-  the fail→pass proof). On the review path it films the reviewed PR head.
+- **repro-agent** films the product journey — a `reproduced` facet yields a
+  **`before`** clip showing the live bug; an `already_fixed` facet yields a
+  **`fixed`** clip showing the correct user-visible outcome.
+- **resolve-agent** films the product journey after the fix as the **`after`**
+  clip (the human-visible half of the fail→pass proof). The recovered test
+  verifies the result separately. On the review path it films the reviewed PR
+  head.
 
 Everything else below — which surface to drive, how to stand the recorder up, and
 the per-surface mechanics — is identical for both. Each agent's own AGENTS.md says
@@ -20,7 +21,9 @@ A `web` / `mobile` / `terminal` / `cli` / `desktop` facet is expected to yield a
 drive it on that surface and film it. Only an `api` facet — a failure no user
 observes on any surface (a wrong value in a response, an internal state a pytest
 asserts) — legitimately has no recording; `recordings: []` is correct there and is
-not a gap.
+not a gap. Tests may drive and verify the journey, but the clip itself must show
+the product surface and user-visible outcome, never the test process, pytest
+output, assertions, logs, or a synthetic evidence-summary slide.
 
 **One verdict-appropriate clip per facet — nothing else.** Every recording must
 correspond to a facet, and its `kind` must match that facet's verdict. Do **not**
@@ -30,11 +33,20 @@ confuses the reader.
 
 Recording is **best-effort**: if the tooling below is missing, or a user-facing
 facet's state is genuinely unreachable in this harness, keep `recordings: []` for
-that facet and **name the specific blocker** in your evidence/handoff — an empty
-recordings list on a `web`/`mobile`/`terminal`/`cli`/`desktop` facet must always come with
-a concrete reason, never a silent skip. Never let recording block or distort the
-work itself, and never fabricate a hollow journey that doesn't reach the failure
-just to produce a video.
+that facet and **name the specific blocker** in `recording_unavailable_reason` —
+an empty recordings list on a `web`/`mobile`/`terminal`/`cli`/`desktop` facet must
+always come with a concrete reason, never a silent skip. Never let recording block
+or distort the work itself, and never fabricate a hollow journey that doesn't
+reach the failure just to produce a video. Missing or rejected footage never
+blocks the verdict, fix, or PR.
+
+Every declared recording includes `capture_mode`, which records how the product
+surface was filmed. Use `playwright_ui` for browser-page capture, `electron` for
+the desktop harness, `vhs_user_command` for a VHS tape that types the real user
+command, and `screen` for a direct device/screen capture. Do not declare a raw
+recorder output: copy the selected clip to a stable `<kind>-<facet>.<ext>` path
+first, then declare only that path. Undeclared media remains available in the CI
+artifact for debugging but is not attached to Linear or a PR.
 
 ## The recorder needs its own local server
 

--- a/dev/repro-agent/AGENTS.md
+++ b/dev/repro-agent/AGENTS.md
@@ -344,12 +344,13 @@ leaked runner env), and the per-surface mechanics (`web` / `mobile` / `terminal`
 `cli` / `desktop`), plus the empty-recordings and caption rules. This section states only
 *which clip repro-agent produces*:
 
-- a **`reproduced`** facet → **before-fix footage** (`kind: "before"`): run the
-  authored test so it FAILS; the failing run's video is the proof the bug is live
-  (e.g. `recordings/1234/before-picker.webm`).
-- an **`already_fixed`** facet → **proof-it-works footage** (`kind: "fixed"`): run
-  the same authored test so it PASSES; the passing run's video shows the journey
-  behaving correctly on the running build (e.g. `recordings/1234/fixed-picker.webm`).
+- a **`reproduced`** facet → **before-fix footage** (`kind: "before"`): use the
+  authored test to drive and verify the failure, but film only the product surface
+  and the user-visible bug (e.g. `recordings/1234/before-picker.webm`). Never film
+  pytest, assertion output, logs, or the test source.
+- an **`already_fixed`** facet → **proof-it-works footage** (`kind: "fixed"`): use
+  the same test to drive and verify the passing journey, while the video shows only
+  the product behaving correctly (e.g. `recordings/1234/fixed-picker.webm`).
 
 `not_reproduced` and `needs_more_info` facets have nothing to film — skip them.
 Name the clip `<before|fixed>-<facet>.<ext>` when you move it to a stable path.
@@ -399,8 +400,10 @@ choice:
   "test_path": "tests/e2e_ui/model_catalog/test_1234.py",
   "recordings": [
     {"surface": "web", "kind": "before", "path": "recordings/1234/before-picker.webm", "format": "webm",
+     "capture_mode": "playwright_ui",
      "caption": "open the model picker → select the catalog → picker shows raw IDs instead of names"}
   ],
+  "recording_unavailable_reason": "",
   "session_id": "dc59e331-...",
   "journey": "open model picker → select catalog → picker shows raw IDs",
   "evidence": "snapshot ref / response / log excerpt, plus root-cause leads"
@@ -438,7 +441,7 @@ Field meanings:
   excerpt), plus any root-cause leads you noticed while reproducing (hypotheses
   only — you do not fix).
 - `recordings` — the Step 4 captures: a list of
-  `{"surface", "kind", "path", "format", "caption"}` objects. `kind` is
+  `{"surface", "kind", "path", "format", "capture_mode", "caption"}` objects. `kind` is
   `"before"` for a `reproduced` facet's failing run or `"fixed"` for an
   `already_fixed` facet's passing run (the fix step later re-records the same
   drivers post-fix as `"after"`); `path` workspace-relative. `caption` is a
@@ -448,10 +451,14 @@ Field meanings:
   the catalog → picker shows raw IDs"`. Phrase it for *this* clip's outcome: a
   `before` caption ends in the failure, a `fixed` caption ends in the correct
   behavior (the journey completing). This is per-recording (each clip drives its
-  own steps), distinct from the bug-level `journey` field. Include an entry for
-  the authored-but-unrendered VHS tape too (`"format": "tape"`) when rendering
-  was skipped. Empty list when nothing was recorded — then say what was missing
-  in `evidence`.
+  own steps), distinct from the bug-level `journey` field. `capture_mode` is one
+  of the surface-appropriate values in `dev/recording-lanes.md`. Keep an
+  authored-but-unrendered VHS tape in the artifact, but do not declare it as a
+  recording. Empty list when nothing valid was recorded.
+- `recording_unavailable_reason` — empty when every expected clip is present;
+  otherwise the concrete per-surface tooling or reachability blocker. For an
+  API-only bug, say that the evidence is textual. Never substitute a synthetic
+  fallback or test-runner video.
 
 Keep the prose before the block terse — the one exception is the full test
 source, which you paste in full. You produce the live-confirmed reproduction +

--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -272,9 +272,10 @@ reproduction test is your objective instrument.
    Use the same lanes as 2B.5 — see [`dev/recording-lanes.md`](../recording-lanes.md)
    (build the SPA first, record via `OMNIGENT_E2E_RECORD_DIR`, per-surface `web` /
    `mobile` / `terminal` / `cli` / `desktop` mechanics) — saving to
-   `recordings/<slug>/after-<facet>.<ext>` with a `caption` for what the clip shows. A passing run's footage is the "after" half (the bug resolved); a
-   failing run's footage shows the PR author exactly what still breaks — either
-   way you record it. When the handoff *does* carry a before clip, carry it
+   `recordings/<slug>/after-<facet>.<ext>` with a `caption` for what the clip
+   shows. The test result determines the verdict separately; the footage must
+   show the product journey and its visible outcome, never the test runner. When
+   the handoff *does* carry a before clip, carry it
    through **and** produce the after; when it carries none, still produce the
    after and note the missing before. Only omit the after clip when it is
    genuinely unobtainable (recorder tooling missing, or the fixture can't come
@@ -495,9 +496,11 @@ per-surface mechanics for `web` / `mobile` / `terminal` / `cli` / `desktop`, plu
 empty-recordings and caption rules. This step states only *which clip resolve
 produces*:
 
-- After the fix, re-run the recovered test on the fixed tree so it **PASSES**; that
-  passing run is the **after-fix clip** (`kind: "after"`) — the human-visible half
-  of your fail→pass proof. Move it to a stable `recordings/<slug>/after-<facet>.<ext>`.
+- After the fix, use the recovered test on the fixed tree to drive and verify the
+  passing journey; the **after-fix clip** (`kind: "after"`) must show only the
+  product surface and corrected user-visible behavior, never pytest, assertions,
+  logs, or test source. Move it to a stable
+  `recordings/<slug>/after-<facet>.<ext>`.
 - If the repro handoff carried a **before** clip (recover it from the repro
   session's `workspace` or the CI artifact bundle), carry it through unchanged
   alongside your after clip; when it carried none, produce the after clip anyway and
@@ -1228,10 +1231,13 @@ the message. Same discipline as repro-agent:
   },
   "recordings": [
     {"surface": "web", "kind": "before", "path": "recordings/1234/before-picker.webm", "format": "webm",
+     "capture_mode": "playwright_ui",
      "caption": "open the model picker → select the catalog → picker shows raw IDs"},
     {"surface": "web", "kind": "after", "path": "recordings/1234/after-picker.webm", "format": "webm",
+     "capture_mode": "playwright_ui",
      "caption": "open the model picker → select the catalog → picker now shows friendly names"}
   ],
+  "recording_unavailable_reason": "",
   "test_audit": "repro e2e was behavioral (failed on raw IDs); no rewrite needed",
   "hermetic_check": "test_picker_label re-run with ambient env vars set — still passes",
   "cross_review": "codex reviewer: no blocking findings; noted a null-guard, addressed",
@@ -1273,7 +1279,8 @@ Field meanings:
   of targeted tests you wrote (empty in review mode).
 - `recordings` — your after-fix footage (`kind: "after"`), plus any before-fix
   footage carried through from the repro handoff, same
-  `{surface, kind, path, format, caption}` shape as repro-agent's field. You
+  `{surface, kind, path, format, capture_mode, caption}` shape as repro-agent's
+  field. You
   produce an `after` clip on **every** author/review run — it is driven off the
   reproduction test, not off an upstream file, so it does not depend on the repro
   handoff carrying footage. When a before clip was recovered, carry its `caption`
@@ -1283,8 +1290,11 @@ Field meanings:
   review mode, the "after" entries are the drivers recorded against the reviewed
   PR head. The list is empty **only** when recording is genuinely blocked — the
   recorder tooling is missing, or the fixture can't come online after the SPA
-  build — never merely because the upstream run left no footage; say which in
-  prose.
+  build — never merely because the upstream run left no footage.
+- `recording_unavailable_reason` — empty when every expected clip is present;
+  otherwise name the concrete blocker. For API-only evidence, say it is textual.
+  Missing or rejected footage never blocks the fix or PR, and must never be
+  replaced with a synthetic fallback or a video of the test runner.
 - `test_audit` — the result of the Step 2B.1 audit (author mode). In review mode,
   note whether the repro test was behavioral as-is.
 - `hermetic_check` — the result of the Step 2B.5 hostile-env re-run when the diff


### PR DESCRIPTION
## Related issue

N/A — agent operating-policy correction.

## Summary

- Require recordings to show the real product surface rather than pytest, logs, API probes, or synthetic fallback slides.
- Add `capture_mode` provenance and an explicit `recording_unavailable_reason` when valid footage cannot be produced.
- Keep recordings best-effort so missing or rejected media never blocks reproduction verdicts, fixes, or PR publication.

ELI5: tests prove the result, but videos should show what a user sees. If there is nothing useful to film, the agent explains why instead of manufacturing a video.

```text
agent journey -> valid product clip -> attach
              -> no valid clip      -> reason + continue PR
```

## Test Plan

- `uv run --with pre-commit pre-commit run --files dev/recording-lanes.md dev/repro-agent/AGENTS.md dev/resolve-agent/AGENTS.md`
- Coordinated enforcement coverage runs in the omnigent-internal PR.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The updated handoff examples show valid `playwright_ui` provenance and explicit empty-reason fields.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Validated the complete agent contracts and recording-lane guidance with the repository pre-commit hooks. The coordinated internal PR adds executable normalization and upload-policy regression tests.