### PR TITLE
fix(cli): continue batch import past a per-session network failure

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -6175,11 +6175,9 @@ def import_session_command(
             target = futures[future]
             results[target] = future.result()
 
-    # A network failure is fatal for the whole batch, matching the serial import.
-    unreachable = next((r for r in results.values() if r.status == "unreachable"), None)
-    if unreachable is not None:
-        raise click.ClickException(unreachable.message or "Could not reach the Omnigent server")
-
+    # A per-session network failure (e.g. one large session's read timeout) is
+    # reported and counted like any other failure so the rest of the batch still
+    # imports; only the single-session path treats unreachable as fatal.
     imported_count = 0
     already_imported_count = 0
     failed_count = 0

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -345,6 +345,47 @@ def test_import_command_continues_batch_after_session_failure(tmp_path: Path) ->
     assert "Failed: 1" in result.output
 
 
+@respx.mock
+def test_import_command_continues_batch_after_network_failure(tmp_path: Path) -> None:
+    """A per-session network failure (e.g. a read timeout on a large session)
+    is counted as a failure without aborting the rest of the batch."""
+    session_ids = (
+        "a1b2c3d4-1234-5678-9abc-def012345676",
+        "a1b2c3d4-1234-5678-9abc-def012345677",
+    )
+    for modified_at, session_id in enumerate(session_ids, start=1):
+        _write_claude_transcript(
+            tmp_path,
+            session_id,
+            text=f"prompt {modified_at}",
+            modified_at=modified_at,
+        )
+
+    # Concurrency makes POST arrival order nondeterministic, so key the outcome
+    # to the session: the oldest times out, the newest imports.
+    def _respond(request: httpx.Request) -> httpx.Response:
+        ext = json.loads(request.content)["external_session_id"]
+        if ext == session_ids[0]:
+            raise httpx.ReadTimeout("The read operation timed out", request=request)
+        return httpx.Response(
+            201, json={"session_id": "imported-new", "status": "imported", "item_count": 1}
+        )
+
+    respx.post(f"{_BASE}/v1/imports").mock(side_effect=_respond)
+
+    with patch("omnigent.cli._resolve_attach_server", return_value=_BASE):
+        result = CliRunner().invoke(
+            cli,
+            ["import", "--harness", "claude", "--last", "2"],
+            env={"HOME": str(tmp_path)},
+        )
+
+    assert result.exit_code == 1, result.output
+    assert "Imported: 1" in result.output
+    assert "Failed: 1" in result.output
+    assert "Could not reach the Omnigent server" in result.output
+
+
 def test_import_command_requires_exactly_one_session_selector() -> None:
     """Single and batch selectors cannot be omitted or combined."""
     runner = CliRunner()


### PR DESCRIPTION
## Related issue

N/A — no tracking issue; surfaced from a user report of an import timeout on a large session.

## Summary

- `omnigent import --last N` (and `--harness all`) ran each session's import concurrently, but a single per-session network failure (e.g. a read timeout on a large session with images/PDFs — an `httpx.RequestError`, classified `unreachable`) raised immediately and aborted the whole batch, discarding every session that had already imported successfully.
- Fold a per-session network failure into the failed count like any other failure so the rest of the batch still imports. The single-session path is unchanged and still treats `unreachable` as fatal.

## Test Plan

- `pytest tests/cli/test_import.py` — 14 passed, including the new `test_import_command_continues_batch_after_network_failure`.
- Confirmed the new test fails against the unpatched `cli.py` (the batch aborts with `Could not reach the Omnigent server` and imports nothing) and passes with the fix (imports 1, reports 1 failed, exit 1).
- `ruff check` / `ruff format --check` clean on the changed files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Before: one timed-out session aborted the run and nothing imported. After:

```
Failed <sid-a>: Could not reach the Omnigent server: The read operation timed out
Imported 1 item(s) from <sid-b> into <link>

Imported: 1
Already imported: 0
Failed: 1
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the added unit test.

## Changelog

`omnigent import --last` now imports every session it can and reports the ones that failed, instead of aborting the whole batch when one session's network request fails
