### PR TITLE
feat(server): per-request audit logging to the ZeroBus table

### DIFF
--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -58,6 +58,15 @@ PRIMARY_SESSION_ID_ENV_VAR = "OMNIGENT_RUNNER_PRIMARY_SESSION_ID"
 USER_ID_ENV_VAR = "OMNIGENT_USER_ID"
 _user_id_var: ContextVar[str | None] = ContextVar("omnigent_debug_user_id", default=None)
 
+# Request-scoped session attribution on the server. The HTTP middleware binds
+# this for the duration of a request whose matched route carries a
+# ``{session_id}`` path param, so records emitted while handling it inherit the
+# session even when the callsite did not thread it explicitly. Unset on the
+# runner/host (they use the ``OMNIGENT_RUNNER_PRIMARY_SESSION_ID`` env instead),
+# so this never changes runner attribution. An explicit ``extra`` session id
+# always wins over this ambient value.
+_session_id_var: ContextVar[str | None] = ContextVar("omnigent_debug_session_id", default=None)
+
 # Origin deployment identity for the workspace_id/app_name columns. The
 # multi-tenant managed service stamps a per-request ``record.workspace_id`` (via
 # its logging ContextFilter), so the sink prefers that; the values below are the
@@ -234,6 +243,32 @@ def current_user_id() -> str | None:
     return _user_id_var.get() or os.environ.get(USER_ID_ENV_VAR) or None
 
 
+def set_current_session_id(session_id: str | None) -> None:
+    """Bind the current request's session (server middleware, session-scoped routes only)."""
+    _session_id_var.set(session_id or None)
+
+
+@contextlib.contextmanager
+def current_session_id_scope(session_id: str | None) -> Iterator[None]:
+    """Bind ``session_id`` for the duration of the block, restoring the prior value on exit."""
+    token = _session_id_var.set(session_id or None)
+    try:
+        yield
+    finally:
+        _session_id_var.reset(token)
+
+
+def current_session_id() -> str | None:
+    """Best-available request-scoped session attribution (server only).
+
+    Bound by the HTTP middleware only for a request whose matched route carries a
+    ``{session_id}`` path param, so it never mis-attributes a non-session route.
+    Unset on the runner/host. An explicit ``extra`` session id always wins over
+    this (see :func:`record_to_row`).
+    """
+    return _session_id_var.get() or None
+
+
 def _clean(value: object) -> str | None:
     """Coerce a missing/blank record attribute to ``None`` so a fallback engages.
 
@@ -343,13 +378,16 @@ def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
     the two shapes the ZeroBus JSON path requires for the ``TIMESTAMP`` and
     ``MAP<STRING,STRING>`` columns respectively.
 
-    ``session_id`` is taken from what the callsite threaded via ``extra`` and,
-    failing that, falls back to the runner's primary (parent) conversation id
-    (:func:`runner_primary_session_id`). That fallback reads a runner-only env
-    that is absent on the multi-tenant server, so a server record with no
-    explicit id stays null rather than risk cross-request mis-attribution --
-    this is deliberate; do NOT add an ambient request-scoped fallback here. On a
-    runner, a co-located subagent turn whose log is not threaded can be
+    ``session_id`` is taken from what the callsite threaded via ``extra`` first,
+    then the server's request-scoped :func:`current_session_id` (bound by the
+    HTTP middleware only for a request whose matched route carries a
+    ``{session_id}`` path param -- so it never mis-attributes a non-session
+    route, and an explicit id always wins), and finally the runner's primary
+    (parent) conversation id (:func:`runner_primary_session_id`). The
+    request-scoped var is unset on the runner (which uses the primary-session
+    env), and the primary-session env is absent on the server, so the two
+    fallbacks never collide. A server record on a non-session route stays null.
+    On a runner, a co-located subagent turn whose log is not threaded can be
     attributed to the parent conversation, an accepted trade-off.
 
     ``workspace_id``/``app_name`` describe the record's origin deployment: the
@@ -360,7 +398,11 @@ def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
     """
     workspace_id, app_name = _process_identity()
     return {
-        "session_id": getattr(record, "session_id", None) or runner_primary_session_id(),
+        "session_id": (
+            getattr(record, "session_id", None)
+            or current_session_id()
+            or runner_primary_session_id()
+        ),
         "turn_id": getattr(record, "turn_id", None),
         "source": source,
         "event_name": getattr(record, "event_name", None),
@@ -693,6 +735,13 @@ _sink_lock = threading.Lock()
 # ids, never content — never reach the on-disk/stderr logs.
 SSE_LOGGER_NAME = "omnigent.sse_events"
 
+# Dedicated logger for server request audit events (the per-method
+# start/ok/error envelope, WS lifecycle, and in-handler checkpoints). Like the
+# SSE logger it gets the sink as its sole handler with ``propagate=False``, so
+# audit rows populate the table without flooding the on-disk/stderr logs, and
+# they disappear entirely when the sink is off (no env vars -> no handler).
+AUDIT_LOGGER_NAME = "omnigent.audit_events"
+
 
 def debug_sink_enabled() -> bool:
     """Whether the debug-log sink is active in this process.
@@ -715,6 +764,16 @@ def sse_event_logger() -> logging.Logger:
     handlers and records are dropped -- so gate on :func:`debug_sink_enabled`.
     """
     return logging.getLogger(SSE_LOGGER_NAME)
+
+
+def audit_event_logger() -> logging.Logger:
+    """Return the table-only logger for server request audit events.
+
+    Records go only to the debug sink (attached with ``propagate=False`` in
+    :func:`attach_debug_log_sink`); when the sink is disabled the logger has no
+    handlers and records are dropped -- so gate on :func:`debug_sink_enabled`.
+    """
+    return logging.getLogger(AUDIT_LOGGER_NAME)
 
 
 def attach_debug_log_sink(
@@ -770,3 +829,10 @@ def attach_debug_log_sink(
         sse_logger.setLevel(level)
         sse_logger.propagate = False
         sse_logger.addHandler(_active_sink)
+        # Table-only server audit-event logger (same rationale as the SSE
+        # logger): sink-only, non-propagating, so request audit rows reach the
+        # table but never the on-disk/stderr logs.
+        audit_logger = logging.getLogger(AUDIT_LOGGER_NAME)
+        audit_logger.setLevel(level)
+        audit_logger.propagate = False
+        audit_logger.addHandler(_active_sink)

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -67,6 +67,15 @@ _user_id_var: ContextVar[str | None] = ContextVar("omnigent_debug_user_id", defa
 # always wins over this ambient value.
 _session_id_var: ContextVar[str | None] = ContextVar("omnigent_debug_session_id", default=None)
 
+# Request-scoped bag of extra audit attributes a handler can attach so they ride
+# the request's audit envelope end-event (e.g. POST /events' event type, a newly
+# created session id) rather than emitting a separate row. Reset per request by
+# the middleware; mutated in place so a handler running in a child context is
+# still visible to the middleware. Unset outside a request.
+_audit_attrs_var: ContextVar[dict[str, str] | None] = ContextVar(
+    "omnigent_audit_attrs", default=None
+)
+
 # Origin deployment identity for the workspace_id/app_name columns. The
 # multi-tenant managed service stamps a per-request ``record.workspace_id`` (via
 # its logging ContextFilter), so the sink prefers that; the values below are the
@@ -267,6 +276,37 @@ def current_session_id() -> str | None:
     this (see :func:`record_to_row`).
     """
     return _session_id_var.get() or None
+
+
+def reset_request_audit_attrs() -> None:
+    """Start a fresh per-request audit-attribute bag (server middleware).
+
+    Called at the top of the request so a handler can attach attributes that
+    ride the request's audit envelope ``ok``/``error`` row instead of emitting
+    a separate row (see :func:`add_audit_attrs`).
+    """
+    _audit_attrs_var.set({})
+
+
+def add_audit_attrs(**attrs: object) -> None:
+    """Merge attributes onto the current request's audit envelope end-event.
+
+    A no-op outside a request (bag unset -> e.g. on the runner). Mutates the
+    bag in place so the value is visible to the middleware even though it runs
+    the downstream app in a child context. Values are coerced to ``str`` and
+    ``None`` dropped, matching the ``MAP<STRING,STRING>`` attributes column.
+    """
+    bag = _audit_attrs_var.get()
+    if bag is None:
+        return
+    for key, value in attrs.items():
+        if value is not None:
+            bag[str(key)] = str(value)
+
+
+def current_request_audit_attrs() -> dict[str, str]:
+    """Return a copy of the current request's accumulated audit attributes."""
+    return dict(_audit_attrs_var.get() or {})
 
 
 def _clean(value: object) -> str | None:

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -309,6 +309,20 @@ def current_request_audit_attrs() -> dict[str, str]:
     return dict(_audit_attrs_var.get() or {})
 
 
+def mark_request_audit_suppressed() -> None:
+    """Suppress this request's audit envelope end-event (high-frequency echoes).
+
+    For endpoints hit per streamed chunk (``POST /events`` with a transient
+    ``external_*_delta`` / usage type) whose per-call row is pure noise — the
+    content is already on the SSE-event logger. Recorded in the shared attribute
+    bag (a reserved key the middleware reads), so it survives the middleware's
+    child-context boundary like any other bag entry.
+    """
+    bag = _audit_attrs_var.get()
+    if bag is not None:
+        bag["_suppress"] = "1"
+
+
 def _clean(value: object) -> str | None:
     """Coerce a missing/blank record attribute to ``None`` so a fallback engages.
 

--- a/omnigent/runtime/session_stream.py
+++ b/omnigent/runtime/session_stream.py
@@ -33,7 +33,12 @@ import threading
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from typing import Any
 
-from omnigent.debug_logging import debug_event, debug_sink_enabled, sse_event_logger
+from omnigent.debug_logging import (
+    audit_event_logger,
+    debug_event,
+    debug_sink_enabled,
+    sse_event_logger,
+)
 from omnigent.runtime import inflight_text, pending_elicitations
 
 _logger = logging.getLogger(__name__)
@@ -89,6 +94,15 @@ _SSE_SKIP_TYPES = frozenset(
 _SSE_WARN_TYPES = frozenset(
     {"response.failed", "response.error", "turn.failed", "response.policy_denied"}
 )
+# Terminal SSE events → the turn's outcome. Emitted once per turn as a
+# first-class ``turn_finished`` audit row (session-scoped), so turn success /
+# failure is queryable without inferring it from the raw SSE stream.
+_TURN_OUTCOME_BY_EVENT_TYPE = {
+    "response.completed": "completed",
+    "response.failed": "failed",
+    "response.cancelled": "cancelled",
+    "response.incomplete": "incomplete",
+}
 # Top-level event fields safe to log — stable identifiers, closed enums, and
 # pure numerics only. Deliberately excludes human/LLM-authored free text
 # (``reason`` — PolicyDeniedEvent's deny reason is LLM-generated and can quote
@@ -163,6 +177,31 @@ def _log_sse_event(conversation_id: str, event: dict[str, Any]) -> None:
         extra = debug_event(event_type, session_id=conversation_id)
         extra["attributes"] = _sse_safe_attributes(event)
         sse_event_logger().log(level, "sse %s", event_type, extra=extra)
+        _log_turn_outcome(conversation_id, event_type, event)
+
+
+def _log_turn_outcome(conversation_id: str, event_type: str, event: dict[str, Any]) -> None:
+    """Emit a first-class ``turn_finished`` audit row on a terminal SSE event.
+
+    One row per turn (terminal events fire once), carrying the outcome plus safe
+    ids, so turn success/failure rate is a direct query rather than an inference
+    over the raw stream. Table-only via the audit logger; caller already gated on
+    :func:`debug_sink_enabled` and wrapped in ``suppress``.
+    """
+    outcome = _TURN_OUTCOME_BY_EVENT_TYPE.get(event_type)
+    if outcome is None:
+        return
+    extra = debug_event("turn_finished", session_id=conversation_id, outcome=outcome)
+    attributes = extra["attributes"]
+    if isinstance(attributes, dict):
+        response = event.get("response")
+        if isinstance(response, dict) and isinstance(response.get("id"), str):
+            attributes["response_id"] = response["id"]
+        error = event.get("error")
+        if isinstance(error, dict) and error.get("code") is not None:
+            attributes["error_code"] = str(error["code"])
+    level = logging.WARNING if outcome in ("failed", "incomplete") else logging.INFO
+    audit_event_logger().log(level, "turn %s", outcome, extra=extra)
 
 
 def publish(conversation_id: str, event: dict[str, Any]) -> None:

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1659,10 +1659,27 @@ def create_app(
             )
             set_request_duration_for_access_log(duration_seconds)
             route = request_route_template_for_metrics(request)
-            # Handler-attached attributes (e.g. POST /events' event type, a
-            # created session id) ride the end event; base attributes win on any
-            # key collision.
-            end_attributes = current_request_audit_attrs()
+            # Handler-attached attributes ride the end event. A handler that
+            # learns the session id mid-request (create_session, launch_runner —
+            # routes with no {session_id} path param) puts it in the bag; the
+            # BaseHTTPMiddleware runs the handler in a child context, so a
+            # ContextVar it sets there would not be visible here, but the bag is a
+            # shared dict, so it is. The bag's session_id becomes the row's column
+            # (not an attribute). Other reserved keys are dropped so a handler can
+            # never shadow an envelope field or collide with an _emit_audit_event
+            # argument (session_id / phase would raise TypeError).
+            _bag = current_request_audit_attrs()
+            end_session_id = _bag.get("session_id") or audit_session_id
+            _reserved = {
+                "session_id",
+                "phase",
+                "route",
+                "method",
+                "request_id",
+                "status",
+                "duration_ms",
+            }
+            end_attributes = {k: v for k, v in _bag.items() if k not in _reserved}
             end_attributes.update(
                 route=audit_route,
                 method=request.method,
@@ -1673,7 +1690,7 @@ def create_app(
             _emit_audit_event(
                 operation,
                 "error" if request_failed else "ok",
-                session_id=audit_session_id,
+                session_id=end_session_id,
                 **end_attributes,
             )
             # Per-route tally (low-cardinality template key) for offline

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -22,12 +22,18 @@ from sqlalchemy.exc import StatementError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.responses import Response
-from starlette.routing import Mount, Route
+from starlette.routing import Match, Mount, Route
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from omnigent._platform import resolve_repo_symlink
 from omnigent.db.db_models import InvalidUuidError
-from omnigent.debug_logging import set_current_user_id
+from omnigent.debug_logging import (
+    audit_event_logger,
+    debug_event,
+    debug_sink_enabled,
+    set_current_session_id,
+    set_current_user_id,
+)
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_plugins import (
     NativeHarnessProvider,
@@ -215,14 +221,39 @@ _SESSION_PATH_RE = re.compile(r"/v1/sessions/([^/]+)")
 def _session_id_from_request(request: Request) -> str | None:
     """Best-effort session id parsed from a ``/v1/sessions/<id>/…`` request path.
 
-    Threaded into exception-handler logs (``extra={"session_id": …}``) so a 500
-    on a session route carries its conversation id in the debug-logs table. Read
-    from the request explicitly per-invocation — no ambient/request-scoped
-    session ContextVar exists on the server, deliberately, to avoid
-    cross-request mis-attribution.
+    Threaded into exception-handler logs so a 500 on a session route carries its
+    conversation id in the debug-logs table. Parsed from the path here (rather
+    than the matched route param) because a handler may raise before the id is
+    otherwise in scope; the ambient request-scoped session ContextVar bound by
+    the middleware (:func:`omnigent.debug_logging.set_current_session_id`) covers
+    the non-exception records.
     """
     match = _SESSION_PATH_RE.search(request.url.path)
     return match.group(1) if match else None
+
+
+def _error_audit_extra(
+    request: Request,
+    *,
+    phase: str = "error",
+    **attributes: object,
+) -> dict[str, object]:
+    """Build the ``extra=`` for an exception-handler log: operation + session id.
+
+    Routing has already happened by the time an exception handler runs, so the
+    matched route's name (the handler function, e.g. ``get_session``) is the
+    operation. The record keeps its message and stack trace (via ``exc_info``)
+    while gaining a queryable ``event_name`` + ``session_id``, correlating it to
+    the middleware's ``error`` envelope row.
+    """
+    route = request.scope.get("route")
+    operation = getattr(route, "name", None) or "unmatched"
+    return debug_event(
+        operation,
+        session_id=_session_id_from_request(request),
+        phase=phase,
+        **attributes,
+    )
 
 
 # polly's and debby's multi-file bundles are packaged under
@@ -318,6 +349,57 @@ def request_route_template_for_metrics(request: Request) -> str:
     if isinstance(route, Route | Mount):
         return route.path
     return _UNMATCHED_ROUTE_TEMPLATE
+
+
+def _resolve_audit_route(request: Request) -> tuple[str, str, str | None]:
+    """Resolve ``(operation, route_template, session_id)`` before routing.
+
+    ``request.scope["route"]`` is only populated *after* routing (inside
+    ``call_next``), so to name the pre-call ``start`` audit event and bind the
+    ambient session id we match the request against the app's routes here. The
+    operation is the matched route's name (its handler function name, e.g.
+    ``create_session``); the session id comes from the matched route's
+    ``{session_id}`` path param — never the loose path regex — so a non-session
+    route (or ``/v1/sessions`` list) resolves to a null session id. Returns
+    ``("unmatched", "<unmatched>", None)`` when nothing matches.
+    """
+    for route in request.app.router.routes:
+        try:
+            match, child_scope = route.matches(request.scope)
+        except Exception:  # noqa: BLE001 — route matching must never fail a request
+            continue
+        if match is Match.FULL:
+            name = getattr(route, "name", None) or "unmatched"
+            template = getattr(route, "path", _UNMATCHED_ROUTE_TEMPLATE)
+            session_id = child_scope.get("path_params", {}).get("session_id")
+            return name, template, session_id
+    return "unmatched", _UNMATCHED_ROUTE_TEMPLATE, None
+
+
+def _emit_audit_event(
+    operation: str,
+    phase: str,
+    *,
+    session_id: str | None,
+    **attributes: object,
+) -> None:
+    """Emit one server audit row (table-only, gated on the debug sink).
+
+    A no-op when the debug-log sink is off, so it costs nothing for OSS / users
+    who never enabled it. ``event_name`` is the operation (handler name) and
+    ``phase`` / ``route`` / ``status`` / ``duration_ms`` ride as attributes so a
+    reader groups by operation and filters by phase.
+    """
+    if not debug_sink_enabled():
+        return
+    # Audit logging must never fail a request.
+    with suppress(Exception):
+        audit_event_logger().info(
+            "%s %s",
+            operation,
+            phase,
+            extra=debug_event(operation, session_id=session_id, phase=phase, **attributes),
+        )
 
 
 def _request_status_code_for_metrics(
@@ -1539,6 +1621,22 @@ def create_app(
         except Exception:  # noqa: BLE001 — attribution is best-effort
             set_current_user_id(None)
 
+        # Resolve the operation + session id from the matched route up front so
+        # the audit ``start`` event is named and records emitted while handling a
+        # session-scoped request inherit the session id (ambient, from the route
+        # ``{session_id}`` param — set to None for non-session routes so no stale
+        # value leaks and no non-session route is mis-attributed).
+        operation, audit_route, audit_session_id = _resolve_audit_route(request)
+        set_current_session_id(audit_session_id)
+        _emit_audit_event(
+            operation,
+            "start",
+            session_id=audit_session_id,
+            route=audit_route,
+            method=request.method,
+            request_id=request_id,
+        )
+
         failed = False
         status_code: int | None = None
         started_at = server_metrics.request_started()
@@ -1558,6 +1656,16 @@ def create_app(
             )
             set_request_duration_for_access_log(duration_seconds)
             route = request_route_template_for_metrics(request)
+            _emit_audit_event(
+                operation,
+                "error" if request_failed else "ok",
+                session_id=audit_session_id,
+                route=audit_route,
+                method=request.method,
+                request_id=request_id,
+                status=str(status_code) if status_code is not None else "none",
+                duration_ms=str(round(duration_seconds * 1000)),
+            )
             # Per-route tally (low-cardinality template key) for offline
             # request-breakdown analysis, e.g. the benchmark harness's
             # per-journey network appendix. Cheap; independent of the OTel path.
@@ -1592,14 +1700,18 @@ def create_app(
                 "Internal error: %s",
                 exc.message,
                 exc_info=exc,
-                extra={"session_id": _session_id_from_request(request)},
+                extra=_error_audit_extra(
+                    request, code=str(exc.code), http_status=str(exc.http_status)
+                ),
             )
         elif exc.http_status == 400 and request.url.path.endswith("/policies/evaluate"):
             _logger.warning(
                 "Policy evaluate rejected 400 on %s: %s",
                 request.url.path,
                 exc.message,
-                extra={"session_id": _session_id_from_request(request)},
+                extra=_error_audit_extra(
+                    request, phase="rejected", code=str(exc.code), http_status="400"
+                ),
             )
         return JSONResponse(
             status_code=exc.http_status,
@@ -1639,7 +1751,9 @@ def create_app(
             "Database error: %s",
             exc,
             exc_info=exc,
-            extra={"session_id": _session_id_from_request(request)},
+            extra=_error_audit_extra(
+                request, code=str(ErrorCode.INTERNAL_ERROR), http_status="500"
+            ),
         )
         return JSONResponse(
             status_code=500,
@@ -1670,7 +1784,9 @@ def create_app(
             "Unhandled exception: %s",
             exc,
             exc_info=exc,
-            extra={"session_id": _session_id_from_request(request)},
+            extra=_error_audit_extra(
+                request, code=str(ErrorCode.INTERNAL_ERROR), http_status="500"
+            ),
         )
         return JSONResponse(
             status_code=500,

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1631,14 +1631,19 @@ def create_app(
         operation, audit_route, audit_session_id = _resolve_audit_route(request)
         set_current_session_id(audit_session_id)
         reset_request_audit_attrs()
-        _emit_audit_event(
-            operation,
-            "start",
-            session_id=audit_session_id,
-            route=audit_route,
-            method=request.method,
-            request_id=request_id,
-        )
+        # ``post_event`` is hit per streamed chunk (the harness echoes its own
+        # output back), so a per-call ``start`` row is pure noise — emit only the
+        # end row for it (and the handler suppresses even that for transient
+        # types). Every other operation keeps its real-time ``start``.
+        if operation != "post_event":
+            _emit_audit_event(
+                operation,
+                "start",
+                session_id=audit_session_id,
+                route=audit_route,
+                method=request.method,
+                request_id=request_id,
+            )
 
         failed = False
         status_code: int | None = None
@@ -1669,30 +1674,37 @@ def create_app(
             # never shadow an envelope field or collide with an _emit_audit_event
             # argument (session_id / phase would raise TypeError).
             _bag = current_request_audit_attrs()
-            end_session_id = _bag.get("session_id") or audit_session_id
-            _reserved = {
-                "session_id",
-                "phase",
-                "route",
-                "method",
-                "request_id",
-                "status",
-                "duration_ms",
-            }
-            end_attributes = {k: v for k, v in _bag.items() if k not in _reserved}
-            end_attributes.update(
-                route=audit_route,
-                method=request.method,
-                request_id=request_id,
-                status=str(status_code) if status_code is not None else "none",
-                duration_ms=str(round(duration_seconds * 1000)),
-            )
-            _emit_audit_event(
-                operation,
-                "error" if request_failed else "ok",
-                session_id=end_session_id,
-                **end_attributes,
-            )
+            # A handler can suppress the whole envelope for this request (e.g. a
+            # transient POST /events echo). An error still logs — a failure is
+            # never noise, and the exception handler carries the detail.
+            if _bag.get("_suppress") and not request_failed:
+                pass
+            else:
+                end_session_id = _bag.get("session_id") or audit_session_id
+                _reserved = {
+                    "_suppress",
+                    "session_id",
+                    "phase",
+                    "route",
+                    "method",
+                    "request_id",
+                    "status",
+                    "duration_ms",
+                }
+                end_attributes = {k: v for k, v in _bag.items() if k not in _reserved}
+                end_attributes.update(
+                    route=audit_route,
+                    method=request.method,
+                    request_id=request_id,
+                    status=str(status_code) if status_code is not None else "none",
+                    duration_ms=str(round(duration_seconds * 1000)),
+                )
+                _emit_audit_event(
+                    operation,
+                    "error" if request_failed else "ok",
+                    session_id=end_session_id,
+                    **end_attributes,
+                )
             # Per-route tally (low-cardinality template key) for offline
             # request-breakdown analysis, e.g. the benchmark harness's
             # per-journey network appendix. Cheap; independent of the OTel path.

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -238,7 +238,7 @@ def _error_audit_extra(
     request: Request,
     *,
     phase: str = "error",
-    **attributes: object,
+    **attributes: str,
 ) -> dict[str, object]:
     """Build the ``extra=`` for an exception-handler log: operation + session id.
 
@@ -383,7 +383,7 @@ def _emit_audit_event(
     phase: str,
     *,
     session_id: str | None,
-    **attributes: object,
+    **attributes: str,
 ) -> None:
     """Emit one server audit row (table-only, gated on the debug sink).
 

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -29,8 +29,10 @@ from omnigent._platform import resolve_repo_symlink
 from omnigent.db.db_models import InvalidUuidError
 from omnigent.debug_logging import (
     audit_event_logger,
+    current_request_audit_attrs,
     debug_event,
     debug_sink_enabled,
+    reset_request_audit_attrs,
     set_current_session_id,
     set_current_user_id,
 )
@@ -1628,6 +1630,7 @@ def create_app(
         # value leaks and no non-session route is mis-attributed).
         operation, audit_route, audit_session_id = _resolve_audit_route(request)
         set_current_session_id(audit_session_id)
+        reset_request_audit_attrs()
         _emit_audit_event(
             operation,
             "start",
@@ -1656,15 +1659,22 @@ def create_app(
             )
             set_request_duration_for_access_log(duration_seconds)
             route = request_route_template_for_metrics(request)
-            _emit_audit_event(
-                operation,
-                "error" if request_failed else "ok",
-                session_id=audit_session_id,
+            # Handler-attached attributes (e.g. POST /events' event type, a
+            # created session id) ride the end event; base attributes win on any
+            # key collision.
+            end_attributes = current_request_audit_attrs()
+            end_attributes.update(
                 route=audit_route,
                 method=request.method,
                 request_id=request_id,
                 status=str(status_code) if status_code is not None else "none",
                 duration_ms=str(round(duration_seconds * 1000)),
+            )
+            _emit_audit_event(
+                operation,
+                "error" if request_failed else "ok",
+                session_id=audit_session_id,
+                **end_attributes,
             )
             # Per-route tally (low-cardinality template key) for offline
             # request-breakdown analysis, e.g. the benchmark harness's

--- a/omnigent/server/routes/dictation.py
+++ b/omnigent/server/routes/dictation.py
@@ -64,6 +64,7 @@ import anyio
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, WebSocketException
 from starlette import status
 
+from omnigent.debug_logging import debug_event
 from omnigent.server.auth import AuthProvider
 from omnigent.server.dictation import (
     DictationEngine,
@@ -114,6 +115,10 @@ def create_dictation_router(
                 reason="authentication required",
             )
         await websocket.accept()
+        _logger.info(
+            "dictation stream connected",
+            extra=debug_event("dictation_stream", phase="connected"),
+        )
 
         if slots.locked():
             await websocket.close(
@@ -129,7 +134,10 @@ def create_dictation_router(
                 engine = await asyncio.to_thread(resolve_engine)
                 handle: DictationStreamHandle = await asyncio.to_thread(engine.create_stream)
             except Exception:
-                _logger.exception("dictation engine failed to initialize")
+                _logger.exception(
+                    "dictation engine failed to initialize",
+                    extra=debug_event("dictation_stream", phase="error", stage="engine_init"),
+                )
                 with contextlib.suppress(RuntimeError):
                     await websocket.send_text(
                         json.dumps({"type": "error", "message": "dictation engine unavailable"})
@@ -144,6 +152,10 @@ def create_dictation_router(
                 await websocket.send_text(json.dumps({"type": "ready"}))
                 await _pump_dictation(websocket, handle)
             finally:
+                _logger.info(
+                    "dictation stream disconnected",
+                    extra=debug_event("dictation_stream", phase="disconnected"),
+                )
                 # An abrupt disconnect tears the ASGI task down via
                 # cancellation, which would cancel this close mid-await and
                 # leak the take (the remote engine holds a worker slot until
@@ -214,7 +226,10 @@ async def _pump_dictation(websocket: WebSocket, handle: DictationStreamHandle) -
     except WebSocketDisconnect:
         return
     except Exception:
-        _logger.exception("dictation stream failed")
+        _logger.exception(
+            "dictation stream failed",
+            extra=debug_event("dictation_stream", phase="error", stage="pump"),
+        )
         with contextlib.suppress(RuntimeError):
             await websocket.send_text(json.dumps({"type": "error", "message": "dictation failed"}))
             await websocket.close(code=_WS_CLOSE_INTERNAL_ERROR)

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -26,7 +26,7 @@ from collections.abc import Awaitable, Callable
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from omnigent.db.db_models import InvalidUuidError, uuid_to_bytes
-from omnigent.debug_logging import set_current_user_id
+from omnigent.debug_logging import debug_event, set_current_user_id
 from omnigent.host.frames import (
     HostConnectionErrorFrame,
     HostCreateDirResultFrame,
@@ -303,6 +303,12 @@ def create_host_tunnel_router(
                 frame.version,
                 frame.name,
                 frame.runners,
+                extra=debug_event(
+                    "host_tunnel",
+                    phase="connected",
+                    host_id=host_id,
+                    version=frame.version,
+                ),
             )
 
             sender_task = asyncio.create_task(
@@ -376,7 +382,11 @@ def create_host_tunnel_router(
                         )
 
         except WebSocketDisconnect:
-            _logger.warning("Host %s disconnected", host_id)
+            _logger.warning(
+                "Host %s disconnected",
+                host_id,
+                extra=debug_event("host_tunnel", phase="disconnected", host_id=host_id),
+            )
             # Only run disconnect cleanup if we actually registered this
             # host on THIS connection. A connect that failed before
             # register — e.g. the upsert IntegrityError when a peer
@@ -394,7 +404,11 @@ def create_host_tunnel_router(
                             host_id,
                         )
         except Exception as exc:
-            _logger.exception("Host tunnel error for %s", host_id)
+            _logger.exception(
+                "Host tunnel error for %s",
+                host_id,
+                extra=debug_event("host_tunnel", phase="error", host_id=host_id, stage=stage),
+            )
             retryable = stage in {"registration", "registry", "connected"}
             await _send_connection_error(
                 ws,

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from omnigent.db.utils import now_epoch
+from omnigent.debug_logging import add_audit_attrs
 from omnigent.entities import Conversation
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_aliases import canonicalize_harness
@@ -1004,6 +1005,9 @@ def create_hosts_router(
                 detail=f"host failed to launch runner: {result.get('error')}",
             )
 
+        # Tag the audit envelope: the runner is bound to a session carried in
+        # the body (not the request path), so surface it plus the target host.
+        add_audit_attrs(session_id=body.session_id, host_id=host_id, runner_id=runner_id)
         return {
             "runner_id": runner_id,
             "status": "launching",

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -1005,8 +1005,9 @@ def create_hosts_router(
                 detail=f"host failed to launch runner: {result.get('error')}",
             )
 
-        # Tag the audit envelope: the runner is bound to a session carried in
-        # the body (not the request path), so surface it plus the target host.
+        # The runner is bound to a session carried in the body (not the request
+        # path); the middleware promotes a bag session_id to the audit row's
+        # session_id column. Host is an attribute.
         add_audit_attrs(session_id=body.session_id, host_id=host_id, runner_id=runner_id)
         return {
             "runner_id": runner_id,

--- a/omnigent/server/routes/runner_tunnel.py
+++ b/omnigent/server/routes/runner_tunnel.py
@@ -23,6 +23,7 @@ from ipaddress import ip_address
 
 from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
 
+from omnigent.debug_logging import debug_event
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.runner.identity import RUNNER_TUNNEL_TOKEN_HEADER, token_bound_runner_id
 from omnigent.runner.transports.ws_tunnel.frames import (
@@ -471,6 +472,12 @@ def create_runner_tunnel_router(
                 runner_id,
                 frame.runner_version,
                 frame.harnesses,
+                extra=debug_event(
+                    "runner_tunnel",
+                    phase="connected",
+                    runner_id=runner_id,
+                    version=frame.runner_version,
+                ),
             )
 
             # 6. Start tunnel helper tasks. The sender task is the
@@ -585,6 +592,12 @@ def create_runner_tunnel_router(
                 runner_id,
                 getattr(exc, "code", None),
                 getattr(exc, "reason", None),
+                extra=debug_event(
+                    "runner_tunnel",
+                    phase="disconnected",
+                    runner_id=runner_id,
+                    code=getattr(exc, "code", None),
+                ),
             )
             if on_runner_disconnect is not None:
                 try:
@@ -595,7 +608,11 @@ def create_runner_tunnel_router(
                         runner_id,
                     )
         except Exception:
-            _logger.exception("Tunnel error for runner %s", runner_id)
+            _logger.exception(
+                "Tunnel error for runner %s",
+                runner_id,
+                extra=debug_event("runner_tunnel", phase="error", runner_id=runner_id),
+            )
             if session is not None:
                 registry.deregister(runner_id, session)
             else:

--- a/omnigent/server/routes/session_mcp_servers.py
+++ b/omnigent/server/routes/session_mcp_servers.py
@@ -17,6 +17,7 @@ import httpx
 import yaml
 from fastapi import APIRouter, Request, Response, status
 
+from omnigent.debug_logging import add_audit_attrs
 from omnigent.entities import Agent
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.runtime import session_stream
@@ -124,6 +125,7 @@ def create_session_mcp_servers_router(
         )
         await _reset_runner_session_agent_cache(session_id, agent.id, runner_router)
         _publish_agent_changed(session_id, agent)
+        add_audit_attrs(server_name=body.name)
         return _summary_from_spec(spec, body.name)
 
     @router.put("/sessions/{session_id}/agent/mcp-servers/{server_name}")
@@ -144,6 +146,7 @@ def create_session_mcp_servers_router(
         )
         await _reset_runner_session_agent_cache(session_id, agent.id, runner_router)
         _publish_agent_changed(session_id, agent)
+        add_audit_attrs(server_name=server_name)
         return _summary_from_spec(spec, body.name)
 
     @router.delete(
@@ -166,6 +169,7 @@ def create_session_mcp_servers_router(
         )
         await _reset_runner_session_agent_cache(session_id, agent.id, runner_router)
         _publish_agent_changed(session_id, agent)
+        add_audit_attrs(server_name=server_name)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     async def _editable_agent(request: Request, session_id: str) -> Agent:

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -370,8 +370,9 @@ def register_core_routes(
             result, project_warnings = await _create_bundled_session_from_multipart(
                 request, user_id
             )
-            # Tag the audit envelope with the created session (not in the request
-            # path, so the envelope would otherwise have a null session_id).
+            # Surface the freshly-minted session id (the request path has no
+            # {session_id} on create); the middleware promotes a bag session_id
+            # to the audit row's session_id column.
             add_audit_attrs(session_id=result.session_id, agent=result.agent_id)
             if project_warnings:
                 return {

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -31,6 +31,7 @@ from omnigent.cost_plan import (
     reserved_cost_control_keys,
 )
 from omnigent.db.utils import generate_agent_id
+from omnigent.debug_logging import add_audit_attrs, debug_event
 from omnigent.entities import (
     CommentsFingerprint,
     Conversation,
@@ -369,6 +370,9 @@ def register_core_routes(
             result, project_warnings = await _create_bundled_session_from_multipart(
                 request, user_id
             )
+            # Tag the audit envelope with the created session (not in the request
+            # path, so the envelope would otherwise have a null session_id).
+            add_audit_attrs(session_id=result.session_id, agent=result.agent_id)
             if project_warnings:
                 return {
                     **result.model_dump(mode="json"),
@@ -594,6 +598,7 @@ def register_core_routes(
                 resp.runner_id = runner_id
                 resp.host_id = launch_host_id
 
+        add_audit_attrs(session_id=resp.id, agent=resp.agent_id)
         if project_warnings:
             return {
                 **resp.model_dump(mode="json"),
@@ -1274,6 +1279,10 @@ def register_core_routes(
                 reason="authentication required",
             )
         await websocket.accept()
+        _logger.info(
+            "session-updates stream connected",
+            extra=debug_event("session_updates", phase="connected"),
+        )
 
         watched: list[str] = []
         # Last SessionListItem dump sent per id, used to diff. Keyed only
@@ -1495,8 +1504,16 @@ def register_core_routes(
                 # A client disconnect is the normal terminal condition; any
                 # other exception is a real bug worth surfacing in logs.
                 if exc is not None and not isinstance(exc, WebSocketDisconnect):
-                    _logger.warning("session-updates stream task crashed: %r", exc)
+                    _logger.warning(
+                        "session-updates stream task crashed: %r",
+                        exc,
+                        extra=debug_event("session_updates", phase="error"),
+                    )
         finally:
+            _logger.info(
+                "session-updates stream disconnected",
+                extra=debug_event("session_updates", phase="disconnected"),
+            )
             with contextlib.suppress(RuntimeError):
                 await websocket.close()
 

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -15,6 +15,7 @@ from fastapi import (
 )
 from fastapi.responses import StreamingResponse
 
+from omnigent.debug_logging import add_audit_attrs, debug_event
 from omnigent.entities import (
     ErrorData,
     NewConversationItem,
@@ -516,6 +517,10 @@ def register_events_routes(
                 f"Allowed types: {sorted(_ALLOWED_EVENT_TYPES)}",
                 code=ErrorCode.INVALID_INPUT,
             )
+        # Tag the audit envelope end-event with the event kind so a message,
+        # interrupt, approval, stop, … are distinguishable in the audit table
+        # (rides the existing row — no per-event firehose for streaming deltas).
+        add_audit_attrs(event_type=body.type)
         # For item types, validate the data payload shape against
         # the item-type's discriminator class. The control types
         # (interrupt, approval) bypass the item-persist path and have

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -15,7 +15,7 @@ from fastapi import (
 )
 from fastapi.responses import StreamingResponse
 
-from omnigent.debug_logging import add_audit_attrs, debug_event, mark_request_audit_suppressed
+from omnigent.debug_logging import add_audit_attrs, mark_request_audit_suppressed
 from omnigent.entities import (
     ErrorData,
     NewConversationItem,

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -15,7 +15,7 @@ from fastapi import (
 )
 from fastapi.responses import StreamingResponse
 
-from omnigent.debug_logging import add_audit_attrs, debug_event
+from omnigent.debug_logging import add_audit_attrs, debug_event, mark_request_audit_suppressed
 from omnigent.entities import (
     ErrorData,
     NewConversationItem,
@@ -225,6 +225,18 @@ _retry_recovery_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
     weakref.WeakValueDictionary()
 )
 _retry_recovery_tasks: dict[str, asyncio.Task[dict[str, bool | str]]] = {}
+
+# POST /events types that arrive per streamed chunk — the harness echoing its
+# own live output back. Their per-call audit row is pure noise (the content is
+# already on the SSE-event logger), so the envelope is suppressed for them.
+_TRANSIENT_AUDIT_EVENT_TYPES = frozenset(
+    {
+        _EXTERNAL_OUTPUT_TEXT_DELTA_TYPE,
+        _EXTERNAL_OUTPUT_REASONING_DELTA_TYPE,
+        _EXTERNAL_TOOL_OUTPUT_DELTA_TYPE,
+        _EXTERNAL_SESSION_USAGE_TYPE,
+    }
+)
 
 
 def _retry_recovery_lock(session_id: str) -> asyncio.Lock:
@@ -518,9 +530,12 @@ def register_events_routes(
                 code=ErrorCode.INVALID_INPUT,
             )
         # Tag the audit envelope end-event with the event kind so a message,
-        # interrupt, approval, stop, … are distinguishable in the audit table
-        # (rides the existing row — no per-event firehose for streaming deltas).
+        # interrupt, approval, stop, … are distinguishable in the audit table.
+        # Transient per-chunk echoes suppress the row entirely (they are the
+        # firehose; the content is already on the SSE-event logger).
         add_audit_attrs(event_type=body.type)
+        if body.type in _TRANSIENT_AUDIT_EVENT_TYPES:
+            mark_request_audit_suppressed()
         # For item types, validate the data payload shape against
         # the item-type's discriminator class. The control types
         # (interrupt, approval) bypass the item-persist path and have
@@ -640,6 +655,13 @@ def register_events_routes(
                 # deny sentinel on the session stream so the
                 # client/REPL sees feedback.
                 reason = _input_verdict.get("reason", "Denied by policy")
+                # Surface the input-policy block on this post_event's audit row
+                # so a "my message was blocked" case is queryable with its reason.
+                add_audit_attrs(
+                    policy_verdict=_input_verdict.get("verdict", "deny"),
+                    policy_phase="input",
+                    policy_reason=reason,
+                )
                 _publish_policy_deny(session_id, reason)
                 await _persist_policy_deny_sentinel(
                     session_id,

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -15,6 +15,7 @@ from fastapi import (
 from fastapi.responses import Response
 
 from omnigent.codex_native_elicitation import codex_elicitation_id
+from omnigent.debug_logging import add_audit_attrs
 from omnigent.entities import Conversation
 from omnigent.errors import ElicitationDeclinedError, ErrorCode, OmnigentError
 from omnigent.runner.routing import RunnerRouter
@@ -898,6 +899,12 @@ def register_hooks_routes(
                                 "result": "POLICY_ACTION_DENY",
                                 "reason": exc.args[0] or "Approval was declined.",
                             }
+                            add_audit_attrs(
+                                policy_verdict="POLICY_ACTION_DENY",
+                                policy_phase=phase.value,
+                                policy_reason=decline_body["reason"],
+                                policy_gate="declined",
+                            )
                             return Response(
                                 content=json.dumps(decline_body),
                                 media_type="application/json",
@@ -910,6 +917,13 @@ def register_hooks_routes(
                                 "reason": result.reason or "Approval was not granted.",
                             }
                         )
+                        add_audit_attrs(
+                            policy_verdict=approval_body["result"],
+                            policy_phase=phase.value,
+                            policy_gate="ask",
+                        )
+                        if approval_body.get("reason"):
+                            add_audit_attrs(policy_reason=approval_body["reason"])
                         return Response(
                             content=json.dumps(approval_body),
                             media_type="application/json",
@@ -928,6 +942,18 @@ def register_hooks_routes(
             resp_body["reason"] = result.reason
         if result.data is not None:
             resp_body["data"] = result.data
+        # Tag the audit envelope with the decision so a DENY/ASK is debuggable
+        # (a deny returns HTTP 200, so status alone can't tell you the verdict).
+        add_audit_attrs(policy_verdict=resp_body["result"], policy_phase=phase.value)
+        if result.reason:
+            add_audit_attrs(policy_reason=result.reason)
+        _policy_tool = data.get("name") if isinstance(data, dict) else None
+        if _policy_tool:
+            add_audit_attrs(policy_tool=_policy_tool)
+        if result.deciding_policy is not None:
+            add_audit_attrs(
+                policy=getattr(result.deciding_policy, "name", None) or str(result.deciding_policy)
+            )
         # A request-phase HARD DENY (no approve option) — surface the reason as a
         # dismissable tmux popup on the native pane. opencode hard-blocks the
         # prompt by its plugin throwing (rendered as a generic error), so this is

--- a/omnigent/server/routes/sessions/routes_permissions.py
+++ b/omnigent/server/routes/sessions/routes_permissions.py
@@ -12,6 +12,7 @@ from fastapi import (
 )
 from fastapi.responses import Response
 
+from omnigent.debug_logging import add_audit_attrs
 from omnigent.entities import (
     Agent,
 )
@@ -180,6 +181,7 @@ def register_permissions_routes(
         # Push the now-shared session to the GRANTEE's open tabs so it
         # appears in their sidebar without a list poll.
         _announce_session_added(body.user_id, session_id)
+        add_audit_attrs(target_user_id=body.user_id, level=body.level)
         return PermissionObject(
             user_id=perm.user_id,
             conversation_id=perm.conversation_id,
@@ -274,6 +276,7 @@ def register_permissions_routes(
         # The leaver's own tab drops the row via the client mutation's success
         # handler; their other tabs converge on the next watch-set diff, which
         # reports the now-inaccessible id as removed. No extra push needed.
+        add_audit_attrs(target_user_id=target_user_id, left_self=leaving_self)
         return Response(status_code=204)
 
     @router.get(

--- a/omnigent/server/routes/terminal_attach.py
+++ b/omnigent/server/routes/terminal_attach.py
@@ -75,6 +75,7 @@ from typing import Final
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect, WebSocketException
 from starlette import status
 
+from omnigent.debug_logging import debug_event
 from omnigent.errors import OmnigentError
 from omnigent.runtime import (
     get_runner_ws_factory,
@@ -159,6 +160,18 @@ def create_terminal_attach_router(
             conversation_store=conversation_store,
         )
         await websocket.accept()
+        _logger.info(
+            "terminal attach connected for session %s terminal %s",
+            session_id,
+            terminal_id,
+            extra=debug_event(
+                "attach_terminal_by_resource_id",
+                session_id=session_id,
+                phase="connected",
+                terminal_id=terminal_id,
+                read_only=read_only,
+            ),
+        )
 
         ws_factory = get_runner_ws_factory()
         if ws_factory is not None:
@@ -333,6 +346,9 @@ async def _authorize_terminal_attach(
             session_id,
             user_id,
             exc,
+            extra=debug_event(
+                "attach_terminal_by_resource_id", session_id=session_id, phase="rejected"
+            ),
         )
         raise WebSocketException(
             code=status.WS_1008_POLICY_VIOLATION,

--- a/tests/runtime/test_session_stream.py
+++ b/tests/runtime/test_session_stream.py
@@ -864,3 +864,46 @@ def test_log_sse_event_noop_when_sink_disabled(monkeypatch: pytest.MonkeyPatch) 
     with _capturing_sse_logger() as records:
         session_stream._log_sse_event("conv_1", {"type": "response.completed"})
     assert records == []
+
+
+@contextlib.contextmanager
+def _capturing_audit_logger() -> Iterator[list[logging.LogRecord]]:
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    logger = session_stream.audit_event_logger()
+    old_level = logger.level
+    logger.setLevel(logging.INFO)
+    handler = _Capture()
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(old_level)
+
+
+def test_log_sse_event_emits_turn_finished_on_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A terminal SSE event emits one first-class turn_finished audit row carrying
+    # the outcome + safe ids; a non-terminal event emits none.
+    monkeypatch.setattr(session_stream, "debug_sink_enabled", lambda: True)
+    with _capturing_audit_logger() as records:
+        session_stream._log_sse_event(
+            "conv_1", {"type": "response.completed", "response": {"id": "resp_1"}}
+        )
+        session_stream._log_sse_event(
+            "conv_1", {"type": "response.failed", "error": {"code": "timeout", "message": "x"}}
+        )
+        session_stream._log_sse_event("conv_1", {"type": "response.output_text.delta"})
+
+    assert [r.event_name for r in records] == ["turn_finished", "turn_finished"]
+    completed = records[0]
+    assert completed.session_id == "conv_1"
+    assert completed.levelno == logging.INFO
+    assert completed.attributes == {"outcome": "completed", "response_id": "resp_1"}
+    failed = records[1]
+    assert failed.levelno == logging.WARNING
+    assert failed.attributes == {"outcome": "failed", "error_code": "timeout"}  # no message text

--- a/tests/server/test_audit_logging_middleware.py
+++ b/tests/server/test_audit_logging_middleware.py
@@ -1,0 +1,144 @@
+"""Tests for the server request audit-logging helpers.
+
+Covers the two pieces the ``_record_server_metrics`` middleware and the
+exception handlers rely on: resolving the operation + session id from the
+matched route before routing, and emitting a gated, table-only audit row.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+import pytest
+from fastapi import FastAPI
+from starlette.requests import Request
+
+from omnigent import debug_logging as dl
+from omnigent.server.app import _resolve_audit_route
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/v1/sessions/{session_id}")
+    def get_session(session_id: str) -> dict[str, str]:  # pragma: no cover - not called
+        return {}
+
+    @app.get("/v1/sessions")
+    def list_sessions() -> list[str]:  # pragma: no cover - not called
+        return []
+
+    @app.get("/v1/hosts")
+    def list_hosts() -> list[str]:  # pragma: no cover - not called
+        return []
+
+    return app
+
+
+def _request(app: FastAPI, method: str, path: str) -> Request:
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": [],
+        "app": app,
+        "router": app.router,
+    }
+    return Request(scope)
+
+
+def test_resolve_audit_route_session_scoped_extracts_id() -> None:
+    app = _app()
+    operation, template, session_id = _resolve_audit_route(
+        _request(app, "GET", "/v1/sessions/abc123")
+    )
+    assert operation == "get_session"
+    assert template == "/v1/sessions/{session_id}"
+    assert session_id == "abc123"
+
+
+def test_resolve_audit_route_list_has_no_session_id() -> None:
+    # The list route must NOT capture a spurious session id (the loose path
+    # regex would treat a literal next segment as one; the route param does not).
+    app = _app()
+    operation, _template, session_id = _resolve_audit_route(_request(app, "GET", "/v1/sessions"))
+    assert operation == "list_sessions"
+    assert session_id is None
+
+
+def test_resolve_audit_route_non_session_route() -> None:
+    app = _app()
+    operation, _template, session_id = _resolve_audit_route(_request(app, "GET", "/v1/hosts"))
+    assert operation == "list_hosts"
+    assert session_id is None
+
+
+def test_resolve_audit_route_unmatched() -> None:
+    app = _app()
+    assert _resolve_audit_route(_request(app, "GET", "/nope")) == (
+        "unmatched",
+        "<unmatched>",
+        None,
+    )
+
+
+def test_emit_audit_event_is_noop_when_sink_disabled() -> None:
+    # Gated on the debug sink: with no sink, building/emitting is skipped
+    # entirely, so nothing reaches the audit logger.
+    from omnigent.server.app import _emit_audit_event
+
+    captured: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    handler = _Capture()
+    audit_logger = dl.audit_event_logger()
+    audit_logger.addHandler(handler)
+    try:
+        assert not dl.debug_sink_enabled()
+        _emit_audit_event(
+            "get_session", "start", session_id="s1", route="/v1/sessions/{session_id}"
+        )
+        assert captured == []
+    finally:
+        audit_logger.removeHandler(handler)
+
+
+def test_emit_audit_event_ships_operation_and_phase(monkeypatch: pytest.MonkeyPatch) -> None:
+    from omnigent.server.app import _emit_audit_event
+
+    monkeypatch.setattr(dl.DebugLogHandler, "_FLUSH_WAIT", 0.01)
+    monkeypatch.setattr(dl, "_active_sink", None)
+    batches: list[list[dl.DebugLogRow]] = []
+    delivered = threading.Event()
+
+    def send(batch: list[dl.DebugLogRow]) -> None:
+        batches.append(batch)
+        delivered.set()
+
+    dl.attach_debug_log_sink([], source="server", level=logging.INFO, send=send)
+    sink = dl._active_sink
+    assert sink is not None
+    try:
+        _emit_audit_event(
+            "get_session",
+            "ok",
+            session_id="conv_1",
+            route="/v1/sessions/{session_id}",
+            method="GET",
+            status="200",
+        )
+        assert delivered.wait(timeout=1.0)
+        row = batches[0][0]
+        assert row["event_name"] == "get_session"
+        assert row["session_id"] == "conv_1"
+        assert row["attributes"]["phase"] == "ok"
+        assert row["attributes"]["route"] == "/v1/sessions/{session_id}"
+        assert row["attributes"]["status"] == "200"
+    finally:
+        dl.audit_event_logger().removeHandler(sink)
+        dl.sse_event_logger().removeHandler(sink)
+        sink.close()

--- a/tests/server/test_audit_logging_middleware.py
+++ b/tests/server/test_audit_logging_middleware.py
@@ -142,3 +142,67 @@ def test_emit_audit_event_ships_operation_and_phase(monkeypatch: pytest.MonkeyPa
         dl.audit_event_logger().removeHandler(sink)
         dl.sse_event_logger().removeHandler(sink)
         sink.close()
+
+
+def test_handler_audit_attrs_ride_the_envelope_end_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # End-to-end: attrs a handler sets via add_audit_attrs must survive
+    # Starlette's BaseHTTPMiddleware (which runs the handler in a child
+    # context) and land on the envelope end-event the middleware emits in its
+    # finally. This is the propagation the whole enrich mechanism relies on.
+    from fastapi.testclient import TestClient
+
+    from omnigent.server.app import _emit_audit_event, _resolve_audit_route
+
+    monkeypatch.setattr(dl.DebugLogHandler, "_FLUSH_WAIT", 0.01)
+    monkeypatch.setattr(dl, "_active_sink", None)
+    rows: list[dl.DebugLogRow] = []
+    got_end = threading.Event()
+
+    def send(batch: list[dl.DebugLogRow]) -> None:
+        rows.extend(batch)
+        for row in batch:
+            if row["attributes"].get("phase") in ("ok", "error"):
+                got_end.set()
+
+    dl.attach_debug_log_sink([], source="server", level=logging.INFO, send=send)
+    sink = dl._active_sink
+    assert sink is not None
+
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _audit(request: Request, call_next):  # type: ignore[no-untyped-def]
+        operation, route, session_id = _resolve_audit_route(request)
+        dl.set_current_session_id(session_id)
+        dl.reset_request_audit_attrs()
+        _emit_audit_event(operation, "start", session_id=session_id, route=route)
+        response = await call_next(request)
+        end = dl.current_request_audit_attrs()
+        end.update(route=route, status=str(response.status_code))
+        _emit_audit_event(operation, "ok", session_id=session_id, **end)
+        return response
+
+    @app.post("/v1/sessions/{session_id}/events")
+    def post_event(session_id: str) -> dict[str, bool]:
+        dl.add_audit_attrs(event_type="message", item_id="it_1")
+        return {"queued": True}
+
+    try:
+        with TestClient(app) as client:
+            client.post("/v1/sessions/conv_9/events")
+        assert got_end.wait(timeout=1.0)
+        end_rows = [r for r in rows if r["attributes"].get("phase") == "ok"]
+        assert len(end_rows) == 1
+        end_row = end_rows[0]
+        assert end_row["event_name"] == "post_event"
+        assert end_row["session_id"] == "conv_9"
+        assert end_row["attributes"]["event_type"] == "message"
+        assert end_row["attributes"]["item_id"] == "it_1"
+        assert end_row["attributes"]["status"] == "200"
+    finally:
+        dl.set_current_session_id(None)
+        dl.audit_event_logger().removeHandler(sink)
+        dl.sse_event_logger().removeHandler(sink)
+        sink.close()

--- a/tests/server/test_audit_logging_middleware.py
+++ b/tests/server/test_audit_logging_middleware.py
@@ -206,3 +206,73 @@ def test_handler_audit_attrs_ride_the_envelope_end_event(
         dl.audit_event_logger().removeHandler(sink)
         dl.sse_event_logger().removeHandler(sink)
         sink.close()
+
+
+def test_reserved_attr_keys_never_crash_and_session_id_binds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A handler that (mis)uses a reserved key like session_id/phase must not
+    # collide with the envelope's own args (which would 500 the request); the
+    # create-session pattern binds the id via set_current_session_id so the ok
+    # row carries it in the session_id column even on a route with no path id.
+    from fastapi.testclient import TestClient
+
+    from omnigent.server.app import _emit_audit_event, _resolve_audit_route
+
+    monkeypatch.setattr(dl.DebugLogHandler, "_FLUSH_WAIT", 0.01)
+    monkeypatch.setattr(dl, "_active_sink", None)
+    rows: list[dl.DebugLogRow] = []
+    got_end = threading.Event()
+
+    def send(batch: list[dl.DebugLogRow]) -> None:
+        rows.extend(batch)
+        for row in batch:
+            if row["attributes"].get("phase") in ("ok", "error"):
+                got_end.set()
+
+    dl.attach_debug_log_sink([], source="server", level=logging.INFO, send=send)
+    sink = dl._active_sink
+    assert sink is not None
+
+    app = FastAPI()
+    _reserved = {"session_id", "phase", "route", "method", "request_id", "status", "duration_ms"}
+
+    @app.middleware("http")
+    async def _audit(request: Request, call_next):  # type: ignore[no-untyped-def]
+        operation, route, session_id = _resolve_audit_route(request)
+        dl.set_current_session_id(session_id)
+        dl.reset_request_audit_attrs()
+        _emit_audit_event(operation, "start", session_id=session_id, route=route)
+        response = await call_next(request)
+        bag = dl.current_request_audit_attrs()
+        end_session_id = bag.get("session_id") or session_id
+        end = {k: v for k, v in bag.items() if k not in _reserved}
+        end.update(route=route, status=str(response.status_code))
+        _emit_audit_event(operation, "ok", session_id=end_session_id, **end)
+        return response
+
+    @app.post("/v1/sessions")
+    def create_session() -> dict[str, str]:
+        # Mimic the real handler: surface the created id via the bag, and
+        # deliberately shove reserved keys through it to prove they can't crash us
+        # (a ContextVar set here would not survive the child->parent boundary).
+        dl.add_audit_attrs(session_id="sess_created", phase="shadow", agent="polly")
+        return {"id": "sess_created"}
+
+    try:
+        with TestClient(app) as client:
+            resp = client.post("/v1/sessions")
+            assert resp.status_code == 200  # no 500 from a reserved-key collision
+        assert got_end.wait(timeout=1.0)
+        end_row = next(r for r in rows if r["attributes"].get("phase") == "ok")
+        assert end_row["event_name"] == "create_session"
+        # session_id column comes from set_current_session_id (route has no path id).
+        assert end_row["session_id"] == "sess_created"
+        # The reserved keys were dropped; the real attribute rode along.
+        assert end_row["attributes"]["agent"] == "polly"
+        assert end_row["attributes"]["phase"] == "ok"
+    finally:
+        dl.set_current_session_id(None)
+        dl.audit_event_logger().removeHandler(sink)
+        dl.sse_event_logger().removeHandler(sink)
+        sink.close()

--- a/tests/server/test_audit_logging_middleware.py
+++ b/tests/server/test_audit_logging_middleware.py
@@ -208,6 +208,79 @@ def test_handler_audit_attrs_ride_the_envelope_end_event(
         sink.close()
 
 
+def test_suppressed_request_emits_no_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A handler that calls mark_request_audit_suppressed() (transient POST /events
+    # echoes) produces ZERO audit rows; a normal request on the same route
+    # produces exactly one end row (no start row for post_event).
+    from fastapi.testclient import TestClient
+
+    from omnigent.server.app import _emit_audit_event, _resolve_audit_route
+
+    monkeypatch.setattr(dl.DebugLogHandler, "_FLUSH_WAIT", 0.01)
+    monkeypatch.setattr(dl, "_active_sink", None)
+    rows: list[dl.DebugLogRow] = []
+    delivered = threading.Event()
+
+    def send(batch: list[dl.DebugLogRow]) -> None:
+        rows.extend(batch)
+        delivered.set()
+
+    dl.attach_debug_log_sink([], source="server", level=logging.INFO, send=send)
+    sink = dl._active_sink
+    assert sink is not None
+
+    app = FastAPI()
+    _reserved = {
+        "_suppress",
+        "session_id",
+        "phase",
+        "route",
+        "method",
+        "request_id",
+        "status",
+        "duration_ms",
+    }
+
+    @app.middleware("http")
+    async def _audit(request: Request, call_next):  # type: ignore[no-untyped-def]
+        operation, route, session_id = _resolve_audit_route(request)
+        dl.set_current_session_id(session_id)
+        dl.reset_request_audit_attrs()
+        if operation != "post_event":
+            _emit_audit_event(operation, "start", session_id=session_id, route=route)
+        response = await call_next(request)
+        bag = dl.current_request_audit_attrs()
+        if not (bag.get("_suppress")):
+            end = {k: v for k, v in bag.items() if k not in _reserved}
+            end.update(route=route, status=str(response.status_code))
+            _emit_audit_event(operation, "ok", session_id=session_id, **end)
+        return response
+
+    @app.post("/v1/sessions/{session_id}/events")
+    def post_event(session_id: str, transient: bool = False) -> dict[str, bool]:
+        dl.add_audit_attrs(event_type="external_output_text_delta" if transient else "message")
+        if transient:
+            dl.mark_request_audit_suppressed()
+        return {"queued": True}
+
+    try:
+        with TestClient(app) as client:
+            client.post("/v1/sessions/conv_1/events?transient=true")
+            client.post("/v1/sessions/conv_1/events")  # normal
+        assert delivered.wait(timeout=1.0)
+        ev = [r for r in rows if r["event_name"] == "post_event"]
+        # Transient -> nothing; normal -> a single end row (no start for post_event).
+        assert all(r["attributes"].get("event_type") != "external_output_text_delta" for r in ev)
+        assert len(ev) == 1
+        assert ev[0]["attributes"]["phase"] == "ok"
+        assert ev[0]["attributes"]["event_type"] == "message"
+    finally:
+        dl.set_current_session_id(None)
+        dl.audit_event_logger().removeHandler(sink)
+        dl.sse_event_logger().removeHandler(sink)
+        sink.close()
+
+
 def test_reserved_attr_keys_never_crash_and_session_id_binds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -215,6 +215,45 @@ def test_record_to_row_falls_back_to_context_var() -> None:
     assert dl.record_to_row(record, source="server")["user_id"] is None
 
 
+def test_record_to_row_session_id_falls_back_to_ambient_scope() -> None:
+    # The server middleware binds an ambient session id for a session-scoped
+    # request; unthreaded records inherit it, and only inside the scope.
+    record = logging.LogRecord("omnigent", logging.INFO, __file__, 1, "hi", (), None)
+    with dl.current_session_id_scope("conv_ambient"):
+        assert dl.record_to_row(record, source="server")["session_id"] == "conv_ambient"
+    assert dl.record_to_row(record, source="server")["session_id"] is None
+
+
+def test_record_to_row_prefers_explicit_session_id_over_ambient() -> None:
+    # An explicit record.session_id wins over the ambient request-scoped value.
+    record = logging.LogRecord("omnigent", logging.INFO, __file__, 1, "hi", (), None)
+    record.session_id = "conv_explicit"
+    with dl.current_session_id_scope("conv_ambient"):
+        assert dl.record_to_row(record, source="server")["session_id"] == "conv_explicit"
+
+
+def test_record_to_row_session_ambient_beats_primary_but_explicit_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Priority on a runner: explicit extra > ambient scope > primary-session env.
+    monkeypatch.setenv(dl.PRIMARY_SESSION_ID_ENV_VAR, "conv_primary")
+    record = logging.LogRecord("omnigent", logging.INFO, __file__, 1, "hi", (), None)
+    with dl.current_session_id_scope("conv_ambient"):
+        assert dl.record_to_row(record, source="runner")["session_id"] == "conv_ambient"
+    assert dl.record_to_row(record, source="runner")["session_id"] == "conv_primary"
+
+
+def test_current_session_id_scope_resets() -> None:
+    assert dl.current_session_id() is None
+    dl.set_current_session_id("outer")
+    try:
+        with dl.current_session_id_scope("inner"):
+            assert dl.current_session_id() == "inner"
+        assert dl.current_session_id() == "outer"
+    finally:
+        dl.set_current_session_id(None)
+
+
 def test_record_to_row_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
     # No explicit user_id and no ContextVar -> the process-constant env (runner/host).
     monkeypatch.setenv(dl.USER_ID_ENV_VAR, "env@x")
@@ -348,9 +387,15 @@ def test_attach_uses_custom_send_without_zerobus_config(
         target.info("custom delivery")
         assert delivered.wait(timeout=1.0)
         assert batches[0][0]["message"] == "custom delivery"
+        # The audit-event logger is wired sink-only and non-propagating, so
+        # request audit rows reach the table but never the on-disk/stderr logs.
+        audit_logger = dl.audit_event_logger()
+        assert audit_logger.propagate is False
+        assert sink in audit_logger.handlers
     finally:
         target.removeHandler(sink)
         dl.sse_event_logger().removeHandler(sink)
+        dl.audit_event_logger().removeHandler(sink)
         sink.close()
 
 

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -243,6 +243,24 @@ def test_record_to_row_session_ambient_beats_primary_but_explicit_wins(
     assert dl.record_to_row(record, source="runner")["session_id"] == "conv_primary"
 
 
+def test_request_audit_attrs_accumulate_and_reset() -> None:
+    # Outside a request (no bag) add_audit_attrs is a no-op and the current
+    # attrs are empty.
+    assert dl.current_request_audit_attrs() == {}
+    dl.add_audit_attrs(event_type="message")
+    assert dl.current_request_audit_attrs() == {}
+    # After a per-request reset, handlers accumulate attrs (coerced to str,
+    # None dropped) that the middleware later reads.
+    dl.reset_request_audit_attrs()
+    dl.add_audit_attrs(event_type="message", item_id="it_1", ignored=None)
+    dl.add_audit_attrs(count=3)
+    assert dl.current_request_audit_attrs() == {
+        "event_type": "message",
+        "item_id": "it_1",
+        "count": "3",
+    }
+
+
 def test_current_session_id_scope_resets() -> None:
     assert dl.current_session_id() is None
     dl.set_current_session_id("outer")

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -261,6 +261,15 @@ def test_request_audit_attrs_accumulate_and_reset() -> None:
     }
 
 
+def test_mark_request_audit_suppressed_sets_reserved_flag() -> None:
+    # Inside a request it sets the reserved _suppress key the middleware reads
+    # to skip the envelope end-event.
+    dl.reset_request_audit_attrs()
+    assert "_suppress" not in dl.current_request_audit_attrs()
+    dl.mark_request_audit_suppressed()
+    assert dl.current_request_audit_attrs()["_suppress"] == "1"
+
+
 def test_current_session_id_scope_resets() -> None:
     assert dl.current_session_id() is None
     dl.set_current_session_id("outer")


### PR DESCRIPTION
## Related issue

<!-- Internal debuggability follow-on (Omnigent Debuggability Plan, OMNI-4198 —
the same effort that added the ZeroBus debug-log sink). No GitHub issue. -->

Closes #

## Summary

Make every server REST method auditable **per session** in the Databricks Delta
table the ZeroBus debug-log sink already writes to. Today only the turn/SSE path
(`orchestration.py`) emits `event_name`, so a query by `session_id` can't
reconstruct what a request did; most methods contribute null `event_name` /
`session_id`.

- **Envelope (every HTTP method, zero per-route edits):** the
  `_record_server_metrics` middleware emits `start` + `ok`/`error` with
  `event_name` set to the matched route's handler name (`create_session`,
  `grant_permission`, …) and `phase`/`route`/`method`/`status`/`duration_ms`
  attributes. The exception handlers emit the same `event_name` + `phase=error`
  so error rows keep the message + stack trace, correlated by `session_id`.
- **`session_id` populated widely:** a request-scoped ContextVar is bound **only**
  when the matched route has a real `{session_id}` path param (explicit
  `debug_event(session_id=…)` always wins; the `/v1/sessions` list and
  non-session routes stay null — no mis-attribution). This reverses the prior
  "no ambient server fallback" note in `record_to_row`, safely: it's never set
  on the runner, so the runner's primary-session fallback never collides.
- **Enrich rides the envelope end-event** (no extra row per call — critical for
  `POST /events`, whose streaming-delta types would otherwise be a firehose) via
  `add_audit_attrs`: `post_event` **event type**, `create_session`'s created id,
  grant/revoke `target_user_id`, mcp-server `server_name`, `launch_runner`
  host/session.
- **WebSocket / long-lived lifecycle events** (the HTTP middleware doesn't run
  for WS): host tunnel, runner tunnel, terminal attach, dictation, and
  session-updates get `connected`/`disconnected`/`error`.
- **Gated + quiet:** all audit rows go through a dedicated table-only
  `omnigent.audit_events` logger (`propagate=False`), so with the
  `OMNIGENT_DEBUG_LOG_*` env unset there is no handler — rows drop at ~zero cost
  and never touch the on-disk log.

Deferred (out of scope for this PR): SSE `stream_session` connect/disconnect and
`mcp_proxy`/env-filesystem outbound checkpoints.

## Test Plan

- `pytest tests/test_debug_logging.py tests/server/test_audit_logging_middleware.py`
  — session-id fallback/priority/scope, the audit-attrs bag, audit-logger wiring
  (sink-only, `propagate=False`), the pre-routing route resolver (incl. that
  `/v1/sessions` yields **no** bogus session id), gating on/off, and a
  **TestClient end-to-end** proving `add_audit_attrs` set inside a handler
  survives `BaseHTTPMiddleware` and lands on the envelope `ok` row.
- Ran the existing app-boot middleware + route tests
  (`tests/server/test_performance_metrics.py`,
  `tests/server/routes/test_hosts_routes.py`,
  `tests/server/routes/test_session_create_validation.py`, …) — green.
- `ruff check` / `ruff format --check` clean on all touched files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

New rows for a "send a message" flow (illustrative):

```
event_name    phase  session_id  attributes
create_session start  (null)     route=/v1/sessions, method=POST
create_session ok     (null)     status=201, session_id=sess_9f3a (enriched)
post_event     start  sess_9f3a  route=…/events, method=POST
post_event     ok     sess_9f3a  event_type=message, status=200, duration_ms=18
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated unit + integration (TestClient) tests cover the new logic. `pyrefly`
(the repo's type-check hook) is not installed in the local venv, so it was not
run locally — CI runs it. The deferred in-handler checkpoints (SSE stream, mcp_proxy) are called out in
the Summary as follow-ups.

This pull request and its description were written by Isaac.
