### PR TITLE
perf(stores): share one pool checkout across the list-read paths

### DIFF
--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -626,6 +626,10 @@ def shared_read_scope() -> Iterator[None]:
     strictly READ-ONLY burst — an access-control check, a snapshot assembly —
     where the per-call checkout dominates the actual query time.
 
+    Usable as a decorator (``@shared_read_scope()``) on a method that is
+    read-only end to end — preferable to a ``with`` wrapper when the reads sit
+    in sibling ``with`` blocks that would otherwise all need reindenting.
+
     Nesting reuses the outer scope. Write makers (``immediate=True``) never
     participate, so they keep their own ``BEGIN IMMEDIATE`` isolation even
     when nested here. Never hold this open across network I/O: it pins a

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -65,6 +65,7 @@ from omnigent.db.utils import (
     insert_fts_bulk,
     make_named_managed_session_maker,
     now_epoch,
+    shared_read_scope,
     strip_nul_bytes,
 )
 from omnigent.entities import (
@@ -1117,6 +1118,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             ).all()
         return {row.id: row.runner_id for row in rows}
 
+    @shared_read_scope()
     def get_session_connectivity(
         self, conversation_ids: list[str]
     ) -> dict[str, SessionConnectivity]:
@@ -1128,6 +1130,10 @@ class SqlAlchemyConversationStore(ConversationStore):
         fork-source connectivity marker — instead of the per-id
         ``get_conversation`` + labels fan-out the sidebar online-dot used
         to drive. See the abstract method for the contract.
+
+        The two reads share one pool checkout per engine, so single-DB mode
+        pays one instead of two — with ``pool_pre_ping`` each checkout is a
+        network round trip, and the sidebar polls this for every session.
 
         :param conversation_ids: Session/conversation IDs to look up,
             e.g. ``["conv_abc123", "conv_def456"]``.
@@ -1182,12 +1188,16 @@ class SqlAlchemyConversationStore(ConversationStore):
             for row in meta_rows
         }
 
+    @shared_read_scope()
     def get_conversations(self, conversation_ids: list[str]) -> dict[str, Conversation]:
         """
         Bulk variant of :meth:`get_conversation` — one ``SELECT ... WHERE
         id IN (...)`` for the rows plus one batched label query, so the
         watch-set rescan costs a constant number of round-trips instead
         of one per id. Missing ids are omitted from the result.
+
+        The AP reads and the Omnigent metadata read share one pool checkout
+        per engine, so single-DB mode pays one instead of two.
 
         :param conversation_ids: Conversation ids to fetch,
             e.g. ``["conv_abc123", "conv_def456"]``. Duplicates are
@@ -2117,6 +2127,7 @@ class SqlAlchemyConversationStore(ConversationStore):
 
         return persisted
 
+    @shared_read_scope()
     def list_projects(
         self,
         accessible_by: str | None = None,
@@ -2135,6 +2146,10 @@ class SqlAlchemyConversationStore(ConversationStore):
         (``omni_*``) to keep this internal storage key distinct from the
         user-facing "project" term and from any future reserved keys; it is
         never surfaced as a label in the UI.
+
+        The ACL pre-fetch and the label scan share one pool checkout per
+        engine, so an ACL-scoped call costs one in single-DB mode instead of
+        two (an unscoped call already needs only the label scan).
 
         :param accessible_by: When set, restrict to sessions that
             ``accessible_by`` has a permission row for (mirrors the
@@ -2224,6 +2239,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 )
             )
 
+    @shared_read_scope()
     def list_conversations(
         self,
         limit: int = 20,
@@ -2248,6 +2264,12 @@ class SqlAlchemyConversationStore(ConversationStore):
     ) -> PagedList[Conversation]:
         """
         List conversations with cursor-based pagination.
+
+        Every read here — the permission pre-fetch, the page query, the
+        ``agent_name`` and project resolutions, the metadata merge — shares one
+        pool checkout per engine. Single-DB mode drops from up to four
+        checkouts to one, which matters because the message-send path rescans
+        the spawn tree with this on every event.
 
         :param limit: Maximum number of conversations to return.
         :param after: Cursor conversation ID; return
@@ -2371,7 +2393,8 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._conv_session("list_conversations") as session:
             # Bound the content-search scan server-side (Postgres only). SET
             # LOCAL scopes to this transaction and reverts on commit, so it
-            # can't leak to the connection's next pooled use. See
+            # can't leak to the connection's next pooled use — the shared read
+            # scope commits when this call returns, which bounds it here. See
             # _SEARCH_STATEMENT_TIMEOUT_MS. A worker-thread query is not stopped
             # by a client disconnect, so this is the only server-side bound.
             is_postgres = session.bind is not None and session.bind.dialect.name == "postgresql"
@@ -3134,12 +3157,16 @@ class SqlAlchemyConversationStore(ConversationStore):
             labels = _fetch_labels(ap_sess, conversation_id)
         return _to_conversation(ap_row, meta, labels)
 
+    @shared_read_scope()
     def list_conversations_by_runner_id(
         self,
         runner_id: str,
     ) -> list[Conversation]:
         """
         Return all conversations bound to the given ``runner_id``.
+
+        The metadata scan and the AP row + label reads share one pool checkout
+        per engine, so single-DB mode pays one instead of two.
 
         :param runner_id: Runner identifier, e.g.
             ``"runner_token_a1b2c3d4..."``.

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
 import pytest
 from sqlalchemy import event, text
 
@@ -21,6 +24,7 @@ from omnigent.session_import import (
     IMPORT_SOURCE_LABEL_KEY,
 )
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.conversation_store import PROJECT_LABEL_KEY
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
@@ -5754,3 +5758,315 @@ def test_item_search_text_seam_redirects_persisted_value(db_uri: str) -> None:
             ).scalars()
         )
     assert stored == ["custom-search-text"]
+
+
+# ── Connection-checkout budget ─────────────────────────
+
+# A well-formed id that no fixture creates, so the batch reads are exercised
+# with a partial hit (ids without a row are omitted from the result).
+_MISSING_ID = "ffffffffffffffffffffffffffffffff"
+
+
+def _count_checkouts(*engines: Any) -> tuple[list[int], Callable[[], None]]:
+    """Count pool checkouts across ``engines`` (deduplicated).
+
+    Attach *after* any setup writes so only the read under test is counted.
+
+    :returns: ``(count, detach)`` — a one-element list incremented per
+        checkout, plus a zero-arg callable that removes the listeners.
+    """
+    count = [0]
+
+    def _on_checkout(_dbapi: object, _record: object, _proxy: object) -> None:
+        count[0] += 1
+
+    unique = list(dict.fromkeys(engines))
+    for engine in unique:
+        event.listen(engine, "checkout", _on_checkout)
+
+    def _detach() -> None:
+        for engine in unique:
+            event.remove(engine, "checkout", _on_checkout)
+
+    return count, _detach
+
+
+def _select_query_names(
+    store: SqlAlchemyConversationStore,
+    call: Callable[[], object],
+) -> list[str | None]:
+    """Run ``call`` and return the semantic query name of every SELECT it issues.
+
+    :param store: Store whose engines are instrumented.
+    :param call: Zero-arg callable performing the read under test.
+    :returns: One name per SELECT, in execution order.
+    """
+    from omnigent.db import current_query_name
+
+    names: list[str | None] = []
+
+    def _capture(
+        _conn: object,
+        _cursor: object,
+        statement: str,
+        _params: object,
+        _ctx: object,
+        _many: bool,
+    ) -> None:
+        if statement.lstrip().upper().startswith("SELECT"):
+            names.append(current_query_name())
+
+    engines = list(dict.fromkeys([store._conv_engine, store._engine]))
+    for engine in engines:
+        event.listen(engine, "before_cursor_execute", _capture)
+    try:
+        call()
+    finally:
+        for engine in engines:
+            event.remove(engine, "before_cursor_execute", _capture)
+    return names
+
+
+def _grant_owner(db_uri: str, conversation_id: str, user_id: str = "alice") -> None:
+    """Give ``user_id`` an owner grant so the ACL-scoped read paths return rows."""
+    from omnigent.server.auth import LEVEL_OWNER
+    from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+
+    SqlAlchemyPermissionStore(db_uri).grant(user_id, conversation_id, LEVEL_OWNER)
+
+
+def test_list_conversations_costs_one_checkout(
+    conversation_store: SqlAlchemyConversationStore,
+    agent_store: SqlAlchemyAgentStore,
+    db_uri: str,
+) -> None:
+    """The list path's four reads must share one pool checkout.
+
+    ``list_conversations`` fans out to the permission pre-fetch, the page
+    query, the ``agent_name`` resolution and the metadata merge — four
+    checkouts, so four ``pool_pre_ping`` round trips on Lakebase, and the
+    message-send path rescans the spawn tree with it on every event. Counting
+    checkouts (not milliseconds) keeps this immune to load noise.
+    """
+    agent = agent_store.create(
+        "ag_0f1a2b3c0f1a2b3c0f1a2b3c0f1a2b3c",
+        "code-assistant",
+        "ag_0f1a2b3c/bundle",
+    )
+    created = conversation_store.create_conversation(
+        title="budget-list",
+        agent_id=agent.id,
+        runner_id="runner_list",
+        host_id="4f64b6ee625f4e8259185c35c6e63f3d",
+        workspace="/tmp/ws",
+        git_branch="feature/x",
+    )
+    conversation_store.set_labels(created.id, {"tag": "value"})
+    _grant_owner(db_uri, created.id)
+
+    count, detach = _count_checkouts(conversation_store._conv_engine, conversation_store._engine)
+    try:
+        page = conversation_store.list_conversations(
+            accessible_by="alice",
+            owned_by="alice",
+            agent_name="code-assistant",
+        )
+    finally:
+        detach()
+
+    assert count[0] == 1, f"list_conversations must take one checkout, got {count[0]}"
+    assert [c.id for c in page.data] == [created.id]
+    conv = page.data[0]
+    # AP-table fields.
+    assert conv.title == "budget-list"
+    assert conv.labels == {"tag": "value"}
+    # Omnigent-metadata fields — all None if the metadata read were dropped.
+    assert (conv.runner_id, conv.host_id) == (
+        "runner_list",
+        "4f64b6ee625f4e8259185c35c6e63f3d",
+    )
+    assert (conv.workspace, conv.git_branch) == ("/tmp/ws", "feature/x")
+
+
+def test_get_conversations_costs_one_checkout(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """The bulk fetch's AP rows, labels and metadata share one checkout."""
+    created = conversation_store.create_conversation(
+        title="budget-bulk",
+        runner_id="runner_bulk",
+        host_id="4f64b6ee625f4e8259185c35c6e63f3d",
+        workspace="/tmp/ws",
+        git_branch="feature/y",
+    )
+    conversation_store.set_labels(created.id, {"tag": "value"})
+
+    count, detach = _count_checkouts(conversation_store._conv_engine, conversation_store._engine)
+    try:
+        by_id = conversation_store.get_conversations([created.id, _MISSING_ID])
+    finally:
+        detach()
+
+    assert count[0] == 1, f"get_conversations must take one checkout, got {count[0]}"
+    assert list(by_id) == [created.id]
+    conv = by_id[created.id]
+    assert conv.title == "budget-bulk"
+    assert conv.labels == {"tag": "value"}
+    assert (conv.runner_id, conv.host_id) == (
+        "runner_bulk",
+        "4f64b6ee625f4e8259185c35c6e63f3d",
+    )
+    assert (conv.workspace, conv.git_branch) == ("/tmp/ws", "feature/y")
+
+
+def test_get_session_connectivity_costs_one_checkout(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """The sidebar's online-dot batch pays one checkout for both bulk reads."""
+    created = conversation_store.create_conversation(
+        title="budget-conn",
+        runner_id="runner_conn",
+        host_id="4f64b6ee625f4e8259185c35c6e63f3d",
+        workspace="/tmp/ws",
+    )
+    conversation_store.set_labels(created.id, {IMPORT_SOURCE_LABEL_KEY: "claude"})
+
+    count, detach = _count_checkouts(conversation_store._conv_engine, conversation_store._engine)
+    try:
+        connectivity = conversation_store.get_session_connectivity([created.id, _MISSING_ID])
+    finally:
+        detach()
+
+    assert count[0] == 1, f"get_session_connectivity must take one checkout, got {count[0]}"
+    assert list(connectivity) == [created.id]
+    entry = connectivity[created.id]
+    # Omnigent-metadata fields.
+    assert (entry.runner_id, entry.host_id) == (
+        "runner_conn",
+        "4f64b6ee625f4e8259185c35c6e63f3d",
+    )
+    # AP-side label read — False if the label query were dropped.
+    assert entry.imported is True
+    assert entry.needs_workspace is False
+
+
+def test_list_projects_costs_one_checkout(
+    conversation_store: SqlAlchemyConversationStore,
+    db_uri: str,
+) -> None:
+    """The owner-scoped project list pays one checkout, not one per DB.
+
+    The sidebar always scopes by ``owned_by``, so the ACL pre-fetch on
+    ``session_permissions`` plus the label scan is the shape that matters; an
+    unscoped call only ever issued the label scan.
+    """
+    created = conversation_store.create_conversation(title="budget-projects")
+    conversation_store.set_labels(created.id, {PROJECT_LABEL_KEY: "proj"})
+    _grant_owner(db_uri, created.id)
+
+    count, detach = _count_checkouts(conversation_store._conv_engine, conversation_store._engine)
+    try:
+        projects = conversation_store.list_projects(accessible_by="alice", owned_by="alice")
+    finally:
+        detach()
+
+    assert count[0] == 1, f"list_projects must take one checkout, got {count[0]}"
+    # Empty if either the ACL pre-fetch or the label scan were dropped.
+    assert projects == ["proj"]
+
+
+def test_list_conversations_by_runner_id_costs_one_checkout(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """The runner-reconnect fan-out pays one checkout for its three reads."""
+    created = conversation_store.create_conversation(
+        title="budget-runner",
+        runner_id="runner_reconnect",
+        host_id="4f64b6ee625f4e8259185c35c6e63f3d",
+        workspace="/tmp/ws",
+        git_branch="feature/z",
+    )
+    conversation_store.set_labels(created.id, {"tag": "value"})
+
+    count, detach = _count_checkouts(conversation_store._conv_engine, conversation_store._engine)
+    try:
+        convs = conversation_store.list_conversations_by_runner_id("runner_reconnect")
+    finally:
+        detach()
+
+    assert count[0] == 1, f"list_conversations_by_runner_id must take one checkout, got {count[0]}"
+    assert [c.id for c in convs] == [created.id]
+    conv = convs[0]
+    assert conv.title == "budget-runner"
+    # The runner session-init envelope is built from these labels.
+    assert conv.labels == {"tag": "value"}
+    assert (conv.workspace, conv.git_branch) == ("/tmp/ws", "feature/z")
+
+
+def test_list_reads_keep_their_semantic_query_names(
+    conversation_store: SqlAlchemyConversationStore,
+    db_uri: str,
+) -> None:
+    """Sharing one checkout must not collapse or rename the reads.
+
+    Every statement still runs under its caller's semantic name even though
+    several ``with`` blocks now reuse one session: the name is scoped by the
+    ``with`` block, not by the session. Asserted as a set plus a floor on the
+    count, because the statement count varies with page shape.
+    """
+    created = conversation_store.create_conversation(
+        title="named-list",
+        runner_id="runner_named",
+    )
+    conversation_store.set_labels(created.id, {PROJECT_LABEL_KEY: "proj"})
+    _grant_owner(db_uri, created.id)
+
+    cases: list[tuple[str, Callable[[], object], int]] = [
+        (
+            "list_conversations",
+            lambda: conversation_store.list_conversations(accessible_by="alice"),
+            3,
+        ),
+        ("get_conversations", lambda: conversation_store.get_conversations([created.id]), 3),
+        (
+            "get_session_connectivity",
+            lambda: conversation_store.get_session_connectivity([created.id]),
+            2,
+        ),
+        ("list_projects", lambda: conversation_store.list_projects(owned_by="alice"), 2),
+        (
+            "list_conversations_by_runner_id",
+            lambda: conversation_store.list_conversations_by_runner_id("runner_named"),
+            3,
+        ),
+    ]
+    for method, call, min_selects in cases:
+        names = _select_query_names(conversation_store, call)
+        expected = f"omnigent.conversation_store.{method}"
+        assert set(names) == {expected}, (method, names)
+        assert len(names) >= min_selects, (method, names)
+
+
+def test_list_read_inside_outer_scope_keeps_its_own_query_name(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A nested read joins the outer scope's session but not its query name.
+
+    The auth path already opens a ``shared_read_scope`` around its own reads,
+    so a store read called inside one reuses that session. The name must still
+    follow the ``with`` block, otherwise every nested query would be attributed
+    to whichever read opened the session first.
+    """
+    from omnigent.db.utils import shared_read_scope
+
+    created = conversation_store.create_conversation(title="nested-name")
+
+    def _both() -> None:
+        with shared_read_scope():
+            conversation_store.list_projects()
+            conversation_store.get_session_connectivity([created.id])
+
+    names = _select_query_names(conversation_store, _both)
+
+    assert names[0] == "omnigent.conversation_store.list_projects"
+    assert set(names[1:]) == {"omnigent.conversation_store.get_session_connectivity"}

--- a/tests/stores/test_conversation_store_split_db.py
+++ b/tests/stores/test_conversation_store_split_db.py
@@ -634,3 +634,182 @@ def test_delete_conversation_keeps_template_agent(
 
     asyncio.run(store.delete_conversation(conv.id))
     assert _col(omnigent_db, "agents", "id") == ["191cbf904e3223e9e00ac9a1abfe79a5"]
+
+
+# ── Connection-checkout budget ─────────────────────────
+
+
+def _per_engine_checkouts(store: SqlAlchemyConversationStore) -> tuple[dict[str, int], Any]:
+    """Count checkouts per engine on a split-DB store.
+
+    :param store: A split-DB store (asserted, so a single-DB fixture cannot
+        silently make the per-engine expectation trivial).
+    :returns: ``(counts, detach)`` — a ``{"conv": n, "omnigent": n}`` mapping
+        and a zero-arg callable that removes the listeners.
+    """
+    from sqlalchemy import event
+
+    assert store._conv_engine is not store._engine, "fixture must be split-DB"
+    counts: dict[str, int] = {"conv": 0, "omnigent": 0}
+
+    def _mk(tag: str) -> Any:
+        def _on_checkout(_dbapi: object, _record: object, _proxy: object) -> None:
+            counts[tag] += 1
+
+        return _on_checkout
+
+    conv_hook, omni_hook = _mk("conv"), _mk("omnigent")
+    event.listen(store._conv_engine, "checkout", conv_hook)
+    event.listen(store._engine, "checkout", omni_hook)
+
+    def _detach() -> None:
+        event.remove(store._conv_engine, "checkout", conv_hook)
+        event.remove(store._engine, "checkout", omni_hook)
+
+    return counts, _detach
+
+
+def test_list_conversations_takes_one_checkout_per_engine(
+    store: SqlAlchemyConversationStore,
+    omnigent_db: Path,
+) -> None:
+    """Split-DB keeps one checkout per engine — not one overall — and still merges.
+
+    The single-DB collapse comes from ``shared_read_scope``, which keys its
+    shared session by engine. Here the metadata, permission and project tables
+    genuinely live on another engine, so their checkout cannot be shared away;
+    what must not regress is the routing or the per-engine budget. Without the
+    scope this shape cost four checkouts (permission pre-fetch, page query,
+    project member pre-fetch, metadata merge).
+    """
+    from omnigent.server.auth import LEVEL_OWNER
+    from omnigent.stores.conversation_store import PROJECT_LABEL_KEY
+    from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+
+    created = store.create_conversation(
+        title="split-list",
+        runner_id="runner_split",
+        host_id="a6bfc420101272fcd5906a9eff904dfd",
+        workspace="/tmp/ws",
+    )
+    store.set_labels(created.id, {PROJECT_LABEL_KEY: "proj"})
+    SqlAlchemyPermissionStore(f"sqlite:///{omnigent_db}").grant("alice", created.id, LEVEL_OWNER)
+
+    counts, detach = _per_engine_checkouts(store)
+    try:
+        page = store.list_conversations(
+            accessible_by="alice",
+            owned_by="alice",
+            project="proj",
+        )
+    finally:
+        detach()
+
+    assert counts == {"conv": 1, "omnigent": 1}, counts
+    assert [c.id for c in page.data] == [created.id]
+    conv = page.data[0]
+    assert conv.title == "split-list"
+    assert (conv.runner_id, conv.host_id) == (
+        "runner_split",
+        "a6bfc420101272fcd5906a9eff904dfd",
+    )
+    assert conv.workspace == "/tmp/ws"
+
+
+def test_get_conversations_takes_one_checkout_per_engine(
+    store: SqlAlchemyConversationStore,
+) -> None:
+    """The bulk fetch still reads metadata from the Omnigent DB, one checkout each."""
+    created = store.create_conversation(
+        title="split-bulk",
+        runner_id="runner_split",
+        host_id="a6bfc420101272fcd5906a9eff904dfd",
+        workspace="/tmp/ws",
+    )
+    store.set_labels(created.id, {"tag": "value"})
+
+    counts, detach = _per_engine_checkouts(store)
+    try:
+        by_id = store.get_conversations([created.id])
+    finally:
+        detach()
+
+    assert counts == {"conv": 1, "omnigent": 1}, counts
+    conv = by_id[created.id]
+    assert conv.labels == {"tag": "value"}
+    assert (conv.runner_id, conv.host_id) == (
+        "runner_split",
+        "a6bfc420101272fcd5906a9eff904dfd",
+    )
+
+
+def test_get_session_connectivity_takes_one_checkout_per_engine(
+    store: SqlAlchemyConversationStore,
+) -> None:
+    """Connectivity reads metadata on one engine and its labels on the other."""
+    from omnigent.session_import import IMPORT_SOURCE_LABEL_KEY
+
+    created = store.create_conversation(
+        title="split-conn",
+        runner_id="runner_split",
+        host_id="a6bfc420101272fcd5906a9eff904dfd",
+        workspace="/tmp/ws",
+    )
+    store.set_labels(created.id, {IMPORT_SOURCE_LABEL_KEY: "claude"})
+
+    counts, detach = _per_engine_checkouts(store)
+    try:
+        connectivity = store.get_session_connectivity([created.id])
+    finally:
+        detach()
+
+    assert counts == {"conv": 1, "omnigent": 1}, counts
+    entry = connectivity[created.id]
+    assert entry.runner_id == "runner_split"
+    assert entry.imported is True
+
+
+def test_list_projects_takes_one_checkout_per_engine(
+    store: SqlAlchemyConversationStore,
+    omnigent_db: Path,
+) -> None:
+    """The ACL pre-fetch stays on the Omnigent DB, the label scan on the AP DB."""
+    from omnigent.server.auth import LEVEL_OWNER
+    from omnigent.stores.conversation_store import PROJECT_LABEL_KEY
+    from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+
+    created = store.create_conversation(title="split-projects")
+    store.set_labels(created.id, {PROJECT_LABEL_KEY: "proj"})
+    SqlAlchemyPermissionStore(f"sqlite:///{omnigent_db}").grant("alice", created.id, LEVEL_OWNER)
+
+    counts, detach = _per_engine_checkouts(store)
+    try:
+        projects = store.list_projects(accessible_by="alice", owned_by="alice")
+    finally:
+        detach()
+
+    assert counts == {"conv": 1, "omnigent": 1}, counts
+    assert projects == ["proj"]
+
+
+def test_list_conversations_by_runner_id_takes_one_checkout_per_engine(
+    store: SqlAlchemyConversationStore,
+) -> None:
+    """The runner fan-out reads metadata on one engine, rows + labels on the other."""
+    created = store.create_conversation(
+        title="split-runner",
+        runner_id="runner_split",
+        workspace="/tmp/ws",
+    )
+    store.set_labels(created.id, {"tag": "value"})
+
+    counts, detach = _per_engine_checkouts(store)
+    try:
+        convs = store.list_conversations_by_runner_id("runner_split")
+    finally:
+        detach()
+
+    assert counts == {"conv": 1, "omnigent": 1}, counts
+    assert [c.id for c in convs] == [created.id]
+    assert convs[0].labels == {"tag": "value"}
+    assert convs[0].workspace == "/tmp/ws"


### PR DESCRIPTION
## Related issue

Closes #

<!-- Refactor / chore + perf: no issue required. -->

## Summary

Production runs on Lakebase (Postgres) with `pool_pre_ping` enabled, so **every
pool checkout costs a network round trip**. Five read-only conversation-store
methods opened a fresh session per logical read, paying that round trip two to
four times for one logical read. Each is now declared read-only end to end with
`@shared_read_scope()`, which makes `managed_session()` reuse one session per
engine for the whole call.

Measured on a real `postgres:16` container with `pool_pre_ping=True`, 400
alternating A/B rounds in one process (A = the method, B = the *same* function
recovered via `__wrapped__`, so both arms run byte-identical bodies and differ
only by the scope):

| method | checkouts | median wall |
|---|---|---|
| `list_conversations` | **4 → 1** | 5.385 → 4.421 ms (**−17.9%**) |
| `get_conversations` | 2 → 1 | 3.922 → 3.474 ms (−11.4%) |
| `get_session_connectivity` | 2 → 1 | 2.570 → 2.131 ms (−17.1%) |
| `list_projects` (ACL-scoped) | 2 → 1 | 3.135 → 2.570 ms (−18.0%) |
| `list_conversations_by_runner_id` | 2 → 1 | 4.038 → 3.502 ms (−13.3%) |

`list_conversations` is why this is worth its own PR: the message-send profile
measured **three spawn-tree scans per send**, and each was up to four checkouts
(permission pre-fetch → page query → `agent_name` resolution → metadata merge).

**Follow-up to #6074** (`get_conversation`, same file, same mechanism). The two
**stack**: `omnigent/` merges clean between them; the only conflict is the
append point at the end of the two test files, resolved by keeping both test
sets and one copy of the shared `_count_checkouts` helper (identical in both
branches).

ELI5: the queries were never the slow part — *asking the pool for a connection*
was, because each ask pings the database first. These methods asked several
times to answer one question; now they ask once.

```
before (single-DB, list_conversations)      after
 ┌ checkout ─ ping ─ SELECT permissions      ┌ checkout ─ ping
 ├ checkout ─ ping ─ SELECT page             │   SELECT permissions
 ├ checkout ─ ping ─ SELECT agents           │   SELECT page / agents / metadata
 └ checkout ─ ping ─ SELECT metadata         └ commit
```

Why a decorator rather than a `with` block: `list_conversations` is ~400 lines,
so wrapping its body would have reindented the whole method for no behavioural
difference. `@shared_read_scope()` is exactly equivalent (`contextlib`
context managers are `ContextDecorator`s, re-created per call, so it is
re-entrant and thread-safe) and keeps the change at one line per method — 29
added lines in `omnigent/`, most of them docstrings.

Scope and safety:

- **Read-only only.** All five use read makers; nothing here writes, so no write
  path joins a read burst. `update_conversation`'s metadata read is deliberately
  still left out (see #6074) — it is a write path on a non-immediate maker.
- **Split-DB unchanged in kind.** The scope keys its sessions by engine, so a
  deployment whose `omnigent_conversation_metadata` lives on another engine
  still pays exactly one checkout **per engine** (the list path drops from four
  to two there). Asserted by five new split-DB tests.
- **Query naming preserved.** The name is scoped by the `with` block, not the
  session, so every statement keeps its semantic operation name even when
  sharing a session. Asserted, including for a read nested inside an outer
  scope (the auth path's), where a bled name would be a real regression.
- The search `SET LOCAL statement_timeout` now reverts when the scope commits at
  the end of the call rather than at the end of its inner `with` block — same
  bound, noted in the comment there.

## Test Plan

12 new tests, run on **both** backends (SQLite default, and
`OMNIGENT_TEST_DB_URI` against a real `postgres:16` container):

```
# single-DB + split-DB (SQLite)
python -m pytest tests/stores/test_conversation_store.py \
                 tests/stores/test_conversation_store_split_db.py \
                 -k "checkout or query_name"          # 12 passed

# same, on Postgres
OMNIGENT_TEST_DB_URI="postgresql+psycopg://…/pg" \
python -m pytest tests/stores/test_conversation_store.py \
                 -k "checkout or query_name"          # 7 passed

# full suites, both backends
python -m pytest tests/stores/test_conversation_store.py \
                 tests/stores/test_conversation_store_split_db.py \
                 tests/db/test_utils.py               # 276 passed, 1 skipped (SQLite)
OMNIGENT_TEST_DB_URI=… python -m pytest tests/stores/test_conversation_store.py \
                 tests/db/test_utils.py               # 243 passed, 1 skipped (Postgres)
```

**Prove-it-fails**: with `omnigent/` reverted (`git checkout -- omnigent/`) and
the tests kept, all five single-DB checkout tests fail with the real prior
counts — on both backends:

```
list_conversations must take one checkout, got 4
get_conversations must take one checkout, got 2
get_session_connectivity must take one checkout, got 2
list_projects must take one checkout, got 2
list_conversations_by_runner_id must take one checkout, got 2
```

plus the split-DB list test (`{'conv': 2, 'omnigent': 2}` → must be
`{'conv': 1, 'omnigent': 1}`). The other four split-DB tests pass either way by
design: they are routing/per-engine-budget guards, not wins.

Each checkout test also asserts every field sourced from the *second* read still
comes back (`runner_id`, `host_id`, `workspace`, `git_branch`, `labels`,
`imported`, the project name), so silently dropping a read fails the test rather
than returning blanks.

`pre-commit run --files <4 changed files>`: all hooks pass except `pyrefly`,
which reports 99 pre-existing `missing-import` errors from an incomplete local
venv — identical count with this change reverted, none in the changed files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The A/B benchmark output (same process, alternating rounds, `pool_pre_ping=True`
against `postgres:16`):

```
pool_pre_ping: True
list_conversations               scoped median  4.421 ms  unscoped median  5.385 ms  delta -17.9%
get_conversations                scoped median  3.474 ms  unscoped median  3.922 ms  delta -11.4%
get_session_connectivity         scoped median  2.131 ms  unscoped median  2.570 ms  delta -17.1%
list_projects                    scoped median  2.570 ms  unscoped median  3.135 ms  delta -18.0%
list_conversations_by_runner_id  scoped median  3.502 ms  unscoped median  4.038 ms  delta -13.3%
```

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the Postgres A/B benchmark above — a wall-clock win
cannot be asserted in CI without making the suite load-sensitive, so the
committed tests assert the **checkout count** (the thing that causes the win)
plus field-completeness and query naming. The wall-clock numbers come from a
real `postgres:16` container with `pool_pre_ping=True`, which is what makes a
checkout expensive; SQLite would show no meaningful difference.

## Changelog

Listing sessions, projects and their online state hits the database once
instead of up to four times, cutting network round trips from the session
list and the message-send path.
