### PR TITLE
feat(import): bind web-imported sessions to the importing host

### DIFF
--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -252,6 +252,7 @@ def create_imports_router(
         user_id: str | None,
         native_title: str | None = None,
         project_id: str | None = None,
+        host_id: str | None = None,
     ) -> tuple[str, str | None]:
         """Create the conversation, append items, stamp import labels, grant owner.
 
@@ -259,9 +260,12 @@ def create_imports_router(
         (server-read transcripts). ``native_title`` is the harness's own title
         when the caller has one; otherwise the title is synthesized from the
         first user message. ``project_id`` files the session into a project the
-        caller owns (``/imports/local`` passes none). Caller handles the
-        already-imported / force decision first. Returns
-        ``(conversation id, title)``.
+        caller owns (``/imports/local`` passes none). ``host_id`` binds the
+        session to the host that read the transcript (``/imports/local``), so
+        resuming defaults to the machine the workspace lives on; bound only
+        alongside a workspace (the ``ck_conversations_workspace_required_for_host``
+        check constraint). Caller handles the already-imported / force decision
+        first. Returns ``(conversation id, title)``.
         """
         native_agent = native_coding_agent_for_harness(f"{source}-native")
         if native_agent is None:
@@ -283,6 +287,11 @@ def create_imports_router(
         create_kwargs: dict[str, Any] = {"agent_id": agent_id}
         if workspace is not None:
             create_kwargs["workspace"] = workspace
+            # The workspace path lives on the importing host; bind there so
+            # resume lands on the right machine. Requires a workspace (check
+            # constraint), so only set host_id when one is recorded.
+            if host_id is not None:
+                create_kwargs["host_id"] = host_id
         if project_id is not None:
             create_kwargs["project_id"] = project_id
         resolved_create = await resolve_project_session_create(
@@ -292,12 +301,14 @@ def create_imports_router(
         )
         agent_id = resolved_create.body.agent_id
         workspace = resolved_create.body.workspace
+        resolved_host_id = resolved_create.body.host_id
         title = (native_title or "").strip() or title_from_items(items)
         try:
             conversation = await asyncio.to_thread(
                 conversation_store.create_conversation,
                 title=title,
                 agent_id=agent_id,
+                host_id=resolved_host_id,
                 workspace=workspace,
                 conversation_id=_import_conversation_id(source, external_session_id),
                 project_id=resolved_create.project_id,
@@ -484,6 +495,7 @@ def create_imports_router(
                     workspace=workspace if isinstance(workspace, str) else None,
                     user_id=user_id,
                     native_title=native_title if isinstance(native_title, str) else None,
+                    host_id=body.host_id,
                 )
             except (OmnigentError, ValueError):
                 failed += 1

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -321,3 +321,103 @@ async def test_stream_local_sessions_raises_on_failed_done() -> None:
             )
         ]
     assert conn.pending_import_local == {}
+
+
+async def test_local_import_binds_session_to_importing_host(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host-mediated batch import binds each read session to that host.
+
+    The transcript (and its recorded workspace) live on the importing host, so
+    that host is the natural place to resume. A session whose transcript had no
+    cwd stays unbound: the workspace-required check constraint forbids a host
+    without one.
+    """
+    from fastapi import FastAPI
+
+    from omnigent.server.routes import imports as imports_module
+
+    _seed_claude_agent(db_uri)
+    conversation_store = SqlAlchemyConversationStore(db_uri)
+
+    async def _fake_stream(**_kwargs: object):
+        yield {
+            "external_session_id": "claude-with-cwd",
+            "workspace": "/repo/on/host",
+            "items": [
+                {
+                    "type": "message",
+                    "response_id": "claude:turn-1",
+                    "data": {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "inspect TODO.md"}],
+                    },
+                }
+            ],
+            "title": "Bound thread",
+            "source": "claude",
+        }
+        yield {
+            "external_session_id": "claude-no-cwd",
+            "workspace": None,
+            "items": [
+                {
+                    "type": "message",
+                    "response_id": "claude:turn-1",
+                    "data": {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "no workspace here"}],
+                    },
+                }
+            ],
+            "title": "Unbound thread",
+            "source": "claude",
+        }
+
+    monkeypatch.setattr(imports_module, "_stream_local_sessions_from_host", _fake_stream)
+
+    host_conn = SimpleNamespace(
+        host_id="host_0123456789abcdef0123456789abcdef", pending_import_local={}
+    )
+    host_registry = SimpleNamespace(get=lambda host_id: host_conn)
+    host_store = SimpleNamespace(get_host=lambda host_id: SimpleNamespace(user_id=None))
+
+    app = FastAPI()
+    app.include_router(
+        imports_module.create_imports_router(
+            conversation_store,
+            SqlAlchemyAgentStore(db_uri),
+            host_registry=host_registry,  # type: ignore[arg-type]
+            host_store=host_store,  # type: ignore[arg-type]
+        ),
+        prefix="/v1",
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.post(
+            "/v1/imports/local",
+            json={
+                "host_id": "host_0123456789abcdef0123456789abcdef",
+                "source": "claude",
+                "limit": 5,
+            },
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["imported"] == 2
+    by_title = {ref["title"]: ref["session_id"] for ref in body["sessions"]}
+
+    bound = conversation_store.get_conversation(by_title["Bound thread"])
+    assert bound is not None
+    # The store canonicalizes host_id to bare 32-hex (the "host_" prefix is
+    # stripped on read), matching every other host-bound conversation.
+    assert bound.host_id == "0123456789abcdef0123456789abcdef"
+    assert bound.workspace == "/repo/on/host"
+
+    unbound = conversation_store.get_conversation(by_title["Unbound thread"])
+    assert unbound is not None
+    assert unbound.host_id is None
+    assert unbound.workspace is None


### PR DESCRIPTION
## Related issue

N/A — no tracking issue; small follow-up to the web session-import flow.

## Summary

- The web "Import sessions" flow reads each transcript over the chosen host's tunnel, so that host is where the recorded workspace lives and the natural place to resume. Imported sessions were left host-unbound, forcing the user through the "Resume on a machine" picker every time.
- `POST /v1/imports/local` now binds each imported session to the host that read it, threading `host_id` through `_persist_import`.
- Bound only alongside a workspace: the `ck_conversations_workspace_required_for_host` check constraint forbids a host without one, so a transcript with no recorded cwd stays unbound. The CLI `/v1/imports` path is unchanged (no host reads it).

## Test Plan

```
uv run pytest tests/server/routes/test_imports.py
```

New test `test_local_import_binds_session_to_importing_host` drives `POST /v1/imports/local` with a stubbed host stream carrying two sessions: one with a recorded workspace (asserts `host_id` is bound + workspace set) and one without (asserts it stays unbound). All 10 tests in the file pass; `ruff` and `pyrefly` are clean.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Backend-only change (no frontend edits). Behavior is covered by the route test above.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — automated route coverage added.

## Changelog

Sessions imported from the web now bind to the machine they were imported from, so resuming them lands on the right host without the machine picker.

<!-- This pull request and its description were written by Isaac. -->
