### PR TITLE
fix(runner): relay the harness error body on the stream=true turn path

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2139,6 +2139,53 @@ def _normalize_turn_error(error: Mapping[str, object]) -> dict[str, str]:
     return {"code": code, "message": message}
 
 
+def _harness_error_response_error(response: object) -> dict[str, str]:
+    """
+    Turn a harness error response into a turn-failure ``error`` dict.
+
+    ``_stream_message_to_harness`` reports a setup failure by returning a
+    ``JSONResponse`` shaped ``{"error": <code>, "detail": <text>}`` instead
+    of a stream. Both turn paths relay that failure to stream subscribers
+    through :func:`_on_proxy_stream_end`, so the body is decoded back into
+    the ``{"message"}`` shape :func:`_normalize_turn_error` reads —
+    subscribers then see the same code and detail the direct HTTP caller
+    received rather than a generic placeholder. The message composition
+    mirrors the server's ``_runner_reject_detail``: the runner's code is
+    named in the message, while the wire ``code`` stays the generic
+    setup-failure code the failure card already describes. A body that is
+    absent, undecodable, or not a runner error object degrades to a preview
+    of the raw text, so this never raises.
+
+    :param response: The non-``StreamingResponse`` returned by
+        ``_stream_message_to_harness``, e.g. a ``JSONResponse`` carrying
+        ``{"error": "harness_spawn_failed", "detail": "Request failed on
+        the runner; ..."}``.
+    :returns: An error dict with a ``message`` key, e.g.
+        ``{"message": "harness_spawn_failed: Request failed on the
+        runner; ..."}``.
+    """
+    text = ""
+    # A stub response without a body, a body that is not bytes, or bytes
+    # that are not UTF-8 all fall back to the generic message below.
+    with contextlib.suppress(UnicodeDecodeError, AttributeError, TypeError):
+        text = bytes(cast(Any, response).body).decode("utf-8")
+    payload: object = None
+    with contextlib.suppress(ValueError):
+        payload = json.loads(text)
+    if isinstance(payload, dict):
+        raw_detail = payload.get("detail")
+        raw_code = payload.get("error")
+        detail = raw_detail.strip() if isinstance(raw_detail, str) else ""
+        code = raw_code.strip() if isinstance(raw_code, str) else ""
+        if code and detail:
+            return {"message": f"{code}: {detail}"}
+        if detail:
+            return {"message": detail}
+        if code:
+            return {"message": code}
+    return {"message": text.strip()[:200] or "harness returned error response"}
+
+
 def _truncate_child_preview(text: str) -> str:
     """
     Truncate a child message preview to the cap with an ellipsis.
@@ -6939,25 +6986,14 @@ def create_runner_app(
         if isinstance(response, StreamingResponse):
             await _drain_streaming_response(response, conv)
         else:
-            err_detail = "harness returned error response"
-            if hasattr(response, "body"):
-                with contextlib.suppress(
-                    UnicodeDecodeError,
-                    AttributeError,
-                ):
-                    err_detail = bytes(response.body).decode(
-                        "utf-8",
-                    )[:200]
+            error = _harness_error_response_error(response)
             _logger.error(
                 "turn bg error for %s: %s",
                 conv,
-                err_detail,
+                error["message"],
                 extra={"session_id": conv},
             )
-            _on_proxy_stream_end(
-                conv,
-                error={"message": err_detail},
-            )
+            _on_proxy_stream_end(conv, error=error)
 
     async def _drain_streaming_response(
         response: StreamingResponse,
@@ -7889,7 +7925,7 @@ def create_runner_app(
                     if not isinstance(response, StreamingResponse):
                         _on_proxy_stream_end(
                             conversation_id,
-                            error={"message": "harness returned error response"},
+                            error=_harness_error_response_error(response),
                         )
                     return response
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2141,28 +2141,14 @@ def _normalize_turn_error(error: Mapping[str, object]) -> dict[str, str]:
 
 def _harness_error_response_error(response: object) -> dict[str, str]:
     """
-    Turn a harness error response into a turn-failure ``error`` dict.
+    Convert a non-streaming harness error response into a turn failure.
 
-    ``_stream_message_to_harness`` reports a setup failure by returning a
-    ``JSONResponse`` shaped ``{"error": <code>, "detail": <text>}`` instead
-    of a stream. Both turn paths relay that failure to stream subscribers
-    through :func:`_on_proxy_stream_end`, so the body is decoded back into
-    the ``{"message"}`` shape :func:`_normalize_turn_error` reads —
-    subscribers then see the same code and detail the direct HTTP caller
-    received rather than a generic placeholder. The message composition
-    mirrors the server's ``_runner_reject_detail``: the runner's code is
-    named in the message, while the wire ``code`` stays the generic
-    setup-failure code the failure card already describes. A body that is
-    absent, undecodable, or not a runner error object degrades to a preview
-    of the raw text, so this never raises.
+    For example, ``{"error": "harness_spawn_failed", "detail": "See runner log"}``
+    becomes ``{"message": "harness_spawn_failed: See runner log"}``. Missing or
+    malformed bodies fall back to a short raw-body preview or a generic message.
 
-    :param response: The non-``StreamingResponse`` returned by
-        ``_stream_message_to_harness``, e.g. a ``JSONResponse`` carrying
-        ``{"error": "harness_spawn_failed", "detail": "Request failed on
-        the runner; ..."}``.
-    :returns: An error dict with a ``message`` key, e.g.
-        ``{"message": "harness_spawn_failed: Request failed on the
-        runner; ..."}``.
+    :param response: Response returned instead of a ``StreamingResponse``.
+    :returns: An error dict suitable for :func:`_on_proxy_stream_end`.
     """
     text = ""
     # A stub response without a body, a body that is not bytes, or bytes

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -52,6 +52,7 @@ from typing import Any, cast
 import httpx
 import pytest
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse, Response
 from fastapi.responses import StreamingResponse as _StreamingResponse
 
 import omnigent.runtime.harnesses._executor_adapter as _adapter_mod_recovery
@@ -79,6 +80,7 @@ from omnigent.runner.app import (
     _build_spawn_env_from_spec,
     _evaluate_policy_via_omnigent,
     _forward_harness_response,
+    _harness_error_response_error,
     _resolve_harness_config,
 )
 from omnigent.runtime.harnesses import _HARNESS_MODULES
@@ -1529,6 +1531,250 @@ async def test_runner_stream_emits_failed_when_tool_spec_resolver_fails() -> Non
     assert "RuntimeError" in response.text
     assert "Failed to resolve the agent spec for this turn." in response.text
     assert "stream spec resolver unavailable for ag_stream" not in response.text
+
+
+# ── Harness error-response detail → stream subscribers ───
+
+_SPAWN_LOG_DETAIL = "Request failed on the runner; see the runner log for details: ~/x.log"
+
+
+@pytest.mark.parametrize(
+    "response, expected",
+    [
+        pytest.param(
+            JSONResponse(
+                status_code=503,
+                content={"error": "harness_spawn_failed", "detail": _SPAWN_LOG_DETAIL},
+            ),
+            {"message": f"harness_spawn_failed: {_SPAWN_LOG_DETAIL}"},
+            id="code-and-detail-compose",
+        ),
+        pytest.param(
+            JSONResponse(status_code=503, content={"error": "spec_resolver_failed"}),
+            {"message": "spec_resolver_failed"},
+            id="code-only-is-the-message",
+        ),
+        pytest.param(
+            JSONResponse(status_code=503, content={"detail": "just prose"}),
+            {"message": "just prose"},
+            id="detail-only-is-the-message",
+        ),
+        pytest.param(
+            JSONResponse(status_code=503, content={"error": "  ", "detail": ""}),
+            {"message": '{"error":"  ","detail":""}'},
+            id="blank-strings-fall-through-to-raw-text",
+        ),
+        pytest.param(
+            Response(content="plain text body", status_code=500),
+            {"message": "plain text body"},
+            id="non-json-body-is-the-message",
+        ),
+        pytest.param(
+            Response(content=b"\xff\xfe", status_code=500),
+            {"message": "harness returned error response"},
+            id="undecodable-body-falls-back",
+        ),
+        pytest.param(
+            object(),
+            {"message": "harness returned error response"},
+            id="missing-body-attribute-falls-back",
+        ),
+        pytest.param(
+            type("_NoneBody", (), {"body": None})(),
+            {"message": "harness returned error response"},
+            id="none-body-falls-back",
+        ),
+        pytest.param(
+            Response(content="x" * 300, status_code=500),
+            {"message": "x" * 200},
+            id="long-body-truncated-to-200",
+        ),
+        pytest.param(
+            JSONResponse(status_code=500, content=["not", "a", "dict"]),
+            {"message": '["not","a","dict"]'},
+            id="non-object-json-is-raw-text",
+        ),
+    ],
+)
+def test_harness_error_response_error_parses_runner_error_bodies(
+    response: object, expected: dict[str, str]
+) -> None:
+    """The helper turns a harness error response into a ``{message}`` error.
+
+    Covers every body shape the runner can hand back: the structured
+    ``{"error", "detail"}`` bodies ``_stream_message_to_harness`` returns,
+    partial and blank variants of those, and the degenerate bodies (plain
+    text, undecodable bytes, a ``None`` body, no ``body`` attribute at
+    all). Reaching the
+    assertion at all is the "never raises" half of the contract.
+
+    :param response: The non-streaming response handed to the helper.
+    :param expected: The exact error dict the helper must return.
+    :returns: None.
+    """
+    assert _harness_error_response_error(response) == expected
+
+
+class _SpawnFailingProcessManager(_FakeProcessManager):
+    """Process manager stub whose harness spawn always fails.
+
+    Inherits :class:`_FakeProcessManager`'s reaper and release no-ops and
+    replaces only ``get_client``, so the runner takes the
+    ``harness_spawn_failed`` 503 arm of ``_stream_message_to_harness``.
+    """
+
+    async def get_client(
+        self,
+        conversation_id: str,
+        harness_name: str,
+        *,
+        env: dict[str, str] | None = None,
+    ) -> _FakeHarnessClient:
+        """
+        Fail the spawn the way a broken harness binary does.
+
+        :param conversation_id: Omnigent conversation id.
+        :param harness_name: Harness name requested by the runner.
+        :param env: Optional spawn environment.
+        :returns: Never returns.
+        :raises RuntimeError: Always.
+        """
+        del conversation_id, harness_name, env
+        raise RuntimeError("harness binary exploded")
+
+
+@pytest.mark.asyncio
+async def test_runner_stream_spawn_failed_reaches_subscribers_with_detail(
+    caplog: pytest.LogCaptureFixture,
+    pinned_runner_log: Path,
+) -> None:
+    """A ``stream=true`` spawn failure publishes the runner's own failure class and detail.
+
+    The direct HTTP caller already received
+    ``{"error": "harness_spawn_failed", "detail": ...}``. Relay subscribers
+    read the same failure off the terminal ``session.status: failed`` event,
+    so that event must carry the same diagnosis rather than a generic
+    placeholder — otherwise the two callers disagree about why the turn died.
+
+    :param caplog: Pytest log capture, used to confirm the raw cause is
+        logged server-side (the other half of the log-and-genericize
+        contract).
+    :param pinned_runner_log: The log path the detail must name.
+    :returns: None.
+    """
+
+    async def _none_spec_resolver(
+        agent_id: str, session_id: str | None = None
+    ) -> AgentSpec | None:
+        """
+        Resolve no spec, so the harness named in the body is used as-is.
+
+        :param agent_id: Agent id requested by the runner.
+        :param session_id: Session id (unused).
+        :returns: Always ``None``.
+        """
+        del agent_id, session_id
+        return None
+
+    conv = "conv_stream_spawn_failed"
+    app = create_runner_app(
+        process_manager=cast(HarnessProcessManager, _SpawnFailingProcessManager()),
+        spec_resolver=_none_spec_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_test_client(app) as http:
+        with caplog.at_level(logging.WARNING, logger="omnigent.runner.app"):
+            response = await http.post(
+                f"/v1/sessions/{conv}/events?stream=true",
+                json={
+                    "type": "message",
+                    "role": "user",
+                    "harness": _TEST_HARNESS_NAME,
+                    "agent_id": "ag_spawn",
+                    "model": "x",
+                    "content": [],
+                },
+            )
+        event = await _drain_failed_status_event(app.state.session_event_queues, conv, timeout=5.0)
+
+    # The direct caller's contract is unchanged.
+    assert response.status_code == 503
+    assert response.json()["error"] == "harness_spawn_failed"
+    # The subscriber's copy now names the same failure. The wire code stays
+    # the generic setup-failure code the failure card describes.
+    assert event is not None
+    assert event["error"]["code"] == "runner_error"
+    expected_detail = (
+        f"Request failed on the runner; see the runner log for details: {pinned_runner_log}"
+    )
+    assert event["error"]["message"] == f"harness_spawn_failed: {expected_detail}"
+    assert "harness returned error response" not in event["error"]["message"]
+    # Log-and-genericize: the raw cause is logged, never relayed.
+    assert "harness binary exploded" not in event["error"]["message"]
+    assert "harness binary exploded" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_runner_background_spawn_failed_reaches_subscribers_with_detail(
+    pinned_runner_log: Path,
+) -> None:
+    """The background turn path publishes the same spawn-failure detail.
+
+    Companion to
+    :func:`test_runner_stream_spawn_failed_reaches_subscribers_with_detail`:
+    both turn paths inspect the harness error response through the same
+    helper, so a 202 background turn must surface the identical message.
+    The resolver returns a spec here (rather than ``None``) because the
+    background path takes its harness from the resolved spec, not from the
+    request body.
+
+    :param pinned_runner_log: The log path the detail must name.
+    :returns: None.
+    """
+
+    async def _spec_resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """
+        Pin the turn to the test harness so dispatch reaches the spawn.
+
+        :param agent_id: Agent id requested by the runner (unused).
+        :param session_id: Session id (unused).
+        :returns: A minimal spec naming the test harness.
+        """
+        del agent_id, session_id
+        return AgentSpec(
+            spec_version=1,
+            name="spawn-failing-agent",
+            executor=ExecutorSpec(type="omnigent", config={"harness": _TEST_HARNESS_NAME}),
+        )
+
+    conv = "conv_bg_spawn_failed"
+    app = create_runner_app(
+        process_manager=cast(HarnessProcessManager, _SpawnFailingProcessManager()),
+        spec_resolver=_spec_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_test_client(app) as http:
+        response = await http.post(
+            f"/v1/sessions/{conv}/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "ag_spawn",
+                "model": "x",
+                "content": [],
+            },
+        )
+        assert response.status_code == 202
+        await _await_bg_turn_task(conv)
+        event = await _drain_failed_status_event(app.state.session_event_queues, conv, timeout=5.0)
+
+    assert event is not None
+    assert event["error"]["code"] == "runner_error"
+    expected_detail = (
+        f"Request failed on the runner; see the runner log for details: {pinned_runner_log}"
+    )
+    assert event["error"]["message"] == f"harness_spawn_failed: {expected_detail}"
+    assert "harness returned error response" not in event["error"]["message"]
 
 
 def test_direct_and_background_switch_sites_share_one_invalidation_routine() -> None:

--- a/tests/runner/test_stream_dispatch_relays_spawn_failure_detail.py
+++ b/tests/runner/test_stream_dispatch_relays_spawn_failure_detail.py
@@ -1,0 +1,211 @@
+"""Direct-stream dispatch must not discard harness spawn-failure detail.
+
+When a harness fails to start, ``_stream_message_to_harness`` returns a
+``JSONResponse`` carrying a real diagnosis
+(``{"error": "harness_spawn_failed", "detail": ...}``). The background
+dispatch path (``_run_turn_bg``) decodes that body into the relay's
+terminal ``session.status: failed`` event and logs it at ERROR. The
+direct-stream dispatch path (``POST /v1/sessions/{id}/events?stream=true``)
+must do the same instead of publishing the fixed string
+``"harness returned error response"`` and logging nothing: otherwise relay
+subscribers cannot distinguish a spawn failure from any other
+non-streaming outcome, and the HTTP response and the relay disagree about
+the same failure.
+
+Journey driven (real runner app, real started ``HarnessProcessManager``):
+POST a user message to ``/v1/sessions/{conv}/events?stream=true`` naming a
+harness that cannot spawn, then read the relay events the runner published
+for that session — the same per-session queue the SSE
+``GET /v1/sessions/{id}/stream`` endpoint drains for subscribers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from omnigent.runner import create_runner_app
+from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
+from tests.runner.conftest import _runner_client
+from tests.runner.helpers import NullServerClient
+
+# A harness name no environment registers, so the REAL
+# HarnessProcessManager.get_client raises the production spawn-failure
+# RuntimeError and the dispatch path builds its 503 harness_spawn_failed
+# JSONResponse — no mocked failure injection.
+_UNSPAWNABLE_HARNESS = "omni-repro-unspawnable-harness"
+
+# The fixed fallback string the direct-stream path must stop publishing
+# unconditionally when a decodable error body is available.
+_GENERIC_RELAY_MESSAGE = "harness returned error response"
+
+
+@pytest.fixture
+async def spawn_failing_manager() -> AsyncIterator[HarnessProcessManager]:
+    """A real, started HarnessProcessManager with no test harness registered.
+
+    Requesting :data:`_UNSPAWNABLE_HARNESS` (or the runner's fallback
+    default, equally unregistered) makes ``get_client`` raise the real
+    unknown-harness ``RuntimeError``, which the dispatch paths convert into
+    the ``503 harness_spawn_failed`` JSONResponse under test.
+
+    Uses a short ``/tmp`` parent rather than pytest's ``tmp_path`` because
+    UDS paths on Linux are capped at 108 chars and the manager's
+    per-conversation socket layout blows past that under pytest's tree.
+
+    :returns: Async iterator yielding the started manager; shuts it down
+        and removes its instance dir on teardown.
+    """
+    short_parent = Path(f"/tmp/oa-rtest-{uuid.uuid4().hex[:8]}")
+    short_parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    mgr = HarnessProcessManager(tmp_parent=short_parent)
+    await mgr.start()
+    try:
+        yield mgr
+    finally:
+        await mgr.shutdown()
+        shutil.rmtree(short_parent, ignore_errors=True)
+
+
+def _build_app(manager: HarnessProcessManager) -> FastAPI:
+    """Build a runner app whose harness spawn genuinely fails.
+
+    :param manager: A real, started process manager with the requested
+        harness unregistered.
+    :returns: The runner FastAPI app under test.
+    """
+    return create_runner_app(
+        process_manager=manager,
+        spec_resolver=None,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+
+async def _post_spawn_failing_turn(
+    http: httpx.AsyncClient,
+    conv: str,
+    *,
+    stream: bool,
+) -> httpx.Response:
+    """Send the user message that triggers the harness spawn failure.
+
+    :param http: ASGI test client against the runner app.
+    :param conv: Session/conversation identifier the turn belongs to.
+    :param stream: ``True`` drives the direct-stream dispatch path
+        (``?stream=true``); ``False`` drives the background 202 path.
+    :returns: The runner's HTTP response for the turn request.
+    """
+    query = "?stream=true" if stream else ""
+    return await http.post(
+        f"/v1/sessions/{conv}/events{query}",
+        json={
+            "type": "message",
+            "role": "user",
+            "harness": _UNSPAWNABLE_HARNESS,
+            "model": "fake/model",
+            "content": [{"type": "input_text", "text": "hello"}],
+        },
+    )
+
+
+async def _failed_relay_event(
+    queues: dict[str, Any],
+    conv: str,
+    *,
+    timeout: float = 2.0,
+) -> dict[str, Any] | None:
+    """Return the ``session.status: failed`` event the runner relayed.
+
+    Reads the runner's per-session event queue
+    (``app.state.session_event_queues``) — the same queue the SSE
+    ``/stream`` endpoint drains for subscribers — rather than a concurrent
+    SSE ``GET``, because ``httpx.ASGITransport`` does not interleave a
+    streaming response with a concurrent ``POST`` on the same client.
+
+    :param queues: The app's per-session event-queue dict, i.e.
+        ``app.state.session_event_queues``.
+    :param conv: Session/conversation identifier, e.g. ``"conv_abc123"``.
+    :param timeout: Hard cap in seconds before giving up.
+    :returns: The ``session.status: failed`` event dict, or ``None``.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        queue = queues.get(conv)
+        drained = False
+        while queue is not None and not queue.empty():
+            event = queue.get_nowait()
+            drained = True
+            if (
+                isinstance(event, dict)
+                and event.get("type") == "session.status"
+                and event.get("status") == "failed"
+            ):
+                return event
+        if not drained:
+            await asyncio.sleep(0.02)
+    return None
+
+
+@pytest.mark.asyncio
+async def test_stream_spawn_failure_relays_error_detail(
+    spawn_failing_manager: HarnessProcessManager,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The stream=true dispatch path must relay and log the spawn diagnosis.
+
+    Drives the real journey: a subscriber-visible turn is started via
+    ``POST /v1/sessions/{conv}/events?stream=true`` with a harness that
+    cannot spawn. The HTTP caller gets the diagnosed
+    ``503 harness_spawn_failed``; the relay subscriber and the runner's
+    ERROR log must learn the same diagnosis instead of the fixed
+    ``"harness returned error response"`` string.
+    """
+    app = _build_app(spawn_failing_manager)
+    conv = f"conv_spawn_detail_{uuid.uuid4().hex[:8]}"
+
+    async with _runner_client(app) as http:
+        with caplog.at_level(logging.ERROR, logger="omnigent.runner.app"):
+            response = await _post_spawn_failing_turn(http, conv, stream=True)
+
+        # Journey sanity: the direct HTTP caller receives the diagnosed
+        # spawn failure (this side has always been correct).
+        assert response.status_code == 503
+        body = response.json()
+        assert body["error"] == "harness_spawn_failed"
+        assert body["detail"]
+
+        failed = await _failed_relay_event(app.state.session_event_queues, conv)
+
+    assert failed is not None, "no session.status: failed event reached the relay"
+    relayed_error = json.dumps(failed.get("error") or {})
+
+    # The relay must not be fobbed off with the generic fallback while the
+    # HTTP response carries a real diagnosis for the same failure.
+    assert relayed_error != json.dumps({"message": _GENERIC_RELAY_MESSAGE}), (
+        "relay subscribers still get the generic fallback instead of the "
+        "harness_spawn_failed diagnosis"
+    )
+    # HTTP response and relay must agree on the failure: the relay error
+    # carries the harness_spawn_failed code and the client-safe detail.
+    assert "harness_spawn_failed" in relayed_error
+    assert "see the runner log for details" in relayed_error
+
+    # The dispatch outcome must be diagnosable from the runner log too: at
+    # least one ERROR record names the decoded harness error, not only the
+    # generic fallback (the background path has always logged its decode).
+    error_lines = [
+        record.getMessage() for record in caplog.records if record.levelno >= logging.ERROR
+    ]
+    assert any("harness_spawn_failed" in line for line in error_lines), (
+        f"no ERROR log line carries the decoded harness error body: {error_lines!r}"
+    )


### PR DESCRIPTION
## Related issue

Closes #4358

## Summary

When `_stream_message_to_harness` returns a non-streaming error (a `JSONResponse` such as `{"error": "harness_spawn_failed", "detail": "Request failed on the runner; see the runner log for details: ~/.omnigent/logs/runner/…"}`), the two turn paths disagreed about what the relay learned:

- The background path (`_run_turn_bg_setup_and_stream`) decoded the body and forwarded it, but as a raw 200-char JSON blob.
- The `stream=true` path (`post_session_events`) published the literal `"harness returned error response"`, discarding the code and detail the runner had just built. Relay subscribers could not tell a spawn failure from any other non-streaming outcome.

This PR extracts the body decoding into one module-level helper, `_harness_error_response_error`, used by both sites. It parses the runner's `{"error", "detail"}` shape the same way the server already does in `_runner_reject_detail`:

- both present → `harness_spawn_failed: Request failed on the runner; see the runner log for details: …`
- only one present → that one
- non-JSON or unexpected shape → body text truncated to 200 chars
- no body, non-bytes body, or undecodable bytes → the previous generic fallback

The HTTP response returned to the direct caller is unchanged. The wire `code` deliberately stays `runner_error`: the failure card's `FAILURE_CODE_DESCRIPTIONS` keys its headline on that code ("Something went wrong setting up the turn on the host."), so the failure class rides in the message, exactly as the server's `runner_rejected_event` sibling does. No new log line is added on the streaming path: `_publish_turn_status` already logs every `failed` status at ERROR, and that line now carries the decoded detail.

ELI5: the runner wrote down exactly why the harness failed to start, then told the audience "something went wrong". Now it reads the note out loud on both paths.

```
_stream_message_to_harness ──► JSONResponse {"error": code, "detail": text}
        │
        ├── background path ─┐
        │                    ├─► _harness_error_response_error ─► {"message": "code: text"}
        └── stream=true path ┘                                          │
                                                                        ▼
                                                    _on_proxy_stream_end ─► _normalize_turn_error
                                                                        │
                                                                        ▼
                                          session.status failed {code: runner_error, message} on the relay
```

## Test Plan

- `test_harness_error_response_error_parses_runner_error_bodies`: 10 parametrized body shapes for the helper (`{"error","detail"}`, code-only, detail-only, blank strings, plain text, invalid UTF-8, no `body` attribute, `None` body, 300-char truncation, JSON list).
- `test_runner_stream_spawn_failed_reaches_subscribers_with_detail`: the actual bug. A process manager whose `get_client` raises drives the `stream=true` path; asserts the direct 503 is unchanged, that the relay's `session.status: failed` event now reads `harness_spawn_failed: Request failed on the runner; see the runner log for details: <pinned log>`, and that the raw exception text is in the runner log but not on the relay. On `main` this fails with the generic message.
- `test_runner_background_spawn_failed_reaches_subscribers_with_detail`: same fakes on the 202 background path, proving both sites share the helper. On `main` this fails with the raw JSON blob.

```
uv run --no-sync pytest tests/runner/test_runner_dispatch.py -q -p no:cacheprovider
# 233 passed, 1 skipped (pre-existing OpenAI-key-gated test)
uv run --no-sync ruff check omnigent/runner/app.py tests/runner/test_runner_dispatch.py
uv run --no-sync ruff format --check omnigent/runner/app.py tests/runner/test_runner_dispatch.py
uv run --no-sync pyrefly check   # 0 errors in the changed files (23 pre-existing missing-import errors in omnigent/runtime/telemetry.py without opentelemetry.sdk installed)
uv run --no-sync pre-commit run --files omnigent/runner/app.py tests/runner/test_runner_dispatch.py
```

To see it by hand: point a native session at a harness command that cannot start (for example a non-existent binary path), send one message from the web UI or the REPL, and read the terminal error line. Before this change it says "harness returned error response"; after, it names `harness_spawn_failed` and points at the runner log.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new runner tests drive both turn paths through a fake process manager whose spawn raises, and assert on the relay-published `failed` event rather than only the HTTP response.

## Changelog

Turn failures on the streaming path now report the real harness error (for example `harness_spawn_failed: …`) instead of "harness returned error response"

## Issues

Resolves [OMNI-2716](https://linear.app/omnigent/issue/OMNI-2716/runner-discards-harness-spawn-failure-detail-on-the-streamtrue-path)
