### PR TITLE
perf(host): scope readiness for dedicated harnesses

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1557,7 +1557,7 @@ class HostProcess:
         # Off the loop: the check runs ``<cli> --version``, up to 10s on a hung
         # CLI, which inline would stall the keepalive pong and every other frame.
         if frame.harness is not None and not await asyncio.to_thread(
-            harness_is_configured, frame.harness
+            _harness_now_configured, frame.harness
         ):
             return HostLaunchRunnerResultFrame(
                 request_id=frame.request_id,
@@ -2995,7 +2995,9 @@ class HostProcess:
         """Collect harness readiness without letting a probe break the channel."""
         try:
             if self._dedicated_harness is not None:
-                available = await asyncio.to_thread(harness_is_configured, self._dedicated_harness)
+                available = await asyncio.to_thread(
+                    _harness_now_configured, self._dedicated_harness
+                )
                 return {self._dedicated_harness: available}
             return await asyncio.to_thread(configured_harness_map)
         except Exception as exc:

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -407,6 +407,8 @@ _AUTH_REJECT_ESCALATE_ATTEMPTS = 30
 # endpoint that accepts and never speaks is functionally down.
 _SILENT_CONNECT_ESCALATE_ATTEMPTS = 10
 
+DEDICATED_HARNESS_ENV_VAR = "OMNIGENT_HOST_DEDICATED_HARNESS"
+
 # Capability discovery is advisory and must not delay the host channel forever.
 _HOST_CAPABILITY_INIT_TIMEOUT_S = 15.0
 
@@ -910,6 +912,7 @@ class HostProcess:
         identity: HostIdentity,
         server_url: str,
         lifecycle_lock: DaemonLifecycleLock | None = None,
+        dedicated_harness: str | None = None,
     ) -> None:
         """Initialize the host process.
 
@@ -918,9 +921,14 @@ class HostProcess:
         :param lifecycle_lock: Optional guard binding this daemon's lifetime
             to its registry record. When present, the daemon holds the lock
             and self-terminates once the record is deleted or reassigned.
+        :param dedicated_harness: Harness this managed host was prepared to
+            run. When set, the host advertises and accepts only that harness.
         """
         self._identity = identity
         self._server_url = server_url.rstrip("/")
+        self._dedicated_harness = dedicated_harness or (
+            os.environ.get(DEDICATED_HARNESS_ENV_VAR, "").strip() or None
+        )
         self._runners: dict[str, _RunnerHandle] = {}
         # Retain the host's refreshable auth context after the first tunnel
         # handshake so runner launches can reuse its warm bearer. Failed or
@@ -957,7 +965,9 @@ class HostProcess:
         # Capability discovery belongs to daemon initialization, not the
         # connection handshake. Reconnects reuse this snapshot while the live
         # refresh task keeps it current.
-        self._configured_harnesses: dict[str, HarnessAvailability] | None = None
+        self._configured_harnesses: dict[str, HarnessAvailability] | None = (
+            {self._dedicated_harness: True} if self._dedicated_harness else None
+        )
         self._gateway_inference: dict[str, bool] | None = None
         self._capabilities_initialized = False
         # Consecutive login-page redirects; reset by a successful upgrade.
@@ -1522,6 +1532,22 @@ class HostProcess:
             ``"harness_not_configured"`` when the harness check
             refuses the launch.
         """
+        if (
+            frame.harness is not None
+            and self._dedicated_harness is not None
+            and canonicalize_harness(frame.harness)
+            != canonicalize_harness(self._dedicated_harness)
+        ):
+            return HostLaunchRunnerResultFrame(
+                request_id=frame.request_id,
+                status="failed",
+                error=(
+                    f"host {self._identity.name!r} is dedicated to harness "
+                    f"{self._dedicated_harness!r}, not {frame.harness!r}"
+                ),
+                error_code=HARNESS_NOT_CONFIGURED_ERROR_CODE,
+            )
+
         # Refuse to spawn for a harness this machine can't actually run —
         # otherwise the runner starts, the session looks alive, and the
         # first turn dies confusingly inside the executor. ``None`` (an
@@ -2968,6 +2994,9 @@ class HostProcess:
     ) -> dict[str, HarnessAvailability] | None:
         """Collect harness readiness without letting a probe break the channel."""
         try:
+            if self._dedicated_harness is not None:
+                available = await asyncio.to_thread(harness_is_configured, self._dedicated_harness)
+                return {self._dedicated_harness: available}
             return await asyncio.to_thread(configured_harness_map)
         except Exception as exc:
             _logger.exception("Host harness readiness probe failed")

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -332,7 +332,7 @@ async def test_handle_model_options_reports_the_endpoints_wider_catalog(
     _cleanup_host(host)
 
 
-def _make_host_process() -> HostProcess:
+def _make_host_process(*, dedicated_harness: str | None = None) -> HostProcess:
     """Create a HostProcess with a test identity.
 
     :returns: A :class:`HostProcess` for testing.
@@ -344,6 +344,7 @@ def _make_host_process() -> HostProcess:
     return HostProcess(
         identity=identity,
         server_url="http://localhost:8000",
+        dedicated_harness=dedicated_harness,
     )
 
 
@@ -445,6 +446,24 @@ async def test_handle_launch_spawns_subprocess(
     )
 
     # Clean up the spawned sleep process (and its exit watcher).
+    _cleanup_host(host)
+
+
+async def test_dedicated_host_rejects_a_different_harness() -> None:
+    host = _make_host_process(dedicated_harness="codex")
+
+    result = await host._handle_launch(
+        HostLaunchRunnerFrame(
+            request_id="req_wrong_harness",
+            binding_token="test_token_abc",
+            workspace="/not-reached",
+            harness="claude-sdk",
+        )
+    )
+
+    assert result.status == "failed"
+    assert result.error_code == HARNESS_NOT_CONFIGURED_ERROR_CODE
+    assert "dedicated to harness 'codex'" in (result.error or "")
     _cleanup_host(host)
 
 
@@ -1319,6 +1338,32 @@ async def test_capability_probe_failure_does_not_block_registration(
     assert hello.configured_harnesses is None
     assert hello.gateway_inference == {"codex": False}
     assert "Permission denied: '/usr/local/bin/codex'" in capsys.readouterr().err
+
+
+async def test_dedicated_host_probes_only_its_prevalidated_harness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checked: list[str] = []
+
+    def _configured(harness: str) -> bool:
+        checked.append(harness)
+        return True
+
+    def _unexpected_full_map() -> dict[str, bool]:
+        raise AssertionError("dedicated host must not inspect unrelated harnesses")
+
+    monkeypatch.setattr("omnigent.host.connect.harness_is_configured", _configured)
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", _unexpected_full_map)
+    monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", lambda: {"codex": False})
+    monkeypatch.setenv("OMNIGENT_HOST_DEDICATED_HARNESS", "codex")
+    host = _make_host_process()
+
+    await host._initialize_capabilities()
+
+    assert checked == ["codex"]
+    assert host._configured_harnesses == {"codex": True}
+    assert host._gateway_inference == {"codex": False}
+    _cleanup_host(host)
 
 
 async def test_hello_advertises_installed_version() -> None:

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1343,6 +1343,9 @@ async def test_capability_probe_failure_does_not_block_registration(
 async def test_dedicated_host_probes_only_its_prevalidated_harness(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from omnigent.host import connect as connect_mod
+
+    connect_mod._invalidate_quick_probe_cache()
     checked: list[str] = []
 
     def _configured(harness: str) -> bool:
@@ -1359,8 +1362,18 @@ async def test_dedicated_host_probes_only_its_prevalidated_harness(
     host = _make_host_process()
 
     await host._initialize_capabilities()
+    result = await host._handle_launch(
+        HostLaunchRunnerFrame(
+            request_id="req_cached_readiness",
+            binding_token="test_token_abc",
+            workspace="/not-reached",
+            harness="codex",
+        )
+    )
 
     assert checked == ["codex"]
+    assert result.status == "failed"
+    assert result.error_code == "workspace_missing"
     assert host._configured_harnesses == {"codex": True}
     assert host._gateway_inference == {"codex": False}
     _cleanup_host(host)


### PR DESCRIPTION
## Summary

- let managed single-purpose hosts declare `OMNIGENT_HOST_DEDICATED_HARNESS` after validating that harness
- probe and advertise only that harness instead of every installed/known harness
- reject launch frames for any different harness, preserving the dedicated-host boundary
- leave ordinary `omni host` behavior unchanged when the environment variable is absent

## Why

OAF provisions an ephemeral host for one prevalidated harness. Running readiness checks for every Omnigent harness adds several seconds before WebSocket registration, even though those results cannot be used by that host.

On the same local environment, initial capability discovery measured:

| mode | run 1 | run 2 |
| --- | ---: | ---: |
| full 50-harness map | 4,134 ms | 2,839 ms |
| dedicated Codex | 531 ms | 559 ms |

The hint is backward-compatible: older Omnigent versions ignore the environment variable.

## Validation

- focused host tests: 2 passed
- Ruff check and format check passed
- dedicated host rejects a mismatched launch before workspace/process setup
- dedicated readiness test fails if the full-map probe is invoked