### PR TITLE
fix(native): preserve session binding across /clear

### DIFF
--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -1087,7 +1087,9 @@ def register_resources_routes(
 
         Used by native Claude ``/clear`` rotation: ownership changes
         from the previous conversation to the fresh one while the tmux
-        pane keeps running.
+        pane keeps running. A successful transfer also carries the
+        source host, workspace, and git branch to the target because the
+        live terminal remains on that same placement.
 
         :param request: The incoming FastAPI request (for auth) with
             JSON body ``{"target_session_id": "conv_new"}``.
@@ -1132,6 +1134,15 @@ def register_resources_routes(
             raise OmnigentError(
                 error.get("message", "Terminal transfer failed"),
                 code=error.get("code", ErrorCode.INTERNAL_ERROR),
+            )
+
+        if conv.host_id is not None:
+            await asyncio.to_thread(
+                conversation_store.set_host_id,
+                target_session_id,
+                conv.host_id,
+                conv.workspace,
+                conv.git_branch,
             )
 
         _publish_and_persist_resource_event(

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -16,14 +16,15 @@ from omnigent.entities import (
 )
 from omnigent.session_import import IMPORT_PROVENANCE_LABEL_KEYS
 
-# Label set on a fork of a session that had a working directory. Its
-# value is the source session id. Presence marks the (unbound) clone as
-# needing a host + working directory before it can run, so the
-# online-dot reports it offline until bound and the UI opens the
-# directory picker instead of silently dropping the first message.
-# Forks of chat-only sources (no workspace) get no label and resume
-# in-process like a brand-new chat session. Canonical home is the store
-# layer; the server route and the SQLAlchemy store both import it.
+# Label set on a fork of a session that had a working directory, or a
+# runner-bound native session whose working-directory metadata was lost.
+# Its value is the source session id. Presence marks the (unbound) clone
+# as needing a host + working directory before it can run, so the
+# online-dot reports it offline until bound and the UI opens the directory
+# picker instead of silently dropping the first message. Forks of
+# chat-only sources get no label and resume in-process like a brand-new
+# chat session. Canonical home is the store layer; the server route and
+# the SQLAlchemy store both import it.
 FORK_SOURCE_LABEL_KEY = "omnigent.fork.source_id"
 
 # One-shot fork directive: the SOURCE session's runtime-native session id

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -74,6 +74,7 @@ from omnigent.entities import (
     PagedList,
     parse_item_data,
 )
+from omnigent.native_coding_agents import native_coding_agent_for_wrapper_label
 from omnigent.session_import.models import (
     IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
     IMPORT_SOURCE_LABEL_KEY,
@@ -3494,7 +3495,8 @@ class SqlAlchemyConversationStore(ConversationStore):
         (:data:`_INSTANCE_SCOPED_LABEL_KEYS` — native bridge ids,
         context metrics), which belong to the source's running instance
         and would mis-route or mis-display on the clone.
-        When the source had a ``workspace``, the fork is additionally
+        When the source had a ``workspace`` — or is a runner-bound native
+        session whose workspace metadata was lost — the fork is additionally
         stamped with ``FORK_SOURCE_LABEL_KEY`` (value = source id) so the
         unbound clone reports offline until it rebinds a directory (see
         :class:`SessionConnectivity`).
@@ -3835,17 +3837,20 @@ class SqlAlchemyConversationStore(ConversationStore):
             # clone is unbound (workspace/host not copied) and must rebind
             # a directory before it can run, so the online-dot reports it
             # offline and the UI opens the directory picker on the first
-            # message instead of dropping it. Forks of chat-only sources
-            # (no workspace) get no such label and resume in-process like
+            # message instead of dropping it. A runner-bound native source
+            # with no workspace gets the same recovery treatment because
+            # that combination reflects lost metadata, not a chat-only
+            # session. Other workspace-less sources resume in-process like
             # a brand-new chat session.
             # Per-user pin keys (``omnigent.pinned.<user>``) are dynamic-suffix,
             # so they're never in the exact-match drop sets — drop them by prefix
             # instead. A fork is a NEW conversation; inheriting the source's pins
             # would show the clone as pinned for the forker AND carry every other
             # user's pin key along as dead data.
+            source_labels = _fetch_labels(session, source_conversation_id)
             fork_labels = {
                 key: value
-                for key, value in _fetch_labels(session, source_conversation_id).items()
+                for key, value in source_labels.items()
                 if key
                 not in (
                     _INSTANCE_SCOPED_LABEL_KEYS
@@ -3881,7 +3886,13 @@ class SqlAlchemyConversationStore(ConversationStore):
                     else None
                 )
             )
-            if source_workspace is not None:
+            source_has_bound_native_runner = bool(
+                source_meta_ref
+                and source_meta_ref.runner_id
+                and native_coding_agent_for_wrapper_label(source_labels.get(WRAPPER_LABEL_KEY))
+                is not None
+            )
+            if source_workspace is not None or source_has_bound_native_runner:
                 fork_labels[FORK_SOURCE_LABEL_KEY] = source_conversation_id
             # Carry the source's native session id as a one-shot fork
             # directive so a native harness can resume + branch the source's

--- a/tests/server/integration/test_sessions_fork.py
+++ b/tests/server/integration/test_sessions_fork.py
@@ -18,6 +18,9 @@ from typing import Any
 import httpx
 import pytest
 
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
 from tests.server.helpers import create_test_agent
 from tests.server.integration.test_sessions_endpoints import (
     _create_session,
@@ -253,8 +256,43 @@ async def test_fork_coding_session_stamps_fork_source_label(
     )
 
 
+async def test_fork_recovers_runner_bound_native_session_without_workspace(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    Forking a runner-bound native session with lost workspace metadata still
+    sends the clone through directory rebinding.
+
+    Older ``/clear`` replacements could retain their live runner and native
+    presentation labels while dropping ``workspace``. Treating that source as
+    chat-only produces an unbound fork that silently cannot run. The native
+    wrapper label plus runner binding is the recovery signal.
+    """
+    agent = await create_test_agent(client)
+    source = await _create_session(
+        client,
+        agent["id"],
+        title="Legacy clear replacement",
+        labels={
+            "omnigent.ui": "terminal",
+            "omnigent.wrapper": "claude-code-native-ui",
+        },
+    )
+    store = SqlAlchemyConversationStore(db_uri)
+    assert store.set_runner_id(source["id"], "runner_legacy_clear")
+
+    resp = await _fork_session(client, source["id"])
+    assert resp.status_code == 201
+    fork = resp.json()
+
+    assert fork["labels"].get("omnigent.fork.source_id") == source["id"]
+    assert fork.get("workspace") is None
+
+
 async def test_fork_chat_session_has_no_fork_source_label(
     client: httpx.AsyncClient,
+    db_uri: str,
 ) -> None:
     """
     Forking a chat-only session (no working directory) adds no
@@ -268,6 +306,8 @@ async def test_fork_chat_session_has_no_fork_source_label(
     """
     agent = await create_test_agent(client)
     source = await _create_session(client, agent["id"], title="Chat only")
+    store = SqlAlchemyConversationStore(db_uri)
+    assert store.set_runner_id(source["id"], "runner_chat_only")
 
     resp = await _fork_session(client, source["id"])
     assert resp.status_code == 201

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -184,6 +184,22 @@ class _ConversationStore:
         conv = self._conversations[conversation_id]
         conv.labels.update(updates)
 
+    def set_host_id(
+        self,
+        conversation_id: str,
+        host_id: str,
+        workspace: str | None = None,
+        git_branch: str | None = None,
+    ) -> Conversation:
+        """Set a conversation's host placement fields."""
+        conv = self._conversations[conversation_id]
+        conv.host_id = host_id
+        if workspace is not None:
+            conv.workspace = workspace
+        if git_branch is not None:
+            conv.git_branch = git_branch
+        return conv
+
     def append(
         self,
         conversation_id: str,
@@ -449,6 +465,8 @@ def runner_globals_reset() -> Iterator[None]:
 def app(runner_globals_reset: None) -> FastAPI:
     del runner_globals_reset
     app = FastAPI()
+    conversation_store = _ConversationStore()
+    app.state.test_conversation_store = conversation_store
 
     @app.exception_handler(OmnigentError)
     async def _handle_omnigent_error(
@@ -473,7 +491,7 @@ def app(runner_globals_reset: None) -> FastAPI:
 
     app.include_router(
         create_sessions_router(
-            _ConversationStore(),  # type: ignore[arg-type]
+            conversation_store,  # type: ignore[arg-type]
             _StubAgentStore(),  # type: ignore[arg-type]
         ),
         prefix="/v1",
@@ -1550,8 +1568,15 @@ async def test_delete_terminal_proxies_to_runner(
 @pytest.mark.asyncio
 async def test_transfer_terminal_authorizes_sessions_and_proxies_to_runner(
     client: httpx.AsyncClient,
+    app: FastAPI,
 ) -> None:
-    """POST terminal transfer validates source and target then proxies."""
+    """POST terminal transfer proxies and carries the source placement."""
+    conversation_store: _ConversationStore = app.state.test_conversation_store
+    source = conversation_store.get_conversation("79b22ebd2309e48fdeb450c65611d51b")
+    assert source is not None
+    source.host_id = "host_arca"
+    source.workspace = "/home/alice/workspace"
+    source.git_branch = "feature/clear"
     terminal_resource = {
         "id": "terminal_bash_s1",
         "object": "session.resource",
@@ -1589,6 +1614,11 @@ async def test_transfer_terminal_authorizes_sessions_and_proxies_to_runner(
         ),
     ]
     assert router.resource_calls == ["79b22ebd2309e48fdeb450c65611d51b"]
+    target = conversation_store.get_conversation("5d29bee4350489d66feafecfebd94a97")
+    assert target is not None
+    assert target.host_id == "host_arca"
+    assert target.workspace == "/home/alice/workspace"
+    assert target.git_branch == "feature/clear"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

N/A — production incident; no public issue.

## Summary

- When a live terminal transfers successfully, carry its source `host_id`, `workspace`, and `git_branch` to the target session. This keeps placement coupled to the terminal that is still running, without launching another runner or introducing a new API.
- Recover legacy runner-bound native sessions whose workspace metadata was already lost by treating their forks as requiring directory rebinding. Runner-bound chat-only sessions remain unaffected.

**ELI5:** `/clear` moved the live terminal and runner into a new conversation but forgot to move the machine and directory recorded on the conversation. The new conversation continued working temporarily, but later appeared unbound and could not be forked normally. Terminal transfer now carries the exact host placement used by the terminal it moved.

## Test Plan

- `uv run --no-sync pytest -q tests/server/routes/test_session_resources.py::test_transfer_terminal_authorizes_sessions_and_proxies_to_runner tests/server/routes/test_session_resources.py::test_transfer_terminal_surfaces_runner_error_without_crashing tests/test_claude_native_forwarder.py tests/test_claude_native_hook.py tests/server/integration/test_sessions_fork.py`
- 217 focused tests passed.
- Changed-file pre-commit checks passed.
- Real UI verification: created a Claude session on an external host, entered `/clear` through the web composer, confirmed the replacement retained the same runner, `host_id`, workspace, git branch, online host badge, and file browser, then successfully sent another message and forked it through the UI onto the same external host/workspace.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Before:
https://github.com/user-attachments/assets/c428e5ab-4952-4ebb-9887-6d4ef9c63a3a

After:
https://github.com/user-attachments/assets/4c18b1f9-e17e-4f34-a6c3-404d701af214

Recovery for existing cleared sessions with inconsistent state:
https://github.com/user-attachments/assets/d870fe09-7ca0-4caa-be9c-67e9c030972b



## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover host/workspace/git-branch propagation during terminal transfer, transfer error handling, and backward-compatible fork recovery for legacy native sessions missing workspace metadata.

## Changelog

Native `/clear` replacements retain the host, workspace, and git branch used by their transferred terminal and remain forkable.
