### PR TITLE
perf(server): serve the session snapshot from one conversation read

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -1723,6 +1723,7 @@ def _resolve_harness_impl(
     *,
     agent_store: AgentStore | None = None,
     agent_cache: AgentCache | None = None,
+    agent: Agent | None = None,
 ) -> str | None:
     """
     Resolve the canonical harness for a conversation's bound agent.
@@ -1739,6 +1740,10 @@ def _resolve_harness_impl(
     :param conv: The conversation entity, or ``None``.
     :param agent_store: Optional store for resolving the bound agent.
     :param agent_cache: Optional cache for loading the bound agent spec.
+    :param agent: The already-read row for ``conv.agent_id``, when the caller
+        holds it. Reused verbatim so the snapshot build does not read the same
+        agent (and its spawn-tree session lookup) twice; a row for a different
+        agent is ignored. ``None`` reads it through *agent_store*.
     :returns: The canonical harness (e.g. ``"openai-agents"`` or
         ``"claude-sdk"``), or ``None`` when unavailable.
     """
@@ -1763,7 +1768,8 @@ def _resolve_harness_impl(
             return None
         if agent_cache is None:
             agent_cache = get_agent_cache()
-        agent = agent_store.get(conv.agent_id)
+        if agent is None or agent.id != conv.agent_id:
+            agent = agent_store.get(conv.agent_id)
         if agent is None:
             return None
         loaded = agent_cache.load(

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -90,6 +90,7 @@ from omnigent.runtime.policies.builder import (
     ancestor_ids_from_tree,
     load_session_tree,
     load_session_usage,
+    load_verified_session_tree,
 )
 from omnigent.runtime.policies.engine import PolicyEngine
 from omnigent.runtime.workflow import _find_spec_by_name
@@ -895,6 +896,8 @@ def _publish_subtree_cost_to_ancestors(
     conv_store: ConversationStore,
     session_id: str,
     conv: Conversation | None = None,
+    *,
+    tree: list[Conversation] | None = None,
 ) -> None:
     """
     Re-publish each ancestor's subtree-summed cost after a child usage update.
@@ -927,13 +930,21 @@ def _publish_subtree_cost_to_ancestors(
         The parameter belongs to this function, not to whichever caller first
         needed it, so that no caller can be removed and leave a signature
         behind that its remaining callers already depend on.
+    :param tree: A spawn tree already loaded for this session — the rows of a
+        :func:`load_verified_session_tree` result, so membership of
+        *session_id* is already established. Callers that just summed the same
+        tree for this session's own badge pass it so the turn-end roll-up loads
+        the tree once instead of twice; the ancestor sums then come from the
+        same rows as the session's own, rather than a second read a few
+        milliseconds later. ``None`` loads the tree here.
     :returns: None.
     """
-    tree = load_session_tree(
-        session_id,
-        conv_store,
-        conv.root_conversation_id if conv is not None else None,
-    )
+    if tree is None:
+        tree = load_session_tree(
+            session_id,
+            conv_store,
+            conv.root_conversation_id if conv is not None else None,
+        )
     for ancestor_id in ancestor_ids_from_tree(tree, session_id):
         ancestor_usage = _sum_subtree_usage(tree, ancestor_id)
         subtree_cost = _priced_cost_for_display(ancestor_usage)
@@ -977,6 +988,7 @@ def _build_session_response(
     viewer_id: str | None = None,
     agent_store: AgentStore | None = None,
     agent_cache: AgentCache | None = None,
+    agent: Agent | None = None,
 ) -> SessionResponse:
     """
     Build a :class:`SessionResponse` from store-side entities.
@@ -1047,6 +1059,9 @@ def _build_session_response(
         ``None`` is treated as ``[]``.
     :param agent_store: Optional store used to resolve the session harness.
     :param agent_cache: Optional cache used to load the session harness spec.
+    :param agent: The bound agent row when the caller already read it, so
+        the harness resolve reuses it instead of reading the same row again.
+        ``None`` reads it through *agent_store* as before.
     :returns: The :class:`SessionResponse` for the API.
     :raises OmnigentError: If ``conv.agent_id`` is ``None``.
     """
@@ -1099,6 +1114,7 @@ def _build_session_response(
             conv,
             agent_store=agent_store,
             agent_cache=agent_cache,
+            agent=agent,
         ),
         model_override=conv.model_override,
         cost_control_mode_override=conv.cost_control_mode_override,
@@ -1650,7 +1666,14 @@ async def _persist_external_session_usage(
     # hide in-flight sub-agent spend until the next child flush (the badge would
     # oscillate own ⇄ subtree). For a childless session the subtree is just
     # itself, so this equals own cost — one indexed tree query per flush.
-    subtree_usage = await asyncio.to_thread(load_session_usage, session_id, conversation_store)
+    #
+    # That one load also serves the ancestor roll-up below: the ancestors are in
+    # this same tree, so summing both from one read keeps a parent's badge
+    # consistent with its child's instead of straddling two reads.
+    subtree_tree = await asyncio.to_thread(
+        load_verified_session_tree, session_id, conversation_store
+    )
+    subtree_usage = _sum_subtree_usage(subtree_tree.rows, session_id)
     subtree_cost = _priced_cost_for_display(subtree_usage)
     usage_by_model = _usage_by_model_for_display(subtree_usage)
     # Only include fields that were sent; the client treats absent
@@ -1675,12 +1698,13 @@ async def _persist_external_session_usage(
     # This session's usage also moves its ANCESTORS' subtree cost (its spend
     # rolls up into every ancestor), so re-publish each ancestor's subtree cost
     # too — otherwise a grandparent's badge wouldn't reflect a deep descendant.
-    # No-op for a top-level session (no ancestors). Threaded: it pages the
-    # conversation tree per ancestor.
+    # No-op for a top-level session (no ancestors). Threaded: SSE fan-out over
+    # the tree already loaded above.
     await asyncio.to_thread(
         _publish_subtree_cost_to_ancestors,
         conversation_store,
         session_id,
+        tree=subtree_tree.rows,
     )
     return raw_tokens
 
@@ -6416,11 +6440,14 @@ async def _relay_runner_stream_once(
                             # surfaces tokens). context_tokens/window already ride
                             # on the response.completed event. Threaded: store
                             # reads + SSE fan-out.
-                            _subtree_usage = await asyncio.to_thread(
-                                load_session_usage,
+                            # One tree load for this session's own badge and
+                            # the ancestor roll-up below — same tree, one read.
+                            _subtree_tree = await asyncio.to_thread(
+                                load_verified_session_tree,
                                 session_id,
                                 conversation_store,
                             )
+                            _subtree_usage = _sum_subtree_usage(_subtree_tree.rows, session_id)
                             _subtree_cost = _priced_cost_for_display(_subtree_usage)
                             _usage_by_model = _usage_by_model_for_display(_subtree_usage)
                             if _subtree_cost is not None or _usage_by_model is not None:
@@ -6442,6 +6469,7 @@ async def _relay_runner_stream_once(
                                     _publish_subtree_cost_to_ancestors,
                                     conversation_store,
                                     session_id,
+                                    tree=_subtree_tree.rows,
                                 )
 
                     # Reset the turn-scoped response_id on any
@@ -9529,6 +9557,9 @@ async def _get_session_snapshot(
     llm_model: str | None = None
     context_window: int | None = None
     agent_name: str | None = None
+    # Kept in scope past the block so the harness resolve below reuses this
+    # row instead of reading the same agent (plus its session lookup) again.
+    agent: Agent | None = None
     if agent_store is not None and agent_cache is not None and conv.agent_id is not None:
         try:
             agent = await asyncio.to_thread(agent_store.get, conv.agent_id)
@@ -9622,7 +9653,16 @@ async def _get_session_snapshot(
     # is persisted on its own child conversation, not the parent's, so the
     # parent's own session_usage would under-report. Off the event loop
     # because it pages the conversation tree from the store.
-    subtree_usage = await asyncio.to_thread(load_session_usage, conv.id, conv_store)
+    # The tree root comes from the row this request already holds, so the
+    # subtree load skips its own ``get_conversation``. It stays a hint:
+    # ``load_session_usage`` verifies the tree it names contains this session
+    # and resolves the root itself when the row was stale.
+    subtree_usage = await asyncio.to_thread(
+        load_session_usage,
+        conv.id,
+        conv_store,
+        root_conversation_id=conv.root_conversation_id,
+    )
     # Static signal telling the open view a host-bound, host-down session is a
     # resumable managed host it can wake by sending a message, vs a terminal
     # host_offline dead-end. Computed independently of liveness_lookup (the web
@@ -9660,6 +9700,7 @@ async def _get_session_snapshot(
         viewer_id=viewer_id,
         agent_store=agent_store,
         agent_cache=agent_cache,
+        agent=agent,
     )
 
 

--- a/tests/server/integration/test_sessions_snapshot_read_budget.py
+++ b/tests/server/integration/test_sessions_snapshot_read_budget.py
@@ -1,0 +1,341 @@
+"""
+Read-budget guard for ``GET /v1/sessions/{session_id}``.
+
+The session snapshot is the widest-reach read in the product: session start
+hits it several times per launch, the REPL polls it as a turn backstop, and
+both the web UI and the SDK re-read it routinely. Layers of it used to do
+their own reads of state the request already held — the authorization pass
+fetched the conversation, then the subtree-usage load fetched the same row
+again to find its tree root, and the harness resolver re-read the agent row
+the snapshot had just loaded.
+
+Behavioural assertions cannot see that: every variant returns the same body.
+So this module pins counters instead —
+
+- the route's total SQL statement count,
+- that no statement is issued twice in one snapshot build,
+- one single-row ``conversations`` fetch and one ``agents`` fetch,
+
+and pins the response body's field set, because a snapshot that silently
+loses ``runner_online`` / ``labels`` / ``runner_id`` / ``harness`` is a far
+worse outcome than a slow one.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_BUDGET_USER = "budget@example.com"
+
+# One authorized ``GET /v1/sessions/{id}`` on a session with zero items,
+# measured with warm spec / ACL caches. The layer-by-layer tally:
+#
+#   3  authorization's ``get_conversation`` (row + metadata + labels)
+#   1  the committed-items page
+#   2  the bound agent row + its spawn-tree session lookup
+#   2  the runner/host liveness lookup (metadata + labels)
+#   3  the spawn-tree page for subtree usage (rows + labels + metadata)
+#
+# Raising this needs a reason in the diff: every caller of this endpoint pays
+# it, several times per session launch.
+_SNAPSHOT_ROUTE_SQL_BUDGET = 11
+
+# Every field the snapshot contract carries for a freshly created session.
+# Asserted as a subset so adding a field is fine and dropping one is not.
+_SNAPSHOT_FIELDS = frozenset(
+    {
+        "active_response_id",
+        "agent_id",
+        "agent_name",
+        "archived",
+        "background_task_count",
+        "background_tasks",
+        "context_window",
+        "cost_control_mode_override",
+        "created_at",
+        "external_session_id",
+        "git_branch",
+        "harness",
+        "host_id",
+        "host_online",
+        "host_resumable",
+        "id",
+        "items",
+        "kind",
+        "labels",
+        "last_task_error",
+        "last_total_tokens",
+        "llm_model",
+        "mcp_startup",
+        "model_options",
+        "model_override",
+        "parent_session_id",
+        "pending_elicitations",
+        "pending_inputs",
+        "permission_level",
+        "project_id",
+        "reasoning_effort",
+        "root_conversation_id",
+        "runner_id",
+        "runner_online",
+        "sandbox_status",
+        "skills",
+        "status",
+        "sub_agent_name",
+        "subagent_routing_override",
+        "terminal_launch_args",
+        "terminal_pending",
+        "title",
+        "todos",
+        "total_cost_usd",
+        "updated_at",
+        "usage_by_model",
+        "workspace",
+    }
+)
+
+
+@pytest.fixture()
+def budget_app(runtime_init: None, db_uri: str, tmp_path: Path) -> FastAPI:
+    """App with permissions + header auth, so the route runs its real auth pass."""
+    from omnigent.runtime.agent_cache import AgentCache
+    from omnigent.server.app import create_app
+    from omnigent.server.auth import UnifiedAuthProvider
+    from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+    from omnigent.stores.artifact_store.local import LocalArtifactStore
+    from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
+    from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+    from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    return create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(artifact_store=artifact_store, cache_dir=tmp_path / "cache"),
+        comment_store=SqlAlchemyCommentStore(db_uri),
+        permission_store=SqlAlchemyPermissionStore(db_uri),
+        auth_provider=UnifiedAuthProvider(source="header"),
+    )
+
+
+@pytest_asyncio.fixture()
+async def budget_client(budget_app: FastAPI, mock_llm: Any, tmp_path: Path):
+    """Async client against the auth-enabled app."""
+    from omnigent.runtime import set_harness_process_manager
+    from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
+
+    pm = HarnessProcessManager(tmp_parent=tmp_path / "harness_pm")
+    await pm.start()
+    set_harness_process_manager(pm)
+    transport = httpx.ASGITransport(app=budget_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    mock_llm.release_all()
+    set_harness_process_manager(None)
+    await pm.shutdown()
+
+
+async def _seed_session(client: httpx.AsyncClient, db_uri: str) -> str:
+    """Create a real agent-bound session owned by the budget user.
+
+    Goes through the real create path with a genuine uploaded bundle: a
+    fabricated agent row cannot be loaded from the artifact store, and the
+    snapshot's agent / harness resolvers would bail before doing the reads
+    this budget measures.
+
+    :param client: The authenticated async client.
+    :param db_uri: Database URI, for granting the session.
+    :returns: The created session id.
+    """
+    from omnigent.server.auth import LEVEL_OWNER
+    from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+    from tests.server.helpers import build_agent_bundle
+
+    perms = SqlAlchemyPermissionStore(db_uri)
+    perms.ensure_user(_BUDGET_USER)
+    resp = await client.post(
+        "/v1/sessions",
+        data={"metadata": _json.dumps({"title": "snapshot budget"})},
+        files={
+            "bundle": (
+                "agent.tar.gz",
+                build_agent_bundle(name="budget-agent"),
+                "application/gzip",
+            )
+        },
+        headers={"X-Forwarded-Email": _BUDGET_USER},
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = str(resp.json()["session_id"])
+    perms.grant(_BUDGET_USER, session_id, LEVEL_OWNER)
+    return session_id
+
+
+def _normalized(statement: str) -> str:
+    """Collapse whitespace so the same query always compares equal."""
+    return re.sub(r"\s+", " ", statement).strip()
+
+
+def _is_conversation_row_fetch(statement: str) -> bool:
+    """Whether *statement* is a single-row ``get_conversation`` entity load.
+
+    The ORM entity select labels its columns (``... AS conversations_id``);
+    the spawn-tree page listing selects them bare, so the two are
+    distinguishable without matching on the WHERE clause.
+    """
+    return statement.startswith("SELECT conversations.workspace_id AS conversations_workspace_id")
+
+
+def _is_agent_row_fetch(statement: str) -> bool:
+    """Whether *statement* reads the bound agent's row."""
+    return " FROM agents " in f" {statement} "
+
+
+async def _measured_get(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    session_id: str,
+) -> tuple[list[str], dict[str, Any]]:
+    """Issue one authorized snapshot GET, recording every SQL statement.
+
+    :param client: The authenticated async client.
+    :param db_uri: Database URI, used to find the engine to listen on.
+    :param session_id: The session to read.
+    :returns: The normalized statements, and the response body.
+    """
+    from sqlalchemy import event as sa_event
+
+    from omnigent.db.utils import _engine_cache
+
+    headers = {"X-Forwarded-Email": _BUDGET_USER}
+    # Warm the spec / ACL / status caches so the count is the steady-state one
+    # a poll pays, not a cold-process one-off.
+    for _ in range(3):
+        warm = await client.get(f"/v1/sessions/{session_id}", headers=headers)
+        assert warm.status_code == 200, warm.text
+
+    engine = _engine_cache[db_uri]
+    statements: list[str] = []
+
+    def _on_exec(conn, cursor, statement, parameters, context, executemany):
+        if not statement.lstrip().upper().startswith("PRAGMA"):
+            statements.append(_normalized(statement))
+
+    sa_event.listen(engine, "before_cursor_execute", _on_exec)
+    try:
+        resp = await client.get(f"/v1/sessions/{session_id}", headers=headers)
+    finally:
+        sa_event.remove(engine, "before_cursor_execute", _on_exec)
+
+    assert resp.status_code == 200, resp.text
+    return statements, resp.json()
+
+
+async def test_snapshot_route_sql_budget(
+    budget_client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Pin the statement count for one snapshot GET on an empty session.
+
+    This is the oracle for threading the request's own state forward:
+    dropping the ``root_conversation_id=`` hint on the subtree-usage load, or
+    the ``agent=`` hand-off to the harness resolver, makes those layers read
+    state the request already held and moves this count. No behavioural
+    assertion can see it — every variant returns the same body.
+    """
+    session_id = await _seed_session(budget_client, db_uri)
+    statements, body = await _measured_get(budget_client, db_uri, session_id)
+
+    assert body["items"] == [], "fixture must be an empty session for this budget"
+    assert len(statements) == _SNAPSHOT_ROUTE_SQL_BUDGET, [s[:90] for s in statements]
+
+
+async def test_snapshot_route_issues_no_statement_twice(
+    budget_client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """No query runs twice in one snapshot build.
+
+    Each layer of the snapshot answers a different question, so a repeated
+    query means two layers observed identical state independently — the shape
+    of redundancy this endpoint kept regressing into.
+    """
+    session_id = await _seed_session(budget_client, db_uri)
+    statements, _ = await _measured_get(budget_client, db_uri, session_id)
+
+    repeated = {s[:110]: n for s, n in Counter(statements).items() if n > 1}
+    assert repeated == {}, repeated
+
+
+async def test_snapshot_route_reads_conversation_and_agent_once(
+    budget_client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """The session's own row and its agent row are each read exactly once.
+
+    The authorization pass is the source of truth for both the conversation
+    row and the caller's level, so it keeps its read; every later layer that
+    needs the same row is handed it. The spawn-tree page listing is NOT this
+    read — it observes the session's descendants, which the single row cannot
+    answer — so it is deliberately still there.
+    """
+    session_id = await _seed_session(budget_client, db_uri)
+    statements, _ = await _measured_get(budget_client, db_uri, session_id)
+
+    row_fetches = [s for s in statements if _is_conversation_row_fetch(s)]
+    assert len(row_fetches) == 1, [s[:90] for s in row_fetches]
+    agent_fetches = [s for s in statements if _is_agent_row_fetch(s)]
+    assert len(agent_fetches) == 1, [s[:90] for s in agent_fetches]
+
+
+async def test_snapshot_body_keeps_every_field(
+    budget_client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """The snapshot still carries its whole contract after the read dedupe.
+
+    Losing a field is far worse than a slow response: session start, the
+    REPL, the web UI and the SDK each pull a different one of these out of
+    the same document, so a dropped ``harness`` or ``runner_online`` breaks a
+    caller that no read-budget number would notice.
+    """
+    session_id = await _seed_session(budget_client, db_uri)
+    _, body = await _measured_get(budget_client, db_uri, session_id)
+
+    assert set(body) >= _SNAPSHOT_FIELDS, sorted(_SNAPSHOT_FIELDS - set(body))
+    # The fields fed by the reads this module dedupes, spelled out: ``harness``
+    # and ``llm_model`` now come from the agent row the snapshot already read,
+    # and the cost fields from a tree loaded off the in-hand row's root.
+    assert body["id"] == session_id
+    assert body["harness"] is not None
+    assert body["agent_name"] == "budget-agent"
+    assert body["agent_id"] is not None
+    assert body["status"] == "idle"
+    assert body["permission_level"] is not None
+    assert body["labels"] == {}
+    assert body["runner_id"] is None
+    # ``runner_online`` must carry a verdict, not ``None``: ``None`` means the
+    # liveness lookup was not wired through, and the CLI treats it as
+    # "optimistically online". Its VALUE is deliberately a superset of
+    # ``GET /v1/runners/{id}/status`` (it stays true through the liveness TTL
+    # after an ungraceful death), which is pinned elsewhere — not here.
+    assert body["runner_online"] is not None
+    assert body["host_id"] is None
+    assert body["host_resumable"] is False

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -131,9 +131,15 @@ class _ConversationStore:
     ) -> None:
         self.items = items
         self.list_items_calls: list[dict[str, object]] = []
+        # Read counters for the snapshot's read-budget tests: the snapshot
+        # threads the row it already holds forward, so a second
+        # ``get_conversation`` for the same id means a layer re-read it.
+        self.get_conversation_calls: list[str] = []
+        self.list_conversations_calls: list[str | None] = []
         self._conversations = conversations
 
     def get_conversation(self, conversation_id: str) -> Conversation | None:
+        self.get_conversation_calls.append(conversation_id)
         if self._conversations is not None:
             return self._conversations.get(conversation_id)
         return Conversation(
@@ -161,6 +167,7 @@ class _ConversationStore:
         conversation sharing the root; otherwise synthesize the single
         childless conversation the legacy tests expect.
         """
+        self.list_conversations_calls.append(root_conversation_id)
         if self._conversations is not None:
             convs = [
                 c
@@ -2351,6 +2358,90 @@ def test_publish_subtree_cost_to_ancestors_publishes_each_ancestor_subtree(
     )
     # The payload is a session.usage broadcast the web client renders as the badge.
     assert by_conv["b460374fc8e697b296708f52dc9d8179"]["type"] == "session.usage"
+
+
+def test_publish_subtree_cost_to_ancestors_reuses_a_supplied_tree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller's already-loaded tree is reused, not re-read.
+
+    A turn end sums this session's own subtree for its badge and then walks
+    the ancestors — the same tree, twice. The caller hands its rows over so
+    the walk costs no store read, and every ancestor's number comes from the
+    same read as the session's own instead of a second one milliseconds later.
+    """
+    g = _graph_conv(
+        "8463f762110b86b1ba33ddf7a8fc1172",
+        root="8463f762110b86b1ba33ddf7a8fc1172",
+        parent=None,
+        cost=1.0,
+    )
+    c = _graph_conv(
+        "405bfe154d5c0e795a2b87021bc897bf",
+        root="8463f762110b86b1ba33ddf7a8fc1172",
+        parent="8463f762110b86b1ba33ddf7a8fc1172",
+        cost=4.0,
+    )
+    conv_store = _ConversationStore(
+        [],
+        conversations={
+            "8463f762110b86b1ba33ddf7a8fc1172": g,
+            "405bfe154d5c0e795a2b87021bc897bf": c,
+        },
+    )
+    recorder = _UsageStreamRecorder()
+    monkeypatch.setattr(_sessions_mod, "session_stream", recorder)
+
+    _publish_subtree_cost_to_ancestors(
+        conv_store,  # type: ignore[arg-type]
+        "405bfe154d5c0e795a2b87021bc897bf",
+        tree=[g, c],
+    )
+
+    # Zero store reads: the whole walk ran off the caller's rows. Without the
+    # hand-off this is one ``get_conversation`` plus one tree page — the second
+    # load of a tree the caller had just summed.
+    assert conv_store.get_conversation_calls == []
+    assert conv_store.list_conversations_calls == []
+    # Same answer as the self-loading path: the root's subtree is $1 + $4.
+    by_conv = {pub.conversation_id: pub.event for pub in recorder.published}
+    assert set(by_conv) == {"8463f762110b86b1ba33ddf7a8fc1172"}
+    assert by_conv["8463f762110b86b1ba33ddf7a8fc1172"]["total_cost_usd"] == 5.0
+
+
+@pytest.mark.asyncio
+async def test_session_snapshot_reads_the_conversation_row_once() -> None:
+    """The snapshot's subtree-usage load reuses the row the request holds.
+
+    The tree root is on the conversation the caller already fetched, so the
+    usage load takes it as a hint instead of re-reading the row. A second
+    ``get_conversation`` here is that read coming back — invisible to every
+    behavioural assertion, because the body is identical either way.
+    """
+    solo = _graph_conv(
+        "6d996c055256e5975b8e5683c4d77d47",
+        root="6d996c055256e5975b8e5683c4d77d47",
+        parent=None,
+        cost=0.42,
+    )
+    conv_store = _ConversationStore(
+        [],
+        conversations={"6d996c055256e5975b8e5683c4d77d47": solo},
+    )
+
+    snapshot = await _get_session_snapshot(
+        conv_store,  # type: ignore[arg-type]
+        "6d996c055256e5975b8e5683c4d77d47",
+        conversation=solo,
+    )
+
+    # The caller supplied the row, so the snapshot must read it zero times:
+    # authorization already paid for it on the route.
+    assert conv_store.get_conversation_calls == []
+    # The tree page still runs — it observes this session's DESCENDANTS, which
+    # the single row cannot answer — and it is rooted at the in-hand row's root.
+    assert conv_store.list_conversations_calls == ["6d996c055256e5975b8e5683c4d77d47"]
+    assert snapshot.total_cost_usd == 0.42
 
 
 # ── _truncate_label ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Related issue

Closes #

<!-- Refactor / chore + Test / CI: no issue required. -->

## Summary

`GET /v1/sessions/{id}` is the widest-reach read in the product — session start
hits it 4-5× per launch (each layer pulling one field out of the same
document), the REPL polls it as a turn backstop, and the web UI and SDK
re-read it routinely. Measured in-process against the real app
(`httpx.ASGITransport` + a SQLAlchemy `before_cursor_execute` listener) on a
session with **zero items and warm caches**, one authorized GET cost **16 SQL
statements over 12 connection checkouts** — and layers of it were reading state
the request already held.

Two reads were provably redundant and are now threaded forward; the third is
not, and stays.

- **Subtree-usage load re-read the conversation row.** `load_session_usage`
  already accepts `root_conversation_id=` to skip its internal
  `get_conversation` (and validates a supplied root against the tree it
  produces, so a stale row still self-corrects). The route holds that row from
  its authorization pass, so it now passes the hint. −3 statements, one fewer
  same-row read.
- **The harness resolver re-read the agent row.** `_get_session_snapshot`
  loads the bound agent for `agent_name` / `llm_model`, then
  `_build_session_response` → `_resolve_harness` read the same row again (2
  statements: the `agents` row plus its spawn-tree session lookup). The row is
  now handed over via a new `agent=` parameter, which ignores a row for a
  different agent and falls back to the store. −2 statements.
- **Turn-end cost roll-up loaded the same spawn tree twice.** Both the relay's
  `response.completed` handler and the native usage flush summed this session's
  subtree for its own badge and then called
  `_publish_subtree_cost_to_ancestors`, which loaded the same tree again.
  `_publish_subtree_cost_to_ancestors` now takes an optional `tree=`, so one
  load serves both — and every ancestor's number comes from the same read as
  the session's own instead of a second read milliseconds later. Both walks
  still compute the client's `session.usage` cost badge; nothing is gated on
  policy state.

### Reads that were kept, and why

- **The authorization pass's `get_conversation` stays.** It is the access-control
  source of truth: the level it resolves decides whether the request is answered
  at all, and every later layer is handed its row.
- **The spawn-tree page listing stays.** It reads this session's row again as
  part of listing the tree, but it answers a different question — *what are this
  session's descendants* — which the single row cannot. Removing it would
  silently drop sub-agent spend from the parent's cost badge.
- **`_bulk_session_liveness` stays.** It reads `omnigent_conversation_metadata`
  + `conversation_labels`, not the conversation row, and its `runner_online` is
  deliberately a *superset* of `GET /v1/runners/{id}/status`'s `online` (it stays
  true through `RUNNER_LIVENESS_TTL_S` after an ungraceful runner death). Left
  exactly as it was.

### Measured, empty session, warm caches

| | before | after |
|---|---|---|
| SQL statements, one GET | 16 | **11** |
| single-row `conversations` fetches | 2 | **1** |
| `agents` row fetches | 2 | **1** |
| connection checkouts | 12 | 8 |
| SQL statements, native usage flush | 22 | **16** |

Response body byte-identical before and after (normalized for ids/timestamps).

Checkout counts are context, not the claim: `perf/store-single-checkout-get-conversation`
makes `get_conversation` take one checkout instead of two, which compounds with
this — each read removed here is a read that fix no longer has to make cheap.

```
GET /v1/sessions/{id}, empty session          before   after
  auth: get_conversation (row+meta+labels)       3        3   ← access-control truth, kept
  committed-items page                           1        1
  agent row + spawn-tree session lookup          2        1   ← reused by harness resolve
  liveness (metadata + labels)                   2        2   ← superset semantics, untouched
  subtree usage: get_conversation                3        0   ← root threaded from in-hand row
  subtree usage: tree page (rows+labels+meta)    3        3   ← observes descendants, kept
                                              ----     ----
                                                16       11
```

## Test Plan

New `tests/server/integration/test_sessions_snapshot_read_budget.py` — an
auth-enabled app, a real uploaded bundle, one empty session, counters over a
`before_cursor_execute` listener:

- total statements for one GET == 11;
- **no statement is issued twice** in one snapshot build (the shape of
  redundancy this endpoint kept regressing into);
- exactly one single-row `conversations` fetch and one `agents` fetch;
- the response still carries every field of its contract (asserted as a subset,
  so adding a field is fine and dropping one is not), plus explicit values for
  `harness`, `agent_name`, `labels`, `runner_id`, `status`, `permission_level`,
  `host_resumable`, and a non-`None` `runner_online`.

Extended `tests/server/routes/test_sessions_snapshot.py` in its idiom (read
counters on the existing fake store):

- `test_session_snapshot_reads_the_conversation_row_once` — zero
  `get_conversation` calls when the caller supplies the row, and the tree page
  still runs, rooted at the in-hand row's root;
- `test_publish_subtree_cost_to_ancestors_reuses_a_supplied_tree` — zero store
  reads for the ancestor walk, same published totals as the self-loading path.

```
cd /home/harry.yao/o36
python -m pytest tests/server/integration/test_sessions_snapshot_read_budget.py \
                 tests/server/routes/test_sessions_snapshot.py -q
# 54 passed
python -m pytest tests/server/routes/test_native_usage_attribution.py \
                 tests/server/routes/test_usage_report.py \
                 tests/runtime/policies/test_builder.py \
                 tests/server/integration/test_sessions_harness_override.py -q
# 80 passed
python -m pytest tests/server/integration/test_sessions_endpoints.py \
                 tests/server/routes/test_session_updates_ws.py \
                 tests/server/integration/test_sessions_child_sessions.py -q
# 323 passed
```

**Prove-it-fails:** with `git checkout -- omnigent/` the five new counter
assertions fail (SQL budget 16 ≠ 11, duplicated statements, 2 conversation
fetches, 2 agent fetches, `tree=` unsupported) and pass again on restore. The
body-contract test passes either way by design — it is a contract guard, not the
regression oracle.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Before/after statement inventory and the layer-by-layer tally are in the Summary
table; the response body is byte-identical.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the measurement itself: the app was driven in-process
via `httpx.ASGITransport` with a SQLAlchemy `before_cursor_execute` listener and
a `checkout` listener, and each statement was attributed to its caller with a
stack capture — that is how the two redundant reads were identified and the
three kept ones ruled out. The normalized response body was dumped with and
without the change and diffed to zero.

Existing coverage carries the behavioural half: `test_sessions_snapshot.py`'s
subtree-cost tests (parent + sub-agent = $3.50, childless = own cost,
`usage_by_model` roll-up) all run through the new root hint, and the
ancestor-publish test still exercises the self-loading path.

Not covered: the relay `response.completed` branch is exercised only through its
shared helper, not end-to-end — there is no server-side test for
`_relay_runner_stream_once`'s usage block on `main` to extend.
