### PR TITLE
feat(providers): integrate llmman as a local model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,14 +399,14 @@ works with four kinds of credentials:
 |---|---|---|
 | 🔑 | **API key** | A first-party vendor key for Anthropic, OpenAI, and similar providers |
 | 🎟️ | **Subscription** | A Claude Pro/Max or ChatGPT plan, via the official `claude` / `codex` CLIs |
-| 🌐 | **Gateway** | Any OpenAI- or Anthropic-compatible `base_url` and key (OpenRouter, LiteLLM, Ollama, vLLM, Azure) |
+| 🌐 | **Gateway** | Any OpenAI- or Anthropic-compatible `base_url` and key (OpenRouter, llmman, LiteLLM, vLLM, Azure) |
 | 🧱 | **Databricks** | A Databricks workspace profile (requires the `databricks` extra) |
 
 Defaults are per agent, so a Claude default and a Codex default coexist. You
 can also switch models in the middle of a session with the `/model` command.
 
 <details>
-<summary>Gateway base URLs (OpenRouter, Ollama)</summary>
+<summary>Gateway base URLs (OpenRouter, local servers)</summary>
 
 When you add a **Gateway** credential, `omnigent setup` asks for a base URL
 and a key. The base URL depends on which agent you point it at:
@@ -415,11 +415,19 @@ and a key. The base URL depends on which agent you point it at:
 |---|---|---|---|
 | **OpenRouter** | Claude Code | `https://openrouter.ai/api` | your OpenRouter key (`sk-or-…`) |
 | **OpenRouter** | Codex / OpenAI agents | `https://openrouter.ai/api/v1` | your OpenRouter key (`sk-or-…`) |
+| **llmman** (local) | Codex / OpenAI agents | `http://localhost:17434/v1` | any value (it is ignored) |
 | **Ollama** (local) | Codex / OpenAI agents | `http://localhost:11434/v1` | any value (Ollama ignores it) |
 
 For Claude Code, point at OpenRouter's Anthropic-compatible endpoint
 (`…/api`, **not** `…/api/v1`). For Codex and the OpenAI-agents harness, use
 the OpenAI-compatible `…/api/v1`.
+
+A running [llmman](https://github.com/llmmanorg/llmman) is detected
+automatically — `omnigent setup` offers it without asking for a base URL. It
+serves the OpenAI, Ollama and Anthropic APIs from one port, so the same
+endpoint backs every agent, whether the model is local or from a hosted
+provider llmman forwards to. The in-process SDK reaches it with the `llmman/`
+model prefix (e.g. `llmman/gemma4`).
 
 </details>
 

--- a/omnigent/llms/LLMCLIENT.md
+++ b/omnigent/llms/LLMCLIENT.md
@@ -216,6 +216,7 @@ Chat Completions IS the native format. Minimal translation (add model to payload
 | `xai` | `https://api.x.ai/v1` | `XAI_API_KEY` |
 | `openrouter` | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
 | `ollama` | `http://localhost:11434/v1` | (none) |
+| `llmman` | `http://localhost:17434/v1` | (none) |
 
 HTTP via sync `httpx` (already a project dependency).
 

--- a/omnigent/llms/adapters/__init__.py
+++ b/omnigent/llms/adapters/__init__.py
@@ -56,6 +56,7 @@ def _create_adapter(provider: str, **kwargs: Any) -> BaseAdapter:
         "xai": "https://api.x.ai/v1",
         "openrouter": "https://openrouter.ai/api/v1",
         "ollama": "http://localhost:11434/v1",
+        "llmman": "http://localhost:17434/v1",
         "moonshot": "https://api.moonshot.cn/v1",
     }
 

--- a/omnigent/llms/routing.py
+++ b/omnigent/llms/routing.py
@@ -28,6 +28,7 @@ PROVIDER_CONFIGS: dict[str, str | None] = {
     "xai": "https://api.x.ai/v1",
     "openrouter": "https://openrouter.ai/api/v1",
     "ollama": "http://localhost:11434/v1",
+    "llmman": "http://localhost:17434/v1",
     "moonshot": "https://api.moonshot.cn/v1",
 }
 

--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -2,13 +2,13 @@
 
 For the ``omnigent setup --no-internal-beta`` first-run experience, this module
 discovers credentials a user already has — vendor API keys in the
-environment, a logged-in ``claude`` / ``codex`` CLI, or a local Ollama
+environment, a logged-in ``claude`` / ``codex`` CLI, or a local model
 server — so the setup flow can offer them as one-tap choices instead of
 asking the user to paste keys they already have.
 
 Detection is almost entirely pure standard library (``os``, ``socket``,
-``pathlib``) and performs no network I/O beyond a single non-blocking
-localhost TCP probe for Ollama. The one exception is macOS Claude detection:
+``pathlib``) and performs no network I/O beyond one non-blocking localhost
+TCP probe per local server. The one exception is macOS Claude detection:
 Claude Code stores its subscription OAuth in the macOS Keychain (not a file),
 so on macOS — and only when the file check comes up empty — Claude detection
 falls back to a ``claude auth status`` subprocess (see
@@ -59,9 +59,15 @@ _OLLAMA_HOST = "localhost"
 _OLLAMA_PORT = 11434
 _OLLAMA_URL = f"http://{_OLLAMA_HOST}:{_OLLAMA_PORT}"
 
-# Timeout (seconds) for the Ollama TCP probe — short so setup stays snappy
-# when nothing is listening.
-_OLLAMA_PROBE_TIMEOUT = 0.25
+# llmman's default endpoint. It serves the OpenAI, Ollama and Anthropic APIs
+# from one port, so the ``/v1`` surface below is reached the same way.
+_LLMMAN_HOST = "localhost"
+_LLMMAN_PORT = 17434
+_LLMMAN_URL = f"http://{_LLMMAN_HOST}:{_LLMMAN_PORT}"
+
+# Timeout (seconds) for the local-server TCP probes — short so setup stays
+# snappy when nothing is listening.
+_LOCAL_PROBE_TIMEOUT = 0.25
 
 # Claude Code's enterprise "managed settings" chain, highest precedence first.
 # An enterprise install (the shape ``isaac configure claude`` writes) configures
@@ -99,7 +105,7 @@ class DetectedProvider:
 
     :param name: The provider/source name, e.g. ``"anthropic"``,
         ``"openai"``, ``"openrouter"``, ``"gemini"``, ``"claude"``,
-        ``"codex"``, or ``"ollama"``.
+        ``"codex"``, ``"ollama"``, or ``"llmman"``.
     :param kind: How the credential authenticates — ``"key"`` (an API key
         in the environment), ``"subscription"`` (a logged-in CLI), or
         ``"local"`` (a self-hosted endpoint).
@@ -609,6 +615,21 @@ def _claude_login_detected() -> bool:
     return False
 
 
+def _tcp_reachable(host: str, port: int) -> bool:
+    """Return whether *host*:*port* accepts a TCP connection.
+
+    :param host: The host to connect to, e.g. ``"localhost"``.
+    :param port: The TCP port to connect to.
+    :returns: ``True`` when the connect succeeds, ``False`` on refusal,
+        timeout, or any socket error.
+    """
+    try:
+        with socket.create_connection((host, port), timeout=_LOCAL_PROBE_TIMEOUT):
+            return True
+    except OSError:
+        return False
+
+
 def _ollama_reachable() -> bool:
     """Return whether a local Ollama server accepts TCP connections.
 
@@ -616,13 +637,21 @@ def _ollama_reachable() -> bool:
     in its own helper so tests can monkeypatch it without real network I/O.
 
     :returns: ``True`` when ``localhost:11434`` accepts a TCP connection,
-        ``False`` on refusal, timeout, or any socket error.
+        ``False`` otherwise.
     """
-    try:
-        with socket.create_connection((_OLLAMA_HOST, _OLLAMA_PORT), timeout=_OLLAMA_PROBE_TIMEOUT):
-            return True
-    except OSError:
-        return False
+    return _tcp_reachable(_OLLAMA_HOST, _OLLAMA_PORT)
+
+
+def _llmman_reachable() -> bool:
+    """Return whether a local llmman server accepts TCP connections.
+
+    Performs a single short-timeout connect to ``localhost:17434``. Isolated
+    in its own helper so tests can monkeypatch it without real network I/O.
+
+    :returns: ``True`` when ``localhost:17434`` accepts a TCP connection,
+        ``False`` otherwise.
+    """
+    return _tcp_reachable(_LLMMAN_HOST, _LLMMAN_PORT)
 
 
 # One-shot prewarmed detection result, produced by
@@ -688,10 +717,12 @@ def detect_providers() -> list[DetectedProvider]:
     4. A logged-in Codex CLI (``~/.codex/auth.json`` exists *and* carries a
        usable credential — see :func:`codex_auth_has_credential`).
     5. A reachable local Ollama (``localhost:11434`` TCP-connectable).
+    6. A reachable local llmman (``localhost:17434`` TCP-connectable).
 
-    No network I/O is performed except the single Ollama probe (see
-    :func:`_ollama_reachable`). On macOS, a ``claude auth status`` subprocess
-    may run as the Claude Keychain fallback (see :func:`_claude_login_detected`).
+    No network I/O is performed except the local-server probes (see
+    :func:`_ollama_reachable` and :func:`_llmman_reachable`). On macOS, a
+    ``claude auth status`` subprocess may run as the Claude Keychain fallback
+    (see :func:`_claude_login_detected`).
 
     :returns: One :class:`DetectedProvider` per credential found, in the
         priority order above. Empty when nothing is detected.
@@ -816,6 +847,17 @@ def _detect_providers_now() -> list[DetectedProvider]:
                 kind=LOCAL_KIND,
                 family=OPENAI_FAMILY,
                 source=_OLLAMA_URL,
+            )
+        )
+
+    # 6. Local llmman.
+    if _llmman_reachable():
+        detected.append(
+            DetectedProvider(
+                name="llmman",
+                kind=LOCAL_KIND,
+                family=OPENAI_FAMILY,
+                source=_LLMMAN_URL,
             )
         )
 

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -254,6 +254,7 @@ _PROVIDER_DISPLAY_NAME: dict[str, str] = {
     "google": "Google Gemini",
     "databricks": "Databricks",
     "ollama": "Ollama",
+    "llmman": "llmman",
 }
 
 
@@ -465,7 +466,7 @@ def add_menu_options() -> list[AddOption]:
         # Cross-vendor extras, alphabetical (Gateway before OpenRouter).
         _opt(
             "Gateway — custom base URL + key",
-            "An OpenAI/Anthropic-compatible proxy: LiteLLM, Ollama, vLLM, …",
+            "An OpenAI/Anthropic-compatible proxy: llmman, LiteLLM, vLLM, …",
             GATEWAY_KIND,
         ),
         _opt(

--- a/omnigent/onboarding/detected.py
+++ b/omnigent/onboarding/detected.py
@@ -1,8 +1,8 @@
 """Turn ambient-detected credentials into first-class provider entries.
 
 :mod:`omnigent.onboarding.ambient` discovers credentials already on the
-machine (env API keys, logged-in ``claude`` / ``codex`` CLIs, a local
-Ollama). This module bridges those raw detections into the kind-typed
+machine (env API keys, logged-in ``claude`` / ``codex`` CLIs, a local model
+server). This module bridges those raw detections into the kind-typed
 ``providers:`` shape consumed by :mod:`omnigent.onboarding.provider_config`,
 so they are treated as real providers everywhere — the ``/model`` readout
 names them truthfully, routing uses them, and ``configure harness`` shows
@@ -201,14 +201,14 @@ def _synthesize_entry(det: DetectedProvider) -> dict[str, object] | None:
         )
 
     if det.kind == "local":
-        # A self-hosted OpenAI-compatible server (Ollama). ``det.source`` is
-        # the base host (e.g. ``http://localhost:11434``); append the
-        # OpenAI-compatible ``/v1`` path. The key is a placeholder the
-        # server ignores but the family block requires a credential source.
+        # A self-hosted OpenAI-compatible server (llmman, Ollama).
+        # ``det.source`` is the base host (e.g. ``http://localhost:17434``);
+        # append the OpenAI-compatible ``/v1`` path. The key is a placeholder
+        # the server ignores but the family block requires a credential source.
         base_url = det.source.rstrip("/") + "/v1"
         return {
             "kind": LOCAL_KIND,
-            det.family: {"base_url": base_url, "api_key": "ollama"},
+            det.family: {"base_url": base_url, "api_key": det.name},
         }
 
     return None

--- a/omnigent/onboarding/providers/__init__.py
+++ b/omnigent/onboarding/providers/__init__.py
@@ -1070,6 +1070,7 @@ _PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     "deepseek": "DeepSeek",
     "openrouter": "OpenRouter",
     "ollama": "Ollama",
+    "llmman": "llmman",
 }
 
 

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -96,13 +96,15 @@ def isolated_config(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     # Stub out the two ambient-detection helpers that read real machine
     # state regardless of HOME / env-var isolation:
-    # - _ollama_reachable: TCP-probes localhost:11434; a running Ollama
-    #   would otherwise add an entry to the harness menu and shift option
-    #   numbers, making input sequences non-deterministic.
+    # - _ollama_reachable / _llmman_reachable: TCP-probe localhost:11434 and
+    #   localhost:17434; a running local server would otherwise add an entry
+    #   to the harness menu and shift option numbers, making input sequences
+    #   non-deterministic.
     # - _claude_login_detected: on macOS falls back to `claude auth status`
     #   which reads the Keychain (not HOME), so a real Claude subscription
     #   leaks through even with HOME redirected to tmp_path.
     monkeypatch.setattr("omnigent.onboarding.ambient._ollama_reachable", lambda: False)
+    monkeypatch.setattr("omnigent.onboarding.ambient._llmman_reachable", lambda: False)
     monkeypatch.setattr("omnigent.onboarding.ambient._claude_login_detected", lambda: False)
     return tmp_path
 

--- a/tests/llms/test_routing.py
+++ b/tests/llms/test_routing.py
@@ -41,6 +41,10 @@ from omnigent.llms.routing import RoutedModel, infer_harness_from_model, parse_m
             RoutedModel(provider="ollama", model="llama3"),
         ),
         (
+            "llmman/gemma4",
+            RoutedModel(provider="llmman", model="gemma4"),
+        ),
+        (
             "gemini/gemini-2.5-pro",
             RoutedModel(provider="gemini", model="gemini-2.5-pro"),
         ),

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -1,10 +1,11 @@
 """Tests for omnigent.onboarding.ambient — machine credential detection.
 
-Detection reads the environment, two CLI-login files under ``$HOME``, a single
-localhost TCP probe for Ollama, and — on macOS only — a ``claude auth status``
+Detection reads the environment, two CLI-login files under ``$HOME``, one
+localhost TCP probe per local server, and — on macOS only — a ``claude auth status``
 fallback for the Keychain-stored Claude credential. These tests redirect
 ``$HOME`` to a tmp dir, control the environment explicitly, and monkeypatch
-both :func:`omnigent.onboarding.ambient._ollama_reachable` and
+the local-server probes (:func:`omnigent.onboarding.ambient._ollama_reachable`,
+:func:`omnigent.onboarding.ambient._llmman_reachable`) and
 :func:`omnigent.onboarding.harness_install.harness_cli_logged_in` so no real
 network or subprocess I/O occurs. Each test asserts the exact
 :class:`DetectedProvider` fields (name / kind / family / source), not just the
@@ -62,6 +63,7 @@ def clean_env(tmp_path, monkeypatch: pytest.MonkeyPatch):
     for var in _PROVIDER_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setattr(ambient, "_ollama_reachable", lambda: False)
+    monkeypatch.setattr(ambient, "_llmman_reachable", lambda: False)
     # Neutralize the macOS Keychain fallback by default (the file check already
     # sees no creds under the tmp HOME). The detected/absent tests override this.
     monkeypatch.setattr(harness_install, "harness_cli_logged_in", lambda key: False)
@@ -447,8 +449,26 @@ def test_ollama_detected_when_reachable(clean_env, monkeypatch: pytest.MonkeyPat
     ]
 
 
+def test_llmman_detected_when_reachable(clean_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A reachable local llmman is detected as a local openai provider.
+
+    Uses the monkeypatched ``_llmman_reachable`` so no real socket is opened.
+    Failure means a running local model server would not be offered.
+    """
+    monkeypatch.setattr(ambient, "_llmman_reachable", lambda: True)
+    detected = detect_providers()
+    assert detected == [
+        DetectedProvider(
+            name="llmman",
+            kind="local",
+            family="openai",
+            source="http://localhost:17434",
+        )
+    ]
+
+
 def test_detection_priority_order(clean_env, monkeypatch: pytest.MonkeyPatch) -> None:
-    """All signals together are returned in env → claude → codex → ollama order.
+    """All signals together are returned in env → claude → codex → local order.
 
     Failure means the stable ordering broke, so the setup UI would present
     detected providers in a non-deterministic / surprising order.
@@ -469,11 +489,19 @@ def test_detection_priority_order(clean_env, monkeypatch: pytest.MonkeyPatch) ->
         '{"auth_mode": "apikey", "OPENAI_API_KEY": "sk-codex-real"}', encoding="utf-8"
     )
     monkeypatch.setattr(ambient, "_ollama_reachable", lambda: True)
+    monkeypatch.setattr(ambient, "_llmman_reachable", lambda: True)
 
     detected = detect_providers()
     # Env keys first, in PROVIDER_ENV_VARS iteration order (openai precedes
-    # anthropic in that dict), then claude login, codex login, ollama.
-    assert [d.name for d in detected] == ["openai", "anthropic", "claude", "codex", "ollama"]
+    # anthropic in that dict), then claude login, codex login, local servers.
+    assert [d.name for d in detected] == [
+        "openai",
+        "anthropic",
+        "claude",
+        "codex",
+        "ollama",
+        "llmman",
+    ]
 
 
 # ── Codex config.toml custom provider (cli-config) detection ───────────────

--- a/tests/onboarding/test_detected.py
+++ b/tests/onboarding/test_detected.py
@@ -242,6 +242,19 @@ def test_synthesize_local_ollama() -> None:
     assert entries["ollama"]["openai"]["base_url"] == "http://localhost:11434/v1"
 
 
+def test_synthesize_local_llmman() -> None:
+    """A reachable llmman becomes a ``local`` openai-family entry with /v1."""
+    det = DetectedProvider(
+        name="llmman", kind="local", family=OPENAI_FAMILY, source="http://localhost:17434"
+    )
+    entries = synthesize_detected_entries([det])
+    assert entries["llmman"]["kind"] == "local"
+    # The OpenAI-compatible path is appended to the detected host.
+    assert entries["llmman"]["openai"]["base_url"] == "http://localhost:17434/v1"
+    # The server ignores the key, but the family block requires a source.
+    assert entries["llmman"]["openai"]["api_key"] == "llmman"
+
+
 def test_effective_merges_and_auto_defaults_per_family() -> None:
     """Empty config + ambient creds → both merged and each its family default.
 

--- a/tests/test_native_codex_provider.py
+++ b/tests/test_native_codex_provider.py
@@ -252,6 +252,7 @@ def test_resolve_native_codex_launch_subscription_no_login_falls_through_to_key(
     # No ambient providers, so the fall-through target is unambiguously the
     # explicitly-configured key (not a detected env key / Ollama).
     monkeypatch.setattr("omnigent.onboarding.ambient._ollama_reachable", lambda: False)
+    monkeypatch.setattr("omnigent.onboarding.ambient._llmman_reachable", lambda: False)
     _seed(
         _isolated,
         {
@@ -289,6 +290,7 @@ def test_resolve_native_codex_launch_subscription_no_login_no_alternative_uses_l
     with base_url/auth overrides would mean we fabricated a route from nothing.
     """
     monkeypatch.setattr("omnigent.onboarding.ambient._ollama_reachable", lambda: False)
+    monkeypatch.setattr("omnigent.onboarding.ambient._llmman_reachable", lambda: False)
     _seed(
         _isolated,
         {"codex-subscription": {"kind": "subscription", "cli": "codex", "default": True}},
@@ -405,6 +407,7 @@ def test_resolve_native_codex_launch_dismissed_config_provider_pins_openai(
     pin codex's built-in ``openai`` provider instead.
     """
     monkeypatch.setattr("omnigent.onboarding.ambient._ollama_reachable", lambda: False)
+    monkeypatch.setattr("omnigent.onboarding.ambient._llmman_reachable", lambda: False)
     codex_dir = _isolated / ".codex"
     codex_dir.mkdir()
     (codex_dir / "config.toml").write_text(_DISMISSIBLE_CODEX_CONFIG)
@@ -430,6 +433,7 @@ def test_resolve_native_codex_launch_undismissed_config_provider_routes_via_pin(
     broadly and breaks the feature's golden path.
     """
     monkeypatch.setattr("omnigent.onboarding.ambient._ollama_reachable", lambda: False)
+    monkeypatch.setattr("omnigent.onboarding.ambient._llmman_reachable", lambda: False)
     codex_dir = _isolated / ".codex"
     codex_dir.mkdir()
     (codex_dir / "config.toml").write_text(_DISMISSIBLE_CODEX_CONFIG)
@@ -450,6 +454,7 @@ def test_config_provider_shadowed_by_nondefault_explicit_entry_still_pins(
     synthesized resume rollout record OpenAI and lose this provider's auth.
     """
     monkeypatch.setattr("omnigent.onboarding.ambient._ollama_reachable", lambda: False)
+    monkeypatch.setattr("omnigent.onboarding.ambient._llmman_reachable", lambda: False)
     codex_dir = _isolated / ".codex"
     codex_dir.mkdir()
     (codex_dir / "config.toml").write_text(_DISMISSIBLE_CODEX_CONFIG)
@@ -477,6 +482,7 @@ def test_shadowed_config_detection_uses_active_profile_provider(
 ) -> None:
     """The fallback pins the provider selected by Codex's active profile."""
     monkeypatch.setattr("omnigent.onboarding.ambient._ollama_reachable", lambda: False)
+    monkeypatch.setattr("omnigent.onboarding.ambient._llmman_reachable", lambda: False)
     codex_dir = _isolated / ".codex"
     codex_dir.mkdir()
     (codex_dir / "config.toml").write_text(


### PR DESCRIPTION
## Related issue

Closes #6091

## Summary

[llmman](https://github.com/llmmanorg/llmman) serves the OpenAI, Ollama and
Anthropic APIs from one loopback port (`17434`), so a user running it already
has every harness's wire format available on the box. Omnigent couldn't see it:
reaching it meant hand-adding a **Gateway** credential and typing the base URL,
and the in-process SDK rejected an `llmman/` model prefix outright.

This registers it the same way the other local server is registered — no new
adapter class, no new credential kind.

- **In-process SDK** — `llms/routing.py` and `llms/adapters/__init__.py` learn
  the provider and its default `http://localhost:17434/v1`, so `llmman/<model>`
  routes to the existing `OpenAICompatibleAdapter`.
- **Ambient detection** — `omnigent setup` probes `17434` and offers a running
  llmman as a one-tap `local` openai-family provider, no base URL to type. Both
  local probes now share one `_tcp_reachable` helper.
- **Synthesized entry** — the `local` entry's placeholder key is now the
  detection name rather than a hardcoded string, so each local server's entry
  names itself. The server ignores the key; the family block requires a
  credential source.

Every consumer of `LOCAL_KIND` (native Claude, native Codex, Pi) is already
kind-generic, so routing works end-to-end without touching them.

### ELI5

You start a model server on your laptop. Omnigent notices the port is open and
adds it to the credential list for you, so Claude Code / Codex / the SDK can all
talk to it without you configuring anything.

```
                     ┌──────────────────────────────┐
  omnigent setup ───▶│ ambient._llmman_reachable()  │  TCP probe :17434
                     └──────────────┬───────────────┘
                                    │ DetectedProvider(local, openai)
                                    ▼
                     ┌──────────────────────────────┐
                     │ detected._synthesize_entry() │  kind: local
                     └──────────────┬───────────────┘  base_url: …:17434/v1
                                    │
            ┌───────────────────────┼───────────────────────┐
            ▼                       ▼                       ▼
      claude_native          codex_native            pi_native
      (LOCAL_KIND)           (LOCAL_KIND)            (LOCAL_KIND)

  llmman/<model> ──▶ routing.PROVIDER_CONFIGS ──▶ OpenAICompatibleAdapter
```

## Test Plan

Unit tests:

```
.venv/bin/python -m pytest tests/onboarding tests/llms tests/cli/test_configure_models.py -q
```

Manual, against a live `llmman serve` on `127.0.0.1:17434`:

```python
>>> from omnigent.llms.routing import parse_model_string
>>> parse_model_string("llmman/gemma4")
RoutedModel(provider='llmman', model='gemma4')

>>> from omnigent.llms.adapters import get_adapter
>>> get_adapter("llmman")._base_url
'http://localhost:17434/v1'

>>> from omnigent.onboarding.ambient import detect_providers
>>> [(d.name, d.kind, d.source) for d in detect_providers()]
[('llmman', 'local', 'http://localhost:17434')]

>>> from omnigent.onboarding.detected import synthesize_detected_entries
>>> synthesize_detected_entries(detect_providers())
{'llmman': {'kind': 'local',
            'openai': {'base_url': 'http://localhost:17434/v1',
                       'api_key': 'llmman'}}}
```

And a real completion round-tripping through the adapter:

```
{'content': "I'm sorry for any confusion, but as a chatbot, I don't",
 'role': 'assistant', 'tool_calls': []}
```

Pre-existing failures on this machine (unchanged by this PR, reproduced on
`main`): the `databricks` extra isn't installed, and three
`tests/test_native_codex_provider.py` cases don't stub the *existing* Ollama
probe, so they fail on any host running a model server on `11434`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the probe-to-detection path
(`test_llmman_detected_when_reachable`), the ordering guarantee
(`test_detection_priority_order`), the synthesized config shape
(`test_synthesize_local_llmman`), and model-string routing
(`test_parse_with_provider_prefix`). The adapter itself is unchanged, so the
existing `OpenAICompatibleAdapter` suite covers the wire behaviour; the live
round-trip above is the manual verification that a real server answers on the
registered base URL.

Every test file that stubs the existing local-server probe now stubs the new one
too, so detection assertions stay hermetic on a machine that actually runs
llmman.

## Changelog

Omnigent now detects a local llmman server and offers it as a credential, and
the in-process SDK accepts `llmman/<model>` model strings.
