### PR TITLE
fix(web): make the skill pill tooltip readable in light mode

### DIFF
--- a/web/src/components/SkillPills.test.tsx
+++ b/web/src/components/SkillPills.test.tsx
@@ -1,0 +1,109 @@
+// Regression tests for the skill pill tooltip's light-mode legibility.
+//
+// The default tooltip surface is inverted in light mode — a near-black chip
+// with white text — and only becomes a light glass panel under `dark:`. This
+// bubble carries two-level content (name + description) and styled that
+// hierarchy with the page-surface tokens --foreground / --muted-foreground,
+// which put dark text on the dark chip: 1.23:1 for the name and 3.80:1 for the
+// description. Dark mode looked correct either way, because --foreground and
+// --popover-foreground resolve to the same near-white there, which is why the
+// bug shipped unnoticed.
+//
+// The fix takes the card surface instead of the chip, mirroring the sidebar's
+// session tooltip (shell/Sidebar.tsx) — the app's only other multi-line bubble.
+// Short one-line tooltips keep the chip.
+//
+// jsdom can't compute Tailwind styles, so contrast isn't directly testable;
+// these tests pin the class-level invariant that produced the bug.
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SkillPills } from "./SkillPills";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+afterEach(cleanup);
+
+const SKILLS = [
+  {
+    name: "cross-review",
+    description: "Verify an implementer's diff with an independent sub-agent.",
+  },
+  { name: "fanout", description: "Run the same prompt across several sub-agents." },
+];
+
+function renderPills(onPick = vi.fn()) {
+  // delayDuration 0: the bubble mounts on the first hover/focus, no timers to
+  // advance.
+  render(
+    <TooltipProvider delayDuration={0}>
+      <SkillPills skills={SKILLS} onPick={onPick} />
+    </TooltipProvider>,
+  );
+  return onPick;
+}
+
+/** The open bubble's own element (radix also mounts a visually-hidden copy). */
+function bubble(): HTMLElement {
+  const els = document.querySelectorAll<HTMLElement>('[data-slot="tooltip-content"]');
+  expect(els.length).toBeGreaterThan(0);
+  return els[0];
+}
+
+describe("SkillPills", () => {
+  it("renders one pill per skill and hands the bare name to onPick", () => {
+    const onPick = renderPills();
+    expect(screen.getByTestId("skill-pill-cross-review").textContent).toBe("/cross-review");
+    expect(screen.getByTestId("skill-pill-fanout").textContent).toBe("/fanout");
+    fireEvent.click(screen.getByTestId("skill-pill-cross-review"));
+    // Bare name, no leading slash — the caller prefills the composer with it.
+    expect(onPick).toHaveBeenCalledWith("cross-review");
+  });
+
+  it("renders nothing when the agent bundles no skills", () => {
+    render(
+      <TooltipProvider>
+        <SkillPills skills={[]} onPick={vi.fn()} />
+      </TooltipProvider>,
+    );
+    expect(screen.queryByTestId("skill-pills")).toBeNull();
+  });
+
+  it("shows the name and description once the pill is focused", () => {
+    renderPills();
+    expect(screen.queryByText(SKILLS[0].description)).toBeNull();
+    fireEvent.focus(screen.getByTestId("skill-pill-cross-review"));
+    expect(bubble().textContent).toContain("/cross-review");
+    expect(bubble().textContent).toContain(SKILLS[0].description);
+  });
+
+  // The guards below are the bug itself. The bubble styles its two lines with
+  // page-surface text tokens, so it MUST also take the page-surface background;
+  // inheriting the chip is what made the text unreadable in light mode.
+  it("takes the card surface so its page-surface text tokens land on a light background", () => {
+    renderPills();
+    fireEvent.focus(screen.getByTestId("skill-pill-cross-review"));
+    const cls = bubble().className;
+    expect(cls).toContain("bg-popover");
+    expect(cls).toContain("text-popover-foreground");
+  });
+
+  it("does not fall back to the inverted chip surface", () => {
+    renderPills();
+    fireEvent.focus(screen.getByTestId("skill-pill-cross-review"));
+    // bg-neutral-900 is the tooltip default this bubble opts out of. If it ever
+    // reappears here, the dark description text is back on a near-black box.
+    expect(bubble().className).not.toMatch(/(^|\s)bg-neutral-\d+(\s|$)/);
+  });
+
+  it("keeps the description dimmed for hierarchy", () => {
+    renderPills();
+    fireEvent.focus(screen.getByTestId("skill-pill-cross-review"));
+    const desc = screen
+      .getAllByText(SKILLS[0].description)
+      .find((el) => el.tagName === "P" && el.closest('[data-slot="tooltip-content"]'));
+    expect(desc).toBeTruthy();
+    // Legible on the card in both themes: 4.83:1 in light, 6.54:1 in dark.
+    expect(desc?.className).toContain("text-muted-foreground");
+  });
+});

--- a/web/src/components/SkillPills.tsx
+++ b/web/src/components/SkillPills.tsx
@@ -40,8 +40,16 @@ export function SkillPills({
               /{skill.name}
             </button>
           </TooltipTrigger>
-          <TooltipContent side="top" align="start" className="block max-w-80 p-3">
-            <p className="text-ui font-semibold text-foreground">/{skill.name}</p>
+          {/* Card surface, not the default tooltip chip: that chip is an
+              inverted near-black box in light mode, which left this bubble's
+              title/description tokens as dark text on dark. Mirrors the
+              sidebar session tooltip, the app's other multi-line bubble. */}
+          <TooltipContent
+            side="top"
+            align="start"
+            className="block max-w-80 rounded-lg bg-popover p-3 text-popover-foreground shadow-menu ring-1 ring-foreground/10"
+          >
+            <p className="text-ui font-semibold">/{skill.name}</p>
             <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
               {skill.description}
             </p>


### PR DESCRIPTION
## Related issue

Closes #6092

## Summary

The skill pill tooltip on the new-session composer was unreadable in light mode: dark text on a near-black box.

`TooltipContent`'s default surface is deliberately inverted in light mode (`bg-neutral-900 text-white`), going light only under `dark:`. `SkillPills` styles its two lines with the page-surface tokens `text-foreground` / `text-muted-foreground`, so both landed dark-on-dark: **1.23:1** for the name and **3.80:1** for the description, both under WCAG AA. Dark mode looked fine either way, because `--foreground` and `--popover-foreground` resolve to the same near-white there, which is why it shipped unnoticed.

This takes the card surface instead of the chip, mirroring the sidebar session tooltip (`shell/Sidebar.tsx`), the app's only other multi-line bubble. Light mode is now **14.9:1** / **4.83:1**; dark mode is unchanged. Short one-line tooltips keep the chip, so the other 51 `TooltipContent` usages are untouched.

## Test Plan

- `pnpm vitest run src/components/SkillPills.test.tsx` — 6 passed (new file).
- `pnpm vitest run` (full web suite) — 6390 passed. 3 NewChatDialog failures (host/sandbox agent selection) reproduce locally with `SkillPills.tsx` restored from `origin/main` and pass in CI's `web test`, so they are local-environment-only and unrelated.
- `pre-commit run --files web/src/components/SkillPills.tsx web/src/components/SkillPills.test.tsx` — prettier, oxlint, tsc all pass.
- Manual, against a local server on this branch: light and dark mode, hovering each of the three `polly` pills, plus a narrow window where the pills wrap to a second line.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

### Before

<img width="1921" height="844" alt="Screenshot 2026-09-01 at 2 36 22 PM" src="https://github.com/user-attachments/assets/93cf6df0-dc7a-4444-bd5d-e3b08f98fb61" />

### After

<img width="1325" height="1039" alt="Screenshot 2026-09-01 at 2 34 39 PM" src="https://github.com/user-attachments/assets/ef58589a-ef0d-4530-998c-a903adcb4cbb" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

jsdom can't compute Tailwind styles, so contrast isn't directly assertable. The new tests pin the class-level invariant that produced the bug: the bubble must carry `bg-popover` / `text-popover-foreground` and must not fall back to a `bg-neutral-*` chip while styling its text with page-surface tokens. Same approach as `ui/button.test.tsx` and the sidebar hover-class assertions in `Sidebar.test.tsx`. Contrast ratios were computed from the token values in `index.css` and confirmed visually in both themes.

## Changelog

Fixed an unreadable skill description tooltip on the composer in light mode

